### PR TITLE
feat(harness): add Aider as a coding-agent harness

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4716,7 +4716,7 @@ def resume(
 _HARNESS_CHOICES_HELP = (
     "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
     "'cursor', "
-    "'openai-agents', 'open-responses', 'pi', 'antigravity', or 'qwen'"
+    "'openai-agents', 'open-responses', 'pi', 'antigravity', 'qwen', or 'aider'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."
 _RUN_HARNESS_HELP = (
@@ -4751,6 +4751,9 @@ _DEFAULT_HARNESS_PROMPTS = {
     "qwen": (
         "You are Qwen Code, running through Omnigent. "
         "Help the user with software engineering tasks."
+    ),
+    "aider": (
+        "You are Aider, running through Omnigent. Help the user with software engineering tasks."
     ),
 }
 _DEFAULT_HARNESS_PROMPT = "You are a helpful coding agent running through Omnigent."

--- a/omnigent/inner/aider_executor.py
+++ b/omnigent/inner/aider_executor.py
@@ -1,0 +1,460 @@
+"""AiderExecutor: run agents through Aider's one-shot CLI mode.
+
+`Aider <https://aider.chat>`_ is a terminal AI pair-programmer. Unlike the
+native qwen/codex/claude harnesses it exposes no streaming agent protocol, and
+its Python ``Coder`` API is explicitly *"not officially supported or documented
+and could change without backwards compatibility"*. So this executor drives the
+CLI in **one-shot** mode, once per turn, in the session workspace::
+
+    aider --message "<prompt>" --yes-always --no-stream --no-pretty \\
+          --no-auto-commits --no-dirty-commits --no-check-update \\
+          --analytics-disable [--model <model>] [--restore-chat-history]
+
+Aider runs its own agent loop (file edits, shell, repo map, tool use)
+internally and prints its reply to stdout; this executor streams stdout lines
+as :class:`TextChunk` events and emits a final :class:`TurnComplete`. Because
+Aider routes models through LiteLLM, it honours ``OPENAI_BASE_URL`` /
+``OPENAI_API_KEY``, so Omnigent's provider/gateway routing works unchanged
+(mirroring :class:`omnigent.inner.qwen_executor.QwenExecutor`). Otherwise auth
+is bring-your-own provider key via the ambient environment.
+
+Multi-turn continuity: each turn is a fresh subprocess, so the system prompt is
+folded into the first turn only and subsequent turns pass
+``--restore-chat-history`` to reload Aider's persisted workspace chat history.
+
+Requirements:
+    The ``aider`` CLI must be installed (``python -m pip install aider-chat``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+import sys
+from collections.abc import AsyncIterator, Sequence
+from pathlib import Path
+from typing import Any
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    TextChunk,
+    TurnComplete,
+)
+
+logger = logging.getLogger(__name__)
+
+# Kill the aider subprocess if it produces no output for this long. Bounds a
+# wedged turn without capping a legitimately long edit (reset implicitly by
+# reading the next stdout line).
+_TURN_IDLE_TIMEOUT_SECONDS = 600.0
+
+# 16 MiB per-line cap for the stdout StreamReader so a long, unbroken aider
+# line (e.g. a big diff) doesn't hit the default 64 KiB limit.
+_STREAM_LIMIT = 16 * 1024 * 1024
+
+
+def _inline_text_file_data(file_data: Any) -> str:  # type: ignore[explicit-any]
+    """Decode a text ``input_file`` ``file_data`` data URI into inline text.
+
+    Mirrors :func:`omnigent.inner.qwen_executor._inline_text_file_data`:
+    ``input_file`` blocks may carry a ``data:<mime>;base64,<payload>`` URI. Text
+    files are decoded so the model sees their content; binary files (PDF,
+    images) can't be inlined as text and return ``""``. A bare, non-data-URI
+    string is treated as already-inline text.
+
+    :param file_data: The block's ``file_data`` value (or ``None``).
+    :returns: Decoded text, or ``""`` when absent/binary/undecodable.
+    """
+    if not isinstance(file_data, str) or not file_data:
+        return ""
+    if not file_data.startswith("data:"):
+        return file_data
+    try:
+        import base64
+
+        meta, b64 = file_data.split(",", 1)
+        mime = meta.split(";")[0].replace("data:", "")
+        if not mime.startswith("text/"):
+            return ""  # binary payloads can't be inlined as prompt text
+        return base64.b64decode(b64).decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001 — best-effort; never break a turn on a bad URI
+        return ""
+
+
+class AiderExecutor(Executor):
+    """Executor that drives Aider via its one-shot ``--message`` CLI mode."""
+
+    def __init__(
+        self,
+        cwd: str | None = None,
+        os_env: OSEnvSpec | None = None,
+        model: str | None = None,
+        aider_path: str | None = None,
+        gateway_base_url: str | None = None,
+        gateway_auth_command: str | None = None,
+    ) -> None:
+        """Initialize the Aider executor.
+
+        :param cwd: Working directory the aider subprocess runs in. When
+            ``None``, inherits the caller's cwd.
+        :param os_env: Environment / sandbox spec. When its ``sandbox`` is not
+            ``"none"``, the aider process tree is wrapped in the platform
+            sandbox (bwrap/seatbelt) at spawn — see :meth:`_sandbox_launch_path`.
+        :param model: Model identifier passed via ``--model`` (e.g.
+            ``"claude-3-5-sonnet"``, ``"gpt-4o"``). ``None`` uses aider's default.
+        :param aider_path: Absolute path to the ``aider`` CLI binary. Defaults to
+            ``"aider"`` (PATH lookup).
+        :param gateway_base_url: OpenAI-compatible base URL of an Omnigent
+            provider/gateway (from ``HARNESS_AIDER_GATEWAY_BASE_URL``). When set
+            with *gateway_auth_command*, the executor exports ``OPENAI_BASE_URL``
+            / ``OPENAI_API_KEY`` / ``OPENAI_MODEL`` into the aider subprocess so
+            the spec's ``auth:`` / ``providers:`` routing takes effect instead of
+            aider's ambient auth.
+        :param gateway_auth_command: Shell command that prints a bearer token to
+            stdout (from ``HARNESS_AIDER_GATEWAY_AUTH_COMMAND``); run once per
+            turn to snapshot ``OPENAI_API_KEY``.
+        """
+        self._cwd = cwd or os.getcwd()
+        self._os_env = os_env
+        self._model = model
+        self._aider_path = aider_path or "aider"
+        self._gateway_base_url = gateway_base_url
+        self._gateway_auth_command = gateway_auth_command
+
+        # Aider has no system-prompt flag, so the persona is folded into the
+        # first turn's message only; later turns reuse it via restored history.
+        self._system_prompt_sent = False
+        # After the first turn has run, aider has persisted chat history to the
+        # workspace, so subsequent turns pass --restore-chat-history.
+        self._has_history = False
+
+    # ------------------------------------------------------------------
+    # Executor capability flags
+    # ------------------------------------------------------------------
+
+    def supports_streaming(self) -> bool:
+        """Aider output is streamed back line-by-line as it arrives."""
+        return True
+
+    def supports_tool_calling(self) -> bool:
+        """Aider does not surface tool calls to Omnigent (it runs its own loop)."""
+        return False
+
+    def handles_tools_internally(self) -> bool:
+        """Aider executes file edits / shell / tools inside its own agent loop."""
+        return True
+
+    # ------------------------------------------------------------------
+    # Prompt construction
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _text_from_blocks(blocks: list[Any]) -> str:  # type: ignore[explicit-any]
+        """Fold a Responses-API content-block list into a single prompt string.
+
+        Mirrors :meth:`omnigent.inner.qwen_executor.QwenExecutor._text_from_blocks`.
+        The harness adapter passes a content **list** whenever a message carries
+        a non-text block (e.g. a file attachment). Aider's ``--message`` is
+        text-only, so each block is folded into text:
+
+        - ``input_text`` / ``output_text`` / ``text`` → the text verbatim.
+        - ``input_file`` → the file's inlined content, fenced with a labeled
+          header/footer when the runner resolved it into a text ``file_data``
+          data URI; otherwise a ``[attached file: <name>]`` marker.
+        - ``input_image`` → a ``[attached image: <name>]`` marker (aider's
+          one-shot CLI can't take inline image blocks).
+
+        :param blocks: The message ``content`` list.
+        :returns: The concatenated prompt text (may be empty).
+        """
+        parts: list[str] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype in ("input_text", "output_text", "text"):
+                text = block.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+            elif btype == "input_file":
+                name = block.get("filename") or block.get("file_id") or "file"
+                inlined = _inline_text_file_data(block.get("file_data"))
+                if inlined:
+                    parts.append(
+                        f"--- attached file: {name} ---\n{inlined}\n--- end of {name} ---"
+                    )
+                else:
+                    parts.append(f"[attached file: {name}]")
+            elif btype == "input_image":
+                name = block.get("filename") or block.get("file_id")
+                parts.append(f"[attached image: {name}]" if name else "[attached image]")
+        return "\n".join(parts)
+
+    def _latest_user_text(self, messages: list[Message]) -> str:
+        """Extract prompt text from the most recent user message."""
+        for msg in reversed(messages):
+            role = msg.get("role", "") if isinstance(msg, dict) else ""
+            if role != "user":
+                continue
+            content = msg.get("content", "") if isinstance(msg, dict) else ""
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                return self._text_from_blocks(content)
+            return ""
+        return ""
+
+    def _build_argv(self, launch_path: str, prompt: str, *, restore: bool) -> list[str]:
+        """Assemble the one-shot aider argv for a turn.
+
+        :param launch_path: argv[0] — the aider binary or a sandbox launcher.
+        :param prompt: The single user message to send.
+        :param restore: When ``True``, pass ``--restore-chat-history`` so aider
+            reloads the workspace chat history from earlier turns.
+        :returns: The full argv list.
+        """
+        argv = [
+            launch_path,
+            "--message",
+            prompt,
+            "--yes-always",  # auto-confirm every prompt (non-interactive)
+            "--no-stream",  # return the full reply at once
+            "--no-pretty",  # plain output for clean capture
+            "--no-auto-commits",  # Omnigent owns workspace change-tracking
+            "--no-dirty-commits",
+            "--no-check-update",  # no network version check / upgrade prompt
+            "--analytics-disable",
+        ]
+        if self._model:
+            argv += ["--model", self._model]
+        if restore:
+            argv.append("--restore-chat-history")
+        return argv
+
+    # ------------------------------------------------------------------
+    # Environment / sandbox plumbing (mirrors QwenExecutor)
+    # ------------------------------------------------------------------
+
+    async def _resolve_gateway_env(self) -> dict[str, str]:
+        """Build the OpenAI-compatible env aider reads from the gateway config.
+
+        When a provider/gateway is wired (base URL + a bearer-token command),
+        run the command once to snapshot a token and return ``OPENAI_BASE_URL``
+        / ``OPENAI_API_KEY`` / ``OPENAI_MODEL``. Returns an empty dict when no
+        gateway is configured (aider's ambient auth path). Mirrors
+        :meth:`QwenExecutor._resolve_gateway_env`.
+
+        :returns: The OPENAI_* overrides, or ``{}`` when no gateway is wired.
+        :raises RuntimeError: If the auth command fails or yields no token.
+        """
+        if not self._gateway_base_url or not self._gateway_auth_command:
+            return {}
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            self._gateway_auth_command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await proc.communicate()
+        if proc.returncode != 0:
+            detail = err.decode("utf-8", errors="replace").strip()[:200]
+            raise RuntimeError(
+                f"aider gateway auth command failed (exit {proc.returncode}): {detail}"
+            )
+        token = out.decode("utf-8", errors="replace").strip()
+        if not token:
+            raise RuntimeError("aider gateway auth command produced an empty token")
+        env: dict[str, str] = {
+            "OPENAI_BASE_URL": self._gateway_base_url,
+            "OPENAI_API_KEY": token,
+        }
+        if self._model:
+            env["OPENAI_MODEL"] = self._model
+        return env
+
+    def _sandbox_launch_path(self, spawn_env_names: Sequence[str]) -> str:
+        """Return the path to spawn for aider — sandbox launcher or bare binary.
+
+        Mirrors :meth:`QwenExecutor._sandbox_launch_path`. When ``os_env.sandbox``
+        requests confinement, wraps the aider binary in the platform sandbox so
+        its file/shell tools run confined to the spec's read/write roots. Falls
+        back to the bare binary (never blocks startup) when no sandbox is
+        requested, the resolved policy is inactive, or the backend is
+        unavailable. Aider is a pip CLI, so the Python interpreter prefixes are
+        added as read roots and ``~/.aider`` + ``/tmp`` as write roots.
+
+        :param spawn_env_names: Env-var names set on the subprocess ``env=``;
+            baked into the policy so the launcher prunes anything else.
+        :returns: The path to pass as argv[0] to ``create_subprocess_exec``.
+        """
+        os_env = self._os_env
+        if os_env is None:
+            return self._aider_path
+        sandbox_spec = os_env.sandbox or OSEnvSandboxSpec()
+        if sandbox_spec.type == "none":
+            return self._aider_path
+        try:
+            from .sandbox import (
+                create_exec_launcher,
+                resolve_sandbox,
+                with_additional_read_roots,
+                with_additional_write_roots,
+                with_spawn_env_allowlist,
+            )
+
+            cwd = Path(self._cwd or os.getcwd()).resolve(strict=False)
+            sandbox = resolve_sandbox(os_env, cwd)
+            if not sandbox.active:
+                return self._aider_path
+            aider_real = shutil.which(self._aider_path) or self._aider_path
+            # aider is a pip CLI: it must read the Python interpreter + its
+            # site-packages and the binary's own tree, and write its config /
+            # history dir (~/.aider) and /tmp, or it can't start inside the jail.
+            read_roots = [
+                Path(sys.base_prefix),
+                Path(sys.prefix),
+                Path(aider_real).resolve().parent.parent,
+            ]
+            sandbox = with_additional_read_roots(sandbox, read_roots)
+            sandbox = with_additional_write_roots(sandbox, [Path.home() / ".aider", Path("/tmp")])
+            sandbox = with_spawn_env_allowlist(sandbox, spawn_env_names)
+            return create_exec_launcher(aider_real, sandbox)
+        except (OSError, ImportError, NotImplementedError) as exc:
+            logger.warning("Could not apply sandbox for aider; running unsandboxed: %s", exc)
+            return self._aider_path
+
+    # ------------------------------------------------------------------
+    # Executor interface
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _drain(stream: asyncio.StreamReader | None, sink: list[str]) -> None:
+        """Continuously drain a subprocess pipe into *sink*.
+
+        Draining stderr concurrently with the stdout read prevents a chatty
+        aider from filling the OS pipe buffer (~64 KiB) and wedging mid-turn.
+        """
+        if stream is None:
+            return
+        while True:
+            line = await stream.readline()
+            if not line:
+                return
+            sink.append(line.decode("utf-8", errors="replace"))
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[Any],  # type: ignore[explicit-any]  # noqa: ARG002 — aider runs its own tool loop; required by the Executor interface
+        system_prompt: str,
+        config: ExecutorConfig | None = None,  # noqa: ARG002 — unused; required by the Executor interface
+    ) -> AsyncIterator[ExecutorEvent]:
+        """Run one turn by invoking aider once in ``--message`` mode.
+
+        :param messages: Conversation history; only the latest user message is
+            sent (aider carries prior context via its restored workspace history).
+        :param tools: Tool specs (ignored — aider uses its own tool registry).
+        :param system_prompt: Agent instructions, folded into the first turn.
+        :param config: Optional executor config (unused).
+        """
+        aider_bin = shutil.which(self._aider_path)
+        if aider_bin is None and not os.path.isfile(self._aider_path):
+            yield ExecutorError(
+                message=(
+                    f"aider CLI not found ({self._aider_path!r}). "
+                    "Install it with `python -m pip install aider-chat`."
+                ),
+                retryable=False,
+            )
+            return
+
+        user_text = self._latest_user_text(messages)
+        if not self._system_prompt_sent and system_prompt:
+            user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
+            self._system_prompt_sent = True
+        if not user_text.strip():
+            yield TurnComplete(response="")
+            return
+
+        try:
+            env = os.environ.copy()
+            env.update(await self._resolve_gateway_env())
+        except Exception as exc:  # noqa: BLE001 — surface gateway failures as a clean error
+            yield ExecutorError(message=str(exc), retryable=False)
+            return
+
+        launch_path = self._sandbox_launch_path(tuple(env.keys()))
+        argv = self._build_argv(launch_path, user_text, restore=self._has_history)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                cwd=self._cwd,
+                limit=_STREAM_LIMIT,
+            )
+        except (OSError, ValueError) as exc:
+            yield ExecutorError(message=f"failed to launch aider: {exc}", retryable=False)
+            return
+
+        stderr_chunks: list[str] = []
+        stderr_task = asyncio.create_task(self._drain(proc.stderr, stderr_chunks))
+        accumulated: list[str] = []
+        assert proc.stdout is not None
+        timed_out = False
+        try:
+            while True:
+                try:
+                    raw = await asyncio.wait_for(
+                        proc.stdout.readline(), timeout=_TURN_IDLE_TIMEOUT_SECONDS
+                    )
+                except asyncio.TimeoutError:
+                    timed_out = True
+                    proc.kill()
+                    break
+                if not raw:
+                    break
+                text = raw.decode("utf-8", errors="replace")
+                accumulated.append(text)
+                if text.strip():
+                    yield TextChunk(text=text)
+        finally:
+            with contextlib.suppress(Exception):
+                await stderr_task
+
+        await proc.wait()
+        # aider has now written workspace chat history; later turns restore it.
+        self._has_history = True
+
+        if timed_out:
+            secs = int(_TURN_IDLE_TIMEOUT_SECONDS)
+            yield ExecutorError(
+                message=f"aider produced no output for {secs}s; turn aborted",
+                retryable=True,
+            )
+            return
+        if proc.returncode != 0:
+            detail = ("".join(stderr_chunks).strip() or "".join(accumulated).strip())[:800]
+            yield ExecutorError(
+                message=f"aider exited with code {proc.returncode}: {detail}",
+                retryable=False,
+            )
+            return
+        yield TurnComplete(response="".join(accumulated).strip(), usage=None)
+
+    async def close_session(self, session_key: str) -> None:
+        """No-op: each turn is its own short-lived subprocess."""
+
+    async def close(self) -> None:
+        """No-op: the executor holds no long-lived subprocess."""

--- a/omnigent/inner/aider_harness.py
+++ b/omnigent/inner/aider_harness.py
@@ -1,0 +1,143 @@
+"""
+``harness: aider`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the
+shared :mod:`omnigent.runtime.harnesses._runner` invokes after
+the parent process resolves ``"aider"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Internally, instantiates :class:`omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`
+around a :class:`omnigent.inner.aider_executor.AiderExecutor`
+configured from env vars the parent process sets before spawning.
+Mirrors the qwen wrap (``qwen_harness.py``).
+
+Env vars read at startup:
+
+- ``HARNESS_AIDER_MODEL``: model identifier passed to ``aider --model``,
+  e.g. ``"claude-3-5-sonnet"``. ``None`` falls back to aider's default.
+- ``HARNESS_AIDER_CWD``: working directory the executor launches aider in.
+  ``None`` falls back to ``OMNIGENT_RUNNER_WORKSPACE`` if set, then to the
+  subprocess's inherited cwd.
+- ``HARNESS_AIDER_PATH``: absolute path to an ``aider`` CLI binary.
+  ``None`` searches ``PATH``.
+- ``HARNESS_AIDER_OS_ENV``: JSON-encoded :class:`OSEnvSpec`
+  (from :func:`dataclasses.asdict`). When unset, the wrap falls back to a
+  default ``OSEnvSpec(type="caller_process", sandbox=type="none")``.
+- ``HARNESS_AIDER_GATEWAY_BASE_URL`` / ``HARNESS_AIDER_GATEWAY_AUTH_COMMAND``:
+  OpenAI-compatible provider/gateway routing from the spec's ``auth:`` /
+  ``providers:`` config. When both are set, the executor exports
+  ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` / ``OPENAI_MODEL`` into the aider
+  subprocess (aider routes via LiteLLM) instead of relying on ambient auth.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from fastapi import FastAPI
+
+from omnigent.inner.aider_executor import AiderExecutor
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+# Env-var keys the wrap reads at executor construction time. Centralizing as
+# constants so misconfigurations surface as a single grep target.
+_ENV_MODEL = "HARNESS_AIDER_MODEL"
+_ENV_CWD = "HARNESS_AIDER_CWD"
+_ENV_AIDER_PATH = "HARNESS_AIDER_PATH"
+_ENV_OS_ENV = "HARNESS_AIDER_OS_ENV"
+# Generic-provider / gateway routing: an OpenAI-compatible base URL plus a
+# shell command that prints a bearer token. The executor translates them into
+# the OPENAI_* env vars aider's LiteLLM backend reads.
+_ENV_GATEWAY_BASE_URL = "HARNESS_AIDER_GATEWAY_BASE_URL"
+_ENV_GATEWAY_AUTH_COMMAND = "HARNESS_AIDER_GATEWAY_AUTH_COMMAND"
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    """
+    Resolve the inner-executor :class:`OSEnvSpec` from env config.
+
+    Reads :data:`_ENV_OS_ENV` and decodes the JSON-encoded dict Omnigent
+    serialized via :func:`dataclasses.asdict` on its :class:`OSEnvSpec`. When
+    the env var is missing or malformed, falls back to
+    ``caller_process + sandbox=none``. Mirrors
+    :func:`omnigent.inner.qwen_harness._resolve_os_env`.
+
+    :returns: An :class:`OSEnvSpec` to hand to :class:`AiderExecutor`.
+    """
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env",
+                _ENV_OS_ENV,
+                exc,
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+def _build_aider_executor() -> Executor:
+    """
+    Construct an :class:`AiderExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first turn.
+
+    :returns: A configured :class:`AiderExecutor` instance.
+    """
+    cwd_raw = os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE")
+    cwd = cwd_raw or None
+    model_raw = os.environ.get(_ENV_MODEL, "").strip()
+    model = model_raw or None
+    aider_path_raw = os.environ.get(_ENV_AIDER_PATH, "").strip()
+    aider_path = aider_path_raw or None
+    gateway_base_url = os.environ.get(_ENV_GATEWAY_BASE_URL, "").strip() or None
+    gateway_auth_command = os.environ.get(_ENV_GATEWAY_AUTH_COMMAND, "").strip() or None
+
+    return AiderExecutor(
+        cwd=cwd,
+        os_env=_resolve_os_env(),
+        model=model,
+        aider_path=aider_path,
+        gateway_base_url=gateway_base_url,
+        gateway_auth_command=gateway_auth_command,
+    )
+
+
+def create_app() -> FastAPI:
+    """
+    Build the aider harness's FastAPI app.
+
+    Required entry point per the harness contract — the runner imports this
+    module (resolved from :data:`omnigent.runtime.harnesses._HARNESS_MODULES`)
+    and invokes ``create_app()`` to get the app it serves. The wrapped
+    :class:`AiderExecutor` is constructed lazily on the first turn, so an absent
+    ``aider`` CLI surfaces as a request-time error, not an app-boot crash.
+
+    :returns: The FastAPI app from :class:`ExecutorAdapter`'s :meth:`build`.
+    """
+    adapter = ExecutorAdapter(executor_factory=_build_aider_executor, harness_label="Aider")
+    return adapter.build()

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -100,6 +100,7 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
     "agy": "antigravity",
     "google-antigravity": "antigravity",
     "qwen": "qwen",
+    "aider": "aider",
 }
 
 # Preferred inline family per single-family harness (pi consumes both).
@@ -109,6 +110,7 @@ _KEY_AUTH_FAMILY: dict[str, str] = {
     "openai-agents-sdk": OPENAI_FAMILY,
     "antigravity": OPENAI_FAMILY,
     "qwen": OPENAI_FAMILY,
+    "aider": OPENAI_FAMILY,
 }
 
 # Multi-family providers (pi): anthropic first, matching _apply_provider_to_pi.

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -26,7 +26,7 @@ _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\[\]-]*$")
 # SDK harnesses whose model override lands in the spawn env — must stay
 # in sync with ``_HARNESS_MODEL_ENV_KEY`` in ``omnigent/runner/app.py``.
 _SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
-    {"claude-sdk", "codex", "pi", "openai-agents", "cursor", "antigravity", "qwen"}
+    {"claude-sdk", "codex", "pi", "openai-agents", "cursor", "antigravity", "qwen", "aider"}
 )
 
 

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -56,6 +56,12 @@ QWEN_KEY = "qwen"
 # installer rather than npm — so it carries an ``install_hint``, not a ``package``.
 CURSOR_KEY = "cursor"
 
+# Aider installs via pip (``pip install aider-chat``), not npm, so like Cursor it
+# carries an ``install_hint`` and no ``package``. The binary name is ``aider``.
+# Auth is bring-your-own provider key via env (no CLI login), like qwen — so no
+# login/logout/status args.
+AIDER_KEY = "aider"
+
 
 @dataclass(frozen=True)
 class HarnessInstallSpec:
@@ -141,6 +147,12 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         install_hint="curl https://cursor.com/install -fsS | bash",
         login_status_key="isAuthenticated",
     ),
+    AIDER_KEY: HarnessInstallSpec(
+        "Aider",
+        "aider",
+        package=None,
+        install_hint="python -m pip install aider-chat",
+    ),
 }
 
 
