### PR TITLE
feat(ap-web): show session owner in the info popover

### DIFF
--- a/ap-web/src/components/AgentInfo.test.tsx
+++ b/ap-web/src/components/AgentInfo.test.tsx
@@ -15,11 +15,24 @@ const { addMutate, deleteMutate, copyTextMock } = vi.hoisted(() => ({
 }));
 const policiesData = { current: [] as unknown[] };
 const registryData = { current: [] as unknown[] };
+// Session owner + viewer identity, controllable per test. Dereferenced lazily
+// inside the mock hooks (same pattern as policiesData) so the closures are safe
+// despite vi.mock hoisting. Default null → no owner row, keeping the pre-existing
+// cost/id/usage tests untouched.
+const ownerData = { current: null as string | null | undefined };
+const viewerData = { current: null as string | null };
 vi.mock("@/hooks/usePolicies", () => ({
   usePolicies: () => ({ data: policiesData.current }),
   usePolicyRegistry: () => ({ data: registryData.current }),
   useAddPolicy: () => ({ mutate: addMutate, isPending: false, isError: false, error: null }),
   useDeletePolicy: () => ({ mutate: deleteMutate }),
+}));
+vi.mock("@/hooks/usePermissions", () => ({
+  useSessionOwner: () => ({ data: ownerData.current }),
+}));
+vi.mock("@/lib/identity", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/identity")>()),
+  getCurrentUserId: () => viewerData.current,
 }));
 vi.mock("@/lib/clipboard", () => ({ copyText: copyTextMock }));
 
