### PR TITLE
fix(antigravity-native): register terminal_antigravity_main so the Chat/Terminal toggle shows (#1157)

### DIFF
--- a/ap-web/src/hooks/useTerminals.test.ts
+++ b/ap-web/src/hooks/useTerminals.test.ts
@@ -495,6 +495,12 @@ describe("inventoryTerminals", () => {
     session: "main",
     running: true,
   };
+  const antigravityPane: TerminalInfo = {
+    id: "terminal_antigravity_main",
+    name: "antigravity",
+    session: "main",
+    running: true,
+  };
   const bash: TerminalInfo = {
     id: "terminal_bash_s1",
     name: "bash",
@@ -532,6 +538,16 @@ describe("inventoryTerminals", () => {
     // mode as the pi/cursor/goose panes above.
     expect(inventoryTerminals([qwenPane, bash], true)).toEqual([bash]);
     expect(isAgentTerminalKey("terminal:terminal_qwen_main")).toBe(true);
+  });
+
+  it("drops the antigravity vendor pane for native Antigravity sessions", () => {
+    // Regression (#1157): terminal_antigravity_main was missing from
+    // AGENT_TERMINAL_IDS, so the agy TUI pane leaked into the Shells inventory
+    // and (via isShellView) hid the Chat/Terminal pill in Terminal view —
+    // stranding the user with no way back to Chat. Same failure mode as the
+    // pi/cursor/goose/qwen panes above.
+    expect(inventoryTerminals([antigravityPane, bash], true)).toEqual([bash]);
+    expect(isAgentTerminalKey("terminal:terminal_antigravity_main")).toBe(true);
   });
 
   it("drops the embedded REPL terminal for terminal-first SDK sessions", () => {

--- a/ap-web/src/hooks/useTerminals.ts
+++ b/ap-web/src/hooks/useTerminals.ts
@@ -50,9 +50,9 @@ export const PANEL_NO_TERMINAL_KEY = "";
  * connection pill's Terminal view, runner-created per session shape:
  * the embedded Omnigent REPL (``tui``/``main``) for SDK sessions,
  * and the vendor pane (``claude``/``main``, ``codex``/``main``,
- * ``pi``/``main``, ``cursor``/``main``, ``goose``/``main``, or
- * ``qwen``/``main``) for native-wrapper sessions. These are plumbing, not
- * part of the session's shell inventory, and at most one exists per session.
+ * ``pi``/``main``, ``cursor``/``main``, ``goose``/``main``, ``qwen``/``main``,
+ * or ``antigravity``/``main``) for native-wrapper sessions. These are plumbing,
+ * not part of the session's shell inventory, and at most one exists per session.
  *
  * Missing an entry here makes that pane read as a *user shell*: the
  * Chat/Terminal pill self-hides in Terminal view (``isShellView``), so the
@@ -68,6 +68,7 @@ export const AGENT_TERMINAL_IDS: ReadonlySet<string> = new Set([
   "terminal_cursor_main",
   "terminal_goose_main",
   "terminal_qwen_main",
+  "terminal_antigravity_main",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1157 — on `antigravity-native`, the Terminal view had no Chat/Terminal toggle, stranding the user in the agy TUI with no way back to chat.

**Root cause:** `terminal_antigravity_main` was missing from `AGENT_TERMINAL_IDS` (`ap-web/src/hooks/useTerminals.ts`). Without it, the agy TUI pane read as a *user shell*: `isShellView` hid the Chat/Terminal pill in Terminal view and the pane leaked into the Shells inventory — the exact failure mode the set's own docstring warns about, and the same omission previously fixed for pi/cursor/goose/qwen.

**Fix:** add the id to the set, extend the docstring to mention `antigravity`/`main`, and add a regression test mirroring the sibling native panes.

## Verification

- `useTerminals.test.ts`: **29 passed** (incl. the new antigravity case asserting the pane is dropped from the Shells inventory and `isAgentTerminalKey` recognizes it).
- prettier clean.

This pull request and its description were written by Isaac.