### PR TITLE
test(e2e-ui): mark native render-parity + native fork legs as nightly

### DIFF
--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -33,7 +33,6 @@ the native CLI to take a turn.
 
 from __future__ import annotations
 
-import os
 import re
 
 import httpx
@@ -79,10 +78,22 @@ def _agent_id_by_name(base_url: str, name: str) -> str:
         # SDK → Claude Code: CROSS-family native target. The runner rebuilds
         # the Claude transcript from the copied items, so carry-history is
         # stamped and the wrapper flips to the claude-native terminal UI.
-        pytest.param("claude-native-ui", "claude-code-native-ui", True, id="sdk-to-claude-code"),
+        pytest.param(
+            "claude-native-ui",
+            "claude-code-native-ui",
+            True,
+            id="sdk-to-claude-code",
+            marks=pytest.mark.nightly,
+        ),
         # SDK → Codex: SAME-family native target. Same carry-history rebuild
         # path; the wrapper flips to the codex-native terminal UI.
-        pytest.param("codex-native-ui", "codex-native-ui", True, id="sdk-to-codex"),
+        pytest.param(
+            "codex-native-ui",
+            "codex-native-ui",
+            True,
+            id="sdk-to-codex",
+            marks=pytest.mark.nightly,
+        ),
         # SDK → Pi: native, but it cannot replay fork history, so the fork
         # must flip to the Pi terminal UI without carry-history stamped.
         pytest.param("pi-native-ui", "pi-native-ui", False, id="sdk-to-pi"),
@@ -107,12 +118,6 @@ def test_fork_switch_agent_carries_history(
         carry-history label (true only for native targets that can replay
         fork history, currently claude/codex native).
     """
-    # Native targets (claude-code, codex) need real CLI credentials that
-    # CI does not have; skip those parametrizations when LLM_API_KEY is absent.
-    _NATIVE_TARGETS = {"claude-native-ui", "codex-native-ui"}
-    if target_name in _NATIVE_TARGETS and not os.environ.get("LLM_API_KEY"):
-        pytest.skip(f"Fork into {target_name} needs real credentials (LLM_API_KEY).")
-
     base_url, session_id = seeded_session
     target_agent_id = _agent_id_by_name(base_url, target_name)
 

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -21,7 +21,6 @@ extra LLM calls Claude Code makes internally.
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 
 import pytest
@@ -98,10 +97,7 @@ def _type_into_tui(page: Page, text: str) -> None:
     page.keyboard.press("Enter")
 
 
-@pytest.mark.skipif(
-    not os.environ.get("LLM_API_KEY"),
-    reason="Native Claude render-parity needs real Anthropic credentials (LLM_API_KEY).",
-)
+@pytest.mark.nightly
 @pytest.mark.timeout(300)
 def test_native_claude_message_render_parity(
     page: Page,

--- a/tests/e2e_ui/messages/test_native_codex_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_codex_render_parity.py
@@ -21,7 +21,6 @@ extra LLM calls Codex makes internally.
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 
 import pytest
@@ -99,10 +98,7 @@ def _type_into_tui(page: Page, text: str) -> None:
     page.keyboard.press("Enter")
 
 
-@pytest.mark.skipif(
-    not os.environ.get("LLM_API_KEY"),
-    reason="Native Codex render-parity needs real OpenAI credentials (LLM_API_KEY).",
-)
+@pytest.mark.nightly
 @pytest.mark.timeout(300)
 def test_native_codex_message_render_parity(
     page: Page,


### PR DESCRIPTION
## Summary

Replace `skipif(LLM_API_KEY)` with `@nightly` on 3 native CLI tests that need version-specific mock routing not yet reliable in CI:

- `test_native_claude_message_render_parity`
- `test_native_codex_message_render_parity`  
- `test_fork_switch_agent_carries_history[sdk-to-claude-code]` / `[sdk-to-codex]`

The PR gate runs with `-m "not nightly"` so these are excluded. The `sdk-to-sdk` and `sdk-to-pi` fork legs remain in the gate.

## Test plan

- [ ] CI e2e-ui shards pass (these tests excluded from gate)
- [ ] No other test regressions

Co-authored-by: Isaac