### PR TITLE
fix(ios): animate sidebar toggle and add drawer leading-edge shadow

### DIFF
--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -417,9 +417,35 @@
     overflow: hidden;
   }
 
+  /* Slide animation for the mobile drawer. Covers BOTH paths that move the
+     panel: the edge-swipe drag settles via an inline `transform`, while the
+     button toggle (and the drag's resting open/closed state) is driven by
+     Tailwind v4's `translate-x` utilities — which animate the `translate`
+     property, not `transform`. Listing only `transform` (as before) left the
+     toggle un-transitioned, so tapping the collapse/expand button snapped the
+     drawer instantly with no animation. Transition both so the toggle slides
+     too. Suppressed inline (`transition: none`) while a drag is live so the
+     overlay tracks the finger 1:1. */
   [data-ios-native] .conversations-sidebar {
-    transition: transform 360ms cubic-bezier(0.32, 0.72, 0, 1);
-    will-change: transform;
+    transition-property: transform, translate;
+    transition-duration: 360ms;
+    transition-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+    will-change: transform, translate;
+  }
+
+  /* Leading-edge shadow so the drawer reads as a native layer lifted above the
+     chat while it slides, instead of a flat sheet. Scoped to the open/dragging
+     state via `:not([data-collapsed])` (the sidebar sets `data-collapsed` only
+     when closed) so the full-bleed overlay doesn't cast a sliver along the
+     screen's left edge while parked off-screen. It's visible only mid-slide and
+     mid-drag — fully open the drawer covers the viewport, so its right edge (and
+     the shadow) sit past the screen. iOS-only: the web overlay is unchanged. */
+  [data-ios-native] .conversations-sidebar:not([data-collapsed]) {
+    box-shadow: 8px 0 28px -6px rgb(0 0 0 / 0.22);
+  }
+
+  .dark [data-ios-native] .conversations-sidebar:not([data-collapsed]) {
+    box-shadow: 8px 0 30px -4px rgb(0 0 0 / 0.55);
   }
 
   [data-ios-native] :is(input, textarea, select, [contenteditable="true"]) {

--- a/ap-web/src/pages/ChatPage.composer.test.tsx
+++ b/ap-web/src/pages/ChatPage.composer.test.tsx
@@ -76,7 +76,9 @@ describe("Composer slash-command menu", () => {
   });
 
   it("highlights the first match as soon as the menu opens", () => {
-    render(<Composer {...composerProps()} />);
+    // /compact is native-wrapper-only (#1139); render a native session so it
+    // appears as the first built-in and is the default highlight.
+    render(<Composer {...composerProps({ isNativeWrapper: true })} />);
     fireEvent.change(textarea(), { target: { value: "/" } });
     // Built-ins are inserted first, so "/compact" tops the list and is the
     // default highlight — the crux of the fix (was -1 / nothing selected).
@@ -148,7 +150,9 @@ describe("Composer slash-command menu", () => {
   });
 
   it("ArrowDown moves the highlight to the next match", () => {
-    render(<Composer {...composerProps()} />);
+    // /compact is native-wrapper-only (#1139); render a native session so the
+    // first built-in is "/compact" and ArrowDown advances to "/context".
+    render(<Composer {...composerProps({ isNativeWrapper: true })} />);
     const ta = textarea();
     fireEvent.change(ta, { target: { value: "/" } });
     expect(activeRow()?.textContent).toContain("/compact");
@@ -428,7 +432,9 @@ describe("Composer effort slash-command visibility", () => {
   });
 
   it("omits /effort from suggestions when effort controls are hidden", () => {
-    render(<Composer {...composerProps({ showEffort: false })} />);
+    // /compact is native-wrapper-only (#1139); render a native session so it
+    // stays present as the control row used to anchor this assertion.
+    render(<Composer {...composerProps({ showEffort: false, isNativeWrapper: true })} />);
     fireEvent.change(textarea(), { target: { value: "/" } });
 
     // Row testids — the active entry ("/compact") also renders in the


### PR DESCRIPTION
## Summary

- The iOS shell's mobile sidebar drawer snapped open/closed when toggled via the collapse/expand button — no animation. Root cause: this is Tailwind v4, where `translate-x` utilities move the panel via the `translate` CSS property, but the `[data-ios-native] .conversations-sidebar` override (which wins on specificity over the web's `transition-transform` class) declared only `transition: transform`. So the button toggle changed an untransitioned property and snapped; the drag animated only because it sets an inline `transform`. Switched the rule to transition both `transform` and `translate`, which also smooths drag-to-close.
- Added a leading-edge `box-shadow` to the drawer (plus a stronger dark-mode variant) so it reads as a native layer lifted above the chat as it slides, instead of a flat sheet. Gated with `:not([data-collapsed])` — the existing open-vs-collapsed convention — so the full-bleed overlay casts no sliver along the screen edge while parked off-screen.
- Both rules are scoped to `[data-ios-native]` inside `@media (width < 48rem)`, so the desktop and mobile-web experiences are untouched.

## Test Plan

<img width="588" height="1280" alt="image" src="https://github.com/user-attachments/assets/6f7c5283-7b0d-42a5-96ae-7d750d8c8ec6" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran `npx vitest run src/index.css.test.ts` (6 passing) — its regression suite parses the real CSS source and pins the `:not([data-collapsed])` open-vs-collapsed selector convention this change reuses for the shadow. Visual slide/shadow behavior verified manually in the iOS shell; no test harness drives WKWebView CSS rendering.