### PR TITLE
feat(qwen,goose): delegate file I/O through Omnigent via ACP fs/*

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -60,6 +60,18 @@ Tracks pending work and known limitations for the Qwen Code harness
   spawn (`_sandbox_launch_path`), confining qwen's own file/shell tools to the
   spec's read/write roots — an OS-level guarantee independent of the per-tool
   permission gate.
+- **File I/O delegation (`fs/*`).** When an `os_env` is configured, the executor
+  advertises `clientCapabilities.fs` in `initialize`, so qwen routes its file
+  reads/writes back to us as `fs/read_text_file` / `fs/write_text_file` requests
+  (qwen's `AcpFileSystemService` swaps in only when the capability is set). The
+  handlers execute the I/O through the Omnigent `OSEnvironment`, so the spec's
+  sandbox read/write roots are enforced at the Python layer — and the bytes flow
+  through Omnigent rather than qwen touching disk directly. Disabled (qwen uses
+  its own tools) when there's no `os_env` or it's a `fork` env (a forked tree's
+  path would diverge from the qwen subprocess cwd). Binary/non-UTF-8 reads are
+  refused; missing-file reads map to qwen's ENOENT code. (Same fix applied to
+  the goose ACP harness.) See the Pending item below for what's still out of
+  scope (event recording / TOOL_RESULT-phase content policy).
 
 ## Pending work
 
@@ -100,15 +112,14 @@ comments; this is the *what*, not the *how*.)
 - [ ] **Omnigent tools.** Qwen can only call its own built-in tools; tools
   defined by Omnigent aren't exposed to it (so they can't be invoked or
   recorded). Permission gating on qwen's *own* tool calls already works.
-- [ ] **File I/O execution / content recording.** Qwen performs file reads and
-  writes with its own tools (we don't advertise `clientCapabilities.fs`), so
-  Omnigent never executes the I/O and can't record the file content or run
-  TOOL_RESULT-phase content policy on it. Note the gaps that are *already*
-  closed: the TOOL_CALL request is gated (permission + policy) when qwen asks,
-  and the ops are confined when `os_env.sandbox` is set (see What works today).
-  What's missing is Omnigent-side execution/recording of the I/O itself —
-  advertise `clientCapabilities.fs` + re-add `fs/read_text_file` /
-  `fs/write_text_file` handlers to route it through Omnigent.
+- [ ] **File I/O recording / content policy.** Omnigent now *executes* delegated
+  file reads/writes through the `OSEnvironment` (see "File I/O delegation" in
+  What works today), so the bytes flow through Omnigent and the sandbox roots are
+  enforced. Still missing on top of that: (a) emitting the I/O into Omnigent's
+  event stream (ToolCall-style records) so it shows in history, and (b) running
+  TOOL_RESULT-phase content policy on the read/written content. Both build on the
+  `_handle_fs_read` / `_handle_fs_write` handlers — the byte-level hook now
+  exists; this is wiring the recording/policy layers onto it.
 
 > LLM-phase policy (`PHASE_LLM_REQUEST` / `PHASE_LLM_RESPONSE`) is intentionally
 > out of scope: qwen's model calls happen internally over ACP and are opaque to

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -50,8 +50,47 @@ from omnigent.inner.executor import (
     TextChunk,
     TurnComplete,
 )
+from omnigent.inner.os_env import OSEnvironment, create_os_environment
 
 logger = logging.getLogger(__name__)
+
+# ACP error code Goose maps to a filesystem "not found" (ENOENT) when a
+# delegated ``fs/read_text_file`` fails — the shared ACP client lib special-
+# cases exactly this code to raise an ENOENT the model understands. Any other
+# code surfaces raw.
+_ACP_RESOURCE_NOT_FOUND_CODE = -32002
+
+
+class _AcpRequestError(Exception):
+    """A handler failure to return as a JSON-RPC error on a server request.
+
+    Carries the JSON-RPC ``code`` / ``message`` so the dispatch in
+    :meth:`GooseExecutor._respond_to_agent_request` can build the error reply
+    without each handler assembling the wire envelope itself.
+    """
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _looks_like_missing_file(message: str) -> bool:
+    """Heuristic: does an os_env error message indicate a missing path?
+
+    The os_env helper returns failures as ``{"error": "<str>"}`` rather than
+    typed exceptions, so the message text is the only signal that a read missed
+    because the file is absent (vs. a permission / decode failure). Used to map
+    onto the ENOENT code so the model sees "file not found".
+    """
+    lowered = message.lower()
+    return (
+        "no such file" in lowered
+        or "errno 2" in lowered
+        or "not found" in lowered
+        or "does not exist" in lowered
+    )
+
 
 # ACP protocol constants (JSON-RPC 2.0 method names).
 _AGENT_METHOD_INITIALIZE = "initialize"
@@ -161,6 +200,16 @@ class GooseExecutor(Executor):
         """
         self._cwd = cwd or os.getcwd()
         self._os_env = os_env
+        # Whether to advertise ``clientCapabilities.fs`` so Goose delegates file
+        # reads/writes back to us (executed through the Omnigent OSEnvironment,
+        # which enforces the spec's sandbox read/write roots) instead of using
+        # its own raw file tools. Enabled only when an os_env is configured and
+        # it isn't a ``fork`` env — a forked env operates on a *copied* tree
+        # whose path would diverge from the cwd the goose subprocess runs in.
+        self._fs_delegation: bool = os_env is not None and not bool(getattr(os_env, "fork", False))
+        # Live OSEnvironment backing fs delegation, created lazily on the first
+        # delegated op and torn down in :meth:`close`. ``None`` until then.
+        self._os_environment: OSEnvironment | None = None
         self._model = model
         self._provider = provider
         self._goose_path = goose_path or "goose"
@@ -396,10 +445,15 @@ class GooseExecutor(Executor):
             {
                 "protocolVersion": _PROTOCOL_VERSION,
                 "clientInfo": {"name": "omnigent", "version": "1.0"},
-                # We don't advertise fs/terminal capabilities, so Goose uses its
-                # own builtin tools (and any fs/* request hits method-not-found).
+                # Advertise fs delegation so Goose routes file reads/writes back
+                # to us (executed via the OSEnvironment) when an os_env is
+                # configured; both false (no os_env / fork env) leaves Goose on
+                # its own builtin tools. Terminal stays unadvertised.
                 "clientCapabilities": {
-                    "fs": {"readTextFile": False, "writeTextFile": False},
+                    "fs": {
+                        "readTextFile": self._fs_delegation,
+                        "writeTextFile": self._fs_delegation,
+                    },
                     "terminal": False,
                 },
             },
@@ -453,6 +507,10 @@ class GooseExecutor(Executor):
         - ``session/request_permission`` — decide via Omnigent's TOOL_CALL policy
           + human-consent elicitation (:meth:`_decide_permission`), then select
           the matching allow/reject option. NOT a blind approve.
+        - ``fs/read_text_file`` / ``fs/write_text_file`` — when fs delegation is
+          advertised (an os_env is configured; see :attr:`_fs_delegation`), Goose
+          routes its file I/O here, executed through the Omnigent OSEnvironment so
+          the spec's sandbox read/write roots are enforced. Off → never arrive.
         - anything else — reply with JSON-RPC ``method not found`` so goose fails
           loudly rather than acting on empty data.
         """
@@ -467,11 +525,17 @@ class GooseExecutor(Executor):
             if method == _AGENT_REQUEST_REQUEST_PERMISSION:
                 allow = await self._decide_permission(params)
                 result = {"outcome": self._permission_outcome(params, allow=allow)}
+            elif method == "fs/read_text_file" and self._fs_delegation:
+                result = await self._handle_fs_read(params)
+            elif method == "fs/write_text_file" and self._fs_delegation:
+                result = await self._handle_fs_write(params)
             else:
                 error = {
                     "code": -32601,
                     "message": f"omnigent: unsupported ACP request method {method!r}",
                 }
+        except _AcpRequestError as exc:
+            error = {"code": exc.code, "message": exc.message}
         except Exception as exc:  # noqa: BLE001
             logger.debug("goose agent request %s failed: %s", method, exc)
             error = {"code": -32603, "message": f"{method} failed: {exc}"}
@@ -482,6 +546,76 @@ class GooseExecutor(Executor):
         else:
             reply["result"] = result
         await self._send(reply)
+
+    # ------------------------------------------------------------------
+    # Filesystem delegation (goose → client, when fs capability advertised)
+    # ------------------------------------------------------------------
+
+    async def _ensure_os_environment(self) -> OSEnvironment:
+        """Lazily create the OSEnvironment backing fs delegation.
+
+        :returns: The live OSEnvironment for this executor's os_env spec.
+        :raises _AcpRequestError: When no usable os_env can be created.
+        """
+        if self._os_environment is None:
+            env = create_os_environment(self._os_env)
+            if env is None:
+                raise _AcpRequestError(-32603, "omnigent: no os_env for fs delegation")
+            self._os_environment = env
+        return self._os_environment
+
+    async def _handle_fs_read(self, params: dict[str, Any]) -> dict[str, Any]:  # type: ignore[explicit-any]
+        """Serve an ACP ``fs/read_text_file`` by reading through the OSEnvironment.
+
+        ACP params ``{path, line?, limit?}`` (1-based start line, max line count;
+        both optional → whole file) map onto :meth:`OSEnvironment.read`.
+
+        :param params: The request params.
+        :returns: ``{"content": <text>}`` per the ACP response shape.
+        :raises _AcpRequestError: On a missing path arg, a non-text/binary file,
+            or a read failure (mapped to ENOENT when it looks like a missing
+            file so goose raises the right error to the model).
+        """
+        path = params.get("path")
+        if not isinstance(path, str) or not path:
+            raise _AcpRequestError(-32602, "fs/read_text_file requires a string 'path'")
+        line = params.get("line")
+        limit = params.get("limit")
+        offset = line if isinstance(line, int) and line >= 1 else 1
+        read_limit = limit if isinstance(limit, int) and limit >= 1 else None
+
+        env = await self._ensure_os_environment()
+        result = await env.read(path, offset=offset, limit=read_limit)
+        if "error" in result:
+            message = str(result["error"])
+            code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+            raise _AcpRequestError(code, message)
+        if result.get("encoding") != "utf-8":
+            raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
+        return {"content": result.get("content", "")}
+
+    async def _handle_fs_write(self, params: dict[str, Any]) -> dict[str, Any]:  # type: ignore[explicit-any]
+        """Serve an ACP ``fs/write_text_file`` by writing through the OSEnvironment.
+
+        ACP params ``{path, content}``; the write goes through the helper so the
+        spec's sandbox write roots are enforced at the Python layer.
+
+        :param params: The request params.
+        :returns: An empty result object (ACP expects no payload on success).
+        :raises _AcpRequestError: On missing/invalid args or a write failure.
+        """
+        path = params.get("path")
+        content = params.get("content")
+        if not isinstance(path, str) or not path:
+            raise _AcpRequestError(-32602, "fs/write_text_file requires a string 'path'")
+        if not isinstance(content, str):
+            raise _AcpRequestError(-32602, "fs/write_text_file requires string 'content'")
+
+        env = await self._ensure_os_environment()
+        result = await env.write(path, content)
+        if "error" in result:
+            raise _AcpRequestError(-32603, str(result["error"]))
+        return {}
 
     @staticmethod
     def _extract_tool_call(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:  # type: ignore[explicit-any]
@@ -905,6 +1039,12 @@ class GooseExecutor(Executor):
             with contextlib.suppress(asyncio.CancelledError):
                 await self._stderr_task
             self._stderr_task = None
+        # Release the fs-delegation OSEnvironment's helper subprocess, if one
+        # was spawned for a delegated file op this session.
+        if self._os_environment is not None:
+            with contextlib.suppress(Exception):
+                self._os_environment.close()
+            self._os_environment = None
         if self._proc:
             with contextlib.suppress(Exception):
                 self._proc.stdin.close()  # type: ignore[union-attr]

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -42,9 +42,49 @@ from omnigent.inner.executor import (
     TextChunk,
     TurnComplete,
 )
+from omnigent.inner.os_env import OSEnvironment, create_os_environment
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 
 logger = logging.getLogger(__name__)
+
+# ACP error code qwen maps to a filesystem "not found" (ENOENT) when a
+# delegated ``fs/read_text_file`` fails — qwen's AcpFileSystemService special-
+# cases exactly this code (cli.js: ``RESOURCE_NOT_FOUND_CODE = -32002``) to
+# raise an ENOENT the model understands. Any other error code surfaces raw.
+_ACP_RESOURCE_NOT_FOUND_CODE = -32002
+
+
+class _AcpRequestError(Exception):
+    """A handler failure to return as a JSON-RPC error on a server request.
+
+    Carries the JSON-RPC ``code`` / ``message`` so the dispatch in
+    :meth:`QwenExecutor._respond_to_agent_request` can build the error reply
+    without each handler assembling the wire envelope itself.
+    """
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _looks_like_missing_file(message: str) -> bool:
+    """Heuristic: does an os_env error message indicate a missing path?
+
+    The os_env helper returns failures as ``{"error": "<str>"}`` rather than
+    typed exceptions, so the only signal that a read missed because the file is
+    absent (vs. a permission / decode failure) is the message text. Used to map
+    onto qwen's ENOENT code so the model sees "file not found" rather than a
+    generic internal error.
+    """
+    lowered = message.lower()
+    return (
+        "no such file" in lowered
+        or "errno 2" in lowered
+        or "not found" in lowered
+        or "does not exist" in lowered
+    )
+
 
 # ACP protocol constants (JSON-RPC 2.0 method names)
 _AGENT_METHOD_INITIALIZE = "initialize"
@@ -161,6 +201,19 @@ class QwenExecutor(Executor):
         """
         self._cwd = cwd or os.getcwd()
         self._os_env = os_env
+        # Whether to advertise ``clientCapabilities.fs`` so qwen delegates file
+        # reads/writes back to us (executed through the Omnigent OSEnvironment,
+        # which enforces the spec's sandbox read/write roots) instead of using
+        # its own raw file tools. Enabled only when an os_env is configured and
+        # it isn't a ``fork`` env — a forked env operates on a *copied* tree
+        # whose path would diverge from the cwd the qwen subprocess actually
+        # runs in, so delegating there would read/write the wrong directory.
+        # When disabled, qwen falls back to its own file tools (see
+        # :meth:`_ensure_initialized` / :meth:`_respond_to_agent_request`).
+        self._fs_delegation: bool = os_env is not None and not bool(getattr(os_env, "fork", False))
+        # Live OSEnvironment backing fs delegation, created lazily on the first
+        # delegated op and torn down in :meth:`close`. ``None`` until then.
+        self._os_environment: OSEnvironment | None = None
         self._model = model
         self._qwen_path = qwen_path or "qwen"
         self._gateway_base_url = gateway_base_url
@@ -500,6 +553,17 @@ class QwenExecutor(Executor):
             {
                 "protocolVersion": _PROTOCOL_VERSION,
                 "clientInfo": {"name": "omnigent", "version": "1.0"},
+                # Advertise fs delegation so qwen routes file reads/writes back
+                # to us (executed via the OSEnvironment) rather than touching
+                # disk directly. qwen's AcpFileSystemService swaps in only when
+                # the matching flag is true (cli.js: ``setupFileSystem``); both
+                # false (no os_env / fork env) leaves qwen on its own tools.
+                "clientCapabilities": {
+                    "fs": {
+                        "readTextFile": self._fs_delegation,
+                        "writeTextFile": self._fs_delegation,
+                    }
+                },
             },
             timeout=_INIT_TIMEOUT_SECONDS,
         )
@@ -563,16 +627,16 @@ class QwenExecutor(Executor):
         - ``session/request_permission`` — decide via Omnigent's TOOL_CALL
           policy + human-consent elicitation (:meth:`_decide_permission`),
           then select the matching allow/reject option. NOT a blind approve.
+        - ``fs/read_text_file`` / ``fs/write_text_file`` — when fs delegation is
+          advertised (an os_env is configured; see :attr:`_fs_delegation`), qwen
+          routes its file I/O here. Executed through the Omnigent OSEnvironment
+          so the spec's sandbox read/write roots are enforced at the Python
+          layer and the I/O flows through Omnigent rather than qwen touching
+          disk directly. With delegation off, these never arrive (qwen uses its
+          own tools) and would hit the ``method not found`` branch.
         - anything else — reply with a JSON-RPC ``method not found`` error
           rather than a bogus success, so qwen fails loudly instead of acting
           on empty data.
-
-        NB: we do **not** advertise ``clientCapabilities.fs`` in ``initialize``,
-        so qwen never delegates file ops to us — it uses its own file tools, and
-        any ``fs/*`` request would hit the ``method not found`` branch. To route
-        file I/O through Omnigent, advertise the capability and add
-        ``fs/read_text_file`` / ``fs/write_text_file`` handlers (see
-        docs/QWEN_FOLLOWUPS.md).
 
         :param request: The decoded JSON-RPC request object (has ``id`` and
             ``method``).
@@ -591,11 +655,19 @@ class QwenExecutor(Executor):
             if method == "session/request_permission":
                 allow = await self._decide_permission(params)
                 result = {"outcome": self._permission_outcome(params, allow=allow)}
+            elif method == "fs/read_text_file" and self._fs_delegation:
+                result = await self._handle_fs_read(params)
+            elif method == "fs/write_text_file" and self._fs_delegation:
+                result = await self._handle_fs_write(params)
             else:
                 error = {
                     "code": -32601,
                     "message": f"omnigent: unsupported ACP request method {method!r}",
                 }
+        except _AcpRequestError as exc:
+            # A handler-raised, client-facing failure (e.g. file not found):
+            # forward its specific code/message so qwen maps it correctly.
+            error = {"code": exc.code, "message": exc.message}
         except Exception as exc:  # noqa: BLE001
             logger.debug("qwen agent request %s failed: %s", method, exc)
             error = {"code": -32603, "message": f"{method} failed: {exc}"}
@@ -606,6 +678,83 @@ class QwenExecutor(Executor):
         else:
             reply["result"] = result
         await self._send(reply)
+
+    # ------------------------------------------------------------------
+    # Filesystem delegation (qwen → client, when fs capability advertised)
+    # ------------------------------------------------------------------
+
+    async def _ensure_os_environment(self) -> OSEnvironment:
+        """Lazily create the OSEnvironment backing fs delegation.
+
+        Created on the first delegated op (not at construction) so a turn that
+        never touches files pays nothing, and torn down in :meth:`close`.
+
+        :returns: The live OSEnvironment for this executor's os_env spec.
+        :raises _AcpRequestError: When no usable os_env can be created — surfaced
+            to qwen as an internal error rather than crashing the turn.
+        """
+        if self._os_environment is None:
+            env = create_os_environment(self._os_env)
+            if env is None:
+                raise _AcpRequestError(-32603, "omnigent: no os_env for fs delegation")
+            self._os_environment = env
+        return self._os_environment
+
+    async def _handle_fs_read(self, params: dict[str, Any]) -> dict[str, Any]:  # type: ignore[explicit-any]
+        """Serve an ACP ``fs/read_text_file`` by reading through the OSEnvironment.
+
+        ACP params: ``{path, line?, limit?}`` where ``line`` is a 1-based start
+        line and ``limit`` a max line count (both optional → whole file). Maps
+        onto :meth:`OSEnvironment.read`'s ``offset`` / ``limit``.
+
+        :param params: The request params.
+        :returns: ``{"content": <text>}`` per the ACP response shape.
+        :raises _AcpRequestError: On a missing path arg, a non-text/binary file,
+            or a read failure (mapped to ENOENT when it looks like a missing
+            file so qwen raises the right error to the model).
+        """
+        path = params.get("path")
+        if not isinstance(path, str) or not path:
+            raise _AcpRequestError(-32602, "fs/read_text_file requires a string 'path'")
+        line = params.get("line")
+        limit = params.get("limit")
+        offset = line if isinstance(line, int) and line >= 1 else 1
+        read_limit = limit if isinstance(limit, int) and limit >= 1 else None
+
+        env = await self._ensure_os_environment()
+        result = await env.read(path, offset=offset, limit=read_limit)
+        if "error" in result:
+            message = str(result["error"])
+            code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+            raise _AcpRequestError(code, message)
+        # A binary file comes back base64-encoded (or descriptor-only); ACP
+        # read_text_file is text-only, so refuse rather than hand back bytes.
+        if result.get("encoding") != "utf-8":
+            raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
+        return {"content": result.get("content", "")}
+
+    async def _handle_fs_write(self, params: dict[str, Any]) -> dict[str, Any]:  # type: ignore[explicit-any]
+        """Serve an ACP ``fs/write_text_file`` by writing through the OSEnvironment.
+
+        ACP params: ``{path, content}``. The write goes through the helper, so
+        the spec's sandbox write roots are enforced at the Python layer.
+
+        :param params: The request params.
+        :returns: An empty result object (ACP expects no payload on success).
+        :raises _AcpRequestError: On missing/invalid args or a write failure.
+        """
+        path = params.get("path")
+        content = params.get("content")
+        if not isinstance(path, str) or not path:
+            raise _AcpRequestError(-32602, "fs/write_text_file requires a string 'path'")
+        if not isinstance(content, str):
+            raise _AcpRequestError(-32602, "fs/write_text_file requires string 'content'")
+
+        env = await self._ensure_os_environment()
+        result = await env.write(path, content)
+        if "error" in result:
+            raise _AcpRequestError(-32603, str(result["error"]))
+        return {}
 
     @staticmethod
     def _extract_tool_call(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:  # type: ignore[explicit-any]
@@ -1143,6 +1292,13 @@ class QwenExecutor(Executor):
             with contextlib.suppress(asyncio.CancelledError):
                 await self._stderr_task
             self._stderr_task = None
+
+        # Release the fs-delegation OSEnvironment's helper subprocess, if one
+        # was spawned for a delegated file op this session.
+        if self._os_environment is not None:
+            with contextlib.suppress(Exception):
+                self._os_environment.close()
+            self._os_environment = None
 
         if self._proc:
             with contextlib.suppress(Exception):

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -262,6 +262,184 @@ async def test_respond_to_unknown_method_returns_jsonrpc_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Filesystem delegation (fs/read_text_file, fs/write_text_file)
+# ---------------------------------------------------------------------------
+
+
+class _FakeOSEnv:
+    """Minimal OSEnvironment stand-in capturing read/write calls."""
+
+    def __init__(self, read_result: dict | None = None, write_result: dict | None = None) -> None:
+        self._read_result = read_result if read_result is not None else {}
+        self._write_result = write_result if write_result is not None else {}
+        self.read_calls: list[tuple] = []
+        self.write_calls: list[tuple] = []
+        self.closed = False
+
+    async def read(self, path: str, offset: int = 1, limit: int | None = None) -> dict:
+        self.read_calls.append((path, offset, limit))
+        return self._read_result
+
+    async def write(self, path: str, content: str) -> dict:
+        self.write_calls.append((path, content))
+        return self._write_result
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_fs_delegation_flag_tracks_os_env() -> None:
+    """Delegation is on with an os_env, off without one or for a fork env."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    assert GooseExecutor()._fs_delegation is False
+    assert GooseExecutor(os_env=OSEnvSpec(type="caller_process"))._fs_delegation is True
+    assert (
+        GooseExecutor(os_env=OSEnvSpec(type="caller_process", fork=True))._fs_delegation is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_advertises_fs_capability_per_delegation() -> None:
+    """initialize advertises clientCapabilities.fs matching the delegation flag."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    init_result = {"result": {"agentCapabilities": {"promptCapabilities": {}}}}
+
+    on = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    on._rpc = AsyncMock(return_value=init_result)  # type: ignore[method-assign]
+    await on._ensure_initialized()
+    assert on._rpc.call_args.args[1]["clientCapabilities"]["fs"] == {
+        "readTextFile": True,
+        "writeTextFile": True,
+    }
+
+    off = GooseExecutor()
+    off._rpc = AsyncMock(return_value=init_result)  # type: ignore[method-assign]
+    await off._ensure_initialized()
+    assert off._rpc.call_args.args[1]["clientCapabilities"]["fs"] == {
+        "readTextFile": False,
+        "writeTextFile": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fs_read_returns_content_and_maps_window() -> None:
+    """fs/read_text_file reads through the OSEnvironment; line/limit → offset/limit."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(read_result={"content": "hi\n", "encoding": "utf-8"})
+    executor._os_environment = fake  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "fs/read_text_file",
+            "params": {"path": "a.txt", "line": 2, "limit": 5},
+        }
+    )
+
+    assert sent[0]["result"] == {"content": "hi\n"}
+    assert fake.read_calls == [("a.txt", 2, 5)]
+
+
+@pytest.mark.asyncio
+async def test_fs_read_missing_file_maps_to_enoent() -> None:
+    """A 'no such file' read error maps to the ENOENT code (-32002)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"error": "[Errno 2] No such file or directory: 'gone.txt'"}
+    )
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 5, "method": "fs/read_text_file", "params": {"path": "gone.txt"}}
+    )
+
+    assert sent[0]["error"]["code"] == -32002
+
+
+@pytest.mark.asyncio
+async def test_fs_read_binary_file_is_rejected() -> None:
+    """A non-utf-8 (binary) file is refused rather than returned as bytes."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "AAAA", "encoding": "base64"}
+    )
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 6, "method": "fs/read_text_file", "params": {"path": "img.png"}}
+    )
+
+    assert sent[0]["error"]["code"] == -32603
+
+
+@pytest.mark.asyncio
+async def test_fs_write_writes_through_os_env() -> None:
+    """fs/write_text_file writes via the OSEnvironment and returns an empty result."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={"path": "out.txt"})
+    executor._os_environment = fake  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "abc"},
+        }
+    )
+
+    assert sent[0]["result"] == {}
+    assert fake.write_calls == [("out.txt", "abc")]
+
+
+@pytest.mark.asyncio
+async def test_fs_unsupported_when_delegation_off() -> None:
+    """Without an os_env, fs/* is method-not-found (delegation not advertised)."""
+    executor = GooseExecutor()  # no os_env
+    assert executor._fs_delegation is False
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 7, "method": "fs/read_text_file", "params": {"path": "/x"}}
+    )
+
+    assert sent[0]["error"]["code"] == -32601
+
+
+@pytest.mark.asyncio
+async def test_close_releases_fs_os_environment() -> None:
+    """close() tears down a lazily-created fs-delegation OSEnvironment."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv()
+    executor._os_environment = fake  # type: ignore[assignment]
+
+    await executor.close()
+
+    assert fake.closed is True
+    assert executor._os_environment is None
+
+
+# ---------------------------------------------------------------------------
 # run_turn streaming
 # ---------------------------------------------------------------------------
 

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -1230,14 +1230,16 @@ async def test_run_turn_no_replay_on_genuine_first_turn() -> None:
 
 
 @pytest.mark.asyncio
-async def test_respond_to_fs_read_text_file_is_unsupported() -> None:
-    """fs/* is intentionally unsupported (no clientCapabilities.fs advertised).
+async def test_respond_to_fs_read_text_file_unsupported_without_os_env() -> None:
+    """fs/* is method-not-found when fs delegation isn't advertised.
 
-    qwen never delegates file ops to us, so the handlers were removed; an
-    ``fs/read_text_file`` request must get a JSON-RPC method-not-found error
+    With no os_env configured, ``_fs_delegation`` is False and we never
+    advertise ``clientCapabilities.fs``, so qwen uses its own file tools. A
+    stray ``fs/read_text_file`` must get a JSON-RPC method-not-found error
     rather than a fabricated (and dangerous) empty/real-file response.
     """
-    executor = QwenExecutor()
+    executor = QwenExecutor()  # no os_env → delegation off
+    assert executor._fs_delegation is False
     sent: list[dict] = []
     executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
 
@@ -1248,6 +1250,228 @@ async def test_respond_to_fs_read_text_file_is_unsupported() -> None:
     assert sent[0]["id"] == 7
     assert sent[0]["error"]["code"] == -32601
     assert "result" not in sent[0]
+
+
+# ---------------------------------------------------------------------------
+# Filesystem delegation (fs/read_text_file, fs/write_text_file)
+# ---------------------------------------------------------------------------
+
+
+class _FakeOSEnv:
+    """Minimal OSEnvironment stand-in capturing read/write calls."""
+
+    def __init__(self, read_result: dict | None = None, write_result: dict | None = None) -> None:
+        self._read_result = read_result if read_result is not None else {}
+        self._write_result = write_result if write_result is not None else {}
+        self.read_calls: list[tuple] = []
+        self.write_calls: list[tuple] = []
+        self.closed = False
+
+    async def read(self, path: str, offset: int = 1, limit: int | None = None) -> dict:
+        self.read_calls.append((path, offset, limit))
+        return self._read_result
+
+    async def write(self, path: str, content: str) -> dict:
+        self.write_calls.append((path, content))
+        return self._write_result
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_fs_delegation_flag_tracks_os_env() -> None:
+    """Delegation is on with an os_env, off without one or for a fork env."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    assert QwenExecutor()._fs_delegation is False  # no os_env
+    assert QwenExecutor(os_env=OSEnvSpec(type="caller_process"))._fs_delegation is True
+    # A fork env operates on a copied tree → path would diverge from the qwen
+    # subprocess cwd, so delegation must stay off.
+    assert QwenExecutor(os_env=OSEnvSpec(type="caller_process", fork=True))._fs_delegation is False
+
+
+@pytest.mark.asyncio
+async def test_initialize_advertises_fs_capability_per_delegation() -> None:
+    """initialize advertises clientCapabilities.fs matching the delegation flag."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    init_result = {"result": {"agentCapabilities": {"promptCapabilities": {}}}}
+
+    # Delegation ON (os_env configured).
+    on = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    on._rpc = AsyncMock(return_value=init_result)  # type: ignore[method-assign]
+    await on._ensure_initialized()
+    caps = on._rpc.call_args.args[1]["clientCapabilities"]["fs"]
+    assert caps == {"readTextFile": True, "writeTextFile": True}
+
+    # Delegation OFF (no os_env).
+    off = QwenExecutor()
+    off._rpc = AsyncMock(return_value=init_result)  # type: ignore[method-assign]
+    await off._ensure_initialized()
+    caps = off._rpc.call_args.args[1]["clientCapabilities"]["fs"]
+    assert caps == {"readTextFile": False, "writeTextFile": False}
+
+
+@pytest.mark.asyncio
+async def test_fs_read_returns_content_and_maps_window() -> None:
+    """fs/read_text_file reads through the OSEnvironment; line/limit → offset/limit."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(read_result={"content": "hello\nworld\n", "encoding": "utf-8"})
+    executor._os_environment = fake  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "fs/read_text_file",
+            "params": {"path": "a.txt", "line": 2, "limit": 5},
+        }
+    )
+
+    assert sent[0]["result"] == {"content": "hello\nworld\n"}
+    assert fake.read_calls == [("a.txt", 2, 5)]  # line→offset, limit→limit
+
+
+@pytest.mark.asyncio
+async def test_fs_read_whole_file_when_no_window() -> None:
+    """Absent line/limit reads the whole file (offset=1, limit=None)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(read_result={"content": "x", "encoding": "utf-8"})
+    executor._os_environment = fake  # type: ignore[assignment]
+    executor._send = AsyncMock()  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    assert fake.read_calls == [("a.txt", 1, None)]
+
+
+@pytest.mark.asyncio
+async def test_fs_read_missing_file_maps_to_enoent() -> None:
+    """A 'no such file' read error maps to qwen's ENOENT code (-32002)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"error": "[Errno 2] No such file or directory: 'gone.txt'"}
+    )
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 5, "method": "fs/read_text_file", "params": {"path": "gone.txt"}}
+    )
+
+    assert sent[0]["error"]["code"] == -32002
+    assert "result" not in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_fs_read_binary_file_is_rejected() -> None:
+    """A non-utf-8 (binary) file is refused rather than returned as bytes."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "AAAA", "encoding": "base64", "total_bytes": 3}
+    )
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 6, "method": "fs/read_text_file", "params": {"path": "img.png"}}
+    )
+
+    assert sent[0]["error"]["code"] == -32603
+    assert "text file" in sent[0]["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_fs_write_writes_through_os_env() -> None:
+    """fs/write_text_file writes via the OSEnvironment and returns an empty result."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={"path": "out.txt", "bytes": 3})
+    executor._os_environment = fake  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "abc"},
+        }
+    )
+
+    assert sent[0]["result"] == {}
+    assert fake.write_calls == [("out.txt", "abc")]
+
+
+@pytest.mark.asyncio
+async def test_fs_write_error_surfaces_as_internal_error() -> None:
+    """A write failure surfaces as a JSON-RPC internal error (-32603)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        write_result={"error": "Permission denied"}
+    )
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "abc"},
+        }
+    )
+
+    assert sent[0]["error"]["code"] == -32603
+    assert "Permission denied" in sent[0]["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_fs_write_rejects_missing_args() -> None:
+    """Missing path / non-string content is an invalid-params error (-32602)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv()  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 10, "method": "fs/write_text_file", "params": {"path": "out.txt"}}
+    )
+
+    assert sent[0]["error"]["code"] == -32602
+
+
+@pytest.mark.asyncio
+async def test_close_releases_fs_os_environment() -> None:
+    """close() tears down a lazily-created fs-delegation OSEnvironment."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv()
+    executor._os_environment = fake  # type: ignore[assignment]
+
+    await executor.close()
+
+    assert fake.closed is True
+    assert executor._os_environment is None
 
 
 # Realistic qwen session/request_permission payload (from the ACP probe).


### PR DESCRIPTION
## What

When an `os_env` is configured, the ACP harnesses (**qwen** and **goose**) now advertise `clientCapabilities.fs` in `initialize`, so the agent routes its file reads/writes back to us as `fs/read_text_file` / `fs/write_text_file` requests instead of touching disk directly. The agent's `AcpFileSystemService` swaps in its delegating file service only when this capability is set (qwen cli.js: `setupFileSystem`), so previously the agents used their own raw file tools and the I/O never passed through Omnigent.

## How it works

- **`initialize`** advertises `fs: {readTextFile, writeTextFile}` = the delegation flag.
- **`_handle_fs_read` / `_handle_fs_write`** execute the I/O through the Omnigent `OSEnvironment`, so the spec's sandbox **read/write roots are enforced at the Python layer** and the bytes flow through Omnigent rather than the agent touching disk directly.
- **Delegation is off** (agent uses its own tools, current behavior) when there's **no `os_env`** or it's a **`fork` env** — a forked tree operates on a *copy* whose path would diverge from the subprocess cwd, so delegating there would read/write the wrong directory.
- **Mapping & errors:** ACP `{path, line?, limit?}` → `OSEnvironment.read(offset, limit)`; whole-file when no window. Binary / non-UTF-8 reads are **refused** (ACP read is text-only); missing-file reads map to the ACP **ENOENT code (`-32002`)** so the model sees "file not found". The `OSEnvironment` is created **lazily** on the first delegated op and torn down in `close()`.

## Out of scope (follow-ups)

This lands the byte-level execution hook. Two layers build on top and remain pending (narrowed in `docs/QWEN_FOLLOWUPS.md`): (a) emitting the I/O into Omnigent's event stream (recording in history), and (b) TOOL_RESULT-phase content policy on the read/written bytes.

## Testing

- 10 new qwen tests + 8 new goose tests: capability advertisement per delegation flag, fork-disables-delegation, line/limit→offset/limit mapping, whole-file read, ENOENT mapping, binary rejection, write + write-error, invalid-args, and `close()` teardown.
- `tests/inner/test_qwen_executor.py tests/inner/test_goose_executor.py` — 137 passed.
- ruff format + check clean; no lock-file changes.

Applied to both ACP harnesses since they share the identical dispatch pattern (same as the history-replay change).