### PR TITLE
fix(antigravity-native): commit the user turn from the read path so it renders above the reply (#1155)

### DIFF
--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -593,6 +593,64 @@ def _message_event(
     )
 
 
+def _user_input_text(user_input: object) -> str:
+    """
+    Extract the user's turn text from a USER_INPUT step's ``userInput``.
+
+    The live wire (agy 1.0.10/1.0.11) carries the turn text both as a single
+    ``userResponse`` string and as ``items[].text`` (the same ``items`` list
+    :func:`omnigent.antigravity_native_rpc.send_user_cascade_message` sends).
+    Prefer ``userResponse``; fall back to joining the item texts.
+
+    :param user_input: The step's ``userInput`` value (expected ``dict``).
+    :returns: The user's text, or ``""`` when absent/unparseable.
+    """
+    if not isinstance(user_input, dict):
+        return ""
+    response = user_input.get("userResponse")
+    if isinstance(response, str) and response.strip():
+        return response
+    items = user_input.get("items")
+    if isinstance(items, list):
+        parts = [
+            item.get("text")
+            for item in items
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        ]
+        joined = "\n".join(part for part in parts if part)
+        if joined.strip():
+            return joined
+    return ""
+
+
+def _user_message_event(*, text: str) -> OutboundEvent:
+    """
+    Build a committed user ``message`` conversation item for a USER_INPUT step.
+
+    Mirrors :func:`_message_event` but for the user's turn (role ``"user"``,
+    ``input_text`` content, no ``response_id``/``agent``). The web UI reconciles
+    its optimistic input bubble against this committed item via
+    ``session.input.consumed``; without it the bubble has no committed
+    counterpart and renders below the assistant reply (#1155). USER_INPUT steps
+    carry no trajectory ``stepIndex`` (the reader dedups them by per-turn
+    ``executionId``), so ``step_index`` is unused here.
+
+    :param text: The user's turn text (from :func:`_user_input_text`).
+    :returns: One ``external_conversation_item`` event.
+    """
+    return OutboundEvent(
+        event_type="external_conversation_item",
+        data={
+            "item_type": "message",
+            "item_data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+        step_index=0,
+    )
+
+
 def _function_call_events(
     *,
     conversation_id: str,
@@ -833,9 +891,24 @@ def map_step_to_events(
     if not isinstance(step_type, str):
         return []
 
-    # USER_INPUT: skip entirely — user turn already persisted by direct POST.
+    # USER_INPUT: commit the user's turn as a ``message`` item so the web UI
+    # reconciles its optimistic bubble against a committed item (parity with
+    # claude/codex/cursor native, which all mirror the user turn from their read
+    # path). The turn OPENS on this step — before the planner response — so the
+    # user message commits first and renders above the reply.
+    #
+    # This replaces the earlier "skip; the user turn is already persisted by a
+    # direct POST /events hook" assumption, which never held for the production
+    # web/mobile flow: the pure-RPC ``SendUserCascadeMessage`` write path fires
+    # no such POST, so the user message was NEVER committed — the optimistic
+    # bubble had no committed counterpart and dropped below the streamed reply
+    # (#1155). The reader dedups USER_INPUT by its per-turn ``executionId``, so
+    # this emits exactly once per turn.
     if step_type == _TYPE_USER_INPUT:
-        return []
+        text = _user_input_text(step.get("userInput"))
+        if not text:
+            return []
+        return [_user_message_event(text=text)]
 
     status = step.get("status")
 

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -120,6 +120,16 @@ class _PostSink:
                 out.append(status if isinstance(status, str) else "<none>")
         return out
 
+    def message_roles(self) -> list[str]:
+        """Return the ``role`` of every committed ``message`` item, in order."""
+        out: list[str] = []
+        for event_type, data in self.posts:
+            if event_type == "external_conversation_item" and data.get("item_type") == "message":
+                item_data = data.get("item_data")
+                role = item_data.get("role") if isinstance(item_data, dict) else None
+                out.append(role if isinstance(role, str) else "<none>")
+        return out
+
     def deltas(self) -> list[dict[str, object]]:
         """Return the ``data`` payload of every ``external_output_text_delta``."""
         return [
@@ -528,17 +538,22 @@ async def test_poll_planner_generating_then_done_posts_one_final_message(
 
 
 # ---------------------------------------------------------------------------
-# USER_INPUT posts nothing
+# USER_INPUT commits the user message exactly once (#1155)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_user_input_posts_nothing(
+async def test_user_input_commits_user_message_once(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     patched_discovery: None,
 ) -> None:
-    """A USER_INPUT step maps to [] — no conversation item is posted for it."""
+    """A USER_INPUT step posts one user ``message`` item, deduped across reads.
+
+    Regression guard for #1155: the user turn must be committed (so the web UI
+    reconciles its optimistic bubble) and committed only ONCE — the reader
+    dedups the step by its per-turn ``executionId`` across repeated polls.
+    """
     user = _load("user_input")
     script = _StepScript([[user], [user]])
     sink = _PostSink()
@@ -551,7 +566,7 @@ async def test_user_input_posts_nothing(
         iterations=2,
     )
 
-    assert sink.item_types() == []
+    assert sink.item_types() == ["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -1449,8 +1464,10 @@ async def test_stream_status_running_then_idle(
     )
 
     assert sink.statuses() == ["running", "idle"]
-    # USER_INPUT still posts no conversation item; the assistant message commits.
-    assert sink.item_types() == ["message"]
+    # USER_INPUT commits the user message first, then the assistant message —
+    # so the web UI renders the user turn ABOVE the reply (#1155).
+    assert sink.item_types() == ["message", "message"]
+    assert sink.message_roles() == ["user", "assistant"]
 
 
 # ---------------------------------------------------------------------------
@@ -2096,8 +2113,10 @@ async def test_two_real_wire_turns_each_emit_running_then_idle(
     )
 
     assert sink.statuses() == ["running", "idle", "running", "idle"]
-    # Each turn commits exactly one assistant message; USER_INPUT commits none.
-    assert sink.item_types() == ["message", "message"]
+    # Each turn commits a user message (from USER_INPUT) then an assistant
+    # message — user-before-assistant ordering, per turn (#1155).
+    assert sink.item_types() == ["message", "message", "message", "message"]
+    assert sink.message_roles() == ["user", "assistant", "user", "assistant"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_antigravity_native_steps.py
+++ b/tests/test_antigravity_native_steps.py
@@ -73,29 +73,46 @@ def _assert_no_delta(events: list[OutboundEvent]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# USER_INPUT → [] (user-dup fix)
+# USER_INPUT → committed user message (#1155)
 # ---------------------------------------------------------------------------
 
 
-class TestUserInputSkipped:
-    """USER_INPUT steps must produce no events (fixes user message duplication)."""
+class TestUserInputCommitted:
+    """
+    USER_INPUT steps commit the user's turn as a ``message`` item.
 
-    def test_user_input_returns_empty(self) -> None:
-        """
-        USER_INPUT step → empty event list.
+    The pure-RPC write path fires no "direct POST /events" to persist the user
+    turn, so the read path must mirror it (parity with claude/codex/cursor
+    native). Without it the web UI's optimistic bubble has no committed
+    counterpart and renders below the assistant reply (#1155).
+    """
 
-        The user turn is already persisted by the direct POST /events; emitting
-        it again from the RPC stream would duplicate the user message in the UI.
-        """
+    def test_user_input_commits_user_message(self) -> None:
+        """USER_INPUT step → exactly one committed user ``message`` item."""
         step = _load("user_input")
         events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
-        assert events == []
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.event_type == "external_conversation_item"
+        assert ev.data["item_type"] == "message"
+        assert ev.data["item_data"]["role"] == "user"
+        assert ev.data["item_data"]["content"] == [
+            {"type": "input_text", "text": "Say hello in one short sentence."}
+        ]
+        # A user turn carries no response_id (not an assistant response).
+        assert "response_id" not in ev.data
 
     def test_user_input_no_delta(self) -> None:
-        """USER_INPUT step produces no delta events (belt-and-suspenders)."""
+        """USER_INPUT commits a message but emits no streaming delta events."""
         step = _load("user_input")
         events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
         _assert_no_delta(events)
+
+    def test_user_input_without_text_is_skipped(self) -> None:
+        """A USER_INPUT step with no recoverable text emits nothing (no empty bubble)."""
+        step = {"type": "CORTEX_STEP_TYPE_USER_INPUT", "userInput": {}}
+        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        assert events == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1155 — on `antigravity-native`, a web/mobile user message rendered **below** the assistant's streamed reply (stuck optimistic bubble).

**Root cause (confirmed live):** the pure-RPC write path (`SendUserCascadeMessage`) fires no "direct POST /events" to persist the user's turn, yet the step mapper *skipped* `CORTEX_STEP_TYPE_USER_INPUT` on exactly that assumption — so the user message was **never committed** to the omnigent session at all. The web UI's optimistic input bubble had no committed counterpart to reconcile against and fell to the bottom. (Reproduced: the only committed items were `[resource_event, assistant message]` — no user item.)

**Fix:** mirror the user turn from the read path, matching `claude`/`codex`/`cursor` native (which all commit the user message from their forwarder). The mapper now emits a committed `message` item (role `"user"`) for `USER_INPUT`, extracting the text from `userInput.userResponse` (fallback `userInput.items[].text`). The turn opens on the `USER_INPUT` step — before the planner response — so the user message commits first and renders **above** the reply. The reader dedups `USER_INPUT` by its per-turn `executionId`, so it emits exactly once.

## Verification

- **221 antigravity unit tests pass.** The two-turn reader regression now asserts `[user, assistant, user, assistant]` ordering; new `TestUserInputCommitted` covers the commit, the no-empty-bubble guard, and no-delta.
- **Live, against a local server:** sending `hi what can you help with?` from web chat now commits the user message at index 1 and the assistant reply at index 2 — correct order. (Confirmed by the reporter.)

## Notes

This addresses the omnigent-side commit/ordering only. The companion issue #1156 (the agy **TUI** not echoing web turns) is tracked separately.

This pull request and its description were written by Isaac.