### PR TITLE
feat(qwen,goose): replay history on a fresh ACP session

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -40,6 +40,21 @@ Tracks pending work and known limitations for the Qwen Code harness
   catalog, so without it they fell back to the wrong 128K default
   (qwen3-coder-plus is 1M). A spec's `executor.context_window` still overrides;
   unrecognized qwen models keep the 128K fallback.
+- **In-session model selection (`/model`).** Switching models mid-session
+  works. The model is fixed in the `qwen --acp` subprocess env
+  (`HARNESS_QWEN_MODEL`) at spawn, so on a `/model` change the runner's
+  `HarnessProcessManager` respawns the harness with the new value — a fresh
+  `QwenExecutor` then opens a new `session/new` carrying the new model. Context
+  survives the respawn because the first turn of the new session replays the
+  prior conversation (see History replay below).
+- **History replay on a fresh ACP session.** When the `qwen --acp` subprocess
+  is (re)spawned — first turn, a `/model` switch, or a `Session not found`
+  reset — qwen holds none of the earlier conversation (it lived in the dead
+  process). `run_turn` normally sends only the latest user turn, so the first
+  turn of any fresh session folds the prior transcript into the prompt as a
+  labeled `Conversation so far:` block (`_history_prefix`), mirroring
+  `ClaudeSDKExecutor._build_prompt`. Keeps a mid-conversation model switch from
+  dropping the thread. (Same fix applied to the goose ACP harness.)
 - **OS sandbox.** When the spec's `os_env.sandbox` is not `none`, the whole
   `qwen` process tree is wrapped in the platform sandbox (bwrap / seatbelt) at
   spawn (`_sandbox_launch_path`), confining qwen's own file/shell tools to the
@@ -53,10 +68,6 @@ comments; this is the *what*, not the *how*.)
 
 ### High
 
-- [ ] **In-session model selection.** The model is fixed at `session/new` and
-  the session is reused across turns, so switching models mid-session (`/model`)
-  has no effect. Supporting it means re-creating the ACP session on a model
-  change (or passing a per-turn model if qwen accepts one).
 - [ ] **Native TUI variant (`native-qwen`).** Attach to the live `qwen` terminal
   (like `pi-native`) for a fully interactive experience instead of a piped turn.
 

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -654,6 +654,47 @@ class GooseExecutor(Executor):
                 parts.append(f"[attached image: {name}]" if name else "[attached image]")
         return "\n".join(parts)
 
+    @classmethod
+    def _history_prefix(cls, prior: list[Any]) -> str:  # type: ignore[explicit-any]
+        """Serialize prior conversation turns into a text prefix.
+
+        On a *fresh* ACP session (the first turn of a newly spawned/respawned
+        ``goose acp`` process, or after a session reset) Goose holds none of the
+        earlier conversation — its context lived in the dead subprocess. Since
+        :meth:`run_turn` normally sends only the latest user turn (relying on
+        the persistent session to retain history), we'd lose everything before
+        the switch. Replaying the transcript as a labeled ``role: content``
+        block restores that context, mirroring
+        ``ClaudeSDKExecutor._build_prompt``. A ``/model`` switch respawns the
+        subprocess (see HarnessProcessManager), so this is what keeps a
+        mid-conversation model change from dropping the thread.
+
+        :param prior: The conversation turns *before* the latest user message
+            (each an inner ``Message`` dict).
+        :returns: A ``"Conversation so far: …"`` text block, or ``""`` when
+            there is nothing to replay.
+        """
+        lines = ["Conversation so far:"]
+        for msg in prior:
+            if not isinstance(msg, dict):
+                continue
+            role = str(msg.get("role", "user")).replace("_", " ")
+            raw = msg.get("content")
+            if raw is None:
+                content = ""
+            elif isinstance(raw, str):
+                content = raw
+            elif isinstance(raw, list):
+                content = cls._text_from_blocks(raw, emit_image_marker=True)
+            else:
+                content = json.dumps(raw, ensure_ascii=True)
+            lines.append(f"{role}: {content}")
+        lines.append("")
+        lines.append(
+            "Respond to the latest user message, using the conversation above as context."
+        )
+        return "\n".join(lines)
+
     # ------------------------------------------------------------------
     # Executor interface
     # ------------------------------------------------------------------
