### PR TITLE
feat: cost-control tier classifier with cross-harness routing

### DIFF
--- a/ap-web/src/components/AdvisorBadge.test.tsx
+++ b/ap-web/src/components/AdvisorBadge.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useChatStore } from "@/store/chatStore";
+
+import { AdvisorBadge, shortAdvisorModel } from "./AdvisorBadge";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  // Reset the advisor-related store fields so each case starts clean.
+  useChatStore.setState({
+    conversationId: null,
+    costControlTier: null,
+    costControlModel: null,
+  });
+});
+
+function renderBadge() {
+  return render(
+    <TooltipProvider>
+      <AdvisorBadge />
+    </TooltipProvider>,
+  );
+}
+
+describe("AdvisorBadge", () => {
+  it("renders nothing when no advisor tier is set", () => {
+    // An agent without cost_control routing (or before the advisor runs)
+    // must not show a pill.
+    useChatStore.setState({ conversationId: "conv_1", costControlTier: null });
+    const { container } = renderBadge();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there is no active conversation", () => {
+    useChatStore.setState({
+      conversationId: null,
+      costControlTier: "cheap",
+      costControlModel: "databricks-claude-haiku-4-5",
+    });
+    const { container } = renderBadge();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the short model name and accent styling for the expensive tier", () => {
+    useChatStore.setState({
+      conversationId: "conv_1",
+      costControlTier: "expensive",
+      costControlModel: "databricks-claude-opus-4-7",
+    });
+    renderBadge();
+    // Pill shows the model with the databricks- prefix stripped.
+    expect(screen.getByText("claude-opus-4-7")).toBeInTheDocument();
+    // aria-label names the tier + full model; expensive tier uses the accent color.
+    const pill = screen.getByLabelText(
+      /routed this session to the expensive tier using databricks-claude-opus-4-7/i,
+    );
+    // text-primary = accent (expensive); a regression to muted would drop this class.
+    expect(pill.className).toContain("text-primary");
+  });
+
+  it("uses muted styling for the cheap tier", () => {
+    useChatStore.setState({
+      conversationId: "conv_1",
+      costControlTier: "cheap",
+      costControlModel: "databricks-claude-haiku-4-5",
+    });
+    renderBadge();
+    const pill = screen.getByLabelText(/cheap tier/i);
+    expect(pill.className).toContain("text-muted-foreground");
+    expect(pill.className).not.toContain("text-primary");
+  });
+
+  it("falls back to the tier word when no model label is present (legacy session)", () => {
+    // Sessions judged before the cost_control.model label existed carry only
+    // the tier; the pill still renders, labelled by tier.
+    useChatStore.setState({
+      conversationId: "conv_1",
+      costControlTier: "cheap",
+      costControlModel: null,
+    });
+    renderBadge();
+    expect(screen.getByText("cheap")).toBeInTheDocument();
+  });
+});
+
+describe("shortAdvisorModel", () => {
+  it("strips the databricks- prefix", () => {
+    expect(shortAdvisorModel("databricks-claude-opus-4-7")).toBe("claude-opus-4-7");
+  });
+
+  it("passes through non-databricks ids unchanged", () => {
+    expect(shortAdvisorModel("gpt-5.4")).toBe("gpt-5.4");
+  });
+});

