### PR TITLE
feat(qwen): size the context meter from a curated Qwen context-window table

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -32,6 +32,14 @@ Tracks pending work and known limitations for the Qwen Code harness
   `cachedReadTokens` out of `input_tokens` (qwen's `inputTokens` is cache-
   inclusive; cost wants the non-cached portion) — see `_accumulate_usage`.
   Verified end-to-end against a live `qwen --acp` turn.
+- **Context status.** The UI context meter shows used/total for qwen. The
+  numerator (per-turn context consumed) comes from `_meta.usage.totalTokens`
+  via cost/token tracking above; the denominator (the model's context-window
+  *limit*) comes from a curated Qwen lookup in `get_model_context_window`
+  (`_QWEN_CONTEXT_WINDOWS`) — qwen models are absent from litellm and the MLflow
+  catalog, so without it they fell back to the wrong 128K default
+  (qwen3-coder-plus is 1M). A spec's `executor.context_window` still overrides;
+  unrecognized qwen models keep the 128K fallback.
 - **OS sandbox.** When the spec's `os_env.sandbox` is not `none`, the whole
   `qwen` process tree is wrapped in the platform sandbox (bwrap / seatbelt) at
   spawn (`_sandbox_launch_path`), confining qwen's own file/shell tools to the
@@ -49,12 +57,6 @@ comments; this is the *what*, not the *how*.)
   the session is reused across turns, so switching models mid-session (`/model`)
   has no effect. Supporting it means re-creating the ACP session on a model
   change (or passing a per-turn model if qwen accepts one).