@@ -709,12 +750,20 @@ class GooseExecutor(Executor):
             yield ExecutorError(message=str(exc), retryable=False)
             return
 
+        # A fresh ACP session (first turn of a new/respawned process, or after
+        # a reset) holds no prior context. Captured before we flip the latch
+        # below so we know whether to replay history into this turn.
+        fresh_session = not self._system_prompt_sent
+
         # Build the prompt payload from the most recent user message.
         user_text = ""
         image_blocks: list[dict[str, Any]] = []  # type: ignore[explicit-any]
-        for msg in reversed(messages):
+        latest_user_idx: int | None = None
+        for idx in range(len(messages) - 1, -1, -1):
+            msg = messages[idx]
             role = msg.get("role", "") if isinstance(msg, dict) else ""
             if role == "user":
+                latest_user_idx = idx
                 content = msg.get("content", "") if isinstance(msg, dict) else ""
                 if isinstance(content, str):
                     user_text = content
@@ -726,9 +775,21 @@ class GooseExecutor(Executor):
                     )
                 break
 
-        # ACP has no system-prompt field, so fold it into the first turn.
-        if not self._system_prompt_sent and system_prompt:
-            user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
+        # On a fresh session, replay the prior conversation so a model switch
+        # (which respawns the subprocess) or a session reset doesn't drop the
+        # thread — Goose otherwise only ever sees this turn's latest message.
+        # Skipped when there's nothing before the latest user turn (the genuine
+        # first turn of a brand-new conversation). See :meth:`_history_prefix`.
+        if fresh_session and latest_user_idx is not None and latest_user_idx > 0:
+            history_prefix = self._history_prefix(messages[:latest_user_idx])
+            user_text = f"{history_prefix}\n\nuser: {user_text}" if user_text else history_prefix
+
+        # ACP has no system-prompt field, so fold it into the first turn. The
+        # latch flips on any fresh session — even with an empty system prompt —
+        # so a continuing session never re-replays history or re-folds.
+        if fresh_session:
+            if system_prompt:
+                user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
             self._system_prompt_sent = True
 
         prompt_blocks: list[dict[str, Any]] = []  # type: ignore[explicit-any]

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -868,6 +868,49 @@ class QwenExecutor(Executor):
             # see docs/QWEN_FOLLOWUPS.md).
         return "\n".join(parts)
 
+    @classmethod
+    def _history_prefix(cls, prior: list[Any]) -> str:  # type: ignore[explicit-any]
+        """Serialize prior conversation turns into a text prefix.
+
+        On a *fresh* ACP session (the first turn of a newly spawned/respawned
+        ``qwen --acp`` process, or after a ``Session not found`` reset) qwen
+        holds none of the earlier conversation — its context lived in the dead
+        subprocess. Since :meth:`run_turn` normally sends only the latest user
+        turn (relying on the persistent session to retain history), we'd lose
+        everything before the switch. Replaying the transcript as a labeled
+        ``role: content`` block restores that context, mirroring
+        ``ClaudeSDKExecutor._build_prompt``. A ``/model`` switch respawns the
+        subprocess (see HarnessProcessManager), so this is what keeps a
+        mid-conversation model change from dropping the thread.
+
+        :param prior: The conversation turns *before* the latest user message
+            (each an inner ``Message`` dict).
+        :returns: A ``"Conversation so far: …"`` text block, or ``""`` when
+            there is nothing to replay.
+        """
+        lines = ["Conversation so far:"]
+        for msg in prior:
+            if not isinstance(msg, dict):
+                continue
+            role = str(msg.get("role", "user")).replace("_", " ")
+            raw = msg.get("content")
+            if raw is None:
+                content = ""
+            elif isinstance(raw, str):
+                content = raw
+            elif isinstance(raw, list):
+                # Reuse the block folder so prior file/image turns render the
+                # same way they did when first sent (fenced files, markers).
+                content = cls._text_from_blocks(raw, emit_image_marker=True)
+            else:
+                content = json.dumps(raw, ensure_ascii=True)
+            lines.append(f"{role}: {content}")
+        lines.append("")
+        lines.append(
+            "Respond to the latest user message, using the conversation above as context."
+        )
+        return "\n".join(lines)
+
     # ------------------------------------------------------------------
     # Executor interface
     # ------------------------------------------------------------------
