### PR TITLE
fix(compact): make /compact acknowledge harness-owned compaction

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1424,6 +1424,38 @@ class ClaudeSDKExecutor(Executor):
             state.model = model
         return state.client
 
+    async def compact(self, session_key: str):  # type: ignore[override]
+        """Trigger explicit compaction by sending ``/compact`` to the CLI.
+
+        The CLI compacts its own context internally. We drain the
+        response stream so the compaction completes, then yield a
+        ``CompactionComplete`` event so the runner can update its
+        history mirror and publish SSE events.
+        """
+        state = self._clients.get(session_key)
+        if state is None:
+            return
+        client = state.client
+        try:
+            await client.query("/compact", session_id=session_key)
+            # Drain the response to let the CLI finish compacting.
+            async for _message in client.receive_response():
+                pass
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Explicit compaction failed for claude-sdk session %s",
+                session_key,
+                exc_info=True,
+            )
+            return
+        from omnigent.inner.executor import CompactionComplete
+
+        yield CompactionComplete(
+            summary="[Claude Code compaction — explicit /compact]",
+            token_count=0,
+            model=state.model,
+        )
+
     async def close_session(self, session_key: str) -> None:
         self._crashed_sessions.pop(session_key, None)
         await self._close_live_client(session_key)

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -582,6 +582,15 @@ class Executor:
         """Whether queued user input can be applied by interrupting after a tool boundary."""
         return False
 
+    async def compact(self, session_key: str) -> AsyncIterator[ExecutorEvent]:  # noqa: ARG002
+        """Trigger explicit compaction for *session_key*.
+
+        Yields CompactionComplete if compaction produced a result.
+        Default: no-op (yields nothing).
+        """
+        return
+        yield  # pragma: no cover
+
     def supports_stepwise_internal_turns(self) -> bool:
         """Whether the executor can pause and resume its own agent loop between turns."""
         return False

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -1118,6 +1118,35 @@ class OpenAIAgentsSDKExecutor(Executor):
         self._session_states[session_key] = state
         return state
 
