### PR TITLE
chore: remove @hzub from ap-web reviewers

### DIFF
--- a/.github/reviewers
+++ b/.github/reviewers
@@ -23,7 +23,7 @@
 /.github/                    @PattaraS @serena-ruan @dhruv0811 @TomeHirata
 
 # Web UI
-/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db @hzub
+/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db
 
 # Core agent runtime & harnesses
 /omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -71,10 +71,10 @@ function assert(name, cond, detail) {
   r = await run({
     files: ["README.md"],
     load: { PattaraS: 9, "serena-ruan": 9, dhruv0811: 9, TomeHirata: 9, SabhyaC26: 9,
-            "daniellok-db": 9, hzub: 0, dbczumar: 1, fanzeyi: 9, "ckcuslife-source": 9,
+            "daniellok-db": 9, dbczumar: 0, fanzeyi: 9, "ckcuslife-source": 9,
             bbqiu: 9, Edwinhe03: 9 },
   });
-  assert("unowned -> lowest from full pool", JSON.stringify(r.added) === JSON.stringify(["hzub"]), JSON.stringify(r));
+  assert("unowned -> lowest from full pool", JSON.stringify(r.added) === JSON.stringify(["dbczumar"]), JSON.stringify(r));
 
   // 3. db area (fanzeyi, SabhyaC26) -> the lower-load one selected.
   r = await run({ files: ["omnigent/db/x.py"], load: { SabhyaC26: 1 } });


### PR DESCRIPTION
Removes `@hzub` from the `/ap-web/` candidate list in .github/reviewers so he is no longer auto-assigned as a reviewer.