### PR TITLE
fix(ci): exclude editable local packages from OSV pip-audit export

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -145,8 +145,16 @@ jobs:
             echo "uv.lock not changed; skipping OSV scan."
             exit 0
           fi
+          # Drop editable local packages (the project itself + sdks/*) before
+          # auditing. pip-audit can't hash an editable path requirement and
+          # errors out when one is present, so without this filter any PR that
+          # actually changes uv.lock fails here. We only want to audit
+          # third-party pinned packages anyway — OSV has no advisories for
+          # local source. Filtering all `-e` lines (rather than naming each
+          # workspace member) keeps this correct if members are added later.
           uv export --frozen --format requirements-txt --all-extras \
-            > /tmp/uv-req.txt
+            > /tmp/uv-req-full.txt
+          grep -v '^-e ' /tmp/uv-req-full.txt > /tmp/uv-req.txt
           uvx pip-audit --requirement /tmp/uv-req.txt --no-deps
 
       - name: Semgrep (changed files, local rules)


### PR DESCRIPTION
## Problem

The OSV advisory scan (added in #1001) runs `uv export --all-extras` then `pip-audit` whenever a PR changes `uv.lock`. `uv export` emits the local workspace members — the project itself (`-e .`) and `sdks/*` — as **editable** requirements. `pip-audit` aborts on an editable path:

```
ERROR: The editable requirement file:///home/runner/work/omnigent/omnigent/pr
cannot be installed when requiring hashes, because there is no single file to hash.
```

The crash happens **before any package is checked**, so the Security Gate fails for *every* PR that actually adds or bumps a dependency. It only stayed hidden because most PRs don't touch `uv.lock` (the step is skipped) and dependency-adding PRs since #1001 landed were rare.

Discovered on #881 (Kubernetes sandbox provider), the first real dependency-adding PR to run this step.

## Fix

Filter out the `-e` editable lines before handing the requirements to `pip-audit`. Only third-party pinned packages are audited — which is all OSV has advisories for anyway; the local source has no CVE entries.

Filtering all editable lines (rather than naming each workspace member via `--no-emit-package`) stays correct if a new member is added later. Note `--no-emit-workspace` alone is insufficient on the pinned uv version — it drops only the root project, leaving `sdks/*` editables that would still crash pip-audit.

## Validation

Ran the exact CI command locally with the filter:
- Before: 3 editable entries (`-e .`, `-e ./sdks/python-client`, `-e ./sdks/ui`) → pip-audit aborts.
- After: 0 editable entries; third-party packages retained.
- `uv export --frozen` does not modify `uv.lock`.

