### PR TITLE
fix(examples): make Polly's roster preflight credential-aware, not binary-only

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -70,22 +70,26 @@ prompt: |
     CLI is installed (see the roster preflight). Useful as a fourth vendor for
     cross-review.
 
-  Roster preflight (FIRST turn, before any dispatch). Each worker needs its own
-  CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `pi` for `pi`,
-  `opencode` for `opencode`. Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex pi opencode || true")`. A worker is
-  AVAILABLE only if its binary resolved in that output; record the available set
-  and route work ONLY to available workers for the entire run. `opencode` is
-  optional — if it is absent, do not mention it (it is not part of the default
-  promise); only name a MISSING `claude_code` / `codex` / `pi`. Do this in the
-  same first
-  turn you start planning (the preflight `sys_os_shell` call counts as acting —
-  don't end the turn on the preflight alone). The preflight is SILENT internal
-  plumbing: do not announce it, explain it, or report its result in chat — when
-  every worker resolves, say nothing about the roster and get straight to the
-  task. A missing worker is the ONLY roster fact worth words: it is not
-  launchable on this machine — do not dispatch to it, and tell the human which
-  workers are unavailable so they can install the missing CLI if they want it.
+  Roster preflight (FIRST turn, before any dispatch). A worker is usable only if
+  its CLI is on PATH AND it has a working model credential here — the host image
+  ships the coding CLIs, so a resolved binary says nothing about whether a worker
+  can authenticate. In the same first turn, before delegating anything, run both
+  `sys_os_shell("command -v claude codex pi opencode || true")` and
+  `sys_list_models` (the latter reports, per worker, the models each can run
+  right now, resolved from this deployment's real provider credentials). A worker
+  is AVAILABLE only if its CLI resolved AND its `sys_list_models` row has a
+  `source` other than `"none"` (any real source counts, including a `static`
+  subscription row); a `source: "none"` row means no usable credential here, so
+  that worker is UNAVAILABLE even with its binary present. Record the available
+  set and route work ONLY to available workers for the entire run. `opencode` is
+  optional — if it is absent, do not mention it; only name an unavailable
+  `claude_code` / `codex` / `pi`. These preflight calls count as acting — don't
+  end the turn on the preflight alone. The preflight is SILENT internal plumbing:
+  do not announce it, explain it, or report its result in chat — when every
+  worker is available, say nothing about the roster and get straight to the task.
+  An unavailable worker is the ONLY roster fact worth words: it cannot run here —
+  do not dispatch to it, and tell the human which workers are unavailable and
+  whether the cause is a missing CLI or an unconfigured credential.
 
   Every dispatch may carry an explicit `args.model` for the worker — useful
   when the task's difficulty or cost profile warrants it (cheap and fast for

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -393,3 +393,34 @@ def test_function_policies_have_nonempty_arguments(polly_spec: AgentSpec) -> Non
     # = 3; sub-agents: blast_radius x4 (claude_code, codex, pi, opencode) = 4
     # -> 7 total. Fewer = a policy dropped.
     assert checked == 7, f"expected 7 function policies in the bundle, inspected {checked}"
+
+
+def test_roster_preflight_is_credential_aware_not_binary_only() -> None:
+    """
+    Regression guard for #152: a worker is AVAILABLE only when its CLI resolves
+    AND ``sys_list_models`` shows a usable credential (``source != "none"``), not
+    on binary presence alone (the host image ships every coding CLI).
+
+    Scoped to the preflight paragraph because ``sys_list_models`` also appears in
+    the per-dispatch paragraph, so a whole-file check would false-pass.
+    """
+    config = (_POLLY_BUNDLE / "config.yaml").read_text(encoding="utf-8")
+    compact = " ".join(config.split())
+    preflight = compact[
+        compact.index("Roster preflight") : compact.index("Every dispatch may carry")
+    ]
+
+    assert "sys_list_models" in preflight, (
+        "roster preflight no longer grounds availability in sys_list_models"
+    )
+    assert any(token in preflight for token in ("credential", "source")), (
+        "roster preflight does not describe credential/provider readiness"
+    )
+    # A logged-in subscription reports source "static" / verified false, so it
+    # must still count as available; gating on verified would re-break #152.
+    assert "static" in preflight, (
+        "roster preflight does not keep a static-subscription worker available"
+    )
+    assert "A worker is AVAILABLE only if its binary resolved" not in preflight, (
+        "preflight still treats a resolved CLI binary as sufficient for availability"
+    )


### PR DESCRIPTION
## Related issue

Part of #152 (the Polly roster-preflight half). This does not close the issue:
the new-session UI picker and the claude-native vs claude-sdk split are left for
the open design discussion below.

## Summary

Polly's roster preflight decided worker availability from `command -v claude
codex pi opencode` alone. The omnigent-host image ships all the coding CLIs, so
a binary-present worker with no configured credential read as available; Polly
then dispatched to it and the run failed at model time, and a cross-review could
be planned with only one authenticating vendor.

This grounds availability in `sys_list_models`, which already resolves each
worker's models from real provider credentials and whose own description
documents `source: "none"` as "dispatches to that worker cannot run in this
deployment." Polly now marks a worker available only if its CLI resolved AND its
`sys_list_models` row has a `source` other than `"none"`, so an uncredentialed
worker is reported unavailable up front. The `command -v` probe is kept (it
detects a missing CLI; `sys_list_models` detects a missing credential), and the
silent-preflight and opencode-optional rules are unchanged.

Availability keys on `source != "none"`, not `verified == true` (a logged-in
subscription is `verified: false` with a `static` list) and not a non-empty
model list (a verified provider can have an empty family-filtered list).

Prompt-only change to `examples/polly/config.yaml`. `sys_list_models` is the
existing per-worker credential oracle, so this wires Polly to consume it rather
than adding a new mechanism.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `test_roster_preflight_is_credential_aware_not_binary_only` to
`tests/e2e/omnigent/test_example_polly.py` (structural, matching the file's
existing prompt-pinning style, no LLM or credentials). Scoped to the preflight
paragraph (`sys_list_models` also appears in the per-dispatch paragraph, so a
whole-file check would false-pass), it asserts availability is grounded in
`sys_list_models` + credential/source readiness, that a `static` subscription
still counts (so the fix cannot regress to a `verified`-only check), and that
the old binary-only rule is gone.

Commands run:
- `pytest tests/e2e/omnigent/test_example_polly.py` -> 14 passed
- Verified fail-without-fix: stashing the config change makes the new test fail;
  restoring it passes.
- `tests/test_opencode_polly_debby_worker.py` still passes (the `command -v`
  probe string is kept).
- `ruff check` + `ruff format --check` clean.

This is a prompt-level change, so the test pins the instruction, not live brain
behavior. It addresses only the Polly-preflight half of #152; the new-session UI
picker (`omnigent/onboarding/wizard.py`) and the claude-native vs claude-sdk
split are deliberately left for the open design discussion. cc @dhruv0811
@TomeHirata: if you would rather land a shared system-level readiness check
consumed by both the picker and the preflight, I am happy to realign this PR to
that shape; flagging since the proposal is still open.