@@ -903,12 +946,20 @@ class QwenExecutor(Executor):
             yield ExecutorError(message=str(exc), retryable=False)
             return
 
+        # A fresh ACP session (first turn of a new/respawned process, or after
+        # a reset) holds no prior context. Captured before we flip the latch
+        # below so we know whether to replay history into this turn.
+        fresh_session = not self._system_prompt_sent
+
         # Build the prompt payload from the most recent user message.
         user_text = ""
         image_blocks: list[dict[str, Any]] = []  # type: ignore[explicit-any]
-        for msg in reversed(messages):
+        latest_user_idx: int | None = None
+        for idx in range(len(messages) - 1, -1, -1):
+            msg = messages[idx]
             role = msg.get("role", "") if isinstance(msg, dict) else ""
             if role == "user":
+                latest_user_idx = idx
                 content = msg.get("content", "") if isinstance(msg, dict) else ""
                 if isinstance(content, str):
                     user_text = content
@@ -923,11 +974,23 @@ class QwenExecutor(Executor):
                     )
                 break
 
+        # On a fresh session, replay the prior conversation so a model switch
+        # (which respawns the subprocess) or a session reset doesn't drop the
+        # thread — qwen otherwise only ever sees this turn's latest message.
+        # Skipped when there's nothing before the latest user turn (the genuine
+        # first turn of a brand-new conversation). See :meth:`_history_prefix`.
+        if fresh_session and latest_user_idx is not None and latest_user_idx > 0:
+            history_prefix = self._history_prefix(messages[:latest_user_idx])
+            user_text = f"{history_prefix}\n\nuser: {user_text}" if user_text else history_prefix
+
         # ACP has no system-prompt field, so fold it into the first turn's
         # user text. Without this the agent's persona / instructions (the
-        # spec ``prompt:``) never reach qwen and it runs uninstructed.
-        if not self._system_prompt_sent and system_prompt:
-            user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
+        # spec ``prompt:``) never reach qwen and it runs uninstructed. The
+        # latch flips on any fresh session — even with an empty system prompt —
+        # so a continuing session never re-replays history or re-folds.
+        if fresh_session:
+            if system_prompt:
+                user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
             self._system_prompt_sent = True
 
         # Text first, then any image blocks (ACP prompt is an ordered array).

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -323,6 +323,108 @@ async def test_run_turn_streams_text_and_usage() -> None:
     assert completes[0].usage == {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10}
 
 
