### PR TITLE
fix(spec): gracefully drop unsupported sub-agents on the execution path

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -621,10 +621,17 @@ async def _resolve_agent_spec_from_server(
     # PUT-induced bundle bumps invalidate naturally.
     version = resp.headers.get("X-Agent-Version", "0")
     dest = _agent_cache_dest(spec_cache_root, agent_id, version)
+    # prune_invalid_sub_agents: the server already validated this bundle
+    # before serving it, so a sub-agent that fails validation *here* means
+    # this runner is older than that server and can't run that sub-agent
+    # (e.g. it names a harness this version doesn't know). Drop the
+    # unsupported sub-agent and launch the parent with what this runner
+    # *does* support, rather than failing every dispatch of the agent.
+    # See omnigent.spec.load.
     if not dest.exists():
         dest.mkdir(parents=True)
-        load(resp.content, dest=dest, expand_env=expand_env)
-    spec = load(dest, expand_env=expand_env)
+        load(resp.content, dest=dest, expand_env=expand_env, prune_invalid_sub_agents=True)
+    spec = load(dest, expand_env=expand_env, prune_invalid_sub_agents=True)
     return ResolvedSpec(spec=spec, workdir=dest)
 
 

--- a/omnigent/runtime/agent_cache.py
+++ b/omnigent/runtime/agent_cache.py
@@ -23,6 +23,15 @@ class AgentCache:
 
     On cache miss the bundle is downloaded from the ArtifactStore,
     extracted to disk, parsed, validated, and stored in both tiers.
+
+    This is an **execution** load path, so it loads with
+    ``prune_invalid_sub_agents=True``: a sub-agent that fails
+    validation here means this server is older than whatever produced
+    the bundle and can't run that sub-agent (version skew), so it is
+    dropped (with a WARNING) and the parent agent still dispatches.
+    Authoring/upload validation stays strict elsewhere
+    (:func:`omnigent.server.bundles.validate_agent_bundle`). See
+    :func:`omnigent.spec.load`.
     """
 
     def __init__(self, artifact_store: ArtifactStore, cache_dir: Path) -> None:
@@ -82,7 +91,7 @@ class AgentCache:
 
         # Tier 2: disk cache (directory already extracted)
         if workdir.is_dir():
-            spec = load_spec(workdir, expand_env=expand_env)
+            spec = load_spec(workdir, expand_env=expand_env, prune_invalid_sub_agents=True)
             self._specs[agent_id] = spec
             return LoadedAgent(spec=spec, workdir=workdir)
 
@@ -130,7 +139,12 @@ class AgentCache:
         tmp_path = Path(tmp_name)
         try:
             tmp_path.write_bytes(bundle_bytes)
-            spec = load_spec(tmp_path, dest=staging_dir, expand_env=expand_env)
+            spec = load_spec(
+                tmp_path,
+                dest=staging_dir,
+                expand_env=expand_env,
+                prune_invalid_sub_agents=True,
+            )
         finally:
             tmp_path.unlink()
 
@@ -182,7 +196,12 @@ class AgentCache:
         tmp_path = Path(tmp_name)
         try:
             tmp_path.write_bytes(bundle_bytes)
-            spec = load_spec(tmp_path, dest=workdir, expand_env=expand_env)
+            spec = load_spec(
+                tmp_path,
+                dest=workdir,
+                expand_env=expand_env,
+                prune_invalid_sub_agents=True,
+            )
         finally:
             tmp_path.unlink()
 

--- a/omnigent/spec/__init__.py
+++ b/omnigent/spec/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 from pathlib import Path
 
@@ -46,6 +47,8 @@ from omnigent.spec.types import (
     ToolsConfig,
 )
 from omnigent.spec.validator import ValidationResult, validate
+
+_logger = logging.getLogger(__name__)
 
 __all__ = [
     "DEFAULT_ASK_TIMEOUT",
@@ -159,6 +162,7 @@ def load(
     dest: Path | None = None,
     expand_env: bool = True,
     enforce_handler_allowlist: bool = False,
+    prune_invalid_sub_agents: bool = False,
 ) -> AgentSpec:
     """
     Load an agent spec from a directory, tarball path, or raw
@@ -195,6 +199,25 @@ def load(
         that parser does not resolve handlers). Defaults to ``False``
         so trusted spec loading (local ``omnigent run``, operator
         configs) keeps supporting custom handlers.
+    :param prune_invalid_sub_agents: When ``True``, a sub-agent that
+        fails validation is **dropped** from the spec (removed from
+        ``sub_agents`` and from any parent's ``tools.agents``
+        reference) and loading continues, instead of failing the whole
+        load. A WARNING is logged for each dropped sub-agent. The root
+        agent must still validate — a genuine root-level error always
+        raises. This is the backwards-compatibility guard for the
+        **execution** paths (runner spec resolution, server
+        :class:`~omnigent.runtime.agent_cache.AgentCache`): a bundle
+        reaching those paths was already validated by the server that
+        produced it, so a sub-agent that fails *here* means this client
+        is older than that server and can't run that sub-agent (e.g. it
+        names a harness this version doesn't know). Dropping the
+        sub-agent lets the parent agent launch with the capabilities
+        this client *does* support, rather than the whole agent failing
+        to start. Defaults to ``False`` so authoring/upload paths
+        (``omnigent run``,
+        :func:`omnigent.server.bundles.validate_agent_bundle`) stay
+        strict and surface real authoring mistakes to the author.
     :returns: A validated :class:`AgentSpec`.
     :raises OmnigentError: If the spec fails validation, if a policy
         names an unregistered handler under
@@ -220,7 +243,11 @@ def load(
         # omnigent.spec._omnigent_compat. Tech-debt aside;
         # remove this branch when omnigent compat ends.
         if is_omnigent_yaml(source):
-            return load_omnigent_yaml(source, enforce_handler_allowlist=enforce_handler_allowlist)
+            return load_omnigent_yaml(
+                source,
+                enforce_handler_allowlist=enforce_handler_allowlist,
+                prune_invalid_sub_agents=prune_invalid_sub_agents,
+            )
         if source.suffix.lower() in {".yaml", ".yml"}:
             # The path is a YAML file but failed the omnigent check
             # (missing required key, ``spec_version`` set, malformed,
@@ -257,9 +284,15 @@ def load(
     # *expand_env* and the flag does not apply.
     candidate = _find_omnigent_yaml_in_dir(root)
     if candidate is not None:
-        return load_omnigent_yaml(candidate, enforce_handler_allowlist=enforce_handler_allowlist)
+        return load_omnigent_yaml(
+            candidate,
+            enforce_handler_allowlist=enforce_handler_allowlist,
+            prune_invalid_sub_agents=prune_invalid_sub_agents,
+        )
 
     spec = parse(root, expand_env=expand_env)
+    if prune_invalid_sub_agents:
+        _prune_invalid_sub_agents(spec)
     result = validate(spec)
     if not result.valid:
         errors = "; ".join(f"{e.path}: {e.message}" for e in result.errors)
@@ -276,6 +309,60 @@ def load(
         # the loader, because that loader executes factories at parse.
         _reject_unregistered_spec_policy_handlers(spec)
     return spec
+
+
+def _prune_invalid_sub_agents(spec: AgentSpec) -> list[str]:
+    """Drop sub-agents that fail validation so the parent can still load.
+
+    Walks *spec*'s sub-agent tree depth-first and removes any
+    sub-agent whose own subtree fails :func:`validate`, mutating
+    *spec* in place: the failing sub-agent is removed from
+    ``sub_agents`` and its name (if any) is removed from the parent's
+    ``tools.agents`` reference list so the dangling reference does not
+    itself fail validation. A WARNING is logged for each drop.
+
+    Depth-first ordering matters: a child's invalid *grandchild* is
+    pruned before the child is judged, so a single bad leaf does not
+    take out an otherwise-valid sub-tree above it.
+
+    This is the mechanism behind ``load(..., prune_invalid_sub_agents=
+    True)`` — see :func:`load` for when and why it is enabled (the
+    execution paths only). It deliberately does **not** touch the root
+    spec: if the root itself is invalid, the caller's subsequent
+    :func:`validate` still fails loud.
+
+    :param spec: The spec to prune in place.
+    :returns: The names (or ``"<unnamed>"``) of every sub-agent dropped
+        anywhere in the tree, parent-most first within each level.
+    """
+    dropped: list[str] = []
+    surviving: list[AgentSpec] = []
+    for sa in spec.sub_agents:
+        # Prune this child's own invalid descendants before deciding
+        # whether the child itself survives.
+        dropped.extend(_prune_invalid_sub_agents(sa))
+        sa_result = validate(sa)
+        if sa_result.valid:
+            surviving.append(sa)
+            continue
+        name = sa.name or "<unnamed>"
+        errors = "; ".join(f"{e.path}: {e.message}" for e in sa_result.errors)
+        _logger.warning(
+            "Dropping sub-agent %r from agent %r: it failed validation on this "
+            "client and will be unavailable. This usually means the spec was "
+            "produced by a newer Omnigent server with a feature this client does "
+            "not support (e.g. a harness it does not recognize) — upgrade this "
+            "client to use it. Validation errors: %s",
+            name,
+            spec.name or "<root>",
+            errors,
+        )
+        dropped.append(name)
+        # Remove the now-dangling reference so the parent still validates.
+        if sa.name is not None and sa.name in spec.tools.agents:
+            spec.tools.agents.remove(sa.name)
+    spec.sub_agents = surviving
+    return dropped
 
 
 def _reject_unregistered_spec_policy_handlers(spec: AgentSpec) -> None:

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -275,7 +275,12 @@ def diagnose_yaml_rejection(path: Path) -> str:
     return "unknown reason — file passes all known checks (likely an internal bug)"
 
 
-def load_omnigent_yaml(path: Path, *, enforce_handler_allowlist: bool = False) -> AgentSpec:
+def load_omnigent_yaml(
+    path: Path,
+    *,
+    enforce_handler_allowlist: bool = False,
+    prune_invalid_sub_agents: bool = False,
+) -> AgentSpec:
     """
     Load an omnigent YAML and translate it to an
     :class:`AgentSpec`.
@@ -293,6 +298,12 @@ def load_omnigent_yaml(path: Path, *, enforce_handler_allowlist: bool = False) -
         unregistered ``type: function`` policy handlers are rejected
         before the loader resolves/calls them (bundle-upload
         guard). See :func:`omnigent.spec.load`.
+    :param prune_invalid_sub_agents: When ``True``, sub-agents that
+        fail validation are dropped (and their ``tools.agents``
+        references removed) instead of failing the whole load, with a
+        WARNING logged per drop. The root agent must still validate.
+        See :func:`omnigent.spec.load` for the full rationale — this
+        is the execution-path backwards-compatibility guard.
     :returns: A validated :class:`AgentSpec` with
         ``executor.type == OMNIGENT_EXECUTOR_TYPE``.
     :raises OmnigentError: If the synthesized spec fails
@@ -341,6 +352,14 @@ def load_omnigent_yaml(path: Path, *, enforce_handler_allowlist: bool = False) -
     if not isinstance(raw, dict):
         raw = {}
     spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw)
+    if prune_invalid_sub_agents:
+        # Local import avoids a module-load cycle: spec/__init__ imports
+        # this module at import time, so it cannot be imported at the top
+        # here. Drops sub-agents this client can't validate (version skew)
+        # before the root validation gate below; see omnigent.spec.load.
+        from omnigent.spec import _prune_invalid_sub_agents
+
+        _prune_invalid_sub_agents(spec)
     result = validate(spec)
     if not result.valid:
         errors = "; ".join(f"{e.path}: {e.message}" for e in result.errors)

--- a/tests/server/test_builtin_bundles.py
+++ b/tests/server/test_builtin_bundles.py
@@ -14,10 +14,14 @@ from __future__ import annotations
 import gzip
 import io
 import tarfile
+from pathlib import Path
 
 import pytest
+import yaml
 
+from omnigent.errors import OmnigentError
 from omnigent.server import app
+from omnigent.spec import load, materialize_bundle
 
 # (builder attribute, the spec entry that proves the bundle was assembled,
 # whether the source is a shipped example that a stripped deployment may omit)
@@ -83,3 +87,110 @@ def test_bundle_builder_is_reproducible(
 
     fn = getattr(app, builder)
     assert fn() == fn(), f"{builder} is not byte-for-byte reproducible across builds."
+
+
+# ── Backwards-compatible loading of the shipped sub-agent examples ──────────
+#
+# polly and debby are the two shipped examples that ship *sub-agents*, so they
+# are the surface for the version-skew regression matei hit: a newer server
+# adds a sub-agent whose harness an older client can't validate, and the old
+# client must still launch the parent (dropping only the unsupported worker)
+# rather than failing every dispatch of the agent. These tests exercise the
+# REAL shipped definitions (not synthetic minimal specs — see
+# tests/spec/test_load.py for those) so a regression in either the prune logic
+# OR the polly/debby structure (e.g. a parent that becomes un-prunable) is
+# caught here. See omnigent.spec.load(..., prune_invalid_sub_agents=True).
+
+# (name, bundle source dir, sub-agents the shipped definition declares today)
+_SHIPPED_SUB_AGENT_EXAMPLES = [
+    ("polly", app._POLLY_BUNDLE_SOURCE, {"claude_code", "codex", "pi"}),
+    ("debby", app._DEBBY_BUNDLE_SOURCE, {"claude", "gpt"}),
+]
+
+
+@pytest.mark.parametrize(("name", "source", "expected_sub_agents"), _SHIPPED_SUB_AGENT_EXAMPLES)
+def test_shipped_example_loads_with_all_sub_agents(
+    name: str, source: Path, expected_sub_agents: set[str]
+) -> None:
+    """The shipped definition loads and every declared sub-agent survives.
+
+    A baseline guard: today's polly/debby validate cleanly on this version, so
+    the version-skew tests below are exercising a genuinely *unsupported* extra
+    sub-agent, not masking a pre-existing breakage in the shipped spec.
+    """
+    if not (source / "config.yaml").is_file():
+        pytest.skip(f"{name} source not packaged in this deployment")
+
+    # expand_env=False mirrors the execution-path default (AgentCache /
+    # session-scoped runner resolution) and keeps the test independent of the
+    # host environment.
+    spec = load(source, expand_env=False)
+    assert spec.name == name
+    sub_names = {sa.name for sa in spec.sub_agents}
+    assert expected_sub_agents <= sub_names, (
+        f"{name} is missing declared sub-agents: "
+        f"{expected_sub_agents - sub_names}; got {sub_names}"
+    )
+    assert expected_sub_agents <= set(spec.tools.agents)
+
+
+@pytest.mark.parametrize(("name", "source", "expected_sub_agents"), _SHIPPED_SUB_AGENT_EXAMPLES)
+def test_shipped_example_survives_unknown_harness_sub_agent(
+    name: str, source: Path, expected_sub_agents: set[str], tmp_path: Path
+) -> None:
+    """A newer-server sub-agent the old client can't validate is dropped, not fatal.
+
+    Reproduces matei's incident on the real bundles: a server bumped polly to a
+    definition with an ``opencode`` sub-agent, and older runners/hosts failed to
+    launch *any* polly because the then-unknown ``opencode-native`` harness
+    failed the whole spec's validation. ``opencode-native`` is a recognized
+    harness now, so we inject a deliberately-synthetic harness — the stand-in
+    for "whatever the next server adds that this client doesn't know yet" — as a
+    worker referenced from the parent's ``tools.agents``, and assert:
+
+    - the strict (authoring/upload) load still fails loud — unchanged behavior;
+    - the execution-path load (``prune_invalid_sub_agents=True``) drops ONLY the
+      unsupported worker and keeps the parent plus every real sub-agent.
+    """
+    if not (source / "config.yaml").is_file():
+        pytest.skip(f"{name} source not packaged in this deployment")
+
+    # Materialize the real bundle (the server's own path) so we test the
+    # shipped sub-agents, then add the worker a newer server would.
+    bundle = materialize_bundle(source, tmp_path / name)
+    future_worker = bundle / "agents" / "future_worker"
+    future_worker.mkdir(parents=True)
+    (future_worker / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "spec_version": 1,
+                "name": "future_worker",
+                "executor": {
+                    "type": "omnigent",
+                    "config": {"harness": "harness-from-a-newer-server"},
+                },
+            }
+        )
+    )
+    # Declare it on the parent exactly as a real newer-server spec would — an
+    # undeclared agents/ dir would be parsed but never referenced, so the
+    # dangling-reference cleanup would go untested.
+    parent_cfg = yaml.safe_load((bundle / "config.yaml").read_text())
+    parent_cfg.setdefault("tools", {}).setdefault("agents", []).append("future_worker")
+    (bundle / "config.yaml").write_text(yaml.dump(parent_cfg))
+
+    # Strict: the whole spec still fails (this is what matei hit, preserved for
+    # authoring/upload so real harness typos surface to the author).
+    with pytest.raises(OmnigentError, match="invalid agent spec"):
+        load(bundle, expand_env=False)
+
+    # Execution path: parent + real workers survive; only the unknown one drops.
+    spec = load(bundle, expand_env=False, prune_invalid_sub_agents=True)
+    assert spec.name == name
+    sub_names = {sa.name for sa in spec.sub_agents}
+    assert "future_worker" not in sub_names
+    assert expected_sub_agents <= sub_names
+    # The dangling reference must be cleaned off the parent too, or the parent
+    # itself would have failed validation on the missing-directory check.
+    assert "future_worker" not in spec.tools.agents
+    assert expected_sub_agents <= set(spec.tools.agents)

--- a/tests/spec/test_load.py
+++ b/tests/spec/test_load.py
@@ -440,3 +440,206 @@ def test_load_omnigent_yaml_missing_harness_omits_version_skew_hint(
     assert "executor.config.harness" in message
     assert "required when" in message
     assert "this client (runner) may be older than the server" not in message
+
+
+# ── prune_invalid_sub_agents (execution-path backwards compat) ──────────
+#
+# The motivating incident: a newer server bumped polly to a definition with an
+# ``opencode`` sub-agent, and older clients failed to launch *any* polly
+# because the unknown ``opencode-native`` harness failed the whole spec's
+# validation. ``opencode-native`` is itself a recognized harness now, so these
+# tests use a deliberately-synthetic harness name to stand in for "whatever the
+# next server adds that this client doesn't know yet" — the mechanism must
+# survive that class of skew regardless of which specific harness triggers it.
+_UNKNOWN_HARNESS = "harness-from-a-newer-server"
+
+
+def _write_parent_with_sub_agents(
+    root: Path,
+    *,
+    parent_agents: list[str],
+    sub_agents: dict[str, dict],
+) -> None:
+    """Write a ``config.yaml`` parent bundle with ``agents/<name>/`` children.
+
+    :param root: Bundle root to populate.
+    :param parent_agents: Names placed under the parent's
+        ``tools.agents`` delegation list.
+    :param sub_agents: Map of sub-agent name → its ``config.yaml`` dict,
+        each written to ``agents/<name>/config.yaml``.
+    """
+    parent = {
+        "spec_version": 1,
+        "name": "parent",
+        "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+        "tools": {"agents": parent_agents},
+    }
+    (root / "config.yaml").write_text(yaml.dump(parent))
+    for name, cfg in sub_agents.items():
+        sub_dir = root / "agents" / name
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "config.yaml").write_text(yaml.dump(cfg))
+
+
+def test_load_drops_invalid_sub_agent_when_pruning(tmp_path: Path) -> None:
+    """An unknown-harness sub-agent is dropped; the parent still loads.
+
+    This is matei's scenario: a newer server's bundle declares a
+    sub-agent whose harness this (older) client doesn't recognize. With
+    pruning on (the runner/AgentCache execution path), the bad sub-agent
+    is dropped — along with its ``tools.agents`` reference — and the
+    parent agent loads with its remaining capabilities.
+    """
+    _write_parent_with_sub_agents(
+        tmp_path,
+        parent_agents=["newcomer", "helper"],
+        sub_agents={
+            "newcomer": {
+                "spec_version": 1,
+                "name": "newcomer",
+                "executor": {
+                    "type": "omnigent",
+                    "config": {"harness": _UNKNOWN_HARNESS},
+                },
+            },
+            "helper": {
+                "spec_version": 1,
+                "name": "helper",
+                "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+            },
+        },
+    )
+
+    spec = load(tmp_path, prune_invalid_sub_agents=True)
+
+    sub_names = {sa.name for sa in spec.sub_agents}
+    assert sub_names == {"helper"}
+    # The dangling reference must be removed too, or the parent itself
+    # would fail validation on "references sub-agent 'newcomer'…".
+    assert spec.tools.agents == ["helper"]
+
+
+def test_load_without_pruning_still_fails_on_invalid_sub_agent(tmp_path: Path) -> None:
+    """Default (strict) load still fails the whole spec — unchanged behavior."""
+    _write_parent_with_sub_agents(
+        tmp_path,
+        parent_agents=["newcomer"],
+        sub_agents={
+            "newcomer": {
+                "spec_version": 1,
+                "name": "newcomer",
+                "executor": {
+                    "type": "omnigent",
+                    "config": {"harness": _UNKNOWN_HARNESS},
+                },
+            },
+        },
+    )
+
+    with pytest.raises(OmnigentError, match="invalid agent spec"):
+        load(tmp_path)
+
+
+def test_load_pruning_still_fails_on_invalid_root(tmp_path: Path) -> None:
+    """Pruning never masks a genuine *root*-level error."""
+    config = {"spec_version": 99, "name": "bad-root"}
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+
+    with pytest.raises(OmnigentError, match="invalid agent spec"):
+        load(tmp_path, prune_invalid_sub_agents=True)
+
+
+def test_load_pruning_keeps_valid_sub_agents_intact(tmp_path: Path) -> None:
+    """With only valid sub-agents, pruning is a no-op (nothing dropped)."""
+    _write_parent_with_sub_agents(
+        tmp_path,
+        parent_agents=["helper"],
+        sub_agents={
+            "helper": {
+                "spec_version": 1,
+                "name": "helper",
+                "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+            },
+        },
+    )
+
+    spec = load(tmp_path, prune_invalid_sub_agents=True)
+    assert {sa.name for sa in spec.sub_agents} == {"helper"}
+    assert spec.tools.agents == ["helper"]
+
+
+def test_load_pruning_logs_warning_for_dropped_sub_agent(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Dropping a sub-agent is loud — a WARNING names it (never silent)."""
+    _write_parent_with_sub_agents(
+        tmp_path,
+        parent_agents=["newcomer"],
+        sub_agents={
+            "newcomer": {
+                "spec_version": 1,
+                "name": "newcomer",
+                "executor": {
+                    "type": "omnigent",
+                    "config": {"harness": _UNKNOWN_HARNESS},
+                },
+            },
+        },
+    )
+
+    with caplog.at_level("WARNING", logger="omnigent.spec"):
+        load(tmp_path, prune_invalid_sub_agents=True)
+
+    assert any("newcomer" in rec.message and rec.levelname == "WARNING" for rec in caplog.records)
+
+
+def test_load_pruning_drops_grandchild_but_keeps_valid_child(tmp_path: Path) -> None:
+    """Depth-first: a bad *grandchild* is pruned without taking out its parent.
+
+    parent → child (valid) → grandchild (unknown harness). Only the
+    grandchild is dropped; the valid child survives with the dangling
+    grandchild reference cleaned off its own ``tools.agents``.
+    """
+    # parent
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "spec_version": 1,
+                "name": "parent",
+                "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+                "tools": {"agents": ["child"]},
+            }
+        )
+    )
+    # parent/agents/child (valid; delegates to grandchild)
+    child_dir = tmp_path / "agents" / "child"
+    child_dir.mkdir(parents=True)
+    (child_dir / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "spec_version": 1,
+                "name": "child",
+                "executor": {"type": "omnigent", "config": {"harness": "claude-sdk"}},
+                "tools": {"agents": ["grandchild"]},
+            }
+        )
+    )
+    # parent/agents/child/agents/grandchild (unknown harness)
+    grandchild_dir = child_dir / "agents" / "grandchild"
+    grandchild_dir.mkdir(parents=True)
+    (grandchild_dir / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "spec_version": 1,
+                "name": "grandchild",
+                "executor": {"type": "omnigent", "config": {"harness": _UNKNOWN_HARNESS}},
+            }
+        )
+    )
+
+    spec = load(tmp_path, prune_invalid_sub_agents=True)
+
+    assert {sa.name for sa in spec.sub_agents} == {"child"}
+    child = spec.sub_agents[0]
+    assert child.sub_agents == []
+    assert child.tools.agents == []


