### PR TITLE
chore(ci): label UI Snapshot job [non-blocking]

### DIFF
--- a/.github/workflows/ui-snapshot.yml
+++ b/.github/workflows/ui-snapshot.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
   ui-snapshot:
-    name: UI Snapshot (visual baselines)
+    name: UI Snapshot (visual baselines) [non-blocking]
     needs: detect
     # Skipped (not failed) when no render input changed -> reports SUCCESS, so a
     # non-UI PR neither runs the render nor blocks a required check.


### PR DESCRIPTION
## What

Add `[non-blocking]` to the UI Snapshot job's display name so the PR check reads:

> UI Snapshot / UI Snapshot (visual baselines) **[non-blocking]**

## Why

The UI Snapshot gate is non-blocking for now. Surfacing that directly in the check name keeps reviewers from treating a failure as a merge blocker.

## Notes

Only the job `name:` changes. The workflow `name: UI Snapshot` is left intact because `ui-snapshot-fail-comment.yml` triggers off `workflows: ["UI Snapshot"]` — renaming it would break that comment workflow.