### PR TITLE
feat(ui): add Create custom agent to new-session picker

### DIFF
--- a/ap-web/src/lib/agentBundle.test.ts
+++ b/ap-web/src/lib/agentBundle.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+// We can't use buildAgentBundle directly in jsdom because
+// CompressionStream is not available. Instead, test the YAML
+// generation logic by importing the module and calling the
+// internal config builder. Since it's not exported, we test
+// indirectly through buildAgentBundle and inspect the generated
+// YAML by mocking the compression + tar layer.
+
+// The module's functions are all private except buildAgentBundle.
+// We mock CompressionStream and verify the config.yaml content
+// that gets fed to the tar/gzip pipeline.
+
+import type { AgentBundleInput } from "./agentBundle";
+
+// Capture what buildAgentBundle passes to `new File(...)` by
+// mocking CompressionStream (not in jsdom) to be a passthrough.
+class PassthroughStream {
+  readable: ReadableStream;
+  writable: WritableStream;
+  constructor() {
+    let controller: ReadableStreamDefaultController;
+    this.readable = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    this.writable = new WritableStream({
+      write(chunk) {
+        controller.enqueue(new Uint8Array(chunk));
+      },
+      close() {
+        controller.close();
+      },
+    });
+  }
+}
+
+// Install mock before importing buildAgentBundle.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).CompressionStream = PassthroughStream;
+
+// Now import the function (it will use our mock CompressionStream).
+const { buildAgentBundle } = await import("./agentBundle");
+
+/** Extract the config.yaml from the raw tar bytes inside the File. */
+async function extractConfigYaml(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const tar = new Uint8Array(buf);
+  // First tar entry: 512-byte header, then content.
+  // File size is at offset 124, 12 bytes, octal null-terminated.
+  const sizeStr = new TextDecoder().decode(tar.slice(124, 135)).replace(/\0/g, "");
+  const size = parseInt(sizeStr, 8);
+  return new TextDecoder().decode(tar.slice(512, 512 + size));
+}
+
+/** Extract AGENTS.md (second tar entry) from the raw tar bytes. */
+async function extractAgentsMd(file: File): Promise<string | null> {
+  const buf = await file.arrayBuffer();
+  const tar = new Uint8Array(buf);
+  const size0Str = new TextDecoder().decode(tar.slice(124, 135)).replace(/\0/g, "");
+  const size0 = parseInt(size0Str, 8);
+  const blocks0 = Math.ceil(size0 / 512);
+  const entry1Start = 512 + blocks0 * 512;
+  if (entry1Start + 512 > tar.length) return null;
+  const name1 = new TextDecoder()
+    .decode(tar.slice(entry1Start, entry1Start + 100))
+    .replace(/\0/g, "");
+  if (!name1.startsWith("AGENTS.md")) return null;
+  const size1Str = new TextDecoder()
+    .decode(tar.slice(entry1Start + 124, entry1Start + 135))
+    .replace(/\0/g, "");
+  const size1 = parseInt(size1Str, 8);
+  return new TextDecoder().decode(tar.slice(entry1Start + 512, entry1Start + 512 + size1));
+}
+
+describe("buildAgentBundle", () => {
+  it("produces a tar.gz file with correct config.yaml for minimal input", async () => {
+    const input: AgentBundleInput = {
+      name: "test-agent",
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+    };
+    const file = await buildAgentBundle(input);
+    expect(file.name).toBe("agent.tar.gz");
+    expect(file.type).toBe("application/gzip");
+
+    const yaml = await extractConfigYaml(file);
+    expect(yaml).toContain("spec_version: 1");
+    expect(yaml).toContain("name: test-agent");
+    expect(yaml).toContain("model: claude-sonnet-4-20250514");
+    expect(yaml).toContain("harness: claude-sdk");
+    expect(yaml).toContain("web_search");
+    expect(yaml).toContain("web_fetch");
+    expect(yaml).not.toContain("instructions:");
+    expect(yaml).not.toContain("description:");
+  });
+
+  it("includes description when provided", async () => {
+    const input: AgentBundleInput = {
+      name: "my-agent",
+      description: "A helpful assistant",
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("description: A helpful assistant");
+  });
+
+  it("quotes description with special characters", async () => {
+    const input: AgentBundleInput = {
+      name: "my-agent",
+      description: 'Has: colons and "quotes"',
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain('description: "Has: colons and \\"quotes\\""');
+  });
+
+  it("includes AGENTS.md when instructions are provided", async () => {
+    const input: AgentBundleInput = {
+      name: "my-agent",
+      instructions: "You are a helpful assistant.",
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+    };
+    const file = await buildAgentBundle(input);
+    const yaml = await extractConfigYaml(file);
+    expect(yaml).toContain("instructions: AGENTS.md");
+
+    const md = await extractAgentsMd(file);
+    expect(md).toBe("You are a helpful assistant.");
+  });
+
+  it("omits AGENTS.md when no instructions", async () => {
+    const input: AgentBundleInput = {
+      name: "my-agent",
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+    };
+    const md = await extractAgentsMd(await buildAgentBundle(input));
+    expect(md).toBeNull();
+  });
+
+  it("includes inline MCP servers (stdio)", async () => {
+    const input: AgentBundleInput = {
+      name: "mcp-agent",
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+      mcpServers: [
+        {
+          name: "github",
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-github"],
+          env: { GITHUB_TOKEN: "ghp_test" },
+        },
+      ],
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("  github:");
+    expect(yaml).toContain("    type: mcp");
+    expect(yaml).toContain("    command: npx");
+    expect(yaml).toContain('    args: [-y, "@modelcontextprotocol/server-github"]');
+    expect(yaml).toContain("      GITHUB_TOKEN: ghp_test");
+  });
+
+  it("includes inline MCP servers (http)", async () => {
+    const input: AgentBundleInput = {
+      name: "http-agent",
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+      mcpServers: [
+        {
+          name: "search",
+          transport: "http",
+          url: "https://mcp.example.com/sse",
+          headers: { Authorization: "Bearer tok_123" },
+        },
+      ],
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("  search:");
+    expect(yaml).toContain("    type: mcp");
+    expect(yaml).toContain('    url: "https://mcp.example.com/sse"');
+    expect(yaml).toContain("      Authorization: Bearer tok_123");
+  });
+
+  it("uses different harness and model values", async () => {
+    const input: AgentBundleInput = {
+      name: "oai-agent",
+      harness: "openai-agents",
+      model: "gpt-4o",
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("harness: openai-agents");
+    expect(yaml).toContain("model: gpt-4o");
+  });
+});

--- a/ap-web/src/lib/agentBundle.ts
+++ b/ap-web/src/lib/agentBundle.ts
@@ -99,14 +99,16 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
   const configYaml = lines.join("\n");
 
   // Build tar archive
-  const files: TarEntry[] = [{ name: "config.yaml", content: new TextEncoder().encode(configYaml) }];
+  const files: TarEntry[] = [
+    { name: "config.yaml", content: new TextEncoder().encode(configYaml) },
+  ];
   if (input.instructions) {
     files.push({ name: "AGENTS.md", content: new TextEncoder().encode(input.instructions) });
   }
 
   const tarBytes = createTar(files);
   const gzipped = await gzip(tarBytes);
-  return new File([gzipped], "agent.tar.gz", { type: "application/gzip" });
+  return new File([new Blob([gzipped])], "agent.tar.gz", { type: "application/gzip" });
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -200,7 +202,7 @@ function writeOctal(header: Uint8Array, offset: number, length: number, value: n
 async function gzip(data: Uint8Array): Promise<Uint8Array> {
   const cs = new CompressionStream("gzip");
   const writer = cs.writable.getWriter();
-  writer.write(data);
+  writer.write(data as unknown as BufferSource);
   writer.close();
 
   const reader = cs.readable.getReader();

--- a/ap-web/src/lib/agentBundle.ts
+++ b/ap-web/src/lib/agentBundle.ts
@@ -6,12 +6,31 @@
  * `config.yaml` and optionally an `AGENTS.md` instructions file.
  */
 
+/** An MCP server to include in the agent bundle. */
+export interface MCPServerInput {
+  name: string;
+  /** "http" for SSE endpoints, "stdio" for local subprocesses. */
+  transport: "http" | "stdio";
+  /** SSE endpoint URL (http transport only). */
+  url?: string;
+  /** HTTP headers (http transport only), e.g. {"Authorization": "Bearer ..."} */
+  headers?: Record<string, string>;
+  /** Executable to spawn (stdio transport only), e.g. "npx". */
+  command?: string;
+  /** Args for the command (stdio transport only). */
+  args?: string[];
+  /** Env vars for the subprocess (stdio transport only). */
+  env?: Record<string, string>;
+}
+
 export interface AgentBundleInput {
   name: string;
   description?: string;
   instructions?: string;
   /** Harness kind, e.g. "claude-sdk", "openai-agents". Defaults to omitting (server default). */
   harness?: string;
+  /** MCP server declarations to include as inline tools entries. */
+  mcpServers?: MCPServerInput[];
 }
 
 /**
@@ -42,6 +61,33 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
   lines.push("  builtins:");
   lines.push("    - web_search");
   lines.push("    - web_fetch");
+  // Inline MCP server declarations (parsed by _parse_inline_mcp_servers).
+  if (input.mcpServers?.length) {
+    for (const mcp of input.mcpServers) {
+      lines.push(`  ${mcp.name}:`);
+      lines.push("    type: mcp");
+      if (mcp.transport === "stdio") {
+        if (mcp.command) lines.push(`    command: ${yamlQuote(mcp.command)}`);
+        if (mcp.args?.length) {
+          lines.push(`    args: [${mcp.args.map((a) => yamlQuote(a)).join(", ")}]`);
+        }
+        if (mcp.env && Object.keys(mcp.env).length > 0) {
+          lines.push("    env:");
+          for (const [k, v] of Object.entries(mcp.env)) {
+            lines.push(`      ${k}: ${yamlQuote(v)}`);
+          }
+        }
+      } else {
+        if (mcp.url) lines.push(`    url: ${yamlQuote(mcp.url)}`);
+        if (mcp.headers && Object.keys(mcp.headers).length > 0) {
+          lines.push("    headers:");
+          for (const [k, v] of Object.entries(mcp.headers)) {
+            lines.push(`      ${k}: ${yamlQuote(v)}`);
+          }
+        }
+      }
+    }
+  }
   lines.push("");
 
   if (input.instructions) {

--- a/ap-web/src/lib/agentBundle.ts
+++ b/ap-web/src/lib/agentBundle.ts
@@ -108,7 +108,9 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
 
   const tarBytes = createTar(files);
   const gzipped = await gzip(tarBytes);
-  return new File([gzipped.buffer], "agent.tar.gz", { type: "application/gzip" });
+  return new File([gzipped.buffer as ArrayBuffer], "agent.tar.gz", {
+    type: "application/gzip",
+  });
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -202,7 +204,7 @@ function writeOctal(header: Uint8Array, offset: number, length: number, value: n
 async function gzip(data: Uint8Array): Promise<Uint8Array> {
   const cs = new CompressionStream("gzip");
   const writer = cs.writable.getWriter();
-  writer.write(data.buffer);
+  writer.write(data.buffer as ArrayBuffer);
   writer.close();
 
   const reader = cs.readable.getReader();

--- a/ap-web/src/lib/agentBundle.ts
+++ b/ap-web/src/lib/agentBundle.ts
@@ -27,8 +27,10 @@ export interface AgentBundleInput {
   name: string;
   description?: string;
   instructions?: string;
-  /** Harness kind, e.g. "claude-sdk", "openai-agents". Defaults to omitting (server default). */
-  harness?: string;
+  /** Harness kind, e.g. "claude-sdk", "openai-agents". */
+  harness: string;
+  /** Model identifier, e.g. "claude-sonnet-4-20250514". Required by the omnigent executor. */
+  model: string;
   /** MCP server declarations to include as inline tools entries. */
   mcpServers?: MCPServerInput[];
 }
@@ -49,13 +51,12 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
   }
   lines.push("");
 
-  if (input.harness) {
-    lines.push("executor:");
-    lines.push("  type: omnigent");
-    lines.push("  config:");
-    lines.push(`    harness: ${input.harness}`);
-    lines.push("");
-  }
+  lines.push("executor:");
+  lines.push("  type: omnigent");
+  lines.push(`  model: ${input.model}`);
+  lines.push("  config:");
+  lines.push(`    harness: ${input.harness}`);
+  lines.push("");
 
   lines.push("tools:");
   lines.push("  builtins:");

--- a/ap-web/src/lib/agentBundle.ts
+++ b/ap-web/src/lib/agentBundle.ts
@@ -108,7 +108,7 @@ export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
 
   const tarBytes = createTar(files);
   const gzipped = await gzip(tarBytes);
-  return new File([new Blob([gzipped])], "agent.tar.gz", { type: "application/gzip" });
+  return new File([gzipped.buffer], "agent.tar.gz", { type: "application/gzip" });
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -202,7 +202,7 @@ function writeOctal(header: Uint8Array, offset: number, length: number, value: n
 async function gzip(data: Uint8Array): Promise<Uint8Array> {
   const cs = new CompressionStream("gzip");
   const writer = cs.writable.getWriter();
-  writer.write(data as unknown as BufferSource);
+  writer.write(data.buffer);
   writer.close();
 
   const reader = cs.readable.getReader();

--- a/ap-web/src/lib/agentBundle.ts
+++ b/ap-web/src/lib/agentBundle.ts
@@ -1,0 +1,175 @@
+/**
+ * Client-side agent bundle builder.
+ *
+ * Produces a minimal `.tar.gz` bundle accepted by the server's
+ * multipart `POST /v1/sessions` endpoint. The bundle contains a
+ * `config.yaml` and optionally an `AGENTS.md` instructions file.
+ */
+
+export interface AgentBundleInput {
+  name: string;
+  description?: string;
+  instructions?: string;
+  /** Harness kind, e.g. "claude-sdk", "openai-agents". Defaults to omitting (server default). */
+  harness?: string;
+}
+
+/**
+ * Build a `.tar.gz` agent bundle from the given input fields.
+ *
+ * Uses the pako library (already a transitive dep via codemirror) for
+ * gzip compression and a hand-rolled POSIX tar header for the two
+ * files. The result is a `File` suitable for `FormData.append`.
+ */
+export async function buildAgentBundle(input: AgentBundleInput): Promise<File> {
+  // Build config.yaml content
+  const lines: string[] = ["spec_version: 1", ""];
+  lines.push(`name: ${input.name}`);
+  if (input.description) {
+    lines.push(`description: ${yamlQuote(input.description)}`);
+  }
+  lines.push("");
+
+  if (input.harness) {
+    lines.push("executor:");
+    lines.push("  type: omnigent");
+    lines.push("  config:");
+    lines.push(`    harness: ${input.harness}`);
+    lines.push("");
+  }
+
+  lines.push("tools:");
+  lines.push("  builtins:");
+  lines.push("    - web_search");
+  lines.push("    - web_fetch");
+  lines.push("");
+
+  if (input.instructions) {
+    lines.push("instructions: AGENTS.md");
+    lines.push("");
+  }
+
+  const configYaml = lines.join("\n");
+
+  // Build tar archive
+  const files: TarEntry[] = [{ name: "config.yaml", content: new TextEncoder().encode(configYaml) }];
+  if (input.instructions) {
+    files.push({ name: "AGENTS.md", content: new TextEncoder().encode(input.instructions) });
+  }
+
+  const tarBytes = createTar(files);
+  const gzipped = await gzip(tarBytes);
+  return new File([gzipped], "agent.tar.gz", { type: "application/gzip" });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Quote a YAML string value if it contains special characters. */
+function yamlQuote(s: string): string {
+  if (/[:\n"'#{}[\],&*?|>!%@`]/.test(s) || s.trim() !== s) {
+    return JSON.stringify(s);
+  }
+  return s;
+}
+
+interface TarEntry {
+  name: string;
+  content: Uint8Array;
+}
+
+/**
+ * Create a minimal POSIX tar archive (uncompressed) from file entries.
+ * Each entry gets a 512-byte header followed by content padded to 512.
+ * Archive ends with two 512-byte zero blocks.
+ */
+function createTar(entries: TarEntry[]): Uint8Array {
+  const blocks: Uint8Array[] = [];
+
+  for (const entry of entries) {
+    const header = new Uint8Array(512);
+    const encoder = new TextEncoder();
+
+    // File name (0..99)
+    const nameBytes = encoder.encode(entry.name);
+    header.set(nameBytes.slice(0, 100), 0);
+
+    // File mode (100..107) — 0644
+    writeOctal(header, 100, 8, 0o644);
+    // Owner ID (108..115)
+    writeOctal(header, 108, 8, 0);
+    // Group ID (116..123)
+    writeOctal(header, 116, 8, 0);
+    // File size (124..135)
+    writeOctal(header, 124, 12, entry.content.length);
+    // Modification time (136..147) — current time
+    writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+    // Type flag (156) — '0' for regular file
+    header[156] = 0x30;
+    // Magic (257..262) — "ustar\0"
+    header.set(encoder.encode("ustar\0"), 257);
+    // Version (263..264) — "00"
+    header.set(encoder.encode("00"), 263);
+
+    // Checksum (148..155) — fill with spaces first, compute, then write
+    for (let i = 148; i < 156; i++) header[i] = 0x20;
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) checksum += header[i];
+    writeOctal(header, 148, 7, checksum);
+    header[155] = 0x20; // trailing space per POSIX
+
+    blocks.push(header);
+
+    // Content blocks (padded to 512-byte boundary)
+    const contentBlocks = Math.ceil(entry.content.length / 512);
+    const padded = new Uint8Array(contentBlocks * 512);
+    padded.set(entry.content);
+    blocks.push(padded);
+  }
+
+  // End-of-archive marker: two 512-byte zero blocks
+  blocks.push(new Uint8Array(1024));
+
+  // Concatenate all blocks
+  const totalSize = blocks.reduce((sum, b) => sum + b.length, 0);
+  const result = new Uint8Array(totalSize);
+  let offset = 0;
+  for (const block of blocks) {
+    result.set(block, offset);
+    offset += block.length;
+  }
+  return result;
+}
+
+/** Write a number as null-terminated octal string into a tar header field. */
+function writeOctal(header: Uint8Array, offset: number, length: number, value: number): void {
+  const str = value.toString(8).padStart(length - 1, "0");
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(str);
+  header.set(bytes.slice(0, length - 1), offset);
+  header[offset + length - 1] = 0; // null terminator
+}
+
+/** Gzip compress bytes using the Compression Streams API. */
+async function gzip(data: Uint8Array): Promise<Uint8Array> {
+  const cs = new CompressionStream("gzip");
+  const writer = cs.writable.getWriter();
+  writer.write(data);
+  writer.close();
+
+  const reader = cs.readable.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const totalSize = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(totalSize);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}

--- a/ap-web/src/lib/sessionsApi.ts
+++ b/ap-web/src/lib/sessionsApi.ts
@@ -453,7 +453,11 @@ export async function createBundledSession(
     const text = await res.text();
     throw new Error(`Failed to create bundled session: ${res.status} ${text}`);
   }
-  return (await res.json()) as { id: string };
+  // The multipart response uses `session_id` (CreatedSessionResponse),
+  // while the JSON path uses `id` (SessionResponse). Normalize to `id`
+  // so callers don't need to care which path was taken.
+  const body = (await res.json()) as { session_id: string };
+  return { id: body.session_id };
 }
 
 /**

--- a/ap-web/src/lib/sessionsApi.ts
+++ b/ap-web/src/lib/sessionsApi.ts
@@ -418,6 +418,45 @@ export async function createSession(
 }
 
 /**
+ * Create a session with an inline agent bundle via multipart
+ * `POST /v1/sessions`.
+ *
+ * The server creates a session-scoped agent from the uploaded bundle
+ * (a `.tar.gz` containing `config.yaml` and optionally `AGENTS.md`)
+ * and binds it to the new session in one atomic operation. Session
+ * metadata (host, workspace, labels, etc.) is sent as a JSON string
+ * in the `metadata` form part.
+ *
+ * @param bundle - The agent bundle as a `File` (`.tar.gz`).
+ * @param metadata - Session-level metadata (host_id, workspace, labels, etc.).
+ * @returns The created session's id.
+ */
+export async function createBundledSession(
+  bundle: File,
+  metadata: {
+    host_id?: string;
+    host_type?: string;
+    workspace?: string;
+    labels?: Record<string, string>;
+    terminal_launch_args?: string[];
+    git?: { branch_name: string; base_branch?: string };
+  } = {},
+): Promise<{ id: string }> {
+  const form = new FormData();
+  form.append("metadata", JSON.stringify(metadata));
+  form.append("bundle", bundle);
+  const res = await authenticatedFetch("/v1/sessions", {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to create bundled session: ${res.status} ${text}`);
+  }
+  return (await res.json()) as { id: string };
+}
+
+/**
  * Fork (clone) a session into a new one via
  * POST /v1/sessions/{source_id}/fork.
  *

--- a/ap-web/src/shell/CreateAgentDialog.tsx
+++ b/ap-web/src/shell/CreateAgentDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { PlusIcon, TrashIcon } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -17,7 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { BRAIN_HARNESS_LABELS } from "@/lib/agentLabels";
-import type { AgentBundleInput } from "@/lib/agentBundle";
+import type { AgentBundleInput, MCPServerInput } from "@/lib/agentBundle";
 
 /**
  * Harness options for the picker. "default" uses the server's default
@@ -28,13 +29,80 @@ const HARNESS_OPTIONS: { value: string; label: string }[] = [
   ...Object.entries(BRAIN_HARNESS_LABELS).map(([value, label]) => ({ value, label })),
 ];
 
+/** A single MCP server row in the form. */
+interface MCPFormEntry {
+  /** Stable key for React list rendering. */
+  key: number;
+  name: string;
+  transport: "http" | "stdio";
+  url: string;
+  headers: string;
+  command: string;
+  args: string;
+  env: string;
+}
+
+function emptyMCPEntry(key: number): MCPFormEntry {
+  return { key, name: "", transport: "stdio", url: "", headers: "", command: "", args: "", env: "" };
+}
+
+/** Parse "KEY=VAL" lines into a Record. */
+function parseKVLines(text: string): Record<string, string> | undefined {
+  const lines = text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return undefined;
+  const result: Record<string, string> = {};
+  for (const line of lines) {
+    const eq = line.indexOf("=");
+    if (eq > 0) {
+      result[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/** Convert form entries to the bundle input shape. */
+function toMCPInputs(entries: MCPFormEntry[]): MCPServerInput[] | undefined {
+  const result: MCPServerInput[] = [];
+  for (const e of entries) {
+    const name = e.name.trim();
+    if (!name) continue;
+    if (e.transport === "stdio") {
+      const command = e.command.trim();
+      if (!command) continue;
+      result.push({
+        name,
+        transport: "stdio",
+        command,
+        args: e.args
+          .split(/\s+/)
+          .map((a) => a.trim())
+          .filter(Boolean),
+        env: parseKVLines(e.env),
+      });
+    } else {
+      const url = e.url.trim();
+      if (!url) continue;
+      result.push({
+        name,
+        transport: "http",
+        url,
+        headers: parseKVLines(e.headers),
+      });
+    }
+  }
+  return result.length > 0 ? result : undefined;
+}
+
 /**
  * Dialog for creating a custom agent from the new-session picker.
  *
  * Collects a name, optional description, optional system instructions,
- * and a harness choice. On submit, passes the agent configuration back
- * to the parent via `onCreate` so it can build a bundle and start a
- * session with it.
+ * a harness choice, and zero or more MCP server declarations. On submit,
+ * passes the agent configuration back to the parent via `onCreate` so it
+ * can build a bundle and start a session with it.
  */
 export function CreateAgentDialog({
   open,
@@ -49,17 +117,34 @@ export function CreateAgentDialog({
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
   const [harness, setHarness] = useState("default");
+  const [mcpEntries, setMcpEntries] = useState<MCPFormEntry[]>([]);
+  const [nextKey, setNextKey] = useState(0);
 
   function reset() {
     setName("");
     setDescription("");
     setInstructions("");
     setHarness("default");
+    setMcpEntries([]);
+    setNextKey(0);
   }
 
   function handleOpenChange(next: boolean) {
     if (!next) reset();
     onOpenChange(next);
+  }
+
+  function addMCPServer() {
+    setMcpEntries((prev) => [...prev, emptyMCPEntry(nextKey)]);
+    setNextKey((k) => k + 1);
+  }
+
+  function removeMCPServer(key: number) {
+    setMcpEntries((prev) => prev.filter((e) => e.key !== key));
+  }
+
+  function updateMCPEntry(key: number, patch: Partial<MCPFormEntry>) {
+    setMcpEntries((prev) => prev.map((e) => (e.key === key ? { ...e, ...patch } : e)));
   }
 
   function handleSubmit() {
@@ -71,6 +156,7 @@ export function CreateAgentDialog({
       description: description.trim() || undefined,
       instructions: instructions.trim() || undefined,
       harness: harness === "default" ? undefined : harness,
+      mcpServers: toMCPInputs(mcpEntries),
     });
     reset();
     onOpenChange(false);
@@ -155,6 +241,32 @@ export function CreateAgentDialog({
               className="min-h-[120px]"
             />
           </div>
+
+          {/* MCP Servers */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">MCP Tools</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={addMCPServer}
+                data-testid="create-agent-add-mcp"
+                className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+              >
+                <PlusIcon className="size-3" />
+                Add server
+              </Button>
+            </div>
+            {mcpEntries.map((entry) => (
+              <MCPServerRow
+                key={entry.key}
+                entry={entry}
+                onChange={(patch) => updateMCPEntry(entry.key, patch)}
+                onRemove={() => removeMCPServer(entry.key)}
+              />
+            ))}
+          </div>
         </div>
 
         <DialogFooter>
@@ -167,5 +279,95 @@ export function CreateAgentDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** A single MCP server entry in the form. */
+function MCPServerRow({
+  entry,
+  onChange,
+  onRemove,
+}: {
+  entry: MCPFormEntry;
+  onChange: (patch: Partial<MCPFormEntry>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-md border border-border p-3"
+      data-testid="create-agent-mcp-entry"
+    >
+      <div className="flex items-center gap-2">
+        <Input
+          data-testid="create-agent-mcp-name"
+          value={entry.name}
+          onChange={(e) => onChange({ name: e.target.value })}
+          placeholder="server-name"
+          className="flex-1"
+        />
+        <Select
+          value={entry.transport}
+          onValueChange={(v: "http" | "stdio") => onChange({ transport: v })}
+        >
+          <SelectTrigger data-testid="create-agent-mcp-transport" className="w-24">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="stdio">stdio</SelectItem>
+            <SelectItem value="http">http</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onRemove}
+          data-testid="create-agent-mcp-remove"
+          className="size-7 text-muted-foreground hover:text-destructive"
+        >
+          <TrashIcon className="size-3.5" />
+        </Button>
+      </div>
+
+      {entry.transport === "stdio" ? (
+        <>
+          <Input
+            data-testid="create-agent-mcp-command"
+            value={entry.command}
+            onChange={(e) => onChange({ command: e.target.value })}
+            placeholder="command (e.g. npx)"
+          />
+          <Input
+            data-testid="create-agent-mcp-args"
+            value={entry.args}
+            onChange={(e) => onChange({ args: e.target.value })}
+            placeholder="args (e.g. -y @modelcontextprotocol/server-github)"
+          />
+          <Textarea
+            data-testid="create-agent-mcp-env"
+            value={entry.env}
+            onChange={(e) => onChange({ env: e.target.value })}
+            placeholder={"Environment variables (KEY=VALUE per line)\ne.g. GITHUB_TOKEN=ghp_..."}
+            className="min-h-[60px] font-mono text-xs"
+          />
+        </>
+      ) : (
+        <>
+          <Input
+            data-testid="create-agent-mcp-url"
+            value={entry.url}
+            onChange={(e) => onChange({ url: e.target.value })}
+            placeholder="https://mcp.example.com/sse"
+          />
+          <Textarea
+            data-testid="create-agent-mcp-headers"
+            value={entry.headers}
+            onChange={(e) => onChange({ headers: e.target.value })}
+            placeholder={"HTTP headers (KEY=VALUE per line)\ne.g. Authorization=Bearer tok_..."}
+            className="min-h-[60px] font-mono text-xs"
+          />
+        </>
+      )}
+    </div>
   );
 }

--- a/ap-web/src/shell/CreateAgentDialog.tsx
+++ b/ap-web/src/shell/CreateAgentDialog.tsx
@@ -24,10 +24,9 @@ import type { AgentBundleInput, MCPServerInput } from "@/lib/agentBundle";
  * Harness options for the picker. "default" uses the server's default
  * executor (no explicit harness in the bundle).
  */
-const HARNESS_OPTIONS: { value: string; label: string }[] = [
-  { value: "default", label: "Default" },
-  ...Object.entries(BRAIN_HARNESS_LABELS).map(([value, label]) => ({ value, label })),
-];
+const HARNESS_OPTIONS: { value: string; label: string }[] = Object.entries(
+  BRAIN_HARNESS_LABELS,
+).map(([value, label]) => ({ value, label }));
 
 /** A single MCP server row in the form. */
 interface MCPFormEntry {
@@ -116,7 +115,7 @@ export function CreateAgentDialog({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
-  const [harness, setHarness] = useState("default");
+  const [harness, setHarness] = useState(HARNESS_OPTIONS[0].value);
   const [mcpEntries, setMcpEntries] = useState<MCPFormEntry[]>([]);
   const [nextKey, setNextKey] = useState(0);
 
@@ -124,7 +123,7 @@ export function CreateAgentDialog({
     setName("");
     setDescription("");
     setInstructions("");
-    setHarness("default");
+    setHarness(HARNESS_OPTIONS[0].value);
     setMcpEntries([]);
     setNextKey(0);
   }
@@ -155,7 +154,7 @@ export function CreateAgentDialog({
       name: trimmedName,
       description: description.trim() || undefined,
       instructions: instructions.trim() || undefined,
-      harness: harness === "default" ? undefined : harness,
+      harness,
       mcpServers: toMCPInputs(mcpEntries),
     });
     reset();
@@ -209,7 +208,9 @@ export function CreateAgentDialog({
 
           {/* Harness */}
           <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-muted-foreground">Harness</label>
+            <label className="text-xs font-medium text-muted-foreground">
+              Harness <span className="text-destructive">*</span>
+            </label>
             <Select value={harness} onValueChange={setHarness}>
               <SelectTrigger data-testid="create-agent-harness" className="w-full">
                 <SelectValue />

--- a/ap-web/src/shell/CreateAgentDialog.tsx
+++ b/ap-web/src/shell/CreateAgentDialog.tsx
@@ -42,7 +42,16 @@ interface MCPFormEntry {
 }
 
 function emptyMCPEntry(key: number): MCPFormEntry {
-  return { key, name: "", transport: "stdio", url: "", headers: "", command: "", args: "", env: "" };
+  return {
+    key,
+    name: "",
+    transport: "stdio",
+    url: "",
+    headers: "",
+    command: "",
+    args: "",
+    env: "",
+  };
 }
 
 /** Parse "KEY=VAL" lines into a Record. */
@@ -179,7 +188,10 @@ export function CreateAgentDialog({
         <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
           {/* Name */}
           <div className="flex flex-col gap-1.5">
-            <label htmlFor="create-agent-name" className="text-xs font-medium text-muted-foreground">
+            <label
+              htmlFor="create-agent-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
               Name <span className="text-destructive">*</span>
             </label>
             <Input
@@ -230,7 +242,10 @@ export function CreateAgentDialog({
 
           {/* Model */}
           <div className="flex flex-col gap-1.5">
-            <label htmlFor="create-agent-model" className="text-xs font-medium text-muted-foreground">
+            <label
+              htmlFor="create-agent-model"
+              className="text-xs font-medium text-muted-foreground"
+            >
               Model <span className="text-destructive">*</span>
             </label>
             <Input

--- a/ap-web/src/shell/CreateAgentDialog.tsx
+++ b/ap-web/src/shell/CreateAgentDialog.tsx
@@ -116,6 +116,7 @@ export function CreateAgentDialog({
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
   const [harness, setHarness] = useState(HARNESS_OPTIONS[0].value);
+  const [model, setModel] = useState("claude-sonnet-4-20250514");
   const [mcpEntries, setMcpEntries] = useState<MCPFormEntry[]>([]);
   const [nextKey, setNextKey] = useState(0);
 
@@ -124,6 +125,7 @@ export function CreateAgentDialog({
     setDescription("");
     setInstructions("");
     setHarness(HARNESS_OPTIONS[0].value);
+    setModel("claude-sonnet-4-20250514");
     setMcpEntries([]);
     setNextKey(0);
   }
@@ -155,13 +157,14 @@ export function CreateAgentDialog({
       description: description.trim() || undefined,
       instructions: instructions.trim() || undefined,
       harness,
+      model: model.trim(),
       mcpServers: toMCPInputs(mcpEntries),
     });
     reset();
     onOpenChange(false);
   }
 
-  const canSubmit = name.trim().length > 0;
+  const canSubmit = name.trim().length > 0 && model.trim().length > 0;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -223,6 +226,20 @@ export function CreateAgentDialog({
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          {/* Model */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="create-agent-model" className="text-xs font-medium text-muted-foreground">
+              Model <span className="text-destructive">*</span>
+            </label>
+            <Input
+              id="create-agent-model"
+              data-testid="create-agent-model"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="claude-sonnet-4-20250514"
+            />
           </div>
 
           {/* Instructions / System Prompt */}

--- a/ap-web/src/shell/CreateAgentDialog.tsx
+++ b/ap-web/src/shell/CreateAgentDialog.tsx
@@ -125,7 +125,7 @@ export function CreateAgentDialog({
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
   const [harness, setHarness] = useState(HARNESS_OPTIONS[0].value);
-  const [model, setModel] = useState("claude-sonnet-4-20250514");
+  const [model, setModel] = useState("");
   const [mcpEntries, setMcpEntries] = useState<MCPFormEntry[]>([]);
   const [nextKey, setNextKey] = useState(0);
 
@@ -134,7 +134,7 @@ export function CreateAgentDialog({
     setDescription("");
     setInstructions("");
     setHarness(HARNESS_OPTIONS[0].value);
-    setModel("claude-sonnet-4-20250514");
+    setModel("");
     setMcpEntries([]);
     setNextKey(0);
   }

--- a/ap-web/src/shell/CreateAgentDialog.tsx
+++ b/ap-web/src/shell/CreateAgentDialog.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { BRAIN_HARNESS_LABELS } from "@/lib/agentLabels";
+import type { AgentBundleInput } from "@/lib/agentBundle";
+
+/**
+ * Harness options for the picker. "default" uses the server's default
+ * executor (no explicit harness in the bundle).
+ */
+const HARNESS_OPTIONS: { value: string; label: string }[] = [
+  { value: "default", label: "Default" },
+  ...Object.entries(BRAIN_HARNESS_LABELS).map(([value, label]) => ({ value, label })),
+];
+
+/**
+ * Dialog for creating a custom agent from the new-session picker.
+ *
+ * Collects a name, optional description, optional system instructions,
+ * and a harness choice. On submit, passes the agent configuration back
+ * to the parent via `onCreate` so it can build a bundle and start a
+ * session with it.
+ */
+export function CreateAgentDialog({
+  open,
+  onOpenChange,
+  onCreate,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreate: (input: AgentBundleInput) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [harness, setHarness] = useState("default");
+
+  function reset() {
+    setName("");
+    setDescription("");
+    setInstructions("");
+    setHarness("default");
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  function handleSubmit() {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+
+    onCreate({
+      name: trimmedName,
+      description: description.trim() || undefined,
+      instructions: instructions.trim() || undefined,
+      harness: harness === "default" ? undefined : harness,
+    });
+    reset();
+    onOpenChange(false);
+  }
+
+  const canSubmit = name.trim().length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        data-testid="create-agent-dialog"
+        className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
+      >
+        <DialogHeader>
+          <DialogTitle>Create custom agent</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+          {/* Name */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="create-agent-name" className="text-xs font-medium text-muted-foreground">
+              Name <span className="text-destructive">*</span>
+            </label>
+            <Input
+              id="create-agent-name"
+              data-testid="create-agent-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-agent"
+              autoFocus
+            />
+          </div>
+
+          {/* Description */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="create-agent-description"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Description
+            </label>
+            <Input
+              id="create-agent-description"
+              data-testid="create-agent-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="A short summary of what this agent does"
+            />
+          </div>
+
+          {/* Harness */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Harness</label>
+            <Select value={harness} onValueChange={setHarness}>
+              <SelectTrigger data-testid="create-agent-harness" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HARNESS_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Instructions / System Prompt */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="create-agent-instructions"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              System instructions
+            </label>
+            <Textarea
+              id="create-agent-instructions"
+              data-testid="create-agent-instructions"
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              placeholder="You are a helpful assistant that..."
+              className="min-h-[120px]"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button data-testid="create-agent-submit" onClick={handleSubmit} disabled={!canSubmit}>
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -906,7 +906,8 @@ export function NewChatLandingScreen() {
   const effectiveAgentId =
     pickedAgentId === PENDING_AGENT_ID
       ? PENDING_AGENT_ID
-      : (agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ?? null;
+      : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
+        null);
   const selectedAgent =
     effectiveAgentId === PENDING_AGENT_ID && pendingAgent
       ? ({
@@ -1242,7 +1243,8 @@ export function NewChatLandingScreen() {
             // Permission / approval mode → CLI flag pair, persisted as
             // terminal_launch_args. Omitted for the default and non-native agents.
             terminal_launch_args:
-              agentSupportsPermissionMode && permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
+              agentSupportsPermissionMode &&
+              permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
                 ? ["--permission-mode", permissionMode]
                 : agentSupportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
                   ? (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.args ?? [])

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1200,8 +1200,14 @@ export function NewChatLandingScreen() {
         // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
         // same way the fork-resume path does.
         const bundle = await buildAgentBundle(pendingAgent);
-        data = await createBundledSession(bundle, {});
-        // Launch the runner on the selected host.
+        const metadata: Record<string, unknown> = {};
+        if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
+        data = await createBundledSession(
+          bundle,
+          metadata as Parameters<typeof createBundledSession>[1],
+        );
+        // Launch the runner on the selected host. The multipart create
+        // only stores DB rows — launchRunner binds + starts the runner.
         if (!sandboxSelected && selectedHostId && workspaceTrimmed) {
           const gitOpts = trimmedBranch
             ? { branchName: trimmedBranch, baseBranch: baseBranch.trim() || undefined }

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -68,7 +68,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
 import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
-import { createBundledSession } from "@/lib/sessionsApi";
+import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
 
 // Preferred display order for the built-in agent picker. The server
 // returns agents newest-registered first (agent_store.list sorts by
@@ -1194,16 +1194,19 @@ export function NewChatLandingScreen() {
 
       if (effectiveAgentId === PENDING_AGENT_ID && pendingAgent) {
         // Custom agent path: build bundle client-side and use multipart POST.
+        // The multipart create only stores the agent + session rows — it does
+        // NOT launch a runner on the host. We must follow up with launchRunner
+        // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
+        // same way the fork-resume path does.
         const bundle = await buildAgentBundle(pendingAgent);
-        const metadata: Record<string, unknown> = {};
-        if (sandboxSelected) {
-          metadata.host_type = "managed";
-          metadata.workspace = composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch);
-        } else {
-          if (selectedHostId) metadata.host_id = selectedHostId;
-          if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
+        data = await createBundledSession(bundle, {});
+        // Launch the runner on the selected host.
+        if (!sandboxSelected && selectedHostId && workspaceTrimmed) {
+          const gitOpts = trimmedBranch
+            ? { branchName: trimmedBranch, baseBranch: baseBranch.trim() || undefined }
+            : undefined;
+          await launchRunner(selectedHostId, data.id, workspaceTrimmed, gitOpts);
         }
-        data = await createBundledSession(bundle, metadata as Parameters<typeof createBundledSession>[1]);
         // Clear pending agent after successful creation.
         setPendingAgent(null);
       } else {

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -66,6 +66,9 @@ import { ComposerMicButton } from "@/components/ComposerMicButton";
 import { IntelligentModelControl, type CostControlMode } from "@/components/CostRoutingControl";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
+import { CreateAgentDialog } from "./CreateAgentDialog";
+import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
+import { createBundledSession } from "@/lib/sessionsApi";
 
 // Preferred display order for the built-in agent picker. The server
 // returns agents newest-registered first (agent_store.list sorts by
@@ -718,6 +721,16 @@ export function NewChatLandingScreen() {
     [agentList],
   );
 
+  // "Create custom agent" dialog state and pending bundle. When the user
+  // creates a custom agent via the dialog, the bundle input is stored
+  // here and the picker switches to a virtual "pending" agent entry. On
+  // form submit, handleCreate detects the pending bundle, builds the
+  // tar.gz, and uses multipart POST instead of the normal JSON path.
+  const [createAgentOpen, setCreateAgentOpen] = useState(false);
+  const [pendingAgent, setPendingAgent] = useState<AgentBundleInput | null>(null);
+  // Sentinel id for the pending custom agent in the picker dropdown.
+  const PENDING_AGENT_ID = "__pending_custom_agent__";
+
   // Surface element backing the iOS native server switcher overlay, which
   // the in-session view shows too — the picker stays reachable while starting
   // a new session. The hook hides it whenever the sidebar covers the surface.
@@ -889,9 +902,22 @@ export function NewChatLandingScreen() {
 
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.
+  // The pending custom agent sentinel also wins when set.
   const effectiveAgentId =
-    (agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ?? null;
-  const selectedAgent = agentList.find((a) => a.id === effectiveAgentId);
+    pickedAgentId === PENDING_AGENT_ID
+      ? PENDING_AGENT_ID
+      : (agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ?? null;
+  const selectedAgent =
+    effectiveAgentId === PENDING_AGENT_ID && pendingAgent
+      ? ({
+          id: PENDING_AGENT_ID,
+          name: pendingAgent.name,
+          display_name: pendingAgent.name,
+          description: pendingAgent.description ?? null,
+          harness: pendingAgent.harness ?? null,
+          skills: [],
+        } satisfies AvailableAgent)
+      : agentList.find((a) => a.id === effectiveAgentId);
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   // Native-terminal agents interpret slash commands inside their own CLI
@@ -1163,58 +1189,78 @@ export function NewChatLandingScreen() {
       const nativeLabels = nativeWrapperLabelsForAgent(agent);
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
       const agentSupportsApprovalMode = nativeAgentHasCapability(agent, "approvalMode");
-      const res = await authenticatedFetch("/v1/sessions", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          agent_id: effectiveAgentId,
-          // Managed (cloud sandbox) creates let the server provision the
-          // host: the schema rejects host_id and path workspaces (and git
-          // needs a host_id). The optional repository inputs compose into
-          // the URL-form workspace the server clones; undefined (no repo)
-          // is dropped by JSON.stringify.
-          ...(sandboxSelected
-            ? {
-                host_type: "managed",
-                workspace: composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch),
-              }
-            : {
-                host_id: selectedHostId,
-                workspace: workspaceTrimmed,
-                git: trimmedBranch
-                  ? { branch_name: trimmedBranch, base_branch: baseBranch.trim() || undefined }
+
+      let data: { id: string };
+
+      if (effectiveAgentId === PENDING_AGENT_ID && pendingAgent) {
+        // Custom agent path: build bundle client-side and use multipart POST.
+        const bundle = await buildAgentBundle(pendingAgent);
+        const metadata: Record<string, unknown> = {};
+        if (sandboxSelected) {
+          metadata.host_type = "managed";
+          metadata.workspace = composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch);
+        } else {
+          if (selectedHostId) metadata.host_id = selectedHostId;
+          if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
+        }
+        data = await createBundledSession(bundle, metadata as Parameters<typeof createBundledSession>[1]);
+        // Clear pending agent after successful creation.
+        setPendingAgent(null);
+      } else {
+        // Normal path: bind to an existing registered agent.
+        const res = await authenticatedFetch("/v1/sessions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agent_id: effectiveAgentId,
+            // Managed (cloud sandbox) creates let the server provision the
+            // host: the schema rejects host_id and path workspaces (and git
+            // needs a host_id). The optional repository inputs compose into
+            // the URL-form workspace the server clones; undefined (no repo)
+            // is dropped by JSON.stringify.
+            ...(sandboxSelected
+              ? {
+                  host_type: "managed",
+                  workspace: composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch),
+                }
+              : {
+                  host_id: selectedHostId,
+                  workspace: workspaceTrimmed,
+                  git: trimmedBranch
+                    ? { branch_name: trimmedBranch, base_branch: baseBranch.trim() || undefined }
+                    : undefined,
+                }),
+            // Native terminal agents open terminal-first: `omnigent.ui:
+            // terminal` tells the UI to render the terminal wrapper, and
+            // `omnigent.wrapper` selects which CLI bridge the runner launches.
+            // The values are the registered wrapper ids the runner keys off —
+            // they must match the wrapper registry, not the agent display name.
+            labels: nativeLabels,
+            // Permission / approval mode → CLI flag pair, persisted as
+            // terminal_launch_args. Omitted for the default and non-native agents.
+            terminal_launch_args:
+              agentSupportsPermissionMode && permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
+                ? ["--permission-mode", permissionMode]
+                : agentSupportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
+                  ? (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.args ?? [])
                   : undefined,
-              }),
-          // Native terminal agents open terminal-first: `omnigent.ui:
-          // terminal` tells the UI to render the terminal wrapper, and
-          // `omnigent.wrapper` selects which CLI bridge the runner launches.
-          // The values are the registered wrapper ids the runner keys off —
-          // they must match the wrapper registry, not the agent display name.
-          labels: nativeLabels,
-          // Permission / approval mode → CLI flag pair, persisted as
-          // terminal_launch_args. Omitted for the default and non-native agents.
-          terminal_launch_args:
-            agentSupportsPermissionMode && permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
-              ? ["--permission-mode", permissionMode]
-              : agentSupportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
-                ? (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.args ?? [])
-                : undefined,
-          // Cost-control switch from the "Cost Optimized" pill; polly-only
-          // (cost control is a polly feature) and omitted when unset so the
-          // session defers to the spec default.
-          cost_control_mode_override:
-            agent?.name === "polly" ? (costControlMode ?? undefined) : undefined,
-          // Brain-harness pick from the agent flyout. Omitted when the user
-          // kept the spec default (pickedHarness is null) so the session
-          // tracks the agent's declared harness.
-          harness_override: pickedHarness ?? undefined,
-        }),
-      });
-      if (!res.ok) {
-        setCreateError(await describeCreateError(res));
-        return;
+            // Cost-control switch from the "Cost Optimized" pill; polly-only
+            // (cost control is a polly feature) and omitted when unset so the
+            // session defers to the spec default.
+            cost_control_mode_override:
+              agent?.name === "polly" ? (costControlMode ?? undefined) : undefined,
+            // Brain-harness pick from the agent flyout. Omitted when the user
+            // kept the spec default (pickedHarness is null) so the session
+            // tracks the agent's declared harness.
+            harness_override: pickedHarness ?? undefined,
+          }),
+        });
+        if (!res.ok) {
+          setCreateError(await describeCreateError(res));
+          return;
+        }
+        data = (await res.json()) as { id: string };
       }