+def test_history_prefix_serializes_prior_turns() -> None:
+    """_history_prefix renders prior turns as labeled role: content lines."""
+    prior = [
+        {"role": "user", "content": "what is 2+2"},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "4"}]},
+    ]
+    out = GooseExecutor._history_prefix(prior)
+    assert out.startswith("Conversation so far:")
+    assert "user: what is 2+2" in out
+    assert "assistant: 4" in out
+    assert out.rstrip().endswith("using the conversation above as context.")
+
+
+@pytest.mark.asyncio
+async def test_run_turn_replays_history_on_fresh_session() -> None:
+    """A fresh Goose session folds prior turns into the prompt (e.g. /model respawn).
+
+    Goose normally only sees the latest user turn; on a brand-new subprocess
+    that would drop everything before the switch, so the first turn replays
+    the transcript to keep context.
+    """
+    executor = GooseExecutor()
+    executor._initialized = True
+    executor._session_id = "20260623_fresh"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    loop = asyncio.get_event_loop()
+
+    sent_prompts: list[str] = []
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            sent_prompts.append(msg["params"]["prompt"][0]["text"])
+            req_id = msg["id"]
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    messages = [
+        {"role": "user", "content": "remember 42"},
+        {"role": "assistant", "content": "ok, 42"},
+        {"role": "user", "content": "what number?"},
+    ]
+    async for _ in executor.run_turn(messages, [], "SYS"):
+        pass
+
+    prompt = sent_prompts[0]
+    assert prompt.startswith("SYS\n\n")
+    assert "Conversation so far:" in prompt
+    assert "user: remember 42" in prompt
+    assert "assistant: ok, 42" in prompt
+    assert prompt.rstrip().endswith("user: what number?")
+
+
+@pytest.mark.asyncio
+async def test_run_turn_no_replay_on_continuing_session() -> None:
+    """A continuing Goose session sends only the latest turn (it retains context)."""
+    executor = GooseExecutor()
+    executor._initialized = True
+    executor._session_id = "20260623_cont"
+    executor._system_prompt_sent = True  # not a fresh session
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    loop = asyncio.get_event_loop()
+
+    sent_prompts: list[str] = []
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            sent_prompts.append(msg["params"]["prompt"][0]["text"])
+            req_id = msg["id"]
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    messages = [
+        {"role": "user", "content": "earlier"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "latest"},
+    ]
+    async for _ in executor.run_turn(messages, [], "SYS"):
+        pass
+
+    assert sent_prompts[0] == "latest"
+
+
 @pytest.mark.asyncio
 async def test_close_with_no_process_is_a_noop() -> None:
     await GooseExecutor().close()  # must not raise

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -1077,6 +1077,154 @@ async def test_run_turn_resends_system_prompt_after_session_reset() -> None:
 
 
 # ---------------------------------------------------------------------------
+# History replay on a fresh session (model switch / reset doesn't drop context)
+# ---------------------------------------------------------------------------
+
+
+def test_history_prefix_serializes_prior_turns() -> None:
+    """_history_prefix renders prior turns as labeled role: content lines."""
+    prior = [
+        {"role": "user", "content": "what is 2+2"},
+        {"role": "assistant", "content": "4"},
+        {"role": "user", "content": [{"type": "input_text", "text": "and 3+3"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "6"}]},
+    ]
+    out = QwenExecutor._history_prefix(prior)
+    assert out.startswith("Conversation so far:")
+    assert "user: what is 2+2" in out
+    assert "assistant: 4" in out
+    assert "user: and 3+3" in out  # list content folded via _text_from_blocks
+    assert "assistant: 6" in out
+    assert out.rstrip().endswith("using the conversation above as context.")
+
+
+@pytest.mark.asyncio
+async def test_run_turn_replays_history_on_fresh_session() -> None:
+    """A fresh session folds prior turns into the prompt (e.g. after /model respawn).
+
+    qwen normally only sees the latest user turn; on a brand-new subprocess
+    (a ``/model`` switch respawns it) that would drop everything before the
+    switch. The first turn must replay the transcript so context survives.
+    """
+    executor = QwenExecutor()
+    executor._initialized = True
+    executor._session_id = "sess-fresh"  # session exists, but no prior turns sent
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    loop = asyncio.get_event_loop()
+
+    sent_prompts: list[str] = []
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            sent_prompts.append(msg["params"]["prompt"][0]["text"])
+            req_id = msg["id"]
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    messages = [
+        {"role": "user", "content": "remember the number 42"},
+        {"role": "assistant", "content": "Got it, 42."},
+        {"role": "user", "content": "what number did I say?"},
+    ]
+    async for _ in executor.run_turn(messages, [], "SYS"):
+        pass
+
+    prompt = sent_prompts[0]
+    # System prompt first, then replayed history, then the latest turn.
+    assert prompt.startswith("SYS\n\n")
+    assert "Conversation so far:" in prompt
+    assert "user: remember the number 42" in prompt
+    assert "assistant: Got it, 42." in prompt
+    assert prompt.rstrip().endswith("user: what number did I say?")
+
+
+@pytest.mark.asyncio
+async def test_run_turn_no_replay_on_continuing_session() -> None:
+    """A continuing session sends only the latest turn (qwen retains context)."""
+    executor = QwenExecutor()
+    executor._initialized = True
+    executor._session_id = "sess-cont"
+    executor._system_prompt_sent = True  # not a fresh session
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    loop = asyncio.get_event_loop()
+
+    sent_prompts: list[str] = []
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            sent_prompts.append(msg["params"]["prompt"][0]["text"])
+            req_id = msg["id"]
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    messages = [
+        {"role": "user", "content": "earlier turn"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "latest turn"},
+    ]
+    async for _ in executor.run_turn(messages, [], "SYS"):
+        pass
+
+    # No history prefix, no system-prompt re-fold — just the latest message.
+    assert sent_prompts[0] == "latest turn"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_no_replay_on_genuine_first_turn() -> None:
+    """A brand-new conversation (single user turn) has nothing to replay."""
+    executor = QwenExecutor()
+    executor._initialized = True
+    executor._session_id = "sess-first"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    loop = asyncio.get_event_loop()
+
+    sent_prompts: list[str] = []
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            sent_prompts.append(msg["params"]["prompt"][0]["text"])
+            req_id = msg["id"]
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    async for _ in executor.run_turn([{"role": "user", "content": "hello"}], [], "SYS"):
+        pass
+
+    assert sent_prompts[0] == "SYS\n\nhello"  # system prompt only, no replay
+    assert "Conversation so far:" not in sent_prompts[0]
+
+
+# ---------------------------------------------------------------------------
 # Server-initiated requests: permission, unsupported methods (incl. fs/*)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Keeps a mid-conversation `/model` switch (or a `Session not found` reset) from dropping the conversation thread on the **ACP harnesses** (qwen + goose).