@@ -166,6 +178,7 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     "native-cursor": CURSOR_KEY,
     QWEN_KEY: QWEN_KEY,
     "qwen-code": QWEN_KEY,
+    AIDER_KEY: AIDER_KEY,
 }
 
 

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -27,7 +27,13 @@ from __future__ import annotations
 import os
 
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
-from omnigent.onboarding.harness_install import CURSOR_KEY, PI_KEY, QWEN_KEY, harness_cli_installed
+from omnigent.onboarding.harness_install import (
+    AIDER_KEY,
+    CURSOR_KEY,
+    PI_KEY,
+    QWEN_KEY,
+    harness_cli_installed,
+)
 from omnigent.onboarding.provider_config import (
     _EXECUTOR_TYPE_HARNESS_ALIASES,
     _HARNESS_FAMILY,
@@ -64,6 +70,12 @@ _CURSOR_NATIVE_HARNESSES: frozenset[str] = frozenset({"cursor-native", "native-c
 # be gated explicitly or they fail open.
 _QWEN_HARNESSES: frozenset[str] = frozenset({QWEN_KEY, "qwen-code"})
 
+# CLI-wrapping aider harness. Gates on the ``aider`` binary (``pip install
+# aider-chat``). Like qwen it has an ``_HARNESS_FAMILY`` entry (the OpenAI
+# family), so ``_install_key`` must special-case it to the ``aider`` CLI rather
+# than the family's claude/codex binary.
+_AIDER_HARNESSES: frozenset[str] = frozenset({AIDER_KEY})
+
 
 def _canonical_harness(harness: str) -> str:
     """Normalize a harness id to its canonical spelling.
@@ -93,6 +105,8 @@ def _install_key(canonical: str) -> str:
     """
     if canonical in _QWEN_HARNESSES:
         return QWEN_KEY
+    if canonical in _AIDER_HARNESSES:
+        return AIDER_KEY
     return _HARNESS_FAMILY.get(canonical) or PI_KEY
 
 
@@ -144,6 +158,7 @@ def harness_is_configured(harness: str) -> bool:
         canonical not in _HARNESS_FAMILY
         and canonical not in _PI_HARNESSES
         and canonical not in _QWEN_HARNESSES
+        and canonical not in _AIDER_HARNESSES
     ):
         # Unknown harness — the daemon has no install metadata for it, so
         # it can't assess readiness. Fail open (custom/newer harnesses,
@@ -171,5 +186,6 @@ def configured_harness_map() -> dict[str, bool]:
     spellings.update(_PI_HARNESSES)
     spellings.update(_CURSOR_NATIVE_HARNESSES)
     spellings.update(_QWEN_HARNESSES)
+    spellings.update(_AIDER_HARNESSES)
     spellings.add(CURSOR_KEY)
     return {spelling: harness_is_configured(spelling) for spelling in spellings}

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -138,6 +138,9 @@ _HARNESS_FAMILY: dict[str, str] = {
     "antigravity": OPENAI_FAMILY,
     # Qwen Code uses an OpenAI-compatible provider (like Kimi v1).
     "qwen": OPENAI_FAMILY,
+    # Aider routes through LiteLLM; default it to the OpenAI-compatible family
+    # (BYO provider key / OpenAI-compatible gateway), like qwen.
+    "aider": OPENAI_FAMILY,
 }
 
 # Executor-type spellings that ``AgentSpec.harness_kind`` returns for SDK

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -13467,6 +13467,7 @@ _HARNESS_MODEL_ENV_KEY: dict[str, str] = {
     # ``--model`` arg in _auto_create_cursor_terminal, not via an env var.
     "antigravity": "HARNESS_ANTIGRAVITY_MODEL",
     "qwen": "HARNESS_QWEN_MODEL",
+    "aider": "HARNESS_AIDER_MODEL",
 }
 
 
@@ -13494,6 +13495,7 @@ def _build_spawn_env_from_spec(
     """
     try:
         from omnigent.runtime.workflow import (
+            _build_aider_spawn_env,
             _build_antigravity_spawn_env,
             _build_claude_sdk_spawn_env,
             _build_codex_spawn_env,
@@ -13517,6 +13519,8 @@ def _build_spawn_env_from_spec(
             env = _build_antigravity_spawn_env(spec)
         elif harness == "qwen":
             env = _build_qwen_spawn_env(spec, workdir=workdir)
+        elif harness == "aider":
+            env = _build_aider_spawn_env(spec, workdir=workdir)
         else:
             # Native terminal harnesses and unknown harnesses build env elsewhere.
             return None

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -77,6 +77,10 @@ _HARNESS_MODULES: dict[str, str] = {
     # Qwen Code harness wrap. See omnigent/inner/qwen_harness.py.
     # Drives the ``qwen`` CLI in ACP mode (``qwen --acp``) for agent execution.
     "qwen": "omnigent.inner.qwen_harness",
+    # Aider harness wrap. See omnigent/inner/aider_harness.py. Drives the
+    # ``aider`` CLI in one-shot mode (``aider --message ...``); an SDK-style
+    # harness (no native TUI), so it is NOT in NATIVE_HARNESSES.
+    "aider": "omnigent.inner.aider_harness",
 }
 
 __all__ = ["_HARNESS_MODULES"]

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -140,7 +140,9 @@ _logger = logging.getLogger(__name__)
 # (hyphen), e.g. ``"claude_sdk"`` → ``"claude-sdk"`` used by ``_HARNESS_MODULES``.
 
 
-AgentHarnessType = Literal["claude-sdk", "codex", "pi", "openai-agents-sdk", "antigravity", "qwen"]
+AgentHarnessType = Literal[
+    "claude-sdk", "codex", "pi", "openai-agents-sdk", "antigravity", "qwen", "aider"
+]
 
 
 @dataclass(frozen=True)
@@ -232,6 +234,16 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         base_urls_key=None,
         host_key="HARNESS_QWEN_GATEWAY_HOST",
         auth_key="HARNESS_QWEN_GATEWAY_AUTH_COMMAND",
+        refresh_key=None,
+    ),
+    "aider": UcodeHarnessConfig(
+        agent_name="aider",
+        model_key="HARNESS_AIDER_MODEL",
+        base_url_key="HARNESS_AIDER_GATEWAY_BASE_URL",
+        base_url_family="openai",
+        base_urls_key=None,
+        host_key="HARNESS_AIDER_GATEWAY_HOST",
+        auth_key="HARNESS_AIDER_GATEWAY_AUTH_COMMAND",
         refresh_key=None,
     ),
     # NB: ``antigravity`` is intentionally absent. Unlike the gateway
@@ -396,6 +408,8 @@ _PROVIDER_HARNESS_FAMILY: dict[AgentHarnessType, str] = {
     "antigravity": OPENAI_FAMILY,
     # Qwen Code routes through OpenAI-compatible providers (like Kimi v1).
     "qwen": OPENAI_FAMILY,
+    # Aider routes through LiteLLM / OpenAI-compatible providers.
+    "aider": OPENAI_FAMILY,
 }
 
 # Maps harnesses that gate the vendor-neutral gateway transport on a
@@ -409,6 +423,7 @@ _HARNESS_GATEWAY_FLAG: dict[AgentHarnessType, str] = {
     "codex": "HARNESS_CODEX_GATEWAY",
     "pi": "HARNESS_PI_GATEWAY",
     "qwen": "HARNESS_QWEN_GATEWAY",
+    "aider": "HARNESS_AIDER_GATEWAY",
 }
 
 # Maps a generic-provider family to the key pi uses in its
@@ -430,6 +445,7 @@ _HARNESS_DATABRICKS_PROFILE: dict[AgentHarnessType, str] = {
     "pi": "HARNESS_PI_DATABRICKS_PROFILE",
     "openai-agents-sdk": "HARNESS_OPENAI_AGENTS_DATABRICKS_PROFILE",
     "qwen": "HARNESS_QWEN_DATABRICKS_PROFILE",
+    "aider": "HARNESS_AIDER_DATABRICKS_PROFILE",
     # NB: no ``antigravity`` — it has no Databricks/gateway path (Gemini-native).
 }
 
@@ -1345,6 +1361,58 @@ def _build_qwen_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_QWEN_OS_ENV"] = os_env_payload
+    return env
+
+
+def _build_aider_spawn_env(
+    spec: AgentSpec,
+    *,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """
+    Build the env-var dict the aider harness wrap reads.
+
+    Maps spec.executor fields → the ``HARNESS_AIDER_*`` env vars defined in
+    ``omnigent/inner/aider_harness.py``. Mirrors :func:`_build_qwen_spawn_env`;
+    aider routes through OpenAI-compatible providers via LiteLLM, so it reuses
+    the same generic-provider / ucode-gateway plumbing.
+
+    :param spec: The agent spec.
+    :param workdir: The bundle's on-disk path. Accepted for signature parity
+        with the other ``_build_*_spawn_env`` builders; the aider wrap does not
+        consume a bundle dir (no skills bridge).
+    :returns: A dict of env-var overrides for
+        :meth:`HarnessProcessManager.get_client(env=...)`.
+    """
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model is not None:
+        env["HARNESS_AIDER_MODEL"] = model
+
+    # Generic-provider branch first (a ProviderAuth on the spec, or the
+    # per-family global default), then the legacy-profile / databricks path —
+    # mirrors _build_qwen_spawn_env. Aider routes through OpenAI-compatible
+    # providers.
+    provider = _resolve_provider_for_build(spec, harness_type="aider")
+    if provider is not None:
+        configure_agent_harness_with_provider(env, provider, harness_type="aider")
+    else:
+        profile = spec.executor.config.get("profile")
+        use_databricks = bool(profile) or (
+            model is not None and model.startswith(("databricks-", "databricks/"))
+        )
+        if use_databricks:
+            env["HARNESS_AIDER_GATEWAY"] = "true"
+            if profile:
+                env["HARNESS_AIDER_DATABRICKS_PROFILE"] = str(profile)
+        configure_agent_harness_with_ucode(
+            env,
+            str(profile) if profile else None,
+            harness_type="aider",
+        )
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_AIDER_OS_ENV"] = os_env_payload
     return env
 
 

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -75,6 +75,7 @@ OMNIGENT_EXECUTOR_TYPE = "omnigent"
 # 'open-responses'" error.
 OMNIGENT_HARNESSES = frozenset(
     {
+        "aider",
         "antigravity",
         "claude-native",
         "claude-sdk",

--- a/tests/inner/test_aider_executor.py
+++ b/tests/inner/test_aider_executor.py
@@ -1,0 +1,369 @@
+"""Unit tests for AiderExecutor (one-shot ``aider --message`` CLI mode).
+
+Tests cover:
+- Executor construction and attribute defaults + capability flags
+- Prompt construction (_text_from_blocks, _latest_user_text)
+- run_turn event translation (stdout lines -> TextChunk, then TurnComplete)
+- run_turn argv (flags, --model, --restore-chat-history, system-prompt fold)
+- run_turn error paths (missing binary, non-zero exit)
+- Harness wrap env plumbing (_build_aider_executor)
+- Harness registry / allowlist / install / readiness wiring
+- FastAPI app shape
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from omnigent.inner import aider_executor
+from omnigent.inner.aider_executor import AiderExecutor
+from omnigent.inner.executor import ExecutorError, TextChunk, TurnComplete
+
+# ---------------------------------------------------------------------------
+# Fakes: stand in for the aider subprocess
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    """Minimal async stream: yields queued byte-lines then EOF (``b""``)."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+
+    async def readline(self) -> bytes:
+        return self._lines.pop(0) if self._lines else b""
+
+    async def read(self) -> bytes:
+        data = b"".join(self._lines)
+        self._lines = []
+        return data
+
+
+class _FakeProc:
+    """Stand-in for an ``asyncio`` subprocess for the one-shot aider run."""
+
+    def __init__(
+        self,
+        stdout_lines: list[bytes],
+        stderr_lines: list[bytes] | None = None,
+        returncode: int = 0,
+    ) -> None:
+        self.stdout = _FakeStream(stdout_lines)
+        self.stderr = _FakeStream(stderr_lines or [])
+        self.returncode = returncode
+        self.killed = False
+
+    async def wait(self) -> int:
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def _install_fake_aider(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout_lines: list[bytes],
+    stderr_lines: list[bytes] | None = None,
+    returncode: int = 0,
+) -> list[list[str]]:
+    """Patch the binary probe + subprocess spawn; capture each call's argv."""
+    captured_argv: list[list[str]] = []
+
+    async def _fake_exec(*args: str, **_kwargs: object) -> _FakeProc:
+        captured_argv.append([str(a) for a in args])
+        return _FakeProc(stdout_lines, stderr_lines, returncode)
+
+    monkeypatch.setattr(aider_executor.shutil, "which", lambda _name: "/usr/bin/aider")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    return captured_argv
+
+
+def _user(text: str) -> dict[str, object]:
+    return {"role": "user", "content": text}
+
+
+# ---------------------------------------------------------------------------
+# Construction / attribute defaults / capabilities
+# ---------------------------------------------------------------------------
+
+
+def test_executor_default_attributes() -> None:
+    executor = AiderExecutor()
+    assert executor._aider_path == "aider"
+    assert executor._model is None
+    assert executor._cwd == os.getcwd()
+    assert executor._system_prompt_sent is False
+    assert executor._has_history is False
+
+
+def test_executor_stores_model_and_cwd() -> None:
+    executor = AiderExecutor(cwd="/tmp", model="gpt-4o", aider_path="/opt/aider")
+    assert executor._cwd == "/tmp"
+    assert executor._model == "gpt-4o"
+    assert executor._aider_path == "/opt/aider"
+
+
+def test_capability_flags() -> None:
+    executor = AiderExecutor()
+    assert executor.supports_streaming() is True
+    # Aider runs its own agent loop and edits files itself.
+    assert executor.handles_tools_internally() is True
+    assert executor.supports_tool_calling() is False
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+def test_latest_user_text_plain_string() -> None:
+    executor = AiderExecutor()
+    messages = [
+        {"role": "assistant", "content": "earlier"},
+        _user("hello there"),
+    ]
+    assert executor._latest_user_text(messages) == "hello there"
+
+
+def test_text_from_blocks_folds_text_and_file() -> None:
+    blocks = [
+        {"type": "input_text", "text": "summarize"},
+        {
+            "type": "input_file",
+            "filename": "a.txt",
+            "file_data": "data:text/plain;base64,aGk=",  # "hi"
+        },
+    ]
+    folded = AiderExecutor._text_from_blocks(blocks)
+    assert "summarize" in folded
+    assert "--- attached file: a.txt ---" in folded
+    assert "hi" in folded
+
+
+def test_text_from_blocks_image_marker() -> None:
+    blocks = [{"type": "input_image", "filename": "pic.png"}]
+    assert AiderExecutor._text_from_blocks(blocks) == "[attached image: pic.png]"
+
+
+# ---------------------------------------------------------------------------
+# run_turn — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_run_turn_streams_text_then_completes(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_aider(monkeypatch, stdout_lines=[b"Hello\n", b"world\n"])
+    executor = AiderExecutor(model="gpt-4o")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "")]
+
+    text_chunks = [e for e in events if isinstance(e, TextChunk)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert [c.text for c in text_chunks] == ["Hello\n", "world\n"]
+    assert len(completes) == 1
+    assert completes[0].response == "Hello\nworld"
+    assert completes[0].usage is None
+
+
+async def test_run_turn_builds_expected_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    argv_calls = _install_fake_aider(monkeypatch, stdout_lines=[b"ok\n"])
+    executor = AiderExecutor(model="claude-3-5-sonnet")
+    _ = [e async for e in executor.run_turn([_user("do it")], [], "")]
+
+    argv = argv_calls[0]
+    assert argv[0] == "aider"
+    assert "--message" in argv
+    assert "--yes-always" in argv
+    assert "--no-stream" in argv
+    assert "--no-pretty" in argv
+    assert "--no-auto-commits" in argv
+    assert "--no-check-update" in argv
+    assert "--model" in argv and "claude-3-5-sonnet" in argv
+    # First turn does not restore history.
+    assert "--restore-chat-history" not in argv
+
+
+async def test_system_prompt_folded_into_first_turn_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    argv_calls = _install_fake_aider(monkeypatch, stdout_lines=[b"ok\n"])
+    executor = AiderExecutor()
+
+    _ = [e async for e in executor.run_turn([_user("first")], [], "BE HELPFUL")]
+    _ = [e async for e in executor.run_turn([_user("second")], [], "BE HELPFUL")]
+
+    first_msg = argv_calls[0][argv_calls[0].index("--message") + 1]
+    second_msg = argv_calls[1][argv_calls[1].index("--message") + 1]
+    assert "BE HELPFUL" in first_msg and "first" in first_msg
+    # System prompt is not re-sent; second turn restores prior history instead.
+    assert "BE HELPFUL" not in second_msg
+    assert second_msg.strip() == "second"
+    assert "--restore-chat-history" not in argv_calls[0]
+    assert "--restore-chat-history" in argv_calls[1]
+
+
+async def test_run_turn_empty_user_text_completes_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_aider(monkeypatch, stdout_lines=[b"unused\n"])
+    executor = AiderExecutor()
+    events = [e async for e in executor.run_turn([_user("   ")], [], "")]
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response == ""
+
+
+# ---------------------------------------------------------------------------
+# run_turn — error paths
+# ---------------------------------------------------------------------------
+
+
+async def test_run_turn_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(aider_executor.shutil, "which", lambda _name: None)
+    executor = AiderExecutor(aider_path="aider")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "")]
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert events[0].retryable is False
+    assert "aider-chat" in events[0].message
+
+
+async def test_run_turn_nonzero_exit_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_aider(
+        monkeypatch,
+        stdout_lines=[b"partial\n"],
+        stderr_lines=[b"boom: bad api key\n"],
+        returncode=2,
+    )
+    executor = AiderExecutor()
+    events = [e async for e in executor.run_turn([_user("hi")], [], "")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert errors[0].retryable is False
+    assert "exited with code 2" in errors[0].message
+    assert "bad api key" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# Harness wrap env plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_build_aider_executor_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.inner import aider_harness
+
+    monkeypatch.setenv("HARNESS_AIDER_MODEL", "gpt-4o-mini")
+    monkeypatch.setenv("HARNESS_AIDER_PATH", "/opt/aider")
+    monkeypatch.setenv("HARNESS_AIDER_GATEWAY_BASE_URL", "https://gw.example/v1")
+    monkeypatch.setenv("HARNESS_AIDER_GATEWAY_AUTH_COMMAND", "printf '%s' sk-x")
+
+    executor = aider_harness._build_aider_executor()
+    assert isinstance(executor, AiderExecutor)
+    assert executor._model == "gpt-4o-mini"
+    assert executor._aider_path == "/opt/aider"
+    assert executor._gateway_base_url == "https://gw.example/v1"
+    assert executor._gateway_auth_command == "printf '%s' sk-x"
+
+
+# ---------------------------------------------------------------------------
+# Registry / allowlist / install / readiness wiring
+# ---------------------------------------------------------------------------
+
+
+def test_aider_in_harness_registry() -> None:
+    from omnigent.runtime.harnesses import _HARNESS_MODULES
+
+    assert _HARNESS_MODULES.get("aider") == "omnigent.inner.aider_harness"
+
+
+def test_aider_in_harness_allowlist() -> None:
+    from omnigent.spec._omnigent_compat import OMNIGENT_HARNESSES
+
+    assert "aider" in OMNIGENT_HARNESSES
+
+
+def test_aider_install_spec_is_pip_not_npm() -> None:
+    from omnigent.onboarding.harness_install import required_cli_for_harness
+
+    spec = required_cli_for_harness("aider")
+    assert spec is not None
+    assert spec.binary == "aider"
+    # pip-installed: no npm package, an install_hint instead (like cursor).
+    assert spec.package is None
+    assert "aider-chat" in (spec.install_hint or "")
+
+
+def test_aider_provider_family_is_openai() -> None:
+    from omnigent.onboarding.provider_config import OPENAI_FAMILY, provider_family_for_harness
+
+    assert provider_family_for_harness("aider") == OPENAI_FAMILY
+
+
+def test_aider_readiness_gates_on_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.onboarding import harness_readiness
+
+    monkeypatch.setattr(harness_readiness, "harness_cli_installed", lambda _key: True)
+    assert harness_readiness.harness_is_configured("aider") is True
+
+    monkeypatch.setattr(harness_readiness, "harness_cli_installed", lambda _key: False)
+    assert harness_readiness.harness_is_configured("aider") is False
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app shape
+# ---------------------------------------------------------------------------
+
+
+def test_aider_harness_creates_fastapi_app() -> None:
+    from omnigent.inner.aider_harness import create_app
+
+    app = create_app()
+    assert app is not None
+    assert hasattr(app, "routes")
+    health_routes = [r for r in app.routes if hasattr(r, "path") and "/health" in r.path]
+    assert len(health_routes) > 0
+
+
+def test_aider_harness_module_importable() -> None:
+    from omnigent.inner import aider_harness
+
+    assert hasattr(aider_harness, "create_app")
+
+
+# ---------------------------------------------------------------------------
+# Spawn-env dispatch wiring (workflow.py / runner.app / model_override)
+# ---------------------------------------------------------------------------
+
+
+def test_aider_in_workflow_spawn_env_dispatch() -> None:
+    """aider must be wired into every workflow spawn-env routing table."""
+    from omnigent.runtime import workflow
+
+    assert workflow._PROVIDER_HARNESS_FAMILY["aider"] == "openai"
+    assert workflow._HARNESS_GATEWAY_FLAG["aider"] == "HARNESS_AIDER_GATEWAY"
+    assert workflow._HARNESS_DATABRICKS_PROFILE["aider"] == "HARNESS_AIDER_DATABRICKS_PROFILE"
+    assert "aider" in workflow._UCODE_HARNESS_CONFIGS
+    assert workflow._UCODE_HARNESS_CONFIGS["aider"].model_key == "HARNESS_AIDER_MODEL"
+    assert callable(workflow._build_aider_spawn_env)
+
+
+def test_aider_in_sdk_model_override_harnesses() -> None:
+    """A per-session /model override must apply to the aider spawn-env harness."""
+    from omnigent.model_override import _SDK_MODEL_OVERRIDE_HARNESSES
+
+    assert "aider" in _SDK_MODEL_OVERRIDE_HARNESSES
+
+
+def test_aider_model_env_key_in_runner_app() -> None:
+    """runner.app maps aider -> HARNESS_AIDER_MODEL.
+
+    Skipped where the runner module can't import (e.g. Windows lacks ``fcntl``);
+    CI on Linux exercises it.
+    """
+    try:
+        from omnigent.runner.app import _HARNESS_MODEL_ENV_KEY
+    except (ImportError, AttributeError) as exc:  # pragma: no cover - platform-dependent
+        pytest.skip(f"omnigent.runner.app not importable here: {exc}")
+    assert _HARNESS_MODEL_ENV_KEY["aider"] == "HARNESS_AIDER_MODEL"

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -145,6 +145,8 @@ def test_configured_harness_map_covers_all_spellings(
         # Qwen harnesses
         "qwen",
         "qwen-code",
+        # Aider harness
+        "aider",
     }
     assert set(result) == expected_keys
 


### PR DESCRIPTION
## Related issue

N/A — net-new harness; no existing tracking issue (and none in any PR/branch).

## Summary

Adds **Aider** ([aider.chat](https://aider.chat), `aider-chat`) as a new coding-agent harness, so agents can run with `harness: aider` (or `omnigent run --harness aider`). Modeled directly on the existing `qwen` harness.

- Aider's Python `Coder` API is explicitly *"not officially supported or documented and could change without backwards compatibility"*, so the executor drives the **CLI one-shot per turn** in the session workspace: `aider --message "<prompt>" --yes-always --no-stream --no-pretty --no-auto-commits --no-check-update --analytics-disable [--model …] [--restore-chat-history]`. stdout lines stream as `TextChunk`s; a final `TurnComplete` carries the response.
- Aider routes models through **LiteLLM**, which honors `OPENAI_BASE_URL` / `OPENAI_API_KEY`, so Omnigent's existing provider/gateway env plumbing (shared with qwen) works unchanged. Aider runs its own agent loop, so the executor reports `handles_tools_internally`.
- Wired across every qwen touchpoint: harness registry, spec allowlist, onboarding install (pip, not npm — `package=None` + `install_hint`, like Cursor) + readiness (gates on the `aider` binary), model-catalog / provider-config families (`openai`), workflow spawn-env (`_build_aider_spawn_env` + the four routing tables), runner dispatch + model-env-key, model-override, and CLI help/prompt.

### ELI5

Omnigent already lets you run agents through Claude Code, Codex, Cursor, Qwen, etc. This adds Aider to that list. When you pick `aider`, Omnigent shells out to the `aider` CLI once per turn, feeds it your message, and streams back whatever Aider prints — Aider does the file edits itself.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

New unit suite `tests/inner/test_aider_executor.py` (22 tests) covers: `TextChunk`+`TurnComplete` synthesis from mocked subprocess stdout; error paths (missing binary -> non-retryable `ExecutorError`; non-zero exit with stderr detail); argv/flags; system-prompt fold on the first turn only; `--restore-chat-history` on later turns; content-block prompt folding; `_build_aider_executor` env plumbing; and the full registration wiring (registry, allowlist, install spec, provider family, readiness gating, workflow spawn-env routing tables + `_build_aider_spawn_env`, model-override). Updated `tests/onboarding/test_harness_readiness.py` for the new `aider` map spelling.

Commands run (Windows, repo venv):
- `python -m pytest tests/inner/test_aider_executor.py` -> 22 passed, 1 skipped (the `runner.app` model-env-key assertion skips where `fcntl` is unavailable; Linux CI runs it).
- `python -m pytest tests/onboarding/test_harness_readiness.py` -> all pass.
- `ruff check` + `ruff format --check` on all changed files -> clean.

**E2E note:** a live e2e happy-path test is deferred — it needs `aider-chat` installed plus provider credentials in CI. Happy to add one following the existing harness e2e pattern if maintainers point me at the preferred fixture/credential path. Flagging explicitly per CONTRIBUTING's e2e expectation for user-facing functionality.

**Known limitations (follow-ups):** one-shot per turn (multi-turn context relies on Aider's persisted workspace chat history via `--restore-chat-history`); no token-usage reporting yet (`usage=None`, same as qwen initially); `--no-auto-commits` in v1 since Omnigent owns workspace change-tracking.