### PR DESCRIPTION
This PR has two related changes addressing matei's incident — an older client failing to launch *any* polly because polly's new `opencode` sub-agent named a harness (`opencode-native`) the client's allowlist didn't know.

1. **General fix** — spec loading degrades gracefully on the execution path, so a future sub-agent a client can't validate no longer bricks the whole agent.
2. **Immediate mitigation** — remove the `opencode` sub-agent from polly, which unblocks *already-deployed* older clients that can't be retrofitted with (1).

---

## 1. Gracefully drop unsupported sub-agents

### Problem

An older client (runner/host) that resolves a spec produced by a **newer** server fails to launch the *whole* agent when any **sub-agent** names a harness the client's allowlist doesn't know:

```
ERROR:omnigent.runner.app:turn setup failed: invalid agent spec:
sub_agents['opencode'].executor.config.harness: must be one of
[...], got 'opencode-native'
```

One sub-agent the client can't run took down the entire orchestrator; the only escape was upgrade + restart.

### Fix

Add `prune_invalid_sub_agents` to `omnigent.spec.load()`. When set, a sub-agent whose subtree fails validation is **dropped** — removed from `sub_agents` *and* the parent's `tools.agents` reference — with a `WARNING`, and the rest of the spec loads. The **root** must still validate. Pruning is depth-first, so a bad grandchild doesn't take out an otherwise-valid sub-tree.

