### PR TITLE
Count nested agents in Agents badge

### DIFF
--- a/tests/e2e_ui/agents/test_agents_tab.py
+++ b/tests/e2e_ui/agents/test_agents_tab.py
@@ -25,6 +25,27 @@ _SUBAGENT_MAIN_ROW = '[data-testid="subagent-main-row"]'
 _SUBAGENT_ROW = '[data-testid="subagent-row"]'
 
 
+def _create_child_session(
+    page: Page,
+    base_url: str,
+    agent_id: str,
+    parent_id: str,
+    sub_agent_name: str,
+) -> str:
+    """Create a child session without spending an LLM turn."""
+    child = page.request.post(
+        f"{base_url}/v1/sessions",
+        data={
+            "agent_id": agent_id,
+            "parent_session_id": parent_id,
+            "sub_agent_name": sub_agent_name,
+        },
+        timeout=30_000,
+    )
+    assert child.ok, f"child session create failed: {child.status} {child.status_text}"
+    return str(child.json()["id"])
+
+
 def test_agents_tab_lists_lone_agent(
     page: Page,
     seeded_session: tuple[str, str],
@@ -52,3 +73,46 @@ def test_agents_tab_lists_lone_agent(
     # and a lone agent has no sub-agent rows beneath it.
     expect(rail.locator(_SUBAGENT_MAIN_ROW)).to_be_visible(timeout=30_000)
     expect(rail.locator(_SUBAGENT_ROW)).to_have_count(0)
+
+
+def test_agents_badge_counts_nested_agents(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The closed Agents-tab badge counts nested coordinator children up to 7."""
+    base_url, root_id = seeded_session
+    parent = page.request.get(f"{base_url}/v1/sessions/{root_id}", timeout=10_000)
+    assert parent.ok, f"root session read failed: {parent.status} {parent.status_text}"
+    agent_id = str(parent.json()["agent_id"])
+    created_ids: list[str] = []
+
+    try:
+        coordinator_ids = [
+            _create_child_session(page, base_url, agent_id, root_id, "coordinator_alpha"),
+            _create_child_session(page, base_url, agent_id, root_id, "coordinator_beta"),
+        ]
+        created_ids.extend(coordinator_ids)
+        worker_ids = [
+            _create_child_session(
+                page, base_url, agent_id, coordinator_ids[0], "platform_preflight"
+            ),
+            _create_child_session(
+                page, base_url, agent_id, coordinator_ids[0], "platform_preflight_retry"
+            ),
+            _create_child_session(page, base_url, agent_id, coordinator_ids[1], "story_worker"),
+            _create_child_session(
+                page, base_url, agent_id, coordinator_ids[1], "story_worker_retry"
+            ),
+        ]
+        created_ids.extend(worker_ids)
+
+        page.goto(f"{base_url}/c/{root_id}")
+        open_right_rail(page)
+        rail = page.get_by_role("complementary", name="Workspace")
+        agents_tab = rail.get_by_role("tab", name=re.compile("^Agents"))
+
+        # Main + two coordinators + four workers nested under the coordinators.
+        expect(agents_tab).to_contain_text("7", timeout=30_000)
+    finally:
+        for child_id in reversed(created_ids):
+            page.request.delete(f"{base_url}/v1/sessions/{child_id}", timeout=10_000)

--- a/web/src/hooks/useChildSessions.test.tsx
+++ b/web/src/hooks/useChildSessions.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { childSessionsQueryKey, type ChildSessionInfo, useChildSessions } from "./useChildSessions";
+
+function child(id: string): ChildSessionInfo {
+  return {
+    id,
+    title: id,
+    tool: "agent",
+    session_name: id,
+    current_task_status: null,
+    busy: id === "a1",
+    last_message_preview: null,
+    pending_elicitations_count: 0,
+  };
+}
+
+function renderWithTree(tree: Record<string, string[]>, includeDescendants = false) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  for (const [sessionId, childIds] of Object.entries(tree)) {
+    client.setQueryData(childSessionsQueryKey(sessionId), childIds.map(child));
+  }
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useChildSessions("root", null, includeDescendants), { wrapper });
+}
+
+afterEach(cleanup);
+
+describe("useChildSessions", () => {
+  it("keeps direct children as the default and includes descendants when requested", () => {
+    const tree = {
+      root: ["coord_a", "coord_b"],
+      coord_a: ["a1", "a2"],
+      coord_b: ["b1", "b2"],
+      a1: ["deep"],
+      a2: [],
+      b1: [],
+      b2: [],
+      deep: ["too_deep"],
+    };
+
+    expect(renderWithTree(tree).result.current.children.map((item) => item.id)).toEqual([
+      "coord_a",
+      "coord_b",
+    ]);
+    expect(renderWithTree(tree, true).result.current.children.map((item) => item.id)).toEqual([
+      "coord_a",
+      "coord_b",
+      "a1",
+      "a2",
+      "b1",
+      "b2",
+      "deep",
+    ]);
+    expect(
+      renderWithTree(tree, true)
+        .result.current.children.filter((item) => item.busy)
+        .map((item) => item.id),
+    ).toEqual(["a1"]);
+  });
+});

--- a/web/src/hooks/useChildSessions.ts
+++ b/web/src/hooks/useChildSessions.ts
@@ -1,4 +1,4 @@
-import { useQuery, type QueryClient } from "@tanstack/react-query";
+import { useQuery, useQueries, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 
 /**
@@ -183,6 +183,17 @@ export async function fetchChildSessions(sessionId: string): Promise<ChildSessio
   }));
 }
 
+function childSessionsQueryOptions(sessionId: string, pollMs?: number | null) {
+  return {
+    queryKey: childSessionsQueryKey(sessionId),
+    queryFn: () => fetchChildSessions(sessionId),
+    staleTime: 60_000,
+    retry: false as const,
+    refetchOnMount: false as const,
+    refetchInterval: pollMs ?? (false as const),
+  };
+}
+
 /**
  * Live child-session list for a conversation, served by
  * ``GET /v1/sessions/{id}/child_sessions``.
@@ -198,11 +209,14 @@ export async function fetchChildSessions(sessionId: string): Promise<ChildSessio
  *     tab is backgrounded). The execution-logs panel passes a value
  *     here so the dropdown updates when new sub-agents spawn;
  *     callers that just need a snapshot (the rail card) can omit it.
+ * :param includeDescendants: Walk the bounded tree for badge totals.
  */
 export function useChildSessions(
   conversationId: string | null,
   pollMs?: number | null,
+  includeDescendants = false,
 ): UseChildSessionsResult {
+  const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({
     queryKey:
       conversationId === null
@@ -215,8 +229,46 @@ export function useChildSessions(
     refetchOnMount: false,
     refetchInterval: pollMs ?? false,
   });
+  const children = data ?? [];
+  const seenParents = new Set<string>();
+  const queryParentIds: string[] = [];
+  let frontier = children;
+  if (includeDescendants) {
+    for (let depth = 1; depth < MAX_TREE_DEPTH; depth++) {
+      const next: ChildSessionInfo[] = [];
+      for (const child of frontier) {
+        if (seenParents.has(child.id)) continue;
+        seenParents.add(child.id);
+        queryParentIds.push(child.id);
+        next.push(
+          ...(queryClient.getQueryData<ChildSessionInfo[]>(childSessionsQueryKey(child.id)) ?? []),
+        );
+      }
+      frontier = next;
+    }
+  }
+  const descendantQueries = useQueries({
+    queries: queryParentIds.map((id) => childSessionsQueryOptions(id, pollMs)),
+  });
+
+  if (!includeDescendants) {
+    return {
+      children,
+      isLoading,
+      error: (error as Error | null) ?? null,
+    };
+  }
+  const seen = new Set<string | null>([conversationId]);
+  const descendants = [children, descendantQueries.flatMap((query) => query.data ?? [])]
+    .flat()
+    .filter((child) => {
+      if (seen.has(child.id)) return false;
+      seen.add(child.id);
+      return true;
+    });
+
   return {
-    children: data ?? [],
+    children: descendants,
     isLoading,
     error: (error as Error | null) ?? null,
   };

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -405,10 +405,10 @@ export function AppShell() {
     // fall back one hop until the walk resolves the true root.
     return activeSession?.parentSessionId ?? conversationId;
   }, [conversationId, activeSession, walkedRoot, queryClient]);
-  // One-shot fetch (no polling) for the Subagents tab's count badge.
+  // One-shot bounded tree fetch (no polling) for the Agents tab's count badge.
   // SubagentsPanel mounts its own polling usage of the hook against
   // the same rootSessionId, so the cache is shared.
-  const { children: childSessions } = useChildSessions(rootSessionId);
+  const { children: childSessions } = useChildSessions(rootSessionId, null, true);
   // Remember the resolved root so a later click into one of its tree
   // members can hold it steady (see ``rootSessionId`` above).
   useEffect(() => {
@@ -828,8 +828,8 @@ export function AppShell() {
         return next;
       });
     },
-    [setSearchParams],
-  ); // eslint-disable-line react-hooks/exhaustive-deps
+    [clearFileViewerUrl, setSearchParams],
+  );
 
   // Switch the workspace rail's tab. The side effect (closing any open
   // file + its comments + URL) lives here, not in WorkspacePanel, so the


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Count the Agents tab badge from the bounded child-session tree, not only the root session's direct children.
- Keep `/v1/sessions/{id}/child_sessions` direct-child only and aggregate descendants client-side to the same `MAX_TREE_DEPTH` rendered by the Agents rail.
- Preserve the existing badge polling policy: `AppShell` performs a one-shot bounded tree read and `SubagentsPanel` continues to own polling when mounted.
- Add hook-level unit coverage and an E2E UI regression for one root/orchestrator, two coordinators, and two worker agents under each coordinator.

## ELI5

The Agents badge used to count only the main agent and its immediate children. Now it also counts agents started underneath coordinator agents.

## Diagram

```mermaid
flowchart TD
  root[Root / orchestrator]
  root --> coordA[Coordinator A]
  root --> coordB[Coordinator B]
  coordA --> a1[Worker A1]
  coordA --> a2[Worker A2]
  coordB --> b1[Worker B1]
  coordB --> b2[Worker B2]
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `ap-web/src/hooks/useChildSessions.test.tsx` coverage for the hook boundary: direct children remain the default, and bounded descendants are included only when requested by the badge path. No integration test was added because the server endpoint remains direct-child only; this PR changes client aggregation and badge display.

Added `tests/e2e_ui/agents/test_agents_tab.py` coverage for the accepted topology: one root/orchestrator, two coordinators, and two worker agents under each coordinator. The E2E creates child sessions through Playwright's request context instead of spending an LLM turn, keeps the Agents panel closed, and verifies the badge reaches `Agents 7`.

Existing AppShell tests continue to cover the badge rendering states, including working/total and neutral total display.

Commands run:

- `npm --prefix ap-web test -- src/hooks/useChildSessions.test.tsx src/shell/AppShell.test.tsx src/shell/AppShell.subagent-nav.test.tsx`
- `npm --prefix ap-web run type-check`
- `npx --prefix ap-web oxlint ap-web/src/hooks/useChildSessions.ts ap-web/src/hooks/useChildSessions.test.tsx ap-web/src/shell/AppShell.tsx`
- `npx --prefix ap-web prettier --check ap-web/src/hooks/useChildSessions.test.tsx ap-web/src/hooks/useChildSessions.ts ap-web/src/shell/AppShell.tsx`
- `npm --prefix ap-web run build`
- `uv run --extra all --extra dev pytest tests/e2e_ui/agents/test_agents_tab.py -v --ui-skip-build`
- `uv run --extra all --extra dev ruff check tests/e2e_ui/agents/test_agents_tab.py`
- `git diff --check`

Manual verification was completed in the local app with one root/orchestrator, two coordinator child sessions, and two child agents under each coordinator. The Agents tab displayed `7`, matching `1 + 2 + 4`.
