### PR TITLE
fix(env): propagate KUBECONFIG to runner subprocesses

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -289,6 +289,14 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # live in HARNESS_CREDENTIAL_ENV_VARS, mirroring ANTHROPIC_API_KEY /
         # ANTHROPIC_BASE_URL. Safe to propagate: not a secret.
         "CLAUDE_CODE_USE_BEDROCK",
+        # Kubernetes config path. A filesystem path (typically
+        # ``~/.kube/config``), not a bearer secret — the file *contains*
+        # cluster certs/tokens but the env var is just a path string,
+        # analogous to ``HOME``. Without it, ``kubectl`` / helm / k9s
+        # inside the agent's shell fall back to the default path which may
+        # not match what the host owner configured (e.g. a non-standard
+        # kubeconfig location or a colon-separated multi-file list).
+        "KUBECONFIG",
     }
 )
 # Locale family (``LC_ALL``, ``LC_CTYPE``, …) — allowed by prefix.

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1056,6 +1056,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "AWS_SECRET_ACCESS_KEY": "aws-secret",
         "SOME_RANDOM_VAR": "x",
         "OMNIGENT_CLAUDE_SDK_NO_SANDBOX": "1",
+        "KUBECONFIG": "/home/alice/.kube/config",
     }
 
     env = _build_runner_env(
@@ -1089,6 +1090,9 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     # must reach the runner without also forcing
     # ``OMNIGENT_RUNNER_ENV_PASSTHROUGH=OMNIGENT_CLAUDE_SDK_NO_SANDBOX``.
     assert env["OMNIGENT_CLAUDE_SDK_NO_SANDBOX"] == "1"
+    # KUBECONFIG is a filesystem path (not a secret) — kubectl, helm, k9s
+    # need it to resolve the user's cluster contexts and namespaces.
+    assert env["KUBECONFIG"] == "/home/alice/.kube/config"
     # Non-harness secrets are stripped — the point of the allowlist.
     assert "DATABRICKS_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env


### PR DESCRIPTION
## Related issue

N/A (user-reported: `omnigent claude` doesn't see Kubernetes contexts/namespaces)

## Summary

`KUBECONFIG` was missing from `_RUNNER_ENV_ALLOWLIST` in `omnigent/host/connect.py`. When the host daemon spawns a runner subprocess, it filters `os.environ` through this allowlist — so `KUBECONFIG` was silently dropped, and `kubectl`/`helm`/`k9s` inside the agent's shell fell back to the default path (`~/.kube/config`), which may not match the host user's configured kubeconfig (e.g. a non-standard location or a colon-separated multi-file list).

The env var is a filesystem path (not a bearer secret), analogous to `DATABRICKS_CONFIG_FILE` which was already allowlisted.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `KUBECONFIG` to the existing `test_build_runner_env_allowlists_host_env_and_strips_secrets` test — confirms the var passes through the allowlist filter. Ran all 6 `build_runner_env` tests: `pytest tests/host/test_connect.py -k build_runner_env` — all pass.