Enabled only on the **execution paths**, where the bundle was already validated by the server that produced it (so a failure means version skew, not an authoring typo):
- runner `_resolve_agent_spec_from_server`
- server-side `AgentCache` `load`/`replace`/`_extract_and_cache`

Authoring/upload paths (`omnigent run` → `_preregister_agent`, `validate_agent_bundle`) stay **strict** so real harness typos still surface to the author.

### Tests
- **`tests/spec/test_load.py`** — drop an unknown-harness sub-agent; strict default still fails; root error never masked; no-op when all valid; `WARNING` logged; grandchild pruned without losing a valid child.
- **`tests/e2e/omnigent/test_example_polly.py`** + **`test_example_debby.py`** — the real shipped bundles survive a newer-server sub-agent the client can't validate; parent + every real worker load, only the unsupported one drops, dangling `tools.agents` ref cleaned off. Uses a synthetic harness name so it keeps exercising the drop path as the allowlist grows.

A *live*/version-matrix test isn't the right tool here: every live entry path is intentionally strict, and the matrix pins clients to released versions that predate the fix. The spec-level e2e tests run on `main` in every matrix cell and exercise the real fix API.

---

## 2. Remove the opencode sub-agent from polly

The graceful-degradation fix only helps clients that *carry* it; matei's already-running 0.2.0 host can't be retrofitted. Removing opencode from polly fixes those too — belt and suspenders.

