### PR TITLE
feat(terminal): detect interactive login URLs and offer one-click copy/open

### DIFF
--- a/ap-web/src/components/blocks/TerminalSession.test.ts
+++ b/ap-web/src/components/blocks/TerminalSession.test.ts
@@ -15,10 +15,12 @@ import {
   SYNC_ECHO_WINDOW_MS,
   TerminalSession,
   applyTerminalCopy,
+  detectLoginUrl,
   isUnexpectedTerminalClose,
   loadWebglRenderer,
   openTerminalLink,
   shouldEchoSynchronously,
+  stripAnsiSequences,
   terminalTheme,
   terminalKeyEventPayload,
 } from "./TerminalSession";
@@ -405,5 +407,63 @@ describe("TerminalSession", () => {
     const observer = FakeResizeObserver.instances[0];
     expect(observer.observed).toContain(container);
     session.dispose();
+  });
+});
+
+describe("stripAnsiSequences", () => {
+  it("removes CSI/SGR sequences but preserves URL query characters", () => {
+    // WHY: the strip must not eat '=' / '&' / '?' — an earlier draft that
+    // matched bare `[=>]` destroyed the query string of the login URL.
+    expect(stripAnsiSequences("\x1b[31mhttps://x/y?a=1&b=2>3\x1b[0m")).toBe(
+      "https://x/y?a=1&b=2>3",
+    );
+  });
+
+  it("strips OSC sequences and bare carriage returns", () => {
+    expect(stripAnsiSequences("\x1b]0;title\x07ok\r\n")).toBe("ok\n");
+  });
+});
+
+describe("detectLoginUrl", () => {
+  // A real Claude Code `/login` URL, hard-wrapped by Ink across rows the way
+  // it arrives in the terminal, framed by the surrounding prompt text.
+  const EXPECTED =
+    "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88" +
+    "ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.co" +
+    "m%2Foauth%2Fcode%2Fcallback&scope=org%3Acreate_api_key&code_challenge=ePv5dp5C" +
+    "&code_challenge_method=S256&state=CrzosaLakVpGGnkQbH";
+  const WRAPPED = [
+    "Browser didn't open? Use the url below to sign in (c to copy)",
+    "",
+    "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88",
+    "ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.co",
+    "m%2Foauth%2Fcode%2Fcallback&scope=org%3Acreate_api_key&code_challenge=ePv5dp5C",
+    "&code_challenge_method=S256&state=CrzosaLakVpGGnkQbH",
+    "",
+    "Paste code here if prompted >",
+  ].join("\n");
+
+  it("rejoins a hard-wrapped OAuth URL into one line", () => {
+    expect(detectLoginUrl(WRAPPED)).toBe(EXPECTED);
+  });
+
+  it("tolerates ANSI styling around the URL without corrupting it", () => {
+    expect(detectLoginUrl(`\x1b[1m${EXPECTED}\x1b[0m\n\nPaste code here >`)).toBe(EXPECTED);
+  });
+
+  it("ignores non-auth URLs in output", () => {
+    expect(detectLoginUrl("see https://example.com/docs for setup help")).toBeNull();
+    expect(detectLoginUrl("cloning https://github.com/omnigent-ai/omnigent.git")).toBeNull();
+  });
+
+  it("returns the most recent login URL when several are in scrollback", () => {
+    const buf =
+      "https://claude.com/oauth/authorize?response_type=code&state=OLD\n\n" +
+      "https://claude.com/oauth/authorize?response_type=code&state=NEW";
+    expect(detectLoginUrl(buf)).toContain("state=NEW");
+  });
+
+  it("returns null when there is no URL", () => {
+    expect(detectLoginUrl("just some build output\n$ ")).toBeNull();
   });
 });

--- a/ap-web/src/components/blocks/TerminalSession.ts
+++ b/ap-web/src/components/blocks/TerminalSession.ts
@@ -130,6 +130,12 @@ export type ConnectionStateListener = (state: ConnectionState) => void;
 export type TerminalActivityListener = () => void;
 /** Listener for user keyboard input sent to the terminal. */
 export type TerminalInputListener = () => void;
+/**
+ * Listener for an interactive login URL detected in terminal output
+ * (see {@link detectLoginUrl}). Called with the reconstructed URL, never
+ * with ``null`` — clearing is the view's concern (dismiss / supersede).
+ */
+export type TerminalLoginUrlListener = (url: string) => void;
 
 /** Kitty Keyboard Protocol / CSI-u encoding for Shift+Enter. */
 export const SHIFT_ENTER_CSI_U = "\x1b[13;2u";
