### PR TITLE
feat(qwen): native-qwen TUI harness (embedded Qwen Code, resume, clean exit)

### DIFF
--- a/ap-web/src/hooks/useTerminals.test.ts
+++ b/ap-web/src/hooks/useTerminals.test.ts
@@ -489,6 +489,12 @@ describe("inventoryTerminals", () => {
     session: "main",
     running: true,
   };
+  const qwenPane: TerminalInfo = {
+    id: "terminal_qwen_main",
+    name: "qwen",
+    session: "main",
+    running: true,
+  };
   const bash: TerminalInfo = {
     id: "terminal_bash_s1",
     name: "bash",
@@ -517,6 +523,15 @@ describe("inventoryTerminals", () => {
     // mode as the pi/cursor panes above.
     expect(inventoryTerminals([goosePane, bash], true)).toEqual([bash]);
     expect(isAgentTerminalKey("terminal:terminal_goose_main")).toBe(true);
+  });
+
+  it("drops the qwen vendor pane for native Qwen sessions", () => {
+    // Regression: terminal_qwen_main was missing from AGENT_TERMINAL_IDS, so
+    // clicking Terminal opened the qwen TUI pane as a plain shell (shell-header
+    // chrome) while hiding the Chat/Terminal pill via isShellView — same failure
+    // mode as the pi/cursor/goose panes above.
+    expect(inventoryTerminals([qwenPane, bash], true)).toEqual([bash]);
+    expect(isAgentTerminalKey("terminal:terminal_qwen_main")).toBe(true);
   });
 
   it("drops the embedded REPL terminal for terminal-first SDK sessions", () => {
@@ -559,6 +574,9 @@ describe("isAgentTerminalKey", () => {
     expect(isAgentTerminalKey("terminal:terminal_pi_main")).toBe(true);
     // cursor-native: same regression class as pi above.
     expect(isAgentTerminalKey("terminal:terminal_cursor_main")).toBe(true);
+    // goose-/qwen-native: same regression class as pi/cursor above.
+    expect(isAgentTerminalKey("terminal:terminal_goose_main")).toBe(true);
+    expect(isAgentTerminalKey("terminal:terminal_qwen_main")).toBe(true);
   });
 
   it("treats a user shell as not-the-agent-terminal", () => {

--- a/ap-web/src/hooks/useTerminals.ts
+++ b/ap-web/src/hooks/useTerminals.ts
@@ -50,8 +50,8 @@ export const PANEL_NO_TERMINAL_KEY = "";
  * connection pill's Terminal view, runner-created per session shape:
  * the embedded Omnigent REPL (``tui``/``main``) for SDK sessions,
  * and the vendor pane (``claude``/``main``, ``codex``/``main``,
- * ``pi``/``main``, or ``cursor``/``main``) for native-wrapper sessions.
- * These are plumbing, not
+ * ``pi``/``main``, ``cursor``/``main``, ``goose``/``main``, or
+ * ``qwen``/``main``) for native-wrapper sessions. These are plumbing, not
  * part of the session's shell inventory, and at most one exists per session.
  *
  * Missing an entry here makes that pane read as a *user shell*: the
@@ -67,6 +67,7 @@ export const AGENT_TERMINAL_IDS: ReadonlySet<string> = new Set([
   "terminal_pi_main",
   "terminal_cursor_main",
   "terminal_goose_main",
+  "terminal_qwen_main",
 ]);
 
 /**

--- a/ap-web/src/lib/agentGrouping.ts
+++ b/ap-web/src/lib/agentGrouping.ts
@@ -18,6 +18,7 @@ export const BUILTIN_AGENTS = new Set([
   "pi-native-ui", // Pi
   "cursor-native-ui", // Cursor
   "goose-native-ui", // Goose
+  "qwen-native-ui", // Qwen Code
   "polly",
   "debby",
 ]);
@@ -32,6 +33,7 @@ export const AGENT_DISPLAY_ORDER = [
   "OpenCode",
   "Cursor",
   "Pi",
+  "Qwen Code",
   "Polly",
   "Debby",
 ];

--- a/ap-web/src/lib/nativeCodingAgents.test.ts
+++ b/ap-web/src/lib/nativeCodingAgents.test.ts
@@ -16,6 +16,18 @@ describe("nativeCodingAgentForHarness", () => {
     expect(nativeCodingAgentForHarness("opencode-native")?.key).toBe("opencode");
   });
 
+  it("resolves the canonical qwen-native harness", () => {
+    const agent = nativeCodingAgentForHarness("qwen-native");
+    expect(agent?.key).toBe("qwen");
+    expect(agent?.displayName).toBe("Qwen Code");
+  });
+
+  it("folds the reversed native-qwen alias to the qwen-native spec", () => {
+    expect(nativeCodingAgentForHarness("native-qwen")).toBe(
+      nativeCodingAgentForHarness("qwen-native"),
+    );
+  });
+
   // The server's harness_kind returns the raw executor.config.harness, so a
   // `native-pi` agent must fold to the same spec — else fork/switch into it
   // would miss the terminal-first wrapper labels and render as chat.

--- a/ap-web/src/lib/nativeCodingAgents.ts
+++ b/ap-web/src/lib/nativeCodingAgents.ts
@@ -4,7 +4,14 @@ export const WRAPPER_LABEL_KEY = "omnigent.wrapper";
 export const UI_MODE_LABEL_KEY = "omnigent.ui";
 export const UI_MODE_TERMINAL_VALUE = "terminal";
 
-export type NativeCodingAgentIconKind = "claude" | "codex" | "opencode" | "pi" | "cursor" | "goose";
+export type NativeCodingAgentIconKind =
+  | "claude"
+  | "codex"
+  | "opencode"
+  | "pi"
+  | "cursor"
+  | "goose"
+  | "qwen";
 export type NativeCodingAgentCapability = "permissionMode" | "approvalMode";
 
 export interface NativeCodingAgentSpec {
@@ -76,6 +83,19 @@ export const NATIVE_CODING_AGENTS = [
     iconKind: "goose",
     sortRank: 50,
   },
+  {
+    // qwen has no brand glyph yet, so it falls back to the generic bot icon
+    // (see AgentCard.iconForAgent / SubagentsPanel) — the `iconKind: "qwen"`
+    // intentionally matches no icon branch. Auth/approval surface in the
+    // embedded terminal, so no capability flags are declared here.
+    key: "qwen",
+    agentName: "qwen-native-ui",
+    harness: "qwen-native",
+    wrapperLabel: "qwen-native-ui",
+    displayName: "Qwen Code",
+    iconKind: "qwen",
+    sortRank: 60,
+  },
 ] as const satisfies readonly NativeCodingAgentSpec[];
 
 const BY_AGENT_NAME: Map<string, NativeCodingAgentSpec> = new Map(
@@ -95,6 +115,7 @@ const HARNESS_ALIASES: Record<string, string> = {
   "native-pi": "pi-native",
   "native-cursor": "cursor-native",
   "native-goose": "goose-native",
+  "native-qwen": "qwen-native",
 };
 
 export function nativeCodingAgentForAgentName(

--- a/ap-web/src/pages/ChatPage.statusLine.test.tsx
+++ b/ap-web/src/pages/ChatPage.statusLine.test.tsx
@@ -65,6 +65,7 @@ describe("Composer status line (branch + context ring)", () => {
       selectedEffort: null,
       codexModelOptions: [],
       codexPlanMode: false,
+      nativeVendorOwnsModel: false,
     });
   });
 
@@ -142,6 +143,20 @@ describe("Composer status line (branch + context ring)", () => {
       "databricks-gpt-5-5 Medium",
     );
     expect(screen.queryByLabelText(/context used/)).toBeNull();
+  });
+
+  it("hides the model/effort label for vendor-owned native sessions (e.g. Qwen)", () => {
+    // qwen/goose/cursor/pi/opencode pick their model inside the vendor TUI, so
+    // Omnigent's bound llmModel is just an unused default — showing it (e.g.
+    // "claude-sonnet-4-6") on a Qwen session is misleading, so it's hidden.
+    useChatStore.setState({
+      llmModel: "claude-sonnet-4-6",
+      selectedEffort: "medium",
+      nativeVendorOwnsModel: true,
+    });
+    renderComposer();
+
+    expect(screen.queryByTestId("composer-model-effort")).toBeNull();
   });
 
   it("draws the ring arc as what's used, not what's left", () => {

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3008,11 +3008,17 @@ function ComposerStatusLine() {
   // alongside contextWindow — so the branch reads from the same store as
   // the other status-line values rather than a separate fetch.
   const gitBranch = useChatStore((s) => s.gitBranch);
+  // qwen/goose/cursor/pi/opencode native sessions pick their model inside the
+  // vendor TUI, so Omnigent's bound `llmModel` is just an unused default
+  // (it would read e.g. "claude-sonnet-4-6" on a Qwen session). Hide the
+  // model/effort label for them; claude-/codex-native keep it (real picker).
+  const nativeVendorOwnsModel = useChatStore((s) => s.nativeVendorOwnsModel);
 
   const showBranch = !!conversationId && !!gitBranch;
-  const modelEffortLabel = conversationId
-    ? formatModelEffortStatusLabel(selectedModel ?? llmModel, selectedEffort, codexModelOptions)
-    : null;
+  const modelEffortLabel =
+    conversationId && !nativeVendorOwnsModel
+      ? formatModelEffortStatusLabel(selectedModel ?? llmModel, selectedEffort, codexModelOptions)
+      : null;
   const showPlanMode = !!conversationId && codexPlanMode;
   // contextWindow > 0: the SSE path validates it but the snapshot path doesn't, and 0/0 → "NaN%".
   const showRing =

--- a/ap-web/src/shell/sidebarNav.ts
+++ b/ap-web/src/shell/sidebarNav.ts
@@ -28,6 +28,7 @@ export type ConversationIconKind =
   | "pi"
   | "cursor"
   | "goose"
+  | "qwen"
   | "nessie"
   | null;
 

--- a/ap-web/src/store/chatStore.test.ts
+++ b/ap-web/src/store/chatStore.test.ts
@@ -948,33 +948,43 @@ describe("chatStore — switchTo", () => {
   // whether to clear the optimistic bubble on idle (see that handler's
   // test). It must be true for every registered native wrapper and false otherwise,
   // or the host-restart "bubble disappears" fix mis-fires.
+  // ``isNativeTerminalSession`` gates the optimistic-bubble clear; the companion
+  // ``nativeVendorOwnsModel`` hides the composer model/effort chip for native
+  // wrappers whose model is chosen inside the vendor TUI (qwen/goose/pi/cursor/
+  // opencode) — claude/codex keep it (they expose an Omnigent model picker).
   it.each([
-    ["claude-code-native-ui", true],
-    ["codex-native-ui", true],
-    ["pi-native-ui", true],
-    ["some-other-wrapper", false],
-    [null, false],
-  ])("switchTo derives isNativeTerminalSession from wrapper=%s", async (wrapper, expected) => {
-    seedSession("conv_wrap", []);
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url.split("?")[0] === "/v1/sessions/conv_wrap" && (init?.method ?? "GET") === "GET") {
-        return mockResponse({
-          id: "conv_wrap",
-          agent_id: "agent_xyz",
-          status: "idle",
-          created_at: 0,
-          items: [],
-          labels: wrapper === null ? {} : { "omnigent.wrapper": wrapper },
-        });
-      }
-      return defaultFetchHandler(input, init);
-    });
+    ["claude-code-native-ui", true, false],
+    ["codex-native-ui", true, false],
+    ["pi-native-ui", true, true],
+    ["qwen-native-ui", true, true],
+    ["goose-native-ui", true, true],
+    ["some-other-wrapper", false, false],
+    [null, false, false],
+  ])(
+    "switchTo derives native flags from wrapper=%s",
+    async (wrapper, expectedNative, expectedVendorOwnsModel) => {
+      seedSession("conv_wrap", []);
+      fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.split("?")[0] === "/v1/sessions/conv_wrap" && (init?.method ?? "GET") === "GET") {
+          return mockResponse({
+            id: "conv_wrap",
+            agent_id: "agent_xyz",
+            status: "idle",
+            created_at: 0,
+            items: [],
+            labels: wrapper === null ? {} : { "omnigent.wrapper": wrapper },
+          });
+        }
+        return defaultFetchHandler(input, init);
+      });
 
-    await useChatStore.getState().switchTo("conv_wrap");
+      await useChatStore.getState().switchTo("conv_wrap");
 
-    expect(useChatStore.getState().isNativeTerminalSession).toBe(expected);
-  });
+      expect(useChatStore.getState().isNativeTerminalSession).toBe(expectedNative);
+      expect(useChatStore.getState().nativeVendorOwnsModel).toBe(expectedVendorOwnsModel);
+    },
+  );
 
   it("refetches the session snapshot even when a stale cached session exists", async () => {
     client.setQueryData(["session", "conv_abc"], {

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -250,6 +250,16 @@ export interface ChatState {
    */
   isNativeTerminalSession: boolean;
   /**
+   * Whether this is a native-terminal wrapper whose model is chosen inside the
+   * vendor TUI (qwen/goose/cursor/pi/opencode) rather than through an Omnigent
+   * model picker. The composer status line hides its model/effort label for
+   * these — Omnigent's bound `llmModel` is just an unused default (it would
+   * otherwise read e.g. "claude-sonnet-4-6" on a Qwen session). claude-/codex-
+   * native DO expose an Omnigent picker, so they keep the label. `false` on
+   * `/`, before the snapshot resolves, and for non-native sessions.
+   */
+  nativeVendorOwnsModel: boolean;
+  /**
    * Server-bound agent id for the active conversation, read from
    * `GET /v1/sessions/{id}.agent_id` during bind. `null` while the
    * snapshot is in flight, on `/`, or for legacy conversations that
@@ -678,6 +688,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   status: "idle",
   sessionStatus: "idle",
   isNativeTerminalSession: false,
+  nativeVendorOwnsModel: false,
   boundAgentId: null,
   boundAgentName: null,
   loadingConversation: false,
@@ -1152,6 +1163,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         status: "idle",
         sessionStatus: "idle",
         isNativeTerminalSession: false,
+        nativeVendorOwnsModel: false,
         boundAgentId: null,
         boundAgentName: null,
         loadingConversation: conversationId !== null,
@@ -1596,6 +1608,7 @@ function sessionBindingPatch(
 ): Pick<
   ChatState,
   | "isNativeTerminalSession"
+  | "nativeVendorOwnsModel"
   | "boundAgentId"
   | "boundAgentName"
   | "llmModel"
@@ -1613,6 +1626,11 @@ function sessionBindingPatch(
   const wrapper = session.labels?.["omnigent.wrapper"];
   return {
     isNativeTerminalSession: isNativeWrapper(wrapper),
+    // Native wrapper whose model lives in the vendor TUI (no Omnigent picker):
+    // qwen/goose/cursor/pi/opencode. nativeModelFamilyForSession is non-null
+    // only for claude-/codex-native, which keep the composer model label.
+    nativeVendorOwnsModel:
+      isNativeWrapper(wrapper) && nativeModelFamilyForSession(session) === null,
     boundAgentId: session.agentId,
     boundAgentName: session.agentName,
     llmModel: session.llmModel ?? null,

--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -80,8 +80,101 @@ comments; this is the *what*, not the *how*.)
 
 ### High
 
-- [ ] **Native TUI variant (`native-qwen`).** Attach to the live `qwen` terminal
-  (like `pi-native`) for a fully interactive experience instead of a piped turn.
+- [x] **Native TUI variant (`qwen-native` / `native-qwen`).** Implemented — the
+  live `qwen` TUI runs in a runner-owned tmux pane embedded in the web UI, driven
+  by `omnigent qwen`. Unlike the goose/cursor `tmux send-keys` native harnesses,
+  it uses qwen's built-in remote-control protocol: web-UI turns are appended to
+  qwen's `--input-file` (a `{"type":"submit"}` line, routed through the same
+  `submitQuery` path the keyboard uses, so it renders in the TUI), and the
+  transcript is mirrored back by tailing qwen's structured `--json-file` event
+  stream (Anthropic stream-json shape). Interrupt/stop still go through the pane
+  (`Escape` / kill) since the input-file watcher has no interrupt command. See
+  `docs/QWEN_NATIVE_DESIGN.md`. **Still a follow-up (PR2):** usage parsing from
+  the `result`/`assistant` events is not yet emitted on `TurnComplete.usage`
+  (see the status-line item below for the model/ring/cost consequences).
+
+- [ ] **Tool-approval elicitation card (TUI → web).** Today a tool call gates
+  only via qwen's **own in-terminal prompt** ("Apply this change? 1. Yes …") —
+  no approval card renders in the web chat, so a user on the Chat tab sees the
+  turn just hang. **Verified feasible** against a live session (and qwen
+  v0.18.1-preview.1): qwen emits a structured
+  `{"type":"control_request","request":{"subtype":"can_use_tool","tool_name",
+  "tool_use_id","input"},"request_id"}` on `--json-file` **and** accepts a
+  `{"type":"confirmation_response","request_id","allowed"}` on `--input-file`,
+  *coexisting* with its own TUI prompt (whichever answers first wins). The
+  forwarder currently just logs the `can_use_tool` (PR2 stub in
+  `qwen_native_forwarder.py`), so the request goes unanswered from the web side.
+  - **Template to copy:** cursor-native's approval mirror —
+    `omnigent/cursor_native_permissions.py` + `supervise_cursor_approval_mirror`
+    (wired in `runner/app.py::_auto_create_cursor_terminal`). qwen is *cleaner*:
+    read the structured `can_use_tool` from the event stream (no pane scraping)
+    and write `confirmation_response` to the input file (no keystrokes).
+  - **Reuse, don't add an endpoint:** POST the tool call to the existing
+    `/v1/sessions/{id}/policies/evaluate` (`_evaluate_tool_call_policy` in
+    `runner/app.py`) — it runs TOOL_CALL policy *and*, on ASK, parks a human
+    approval card (`response.elicitation_request`) and blocks for the verdict.
+    Map the verdict → `confirmation_response`. This delivers both the card and
+    the deferred policy gating in one shot.
+  - **Tricky edge (needs live E2E):** the user can answer in the **terminal**
+    *or* the **card**. The loser must be released — if qwen proceeds first
+    (a `tool_result` / next assistant event for that `tool_use_id` appears),
+    cancel the park via `external_elicitation_resolved` and skip the stale
+    `confirmation_response`; if the card answers first, write the response and
+    let the TUI prompt clear. Run the mirror as a supervised task alongside the
+    transcript forwarder in `_auto_create_qwen_terminal`.
+
+- [ ] **Composer status line: real model + context ring (Web UI).** For
+  native-qwen the composer's model/effort chip is currently **hidden** (web UI
+  flag `nativeVendorOwnsModel` in `chatStore.sessionBindingPatch` →
+  `ComposerStatusLine` in `ap-web/src/pages/ChatPage.tsx`). It was showing the
+  bound spec's *default* model (`claude-sonnet-4-6`) because the qwen-native-ui
+  spec sets no model and qwen picks its model inside the vendor TUI (OpenAI-compat
+  env / qwen's own `/model`), so Omnigent's `llmModel` was a misleading default.
+  Hiding it is the interim; the real fix is to **surface qwen's actual model**
+  (and effort/approval-mode if meaningful). The data is already on qwen's
+  `--json-file` stream — `assistant` message events carry `message.model` (e.g.
+  `openai/gpt-oss-120b:free`) and the `system/session_start` event carries model
+  metadata. The forwarder (`omnigent/qwen_native_forwarder.py`) could parse it
+  and report it onto the session so the chip reflects qwen's reality.
+  - **Context ring + cost tracking also missing**, same root cause: native-qwen
+    emits no token usage, so `tokensUsed` / `contextWindow` stay null (the ring
+    renders only when `contextWindow > 0 && tokensUsed != null`) and the session
+    cost stays $0 (cost is derived from per-turn usage × model price). The ACP
+    `qwen` harness already does this — see "Cost / token tracking" in *What works
+    today* (`_accumulate_usage`); native-qwen needs the equivalent off the
+    `--json-file` stream. Parse `result.usage` (`input_tokens` / `output_tokens`
+    / `cache_read_input_tokens` / `total_tokens`) in
+    `omnigent/qwen_native_forwarder.py`, split `cache_read_input_tokens` out of
+    `input_tokens` (qwen's `input_tokens` is cache-inclusive; cost wants the
+    non-cached portion), and report it onto the session so the cost observer +
+    context ring pick it up; the context-window *limit* comes from the curated
+    `_QWEN_CONTEXT_WINDOWS` lookup. One usage-parsing change feeds the model
+    chip, the ring, and cost together.
+
+- [x] **Restore qwen's TUI history on resume.** `omni qwen --resume <conv_id>`
+  used to relaunch a **blank** `qwen` TUI (only the web chat kept history, via the
+  forwarder). Fixed, using the **same `external_session_id` convention as
+  claude-/codex-/pi-native** (so it's consistent and fork-capable):
+  `_auto_create_qwen_terminal` persists the qwen session id on the Omnigent
+  session (`_persist_qwen_external_session_id` → `PATCH /v1/sessions/{id}`), reads
+  it back from the snapshot (`launch_config.external_session_id`) on the next
+  launch, and it's stamped as `omnigent.fork.source_external_session_id` for fork
+  history carry-over. qwen is cleaner than claude/codex here — it lets us *assign*
+  the id via `--session-id`, so we mint a deterministic one
+  (`qwen_session_id_for_conversation`, UUIDv5 of the `conv_id`) up front instead
+  of capturing a vendor-generated id, and a failed persist self-heals (the id is
+  recomputable). Launch is fresh `--session-id <id>` the first time, `--resume
+  <id>` once qwen has an on-disk recording — the recording check
+  (`qwen_session_recording_exists`, scoped to the launch workspace's qwen project
+  slug at `~/.qwen/projects/<slug>/chats/<id>.jsonl`) is the `--resume` guard,
+  since `--resume` on an id not recorded *under that cwd* shows qwen's blocking
+  "No saved session found" screen — qwen resolves `--resume` per-project, so the
+  check must be workspace-scoped, not a cross-project glob (also keeps
+  never-messaged / pre-convention sessions on the clean fresh path). **No forwarder change
+  needed:** verified that on `--resume` qwen restores history into the TUI from
+  its own checkpoint and emits *only new* events to `--json-file`, so the
+  transcript is never re-mirrored — qwen sidesteps the double-mirror problem that
+  forced goose-native to start fresh.
 
 ### Medium
 

--- a/docs/QWEN_NATIVE_DESIGN.md
+++ b/docs/QWEN_NATIVE_DESIGN.md
@@ -1,0 +1,418 @@
+# `native-qwen` — Design Proposal
+
+A terminal-native Qwen Code harness (`harness: qwen-native`, alias `native-qwen`)
+that embeds the **live interactive `qwen` TUI** in the Omnigent web UI, instead of
+driving `qwen --acp` as a piped request/response subprocess (the existing `qwen`
+harness — see [QWEN_FOLLOWUPS.md](./QWEN_FOLLOWUPS.md)).
+
+This is the High-priority "Native TUI variant" item from the follow-ups doc.
+
+## Key insight
+
+Unlike goose / cursor / claude-native (which can only `tmux send-keys` into a
+pane and scrape its output), `qwen` ships a **built-in remote-control protocol**.
+Verified against `qwen` v0.18.1 (`RemoteInputWatcher` + dual-output in `cli.js`):
+
+- **Inbound** — `--input-file <path>`: qwen `watchFile`s it and parses appended
+  JSONL commands.
+- **Outbound** — `--json-file <path>` / `--json-fd <n>`: structured JSON events
+  stream out **while the TUI still renders normally** in the terminal.
+
+This lets Omnigent inject turns atomically *and* recover two things the other
+native harnesses surrender to the vendor: **per-tool permission gating** and
+**token/usage tracking**.
+
+## Protocol surface (verified from the binary)
+
+```jsonc
+// us → qwen   (append a line to --input-file)
+{"type":"submit","text":"<user message>"}
+{"type":"confirmation_response","request_id":"<id>","allowed":true|false}
+
+// qwen → us   (lines emitted to --json-file / --json-fd)
+{"type":"control_request",
+ "request":{"subtype":"can_use_tool","tool_name":"...","tool_use_id":"...",
+            "input":{...},"blocked_path":null},
+ "request_id":"<id>"}
+// ...plus assistant / tool / result / usage stream-json events
+```
+
+Relevant launch flags: `-m/--model`, `--openai-api-key`, `--openai-base-url`,
+`--system-prompt` / `--append-system-prompt`, `--approval-mode`,
+`-c/--continue`, `-r/--resume`, `--include-partial-messages`.
+
+## Architecture: hybrid — tmux pane for *display*, files for *control*
+
+The web UI embeds a terminal pane for native harnesses (`UI_MODE=terminal`), so
+`qwen` still runs inside a runner-owned **tmux pane** purely so the user sees the
+live TUI. But message injection and event capture flow through the **files**, not
+`send-keys`. The one exception is **interrupt**: the input-file watcher only
+accepts `submit` + `confirmation_response`, so Stop sends `Escape` to the pane.
+
+```mermaid
+flowchart TD
+    subgraph CLI["omnigent qwen (CLI wrapper)"]
+      W[qwen_native.py<br/>daemon bind · terminal-ready poll · tmux attach]
+    end
+
+    subgraph Runner["Omnigent Runner"]
+      AC["_auto_create_qwen_terminal<br/>(runner/app.py)"]
+      BR["qwen_native_bridge.py<br/>writes tmux.json + IN/OUT paths"]
+      FW["qwen_native_forwarder.py<br/>tails --json-file"]
+      POL["TOOL_CALL policy<br/>+ human elicitation<br/>(reuses ACP _decide_permission)"]
+    end
+
+    subgraph Harness["qwen-native harness process"]
+      EX["QwenNativeExecutor.run_turn()<br/>supports_streaming=False<br/>supports_live_message_queue=True"]
+    end
+
+    subgraph Term["tmux pane (embedded in web UI)"]
+      Q["qwen TUI<br/>-m MODEL --openai-*<br/>--input-file IN --json-file OUT"]
+    end
+
+    UI["Web chat UI"]
+
+    W --> AC
+    AC --> BR
+    BR -->|launch| Q
+    BR -. tmux.json .-> FW
+
+    UI -->|user turn| EX
+    EX -->|append {type:submit}| IN[(IN file)]
+    IN -->|watchFile| Q
+
+    Q -->|assistant / tool / usage events| OUT[(OUT file)]
+    OUT --> FW
+    FW -->|mirror transcript| UI
+
+    Q -->|control_request: can_use_tool| OUT
+    FW -->|request_id| POL
+    POL -->|allowed?| EX
+    EX -->|append {type:confirmation_response}| IN
+
+    UI -.->|Stop| BR
+    BR -.->|Escape / kill-session| Q
+```
+
+## Turn lifecycle (sequence)
+
+```mermaid
+sequenceDiagram
+    participant UI as Web UI
+    participant EX as QwenNativeExecutor
+    participant IN as --input-file
+    participant Q as qwen TUI
+    participant OUT as --json-file
+    participant FW as forwarder
+    participant POL as policy + elicitation
+
+    UI->>EX: user turn
+    EX->>IN: {"type":"submit","text":...}
+    EX-->>UI: TurnComplete(response=None)
+    IN-->>Q: watchFile picks up line
+    Q->>OUT: assistant text chunks
+    OUT-->>FW: tail
+    FW-->>UI: mirror transcript
+
+    Note over Q: model wants to run a tool
+    Q->>OUT: control_request {can_use_tool, request_id}
+    OUT-->>FW: tail
+    FW->>POL: evaluate tool_name + input
+    POL-->>FW: allow / deny (DENY rejects; ASK → user)
+    FW->>IN: {"type":"confirmation_response", request_id, allowed}
+    IN-->>Q: watchFile picks up line
+    Q->>OUT: tool_result + assistant continuation
+    OUT-->>FW: tail
+    FW-->>UI: mirror
+```
+
+## ASCII view (same design, for non-mermaid renderers)
+
+```
+                          ┌──────────────────────────┐
+                          │       Web Chat UI         │
+                          │  (embeds the tmux pane)   │
+                          └──────────────────────────┘
+                            │  ▲           ▲      ┊ Stop
+                   user turn│  │transcript │      ┊ button
+                            ▼  │           │      ▼
+   ┌───────────────────────────────┐   ┌──────────────────────────────┐
+   │      QwenNativeExecutor        │   │     qwen_native_forwarder     │
+   │  run_turn(): append "submit"   │   │   tails OUT (--json-file):    │
+   │  supports_streaming = False    │   │   • assistant/tool/usage →UI  │
+   │  live_message_queue = True     │   │   • can_use_tool → policy     │
+   └───────────────────────────────┘   └──────────────────────────────┘
+            │ append                         │  ▲ allow?        ▲ tail
+            │ {"type":"submit",              │  │              │
+            │  "text":...}                   ▼  │              │
+            │                         ┌─────────────────────┐ │
+            │   ┌─────────────────────│  TOOL_CALL policy   │ │
+            │   │ append              │  + human elicitation│ │
+            │   │ {"type":            │  (ACP _decide_      │ │
+            │   │  "confirmation_     │   permission reuse) │ │
+            │   │  response",         └─────────────────────┘ │
+            │   │  request_id,allowed}                         │
+            ▼   ▼                                              │
+   ╔═══════════════════╗                          ╔═══════════════════╗
+   ║   IN file         ║                          ║   OUT file        ║
+   ║ (--input-file)    ║                          ║ (--json-file)     ║
+   ╚═══════════════════╝                          ╚═══════════════════╝
+            │ watchFile                                  ▲ emits events
+            ▼                                            │
+   ┌──────────────────────────────────────────────────────────────────┐
+   │                    qwen TUI  (live, interactive)                   │
+   │   launched as:  qwen -m MODEL --openai-* \                         │
+   │                      --input-file IN --json-file OUT               │
+   │                                                                    │
+   │   • renders normally in the tmux pane  ← user SEES this            │
+   │   • RemoteInputWatcher reads IN  • dual-output writes OUT          │
+   └──────────────────────────────────────────────────────────────────┘
+            ▲ runs inside
+            │
+   ┌──────────────────────────────────────────────────────────────────┐
+   │   tmux pane (runner-owned)   ── Escape/kill-session on Stop ──┐    │
+   │   created by _auto_create_qwen_terminal → qwen_native_bridge  │    │
+   │   bridge writes tmux.json (socket+target) + IN/OUT paths      ◄────┘
+   └──────────────────────────────────────────────────────────────────┘
+            ▲ launched by
+            │
+   ┌──────────────────────────────────────────────────────────────────┐
+   │   omnigent qwen  (CLI wrapper, qwen_native.py)                     │
+   │   daemon bind · terminal-ready poll · attach local TTY            │
+   └──────────────────────────────────────────────────────────────────┘
+```
+
+Two channels, two purposes:
+
+- **Display** — qwen runs in a runner-owned **tmux pane** the web UI embeds, so the
+  user watches the real TUI live.
+- **Control** — instead of racy `tmux send-keys`, Omnigent writes JSONL to the **IN
+  file** and reads structured events from the **OUT file**.
+
+## Does the user's message still show in the terminal?
+
+**Yes.** This is the most important thing to get right about the file-based design,
+and it's verified from the binary. qwen wires the input-file handler to the *same*
+function the keyboard uses:
+
+```js
+// qwen cli.js — RemoteInput consumer
+setSubmitFn((text) => submitQuery(text));
+```
+
+`submitQuery` is the canonical submit path — the one invoked when a user types in
+the box and presses Enter. So a `{"type":"submit","text":...}` line is **not** a
+hidden side-channel; qwen renders it in the TUI transcript exactly like typed
+input (the user-message bubble appears, then the streaming reply). Because the web
+UI embeds that same pane, the message shows in **both** surfaces, identically.
+
+The difference from `tmux send-keys` is *how the text arrives*, not *whether it
+shows*:
+
+| | `tmux send-keys` (goose/cursor) | `--input-file` (qwen-native) |
+|---|---|---|
+| Path into qwen | simulate keystrokes into the input box, then Enter | qwen calls `submitQuery(text)` directly |
+| Renders in TUI? | yes (you literally see it typed) | yes (rendered via the normal submit path) |
+| Failure modes | paste/Enter races, settle-detection, draft-clearing | none of those — atomic line append |
+
+So we lose the keystroke *simulation*, but not the on-screen *display*.
+
+## Why this beats the goose-native model
+
+| Capability | goose / cursor / claude-native | **qwen-native** |
+|---|---|---|
+| Message injection | `tmux send-keys` + settle/paste-commit polling (racy) | append one JSONL line (atomic) |
+| Transcript / output | scrape the tmux pane | structured `--json-file` events |
+| **Tool permission gating** | **surrendered to vendor** | **Omnigent gates** via `can_use_tool` → policy → `confirmation_response` |
+| Token / usage | none | usage events from the stream |
+| Model / auth / gateway | env-only (`~/.qwen/settings.json` can win) | CLI flags (`-m`, `--openai-*`) — precedence fight moot |
+
+## Pros & cons
+
+### Pros
+
+- **No injection races.** Appending a JSONL line is atomic; we skip goose-native's
+  settle-detection, paste-commit polling, and draft-clearing entirely — and the
+  whole class of "message silently dropped because Enter folded into the paste"
+  bugs goes away.
+- **Structured I/O.** The forwarder parses real events (`--json-file`) instead of
+  diffing scraped pane text, so transcript fidelity, tool calls, and usage are
+  reliable rather than best-effort regex over ANSI.
+- **Permission gating works** — the headline win. `can_use_tool` control requests
+  let Omnigent run its TOOL_CALL policy + human elicitation and answer with
+  `confirmation_response`, reusing the ACP harness's `_decide_permission`. The
+  other native harnesses surrender this to the vendor.
+- **Token / usage tracking** comes back for free from the event stream.
+- **Clean model / auth / gateway.** `-m`, `--openai-api-key`, `--openai-base-url`
+  are explicit launch flags, so the `~/.qwen/settings.json`-precedence fight that
+  dogs the ACP path (see QWEN_FOLLOWUPS "Pending work") is moot.
+- **Message still displays in the terminal** (see section above) — no UX regression
+  vs. send-keys.
+
+### Cons / trade-offs
+
+- **Two extra files per session** (IN + OUT) to create, secure (`0700`), and clean
+  up — more lifecycle surface than a pure tmux pane.
+- **Interrupt isn't in the protocol.** The input-file watcher only accepts `submit`
+  and `confirmation_response`, so Stop still falls back to `Escape` on the tmux
+  pane (we keep a foot in the tmux world anyway, for display).
+- **Couples us to qwen's dual-output / RemoteInput protocol**, which is newer and
+  less battle-tested than typing keystrokes. If qwen changes the JSONL schema we
+  break; `tmux send-keys` would not. Mitigated by pinning behavior to the verified
+  v0.18.1 shape and a live smoke test in CI.
+- **Diverges from the other native harnesses.** Reviewers expecting the goose/cursor
+  send-keys pattern will see a different bridge; the upside (gating + usage) is worth
+  documenting so the divergence reads as intentional.
+- **Still needs tmux** for the embedded display, so we don't actually shed the tmux
+  dependency — we just stop using it as the *control* channel.
+
+### Mitigations
+
+Mapping each con to how we address it. Most are solvable; two are acceptable
+trade-offs; one is inherent to the embedded-terminal UX.
+
+| Con | Status | How we address it |
+|---|---|---|
+| Two extra files to manage | **Solved** | Reuse the existing bridge-dir pattern (`/tmp/omnigent-<uid>/qwen-native/<hash>`, `0700`) and the runner's session-close hook (goose-native already has stop/cleanup sites). Make **OUT a FIFO** (qwen's `--json-file` accepts a FIFO / `/dev/fd/N`) so it streams and never grows on disk; IN stays a small append-only file rotated/cleared on close. |
+| Interrupt not in the protocol | **Acceptable** | `Escape` via the tmux pane is reliable and we keep tmux for display anyway, so this costs nothing extra. Optional follow-up: upstream an `interrupt` command to qwen's `RemoteInputWatcher` so Stop becomes fully file-based too. |
+| Coupled to qwen's dual-output schema | **Solved (defense in depth)** | (1) **Graceful degradation** — detect `qwen --version`/flag support at launch; if `--input-file`/`--json-file` are absent on an older qwen, fall back to the goose-style `tmux send-keys` bridge. We support both; file-based is just the default when available. (2) Defensive parser that ignores unknown event types (like the existing forwarders). (3) A CI **smoke test** that launches the real binary and asserts the protocol shape, so a version bump that breaks it fails loudly. |
+| Diverges from other native harnesses | **Solved (design)** | Define a small shared native-bridge contract (`inject` / `interrupt` / `kill`) that both the file-based (qwen) and send-keys (goose/cursor) bridges implement, so reviewers see one shape with two backends. The win (gating + usage) is documented so the divergence reads as intentional. |
+| Still needs tmux for display | **Inherent** | Any *embedded live terminal* needs a real terminal — unavoidable for the native-TUI goal. Upside: because we already parse the full JSON event stream, a future **pure-web rendering mode** (Omnigent renders qwen with no tmux) becomes possible as a separate option — but that is explicitly out of scope here. |
+
+## Files to add (mirrors goose-native; bridge is file-based, not send-keys)
+
+| New file | Role |
+|---|---|
+| `omnigent/inner/qwen_native_executor.py` | `submit` via input-file; `supports_streaming=False`, `supports_live_message_queue=True` |
+| `omnigent/inner/qwen_native_harness.py` | `create_app()` factory |
+| `omnigent/qwen_native_bridge.py` | input-file append (`submit` / `confirmation_response`), tmux.json, `inject_interrupt` (Escape), `kill_session`, `build_qwen_native_spawn_env` |
+| `omnigent/qwen_native_forwarder.py` | tail `--json-file`, mirror transcript, drive the permission gate |
+| `omnigent/qwen_native.py` | `omnigent qwen` wrapper (clone `goose_native.py`) |
+
+## Registration touch-points (one-liners, beside the goose entries)
+
+- `omnigent/runtime/harnesses/__init__.py` → `"qwen-native": "omnigent.inner.qwen_native_harness"`
+- `omnigent/harness_aliases.py` → add `qwen-native` + `native-qwen` to `NATIVE_HARNESSES`
+- `omnigent/native_coding_agents.py` + `omnigent/_wrapper_labels.py` → `QWEN_NATIVE_*`
+- `omnigent/onboarding/harness_install.py` → `_HARNESS_NAME_TO_KEY` → existing `QWEN_KEY`
+- `omnigent/runner/app.py` → `_auto_create_qwen_terminal` + the ~7 goose-native dispatch sites
+- `omnigent/cli.py` → `omnigent qwen` command
+
+> Naming: keep `qwen` = ACP (piped); add `qwen-native` / `native-qwen` for the TUI,
+> mirroring how `goose` and `goose-native` coexist. The default can be flipped later.
+
+## Sequencing
+
+- **PR 1 — core:** the 5 files + registration; launch `qwen` in the pane, submit
+  via input-file, tail json-file to the web UI. Live smoke test against the real
+  binary.
+- **PR 2 — polish:** wire `can_use_tool` → policy/elicitation → `confirmation_response`
+  (reuse ACP `_decide_permission`); usage parsing; interrupt/stop; `-c/-r` resume;
+  attachments; update `QWEN_FOLLOWUPS.md` (native-qwen Pending → Works).
+
+## Live-verification items — resolved against `qwen` v0.18.1
+
+Verified end-to-end via a PTY-driven TUI run (`--input-file` + `--json-file`):
+
+1. **`--json-file` event shape** — confirmed it's the Anthropic/claude-sdk
+   stream-json envelope, identical to `--output-format stream-json`:
+   - `{"type":"system","subtype":"init", session_id, model, tools, slash_commands,
+     permission_mode, ...}`
+   - `{"type":"stream_event","event":{...Anthropic streaming deltas...}}`
+   - `{"type":"user"|"assistant","message":{role, content:[{type:"thinking"|"text"|
+     "tool_use"...}]}}`
+   - `{"type":"result","subtype":"success","result":"<final>","usage":{input_tokens,
+     output_tokens,cache_read_input_tokens,total_tokens},"permission_denials":[...]}`
+   - tool gating arrives as `{"type":"control_request","request":{"subtype":
+     "can_use_tool",...},"request_id":...}` (answered via `confirmation_response`).
+   So the forwarder can reuse the existing claude-sdk/claude-native stream-json
+   parsing rather than inventing a parser.
+2. **`--input-file` must pre-exist** — qwen `watchFile`s the path; the bridge
+   `touch`es it before launch. A `{"type":"submit","text":...}` line is picked up
+   and qwen emits a matching `user` event.
+3. **Display confirmed** — the submitted text renders in the pane (the user bubble
+   appears), proving the file-based path is not a hidden side-channel.
+4. **`--json-file` is TUI-only** — headless `-p` ignores it (it uses
+   `--output-format stream-json` instead), which is exactly the native-TUI case.
+
+Still to confirm at integration time: that `Escape` to the pane interrupts a
+running turn (the input-file watcher has no interrupt command, so Stop uses the
+pane — same as goose-native).
+
+## Boot-order race + readiness gate (verified fix)
+
+qwen's `RemoteInputWatcher` initializes its read offset (`bytesRead`) to the
+**current size of `--input-file`** when it starts watching — synchronously in the
+watcher's constructor, during TUI boot, *before* the React app mounts and wires
+`setSubmitFn`. If the executor appends a `submit` line *before* that runs, qwen
+takes its offset past the line and never reads it: the message is silently
+dropped. The **first turn of a fresh session hits this every time**, because the
+harness turn fires while `qwen` is still starting up (it takes seconds to boot).
+
+Fix (`qwen_native_bridge.wait_for_ready` + `QwenNativeExecutor._ensure_ready`):
+before its first append, the executor blocks until qwen's first `system` event
+(`subtype:"session_start"`) appears on `--json-file`. That event is emitted
+*after* the watcher's constructor has run, so its presence guarantees the offset
+was taken on the still-empty input file — a subsequent append is reliably
+detected. The wait is latched (once-per-session); warm turns don't re-block.
+A side benefit: once qwen is watching, *any* later append lands beyond the
+offset, so even a session that lost its first message recovers on the next one.
+
+Schema note: `qwen` v0.18.1-preview.1 renamed the first system event
+`subtype` from `init` → `session_start` (and wraps payload in `data`). The
+forwarder ignores `system` events (it mirrors only `user`/`assistant`), and the
+`user`/`assistant` event shape (`uuid` + `message.content[].text`) is unchanged,
+so only the readiness probe keys on `system` — matched loosely by `"type":
+"system"`.
+
+## Quitting the TUI (clean-exit handling)
+
+The user drives the qwen TUI directly, so quitting it (Ctrl+C / `/quit`) is a
+normal end-of-session, not a crash. The runner's generic required-terminal-exit
+classifier infers "clean" from the last PTY status (`session_was_idle`), but
+qwen's "powering down" redraw on quit trips the activity watcher and flips the
+status to `running` in the instant before the process exits — so a quit was
+misclassified as a crash and rendered the scary `required_terminal_exited` card.
+
+Fix (`_publish_terminal_exit` in `runner/app.py`): a qwen required-terminal exit
+is treated as a clean shutdown (release the harness, no `failed` card). This is
+safe because genuine *boot* failures never reach this path — they surface via
+`_auto_create_qwen_terminal`'s error handler → `_publish_native_terminal_start_error`
+— so a qwen terminal exit here is always post-boot, i.e. user-initiated.
+
+## Session resume (verified)
+
+On `omni qwen --resume <conv_id>` (or a runner restart), `_auto_create_qwen_terminal`
+restores the qwen TUI's own history so the embedded pane shows the prior
+conversation instead of a blank prompt. It follows the **same
+`external_session_id` convention as claude-/codex-/pi-native** so it's consistent
+and fork-capable:
+
+- **Persisted id (the convention).** The qwen session id is recorded on the
+  Omnigent session via `external_session_id` (`_persist_qwen_external_session_id`
+  → `PATCH /v1/sessions/{id}`), read back from the snapshot on the next launch
+  (`launch_config.external_session_id`), and stamped as
+  `omnigent.fork.source_external_session_id` so a fork carries history — exactly
+  like the other resuming native harnesses.
+- **Minting the id.** qwen is cleaner than claude/codex here: it lets us *assign*
+  the id via `--session-id`, so instead of capturing a vendor-generated id off the
+  event stream we mint a deterministic one — `qwen_session_id_for_conversation`
+  (UUIDv5 of the `conv_id`). Being recomputable means a failed persist self-heals
+  on the next launch.
+- **Fresh vs resume guard.** qwen records to `~/.qwen/projects/<slug>/chats/<id>.jsonl`
+  (`--chat-recording`, on by default) and resolves `--resume <id>` **per-project**
+  (the cwd's slug), not globally. So `qwen_session_recording_exists(id, workspace)`
+  checks that file under the *launch workspace's* slug (`<slug>` = the realpath
+  with every non-alphanumeric char → `-`); if present launch `--resume <id>`,
+  else `--session-id <id>`. Scoping to the workspace is essential: a check across
+  all projects would pick `--resume` for a recording made under a *different*
+  workspace and land the user on qwen's blocking "No saved session found" screen
+  (moved/renamed repo, or resume from another cwd). A false negative (slug drift)
+  only degrades to a clean fresh launch. This also covers the never-messaged edge
+  and pre-convention sessions.
+- **No double-mirror.** Verified that on `--resume` qwen rebuilds the TUI display
+  from its on-disk checkpoint but emits **only new** events to `--json-file` — it
+  does not replay the prior transcript. So the forwarder (cursor reset on
+  re-launch) sees only new messages; the web chat keeps its already-persisted
+  history and gains the new exchange, with no duplicate bubbles. This is why qwen
+  can restore TUI history where goose-native deliberately starts fresh.

--- a/omnigent/_wrapper_labels.py
+++ b/omnigent/_wrapper_labels.py
@@ -61,3 +61,7 @@ CURSOR_NATIVE_WRAPPER_VALUE = "cursor-native-ui"
 # Value the ``omnigent goose`` wrapper writes into
 # ``conversations.labels[WRAPPER_LABEL_KEY]``.
 GOOSE_NATIVE_WRAPPER_VALUE = "goose-native-ui"
+
+# Value the ``omnigent qwen`` wrapper writes into
+# ``conversations.labels[WRAPPER_LABEL_KEY]``.
+QWEN_NATIVE_WRAPPER_VALUE = "qwen-native-ui"

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1179,6 +1179,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "pane-split",
         "pi",
         "polly",
+        "qwen",
         "resume",
         "run",
         "sandbox",
@@ -4755,6 +4756,86 @@ def goose(
         session_id=resolved_session_id,
         resume_picker=choice.picker,
         goose_args=goose_args,
+        auto_open_conversation=auto_open_conversation,
+    )
+
+
+@cli.command(
+    context_settings={
+        "ignore_unknown_options": True,
+        "allow_extra_args": True,
+    }
+)
+@click.option(
+    "--server",
+    default=None,
+    help=(
+        "Remote omnigent URL. Ensures the host daemon, asks the "
+        "daemon-spawned runner to launch the qwen TUI, and attaches this TTY. "
+        'Pass --server "" to auto-spawn a persistent local server in the '
+        "background and use that instead of a remote one."
+    ),
+)
+@click.option(
+    "-r",
+    "--resume",
+    "resume",
+    is_flag=False,
+    flag_value=_RESUME_PICKER_SENTINEL,
+    default=None,
+    help=(
+        "Resume a prior Omnigent conversation. With a conversation id "
+        "(e.g. ``--resume conv_abc123``) attaches directly; with no value "
+        "opens an interactive picker scoped to qwen-native sessions."
+    ),
+)
+@click.option(
+    "--session",
+    "session_id",
+    metavar="SESSION_ID",
+    default=None,
+    hidden=True,
+    help="Deprecated alias for ``--resume <id>``; kept for one release.",
+)
+@click.argument("qwen_args", nargs=-1, type=click.UNPROCESSED)
+def qwen(
+    server: str | None,
+    resume: str | None,
+    session_id: str | None,
+    qwen_args: tuple[str, ...],
+) -> None:
+    """Launch the qwen (Qwen Code) TUI in an Omnigent terminal.
+
+    \b
+    Examples:
+      omnigent qwen
+      omnigent qwen --resume conv_abc123
+      omnigent qwen --resume                  # interactive picker
+    """
+    choice = _split_resume_value(resume)
+    if session_id is not None and (choice.picker or choice.conversation_id is not None):
+        raise click.UsageError(
+            "--session and --resume are mutually exclusive; "
+            "prefer --resume (--session is deprecated).",
+        )
+
+    from omnigent.qwen_native import run_qwen_native
+
+    cfg = _load_effective_config()
+    if server is None:
+        server = cfg.get("server")
+    auto_open_conversation = _resolve_auto_open_conversation_from_config(cfg)
+
+    server = _ensure_backend(server)
+    resolved_session_id = (
+        choice.conversation_id if choice.conversation_id is not None else session_id
+    )
+
+    run_qwen_native(
+        server=server,
+        session_id=resolved_session_id,
+        resume_picker=choice.picker,
+        qwen_args=qwen_args,
         auto_open_conversation=auto_open_conversation,
     )
 

--- a/omnigent/harness_aliases.py
+++ b/omnigent/harness_aliases.py
@@ -20,6 +20,9 @@ HARNESS_ALIASES: dict[str, str] = {
     "native-goose": "goose-native",
     # Qwen Code harness alias.
     "qwen-code": "qwen",
+    # User-facing reversed spelling for the qwen native-CLI harness; canonical
+    # id is "qwen-native" (the ACP-piped harness keeps the bare "qwen" name).
+    "native-qwen": "qwen-native",
     # OpenCode native-server harness: the bare ``opencode`` name and the
     # reversed ``native-opencode`` spelling both fold to ``opencode-native``
     # (there is no separate SDK ``opencode`` harness, so the bare name is free).
@@ -48,6 +51,8 @@ NATIVE_HARNESSES: frozenset[str] = frozenset(
         "native-cursor",
         "goose-native",
         "native-goose",
+        "qwen-native",
+        "native-qwen",
         "opencode-native",
         "native-opencode",
     }

--- a/omnigent/inner/qwen_native_executor.py
+++ b/omnigent/inner/qwen_native_executor.py
@@ -1,0 +1,183 @@
+"""Executor that bridges Omnigent web-chat turns into the native qwen TUI.
+
+It does not launch ``qwen`` — the ``omnigent qwen`` wrapper already launched the
+interactive ``qwen`` TUI in the session terminal (with ``--input-file`` /
+``--json-file``). Each web-UI turn appends a ``{"type":"submit",...}`` line to
+that input file, which qwen's ``RemoteInputWatcher`` routes through the same
+``submitQuery`` path the keyboard uses, so the message appears in the running TUI
+(and, since the web UI embeds the pane, in both surfaces). Output is
+terminal-originated; the embedded terminal renders it live and
+:mod:`omnigent.qwen_native_forwarder` mirrors the JSON event stream.
+
+Unlike goose-/cursor-native (tmux ``send-keys``), injection here is an atomic
+file append — no settle-detection, paste-commit polling, or draft-clearing. See
+``docs/QWEN_NATIVE_DESIGN.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from omnigent.inner.executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    ToolSpec,
+    TurnComplete,
+)
+from omnigent.qwen_native_bridge import (
+    BRIDGE_DIR_ENV_VAR,
+    submit_user_message,
+    wait_for_ready,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class QwenNativeExecutor(Executor):
+    """Harness-side executor for ``omnigent qwen`` web-UI turns.
+
+    Appends each web-UI message as a ``submit`` command to the running qwen TUI's
+    input file. Does not stream output (the embedded terminal shows it, and the
+    forwarder mirrors the JSON event stream); accepts mid-turn steering.
+
+    :param bridge_dir: Optional bridge dir override; ``None`` reads
+        :data:`BRIDGE_DIR_ENV_VAR` from the harness spawn env.
+    """
+
+    def __init__(self, bridge_dir: Path | None = None) -> None:
+        self._bridge_dir = bridge_dir or _bridge_dir_from_env()
+        # Serializes appends to the shared input file: run_turn (initiating
+        # message) and enqueue_session_message (steering) run concurrently
+        # against one cached executor. Each append is a single line write, but
+        # the lock keeps their ordering deterministic.
+        self._inject_lock = asyncio.Lock()
+        # Latched once qwen has booted its input watcher (see _ensure_ready).
+        # Guards the boot-order race where the first turn fires while qwen is
+        # still starting up and would otherwise be dropped.
+        self._ready = False
+
+    async def _ensure_ready(self) -> None:
+        """Block (once) until qwen's input watcher is active before the first append.
+
+        qwen takes the input file's size as its read offset when it starts
+        watching, during boot. Appending before that drops the message. We wait
+        for qwen's first ``system`` event on the events stream — emitted after the
+        watcher is up — so the offset is taken on the still-empty input file.
+
+        Only latches ``_ready`` on a confirmed-ready result, so a warm session
+        never re-blocks but a *timeout* re-checks on the next turn (qwen is
+        almost certainly up by then). On timeout we log and let the caller submit
+        anyway — best-effort beats hanging the turn — but the warning makes the
+        rare dropped-first-message failure diagnosable rather than silent.
+        """
+        if self._ready:
+            return
+        ready = await asyncio.to_thread(wait_for_ready, self._bridge_dir)
+        if ready:
+            self._ready = True
+        else:
+            logger.warning(
+                "qwen-native readiness gate timed out for %s; submitting anyway — "
+                "the first message may be dropped if qwen's input watcher is not up "
+                "yet (will re-check next turn)",
+                self._bridge_dir,
+            )
+
+    def supports_streaming(self) -> bool:
+        """:returns: ``False`` — output is shown by the embedded terminal, not this executor."""
+        return False
+
+    def supports_live_message_queue(self) -> bool:
+        """:returns: ``True`` — messages can be injected mid-turn (steering)."""
+        return True
+
+    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+        """Append a live steering message to the qwen TUI input file."""
+        del session_key
+        text = _content_to_text(content, self._bridge_dir)
+        if not text:
+            return False
+        try:
+            await self._ensure_ready()
+            async with self._inject_lock:
+                await asyncio.to_thread(submit_user_message, self._bridge_dir, content=text)
+        except RuntimeError:
+            return False
+        return True
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        """Append the latest web-UI user message to the qwen TUI input file."""
+        del tools, system_prompt, config
+        text = _latest_user_text(messages, self._bridge_dir)
+        if not text:
+            yield ExecutorError(message="qwen native turn had no user text to send")
+            return
+        try:
+            await self._ensure_ready()
+            async with self._inject_lock:
+                await asyncio.to_thread(submit_user_message, self._bridge_dir, content=text)
+        except RuntimeError as exc:
+            yield ExecutorError(message=str(exc))
+            return
+        yield TurnComplete(response=None)
+
+
+def _bridge_dir_from_env() -> Path:
+    """Resolve the qwen-native bridge dir from the harness spawn env."""
+    raw = os.environ.get(BRIDGE_DIR_ENV_VAR, "").strip()
+    if not raw:
+        raise RuntimeError(f"{BRIDGE_DIR_ENV_VAR} is required for the qwen-native harness")
+    return Path(raw)
+
+
+def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
+    """Return the latest user message's text (attachments materialized to disk)."""
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            return _content_to_text(message.get("content"), bridge_dir)
+    return ""
+
+
+def _content_to_text(content: Any, bridge_dir: Path) -> str:
+    """Normalize executor content into text the qwen TUI receives.
+
+    Text blocks are extracted directly. Image/file blocks carrying a base64 data
+    URI are materialized to the bridge dir and referenced by absolute path
+    (``[Attached: <path>]``) so qwen can open them with its tools — otherwise
+    web-UI attachments are silently dropped. Mirrors goose-/cursor-native.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        from omnigent.inner.native_attachments import materialize_attachment
+
+        attachment_lines: list[str] = []
+        text_parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type", "")
+            if block_type in ("input_text", "text"):
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+            elif block_type in ("input_image", "input_file"):
+                path = materialize_attachment(block, bridge_dir)
+                if path is not None:
+                    attachment_lines.append(f"[Attached: {path}]")
+        return "\n\n".join(attachment_lines + text_parts)
+    return ""

--- a/omnigent/inner/qwen_native_harness.py
+++ b/omnigent/inner/qwen_native_harness.py
@@ -1,0 +1,38 @@
+"""``harness: qwen-native`` wrap (the native qwen TUI).
+
+Thin module exposing :func:`create_app` — the entry point the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"qwen-native"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Wraps a :class:`omnigent.inner.qwen_native_executor.QwenNativeExecutor`, which
+appends web-UI messages to the running ``qwen`` TUI's ``--input-file`` (launched
+by ``omnigent qwen`` in the session terminal). The bridge dir is read from
+:data:`~omnigent.qwen_native_bridge.BRIDGE_DIR_ENV_VAR` in the spawn env.
+
+Tool policies: in this first cut, qwen runs its tools inside its own TUI and
+gates them with its own in-terminal approval (like goose-/cursor-native), which
+Omnigent does not intercept. qwen *can* delegate approval externally
+(``can_use_tool`` control requests on ``--json-file``, answered via
+``confirmation_response`` on ``--input-file``) — wiring that through Omnigent's
+TOOL_CALL policy is the documented follow-up; see ``docs/QWEN_NATIVE_DESIGN.md``.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from omnigent.inner.executor import Executor
+from omnigent.inner.qwen_native_executor import QwenNativeExecutor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+
+def _build_qwen_native_executor() -> Executor:
+    """Construct a :class:`QwenNativeExecutor` (reads the bridge dir from env)."""
+    return QwenNativeExecutor()
+
+
+def create_app() -> FastAPI:
+    """Build the qwen-native harness's FastAPI app (required entry point)."""
+    adapter = ExecutorAdapter(executor_factory=_build_qwen_native_executor)
+    return adapter.build()

--- a/omnigent/native_coding_agents.py
+++ b/omnigent/native_coding_agents.py
@@ -11,6 +11,7 @@ from omnigent._wrapper_labels import (
     GOOSE_NATIVE_WRAPPER_VALUE,
     OPENCODE_NATIVE_WRAPPER_VALUE,
     PI_NATIVE_WRAPPER_VALUE,
+    QWEN_NATIVE_WRAPPER_VALUE,
     UI_MODE_LABEL_KEY,
     UI_MODE_TERMINAL_VALUE,
     WRAPPER_LABEL_KEY,
@@ -96,6 +97,15 @@ GOOSE_NATIVE_CODING_AGENT = NativeCodingAgent(
     terminal_name="goose",
 )
 
+QWEN_NATIVE_CODING_AGENT = NativeCodingAgent(
+    key="qwen",
+    display_name="Qwen Code",
+    agent_name="qwen-native-ui",
+    harness="qwen-native",
+    wrapper_label=QWEN_NATIVE_WRAPPER_VALUE,
+    terminal_name="qwen",
+)
+
 NATIVE_CODING_AGENTS: tuple[NativeCodingAgent, ...] = (
     CLAUDE_NATIVE_CODING_AGENT,
     CODEX_NATIVE_CODING_AGENT,
@@ -103,6 +113,7 @@ NATIVE_CODING_AGENTS: tuple[NativeCodingAgent, ...] = (
     OPENCODE_NATIVE_CODING_AGENT,
     CURSOR_NATIVE_CODING_AGENT,
     GOOSE_NATIVE_CODING_AGENT,
+    QWEN_NATIVE_CODING_AGENT,
 )
 
 _BY_AGENT_NAME = {agent.agent_name: agent for agent in NATIVE_CODING_AGENTS}

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -201,6 +201,10 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     GOOSE_KEY: GOOSE_KEY,
     QWEN_KEY: QWEN_KEY,
     "qwen-code": QWEN_KEY,
+    # Native qwen TUI (``qwen-native``) wraps the same ``qwen`` CLI as the ACP
+    # harness; the ``native-qwen`` reversed spelling gates on the same binary.
+    "qwen-native": QWEN_KEY,
+    "native-qwen": QWEN_KEY,
     # Native OpenCode (``opencode-native``) wraps the ``opencode`` CLI; its
     # ``native-opencode`` reversed spelling gates on the same binary.
     "opencode-native": OPENCODE_KEY,

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -77,11 +77,12 @@ _CURSOR_NATIVE_HARNESSES: frozenset[str] = frozenset({"cursor-native", "native-c
 # there is no SDK variant or key to gate on.
 _GOOSE_NATIVE_HARNESSES: frozenset[str] = frozenset({"goose-native", "native-goose"})
 
-# CLI-wrapping qwen harnesses. Both ``qwen`` and ``qwen-code`` resolve to the
-# same ``qwen`` binary (canonicalize_harness folds ``qwen-code`` → ``qwen``).
-# Unlike claude/codex they have no ``_HARNESS_FAMILY`` entry, so they must
-# be gated explicitly or they fail open.
-_QWEN_HARNESSES: frozenset[str] = frozenset({QWEN_KEY, "qwen-code"})
+# CLI-wrapping qwen harnesses. ``qwen`` / ``qwen-code`` (the ACP harness) and
+# ``qwen-native`` / ``native-qwen`` (the native TUI via ``omni qwen``) all resolve
+# to the same ``qwen`` binary (canonicalize_harness folds ``qwen-code`` → ``qwen``
+# and ``native-qwen`` → ``qwen-native``). Unlike claude/codex they have no
+# ``_HARNESS_FAMILY`` entry, so they must be gated explicitly or they fail open.
+_QWEN_HARNESSES: frozenset[str] = frozenset({QWEN_KEY, "qwen-code", "qwen-native", "native-qwen"})
 
 
 def _canonical_harness(harness: str) -> str:

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -1,0 +1,623 @@
+"""Native qwen TUI wrapper for the Omnigent CLI.
+
+``omnigent qwen`` launches Qwen Code's interactive TUI (``qwen``) inside an
+Omnigent-runner-owned tmux terminal and attaches the local TTY — the qwen analog
+of ``omnigent goose`` / ``omnigent cursor``. The runner spawns the process (see
+:func:`omnigent.runner.app._auto_create_qwen_terminal`), pointing qwen at the
+bridge dir's ``--input-file`` / ``--json-file`` so web-UI turns and the
+transcript mirror flow through files; this module owns the CLI-side
+orchestration: session create/resume, daemon runner bind, terminal-ready poll,
+and the direct tmux attach.
+
+Auth is qwen's own configuration (OpenAI-compatible env vars, or the interactive
+``/auth`` command persisted under ``~/.qwen``); no Omnigent-managed key is
+required. Like goose there is no extension bridge — the runner sets up the
+terminal environment and the dual-output / input-file flags directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import click
+import httpx
+import yaml
+
+from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
+from omnigent._wrapper_labels import QWEN_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
+from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
+from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
+from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.host.daemon_launch import (
+    error_text,
+    launch_or_reuse_daemon_runner,
+    wait_for_host_online,
+    wait_for_runner_online,
+)
+from omnigent.native_terminal import (
+    DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_RUNNER_ONLINE_TIMEOUT_S as _DAEMON_RUNNER_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
+)
+from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import url_component
+
+_DEFAULT_QWEN_COMMAND = "qwen"
+_QWEN_PATH_ENV = "OMNIGENT_QWEN_PATH"
+_AGENT_NAME = "qwen-native-ui"
+_TERMINAL_NAME = "qwen"
+_TERMINAL_SESSION_KEY = "main"
+_SESSION_LABELS = {
+    "omnigent.ui": "terminal",
+    _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
+}
+
+
+@dataclass(frozen=True)
+class NativeQwenLaunch:
+    """Resolved native qwen process launch."""
+
+    executable: str
+    argv: list[str]
+
+
+@dataclass(frozen=True)
+class LaunchedQwenTerminal:
+    """Terminal resource returned by the Omnigent runner launch path."""
+
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+
+
+@dataclass(frozen=True)
+class PreparedQwenTerminal:
+    """Prepared native qwen terminal attachment details.
+
+    :param reattached: ``True`` when an existing, still-running session terminal
+        was reused (the live-reattach path: prior session intact).
+    :param cold_resumed: ``True`` when resuming an existing Omnigent session whose
+        terminal had already exited, so a *fresh* ``qwen`` TUI was launched.
+        Mirrors goose-native: ``cold_resumed`` and ``reattached`` are mutually
+        exclusive (the cold-resume path leaves ``reattached`` False).
+    """
+
+    session_id: str
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+    reattached: bool
+    cold_resumed: bool = False
+
+
+def _configured_qwen_command(env: Mapping[str, str]) -> str:
+    """Return the configured qwen executable name/path from *env*."""
+    value = env.get(_QWEN_PATH_ENV, "").strip()
+    return value or _DEFAULT_QWEN_COMMAND
+
+
+def resolve_qwen_executable(
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> str:
+    """
+    Resolve the native qwen (``qwen``) executable.
+
+    :param env: Environment mapping to inspect. Defaults to ``os.environ``.
+    :param which: Resolver hook for tests; defaults to ``shutil.which``.
+    :returns: Absolute executable path.
+    :raises click.ClickException: If no qwen CLI is available.
+    """
+    env = os.environ if env is None else env
+    which = shutil.which if which is None else which
+    command = _configured_qwen_command(env)
+    resolved = which(command)
+    if resolved is None:
+        raise click.ClickException(
+            "Native qwen requires the 'qwen' CLI on PATH. Install it with: "
+            "npm install -g @qwen-code/qwen-code, then authenticate (set "
+            "OPENAI_API_KEY/OPENAI_BASE_URL/OPENAI_MODEL, or run 'qwen' and use "
+            f"/auth). You can also set {_QWEN_PATH_ENV}=/path/to/qwen."
+        )
+    return resolved
+
+
+def build_qwen_launch(
+    qwen_args: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> NativeQwenLaunch:
+    """Build the argv for a native qwen process."""
+    executable = resolve_qwen_executable(env=env, which=which)
+    return NativeQwenLaunch(executable=executable, argv=[executable, *qwen_args])
+
+
+def run_qwen_native(
+    *,
+    server: str | None,
+    session_id: str | None,
+    qwen_args: tuple[str, ...],
+    resume_picker: bool = False,
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch the qwen TUI in an Omnigent terminal.
+
+    :param server: Resolved Omnigent server URL.
+    :param session_id: Optional existing Omnigent conversation id.
+    :param qwen_args: Raw qwen CLI args to persist for the runner-owned TUI.
+    :param resume_picker: ``True`` runs the qwen-native picker.
+    :param auto_open_conversation: When ``True``, open the browser conversation
+        URL after launch.
+    :returns: None after the terminal attach session ends.
+    """
+    _preflight_local_tools()
+    if server is None:
+        raise click.ClickException(
+            "qwen requires a resolved Omnigent server URL. The CLI should call "
+            "_ensure_backend before run_qwen_native."
+        )
+    with TemporaryDirectory(prefix="omnigent-qwen-native-") as tmpdir:
+        spec_path = _materialize_qwen_agent_spec(Path(tmpdir))
+        _run_with_remote_server(
+            server.rstrip("/"),
+            spec_path,
+            session_id=session_id,
+            resume_picker=resume_picker,
+            qwen_args=qwen_args,
+            auto_open_conversation=auto_open_conversation,
+        )
+
+
+def _materialize_qwen_agent_spec(tmpdir: Path) -> Path:
+    """
+    Write the terminal-first agent spec used by ``omnigent qwen``.
+
+    :param tmpdir: Temporary directory for the generated YAML file.
+    :returns: Path to the generated YAML spec.
+    """
+    yaml_path = tmpdir / "qwen-native-ui.yaml"
+    raw: dict[str, Any] = {
+        "name": _AGENT_NAME,
+        "prompt": (
+            "qwen is running in the session terminal. The user drives the qwen TUI directly."
+        ),
+        "executor": {"harness": "qwen-native"},
+        "spawn": True,
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {"type": "none"},
+        },
+        "terminals": {
+            "shell": {
+                "command": "bash",
+                "allow_cwd_override": True,
+                "os_env": {
+                    "type": "caller_process",
+                    "cwd": ".",
+                    "sandbox": {"type": "none"},
+                },
+            },
+        },
+    }
+    yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return yaml_path
+
+
+def _run_with_remote_server(
+    base_url: str,
+    spec_path: Path,
+    *,
+    session_id: str | None,
+    resume_picker: bool,
+    qwen_args: tuple[str, ...],
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch qwen on an Omnigent server via a daemon-spawned runner.
+
+    :param base_url: Omnigent server base URL.
+    :param spec_path: Generated qwen wrapper agent spec.
+    :param session_id: Optional existing Omnigent session id.
+    :param resume_picker: When ``True``, run the qwen-native picker.
+    :param qwen_args: Raw qwen CLI args.
+    :param auto_open_conversation: Whether to open the web conversation URL.
+    """
+    from omnigent.chat import _bundle_agent, _remote_headers
+    from omnigent.cli import _ensure_host_daemon
+    from omnigent.host.identity import load_or_create_host_identity
+
+    headers = _remote_headers(server_url=base_url)
+    try:
+        resolved_session_id = _resolve_session_id_for_resume(
+            base_url=base_url,
+            headers=headers,
+            session_id=session_id,
+            resume_picker=resume_picker,
+        )
+        if resolved_session_id is None and resume_picker and session_id is None:
+            return
+
+        async def _drive() -> None:
+            with runner_startup_progress(initial_message="Preparing qwen...") as progress:
+                _update_startup_progress(progress, "Connecting to local daemon...")
+                _ensure_host_daemon(base_url)
+                host_id = load_or_create_host_identity().host_id
+                bundle = None if resolved_session_id is not None else _bundle_agent(spec_path)
+                prepared = await _prepare_qwen_terminal_via_daemon(
+                    base_url=base_url,
+                    headers=headers,
+                    session_id=resolved_session_id,
+                    session_bundle=bundle,
+                    qwen_args=qwen_args,
+                    host_id=host_id,
+                    workspace=str(Path.cwd().resolve()),
+                    startup_progress=progress,
+                )
+            click.echo(f"Web UI: {conversation_url(base_url, prepared.session_id)}", err=True)
+            open_conversation_link_if_enabled(
+                base_url=base_url,
+                conversation_id=prepared.session_id,
+                enabled=auto_open_conversation,
+                warn=lambda message: click.echo(message, err=True),
+            )
+            if prepared.cold_resumed:
+                echo_native_cold_resume_hint(agent_label="qwen")
+            await _attach_terminal_resource(prepared)
+            if resolved_session_id is None:
+                echo_native_resume_hint(
+                    native_command="qwen",
+                    session_id=prepared.session_id,
+                    server=base_url,
+                )
+
+        asyncio.run(_drive())
+    except httpx.ConnectError as exc:
+        raise click.ClickException(
+            f"Could not reach the omnigent server at {base_url}. "
+            "Confirm the server is running and reachable from here "
+            f"(e.g. `curl {base_url}/health`), and that --server is correct."
+        ) from exc
+
+
+async def _prepare_qwen_terminal_via_daemon(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    session_bundle: bytes | None,
+    qwen_args: tuple[str, ...],
+    host_id: str,
+    workspace: str,
+    startup_progress: RunnerStartupProgress | None = None,
+) -> PreparedQwenTerminal:
+    """
+    Create or resume a qwen-native session through a daemon runner.
+
+    :returns: Prepared terminal details for attaching.
+    """
+    persist_args = list(qwen_args)
+    timeout = httpx.Timeout(30.0, read=120.0)
+    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+        reattached = False
+        cold_resumed = False
+        if session_id is None:
+            if session_bundle is None:
+                raise click.ClickException("Creating a qwen session requires a session bundle.")
+            _update_startup_progress(startup_progress, "Creating qwen session...")
+            session_id = await _create_qwen_session(
+                client,
+                session_bundle,
+                terminal_launch_args=persist_args or None,
+            )
+        else:
+            _update_startup_progress(startup_progress, "Loading qwen session...")
+            payload = await _fetch_qwen_session(client, session_id)
+            labels = payload.get("labels") if isinstance(payload, dict) else None
+            if (
+                not isinstance(labels, dict)
+                or labels.get(_WRAPPER_LABEL_KEY) != _WRAPPER_LABEL_VALUE
+            ):
+                raise click.ClickException(
+                    f"Conversation {session_id!r} is not a qwen-native session."
+                )
+            existing_terminal = await _find_running_qwen_terminal(client, session_id)
+            if existing_terminal is not None:
+                if persist_args:
+                    click.echo(
+                        "Ignoring qwen launch args for an already-running terminal; "
+                        "restart the session terminal to apply them.",
+                        err=True,
+                    )
+                _update_startup_progress(startup_progress, "qwen terminal ready.")
+                return PreparedQwenTerminal(
+                    session_id=session_id,
+                    terminal_id=existing_terminal.terminal_id,
+                    tmux_socket=existing_terminal.tmux_socket,
+                    tmux_target=existing_terminal.tmux_target,
+                    reattached=True,
+                )
+            # Session exists but its terminal exited: relaunch a fresh TUI.
+            cold_resumed = True
+            if persist_args:
+                _update_startup_progress(startup_progress, "Updating qwen session...")
+                resp = await client.patch(
+                    f"/v1/sessions/{url_component(session_id)}",
+                    json={"terminal_launch_args": persist_args},
+                )
+                if resp.status_code >= 400:
+                    raise click.ClickException(
+                        f"qwen session launch config update failed "
+                        f"({resp.status_code}): {error_text(resp)}"
+                    )
+
+        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        _update_startup_progress(startup_progress, "Starting runner...")
+        runner_id = await launch_or_reuse_daemon_runner(
+            client,
+            host_id=host_id,
+            session_id=session_id,
+            workspace=workspace,
+        )
+        _update_startup_progress(startup_progress, "Waiting for runner...")
+        await wait_for_runner_online(client, runner_id, timeout_s=_DAEMON_RUNNER_ONLINE_TIMEOUT_S)
+        await _bind_session_runner(client, session_id, runner_id)
+        _update_startup_progress(startup_progress, "Starting qwen terminal...")
+        await _ensure_qwen_terminal_on_runner(client, session_id)
+        terminal = await _wait_for_qwen_terminal_ready(
+            client,
+            session_id,
+            timeout_s=_DAEMON_TERMINAL_READY_TIMEOUT_S,
+        )
+        _update_startup_progress(startup_progress, "qwen terminal ready.")
+    return PreparedQwenTerminal(
+        session_id=session_id,
+        terminal_id=terminal.terminal_id,
+        tmux_socket=terminal.tmux_socket,
+        tmux_target=terminal.tmux_target,
+        reattached=reattached,
+        cold_resumed=cold_resumed,
+    )
+
+
+async def _create_qwen_session(
+    client: httpx.AsyncClient,
+    bundle: bytes,
+    *,
+    terminal_launch_args: list[str] | None = None,
+) -> str:
+    """Create a bundled terminal-first qwen-native session."""
+    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    if terminal_launch_args:
+        metadata["terminal_launch_args"] = terminal_launch_args
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps(metadata)},
+        files={"bundle": ("qwen-native-ui.tar.gz", bundle, "application/gzip")},
+        timeout=120.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"qwen session creation failed ({resp.status_code}): {error_text(resp)}"
+        )
+    body = resp.json()
+    new_session_id = body.get("session_id")
+    if not isinstance(new_session_id, str) or not new_session_id:
+        raise click.ClickException("qwen session creation response did not include session_id.")
+    return new_session_id
+
+
+async def _fetch_qwen_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+    """Fetch an existing Omnigent session."""
+    resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
+    if resp.status_code == 404:
+        raise click.ClickException(f"Conversation {session_id!r} not found on the server.")
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Failed to fetch conversation {session_id!r} ({resp.status_code}): {error_text(resp)}"
+        )
+    payload = resp.json()
+    if not isinstance(payload, dict):
+        raise click.ClickException("Conversation fetch returned non-object JSON.")
+    return payload
+
+
+async def _ensure_qwen_terminal_on_runner(client: httpx.AsyncClient, session_id: str) -> None:
+    """Ask the bound runner to ensure the qwen terminal exists."""
+    resp = await client.post(
+        f"/v1/sessions/{url_component(session_id)}/resources/terminals",
+        json={
+            "terminal": _TERMINAL_NAME,
+            "session_key": _TERMINAL_SESSION_KEY,
+            "ensure_native_terminal": True,
+        },
+        timeout=60.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"qwen terminal ensure failed ({resp.status_code}): {error_text(resp)}"
+        )
+
+
+async def _wait_for_qwen_terminal_ready(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    timeout_s: float,
+) -> LaunchedQwenTerminal:
+    """Wait until the runner exposes the qwen terminal resource."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        terminal = await _find_running_qwen_terminal(client, session_id)
+        if terminal is not None:
+            return terminal
+        await asyncio.sleep(0.2)
+    raise click.ClickException(
+        f"The runner did not create the qwen terminal for {session_id!r} within {timeout_s:.0f}s."
+    )
+
+
+async def _find_running_qwen_terminal(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> LaunchedQwenTerminal | None:
+    """Return the existing running qwen terminal id if present."""
+    terminal_id = qwen_terminal_resource_id()
+    resp = await client.get(
+        f"/v1/sessions/{url_component(session_id)}"
+        f"/resources/terminals/{url_component(terminal_id)}"
+    )
+    if resp.status_code == 404:
+        return None
+    if resp.status_code >= 400:
+        text = error_text(resp)
+        if resp.status_code in {409, 503} and (
+            "not bound to a runner" in text or "offline" in text
+        ):
+            return None
+        raise click.ClickException(f"Failed to fetch qwen terminal ({resp.status_code}): {text}")
+    payload = resp.json()
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    if isinstance(metadata, dict) and metadata.get("running") is False:
+        return None
+    return _launched_qwen_terminal_from_payload(payload)
+
+
+def _launched_qwen_terminal_from_payload(payload: object) -> LaunchedQwenTerminal:
+    """Decode terminal launch metadata returned by the runner."""
+    if not isinstance(payload, dict):
+        raise click.ClickException("qwen terminal launch returned non-object JSON.")
+    terminal_id = payload.get("id")
+    if not isinstance(terminal_id, str) or not terminal_id:
+        raise click.ClickException("qwen terminal launch response did not include terminal id.")
+    metadata = payload.get("metadata")
+    tmux_socket: Path | None = None
+    tmux_target: str | None = None
+    if isinstance(metadata, dict):
+        raw_socket = metadata.get("tmux_socket")
+        raw_target = metadata.get("tmux_target")
+        if isinstance(raw_socket, str) and raw_socket:
+            tmux_socket = Path(raw_socket)
+        if isinstance(raw_target, str) and raw_target:
+            tmux_target = raw_target
+    return LaunchedQwenTerminal(
+        terminal_id=terminal_id,
+        tmux_socket=tmux_socket,
+        tmux_target=tmux_target,
+    )
+
+
+async def _attach_terminal_resource(prepared: PreparedQwenTerminal) -> None:
+    """Attach the current terminal to the prepared qwen terminal resource."""
+    direct_tmux_error = _direct_tmux_unavailable_reason(prepared)
+    if direct_tmux_error is not None:
+        raise click.ClickException(
+            f"Runner-owned qwen terminal requires direct tmux attach, but {direct_tmux_error}"
+        )
+    if prepared.tmux_socket is None or prepared.tmux_target is None:
+        raise click.ClickException("qwen tmux attach metadata was incomplete.")
+    await _attach_direct_tmux(prepared.tmux_socket, prepared.tmux_target)
+
+
+async def _attach_direct_tmux(socket_path: Path, tmux_target: str) -> None:
+    """Attach the current terminal directly to the runner-owned tmux pane."""
+    # ``os.environ.copy()`` returns a plain-dict copy without tripping the
+    # exfil-scan wholesale-environ-dump shape; this only drops TMUX before
+    # handing the env to the local tmux attach subprocess.
+    env = os.environ.copy()
+    env.pop("TMUX", None)
+    process = await asyncio.create_subprocess_exec(
+        "tmux",
+        "-S",
+        str(socket_path),
+        "-f",
+        os.devnull,
+        "attach",
+        "-t",
+        tmux_target,
+        env=env,
+    )
+    await process.wait()
+
+
+def _direct_tmux_unavailable_reason(prepared: PreparedQwenTerminal) -> str | None:
+    """Explain why direct tmux attach is unavailable."""
+    if prepared.tmux_socket is None:
+        return "the terminal resource did not include a tmux socket path."
+    if prepared.tmux_target is None:
+        return "the terminal resource did not include a tmux target."
+    if not prepared.tmux_socket.exists():
+        return f"tmux socket {prepared.tmux_socket} is not reachable from this CLI process."
+    if shutil.which("tmux") is None:
+        return "tmux is not available on PATH."
+    return None
+
+
+def _resolve_session_id_for_resume(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    resume_picker: bool,
+) -> str | None:
+    """Translate resume inputs into a concrete qwen-native session id."""
+    if session_id is not None:
+        return session_id
+    if not resume_picker:
+        return None
+    from omnigent_client import OmnigentClient
+
+    from omnigent.repl._resume_picker import pick_conversation_by_wrapper_label_from_sdk
+
+    async def _drive() -> str | None:
+        async with OmnigentClient(
+            base_url=base_url,
+            headers=headers if headers else None,
+        ) as client:
+            return await pick_conversation_by_wrapper_label_from_sdk(
+                client,
+                wrapper_value=_WRAPPER_LABEL_VALUE,
+                agent_name=_AGENT_NAME,
+            )
+
+    return asyncio.run(_drive())
+
+
+def _update_startup_progress(
+    startup_progress: RunnerStartupProgress | None,
+    message: str,
+) -> None:
+    """Show one concise qwen startup milestone when a renderer is active."""
+    if startup_progress is not None:
+        startup_progress.update(message)
+
+
+def _preflight_local_tools() -> None:
+    """Verify local executables required by the native qwen wrapper."""
+    if shutil.which("tmux") is None:
+        raise click.ClickException(
+            "tmux was not found on local PATH. The native qwen wrapper "
+            "attaches to the runner-owned qwen tmux terminal."
+        )
+
+
+def qwen_terminal_resource_id() -> str:
+    """Return the deterministic terminal resource id for qwen."""
+    return terminal_resource_id(_TERMINAL_NAME, _TERMINAL_SESSION_KEY)

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -1,0 +1,390 @@
+"""File + tmux bridge for the qwen-native terminal harness.
+
+Unlike goose-/cursor-native (which simulate keystrokes via ``tmux send-keys``),
+``qwen`` ships a built-in remote-control protocol that we drive through two files
+the TUI is launched against:
+
+- ``--input-file`` (:func:`input_file_path`): ``qwen`` ``watchFile``\\s it and
+  parses appended JSONL commands. We append ``{"type":"submit","text":...}`` to
+  deliver a web-UI turn (qwen routes it through the *same* ``submitQuery`` path
+  the keyboard uses, so it renders in the TUI transcript) and
+  ``{"type":"confirmation_response","request_id":...,"allowed":...}`` to answer a
+  tool-approval request.
+- ``--json-file`` (:func:`events_file_path`): ``qwen`` streams structured JSON
+  events here while the TUI renders normally; :mod:`omnigent.qwen_native_forwarder`
+  tails it.
+
+The runner launches the TUI in a runner-owned tmux pane (for the embedded
+display) and records that pane via :func:`write_tmux_target`. Message injection
+is file-based, but two affordances still go through the pane because qwen's
+input-file watcher has no command for them: **interrupt** (Stop → ``Escape``, see
+:func:`inject_interrupt`) and **hard stop** (:func:`kill_session`).
+
+Verified against ``qwen`` v0.18.1 (``RemoteInputWatcher`` + dual-output). See
+``docs/QWEN_NATIVE_DESIGN.md``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+#: Env var carrying the bridge dir into the harness executor process.
+BRIDGE_DIR_ENV_VAR = "HARNESS_QWEN_NATIVE_BRIDGE_DIR"
+
+#: Fixed namespace for deriving a stable qwen ``--session-id`` from an Omnigent
+#: conversation id (UUIDv5). Never change it — it would orphan every existing
+#: qwen recording (resume would mint a new id and lose history).
+_QWEN_SESSION_NAMESPACE = uuid.UUID("6b6f3d2e-9a1c-5e84-bf0a-1d7c5a2e9f43")
+
+_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "qwen-native"
+_TMUX_FILE = "tmux.json"
+#: JSONL command file qwen watches (``--input-file``); we append to it.
+_INPUT_FILE = "qwen_in.jsonl"
+#: NDJSON event file qwen writes (``--json-file``); the forwarder tails it.
+_EVENTS_FILE = "qwen_out.ndjson"
+_TMUX_READY_TIMEOUT_S = 30.0
+_TMUX_SEND_TIMEOUT_S = 10.0
+_POLL_INTERVAL_S = 0.2
+
+
+def bridge_dir_for_session_id(session_id: str) -> Path:
+    """Return the per-session bridge dir, e.g. ``/tmp/omnigent-<uid>/qwen-native/<hash>``."""
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
+    return _BRIDGE_ROOT / digest
+
+
+def bridge_root() -> Path:
+    """Return the configured qwen-native bridge root."""
+    return _BRIDGE_ROOT
+
+
+def qwen_session_id_for_conversation(conversation_id: str) -> str:
+    """Return the deterministic qwen ``--session-id`` for an Omnigent conversation.
+
+    UUIDv5 of the conversation id: stable across resumes (recomputable, never
+    stored) and a valid UUID (qwen requires one). The runner launches a fresh
+    session with ``--session-id <this>`` and later restores it with
+    ``--resume <this>`` so the qwen TUI shows the prior conversation on resume.
+
+    :param conversation_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :returns: A stable UUID string usable as qwen's session id.
+    """
+    return str(uuid.uuid5(_QWEN_SESSION_NAMESPACE, conversation_id))
+
+
+def _qwen_project_slug(workspace: Path | str) -> str:
+    """Return qwen's per-project directory slug for *workspace*.
+
+    qwen keys its on-disk session store by project: the cwd's real path with
+    every non-alphanumeric character replaced by ``-`` (verified against qwen
+    v0.18.1 — e.g. ``/private/tmp/qwen_x`` → ``-private-tmp-qwen-x``). Uses
+    ``realpath`` because the runner launches qwen with ``cwd=realpath(workspace)``
+    and qwen records under ``process.cwd()``.
+    """
+    real = os.path.realpath(str(workspace))
+    return re.sub(r"[^A-Za-z0-9]", "-", real)
+
+
+def qwen_session_recording_exists(session_id: str, workspace: Path | str) -> bool:
+    """Return whether qwen has an on-disk chat recording for *session_id* in *workspace*.
+
+    qwen records interactive sessions (``--chat-recording``, on by default) to
+    ``~/.qwen/projects/<project-slug>/chats/<session-id>.jsonl`` and resolves
+    ``--resume <id>`` **relative to the current project** (cwd slug) — not
+    globally. So the check must be scoped to the *launch workspace's* slug: a
+    glob across all projects would report a recording made under workspace A as
+    present when resuming from workspace B, choosing ``--resume`` and landing the
+    user on qwen's blocking "No saved session found with ID" error screen — the
+    exact failure this guard exists to prevent (moved/renamed repo, or resume
+    from a different cwd). The runner uses this to choose ``--resume`` (recording
+    present here) vs ``--session-id`` (fresh). A false negative (slug drift) only
+    degrades to a clean fresh launch, never the blocking error.
+
+    :param session_id: A qwen session id (see :func:`qwen_session_id_for_conversation`).
+    :param workspace: The cwd qwen will be (re)launched in.
+    :returns: ``True`` if a recording for *session_id* exists under *workspace*'s
+        qwen project dir.
+    """
+    recording = (
+        Path.home()
+        / ".qwen"
+        / "projects"
+        / _qwen_project_slug(workspace)
+        / "chats"
+        / f"{session_id}.jsonl"
+    )
+    try:
+        return recording.is_file()
+    except OSError:
+        return False
+
+
+def input_file_path(bridge_dir: Path) -> Path:
+    """Return the ``--input-file`` path qwen watches for JSONL commands."""
+    return bridge_dir / _INPUT_FILE
+
+
+def events_file_path(bridge_dir: Path) -> Path:
+    """Return the ``--json-file`` path qwen writes structured events to."""
+    return bridge_dir / _EVENTS_FILE
+
+
+def _ensure_dir(path: Path) -> None:
+    """Create *path* (and parents) with owner-only permissions."""
+    path.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o700)
+
+
+def prepare_bridge_files(bridge_dir: Path) -> None:
+    """Create the bridge dir and a fresh, empty input file before launch.
+
+    qwen ``watchFile``\\s the ``--input-file`` and reads from a byte offset, so
+    the path must exist when the TUI starts. We truncate it (and the events file)
+    so a relaunched terminal can't replay a prior process's queued commands.
+    """
+    _ensure_dir(bridge_dir)
+    # Truncate both so a re-created terminal starts from a clean slate.
+    input_file_path(bridge_dir).write_text("", encoding="utf-8")
+    events_file_path(bridge_dir).write_text("", encoding="utf-8")
+
+
+def build_qwen_native_spawn_env(session_id: str) -> dict[str, str]:
+    """Build the ``HARNESS_QWEN_NATIVE_*`` env the harness executor reads.
+
+    The executor only needs the bridge dir (to locate the input file it appends
+    to). qwen's model / auth / dual-output flags are set by the runner when it
+    launches the TUI (``_auto_create_qwen_terminal``), not here.
+
+    :param session_id: The Omnigent session id (keys the bridge dir).
+    :returns: Env-var overrides for the harness spawn.
+    """
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    _ensure_dir(bridge_dir)
+    return {BRIDGE_DIR_ENV_VAR: str(bridge_dir)}
+
+
+def _append_command(bridge_dir: Path, command: dict[str, Any]) -> None:
+    """Append one JSONL command line to the input file qwen watches.
+
+    A single ``write`` of one ``\\n``-terminated line is atomic enough for qwen's
+    incremental ``readNewLines`` reader (it splits on newlines), so concurrent
+    appends from ``run_turn`` and a confirmation response don't interleave.
+
+    :raises RuntimeError: If the input file can't be written.
+    """
+    line = json.dumps(command, ensure_ascii=False) + "\n"
+    try:
+        _ensure_dir(bridge_dir)
+        with open(input_file_path(bridge_dir), "a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+    except OSError as exc:
+        raise RuntimeError(f"qwen-native could not write input command: {exc}") from exc
+
+
+def wait_for_ready(
+    bridge_dir: Path,
+    *,
+    timeout_s: float = 30.0,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+) -> bool:
+    """Block until the qwen TUI has booted its dual-output stream.
+
+    qwen's ``RemoteInputWatcher`` initializes its read offset (``bytesRead``) to
+    the **current size of the input file** when it starts watching, synchronously
+    during TUI boot (before the React app renders). If we append a ``submit``
+    *before* that runs, qwen initializes ``bytesRead`` past our line and never
+    reads it — the message is silently dropped. The first turn of a freshly
+    launched session hits exactly this race, since the harness turn fires while
+    ``qwen`` is still starting up (it takes seconds).
+
+    qwen emits its first event — a ``{"type":"system","subtype":"session_start"}``
+    on the ``--json-file`` stream — only *after* the watcher's constructor (and
+    thus ``startWatching``) has run. So the appearance of a ``system`` event in
+    the events file is a safe "the watcher is active, ``bytesRead`` was taken on
+    the still-empty input file" signal: appending after it is reliably detected.
+
+    :param bridge_dir: The qwen-native bridge dir holding the events file.
+    :param timeout_s: Max seconds to wait for the boot signal.
+    :param poll_interval_s: Seconds between polls of the events file.
+    :returns: ``True`` once the boot signal is seen; ``False`` on timeout (the
+        caller submits anyway — best effort beats hanging the turn).
+    """
+    events_file = events_file_path(bridge_dir)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _events_file_has_system_event(events_file):
+            return True
+        time.sleep(poll_interval_s)
+    return False
+
+
+def _events_file_has_system_event(events_file: Path) -> bool:
+    """Return whether the NDJSON events file contains a parsed ``system`` event.
+
+    Parses line by line and checks ``event["type"] == "system"`` rather than a
+    raw substring scan: a substring like ``"type":"system"`` could appear inside
+    another event's payload (latching ready early and re-opening the boot race),
+    and the first ``system`` event isn't guaranteed to sit within a fixed byte
+    window. The boot ``session_start`` is qwen's first emitted line, so this
+    returns on the first line in practice.
+    """
+    try:
+        with open(events_file, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except ValueError:
+                    continue  # tolerate a partial/garbled line mid-write
+                if isinstance(event, dict) and event.get("type") == "system":
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def submit_user_message(bridge_dir: Path, *, content: str) -> None:
+    """Deliver a web-UI user message into the qwen TUI via the input file.
+
+    Appends ``{"type":"submit","text":content}``; qwen's ``RemoteInputWatcher``
+    routes it through ``submitQuery`` (the keyboard's submit path), so the message
+    renders in the TUI transcript exactly like typed input.
+
+    :param bridge_dir: The qwen-native bridge dir holding the input file.
+    :param content: User text (non-empty).
+    :raises RuntimeError: If *content* is empty or the input file can't be written.
+    """
+    if not content:
+        raise RuntimeError("qwen-native submit requires non-empty content")
+    _append_command(bridge_dir, {"type": "submit", "text": content})
+
+
+def submit_confirmation(bridge_dir: Path, *, request_id: str, allowed: bool) -> None:
+    """Answer a qwen ``can_use_tool`` control request via the input file.
+
+    :param bridge_dir: The qwen-native bridge dir holding the input file.
+    :param request_id: The ``request_id`` from the ``control_request`` event.
+    :param allowed: Whether the tool call is permitted.
+    :raises RuntimeError: If the input file can't be written.
+    """
+    _append_command(
+        bridge_dir,
+        {"type": "confirmation_response", "request_id": request_id, "allowed": allowed},
+    )
+
+
+# ---------------------------------------------------------------------------
+# tmux target (display pane) — used only for interrupt / hard-stop.
+# ---------------------------------------------------------------------------
+
+
+def write_tmux_target(
+    bridge_dir: Path,
+    *,
+    socket_path: Path,
+    tmux_target: str,
+    pid: int | None = None,
+) -> None:
+    """Advertise the tmux socket + target for the running qwen terminal."""
+    _ensure_dir(bridge_dir)
+    payload: dict[str, Any] = {
+        "socket_path": str(socket_path),
+        "tmux_target": tmux_target,
+        "updated_at": time.time(),
+    }
+    if pid is not None:
+        payload["pid"] = pid
+    tmp = bridge_dir / (_TMUX_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp, bridge_dir / _TMUX_FILE)
+
+
+def read_tmux_info(bridge_dir: Path) -> dict[str, str] | None:
+    """Return ``{socket_path, tmux_target}`` from ``tmux.json``, or ``None``."""
+    try:
+        raw = (bridge_dir / _TMUX_FILE).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    socket_path = data.get("socket_path")
+    tmux_target = data.get("tmux_target")
+    if (
+        isinstance(socket_path, str)
+        and socket_path
+        and isinstance(tmux_target, str)
+        and tmux_target
+    ):
+        return {"socket_path": socket_path, "tmux_target": tmux_target}
+    return None
+
+
+def _wait_for_tmux_info(bridge_dir: Path, *, timeout_s: float) -> dict[str, str]:
+    """Block until ``tmux.json`` is advertised, or raise on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        info = read_tmux_info(bridge_dir)
+        if info is not None:
+            return info
+        time.sleep(_POLL_INTERVAL_S)
+    raise RuntimeError(f"qwen-native tmux target was not advertised within {timeout_s:.0f}s")
+
+
+def _run_tmux(socket_path: str, *args: str) -> None:
+    """Invoke ``tmux -S <socket> <args...>`` and raise on failure."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_SEND_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"tmux command timed out after {_TMUX_SEND_TIMEOUT_S}s") from exc
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "<no output>"
+        raise RuntimeError(f"tmux command failed (rc={proc.returncode}): {detail}")
+
+
+def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
+    """Cancel the in-flight qwen turn by sending ``Escape`` to the pane.
+
+    qwen's input-file watcher accepts only ``submit`` / ``confirmation_response``,
+    so the web UI's Stop button drives interrupt through the display pane — the
+    analog of :func:`submit_user_message` for cancellation. The harness
+    ``run_turn`` returns right after appending the submit line, so the runner's
+    in-process cancel floor can't reach the turn.
+
+    :raises RuntimeError: If the tmux target is not advertised or send-keys fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    # No ``-l``: tmux must interpret ``Escape`` as a key name.
+    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
+
+
+def kill_session(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
+    """Hard-stop the qwen session by killing its tmux session.
+
+    Terminates ``qwen`` and the pane outright — the analog of the user manually
+    exiting the attached TUI, for the web UI's "Stop session" affordance.
+
+    :raises RuntimeError: If the tmux target is not advertised or kill-session fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    _run_tmux(info["socket_path"], "kill-session", "-t", info["tmux_target"])

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -1,0 +1,389 @@
+"""TUI→web forwarder for the qwen-native harness.
+
+The ``omnigent qwen`` wrapper launches the real ``qwen`` TUI in a runner-owned
+tmux pane with ``--json-file`` pointed at the bridge dir, and
+:mod:`omnigent.qwen_native_bridge` appends web-UI messages to its ``--input-file``.
+That covers the web→TUI direction, but the *embedded terminal* is then the only
+surface that reflects the agent's work — the Omnigent conversation view stays
+empty because nothing mirrors the transcript back into the session.
+
+This module is that missing mirror — the qwen analog of
+:mod:`omnigent.goose_native_forwarder`. Where goose has to scrape a SQLite store,
+qwen emits a structured **stream-json event stream** (verified Anthropic-shaped
+against ``qwen`` v0.18.1): we tail the ``--json-file`` NDJSON by byte offset and
+POST each new ``user`` / ``assistant`` message as an ``external_conversation_item``
+event (which also seeds the session title).
+
+Event shapes consumed (others are ignored defensively):
+
+- ``{"type":"user","message":{"role":"user","content":[{"type":"text","text":...}]}}``
+- ``{"type":"assistant","message":{"role":"assistant","content":[{"type":"text"|
+  "thinking"|"tool_use",...}]}}`` — only ``text`` blocks are mirrored.
+- ``{"type":"control_request","request":{"subtype":"can_use_tool",...},
+  "request_id":...}`` — recognized and logged; Omnigent-side policy gating
+  (answer via ``confirmation_response``) is the documented follow-up. With the
+  default in-terminal approval mode qwen does not emit these.
+
+Status (``running``/``idle``) is intentionally NOT posted here: the runner's
+PTY-activity watcher owns those edges for qwen-native (see
+:mod:`omnigent.runner.app`), exactly as for goose-/cursor-native.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from omnigent.qwen_native_bridge import events_file_path
+
+_logger = logging.getLogger(__name__)
+
+#: Seconds between event-file polls. qwen flushes events per streaming step, so a
+#: sub-second cadence keeps the mirrored chat tracking the terminal step by step.
+_DEFAULT_POLL_INTERVAL_S = 0.4
+_POST_TIMEOUT_S = 30.0
+
+# Supervisor backoff (mirrors goose_native_forwarder.supervise_goose_forwarder).
+_SUPERVISOR_INITIAL_BACKOFF_S = 1.0
+_SUPERVISOR_MAX_BACKOFF_S = 30.0
+_SUPERVISOR_HEALTHY_UPTIME_S = 60.0
+
+_STATE_FILE = "qwen_forwarder.json"
+
+# The executor injects ``[Attached: <path>]`` markers for web-UI attachments
+# before submitting; strip them from the mirrored bubble (the path is an internal
+# bridge detail).
+_ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
+
+
+@dataclass
+class _ForwardState:
+    """Durable forwarder cursor, persisted to ``bridge_dir/qwen_forwarder.json``.
+
+    :param offset: Byte offset into the ``--json-file`` already consumed. The
+        event file is append-only within a TUI lifetime; a relaunched terminal
+        truncates it (see :func:`~omnigent.qwen_native_bridge.prepare_bridge_files`),
+        which we detect as ``size < offset`` and reset to 0.
+    :param seen_uuids: Recently posted event uuids, for idempotent dedup across a
+        truncation/restart. Bounded to the most recent entries.
+    """
+
+    offset: int = 0
+    seen_uuids: list[str] | None = None
+
+
+def _read_state(bridge_dir: Path) -> _ForwardState:
+    """Load the persisted forward cursor, or a cold default."""
+    try:
+        raw = (bridge_dir / _STATE_FILE).read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError):
+        return _ForwardState(offset=0, seen_uuids=[])
+    offset = data.get("offset")
+    seen = data.get("seen_uuids")
+    return _ForwardState(
+        offset=offset if isinstance(offset, int) and offset >= 0 else 0,
+        seen_uuids=[u for u in seen if isinstance(u, str)] if isinstance(seen, list) else [],
+    )
+
+
+def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
+    """Atomically persist the forward cursor (tmp write + rename)."""
+    try:
+        bridge_dir.mkdir(parents=True, exist_ok=True)
+        tmp = bridge_dir / (_STATE_FILE + ".tmp")
+        # Cap the dedup window so the state file can't grow unbounded.
+        seen = (state.seen_uuids or [])[-512:]
+        tmp.write_text(
+            json.dumps({"offset": state.offset, "seen_uuids": seen}),
+            encoding="utf-8",
+        )
+        os.replace(tmp, bridge_dir / _STATE_FILE)
+        return True
+    except OSError:
+        _logger.warning("qwen forwarder could not persist state to %s", bridge_dir, exc_info=True)
+        return False
+
+
+def clear_qwen_bridge_state(bridge_dir: Path) -> None:
+    """Remove the persisted forward cursor so a re-created terminal starts clean."""
+    with contextlib.suppress(OSError):
+        (bridge_dir / _STATE_FILE).unlink()
+
+
+@dataclass
+class _MirrorItem:
+    """One conversation item ready to POST, plus the event uuid that produced it."""
+
+    uuid: str
+    item_type: str
+    item_data: dict[str, object]
+    response_id: str
+
+
+def _text_from_content(content: object) -> str:
+    """Join the ``text`` blocks of a stream-json message ``content`` array.
+
+    ``thinking`` and ``tool_use`` blocks are skipped — only user-facing prose is
+    mirrored into the chat bubble. Tolerant of a bare string or odd shapes so a
+    schema tweak degrades to "best available text" rather than dropping the row.
+    """
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts).strip()
+
+
+def _event_to_item(event: dict[str, object], agent_name: str) -> _MirrorItem | None:
+    """Convert one qwen stream-json event to a mirror item, or ``None`` to skip it."""
+    etype = event.get("type")
+    if etype not in ("user", "assistant"):
+        if etype == "control_request":
+            request = event.get("request")
+            subtype = request.get("subtype") if isinstance(request, dict) else None
+            if subtype == "can_use_tool":
+                # Recognized but not yet gated through Omnigent's policy engine —
+                # qwen's in-terminal approval is the gate for now. Wiring
+                # confirmation_response back through TOOL_CALL policy is the
+                # documented follow-up (see module docstring / design doc).
+                _logger.debug("qwen forwarder saw can_use_tool control_request (in-terminal gate)")
+        return None
+    uuid = event.get("uuid")
+    if not isinstance(uuid, str) or not uuid:
+        return None
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return None
+    text = _ATTACHMENT_MARKER_RE.sub("", _text_from_content(message.get("content"))).strip()
+    if not text:
+        return None  # tool-only / thinking-only turn with no prose
+    response_id = f"qwen:{uuid}"
+    if etype == "user":
+        return _MirrorItem(
+            uuid=uuid,
+            item_type="message",
+            item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
+            response_id=response_id,
+        )
+    return _MirrorItem(
+        uuid=uuid,
+        item_type="message",
+        item_data={
+            "role": "assistant",
+            "agent": agent_name,
+            "content": [{"type": "output_text", "text": text}],
+        },
+        response_id=response_id,
+    )
+
+
+def _read_new_events(
+    events_file: Path, offset: int, seen: set[str], agent_name: str
+) -> tuple[list[_MirrorItem], int]:
+    """Read NDJSON lines past *offset*, returning new mirror items + the new offset.
+
+    Detects a truncated/recreated event file (``size < offset``) and rewinds to 0.
+    Only fully terminated lines (ending in ``\\n``) are consumed; a trailing
+    partial line is left for the next poll by not advancing past it.
+    """
+    try:
+        size = events_file.stat().st_size
+    except OSError:
+        return [], offset
+    if size < offset:
+        offset = 0  # file truncated by a relaunched terminal
+    if size == offset:
+        return [], offset
+    try:
+        with open(events_file, "rb") as fh:
+            fh.seek(offset)
+            data = fh.read(size - offset)
+    except OSError:
+        return [], offset
+    # Only consume up to the last newline; keep any trailing partial line.
+    last_nl = data.rfind(b"\n")
+    if last_nl == -1:
+        return [], offset  # no complete line yet
+    consumed = data[: last_nl + 1]
+    new_offset = offset + len(consumed)
+    items: list[_MirrorItem] = []
+    for raw in consumed.split(b"\n"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            continue  # tolerate a malformed line rather than stalling the tail
+        if not isinstance(event, dict):
+            continue
+        item = _event_to_item(event, agent_name)
+        if item is not None and item.uuid not in seen:
+            items.append(item)
+    return items, new_offset
+
+
+async def _post_conversation_item(
+    client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
+) -> None:
+    """POST one mirrored item as an ``external_conversation_item`` event."""
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": item.item_type,
+                "item_data": item.item_data,
+                "response_id": item.response_id,
+            },
+        },
+    )
+    resp.raise_for_status()
+
+
+async def forward_qwen_events_to_session(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    agent_name: str,
+    events_file: Path | None = None,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    auth: httpx.Auth | None = None,
+) -> None:
+    """Tail qwen's ``--json-file`` and mirror new messages into the AP session.
+
+    Polls the event file past a persisted byte offset, posting each new
+    user/assistant message as an ``external_conversation_item``. The offset +
+    dedup set are persisted to ``bridge_dir`` so a supervisor restart resumes
+    without re-posting.
+
+    :param base_url: Omnigent server base URL.
+    :param headers: Static HTTP headers (auth normally via ``auth``).
+    :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: The qwen-native bridge dir (holds the persisted cursor).
+    :param agent_name: Agent label stamped on mirrored assistant items.
+    :param events_file: qwen ``--json-file`` path; defaults to the bridge dir's.
+    :param poll_interval_s: Seconds between event-file polls.
+    :param auth: Optional refresh-capable httpx Auth for remote deployments.
+    :returns: Never normally returns; cancel the task to stop it.
+    """
+    target = events_file or events_file_path(bridge_dir)
+    persisted = _read_state(bridge_dir)
+    offset = persisted.offset
+    seen: set[str] = set(persisted.seen_uuids or [])
+    timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=headers, auth=auth, timeout=timeout
+    ) as client:
+        while True:
+            try:
+                items, new_offset = await asyncio.to_thread(
+                    _read_new_events, target, offset, seen, agent_name
+                )
+                for item in items:
+                    await _post_conversation_item(client, session_id=session_id, item=item)
+                    seen.add(item.uuid)
+                if new_offset != offset or items:
+                    offset = new_offset
+                    _write_state(
+                        bridge_dir,
+                        _ForwardState(offset=offset, seen_uuids=list(seen)),
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "qwen forwarder poll failed; session=%s bridge_dir=%s",
+                    session_id,
+                    bridge_dir,
+                )
+            await asyncio.sleep(poll_interval_s)
+
+
+def _supervisor_monotonic() -> float:
+    """Indirection so tests can stub the supervisor's clock."""
+    return time.monotonic()
+
+
+async def _supervisor_sleep(seconds: float) -> None:
+    """Indirection so tests can stub the supervisor's backoff sleep."""
+    await asyncio.sleep(seconds)
+
+
+async def supervise_qwen_forwarder(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    agent_name: str,
+    events_file: Path | None = None,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    auth: httpx.Auth | None = None,
+) -> None:
+    """Run :func:`forward_qwen_events_to_session` under a restart supervisor.
+
+    Mirrors :func:`omnigent.goose_native_forwarder.supervise_goose_forwarder`:
+    bounded exponential backoff, :class:`asyncio.CancelledError` propagates for
+    clean teardown, and the persisted offset means restarts resume exactly where
+    they left off.
+
+    :returns: Never normally returns; cancel the task to stop it.
+    """
+    backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+    while True:
+        run_started_at = _supervisor_monotonic()
+        crash_exc: Exception | None = None
+        try:
+            await forward_qwen_events_to_session(
+                base_url=base_url,
+                headers=headers,
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                agent_name=agent_name,
+                events_file=events_file,
+                poll_interval_s=poll_interval_s,
+                auth=auth,
+            )
+            _logger.warning(
+                "qwen forwarder returned unexpectedly; restarting; session=%s bridge_dir=%s",
+                session_id,
+                bridge_dir,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — supervisor restarts on any Exception
+            crash_exc = exc
+        if _supervisor_monotonic() - run_started_at >= _SUPERVISOR_HEALTHY_UPTIME_S:
+            backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+        if crash_exc is not None:
+            _logger.error(
+                "qwen forwarder crashed; restarting in %.1fs; session=%s bridge_dir=%s",
+                backoff_s,
+                session_id,
+                bridge_dir,
+                exc_info=crash_exc,
+            )
+        await _supervisor_sleep(backoff_s)
+        backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)

--- a/omnigent/resume_dispatch.py
+++ b/omnigent/resume_dispatch.py
@@ -261,6 +261,15 @@ def _dispatch_wrapper(
             goose_args=(),
         )
         return True
+    if native_agent.key == "qwen":
+        from omnigent.qwen_native import run_qwen_native
+
+        run_qwen_native(
+            server=server,
+            session_id=session_id,
+            qwen_args=(),
+        )
+        return True
     return False
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -61,6 +61,7 @@ from omnigent.runner.resource_registry import (
     OMNIGENT_REPL_TERMINAL_ROLE,
     OPENCODE_NATIVE_TERMINAL_ROLE,
     PI_NATIVE_TERMINAL_ROLE,
+    QWEN_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
     TerminalExitEvent,
     TerminalLifecycle,
@@ -1701,6 +1702,220 @@ async def _auto_create_goose_terminal(
     _register_auto_forwarder_task(session_id, _forwarder_task)
     _logger.info(
         "Auto-created goose terminal + forwarder for session %s; forwarder_task=%s",
+        session_id,
+        _forwarder_task.get_name(),
+    )
+    return terminal_view
+
+
+async def _persist_qwen_external_session_id(
+    server_client: httpx.AsyncClient | None,
+    session_id: str,
+    qwen_session_id: str,
+) -> None:
+    """Record the qwen session id on the Omnigent session as ``external_session_id``.
+
+    Mirrors claude-/codex-/pi-native: the persisted id is what a later resume
+    reads back from the session snapshot to restore the vendor TUI, and what
+    ``fork_conversation`` stamps as ``omnigent.fork.source_external_session_id``
+    so a fork can carry history. Best-effort — a transient failure only degrades
+    resume/fork carry-over, never the live turn (the deterministic id +
+    on-disk-recording check still let the *next* launch resume).
+
+    :param server_client: Runner Omnigent server client (``None`` skips the write).
+    :param session_id: Omnigent session/conversation id.
+    :param qwen_session_id: The qwen ``--session-id`` to persist.
+    """
+    if server_client is None:
+        return
+    try:
+        resp = await server_client.patch(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
+            json={"external_session_id": qwen_session_id},
+            timeout=10.0,
+        )
+    except httpx.HTTPError:
+        _logger.warning(
+            "Could not record qwen external_session_id for %s; resume/fork will start fresh",
+            session_id,
+            exc_info=True,
+        )
+        return
+    if resp.status_code >= 400:
+        _logger.warning(
+            "AP rejected qwen external_session_id PATCH (%s); session=%s",
+            resp.status_code,
+            session_id,
+        )
+
+
+async def _auto_create_qwen_terminal(
+    session_id: str,
+    resource_registry: SessionResourceRegistry,
+    publish_event: Callable[[str, dict[str, Any]], None],
+    *,
+    server_client: httpx.AsyncClient | None,
+    ensure_comment_relay: Callable[..., Awaitable[None]] | None = None,
+) -> SessionResourceView:
+    """
+    Auto-create the qwen TUI terminal for a qwen-native session.
+
+    Launches the interactive ``qwen`` TUI in a runner-owned tmux pane, pointed at
+    the bridge dir's ``--input-file`` (web-UI turns are appended here as JSONL
+    ``submit`` commands) and ``--json-file`` (qwen streams structured events here
+    for the forwarder to mirror). Auth is qwen's own configuration (OpenAI-compat
+    env vars or ``~/.qwen`` from ``/auth``), so HOME is inherited and Omnigent
+    writes no vendor config. Mirrors :func:`_auto_create_goose_terminal`, with a
+    file-based bridge instead of tmux ``send-keys``.
+
+    :param session_id: Session/conversation identifier.
+    :param resource_registry: Session resource registry for launching the terminal.
+    :param publish_event: Runner session event publisher.
+    :param server_client: Runner Omnigent server client.
+    :returns: Created terminal resource view.
+    """
+    from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
+    from omnigent.qwen_native import resolve_qwen_executable
+
+    # Tear down any forwarder left from a prior terminal for this session before
+    # re-creating, so old and new tasks can't both mirror (double-posting), and
+    # drop the prior terminal's stale forward cursor + queued input.
+    await _cancel_auto_forwarder_task(session_id)
+    from omnigent.qwen_native_bridge import (
+        bridge_dir_for_session_id,
+        events_file_path,
+        input_file_path,
+        prepare_bridge_files,
+        qwen_session_id_for_conversation,
+        qwen_session_recording_exists,
+        write_tmux_target,
+    )
+    from omnigent.qwen_native_forwarder import clear_qwen_bridge_state
+
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    clear_qwen_bridge_state(bridge_dir)
+    # Create fresh, empty input + event files before launch: qwen ``watchFile``\\s
+    # the ``--input-file`` (it must exist) and a relaunched terminal must not
+    # replay a prior process's queued commands or events.
+    prepare_bridge_files(bridge_dir)
+    in_path = input_file_path(bridge_dir)
+    out_path = events_file_path(bridge_dir)
+
+    # ``_pi_native_launch_config`` is a generic session-snapshot reader
+    # (workspace + terminal_launch_args); reused here, not Pi-specific.
+    launch_config = await _pi_native_launch_config(
+        session_id=session_id,
+        server_client=server_client,
+    )
+    workspace = os.path.realpath(str(launch_config.workspace))
+    qwen_command = resolve_qwen_executable()
+    # Resume the qwen TUI's own history on re-launch (resume / runner restart) so
+    # the embedded pane shows the prior conversation, not a blank prompt. Uses the
+    # same ``external_session_id`` convention as claude-/codex-/pi-native: the id
+    # is persisted on the Omnigent session and read back from the snapshot
+    # (``launch_config.external_session_id``), which also lets a fork carry history
+    # (``omnigent.fork.source_external_session_id``). qwen is cleaner than
+    # claude/codex here — it lets us *assign* the id via ``--session-id``, so we
+    # mint a deterministic per-conversation one up front instead of capturing a
+    # vendor-generated id off the event stream (and a failed persist self-heals,
+    # since the id is recomputable).
+    #
+    # ``--resume`` on an id qwen never recorded shows its blocking "No saved
+    # session found" screen, so the actual resume guard is the on-disk recording
+    # check (also covers the never-messaged edge and pre-convention sessions →
+    # clean fresh launch). qwen restores history into the TUI from its own
+    # checkpoint and emits only NEW events to ``--json-file`` on resume (verified),
+    # so the forwarder never re-mirrors the prior transcript — no duplicate bubbles.
+    existing_session_id = launch_config.external_session_id
+    qwen_session_id = existing_session_id or qwen_session_id_for_conversation(session_id)
+    # Scope the recording check to THIS workspace's qwen project slug: qwen
+    # resolves ``--resume`` per-project (cwd), so a recording made under another
+    # workspace must not pick ``--resume`` here (→ blocking "No saved session").
+    if qwen_session_recording_exists(qwen_session_id, workspace):
+        resume_args = ["--resume", qwen_session_id]
+    else:
+        resume_args = ["--session-id", qwen_session_id]
+    if existing_session_id != qwen_session_id:
+        # First launch (or a prior persist that didn't land): record the id so the
+        # next resume reads it from the snapshot and forks can carry history.
+        await _persist_qwen_external_session_id(server_client, session_id, qwen_session_id)
+    # The dual-output + input-file flags wire qwen to the bridge; any user
+    # ``terminal_launch_args`` (e.g. ``-m <model>``) precede them. Approval stays
+    # the default in-terminal prompt (the embedded pane shows it) — Omnigent-side
+    # gating via ``confirmation_response`` is a follow-up (see design doc).
+    qwen_args = [
+        *(launch_config.terminal_launch_args or []),
+        *resume_args,
+        "--input-file",
+        str(in_path),
+        "--json-file",
+        str(out_path),
+    ]
+    terminal_view = await resource_registry.launch_required_terminal(
+        session_id=session_id,
+        terminal_name="qwen",
+        session_key="main",
+        resource_role=QWEN_NATIVE_TERMINAL_ROLE,
+        spec=TerminalEnvSpec(
+            os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+            command=qwen_command,
+            args=qwen_args,
+            scrollback=100_000,
+            tmux_allow_passthrough=True,
+            tmux_start_on_attach=False,
+        ),
+    )
+    # Advertise the tmux socket+target so interrupt (Escape) / stop (kill) can
+    # reach this pane — message injection itself is file-based, not tmux.
+    terminal_registry = resource_registry.terminal_registry
+    if terminal_registry is not None:
+        instance = terminal_registry.get(session_id, "qwen", "main")
+        if instance is not None and instance.running:
+            write_tmux_target(
+                bridge_dir,
+                socket_path=instance.socket_path,
+                tmux_target=instance.tmux_target,
+            )
+    publish_event(
+        session_id,
+        {
+            "type": "session.resource.created",
+            "resource": session_resource_view_to_dict(terminal_view),
+        },
+    )
+
+    # Mirror the qwen TUI's conversation back into the Omnigent session so the
+    # chat view tracks the embedded terminal. Host-spawned sessions have no CLI
+    # client to start this, so the runner owns it — reusing the runner's own
+    # server URL + refresh-capable auth.
+    from omnigent.runner._entry import _make_auth_token_factory, _RunnerDatabricksAuth
+
+    server_url = _required_runner_env("RUNNER_SERVER_URL")
+    _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
+
+    from omnigent.qwen_native_forwarder import supervise_qwen_forwarder
+
+    if server_client is not None and ensure_comment_relay is not None:
+        await ensure_comment_relay(
+            session_id,
+            explicit_bridge_dir=bridge_dir,
+            await_notify=False,
+        )
+
+    _forwarder_task = asyncio.create_task(
+        supervise_qwen_forwarder(
+            base_url=server_url,
+            headers={},
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            agent_name="qwen-native-ui",
+            auth=_runner_auth,
+        ),
+        name=f"qwen-forwarder-{session_id}",
+    )
+    _register_auto_forwarder_task(session_id, _forwarder_task)
+    _logger.info(
+        "Auto-created qwen terminal + forwarder for session %s; forwarder_task=%s",
         session_id,
         _forwarder_task.get_name(),
     )
@@ -5295,6 +5510,7 @@ def create_runner_app(
     _opencode_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _cursor_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _goose_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
+    _qwen_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     # Per-session lock guarding the claude-native terminal auto-create in
     # ``create_session``. Two ``POST /v1/sessions`` calls can land
     # concurrently on a host-launched runner — ``_on_runner_connect``
@@ -5716,6 +5932,27 @@ def create_runner_app(
             },
         )
         if event.lifecycle != TerminalLifecycle.REQUIRED:
+            return
+
+        # qwen-native: the user drives the qwen TUI directly, so quitting it
+        # (Ctrl+C / /quit) is a normal end-of-session, not a crash. The
+        # ``session_was_idle`` guard below is meant to catch a clean exit, but
+        # qwen's "powering down" redraw on quit trips the PTY-activity watcher
+        # and flips the status to ``running`` in the instant before the process
+        # exits — so the quit is misclassified as a crash and the scary
+        # ``required_terminal_exited`` card renders. Treat the qwen terminal's
+        # exit as a clean shutdown: genuine *boot* failures never reach here
+        # (they surface via ``_auto_create_qwen_terminal``'s error handler →
+        # ``_publish_native_terminal_start_error``), so a qwen required-terminal
+        # exit is always post-boot, i.e. user-initiated.
+        if event.terminal_name == "qwen" and event.session_key == "main":
+            # Publish a final ``idle`` to clear the web "Working…" spinner: the
+            # powering-down redraw may have left the PTY watcher's last edge on
+            # ``running``, and the watcher is gone once the pane dies, so without
+            # this the session spins forever. Then release the harness (no
+            # ``failed`` card — the user quit).
+            _publish_event(event.session_id, {"type": "session.status", "status": "idle"})
+            _release_required_terminal_session(event.session_id)
             return
 
         # Exit while idle = the turn already finished and the pane shut down
@@ -6183,6 +6420,10 @@ def create_runner_app(
                 from omnigent.goose_native_bridge import build_goose_native_spawn_env
 
                 spawn_env = build_goose_native_spawn_env(session_id)
+            if harness_name == "qwen-native" and spawn_env is None:
+                from omnigent.qwen_native_bridge import build_qwen_native_spawn_env
+
+                spawn_env = build_qwen_native_spawn_env(session_id)
             _session_spec_cache[session_id] = spec_entry
         else:
             harness_name = "runner-test-default"
@@ -6604,6 +6845,37 @@ def create_runner_app(
                     finally:
                         _publish_terminal_pending(_publish_event, session_id, False)
 
+        if harness_name == "qwen-native":
+            _qwen_ensure_lock = _qwen_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
+            async with _qwen_ensure_lock:
+                _tr = resource_registry.terminal_registry
+                _has_qwen_terminal = (
+                    _tr is not None and _tr.get(session_id, "qwen", "main") is not None
+                )
+                if not _has_qwen_terminal:
+                    _publish_terminal_pending(_publish_event, session_id, True)
+                    try:
+                        await _auto_create_qwen_terminal(
+                            session_id,
+                            resource_registry,
+                            _publish_event,
+                            server_client=server_client,
+                            ensure_comment_relay=_ensure_comment_relay_started,
+                        )
+                    except Exception as exc:
+                        _logger.exception(
+                            "Failed to auto-create qwen terminal for %s",
+                            session_id,
+                        )
+                        _publish_native_terminal_start_error(
+                            _publish_event,
+                            session_id,
+                            "qwen",
+                            exc,
+                        )
+                    finally:
+                        _publish_terminal_pending(_publish_event, session_id, False)
+
         # Auto-bootstrap the Omnigent REPL terminal for non-native
         # (SDK-harness) top-level sessions: host the framework's own TUI
         # (``omnigent attach``) in a tmux pane so the web UI can embed it
@@ -6873,6 +7145,7 @@ def create_runner_app(
         _pi_terminal_ensure_locks.pop(session_id, None)
         _cursor_terminal_ensure_locks.pop(session_id, None)
         _goose_terminal_ensure_locks.pop(session_id, None)
+        _qwen_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         _interrupted_sessions.discard(session_id)
         # Stop any TUI→web transcript forwarder (cursor-/goose-native) for this
@@ -7483,6 +7756,7 @@ def create_runner_app(
             "pi-native",
             "cursor-native",
             "goose-native",
+            "qwen-native",
         }:
             return
         if status == "idle" and harness == "codex-native":
@@ -8259,6 +8533,78 @@ def create_runner_app(
         ):
             _logger.warning(
                 "Goose-native stop succeeded but sub-agent delivery was "
+                "not confirmed; session=%s reason=%s",
+                conv_id,
+                delivery_ack.reason,
+            )
+        return Response(status_code=204)
+
+    async def _handle_qwen_native_interrupt(conv_id: str) -> Response:
+        """Cancel the in-flight qwen turn by sending ``Escape`` to its TUI pane.
+
+        qwen-native turns run inside the ``qwen`` TUI; the runner harness task
+        returns right after appending the input-file submit, so the in-process
+        cancel floor has nothing to cancel. qwen's input-file protocol has no
+        interrupt command, so — like goose-native — Stop drives Escape through
+        the display pane.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 204 when Escape was sent; 503 if the tmux target is unavailable.
+        """
+        from omnigent.qwen_native_bridge import bridge_dir_for_session_id, inject_interrupt
+
+        try:
+            await asyncio.to_thread(
+                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
+            )
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "qwen_native_interrupt_failed",
+                    "detail": _client_safe_error_detail(exc, context="qwen-native interrupt"),
+                },
+            )
+        _wake_parent_after_native_interrupt(conv_id)
+        return Response(status_code=204)
+
+    async def _handle_qwen_native_stop(conv_id: str) -> Response:
+        """Hard-stop a qwen-native session by killing its tmux session.
+
+        Mirrors :func:`_handle_goose_native_stop`: kill the pane (ends ``qwen``),
+        tear the terminal resource down, cancel the forwarder, publish ``idle``,
+        and reclaim any sub-agent work entry.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 204 on success; 503 if the tmux target is unavailable.
+        """
+        from omnigent.qwen_native_bridge import bridge_dir_for_session_id, kill_session
+
+        try:
+            await asyncio.to_thread(
+                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
+            )
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "qwen_native_stop_failed",
+                    "detail": _client_safe_error_detail(exc, context="qwen-native stop"),
+                },
+            )
+        await _teardown_session_terminals(conv_id)
+        await _cancel_auto_forwarder_task(conv_id)
+        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
+        delivery_ack = _mark_subagent_terminal_and_wake(
+            conv_id,
+            status="cancelled",
+            output="[System: sub-agent stopped]",
+        )
+        if not delivery_ack.delivered and (
+            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
+        ):
+            _logger.warning(
+                "qwen-native stop succeeded but sub-agent delivery was "
                 "not confirmed; session=%s reason=%s",
                 conv_id,
                 delivery_ack.reason,
@@ -10216,6 +10562,10 @@ def create_runner_app(
             from omnigent.goose_native_bridge import build_goose_native_spawn_env
 
             spawn_env = build_goose_native_spawn_env(conv_id)
+        if harness_name == "qwen-native" and spawn_env is None:
+            from omnigent.qwen_native_bridge import build_qwen_native_spawn_env
+
+            spawn_env = build_qwen_native_spawn_env(conv_id)
 
         agent_version = dispatch.agent_version if dispatch else body.get("agent_version")
         if agent_version is not None and conv_id in _version_cache:
@@ -11126,6 +11476,9 @@ def create_runner_app(
             if _harness == "goose-native":
                 # goose turn lives in the goose session TUI; send Escape to stop it.
                 return await _handle_goose_native_interrupt(conversation_id)
+            if _harness == "qwen-native":
+                # qwen turn lives in the qwen TUI; send Escape to stop it.
+                return await _handle_qwen_native_interrupt(conversation_id)
             # In-process harness: mark interrupted, forward an interrupt to the
             # harness, and force-cancel the runner turn task so the turn ends
             # promptly even if the harness can't honor the interrupt in time.
@@ -11199,6 +11552,9 @@ def create_runner_app(
             if _harness == "goose-native":
                 # Hard-kill the goose session tmux pane (the TUI is the runtime).
                 return await _handle_goose_native_stop(conversation_id)
+            if _harness == "qwen-native":
+                # Hard-kill the qwen tmux pane (the TUI is the runtime).
+                return await _handle_qwen_native_stop(conversation_id)
             await _cancel_inprocess_turn(conversation_id)
             return Response(status_code=204)
 
@@ -11900,6 +12256,41 @@ def create_runner_app(
                         session_id,
                     )
                     return _native_terminal_start_error_response(exc, "Goose")
+            return JSONResponse(
+                status_code=200,
+                content=session_resource_view_to_dict(terminal_view),
+            )
+
+        if (
+            body.get("ensure_native_terminal")
+            and terminal_name == "qwen"
+            and session_key == "main"
+        ):
+            qwen_terminal_id = terminal_resource_id("qwen", "main")
+            ensure_lock = _qwen_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
+            async with ensure_lock:
+                existing = await resource_registry.get_terminal_resource(
+                    session_id, qwen_terminal_id
+                )
+                if existing is not None:
+                    return JSONResponse(
+                        status_code=200,
+                        content=session_resource_view_to_dict(existing),
+                    )
+                try:
+                    terminal_view = await _auto_create_qwen_terminal(
+                        session_id,
+                        resource_registry,
+                        _publish_event,
+                        server_client=server_client,
+                        ensure_comment_relay=_ensure_comment_relay_started,
+                    )
+                except Exception as exc:
+                    _logger.exception(
+                        "qwen terminal ensure failed for session=%s",
+                        session_id,
+                    )
+                    return _native_terminal_start_error_response(exc, "qwen")
             return JSONResponse(
                 status_code=200,
                 content=session_resource_view_to_dict(terminal_view),
@@ -13381,6 +13772,7 @@ def create_runner_app(
         _pi_terminal_ensure_locks.pop(session_id, None)
         _cursor_terminal_ensure_locks.pop(session_id, None)
         _goose_terminal_ensure_locks.pop(session_id, None)
+        _qwen_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         await resource_registry.cleanup_session(session_id)
         return JSONResponse(
@@ -13435,6 +13827,7 @@ def create_runner_app(
         _pi_terminal_ensure_locks.pop(session_id, None)
         _cursor_terminal_ensure_locks.pop(session_id, None)
         _goose_terminal_ensure_locks.pop(session_id, None)
+        _qwen_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         # Close terminals with ``session.resource.deleted`` events BEFORE
         # cleanup_session — cleanup_conversation would silently pop them

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -53,6 +53,7 @@ PI_NATIVE_TERMINAL_ROLE = "pi-native"
 OPENCODE_NATIVE_TERMINAL_ROLE = "opencode-native"
 CURSOR_NATIVE_TERMINAL_ROLE = "cursor-native"
 GOOSE_NATIVE_TERMINAL_ROLE = "goose-native"
+QWEN_NATIVE_TERMINAL_ROLE = "qwen-native"
 # Role marker for the embedded Omnigent REPL terminal auto-created for
 # runner-hosted SDK sessions (``omnigent attach`` in a tmux pane — the
 # SDK mirror of the native terminals above). The attach WebSocket uses
@@ -966,6 +967,10 @@ class SessionResourceRegistry:
             # goose-native injects then returns (its forwarder only mirrors the
             # transcript, not status), so the PTY watcher is its status source too.
             GOOSE_NATIVE_TERMINAL_ROLE,
+            # qwen-native appends then returns (its forwarder only mirrors the
+            # JSON event transcript, not status), so the PTY watcher is its
+            # status source too.
+            QWEN_NATIVE_TERMINAL_ROLE,
         }
         if activity_publisher is None and not emit_status and exit_publisher is None:
             return

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -73,6 +73,13 @@ _HARNESS_MODULES: dict[str, str] = {
     # cursor-native, so it IS in ``NATIVE_HARNESSES``. See
     # omnigent/inner/goose_native_harness.py.
     "goose-native": "omnigent.inner.goose_native_harness",
+    # qwen-native harness wrap. Drives the resident ``qwen`` TUI by appending
+    # JSONL ``submit`` commands to its ``--input-file`` and mirroring the
+    # transcript back from its ``--json-file`` event stream — a native-CLI
+    # harness like goose-native, so it IS in ``NATIVE_HARNESSES``. The bare
+    # ``qwen`` name stays the ACP-piped harness. See
+    # omnigent/inner/qwen_native_harness.py.
+    "qwen-native": "omnigent.inner.qwen_native_harness",
     # Google Antigravity SDK harness wrap. See
     # omnigent/inner/antigravity_harness.py. In-process SDK harness
     # (``google-antigravity``), like openai-agents — Omnigent spawns no CLI

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -25,6 +25,7 @@ from omnigent.native_coding_agents import (
     CURSOR_NATIVE_CODING_AGENT,
     OPENCODE_NATIVE_CODING_AGENT,
     PI_NATIVE_CODING_AGENT,
+    QWEN_NATIVE_CODING_AGENT,
 )
 from omnigent.resources import examples as _examples_resources
 from omnigent.runtime import (
@@ -80,6 +81,7 @@ _CODEX_NATIVE_AGENT_NAME = CODEX_NATIVE_CODING_AGENT.agent_name
 _PI_NATIVE_AGENT_NAME = PI_NATIVE_CODING_AGENT.agent_name
 _OPENCODE_NATIVE_AGENT_NAME = OPENCODE_NATIVE_CODING_AGENT.agent_name
 _CURSOR_NATIVE_AGENT_NAME = CURSOR_NATIVE_CODING_AGENT.agent_name
+_QWEN_NATIVE_AGENT_NAME = QWEN_NATIVE_CODING_AGENT.agent_name
 _DEBBY_AGENT_NAME = "debby"
 _POLLY_AGENT_NAME = "polly"
 _UNMATCHED_ROUTE_TEMPLATE = "<unmatched>"
@@ -356,6 +358,7 @@ def _ensure_default_agents(
     _ensure_default_pi_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_opencode_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_cursor_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_qwen_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_debby_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_polly_agent(agent_store, artifact_store, agent_cache)
     _ensure_extra_builtin_agents(agent_store, artifact_store, agent_cache)
@@ -643,6 +646,49 @@ def _ensure_default_cursor_agent(
         agent_cache,
         name=_CURSOR_NATIVE_AGENT_NAME,
         bundle_bytes=_build_cursor_native_bundle(),
+    )
+
+
+def _build_qwen_native_bundle() -> bytes:
+    """
+    Build a gzipped tarball of the qwen-native-ui agent spec.
+
+    :returns: Gzipped tarball bytes suitable for the artifact store.
+    """
+    import tempfile
+
+    from omnigent.qwen_native import _materialize_qwen_agent_spec
+    from omnigent.spec import materialize_bundle
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spec_path = _materialize_qwen_agent_spec(Path(tmpdir))
+        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
+        return _tar_gz_dir(bundle_dir)
+
+
+def _ensure_default_qwen_agent(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """
+    Register or refresh the qwen-native-ui agent.
+
+    Called during server lifespan startup so the Web UI offers Qwen Code as a
+    built-in native-terminal agent on every deployment (not only after the
+    ``omnigent qwen`` CLI first registers it). Content-aware via
+    :func:`_ensure_builtin_agent`.
+
+    :param agent_store: Store for agent metadata.
+    :param artifact_store: Store for agent bundles.
+    :param agent_cache: Cache for loaded agent specs.
+    """
+    _ensure_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_cache,
+        name=_QWEN_NATIVE_AGENT_NAME,
+        bundle_bytes=_build_qwen_native_bundle(),
     )
 
 

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -95,6 +95,7 @@ OMNIGENT_HARNESSES = frozenset(
         "pi",
         "pi-native",
         "qwen",
+        "qwen-native",
     },
 )
 # User-facing aliases accepted in specs and normalized before runtime dispatch.

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -180,6 +180,12 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     ``goose-native`` is excluded for the same reason as ``claude-native`` /
     ``cursor-native``: it is a terminal-first TUI launched via ``omni goose``
     (tmux pane + bridge dir), not ``omnigent run --harness goose-native``.
+
+    ``qwen-native`` is excluded for the same reason as ``goose-native`` /
+    ``cursor-native``: it is a terminal-first TUI launched via ``omni qwen``
+    (tmux pane + bridge dir, driving qwen's ``--input-file`` / ``--json-file``),
+    not ``omnigent run --harness qwen-native``. Its coverage is the dedicated
+    qwen-native bridge/executor/forwarder unit tests.
     """
     expected_live_harnesses = set(OMNIGENT_HARNESSES).intersection(_HARNESS_MODULES) - {
         "claude-native",
@@ -191,6 +197,7 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
         "antigravity",
         "copilot",
         "qwen",
+        "qwen-native",
         "goose",
         "goose-native",
     }

--- a/tests/inner/test_qwen_native_executor.py
+++ b/tests/inner/test_qwen_native_executor.py
@@ -1,0 +1,177 @@
+"""Unit tests for QwenNativeExecutor — the harness-side input-file injector.
+
+Mirrors ``tests/inner/test_goose_native_executor.py`` (the closest analog), plus
+qwen-specific coverage for the boot-order readiness gate (``_ensure_ready``) that
+goose/cursor don't have — qwen drops a submit appended before its input watcher
+starts, so the executor must wait for qwen to be ready before the first append.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner import qwen_native_executor as qne
+from omnigent.inner.executor import ExecutorError, TurnComplete
+
+
+def test_supports_flags(tmp_path: Path) -> None:
+    ex = qne.QwenNativeExecutor(bridge_dir=tmp_path)
+    # Output is shown by the embedded terminal + mirrored by the forwarder, and
+    # mid-turn steering is appended as another submit line.
+    assert ex.supports_streaming() is False
+    assert ex.supports_live_message_queue() is True
+
+
+def test_content_to_text_plain_and_parts(tmp_path: Path) -> None:
+    assert qne._content_to_text("hello", tmp_path) == "hello"
+    blocks = [{"type": "input_text", "text": "a"}, {"type": "text", "text": "b"}]
+    assert qne._content_to_text(blocks, tmp_path) == "a\n\nb"
+    # Unknown / empty shapes degrade to empty rather than raising.
+    assert qne._content_to_text(None, tmp_path) == ""
+    assert qne._content_to_text([{"type": "image"}], tmp_path) == ""
+
+
+def test_content_to_text_materializes_attachment(tmp_path: Path) -> None:
+    # An image/file block carrying a base64 data URI is written to the bridge
+    # dir and referenced by path (so qwen can open it), not inlined as base64.
+    png = (
+        "data:image/png;base64,"
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
+    out = qne._content_to_text(
+        [{"type": "input_image", "image_url": png}, {"type": "text", "text": "look"}],
+        tmp_path,
+    )
+    assert "[Attached: " in out
+    assert out.endswith("look")  # attachment lines precede the text
+
+
+def test_latest_user_text_picks_last_user(tmp_path: Path) -> None:
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply"},
+        {"role": "user", "content": "second"},
+    ]
+    assert qne._latest_user_text(messages, tmp_path) == "second"
+    assert qne._latest_user_text([{"role": "assistant", "content": "x"}], tmp_path) == ""
+
+
+def test_bridge_dir_from_env_requires_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(qne.BRIDGE_DIR_ENV_VAR, raising=False)
+    with pytest.raises(RuntimeError):
+        qne._bridge_dir_from_env()
+
+
+def test_bridge_dir_from_env_reads_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(qne.BRIDGE_DIR_ENV_VAR, str(tmp_path))
+    assert qne._bridge_dir_from_env() == tmp_path
+
+
+async def test_run_turn_injects_latest_user_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    monkeypatch.setattr(qne, "wait_for_ready", lambda *a, **k: order.append("ready") or True)
+
+    def _record_submit(_bridge_dir: Path, *, content: str) -> None:
+        order.append(f"submit:{content}")
+
+    monkeypatch.setattr(qne, "submit_user_message", _record_submit)
+    ex = qne.QwenNativeExecutor(bridge_dir=tmp_path)
+    events = [e async for e in ex.run_turn([{"role": "user", "content": "do it"}], [], "")]
+    # Readiness is awaited BEFORE the submit (else qwen drops the first message).
+    assert order == ["ready", "submit:do it"]
+    assert len(events) == 1 and isinstance(events[0], TurnComplete)
+    assert events[0].response is None  # output is terminal-originated
+
+
+async def test_run_turn_errors_with_no_user_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    submitted: list[str] = []
+    monkeypatch.setattr(qne, "wait_for_ready", lambda *a, **k: True)
+    monkeypatch.setattr(qne, "submit_user_message", lambda *a, **k: submitted.append("x"))
+    ex = qne.QwenNativeExecutor(bridge_dir=tmp_path)
+    events = [e async for e in ex.run_turn([{"role": "assistant", "content": "x"}], [], "")]
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+    assert submitted == []  # nothing injected when there's no user text
+
+
+async def test_run_turn_surfaces_bridge_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(qne, "wait_for_ready", lambda *a, **k: True)
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("input file gone")
+
+    monkeypatch.setattr(qne, "submit_user_message", _boom)
+    ex = qne.QwenNativeExecutor(bridge_dir=tmp_path)
+    events = [e async for e in ex.run_turn([{"role": "user", "content": "hi"}], [], "")]
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+
+
+async def test_enqueue_session_message_injects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(qne, "wait_for_ready", lambda *a, **k: True)
+    monkeypatch.setattr(
+        qne, "submit_user_message", lambda bridge_dir, *, content: seen.append(content)
+    )
+    ex = qne.QwenNativeExecutor(bridge_dir=tmp_path)
+    assert await ex.enqueue_session_message("main", "steer") is True
+    assert seen == ["steer"]
+    # Empty content is a no-op (no injection).
+    assert await ex.enqueue_session_message("main", "") is False
+    assert seen == ["steer"]
+
+
+async def test_ensure_ready_does_not_latch_on_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ready_calls = {"n": 0}
+
+    def _timeout(*_a: object, **_k: object) -> bool:
+        ready_calls["n"] += 1
+        return False  # readiness gate times out every time
+
+    submitted: list[str] = []
+    monkeypatch.setattr(qne, "wait_for_ready", _timeout)
+    monkeypatch.setattr(
+        qne, "submit_user_message", lambda _b, *, content: submitted.append(content)
+    )
+    ex = qne.QwenNativeExecutor(bridge_dir=tmp_path)
+    async for _ in ex.run_turn([{"role": "user", "content": "a"}], [], ""):
+        pass
+    async for _ in ex.run_turn([{"role": "user", "content": "b"}], [], ""):
+        pass
+    # On timeout the gate is NOT latched — it re-checks each turn (qwen is almost
+    # certainly up by the next one) — yet still submits best-effort both times.
+    assert ready_calls["n"] == 2
+    assert submitted == ["a", "b"]
+    assert ex._ready is False
+
+
+async def test_ensure_ready_is_latched_across_turns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ready_calls = {"n": 0}
+
+    def _wait(*_a: object, **_k: object) -> bool:
+        ready_calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(qne, "wait_for_ready", _wait)
+    monkeypatch.setattr(qne, "submit_user_message", lambda *a, **k: None)
+    ex = qne.QwenNativeExecutor(bridge_dir=tmp_path)
+    async for _ in ex.run_turn([{"role": "user", "content": "one"}], [], ""):
+        pass
+    await ex.enqueue_session_message("main", "two")
+    async for _ in ex.run_turn([{"role": "user", "content": "three"}], [], ""):
+        pass
+    # Readiness is awaited once per session, not once per turn (warm turns don't
+    # re-block on the events-file poll).
+    assert ready_calls["n"] == 1

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -157,9 +157,12 @@ def test_configured_harness_map_covers_all_spellings(
         "opencode-native",
         "native-opencode",
         "opencode",
-        # Qwen harnesses
+        # Qwen harnesses — ACP (``qwen`` / ``qwen-code``) + native TUI
+        # (``qwen-native`` / ``native-qwen``); all gate on the qwen CLI.
         "qwen",
         "qwen-code",
+        "qwen-native",
+        "native-qwen",
         # Copilot SDK harness + its user-facing alias.
         "copilot",
         "github-copilot",

--- a/tests/runner/test_qwen_native_runner.py
+++ b/tests/runner/test_qwen_native_runner.py
@@ -1,0 +1,43 @@
+"""Unit tests for qwen-native runner-side helpers."""
+
+from __future__ import annotations
+
+import httpx
+
+from omnigent.runner.app import _persist_qwen_external_session_id
+
+
+class _RecordingClient:
+    """Async httpx-client stub recording PATCHes; returns a chosen status."""
+
+    def __init__(self, status: int = 200) -> None:
+        self.patches: list[tuple[str, dict]] = []
+        self._status = status
+
+    async def patch(self, url: str, *, json: dict, timeout: float | None = None) -> httpx.Response:
+        self.patches.append((url, json))
+        return httpx.Response(self._status, request=httpx.Request("PATCH", url))
+
+
+async def test_persist_external_session_id_patches_session() -> None:
+    client = _RecordingClient()
+    await _persist_qwen_external_session_id(client, "conv_abc", "qsid-1")  # type: ignore[arg-type]
+    assert client.patches == [("/v1/sessions/conv_abc", {"external_session_id": "qsid-1"})]
+
+
+async def test_persist_external_session_id_noop_without_client() -> None:
+    # No server client (e.g. embedded/test runner) → silent no-op, no raise.
+    await _persist_qwen_external_session_id(None, "conv_abc", "qsid-1")
+
+
+async def test_persist_external_session_id_swallows_errors() -> None:
+    # Best-effort: a rejected PATCH or transport error must not raise (only
+    # resume/fork carry-over degrades, never the live turn).
+    rejected = _RecordingClient(status=500)
+    await _persist_qwen_external_session_id(rejected, "conv_abc", "qsid-1")  # type: ignore[arg-type]
+
+    class _Boom:
+        async def patch(self, *_a: object, **_k: object) -> httpx.Response:
+            raise httpx.ConnectError("down")
+
+    await _persist_qwen_external_session_id(_Boom(), "conv_abc", "qsid-1")  # type: ignore[arg-type]

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -498,6 +498,48 @@ def test_ensure_extra_builtin_agents_skips_bad_path_and_seeds_good(
     assert seed_stores.agent_store.get_by_name("does-not-exist") is None
 
 
+def test_ensure_default_qwen_agent_seeds_card(seed_stores: _SeedStores) -> None:
+    """
+    Seeding registers qwen-native-ui as a built-in the picker can render.
+
+    The new-session picker reads built-ins from ``GET /v1/agents``; without this
+    seeder Qwen Code only appears after the ``omnigent qwen`` CLI first registers
+    it, so it was absent from the Web UI dropdown.
+    """
+    server_app._ensure_default_qwen_agent(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+
+    seeded = seed_stores.agent_store.get_by_name(server_app._QWEN_NATIVE_AGENT_NAME)
+    assert seeded is not None, "qwen-native-ui was not registered"
+    assert seeded.name == "qwen-native-ui"
+    # The bundle must be retrievable, not just referenced.
+    assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
+
+
+def test_ensure_default_qwen_agent_is_idempotent(seed_stores: _SeedStores) -> None:
+    """A second seed call is a no-op — startup runs the seeder every boot."""
+    server_app._ensure_default_qwen_agent(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+    first = seed_stores.agent_store.get_by_name(server_app._QWEN_NATIVE_AGENT_NAME)
+    assert first is not None
+    server_app._ensure_default_qwen_agent(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+    page = seed_stores.agent_store.list(limit=100)
+    qwen_rows = [a for a in page.data if a.name == "qwen-native-ui"]
+    assert len(qwen_rows) == 1
+    assert qwen_rows[0].id == first.id
+    assert qwen_rows[0].version == first.version == 1
+
+
 def test_ensure_default_polly_agent_seeds_card(seed_stores: _SeedStores) -> None:
     """
     Seeding registers polly as a built-in the picker can render.

--- a/tests/test_qwen_native.py
+++ b/tests/test_qwen_native.py
@@ -1,0 +1,367 @@
+"""Unit tests for the omni qwen CLI-side helpers (no server needed).
+
+Mirrors ``tests/test_goose_native.py`` and adds qwen-specific pure helpers
+(agent-spec materialization, terminal-payload decoding, direct-tmux preflight).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import httpx
+import pytest
+import yaml
+
+from omnigent import qwen_native as qn
+
+
+def test_resolve_qwen_executable_found() -> None:
+    resolved = qn.resolve_qwen_executable(
+        env={}, which=lambda cmd: f"/usr/local/bin/{cmd}" if cmd == "qwen" else None
+    )
+    assert resolved == "/usr/local/bin/qwen"
+
+
+def test_resolve_qwen_executable_honors_path_override() -> None:
+    resolved = qn.resolve_qwen_executable(
+        env={"OMNIGENT_QWEN_PATH": "/opt/qwen"},
+        which=lambda cmd: cmd if cmd == "/opt/qwen" else None,
+    )
+    assert resolved == "/opt/qwen"
+
+
+def test_resolve_qwen_executable_missing_raises_with_hint() -> None:
+    with pytest.raises(click.ClickException) as exc:
+        qn.resolve_qwen_executable(env={}, which=lambda _cmd: None)
+    msg = str(exc.value)
+    assert "@qwen-code/qwen-code" in msg
+    assert "OMNIGENT_QWEN_PATH" in msg
+
+
+def test_build_qwen_launch_argv() -> None:
+    launch = qn.build_qwen_launch(
+        ["-m", "qwen3-coder-plus"],
+        env={},
+        which=lambda cmd: f"/bin/{cmd}",
+    )
+    assert launch.executable == "/bin/qwen"
+    assert launch.argv == ["/bin/qwen", "-m", "qwen3-coder-plus"]
+
+
+def test_terminal_resource_id_stable() -> None:
+    assert qn.qwen_terminal_resource_id() == qn.qwen_terminal_resource_id()
+
+
+def test_materialize_agent_spec_declares_qwen_native_harness(tmp_path: Path) -> None:
+    spec_path = qn._materialize_qwen_agent_spec(tmp_path)
+    raw = yaml.safe_load(spec_path.read_text())
+    assert raw["name"] == "qwen-native-ui"
+    assert raw["executor"] == {"harness": "qwen-native"}
+
+
+def test_launched_terminal_from_payload_decodes_tmux(tmp_path: Path) -> None:
+    sock = tmp_path / "tmux.sock"
+    payload = {
+        "id": "terminal_qwen_main",
+        "metadata": {"tmux_socket": str(sock), "tmux_target": "sess:0.0"},
+    }
+    launched = qn._launched_qwen_terminal_from_payload(payload)
+    assert launched.terminal_id == "terminal_qwen_main"
+    assert launched.tmux_socket == sock
+    assert launched.tmux_target == "sess:0.0"
+
+
+def test_launched_terminal_from_payload_requires_id() -> None:
+    with pytest.raises(click.ClickException):
+        qn._launched_qwen_terminal_from_payload({"metadata": {}})
+    with pytest.raises(click.ClickException):
+        qn._launched_qwen_terminal_from_payload("not-a-dict")
+
+
+def test_direct_tmux_unavailable_reason_reports_missing_pieces(tmp_path: Path) -> None:
+    no_socket = qn.PreparedQwenTerminal(
+        session_id="c", terminal_id="t", tmux_socket=None, tmux_target="x", reattached=False
+    )
+    assert "socket" in (qn._direct_tmux_unavailable_reason(no_socket) or "")
+
+    missing_socket = qn.PreparedQwenTerminal(
+        session_id="c",
+        terminal_id="t",
+        tmux_socket=tmp_path / "absent.sock",
+        tmux_target="x",
+        reattached=False,
+    )
+    assert "not reachable" in (qn._direct_tmux_unavailable_reason(missing_socket) or "")
+
+
+# --- async server-interaction helpers (fake httpx client) --------------------
+
+
+def _resp(status: int, body: object | None = None, *, method: str = "GET") -> httpx.Response:
+    kwargs: dict = {"request": httpx.Request(method, "http://test/x")}
+    if body is not None:
+        kwargs["json"] = body
+    return httpx.Response(status, **kwargs)
+
+
+class _FakeClient:
+    """Async httpx-client stub with per-method canned responses."""
+
+    def __init__(self) -> None:
+        self.get_responses: list[httpx.Response] = []
+        self.post_response: httpx.Response | None = None
+        self.calls: list[tuple[str, str, dict]] = []
+
+    async def get(self, url: str, **kw: object) -> httpx.Response:
+        self.calls.append(("GET", url, kw))
+        return self.get_responses.pop(0) if self.get_responses else _resp(404)
+
+    async def post(self, url: str, **kw: object) -> httpx.Response:
+        self.calls.append(("POST", url, kw))
+        assert self.post_response is not None
+        return self.post_response
+
+
+async def test_create_qwen_session_returns_id_and_sends_labels() -> None:
+    client = _FakeClient()
+    client.post_response = _resp(200, {"session_id": "conv_new"}, method="POST")
+    sid = await qn._create_qwen_session(client, b"bundle", terminal_launch_args=["-m", "x"])  # type: ignore[arg-type]
+    assert sid == "conv_new"
+    _, url, kw = client.calls[0]
+    assert url == "/v1/sessions"
+    # Terminal-first labels + launch args ride along in the multipart metadata.
+    import json as _json
+
+    meta = _json.loads(kw["data"]["metadata"])
+    assert meta["labels"]["omnigent.wrapper"] == "qwen-native-ui"
+    assert meta["terminal_launch_args"] == ["-m", "x"]
+
+
+async def test_create_qwen_session_raises_on_error_and_missing_id() -> None:
+    bad = _FakeClient()
+    bad.post_response = _resp(500, {"detail": "boom"}, method="POST")
+    with pytest.raises(click.ClickException):
+        await qn._create_qwen_session(bad, b"b")  # type: ignore[arg-type]
+    noid = _FakeClient()
+    noid.post_response = _resp(200, {}, method="POST")
+    with pytest.raises(click.ClickException):
+        await qn._create_qwen_session(noid, b"b")  # type: ignore[arg-type]
+
+
+async def test_fetch_qwen_session_paths() -> None:
+    ok = _FakeClient()
+    ok.get_responses = [_resp(200, {"id": "conv", "labels": {}})]
+    assert await qn._fetch_qwen_session(ok, "conv") == {"id": "conv", "labels": {}}
+    for status in (404, 500):
+        c = _FakeClient()
+        c.get_responses = [_resp(status, {"detail": "x"})]
+        with pytest.raises(click.ClickException):
+            await qn._fetch_qwen_session(c, "conv")
+    nondict = _FakeClient()
+    nondict.get_responses = [_resp(200, ["not", "a", "dict"])]
+    with pytest.raises(click.ClickException):
+        await qn._fetch_qwen_session(nondict, "conv")
+
+
+async def test_ensure_qwen_terminal_on_runner() -> None:
+    ok = _FakeClient()
+    ok.post_response = _resp(200, {}, method="POST")
+    await qn._ensure_qwen_terminal_on_runner(ok, "conv")  # no raise
+    _, url, kw = ok.calls[0]
+    assert url.endswith("/resources/terminals")
+    assert kw["json"]["ensure_native_terminal"] is True
+    bad = _FakeClient()
+    bad.post_response = _resp(503, {"detail": "no"}, method="POST")
+    with pytest.raises(click.ClickException):
+        await qn._ensure_qwen_terminal_on_runner(bad, "conv")
+
+
+async def test_find_running_qwen_terminal_variants() -> None:
+    # 404 → not created yet.
+    c404 = _FakeClient()
+    c404.get_responses = [_resp(404)]
+    assert await qn._find_running_qwen_terminal(c404, "conv") is None
+    # running:false metadata → treated as absent.
+    cstopped = _FakeClient()
+    cstopped.get_responses = [
+        _resp(200, {"id": "terminal_qwen_main", "metadata": {"running": False}})
+    ]
+    assert await qn._find_running_qwen_terminal(cstopped, "conv") is None
+    # transient "offline"/"not bound" → None (caller keeps polling).
+    coffline = _FakeClient()
+    coffline.get_responses = [_resp(503, {"detail": "runner is offline"})]
+    assert await qn._find_running_qwen_terminal(coffline, "conv") is None
+    # hard error → raise.
+    cerr = _FakeClient()
+    cerr.get_responses = [_resp(500, {"detail": "boom"})]
+    with pytest.raises(click.ClickException):
+        await qn._find_running_qwen_terminal(cerr, "conv")
+    # healthy → decoded terminal.
+    cok = _FakeClient()
+    cok.get_responses = [
+        _resp(
+            200,
+            {"id": "terminal_qwen_main", "metadata": {"tmux_socket": "/s", "tmux_target": "t:0"}},
+        )
+    ]
+    launched = await qn._find_running_qwen_terminal(cok, "conv")
+    assert launched is not None and launched.terminal_id == "terminal_qwen_main"
+
+
+async def test_wait_for_qwen_terminal_ready_returns_then_times_out() -> None:
+    ready = _FakeClient()
+    ready.get_responses = [_resp(200, {"id": "terminal_qwen_main", "metadata": {}})]
+    launched = await qn._wait_for_qwen_terminal_ready(ready, "conv", timeout_s=1.0)
+    assert launched.terminal_id == "terminal_qwen_main"
+    # Never appears → ClickException after the deadline.
+    never = _FakeClient()  # get() returns 404 by default
+    with pytest.raises(click.ClickException):
+        await qn._wait_for_qwen_terminal_ready(never, "conv", timeout_s=0.05)
+
+
+def test_resolve_session_id_for_resume_direct_and_no_picker() -> None:
+    # Explicit id is returned verbatim (no server call).
+    assert (
+        qn._resolve_session_id_for_resume(
+            base_url="http://t", headers={}, session_id="conv_x", resume_picker=False
+        )
+        == "conv_x"
+    )
+    # No id and no picker → None (the CLI then creates a fresh session).
+    assert (
+        qn._resolve_session_id_for_resume(
+            base_url="http://t", headers={}, session_id=None, resume_picker=False
+        )
+        is None
+    )
+
+
+def test_preflight_local_tools_requires_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qn.shutil, "which", lambda _cmd: None)
+    with pytest.raises(click.ClickException, match="tmux"):
+        qn._preflight_local_tools()
+    monkeypatch.setattr(qn.shutil, "which", lambda _cmd: "/usr/bin/tmux")
+    qn._preflight_local_tools()  # present → no raise
+
+
+def test_update_startup_progress_is_optional() -> None:
+    qn._update_startup_progress(None, "msg")  # no renderer → no-op
+
+    class _P:
+        def __init__(self) -> None:
+            self.msgs: list[str] = []
+
+        def update(self, m: str) -> None:
+            self.msgs.append(m)
+
+    p = _P()
+    qn._update_startup_progress(p, "hi")  # type: ignore[arg-type]
+    assert p.msgs == ["hi"]
+
+
+# --- _prepare_qwen_terminal_via_daemon (orchestration, patched helpers) -------
+
+
+def _aret(value: object):
+    async def _f(*_a: object, **_k: object) -> object:
+        return value
+
+    return _f
+
+
+async def test_prepare_reattaches_running_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        qn, "_fetch_qwen_session", _aret({"labels": {"omnigent.wrapper": "qwen-native-ui"}})
+    )
+    term = qn.LaunchedQwenTerminal(
+        terminal_id="terminal_qwen_main", tmux_socket=Path("/s"), tmux_target="t:0"
+    )
+    monkeypatch.setattr(qn, "_find_running_qwen_terminal", _aret(term))
+    prepared = await qn._prepare_qwen_terminal_via_daemon(
+        base_url="http://test",
+        headers={},
+        session_id="conv",
+        session_bundle=None,
+        qwen_args=(),
+        host_id="host",
+        workspace="/ws",
+    )
+    # A still-running terminal is reused (no daemon relaunch).
+    assert prepared.reattached is True
+    assert prepared.session_id == "conv"
+    assert prepared.terminal_id == "terminal_qwen_main"
+
+
+async def test_prepare_rejects_non_qwen_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        qn, "_fetch_qwen_session", _aret({"labels": {"omnigent.wrapper": "claude-code-native-ui"}})
+    )
+    with pytest.raises(click.ClickException, match="not a qwen-native session"):
+        await qn._prepare_qwen_terminal_via_daemon(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            session_bundle=None,
+            qwen_args=(),
+            host_id="host",
+            workspace="/ws",
+        )
+
+
+async def test_prepare_creates_and_launches_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qn, "_create_qwen_session", _aret("conv_new"))
+    monkeypatch.setattr(qn, "wait_for_host_online", _aret(None))
+    monkeypatch.setattr(qn, "launch_or_reuse_daemon_runner", _aret("runner_1"))
+    monkeypatch.setattr(qn, "wait_for_runner_online", _aret(None))
+    monkeypatch.setattr(qn, "_bind_session_runner", _aret(None))
+    monkeypatch.setattr(qn, "_ensure_qwen_terminal_on_runner", _aret(None))
+    term = qn.LaunchedQwenTerminal(
+        terminal_id="terminal_qwen_main", tmux_socket=Path("/s"), tmux_target="t:0"
+    )
+    monkeypatch.setattr(qn, "_wait_for_qwen_terminal_ready", _aret(term))
+    prepared = await qn._prepare_qwen_terminal_via_daemon(
+        base_url="http://test",
+        headers={},
+        session_id=None,
+        session_bundle=b"bundle",
+        qwen_args=("-m", "x"),
+        host_id="host",
+        workspace="/ws",
+    )
+    assert prepared.session_id == "conv_new"
+    assert prepared.reattached is False
+    assert prepared.cold_resumed is False
+    assert prepared.terminal_id == "terminal_qwen_main"
+
+
+async def test_prepare_requires_bundle_for_new_session() -> None:
+    with pytest.raises(click.ClickException, match="requires a session bundle"):
+        await qn._prepare_qwen_terminal_via_daemon(
+            base_url="http://test",
+            headers={},
+            session_id=None,
+            session_bundle=None,
+            qwen_args=(),
+            host_id="host",
+            workspace="/ws",
+        )
+
+
+def test_direct_tmux_reason_target_missing_and_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sock = tmp_path / "s.sock"
+    sock.write_text("")  # exists on disk
+    no_target = qn.PreparedQwenTerminal(
+        session_id="c", terminal_id="t", tmux_socket=sock, tmux_target=None, reattached=False
+    )
+    assert "target" in (qn._direct_tmux_unavailable_reason(no_target) or "")
+
+    good = qn.PreparedQwenTerminal(
+        session_id="c", terminal_id="t", tmux_socket=sock, tmux_target="x:0", reattached=False
+    )
+    monkeypatch.setattr(qn.shutil, "which", lambda _c: "/usr/bin/tmux")
+    assert qn._direct_tmux_unavailable_reason(good) is None  # all present → attachable
+    monkeypatch.setattr(qn.shutil, "which", lambda _c: None)
+    assert "PATH" in (qn._direct_tmux_unavailable_reason(good) or "")

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -1,0 +1,448 @@
+"""Unit tests for the qwen-native bridge + forwarder (the file-based core).
+
+These cover the logic that diverges from goose-native: appending JSONL commands
+to qwen's ``--input-file`` and parsing its ``--json-file`` stream-json events.
+The event shapes are pinned to ``qwen`` v0.18.1 (see ``docs/QWEN_NATIVE_DESIGN.md``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent import qwen_native_bridge as qnb
+from omnigent import qwen_native_forwarder as fwd
+from omnigent.qwen_native_bridge import (
+    BRIDGE_DIR_ENV_VAR,
+    bridge_dir_for_session_id,
+    build_qwen_native_spawn_env,
+    events_file_path,
+    input_file_path,
+    prepare_bridge_files,
+    qwen_session_id_for_conversation,
+    qwen_session_recording_exists,
+    read_tmux_info,
+    submit_confirmation,
+    submit_user_message,
+    wait_for_ready,
+    write_tmux_target,
+)
+from omnigent.qwen_native_forwarder import (
+    _event_to_item,
+    _ForwardState,
+    _read_new_events,
+    _read_state,
+    _write_state,
+    clear_qwen_bridge_state,
+)
+
+_AGENT = "qwen-native-ui"
+
+
+def _user_ev(uuid: str, text: str) -> dict:
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _asst_ev(uuid: str, content: list[dict]) -> dict:
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "message": {"role": "assistant", "content": content},
+    }
+
+
+def _ev_bytes(obj: dict) -> bytes:
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+def test_user_event_maps_to_input_text() -> None:
+    item = _event_to_item(_user_ev("u1", "hi"), _AGENT)
+    assert item is not None
+    assert item.response_id == "qwen:u1"
+    assert item.item_data == {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+
+
+def test_assistant_text_maps_to_output_text_and_skips_thinking() -> None:
+    item = _event_to_item(
+        _asst_ev(
+            "a1",
+            [
+                {"type": "thinking", "thinking": "secret reasoning"},
+                {"type": "text", "text": "Hi there!"},
+            ],
+        ),
+        _AGENT,
+    )
+    assert item is not None
+    assert item.item_data["role"] == "assistant"
+    assert item.item_data["agent"] == _AGENT
+    assert item.item_data["content"] == [{"type": "output_text", "text": "Hi there!"}]
+
+
+def test_thinking_only_assistant_skipped() -> None:
+    item = _event_to_item(_asst_ev("a2", [{"type": "thinking", "thinking": "x"}]), _AGENT)
+    assert item is None
+
+
+def test_non_message_events_ignored() -> None:
+    for etype in ("system", "stream_event", "result"):
+        assert _event_to_item({"type": etype, "uuid": "x"}, _AGENT) is None
+    # control_request is recognized but produces no mirror item.
+    control = {
+        "type": "control_request",
+        "request": {"subtype": "can_use_tool", "tool_name": "shell"},
+        "request_id": "r1",
+    }
+    assert _event_to_item(control, _AGENT) is None
+
+
+def test_attachment_marker_stripped() -> None:
+    item = _event_to_item(_user_ev("u2", "[Attached: /tmp/x.png]\n\nlook"), _AGENT)
+    assert item is not None
+    assert item.item_data["content"][0]["text"] == "look"
+
+
+def test_read_new_events_incremental_and_partial_line(tmp_path: Path) -> None:
+    f = tmp_path / "out.ndjson"
+    f.write_bytes(_ev_bytes(_user_ev("u1", "q")))
+    items, off = _read_new_events(f, 0, set(), _AGENT)
+    assert [i.uuid for i in items] == ["u1"]
+    assert off == f.stat().st_size
+
+    # Append a complete assistant line plus a trailing *partial* line.
+    with open(f, "ab") as fh:
+        fh.write(_ev_bytes(_asst_ev("a1", [{"type": "text", "text": "a"}])))
+        fh.flush()
+        complete_size = f.stat().st_size
+        fh.write(b'{"type":"assistant","uuid":"a2"')  # no newline yet
+        fh.flush()
+    items, off2 = _read_new_events(f, off, {"u1"}, _AGENT)
+    assert [i.uuid for i in items] == ["a1"]
+    # Offset stops at the last newline — the partial line is not consumed.
+    assert off2 == complete_size
+
+
+def test_read_new_events_detects_truncation(tmp_path: Path) -> None:
+    f = tmp_path / "out.ndjson"
+    # A long first line so the stale offset exceeds the post-truncation size.
+    f.write_bytes(_ev_bytes(_user_ev("u1", "first message, intentionally long " * 4)))
+    _, off = _read_new_events(f, 0, set(), _AGENT)
+    assert off > 0
+    # A relaunched terminal truncates + writes a shorter line; size < offset
+    # must rewind so the fresh content is not skipped.
+    f.write_bytes(_ev_bytes(_user_ev("u2", "fresh")))
+    assert f.stat().st_size < off
+    items, _ = _read_new_events(f, off, set(), _AGENT)
+    assert [i.uuid for i in items] == ["u2"]
+
+
+def test_malformed_line_tolerated(tmp_path: Path) -> None:
+    f = tmp_path / "out.ndjson"
+    f.write_bytes(b"not json\n" + _ev_bytes(_user_ev("u1", "ok")))
+    items, _ = _read_new_events(f, 0, set(), _AGENT)
+    assert [i.uuid for i in items] == ["u1"]
+
+
+def test_wait_for_ready_times_out_without_boot_signal(tmp_path: Path) -> None:
+    bridge = tmp_path / "bridge"
+    prepare_bridge_files(bridge)
+    # No events written → never ready; returns False fast (tiny timeout).
+    assert wait_for_ready(bridge, timeout_s=0.05, poll_interval_s=0.01) is False
+
+
+def test_wait_for_ready_detects_system_event(tmp_path: Path) -> None:
+    bridge = tmp_path / "bridge"
+    prepare_bridge_files(bridge)
+    # qwen emits a compact system/session_start as its first event.
+    events_file_path(bridge).write_bytes(
+        _ev_bytes({"type": "system", "subtype": "session_start", "uuid": "s1"})
+    )
+    assert wait_for_ready(bridge, timeout_s=1.0, poll_interval_s=0.01) is True
+
+
+def test_wait_for_ready_ignores_system_substring_in_non_system_event(tmp_path: Path) -> None:
+    bridge = tmp_path / "bridge"
+    prepare_bridge_files(bridge)
+    # An assistant event whose text payload contains the bytes '"type":"system"'
+    # must NOT be read as the boot signal — readiness parses per-line and checks
+    # event["type"], so a substring inside another event can't latch ready early.
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_asst_ev("a1", [{"type": "text", "text": 'note "type":"system" inside'}]))
+    )
+    assert wait_for_ready(bridge, timeout_s=0.05, poll_interval_s=0.01) is False
+
+
+def test_qwen_session_id_is_deterministic_and_uuid() -> None:
+    a = qwen_session_id_for_conversation("conv_abc123")
+    b = qwen_session_id_for_conversation("conv_abc123")
+    c = qwen_session_id_for_conversation("conv_other")
+    assert a == b  # stable across calls → resume can recompute it
+    assert a != c  # distinct per conversation
+    # Valid UUID (qwen requires one for --session-id / --resume).
+    import uuid as _uuid
+
+    assert str(_uuid.UUID(a)) == a
+
+
+def test_qwen_session_recording_exists_is_workspace_scoped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from omnigent.qwen_native_bridge import _qwen_project_slug
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ws_a = tmp_path / "repo_a"
+    ws_a.mkdir()
+    ws_b = tmp_path / "repo_b"
+    ws_b.mkdir()
+    sid = qwen_session_id_for_conversation("conv_resume_me")
+    # No recording yet → fresh launch (--session-id).
+    assert qwen_session_recording_exists(sid, ws_a) is False
+    # qwen records under the LAUNCH workspace's project slug.
+    chats = tmp_path / ".qwen" / "projects" / _qwen_project_slug(ws_a) / "chats"
+    chats.mkdir(parents=True)
+    (chats / f"{sid}.jsonl").write_text("{}\n", encoding="utf-8")
+    assert qwen_session_recording_exists(sid, ws_a) is True
+    # Resuming the SAME conversation from a DIFFERENT workspace must NOT see it:
+    # qwen --resume is per-project, so a cross-workspace True would pick --resume
+    # and land on qwen's blocking "No saved session found" screen.
+    assert qwen_session_recording_exists(sid, ws_b) is False
+    # A different conversation's id under the same workspace is unaffected.
+    assert qwen_session_recording_exists(qwen_session_id_for_conversation("conv_x"), ws_a) is False
+
+
+def test_bridge_submit_and_confirmation_append_jsonl(tmp_path: Path) -> None:
+    bridge = tmp_path / "bridge"
+    prepare_bridge_files(bridge)
+    in_file = input_file_path(bridge)
+    assert in_file.exists() and in_file.read_text() == ""
+
+    submit_user_message(bridge, content="hello world")
+    submit_confirmation(bridge, request_id="r1", allowed=True)
+
+    lines = [json.loads(line) for line in in_file.read_text().splitlines() if line.strip()]
+    assert lines[0] == {"type": "submit", "text": "hello world"}
+    assert lines[1] == {"type": "confirmation_response", "request_id": "r1", "allowed": True}
+
+
+def test_forward_state_roundtrip_and_clear(tmp_path: Path) -> None:
+    state = _ForwardState(offset=123, seen_uuids=["a", "b"])
+    assert _write_state(tmp_path, state) is True
+    loaded = _read_state(tmp_path)
+    assert loaded.offset == 123
+    assert loaded.seen_uuids == ["a", "b"]
+    # Clearing resets the cursor so a re-created terminal starts clean.
+    clear_qwen_bridge_state(tmp_path)
+    cleared = _read_state(tmp_path)
+    assert cleared.offset == 0
+    assert cleared.seen_uuids == []
+
+
+def test_forward_state_caps_seen_uuids(tmp_path: Path) -> None:
+    # The dedup window is bounded so the state file can't grow unbounded.
+    state = _ForwardState(offset=1, seen_uuids=[str(i) for i in range(1000)])
+    assert _write_state(tmp_path, state) is True
+    loaded = _read_state(tmp_path)
+    assert len(loaded.seen_uuids or []) == 512
+    assert (loaded.seen_uuids or [])[-1] == "999"  # most-recent retained
+
+
+def test_tmux_target_round_trip(tmp_path: Path) -> None:
+    write_tmux_target(tmp_path, socket_path=Path("/tmp/qwen.sock"), tmux_target="sess:0.0")
+    info = read_tmux_info(tmp_path)
+    assert info == {"socket_path": "/tmp/qwen.sock", "tmux_target": "sess:0.0"}
+
+
+def test_read_tmux_info_missing(tmp_path: Path) -> None:
+    assert read_tmux_info(tmp_path) is None
+
+
+def test_spawn_env_carries_bridge_dir() -> None:
+    env = build_qwen_native_spawn_env("conv_spawn_env")
+    assert env[BRIDGE_DIR_ENV_VAR] == str(bridge_dir_for_session_id("conv_spawn_env"))
+
+
+def test_harness_registered_aliased_and_native() -> None:
+    from omnigent.harness_aliases import canonicalize_harness, is_native_harness
+    from omnigent.native_coding_agents import native_coding_agent_for_harness
+    from omnigent.runtime.harnesses import _HARNESS_MODULES
+    from omnigent.spec._omnigent_compat import OMNIGENT_HARNESSES
+
+    # Registry entry resolves to the harness module.
+    assert _HARNESS_MODULES["qwen-native"] == "omnigent.inner.qwen_native_harness"
+    # Allowlisted + recognized as a native-terminal harness (both spellings).
+    assert "qwen-native" in OMNIGENT_HARNESSES
+    assert is_native_harness("qwen-native") is True
+    assert is_native_harness("native-qwen") is True
+    assert canonicalize_harness("native-qwen") == "qwen-native"
+    # Native coding-agent metadata is wired for the picker / labels.
+    agent = native_coding_agent_for_harness("qwen-native")
+    assert agent is not None
+    assert agent.terminal_name == "qwen"
+    assert agent.display_name == "Qwen Code"
+    assert agent.agent_name == "qwen-native-ui"
+
+
+def test_harness_create_app_builds() -> None:
+    from omnigent.inner.qwen_native_harness import create_app
+
+    app = create_app()
+    assert app is not None
+
+
+# --- bridge tmux helpers (interrupt / hard-stop) -----------------------------
+
+
+class _FakeProc:
+    """Minimal ``subprocess.run`` result stand-in."""
+
+    def __init__(self, returncode: int = 0, stderr: str = "", stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+def test_inject_interrupt_sends_escape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    write_tmux_target(tmp_path, socket_path=Path("/tmp/q.sock"), tmux_target="sess:0.0")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        qnb.subprocess, "run", lambda cmd, **_k: captured.append(cmd) or _FakeProc(0)
+    )
+    qnb.inject_interrupt(tmp_path, timeout_s=1.0)
+    # No ``-l`` flag: tmux interprets ``Escape`` as a key name, not literal text.
+    assert captured[0] == ["tmux", "-S", "/tmp/q.sock", "send-keys", "-t", "sess:0.0", "Escape"]
+
+
+def test_kill_session_kills_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    write_tmux_target(tmp_path, socket_path=Path("/tmp/q.sock"), tmux_target="sess:0.0")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        qnb.subprocess, "run", lambda cmd, **_k: captured.append(cmd) or _FakeProc(0)
+    )
+    qnb.kill_session(tmp_path, timeout_s=1.0)
+    assert captured[0] == ["tmux", "-S", "/tmp/q.sock", "kill-session", "-t", "sess:0.0"]
+
+
+def test_run_tmux_raises_on_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qnb.subprocess, "run", lambda *_a, **_k: _FakeProc(1, stderr="boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        qnb._run_tmux("/tmp/q.sock", "send-keys")
+
+
+def test_inject_interrupt_raises_when_target_unadvertised(tmp_path: Path) -> None:
+    # No tmux.json written → the wait times out fast and raises.
+    with pytest.raises(RuntimeError):
+        qnb.inject_interrupt(tmp_path, timeout_s=0.05)
+
+
+# --- forwarder: post + poll loop + supervisor --------------------------------
+
+
+class _RecordingClient:
+    """Async httpx-client stub that records POSTs and returns HTTP 200."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict]] = []
+
+    async def post(self, url: str, *, json: dict) -> httpx.Response:
+        self.posts.append((url, json))
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+
+async def test_post_conversation_item_shape() -> None:
+    client = _RecordingClient()
+    item = fwd._MirrorItem(
+        uuid="u1",
+        item_type="message",
+        item_data={"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        response_id="qwen:u1",
+    )
+    await fwd._post_conversation_item(client, session_id="conv_1", item=item)  # type: ignore[arg-type]
+    url, body = client.posts[0]
+    assert url == "/v1/sessions/conv_1/events"
+    assert body["type"] == "external_conversation_item"
+    assert body["data"] == {
+        "item_type": "message",
+        "item_data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        "response_id": "qwen:u1",
+    }
+
+
+async def test_forward_loop_posts_new_events_and_persists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(_ev_bytes(_user_ev("u1", "hello")))
+
+    posted: list[str] = []
+
+    async def _fake_post(_client: object, *, session_id: str, item: object) -> None:
+        posted.append(item.response_id)  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(fwd, "_post_conversation_item", _fake_post)
+
+    task = asyncio.create_task(
+        fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0.01,
+        )
+    )
+    for _ in range(200):
+        if posted:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    # Awaiting the cancelled task must propagate CancelledError (clean teardown).
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    assert posted == ["qwen:u1"]
+    # Offset + dedup set are persisted so a restart resumes without re-posting.
+    state = _read_state(bridge)
+    assert state.offset > 0
+    assert "u1" in (state.seen_uuids or [])
+
+
+async def test_supervise_restarts_then_propagates_cancel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    async def _fake_forward(**_kw: object) -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("boom")  # first run crashes → supervisor restarts
+        raise asyncio.CancelledError()  # second run cancelled → propagates out
+
+    async def _fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(fwd, "forward_qwen_events_to_session", _fake_forward)
+    monkeypatch.setattr(fwd, "_supervisor_sleep", _fake_sleep)
+    # Never "healthy" (uptime 0) so the backoff is not reset between runs.
+    monkeypatch.setattr(fwd, "_supervisor_monotonic", lambda: 0.0)
+
+    with pytest.raises(asyncio.CancelledError):
+        await fwd.supervise_qwen_forwarder(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=tmp_path,
+            agent_name=_AGENT,
+        )
+
+    assert calls["n"] == 2
+    assert sleeps == [1.0]  # initial backoff before the one restart


### PR DESCRIPTION
## Summary

Adds a terminal-native **Qwen Code** harness — `qwen-native` (alias `native-qwen`) — that embeds the live `qwen` TUI in the Omnigent web UI, alongside the existing ACP `qwen` harness. Unlike the goose/cursor `tmux send-keys` natives, it drives qwen's built-in remote-control protocol: web-UI turns are appended to qwen's `--input-file`, and the transcript is mirrored back by tailing the structured `--json-file` event stream. Verified end-to-end against `qwen` v0.18.1-preview.1. See `docs/QWEN_NATIVE_DESIGN.md`.

## What's included

- **Core harness**: `qwen_native_bridge.py` (file-based submit/confirmation + tmux for interrupt/stop), `inner/qwen_native_executor.py`, `inner/qwen_native_harness.py`, `qwen_native_forwarder.py` (json-file → chat mirror), and the `omnigent qwen` CLI wrapper.
- **Registration**: harness registry, aliases + `NATIVE_HARNESSES`, native-coding-agent + wrapper labels, install spec, readiness, resume dispatch, resource role, and **server built-in seeding** so **Qwen Code** appears in the new-session picker.
- **Readiness gate**: the executor waits for qwen's first `system` event before the first submit, fixing the boot-order race where a message appended before qwen's input watcher started was silently dropped.
- **Session resume** via the `external_session_id` convention (consistent with claude-/codex-/pi-native, fork-capable): deterministic per-conversation qwen session id; `--session-id` on first launch, `--resume` once a recording exists. qwen restores its own TUI history and emits only new events, so no double-mirroring.
- **Clean TUI quit**: a qwen required-terminal exit publishes `idle` and is treated as a normal shutdown — no `required_terminal_exited` crash card, no stuck "Working…" spinner.
- **Web UI**: the qwen pane is recognized as the agent terminal (Chat/Terminal pill works); the composer hides the model/effort chip for vendor-owned-model native sessions.

## Follow-ups (tracked in `docs/QWEN_FOLLOWUPS.md`)

- Tool-approval **elicitation card** (bridge qwen's `can_use_tool` → policy → `confirmation_response`); today qwen's in-terminal approval is the gate.
- Surface qwen's **real model + context ring + cost** (one usage-parsing change off the event stream).

## Testing

- Python: executor, CLI wrapper, bridge/forwarder, and server seeding tests.
- Web: `nativeCodingAgents`, `chatStore` native flags, `useTerminals`, and composer `statusLine`.
- Manual end-to-end against live `qwen` for the readiness race, resume/replay, and clean-exit paths.

This pull request and its description were written by Isaac.