### PR TITLE
feat(chat): pin pending elicitation cards above the composer

### DIFF
--- a/ap-web/src/components/blocks/ApprovalCard.tsx
+++ b/ap-web/src/components/blocks/ApprovalCard.tsx
@@ -49,6 +49,7 @@ import {
   parseAskUserQuestionPreview,
 } from "@/lib/askUserQuestion";
 import { formatPreview } from "@/lib/previewFormat";
+import type { RenderItem } from "@/lib/renderItems";
 import type { RememberScope } from "@/lib/types";
 import { useChatStore } from "@/store/chatStore";
 import { AskUserQuestionForm, type AskUserQuestionAnswers } from "./AskUserQuestionForm";
@@ -546,5 +547,40 @@ export function ApprovalCard({
         )}
       </AlertDescription>
     </Alert>
+  );
+}
+
+/**
+ * Render an elicitation ``RenderItem`` as an ``ApprovalCard``. The prop
+ * mapping lives here, in one place, so the two callers stay in sync:
+ * ``BlockRenderer`` (inline in the message stream) and ``ChatPage``'s
+ * pinned tray (pending cards lifted above the composer). Pass ``onSubmit``
+ * to route the verdict somewhere other than the active chat store.
+ */
+export function ElicitationCard({
+  item,
+  onSubmit,
+}: {
+  item: Extract<RenderItem, { kind: "elicitation" }>;
+  onSubmit?: SubmitApprovalFn;
+}) {
+  return (
+    <ApprovalCard
+      elicitationId={item.elicitationId}
+      message={item.message}
+      phase={item.phase}
+      policyName={item.policyName}
+      contentPreview={item.contentPreview}
+      requestedSchema={item.requestedSchema}
+      url={item.url}
+      status={item.status}
+      response={item.response}
+      askUserQuestion={item.askUserQuestion}
+      exitPlanMode={item.exitPlanMode}
+      codexCommand={item.codexCommand}
+      allowAllEdits={item.allowAllEdits}
+      rememberScope={item.rememberScope}
+      onSubmit={onSubmit}
+    />
   );
 }

--- a/ap-web/src/components/blocks/BlockRenderer.tsx
+++ b/ap-web/src/components/blocks/BlockRenderer.tsx
@@ -30,7 +30,7 @@ import {
   useWorkspacePaths,
 } from "@/shell/FileViewerContext";
 import { toWorkspaceRelativePath, useWorkspaceFileExists } from "@/hooks/useWorkspaceChangedFiles";
-import { ApprovalCard } from "./ApprovalCard";
+import { ElicitationCard } from "./ApprovalCard";
 import { ReasoningView } from "./ReasoningView";
 import { SlashCommandCard } from "./SlashCommandCard";
 import { TerminalCommandCard } from "./TerminalCommandCard";
@@ -467,25 +467,7 @@ function renderItem(item: RenderItem, index: number, isReasoningStreaming: boole
         />
       );
     case "elicitation":
-      return (
-        <ApprovalCard
-          key={key}
-          elicitationId={item.elicitationId}
-          message={item.message}
-          phase={item.phase}
-          policyName={item.policyName}
-          contentPreview={item.contentPreview}
-          requestedSchema={item.requestedSchema}
-          url={item.url}
-          status={item.status}
-          response={item.response}
-          askUserQuestion={item.askUserQuestion}
-          exitPlanMode={item.exitPlanMode}
-          codexCommand={item.codexCommand}
-          allowAllEdits={item.allowAllEdits}
-          rememberScope={item.rememberScope}
-        />
-      );
+      return <ElicitationCard key={key} item={item} />;
   }
 }
 