@@ -275,6 +281,95 @@ export function applyTerminalCopy(
 }
 
 /**
+ * Strip ANSI escape sequences (CSI/SGR, OSC, charset selects) and bare
+ * carriage returns from terminal text, so URL detection sees plain
+ * characters. Not a terminal emulator — just enough to remove the control
+ * bytes that interleave printed output around a login URL.
+ *
+ * Pure helper — exported for direct unit testing.
+ */
+export function stripAnsiSequences(text: string): string {
+  return (
+    text
+      // CSI / SGR / cursor sequences: ESC [ … final byte.
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
+      // OSC sequences: ESC ] … (BEL | ST).
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+      // Charset selection / single-byte escapes: ESC ( B, ESC =, ESC >, …
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b[()#][0-9A-Za-z]/g, "")
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b[=>]/g, "")
+      .replace(/\r/g, "")
+  );
+}
+
+/**
+ * Detect an interactive login / OAuth-authorize URL in recent terminal
+ * output and return it reconstructed as a single line.
+ *
+ * CLIs built on Ink (Claude Code's ``claude /login`` and
+ * ``claude setup-token``, for example) HARD-wrap their long authorize URL
+ * at the terminal width — inserting real newlines — so the URL arrives
+ * split across several rows. {@link WebLinksAddon} can only linkify a URL
+ * that lives on one logical line, and a manual select-drag pulls in the
+ * wrap breaks: that is the "the login link splits into pieces and won't
+ * copy" papercut. This rejoins the wrapped chunks (consecutive,
+ * whitespace-free lines from the ``https://`` marker, stopping at a blank
+ * or prose line such as "Paste code here") and validates the result is an
+ * OAuth-authorize URL before surfacing it, so arbitrary URLs in scrollback
+ * never raise a false login banner. The last validating URL wins, so a
+ * fresh prompt supersedes a stale one still in the buffer.
+ *
+ * Pure helper — exported for direct unit testing.
+ *
+ * :param text: Recent terminal output (ANSI tolerated; stripped here).
+ * :returns: The reconstructed login URL, or ``null`` when none is found.
+ */
+export function detectLoginUrl(text: string): string | null {
+  const stripped = stripAnsiSequences(text);
+  let found: string | null = null;
+  // eslint-disable-next-line no-control-regex
+  const marker = /https?:\/\//g;
+  let m: RegExpExecArray | null;
+  while ((m = marker.exec(stripped)) !== null) {
+    let url = "";
+    for (const rawLine of stripped.slice(m.index).split("\n")) {
+      const line = rawLine.trim();
+      if (line === "" || /\s/.test(line)) break; // blank or prose ends the URL
+      url += line;
+      if (url.length > 4096) break;
+    }
+    const candidate = sanitizeLoginUrl(url);
+    if (candidate) found = candidate;
+  }
+  return found;
+}
+
+/**
+ * Validate a reconstructed string is an interactive-auth URL worth
+ * surfacing, returning it unchanged (NOT re-serialized — the OAuth flow is
+ * sensitive to the exact ``state`` / ``code_challenge``) or ``null``.
+ */
+function sanitizeLoginUrl(raw: string): string | null {
+  if (!raw || raw.length > 4096) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+  const looksOauth =
+    parsed.pathname.includes("authorize") ||
+    parsed.searchParams.has("code_challenge") ||
+    parsed.searchParams.get("response_type") === "code";
+  return looksOauth ? raw : null;
+}
+
+/**
  * One xterm ↔ tmux WebSocket bridge tied to a single DOM container.
  *
  * The constructor performs all the setup synchronously — open the
@@ -298,6 +393,14 @@ export class TerminalSession {
   private lastUserInputAt = 0;
   /** Guards {@link dispose} so calling it twice is a safe no-op. */
   private disposed = false;
