### PR TITLE
fix(antigravity-native): unify the agy TUI and web mirror onto one cascade (#1156, #1158)

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -809,6 +809,7 @@ async def supervise_reader(
     stop: StopPredicate | None = None,
     detect_rotation_interval_s: float = _DEFAULT_ROTATION_INTERVAL_S,
     skip_cascade_ids: frozenset[str] = frozenset(),
+    committed_steps_out: list[int] | None = None,
 ) -> str | None:
     """
     Poll agy's RPC for trajectory steps and mirror them into the Omnigent session.
@@ -1017,6 +1018,13 @@ async def supervise_reader(
             with contextlib.suppress(asyncio.CancelledError):
                 await active
 
+    # Report how many committed steps (turns) this run mirrored for the bound
+    # cascade. The caller uses a count of 0 to distinguish "first TUI-minted
+    # cascade adoption" (the cold-start StartCascade phantom never took a turn)
+    # from a genuine ``/clear`` (the bound cascade HAD turns) — see
+    # :func:`run_reader_with_bridge`.
+    if committed_steps_out is not None:
+        committed_steps_out.append(len(state.seen))
     return rotation_holder[0] if rotation_holder else None
 
 
@@ -2074,6 +2082,43 @@ async def _fetch_session_snapshot(client: httpx.AsyncClient, session_id: str) ->
     return payload
 
 
+def _adopt_cascade_in_place(bridge_dir: Path, session_id: str, new_cascade_id: str) -> None:
+    """
+    Rebind the reader to a newly-minted cascade WITHOUT forking the session.
+
+    The cold-start ``StartCascade`` cascade is a headless placeholder the agy TUI
+    never displays; the agy TUI mints its OWN cascade on the first typed turn
+    (web turns are typed into the TUI — see
+    :meth:`omnigent.inner.antigravity_native_executor.AntigravityNativeExecutor._deliver`).
+    The first transition off a never-used bound cascade is therefore the
+    conversation STARTING, not a ``/clear`` — so adopt the new cascade in the
+    SAME Omnigent session by rewriting bridge state's conversation id (the reader
+    rebinds to it on the next :func:`supervise_reader` loop). No new session, no
+    terminal transfer — the user's current session simply starts mirroring the
+    turn they sent, instead of being stranded empty while a forked session fills.
+
+    A genuine ``/clear`` (the bound cascade HAD committed turns) still forks a
+    replacement session via :func:`_rotate_session_for_cascade`.
+
+    :param bridge_dir: The agy bridge directory the reader is using.
+    :param session_id: The Omnigent session to keep mirroring into.
+    :param new_cascade_id: agy's freshly TUI-minted cascade/conversation id.
+    """
+    write_bridge_state(
+        bridge_dir,
+        AntigravityNativeBridgeState(
+            session_id=session_id,
+            conversation_id=new_cascade_id,
+        ),
+    )
+    _logger.info(
+        "agy reader adopted the first TUI-minted cascade in place (no fork): "
+        "session=%s new_cascade=%s",
+        session_id,
+        new_cascade_id,
+    )
+
+
 async def _rotate_session_for_cascade(
     *,
     client: httpx.AsyncClient,
@@ -2325,19 +2370,33 @@ async def run_reader_with_bridge(
         # so a persistent rotation failure does not hot-loop detect→fail→detect.
         failed_rotations: set[str] = set()
         while True:
+            committed_steps_out: list[int] = []
             new_cascade_id = await supervise_reader(
                 bridge_dir,
                 current["session_id"],
                 client=client,
                 on_pending_interaction=_on_pending,
                 skip_cascade_ids=frozenset(failed_rotations),
+                committed_steps_out=committed_steps_out,
             )
             if new_cascade_id is None:
                 # The reader body ended on its own (cancelled / bounded stop): done.
                 return
-            # A /clear rotation was detected: move Omnigent ownership onto a fresh
-            # conversation bound to the new cascade, then rebind by re-entering
-            # supervise_reader (which rediscovers from the rewritten bridge state).
+            bound_committed_turns = committed_steps_out[0] if committed_steps_out else 0
+            if bound_committed_turns == 0:
+                # FIRST-CASCADE ADOPTION (not a /clear): the bound cascade was the
+                # cold-start StartCascade phantom (or any binding that never
+                # committed a turn), and the agy TUI minted its OWN cascade on the
+                # first typed turn. Adopt that cascade in the SAME Omnigent session
+                # so the user's current session starts mirroring — forking here
+                # would strand the current session empty while the turn filled a
+                # new one (the web/mobile UI watches the current session). The agy
+                # TUI and the web mirror then share ONE cascade (#1156/#1158).
+                _adopt_cascade_in_place(bridge_dir, current["session_id"], new_cascade_id)
+                continue
+            # GENUINE /clear (the bound cascade HAD turns): move Omnigent ownership
+            # onto a fresh conversation bound to the new cascade, then rebind by
+            # re-entering supervise_reader (which rediscovers from bridge state).
             new_session_id = await _rotate_session_for_cascade(
                 client=client,
                 old_session_id=current["session_id"],

--- a/omnigent/inner/antigravity_native_executor.py
+++ b/omnigent/inner/antigravity_native_executor.py
@@ -3,24 +3,30 @@
 ``omnigent antigravity`` runs the Antigravity ``agy`` CLI in a runner-owned tmux
 terminal and mirrors its transcript into the Omnigent session via the RPC read
 driver (the read path). This executor is the **write path**: when a turn is
-submitted from the Omnigent web/mobile UI it delivers the user's message to the
-running agy over its connect-RPC ``SendUserCascadeMessage``
-(:func:`omnigent.antigravity_native_rpc.send_user_cascade_message`). agy then
-runs a real model turn and its reply flows back through the read driver — exactly
-like the **claude**/**codex** native bridges (whose web turns also reach the
-agent over its own protocol, not by faking a transcript entry).
+submitted from the Omnigent web/mobile UI it delivers the user's message by
+TYPING IT INTO the agy TUI pane over tmux
+(:func:`omnigent.antigravity_native_bridge.inject_user_message_via_tui`), exactly
+like the **claude**/**codex** native bridges drive their vendor panes. agy then
+runs a real model turn and its reply flows back through the read driver.
 
-**Why ``SendUserCascadeMessage``, not ``SendAgentMessage`` or tmux send-keys.**
-agy exposes a connect-RPC ``SendAgentMessage``, but a turn delivered that way is
-recorded as a ``SYSTEM_MESSAGE`` ("not actually sent by the user"), NOT a
-``USER_INPUT`` step — so the read driver (which mirrors user turns from
-``USER_INPUT``) would never commit the user's message. ``SendUserCascadeMessage``
-records a real ``CORTEX_STEP_TYPE_USER_INPUT`` step with
-``metadata.source == CORTEX_STEP_SOURCE_USER_EXPLICIT`` (byte-for-byte what the
-read driver keys on), matching claude/codex native (both commit the user message
-before its assistant reply) — and replaces the legacy tmux send-keys path and its
-attended-TUI swallow hazard (verified against agy 1.0.10; see design §10.1). The
-same path serves mid-turn steering.
+**Why typing into the TUI, not headless ``SendUserCascadeMessage`` RPC
+(#1156/#1158).** Typing into the TUI gives true parity with claude/codex native:
+the turn RENDERS in the agy TUI AND lands on the SAME cascade the TUI displays,
+so the agy TUI and the Omnigent web mirror share ONE conversation in both
+directions. The prior headless RPC path delivered onto a separate
+``StartCascade`` cascade the TUI never showed — so the agy TUI never echoed web
+turns (#1156) and TUI-typed turns never mirrored to the web (#1158). agy records
+a TUI-typed turn as a real ``CORTEX_STEP_TYPE_USER_INPUT`` step (what the read
+driver keys on); the careful inject (draft-clear + bracketed paste +
+footer-verified submit) handles the attended-TUI race. RPC remains the
+read/control transport only (``StreamAgentStateUpdates`` /
+``GetAllCascadeTrajectories`` / ``CancelCascadeSteps`` /
+``HandleCascadeUserInteraction``). The same path serves mid-turn steering.
+
+.. note:: The now-unused RPC-delivery helpers below
+   (``_resolve_ready_cascade_id`` / ``_resolve_plan_model`` / ``_wait_for_state``
+   and the model-resolution module functions) are retained pending a focused
+   follow-up cleanup; the live write path is :meth:`_deliver` → the TUI inject.
 
 Because agy owns its own model loop and emits output via the read path, this
 executor:
@@ -66,16 +72,15 @@ from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
     ANTIGRAVITY_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     AntigravityNativeBridgeState,
+    inject_user_message_via_tui,
     is_placeholder_conversation_id,
     read_bridge_state,
 )
 from omnigent.antigravity_native_rpc import (
-    AntigravityRpcError,
     cancel_cascade_steps,
     get_available_models,
     get_trajectory_steps,
     resolve_language_server_port,
-    send_user_cascade_message,
 )
 from omnigent.inner.executor import (
     EnqueuedContent,
@@ -257,19 +262,36 @@ class AntigravityNativeExecutor(Executor):
 
     async def _deliver(self, text: str) -> str | None:
         """
