### PR TITLE
fix: hide 'Load more' button when Archived section is collapsed

### DIFF
--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -273,9 +273,10 @@ describe("Sidebar collapsible sections", () => {
   });
 });
 
-// Pagination belongs to the Recent list: collapsing Recent must take the
-// "Load more" button with it, or the button floats under nothing.
-describe("Sidebar load-more vs collapsed Recent", () => {
+// Pagination button must hide when every expanded section is empty —
+// loading more pages adds nothing visible while all receiving groups
+// are collapsed.
+describe("Sidebar load-more vs collapsed sections", () => {
   it("hides Load more while Recent is collapsed and restores it on expand", () => {
     const rows = [conv("conv_mine", "Claude Code")];
     useConvMock.mockImplementation(
@@ -301,6 +302,63 @@ describe("Sidebar load-more vs collapsed Recent", () => {
     expect(screen.queryByText("conv_mine")).toBeNull();
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Recent" }));
+    expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+  });
+
+  it("hides Load more while Archived is collapsed when no other section has data", () => {
+    const rows = [conv("conv_archived", "Claude Code", { archived: true })];
+    useConvMock.mockImplementation(
+      () =>
+        ({
+          data: {
+            pages: [{ data: rows, first_id: rows[0]!.id, last_id: rows[0]!.id, has_more: true }],
+            pageParams: [undefined],
+          },
+          isLoading: false,
+          isError: false,
+          error: null,
+          fetchNextPage: vi.fn(),
+          hasNextPage: true,
+          isFetchingNextPage: false,
+        }) as unknown as ReturnType<typeof useConversations>,
+    );
+    renderSidebar();
+
+    // Archived starts collapsed by default — Load more must not float
+    // under the collapsed group.
+    expect(screen.getByRole("button", { name: "Archived" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+
+    // Expanding Archived restores the button.
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+  });
+
+  it("keeps Load more visible when Archived is collapsed but another section has data", () => {
+    const rows = [
+      conv("conv_recent", "Claude Code"),
+      conv("conv_archived", "Claude Code", { archived: true }),
+    ];
+    useConvMock.mockImplementation(
+      () =>
+        ({
+          data: {
+            pages: [{ data: rows, first_id: rows[0]!.id, last_id: rows[1]!.id, has_more: true }],
+            pageParams: [undefined],
+          },
+          isLoading: false,
+          isError: false,
+          error: null,
+          fetchNextPage: vi.fn(),
+          hasNextPage: true,
+          isFetchingNextPage: false,
+        }) as unknown as ReturnType<typeof useConversations>,
+    );
+    renderSidebar();
+
+    // Archived is collapsed by default, but Recent is expanded with data —
+    // Load more should stay visible because newly loaded rows could land
+    // in the visible Recent section.
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
   });
 });

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -696,27 +696,34 @@ function ConversationList({
               onToggleSelected={onToggleSelected}
             />
           )}
-          {/* Pagination extends the Recent list, so the button hides with
-              it — a Load more under a collapsed group reads orphaned. */}
-          {hasMorePages && !effectiveCollapsedSections.includes("Recent") && (
-            <button
-              type="button"
-              disabled={conversationsQuery.isFetchingNextPage}
-              onClick={() => {
-                if (conversationsQuery.hasNextPage) void conversationsQuery.fetchNextPage();
-              }}
-              className="flex cursor-pointer items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-muted-foreground text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-            >
-              {conversationsQuery.isFetchingNextPage ? (
-                <>
-                  <Loader2Icon className="size-3 animate-spin" />
-                  Loading…
-                </>
-              ) : (
-                "Load more"
-              )}
-            </button>
-          )}
+          {/* Pagination extends the session list — hide the button when
+              every rendered section is collapsed, leaving no expanded
+              group to display newly loaded rows. */}
+          {hasMorePages &&
+            ((sections.pinned.length > 0 && !effectiveCollapsedSections.includes("Pinned")) ||
+              (sections.sessions.length > 0 && !effectiveCollapsedSections.includes("Recent")) ||
+              (sections.shared.length > 0 &&
+                !effectiveCollapsedSections.includes("Shared with me")) ||
+              (sections.archived.length > 0 &&
+                !effectiveCollapsedSections.includes("Archived"))) && (
+              <button
+                type="button"
+                disabled={conversationsQuery.isFetchingNextPage}
+                onClick={() => {
+                  if (conversationsQuery.hasNextPage) void conversationsQuery.fetchNextPage();
+                }}
+                className="flex cursor-pointer items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-muted-foreground text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+              >
+                {conversationsQuery.isFetchingNextPage ? (
+                  <>
+                    <Loader2Icon className="size-3 animate-spin" />
+                    Loading…
+                  </>
+                ) : (
+                  "Load more"
+                )}
+              </button>
+            )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixes #1101

Previously the 'Load more' pagination button only checked whether the 'Recent' section was collapsed. When no expanded section could display newly loaded rows (e.g. only archived sessions exist and Archived is collapsed by default), the button floated under nothing and clicking it had no visible effect.

## Change

In `ConversationList`, the 'Load more' button visibility condition now checks all four sidebar sections (Pinned, Recent, Shared with me, Archived) instead of only Recent. The button hides when every section that has data is collapsed.

## Verification

- `NODE_ENV=test npx vitest run src/shell/Sidebar.test.tsx` — all 12 tests pass
- Two new test cases cover the archived section collapse behavior