--- a/ap-web/src/components/blocks/ExitPlanModeReview.tsx
+++ b/ap-web/src/components/blocks/ExitPlanModeReview.tsx
@@ -46,7 +46,12 @@ export function ExitPlanModeReview({
 
   return (
     <div className="flex flex-col gap-2" data-testid="exit-plan-mode-review">
-      <div className="text-sm">
+      {/* text-foreground: the plan body is the card's primary content, so it
+          renders in normal text color like a regular assistant message —
+          escaping AlertDescription's muted default (which otherwise washes
+          the whole plan out). The short lead-in caption above stays muted
+          for hierarchy, matching the Codex command card. */}
+      <div className="text-sm text-foreground">
         <MessageResponse>{plan}</MessageResponse>
       </div>
       {rejecting ? (

--- a/ap-web/src/pages/ChatPage.test.ts
+++ b/ap-web/src/pages/ChatPage.test.ts
@@ -23,7 +23,7 @@ import {
   shouldShowWorkingIndicator,
   shouldShowTerminalSurface,
   splitSlashCommand,
-  stripPinnedElicitations,
+  stripPendingElicitations,
   subAgentComposerLabel,
 } from "./ChatPage";
 
@@ -537,31 +537,31 @@ describe("collectPendingElicitations", () => {
   });
 });
 
-describe("stripPinnedElicitations", () => {
+describe("stripPendingElicitations", () => {
   it("removes a pending card but keeps the trailing text in the same bubble", () => {
     // The motivating case: the agent emits a card AND a bunch of text. The
-    // card is pinned (removed here); the text stays inline.
+    // card floats to the bottom (removed here); the text stays inline.
     const bubbles = [assistantWith("a1", [elicitItem("e1", "pending"), textItem("t1")])];
-    const stripped = stripPinnedElicitations(bubbles);
+    const stripped = stripPendingElicitations(bubbles);
     const a1 = stripped[0] as Extract<Bubble, { kind: "assistant" }>;
     expect(a1.items.map((it) => it.kind)).toEqual(["text"]);
   });
 
   it("leaves answered cards inline", () => {
     const bubbles = [assistantWith("a1", [elicitItem("e1", "responded")])];
-    const stripped = stripPinnedElicitations(bubbles);
+    const stripped = stripPendingElicitations(bubbles);
     expect(stripped).toBe(bubbles);
   });
 
-  it("returns the same array reference when nothing is pinned (memo stability)", () => {
+  it("returns the same array reference when nothing is pending (memo stability)", () => {
     const bubbles = [userBubble("u1"), assistantText("a1")];
-    expect(stripPinnedElicitations(bubbles)).toBe(bubbles);
+    expect(stripPendingElicitations(bubbles)).toBe(bubbles);
   });
 
   it("clones only the affected bubble and keeps other references intact", () => {
     const a1 = assistantText("a1");
     const a2 = assistantWith("a2", [elicitItem("e2", "pending")]);
-    const stripped = stripPinnedElicitations([a1, a2]);
+    const stripped = stripPendingElicitations([a1, a2]);
     expect(stripped[0]).toBe(a1);
     expect(stripped[1]).not.toBe(a2);
     expect((stripped[1] as Extract<Bubble, { kind: "assistant" }>).items).toEqual([]);

--- a/ap-web/src/pages/ChatPage.test.ts
+++ b/ap-web/src/pages/ChatPage.test.ts
@@ -8,6 +8,7 @@ import {
   buildSlashCommandMap,
   buildSlashCommandWithArgsSet,
   collectBubbleMarkdown,
+  collectPendingElicitations,
   computeIsWorking,
   computeShowsWorking,
   containsMarkdownTable,
@@ -22,6 +23,7 @@ import {
   shouldShowWorkingIndicator,
   shouldShowTerminalSurface,
   splitSlashCommand,
+  stripPinnedElicitations,
   subAgentComposerLabel,
 } from "./ChatPage";
 
@@ -478,6 +480,91 @@ describe("reorderCommittedRequestElicitations", () => {
     const result = reorderCommittedRequestElicitations(committed);
     expect(result).toBe(committed);
     expect(bubbleIds(result)).toEqual(["e1", "u1"]);
+  });
+});
+
+// ── pinned elicitations ─────────────────────────────────────────────────────
+
+// Assistant bubble carrying arbitrary render items — lets these tests mix a
+// card with trailing text (the "card + a bunch of text" case that motivated
+// pinning) and toggle a card's answered status.
+const assistantWith = (id: string, items: RenderItem[]): Bubble => ({
+  kind: "assistant",
+  responseId: id,
+  stableId: id,
+  lifecycle: "completed",
+  error: null,
+  items,
+});
+const textItem = (id: string): RenderItem => ({ kind: "text", itemId: id, text: "hi", final: true });
+const elicitItem = (id: string, status: "pending" | "responded"): RenderItem => ({
+  kind: "elicitation",
+  itemId: id,
+  elicitationId: id,
+  message: "Continue?",
+  phase: "tool_call",
+  policyName: "p",
+  contentPreview: "{}",
+  requestedSchema: {},
+  status,
+  response: status === "responded" ? { action: "accept" } : null,
+});
+const pendingIds = (items: RenderItem[]): string[] =>
+  items.map((it) => (it.kind === "elicitation" ? it.elicitationId : ""));
+
+describe("collectPendingElicitations", () => {
+  it("collects pending cards across bubbles in document order (newest last)", () => {
+    const bubbles = [
+      assistantWith("a1", [elicitItem("e1", "pending")]),
+      userBubble("u1"),
+      assistantWith("a2", [textItem("t1"), elicitItem("e2", "pending")]),
+    ];
+    expect(pendingIds(collectPendingElicitations(bubbles))).toEqual(["e1", "e2"]);
+  });
+
+  it("ignores answered cards and user bubbles", () => {
+    const bubbles = [
+      userBubble("u1"),
+      assistantWith("a1", [elicitItem("e1", "responded")]),
+      assistantWith("a2", [elicitItem("e2", "pending")]),
+    ];
+    expect(pendingIds(collectPendingElicitations(bubbles))).toEqual(["e2"]);
+  });
+
+  it("returns an empty list when nothing is pending", () => {
+    const bubbles = [userBubble("u1"), assistantText("a1")];
+    expect(collectPendingElicitations(bubbles)).toEqual([]);
+  });
+});
+
+describe("stripPinnedElicitations", () => {
+  it("removes a pending card but keeps the trailing text in the same bubble", () => {
+    // The motivating case: the agent emits a card AND a bunch of text. The
+    // card is pinned (removed here); the text stays inline.
+    const bubbles = [assistantWith("a1", [elicitItem("e1", "pending"), textItem("t1")])];
+    const stripped = stripPinnedElicitations(bubbles);
+    const a1 = stripped[0] as Extract<Bubble, { kind: "assistant" }>;
+    expect(a1.items.map((it) => it.kind)).toEqual(["text"]);
+  });
+
+  it("leaves answered cards inline", () => {
+    const bubbles = [assistantWith("a1", [elicitItem("e1", "responded")])];
+    const stripped = stripPinnedElicitations(bubbles);
+    expect(stripped).toBe(bubbles);
+  });
+
+  it("returns the same array reference when nothing is pinned (memo stability)", () => {
+    const bubbles = [userBubble("u1"), assistantText("a1")];
+    expect(stripPinnedElicitations(bubbles)).toBe(bubbles);
+  });
+
+  it("clones only the affected bubble and keeps other references intact", () => {
+    const a1 = assistantText("a1");
+    const a2 = assistantWith("a2", [elicitItem("e2", "pending")]);
+    const stripped = stripPinnedElicitations([a1, a2]);
+    expect(stripped[0]).toBe(a1);
+    expect(stripped[1]).not.toBe(a2);
+    expect((stripped[1] as Extract<Bubble, { kind: "assistant" }>).items).toEqual([]);
   });
 });
 

--- a/ap-web/src/pages/ChatPage.test.ts
+++ b/ap-web/src/pages/ChatPage.test.ts
@@ -496,7 +496,12 @@ const assistantWith = (id: string, items: RenderItem[]): Bubble => ({
   error: null,
   items,
 });
-const textItem = (id: string): RenderItem => ({ kind: "text", itemId: id, text: "hi", final: true });
+const textItem = (id: string): RenderItem => ({
+  kind: "text",
+  itemId: id,
+  text: "hi",
+  final: true,
+});
 const elicitItem = (id: string, status: "pending" | "responded"): RenderItem => ({
   kind: "elicitation",
   itemId: id,

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -316,19 +316,19 @@ export function mergePendingBubbles(committed: Bubble[], pending: Bubble[]): Bub
 
 type ElicitationItem = Extract<RenderItem, { kind: "elicitation" }>;
 
-// A pending elicitation is unanswered — only these are pinned.
+// A pending elicitation is unanswered — only these float to the bottom.
 function isPendingElicitation(item: RenderItem): item is ElicitationItem {
   return item.kind === "elicitation" && item.status === "pending";
 }
 
-// Pending elicitation cards are lifted out of the scrolling transcript and
-// pinned in a tray above the composer, so an outstanding question stays
-// reachable no matter how much text the agent streams after it (otherwise
-// stick-to-bottom scrolls the card up off the top of the viewport).
-// Collect them in document order: oldest first, so the newest pending card
-// sits at the BOTTOM of the stack, nearest the composer. Once answered, a
-// card drops out of this list (status flips to "responded") and flows back
-// into the transcript inline via `stripPinnedElicitations`.
+// Pending elicitation cards float to the bottom of the chat: lifted out of
+// their inline position and re-rendered as the last items in the scroll flow,
+// so stick-to-bottom keeps an outstanding question in view no matter how much
+// text the agent streams after it (otherwise the card scrolls up off the top
+// of the viewport). Collect them in document order — oldest first, so the
+// newest sits last, closest to the composer. Once answered, a card drops out
+// of this list (status flips to "responded") and stays inline at its natural
+// spot (it is no longer removed by `stripPendingElicitations`).
 export function collectPendingElicitations(bubbles: Bubble[]): ElicitationItem[] {
   const pending: ElicitationItem[] = [];
   for (const bubble of bubbles) {
@@ -340,15 +340,15 @@ export function collectPendingElicitations(bubbles: Bubble[]): ElicitationItem[]
   return pending;
 }
 
-// Drop the pinned (pending) elicitation cards from the transcript bubbles so
-// they don't render twice — once in the tray, once inline. Only clones the
-// assistant bubbles that actually carry a pinned card; every other bubble
+// Drop the pending elicitation cards from the transcript bubbles so they
+// don't render twice — once at the bottom, once inline. Only clones the
+// assistant bubbles that actually carry a pending card; every other bubble
 // keeps its reference so `BubbleView`'s memo holds. An assistant bubble left
 // with no items renders nothing (`AssistantBubble` returns null), so a
 // standalone elicitation bubble collapses cleanly while its gating user
 // message stays put. Returns the input array unchanged when nothing is
-// pinned, so the memo stays stable.
-export function stripPinnedElicitations(bubbles: Bubble[]): Bubble[] {
+// pending, so the memo stays stable.
+export function stripPendingElicitations(bubbles: Bubble[]): Bubble[] {
   let result: Bubble[] | null = null;
   for (let i = 0; i < bubbles.length; i += 1) {
     const bubble = bubbles[i]!;
@@ -1310,15 +1310,17 @@ function MainAgentSurface({
   );
   const nav = useUserMessageNav(userMessageIds);
 
-  // Pending elicitation cards are pinned in a tray above the composer (so an
-  // outstanding question never scrolls off the top) and removed from the
-  // transcript to avoid rendering twice. Answered cards leave the tray and
-  // reappear inline at their natural spot. `streamBubbles` keeps `bubbles`'
-  // reference when nothing is pinned, so the common case allocates nothing.
-  const pinnedElicitations = useMemo(() => collectPendingElicitations(bubbles), [bubbles]);
+  // Pending elicitation cards float to the bottom of the chat: rendered as the
+  // last items in the scroll flow and removed from their inline position so
+  // they don't render twice. Stick-to-bottom then keeps an outstanding
+  // question in view instead of letting trailing text scroll it off the top.
+  // Answered cards stay inline at their natural spot. `streamBubbles` keeps
+  // `bubbles`' reference when nothing is pending, so the common case allocates
+  // nothing.
+  const pendingElicitations = useMemo(() => collectPendingElicitations(bubbles), [bubbles]);
   const streamBubbles = useMemo(
-    () => (pinnedElicitations.length === 0 ? bubbles : stripPinnedElicitations(bubbles)),
-    [bubbles, pinnedElicitations.length],
+    () => (pendingElicitations.length === 0 ? bubbles : stripPendingElicitations(bubbles)),
+    [bubbles, pendingElicitations.length],
   );
 
   // Cmd+Alt+↑/↓ (Ctrl+Alt on win/linux) — guarded so the composer's
@@ -1513,6 +1515,25 @@ function MainAgentSurface({
                     Self-gates to null off the spin-up window; rendered only
                     when not already showing Working… so the two never stack. */}
                 {!showWorkingIndicator && <RunnerStartingIndicator variant="row" />}
+                {/* Pending elicitation cards, floated to the bottom of the
+                    chat so an outstanding question stays in view (stick-to-
+                    bottom) no matter how much text the agent streamed after
+                    it. Wrapped in an assistant Message so each matches an
+                    inline card's look; removed from their inline slot by
+                    `stripPendingElicitations`. Newest renders last, nearest
+                    the composer. */}
+                {pendingElicitations.map((item) => (
+                  <Message
+                    key={item.elicitationId}
+                    from="assistant"
+                    className="max-w-full"
+                    data-testid="bottom-elicitation"
+                  >
+                    <MessageContent className="w-full">
+                      <ElicitationCard item={item} />
+                    </MessageContent>
+                  </Message>
+                ))}
               </>
             )}
           </ConversationContent>
@@ -1543,26 +1564,6 @@ function MainAgentSurface({
         containerRef={conversationRef}
         onReply={(text) => setReplyQuotes((prev) => [...prev, text])}
       />
-
-      {/* Pending elicitation cards, pinned just above the composer so an
-          outstanding question stays visible no matter how much text the
-          agent streams after it. Lives OUTSIDE the scroll container (like
-          the composer) and mirrors its column width. Capped height with
-          internal scroll keeps a tall stack of pending cards from crowding
-          out the transcript; newest sits at the bottom, nearest the
-          composer. Answered cards drop back inline (`stripPinnedElicitations`). */}
-      {pinnedElicitations.length > 0 && (
-        <div
-          data-testid="pinned-elicitations"
-          className={cn("mx-auto w-full px-6", CHAT_COLUMN_WIDTH)}
-        >
-          <div className="flex max-h-[45vh] flex-col gap-2 overflow-y-auto pb-2">
-            {pinnedElicitations.map((item) => (
-              <ElicitationCard key={item.elicitationId} item={item} />
-            ))}
-          </div>
-        </div>
-      )}
 
       <Composer
         disabled={disabled}

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -51,6 +51,7 @@ import {
   MessageContent,
 } from "@/components/ai-elements/message";
 import { Shimmer } from "@/components/ai-elements/shimmer";
+import { ElicitationCard } from "@/components/blocks/ApprovalCard";
 import { BlockRenderer, FilePathAwareMessageResponse } from "@/components/blocks/BlockRenderer";
 import { CompactionMarker } from "@/components/blocks/StatusBlocks";
 import { SystemMessageView } from "@/components/blocks/SystemMessage";
@@ -311,6 +312,51 @@ export function mergePendingBubbles(committed: Bubble[], pending: Bubble[]): Bub
   }
   if (insertAt === committed.length) return [...committed, ...pending];
   return [...committed.slice(0, insertAt), ...pending, ...committed.slice(insertAt)];
+}
+
+type ElicitationItem = Extract<RenderItem, { kind: "elicitation" }>;
+
+// A pending elicitation is unanswered — only these are pinned.
+function isPendingElicitation(item: RenderItem): item is ElicitationItem {
+  return item.kind === "elicitation" && item.status === "pending";
+}
+
+// Pending elicitation cards are lifted out of the scrolling transcript and
+// pinned in a tray above the composer, so an outstanding question stays
+// reachable no matter how much text the agent streams after it (otherwise
+// stick-to-bottom scrolls the card up off the top of the viewport).
+// Collect them in document order: oldest first, so the newest pending card
+// sits at the BOTTOM of the stack, nearest the composer. Once answered, a
+// card drops out of this list (status flips to "responded") and flows back
+// into the transcript inline via `stripPinnedElicitations`.
+export function collectPendingElicitations(bubbles: Bubble[]): ElicitationItem[] {
+  const pending: ElicitationItem[] = [];
+  for (const bubble of bubbles) {
+    if (bubble.kind !== "assistant") continue;
+    for (const item of bubble.items) {
+      if (isPendingElicitation(item)) pending.push(item);
+    }
+  }
+  return pending;
+}
+
+// Drop the pinned (pending) elicitation cards from the transcript bubbles so
+// they don't render twice — once in the tray, once inline. Only clones the
+// assistant bubbles that actually carry a pinned card; every other bubble
+// keeps its reference so `BubbleView`'s memo holds. An assistant bubble left
+// with no items renders nothing (`AssistantBubble` returns null), so a
+// standalone elicitation bubble collapses cleanly while its gating user
+// message stays put. Returns the input array unchanged when nothing is
+// pinned, so the memo stays stable.
+export function stripPinnedElicitations(bubbles: Bubble[]): Bubble[] {
+  let result: Bubble[] | null = null;
+  for (let i = 0; i < bubbles.length; i += 1) {
+    const bubble = bubbles[i]!;
+    if (bubble.kind !== "assistant" || !bubble.items.some(isPendingElicitation)) continue;
+    if (result === null) result = [...bubbles];
+    result[i] = { ...bubble, items: bubble.items.filter((it) => !isPendingElicitation(it)) };
+  }
+  return result ?? bubbles;
 }
 
 // Whether a user bubble should carry the author's avatar badge (and the
@@ -1264,6 +1310,17 @@ function MainAgentSurface({
   );
   const nav = useUserMessageNav(userMessageIds);
 
+  // Pending elicitation cards are pinned in a tray above the composer (so an
+  // outstanding question never scrolls off the top) and removed from the
+  // transcript to avoid rendering twice. Answered cards leave the tray and
+  // reappear inline at their natural spot. `streamBubbles` keeps `bubbles`'
+  // reference when nothing is pinned, so the common case allocates nothing.
+  const pinnedElicitations = useMemo(() => collectPendingElicitations(bubbles), [bubbles]);
+  const streamBubbles = useMemo(
+    () => (pinnedElicitations.length === 0 ? bubbles : stripPinnedElicitations(bubbles)),
+    [bubbles, pinnedElicitations.length],
+  );
+
   // Cmd+Alt+↑/↓ (Ctrl+Alt on win/linux) — guarded so the composer's
   // own unmodified ArrowUp/Down history-recall still works.
   useEffect(() => {
@@ -1427,7 +1484,7 @@ function MainAgentSurface({
               )
             ) : (
               <>
-                {bubbles.map((bubble) => (
+                {streamBubbles.map((bubble) => (
                   <BubbleView key={bubbleKey(bubble)} bubble={bubble} />
                 ))}
                 {/* Working… shimmer between send and first rendered block.
@@ -1486,6 +1543,26 @@ function MainAgentSurface({
         containerRef={conversationRef}
         onReply={(text) => setReplyQuotes((prev) => [...prev, text])}
       />
+
+      {/* Pending elicitation cards, pinned just above the composer so an
+          outstanding question stays visible no matter how much text the
+          agent streams after it. Lives OUTSIDE the scroll container (like
+          the composer) and mirrors its column width. Capped height with
+          internal scroll keeps a tall stack of pending cards from crowding
+          out the transcript; newest sits at the bottom, nearest the
+          composer. Answered cards drop back inline (`stripPinnedElicitations`). */}
+      {pinnedElicitations.length > 0 && (
+        <div
+          data-testid="pinned-elicitations"
+          className={cn("mx-auto w-full px-6", CHAT_COLUMN_WIDTH)}
+        >
+          <div className="flex max-h-[45vh] flex-col gap-2 overflow-y-auto pb-2">
+            {pinnedElicitations.map((item) => (
+              <ElicitationCard key={item.elicitationId} item={item} />
+            ))}
+          </div>
+        </div>
+      )}
 
       <Composer
         disabled={disabled}

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -1489,6 +1489,27 @@ function MainAgentSurface({
                 {streamBubbles.map((bubble) => (
                   <BubbleView key={bubbleKey(bubble)} bubble={bubble} />
                 ))}
+                {/* Pending elicitation cards, floated to the bottom of the
+                    chat so an outstanding question stays in view (stick-to-
+                    bottom) no matter how much text the agent streamed after
+                    it. Wrapped in an assistant Message so each matches an
+                    inline card's look; removed from their inline slot by
+                    `stripPendingElicitations`. Newest renders last, nearest
+                    the composer. Rendered ABOVE the Working… indicator so the
+                    card sits closest to the prompt and the shimmer stays the
+                    last thing in the flow. */}
+                {pendingElicitations.map((item) => (
+                  <Message
+                    key={item.elicitationId}
+                    from="assistant"
+                    className="max-w-full"
+                    data-testid="bottom-elicitation"
+                  >
+                    <MessageContent className="w-full">
+                      <ElicitationCard item={item} />
+                    </MessageContent>
+                  </Message>
+                ))}
                 {/* Working… shimmer between send and first rendered block.
                     Suppressed when the last bubble is a compaction spinner —
                     that bubble already owns the "in-progress" slot. aria-hidden:
@@ -1515,25 +1536,6 @@ function MainAgentSurface({
                     Self-gates to null off the spin-up window; rendered only
                     when not already showing Working… so the two never stack. */}
                 {!showWorkingIndicator && <RunnerStartingIndicator variant="row" />}
-                {/* Pending elicitation cards, floated to the bottom of the
-                    chat so an outstanding question stays in view (stick-to-
-                    bottom) no matter how much text the agent streamed after
-                    it. Wrapped in an assistant Message so each matches an
-                    inline card's look; removed from their inline slot by
-                    `stripPendingElicitations`. Newest renders last, nearest
-                    the composer. */}
-                {pendingElicitations.map((item) => (
-                  <Message
-                    key={item.elicitationId}
-                    from="assistant"
-                    className="max-w-full"
-                    data-testid="bottom-elicitation"
-                  >
-                    <MessageContent className="w-full">
-                      <ElicitationCard item={item} />
-                    </MessageContent>
-                  </Message>
-                ))}
               </>
             )}
           </ConversationContent>

--- a/tests/e2e_ui/approvals/test_elicitation_floats_to_bottom.py
+++ b/tests/e2e_ui/approvals/test_elicitation_floats_to_bottom.py
@@ -1,0 +1,126 @@
+r"""E2E: a pending elicitation card floats to the bottom of the chat.
+
+Regression coverage for the float-to-bottom behavior. A pending elicitation
+card is lifted out of its inline transcript position and re-rendered as the
+last item in the chat scroll flow — wrapped in a ``bottom-elicitation``
+Message — so an outstanding question stays in view no matter how much text the
+agent streams after it. Once answered, the card leaves the floated slot and
+returns inline showing its ``responded`` state.
+
+Like ``test_ask_user_question.py``, this drives a synthetic permission-request
+hook against a seeded session (no real LLM turn), so it completes in seconds.
+The distinction from that sibling: this test asserts WHERE the card renders
+(inside the floated ``bottom-elicitation`` wrapper while pending, and no longer
+wrapped once answered), which is exactly the behavior the float-to-bottom
+change introduced.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_log = logging.getLogger(__name__)
+
+_APPROVAL_CARD = '[data-testid="approval-card"]'
+_BOTTOM = '[data-testid="bottom-elicitation"]'
+_FORM = '[data-testid="ask-user-question-form"]'
+_SUBMIT = '[data-testid="ask-user-question-submit"]'
+
+_MOCK_ELICITATION_TIMEOUT_MS = 15_000
+
+# The exact option labels used in the hook payload and form assertions.
+_OPTION_ONE = "Alpha"
+_OPTION_TWO = "Bravo"
+
+
+def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
+    """Return the session snapshot's pending elicitation events (owner view)."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json().get("pending_elicitations") or []
+
+
+def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) -> None:
+    """Poll *predicate* until truthy or the deadline passes."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise AssertionError("condition not met within timeout")
+
+
+@pytest.mark.timeout(90)
+def test_pending_elicitation_floats_to_bottom(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Pending card renders in the floated bottom slot, then returns inline once answered."""
+    base_url, session_id = seeded_session
+    _log.info("seeded session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    result_holder: dict = {}
+
+    def _post_hook() -> None:
+        try:
+            resp = httpx.post(
+                f"{base_url}/v1/sessions/{session_id}/hooks/permission-request",
+                json={
+                    "tool_name": "AskUserQuestion",
+                    "tool_input": {
+                        "questions": [
+                            {
+                                "question": "Which option do you prefer?",
+                                "options": [_OPTION_ONE, _OPTION_TWO],
+                            }
+                        ]
+                    },
+                },
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            result_holder["response"] = resp.json()
+        except Exception as exc:
+            result_holder["error"] = exc
+
+    hook_thread = threading.Thread(target=_post_hook, daemon=True)
+    hook_thread.start()
+
+    # Let the server park the elicitation before the SPA tries to render it.
+    page.wait_for_timeout(500)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # While pending, the card lives INSIDE the floated bottom-elicitation
+    # wrapper — not in its inline transcript slot. Scoping the locator to the
+    # wrapper is the assertion that distinguishes float-to-bottom from the old
+    # inline rendering.
+    floated_card = page.locator(f'{_BOTTOM} {_APPROVAL_CARD}[data-state="pending"]').first
+    expect(floated_card).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
+    form = floated_card.locator(_FORM)
+    expect(form).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
+    assert _pending_elicitations(base_url, session_id), "server has no parked elicitation"
+
+    # Answer it.
+    form.get_by_role("radio", name=_OPTION_ONE).check()
+    form.locator(_SUBMIT).click()
+
+    # Answered: the card flips to responded, leaves the floated slot, and the
+    # bottom-elicitation wrapper disappears (it returns inline).
+    responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
+    expect(responded).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
+    expect(page.locator(_BOTTOM)).to_have_count(0)
+
+    hook_thread.join(timeout=30)
+    if "error" in result_holder:
+        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder[
+            "error"
+        ]
+
+    _wait_for(lambda: not _pending_elicitations(base_url, session_id))


### PR DESCRIPTION
## Problem

Elicitation cards (`ApprovalCard`) render inline in the scrolling transcript. When the agent renders an elicitation **and** a bunch of text, the text (with stick-to-bottom) scrolls the card up off the top of the viewport — pushing the actionable prompt out of reach.

## Fix

Lift every **pending** elicitation card out of the transcript into a sticky tray pinned directly above the composer (outside the scroll container, like the composer itself). All pending cards stack, newest nearest the composer, so an outstanding question is always visible no matter how much text streams after it. Once answered, a card drops from the tray and flows back inline at its natural spot showing the responded state.

```
┌─ chat scroll area ─────────────┐
│ ...agent text...               │
│ ...more streamed text...       │
├────────────────────────────────┤
│ ▓ ELICITATION CARD (pinned) ▓  │  ← always visible
│   [ Approve ]  [ Reject ]      │
├────────────────────────────────┤
│ > composer…                    │
└────────────────────────────────┘
```

## Changes

- **`ApprovalCard.tsx`** — extract a shared `ElicitationCard` wrapper so the `RenderItem` → `ApprovalCard` prop mapping lives in one place, reused by the inline `BlockRenderer` path and the new tray.
- **`BlockRenderer.tsx`** — inline `elicitation` case now uses `ElicitationCard`.
- **`ChatPage.tsx`**
  - `collectPendingElicitations(bubbles)` — gathers pending cards in document order (newest sits at the bottom of the stack).
  - `stripPinnedElicitations(bubbles)` — removes pending cards from the transcript so they don't render twice. Only clones affected bubbles (others keep their reference so the `BubbleView` memo holds); an emptied standalone elicitation bubble collapses to `null` while its gating user message stays put.
  - `MainAgentSurface` renders `streamBubbles` (stripped) plus the tray above `<Composer>`, mirroring the composer column width with `max-h-[45vh] overflow-y-auto` so a tall stack scrolls internally instead of crowding out the transcript.

## Reconciliation

Answering a pinned card flips the block `pending` → `responded`: it drops from `pinnedElicitations` (tray) and is no longer stripped (reappears inline as responded). `bubblesEqual` re-renders on both the item-count change from stripping and the `status` change. The existing REQUEST-phase reorder logic still governs user-message ordering.

## Testing

- `type-check` and `lint` clean (no new issues).
- New unit tests for `collectPendingElicitations` and `stripPinnedElicitations`.
- Full ApprovalCard / BlockRenderer / InboxPage / ApprovePage / AppShell / ChatPage suites pass.

Not yet verified in a live browser — visual placement and the `max-h-[45vh]` cap are easy to tune.

This pull request and its description were written by Isaac.