### PR TITLE
fix(ui): hide /compact for non-native harnesses

### DIFF
--- a/ap-web/src/pages/ChatPage.test.ts
+++ b/ap-web/src/pages/ChatPage.test.ts
@@ -892,6 +892,24 @@ describe("buildSlashCommandMap", () => {
     );
   });
 
+  it("omits /compact when showCompact is false", () => {
+    const map = buildSlashCommandMap([], true, true, false);
+    expect(map["/compact"]).toBeUndefined();
+    expect(map["/effort"]).toBe(BUILTIN_SLASH_COMMANDS["/effort"]);
+    expect(map["/help"]).toBe(BUILTIN_SLASH_COMMANDS["/help"]);
+  });
+
+  it("includes /compact by default and when showCompact is true", () => {
+    // Default (no showCompact arg) → included for backward compat.
+    expect(buildSlashCommandMap([], true, true)["/compact"]).toBe(
+      BUILTIN_SLASH_COMMANDS["/compact"],
+    );
+    // Explicit true → included.
+    expect(buildSlashCommandMap([], true, true, true)["/compact"]).toBe(
+      BUILTIN_SLASH_COMMANDS["/compact"],
+    );
+  });
+
   it("appends each skill as /<name> after the built-ins", () => {
     const map = buildSlashCommandMap(
       [

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -2845,11 +2845,13 @@ export function buildSlashCommandMap(
   skills: ReadonlyArray<{ name: string; description: string }>,
   showEffort: boolean,
   showModel: boolean,
+  showCompact: boolean = true,
 ): Record<string, string> {
   const m: Record<string, string> = {};
   for (const [name, description] of Object.entries(BUILTIN_SLASH_COMMANDS)) {
     if (name === "/effort" && !showEffort) continue;
     if (name === "/model" && !showModel) continue;
+    if (name === "/compact" && !showCompact) continue;
     m[name] = description;
   }
   for (const skill of skills) {
@@ -3300,9 +3302,13 @@ export function Composer({
   // it each turn; native wrappers expose it only when they have a picker
   // path that the runner can propagate without blocking the vendor TUI.
   const showModel = !isNativeWrapper || showModels;
+  // /compact is only functional for native wrappers (claude-native,
+  // codex-native) which inject the slash command into the terminal.
+  // SDK harnesses (openai-agents-sdk, claude-sdk) don't support it yet.
+  const showCompact = isNativeWrapper;
   const slashCommands = useMemo(
-    () => buildSlashCommandMap(skills, showEffort, showModel),
-    [skills, showEffort, showModel],
+    () => buildSlashCommandMap(skills, showEffort, showModel, showCompact),
+    [skills, showEffort, showModel, showCompact],
   );
   // Skills always need an optional argument fill-in so the user can
   // type extra context after the name; built-in commands keep their
@@ -3371,6 +3377,10 @@ export function Composer({
   const executeSlashCommand = (cmd: string, arg: string): boolean => {
     switch (cmd) {
       case "/compact":
+        if (!showCompact) {
+          setCommandError("/compact is not supported for this agent type");
+          return true;
+        }
         dirtyRef.current = true;
         setValue("");
         setCommandError(null);


### PR DESCRIPTION
## Summary

- Hide `/compact` from the slash-command menu for SDK harnesses (openai-agents-sdk, claude-sdk) — only show it for native wrappers (claude-native, codex-native, etc.)
- Show an error message if `/compact` is typed manually in a non-native session
- `/compact` is a no-op for SDK harnesses: the Claude Agent SDK lacks a `compact` control request, and sending `/compact` as a user message just prompts Claude with the literal text

## Test plan

- [ ] Verify `/compact` appears in the slash-command menu for a claude-native session
- [ ] Verify `/compact` does NOT appear in the menu for an openai-agents-sdk session
- [ ] Verify typing `/compact` manually in a claude-sdk session shows "/compact is not supported for this agent type"
- [ ] `npx vitest run src/pages/ChatPage.test.ts` — 123 tests pass (includes 2 new tests for showCompact gating)

This pull request and its description were written by Isaac.