## Background

`/model` already *switches models* for qwen/goose: the model is baked into the harness subprocess env (`HARNESS_QWEN_MODEL` / `HARNESS_GOOSE_MODEL`) at spawn, so `HarnessProcessManager` respawns the harness when a turn requests a different model. **No work was needed there** — that was the original "in-session model selection" follow-up, now confirmed working.

The gap: respawning kills the `qwen --acp` / `goose acp` process, and these executors send **only the latest user turn** each call, relying on the persistent in-process ACP session for context. So after a respawn the new process starts blank and the prior conversation was silently lost.

This is specific to the ACP harnesses — the SDK harnesses already survive a respawn (claude-sdk replays full history into a fresh session, openai-agents persists a SQLite session, codex persists its thread in `CODEX_HOME`).

## Changes

- **`_history_prefix`** (qwen + goose): serializes prior turns into a labeled `Conversation so far:\n<role>: <content>` block, mirroring `ClaudeSDKExecutor._build_prompt`.
- **`run_turn`**: on a *fresh* session (first turn of a new/respawned process), fold that prefix in before the latest user turn. Skipped on a genuine brand-new conversation (nothing prior to replay) and on continuing sessions (qwen/goose retain context in-process).
- The fresh-session latch (`_system_prompt_sent`) now flips even when the system prompt is empty, so a continuing session never re-replays or re-folds (fixes a latent edge case).
- Applied to **both** ACP harnesses since they share the exact pattern.

## Testing

- qwen: 4 new tests (prefix serialization, replay on fresh session, no-replay on continuing session, no-replay on genuine first turn).
- goose: 3 new tests (prefix serialization, replay on fresh session, no-replay on continuing session).
- `tests/inner/test_qwen_executor.py tests/inner/test_goose_executor.py` — 119 passed.

## Docs

`QWEN_FOLLOWUPS.md`: removed the stale "in-session model selection" item, documented both `/model` (works via respawn) and history replay under "What works today".