### PR TITLE
fix(context-window): authoritative window resolution + compaction-failure surfacing + /context meter (#1121)

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2550,9 +2550,24 @@ class ClaudeSDKExecutor(Executor):
                     for m in _msgs
                     if isinstance(m.message, dict)
                 ]
+                if not _compacted:
+                    logger.warning(
+                        "Claude post-compaction read returned no messages "
+                        "(session=%s); resume will fall back to the synthetic "
+                        "summary instead of the harness's real compacted state.",
+                        claude_session_id,
+                    )
             except Exception:  # noqa: BLE001
-                logger.debug(
-                    "Failed to read Claude session messages for compaction persist",
+                # WARNING, not DEBUG: a swallowed read here silently degrades
+                # EVERY later resume of this conversation. The runner persists a
+                # compaction item with no ``compacted_messages``, so resume
+                # replays the lossy synthetic-summary pair instead of the
+                # harness's real post-compaction context (OMNI-143). Surface it.
+                logger.warning(
+                    "Failed to read Claude post-compaction session messages "
+                    "(session=%s); resume fidelity for this conversation will "
+                    "degrade to the synthetic summary.",
+                    claude_session_id,
                     exc_info=True,
                 )
             yield CompactionComplete(

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2562,7 +2562,7 @@ class ClaudeSDKExecutor(Executor):
                 # EVERY later resume of this conversation. The runner persists a
                 # compaction item with no ``compacted_messages``, so resume
                 # replays the lossy synthetic-summary pair instead of the
-                # harness's real post-compaction context (OMNI-143). Surface it.
+                # harness's real post-compaction context. Surface it.
                 logger.warning(
                     "Failed to read Claude post-compaction session messages "
                     "(session=%s); resume fidelity for this conversation will "

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -54,16 +54,22 @@ _MODEL_PREFIX_TO_PROVIDER: dict[str, str] = {
 
 _DEFAULT_CONTEXT_WINDOW: int = 128_000
 
-# Curated context windows for the Qwen models the qwen (``qwen --acp``) harness
-# drives. Qwen models are absent from both litellm's bundled registry and the
-# MLflow provider catalog, so without this they fall back to the conservative
-# 128K default — wrong by ~8x for the coding-plan defaults (qwen3-coder-plus is
-# 1M), leaving the UI context meter mis-sized. Keyed by the *normalized* base id
-# (provider prefix and ``:tag`` suffix stripped — see
-# :func:`_qwen_context_window`). Values are the published Alibaba Cloud Model
-# Studio / DashScope maxima; unrecognized qwen models keep the 128K fallback
-# (and a spec's ``executor.context_window`` always overrides this).
-_QWEN_CONTEXT_WINDOWS: dict[str, int] = {
+# Omnigent's authoritative context-window registry, consulted BEFORE litellm
+# and the MLflow catalog (see :func:`get_model_context_window`). The upstream
+# backends mis-size or omit several ids we actually serve, and offline both
+# collapse to the conservative 128K default — so for those models this registry
+# is our single source of truth, not a last-resort fallback. Keyed by the
+# *normalized* base id (provider prefix and OpenRouter ``:tag`` suffix stripped,
+# lowercased; the ``[1m]`` beta marker is PRESERVED so the 1M variant stays
+# distinct from its base — see :func:`_registry_context_window`). A spec's
+# ``executor.context_window`` still overrides everything.
+#
+# Covered today:
+#  - Qwen models (absent from litellm + the MLflow catalog) — published Alibaba
+#    Cloud Model Studio / DashScope maxima.
+#  - Anthropic 1M-context beta ids (the ``[1m]`` suffix) — handled by a rule in
+#    :func:`_registry_context_window` rather than enumerated per base model.
+_CONTEXT_WINDOW_REGISTRY: dict[str, int] = {
     "qwen3-coder-plus": 1_048_576,  # DashScope coding-plan default: 1M tokens
     "qwen3-coder-flash": 1_048_576,  # served flash variant: 1M tokens
     "qwen3-coder": 262_144,  # 480B open weights: 256K native (1M w/ YaRN)
@@ -73,21 +79,43 @@ _QWEN_CONTEXT_WINDOWS: dict[str, int] = {
     "qwen-flash": 1_000_000,
 }
 
+# The Anthropic 1M-context beta encodes its window in the model id via a
+# trailing ``[1m]`` marker (e.g. ``claude-opus-4-8[1m]``). Neither litellm nor
+# the MLflow catalog keys on the bracketed form, so without this it resolves to
+# the 128K default — under-sizing both the context meter and the compaction /
+# overflow threshold by ~8x. The suffix *is* the window, so we read it directly
+# rather than stripping it (the base id may legitimately have a smaller window).
+_ANTHROPIC_1M_BETA_SUFFIX = "[1m]"
+_ANTHROPIC_1M_BETA_WINDOW = 1_000_000
 
-def _qwen_context_window(model: str) -> int | None:
-    """Look up a Qwen model's context window from the curated table.
 
-    Normalizes the id the way model strings reach us — a provider prefix
-    (``qwen/qwen3-coder``, ``openrouter/qwen/qwen3-coder``) and an OpenRouter-
-    style ``:tag`` suffix (``qwen3-coder:free``) — down to the bare base id
-    before matching against :data:`_QWEN_CONTEXT_WINDOWS`.
+def _registry_context_window(model: str) -> int | None:
+    """Resolve a model's context window from Omnigent's authoritative registry.
+
+    Consulted BEFORE litellm and the MLflow catalog. Normalizes the id the way
+    model strings reach us — a provider prefix (``qwen/qwen3-coder``,
+    ``openrouter/qwen/qwen3-coder``) and an OpenRouter-style ``:tag`` suffix
+    (``qwen3-coder:free``) — down to the bare id, lowercased, with the ``[1m]``
+    beta marker preserved.
+
+    Resolution: an exact :data:`_CONTEXT_WINDOW_REGISTRY` entry, then the
+    Anthropic 1M-context beta rule (a trailing ``[1m]`` on a Claude id →
+    1,000,000). The rule is scoped to Claude ids so a custom/self-hosted model
+    that merely happens to end in ``[1m]`` isn't force-sized to 1M.
 
     :param model: The model identifier (any namespacing).
-    :returns: The context window in tokens, or ``None`` when the model isn't a
-        recognized Qwen entry (caller falls back to the 128K default).
+    :returns: The context window in tokens, or ``None`` when the model isn't in
+        our registry (caller falls back to litellm / the catalog / the default).
     """
     bare = model.rsplit("/", 1)[-1].split(":", 1)[0].strip().lower()
-    return _QWEN_CONTEXT_WINDOWS.get(bare)
+    if bare in _CONTEXT_WINDOW_REGISTRY:
+        return _CONTEXT_WINDOW_REGISTRY[bare]
+    # ``[1m]`` is an Anthropic-only beta convention, so gate on Claude ids
+    # (covers ``claude-*`` and ``databricks-claude-*``); other providers fall
+    # through to litellm/catalog rather than being forced to 1M.
+    if "claude" in bare and bare.endswith(_ANTHROPIC_1M_BETA_SUFFIX):
+        return _ANTHROPIC_1M_BETA_WINDOW
+    return None
 
 
 # Fallback cache pricing as a multiple of the plain input rate, used when the
@@ -265,13 +293,17 @@ def get_model_context_window(model: str) -> int:
 
     1. ``AP_CONTEXT_WINDOW_OVERRIDE`` env var — overrides everything.
        Supports custom/self-hosted models and e2e compaction tests.
-    2. ``litellm.get_model_info()`` — fast, local, no network. Also
+    2. :func:`_registry_context_window` — Omnigent's own authoritative
+       registry (Qwen models, Anthropic ``[1m]`` beta). Supersedes the
+       upstream backends, which mis-size or omit these ids and collapse to
+       the 128K default offline.
+    3. ``litellm.get_model_info()`` — fast, local, no network. Also
        tried with the ``databricks/`` prefix for Databricks models.
-    3. MLflow GitHub Release catalog — per-provider JSON fetched from
+    4. MLflow GitHub Release catalog — per-provider JSON fetched from
        ``github.com/mlflow/mlflow/releases``. Covers models not yet
        in litellm's bundled registry, with a family-prefix fallback
        for newly released variants.
-    4. ``_DEFAULT_CONTEXT_WINDOW`` (128 K) — conservative fallback.
+    5. ``_DEFAULT_CONTEXT_WINDOW`` (128 K) — conservative fallback.
 
     :param model: The model identifier, e.g. ``"openai/gpt-4o"`` or
         ``"databricks-gpt-5-5"``.
@@ -280,14 +312,17 @@ def get_model_context_window(model: str) -> int:
     override = os.environ.get("AP_CONTEXT_WINDOW_OVERRIDE")
     if override is not None:
         return int(override)
+    # Our registry supersedes the upstream backends: litellm and the MLflow
+    # catalog mis-size or omit ids we serve (the Anthropic ``[1m]`` beta resolves
+    # to 128K; Qwen models are absent), and offline both collapse to the 128K
+    # default. Consult ours first.
+    registered = _registry_context_window(model)
+    if registered is not None:
+        return registered
     try:
         import litellm
     except ImportError:
-        return (
-            _fetch_context_window_from_mlflow(model)
-            or _qwen_context_window(model)
-            or _DEFAULT_CONTEXT_WINDOW
-        )
+        return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
     try:
         info = litellm.get_model_info(model)
         if info:
@@ -305,11 +340,7 @@ def get_model_context_window(model: str) -> int:
                     return int(limit)
         except Exception:
             pass
-    return (
-        _fetch_context_window_from_mlflow(model)
-        or _qwen_context_window(model)
-        or _DEFAULT_CONTEXT_WINDOW
-    )
+    return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
 
 
 def resolve_effective_context_window(

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -5661,8 +5661,12 @@ def _render_context_tree(
         + _CONTEXT_COIN_BUF * buf_coins
     )
 
-    free_tokens = max(context_window - message_tokens, 0)
     buf_tokens = int(context_window * buf_frac)
+    # Free space excludes the compaction buffer so the three rows partition the
+    # window (Messages + Free + Buffer = window) and each row's token count
+    # agrees with its own percentage. (Previously free omitted the buffer, so it
+    # read e.g. "920,150 tokens (72%)" — a count that is 92% of the window.)
+    free_tokens = max(context_window - message_tokens - buf_tokens, 0)
     used_pct = used_frac * 100.0
 
     tree.add(

--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -735,6 +735,25 @@ def _history_idx_to_msg_idx(
     return msg_idx
 
 
+def _is_summary_auth_error(exc: BaseException) -> bool:
+    """Return ``True`` when *exc* is (or wraps) an HTTP 401/403.
+
+    Layer 2 summarization calls an LLM *outside* the harness, so a missing or
+    invalid summarizer credential surfaces here as an auth error. Detecting it
+    lets the caller surface a distinct, actionable message instead of burying a
+    persistent misconfiguration behind a routine Layer-3 truncation fallback
+    (issue #1121).
+
+    :param exc: The exception raised by the summarization call.
+    :returns: ``True`` for a 401/403 (by ``response.status_code`` or message).
+    """
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if status in (401, 403):
+        return True
+    text = str(exc)
+    return any(token in text for token in ("401", "403", "Unauthorized", "Forbidden"))
+
+
 async def _run_layer2(
     messages: list[dict[str, Any]],
     history: list[ConversationItem],
@@ -799,12 +818,25 @@ async def _run_layer2(
             model,
             **summarize_kwargs,
         )
-    except Exception:
-        _logger.warning(
-            "Layer 2 summarisation failed for task %s — falling back to Layer 3",
-            task_id,
-            exc_info=True,
-        )
+    except Exception as exc:
+        if _is_summary_auth_error(exc):
+            # Distinct, actionable signal: an auth/config problem (not a
+            # transient blip) is silently degrading compaction to lossy
+            # truncation. Don't bury a 401 as a routine fallback (issue #1121).
+            _logger.error(
+                "Compaction Layer 2 summarisation is UNAUTHORIZED for task %s "
+                "(%s) — the summarizer's credentials are missing or invalid, so "
+                "compaction is degrading to lossy Layer-3 truncation. Fix the "
+                "summarizer auth/config to restore summary-quality compaction.",
+                task_id,
+                exc,
+            )
+        else:
+            _logger.warning(
+                "Layer 2 summarisation failed for task %s — falling back to Layer 3",
+                task_id,
+                exc_info=True,
+            )
         if fail_on_error:
             raise
         return None

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -15,7 +15,7 @@ import pytest
 from omnigent.llms import context_window
 from omnigent.llms.context_window import (
     ModelPricing,
-    _qwen_context_window,
+    _registry_context_window,
     compute_llm_cost,
     fetch_model_pricing,
     get_model_context_window,
@@ -356,29 +356,57 @@ def test_provider_catalog_caches_fetch_failure(
 
 
 # ---------------------------------------------------------------------------
-# Qwen context-window fallback (models absent from litellm + MLflow catalog)
+# Omnigent's authoritative context-window registry (supersedes litellm/catalog)
 # ---------------------------------------------------------------------------
 
 
-def test_qwen_context_window_normalizes_id() -> None:
-    """The lookup strips provider prefixes and ``:tag`` suffixes before matching."""
-    assert _qwen_context_window("qwen3-coder-plus") == 1_048_576
-    assert _qwen_context_window("qwen/qwen3-coder") == 262_144
-    assert _qwen_context_window("qwen3-coder:free") == 262_144
-    assert _qwen_context_window("openrouter/qwen/qwen3-coder:free") == 262_144
-    assert _qwen_context_window("QWEN3-CODER-PLUS") == 1_048_576  # case-insensitive
-    # Unknown qwen variant → None (caller falls back to the default).
-    assert _qwen_context_window("qwen-nonexistent-xyz") is None
+def test_registry_context_window_normalizes_id() -> None:
+    """The registry strips provider prefixes and ``:tag`` suffixes before matching."""
+    assert _registry_context_window("qwen3-coder-plus") == 1_048_576
+    assert _registry_context_window("qwen/qwen3-coder") == 262_144
+    assert _registry_context_window("qwen3-coder:free") == 262_144
+    assert _registry_context_window("openrouter/qwen/qwen3-coder:free") == 262_144
+    assert _registry_context_window("QWEN3-CODER-PLUS") == 1_048_576  # case-insensitive
+    # A model the registry doesn't own → None (caller falls back to litellm).
+    assert _registry_context_window("qwen-nonexistent-xyz") is None
+    assert _registry_context_window("gpt-5.4") is None
 
 
-def test_get_model_context_window_uses_qwen_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A known qwen model resolves to its curated window, not the 128K default.
+def test_registry_resolves_anthropic_1m_beta_suffix() -> None:
+    """The Anthropic ``[1m]`` beta marker resolves to a 1M window via the registry.
 
-    Catalog lookup is disabled so the resolution is hermetic (no network):
-    litellm has no qwen entry, MLflow is skipped, so the qwen table answers.
+    The suffix *is* the window — we read it, not strip it — so any
+    ``<model>[1m]`` resolves to 1,000,000 while the bare base defers to the
+    upstream backends (which may size it differently).
+    """
+    assert _registry_context_window("claude-opus-4-8[1m]") == 1_000_000
+    assert _registry_context_window("anthropic/claude-opus-4-8[1m]") == 1_000_000
+    assert _registry_context_window("claude-sonnet-4-6[1m]") == 1_000_000
+    assert _registry_context_window("CLAUDE-OPUS-4-8[1M]") == 1_000_000  # case-insensitive
+    # Databricks-hosted Claude (contains "claude") also resolves.
+    assert _registry_context_window("databricks-claude-opus-4-8[1m]") == 1_000_000
+    # Without the suffix the registry defers (None → caller uses litellm/catalog).
+    assert _registry_context_window("claude-opus-4-8") is None
+    # The rule is Claude-scoped: a non-Claude id ending in [1m] is NOT forced to
+    # 1M (it defers to litellm/catalog), so custom/self-hosted ids are safe.
+    assert _registry_context_window("my-local-model[1m]") is None
+    assert _registry_context_window("gpt-5.4[1m]") is None
+
+
+def test_get_model_context_window_uses_registry_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Registry-curated ids resolve to their window with NO network.
+
+    Catalog lookup is disabled to prove hermeticity: the registry is consulted
+    before litellm and the catalog, so qwen models and the Anthropic ``[1m]``
+    beta resolve correctly even offline (the OMNI-142 meter / OMNI-143 overflow
+    bug was that these collapsed to the 128K default).
     """
     monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
     monkeypatch.delenv("AP_CONTEXT_WINDOW_OVERRIDE", raising=False)
+    # Anthropic 1M beta: resolves via the registry, not the 128K default.
+    assert get_model_context_window("claude-opus-4-8[1m]") == 1_000_000
+    assert get_model_context_window("anthropic/claude-opus-4-8[1m]") == 1_000_000
+    # Qwen: curated window, not the default.
     assert get_model_context_window("qwen3-coder-plus") == 1_048_576
-    # An unrecognized qwen model still falls back to the conservative default.
+    # A model the registry doesn't own still falls back to the conservative default.
     assert get_model_context_window("qwen-nonexistent-xyz") == 128_000

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -398,7 +398,7 @@ def test_get_model_context_window_uses_registry_first(monkeypatch: pytest.Monkey
 
     Catalog lookup is disabled to prove hermeticity: the registry is consulted
     before litellm and the catalog, so qwen models and the Anthropic ``[1m]``
-    beta resolve correctly even offline (the OMNI-142 meter / OMNI-143 overflow
+    beta resolve correctly even offline (the meter / overflow-threshold
     bug was that these collapsed to the 128K default).
     """
     monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")

--- a/tests/repl/test_context_command.py
+++ b/tests/repl/test_context_command.py
@@ -208,6 +208,45 @@ async def test_context_coin_bar_low_usage(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_context_free_space_count_matches_its_percentage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Free-space token count partitions the window with messages + buffer.
+
+    Regression for the count/percent mismatch: free space used to be
+    ``window - messages`` (omitting the 20% compaction buffer) while its
+    percentage subtracted the buffer — so it read e.g. "920,150 tokens (72%)",
+    a count that is 92% of the window. With window=100k, messages=10k, buffer
+    20k, free must be 70k (70%): count and percent now agree, and the three
+    rows sum to the window.
+    """
+    _patch_count_tokens(monkeypatch, message_tokens=10_000)
+    host = CapturingHost()
+    session = _Session(model_override="openai/gpt-4o", context_window=100_000)
+    await handle_slash_command(
+        "/context",
+        session,
+        None,
+        host,
+        RichBlockFormatter(),  # type: ignore[arg-type]
+    )
+    output = host.text
+    # Compute the expected partition the way the renderer does (the buffer
+    # fraction is 1 - trigger, i.e. ~0.2 with float wobble).
+    from omnigent.repl._repl import _CONTEXT_COMPACTION_TRIGGER
+
+    window, msgs = 100_000, 10_000
+    buf = int(window * (1.0 - _CONTEXT_COMPACTION_TRIGGER))
+    free = window - msgs - buf
+    assert msgs + free + buf == window  # the three rows partition the window
+    # Each row's rendered count agrees with its percentage (the bug was free
+    # showing window-messages while its % subtracted the buffer).
+    assert f"{free:,} tokens (70%)" in output  # buffer now excluded from free
+    assert f"{buf:,} tokens (20%)" in output
+    assert f"{msgs:,} tokens (10%)" in output
+
+
+@pytest.mark.asyncio
 async def test_context_coin_bar_over_trigger_threshold(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -19,6 +19,7 @@ from omnigent.llms.types import MessageOutput, OutputText, Response
 from omnigent.runtime.compaction import (
     _BINARY_CONTENT_CLEARED,
     _TOOL_RESULT_CLEARED,
+    _is_summary_auth_error,
     _pair_aware_drop_count,
     _truncate_oldest,
     compact,
@@ -1506,3 +1507,32 @@ async def test_default_window_compacts_same_fill(monkeypatch: pytest.MonkeyPatch
         llm_client=_ReturnsTextClient("Summary of earlier context."),
     )
     assert result.summary_metadata is not None
+
+
+# ---------------------------------------------------------------------------
+# Layer-2 auth-failure detection (issue #1121: don't bury a 401)
+# ---------------------------------------------------------------------------
+
+
+def test_is_summary_auth_error_distinguishes_401_403() -> None:
+    """401/403 (by status code or message) are auth errors; others are not."""
+
+    class _Resp:
+        def __init__(self, code: int) -> None:
+            self.status_code = code
+
+    class _HTTPStatusError(Exception):
+        def __init__(self, code: int) -> None:
+            super().__init__(f"status {code}")
+            self.response = _Resp(code)
+
+    # By response.status_code (as httpx.HTTPStatusError carries it).
+    assert _is_summary_auth_error(_HTTPStatusError(401)) is True
+    assert _is_summary_auth_error(_HTTPStatusError(403)) is True
+    assert _is_summary_auth_error(_HTTPStatusError(500)) is False
+    # By message text (when no structured response is attached).
+    assert _is_summary_auth_error(Exception("Client error '401 Unauthorized'")) is True
+    assert _is_summary_auth_error(Exception("Forbidden")) is True
+    # Non-auth failures fall through to the generic warning path.
+    assert _is_summary_auth_error(Exception("connection reset by peer")) is False
+    assert _is_summary_auth_error(TimeoutError("read timed out")) is False


### PR DESCRIPTION
## Summary

Collapsed from the original "compaction fixes" set. After a live investigation, the **resume safety net** (this PR's original centerpiece) **was dropped** — it never executes on the real resume path, and the overflow it was meant to prevent could not be reproduced. See *Why the resume guard was dropped* below.

What remains is four independent, verified fixes:

### 1. Authoritative context-window resolution
`get_model_context_window` consults a curated registry **before** litellm / the MLflow catalog, so window resolution is correct and offline-safe. Concretely this fixes the Anthropic `[1m]` beta suffix: `claude-…[1m]` now resolves to **1,000,000** instead of collapsing to the 128K default (an 8× under-count that caused premature compaction and a wrong `/context` meter). The `[1m]` rule is scoped to Claude ids so a custom/self-hosted model merely ending in `[1m]` isn't force-sized to 1M.

### 2. Surface post-compaction read failures (claude-sdk)
A swallowed failure to read Claude's post-compaction session was logged at DEBUG; it now logs at **WARNING**. That read failing silently degrades resume fidelity for the entire conversation, so it should be visible.

### 3. Surface Layer-2 compaction auth failures (#1121)
A 401/403 on the Layer-2 (LLM-summarization) compaction path was indistinguishable from any other failure in the logs. Added `_is_summary_auth_error` and a distinct ERROR so an auth misconfiguration is actionable rather than buried.

### 4. `/context` free-space accuracy
The free-space token count now subtracts the compaction buffer so it agrees with the percentage shown beside it.

## Why the resume guard was dropped
The original `_guard_resume_history_budget` / `reduce_messages_to_budget` "resume safety net" is **inert as wired**. It is gated on `_history_cold_loaded = conv not in _session_histories`, but the cold-cache rehydration path populates `_session_histories[conv]` *before* the turn runs — so on a real resume the gate is always `False` and the guard is never entered (`reduce_messages_to_budget` had exactly one caller, so the whole reduction was dead code on that path).

Separately, live testing could not produce a fatal resume overflow: a stateful SDK harness (claude-sdk / Claude Code) auto-compacts an oversized resumed prompt, and every over-window resume completed correctly. If a real fix is ever warranted, the reduction must move *into* the rehydration path — and only after an actually-fatal overflow is reproduced.

## Tests
`tests/llms/test_context_window.py`, `tests/runtime/test_compaction.py`, `tests/repl/test_context_command.py` — 57 passing.

This pull request and its description were written by Isaac.