Reverts polly to its three-worker roster (`claude_code` / `codex` / `pi`):
- delete `examples/polly/agents/opencode/`
- drop `opencode` from `tools.agents` and every prompt reference (back to "exactly THREE sub-agents", three-vendor cross-review)
- drop the codex `allowed_harnesses: [codex-native, opencode-native]` opt-in, so polly can't spawn an `opencode-native` child via an `args.harness` override either — no `opencode-native` is left anywhere in polly's spec surface

**debby is unchanged** (keeps the optional OpenCode perspective; default fanout still claude + gpt). The opencode harness itself is untouched. `test_opencode_polly_debby_worker.py` flips polly to a negative guard (stays opencode-free) and keeps the debby coverage; `test_example_polly.py` and the brain-harness-override test in `test_chat.py` updated to the three-worker roster.

---

## Repro / verification (manual, against `omnigent==0.2.0`)

- **Before:** 0.2.0 + main's polly → reproduced matei's error byte-for-byte (hard fail, polly won't launch).
- **Fix (1):** applying the prune mechanism on 0.2.0's own parser/validator drops only `opencode` → polly loads with `claude_code`/`codex`/`pi`.
- **Fix (2):** 0.2.0 loads the now-opencode-free polly cleanly with no fix at all → `['claude_code', 'codex', 'pi']`.
- Up-to-date client loads polly fully (no regression).

## Notes
- `origin/main` has no graceful-degradation fix yet, so (1) doesn't collide with Corey's planned work.

This pull request and its description were written by Isaac.