--- a/ap-web/src/components/AdvisorBadge.tsx
+++ b/ap-web/src/components/AdvisorBadge.tsx
@@ -1,0 +1,73 @@
+import { RouteIcon } from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useChatStore } from "@/store/chatStore";
+
+/**
+ * Strip the ``databricks-`` provider prefix for a compact pill label.
+ *
+ * ``"databricks-claude-opus-4-7"`` -> ``"claude-opus-4-7"``. Non-prefixed
+ * model ids pass through unchanged. The full id stays in the tooltip.
+ *
+ * @param model - The model id to shorten, e.g. ``"databricks-gpt-5-5"``.
+ * @returns The model id without the ``databricks-`` prefix.
+ */
+export function shortAdvisorModel(model: string): string {
+  return model.startsWith("databricks-") ? model.slice("databricks-".length) : model;
+}
+
+/**
+ * Pill surfacing that the cost-control advisor auto-picked this session's
+ * model tier. Rendered next to the context ring; reads the tier/model the
+ * store hydrated from the ``cost_control.{tier,model}`` session labels.
+ * Hidden unless an advisor actually routed this session. The expensive
+ * tier reads in the accent color, the cheap tier muted, so the cost weight
+ * is glanceable; the tooltip names the full model and how to override.
+ */
+export function AdvisorBadge() {
+  const tier = useChatStore((s) => s.costControlTier);
+  const model = useChatStore((s) => s.costControlModel);
+  const conversationId = useChatStore((s) => s.conversationId);
+
+  if (!conversationId || !tier) return null;
+  const isExpensive = tier === "expensive";
+  // Prefer the concrete model on the pill; fall back to the tier word for
+  // sessions judged before the model label existed.
+  const pillLabel = model ? shortAdvisorModel(model) : tier;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            "inline-flex h-6 select-none items-center gap-1 rounded-full border px-2 text-xs font-medium",
+            isExpensive
+              ? "border-primary/30 bg-primary/10 text-primary"
+              : "border-border bg-muted text-muted-foreground",
+          )}
+          aria-label={`Cost advisor routed this session to the ${tier} tier${
+            model ? ` using ${model}` : ""
+          }`}
+        >
+          <RouteIcon className="size-3" aria-hidden="true" />
+          <span className="font-mono">{pillLabel}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-64 text-center text-xs">
+        <p>
+          Cost advisor routed this chat to the <span className="font-semibold">{tier}</span> tier
+          {model ? (
+            <>
+              {" "}
+              → <span className="font-mono">{model}</span>
+            </>
+          ) : null}
+          .
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          Type <span className="font-mono">/model &lt;name&gt;</span> to override.
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ap-web/src/pages/ChatPage.test.ts
+++ b/ap-web/src/pages/ChatPage.test.ts
@@ -511,6 +511,7 @@ describe("computeShowsWorking", () => {
   ): Parameters<typeof computeShowsWorking>[1] => ({
     hasPendingElicitation: false,
     runnerOnline: true,
+    localStreaming: false,
     ...overrides,
   });
 

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -74,6 +74,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { type Agent, useSessionAgent, useAgents } from "@/hooks/useAgents";
+import { AdvisorBadge } from "@/components/AdvisorBadge";
 import { agentDisplayLabel } from "@/components/AgentInfo";
 import { BRAIN_HARNESS_LABELS } from "@/lib/agentLabels";
 import { useConversations } from "@/hooks/useConversations";
@@ -700,7 +701,14 @@ export function ChatPage() {
   // + shimmer/pill) for the main chat and is suppressed mid-elicitation or
   // when the runner is known offline.
   const isWorking = !hasPendingElicitation && computeIsWorking(sessionStatus);
-  const showsWorking = computeShowsWorking(sessionStatus, { hasPendingElicitation, runnerOnline });
+  const showsWorking = computeShowsWorking(sessionStatus, {
+    hasPendingElicitation,
+    runnerOnline,
+    // Light up the moment we send locally, before the server's
+    // `session.status: running` arrives — closes the first-turn
+    // judge gap. `status` is the local optimistic streaming flag.
+    localStreaming: status === "streaming",
+  });
 
   // A fork of a coding session carries the source id in this label (set by
   // fork_conversation). It is provenance — it persists after the clone is
@@ -3893,6 +3901,8 @@ export function Composer({
                 if (commandError !== null) setCommandError(null);
               }}
             />
+            <ComposerUsageIndicators />
+            <AdvisorBadge />
           </div>
           {/* Cost toggle + agent picker + Send — right side */}
           <div className="flex min-w-0 items-center gap-0.5">
@@ -4007,15 +4017,25 @@ export function computeIsWorking(sessionStatus: SessionStatus): boolean {
  * @param options.runnerOnline - Runner liveness: ``true`` online, ``false``
  *   known offline, ``undefined`` before the health poll resolves. Only known
  *   offline suppresses the indicator.
+ * @param options.localStreaming - ``true`` the instant the local client sends,
+ *   before the server's ``session.status: running`` arrives (it lags the
+ *   POST — by seconds on the first turn, where the cost-control judge runs
+ *   synchronously before dispatch). Lights the indicator immediately so the
+ *   user isn't left staring at a sent message with no feedback. ``send`` sets
+ *   it; every terminal/error path clears it, so it can't stick.
  * @returns ``true`` when the main session's own status should render Working.
  */
 export function computeShowsWorking(
   sessionStatus: SessionStatus,
-  options: { hasPendingElicitation: boolean; runnerOnline: boolean | undefined },
+  options: {
+    hasPendingElicitation: boolean;
+    runnerOnline: boolean | undefined;
+    localStreaming: boolean;
+  },
 ): boolean {
   if (options.runnerOnline === false) return false;
   if (options.hasPendingElicitation) return false;
-  return computeIsWorking(sessionStatus);
+  return computeIsWorking(sessionStatus) || options.localStreaming;
 }
 
 /**

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -345,6 +345,32 @@ export interface ChatState {
    */
   tokensUsed: number | null;
   /**
+   * Cost-control advisor's chosen tier for this session
+   * (``"cheap"`` | ``"expensive"``), hydrated from the
+   * ``cost_control.tier`` session label. ``null`` when the agent
+   * has no cost-control routing or the advisor hasn't run yet.
+   */
+  costControlTier: string | null;
+  /**
+   * The concrete model the advisor's tier resolved to (e.g.
+   * ``"databricks-claude-opus-4-7"``), from the ``cost_control.model``
+   * session label. ``null`` when no advisor routing applies.
+   */
+  costControlModel: string | null;
+  /**
+   * Whether the post-first-turn cost-control label refetch has already
+   * run for this session. The advisor judges once, on the first user
+   * turn, and persists ``cost_control.tier`` / ``.model`` labels
+   * server-side *after* the stream bound — so the bind-time snapshot
+   * misses them. When the first turn's ``session.status: running``
+   * arrives (the labels already exist by then) we refetch once to
+   * surface the advisor pick live, while the response streams; this flag
+   * stops the refetch from re-firing every turn on agents that have no
+   * cost-control routing (where the labels never appear). Reset on
+   * conversation switch.
+   */
+  costControlChecked: boolean;
+  /**
    * Cumulative session spend in USD, server-computed (the same total
    * the cost-budget policy gates on). Seeded from the session snapshot
    * and updated by ``session.usage`` SSE events. ``null`` when the
@@ -695,6 +721,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   sessionHarness: null,
   contextWindow: null,
   tokensUsed: null,
+  costControlTier: null,
+  costControlModel: null,
+  costControlChecked: false,
   sessionCostUsd: null,
   sessionUsageByModel: null,
   gitBranch: null,
@@ -1170,6 +1199,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
         codexPlanMode: false,
         contextWindow: null,
         tokensUsed: null,
+        costControlTier: null,
+        costControlModel: null,
+        costControlChecked: false,
         sessionCostUsd: null,
         sessionUsageByModel: null,
         gitBranch: null,
@@ -1946,6 +1978,8 @@ async function bindStream(
         // handoff (fired above, silent) shows immediately.
         sessionModelOverride: effectiveSessionOverride,
         tokensUsed: session.lastTotalTokens ?? null,
+        costControlTier: session.labels?.["cost_control.tier"] ?? null,
+        costControlModel: session.labels?.["cost_control.model"] ?? null,
         sessionCostUsd: session.totalCostUsd ?? null,
         sessionUsageByModel: session.usageByModel ?? null,
         todos: (session.todos ?? []) as Array<{
@@ -3297,6 +3331,56 @@ function removeFromPendingStash(
  *
  * No-op for events outside the `session.*` family.
  */
+/**
+ * Refetch the current session's cost-control labels once, after the
+ * first turn, so the advisor pill surfaces live without a reload.
+ *
+ * The advisor runs server-side on the first user turn and writes the
+ * ``cost_control.tier`` / ``cost_control.model`` labels *after* the SSE
+ * stream bound — so {@link bindStream}'s snapshot never saw them. The
+ * judge writes them *before* the turn dispatches, so they already exist
+ * by the time the turn's first ``session.status: running`` arrives — we
+ * trigger this there so the pill appears *while the response streams*,
+ * with ``response_completed`` kept as a fallback (e.g. a missed running
+ * event on reconnect). The once-per-session gate makes whichever fires
+ * first win.
+ *
+ * Gated so it runs at most once per session:
+ * - ``costControlChecked`` is flipped true up front (before the await)
+ *   so concurrent triggers (running + completed) can't fan out into
+ *   parallel fetches.
+ * - Skipped when a tier is already known (reload of an established
+ *   session hydrated it at bind).
+ *
+ * The result is applied only if the user is still on the same
+ * conversation — a fetch that resolves after a navigate-away must not
+ * write another session's pill.
+ */
+async function maybeRefetchCostControlLabels(): Promise<void> {
+  const { conversationId, costControlChecked, costControlTier } = useChatStore.getState();
+  if (conversationId === null || costControlChecked || costControlTier !== null) return;
+  // Claim the one-shot slot before awaiting so concurrent completions
+  // don't each launch a fetch.
+  useChatStore.setState({ costControlChecked: true });
+  let session: Session;
+  try {
+    session = await getSession(conversationId);
+  } catch {
+    // Transient snapshot fetch failure — leave the pill hidden. The
+    // labels still hydrate on the next bind (reload / navigate-back).
+    return;
+  }
+  const tier = session.labels?.["cost_control.tier"] ?? null;
+  if (tier === null) return;
+  // Drop the result if the user navigated away while the fetch was in
+  // flight — the store now describes a different conversation.
+  if (useChatStore.getState().conversationId !== conversationId) return;
+  useChatStore.setState({
+    costControlTier: tier,
+    costControlModel: session.labels?.["cost_control.model"] ?? null,
+  });
+}
+
 export function handleSessionEvent(event: StreamEvent): void {
   switch (event.type) {
     case "response_completed":
@@ -3311,6 +3395,12 @@ export function handleSessionEvent(event: StreamEvent): void {
           useChatStore.setState({ tokensUsed: ringTokens });
         }
       }
+      // The cost-control advisor judges once, on the first user turn, and
+      // persists its tier/model labels server-side — but only after the
+      // stream had already bound, so the bind-time snapshot missed them.
+      // Refetch the labels once now so the advisor pill appears live
+      // (no reload). See `costControlChecked` for the once-per-session gate.
+      void maybeRefetchCostControlLabels();
       return;
     case "session_todos":
       // Replace the todo list entirely — each event carries the full
@@ -3583,6 +3673,15 @@ export function handleSessionEvent(event: StreamEvent): void {
             queryKey: ["session", event.conversationId],
           });
         }
+      }
+      // Surface the cost-control advisor pick as soon as the turn STARTS,
+      // not just at completion. The judge writes the tier/model labels
+      // server-side before the turn dispatches, so by the time a
+      // `running`/`waiting` status arrives they already exist — refetch once
+      // here (gated once-per-session in the helper) so the pill appears
+      // while the response is still streaming, not after it ends.
+      if (event.status === "running" || event.status === "waiting") {
+        void maybeRefetchCostControlLabels();
       }
       return;
     }

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -230,6 +230,163 @@ def deny_trivial_to_expensive_model(
     return evaluate  # type: ignore[return-value]
 
 
+# ── Cost-control tier classifier ────────────────────────────────────────────
+
+# Session-state key: set to ``"1"`` after the first classification so
+# subsequent REQUEST evaluations short-circuit without an LLM call.
+_CC_JUDGED_KEY = "_cost_control_judged"
+
+
+def cost_control_classifier(
+    *,
+    rubric: str,
+    tiers: dict[str, str | dict[str, str]],
+) -> PolicyCallable:
+    """Factory: classify the session's first user message into a cost tier.
+
+    Fires on ``request`` events. On the first user message of a
+    session (gated by ``session_state["_cost_control_judged"]``),
+    classifies the prompt into one of the configured tiers using the
+    server-level ``PolicyLLMClient``. The verdict is persisted as
+    ``cost_control.tier``, ``cost_control.model``, and (when
+    configured) ``cost_control.harness`` labels via ``set_labels``,
+    then re-read by the sessions route to apply ``model_override`` /
+    ``harness_override``.
+
+    On subsequent turns the classifier short-circuits (returns ALLOW
+    with no LLM call). On classification failure the classifier
+    degrades gracefully (ALLOW, no labels — the session runs on the
+    agent's declared model).
+
+    :param rubric: Author-supplied guidance for the classification,
+        e.g. ``"Use tier_3 for multi-step coding; tier_1 for simple
+        lookups."``. The tier names used in the rubric must match
+        the keys in *tiers*.
+    :param tiers: Mapping of tier name → model config. Each value is
+        either a bare model-id string (model-only routing) or a dict
+        with ``model`` and optional ``harness`` (cross-harness
+        routing). At least two tiers must be defined. Examples::
+
+            # Two tiers, model-only:
+            {"cheap": "databricks-claude-haiku-4-5",
+             "expensive": "databricks-claude-opus-4-8"}
+
+            # Three tiers with harness routing:
+            {"tier_1": "databricks-claude-haiku-4-5",
+             "tier_2": {"model": "databricks-claude-sonnet-4-6"},
+             "tier_3": {"model": "databricks-claude-opus-4-8",
+                        "harness": "claude-sdk"}}
+
+    :returns: An async policy callable that always ALLOWs but may
+        write ``cost_control.tier``, ``cost_control.model``, and
+        ``cost_control.harness`` labels on the first turn.
+    """
+    # Normalize tiers into model + optional harness lookups.
+    tier_names = sorted(tiers.keys())
+    tier_to_model: dict[str, str] = {}
+    tier_to_harness: dict[str, str | None] = {}
+    for name, value in tiers.items():
+        if isinstance(value, str):
+            tier_to_model[name] = value
+            tier_to_harness[name] = None
+        else:
+            tier_to_model[name] = value["model"]
+            tier_to_harness[name] = value.get("harness")
+
+    # Build the prompt fragment listing valid tier names.
+    tier_choices = " or ".join(f'{{"tier": "{t}"}}' for t in tier_names)
+
+    async def evaluate(event: PolicyEvent) -> PolicyResponse | None:
+        """Classify on first request, short-circuit on later turns.
+
+        :param event: Policy event dict.
+        :returns: ALLOW with ``set_labels`` on the first user message;
+            ``None`` (abstain) on non-request events or after the first
+            classification.
+        """
+        if event.get("type") != "request":
+            return None
+
+        # Once-per-session gate: skip if already classified.
+        state = event.get("session_state") or {}
+        if state.get(_CC_JUDGED_KEY):
+            return None
+
+        user_text = event.get("data")
+        if not isinstance(user_text, str) or not user_text.strip():
+            return None
+
+        llm_client = event.get("llm_client")
+        if llm_client is None:
+            _log.warning(
+                "cost_control_classifier: event['llm_client'] is None — "
+                "server has no llm: config. Skipping classification."
+            )
+            return None
+
+        try:
+            response = await llm_client.create(
+                input=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": user_text}],
+                    },
+                ],
+                instructions=(
+                    "You are a cost-control router for an AI agent. Decide "
+                    "which tier should handle the user request below.\n\n"
+                    f"Routing rubric:\n{rubric}\n\n"
+                    f"Respond with ONLY a JSON object: {tier_choices}. "
+                    "No other text."
+                ),
+            )
+            raw_text = _extract_response_text(response)
+            # Strip markdown code fences the model may wrap around JSON.
+            raw_text = raw_text.strip()
+            if raw_text.startswith("```"):
+                raw_text = raw_text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+            if not raw_text:
+                _log.warning("cost_control_classifier: empty LLM response")
+                return _ALLOW
+            classification = json.loads(raw_text)
+        except Exception:  # noqa: BLE001 — degrade on ANY failure
+            _log.exception("cost_control_classifier: classification call failed")
+            return _ALLOW
+
+        tier = classification.get("tier", "") if isinstance(classification, dict) else ""
+        if tier not in tier_to_model:
+            _log.warning(
+                "cost_control_classifier: unexpected tier %r (valid: %s); skipping",
+                tier,
+                tier_names,
+            )
+            return _ALLOW
+
+        model = tier_to_model[tier]
+        harness = tier_to_harness[tier]
+        _log.info(
+            "cost_control_classifier: classified as %r (model=%s, harness=%s)",
+            tier,
+            model,
+            harness or "<executor default>",
+        )
+        labels: dict[str, str] = {
+            "cost_control.tier": tier,
+            "cost_control.model": model,
+        }
+        if harness is not None:
+            labels["cost_control.harness"] = harness
+        return {
+            "result": "ALLOW",
+            "set_labels": labels,
+            "state_updates": [
+                {"key": _CC_JUDGED_KEY, "action": "set", "value": "1"},
+            ],
+        }
+
+    return evaluate  # type: ignore[return-value]
+
+
 # ── Registry ─────────────────────────────────────────────────────────────────
 
 POLICY_REGISTRY: list[dict[str, Any]] = [
@@ -263,6 +420,53 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                 },
             },
             "required": ["expensive_models"],