@@ -28,6 +41,8 @@ import { AgentInfoButton, AgentInfoContent, agentDisplayLabel } from "./AgentInf
 afterEach(() => {
   cleanup();
   copyTextMock.mockClear();
+  ownerData.current = null;
+  viewerData.current = null;
 });
 
 function renderButton(agent: Agent | undefined) {
@@ -170,6 +185,54 @@ describe("AgentInfoButton session id row", () => {
     expect(copyTextMock).toHaveBeenCalledTimes(1);
     expect(copyTextMock).toHaveBeenCalledWith("conv_info123");
     expect(await screen.findByRole("button", { name: "Copied session ID" })).toBeInTheDocument();
+  });
+});
+
+describe("AgentInfoButton session owner row", () => {
+  // The owner row lets a viewer see whose session a shared chat is. It reads
+  // the owner via useSessionOwner (mocked) and the viewer via getCurrentUserId
+  // (mocked); both reset to null in afterEach.
+
+  it("shows the session owner in the popover when one is known", () => {
+    ownerData.current = "alice@example.com";
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
+    // Closed popover: the owner row is not mounted yet.
+    expect(screen.queryByTestId("agent-info-session-owner")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+
+    expect(screen.getByTestId("agent-info-session-owner")).toHaveTextContent("alice@example.com");
+  });
+
+  it("appends (you) when the viewer owns the session", () => {
+    ownerData.current = "alice@example.com";
+    viewerData.current = "alice@example.com";
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+
+    const row = screen.getByTestId("agent-info-session-owner");
+    expect(row).toHaveTextContent("alice@example.com");
+    expect(row).toHaveTextContent("(you)");
+  });
+
+  it("omits (you) when someone else owns the session", () => {
+    ownerData.current = "alice@example.com";
+    viewerData.current = "bob@example.com";
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+
+    const row = screen.getByTestId("agent-info-session-owner");
+    expect(row).toHaveTextContent("alice@example.com");
+    expect(row).not.toHaveTextContent("(you)");
+  });
+
+  it("omits the owner row when no owner is known (permissions off / loading)", () => {
+    // owner null → no row at all, rather than an empty placeholder. The rest of
+    // the popover still renders (agent name proves it opened).
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+    expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-info-session-owner")).toBeNull();
   });
 });
 

--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -20,6 +20,8 @@ import {
   useDeletePolicy,
   type PolicyRegistryEntry,
 } from "@/hooks/usePolicies";
+import { useSessionOwner } from "@/hooks/usePermissions";
+import { getCurrentUserId } from "@/lib/identity";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -630,6 +632,12 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
   // popover renders it directly — the frontend derives any aggregate view
   // from this map rather than receiving flat token fields.
   const usageByModel = useChatStore((s) => s.sessionUsageByModel);
+  // Session owner (the user_id granted LEVEL_OWNER), so a viewer can see whose
+  // session this is — e.g. a chat shared into a workspace group. ``null`` /
+  // undefined when permissions are off (single-user) or still loading, in
+  // which case the row is omitted rather than showing a placeholder.
+  const { data: owner } = useSessionOwner(sessionId ?? null);
+  const viewerId = getCurrentUserId();
 
   useEffect(() => {
     return () => {
@@ -658,6 +666,19 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
           {agent?.description && (
             <span className="text-xs text-muted-foreground">{agent.description}</span>
           )}
+        </div>
+      )}
+      {sessionId && owner && (
+        <div className="flex flex-col gap-1.5">
+          <SectionLabel>Owner</SectionLabel>
+          <span
+            className="truncate font-mono text-xs text-muted-foreground"
+            data-testid="agent-info-session-owner"
+            title={owner}
+          >
+            {owner}
+            {owner === viewerId && <span className="ml-1 text-muted-foreground/60">(you)</span>}
+          </span>
         </div>
       )}
       {sessionId && (

--- a/ap-web/src/hooks/usePermissions.ts
+++ b/ap-web/src/hooks/usePermissions.ts
@@ -8,6 +8,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type Permission,
   derivePermissionLevel,
+  getSessionOwner,
   grantPermission,
   listPermissions,
   revokePermission,
@@ -19,11 +20,32 @@ function permissionsKey(sessionId: string) {
   return ["permissions", sessionId] as const;
 }
 
+function sessionOwnerKey(sessionId: string) {
+  return ["sessionOwner", sessionId] as const;
+}
+
 /** Fetch all permission grants for a session. */
 export function usePermissions(sessionId: string | null) {
   return useQuery({
     queryKey: permissionsKey(sessionId ?? ""),
     queryFn: () => listPermissions(sessionId!),
+    enabled: !!sessionId,
+  });
+}
+
+/**
+ * Fetch the owner (the ``user_id`` granted ``LEVEL_OWNER``) of a session.
+ *
+ * Returns ``null`` when permissions are disabled (single-user mode), so the
+ * caller can omit any owner UI. Requires only read access, so it resolves for
+ * anyone a session is shared with — letting the info popover answer "whose
+ * session is this?" for chats shared into a workspace group. Disabled until a
+ * sessionId is known.
+ */
+export function useSessionOwner(sessionId: string | null) {
+  return useQuery({
+    queryKey: sessionOwnerKey(sessionId ?? ""),
+    queryFn: () => getSessionOwner(sessionId!),
     enabled: !!sessionId,
   });
 }

--- a/tests/e2e_ui/collaboration/test_sharing_journey.py
+++ b/tests/e2e_ui/collaboration/test_sharing_journey.py
@@ -47,6 +47,9 @@ _BUBBLE = '[data-testid="message-bubble"]'
 _LEVEL_READ = 1
 _LEVEL_EDIT = 2
 
+_AGENT_INFO_TRIGGER = '[data-testid="agent-info-trigger"]'
+_OWNER_ROW = '[data-testid="agent-info-session-owner"]'
+
 
 @dataclass
 class _SharedFixture:
@@ -224,3 +227,75 @@ def test_share_grant_downgrade_revoke_journey(
     finally:
         owner_ctx.close()
         bob_ctx.close()
+
+
+def _open_agent_info(page: Page) -> None:
+    """Open the header agent-info popover from a known-closed state.
+
+    Escape first so we re-open from closed rather than toggling shut, mirroring
+    ``agents/test_agent_info_popover.py``. The trigger is desktop-only
+    (``md:inline-flex``), which the e2e viewport satisfies.
+    """
+    page.keyboard.press("Escape")
+    trigger = page.locator(_AGENT_INFO_TRIGGER)
+    expect(trigger).to_be_visible(timeout=30_000)
+    trigger.click()
+
+
+def test_agent_info_popover_shows_session_owner(
+    browser: Browser,
+    live_server: str,
+    shared: _SharedFixture,
+) -> None:
+    """The info popover's Owner row surfaces the session owner per viewer.
+
+    Covers ``components/AgentInfo.tsx`` → ``AgentInfoContent``'s owner row
+    (``GET /v1/sessions/<id>/owner`` via ``useSessionOwner``):
+
+    * a collaborator (Bob, edit) sees the owner **without** the ``(you)`` hint;
+    * the owner (headerless ``local``) sees the same row **with** ``(you)``.
+
+    The expected owner string is read from the API, not hard-coded, so the
+    assertion doesn't bake in the headerless-owner sentinel.
+    """
+    sid = shared.session_id
+    owner_id = shared.owner.get(f"/v1/sessions/{sid}/owner").json()["owner"]
+    # The row only renders for a resolvable owner; a null here would mean
+    # permissions are off in this env (then the feature has nothing to show).
+    assert owner_id, "expected a resolvable session owner"
+    # The headerless browser context resolves to the same identity that owns the
+    # session, so the owner view is the "(you)" case.
+    assert shared.owner.get("/v1/me").json()["user_id"] == owner_id
+
+    # Bob needs at least read to open the session + popover.
+    shared.owner.put(
+        f"/v1/sessions/{sid}/permissions",
+        json={"user_id": shared.bob_email, "level": _LEVEL_EDIT},
+    ).raise_for_status()
+
+    # ── Collaborator (Bob): sees the owner, but not "(you)" ──────────
+    bob_ctx = _user_context(browser, shared.bob_email)
+    try:
+        bob_page = bob_ctx.new_page()
+        bob_page.goto(f"{live_server}/c/{sid}")
+        expect(bob_page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+        _open_agent_info(bob_page)
+        bob_row = bob_page.locator(_OWNER_ROW)
+        expect(bob_row).to_be_visible(timeout=15_000)
+        expect(bob_row).to_contain_text(owner_id)
+        expect(bob_row).not_to_contain_text("(you)")
+    finally:
+        bob_ctx.close()
+
+    # ── Owner (headerless): same row, now with "(you)" ───────────────
+    owner_ctx = browser.new_context()
+    try:
+        owner_page = owner_ctx.new_page()
+        owner_page.goto(f"{live_server}/c/{sid}")
+        expect(owner_page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+        _open_agent_info(owner_page)
+        owner_row = owner_page.locator(_OWNER_ROW)
+        expect(owner_row).to_be_visible(timeout=15_000)
+        expect(owner_row).to_contain_text("(you)")
+    finally:
+        owner_ctx.close()


### PR DESCRIPTION
## Related issue

## Summary

- Adds an **Owner** row to the agent info popover (the panel that already shows Session ID, cost, tools, and policies), so a viewer can see whose session a shared chat is.
- Reuses the existing-but-unused `GET /v1/sessions/{id}/owner` endpoint via a new `useSessionOwner` hook — no backend changes.
- The row is omitted in single-user mode (no owner / permissions off) and while loading, and appends `(you)` when the viewer owns the session.

## Test Plan

- `yarn test` — added 4 cases to `AgentInfo.test.tsx` (owner shown, `(you)` when viewer owns it, no `(you)` for others, row omitted when no owner). Re-ran AgentInfo (34), AppShell (73, covers the mobile dialog) and ChatHeader (5) suites — all pass.
- `tsc -b` and `oxlint` clean.

<img width="667" height="381" alt="Screenshot 2026-06-24 at 6 34 57 PM" src="https://github.com/user-attachments/assets/a7574855-5f02-4e6c-a311-ecc7aa42d566" />
<img width="580" height="483" alt="Screenshot 2026-06-24 at 6 35 07 PM" src="https://github.com/user-attachments/assets/f7f531b0-6157-4a81-bc61-a789081d92b5" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Owner display, the `(you)` self-match, and the omitted-when-absent path are all unit-tested. The underlying `/owner` endpoint already has backend coverage.

This pull request and its description were written by Isaac.