-- [ ] **Context status.** Per-turn context *consumed* is now available
-  (qwen's `_meta.usage.totalTokens`, surfaced via cost/token tracking — see
-  What works today), but the executor still overrides no `max_context_tokens`,
-  so the UI's context meter has the numerator without the denominator. Report
-  the model's context-window *limit* (a model-capability lookup, not in the ACP
-  stream) so the meter can show used/total.
 - [ ] **Native TUI variant (`native-qwen`).** Attach to the live `qwen` terminal
   (like `pi-native`) for a fully interactive experience instead of a piped turn.
 

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -54,6 +54,42 @@ _MODEL_PREFIX_TO_PROVIDER: dict[str, str] = {
 
 _DEFAULT_CONTEXT_WINDOW: int = 128_000
 
+# Curated context windows for the Qwen models the qwen (``qwen --acp``) harness
+# drives. Qwen models are absent from both litellm's bundled registry and the
+# MLflow provider catalog, so without this they fall back to the conservative
+# 128K default — wrong by ~8x for the coding-plan defaults (qwen3-coder-plus is
+# 1M), leaving the UI context meter mis-sized. Keyed by the *normalized* base id
+# (provider prefix and ``:tag`` suffix stripped — see
+# :func:`_qwen_context_window`). Values are the published Alibaba Cloud Model
+# Studio / DashScope maxima; unrecognized qwen models keep the 128K fallback
+# (and a spec's ``executor.context_window`` always overrides this).
+_QWEN_CONTEXT_WINDOWS: dict[str, int] = {
+    "qwen3-coder-plus": 1_048_576,  # DashScope coding-plan default: 1M tokens
+    "qwen3-coder-flash": 1_048_576,  # served flash variant: 1M tokens
+    "qwen3-coder": 262_144,  # 480B open weights: 256K native (1M w/ YaRN)
+    "qwen-plus": 131_072,
+    "qwen-max": 131_072,
+    "qwen-turbo": 1_008_192,
+    "qwen-flash": 1_000_000,
+}
+
+
+def _qwen_context_window(model: str) -> int | None:
+    """Look up a Qwen model's context window from the curated table.
+
+    Normalizes the id the way model strings reach us — a provider prefix
+    (``qwen/qwen3-coder``, ``openrouter/qwen/qwen3-coder``) and an OpenRouter-
+    style ``:tag`` suffix (``qwen3-coder:free``) — down to the bare base id
+    before matching against :data:`_QWEN_CONTEXT_WINDOWS`.
+
+    :param model: The model identifier (any namespacing).
+    :returns: The context window in tokens, or ``None`` when the model isn't a
+        recognized Qwen entry (caller falls back to the 128K default).
+    """
+    bare = model.rsplit("/", 1)[-1].split(":", 1)[0].strip().lower()
+    return _QWEN_CONTEXT_WINDOWS.get(bare)
+
+
 # Fallback cache pricing as a multiple of the plain input rate, used when the
 # catalog publishes no explicit cache rate for a model (e.g. ``databricks-*``
 # entries today omit them). Both providers we serve publish the same ratios:
@@ -247,7 +283,11 @@ def get_model_context_window(model: str) -> int:
     try:
         import litellm
     except ImportError:
-        return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
+        return (
+            _fetch_context_window_from_mlflow(model)
+            or _qwen_context_window(model)
+            or _DEFAULT_CONTEXT_WINDOW
+        )
     try:
         info = litellm.get_model_info(model)
         if info:
@@ -265,7 +305,11 @@ def get_model_context_window(model: str) -> int:
                     return int(limit)
         except Exception:
             pass
-    return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
+    return (
+        _fetch_context_window_from_mlflow(model)
+        or _qwen_context_window(model)
+        or _DEFAULT_CONTEXT_WINDOW
+    )
 
 
 def resolve_effective_context_window(

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -15,8 +15,10 @@ import pytest
 from omnigent.llms import context_window
 from omnigent.llms.context_window import (
     ModelPricing,
+    _qwen_context_window,
     compute_llm_cost,
     fetch_model_pricing,
+    get_model_context_window,
     resolve_effective_context_window,
 )
 
@@ -351,3 +353,32 @@ def test_provider_catalog_caches_fetch_failure(
     assert first == 128_000  # _DEFAULT_CONTEXT_WINDOW fallback
     assert second == 128_000
     assert calls == ["anthropic"]
+
+
+# ---------------------------------------------------------------------------
+# Qwen context-window fallback (models absent from litellm + MLflow catalog)
+# ---------------------------------------------------------------------------
+
+
+def test_qwen_context_window_normalizes_id() -> None:
+    """The lookup strips provider prefixes and ``:tag`` suffixes before matching."""
+    assert _qwen_context_window("qwen3-coder-plus") == 1_048_576
+    assert _qwen_context_window("qwen/qwen3-coder") == 262_144
+    assert _qwen_context_window("qwen3-coder:free") == 262_144
+    assert _qwen_context_window("openrouter/qwen/qwen3-coder:free") == 262_144
+    assert _qwen_context_window("QWEN3-CODER-PLUS") == 1_048_576  # case-insensitive
+    # Unknown qwen variant → None (caller falls back to the default).
+    assert _qwen_context_window("qwen-nonexistent-xyz") is None
+
+
+def test_get_model_context_window_uses_qwen_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A known qwen model resolves to its curated window, not the 128K default.
+
+    Catalog lookup is disabled so the resolution is hermetic (no network):
+    litellm has no qwen entry, MLflow is skipped, so the qwen table answers.
+    """
+    monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
+    monkeypatch.delenv("AP_CONTEXT_WINDOW_OVERRIDE", raising=False)
+    assert get_model_context_window("qwen3-coder-plus") == 1_048_576
+    # An unrecognized qwen model still falls back to the conservative default.
+    assert get_model_context_window("qwen-nonexistent-xyz") == 128_000


### PR DESCRIPTION
## What

Fixes the qwen context meter's **denominator**. After #1084 the meter renders used/total for qwen (the numerator — per-turn tokens — flows from the usage work), but the window size was wrong.

`get_model_context_window()` resolves via env override → litellm registry → MLflow provider catalog → 128K default. **Qwen models are in none of those**, so they fell through to the conservative 128K default — ~8× too small for the coding-plan default `qwen3-coder-plus` (1M tokens), mis-sizing the meter.

(Note: the executor's `max_context_tokens()` is dead — nothing calls it. The server populates `SessionResponse.context_window` from `get_model_context_window`, so that's the real lever.)

## Changes

- **`_QWEN_CONTEXT_WINDOWS`** — curated table of published Alibaba Cloud Model Studio / DashScope context maxima (qwen3-coder-plus/flash → 1M, qwen3-coder → 256K, qwen-plus/max → 128K, etc.).
- **`_qwen_context_window()`** normalizes the id (strips provider prefix + `:tag` suffix) so `qwen/qwen3-coder`, `qwen3-coder:free`, and bare ids all match.
- Consulted as a fallback in `get_model_context_window`, **after** litellm/MLflow and **before** the 128K default — so litellm stays authoritative when it has data, and unrecognized qwen models keep the 128K fallback (no regression). A spec's `executor.context_window` still overrides everything.

## Why a static table

- Qwen reports **no** context window over ACP (only token usage in `_meta`).
- The default **DashScope** `/v1/models` route exposes no `context_length` (OpenRouter does, but that's not the default route, and wiring a live lookup would add a network call + credential resolution to the hot `GET /v1/sessions/{id}` path).
- qwen's own CLI falls back to a hardcoded `tokenLimit()` table for the same reason.

## Testing

- 2 new tests in `tests/llms/test_context_window.py` (id normalization + hermetic end-to-end fallback with catalog disabled).
- Related sweep green: `tests/llms/test_context_window.py tests/test_model_catalog.py tests/inner/test_qwen_executor.py tests/runtime/test_compaction.py` — 135 passed.

Closes the **Context status** follow-up in `docs/QWEN_FOLLOWUPS.md`.