### PR TITLE
feat(ios): unify shell inset handling into a single system

### DIFF
--- a/ap-web/ios/Omnigent/ChatTerminalBar.swift
+++ b/ap-web/ios/Omnigent/ChatTerminalBar.swift
@@ -18,7 +18,7 @@ struct ChatTerminalBar: View {
       segment(.chat, title: "Chat", systemImage: "message")
       segment(.terminal, title: "Terminal", systemImage: "terminal")
     }
-    .padding(4)
+    .padding(InsetMetrics.barCapsulePadding)
     .modifier(GlassCapsule(colorScheme: colorScheme))
     .animation(.easeInOut(duration: 0.18), value: mode)
     .accessibilityElement(children: .contain)
@@ -50,7 +50,7 @@ struct ChatTerminalBar: View {
           ? DesignTokens.foreground(colorScheme) : DesignTokens.mutedForeground(colorScheme)
       )
       .padding(.horizontal, 14)
-      .frame(height: 34)
+      .frame(height: InsetMetrics.barSegmentHeight)
       .background {
         if isSelected {
           Capsule(style: .continuous)

--- a/ap-web/ios/Omnigent/OmnigentWebView.swift
+++ b/ap-web/ios/Omnigent/OmnigentWebView.swift
@@ -135,6 +135,21 @@ struct OmnigentWebView: UIViewRepresentable {
           try { callback(mode); } catch {}
         }
       });
+      const insetCallbacks = new Set();
+      // Cache the last footprint so a subscriber that registers AFTER native
+      // first emitted (the React app mounts later than document-start) still
+      // gets the current value immediately on subscribe.
+      let lastInsets = null;
+      defineEmit("__omnigentNativeEmitInsets", (topBar, bottomBar) => {
+        const insets = {
+          topBar: typeof topBar === "number" && Number.isFinite(topBar) ? topBar : 0,
+          bottomBar: typeof bottomBar === "number" && Number.isFinite(bottomBar) ? bottomBar : 0,
+        };
+        lastInsets = insets;
+        for (const callback of insetCallbacks) {
+          try { callback(insets); } catch {}
+        }
+      });
       const sidebarDragCallbacks = new Set();
       Object.defineProperty(window, "__omnigentNativeEmitSidebarDrag", {
         configurable: false,
@@ -207,6 +222,12 @@ struct OmnigentWebView: UIViewRepresentable {
           if (typeof callback !== "function") return () => {};
           viewModeCallbacks.add(callback);
           return () => viewModeCallbacks.delete(callback);
+        },
+        onNativeInsets(callback) {
+          if (typeof callback !== "function") return () => {};
+          insetCallbacks.add(callback);
+          if (lastInsets) { try { callback(lastInsets); } catch {} }
+          return () => insetCallbacks.delete(callback);
         },
       });
     })();

--- a/ap-web/ios/Omnigent/WebShellView.swift
+++ b/ap-web/ios/Omnigent/WebShellView.swift
@@ -33,7 +33,7 @@ struct WebShellView: View {
           connectToNewServer: connectToNewServer,
           reload: model.reload
         )
-        .padding(.top, 8)
+        .padding(.top, InsetMetrics.serverSwitcherTopPadding)
         .opacity(model.serverSwitcherHidden ? 0 : 1)
         .scaleEffect(model.serverSwitcherHidden ? 0.96 : 1, anchor: .top)
         .allowsHitTesting(!model.serverSwitcherHidden)
@@ -56,7 +56,7 @@ struct WebShellView: View {
             model.emitViewModeChanged(newMode)
           }
         )
-        .padding(.bottom, 6)
+        .padding(.bottom, InsetMetrics.barBottomPadding)
         .opacity(model.bottomBarVisible ? 1 : 0)
         .allowsHitTesting(model.bottomBarVisible)
         .accessibilityHidden(!model.bottomBarVisible)