-        Deliver one message to agy over ``SendUserCascadeMessage``.
+        Deliver one message to agy by typing it into the agy TUI.
 
         Shared by :meth:`run_turn` (initiating message) and
-        :meth:`enqueue_session_message` (mid-turn steering): agy records either as
-        a real ``USER_INPUT`` turn, so the two need no special-casing. Resolves
-        the cascade id (waiting for the runner to mint it on a fresh session —
-        see :meth:`_resolve_ready_cascade_id`), the connect-RPC port, and the
-        per-turn model (:meth:`_resolve_plan_model`), then sends.
+        :meth:`enqueue_session_message` (mid-turn steering). The turn is injected
+        into the agy TUI pane over tmux (bracketed paste + Enter — see
+        :func:`omnigent.antigravity_native_bridge.inject_user_message_via_tui`)
+        rather than delivered over headless ``SendUserCascadeMessage`` RPC.
+
+        Typing into the TUI is what gives antigravity-native true parity with
+        claude/codex native (#1156/#1158): the turn renders in the agy TUI AND
+        lands on the SAME cascade the TUI displays, so the read driver mirrors a
+        single, unified conversation in both directions. The headless RPC path,
+        by contrast, delivered onto a separate ``StartCascade`` cascade the TUI
+        never showed — splitting the TUI and the web mirror into two cascades
+        (the agy TUI never echoed web turns; TUI-typed turns never mirrored).
+        agy records a TUI-typed turn as a real ``CORTEX_STEP_TYPE_USER_INPUT``
+        step, exactly what the read driver keys on; the careful inject
+        (draft-clear + bracketed paste + footer-verified submit) handles the
+        attended-TUI race. RPC remains the read/control transport
+        (``StreamAgentStateUpdates`` / ``GetAllCascadeTrajectories`` /
+        ``CancelCascadeSteps`` / ``HandleCascadeUserInteraction``).
+
+        Unlike the RPC path, this needs no cascade id, port, or per-turn model
+        resolution up front: the TUI owns its cascade and its selected model, and
+        agy mints the cascade on the first typed turn (which the read driver then
+        discovers/binds — see :mod:`omnigent.antigravity_native_reader`).
 
         :param text: User message text to deliver.
-        :returns: ``None`` on success, or a human-readable error string
-            describing why the message could not be delivered (including agy's own
-            message on a model/validation error).
+        :returns: ``None`` on success, or a human-readable error string when the
+            turn could not be delivered to the TUI (e.g. the agy pane exited).
         """
         async with self._send_lock:
             # The runner seeds bridge state before launching the terminal, so a
@@ -280,46 +302,20 @@ class AntigravityNativeExecutor(Executor):
                 return "Antigravity native bridge state is missing"
             if not _session_is_active(state.session_id, self._request_session_id):
                 return "Antigravity native session is no longer active"
-            cascade_id = await self._resolve_ready_cascade_id(state)
-            if cascade_id is None:
-                # The runner mints agy's real conversation on cold-start (Task
-                # 11); until it lands there is no live cascade to RPC. Pure-RPC
-                # turn-send no longer types into the TUI to trigger minting, so a
-                # fresh session's first turn waits then errors "not ready" rather
-                # than delivering to the ``agy_conv_*`` placeholder.
-                return (
-                    "Antigravity native conversation is not ready yet "
-                    "(agy has not registered a conversation — is the agy terminal "
-                    "attached and running?)"
-                )
-            port = await asyncio.to_thread(resolve_language_server_port, cascade_id)
-            if port is None:
-                return (
-                    "Could not reach the agy connect-RPC server for conversation "
-                    f"{cascade_id} (is the agy terminal still running?)"
-                )
-            plan_model = await self._resolve_plan_model(port, cascade_id)
-            if plan_model is None:
-                return (
-                    "Could not resolve an agy model for the turn "
-                    "(no current model to echo and no recommended model available)"
-                )
             try:
                 await asyncio.to_thread(
-                    send_user_cascade_message,
-                    port,
-                    cascade_id,
-                    text,
-                    plan_model=plan_model,
+                    inject_user_message_via_tui,
+                    self._bridge_dir,
+                    content=text,
                 )
-            except AntigravityRpcError as exc:
-                # Surface agy's own message (e.g. a model/validation error) rather
-                # than a fake success — the read driver mirrors only real turns.
-                return f"agy rejected the turn: {exc}"
+            except RuntimeError as exc:
+                # The TUI pane is gone / never advertised / the submit never
+                # started a turn. Surface it so the UI can prompt a restart
+                # rather than reporting a fake success the mirror never fills.
+                return f"Could not deliver the turn to the agy TUI: {exc}"
             _logger.info(
-                "antigravity native delivered turn via RPC: conversation=%s model=%s",
-                cascade_id,
-                plan_model,
+                "antigravity native delivered turn via TUI injection (session=%s)",
+                state.session_id,
             )
             return None
 

--- a/tests/inner/test_antigravity_native_executor.py
+++ b/tests/inner/test_antigravity_native_executor.py
@@ -1,20 +1,14 @@
 """Tests for the native Antigravity (agy) executor bridge (web-turn injection).
 
-These pin the write path: a web/mobile turn is delivered to the running agy over
-its connect-RPC ``SendUserCascadeMessage`` (``send_user_cascade_message``, mocked
-here), which agy records as a real ``USER_INPUT`` step; agy's reply is mirrored
-back by the read driver — so the executor yields a ``TurnComplete`` with no text
-rather than fabricating a reply. Delivery is RPC for EVERY turn (the old tmux
-send-keys path is retired). The RPC wire shapes are exercised in
-``test_antigravity_native_rpc``; here the RPC client is stubbed so the tests
-assert the executor's wiring — what text + resolved model it delivers, how it
-resolves the cascade id / port, and how it maps success/failure to events.
-
-Model resolution (two-tier, see design §10.1/§10.4): the executor echoes agy's
-CURRENT model from the latest ``USER_INPUT`` step's
-``userInput.userConfig.plannerConfig.planModel`` (via ``get_trajectory_steps``);
-on the first turn / when not yet observable it falls back to the ``recommended``
-entry from ``get_available_models``.
+These pin the write path: a web/mobile turn is delivered to the running agy by
+TYPING IT INTO the agy TUI pane over tmux (``inject_user_message_via_tui``,
+mocked here), which agy records as a real ``USER_INPUT`` step on the cascade the
+TUI displays; agy's reply is mirrored back by the read driver — so the executor
+yields a ``TurnComplete`` with no text rather than fabricating a reply. Typing
+into the TUI (not headless ``SendUserCascadeMessage`` RPC) is what unifies the
+agy TUI and the web mirror onto ONE cascade, giving claude/codex-native parity
+(#1156/#1158). Here the inject is stubbed so the tests assert the executor's
+wiring — what text it delivers and how it maps success/failure to events.
 """
 
 from __future__ import annotations
@@ -29,7 +23,6 @@ from omnigent.antigravity_native_bridge import (
     AntigravityNativeBridgeState,
     write_bridge_state,
 )
-from omnigent.antigravity_native_rpc import AntigravityRpcError
 from omnigent.inner.antigravity_native_executor import AntigravityNativeExecutor
 from omnigent.inner.executor import ExecutorError, ExecutorEvent, TurnComplete
 
@@ -93,80 +86,38 @@ def _steps_with_model(model: str) -> list[dict[str, object]]:
 
 
 @pytest.fixture
-def sent(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+def injected(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
     """
-    Stub the RPC turn-send + discovery, recording what the executor delivers.
+    Stub the agy TUI inject, recording each turn the executor delivers.
 
-    Wires the executor's whole RPC surface to in-memory fakes:
-
-    * ``resolve_language_server_port`` -> ``rec["port"]`` (``None`` models "no
-      agy resolvable").
-    * ``get_trajectory_steps`` -> ``rec["steps"]`` (the model-echo source).
-    * ``get_available_models`` -> ``rec["models"]`` (the recommended fallback).
-    * ``send_user_cascade_message`` records each ``{cascade_id, text,
-      plan_model}`` call; set ``rec["send_raise"]`` to raise it.
+    The write path types the turn into the agy TUI pane via
+    ``inject_user_message_via_tui``; this records every ``{bridge_dir, content}``
+    call and, when ``rec["raise"]`` is set, raises it (modeling a dead/unavailable
+    TUI pane).
 
     :param monkeypatch: pytest monkeypatch fixture.
-    :returns: A mutable dict of fakes + recordings (see keys above).
+    :returns: A mutable dict: ``calls`` (recorded injects) + ``raise`` (optional).
     """
-    rec: dict[str, object] = {
-        "port": _PORT,
-        "steps": _steps_with_model(_ECHOED_MODEL),
-        "models": {
-            "models": {
-                "k1": {"model": _RECOMMENDED_MODEL, "displayName": "Rec", "recommended": True},
-                "k2": {"model": "MODEL_OTHER", "displayName": "Other", "recommended": False},
-            }
-        },
-        "send_raise": None,
-        "sends": [],
-        "trajectory_calls": [],
-        "models_calls": 0,
-    }
+    rec: dict[str, object] = {"calls": [], "raise": None}
 
-    def _resolve_port(conversation_id: str) -> int | None:
-        del conversation_id
-        port = rec["port"]
-        return port if isinstance(port, int) else None
-
-    def _get_steps(port: int, cascade_id: str) -> list[dict[str, object]]:
-        calls = rec["trajectory_calls"]
+    def _inject(bridge_dir: Path, *, content: str, **_kw: object) -> None:
+        calls = rec["calls"]
         assert isinstance(calls, list)
-        calls.append({"port": port, "cascade_id": cascade_id})
-        steps = rec["steps"]
-        return steps if isinstance(steps, list) else []
-
-    def _get_models(port: int) -> dict[str, object]:
-        del port
-        prior = rec["models_calls"]
-        assert isinstance(prior, int)
-        rec["models_calls"] = prior + 1  # running tally
-        models = rec["models"]
-        return models if isinstance(models, dict) else {}
-
-    def _send(port: int, cascade_id: str, text: str, *, plan_model: str) -> None:
-        sends = rec["sends"]
-        assert isinstance(sends, list)
-        sends.append(
-            {"port": port, "cascade_id": cascade_id, "text": text, "plan_model": plan_model}
-        )
-        exc = rec["send_raise"]
+        calls.append({"bridge_dir": bridge_dir, "content": content})
+        exc = rec["raise"]
         if exc is not None:
             assert isinstance(exc, BaseException)
             raise exc
 
-    monkeypatch.setattr(executor_mod, "resolve_language_server_port", _resolve_port)
-    monkeypatch.setattr(executor_mod, "get_trajectory_steps", _get_steps)
-    monkeypatch.setattr(executor_mod, "get_available_models", _get_models)
-    monkeypatch.setattr(executor_mod, "send_user_cascade_message", _send)
+    monkeypatch.setattr(executor_mod, "inject_user_message_via_tui", _inject)
     return rec
 
 
-def _sends(rec: dict[str, object]) -> list[dict[str, object]]:
-    """Return the recorded ``send_user_cascade_message`` calls, in order."""
-    sends = rec["sends"]
-    assert isinstance(sends, list)
-    return sends
+def _injected(rec: dict[str, object]) -> list[dict[str, object]]:
+    """Return the recorded TUI inject calls, in order."""
+    calls = rec["calls"]
+    assert isinstance(calls, list)
+    return calls
 
 
 async def _run(executor: AntigravityNativeExecutor, text: str) -> list[ExecutorEvent]:
@@ -215,74 +166,34 @@ def test_supports_live_message_queue(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# run_turn — delivery (RPC turn-send)
+# run_turn — delivery (TUI injection)
 # ---------------------------------------------------------------------------
 
 
-def test_run_turn_sends_via_rpc_and_completes(tmp_path: Path, sent: dict[str, object]) -> None:
+def test_run_turn_delivers_via_tui_and_completes(
+    tmp_path: Path, injected: dict[str, object]
+) -> None:
     """
-    ``run_turn`` sends the user text over RPC and yields a text-less TurnComplete.
+    ``run_turn`` types the user text into the agy TUI and yields a text-less TurnComplete.
 
-    The executor resolves the cascade id (bridge state) + port, resolves the
-    model (echoing the latest USER_INPUT step), calls
-    ``send_user_cascade_message``, and yields ``TurnComplete`` with
-    ``response=None`` — the read driver mirrors agy's actual reply, so
-    fabricating text here would duplicate it.
+    The turn is injected into the TUI pane (#1156/#1158) — agy records it as a
+    real USER_INPUT on the cascade the TUI displays and the read driver mirrors
+    the reply, so the executor yields ``TurnComplete`` with ``response=None``
+    (fabricating text here would duplicate the mirrored reply).
     """
     _seed_state(tmp_path)
     events = asyncio.run(_run(_executor(tmp_path), "what is 2+2?"))
-    assert _sends(sent) == [
-        {
-            "port": _PORT,
-            "cascade_id": _CONVERSATION_ID,
-            "text": "what is 2+2?",
-            "plan_model": _ECHOED_MODEL,
-        }
-    ]
+    calls = _injected(injected)
+    assert len(calls) == 1
+    assert calls[0]["content"] == "what is 2+2?"
+    assert calls[0]["bridge_dir"] == tmp_path
     assert len(events) == 1
     assert isinstance(events[0], TurnComplete)
     assert events[0].response is None
 
 
-def test_run_turn_echoes_current_model_from_trajectory(
-    tmp_path: Path, sent: dict[str, object]
-) -> None:
-    """
-    The plan model is echoed from the latest USER_INPUT step (tier-1 resolution).
-
-    The executor must reflect the user's current TUI/session model without new
-    plumbing, so it reads the most recent USER_INPUT step's ``planModel`` and
-    does NOT consult the catalog when that is available.
-    """
-    _seed_state(tmp_path)
-    asyncio.run(_run(_executor(tmp_path), "hi"))
-    assert _sends(sent)[0]["plan_model"] == _ECHOED_MODEL
-    assert sent["models_calls"] == 0, "must not hit the catalog when the model echoes"
-
-
-def test_run_turn_falls_back_to_recommended_model(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    With no observable current model, the recommended catalog entry is used (tier-2).
-
-    On a first turn there is no prior USER_INPUT step to echo, so the executor
-    must resolve the model from ``get_available_models`` by picking the
-    ``recommended`` entry — agy rejects a turn with no ``planModel``.
-    """
-    _seed_state(tmp_path)
-    sent["steps"] = []  # no USER_INPUT step yet -> nothing to echo
-    asyncio.run(_run(_executor(tmp_path), "first turn"))
-    assert _sends(sent)[0]["plan_model"] == _RECOMMENDED_MODEL
-    assert sent["models_calls"] == 1
-
-
-def test_run_turn_flattens_content_blocks(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    Content-block user messages are flattened to text before delivery.
-
-    A web turn arrives as ``input_text`` blocks; the executor must join their
-    text (and drop image/file blocks the text turn cannot carry) so agy receives
-    the typed prompt.
-    """
+def test_run_turn_flattens_content_blocks(tmp_path: Path, injected: dict[str, object]) -> None:
+    """Content-block user messages are flattened to text before injection."""
     _seed_state(tmp_path)
 
     async def _drive() -> list[ExecutorEvent]:
@@ -305,17 +216,12 @@ def test_run_turn_flattens_content_blocks(tmp_path: Path, sent: dict[str, object
         ]
 
     events = asyncio.run(_drive())
-    assert _sends(sent)[0]["text"] == "line one\nline two"
+    assert _injected(injected)[0]["content"] == "line one\nline two"
     assert isinstance(events[0], TurnComplete)
 
 
-def test_run_turn_uses_latest_user_message(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    Only the latest user message is delivered (history is not replayed).
-
-    agy already holds the conversation history; re-sending older turns would
-    duplicate them. The executor must pick the most recent user message.
-    """
+def test_run_turn_uses_latest_user_message(tmp_path: Path, injected: dict[str, object]) -> None:
+    """Only the latest user message is delivered (history is not replayed)."""
     _seed_state(tmp_path)
 
     async def _drive() -> list[ExecutorEvent]:
@@ -333,16 +239,11 @@ def test_run_turn_uses_latest_user_message(tmp_path: Path, sent: dict[str, objec
         ]
 
     asyncio.run(_drive())
-    assert _sends(sent)[0]["text"] == "new question"
+    assert _injected(injected)[0]["content"] == "new question"
 
 
-def test_run_turn_no_user_text_errors(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    A turn with no user text yields an ExecutorError without sending.
-
-    Guards against sending an empty message to agy; there is nothing to send, so
-    the executor reports an error instead.
-    """
+def test_run_turn_no_user_text_errors(tmp_path: Path, injected: dict[str, object]) -> None:
+    """A turn with no user text yields an ExecutorError without injecting."""
     _seed_state(tmp_path)
 
     async def _drive() -> list[ExecutorEvent]:
@@ -356,78 +257,9 @@ def test_run_turn_no_user_text_errors(tmp_path: Path, sent: dict[str, object]) -
         ]
 
     events = asyncio.run(_drive())
-    assert _sends(sent) == []
+    assert _injected(injected) == []
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
-
-
-# ---------------------------------------------------------------------------
-# run_turn — first-turn (placeholder) readiness (Option A: pure RPC)
-# ---------------------------------------------------------------------------
-
-
-def test_run_turn_first_turn_waits_for_discovered_id(
-    tmp_path: Path, sent: dict[str, object], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """
-    On a placeholder (fresh) session, the turn waits for the real id, then sends.
-
-    Under pure-RPC turn-send the executor never types into the TUI to mint the
-    conversation (the runner does that — Task 11). It instead waits for the
-    forwarder/runner to overwrite the ``agy_conv_*`` placeholder with agy's real
-    id, then sends to that id. Modeled here by flipping bridge state to the real
-    id after the first read.
-    """
-    _seed_state(tmp_path, conversation_id=_PLACEHOLDER_ID)
-    monkeypatch.setattr(executor_mod, "_STATE_WAIT_INTERVAL_S", 0.0)
-    flip = {"done": False}
-
-    def _read(bridge_dir: Path) -> AntigravityNativeBridgeState | None:
-        del bridge_dir
-        # First read returns the placeholder; subsequent reads return the real id
-        # (as if the runner discovered + persisted it).
-        if not flip["done"]:
-            flip["done"] = True
-            return AntigravityNativeBridgeState(
-                session_id="conv_test", conversation_id=_PLACEHOLDER_ID
-            )
-        return AntigravityNativeBridgeState(
-            session_id="conv_test", conversation_id=_CONVERSATION_ID
-        )
-
-    monkeypatch.setattr(executor_mod, "read_bridge_state", _read)
-    events = asyncio.run(_run(_executor(tmp_path), "first hello"))
-    assert _sends(sent) == [
-        {
-            "port": _PORT,
-            "cascade_id": _CONVERSATION_ID,
-            "text": "first hello",
-            "plan_model": _ECHOED_MODEL,
-        }
-    ]
-    assert len(events) == 1
-    assert isinstance(events[0], TurnComplete)
-
-
-def test_run_turn_first_turn_not_ready_errors(
-    tmp_path: Path, sent: dict[str, object], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """
-    If the real id never lands, the turn surfaces a clear "not ready" error.
-
-    Pure-RPC turn-send cannot deliver to the ``agy_conv_*`` placeholder, so when
-    the runner has not yet minted agy's real conversation within the wait window
-    the executor errors gracefully (no crash, no send) rather than RPC-ing a
-    placeholder. The wait is shortened so the test does not block.
-    """
-    _seed_state(tmp_path, conversation_id=_PLACEHOLDER_ID)
-    monkeypatch.setattr(executor_mod, "_STATE_WAIT_ATTEMPTS", 1)
-    monkeypatch.setattr(executor_mod, "_STATE_WAIT_INTERVAL_S", 0.0)
-    events = asyncio.run(_run(_executor(tmp_path), "hi"))
-    assert _sends(sent) == []
-    assert len(events) == 1
-    assert isinstance(events[0], ExecutorError)
-    assert "not ready" in events[0].message
 
 
 # ---------------------------------------------------------------------------
@@ -435,71 +267,43 @@ def test_run_turn_first_turn_not_ready_errors(
 # ---------------------------------------------------------------------------
 
 
-def test_run_turn_missing_state_errors(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    With no bridge state, ``run_turn`` yields an ExecutorError (no send).
-
-    The runner seeds bridge state before launching the terminal, so a missing
-    state file means broken wiring and the executor reads it once and errors
-    immediately (no polling, no send).
-    """
+def test_run_turn_missing_state_errors(tmp_path: Path, injected: dict[str, object]) -> None:
+    """With no bridge state, ``run_turn`` yields an ExecutorError (no inject)."""
     events = asyncio.run(_run(_executor(tmp_path), "hi"))
-    assert _sends(sent) == []
+    assert _injected(injected) == []
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
     assert "bridge state is missing" in events[0].message
 
 
 def test_run_turn_inactive_session_errors(
-    tmp_path: Path, sent: dict[str, object], monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """
-    A mismatched request session id blocks delivery with an ExecutorError.
-
-    The harness only steers the conversation it was spawned for; if the bridge
-    state names a different session, delivery must be refused.
-    """
+    """A mismatched request session id blocks delivery with an ExecutorError."""
     _seed_state(tmp_path)
     executor = _executor(tmp_path)
     monkeypatch.setattr(executor, "_request_session_id", "conv_other")
     events = asyncio.run(_run(executor, "hi"))
-    assert _sends(sent) == []
+    assert _injected(injected) == []
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
     assert "no longer active" in events[0].message
 
 
-def test_run_turn_no_port_errors(tmp_path: Path, sent: dict[str, object]) -> None:
+def test_run_turn_tui_inject_error_surfaces(tmp_path: Path, injected: dict[str, object]) -> None:
     """
-    When no agy connect-RPC port resolves, ``run_turn`` errors (no send).
+    A ``RuntimeError`` from the TUI inject surfaces as an ExecutorError.
 
-    The turn cannot be delivered to an agy that cannot be located on the loopback
-    socket table, so the executor reports a clear error rather than a false
-    success.
-    """
-    _seed_state(tmp_path)
-    sent["port"] = None
-    events = asyncio.run(_run(_executor(tmp_path), "hi"))
-    assert _sends(sent) == []
-    assert len(events) == 1
-    assert isinstance(events[0], ExecutorError)
-
-
-def test_run_turn_rpc_error_surfaces(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    An ``AntigravityRpcError`` from the turn-send surfaces as an ExecutorError.
-
-    A model/validation error (e.g. "neither PlanModel nor RequestedModel
-    specified") or a transport failure from ``send_user_cascade_message`` must be
-    propagated — carrying agy's message — not silently swallowed into a fake
-    success.
+    The inject raises when the agy pane is gone / never advertised / the submit
+    never started a turn; the executor must surface it (so the UI can prompt a
+    restart) rather than report a fake success the mirror never fills.
     """
     _seed_state(tmp_path)
-    sent["send_raise"] = AntigravityRpcError("neither PlanModel nor RequestedModel specified")
+    injected["raise"] = RuntimeError("the agy terminal is no longer running (the TUI exited)")
     events = asyncio.run(_run(_executor(tmp_path), "hi"))
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
-    assert "neither PlanModel nor RequestedModel specified" in events[0].message
+    assert "the agy TUI" in events[0].message
 
 
 # ---------------------------------------------------------------------------
@@ -507,44 +311,30 @@ def test_run_turn_rpc_error_surfaces(tmp_path: Path, sent: dict[str, object]) ->
 # ---------------------------------------------------------------------------
 
 
-def test_enqueue_session_message_delivers(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    ``enqueue_session_message`` sends the steer via the same RPC path and returns True.
-
-    Mid-turn web steering reuses the RPC turn-send, so a successful enqueue must
-    deliver the content and report success.
-    """
+def test_enqueue_session_message_delivers(tmp_path: Path, injected: dict[str, object]) -> None:
+    """``enqueue_session_message`` injects the steer via the same TUI path and returns True."""
     _seed_state(tmp_path)
     result = asyncio.run(_executor(tmp_path).enqueue_session_message("main", "steer me"))
     assert result is True
-    assert _sends(sent)[0]["text"] == "steer me"
+    assert _injected(injected)[0]["content"] == "steer me"
 
 
 def test_enqueue_session_message_empty_returns_false(
-    tmp_path: Path, sent: dict[str, object]
+    tmp_path: Path, injected: dict[str, object]
 ) -> None:
-    """
-    Enqueuing empty content returns False without sending.
-
-    There is nothing to steer with, so the executor reports it did nothing.
-    """
+    """Enqueuing empty content returns False without injecting."""
     _seed_state(tmp_path)
     result = asyncio.run(_executor(tmp_path).enqueue_session_message("main", ""))
     assert result is False
-    assert _sends(sent) == []
+    assert _injected(injected) == []
 
 
-def test_enqueue_session_message_rpc_failure_returns_false(
-    tmp_path: Path, sent: dict[str, object]
+def test_enqueue_session_message_inject_failure_returns_false(
+    tmp_path: Path, injected: dict[str, object]
 ) -> None:
-    """
-    A failed RPC send during enqueue returns False.
-
-    Mid-turn steering is best-effort; a failed turn-send must be reported as not
-    delivered.
-    """
+    """A failed TUI inject during enqueue returns False."""
     _seed_state(tmp_path)
-    sent["send_raise"] = AntigravityRpcError("boom")
+    injected["raise"] = RuntimeError("boom")
     result = asyncio.run(_executor(tmp_path).enqueue_session_message("main", "steer"))
     assert result is False
 
@@ -760,23 +550,6 @@ def test_recommended_model_none_when_absent() -> None:
     assert _recommended_model({}) is None
 
 
-def test_run_turn_no_model_resolvable_errors(tmp_path: Path, sent: dict[str, object]) -> None:
-    """
-    When neither tier yields a model, ``run_turn`` errors without sending.
-
-    agy requires a ``planModel`` per turn; if the trajectory has no model to echo
-    AND the catalog has no recommended entry, the executor cannot construct a
-    valid turn and must surface an error rather than send an invalid request.
-    """
-    _seed_state(tmp_path)
-    sent["steps"] = []
-    sent["models"] = {"models": {}}
-    events = asyncio.run(_run(_executor(tmp_path), "hi"))
-    assert _sends(sent) == []
-    assert len(events) == 1
-    assert isinstance(events[0], ExecutorError)
-
-
 # ---------------------------------------------------------------------------
 # construction
 # ---------------------------------------------------------------------------
@@ -802,17 +575,17 @@ def test_init_requires_bridge_dir_env_when_unset(monkeypatch: pytest.MonkeyPatch
 
 @pytest.mark.parametrize("effort", ["low", "medium", "high"])
 def test_run_turn_valid_effort_is_accepted(
-    tmp_path: Path, sent: dict[str, object], effort: str
+    tmp_path: Path, injected: dict[str, object], effort: str
 ) -> None:
     """
     A valid Antigravity effort level (low/medium/high) does not block delivery.
 
     agy's Gemini backend supports these three levels. A valid effort in the
     config must not surface as an error — the executor validates it and proceeds
-    to send.
+    to inject the turn into the TUI.
 
     :param tmp_path: Bridge directory (injected by pytest).
-    :param sent: Stub recording RPC turn-sends.
+    :param injected: Stub recording TUI injects.
     :param effort: One valid effort level to test.
     :returns: None.
     """
@@ -838,7 +611,7 @@ def test_run_turn_valid_effort_is_accepted(
 
 @pytest.mark.parametrize("bad_effort", ["xhigh", "max", "none", "minimal"])
 def test_run_turn_unsupported_effort_surfaces_error(
-    tmp_path: Path, sent: dict[str, object], bad_effort: str
+    tmp_path: Path, injected: dict[str, object], bad_effort: str
 ) -> None:
     """
     An effort level unsupported by Antigravity/Gemini yields an ExecutorError.
@@ -849,7 +622,7 @@ def test_run_turn_unsupported_effort_surfaces_error(
     mismatch.
 
     :param tmp_path: Bridge directory.
-    :param sent: Stub recording RPC turn-sends.
+    :param injected: Stub recording TUI injects.
     :param bad_effort: An effort level that is invalid for Antigravity.
     :returns: None.
     """
@@ -869,7 +642,7 @@ def test_run_turn_unsupported_effort_surfaces_error(
         ]
 
     events = asyncio.run(_drive())
-    assert _sends(sent) == [], "delivery must not happen on bad effort"
+    assert _injected(injected) == [], "delivery must not happen on bad effort"
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
     assert bad_effort in events[0].message

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -2856,9 +2856,15 @@ async def test_run_reader_with_bridge_rebinds_after_rotation(
         client: object,
         on_pending_interaction: object,
         skip_cascade_ids: frozenset[str] = frozenset(),
+        committed_steps_out: list[int] | None = None,
         **_kwargs: object,
     ) -> str | None:
         supervise_session_ids.append(session_id)
+        # Model a GENUINE /clear: the bound cascade HAD committed turns, so the
+        # loop FORKS a replacement session (not the first-cascade adopt-in-place
+        # path, which fires only when the bound cascade committed zero turns).
+        if committed_steps_out is not None:
+            committed_steps_out.append(3)
         # First run detects a rotation; the rebound second run ends normally.
         return new_cascade if len(supervise_session_ids) == 1 else None
 
@@ -2896,6 +2902,72 @@ async def test_run_reader_with_bridge_rebinds_after_rotation(
 
 
 @pytest.mark.asyncio
+async def test_run_reader_with_bridge_adopts_first_cascade_in_place(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-cascade adoption: a rotation off a ZERO-turn bound cascade rebinds in place.
+
+    The cold-start ``StartCascade`` cascade is a headless placeholder the agy TUI
+    never shows; the TUI mints its OWN cascade on the first typed turn. That first
+    transition is the conversation STARTING, not a ``/clear`` — so the loop must
+    adopt the new cascade in the SAME Omnigent session (rewrite bridge state, NO
+    fork) so the user's current session starts mirroring (#1156/#1158). Modeled by
+    a supervise_reader that reports ZERO committed turns on the rotation run.
+    """
+    new_cascade = "11111111-2222-3333-4444-555555555555"
+    supervise_session_ids: list[str] = []
+    rotate_calls: list[str] = []
+
+    async def _fake_supervise(
+        bridge_dir: Path,
+        session_id: str,
+        *,
+        client: object,
+        on_pending_interaction: object,
+        skip_cascade_ids: frozenset[str] = frozenset(),
+        committed_steps_out: list[int] | None = None,
+        **_kwargs: object,
+    ) -> str | None:
+        supervise_session_ids.append(session_id)
+        # The bound cascade committed ZERO turns → first-cascade adoption.
+        if committed_steps_out is not None:
+            committed_steps_out.append(0)
+        return new_cascade if len(supervise_session_ids) == 1 else None
+
+    async def _fake_rotate(**_kwargs: object) -> str | None:
+        rotate_calls.append("forked")  # must NOT happen on adopt-in-place
+        return "conv_should_not_be_used"
+
+    monkeypatch.setattr(reader, "supervise_reader", _fake_supervise)
+    monkeypatch.setattr(reader, "_rotate_session_for_cascade", _fake_rotate)
+    monkeypatch.setattr(
+        "omnigent.antigravity_native_interactions.bridge_interaction",
+        lambda *a, **k: None,
+    )
+
+    bridge_dir = _bridge_dir(tmp_path)
+    await reader.run_reader_with_bridge(
+        base_url="http://test",
+        headers={},
+        auth=None,
+        session_id=_SESSION_ID,
+        bridge_dir=bridge_dir,
+    )
+
+    # NO fork: _rotate_session_for_cascade must never be called.
+    assert rotate_calls == []
+    # Both supervise runs stay on the SAME (original) session id; the second
+    # rebinds to the adopted cascade via the rewritten bridge state.
+    assert supervise_session_ids == [_SESSION_ID, _SESSION_ID]
+    # Bridge state now names the adopted cascade under the SAME session.
+    state = reader.read_bridge_state(bridge_dir)
+    assert state is not None
+    assert state.session_id == _SESSION_ID
+    assert state.conversation_id == new_cascade
+
+
+@pytest.mark.asyncio
 async def test_run_reader_with_bridge_keeps_old_binding_when_rotation_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2917,9 +2989,14 @@ async def test_run_reader_with_bridge_keeps_old_binding_when_rotation_fails(
         client: object,
         on_pending_interaction: object,
         skip_cascade_ids: frozenset[str] = frozenset(),
+        committed_steps_out: list[int] | None = None,
         **_kwargs: object,
     ) -> str | None:
         supervise_calls.append((session_id, skip_cascade_ids))
+        # Genuine /clear (bound cascade had committed turns) → the loop attempts a
+        # FORK (which fails here), not the zero-turn adopt-in-place path.
+        if committed_steps_out is not None:
+            committed_steps_out.append(2)
         # First run detects the rotation; the second (post-failure) run ends.
         return failed_cascade if len(supervise_calls) == 1 else None
 


### PR DESCRIPTION
## Summary

Fixes #1156 and #1158 with one change: converge antigravity-native onto the agy **TUI as the single source of truth**, matching `claude`/`codex` native.

**Root cause (shared):** web turns were delivered over headless `SendUserCascadeMessage` RPC onto a `StartCascade`-minted cascade the agy TUI never displays, while the agy TUI ran on its **own** cascade. The two were desynced in both directions:
- web turns never echoed in the agy TUI → **#1156**
- turns typed directly into the agy TUI never mirrored to the web → **#1158**

## The fix

**Write path** (`AntigravityNativeExecutor._deliver`): deliver web/mobile turns by **typing them into the agy TUI pane** (`inject_user_message_via_tui`) instead of headless RPC. The turn now renders in the TUI **and** lands on the cascade the TUI displays; agy records it as a real `USER_INPUT` (what the read driver keys on). RPC remains the read/control transport only (`StreamAgentStateUpdates` / `GetAllCascadeTrajectories` / `CancelCascadeSteps` / `HandleCascadeUserInteraction`).

**Read path** (`run_reader_with_bridge`): when the bound cascade committed **no** turns (the cold-start `StartCascade` phantom) and the TUI mints its own cascade on the first typed turn, **adopt that cascade in the same Omnigent session** (rewrite bridge state, no fork) instead of misreading it as a `/clear` and forking a new session — which stranded the user's session empty while the turn filled a forked one. A genuine `/clear` (bound cascade *had* turns) still forks. `supervise_reader` now reports the committed-turn count for this decision.

**Result:** bidirectional agy-TUI ⟷ web sync on **one** cascade — web turns appear in the TUI and mirror to the web; TUI-typed turns mirror to the web — true parity with claude/codex native.

## Verification

**Live** (agy 1.0.11, local server):
- a web turn renders in the agy TUI **and** commits to the **original** session, user-before-assistant ✅
- a 2-turn flow stays on one session as `[user, assistant, user, assistant]` ✅
- reader logs `adopted the first TUI-minted cascade in place (no fork)` ✅

**Unit/integration:** 103 executor+reader tests (incl. new adopt-in-place + TUI-inject-error coverage), 311 broader antigravity tests, and 205 runner-native integration tests pass; ruff clean.

## Note

The now-unused RPC-delivery helpers (`_resolve_ready_cascade_id` / `_resolve_plan_model` / `_wait_for_state` + model-resolution functions) are retained for a focused follow-up cleanup; the live write path is `_deliver` → the TUI inject. Stacks on #1155 (already merged).

This pull request and its description were written by Isaac.