### PR TITLE
fix(ios): preserve transcript scroll position across keyboard/composer resize

### DIFF
--- a/ap-web/ios/Omnigent/OmnigentWebView.swift
+++ b/ap-web/ios/Omnigent/OmnigentWebView.swift
@@ -42,6 +42,15 @@ struct OmnigentWebView: UIViewRepresentable {
     webView.scrollView.backgroundColor = .clear
     webView.scrollView.contentInsetAdjustmentBehavior = .never
 
+    // Allow Safari Web Inspector to attach to the web content. Since iOS 16.4 a
+    // WKWebView is inspectable only when this is opt-in. Debug-only so shipping
+    // builds aren't inspectable.
+    #if DEBUG
+      if #available(iOS 16.4, *) {
+        webView.isInspectable = true
+      }
+    #endif
+
     let edgePan = UIScreenEdgePanGestureRecognizer(
       target: context.coordinator,
       action: #selector(Coordinator.handleLeftEdgePan(_:))

--- a/ap-web/src/hooks/useIOSViewportLock.ts
+++ b/ap-web/src/hooks/useIOSViewportLock.ts
@@ -7,18 +7,18 @@ import { isIOSShell } from "@/lib/nativeBridge";
  * the whole document.
  *
  * The native shell keeps the WKWebView full-height when the keyboard opens
- * (`.ignoresSafeArea(.keyboard)`), and the shell is otherwise sized to the
- * large viewport (`100lvh`). So when the keyboard appears the composer/inputs
- * sit *behind* it, and WebKit pans the entire document up to reveal the focused
- * field — hiding the header and letting the user scroll the whole page, which
- * breaks the fixed-shell layout.
+ * (`.ignoresSafeArea(.keyboard)`), so the layout viewport (`window.innerHeight`,
+ * `100lvh`) stays full while the keyboard overlays the bottom. Left alone, the
+ * composer/inputs sit *behind* the keyboard and WebKit pans the whole document
+ * up to reveal the focused field — hiding the header and letting the user scroll
+ * the entire page.
  *
- * Instead we publish the live `visualViewport.height` to
- * `--omnigent-viewport-height`; the app-shell sizes to that (see index.css), so
- * the focused input is always within the visible area. WebKit then never needs
- * to pan, the header stays put, and only the inner scroll panes (conversation
- * history, terminal, page bodies) move. As a safety net we also snap any
- * residual document pan back to the top.
+ * `visualViewport.height` *does* track the keyboard here (verified: it drops to
+ * the area above the keyboard while `innerHeight` stays full), so we publish it
+ * to `--omnigent-viewport-height`; the app-shell sizes to that (see index.css).
+ * The focused input is then always within the visible area, WebKit never needs
+ * to pan, the header stays put, and only the inner scroll panes move. As a
+ * safety net we also snap any residual document pan back to the top.
  *
  * No-op off the iOS shell — the browser and Electron handle the keyboard via
  * normal layout, and the CSS var falls back to `100lvh`.
@@ -32,12 +32,19 @@ export function useIOSViewportLock(): void {
     const root = document.documentElement;
     let frame = 0;
 
+    // With the shell sized to the visual viewport there is nothing to scroll, so
+    // counter any pan WebKit applies while revealing a focused field — that pan
+    // is what moves the whole page (and the absolute header). Wired as its own
+    // listener too, so it fires the instant WebKit scrolls, not just on the
+    // rAF-coalesced resize.
+    const resetPan = () => {
+      if (viewport.offsetTop !== 0 || window.scrollY !== 0) window.scrollTo(0, 0);
+    };
+
     const apply = () => {
       frame = 0;
       root.style.setProperty("--omnigent-viewport-height", `${Math.round(viewport.height)}px`);
-      // With the shell sized to the visual viewport there is nothing to scroll,
-      // so counter any transient pan WebKit applies while revealing a field.
-      if (viewport.offsetTop !== 0 || window.scrollY !== 0) window.scrollTo(0, 0);
+      resetPan();
     };
 
     // Coalesce the burst of resize/scroll events the keyboard animation fires.
@@ -49,12 +56,14 @@ export function useIOSViewportLock(): void {
     apply();
     viewport.addEventListener("resize", schedule);
     viewport.addEventListener("scroll", schedule);
+    window.addEventListener("scroll", resetPan, { passive: true });
     window.addEventListener("orientationchange", schedule);
 
     return () => {
       if (frame) window.cancelAnimationFrame(frame);
       viewport.removeEventListener("resize", schedule);
       viewport.removeEventListener("scroll", schedule);
+      window.removeEventListener("scroll", resetPan);
       window.removeEventListener("orientationchange", schedule);
       root.style.removeProperty("--omnigent-viewport-height");
     };

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -1454,6 +1454,7 @@ function MainAgentSurface({
           >
             {/* Scroll helpers — must live inside StickToBottom to access context. */}
             <ScrollToBottomOnSend nonce={sendScrollNonce} />
+            <PreserveScrollDistanceOnResize />
             <ConversationScrollRefBridge onScroller={setScroller} />
             <HistoryAutoLoader
               hasMoreHistory={hasMoreHistory}
@@ -1737,6 +1738,76 @@ function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
     scrollToBottom("instant");
     requestAnimationFrame(() => scrollToBottom("instant"));
   }, [nonce, scrollToBottom]);
+
+  return null;
+}
+
+/**
+ * Preserves the transcript's distance-from-bottom whenever its scroll container
+ * resizes on the iOS shell — so the content you're looking at stays put while
+ * the soft keyboard opens/closes (and while the composer grows on focus).
+ *
+ * Two things resize the container, and neither is handled by `use-stick-to-
+ * bottom` (which only re-anchors on *content* resize): the keyboard, via
+ * `useIOSViewportLock` shrinking the app-shell; and the composer growing taller
+ * when focused (its send row / status line), which steals flex height from the
+ * transcript a couple of lines at a time — *without* firing a visualViewport
+ * resize. Watching only visualViewport missed the composer growth, which is why
+ * the transcript crept up ~2 lines on focus.
+ *
+ * So we watch the scroll container itself with a `ResizeObserver` and, on any
+ * size change, hold the scroll position relative to the bottom constant:
+ * `scrollTop = scrollHeight - clientHeight - distance`. `distance` is tracked
+ * from genuine user scrolls only — scrolls that coincide with a dimension change
+ * (the resize's own clamp, or our restore) are ignored so they can't corrupt it.
+ * At the bottom (distance 0) you stay at the bottom; scrolled up reading
+ * history, you keep seeing the same messages. New messages still go through the
+ * library (content resize doesn't change the container's box). Stateless across
+ * any number of keyboard cycles.
+ */
+function PreserveScrollDistanceOnResize() {
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef?: React.RefObject<HTMLElement>;
+  };
+  const scrollRef = ctx.scrollRef;
+
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    const el = scrollRef?.current;
+    if (!el) return;
+
+    const measure = () => el.scrollHeight - el.clientHeight - el.scrollTop;
+    let distance = Math.max(0, measure());
+    let prevSH = el.scrollHeight;
+    let prevCH = el.clientHeight;
+
+    const onScroll = () => {
+      const sh = el.scrollHeight;
+      const ch = el.clientHeight;
+      // A scroll that lands on the same frame as a size change is resize-induced
+      // (the browser's clamp, or our own restore below) — not the user. Skip it
+      // so it can't overwrite the distance we're trying to preserve.
+      if (sh !== prevSH || ch !== prevCH) {
+        prevSH = sh;
+        prevCH = ch;
+        return;
+      }
+      distance = Math.max(0, measure());
+    };
+
+    const observer = new ResizeObserver(() => {
+      el.scrollTop = el.scrollHeight - el.clientHeight - distance;
+      prevSH = el.scrollHeight;
+      prevCH = el.clientHeight;
+    });
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      observer.disconnect();
+    };
+  }, [scrollRef]);
 
   return null;
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Follow-up to the visual-viewport shell lock. The shell-lock kept the composer above the keyboard, but the chat transcript didn't follow: the rising composer covered the last message, and re-pinning approaches that read use-stick-to-bottom's `isAtBottom` worked once then broke (the shrink flips that flag false before any handler reads it) or crept up ~2 lines on focus.
- Replace the bottom-pinning logic with `PreserveScrollDistanceOnResize`: a `ResizeObserver` on the transcript's scroll container that holds the scroll position relative to the bottom (`scrollTop = scrollHeight - clientHeight - distance`) on any container resize. `distance` is tracked from genuine user scrolls only — scrolls coinciding with a dimension change (the resize clamp or our own restore) are ignored so they can't corrupt it. At the bottom you stay flush above the composer; scrolled up reading history, you stay on the same messages — across unlimited keyboard cycles.
- Watch the container (not visualViewport) so the fix also covers the composer growing taller on focus, which steals transcript height without firing a visualViewport resize — the source of the ~2-line creep. New messages still flow through the library (content resize doesn't change the container box).
- useIOSViewportLock: split the document-pan reset into its own `window` `scroll` listener so a stray WebKit pan is snapped back immediately, not only on the rAF-coalesced resize; refresh the doc comment to match the verified behavior (`visualViewport.height` tracks the keyboard while `innerHeight` stays full).
- OmnigentWebView: set `webView.isInspectable = true` under `#if DEBUG` so Safari Web Inspector can attach to the web content (opt-in since iOS 16.4); shipping builds stay non-inspectable.

## Test Plan

- `npm run type-check` — passes.
- `npx vitest run src/pages/ChatPage.composer.test.tsx` — 47/47 pass.
- On-device (iOS simulator, Vite dev server) with Safari Web Inspector: diagnosed via logging that the transcript settled correctly at the bottom (dist 0) and mid-history (dist preserved), and that the residual ~2-line creep came from a container resize with no visualViewport event (composer growth) — which the ResizeObserver now compensates. Verified focusing at the bottom keeps the last message above the composer with no creep, and focusing while scrolled up holds position, across repeated keyboard open/dismiss.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is iOS WKWebView keyboard/scroll-anchoring behavior that can't be exercised in jsdom (no real visualViewport, ResizeObserver geometry, or keyboard). Verified via type-check, the existing chat composer test suite (no regressions), and on-device inspection through Safari Web Inspector — using temporary scroll-geometry logging (since removed) to confirm the distance is preserved at the bottom and mid-history and that the composer-growth reflow is now compensated.
