### PR TITLE
feat(skills): harness-aware slash-command discovery for the web composer

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -411,6 +411,83 @@ def _clean_codex_env() -> dict[str, str]:
     return env
 
 
+def codex_skill_sources(bundle_dir: Path | None, home: Path) -> list[Path]:
+    """
+    Build the ordered Codex skill-source list: bundle skills, then host skills.
+
+    The single source of truth for *where* Codex skills come from, shared
+    by :func:`populate_codex_skills_from_bundle` (which symlinks them into
+    ``$CODEX_HOME/skills/``) and the slash-command menu's ``codex_host_skills``
+    provider — so the linked set and the menu cannot drift on which roots
+    are scanned. Priority order: the agent's own ``<bundle>/skills/`` before
+    host-installed ``<home>/.codex/skills/`` (a bundled skill shadows a host
+    skill of the same name). Only existing directories are returned.
+
+    :param bundle_dir: Materialized agent-bundle root, or ``None``.
+    :param home: The user home directory (``Path.home()``); injected so
+        tests and the menu provider can pin it.
+    :returns: Existing skill-dir roots in priority order.
+    """
+    sources: list[Path] = []
+    if bundle_dir is not None and (bundle_dir / "skills").is_dir():
+        sources.append(bundle_dir / "skills")
+    host = home / ".codex" / "skills"
+    if host.is_dir():
+        sources.append(host)
+    return sources
+
+
+def select_codex_skill_dirs(
+    skills_filter: str | list[str],
+    sources: list[Path],
+) -> dict[str, Path]:
+    """
+    Resolve skill name → directory for a Codex skill source list.
+
+    The single source of truth for "which skills does this Codex session
+    expose", shared by :func:`_populate_codex_skills` (which symlinks the
+    result into ``$CODEX_HOME/skills/``) and the slash-command menu's
+    Codex skill source — so the menu and the actually-linked set cannot
+    diverge.
+
+    :param skills_filter: ``"all"`` selects every skill found in
+        *sources*; ``"none"`` selects nothing; a ``list[str]`` selects
+        only the named skills present in some source. Names not present
+        are silently skipped.
+    :param sources: Ordered skill-dir roots (each containing
+        ``<name>/SKILL.md`` subdirs). The first source that contains a
+        given skill name wins.
+    :returns: Ordered mapping of selected skill name → absolute dir.
+    """
+    if skills_filter == "none":
+        return {}
+    available: dict[str, Path] = {}
+    for source in sources:
+        if not source.is_dir():
+            continue
+        try:
+            children = sorted(source.iterdir())
+        except OSError as exc:
+            # An unreadable source (permission denied, races) must not abort
+            # skill discovery / session startup — skip it and continue.
+            logger.warning("could not list codex skill source %s (%s); skipping", source, exc)
+            continue
+        for child in children:
+            if not child.is_dir():
+                continue
+            if not (child / "SKILL.md").is_file():
+                continue
+            available.setdefault(child.name, child)
+
+    if skills_filter == "all":
+        names = list(available.keys())
+    elif isinstance(skills_filter, list):
+        names = [n for n in skills_filter if n in available]
+    else:
+        return {}
+    return {n: available[n] for n in names}
+
+
 def _populate_codex_skills(
     target_dir: Path,
     skills_filter: str | list[str],
@@ -425,7 +502,8 @@ def _populate_codex_skills(
     which means by default Codex sees zero skills. This helper populates
     the temp ``skills/`` subdir based on the agent spec's ``skills:``
     field, sourcing skill directories from ``sources`` (typically the
-    user's ``~/.codex/skills/`` plus any ``<bundle>/skills/``).
+    user's ``~/.codex/skills/`` plus any ``<bundle>/skills/``). Skill
+    selection is delegated to :func:`select_codex_skill_dirs`.
 
     :param target_dir: ``<temp_codex_home>/skills/`` — the directory
         Codex will scan. Created if it doesn't exist (unless
@@ -445,25 +523,9 @@ def _populate_codex_skills(
         return
 
     target_dir.mkdir(parents=True, exist_ok=True)
-    available: dict[str, Path] = {}
-    for source in sources:
-        if not source.is_dir():
-            continue
-        for child in sorted(source.iterdir()):
-            if not child.is_dir():
-                continue
-            if not (child / "SKILL.md").is_file():
-                continue
-            available.setdefault(child.name, child)
+    selected = select_codex_skill_dirs(skills_filter, sources)
 
-    if skills_filter == "all":
-        names = list(available.keys())
-    elif isinstance(skills_filter, list):
-        names = [n for n in skills_filter if n in available]
-    else:
-        return
-
-    for name in names:
+    for name, skill_dir in selected.items():
         link_path = target_dir / name
         if link_path.exists() or link_path.is_symlink():
             continue
@@ -471,7 +533,7 @@ def _populate_codex_skills(
             # Resolve to absolute so the symlink doesn't break when
             # the source was a relative path (relative symlinks resolve
             # against the link's parent, not the original cwd).
-            link_path.symlink_to(available[name].resolve())
+            link_path.symlink_to(skill_dir.resolve())
         except OSError as exc:
             # Filesystems without symlink support (e.g. some Windows
             # configs) — fall back to a copy. Don't crash the harness
@@ -482,7 +544,17 @@ def _populate_codex_skills(
                 target_dir,
                 exc,
             )
-            shutil.copytree(available[name], link_path)
+            try:
+                shutil.copytree(skill_dir, link_path)
+            except OSError as copy_exc:
+                # Copy fallback can also fail (unreadable source, race) — skip
+                # this one skill rather than abort the whole session boot.
+                logger.warning(
+                    "could not copy skill %r into %s (%s); skipping",
+                    name,
+                    target_dir,
+                    copy_exc,
+                )
 
 
 def populate_codex_skills_from_bundle(
@@ -512,14 +584,7 @@ def populate_codex_skills_from_bundle(
         ``"none"`` / a list of skill names.
     :returns: None.
     """
-    skill_sources: list[Path] = []
-    if bundle_dir is not None:
-        bundle_skills = bundle_dir / "skills"
-        if bundle_skills.is_dir():
-            skill_sources.append(bundle_skills)
-    host_skills = Path.home() / ".codex" / "skills"
-    if host_skills.is_dir():
-        skill_sources.append(host_skills)
+    skill_sources = codex_skill_sources(bundle_dir, Path.home())
     _populate_codex_skills(codex_home / "skills", skills_filter, skill_sources)
 
 

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import sys
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
@@ -7941,6 +7942,13 @@ def _render_history_item(
 _SLASH_COMMAND_ALIASES: frozenset[str] = frozenset({"/?", "/exit"})
 
 
+# A skill name must read as a slash-command token: an alphanumeric start then
+# word chars, ``:`` (Claude ``plugin:skill``), or ``-`` (Cursor ``plugin--skill``).
+# Rejects whitespace, ``/``, and control characters. Mirrors the web composer's
+# SLASH_COMMAND_RE so the terminal and the menu agree on what is a command.
+_SKILL_COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9][\w:-]*$")
+
+
 def register_skill_commands(skills: list[SkillSpec]) -> list[str]:
     """
     Auto-register each discovered skill as a REPL slash command.
@@ -7950,6 +7958,12 @@ def register_skill_commands(skills: list[SkillSpec]) -> list[str]:
     global :data:`COMMANDS` registry. Collisions are skipped with a
     warning log so built-in commands always win.
 
+    Skills marked ``user-invocable: false`` are skipped — they are
+    internal orchestration skills, not user-typeable slash commands, so
+    they must not appear in the REPL's slash-command/autocomplete surface
+    (the same contract the web composer menu honors). The skill stays
+    loadable by the agent itself; only the user-facing command is hidden.
+
     :param skills: The agent's parsed skill list.
     :returns: List of registered command names (e.g. ``["/code-review"]``).
         Callers should pass this to :func:`unregister_skill_commands`
@@ -7957,6 +7971,17 @@ def register_skill_commands(skills: list[SkillSpec]) -> list[str]:
     """
     registered: list[str] = []
     for skill in skills:
+        if not skill.user_invocable:
+            continue
+        if not _SKILL_COMMAND_NAME_RE.match(skill.name):
+            # A name with whitespace, ``/``, or control chars yields an
+            # uninvocable or colliding command — skip + warn rather than
+            # register garbage. Mirrors the web composer's SLASH_COMMAND_RE.
+            _log.warning(
+                "Skill %r skipped: name is not a valid slash-command token",
+                skill.name,
+            )
+            continue
         cmd_name = f"/{skill.name}"
         if cmd_name in COMMANDS:
             _log.warning(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -64,7 +64,7 @@ from omnigent.runner.resource_registry import (
     TerminalLifecycle,
 )
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
-from omnigent.spec.parser import discover_host_skills
+from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -12278,14 +12278,37 @@ def create_runner_app(
             roots.append(Path.cwd())
 
         def _discover() -> list[SkillSpec]:
-            """Merge bundled + host skills (every root) off the event loop."""
-            merged: list[SkillSpec] = list(spec.skills)
-            seen = {s.name for s in merged}
-            for root in roots:
-                for hs in discover_host_skills(root, spec.skills_filter):
-                    if hs.name not in seen:
-                        seen.add(hs.name)
-                        merged.append(hs)
+            """Merge bundled skills with the harness's extra skills off the loop."""
+            # Drop user-invocable:false skills from the bundle too, so the
+            # composer menu never lists a non-invocable skill regardless of
+            # source (harness skills are already filtered in resolve_harness_skills).
+            merged: list[SkillSpec] = [s for s in spec.skills if s.user_invocable]
+            # Seed the dedup set from EVERY bundled name — including the
+            # non-invocable ones dropped above — so marking a bundled skill
+            # non-invocable can't un-shadow a same-named host/harness skill
+            # the author never meant to surface.
+            seen = {s.name for s in spec.skills}
+            # Also dedup by on-disk skill dir: a harness provider (e.g. codex)
+            # may rediscover a bundle skill under a *different* name than its
+            # frontmatter ``name`` (it keys by directory), which would otherwise
+            # double-list the same skill. Same dir == same skill, drop it.
+            seen_dirs = {s.skill_dir.resolve() for s in spec.skills if s.skill_dir is not None}
+            ctx = SkillSourceContext(
+                roots=tuple(roots),
+                home=Path.home(),
+                skills_filter=spec.skills_filter,
+                bundle_dir=_resolved_spec_workdir(entry),
+            )
+            harness = canonicalize_harness(spec.executor.harness_kind)
+            for hs in resolve_harness_skills(ctx, harness):
+                if hs.name in seen:
+                    continue
+                if hs.skill_dir is not None and hs.skill_dir.resolve() in seen_dirs:
+                    continue
+                seen.add(hs.name)
+                if hs.skill_dir is not None:
+                    seen_dirs.add(hs.skill_dir.resolve())
+                merged.append(hs)
             return merged
 
         skills = await asyncio.to_thread(_discover)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4470,6 +4470,14 @@ def get_session_agent_id(session_id: str) -> str | None:
     return _session_agent_ids_ref.get(session_id)
 
 
+# How long a session's discovered skills stay cached before the runner
+# re-walks the filesystem. Short enough that a skill or plugin installed
+# mid-session surfaces in the composer menu without a session restart, long
+# enough to collapse the bursty menu-open + per-invocation resolve calls onto
+# a single walk. Module-level so it can be tuned/patched in one place.
+_SESSION_SKILLS_CACHE_TTL_SECONDS = 60.0
+
+
 def create_runner_app(
     *,
     process_manager: HarnessProcessManager | None = None,
@@ -4578,10 +4586,12 @@ def create_runner_app(
     _session_snapshot_cache: dict[str, _SessionSnapshot] = {}  # session_id → snapshot
     _session_snapshot_locks: dict[str, asyncio.Lock] = {}  # session_id → snapshot fetch lock
     _session_spec_locks: dict[str, asyncio.Lock] = {}  # session_id → spec resolution lock
-    # session_id → merged (bundled + host) skills, discovered against
-    # this runner's filesystem. Skills are runner-owned: the walk runs
-    # once per session lifetime and is dropped in ``delete_session``.
-    _session_skills_cache: dict[str, list[SkillSpec]] = {}
+    # session_id → (monotonic expiry, merged bundled + host skills),
+    # discovered against this runner's filesystem. Skills are runner-owned:
+    # the walk reruns at most once per ``_SESSION_SKILLS_CACHE_TTL_SECONDS``
+    # (so a mid-session skill/plugin install surfaces) and the entry is
+    # dropped in ``delete_session``.
+    _session_skills_cache: dict[str, tuple[float, list[SkillSpec]]] = {}
     _session_workspace_cache: dict[str, str | None] = {}  # session_id → workspace path
     _session_agent_ids = _session_agent_ids_ref  # shared with module-level get_session_agent_id
     # Sub-agent name per session. Set from POST /v1/sessions body
@@ -12236,8 +12246,11 @@ def create_runner_app(
         contributes nothing). Falls back to the runner's global workspace,
         then the process cwd, when no workspace is known. Deduplicated by
         name with bundled winning, then earlier roots winning. Cached per
-        session so the filesystem walk runs once per session lifetime
-        (dropped in ``delete_session``).
+        session with a short TTL (``_SESSION_SKILLS_CACHE_TTL_SECONDS``) so the
+        walk reruns at most once per window — fresh enough to surface a
+        skill/plugin installed mid-session, while still collapsing the bursty
+        menu-open + per-invocation resolve calls (dropped in
+        ``delete_session``).
 
         :param session_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.
@@ -12249,7 +12262,11 @@ def create_runner_app(
         """
         cached = _session_skills_cache.get(session_id)
         if cached is not None:
-            return cached
+            expires_at, cached_skills = cached
+            if time.monotonic() < expires_at:
+                return cached_skills
+            # TTL elapsed — fall through to re-walk so a skill or plugin
+            # installed mid-session surfaces without a session restart.
         entry = await _resolve_session_spec_entry(session_id)
         spec = _unwrap_resolved_spec(entry) if entry is not None else None
         if spec is None:
@@ -12312,7 +12329,10 @@ def create_runner_app(
             return merged
 
         skills = await asyncio.to_thread(_discover)
-        _session_skills_cache[session_id] = skills
+        _session_skills_cache[session_id] = (
+            time.monotonic() + _SESSION_SKILLS_CACHE_TTL_SECONDS,
+            skills,
+        )
         return skills
 
     @app.get("/v1/sessions/{session_id}/skills")

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -1896,8 +1896,19 @@ def _discover_skills(
     """
     if not skills_dir.is_dir():
         return []
+    try:
+        entries = sorted(skills_dir.iterdir())
+    except OSError as exc:
+        # Lenient mode (a skipped list was passed, e.g. host/plugin menu
+        # discovery): an unreadable skills dir must not 500 the caller —
+        # log and yield nothing. Strict mode (bundle parse) re-raises.
+        if skipped is None:
+            raise
+        _log.warning("Skipping unreadable skills dir %s: %s", skills_dir, exc)
+        skipped.append(f"{skills_dir}: {exc}")
+        return []
     skills: list[SkillSpec] = []
-    for skill_dir in sorted(skills_dir.iterdir()):
+    for skill_dir in entries:
         if not skill_dir.is_dir():
             continue
         skill_md = skill_dir / "SKILL.md"
@@ -1914,6 +1925,35 @@ def _discover_skills(
             continue
         skills.append(skill)
     return skills
+
+
+# Quoted string spellings treated as boolean false. PyYAML already parses the
+# *bare* YAML 1.1 false words (``false``/``False``/``no``/``off``) to a real
+# ``bool``, caught by the ``raw is False`` branch below; this set only catches
+# the *quoted* forms (e.g. ``user-invocable: "no"``) that arrive as ``str``.
+_FALSEY_STRINGS = frozenset({"false", "no", "off", "0"})
+
+
+def _falsey_flag(raw: object) -> bool:
+    """
+    Return whether a YAML frontmatter flag reads as boolean ``false``.
+
+    Accepts a genuine YAML bool (``raw is False`` — which already covers
+    the bare words ``false``/``no``/``off`` that PyYAML parses to a
+    ``bool``) and the quoted string spellings in :data:`_FALSEY_STRINGS`
+    (case-insensitive, surrounding whitespace ignored) — YAML keeps a
+    quoted value as a ``str``, so the string branch is the one that
+    silently regresses without a test. Every other value (absent ⇒
+    caller's default, ``true``, other strings, ``0`` as int) is not
+    falsey.
+
+    :param raw: The raw frontmatter value, e.g. ``False``, ``"no"``,
+        or ``True``.
+    :returns: ``True`` only when *raw* means boolean false.
+    """
+    if raw is False:
+        return True
+    return isinstance(raw, str) and raw.strip().lower() in _FALSEY_STRINGS
 
 
 def _parse_skill(skill_md: Path) -> SkillSpec:
@@ -1934,7 +1974,11 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
     """
     try:
         text = skill_md.read_text()
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
+        # UnicodeDecodeError (a non-UTF-8 SKILL.md) is a ValueError, not an
+        # OSError — funnel it through OmnigentError too so the lenient
+        # scanner in _discover_skills and the per-skill guards in the menu
+        # providers catch it and skip the file instead of 500-ing the menu.
         raise OmnigentError(
             f"SKILL.md could not be read: {skill_md}: {exc}",
             code=ErrorCode.INVALID_INPUT,
@@ -1970,11 +2014,15 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
             f"SKILL.md frontmatter missing required field 'description': {skill_md}",
             code=ErrorCode.INVALID_INPUT,
         )
+    # ``user-invocable: false`` marks an internal orchestration skill that
+    # the user should not invoke directly; absent/true ⇒ invocable.
+    user_invocable = not _falsey_flag(frontmatter.get("user-invocable", True))
     return SkillSpec(
         name=str(name),
         description=str(description),
         content=content.strip(),
         skill_dir=skill_md.parent,
+        user_invocable=user_invocable,
     )
 
 

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -156,19 +156,46 @@ def _enabled_plugin_settings_files(ctx: SkillSourceContext) -> list[Path]:
     return files
 
 
+def _managed_plugin_keys(ctx: SkillSourceContext) -> set[str]:
+    """
+    Plugin keys force-enabled by Claude Code's managed (policy) tier.
+
+    ``~/.claude/plugins/managed_plugins.json`` carries a ``managed_plugins``
+    list of ``<plugin>@<marketplace>`` keys that an organization's policy
+    force-installs. Claude Code treats the managed tier as the highest
+    precedence — it cannot be overridden by a user/project ``enabledPlugins``
+    toggle — so a managed plugin is enabled even when it carries no
+    ``enabledPlugins`` entry (or an explicit ``false``) in any settings file.
+
+    :param ctx: Session discovery context.
+    :returns: The set of managed ``<plugin>@<marketplace>`` keys, empty when
+        the file is absent, unreadable, or malformed.
+    """
+    data = _read_json(ctx.home / ".claude" / "plugins" / "managed_plugins.json")
+    if data is None:
+        return set()
+    managed = data.get("managed_plugins")
+    if not isinstance(managed, list):
+        return set()
+    return {key for key in managed if isinstance(key, str) and key}
+
+
 def _enabled_plugin_keys(ctx: SkillSourceContext) -> set[str]:
     """
-    Resolve which plugins are enabled, honoring scope + local precedence.
+    Resolve which plugins are enabled, honoring scope + local precedence
+    and the managed (policy) tier.
 
     Merges ``enabledPlugins`` across the settings files from
     :func:`_enabled_plugin_settings_files` in increasing-precedence order
     (last-wins per key), so a plugin enabled globally but explicitly
     disabled in a project's ``settings.local.json`` is correctly excluded
-    (and vice-versa).
+    (and vice-versa). The managed tier (:func:`_managed_plugin_keys`) is then
+    unioned on top: it force-enables at the highest precedence and so cannot
+    be overridden by a settings disable.
 
     :param ctx: Session discovery context.
     :returns: The set of ``<plugin>@<marketplace>`` keys whose effective
-        enablement is truthy.
+        enablement is truthy, unioned with the managed (policy) keys.
     """
     state: dict[str, bool] = {}
     for path in _enabled_plugin_settings_files(ctx):
@@ -184,7 +211,11 @@ def _enabled_plugin_keys(ctx: SkillSourceContext) -> set[str]:
                 # real bool from a weaker-precedence tier).
                 if isinstance(value, bool):
                     state[key] = value
-    return {key for key, on in state.items() if on}
+    enabled = {key for key, on in state.items() if on}
+    # Managed (policy) plugins are force-enabled at the highest precedence and
+    # cannot be overridden by a user/project enabledPlugins toggle, so union
+    # them on top of the settings-derived set (force-enable, never disable).
+    return enabled | _managed_plugin_keys(ctx)
 
 
 def _plugin_install_paths(ctx: SkillSourceContext, enabled: set[str]) -> dict[str, Path]:

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -1,0 +1,384 @@
+"""
+Harness-aware host/plugin skill discovery for the web composer's
+slash-command menu.
+
+The runner's ``_resolve_session_skills`` unions a session's bundled
+skills with the *extra* skills its harness surfaces in its own terminal.
+"What a harness exposes" differs per vendor (Claude Code plugins, Codex
+``~/.codex/skills``, Cursor ``~/.cursor``), so resolution dispatches to a
+per-family provider. Unknown harnesses fall back to the generic host walk
+(``discover_host_skills``) for backwards compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from omnigent.errors import OmnigentError
+from omnigent.spec.parser import _discover_skills, _parse_skill, discover_host_skills
+from omnigent.spec.types import SkillSpec
+
+_log = logging.getLogger(__name__)
+
+_SKILL_FAMILIES = frozenset({"claude", "codex", "cursor", "pi"})
+
+
+def _harness_family(harness: str | None) -> str | None:
+    """
+    Map any harness spelling to its vendor family, or ``None``.
+
+    Collapses variant suffixes/prefixes — ``claude-sdk``,
+    ``claude-native`` and ``native-claude`` all map to ``"claude"`` —
+    so the provider registry can be keyed by family rather than by every
+    canonical variant.
+
+    :param harness: A harness id (canonical or alias), e.g.
+        ``"codex-native"``; ``None`` or ``""`` returns ``None``.
+    :returns: One of ``"claude"``, ``"codex"``, ``"cursor"``, ``"pi"``,
+        or ``None`` for unknown/other harnesses.
+    """
+    if not harness:
+        return None
+    # Normalize the underscore executor-type spelling (``claude_sdk``,
+    # ``agents_sdk``) to the hyphen form before splitting — the in-process
+    # SDK harness flows in as ``claude_sdk`` (canonicalize_harness leaves it
+    # unchanged), and without this it would miss the ``claude`` family and
+    # silently lose plugin slash-commands.
+    parts = harness.replace("_", "-").split("-")
+    base = parts[1] if parts[0] == "native" and len(parts) > 1 else parts[0]
+    return base if base in _SKILL_FAMILIES else None
+
+
+@dataclass(frozen=True)
+class SkillSourceContext:
+    """
+    Inputs a per-harness skill provider needs.
+
+    :param roots: Host-discovery roots in priority order — the session
+        workspace, then the agent bundle workdir (the same roots
+        ``_resolve_session_skills`` already computes).
+    :param home: The user home directory (``Path.home()``); injected so
+        tests can pin it.
+    :param skills_filter: The spec's ``skills:`` filter
+        (``"all"`` / ``"none"`` / list of names).
+    :param bundle_dir: The materialized bundle root, or ``None``.
+    """
+
+    roots: tuple[Path, ...]
+    home: Path
+    skills_filter: str | list[str]
+    bundle_dir: Path | None
+
+
+SkillSource = Callable[[SkillSourceContext], list[SkillSpec]]
+
+
+def _dedup(specs: list[SkillSpec]) -> list[SkillSpec]:
+    """Return *specs* with later same-name entries dropped (first wins)."""
+    seen: set[str] = set()
+    out: list[SkillSpec] = []
+    for s in specs:
+        if s.name in seen:
+            continue
+        seen.add(s.name)
+        out.append(s)
+    return out
+
+
+def _generic_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
+    """Today's behavior: ``discover_host_skills`` over each root."""
+    out: list[SkillSpec] = []
+    for root in ctx.roots:
+        out.extend(discover_host_skills(root, ctx.skills_filter))
+    return _dedup(out)
+
+
+def resolve_harness_skills(ctx: SkillSourceContext, harness: str | None) -> list[SkillSpec]:
+    """
+    Return the extra (non-bundled) skills the session's harness exposes.
+
+    Dispatches by harness family. An unknown/other family falls back to
+    the generic host walk so behavior is unchanged for harnesses without
+    a dedicated provider.
+
+    :param ctx: Session discovery context.
+    :param harness: The session's harness id (canonical or alias).
+    :returns: Deduplicated skill specs (first occurrence wins).
+        Skills marked ``user-invocable: false`` are excluded — they are
+        internal orchestration skills, not user-typeable slash commands
+        (applied uniformly across every harness).
+    """
+    family = _harness_family(harness)
+    provider = _SKILL_SOURCES.get(family, _generic_host_skills)
+    return [s for s in _dedup(provider(ctx)) if s.user_invocable]
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    """Best-effort JSON read; ``None`` on missing/unreadable/non-dict."""
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _enabled_plugin_settings_files(ctx: SkillSourceContext) -> list[Path]:
+    """
+    Settings files carrying ``enabledPlugins``, weakest→strongest.
+
+    Claude Code merges ``enabledPlugins`` across its settings tiers, and
+    the gitignored ``settings.local.json`` (the "local" tier) wins over
+    the shared ``settings.json`` within a scope. Reading only
+    ``settings.json`` would miss a plugin toggled in the local file. We
+    approximate Claude's precedence for the menu (last-wins):
+
+        user (home) .json → .local  <  bundle .json → .local
+            <  workspace .json → .local
+
+    — ``.local`` over ``.json`` within each scope, project (roots) over
+    user (home), and the primary workspace (``roots[0]``) over the shipped
+    bundle (``roots[1]``), matching the workspace-first precedence the host
+    skill walk already uses.
+
+    :param ctx: Session discovery context.
+    :returns: Candidate settings paths in increasing precedence order.
+    """
+    files: list[Path] = []
+    # ``reversed`` puts the primary workspace (roots[0]) last → strongest.
+    for scope in (ctx.home, *reversed(ctx.roots)):
+        files.append(scope / ".claude" / "settings.json")
+        files.append(scope / ".claude" / "settings.local.json")
+    return files
+
+
+def _enabled_plugin_keys(ctx: SkillSourceContext) -> set[str]:
+    """
+    Resolve which plugins are enabled, honoring scope + local precedence.
+
+    Merges ``enabledPlugins`` across the settings files from
+    :func:`_enabled_plugin_settings_files` in increasing-precedence order
+    (last-wins per key), so a plugin enabled globally but explicitly
+    disabled in a project's ``settings.local.json`` is correctly excluded
+    (and vice-versa).
+
+    :param ctx: Session discovery context.
+    :returns: The set of ``<plugin>@<marketplace>`` keys whose effective
+        enablement is truthy.
+    """
+    state: dict[str, bool] = {}
+    for path in _enabled_plugin_settings_files(ctx):
+        data = _read_json(path)
+        if data is None:
+            continue
+        ep = data.get("enabledPlugins")
+        if isinstance(ep, dict):
+            for key, value in ep.items():
+                # Accept only a real JSON boolean — a string ``"false"`` is
+                # truthy under ``bool()`` and would wrongly enable a plugin.
+                # Non-bool values are ignored (they don't override a prior
+                # real bool from a weaker-precedence tier).
+                if isinstance(value, bool):
+                    state[key] = value
+    return {key for key, on in state.items() if on}
+
+
+def _plugin_install_paths(ctx: SkillSourceContext, enabled: set[str]) -> dict[str, Path]:
+    """Map ``<plugin>@<marketplace>`` → installPath for enabled+installed plugins."""
+    data = _read_json(ctx.home / ".claude" / "plugins" / "installed_plugins.json")
+    if data is None:
+        return {}
+    plugins = data.get("plugins")
+    if not isinstance(plugins, dict):
+        return {}
+    # installPath values from installed_plugins.json are trusted only within
+    # the Claude plugins cache root; anything pointing elsewhere is logged and
+    # skipped so a tampered/odd manifest can't turn an arbitrary directory into
+    # a discovery root.
+    plugins_root = (ctx.home / ".claude" / "plugins").resolve()
+    out: dict[str, Path] = {}
+    for key, entries in plugins.items():
+        if key not in enabled or not isinstance(entries, list):
+            continue
+        # A plugin may have multiple scope entries (user/project); take the
+        # first one carrying a usable installPath rather than assuming it's
+        # entries[0], whose scope may not have an installed path.
+        for entry in entries:
+            path = entry.get("installPath") if isinstance(entry, dict) else None
+            if not (isinstance(path, str) and path):
+                continue
+            # A relative installPath is resolved against the plugins root
+            # (its only sensible base), never the runner's cwd.
+            path_obj = Path(path)
+            resolved = (path_obj if path_obj.is_absolute() else plugins_root / path_obj).resolve()
+            if not resolved.is_relative_to(plugins_root):
+                _log.warning(
+                    "Skipping plugin %r: installPath %r is outside %s",
+                    key,
+                    path,
+                    plugins_root,
+                )
+                break
+            out[key] = resolved
+            break
+    return out
+
+
+def _claude_plugin_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
+    """
+    Enabled Claude Code plugin skills, namespaced ``<plugin>:<skill>``.
+
+    Plugin skills are host skills, so they obey the spec's
+    ``skills_filter`` exactly as :func:`discover_host_skills` does:
+    ``"none"`` suppresses them entirely (hermetic), ``"all"`` surfaces
+    every skill from every enabled plugin, and a list selects by the
+    skill's own (bare) name — matching how the filter names skills,
+    independent of the display namespace.
+    """
+    if ctx.skills_filter == "none":
+        return []
+    filter_names: set[str] | None = (
+        set(ctx.skills_filter) if isinstance(ctx.skills_filter, list) else None
+    )
+    enabled = _enabled_plugin_keys(ctx)
+    if not enabled:
+        return []
+    out: list[SkillSpec] = []
+    for key, install_path in _plugin_install_paths(ctx, enabled).items():
+        plugin = key.split("@", 1)[0]
+        skipped: list[str] = []
+        for spec in _discover_skills(install_path / "skills", skipped=skipped):
+            if filter_names is not None and spec.name not in filter_names:
+                continue
+            out.append(replace(spec, name=f"{plugin}:{spec.name}"))
+        # Surface dropped skills with the plugin key so a missing command is
+        # diagnosable rather than silently absent.
+        for detail in skipped:
+            _log.warning("Plugin %r: skipped skill: %s", key, detail)
+    return out
+
+
+def claude_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
+    """Generic host walk (``~/.claude/skills`` etc.) plus enabled plugins."""
+    return _generic_host_skills(ctx) + _claude_plugin_skills(ctx)
+
+
+def codex_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
+    """
+    Codex skills: ``<bundle>/skills`` + ``~/.codex/skills`` under the filter.
+
+    Reuses the Codex executor's own helpers — ``codex_skill_sources`` (the
+    shared source-list builder) and ``select_codex_skill_dirs`` (the shared
+    selector) — so the menu draws from the same roots and selection the
+    executor symlinks into ``$CODEX_HOME/skills/``. The menu is the subset of
+    that selection whose ``SKILL.md`` parses: the executor links by existence,
+    so a present-but-unparseable skill is linked but not shown (correct — Codex
+    won't register a malformed skill as a command either).
+
+    Names are surfaced by **directory name** (the selector's key), not the
+    frontmatter ``name``. Codex registers a skill's slash command under its
+    directory, and the executor symlinks under that dir name — so when the
+    two differ, the menu label must match the directory (mirrors the Cursor
+    provider). The lazy import keeps the Codex-specific dependency out of
+    ``omnigent.spec``'s module-load path.
+    """
+    from omnigent.inner.codex_executor import codex_skill_sources, select_codex_skill_dirs
+
+    sources = codex_skill_sources(ctx.bundle_dir, ctx.home)
+    out: list[SkillSpec] = []
+    for name, skill_dir in select_codex_skill_dirs(ctx.skills_filter, sources).items():
+        try:
+            spec = _parse_skill(skill_dir / "SKILL.md")
+        except (OmnigentError, OSError):  # best-effort discovery
+            continue
+        out.append(replace(spec, name=name))
+    return out
+
+
+def cursor_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
+    """
+    Cursor skills under ``~/.cursor/skills`` (the ambient real home a
+    cursor-native session runs against).
+
+    Cursor names a skill by its ``plugin--skill`` *directory* (e.g.
+    ``fe-epl-tools--metric-view-adoption``), not the bare frontmatter
+    ``name`` — the dir carries the namespace and is collision-safe across
+    the many installed plugins. So this surfaces the dir name, overriding
+    the parsed bare name. Honors ``skills_filter`` (``"none"`` hermetic,
+    ``"all"`` everything, a list selecting by the surfaced dir name).
+    Only ``~/.cursor/skills`` is scanned; ``skills-cursor`` (Cursor's own
+    managed built-ins) is left out until confirmed runnable as a command.
+    """
+    if ctx.skills_filter == "none":
+        return []
+    filter_names: set[str] | None = (
+        set(ctx.skills_filter) if isinstance(ctx.skills_filter, list) else None
+    )
+    skills_dir = ctx.home / ".cursor" / "skills"
+    if not skills_dir.is_dir():
+        return []
+    try:
+        children = sorted(skills_dir.iterdir())
+    except OSError as exc:
+        # An unreadable skills dir must not 500 the /skills endpoint (matches
+        # the lenient codex/_discover_skills behavior) — log and yield nothing.
+        _log.warning("Skipping unreadable cursor skills dir %s: %s", skills_dir, exc)
+        return []
+    out: list[SkillSpec] = []
+    for child in children:
+        if not child.is_dir() or not (child / "SKILL.md").is_file():
+            continue
+        if filter_names is not None and child.name not in filter_names:
+            continue
+        try:
+            spec = _parse_skill(child / "SKILL.md")
+        except (OmnigentError, OSError):  # best-effort discovery
+            continue
+        out.append(replace(spec, name=child.name))
+    return out
+
+
+def pi_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
+    """
+    Pi exposes no *extra* discoverable skills to the menu.
+
+    Pi has its **own** host-skill mechanism: it loads bundle skills via
+    ``--skill`` (already carried by ``spec.skills``, which the runner
+    unions in separately) and runs its own auto-discovery at runtime,
+    sourcing from Pi's internal extension layout. omnigent can't enumerate
+    that layout to name/resolve those skills for the menu, so listing any
+    would risk surfacing a command Pi can't invoke. Hence the explicit
+    no-op (under-report when unsure).
+
+    This is why Pi gets a dedicated provider rather than the generic
+    ``~/.claude/skills`` fallback: the fallback's skills are resolvable by
+    omnigent on harnesses that have *no* host-skill mechanism of their own
+    (the unregistered SDK/CLI harnesses — antigravity, qwen — which route a
+    typed skill through omnigent's own resolve+inject), but Pi's competing,
+    unenumerable mechanism makes that fallback unsafe. The distinction is
+    "does the harness own an unenumerable host-skill mechanism", not the
+    vendor.
+
+    :param ctx: Session discovery context (unused).
+    :returns: Always an empty list.
+    """
+    del ctx
+    return []
+
+
+# Keyed by harness family (see _harness_family). A harness with no entry
+# (antigravity, qwen, openai-agents, …) falls through to _generic_host_skills
+# in resolve_harness_skills — the unchanged pre-existing ~/.claude/skills walk,
+# whose skills omnigent resolves+injects regardless of vendor. Pi is the one
+# harness that needs an explicit no-op (see pi_host_skills) because it owns a
+# host-skill mechanism omnigent can't enumerate.
+_SKILL_SOURCES: dict[str | None, SkillSource] = {
+    "claude": claude_host_skills,
+    "codex": codex_host_skills,
+    "cursor": cursor_host_skills,
+    "pi": pi_host_skills,
+}

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -827,12 +827,18 @@ class SkillSpec:
         disk, e.g. ``Path("/agents/code-review")``. Used by
         ``read_skill_file`` to resolve resource paths. ``None``
         when the skill was created in-memory (e.g. tests).
+    :param user_invocable: Whether the skill may be invoked directly
+        by a user as a slash command. ``False`` for internal
+        orchestration skills (frontmatter ``user-invocable: false``);
+        such skills are excluded from the composer's ``/`` menu.
+        Defaults to ``True`` (absent frontmatter field = invocable).
     """
 
     name: str
     description: str
     content: str
     skill_dir: Path | None = None
+    user_invocable: bool = True
 
 
 @dataclass

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2622,3 +2622,56 @@ def test_model_provider_override_with_gateway_raises() -> None:
             model="some-model",
             model_provider_override="Databricks",
         )
+
+
+def _mk_codex_skill(skills_dir: Path, name: str) -> None:
+    """Create a ``<skills_dir>/<name>/SKILL.md`` skill directory."""
+    d = skills_dir / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: d\n---\nbody\n")
+
+
+def test_select_codex_skill_dirs_all_first_source_wins(tmp_path: Path) -> None:
+    from omnigent.inner.codex_executor import select_codex_skill_dirs
+
+    a, b = tmp_path / "a", tmp_path / "b"
+    _mk_codex_skill(a, "shared")
+    _mk_codex_skill(b, "shared")
+    _mk_codex_skill(b, "only-b")
+    out = select_codex_skill_dirs("all", [a, b])
+    assert out["shared"] == a / "shared"
+    assert out["only-b"] == b / "only-b"
+
+
+def test_select_codex_skill_dirs_none_and_list(tmp_path: Path) -> None:
+    from omnigent.inner.codex_executor import select_codex_skill_dirs
+
+    a = tmp_path / "a"
+    _mk_codex_skill(a, "x")
+    _mk_codex_skill(a, "y")
+    assert select_codex_skill_dirs("none", [a]) == {}
+    assert set(select_codex_skill_dirs(["x"], [a])) == {"x"}
+
+
+def test_codex_skill_sources_order_bundle_then_host(tmp_path: Path) -> None:
+    """codex_skill_sources lists <bundle>/skills before <home>/.codex/skills."""
+    from omnigent.inner.codex_executor import codex_skill_sources
+
+    bundle = tmp_path / "bundle"
+    (bundle / "skills").mkdir(parents=True)
+    home = tmp_path / "home"
+    (home / ".codex" / "skills").mkdir(parents=True)
+    assert codex_skill_sources(bundle, home) == [
+        bundle / "skills",
+        home / ".codex" / "skills",
+    ]
+
+
+def test_codex_skill_sources_omits_absent_dirs(tmp_path: Path) -> None:
+    """Only existing dirs are returned (bundle absent → host only)."""
+    from omnigent.inner.codex_executor import codex_skill_sources
+
+    home = tmp_path / "home"
+    (home / ".codex" / "skills").mkdir(parents=True)
+    assert codex_skill_sources(None, home) == [home / ".codex" / "skills"]
+    assert codex_skill_sources(tmp_path / "no-bundle", home) == [home / ".codex" / "skills"]

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2112,6 +2112,41 @@ async def test_registered_skill_command_uses_structured_slash_command() -> None:
     assert "load_skill" not in rendered
 
 
+def test_register_skill_commands_skips_non_user_invocable() -> None:
+    """``user-invocable: false`` skills are not registered as REPL slash commands."""
+    from omnigent.repl import _repl as repl_mod
+
+    invocable = SkillSpec(name="visible-skill", description="d", content="c")
+    internal = SkillSpec(name="internal-skill", description="d", content="c", user_invocable=False)
+    registered = repl_mod.register_skill_commands([invocable, internal])
+    try:
+        assert "/visible-skill" in registered
+        assert "/internal-skill" not in registered
+        assert "/internal-skill" not in repl_mod.COMMANDS
+    finally:
+        repl_mod.unregister_skill_commands(registered)
+
+
+def test_register_skill_commands_skips_invalid_command_names() -> None:
+    """Skill names that aren't valid slash-command tokens are skipped + not registered."""
+    from omnigent.repl import _repl as repl_mod
+
+    valid = SkillSpec(name="superpowers:using-superpowers", description="d", content="c")
+    namespaced = SkillSpec(name="fe-innovate--innovate", description="d", content="c")
+    spacey = SkillSpec(name="bad name", description="d", content="c")
+    slashy = SkillSpec(name="etc/hosts", description="d", content="c")
+    registered = repl_mod.register_skill_commands([valid, namespaced, spacey, slashy])
+    try:
+        assert "/superpowers:using-superpowers" in registered  # ``:`` namespace ok
+        assert "/fe-innovate--innovate" in registered  # ``--`` namespace ok
+        assert "/bad name" not in registered
+        assert "/etc/hosts" not in registered
+        assert "/bad name" not in repl_mod.COMMANDS
+        assert "/etc/hosts" not in repl_mod.COMMANDS
+    finally:
+        repl_mod.unregister_skill_commands(registered)
+
+
 def test_consume_pending_local_skill_slash_command_only_suppresses_match() -> None:
     """Live TUI rendering skips only the server echo for a local skill command."""
     session = _StubSkillSession()

--- a/tests/runner/test_skills.py
+++ b/tests/runner/test_skills.py
@@ -15,6 +15,7 @@ server delegates to:
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -38,23 +39,41 @@ def _skill_md(name: str, description: str) -> str:
     return f"---\nname: {name}\ndescription: {description}\n---\n\nbody for {name}\n"
 
 
+class _ExecutorStub:
+    """Minimal ``ExecutorSpec`` stand-in exposing ``harness_kind``."""
+
+    def __init__(self, harness: str) -> None:
+        """:param harness: The session's harness, e.g. ``"claude-sdk"``."""
+        self.harness_kind = harness
+
+
 class _SpecStub:
     """
     Minimal stand-in for an ``AgentSpec`` exposing only what skill
-    discovery reads: the bundled ``skills`` list and ``skills_filter``.
+    discovery reads: the bundled ``skills`` list, ``skills_filter``, and
+    ``executor.harness_kind`` (so the runner can dispatch to the right
+    per-harness skill source).
 
     :param skills: Bundled skills the agent ships.
     :param skills_filter: Host-skill filter (``"all"`` / ``"none"`` /
         list of names).
+    :param harness: The session's harness; defaults to ``"claude-sdk"``.
     """
 
-    def __init__(self, skills: list[SkillSpec], skills_filter: str | list[str]) -> None:
+    def __init__(
+        self,
+        skills: list[SkillSpec],
+        skills_filter: str | list[str],
+        harness: str = "claude-sdk",
+    ) -> None:
         """
         :param skills: Bundled skills the agent ships.
         :param skills_filter: Host-skill filter from the agent spec.
+        :param harness: Harness id driving per-harness skill discovery.
         """
         self.skills = skills
         self.skills_filter = skills_filter
+        self.executor = _ExecutorStub(harness)
 
 
 class _ServerClient:
@@ -109,6 +128,7 @@ def _make_app(
     *,
     workspace: Path | None = None,
     resolver_calls: list[str] | None = None,
+    harness: str = "claude-sdk",
 ):  # type: ignore[no-untyped-def]
     """
     Build a runner app whose spec resolver returns a stub spec.
@@ -121,9 +141,11 @@ def _make_app(
         host-skill discovery root. ``None`` omits it.
     :param resolver_calls: Optional list appended to on each
         ``spec_resolver`` invocation, for asserting cache behavior.
+    :param harness: The stub spec's harness, driving per-harness skill
+        discovery. Defaults to ``"claude-sdk"`` (today's behavior).
     :returns: The configured FastAPI app.
     """
-    spec = _SpecStub(bundled, skills_filter)
+    spec = _SpecStub(bundled, skills_filter, harness=harness)
     entry = ResolvedSpec(spec=spec, workdir=bundle_dir)
 
     async def _spec_resolver(agent_id: str, session_id: str | None) -> Any:
@@ -411,3 +433,194 @@ async def test_session_skills_cached_per_session(tmp_path: Path) -> None:
     # was not consulted (a walk per request); zero would mean discovery
     # never ran at all.
     assert resolver_calls == ["ag_x"]
+
+
+def _seed_claude_plugin(home: Path) -> None:
+    """Seed a fake ~/.claude with one enabled plugin exposing one skill."""
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / "superpowers" / "1.0.0"
+    (install / "skills" / "using-superpowers").mkdir(parents=True)
+    (install / "skills" / "using-superpowers" / "SKILL.md").write_text(
+        _skill_md("using-superpowers", "Use superpowers.")
+    )
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"superpowers@mkt": True}})
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {
+                    "superpowers@mkt": [{"installPath": str(install), "version": "1.0.0"}]
+                },
+            }
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_session_skills_includes_enabled_claude_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claude session surfaces enabled-plugin skills, namespaced."""
+    home = tmp_path / "home"
+    _seed_claude_plugin(home)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    app = _make_app(bundle, [], "all", workspace=workspace, harness="claude-native")
+
+    async for c in _client(app):
+        resp = await c.get("/v1/sessions/conv_cc/skills")
+
+    assert resp.status_code == 200, resp.text
+    assert "superpowers:using-superpowers" in [s["name"] for s in resp.json()["skills"]]
+
+
+@pytest.mark.asyncio
+async def test_codex_session_does_not_list_claude_plugin_skills(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parity: a codex session must not show Claude plugin skills."""
+    home = tmp_path / "home"
+    _seed_claude_plugin(home)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    app = _make_app(bundle, [], "all", workspace=workspace, harness="codex-native")
+
+    async for c in _client(app):
+        resp = await c.get("/v1/sessions/conv_codex/skills")
+
+    assert resp.status_code == 200, resp.text
+    assert "superpowers:using-superpowers" not in [s["name"] for s in resp.json()["skills"]]
+
+
+@pytest.mark.asyncio
+async def test_resolve_finds_a_surfaced_plugin_skill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anything ``/skills`` lists, ``/skills/resolve`` resolves by name."""
+    home = tmp_path / "home"
+    _seed_claude_plugin(home)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    app = _make_app(bundle, [], "all", workspace=workspace, harness="claude-native")
+
+    async for c in _client(app):
+        resp = await c.post(
+            "/v1/sessions/conv_cc/skills/resolve",
+            json={"name": "superpowers:using-superpowers", "arguments": "go"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert "<skill>" in resp.json()["meta_text"]
+
+
+@pytest.mark.asyncio
+async def test_get_session_skills_excludes_user_invocable_false_bundled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user-invocable:false bundled skill is kept out of the composer menu."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    bundled = [
+        SkillSpec(name="visible", description="Shown.", content="c"),
+        SkillSpec(name="internal", description="Hidden.", content="c", user_invocable=False),
+    ]
+    app = _make_app(bundle, bundled, "all", workspace=workspace, harness="claude-native")
+
+    async for c in _client(app):
+        resp = await c.get("/v1/sessions/conv_ui/skills")
+
+    assert resp.status_code == 200, resp.text
+    names = [s["name"] for s in resp.json()["skills"]]
+    assert "visible" in names
+    assert "internal" not in names
+
+
+@pytest.mark.asyncio
+async def test_non_invocable_bundled_skill_does_not_unshadow_host_skill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A bundled skill marked user-invocable:false stays hidden AND keeps a
+    same-named host skill hidden — the non-invocable name still shadows.
+    """
+    home = tmp_path / "home"
+    # Host skill that shares the bundled skill's name.
+    hostdir = home / ".claude" / "skills" / "shared"
+    hostdir.mkdir(parents=True)
+    (hostdir / "SKILL.md").write_text(_skill_md("shared", "Host version."))
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    bundled = [
+        SkillSpec(name="shared", description="Internal.", content="c", user_invocable=False),
+    ]
+    app = _make_app(bundle, bundled, "all", workspace=workspace, harness="claude-native")
+
+    async for c in _client(app):
+        resp = await c.get("/v1/sessions/conv_shadow/skills")
+
+    assert resp.status_code == 200, resp.text
+    # Neither the hidden bundled skill nor the host skill of the same name shows.
+    assert "shared" not in [s["name"] for s in resp.json()["skills"]]
+
+
+@pytest.mark.asyncio
+async def test_codex_bundle_skill_not_duplicated_when_dir_differs_from_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A codex session must not double-list a bundle skill whose directory name
+    differs from its SKILL.md frontmatter name: spec.skills adds it by
+    frontmatter name, the codex provider rediscovers it by dir name, and the
+    skill_dir dedup collapses the two into one entry.
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    bundle = tmp_path / "bundle"
+    skill_dir = bundle / "skills" / "sra--triage"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(_skill_md("triage", "Triage things."))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    # The runner's spec.skills carries the bundle skill by frontmatter name.
+    bundled = [
+        SkillSpec(
+            name="triage",
+            description="Triage things.",
+            content="c",
+            skill_dir=skill_dir,
+        )
+    ]
+    app = _make_app(bundle, bundled, "all", workspace=workspace, harness="codex-native")
+
+    async for c in _client(app):
+        resp = await c.get("/v1/sessions/conv_dup/skills")
+
+    assert resp.status_code == 200, resp.text
+    names = [s["name"] for s in resp.json()["skills"]]
+    # Exactly one entry for the skill (no phantom dir-named duplicate).
+    assert names.count("triage") + names.count("sra--triage") == 1

--- a/tests/runner/test_skills.py
+++ b/tests/runner/test_skills.py
@@ -435,6 +435,50 @@ async def test_session_skills_cached_per_session(tmp_path: Path) -> None:
     assert resolver_calls == ["ag_x"]
 
 
+@pytest.mark.asyncio
+async def test_session_skills_cache_ttl_expiry_rediscovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The per-session cache honors a TTL: once it elapses, the next request
+    re-walks the filesystem and picks up a skill installed mid-session.
+
+    With the TTL pinned to 0 every cached entry is immediately stale, so a
+    host skill created AFTER the first request must appear in the second —
+    proof the walk reran rather than serving the stale cache (the converse of
+    ``test_session_skills_cached_per_session``, which proves the cache holds
+    within the window).
+    """
+    home = tmp_path / "home"
+    (home / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("omnigent.runner.app._SESSION_SKILLS_CACHE_TTL_SECONDS", 0.0)
+
+    workspace = tmp_path / "workspace"
+    first_skill = workspace / ".claude" / "skills" / "first"
+    first_skill.mkdir(parents=True)
+    (first_skill / "SKILL.md").write_text(_skill_md("first", "Present from the start."))
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    app = _make_app(bundle, [], "all", workspace=workspace)
+
+    async for c in _client(app):
+        first = await c.get("/v1/sessions/conv_ttl/skills")
+        # Install a second host skill only AFTER the first response is served.
+        second_skill = workspace / ".claude" / "skills" / "second"
+        second_skill.mkdir(parents=True)
+        (second_skill / "SKILL.md").write_text(_skill_md("second", "Installed mid-session."))
+        second = await c.get("/v1/sessions/conv_ttl/skills")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert {s["name"] for s in first.json()["skills"]} == {"first"}
+    # TTL=0 ⇒ the second request re-walked and discovered the new skill.
+    assert {s["name"] for s in second.json()["skills"]} == {"first", "second"}
+
+
 def _seed_claude_plugin(home: Path) -> None:
     """Seed a fake ~/.claude with one enabled plugin exposing one skill."""
     install = home / ".claude" / "plugins" / "cache" / "mkt" / "superpowers" / "1.0.0"

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -407,6 +407,61 @@ def test_parse_skill(agent_dir: Path) -> None:
     assert skill.description == "Search the web for sources."
     assert skill.content == "When asked to research, use search.web."
     assert skill.skill_dir == skill_dir
+    # Absent ``user-invocable`` frontmatter defaults to invocable.
+    assert skill.user_invocable is True
+
+
+def test_parse_skill_user_invocable_false(agent_dir: Path) -> None:
+    """``user-invocable: false`` frontmatter parses to ``user_invocable=False``."""
+    skill_dir = agent_dir / "skills" / "internal-hook"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: internal-hook\n"
+        "description: Internal orchestration skill.\n"
+        "user-invocable: false\n"
+        "---\n"
+        "Body."
+    )
+    spec = parse(agent_dir)
+    skill = next(s for s in spec.skills if s.name == "internal-hook")
+    assert skill.user_invocable is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Quoted-string spellings (YAML keeps these as ``str``, not bool) —
+        # the string branch of _falsey_flag, never exercised by the bare forms.
+        ('"false"', False),
+        ('"False"', False),
+        ('"FALSE"', False),
+        ('" false "', False),
+        ('"no"', False),  # extended false spellings (quoted → str)
+        ('"off"', False),
+        ('"0"', False),
+        ('"true"', True),
+        ('"yes"', True),  # not in the false set
+        ('"maybe"', True),
+        # Genuine YAML booleans — PyYAML parses bare false/no/off to ``bool``.
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("true", True),
+    ],
+)
+def test_parse_skill_user_invocable_string_and_bool_spellings(
+    agent_dir: Path, raw: str, expected: bool
+) -> None:
+    """Both the YAML bool ``false`` and the quoted string ``"false"`` parse falsey."""
+    skill_dir = agent_dir / "skills" / "flag-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: flag-skill\ndescription: d\nuser-invocable: {raw}\n---\nBody."
+    )
+    spec = parse(agent_dir)
+    skill = next(s for s in spec.skills if s.name == "flag-skill")
+    assert skill.user_invocable is expected
 
 
 def test_parse_skill_missing_frontmatter(agent_dir: Path) -> None:
@@ -430,6 +485,20 @@ def test_parse_skill_missing_description(agent_dir: Path) -> None:
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: no-desc\n---\nContent.")
     with pytest.raises(OmnigentError, match=r"missing required field 'description'"):
+        parse(agent_dir)
+
+
+def test_parse_skill_non_utf8_raises_omnigent_error(agent_dir: Path) -> None:
+    """
+    A non-UTF-8 SKILL.md must funnel through OmnigentError (not escape as a
+    bare UnicodeDecodeError) so the lenient scanner / menu providers can
+    catch it and skip the file instead of crashing.
+    """
+    skill_dir = agent_dir / "skills" / "bad-bytes"
+    skill_dir.mkdir(parents=True)
+    # 0xff is invalid UTF-8 — read_text() raises UnicodeDecodeError.
+    (skill_dir / "SKILL.md").write_bytes(b"---\nname: bad-bytes\ndescription: \xff\n---\nx")
+    with pytest.raises(OmnigentError, match=r"could not be read"):
         parse(agent_dir)
 
 

--- a/tests/spec/test_skill_sources.py
+++ b/tests/spec/test_skill_sources.py
@@ -1,0 +1,584 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec.skill_sources import (
+    SkillSourceContext,
+    _harness_family,
+    resolve_harness_skills,
+)
+
+
+def _write_skill(skills_dir: Path, name: str, *, user_invocable: bool | None = None) -> None:
+    """
+    Write a minimal ``<skills_dir>/<name>/SKILL.md`` with valid frontmatter.
+
+    :param user_invocable: When not ``None``, emit a ``user-invocable:``
+        frontmatter line with this value. Omitted (the default) leaves the
+        field absent, which parses as user-invocable.
+    """
+    d = skills_dir / name
+    d.mkdir(parents=True)
+    ui = "" if user_invocable is None else f"user-invocable: {str(user_invocable).lower()}\n"
+    (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: {name} desc\n{ui}---\nbody\n")
+
+
+def _ctx(root: Path, home: Path, skills_filter: str | list[str] = "all") -> SkillSourceContext:
+    """Build a context with a single discovery root and a pinned home."""
+    return SkillSourceContext(
+        roots=(root,), home=home, skills_filter=skills_filter, bundle_dir=None
+    )
+
+
+@pytest.mark.parametrize(
+    "harness,expected",
+    [
+        ("claude-sdk", "claude"),
+        ("claude_sdk", "claude"),  # in-process SDK executor-type spelling (B1)
+        ("claude-native", "claude"),
+        ("native-claude", "claude"),
+        ("agents_sdk", None),  # underscore non-claude executor type stays unmapped
+        ("codex", "codex"),
+        ("codex-native", "codex"),
+        ("native-codex", "codex"),
+        ("cursor", "cursor"),
+        ("cursor-native", "cursor"),
+        ("pi", "pi"),
+        ("pi-native", "pi"),
+        ("native-pi", "pi"),
+        ("openai-agents", None),
+        ("antigravity", None),
+        ("qwen", None),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_harness_family(harness: str | None, expected: str | None) -> None:
+    assert _harness_family(harness) == expected
+
+
+def test_unknown_harness_falls_back_to_generic_host_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    (home / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    workspace = tmp_path / "ws"
+    _write_skill(workspace / ".claude" / "skills", "ws-skill")
+
+    out = resolve_harness_skills(_ctx(workspace, home), "openai-agents")
+    assert [s.name for s in out] == ["ws-skill"]
+
+
+def test_none_harness_falls_back_to_generic_host_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    (home / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    workspace = tmp_path / "ws"
+    _write_skill(workspace / ".claude" / "skills", "ws-skill")
+
+    out = resolve_harness_skills(_ctx(workspace, home), None)
+    assert [s.name for s in out] == ["ws-skill"]
+
+
+def _claude_home_with_plugin(
+    home: Path, *, plugin: str, marketplace: str, skill: str, enabled: bool
+) -> Path:
+    """Seed a fake ~/.claude with one installed plugin and an enablement flag."""
+    install = home / ".claude" / "plugins" / "cache" / marketplace / plugin / "1.0.0"
+    _write_skill(install / "skills", skill)
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {f"{plugin}@{marketplace}": enabled}})
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {
+                    f"{plugin}@{marketplace}": [
+                        {"scope": "user", "installPath": str(install), "version": "1.0.0"}
+                    ]
+                },
+            }
+        )
+    )
+    return home
+
+
+def test_claude_provider_surfaces_enabled_plugin_skill_namespaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = _claude_home_with_plugin(
+        tmp_path / "home",
+        plugin="superpowers",
+        marketplace="claude-plugins-official",
+        skill="using-superpowers",
+        enabled=True,
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")
+    assert "superpowers:using-superpowers" in [s.name for s in out]
+
+
+def test_claude_sdk_underscore_harness_surfaces_plugin_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    B1 regression: the in-process Claude SDK harness flows in as the
+    underscore executor-type spelling ``claude_sdk``; it must still
+    resolve to the claude family and surface enabled-plugin skills.
+    """
+    home = _claude_home_with_plugin(
+        tmp_path / "home",
+        plugin="superpowers",
+        marketplace="mkt",
+        skill="using-superpowers",
+        enabled=True,
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude_sdk")
+    assert "superpowers:using-superpowers" in [s.name for s in out]
+
+
+def test_claude_provider_excludes_disabled_plugin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = _claude_home_with_plugin(
+        tmp_path / "home",
+        plugin="superpowers",
+        marketplace="claude-plugins-official",
+        skill="using-superpowers",
+        enabled=False,
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-sdk")
+    assert "superpowers:using-superpowers" not in [s.name for s in out]
+
+
+def test_claude_provider_tolerates_missing_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    (home / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")
+    assert out == []  # no plugins, empty host walk → no crash
+
+
+def test_claude_provider_tolerates_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude" / "settings.json").write_text("{not json")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")
+    assert out == []
+
+
+def test_claude_provider_none_filter_suppresses_plugins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``skills_filter="none"`` is hermetic: no plugin skills leak in."""
+    home = _claude_home_with_plugin(
+        tmp_path / "home",
+        plugin="superpowers",
+        marketplace="claude-plugins-official",
+        skill="using-superpowers",
+        enabled=True,
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    ctx = SkillSourceContext(
+        roots=(tmp_path / "ws",), home=home, skills_filter="none", bundle_dir=None
+    )
+    assert resolve_harness_skills(ctx, "claude-native") == []
+
+
+def test_claude_provider_list_filter_selects_by_bare_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A list filter selects plugin skills by their bare (un-namespaced) name."""
+    home = tmp_path / "home"
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / "superpowers" / "1.0.0"
+    _write_skill(install / "skills", "using-superpowers")
+    _write_skill(install / "skills", "writing-plans")
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"superpowers@mkt": True}})
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps({"version": 2, "plugins": {"superpowers@mkt": [{"installPath": str(install)}]}})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    ctx = SkillSourceContext(
+        roots=(tmp_path / "ws",),
+        home=home,
+        skills_filter=["writing-plans"],
+        bundle_dir=None,
+    )
+    names = [s.name for s in resolve_harness_skills(ctx, "claude-native")]
+    assert names == ["superpowers:writing-plans"]
+
+
+def test_codex_provider_surfaces_home_codex_skills(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_skill(home / ".codex" / "skills", "using-superpowers")
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "codex-native")
+    assert "using-superpowers" in [s.name for s in out]
+
+
+def test_codex_provider_respects_none_filter(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_skill(home / ".codex" / "skills", "using-superpowers")
+    ctx = SkillSourceContext(
+        roots=(tmp_path / "ws",), home=home, skills_filter="none", bundle_dir=None
+    )
+    assert resolve_harness_skills(ctx, "codex") == []
+
+
+def test_cursor_provider_surfaces_skills_by_dir_name(tmp_path: Path) -> None:
+    """
+    Cursor names a skill by its ``plugin--skill`` directory (collision-safe
+    across the many ``fe-*`` plugins), not the bare frontmatter ``name``.
+    """
+    home = tmp_path / "home"
+    skill_dir = home / ".cursor" / "skills" / "fe-epl-tools--metric-view-adoption"
+    skill_dir.mkdir(parents=True)
+    # Frontmatter name is the BARE name; the dir carries the namespace.
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: metric-view-adoption\ndescription: MV adoption workflow.\n---\nbody\n"
+    )
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "cursor-native")
+    assert "fe-epl-tools--metric-view-adoption" in [s.name for s in out]
+
+
+def test_cursor_provider_respects_none_filter(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    skill_dir = home / ".cursor" / "skills" / "fe-epl-tools--metric-view-adoption"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: metric-view-adoption\ndescription: d\n---\nbody\n"
+    )
+    ctx = SkillSourceContext(
+        roots=(tmp_path / "ws",), home=home, skills_filter="none", bundle_dir=None
+    )
+    assert resolve_harness_skills(ctx, "cursor") == []
+
+
+def test_pi_provider_is_bundle_only_noop(tmp_path: Path) -> None:
+    """
+    Pi loads skills from the bundle (already carried by ``spec.skills``,
+    the base layer) and auto-discovers host skills internally — but
+    omnigent can't enumerate Pi's host-skill layout to name/resolve them,
+    so the provider surfaces nothing extra (under-report rather than list
+    a command that won't resolve).
+    """
+    home = tmp_path / "home"
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "pi-native")
+    assert out == []
+
+
+def test_pi_session_does_not_inherit_generic_claude_host_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A Pi session must not surface ``~/.claude/skills`` host skills (those
+    belong to Claude). Proves Pi has an explicit provider rather than
+    falling through to the generic host walk.
+    """
+    home = tmp_path / "home"
+    _write_skill(home / ".claude" / "skills", "claude-only-skill")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "pi-native")
+    assert "claude-only-skill" not in [s.name for s in out]
+
+
+def test_codex_provider_filters_user_invocable_false(tmp_path: Path) -> None:
+    """Codex (and all harnesses) must not surface user-invocable:false skills."""
+    home = tmp_path / "home"
+    _write_skill(home / ".codex" / "skills", "triage", user_invocable=False)
+    _write_skill(home / ".codex" / "skills", "account-review-deck")  # absent -> shown
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "codex-native")]
+    assert "triage" not in names
+    assert "account-review-deck" in names
+
+
+def test_cursor_provider_filters_user_invocable_false(tmp_path: Path) -> None:
+    """A user-invocable:false cursor skill is dropped (consistent across harnesses)."""
+    home = tmp_path / "home"
+    _write_skill(home / ".cursor" / "skills", "sra--triage", user_invocable=False)
+    _write_skill(home / ".cursor" / "skills", "fe--report", user_invocable=True)
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "cursor-native")]
+    assert "sra--triage" not in names
+    assert "fe--report" in names
+
+
+def test_claude_plugin_provider_filters_user_invocable_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An enabled plugin's user-invocable:false skill is not surfaced."""
+    home = tmp_path / "home"
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / "sra" / "1.0.0"
+    _write_skill(install / "skills", "triage", user_invocable=False)
+    _write_skill(install / "skills", "aisec-review", user_invocable=True)
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sra@mkt": True}})
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps({"version": 2, "plugins": {"sra@mkt": [{"installPath": str(install)}]}})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")]
+    assert "sra:triage" not in names
+    assert "sra:aisec-review" in names
+
+
+def test_codex_provider_surfaces_skills_by_dir_name(tmp_path: Path) -> None:
+    """
+    When a Codex skill's directory name differs from its frontmatter name,
+    the menu surfaces the DIRECTORY name — the command Codex registers and
+    the name the executor symlinks under (so menu label == runnable name).
+    """
+    home = tmp_path / "home"
+    skill_dir = home / ".codex" / "skills" / "sra--triage"
+    skill_dir.mkdir(parents=True)
+    # Frontmatter name is bare; directory carries the namespace.
+    (skill_dir / "SKILL.md").write_text("---\nname: triage\ndescription: d\n---\nbody\n")
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "codex-native")]
+    assert "sra--triage" in names
+    assert "triage" not in names
+
+
+def test_codex_menu_set_matches_executor_linked_set(tmp_path: Path) -> None:
+    """
+    Invariant: the menu provider and the executor's symlink path select the
+    SAME skill set from the SAME sources (both via codex_skill_sources +
+    select_codex_skill_dirs) — so a / menu entry is always actually linked.
+    """
+    from omnigent.inner.codex_executor import (
+        codex_skill_sources,
+        select_codex_skill_dirs,
+    )
+
+    home = tmp_path / "home"
+    host = home / ".codex" / "skills"
+    for n in ("alpha", "beta--gamma"):
+        d = host / n
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"---\nname: {n.split('--')[-1]}\ndescription: d\n---\nx\n")
+
+    # What the executor would symlink (keys = dir names linked into CODEX_HOME).
+    linked = set(select_codex_skill_dirs("all", codex_skill_sources(None, home)))
+    # What the menu surfaces.
+    menu = {s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "codex-native")}
+    assert menu == linked == {"alpha", "beta--gamma"}
+
+
+def test_claude_provider_project_disable_overrides_global_enable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plugin enabled globally but disabled in-project is excluded (scope precedence)."""
+    home = tmp_path / "home"
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / "sp" / "1.0.0"
+    _write_skill(install / "skills", "using-superpowers")
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": True}})  # global: enabled
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps({"version": 2, "plugins": {"sp@mkt": [{"installPath": str(install)}]}})
+    )
+    # Project root disables it.
+    ws = tmp_path / "ws"
+    (ws / ".claude").mkdir(parents=True)
+    (ws / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": False}})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    ctx = SkillSourceContext(roots=(ws,), home=home, skills_filter="all", bundle_dir=None)
+    names = [s.name for s in resolve_harness_skills(ctx, "claude-native")]
+    assert "sp:using-superpowers" not in names
+
+
+def test_claude_provider_install_path_from_later_scope_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """installPath is taken from the first entry that has one, not blindly entries[0]."""
+    home = tmp_path / "home"
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / "sp" / "1.0.0"
+    _write_skill(install / "skills", "using-superpowers")
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": True}})
+    )
+    # First entry lacks installPath; the second carries it.
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {
+                    "sp@mkt": [
+                        {"scope": "project"},
+                        {"scope": "user", "installPath": str(install)},
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")]
+    assert "sp:using-superpowers" in names
+
+
+def _claude_home_plugin_installed(home: Path, key: str, skill: str) -> None:
+    """Install (not toggle) one plugin + skill under a fake ~/.claude."""
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / key.split("@")[0] / "1.0.0"
+    _write_skill(install / "skills", skill)
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps({"version": 2, "plugins": {key: [{"installPath": str(install)}]}})
+    )
+
+
+def test_claude_local_settings_disable_overrides_settings_json_enable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """settings.local.json (local override) wins over settings.json within a scope."""
+    home = tmp_path / "home"
+    _claude_home_plugin_installed(home, "sp@mkt", "using-superpowers")
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": True}})  # enabled in shared
+    )
+    (home / ".claude" / "settings.local.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": False}})  # disabled locally
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")]
+    assert "sp:using-superpowers" not in names
+
+
+def test_claude_local_settings_enable_overrides_settings_json_disable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plugin enabled only in settings.local.json is surfaced."""
+    home = tmp_path / "home"
+    _claude_home_plugin_installed(home, "sp@mkt", "using-superpowers")
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": False}})
+    )
+    (home / ".claude" / "settings.local.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": True}})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")]
+    assert "sp:using-superpowers" in names
+
+
+def test_claude_workspace_settings_win_over_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Among roots, the workspace (primary) overrides the shipped bundle."""
+    home = tmp_path / "home"
+    _claude_home_plugin_installed(home, "sp@mkt", "using-superpowers")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    workspace = tmp_path / "ws"
+    bundle = tmp_path / "bundle"
+    (workspace / ".claude").mkdir(parents=True)
+    (bundle / ".claude").mkdir(parents=True)
+    # Bundle enables; workspace disables — workspace must win.
+    (bundle / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": True}})
+    )
+    (workspace / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": False}})
+    )
+    ctx = SkillSourceContext(
+        roots=(workspace, bundle), home=home, skills_filter="all", bundle_dir=None
+    )
+    names = [s.name for s in resolve_harness_skills(ctx, "claude-native")]
+    assert "sp:using-superpowers" not in names
+
+
+def test_non_invocable_host_skill_shadows_same_named_invocable_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Documented behavior: a workspace skill marked user-invocable:false
+    shadows a same-named invocable home skill, so it is filtered out
+    entirely rather than falling back to the invocable copy — the
+    project's authoritative copy wins (it shadows in execution too).
+    """
+    home = tmp_path / "home"
+    _write_skill(home / ".claude" / "skills", "x")  # home: invocable
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    workspace = tmp_path / "ws"
+    _write_skill(workspace / ".claude" / "skills", "x", user_invocable=False)  # project: internal
+
+    out = resolve_harness_skills(_ctx(workspace, home), "claude-native")
+    assert "x" not in [s.name for s in out]
+
+
+def test_claude_provider_string_false_enablement_does_not_enable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A JSON string ``"false"`` must not enable a plugin (only real bools count)."""
+    home = tmp_path / "home"
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / "sp" / "1.0.0"
+    _write_skill(install / "skills", "using-superpowers")
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": "false"}})  # truthy string, not a bool
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps({"version": 2, "plugins": {"sp@mkt": [{"installPath": str(install)}]}})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")]
+    assert "sp:using-superpowers" not in names
+
+
+def test_claude_provider_skips_install_path_outside_plugins_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An installPath escaping ~/.claude/plugins/ is skipped, not scanned."""
+    home = tmp_path / "home"
+    # Skill lives OUTSIDE the plugins cache root (a tampered/odd manifest).
+    outside = tmp_path / "evil"
+    _write_skill(outside / "skills", "using-superpowers")
+    (home / ".claude" / "plugins").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"sp@mkt": True}})
+    )
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps({"version": 2, "plugins": {"sp@mkt": [{"installPath": str(outside)}]}})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-native")]
+    assert "sp:using-superpowers" not in names
+
+
+def test_cursor_provider_tolerates_unreadable_skills_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable ~/.cursor/skills must yield [] (lenient), not 500 the menu."""
+    home = tmp_path / "home"
+    _write_skill(home / ".cursor" / "skills", "fe--report")
+
+    real_iterdir = Path.iterdir
+
+    def _boom(self: Path):
+        if self.name == "skills" and self.parent.name == ".cursor":
+            raise PermissionError("permission denied")
+        return real_iterdir(self)
+
+    monkeypatch.setattr("pathlib.Path.iterdir", _boom)
+    # Must not raise.
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "cursor-native")
+    assert out == []

--- a/tests/spec/test_skill_sources.py
+++ b/tests/spec/test_skill_sources.py
@@ -161,6 +161,62 @@ def test_claude_provider_excludes_disabled_plugin(
     assert "superpowers:using-superpowers" not in [s.name for s in out]
 
 
+def test_claude_managed_plugin_surfaces_when_absent_from_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A plugin force-enabled only via ``managed_plugins.json`` — with no
+    ``enabledPlugins`` entry in any settings file — is still surfaced.
+    Claude Code's managed (policy) tier enables it regardless of settings.
+    """
+    home = tmp_path / "home"
+    install = home / ".claude" / "plugins" / "cache" / "mkt" / "secrev" / "1.0.0"
+    _write_skill(install / "skills", "do-review")
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(json.dumps({"enabledPlugins": {}}))
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {
+                    "secrev@mkt": [
+                        {"scope": "user", "installPath": str(install), "version": "1.0.0"}
+                    ]
+                },
+            }
+        )
+    )
+    (home / ".claude" / "plugins" / "managed_plugins.json").write_text(
+        json.dumps({"managed_plugins": ["secrev@mkt"]})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-sdk")
+    assert "secrev:do-review" in [s.name for s in out]
+
+
+def test_claude_managed_plugin_overrides_settings_disable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    ``managed_plugins.json`` force-enables even when ``enabledPlugins``
+    explicitly disables the same plugin: the managed tier is highest
+    precedence in Claude Code and cannot be overridden by a settings toggle.
+    """
+    home = _claude_home_with_plugin(
+        tmp_path / "home",
+        plugin="secrev",
+        marketplace="mkt",
+        skill="do-review",
+        enabled=False,
+    )
+    (home / ".claude" / "plugins" / "managed_plugins.json").write_text(
+        json.dumps({"managed_plugins": ["secrev@mkt"]})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "claude-sdk")
+    assert "secrev:do-review" in [s.name for s in out]
+
+
 def test_claude_provider_tolerates_missing_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A — no single filed issue. Related context (not closed by this PR): the
composer `/`-menu only surfaced `~/.claude/skills`; #850 (Capabilities panel)
and #197 (declarative skill sources) touch adjacent areas.
Closes #

## Summary

- Make the runner's skill resolution **harness-aware** so each session's `/`
  menu lists the skills that session's own harness exposes in its terminal —
  Claude Code plugin skills (`<plugin>:<skill>`), Codex `~/.codex/skills`,
  Cursor `~/.cursor/skills` — via a per-harness provider registry
  (`omnigent/spec/skill_sources.py`). Pi is an explicit no-op; unknown harnesses
  keep today's generic host walk (back-compat).
- The Codex menu reuses the **same** selector the executor uses to populate
  `$CODEX_HOME/skills/`, so the menu and the actually-linked set can't drift.
- Add `SkillSpec.user_invocable` (from `SKILL.md` frontmatter); skills marked
  `user-invocable: false` are filtered out everywhere a skill becomes a
  user-facing slash command (web menu, runner bundled merge, REPL registry)
  while staying agent-loadable.
- Hardening: non-UTF-8 `SKILL.md` → `OmnigentError`; lenient `OSError` on dir
  listing; boolean-only `enabledPlugins` with `settings.local.json` precedence;
  `installPath` validated under the plugins cache root; slash-command name
  validation before REPL registration.

### ELI5

Your terminal coding agent (Claude, Codex, Cursor) knows a bunch of `/commands`.
The web chat box didn't show most of them, because it only looked in one folder
that fits Claude. Now the chat box asks the *right* place for *each* agent, so
you see the same `/commands` in chat that you'd see in that agent's terminal —
and we hide the internal ones you're not meant to type.

### Flow

```mermaid
flowchart LR
  A[GET /v1/sessions/:id/skills] --> B[_resolve_session_skills]
  B --> C{harness family}
  C -->|claude| D[~/.claude/skills + enabled plugins]
  C -->|codex| E[~/.codex/skills + bundle\nshared select_codex_skill_dirs]
  C -->|cursor| F[~/.cursor/skills]
  C -->|pi| G[no-op]
  C -->|other| H[generic host walk]
  D & E & F & G & H --> I[union with spec.skills\nfilter user_invocable:false\ndedup by name + skill_dir]
  I --> J[composer / menu]
```



## Test Plan

```
uv run pytest tests/spec tests/inner/test_codex_executor.py \
              tests/runner/test_skills.py tests/repl/test_repl.py
uv run ruff check . && uv run ruff format --check .
```
All green; lint + format clean. Also manually verified in a local server + omnigent host + npm run dev stack: Claude, Codex, and Cursor sessions each show their harness's skills in the / menu (Pi correctly shows none).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Per-provider unit tests (tests/spec/test_skill_sources.py), parser tests for the user-invocable flag (tests/spec/test_parser.py), the shared Codex selector + executor parity (tests/inner/test_codex_executor.py), and REPL command-registration filtering (tests/repl/test_repl.py). The runner endpoint behavior — cross-harness isolation, the /skills ↔ /skills/resolve coupling, and user-invocable filtering — is covered in tests/runner/test_skills.py via real ASGI requests against the runner app.

No new E2E test: the shared E2E runner reads the host's real ~/.claude, so a plugin fixture can't be seeded cleanly without affecting other tests; the backend path is covered by the runner tests above, and no ap-web/ source changed (the menu's render path is untouched). Manual verification covered the live UI across harnesses as described in the Test Plan.