+  /** Surfaces a detected interactive login URL; unset when not wired. */
+  private readonly onLoginUrl?: TerminalLoginUrlListener;
+  /** Rolling, ANSI-bearing tail of recent output, scanned for a login URL. */
+  private loginScanBuf = "";
+  /** Last URL handed to {@link onLoginUrl}; dedupes repeat detections. */
+  private lastLoginUrl: string | null = null;
+  /** Streaming decoder so a URL split across WS frames still reconstructs. */
+  private readonly loginDecoder = new TextDecoder();
 
   /**
    * Construct, attach to the DOM, and open the WebSocket.
@@ -312,6 +415,9 @@ export class TerminalSession {
    *     server. This is a best-effort UI activity signal, not a shell
    *     job-state oracle.
    * :param onInput: Called when user input is sent to the terminal.
+   * :param onLoginUrl: Called with an interactive login URL detected in
+   *     output (see {@link detectLoginUrl}), so the view can offer a
+   *     one-click copy/open instead of fighting Ink's hard-wrapped URL.
    */
   constructor(
     container: HTMLElement,
@@ -320,7 +426,9 @@ export class TerminalSession {
     isDark = false,
     onActivity?: TerminalActivityListener,
     onInput?: TerminalInputListener,
+    onLoginUrl?: TerminalLoginUrlListener,
   ) {
+    this.onLoginUrl = onLoginUrl;
     this.term = new Terminal({
       // Match the system mono stack at the configured base size. The
       // xterm.js defaults (15px, no theme) feel out of place inside the
@@ -524,6 +632,7 @@ export class TerminalSession {
    * off the echo when present.
    */
   private writeOutput(bytes: Uint8Array): void {
+    this.scanForLoginUrl(bytes);
     if (shouldEchoSynchronously(bytes.length, performance.now() - this.lastUserInputAt)) {
       // eslint-disable-next-line no-underscore-dangle
       const core = (this.term as unknown as TerminalCore)._core;
@@ -537,6 +646,29 @@ export class TerminalSession {
       }
     }
     this.term.write(bytes);
+  }
+
+  /**
+   * Tap inbound output for an interactive login URL and hand it to
+   * {@link onLoginUrl} (deduped). Cheap by design on the output hot path:
+   * a streaming decode into a bounded tail, an early ``"http"`` substring
+   * gate, then the {@link detectLoginUrl} rejoin only when that hits. No-op
+   * unless a listener is wired.
+   */
+  private scanForLoginUrl(bytes: Uint8Array): void {
+    if (!this.onLoginUrl) return;
+    this.loginScanBuf += this.loginDecoder.decode(bytes, { stream: true });
+    // The login block is well under 1 KB; keep a generous tail and drop the
+    // rest so scrollback can't grow this without bound.
+    if (this.loginScanBuf.length > 16384) {
+      this.loginScanBuf = this.loginScanBuf.slice(-16384);
+    }
+    if (!this.loginScanBuf.includes("http")) return;
+    const url = detectLoginUrl(this.loginScanBuf);
+    if (url && url !== this.lastLoginUrl) {
+      this.lastLoginUrl = url;
+      this.onLoginUrl(url);
+    }
   }
 
   private sendResize(): void {

--- a/ap-web/src/components/blocks/TerminalView.tsx
+++ b/ap-web/src/components/blocks/TerminalView.tsx
@@ -8,7 +8,7 @@
 // returned cleanup directly — no `useEffect` + `useRef` dance, no
 // guard against a missing `ref.current`.
 
-import { Loader2Icon } from "lucide-react";
+import { CheckIcon, ExternalLinkIcon, KeyRoundIcon, Loader2Icon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
@@ -80,6 +80,10 @@ export function TerminalView({
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
   const [connectAttempt, setConnectAttempt] = useState(0);
   const [resumeError, setResumeError] = useState<string | null>(null);
+  // An interactive login URL detected in output (e.g. `claude /login`),
+  // surfaced as a copy/open banner so the user never has to wrestle the
+  // hard-wrapped link out of the terminal. Null when none is pending.
+  const [loginUrl, setLoginUrl] = useState<string | null>(null);
   // True between an unexpected close and the re-dial it scheduled, so
   // the overlay reads "Reconnecting…" instead of the dead-end
   // "Bridge closed" message during automatic recovery.
@@ -121,6 +125,9 @@ export function TerminalView({
     onInputRef.current?.();
   }, []);
 
+  // Stable: the session calls this when it detects a login URL in output.
+  const notifyLoginUrl = useCallback((url: string) => setLoginUrl(url), []);
+
   // Dispose the outgoing session before a remount re-dials. React 18
   // ignores the cleanup function attachSession returns (ref cleanups
   // arrived in React 19), so without this every remount would abandon
@@ -150,6 +157,9 @@ export function TerminalView({
       // handshake. The session's WS ``open`` handler transitions us
       // to ``connected``.
       notifyState({ kind: "connecting" });
+      // Drop any login banner from a prior mount; a re-attached tmux
+      // re-emits the prompt if the flow is still waiting.
+      setLoginUrl(null);
 
       // Defer the actual session construction by one microtask so
       // React 19 StrictMode's synchronous attach → cleanup → attach
@@ -172,6 +182,7 @@ export function TerminalView({
           isDarkRef.current,
           notifyActivity,
           notifyInput,
+          notifyLoginUrl,
         );
         sessionRef.current = terminalSession;
       });
@@ -182,7 +193,7 @@ export function TerminalView({
         onStateChangeRef.current?.(null);
       };
     },
-    [sessionId, terminalId, readOnly, notifyState, notifyActivity, notifyInput],
+    [sessionId, terminalId, readOnly, notifyState, notifyActivity, notifyInput, notifyLoginUrl],
   );
 
   // Push theme changes into the live session without remounting.
@@ -256,6 +267,7 @@ export function TerminalView({
       data-terminal-id={terminalId}
       className="relative flex min-h-0 flex-1 flex-col"
     >
+      {loginUrl && <LoginLinkBanner url={loginUrl} onDismiss={() => setLoginUrl(null)} />}
       {/* `p-1` lives on the wrapper, not the xterm mount node: FitAddon
           reads the parent's border-box height but only subtracts the xterm
           element's own padding, so padding on the mount node oversizes the
@@ -330,6 +342,73 @@ export function selectionHintText(isMac: boolean): string {
   return isMac
     ? "Hold ⌥ and drag to select · ⌘C to copy"
     : "Hold Shift and drag to select · right-click to copy";
+}
+
+/**
+ * Banner shown above the terminal when an interactive login URL is
+ * detected in output (see {@link detectLoginUrl}).
+ *
+ * Claude Code (and other Ink CLIs) hard-wrap their long OAuth URL at the
+ * terminal width, so in the raw terminal it splits across rows and resists
+ * both click (the link is broken in two) and select-drag (the wrap break
+ * comes along). This surfaces the rejoined URL with one-click Copy and
+ * Open, so signing in is friction-free.
+ */
+function LoginLinkBanner({ url, onDismiss }: { url: string; onDismiss: () => void }) {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard blocked (insecure context / denied) — Open still works.
+    }
+  }, [url]);
+  return (
+    <div
+      data-testid="terminal-login-banner"
+      className="flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs"
+    >
+      <KeyRoundIcon className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <span className="shrink-0 font-medium">Login link detected</span>
+      <code className="min-w-0 flex-1 truncate font-mono text-muted-foreground" title={url}>
+        {url}
+      </code>
+      <Button
+        type="button"
+        size="xs"
+        variant="secondary"
+        onClick={copy}
+        data-testid="terminal-login-copy"
+      >
+        {copied ? (
+          <>
+            <CheckIcon className="size-3" /> Copied
+          </>
+        ) : (
+          "Copy"
+        )}
+      </Button>
+      <Button
+        type="button"
+        size="xs"
+        variant="secondary"
+        onClick={() => window.open(url, "_blank", "noopener,noreferrer")}
+        data-testid="terminal-login-open"
+      >
+        <ExternalLinkIcon className="size-3" /> Open
+      </Button>
+      <button
+        type="button"
+        aria-label="Dismiss login link"
+        onClick={onDismiss}
+        className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </div>
+  );
 }
 
 function StatusOverlay({


### PR DESCRIPTION
## Problem

Running an interactive login in the in-session terminal — `claude /login`, `claude setup-token`, and other Ink-based CLIs — prints a long OAuth URL that Ink **hard-wraps** at the terminal width. The URL arrives split across several rows with real newlines, so:

- `WebLinksAddon` can't linkify it (the link is broken into two halves), and
- a Shift/⌥ select-drag pulls the wrap break into the copied text.

The user can neither click nor cleanly copy the login link, and the sign-in flow stalls.

## Fix

Detect an OAuth-authorize URL in terminal output, rejoin the hard-wrapped chunks into one line, and surface a dismissible **"Login link detected"** banner above the terminal with one-click **Copy** and **Open**.

- `detectLoginUrl` / `stripAnsiSequences` — pure, unit-tested helpers. Detection validates the reconstructed URL is an auth flow (`authorize` path, `code_challenge`, or `response_type=code`) so arbitrary URLs in scrollback never raise a false banner; the most recent match wins so a fresh prompt supersedes a stale one. The URL is returned verbatim (not re-serialized) — the OAuth `state` / `code_challenge` must survive byte-for-byte.
- `TerminalSession` taps `writeOutput` cheaply: a bounded tail, a streaming decode (so a URL split across WS frames still reconstructs), and an early `"http"` substring gate before the rejoin runs, keeping the output hot path clear.
- `TerminalView` renders the banner via a new optional `onLoginUrl` callback; it clears on dismiss and on re-attach.

## Testing

- New unit tests for `detectLoginUrl` (wrapped reconstruction, ANSI tolerance, non-auth URLs ignored, most-recent wins) and `stripAnsiSequences` (preserves `=`/`&`/`?`/`>`, strips CSI/OSC/CR).
- `tsc -b` clean, `oxlint` clean, the terminal test suites pass (45/45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