-      const data = (await res.json()) as { id: string };
       // Sandbox creates have no user-picked workspace to remember.
       if (!sandboxSelected) addRecent(workspaceTrimmed);
       // Fire-and-forget: don't block navigation on the sidebar list refresh.
@@ -1522,6 +1568,36 @@ export function NewChatLandingScreen() {
                         <DropdownMenuSeparator />
                       )}
                       {customAgents.map((agent) => renderAgentRow(agent))}
+                      {/* Show the pending custom agent if one was created */}
+                      {pendingAgent && (
+                        <DropdownMenuItem
+                          key={PENDING_AGENT_ID}
+                          data-testid="new-chat-landing-agent-pending"
+                          data-active={effectiveAgentId === PENDING_AGENT_ID ? "true" : undefined}
+                          onSelect={() => {
+                            setPickedAgentId(PENDING_AGENT_ID);
+                            setPickedHarness(null);
+                          }}
+                          className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+                        >
+                          <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
+                            <span className="truncate">{pendingAgent.name}</span>
+                            <span className="truncate text-[11px] text-muted-foreground/70">
+                              Custom
+                            </span>
+                          </div>
+                        </DropdownMenuItem>
+                      )}
+                      {/* "Create custom agent" action at the end */}
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        data-testid="new-chat-landing-create-agent"
+                        onSelect={() => setCreateAgentOpen(true)}
+                        className="gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground"
+                      >
+                        <PlusIcon className="size-3.5" />
+                        Create custom agent
+                      </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
                 ) : (
@@ -1946,6 +2022,17 @@ export function NewChatLandingScreen() {
           />
         </DialogContent>
       </Dialog>
+
+      {/* Create custom agent dialog — opened from the agent picker dropdown. */}
+      <CreateAgentDialog
+        open={createAgentOpen}
+        onOpenChange={setCreateAgentOpen}
+        onCreate={(input) => {
+          setPendingAgent(input);
+          setPickedAgentId(PENDING_AGENT_ID);
+          setPickedHarness(null);
+        }}
+      />
     </div>
   );
 }

