### PR TITLE
Scope the UI-snapshot gate to render-affecting changes

### DIFF
--- a/.github/workflows/ui-snapshot.yml
+++ b/.github/workflows/ui-snapshot.yml
@@ -22,7 +22,13 @@ name: UI Snapshot
 #   pull_request       compare the rendered pages against the committed
 #                      baselines; fail (with actual/expected/diff PNGs in the
 #                      artifact) on any mismatch. No secrets, so fork PRs run
-#                      fine.
+#                      fine. The render job is gated on the `detect` job (below):
+#                      a PR that touches none of the render inputs (ap-web, the
+#                      visual tests + fixtures, the pinned toolchain) SKIPS the
+#                      render. We gate at the job (not via `on: paths:`) on
+#                      purpose -- a job skipped by `if` reports SUCCESS, so this
+#                      stays safe to register as a required check, whereas a
+#                      path-filtered *workflow* would sit "pending" and block.
 #   workflow_dispatch  regenerate the baselines with --update-snapshots in the
 #                      same pinned image; the regenerated PNGs are in the
 #                      `ui-snapshot-<run_id>` artifact to download and commit.
@@ -45,6 +51,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read  # detect: list the PR's changed files
 
 concurrency:
   group: ui-snapshot-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.ref || github.ref }}
@@ -62,8 +69,48 @@ env:
   UV_PYTHON_PREFERENCE: only-system
 
 jobs:
+  # Cheap pre-flight (no container/build): does this PR touch anything that can
+  # change the render? The heavy job below is `if`-gated on it, so non-UI PRs
+  # skip the render (no wasted CI, no flaking against unrelated changes). The
+  # render is a pure function of the ap-web bundle + the visual tests + their
+  # shared fixtures + the pinned toolchain (npm pin, the image digest in THIS
+  # file, and the playwright/plugin versions in the lock), so watch exactly
+  # those. Fails open: if the file list can't be fetched, render rather than
+  # risk a false pass.
+  detect:
+    name: Detect render-affecting changes
+    runs-on: ubuntu-latest
+    outputs:
+      ui: ${{ steps.changes.outputs.ui }}
+    steps:
+      - id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "${PR:-}" ]; then
+            echo "ui=true" >> "$GITHUB_OUTPUT"; echo "no PR (dispatch) -> render"; exit 0
+          fi
+          if ! files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'); then
+            echo "ui=true" >> "$GITHUB_OUTPUT"; echo "file list unavailable -> render"; exit 0
+          fi
+          pattern='^(ap-web/|tests/e2e_ui/visual/|tests/e2e_ui/conftest\.py|\.github/actions/setup-node/|\.github/workflows/ui-snapshot\.yml|pyproject\.toml|uv\.lock)'
+          if printf '%s\n' "$files" | grep -qE "$pattern"; then
+            echo "ui=true" >> "$GITHUB_OUTPUT"
+            echo "render-affecting files changed:"
+            printf '%s\n' "$files" | grep -E "$pattern" | sed 's/^/  /'
+          else
+            echo "ui=false" >> "$GITHUB_OUTPUT"
+            echo "no render-affecting files changed -> skip the render"
+          fi
+
   ui-snapshot:
     name: UI Snapshot (visual baselines)
+    needs: detect
+    # Skipped (not failed) when no render input changed -> reports SUCCESS, so a
+    # non-UI PR neither runs the render nor blocks a required check.
+    if: ${{ needs.detect.outputs.ui == 'true' }}
     runs-on: ubuntu-24.04
     # Render in the digest-pinned Playwright image (browsers + fonts baked in),
     # so the committed baseline and the PR comparison are byte-identical and a

--- a/tests/e2e_ui/visual/README.md
+++ b/tests/e2e_ui/visual/README.md
@@ -48,10 +48,18 @@ which is generated and synced separately). Until it's added there it's an
 **advisory** red check — visible, but not enforced. Registering it as required is
 a one-line change to that synced config, outside this directory.
 
+It's **safe to register as required**: a PR that touches none of the render
+inputs skips the render via the `detect` job's `if` gate, and a job skipped by
+`if` reports **success** — so non-UI PRs satisfy the check instead of sitting
+"pending" (which is what an `on: paths:` filter would cause, blocking merges).
+
 ## How the gate behaves
 
-- On every PR, `ui-snapshot.yml` renders each page and compares it to its
-  committed baseline. Any pixel difference on any page fails the check.
+- On every PR that touches a render input (ap-web, the visual tests + fixtures,
+  or the pinned toolchain — see the `detect` job in `ui-snapshot.yml`),
+  `ui-snapshot.yml` renders each page and compares it to its committed baseline.
+  Any pixel difference on any page fails the check; PRs that touch none of those
+  skip the render (reported as a passing skip).
 - **Every run (pass or fail)** uploads one artifact and links it in the job
   summary, so the screenshots are always one click away:
   `ui-snapshot-<run_id>` carries this run's renders (`snapshots/`); on a mismatch


### PR DESCRIPTION
## Related issue

N/A — CI quality-of-life follow-up to the UI visual-snapshot suite.

## Summary

- The `UI Snapshot` gate (render in a pinned Playwright image) used to run on **every** PR, burning CI and occasionally flaking against changes that don't touch the UI at all.
- Now a cheap **`detect`** job (no container/build) lists the PR's changed files and the heavy render job runs only `if` a render input changed. The render is a pure function of: `ap-web/**`, the visual tests + shared fixtures (`tests/e2e_ui/visual/**`, `tests/e2e_ui/conftest.py`), and the pinned toolchain (`.github/actions/setup-node/**`, this workflow — which pins the image digest — and `pyproject.toml`/`uv.lock`).
- **Why a job `if`, not `on: paths:`**: a *workflow* skipped by a path filter never reports its check and would block a PR that lists it as **required** ("Expected — waiting for status"). A *job* skipped by `if` reports **success**, so a non-UI PR satisfies the check. This makes the gate safe to register as required.
- **Fails open**: if the changed-file list can't be fetched (or it's a `workflow_dispatch`), it renders rather than risk a false pass.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

CI-config change validated against the live gate behavior earlier in this suite's rollout: the render fails on a real UI change (e.g. a sidebar label edit shifts both committed snapshots) and passes on an unchanged render; the `detect` gate is additive and skip-passes non-UI PRs. `README.md` documents the required-check safety and the skip behavior. Squashed into a single commit.