### PR TITLE
fix(ios): lock shell to visual viewport so the keyboard can't pan the page

### DIFF
--- a/ap-web/src/hooks/useIOSNativeKeyboardInset.ts
+++ b/ap-web/src/hooks/useIOSNativeKeyboardInset.ts
@@ -85,11 +85,17 @@ function getIOSNativeKeyboardInset(): number {
   const viewport = window.visualViewport;
   if (!viewport) return 0;
 
-  const shellBottom =
-    document.querySelector<HTMLElement>("[data-ios-native].app-shell")?.getBoundingClientRect()
-      .bottom ?? window.innerHeight;
+  // Keyboard height = the layout viewport (the full webview, kept keyboard-
+  // independent by the native shell's `.ignoresSafeArea(.keyboard)`) minus the
+  // visible visual viewport. Measured against `window.innerHeight`, NOT the
+  // app-shell: useIOSViewportLock resizes the shell down to the visual viewport
+  // when the keyboard opens, so an app-shell-relative measurement would always
+  // read ~0. This value is for fixed, full-viewport overlays (e.g. the mobile
+  // TerminalsPanel) that the shell-lock does not resize — flow content inside
+  // the shell is handled by the lock and needs no manual padding.
+  const layoutBottom = window.innerHeight;
   const visibleBottom = viewport.offsetTop + viewport.height;
-  return Math.max(0, Math.round(shellBottom - visibleBottom));
+  return Math.max(0, Math.round(layoutBottom - visibleBottom));
 }
 
 function isEditableElementFocused(): boolean {

--- a/ap-web/src/hooks/useIOSViewportLock.ts
+++ b/ap-web/src/hooks/useIOSViewportLock.ts
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+
+import { isIOSShell } from "@/lib/nativeBridge";
+
+/**
+ * Lock the iOS shell to the visual viewport so the soft keyboard can never pan
+ * the whole document.
+ *
+ * The native shell keeps the WKWebView full-height when the keyboard opens
+ * (`.ignoresSafeArea(.keyboard)`), and the shell is otherwise sized to the
+ * large viewport (`100lvh`). So when the keyboard appears the composer/inputs
+ * sit *behind* it, and WebKit pans the entire document up to reveal the focused
+ * field — hiding the header and letting the user scroll the whole page, which
+ * breaks the fixed-shell layout.
+ *
+ * Instead we publish the live `visualViewport.height` to
+ * `--omnigent-viewport-height`; the app-shell sizes to that (see index.css), so
+ * the focused input is always within the visible area. WebKit then never needs
+ * to pan, the header stays put, and only the inner scroll panes (conversation
+ * history, terminal, page bodies) move. As a safety net we also snap any
+ * residual document pan back to the top.
+ *
+ * No-op off the iOS shell — the browser and Electron handle the keyboard via
+ * normal layout, and the CSS var falls back to `100lvh`.
+ */
+export function useIOSViewportLock(): void {
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const root = document.documentElement;
+    let frame = 0;
+
+    const apply = () => {
+      frame = 0;
+      root.style.setProperty("--omnigent-viewport-height", `${Math.round(viewport.height)}px`);
+      // With the shell sized to the visual viewport there is nothing to scroll,
+      // so counter any transient pan WebKit applies while revealing a field.
+      if (viewport.offsetTop !== 0 || window.scrollY !== 0) window.scrollTo(0, 0);
+    };
+
+    // Coalesce the burst of resize/scroll events the keyboard animation fires.
+    const schedule = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(apply);
+    };
+
+    apply();
+    viewport.addEventListener("resize", schedule);
+    viewport.addEventListener("scroll", schedule);
+    window.addEventListener("orientationchange", schedule);
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      viewport.removeEventListener("resize", schedule);
+      viewport.removeEventListener("scroll", schedule);
+      window.removeEventListener("orientationchange", schedule);
+      root.style.removeProperty("--omnigent-viewport-height");
+    };
+  }, []);
+}

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -445,12 +445,19 @@
  * bridge marker so normal iOS Safari keeps its existing browser-safe layout. */
 @media (width < 48rem) {
   [data-ios-native].app-shell {
-    height: 100vh;
+    /* Lock the shell to the live visual viewport so the soft keyboard can never
+       pan the whole document (which hides the header). --omnigent-viewport-
+       height is published by useIOSViewportLock from visualViewport.height; it
+       shrinks when the keyboard opens so inputs stay above it and only inner
+       panes scroll. Falls back to the large viewport before JS runs / on older
+       WebKit. The two-line pattern keeps the lvh fallback for browsers without
+       the var. */
     height: 100lvh;
-    min-height: 100vh;
+    height: var(--omnigent-viewport-height, 100lvh);
     min-height: 100lvh;
-    max-height: 100vh;
+    min-height: var(--omnigent-viewport-height, 100lvh);
     max-height: 100lvh;
+    max-height: var(--omnigent-viewport-height, 100lvh);
     overflow: hidden;
   }
 

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import { useSessionAgent } from "@/hooks/useAgents";
 import { useApproveHotkey } from "@/hooks/useApproveHotkey";
 import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
+import { useIOSViewportLock } from "@/hooks/useIOSViewportLock";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import { isIOSShell, isMacElectronShell, onNativeSidebarDrag } from "@/lib/nativeBridge";
@@ -108,6 +109,11 @@ export function AppShell() {
   // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
   // here so it works on every chat route, regardless of where focus sits.
   useApproveHotkey();
+
+  // Lock the iOS shell to the visual viewport so the soft keyboard can't pan
+  // the whole document (which would hide the header and break the layout).
+  // No-op off the iOS shell. Scoped here so auth pages keep normal scrolling.
+  useIOSViewportLock();
 
   // Read early: the conversationId scopes the per-session workspace state
   // (rail open/width/tab/open files) used throughout this component.

--- a/ap-web/src/shell/MainTerminalView.tsx
+++ b/ap-web/src/shell/MainTerminalView.tsx
@@ -14,11 +14,9 @@
 // shells are enumerated and created in the rail's Shells tab.
 
 import { TerminalIcon, XIcon } from "lucide-react";
-import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TerminalView } from "@/components/blocks/TerminalView";
 import { AGENT_TERMINAL_IDS, terminalTabKey, useTerminals } from "@/hooks/useTerminals";
-import { useIOSNativeKeyboardInset } from "@/hooks/useIOSNativeKeyboardInset";
 import { useTerminalFirst } from "./TerminalFirstContext";
 import { TerminalStatusBadge } from "./terminalStatus";
 import { useTerminalStatuses } from "./useTerminalStatuses";
@@ -71,9 +69,10 @@ export function MainTerminalView({
   const [activeKey, setActiveKey] = useState(initialTerminalKey || "");
   const { getStatus, setTerminalConnectionState, markTerminalActive } =
     useTerminalStatuses(terminals);
-  const keyboardInset = useIOSNativeKeyboardInset();
-  const containerStyle: CSSProperties | undefined =
-    keyboardInset > 0 ? { paddingBottom: `calc(0.375rem + ${keyboardInset}px)` } : undefined;
+  // No manual keyboard padding here: this view is flow content inside the
+  // app-shell, which useIOSViewportLock sizes to the visual viewport, so the
+  // terminal already sits above the keyboard. (Fixed overlays like the mobile
+  // TerminalsPanel still pad themselves with useIOSNativeKeyboardInset.)
 
   // Honor a retarget while already open (a rail shell click can point
   // an open view at a different terminal); the validity effect below
@@ -126,7 +125,6 @@ export function MainTerminalView({
       // terminal (not just that the view opened).
       data-active-terminal={activeKey}
       className="main-terminal-view flex min-h-0 flex-1 flex-col px-3 pt-16 pb-1.5"
-      style={containerStyle}
     >
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card p-3 shadow-sm">
         {terminals.length === 0 ? (


### PR DESCRIPTION
## Related issue

N/A

## Summary

- On the iOS shell the native side keeps the WKWebView full-height when the keyboard opens (`.ignoresSafeArea(.keyboard)`) and the web shell is sized to `100lvh`, so a focused composer/terminal input sits behind the keyboard and WebKit pans the whole document up to reveal it — hiding the header and letting the entire page scroll.
- Add `useIOSViewportLock` (called once in `AppShell`): it publishes the live `visualViewport.height` to `--omnigent-viewport-height` and snaps any residual document pan back to the top. No-op off the iOS shell; scoped to the shell so auth pages keep normal scrolling.
- Size `[data-ios-native].app-shell` to `var(--omnigent-viewport-height, 100lvh)` so the shell shrinks with the keyboard: inputs stay above it, the header stays put, and only inner panes (conversation history, terminal, page bodies) scroll.
- Reconcile keyboard plumbing now that the shell is resized: `getIOSNativeKeyboardInset` measures against the layout viewport (`window.innerHeight`) instead of the app-shell (which would now read ~0), keeping the fixed full-viewport `TerminalsPanel` correct and fixing `useIOSNativeKeyboardVisible` detection. Drop the now-redundant manual keyboard padding from the flow-based `MainTerminalView` (the shell-lock handles it).

## Test Plan

- `npm run type-check` — passes.
- `npx oxlint` on changed files — clean (only the pre-existing `clearFileViewerUrl` exhaustive-deps error in AppShell, confirmed on the base).
- `npm run build` — succeeds; `--omnigent-viewport-height` present in built CSS.
- `npx vitest run` — full suite green, no unexpected failures.
- Manual on-device check still recommended: focus the composer and the terminal input on a notched simulator and confirm the header stays fixed, the page no longer pans, the input sits above the keyboard, and inner panes still scroll.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is iOS WKWebView keyboard/viewport layout behavior that can't be exercised in jsdom. Verified via type-check, lint, production build (confirming the new CSS var is emitted), and the full vitest suite (no regressions). The remaining visual confirmation — header stays fixed and the page no longer pans when the keyboard opens in chat and terminal views — must be done on a simulator/device against a live server.
