### PR TITLE
fix(cli): add explicit daemon env passthrough

### DIFF
--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -258,15 +258,15 @@ network_policies:
 ```
 
 > [!IMPORTANT]
-> **Forward the proxy vars to the runner.** The host inherits the sandbox's
-> `https_proxy`/`http_proxy`, but the runner subprocess it spawns does **not** —
-> so the runner fails with `Temporary failure in name resolution` even though the
-> host connected. Inject `OMNIGENT_RUNNER_ENV_PASSTHROUGH` naming the proxy vars so
-> the host forwards them:
+> **Forward the proxy vars to the daemon and the runner.** The local host daemon
+> may need the proxy before any runner exists (for example, to reach a model
+> backend while booting), and the runner subprocess it spawns does **not** inherit
+> arbitrary proxy vars either. Inject both passthrough knobs naming the proxy vars:
 > ```yaml
 > sandbox:
 >   openshell:
->     env: [OMNIGENT_RUNNER_ENV_PASSTHROUGH, …]   # value set in the server env:
+>     env: [OMNIGENT_DAEMON_ENV_PASSTHROUGH, OMNIGENT_RUNNER_ENV_PASSTHROUGH, …]
+> # OMNIGENT_DAEMON_ENV_PASSTHROUGH=https_proxy,http_proxy,HTTPS_PROXY,HTTP_PROXY,NO_PROXY,no_proxy
 > # OMNIGENT_RUNNER_ENV_PASSTHROUGH=https_proxy,http_proxy,HTTPS_PROXY,HTTP_PROXY,NO_PROXY,no_proxy
 > ```
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -273,6 +273,11 @@ _LOCAL_DAEMON_ENV_PREFIXES: tuple[str, ...] = (
     "OMNIGENT_",
     "OPENAI_",
 )
+# Comma-separated EXTRA env var names to forward CLI -> host daemon, beyond the
+# standard local-daemon allowlists. Mirrors the runner-side passthrough and keeps
+# daemon forwarding opt-in for names like corporate proxy vars that are not safe
+# to universally inherit by default.
+DAEMON_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_DAEMON_ENV_PASSTHROUGH"
 _HostJsonValue: TypeAlias = (
     str | int | float | bool | None | list["_HostJsonValue"] | dict[str, "_HostJsonValue"]
 )
@@ -2265,6 +2270,12 @@ def _build_host_daemon_env(
         _RUNNER_ENV_ALLOWLIST_PREFIXES,
     )
 
+    extra_names = {
+        name.strip()
+        for name in os.environ.get(DAEMON_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
+        if name.strip()
+    }
+
     if not server_url:
         daemon_env_prefixes = (*_RUNNER_ENV_ALLOWLIST_PREFIXES, *_LOCAL_DAEMON_ENV_PREFIXES)
         env = {
@@ -2272,6 +2283,7 @@ def _build_host_daemon_env(
             for key, value in os.environ.items()
             if key in _RUNNER_ENV_ALLOWLIST
             or key in _LOCAL_DAEMON_ENV_ALLOWLIST
+            or key in extra_names
             or key.startswith(daemon_env_prefixes)
         }
     else:
@@ -2283,7 +2295,9 @@ def _build_host_daemon_env(
         env = {
             key: value
             for key, value in os.environ.items()
-            if key in _RUNNER_ENV_ALLOWLIST or key.startswith(daemon_env_prefixes)
+            if key in _RUNNER_ENV_ALLOWLIST
+            or key in extra_names
+            or key.startswith(daemon_env_prefixes)
         }
     return env
 

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -233,6 +233,43 @@ def test_build_host_daemon_env_local_preserves_server_credentials(
     assert empty_string_env["OPENAI_API_KEY"] == "test-key"
 
 
+def test_build_host_daemon_env_local_passthrough_extends_forwarded_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OMNIGENT_DAEMON_ENV_PASSTHROUGH opt-in forwards extra daemon vars.
+
+    Covers corporate-proxy style env vars that the local host daemon may need
+    before any runner exists, while keeping unrelated shell secrets blocked by
+    default.
+    """
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("OMNIGENT_DAEMON_ENV_PASSTHROUGH", "HTTPS_PROXY, NO_PROXY")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1")
+    monkeypatch.setenv("UNLISTED_SECRET", "nope")
+
+    env = _build_host_daemon_env(server_url=None)
+
+    assert env["HTTPS_PROXY"] == "http://proxy.example.com:3128"
+    assert env["NO_PROXY"] == "localhost,127.0.0.1"
+    assert "UNLISTED_SECRET" not in env
+
+
+def test_build_host_daemon_env_remote_passthrough_extends_forwarded_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote daemons also honor the explicit daemon passthrough set."""
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("OMNIGENT_DAEMON_ENV_PASSTHROUGH", "HTTPS_PROXY")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
+    monkeypatch.setenv("UNLISTED_SECRET", "nope")
+
+    env = _build_host_daemon_env(server_url="https://example.databricksapps.com")
+
+    assert env["HTTPS_PROXY"] == "http://proxy.example.com:3128"
+    assert "UNLISTED_SECRET" not in env
+
+
 def test_build_host_daemon_env_remote_strips_provider_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #1022.

The host daemon and the runner had asymmetric env-forwarding knobs:

- runners already support explicit extras via `OMNIGENT_RUNNER_ENV_PASSTHROUGH`
- the host daemon only inherited the fixed allowlists

That meant standard proxy vars such as `HTTPS_PROXY` could be forwarded to runners, but there was no equivalent opt-in path for the daemon itself. In setups where the daemon must reach the model backend before any runner exists, the daemon could still fail while the runner-side passthrough remained irrelevant.

This PR adds a daemon-side opt-in passthrough:

- new `OMNIGENT_DAEMON_ENV_PASSTHROUGH` in `omnigent/cli.py`
- `_build_host_daemon_env()` now forwards explicitly named extra vars in both local-daemon and remote-daemon modes
- unchanged default security posture: nothing new is forwarded unless the operator names it
- deploy docs updated to show forwarding proxy vars to both the daemon and the runner when needed

## Validation

- `uv run pytest tests/cli/test_backend.py -q -k daemon_env`
- `uv run pytest tests/host/test_connect.py -q -k passthrough`
- `uv run ruff check omnigent/cli.py tests/cli/test_backend.py`

## Details

- Added local-mode coverage proving `OMNIGENT_DAEMON_ENV_PASSTHROUGH=HTTPS_PROXY,NO_PROXY` forwards only those vars.
- Added remote-mode coverage proving the same passthrough works for remote daemons too.
- Left unrelated secrets blocked unless explicitly named.