+        },
+    },
+    {
+        "handler": "omnigents.policies.builtins.routing.cost_control_classifier",
+        "kind": "factory",
+        "name": "Cost Control Tier Classifier",
+        "description": (
+            "Classifies the session's first user message into one of the "
+            "configured tiers. Writes the verdict as cost_control.tier, "
+            "cost_control.model, and (optionally) cost_control.harness "
+            "labels. Always ALLOWs — this is a classifier, not a gate. "
+            "Requires the server to have an llm: config block."
+        ),
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "rubric": {
+                    "type": "string",
+                    "description": (
+                        "Author-supplied classification guidance. Tier names "
+                        "in the rubric must match the keys in 'tiers'."
+                    ),
+                },
+                "tiers": {
+                    "type": "object",
+                    "description": (
+                        "Mapping of tier name to model config. Each value is "
+                        "a model id string or {model, harness?} dict. "
+                        "Example: {cheap: 'model-a', medium: 'model-b', "
+                        "expensive: {model: 'model-c', harness: 'claude-sdk'}}"
+                    ),
+                    "additionalProperties": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "model": {"type": "string"},
+                                    "harness": {"type": "string"},
+                                },
+                                "required": ["model"],
+                            },
+                        ],
+                    },
+                },
+            },
+            "required": ["rubric", "tiers"],
         },
     },
 ]

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10149,6 +10149,11 @@ def create_runner_app(
                 or cached_spec.executor.type
             )
             harness_name = canonicalize_harness(h) or h