--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -1,0 +1,365 @@
+"""E2E: "Create custom agent" dialog on the new-session landing page.
+
+Covers the user journey of creating a custom agent from the agent picker
+dropdown, configuring it (name, description, MCP tools), and submitting the
+form to create a session with the bundled agent.
+
+Uses the same route-stubbing approach as ``test_start_session.py``: the
+server's ``/v1/hosts``, ``/v1/agents``, and ``POST /v1/sessions`` are faked
+so the tests don't need a real host. The create POST is intercepted to
+capture the multipart request body for assertion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+# Stubbed host the composer auto-selects.
+_HOST_ID = "host_e2e"
+# Bare create endpoint — intercepts POST but lets GET through.
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* in a dedicated thread with its own event loop."""
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def _agents_body() -> str:
+    """Single Claude Code agent for the stub."""
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_claude_e2e",
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Anthropic's coding agent",
+                    "harness": None,
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+def _hosts_body() -> str:
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": "e2e-host",
+                    "owner": "e2e",
+                    "status": "online",
+                }
+            ]
+        }
+    )
+
+
+async def _register_routes(
+    page,
+    *,
+    created_session_id: str,
+    create_requests: list[dict[str, Any]],
+) -> None:
+    """Install stubs for hosts, agents, session create, and events."""
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    async def handle_events(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+        )
+
+    async def handle_sessions(route: Route) -> None:
+        if route.request.method == "POST":
+            # Capture multipart or JSON create requests.
+            content_type = route.request.headers.get("content-type", "")
+            if "multipart" in content_type:
+                # For multipart, we can't easily parse the binary body in
+                # Playwright, so just record that a multipart POST happened.
+                create_requests.append({"__multipart__": True})
+            else:
+                create_requests.append(route.request.post_data_json)
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"id": created_session_id, "session_id": created_session_id}),
+            )
+        else:
+            await route.continue_()
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route("**/v1/sessions/*/events", handle_events)
+    await page.route(_SESSIONS_RE, handle_sessions)
+
+
+async def _seed_workspace(page) -> None:
+    """Seed a recent workspace so the composer can enable Send."""
+    await page.add_init_script(
+        f"""window.localStorage.setItem(
+            "omnigent:recent-workspaces",
+            JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+        );"""
+    )
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+def test_create_agent_dialog_opens_from_dropdown(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The agent dropdown shows a "Create custom agent" item that opens the dialog."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_dialog_opens(base_url, session_id))
+
+
+async def _drive_dialog_opens(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_requests: list[dict[str, Any]] = []
+            await _register_routes(
+                page, created_session_id=session_id, create_requests=create_requests
+            )
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open the agent dropdown.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+
+            # "Create custom agent" item should be visible.
+            create_item = page.get_by_test_id("new-chat-landing-create-agent")
+            await expect(create_item).to_be_visible()
+
+            # Click it — dialog should open.
+            await create_item.click()
+            dialog = page.get_by_test_id("create-agent-dialog")
+            await expect(dialog).to_be_visible(timeout=5_000)
+
+            # Verify form fields are present.
+            await expect(page.get_by_test_id("create-agent-name")).to_be_visible()
+            await expect(page.get_by_test_id("create-agent-description")).to_be_visible()
+            await expect(page.get_by_test_id("create-agent-harness")).to_be_visible()
+            await expect(page.get_by_test_id("create-agent-instructions")).to_be_visible()
+            await expect(page.get_by_test_id("create-agent-add-mcp")).to_be_visible()
+        finally:
+            await browser.close()
+
+
+def test_create_agent_submits_multipart_bundle(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Creating a custom agent and sending produces a multipart POST."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_create_and_submit(base_url, session_id))
+
+
+async def _drive_create_and_submit(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_requests: list[dict[str, Any]] = []
+            await _register_routes(
+                page, created_session_id=session_id, create_requests=create_requests
+            )
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open dropdown → Create custom agent.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-create-agent").click()
+
+            dialog = page.get_by_test_id("create-agent-dialog")
+            await expect(dialog).to_be_visible(timeout=5_000)
+
+            # Fill in agent details.
+            await page.get_by_test_id("create-agent-name").fill("test-agent")
+            await page.get_by_test_id("create-agent-description").fill("A test agent")
+            await page.get_by_test_id("create-agent-instructions").fill(
+                "You are a test assistant."
+            )
+
+            # Submit the dialog.
+            await page.get_by_test_id("create-agent-submit").click()
+
+            # Dialog should close.
+            await expect(dialog).to_be_hidden(timeout=5_000)
+
+            # The agent chip should now show the custom agent name.
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+                "test-agent"
+            )
+
+            # Type a message and submit the session.
+            await page.get_by_test_id("new-chat-landing-input").fill("hello world")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            # The create POST should have been a multipart request (the bundle).
+            await _wait_until(lambda: len(create_requests) == 1)
+            assert create_requests[0].get("__multipart__") is True, (
+                f"Expected multipart POST, got: {create_requests[0]}"
+            )
+        finally:
+            await browser.close()
+
+
+def test_create_agent_with_mcp_server(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Adding an MCP server in the dialog includes it in the bundle."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_mcp_server(base_url, session_id))
+
+
+async def _drive_mcp_server(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_requests: list[dict[str, Any]] = []
+            await _register_routes(
+                page, created_session_id=session_id, create_requests=create_requests
+            )
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open dropdown → Create custom agent.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-create-agent").click()
+
+            dialog = page.get_by_test_id("create-agent-dialog")
+            await expect(dialog).to_be_visible(timeout=5_000)
+
+            # Fill in agent name (required).
+            await page.get_by_test_id("create-agent-name").fill("mcp-agent")
+
+            # Add an MCP server.
+            await page.get_by_test_id("create-agent-add-mcp").click()
+
+            # An MCP entry card should appear.
+            mcp_entry = page.get_by_test_id("create-agent-mcp-entry")
+            await expect(mcp_entry).to_be_visible()
+
+            # Fill in MCP server details (stdio transport is default).
+            await page.get_by_test_id("create-agent-mcp-name").fill("github")
+            await page.get_by_test_id("create-agent-mcp-command").fill("npx")
+            await page.get_by_test_id("create-agent-mcp-args").fill(
+                "-y @modelcontextprotocol/server-github"
+            )
+            await page.get_by_test_id("create-agent-mcp-env").fill("GITHUB_TOKEN=ghp_test123")
+
+            # Submit the dialog.
+            await page.get_by_test_id("create-agent-submit").click()
+            await expect(dialog).to_be_hidden(timeout=5_000)
+
+            # Submit session.
+            await page.get_by_test_id("new-chat-landing-input").fill("list repos")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_requests) == 1)
+            assert create_requests[0].get("__multipart__") is True
+        finally:
+            await browser.close()
+
+
+def test_create_agent_cancel_closes_dialog(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Cancelling the dialog closes it without creating an agent."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_cancel(base_url, session_id))
+
+
+async def _drive_cancel(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_requests: list[dict[str, Any]] = []
+            await _register_routes(
+                page, created_session_id=session_id, create_requests=create_requests
+            )
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open dropdown → Create custom agent.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-create-agent").click()
+
+            dialog = page.get_by_test_id("create-agent-dialog")
+            await expect(dialog).to_be_visible(timeout=5_000)
+
+            # Fill some fields.
+            await page.get_by_test_id("create-agent-name").fill("should-not-persist")
+
+            # Cancel.
+            cancel_btn = dialog.get_by_role("button", name="Cancel")
+            await cancel_btn.click()
+
+            # Dialog should close.
+            await expect(dialog).to_be_hidden(timeout=5_000)
+
+            # The agent chip should still show the original agent (Claude Code).
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+                "Claude Code"
+            )
+        finally:
+            await browser.close()

--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -225,6 +225,7 @@ async def _drive_create_and_submit(base_url: str, session_id: str) -> None:
             # Fill in agent details.
             await page.get_by_test_id("create-agent-name").fill("test-agent")
             await page.get_by_test_id("create-agent-description").fill("A test agent")
+            await page.get_by_test_id("create-agent-model").fill("claude-sonnet-4-20250514")
             await page.get_by_test_id("create-agent-instructions").fill(
                 "You are a test assistant."
             )
@@ -284,8 +285,9 @@ async def _drive_mcp_server(base_url: str, session_id: str) -> None:
             dialog = page.get_by_test_id("create-agent-dialog")
             await expect(dialog).to_be_visible(timeout=5_000)
 
-            # Fill in agent name (required).
+            # Fill in agent name and model (both required).
             await page.get_by_test_id("create-agent-name").fill("mcp-agent")
+            await page.get_by_test_id("create-agent-model").fill("claude-sonnet-4-20250514")
 
             # Add an MCP server.
             await page.get_by_test_id("create-agent-add-mcp").click()

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1137,8 +1137,9 @@ async def _drive_fork_of_fork_dedup(base_url: str, session_id: str) -> None:
             await expect(page.get_by_test_id("new-chat-landing-agent-ag_forkfork")).to_have_count(
                 0
             )
-            # Exactly two options total: the built-in + the one custom agent —
-            # no duplicate "Claude Code" sneaks in via a leaked clone.
-            await expect(page.get_by_role("menuitem")).to_have_count(2)
+            # Three options total: the built-in + the one custom agent +
+            # the "Create custom agent" action — no duplicate "Claude Code"
+            # sneaks in via a leaked clone.
+            await expect(page.get_by_role("menuitem")).to_have_count(3)
         finally:
             await browser.close()


### PR DESCRIPTION
## Summary
- Adds a **"Create custom agent"** option at the bottom of the agent dropdown on the new session page
- `CreateAgentDialog` collects: name, description, harness choice, system instructions, and **MCP tool servers** (stdio or HTTP transport, with dynamic add/remove rows)
- Builds a minimal `.tar.gz` agent bundle client-side (POSIX tar + CompressionStream gzip) with MCP servers serialized as inline `tools:` entries
- Uses the existing multipart `POST /v1/sessions` to create agent + session atomically
- Adds `createBundledSession()` to the sessions API client for multipart uploads
- **E2E tests** covering the full dialog flow (open, fill, submit, cancel, MCP configuration)

## Test plan
- [ ] Open the new session page, click the agent dropdown, verify "Create custom agent" appears at the bottom with a `+` icon
- [ ] Click it, fill in name + optional fields, click "Create" — verify the custom agent appears selected in the dropdown
- [ ] Add an MCP server (stdio or HTTP), verify fields render correctly and toggle between transports
- [ ] Fill in host/workspace and a message, submit — verify a session is created and navigated to
- [ ] Cancel the dialog — verify it closes cleanly with no side effects
- [ ] Verify existing agent selection and session creation still works unchanged
- [ ] All 132 existing NewChatDialog unit tests pass
- [ ] E2E tests in `tests/e2e_ui/start_session/test_create_custom_agent.py`

This pull request and its description were written by Isaac.