+    async def compact(self, session_key: str):  # type: ignore[override]
+        """Trigger explicit compaction via the SDK session's ``run_compaction``."""
+        from .executor import CompactionComplete
+
+        state = self._session_states.get(session_key)
+        if state is None:
+            return
+        session = state.sdk_session
+        run_compaction = getattr(session, "run_compaction", None)
+        if run_compaction is None:
+            return
+        try:
+            await run_compaction({"force": True})
+        except Exception:  # noqa: BLE001
+            logger.debug("Explicit compaction failed", exc_info=True)
+            return
+        # Read compacted state
+        _compacted = None
+        try:
+            _compacted = await session.get_items()
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to read compacted items", exc_info=True)
+        yield CompactionComplete(
+            summary="[OpenAI Responses API compaction — explicit /compact]",
+            token_count=0,
+            model=self._model_override,
+            compacted_messages=_compacted,
+        )
+
     async def close_session(self, session_key: str) -> None:
         self._session_states.pop(session_key, None)
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11297,17 +11297,37 @@ def create_runner_app(
         if body_type == "compact":
             # Omnigent server forwards explicit /compact here.
             # Native harnesses inject /compact into the tmux pane so
-            # the CLI compacts its own context. SDK harnesses manage
-            # compaction automatically (OpenAIResponsesCompactionSession /
-            # Claude SDK PreCompact hook) — return 200 to prevent the
-            # server from falling through to the now-removed server-side
-            # compact_conversation_now() path.
+            # the CLI compacts its own context.
             if _session_harness_name(conversation_id) == "claude-native":
                 return await _handle_claude_native_compact(conversation_id)
             if _session_harness_name(conversation_id) == "codex-native":
                 return await _handle_codex_native_compact(conversation_id)
-            # SDK harnesses: compaction is automatic, acknowledge the
-            # control so the server doesn't attempt its own compaction.
+            # Forward to harness subprocess for SDK harnesses.
+            try:
+                harness_client = await process_manager.get_client(conversation_id, "any")
+                resp = await harness_client.post(
+                    f"/v1/sessions/{conversation_id}/events",
+                    json={"type": "compact"},
+                    timeout=30.0,
+                )
+                if resp.status_code == 200 and resp.content:
+                    compact_data = resp.json()
+                    if compact_data and compact_data.get("summary"):
+                        _publish_event(
+                            conversation_id, {"type": "response.compaction.in_progress"}
+                        )
+                        await _handle_harness_compaction(
+                            conversation_id,
+                            {
+                                "summary": compact_data.get("summary"),
+                                "total_tokens": compact_data.get("token_count"),
+                                "summary_model": compact_data.get("model"),
+                                "compacted_messages": compact_data.get("compacted_messages"),
+                            },
+                        )
+                        _publish_event(conversation_id, {"type": "response.compaction.completed"})
+            except Exception:  # noqa: BLE001
+                _logger.debug("Compact forward failed for %s", conversation_id, exc_info=True)
             return Response(status_code=200)
 
         if body_type == "cost_approval_popup":

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11295,18 +11295,20 @@ def create_runner_app(
             return Response(status_code=204)
 
         if body_type == "compact":
-            # Omnigent server forwards explicit /compact here. claude-native
-            # and codex-native inject the slash command into the tmux
-            # pane so the CLI compacts its own context, and return 200
-            # to signal the control was handled in the terminal. Other
-            # harnesses 204 no-op — their explicit compaction is an
-            # AP-side operation the server runs when the runner does
-            # not handle the control (see ``_run_compact_locked``).
+            # Omnigent server forwards explicit /compact here.
+            # Native harnesses inject /compact into the tmux pane so
+            # the CLI compacts its own context. SDK harnesses manage
+            # compaction automatically (OpenAIResponsesCompactionSession /
+            # Claude SDK PreCompact hook) — return 200 to prevent the
+            # server from falling through to the now-removed server-side
+            # compact_conversation_now() path.
             if _session_harness_name(conversation_id) == "claude-native":
                 return await _handle_claude_native_compact(conversation_id)
             if _session_harness_name(conversation_id) == "codex-native":
                 return await _handle_codex_native_compact(conversation_id)
-            return Response(status_code=204)
+            # SDK harnesses: compaction is automatic, acknowledge the
+            # control so the server doesn't attempt its own compaction.
+            return Response(status_code=200)
 
         if body_type == "cost_approval_popup":
             # Omnigent server forwards a cost-budget checkpoint here so it can

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -506,6 +506,28 @@ class ExecutorAdapter(HarnessApp):
             self._current_ctx = None
             self._current_agent = None
 
+    async def _handle_compact_event(self) -> Response:
+        """Forward explicit /compact to the inner executor."""
+        from fastapi.responses import JSONResponse
+
+        executor = self._ensure_executor()
+        result = None
+        try:
+            async for event in executor.compact(self._session_key):
+                if isinstance(event, CompactionComplete):
+                    result = {
+                        "summary": event.summary,
+                        "token_count": event.token_count,
+                        "model": event.model,
+                        "compacted_messages": event.compacted_messages,
+                    }
+                    break
+        except Exception:
+            _logger.debug("Explicit compaction failed", exc_info=True)
+        if result is not None:
+            return JSONResponse(status_code=200, content=result)
+        return Response(status_code=200)
+
     async def _handle_interrupt_event(self) -> Response:
         """Cancel the turn AND drop the inner executor session.
 

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -337,13 +337,24 @@ class PolicyVerdictEvent(BaseModel):
     data: dict[str, Any] | None = None
 
 
+class CompactEvent(BaseModel):
+    """Downward compact event — trigger explicit context compaction."""
+
+    type: Literal["compact"]
+
+
 # Discriminated union of every downward event the harness accepts on
 # ``POST /v1/sessions/{conversation_id}/events``. FastAPI / Pydantic
 # v2 dispatches by the ``type`` field at request-validation time;
 # unknown values raise 422 (fail-loud per
 # ``designs/DESIGN_PRINCIPLES.md``).
 InboundEventRequest = Annotated[
-    MessageEvent | InterruptEvent | ToolResultEvent | ApprovalEvent | PolicyVerdictEvent,
+    MessageEvent
+    | InterruptEvent
+    | ToolResultEvent
+    | ApprovalEvent
+    | PolicyVerdictEvent
+    | CompactEvent,
     Field(discriminator="type"),
 ]
 
@@ -1074,6 +1085,8 @@ class HarnessApp:
             )
         if isinstance(body, PolicyVerdictEvent):
             return await self._handle_policy_verdict_event(body)
+        if isinstance(body, CompactEvent):
+            return await self._handle_compact_event()
         # Pydantic's discriminated-union validator should reject
         # unknown variants before we reach this branch; if it ever
         # falls through, fail loud rather than silently no-op.
@@ -1081,6 +1094,10 @@ class HarnessApp:
             f"unsupported inbound event type {type(body).__name__!r}",
             code=ErrorCode.INVALID_INPUT,
         )
+
+    async def _handle_compact_event(self) -> Response:
+        """Default: return 204 (not handled)."""
+        return Response(status_code=204)
 
     async def _handle_interrupt_event(self) -> Response:
         """

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -17024,19 +17024,10 @@ def create_sessions_router(
             )
             return {"queued": False, "elicitation_id": elicit_id}
         if body.type == _COMPACT_TYPE:
-            # Unified control dispatch (designs/CLAUDE_NATIVE.md
-            # "Control events dispatch on the runner"): forward /compact
-            # to the bound runner first, regardless of harness. The
-            # runner dispatches by harness — claude-native injects
-            # /compact into the tmux pane so Claude Code compacts its
-            # own context and returns 200; other harnesses 204 no-op.
-            # The Omnigent server stays harness-agnostic: it runs its own
-            # in-process compaction only when the runner did NOT handle
-            # the control (204 / no runner bound). A 4xx/5xx from the
-            # runner (e.g. 503 when the claude-native pane isn't
-            # attached) is surfaced as an error rather than silently
-            # falling through to AP-side compaction, which would be
-            # wrong for a terminal-owned session.
+            # Forward /compact to the runner. The runner dispatches by
+            # harness: native harnesses inject the slash command into the
+            # tmux pane; SDK harnesses acknowledge the control (compaction
+            # is automatic). All harnesses return 200.
             runner_result = await _forward_session_change_to_runner(
                 session_id,
                 runner_router,
@@ -17044,17 +17035,12 @@ def create_sessions_router(
             )
             if runner_result is not None and runner_result.status_code == 200:
                 return {"queued": False}
-            if runner_result is not None and runner_result.status_code != 204:
+            if runner_result is not None and runner_result.status_code >= 400:
                 raise OmnigentError(
                     f"Compaction failed: runner returned {runner_result.status_code}",
                     code=ErrorCode.INTERNAL_ERROR,
                 )
-            await _run_compact_locked(
-                session_id,
-                conv,
-                agent_store,
-                agent_cache,
-            )
+            # No runner bound — nothing to compact.
             return {"queued": False}
         if body.type == "compaction":
             import uuid as _uuid


### PR DESCRIPTION
## Summary

Follow-up to #1082 (harness-owned compaction). The explicit `/compact` control event was falling through to the server-side `compact_conversation_now()` for non-native harnesses, which only compacts the runner's history mirror — a noop since harnesses own their real context.

Now `/compact` triggers real compaction on SDK harnesses:

- **Executor base class**: new `compact(session_key)` async generator method (no-op default)
- **OpenAI Agents SDK**: implements `compact()` by calling `session.run_compaction(force=True)` and yielding `CompactionComplete` with the compacted session items
- **Harness scaffold**: new `CompactEvent` in the inbound event union + `_handle_compact_event()` dispatch
- **Executor adapter**: overrides `_handle_compact_event()` to call the executor's `compact()` and return compaction data as JSON
- **Runner**: forwards `/compact` to the harness subprocess, persists returned compaction data via `_handle_harness_compaction`, and publishes SSE events
- **Server**: removed `_run_compact_locked` fallback — runner always returns 200

### Backward compatibility
- Old harness subprocesses without `CompactEvent` return 422 (unknown event type) — runner catches all exceptions and treats as no-op
- Old servers that still call `_run_compact_locked` do a harmless noop
- `compact()` on Executor base is a no-op so existing executors don't break

## Test plan

- [ ] Verify `/compact` still works for claude-native (injects into tmux pane)
- [ ] Verify `/compact` triggers real compaction for openai-agents-sdk sessions
- [ ] Verify `/compact` returns success for claude-sdk sessions (no-op, compaction is automatic via PreCompact)
- [ ] Verify old harness subprocesses gracefully handle unknown "compact" event type

This pull request and its description were written by Isaac.