+            # Cost-control cross-harness routing: the server may direct
+            # this session onto a different harness than the spec declares.
+            _cc_harness = msg_body.get("harness_override")
+            if _cc_harness:
+                harness_name = canonicalize_harness(_cc_harness) or _cc_harness
             spawn_env = _build_spawn_env_from_spec(
                 cached_spec,
                 harness_name,
@@ -10605,6 +10610,23 @@ def create_runner_app(
                 await process_manager.release(conv_id)
         if agent_version is not None:
             _version_cache[conv_id] = agent_version
+
+        # Cost-control cross-harness routing: when the resolved harness
+        # differs from the one currently spawned for this session, tear
+        # the old subprocess down so ``get_client`` respawns onto the
+        # requested harness. The classifier picks a harness once per
+        # session — the verdict is persisted as a label and reused —
+        # so this fires at most once. Conversation history lives in
+        # the store, not the subprocess, so the respawn loses no context.
+        _active_harness = process_manager.current_harness(conv_id)
+        if _active_harness is not None and _active_harness != harness_name:
+            _logger.info(
+                "cost_control: session %s switching harness %s -> %s; respawning",
+                conv_id,
+                _active_harness,
+                harness_name,
+            )
+            await process_manager.release(conv_id)
 
         try:
             client = await process_manager.get_client(conv_id, harness_name, env=spawn_env)

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -685,6 +685,24 @@ class HarnessProcessManager:
         """
         return conversation_id in self._in_flight_response_ids
 
+    def current_harness(self, conversation_id: str) -> str | None:
+        """
+        Return the harness name of the live subprocess for a session.
+
+        The single source of truth for "which harness is spawned right
+        now" — read by the cost-control cross-harness path to decide
+        whether a tier's harness differs from the running one and a
+        respawn (``release`` + ``get_client``) is needed.
+
+        :param conversation_id: AP-allocated conversation id,
+            e.g. ``"conv_abc123"``.
+        :returns: The spawned harness name (e.g. ``"claude-sdk"``), or
+            ``None`` when no subprocess is currently registered for the
+            session (never spawned, or already released).
+        """
+        entry = self._entries.get(conversation_id)
+        return entry.harness if entry is not None else None
+
     async def release(self, conversation_id: str) -> None:
         """
         Terminate and unregister the subprocess for a conversation.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -7795,6 +7795,45 @@ async def _persist_session_event(
     return item_id
 
 
+@dataclass(frozen=True)
+class _CostControlRoute:
+    """
+    Resolved cost-control routing from persisted labels.
+
+    :param model: The chosen tier's model id, e.g.
+        ``"databricks-claude-opus-4-7"``.
+    :param harness: The chosen tier's harness, or ``None`` when
+        the classifier didn't set one (inherit executor default).
+    """
+
+    model: str
+    harness: str | None
+
+
+def _resolve_cost_control_route(
+    conv: Conversation,
+) -> _CostControlRoute | None:
+    """
+    Read cost-control labels and resolve the route.
+
+    The ``cost_control_classifier`` builtin policy writes
+    ``cost_control.model`` (and optionally ``cost_control.harness``)
+    during ``_evaluate_input_policy``. This function reads them back.
+    Returns ``None`` when no model label exists (classifier hasn't
+    run, abstained, or the agent doesn't use cost-control routing).
+
+    :param conv: The conversation entity (freshly loaded after
+        input-policy evaluation so its labels include the
+        classifier's writes).
+    :returns: A :class:`_CostControlRoute`, or ``None``.
+    """
+    model = conv.labels.get("cost_control.model")
+    if not model:
+        return None
+    harness = conv.labels.get("cost_control.harness") or None
+    return _CostControlRoute(model=model, harness=harness)
+
+
 async def _forward_event_to_runner(
     session_id: str,
     conv: Conversation,
@@ -7806,6 +7845,7 @@ async def _forward_event_to_runner(
     artifact_store: ArtifactStore | None = None,
     has_mcp_servers: bool = False,
     created_by: str | None = None,
+    cost_control_route: _CostControlRoute | None = None,
 ) -> str:
     """
     Persist a user event and forward it to the runner.
@@ -7927,15 +7967,29 @@ async def _forward_event_to_runner(
     # and the model can't invoke client-side Read/Write/Glob/etc.
     if body.tools:
         runner_body["tools"] = body.tools
-    # Per-event override wins; fall back to the persisted column so a
-    # UI / REPL PATCH applies even when the client doesn't repeat
-    # model_override on every event. ``is not None`` over ``or`` per
-    # the no-invented-defaults rule.
-    effective_runner_override = (
-        body.model_override if body.model_override is not None else conv.model_override
+    # Per-event override wins; fall back to the persisted column; fall
+    # back to the cost-control classifier's route. ``is not None`` over
+    # ``or`` per the no-invented-defaults rule.
+    _using_cost_control = (
+        body.model_override is None
+        and conv.model_override is None
+        and cost_control_route is not None
     )
+    if body.model_override is not None:
+        effective_runner_override = body.model_override
+    elif conv.model_override is not None:
+        effective_runner_override = conv.model_override
+    elif _using_cost_control:
+        effective_runner_override = cost_control_route.model
+    else:
+        effective_runner_override = None
     if effective_runner_override is not None:
         runner_body["model_override"] = effective_runner_override
+    # Cross-harness routing: when the classified tier names a harness
+    # (and the user did not override the model), tell the runner which
+    # harness to (re)spawn onto for this session.
+    if _using_cost_control and cost_control_route.harness is not None:
+        runner_body["harness_override"] = cost_control_route.harness
     # Per-session brain-harness override — create-time only, so no
     # per-event value exists; the persisted column is the source.
     if conv.harness_override is not None:
@@ -7996,6 +8050,7 @@ async def _dispatch_session_event_to_runner(
     has_mcp_servers: bool = False,
     created_by: str | None = None,
     runner_router: RunnerRouter | None = None,
+    cost_control_route: _CostControlRoute | None = None,
 ) -> _SessionEventDispatchResult:
     """
     Forward an item-event to the runner with harness-aware dispatch.
@@ -8130,6 +8185,7 @@ async def _dispatch_session_event_to_runner(
         artifact_store=artifact_store,
         has_mcp_servers=has_mcp_servers,
         created_by=created_by,
+        cost_control_route=cost_control_route,
     )
     return _SessionEventDispatchResult(item_id=item_id, pending_id=None)
 
@@ -17471,6 +17527,24 @@ def create_sessions_router(
                 created_by=_attribution_user(user_id),
             )
             return {"queued": True, "item_id": item_id}
+        # ── Cost-control tier routing ──────────────────────────────
+        # The cost_control_classifier policy may have written
+        # cost_control.model / cost_control.harness labels during
+        # _evaluate_input_policy above. Only re-read if the
+        # already-loaded conv has (or might have) the label — skip
+        # the extra DB round-trip for the vast majority of agents
+        # that don't use cost-control routing.
+        _cc_route: _CostControlRoute | None = None
+        if "cost_control.model" in conv.labels:
+            # Label already present from a prior turn — read directly.
+            _cc_route = _resolve_cost_control_route(conv)
+        elif body.type == "message" and body.data.get("role") == "user":
+            # First turn: the classifier may have just written labels
+            # during _evaluate_input_policy — re-read to pick them up
+            # (the in-memory conv predates the policy write).
+            _fresh_conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+            if _fresh_conv is not None:
+                _cc_route = _resolve_cost_control_route(_fresh_conv)
         dispatch = await _dispatch_session_event_to_runner(
             session_id,
             conv,
@@ -17483,6 +17557,7 @@ def create_sessions_router(
             has_mcp_servers=_has_mcp_servers,
             created_by=_attribution_user(user_id),
             runner_router=runner_router,
+            cost_control_route=_cc_route,
         )
         response: dict[str, Any] = {"queued": True}
         if dispatch.item_id is not None:

--- a/tests/policies/builtins/test_cost_control_classifier.py
+++ b/tests/policies/builtins/test_cost_control_classifier.py
@@ -1,0 +1,424 @@
+"""Tests for :func:`omnigent.policies.builtins.routing.cost_control_classifier`.
+
+Covers:
+
+- First request classifies and writes ``cost_control.tier`` / ``cost_control.model`` labels.
+- Second request (already judged) short-circuits — no LLM call.
+- Non-request event returns ``None`` (abstain).
+- Missing ``llm_client`` returns ``None`` (abstain).
+- LLM failure degrades gracefully (returns ALLOW, no labels).
+- Empty user text returns ``None`` (abstain).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from omnigent.policies.builtins.routing import (
+    _CC_JUDGED_KEY,
+    cost_control_classifier,
+)
+from omnigent.policies.schema import PolicyEvent
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+class _StubResponse:
+    """Minimal response stub exposing ``output_text``.
+
+    Production code reads ``output_text`` via :func:`_extract_response_text`.
+    This stub mirrors the ``output_text`` property of a real LLM response.
+
+    :param text: The raw text the "LLM" returned, e.g.
+        ``'{"tier": "cheap"}'``.
+    """
+
+    def __init__(self, text: str) -> None:
+        self.output_text = text
+
+
+class _StubLLMClient:
+    """Stub ``PolicyLLMClient`` that returns a fixed response.
+
+    Does NOT use MagicMock — all attributes are explicit. Tracks
+    call count so tests can verify whether the classifier invoked
+    the LLM.
+
+    :param response_text: The JSON string the "LLM" should return.
+    """
+
+    def __init__(self, response_text: str) -> None:
+        self._response_text = response_text
+        self.call_count = 0
+
+    async def create(self, **kwargs: Any) -> _StubResponse:
+        """Return the fixed response and increment the call counter.
+
+        :param kwargs: Forwarded (ignored); mirrors the real signature.
+        :returns: A :class:`_StubResponse`.
+        """
+        self.call_count += 1
+        return _StubResponse(self._response_text)
+
+
+class _FailingLLMClient:
+    """Stub ``PolicyLLMClient`` that raises on every call.
+
+    Used to test graceful degradation when the classifier LLM call fails.
+    Does NOT use MagicMock.
+    """
+
+    async def create(self, **kwargs: Any) -> None:
+        """Always raises RuntimeError.
+
+        :raises RuntimeError: Unconditionally.
+        """
+        raise RuntimeError("simulated LLM failure")
+
+
+class _RaisesIfCalledLLMClient:
+    """Stub that fails the test if ``create()`` is called.
+
+    Used in tests where the classifier should short-circuit before
+    reaching the LLM client.
+    """
+
+    async def create(self, **kwargs: Any) -> None:
+        """Fail the test — the client should never be reached.
+
+        :raises AssertionError: Unconditionally.
+        """
+        raise AssertionError(
+            "LLM client was called unexpectedly — the code path that should short-circuit did not."
+        )
+
+
+def _request_event(
+    user_text: str = "Help me refactor this module",
+    *,
+    llm_client: Any = None,
+    session_state: dict[str, Any] | None = None,
+) -> PolicyEvent:
+    """Build a ``request`` event for the cost-control classifier.
+
+    :param user_text: The user's message text, placed in ``data``.
+    :param llm_client: The LLM client stub (or None).
+    :param session_state: Session state dict (or None for empty).
+    :returns: A ``request`` :class:`PolicyEvent`.
+    """
+    return {
+        "type": "request",
+        "target": "",
+        "data": user_text,
+        "context": {"actor": {}, "usage": {}},
+        "session_state": session_state or {},
+        "llm_client": llm_client,
+    }
+
+
+_CHEAP = "databricks-claude-haiku-4-5"
+_EXPENSIVE = "databricks-claude-opus-4-7"
+_RUBRIC = "Use expensive for multi-step coding; cheap for simple lookups."
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_first_request_classifies_and_writes_labels() -> None:
+    """First request classifies the user message and writes tier + model labels.
+
+    The classifier should invoke the LLM exactly once, return ALLOW,
+    and include ``set_labels`` with ``cost_control.tier`` and
+    ``cost_control.model`` plus a ``state_updates`` entry that gates
+    future evaluations.
+
+    A failure here means the classifier either did not call the LLM,
+    did not parse the structured output, or did not emit the correct
+    labels — any of which would leave the session un-routed.
+    """
+    client = _StubLLMClient(json.dumps({"tier": "cheap"}))
+    event = _request_event(llm_client=client)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    # LLM was called exactly once for the classification.
+    assert client.call_count == 1, (
+        f"Expected 1 LLM call for classification, got {client.call_count}. "
+        "If 0, the classifier short-circuited when it should not have."
+    )
+    assert result is not None, "Classifier must return a response on the first request, not None."
+    # ALLOW — cost control is advisory, never blocks.
+    assert result["result"] == "ALLOW", (
+        f"Cost-control classifier must always ALLOW, got {result['result']!r}."
+    )
+    # Labels carry the tier verdict and the resolved model.
+    labels = result.get("set_labels", {})
+    assert labels.get("cost_control.tier") == "cheap", (
+        f"Expected tier label 'cheap', got {labels.get('cost_control.tier')!r}. "
+        "The classifier did not write the tier label correctly."
+    )
+    assert labels.get("cost_control.model") == _CHEAP, (
+        f"Expected model label '{_CHEAP}', got {labels.get('cost_control.model')!r}. "
+        "The tier-to-model mapping is broken."
+    )
+    # State update gates subsequent evaluations.
+    state_updates = result.get("state_updates", [])
+    judged_updates = [u for u in state_updates if u.get("key") == _CC_JUDGED_KEY]
+    assert len(judged_updates) == 1, (
+        f"Expected exactly 1 state_update for {_CC_JUDGED_KEY}, "
+        f"got {len(judged_updates)}. Without this, the classifier will "
+        "re-classify on every turn instead of once per session."
+    )
+    assert judged_updates[0]["value"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_first_request_expensive_tier() -> None:
+    """First request classified as 'expensive' maps to the expensive model.
+
+    A failure here means the tier-to-model mapping is wrong for the
+    expensive tier specifically.
+    """
+    client = _StubLLMClient(json.dumps({"tier": "expensive"}))
+    event = _request_event(llm_client=client)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    assert result is not None
+    labels = result.get("set_labels", {})
+    assert labels.get("cost_control.tier") == "expensive"
+    assert labels.get("cost_control.model") == _EXPENSIVE, (
+        f"Expected model '{_EXPENSIVE}' for expensive tier, "
+        f"got {labels.get('cost_control.model')!r}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_already_judged_short_circuits() -> None:
+    """Second request (session already classified) short-circuits — no LLM call.
+
+    The ``_cost_control_judged`` session state key gates re-evaluation.
+    A failure here means the classifier re-classifies on every turn,
+    wasting LLM calls and potentially changing the tier mid-session.
+    """
+    client = _RaisesIfCalledLLMClient()
+    event = _request_event(
+        llm_client=client,
+        session_state={_CC_JUDGED_KEY: "1"},
+    )
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    # None = abstain; the once-per-session gate fired.
+    assert result is None, (
+        f"Expected None (abstain) for already-judged session, got {result!r}. "
+        "The classifier did not check the session_state gate."
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_request_event_returns_none() -> None:
+    """Non-request events (e.g. tool_call) are ignored — returns None.
+
+    The classifier only fires on ``request`` events. A failure here
+    means the classifier processes event types it should ignore.
+    """
+    client = _RaisesIfCalledLLMClient()
+    event: PolicyEvent = {
+        "type": "tool_call",
+        "target": "some_tool",
+        "data": {"name": "some_tool", "arguments": {}},
+        "context": {"actor": {}, "usage": {}},
+        "session_state": {},
+        "llm_client": client,
+    }
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    assert result is None, (
+        f"Expected None for non-request event type, got {result!r}. "
+        "The classifier should only fire on type='request'."
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_llm_client_returns_none() -> None:
+    """Missing llm_client (no server llm: config) returns None.
+
+    Without a PolicyLLMClient the classifier cannot classify. It
+    should abstain rather than crash. A failure here means the
+    classifier does not guard against a None llm_client.
+    """
+    event = _request_event(llm_client=None)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    assert result is None, (
+        f"Expected None when llm_client is None, got {result!r}. "
+        "The classifier should abstain when no LLM client is available."
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_failure_degrades_gracefully() -> None:
+    """LLM call failure returns ALLOW with no labels.
+
+    The classifier must not crash the policy engine on transient
+    LLM errors. It degrades to ALLOW (no routing) so the session
+    runs on the agent's declared model. A failure here means the
+    classifier propagates the exception instead of catching it.
+    """
+    client = _FailingLLMClient()
+    event = _request_event(llm_client=client)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    assert result is not None, "On LLM failure the classifier must return ALLOW, not None."
+    assert result["result"] == "ALLOW", (
+        f"On LLM failure the classifier must ALLOW, got {result['result']!r}."
+    )
+    # No labels — the classification did not complete, so no routing.
+    assert (
+        "set_labels" not in result or result["set_labels"] is None or result["set_labels"] == {}
+    ), (
+        f"On LLM failure there must be no labels, got {result.get('set_labels')!r}. "
+        "Emitting labels on a failed classification would route to a "
+        "tier chosen by garbage data."
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_user_text_returns_none() -> None:
+    """Empty (whitespace-only) user text returns None.
+
+    An empty message has nothing to classify. A failure here means
+    the classifier sends an empty string to the LLM, wasting a call.
+    """
+    client = _RaisesIfCalledLLMClient()
+    event = _request_event(user_text="   ", llm_client=client)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    assert result is None, (
+        f"Expected None for empty user text, got {result!r}. "
+        "The classifier should not call the LLM for empty messages."
+    )
+
+
+@pytest.mark.asyncio
+async def test_harness_written_when_configured() -> None:
+    """When a tier has a harness, the classifier writes ``cost_control.harness``.
+
+    Cross-harness routing requires the classifier to write the harness
+    label so the sessions route can inject ``harness_override`` into
+    the runner body. A failure here means the runner stays on the
+    spec's declared harness regardless of the tier.
+    """
+    client = _StubLLMClient(json.dumps({"tier": "cheap"}))
+    event = _request_event(llm_client=client)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={
+            "cheap": {"model": _CHEAP, "harness": "pi"},
+            "expensive": {"model": _EXPENSIVE, "harness": "claude-sdk"},
+        },
+    )
+    result = await evaluate(event)
+
+    assert result is not None
+    labels = result.get("set_labels", {})
+    # The cheap tier was selected, so the cheap harness should be written.
+    assert labels.get("cost_control.harness") == "pi", (
+        f"Expected harness label 'pi', got {labels.get('cost_control.harness')!r}. "
+        "The classifier did not write the harness for the cheap tier."
+    )
+
+
+@pytest.mark.asyncio
+async def test_harness_omitted_when_not_configured() -> None:
+    """When no tier harness is configured, ``cost_control.harness`` is absent.
+
+    Model-only routing (no cross-harness) should not emit a harness
+    label. A failure here means the runner would try to respawn onto
+    an empty/None harness string.
+    """
+    client = _StubLLMClient(json.dumps({"tier": "cheap"}))
+    event = _request_event(llm_client=client)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "expensive": _EXPENSIVE},
+        # Bare strings — no harness, model-only routing.
+    )
+    result = await evaluate(event)
+
+    assert result is not None
+    labels = result.get("set_labels", {})
+    assert "cost_control.harness" not in labels, (
+        f"Expected no harness label for model-only routing, "
+        f"but got {labels.get('cost_control.harness')!r}."
+    )
+
+
+_MEDIUM = "databricks-claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_three_tier_classification() -> None:
+    """Three-tier config routes to the middle tier when the LLM picks it.
+
+    Proves the classifier isn't hardcoded to cheap/expensive — it
+    accepts arbitrary tier names from the ``tiers`` dict. A failure
+    here means the classifier rejects valid tier names outside the
+    original two.
+    """
+    client = _StubLLMClient(json.dumps({"tier": "medium"}))
+    event = _request_event(llm_client=client)
+
+    evaluate = cost_control_classifier(
+        rubric=_RUBRIC,
+        tiers={"cheap": _CHEAP, "medium": _MEDIUM, "expensive": _EXPENSIVE},
+    )
+    result = await evaluate(event)
+
+    assert result is not None
+    labels = result.get("set_labels", {})
+    assert labels.get("cost_control.tier") == "medium", (
+        f"Expected tier 'medium', got {labels.get('cost_control.tier')!r}."
+    )
+    assert labels.get("cost_control.model") == _MEDIUM, (
+        f"Expected model '{_MEDIUM}', got {labels.get('cost_control.model')!r}."
+    )

--- a/tests/policies/builtins/test_routing.py
+++ b/tests/policies/builtins/test_routing.py
@@ -482,14 +482,15 @@ async def test_different_message_not_cached() -> None:
 
 def test_registry_entry_well_formed() -> None:
     """
-    The ``POLICY_REGISTRY`` has one entry with the expected handler
-    path and kind, and ``expensive_models`` is required.
+    The ``POLICY_REGISTRY`` has entries for both routing policies with
+    the expected handler paths and kinds.
 
     What breaks if this fails: the server startup scan won't
-    discover the routing policy, or operators can omit the
-    required ``expensive_models`` parameter.
+    discover the routing policies, or operators can omit required
+    parameters.
     """
-    assert len(POLICY_REGISTRY) == 1
+    # 2 = deny_trivial_to_expensive_model + cost_control_classifier
+    assert len(POLICY_REGISTRY) == 2
     entry = POLICY_REGISTRY[0]
     assert entry["handler"] == (
         "omnigent.policies.builtins.routing.deny_trivial_to_expensive_model"
@@ -498,3 +499,11 @@ def test_registry_entry_well_formed() -> None:
     schema = entry["params_schema"]
     assert "expensive_models" in schema["properties"]
     assert "expensive_models" in schema["required"]
+
+    cc_entry = POLICY_REGISTRY[1]
+    assert cc_entry["handler"] == ("omnigents.policies.builtins.routing.cost_control_classifier")
+    assert cc_entry["kind"] == "factory"
+    cc_schema = cc_entry["params_schema"]
+    # Both factory params are required.
+    assert "rubric" in cc_schema["required"]
+    assert "tiers" in cc_schema["required"]

--- a/tests/resources/examples/agent_with_cost_control.yaml
+++ b/tests/resources/examples/agent_with_cost_control.yaml
@@ -1,0 +1,54 @@
+# Demo: cost-control tier routing via the cost_control_classifier policy.
+#
+# Classifies each session's first user message into a tier and routes
+# to a cheaper or more expensive model. Requires the server to have an
+# llm: config block (the classifier calls the server-level LLM).
+#
+# Usage:
+#   # Start the server with an llm: config:
+#   omnigents server --config <server_config_with_llm.yaml>
+#
+#   # Run the agent against the server:
+#   omnigents run tests/resources/examples/agent_with_cost_control.yaml \
+#       --server http://localhost:8000
+#
+#   # Simple question → cheap tier (haiku):
+#   > What's the capital of France?
+#
+#   # Complex question → expensive tier (opus):
+#   > Design a microservice architecture for a real-time analytics pipeline
+
+name: agent_with_cost_control
+prompt: |
+  You are a helpful assistant. Answer the user's question concisely.
+
+executor:
+  harness: openai-agents
+  model: databricks-gpt-5-5-mini
+  auth:
+    type: databricks
+    profile: oss
+
+policies:
+  cost_control:
+    type: function
+    function:
+      path: omnigents.policies.builtins.routing.cost_control_classifier
+      arguments:
+        rubric: |
+          Use the EXPENSIVE tier for: multi-step reasoning, architecture
+          design, complex debugging, large refactors, research synthesis.
+          Use the MEDIUM tier for: moderate coding tasks, explanations
+          requiring some depth, multi-paragraph writing.
+          Use the CHEAP tier for: simple lookups, greetings, short Q&A,
+          single-fact answers, status checks.
+        tiers:
+          cheap:
+            model: databricks-claude-haiku-4-5
+            harness: claude-sdk
+          medium:
+            model: databricks-claude-sonnet-4-6
+            harness: openai-agents
+          expensive:
+            model: databricks-claude-opus-4-8
+            harness: claude-sdk

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -228,6 +228,10 @@ class _FakeProcessManager:
         self.cancelled.append(conversation_id)
         return True
 
+    def current_harness(self, conversation_id: str) -> str | None:
+        """Return ``None`` — fake manager doesn't track harness names."""
+        return None
+
     async def release(self, conversation_id: str) -> None:
         """Record a release and remove the session."""
         self.released.append(conversation_id)

--- a/tests/runner/test_enforce_sandbox_gate.py
+++ b/tests/runner/test_enforce_sandbox_gate.py
@@ -93,6 +93,10 @@ class _FakeProcessManager:
         """
         return True
 
+    def current_harness(self, conversation_id: str) -> str | None:
+        """Return ``None`` — fake manager doesn't track harness names."""
+        return None
+
     async def release(self, conversation_id: str) -> None:
         """No-op release stub.
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -305,6 +305,13 @@ class _FakeProcessManager:
             raise AssertionError("get_client should not be called")
         return self._harness_client
 
+    def current_harness(self, conversation_id: str) -> str | None:
+        """Return ``None`` — fake manager doesn't track harness names."""
+        return None
+
+    async def release(self, conversation_id: str) -> None:
+        """No-op release."""
+
 
 @pytest.fixture
 async def started_manager() -> AsyncIterator[HarnessProcessManager]:
@@ -459,6 +466,13 @@ class _RecordingProcessManager:
         self._reached.set()
         return _FakeHarnessClient([])
 
+    def current_harness(self, conversation_id: str) -> str | None:
+        """Return ``None`` — recording manager doesn't track harness names."""
+        return None
+
+    async def release(self, conversation_id: str) -> None:
+        """No-op release."""
+
 
 @pytest.mark.asyncio
 async def test_runner_resolves_agent_from_server_snapshot_when_msg_lacks_agent_id() -> None:
@@ -599,6 +613,13 @@ class _ContentCapturingProcessManager:
         """
         del conversation_id, harness_name, env
         return _ContentCapturingHarnessClient(self._captured, self._reached)
+
+    def current_harness(self, conversation_id: str) -> str | None:
+        """Return ``None`` — capturing manager doesn't track harness names."""
+        return None
+
+    async def release(self, conversation_id: str) -> None:
+        """No-op release."""
 
 
 class _ContentCapturingHarnessClient:

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -850,6 +850,9 @@ async def test_runner_shutdown_closes_terminal_registry(
         async def shutdown(self) -> None:
             self.shutdown_called = True
 
+        def current_harness(self, conversation_id: str) -> str | None:
+            return None
+
     def _terminal_registry_factory(
         *,
         conversation_link_base_url: str | None = None,

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -151,6 +151,10 @@ class FakeProcessManager:
         self._apps.pop(conversation_id, None)
         self._in_flight.pop(conversation_id, None)
 
+    def current_harness(self, conversation_id: str) -> str | None:
+        """Return ``None`` — fake manager doesn't track harness names."""
+        return None
+
     async def forward_cancel(self, conversation_id: str) -> None:
         # EchoHarness completes synchronously; cancellation is not
         # exercised by the happy-path test. A future tunneled


### PR DESCRIPTION
## Summary
- Adds a `cost_control_classifier` builtin policy that classifies the session's first user message into a cost tier (cheap/medium/expensive) using the server-level LLM, persisting the verdict as `cost_control.tier`, `cost_control.model`, and optionally `cost_control.harness` session labels.
- The sessions route resolves these labels into `model_override` and `harness_override` on the runner body; the runner respawns onto the target harness when the classifier picks one different from the current subprocess.
- Adds an `AdvisorBadge` React component that surfaces the routed tier/model as a pill in the composer, with live refetch so it appears while the first response streams.
- Fixes the local streaming working indicator gap on the first turn (the cost-control judge adds latency before the server's `session.status: running` arrives).
- Adds `current_harness()` to `HarnessProcessManager` for cross-harness routing decisions.
- Includes tests for the classifier policy, registry entry, process manager, runner dispatch, and the AdvisorBadge component.
- Adds an example agent YAML (`agent_with_cost_control.yaml`) demonstrating three-tier routing with harness overrides.

## Test plan
- [ ] `pytest tests/policies/builtins/test_cost_control_classifier.py` passes (classifier logic, short-circuit, degradation, harness labels)
- [ ] `pytest tests/policies/builtins/test_routing.py` passes (registry entry count and schema validation)
- [ ] `pytest tests/runner/test_runner_dispatch.py tests/runner/test_app_sessions_native.py tests/runner/test_enforce_sandbox_gate.py tests/runner/test_runner_entry.py` pass (fake process managers updated with `current_harness`)
- [ ] `vitest ap-web/src/components/AdvisorBadge.test.tsx` passes (badge rendering, tier styling, model shortening)
- [ ] `vitest ap-web/src/pages/ChatPage.test.ts` passes (computeShowsWorking with localStreaming)
- [ ] Manual: deploy with an agent using `cost_control_classifier` policy, verify the advisor pill appears in the composer after the first turn

This pull request and its description were written by Isaac.