### PR TITLE
fix(elicitation): match terminal-resolved prompts by exact tool_input only

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -1424,6 +1424,27 @@ async def _publish_and_wait_for_harness_elicitation(
                 )
 
 
+def _canonical_tool_input(tool_input: dict[str, Any] | None) -> dict[str, Any]:
+    """
+    Canonicalize a tool input for terminal-resolved correlation.
+
+    The park side records an absent / non-dict input as ``None`` (a
+    permission prompt whose hook payload carries no ``tool_input`` — see
+    the ``_publish_and_wait_for_harness_elicitation`` call sites), while
+    the mirror side normalizes the parsed transcript arguments to ``{}``
+    (see :func:`_drive_terminal_resolved_elicitation`). Both mean "no
+    input", so collapse them to ``{}`` before comparing — otherwise a
+    no-input prompt would never match its own mirrored result (``None ==
+    {}`` is ``False``) and, with no count-based fallback, would orphan
+    until the hook timeout.
+
+    :param tool_input: Parked or mirrored tool input, e.g.
+        ``{"command": "ls"}``, ``{}``, or ``None``.
+    :returns: The dict unchanged, or ``{}`` when it is ``None``.
+    """
+    return tool_input if isinstance(tool_input, dict) else {}
+
+
 def _signal_terminal_resolved_harness_elicitation(
     session_id: str,
     tool_name: str,
@@ -1448,8 +1469,11 @@ def _signal_terminal_resolved_harness_elicitation(
     check), so ``(tool_name, tool_input)`` is the only correlation signal
     available — and both sides are unmodified JSON round-trips of the
     same input, so exact equality holds whenever they describe the same
-    call. A non-matching or ambiguous result resolves nothing; the web
-    verdict or timeout still applies. Exact-only matching is what stops
+    call (absent input and empty input both canonicalize to ``{}`` via
+    :func:`_canonical_tool_input`, since the park and mirror sides spell
+    "no input" differently — ``None`` vs ``{}``). A non-matching or
+    ambiguous result resolves nothing; the web verdict or timeout still
+    applies. Exact-only matching is what stops
     one prompt's result from clearing a different prompt: approving
     ``Bash{ls}`` in the web UI un-parks it, and mirroring its own output
     must not then clear a still-pending ``Bash{pwd}`` sibling (an
@@ -1477,8 +1501,9 @@ def _signal_terminal_resolved_harness_elicitation(
     ]
     if not candidates:
         return
+    mirrored_input = _canonical_tool_input(tool_input)
     for parked in candidates:
-        if parked.tool_input == tool_input:
+        if _canonical_tool_input(parked.tool_input) == mirrored_input:
             parked.resolved_elsewhere.set()
             return
     # No exact input match. Correlation is exact-only: resolving a

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -1440,17 +1440,21 @@ def _signal_terminal_resolved_harness_elicitation(
     on reject the harness records a rejection result — so its arrival is
     a reliable "the terminal already resolved this" signal.
 
-    Correlation is by tool identity, never positional: a result only
-    resolves a parked prompt for the SAME ``tool_name`` in the same
-    session. That is what stops an unrelated auto-allowed tool's output
-    from clearing a different tool's pending prompt. Among
-    same-named parked prompts it prefers an exact ``tool_input`` match;
-    if none match exactly but exactly one same-named prompt is parked it
-    resolves that one (the hook payload and the transcript can serialize
-    identical input differently, so a single unambiguous candidate is
-    treated as the match). If several same-named prompts are parked and
-    none match by input it stays conservative and resolves none — the
-    web verdict or timeout still applies.
+    Correlation is by exact tool identity, never positional: a result
+    resolves a parked prompt only when it has the SAME ``tool_name`` AND
+    the SAME ``tool_input`` in the same session. Claude Code's
+    ``PermissionRequest`` payload carries no ``tool_use_id`` (the id is
+    minted only when the tool call is emitted, after the permission
+    check), so ``(tool_name, tool_input)`` is the only correlation signal
+    available — and both sides are unmodified JSON round-trips of the
+    same input, so exact equality holds whenever they describe the same
+    call. A non-matching or ambiguous result resolves nothing; the web
+    verdict or timeout still applies. Exact-only matching is what stops
+    one prompt's result from clearing a different prompt: approving
+    ``Bash{ls}`` in the web UI un-parks it, and mirroring its own output
+    must not then clear a still-pending ``Bash{pwd}`` sibling (an
+    unrelated auto-allowed same-named tool's output is harmless for the
+    same reason).
 
     Best-effort and idempotent: a no-op when no parked prompt matches
     (e.g. the web UI already resolved it, the tool needed no permission,
@@ -1477,8 +1481,23 @@ def _signal_terminal_resolved_harness_elicitation(
         if parked.tool_input == tool_input:
             parked.resolved_elsewhere.set()
             return
-    if len(candidates) == 1:
-        candidates[0].resolved_elsewhere.set()
+    # No exact input match. Correlation is exact-only: resolving a
+    # same-named-but-different-input prompt here would clear the wrong
+    # card, so leave every candidate to its own result / web verdict /
+    # timeout. This branch is reached routinely and benignly — e.g. after
+    # a sibling prompt was web-approved and un-parked, its mirrored output
+    # finds only the still-pending different-input prompt — so it logs at
+    # debug, not warning. (A genuine match failing to compare equal would
+    # also land here, but is indistinguishable from the benign case inside
+    # this call; both inputs are unmodified JSON round-trips, so such drift
+    # is not expected.)
+    _logger.debug(
+        "Mirrored %s result in %s matched no parked prompt by input "
+        "(%d same-named prompt(s) pending); leaving them to web verdict/timeout.",
+        tool_name,
+        session_id,
+        len(candidates),
+    )
 
 
 # Strong refs so deferred card-clear tasks aren't GC'd mid-sleep.

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -772,9 +772,13 @@ async def test_permission_request_hook_forwards_cwd_and_permission_mode(
     Note: ``tool_use_id`` is intentionally absent — the fixtures omit
     it because Claude Code's PermissionRequest payload doesn't carry one
     (the id is only minted when the tool call is emitted, AFTER
-    the permission check). The UI's auto-clear falls back to a
-    "first pending" heuristic instead — see
-    :file:`ap-web/src/store/chatStore.ts`'s ``tool_call`` case.
+    the permission check). With no id, the terminal-resolved fast path
+    correlates a mirrored tool result to a parked prompt by exact
+    ``(tool_name, tool_input)`` (see
+    :func:`omnigent.server.routes.sessions._signal_terminal_resolved_harness_elicitation`),
+    and the web UI clears a card strictly by ``elicitation_id`` on the
+    server's ``response.elicitation_resolved`` event — never by a
+    "first pending" heuristic.
     """
     agent = await create_test_agent(client, "test-permission-extras")
     session_id = await _create_session(client, agent["id"])

--- a/tests/server/test_terminal_resolved_elicitation.py
+++ b/tests/server/test_terminal_resolved_elicitation.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for the claude-native terminal-resolved elicitation fast path.
+
+When a permission prompt is answered (in Claude's native TUI or the web
+UI) the gated tool runs and its result is mirrored back as a
+``function_call_output``. ``_drive_terminal_resolved_elicitation`` recovers
+the tool identity by ``call_id`` (cached from the earlier mirrored
+``function_call``) and ``_signal_terminal_resolved_harness_elicitation``
+resolves the parked prompt it belongs to.
+
+Correlation is exact-only on ``(tool_name, tool_input)``: Claude Code's
+``PermissionRequest`` payload carries no ``tool_use_id``, so the id can
+never tie a parked prompt to its output, and both inputs are unmodified
+JSON round-trips of the same data so exact equality is the signal.
+
+These tests pin that contract and guard the regression that prompted it:
+a result must NEVER resolve a same-named prompt with a *different* input.
+That used to happen via a ``len(candidates) == 1`` fallback — approving
+``Bash{ls}`` in the web UI un-parked it, then mirroring its own output
+found the lone remaining ``Bash{pwd}`` sibling and wrongly cleared it.
+
+State isolation: ``_harness_parked_elicitations`` is reset between tests by
+the ``_reset_elicitation_state`` autouse fixture in
+``tests/server/conftest.py``; the ``_recent_mirrored_tool_calls`` cache is
+cleared per test below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from omnigent.entities.conversation import (
+    ConversationItem,
+    FunctionCallData,
+    FunctionCallOutputData,
+)
+from omnigent.server._elicitation_registry import (
+    _harness_parked_elicitations,
+    _ParkedHarnessElicitation,
+)
+from omnigent.server.routes import sessions as sessions_route
+
+SESSION = "conv_test"
+
+
+@pytest.fixture(autouse=True)
+def _clear_mirrored_tool_calls() -> Iterator[None]:
+    """Clear the call-id cache so call_ids don't leak across tests."""
+    sessions_route._recent_mirrored_tool_calls.clear()
+    yield
+    sessions_route._recent_mirrored_tool_calls.clear()
+
+
+def _park(
+    elicitation_id: str,
+    tool_name: str | None,
+    tool_input: dict[str, Any] | None,
+    *,
+    session_id: str = SESSION,
+) -> _ParkedHarnessElicitation:
+    """Register a parked prompt in the registry and return it."""
+    parked = _ParkedHarnessElicitation(
+        session_id=session_id,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        resolved_elsewhere=asyncio.Event(),
+    )
+    _harness_parked_elicitations[elicitation_id] = parked
+    return parked
+
+
+def _function_call_item(call_id: str, name: str, tool_input: dict[str, Any]) -> ConversationItem:
+    """Build a mirrored ``function_call`` item as the forwarder posts it."""
+    return ConversationItem(
+        id=f"item_{call_id}_fc",
+        type="function_call",
+        status="completed",
+        response_id="resp_test",
+        created_at=0,
+        data=FunctionCallData(
+            agent="claude",
+            name=name,
+            # The forwarder serializes the JSONL tool_use.input exactly
+            # this way (see claude_native_bridge); mirror that here.
+            arguments=json.dumps(tool_input, separators=(",", ":")),
+            call_id=call_id,
+        ),
+    )
+
+
+def _function_call_output_item(call_id: str, output: str = "ok") -> ConversationItem:
+    """Build a mirrored ``function_call_output`` item for ``call_id``."""
+    return ConversationItem(
+        id=f"item_{call_id}_fco",
+        type="function_call_output",
+        status="completed",
+        response_id="resp_test",
+        created_at=0,
+        data=FunctionCallOutputData(call_id=call_id, output=output),
+    )
+
+
+def test_exact_input_match_resolves_only_that_prompt() -> None:
+    """
+    Among same-named prompts, only the one whose ``tool_input`` matches
+    the result exactly is resolved; its sibling stays pending.
+    """
+    a = _park("e_a", "Bash", {"command": "ls"})
+    b = _park("e_b", "Bash", {"command": "pwd"})
+
+    sessions_route._signal_terminal_resolved_harness_elicitation(
+        SESSION, "Bash", {"command": "ls"}
+    )
+
+    assert a.resolved_elsewhere.is_set()
+    assert not b.resolved_elsewhere.is_set()
+
+
+def test_lone_same_name_prompt_with_different_input_is_not_resolved(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Regression: a result must not resolve a lone same-named prompt whose
+    input differs. The removed ``len(candidates) == 1`` fallback used to
+    clear it; now a non-match resolves nothing and logs (at debug) the
+    skipped path.
+    """
+    a = _park("e_a", "Bash", {"command": "ls"})
+
+    with caplog.at_level(logging.DEBUG, logger="omnigent.server.routes.sessions"):
+        sessions_route._signal_terminal_resolved_harness_elicitation(
+            SESSION, "Bash", {"command": "pwd"}
+        )
+
+    assert not a.resolved_elsewhere.is_set()
+    assert "matched no parked prompt by input" in caplog.text
+
+
+def test_approved_prompt_output_does_not_clear_sibling() -> None:
+    """
+    The exact scenario reported: two same-named prompts pending, the
+    user approves one in the web UI (which un-parks it), and that tool's
+    own mirrored output must not clear the still-pending sibling.
+    """
+    _park("e_a", "Bash", {"command": "ls"})
+    b = _park("e_b", "Bash", {"command": "pwd"})
+
+    # Web approval of A returns and un-parks it (sessions.py finally block).
+    del _harness_parked_elicitations["e_a"]
+
+    # A's own tool now runs; its mirrored output arrives for ``ls``.
+    sessions_route._signal_terminal_resolved_harness_elicitation(
+        SESSION, "Bash", {"command": "ls"}
+    )
+
+    assert not b.resolved_elsewhere.is_set()
+
+
+def test_different_tool_name_is_noop() -> None:
+    """A result for a different tool never touches a parked prompt."""
+    a = _park("e_a", "Bash", {"command": "ls"})
+
+    sessions_route._signal_terminal_resolved_harness_elicitation(
+        SESSION, "Read", {"file_path": "x"}
+    )
+
+    assert not a.resolved_elsewhere.is_set()
+
+
+def test_different_session_is_noop() -> None:
+    """A result in another session never touches this session's prompt."""
+    a = _park("e_a", "Bash", {"command": "ls"})
+
+    sessions_route._signal_terminal_resolved_harness_elicitation(
+        "conv_other", "Bash", {"command": "ls"}
+    )
+
+    assert not a.resolved_elsewhere.is_set()
+
+
+def test_already_resolved_candidate_is_skipped() -> None:
+    """
+    A prompt already marked resolved is filtered out, so an identical
+    input resolves the next still-pending same-named prompt instead.
+    """
+    a = _park("e_a", "Bash", {"command": "ls"})
+    a.resolved_elsewhere.set()
+    b = _park("e_b", "Bash", {"command": "ls"})
+
+    sessions_route._signal_terminal_resolved_harness_elicitation(
+        SESSION, "Bash", {"command": "ls"}
+    )
+
+    assert b.resolved_elsewhere.is_set()
+
+
+def test_drive_mirrored_output_resolves_matching_parked_prompt() -> None:
+    """
+    End-to-end server path: a mirrored ``function_call`` caches the tool
+    identity by ``call_id`` and the matching ``function_call_output``
+    resolves the exact-input prompt, leaving the sibling pending.
+    """
+    a = _park("e_a", "Bash", {"command": "ls"})
+    b = _park("e_b", "Bash", {"command": "pwd"})
+
+    sessions_route._drive_terminal_resolved_elicitation(
+        SESSION, _function_call_item("toolu_a", "Bash", {"command": "ls"})
+    )
+    sessions_route._drive_terminal_resolved_elicitation(
+        SESSION, _function_call_output_item("toolu_a")
+    )
+
+    assert a.resolved_elsewhere.is_set()
+    assert not b.resolved_elsewhere.is_set()
+
+
+def test_drive_output_without_known_call_id_is_noop() -> None:
+    """
+    A ``function_call_output`` whose ``call_id`` was never mirrored as a
+    ``function_call`` recovers no identity, so nothing is resolved.
+    """
+    a = _park("e_a", "Bash", {"command": "ls"})
+
+    sessions_route._drive_terminal_resolved_elicitation(
+        SESSION, _function_call_output_item("toolu_unknown")
+    )
+
+    assert not a.resolved_elsewhere.is_set()

--- a/tests/server/test_terminal_resolved_elicitation.py
+++ b/tests/server/test_terminal_resolved_elicitation.py
@@ -122,6 +122,38 @@ def test_exact_input_match_resolves_only_that_prompt() -> None:
     assert not b.resolved_elsewhere.is_set()
 
 
+def test_no_input_prompt_resolved_by_empty_mirrored_output() -> None:
+    """
+    A prompt parked with no input (``tool_input=None`` — its hook payload
+    carried no ``tool_input``) is resolved by its mirrored result, whose
+    parsed arguments normalize to ``{}``. The park side spells "no input"
+    as ``None`` and the mirror side as ``{}``; both canonicalize to ``{}``
+    so they compare equal. Without that, ``None == {}`` is ``False`` and —
+    with no count-based fallback — the prompt would orphan until the hook
+    timeout.
+    """
+    a = _park("e_a", "Bash", None)
+
+    sessions_route._signal_terminal_resolved_harness_elicitation(SESSION, "Bash", {})
+
+    assert a.resolved_elsewhere.is_set()
+
+
+def test_no_input_prompt_not_cleared_by_result_with_input() -> None:
+    """
+    Canonicalizing ``None`` to ``{}`` must not over-match: a no-input
+    prompt is left pending by a same-named result that carried real input
+    (they describe different calls), even as the lone candidate.
+    """
+    a = _park("e_a", "Bash", None)
+
+    sessions_route._signal_terminal_resolved_harness_elicitation(
+        SESSION, "Bash", {"command": "ls"}
+    )
+
+    assert not a.resolved_elsewhere.is_set()
+
+
 def test_lone_same_name_prompt_with_different_input_is_not_resolved(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Problem

In the claude-native permission flow, approving **one** of several pending permission prompts in the web UI would dismiss its **siblings** too. With multiple same-tool-name prompts pending in a single turn (e.g. two `Bash` calls), answering one orphan-dismissed the others as "resolved elsewhere" (fail-ask).

Before:

https://github.com/user-attachments/assets/2f7e1333-28f1-4553-86f3-5748a18ee192




After:


https://github.com/user-attachments/assets/f70f52cd-c67f-41e7-8be7-51fca1313a0e



## Root cause

When the gated tool's result is mirrored back from the transcript, `_signal_terminal_resolved_harness_elicitation` resolves the parked web prompt it belongs to. Among same-tool-name prompts it preferred an exact `(tool_name, tool_input)` match, but fell back to resolving the *sole* same-named candidate when no input matched:

```python
for parked in candidates:
    if parked.tool_input == tool_input:
        parked.resolved_elsewhere.set(); return
if len(candidates) == 1:                  # <-- the bug
    candidates[0].resolved_elsewhere.set()
```

Approving `Bash{ls}` un-parks it; Claude then runs `ls` and its own `function_call_output` is mirrored back. `Bash{ls}` is already gone, so the lone remaining same-named candidate is the still-pending `Bash{pwd}` sibling — no exact input match, so the `len==1` fallback fires and wrongly clears it. Auto-allowed same-name tools leaked the same way. The frontend was not the cause: `chatStore.ts` clears strictly by `elicitationId`; the server was telling it to clear the wrong card.

## Fix

Drop the `len(candidates) == 1` fallback so correlation is **exact-only**: a mirrored result resolves a parked prompt only on an exact `(tool_name, tool_input)` match; a non-matching or ambiguous result resolves nothing and leaves each prompt to its own result / web verdict / timeout.

This is safe because Claude Code's `PermissionRequest` payload carries no `tool_use_id` (the id is minted only when the tool call is emitted, after the permission check), so `(tool_name, tool_input)` is the only correlation signal — and both sides are **unmodified JSON round-trips** of the same input, so exact equality holds whenever they describe the same call. The skipped no-match branch logs at `debug` (not `warning`): it is hit routinely and benignly once a sibling is web-approved and un-parked.

## Tests

- New `tests/server/test_terminal_resolved_elicitation.py` — 8 unit tests over `_signal_terminal_resolved_harness_elicitation` and the end-to-end mirrored `call_id → identity → resolve` path (`_drive_terminal_resolved_elicitation`): exact-match-only, the lone-different-input no-op, the reported approve-A-must-not-clear-sibling-B scenario, different-tool/different-session no-ops, already-resolved skipping. Two of these were confirmed to fail with the fallback restored.
- Corrected a stale note in `test_sessions_permission_request_hook.py` that described a UI "first pending" auto-clear heuristic that no longer exists.

This pull request and its description were written by Isaac.