@@ -67,6 +67,16 @@ struct WebShellView: View {
     .onChange(of: router.pendingNotificationPath) { _, _ in
       if let path = router.consumeNotificationPath() {
         model.emitNotificationActivation(path)
+      }
+    }
+    .onChange(of: model.isLoading) { _, loading in
+      // Re-push the native bar footprints once each load completes; the JS
+      // bridge caches the value so a later-mounting subscriber still gets it.
+      if !loading {
+        model.emitInsets(
+          topBar: InsetMetrics.topBarFootprint,
+          bottomBar: InsetMetrics.bottomBarFootprint
+        )
       }
     }
   }
@@ -141,7 +151,7 @@ private struct ServerSwitcher: View {
       .font(.system(size: 12))
       .foregroundStyle(DesignTokens.foreground(colorScheme))
       .padding(.horizontal, 10)
-      .frame(height: 28)
+      .frame(height: InsetMetrics.serverSwitcherHeight)
       .frame(maxWidth: maxWidth)
       .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
     }
@@ -164,5 +174,27 @@ private struct ServerSwitcher: View {
 private enum ServerSwitcherMetrics {
   static func maxWidth(for containerWidth: CGFloat) -> CGFloat {
     min(172, max(120, containerWidth * 0.38))
+  }
+}
+
+/// Single source of truth for the floating native bars' dimensions. These drive
+/// both the SwiftUI layout (the `.frame`/`.padding` calls above and in
+/// `ChatTerminalBar`) and the footprint pushed to the web layer via
+/// `WebViewModel.emitInsets`, so the web's content insets can never drift from
+/// the bars' real size. Values are CSS points, excluding the OS safe area (the
+/// web layer adds that with `env(safe-area-inset-*)`).
+enum InsetMetrics {
+  // Server switcher — the top floating pill.
+  static let serverSwitcherHeight: CGFloat = 28
+  static let serverSwitcherTopPadding: CGFloat = 8
+  static var topBarFootprint: CGFloat { serverSwitcherHeight + serverSwitcherTopPadding }
+
+  // Chat/Terminal bar — the bottom floating capsule. The capsule wraps the
+  // segment row (`barSegmentHeight`) in `barCapsulePadding` on every side.
+  static let barSegmentHeight: CGFloat = 34
+  static let barCapsulePadding: CGFloat = 4
+  static let barBottomPadding: CGFloat = 6
+  static var bottomBarFootprint: CGFloat {
+    barSegmentHeight + barCapsulePadding * 2 + barBottomPadding
   }
 }

--- a/ap-web/ios/Omnigent/WebViewModel.swift
+++ b/ap-web/ios/Omnigent/WebViewModel.swift
@@ -35,6 +35,17 @@ final class WebViewModel: ObservableObject {
     webView?.evaluateJavaScript(script)
   }
 
+  /// Push the footprint (in CSS px, excluding the OS safe area which the web
+  /// layer adds via `env()`) of the native floating bars to the web app. The
+  /// web side folds these into its `--omnigent-inset-*` variables so page
+  /// content reserves the right amount of space — making native bar dimensions
+  /// the single source of truth instead of magic numbers duplicated in CSS.
+  func emitInsets(topBar: CGFloat, bottomBar: CGFloat) {
+    let script =
+      "window.__omnigentNativeEmitInsets?.(\(jsNumber(topBar)), \(jsNumber(bottomBar)));"
+    webView?.evaluateJavaScript(script)
+  }
+
   /// Tell the web app the user tapped a segment in the native switcher.
   func emitViewModeChanged(_ mode: WebViewMode) {
     let script =
@@ -47,6 +58,12 @@ final class WebViewModel: ObservableObject {
     let script =
       "window.__omnigentNativeEmitSidebarDrag?.(\(Self.javascriptString(phase)), \(clamped));"
     webView?.evaluateJavaScript(script)
+  }
+
+  /// Format a CGFloat as a bare JS number literal (no units, finite-guarded).
+  private func jsNumber(_ value: CGFloat) -> String {
+    guard value.isFinite else { return "0" }
+    return String(format: "%g", Double(value))
   }
 
   static func javascriptString(_ value: String) -> String {

--- a/ap-web/src/components/PageScroll.tsx
+++ b/ap-web/src/components/PageScroll.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The single scroll primitive for routed pages. It owns the one thing every
+ * page used to reinvent by hand: keeping content clear of the chrome at the top
+ * (the AppShell header + OS safe area) and bottom (the iOS native chat/terminal
+ * bar + OS safe area).
+ *
+ * All of that comes from the shared inset variables defined in index.css
+ * (`--omnigent-header-height`, `--omnigent-inset-top/bottom`). Off the iOS shell
+ * those resolve to `0` / plain `env(safe-area-*)`, so the SAME component renders
+ * correctly in the browser, Electron, and the iOS shell with no runtime branch.
+ *
+ * This is the "respect the inset" side of the system. Full-bleed elements that
+ * intentionally ignore the inset (the webview, app-shell background, sidebar
+ * drawer) simply don't use this — they stay edge-to-edge as before.
+ */
+interface PageScrollProps {
+  children: ReactNode;
+  /** Reserve room for the AppShell's absolute header at the top. Default true. */
+  clearHeader?: boolean;
+  /** Reserve the top OS safe-area inset. Default true. */
+  insetTop?: boolean;
+  /** Reserve the bottom inset (safe area + native chat/terminal bar). Default true. */
+  insetBottom?: boolean;
+  /** Extra top padding beyond the header/inset, as a CSS length. */
+  extraTop?: string;
+  /** Extra bottom padding beyond the inset, as a CSS length. */
+  extraBottom?: string;
+  /** Max-width class for the centered content column. Default "max-w-3xl". */
+  maxWidthClassName?: string;
+  /** Extra classes for the centered content column (e.g. horizontal padding). */
+  contentClassName?: string;
+  /** Extra classes for the scroll container itself. */
+  className?: string;
+  /** Forwarded to the scroll container (e.g. data-testid). */
+  "data-testid"?: string;
+}
+
+export function PageScroll({
+  children,
+  clearHeader = true,
+  insetTop = true,
+  insetBottom = true,
+  extraTop = "1.5rem",
+  extraBottom = "2rem",
+  maxWidthClassName = "max-w-3xl",
+  contentClassName,
+  className,
+  "data-testid": testId,
+}: PageScrollProps) {
+  // Padding is composed from the shared inset vars rather than the old fixed
+  // `pt-14 py-8`, so the bottom always clears the native bar + home indicator
+  // and the top always clears the header + notch — the bug those magic numbers
+  // missed. The padding lives on the scroll container so the last item can
+  // scroll up clear of the bar.
+  const style: CSSProperties = {
+    paddingTop: `calc(${extraTop}${clearHeader ? " + var(--omnigent-header-height)" : ""}${
+      insetTop ? " + var(--omnigent-inset-top)" : ""
+    })`,
+    paddingBottom: `calc(${extraBottom}${insetBottom ? " + var(--omnigent-inset-bottom)" : ""})`,
+  };
+
+  return (
+    <div
+      data-testid={testId}
+      className={cn("min-h-0 w-full flex-1 overflow-y-auto", className)}
+      style={style}
+    >
+      <div className={cn("mx-auto w-full", maxWidthClassName, contentClassName)}>{children}</div>
+    </div>
+  );
+}

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -99,6 +99,43 @@
  * buttons stay neutral grey (hue 240). See designs/UI/WEB_UI.md (still
  * describes the older cobalt direction). */
 :root {
+  /* ---- Inset system -------------------------------------------------------
+   * Single source of truth for how far content must stay clear of screen
+   * chrome. The SAME bundle runs in a browser, in Electron, and inside the
+   * iOS WKWebView shell, so these variables are defined universally and the
+   * runtime-specific inputs default to zero — `<PageScroll>` and the scoped
+   * rules below consume them without any `isIOSShell()` branching.
+   *
+   * Three inputs combine:
+   *   1. OS safe area  — `env(safe-area-inset-*)`, nonzero only on notched /
+   *      home-indicator devices (and only when `viewport-fit=cover`).
+   *   2. Native bar footprint — the pixel height of the iOS shell's floating
+   *      server switcher (top) and chat/terminal bar (bottom). The native
+   *      layer owns these dimensions and pushes them over the bridge (see
+   *      src/lib/nativeInsets.ts); they stay 0 off-shell.
+   *   3. Bar visibility — 0|1, owned by the web app (it is what tells the
+   *      shell to show/hide each bar). Folded in via a unitless multiply so a
+   *      hidden bar contributes nothing.
+   *
+   * The bottom chat/terminal bar overlays page content, so it feeds the
+   * content inset. The top server switcher floats within the web header band
+   * (ChatHeader, --omnigent-header-height) and is narrower than it, so content
+   * that already clears the header also clears the switcher — its size is
+   * tracked here for symmetry/introspection but is intentionally NOT added to
+   * the content top inset to avoid double-counting the header band. */
+  --omnigent-header-height: 3.5rem; /* web ChatHeader (h-14) */
+  --omnigent-safe-top: env(safe-area-inset-top, 0px);
+  --omnigent-safe-bottom: env(safe-area-inset-bottom, 0px);
+  --omnigent-native-top-bar: 0px; /* set by native bridge (px) */
+  --omnigent-native-bottom-bar: 0px; /* set by native bridge (px) */
+  --omnigent-top-bar-visible: 0; /* web-owned 0|1 */
+  --omnigent-bottom-bar-visible: 0; /* web-owned 0|1 */
+  --omnigent-inset-top: var(--omnigent-safe-top);
+  --omnigent-inset-bottom: calc(
+    var(--omnigent-safe-bottom) + var(--omnigent-native-bottom-bar) *
+      var(--omnigent-bottom-bar-visible)
+  );
+
   /* Brand palette (light). Hex values are the brand spec, kept verbatim
      * for fidelity. --background is white: the lavender brand canvas is
      * expressed by the .app-shell gradient (see index.css .app-shell), so
@@ -457,28 +494,30 @@
   }
 
   [data-ios-native] .chat-conversation-content {
-    padding-top: calc(5rem + env(safe-area-inset-top, 0px));
+    /* header band + 1.5rem breathing room + OS safe area, sourced from the
+       shared inset vars (was a hardcoded 5rem). */
+    padding-top: calc(var(--omnigent-header-height) + 1.5rem + var(--omnigent-inset-top));
   }
 
   [data-ios-native] .main-terminal-view {
-    padding-top: calc(3.25rem + env(safe-area-inset-top, 0px));
+    padding-top: calc(3.25rem + var(--omnigent-inset-top));
   }
 
   [data-ios-native] .chat-scroll-fade {
     mask-image: linear-gradient(
       to bottom,
-      transparent calc(48px + env(safe-area-inset-top, 0px)),
-      black calc(80px + env(safe-area-inset-top, 0px))
+      transparent calc(48px + var(--omnigent-inset-top)),
+      black calc(80px + var(--omnigent-inset-top))
     );
     -webkit-mask-image: linear-gradient(
       to bottom,
-      transparent calc(48px + env(safe-area-inset-top, 0px)),
-      black calc(80px + env(safe-area-inset-top, 0px))
+      transparent calc(48px + var(--omnigent-inset-top)),
+      black calc(80px + var(--omnigent-inset-top))
     );
   }
 
   [data-ios-native] .chat-composer-form {
-    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(0.75rem + var(--omnigent-safe-bottom));
   }
 
   [data-ios-native] .chat-composer-form.terminal-first-composer-form {
@@ -486,20 +525,22 @@
   }
 
   [data-ios-native] .terminal-first-switcher-container {
-    padding-bottom: calc(0.35rem + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(0.35rem + var(--omnigent-safe-bottom));
   }
 
   /* Reserve room for the native Liquid Glass switcher that floats over the web
-     view (the in-page pill is suppressed in the iOS shell). Fixed height: the
-     bar's footprint above the home-indicator inset (env). Chat sits 1rem
-     tighter — its composer status line already cushions the gap to the bar. */
+     view (the in-page pill is suppressed in the iOS shell). Height is the
+     shared bottom inset — the native bar footprint (sourced from the shell, see
+     nativeInsets.ts) plus the home-indicator safe area — so it can never drift
+     from the bar's real size. Chat sits 1rem tighter: its composer status line
+     already cushions the gap to the bar. */
   [data-ios-native] .omnigent-native-bottom-spacer {
-    height: calc(3rem + env(safe-area-inset-bottom, 0px));
+    height: var(--omnigent-inset-bottom);
     flex: none;
   }
 
   [data-ios-native] .omnigent-native-bottom-spacer--chat {
-    height: calc(2rem + env(safe-area-inset-bottom, 0px));
+    height: calc(var(--omnigent-inset-bottom) - 1rem);
   }
 
   [data-ios-native] .terminal-first-switcher {
@@ -575,8 +616,8 @@
       [data-testid="subagents-panel-drawer"],
       [data-testid="todos-panel-drawer"]
     ) {
-    padding-top: env(safe-area-inset-top, 0px);
-    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-top: var(--omnigent-safe-top);
+    padding-bottom: var(--omnigent-safe-bottom);
   }
 }
 

--- a/ap-web/src/lib/nativeBridge.ts
+++ b/ap-web/src/lib/nativeBridge.ts
@@ -76,6 +76,22 @@ interface NativeShellApi {
   setViewMode?: (params: NativeViewModeParams) => void;
   /** Subscribe to taps on the native switcher; returns an unsubscribe. */
   onViewModeChanged?: (callback: (mode: NativeViewMode) => void) => () => void;
+  /**
+   * Subscribe to the footprint (CSS px, excluding the OS safe area) of the
+   * native floating bars. The shell pushes this whenever it changes — and
+   * immediately on subscribe, since it caches the last value — so the web
+   * layer can fold the real bar dimensions into its inset variables instead of
+   * hardcoding them. Absent on older shells. Returns an unsubscribe.
+   */
+  onNativeInsets?: (callback: (insets: NativeInsets) => void) => () => void;
+}
+
+/** Footprints (CSS px) of the native floating bars, reported by the shell. */
+export interface NativeInsets {
+  /** Server switcher pill height + its top padding. */
+  topBar: number;
+  /** Chat/Terminal bar capsule height + its bottom padding. */
+  bottomBar: number;
 }
 
 export type NativeViewMode = "chat" | "terminal";
@@ -265,10 +281,24 @@ export async function setBadgeCount(count: number): Promise<void> {
 }
 
 /**
+ * Set one of the inset-system CSS variables on the document root. Visibility of
+ * the native bars is web-owned (the web app is what shows/hides them), so the
+ * setters below fold it into `--omnigent-*-bar-visible`; the bars' size comes
+ * from the native bridge (see {@link onNativeInsets} / nativeInsets.ts). Both
+ * combine in `--omnigent-inset-*` (index.css). Harmless off-shell — the size
+ * vars stay 0 there, so a stray visibility flag contributes nothing.
+ */
+function setInsetVar(name: string, value: string): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.style.setProperty(name, value);
+}
+
+/**
  * Inform a native shell that its server switcher should hide. Older shells
  * simply lack this optional method, so this degrades to a no-op.
  */
 export function setNativeServerSwitcherHidden(hidden: boolean): void {
+  setInsetVar("--omnigent-top-bar-visible", hidden ? "0" : "1");
   const native = nativeApi();
   const setter = native?.setServerSwitcherHidden ?? native?.setSidebarOpen;
   if (!setter) return;
@@ -292,6 +322,7 @@ export function setNativeSidebarOpen(open: boolean): void {
  * caller renders its own in-page pill there.
  */
 export function setNativeViewMode(params: NativeViewModeParams): void {
+  setInsetVar("--omnigent-bottom-bar-visible", params.visible ? "1" : "0");
   const native = nativeApi();
   if (!native?.setViewMode) return;
   try {
@@ -313,6 +344,24 @@ export function onNativeViewModeChanged(callback: (mode: NativeViewMode) => void
     return native.onViewModeChanged(callback);
   } catch (err) {
     console.warn("[nativeBridge] native onViewModeChanged failed:", err);
+    return () => {};
+  }
+}
+
+/**
+ * Subscribe to the native bars' footprint from the shell. The shell pushes the
+ * current value immediately on subscribe (it caches the last emit), then again
+ * on any change. Returns an unsubscribe; a no-op outside a shell that reports
+ * insets (Electron, plain browser, older iOS shells), where the bars don't
+ * exist and the inset CSS vars stay 0.
+ */
+export function onNativeInsets(callback: (insets: NativeInsets) => void): () => void {
+  const native = nativeApi();
+  if (!native?.onNativeInsets) return () => {};
+  try {
+    return native.onNativeInsets(callback);
+  } catch (err) {
+    console.warn("[nativeBridge] native onNativeInsets failed:", err);
     return () => {};
   }
 }

--- a/ap-web/src/lib/nativeInsets.ts
+++ b/ap-web/src/lib/nativeInsets.ts
@@ -1,0 +1,27 @@
+// Applies the native iOS shell's reported bar footprints to the inset CSS
+// variables the layout consumes.
+//
+// The iOS shell pushes the pixel height of its floating server switcher (top)
+// and chat/terminal bar (bottom) over the bridge — the one piece of the inset
+// system that CSS/JS cannot compute on its own. This module writes those onto
+// `--omnigent-native-top-bar` / `--omnigent-native-bottom-bar`; index.css folds
+// them (together with the web-owned visibility flags and `env(safe-area-*)`)
+// into `--omnigent-inset-top` / `--omnigent-inset-bottom`, which `<PageScroll>`
+// and the scoped iOS rules read.
+//
+// No-op off the iOS shell: the size vars keep their `0px` defaults, so the same
+// inset variables resolve to plain `env(safe-area-*)` (browser, Electron).
+
+import { onNativeInsets } from "@/lib/nativeBridge";
+
+/**
+ * Start mirroring native bar footprints into the inset CSS variables. Call once
+ * at app startup. Returns an unsubscribe (a no-op outside the iOS shell).
+ */
+export function initNativeInsets(): () => void {
+  return onNativeInsets(({ topBar, bottomBar }) => {
+    const root = document.documentElement.style;
+    root.setProperty("--omnigent-native-top-bar", `${topBar}px`);
+    root.setProperty("--omnigent-native-bottom-bar", `${bottomBar}px`);
+  });
+}

--- a/ap-web/src/main.tsx
+++ b/ap-web/src/main.tsx
@@ -10,6 +10,7 @@ import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
 import { CapabilitiesProvider } from "./lib/CapabilitiesContext";
 import { resolveIdentity } from "./lib/identity";
+import { initNativeInsets } from "./lib/nativeInsets";
 import { initChatStore } from "./store/chatStore";
 import "./index.css";
 
@@ -34,6 +35,10 @@ initChatStore(queryClient);
 // all subsequent fetch calls include X-Forwarded-Email so session
 // routes know who's making the request.
 void resolveIdentity();
+
+// Mirror the iOS shell's native bar footprints into the inset CSS variables.
+// No-op off the iOS shell (the inset vars stay at their env()-only defaults).
+initNativeInsets();
 
 // Probe /v1/info BEFORE the first render so the route table knows
 // whether to mount accounts routes. The probe is unauthed and the

--- a/ap-web/src/pages/InboxPage.tsx
+++ b/ap-web/src/pages/InboxPage.tsx
@@ -45,6 +45,7 @@ import {
   Loader2Icon,
 } from "lucide-react";
 import { ApprovalCard, type SubmitApprovalFn } from "@/components/blocks/ApprovalCard";
+import { PageScroll } from "@/components/PageScroll";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useCommentInbox } from "@/hooks/useCommentInbox";
@@ -184,9 +185,7 @@ export function InboxPage() {
   };
 
   return (
-    <div className="mx-auto w-full max-w-3xl overflow-y-auto px-6 py-8 pt-14">
-      {/* pt-14 leaves room for the AppShell's absolute-positioned header,
-          matching MembersPage / PoliciesPage. */}
+    <PageScroll contentClassName="px-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Inbox</h1>
         {(items.length > 0 || commentInbox.items.length > 0) && (
@@ -401,6 +400,6 @@ export function InboxPage() {
           </div>
         )}
       </div>
-    </div>
+    </PageScroll>
   );
 }

--- a/ap-web/src/pages/LoginPage.tsx
+++ b/ap-web/src/pages/LoginPage.tsx
@@ -118,7 +118,15 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+    <div
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+      // Centered auth page (no header / native bars): just keep the card clear
+      // of the notch + home indicator. 0 off the iOS shell. See index.css.
+      style={{
+        paddingTop: "var(--omnigent-safe-top)",
+        paddingBottom: "var(--omnigent-safe-bottom)",
+      }}
+    >
       <div className="w-full max-w-sm space-y-6">
         <div className="space-y-1 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>

--- a/ap-web/src/pages/MembersPage.tsx
+++ b/ap-web/src/pages/MembersPage.tsx
@@ -25,6 +25,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "@/lib/routing";
 import { CopyIcon, KeyRoundIcon, RefreshCwIcon, Trash2Icon, UserPlusIcon } from "lucide-react";
+import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -160,10 +161,7 @@ export function MembersPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-6 py-8 pt-14">
-      {/* pt-14 leaves room for the AppShell's absolute-positioned
-          header (sidebar toggle / account menu) so the page title
-          isn't tucked under it. */}
+    <PageScroll contentClassName="px-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Members</h1>
         <Button onClick={() => setShowCreateInvite(true)}>
@@ -389,7 +387,7 @@ export function MembersPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageScroll>
   );
 }
 

--- a/ap-web/src/pages/PoliciesPage.tsx
+++ b/ap-web/src/pages/PoliciesPage.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "@/lib/routing";
 import { PlusIcon, RefreshCwIcon, ShieldCheckIcon, TrashIcon } from "lucide-react";
+import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -414,7 +415,7 @@ export function PoliciesPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-6 py-8 pt-14">
+    <PageScroll contentClassName="px-6">
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold">Global Policies</h1>
@@ -567,6 +568,6 @@ export function PoliciesPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageScroll>
   );
 }

