### PR TITLE
fix(web): render the collapse toggle in the desktop files rail

### DIFF
--- a/ap-web/src/shell/FilesPanel.tsx
+++ b/ap-web/src/shell/FilesPanel.tsx
@@ -302,7 +302,14 @@ export function FilesPanel({
   // Full-screen drawer mode: forced-open content, no rounded card,
   // section grows to fill the parent rather than capping at max-h.
   const fullScreen = onClose !== undefined || frameless === true;
-  const contentVisible = !collapsed || fullScreen;
+  // Drawer mode (mobile ``onClose``) owns its own header — a static title
+  // plus an X close — and is always-open, so the collapse toggle does not
+  // apply there. The inline/rail variants (no ``onClose``) render the
+  // collapsible "Working folder" header and honor ``collapsed`` so the
+  // desktop rail can collapse the panel and persist that choice. ``fullScreen``
+  // stays a pure layout flag (fill height, no card) shared by both.
+  const drawerMode = onClose !== undefined;
+  const contentVisible = !collapsed || drawerMode;
   const changedQuery = useWorkspaceChangedFiles(conversationId, {
     enabled: contentVisible,
   });
@@ -362,7 +369,7 @@ export function FilesPanel({
     >
       {/* Header — single row: [title · workingDir] [eye] [chevron / close] */}
       <div className="flex shrink-0 items-center gap-2 px-3 py-2">
-        {fullScreen ? (
+        {drawerMode ? (
           <>
             <span className="shrink-0 font-medium text-sm">Working folder</span>
             {workingDir && <WorkingDirLabel dir={workingDir} />}


### PR DESCRIPTION
## What

Make the desktop Workspace rail's `FilesPanel` render the collapsible "Working folder" header (a real toggle button with `aria-expanded`) and honor/persist the `collapsed` state, by splitting the always-open drawer behavior out of the `fullScreen` layout flag.

## Why

The "persist file-browser collapsed state" feature (#1025) shipped a collapse toggle that **never rendered in the running app**. `FilesPanel` picks its header style from `fullScreen`:

```ts
const fullScreen = onClose !== undefined || frameless === true;
// fullScreen → static "Working folder" <span>
// else       → collapsible <button> with aria-expanded
```

But **both** production mounts force `fullScreen = true`:
- desktop rail passes `frameless` (`WorkspacePanel.tsx`)
- mobile drawer passes `onClose` (`FilesPanelDrawer.tsx`)

So the collapse button only ever rendered in jsdom unit-test mounts. `fullScreen` was overloaded — it meant both *"fill-height layout, no card"* **and** *"no toggle, always open."* The mobile drawer genuinely needs the static always-open header (it owns its own title + X close); the desktop rail does not.

## Fix

Introduce `drawerMode = onClose !== undefined` for the always-open header, and keep `fullScreen` as a pure layout flag:

```ts
const drawerMode = onClose !== undefined;
const contentVisible = !collapsed || drawerMode;
// header: {drawerMode ? <static span + X close> : <collapsible button>}
```

- **Desktop rail** (`frameless`, no `onClose`): now renders the collapse toggle and honors `collapsed` → the choice persists across reload/sessions as #1025 intended.
- **Mobile drawer** (`onClose`): unchanged — static header, always open.
- `fullScreen` layout (fill height, no card) unchanged for both.

## Fixes a deterministic e2e failure

`tests/e2e_ui/files/test_reload_persistence.py::test_files_panel_collapsed_state_persists_across_reload` drives the real rail and timed out waiting for the never-rendered toggle button. It's been failing deterministically (surfacing intermittently only via xdist sharding) since #1025 added it. No test change needed — it passes against this fix.

## Test

- `vitest`: FilesPanel (31), WorkspacePanel + AppShell (81) — all pass.
- `tsc --noEmit`: clean. `prettier --check`: clean.
- Rebuilt the SPA and ran the e2e test against it: **1 passed in 11.8s** (was timing out at ~60s).