--- a/ap-web/src/pages/RegisterPage.tsx
+++ b/ap-web/src/pages/RegisterPage.tsx
@@ -70,7 +70,15 @@ export function RegisterPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+    <div
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+      // Centered auth page (no header / native bars): just keep the card clear
+      // of the notch + home indicator. 0 off the iOS shell. See index.css.
+      style={{
+        paddingTop: "var(--omnigent-safe-top)",
+        paddingBottom: "var(--omnigent-safe-bottom)",
+      }}
+    >
       <div className="w-full max-w-sm space-y-6">
         <div className="space-y-1 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">Create your account</h1>

--- a/ap-web/src/pages/SettingsPage.tsx
+++ b/ap-web/src/pages/SettingsPage.tsx
@@ -32,6 +32,7 @@ import {
 import { LaptopMinimalIcon, MoonIcon, SunIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Link } from "@/lib/routing";
+import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -62,8 +63,8 @@ import { cn } from "@/lib/utils";
  * Settings content panel. The section nav lives in the sidebar card
  * (SettingsSidebarBody); this renders only the selected section into the
  * AppShell main outlet. The active section is read from the URL so the two
- * stay in sync. pt-14 clears the shell's absolute top-0 h-14 header overlay,
- * matching the Inbox / Members pages.
+ * stay in sync. PageScroll handles clearing the shell's absolute header and
+ * the iOS native bars, matching the Inbox / Members pages.
  */
 export function SettingsPage() {
   const info = useServerInfo();
@@ -71,14 +72,12 @@ export function SettingsPage() {
   const { section } = useSettingsRoute();
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="mx-auto w-full max-w-3xl px-8 pb-10 pt-14">
-        {section === "appearance" && <AppearanceSection />}
-        {section === "shortcuts" && <ShortcutsSection />}
-        {section === "account" && accountsEnabled && <AccountSection />}
-        {section === "archived" && <ArchivedSection />}
-      </div>
-    </div>
+    <PageScroll contentClassName="px-8" extraBottom="2.5rem">
+      {section === "appearance" && <AppearanceSection />}
+      {section === "shortcuts" && <ShortcutsSection />}
+      {section === "account" && accountsEnabled && <AccountSection />}
+      {section === "archived" && <ArchivedSection />}
+    </PageScroll>
   );
 }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace the ad-hoc, per-page padding and the duplicated `[data-ios-native]` CSS magic numbers with one inset system. A single set of composite CSS variables (`--omnigent-inset-top/bottom`, `--omnigent-header-height`) in `index.css` is the source of truth; off the iOS shell they resolve to plain `env(safe-area-*)`/0, so the same code works in browser, Electron, and iOS with no `isIOSShell()` branching.
- Make the native layer the source of truth for the floating bars' footprint: a shared `InsetMetrics` in Swift drives both the SwiftUI layout and a new `emitInsets` bridge push; `nativeInsets.ts` mirrors it into the CSS vars. Bar visibility (already web-owned) is folded in at the existing bridge call sites. This kills the native<->CSS drift that the hardcoded spacer had.
- Add a shared `<PageScroll>` primitive that owns header clearance + top/bottom insets, and adopt it across Inbox, Settings, Members, and Policies. Auth pages (Login/Register) get safe-area padding without breaking centering.
- Fix the reported bug: Inbox/Settings buttons covered text because those pages reserved nothing for the native bottom bar and omitted `safe-area-inset-*`.

## Test Plan

- `npm run type-check` (clean), `npx oxlint` on changed files (only a pre-existing `_bootProbe` warning), `npm run build` (succeeds; confirmed the new inset vars are present in the emitted CSS).
- `npx vitest run`: 2990 passed; the only 3 failures are in `ChatPage.composer.test.tsx` and were confirmed pre-existing on a clean tree (ChatPage untouched). Native bridge tests pass 27/27.
- iOS: `swift format lint` clean; `xcodebuild` for the Omnigent scheme on the iPhone 17 Pro simulator -> BUILD SUCCEEDED.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified via web type-check, oxlint, the full vitest suite, and a production build (inset CSS vars confirmed in the bundle output), plus an iOS simulator build (BUILD SUCCEEDED) and swift-format lint. The bridge changes are covered by the existing `nativeBridge.test.ts` (27/27). Runtime visual confirmation on a notched simulator (content clearing the native bars, visibility toggling the bottom inset) is the remaining manual step and needs a live server to render Inbox/Settings end-to-end.
