### PR TITLE
fix(antigravity-native): record the adopted TUI cascade as external_session_id so resume keeps the conversation

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -1272,33 +1272,15 @@ async def _cold_start_agy_conversation(
             cascade_id,
             session_id,
         )
-    # PATCH the real id onto the session so a later ``--resume`` continues this
-    # conversation (best-effort; mirrors the runner cold-start + codex/pi). A
-    # short-lived client suffices for this one call.
-    try:
-        async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=10.0) as client:
-            resp = await client.patch(
-                f"/v1/sessions/{url_component(session_id)}",
-                json={"external_session_id": cascade_id},
-            )
-    except httpx.HTTPError:
-        _logger.warning(
-            "Antigravity cold-start: failed to PATCH external_session_id=%s onto session %s; "
-            "the conversation is mirrored but `--resume` will cold-start fresh.",
-            cascade_id,
-            session_id,
-            exc_info=True,
-        )
-    else:
-        if resp.status_code >= 400:
-            _logger.warning(
-                "Antigravity cold-start: server rejected external_session_id PATCH (%s); "
-                "session=%s cascade=%s — the conversation is mirrored but `--resume` will "
-                "cold-start fresh.",
-                resp.status_code,
-                session_id,
-                cascade_id,
-            )
+    # Do NOT record this cold-start cascade as the session's external_session_id:
+    # it is the headless ``StartCascade`` bootstrap that the agy TUI never shows.
+    # The TUI mints its OWN cascade on the first typed turn, which the read driver
+    # ADOPTS in place and records as external_session_id
+    # (``antigravity_native_reader._record_external_session_id``). Recording the
+    # phantom here used to lose the whole conversation on resume (``--resume``
+    # launched ``--conversation <phantom>`` -> EMPTY conversation); external_session_id
+    # is set-once, so it MUST be left unset here for the reader's adoption to set it.
+    del base_url, headers  # retained for signature parity; no longer PATCH here
     _logger.info(
         "Antigravity cold-start: created conversation %s on port %s for session %s",
         cascade_id,

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -2119,6 +2119,51 @@ def _adopt_cascade_in_place(bridge_dir: Path, session_id: str, new_cascade_id: s
     )
 
 
+async def _record_external_session_id(
+    client: httpx.AsyncClient, session_id: str, cascade_id: str
+) -> None:
+    """
+    Best-effort record the agy cascade id as the session's ``external_session_id``.
+
+    So a later ``omnigent antigravity --resume`` / omnigent server restart
+    relaunches agy with ``--conversation <cascade_id>`` and continues THIS
+    conversation. Called on first-cascade adoption with the TUI-minted cascade.
+
+    The cold-start no longer records its headless ``StartCascade`` phantom (which
+    the agy TUI never displays) — that was the data-loss bug: a resume launched
+    ``--conversation <phantom>`` and loaded an EMPTY conversation, silently losing
+    the entire chat. ``external_session_id`` is set-once in the store; an overwrite
+    attempt (e.g. a second adoption) returns 400 and is logged, not raised — the
+    chat mirror does not depend on it.
+
+    :param client: The reader's Omnigent HTTP client.
+    :param session_id: Omnigent conversation id to record onto.
+    :param cascade_id: agy's adopted (TUI-minted) cascade/conversation id.
+    """
+    try:
+        resp = await client.patch(
+            f"/v1/sessions/{url_component(session_id)}",
+            json={"external_session_id": cascade_id},
+        )
+    except httpx.HTTPError:
+        _logger.warning(
+            "agy adopt: failed to record external_session_id=%s on session %s; "
+            "a later --resume will cold-start fresh.",
+            cascade_id,
+            session_id,
+            exc_info=True,
+        )
+        return
+    if resp.status_code >= 400:
+        _logger.info(
+            "agy adopt: external_session_id PATCH returned %s (likely already set); "
+            "session=%s cascade=%s",
+            resp.status_code,
+            session_id,
+            cascade_id,
+        )
+
+
 async def _rotate_session_for_cascade(
     *,
     client: httpx.AsyncClient,
@@ -2393,6 +2438,17 @@ async def run_reader_with_bridge(
                 # new one (the web/mobile UI watches the current session). The agy
                 # TUI and the web mirror then share ONE cascade (#1156/#1158).
                 _adopt_cascade_in_place(bridge_dir, current["session_id"], new_cascade_id)
+                # Record the adopted (TUI-minted) cascade as the session's
+                # external_session_id so a later --resume / omnigent server
+                # restart relaunches agy with --conversation <this cascade> and
+                # continues THIS conversation — NOT the headless cold-start
+                # StartCascade phantom the cold-start used to record, which a
+                # resume loaded as an EMPTY conversation (the whole chat silently
+                # vanished). external_session_id is set-once; the cold-start no
+                # longer records the phantom, so this first adoption sets it.
+                await _record_external_session_id(
+                    client, current["session_id"], new_cascade_id
+                )
                 continue
             # GENUINE /clear (the bound cascade HAD turns): move Omnigent ownership
             # onto a fresh conversation bound to the new cascade, then rebind by

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -2446,9 +2446,7 @@ async def run_reader_with_bridge(
                 # resume loaded as an EMPTY conversation (the whole chat silently
                 # vanished). external_session_id is set-once; the cold-start no
                 # longer records the phantom, so this first adoption sets it.
-                await _record_external_session_id(
-                    client, current["session_id"], new_cascade_id
-                )
+                await _record_external_session_id(client, current["session_id"], new_cascade_id)
                 continue
             # GENUINE /clear (the bound cascade HAD turns): move Omnigent ownership
             # onto a fresh conversation bound to the new cascade, then rebind by

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3117,10 +3117,16 @@ async def _cold_start_agy_conversation(
             cascade_id,
             session_id,
         )
-    # PATCH the real id onto the session so a later ``--resume`` continues this
-    # conversation (best-effort; mirrors codex/pi). A failure leaves the chat
-    # mirrored but loses agy's in-process resume continuity for this session.
-    await _patch_agy_external_session_id(server_client, session_id, cascade_id)
+    # Do NOT record this cold-start cascade as the session's external_session_id:
+    # it is the headless ``StartCascade`` bootstrap that the agy TUI never
+    # displays. The TUI mints its OWN cascade on the first typed turn, which the
+    # read driver ADOPTS in place and records as external_session_id (see
+    # ``antigravity_native_reader._record_external_session_id``). Recording the
+    # phantom here used to lose the whole conversation on resume: a later
+    # ``--resume`` launched ``--conversation <phantom>`` and loaded an EMPTY
+    # conversation. external_session_id is set-once, so it MUST be left unset here
+    # for the reader's adoption PATCH to set the real id.
+    del server_client  # retained for signature parity; no longer PATCHes here
     _logger.info(
         "Antigravity cold-start: created conversation %s on port %s for session %s",
         cascade_id,
@@ -3128,54 +3134,6 @@ async def _cold_start_agy_conversation(
         session_id,
     )
     return cascade_id
-
-
-async def _patch_agy_external_session_id(
-    server_client: httpx.AsyncClient | None,
-    session_id: str,
-    cascade_id: str,
-) -> None:
-    """
-    PATCH a cold-started agy cascade id onto the Omnigent session (best-effort).
-
-    Records ``external_session_id`` so a later ``omnigent antigravity --resume``
-    reads agy's real id back and passes ``--conversation <id>``. Read-path
-    replacement for the retired forwarder's ``_patch_external_session_id``;
-    mirrors the codex/pi recorder PATCH (best-effort — a transport
-    ``httpx.HTTPError`` or a ``>= 400`` rejection is logged, not raised, since the
-    chat mirror does not depend on it). A ``None`` client (no server client
-    available) is a no-op.
-
-    :param server_client: Runner Omnigent server client, or ``None`` to skip.
-    :param session_id: Omnigent conversation id to PATCH.
-    :param cascade_id: agy's real (cold-started) conversation id to record.
-    :returns: None.
-    """
-    if server_client is None:
-        return
-    try:
-        resp = await server_client.patch(
-            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
-            json={"external_session_id": cascade_id},
-            timeout=10.0,
-        )
-    except httpx.HTTPError:
-        _logger.warning(
-            "Antigravity cold-start: failed to PATCH external_session_id=%s onto session %s; "
-            "the conversation is mirrored but `--resume` will cold-start fresh.",
-            cascade_id,
-            session_id,
-            exc_info=True,
-        )
-        return
-    if resp.status_code >= 400:
-        _logger.warning(
-            "Antigravity cold-start: AP rejected external_session_id PATCH (%s); session=%s "
-            "cascade=%s — the conversation is mirrored but `--resume` will cold-start fresh.",
-            resp.status_code,
-            session_id,
-            cascade_id,
-        )
 
 
 def _terminal_tmux_pane(

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -2884,7 +2884,7 @@ async def test_auto_create_antigravity_cold_starts_real_conversation(
     # The same real id is PATCHed onto the session as external_session_id so a
     # later --resume continues agy's actual conversation (the read-path
     # replacement for the retired forwarder's _patch_external_session_id).
-    assert patch_calls == [(f"/v1/sessions/{session_id}", {"external_session_id": called_id})]
+    assert patch_calls == []  # cold-start no longer records the phantom cascade (#2 data-loss)
     # The RPC reader spawns (it replaced the transcript forwarder).
     assert len(reader_calls) == 1
 
@@ -2923,7 +2923,7 @@ async def test_auto_create_antigravity_cold_start_scopes_to_pane_agy(
     assert not bridge_mod_is_placeholder(called_id)
     assert state is not None
     assert state.conversation_id == called_id
-    assert patch_calls == [(f"/v1/sessions/{session_id}", {"external_session_id": called_id})]
+    assert patch_calls == []  # cold-start no longer records the phantom cascade (#2 data-loss)
 
 
 @pytest.mark.asyncio
@@ -2952,9 +2952,7 @@ async def test_auto_create_antigravity_cold_start_falls_back_when_no_pane(
     called_port, _called_id = start_cascade_calls[0]
     assert called_port == 52548  # the lowest candidate, NOT the (ignored) pane port
     assert state is not None
-    assert patch_calls == [
-        (f"/v1/sessions/{session_id}", {"external_session_id": state.conversation_id})
-    ]
+    assert patch_calls == []  # cold-start no longer records the phantom cascade (#2 data-loss)
 
 
 @pytest.mark.asyncio
@@ -3016,9 +3014,7 @@ async def test_auto_create_antigravity_cold_start_falls_back_when_port_unattribu
     assert len(start_cascade_calls) == 1
     assert start_cascade_calls[0][0] == 52548  # safe candidate fallback
     assert state is not None
-    assert patch_calls == [
-        (f"/v1/sessions/{session_id}", {"external_session_id": state.conversation_id})
-    ]
+    assert patch_calls == []  # cold-start no longer records the phantom cascade (#2 data-loss)
 
 
 @pytest.mark.asyncio
@@ -3146,67 +3142,6 @@ async def test_auto_create_antigravity_cold_start_port_timeout_keeps_placeholder
     assert patch_calls == []
     # The RPC reader still spawns regardless of the cold-start outcome.
     assert len(reader_calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_patch_agy_external_session_id_noop_without_client() -> None:
-    """A ``None`` server client makes the external_session_id PATCH a no-op.
-
-    The cold-start helper threads its (optional) runner server client through;
-    when absent there is nothing to PATCH against, so the call must simply return
-    without raising — the cascade id still lives in bridge state.
-    """
-    import omnigent.runner.app as runner_app_mod
-
-    # No client, no exception, no work — just returns.
-    await runner_app_mod._patch_agy_external_session_id(None, "conv_x", "cascade_x")
-
-
-@pytest.mark.asyncio
-async def test_patch_agy_external_session_id_swallows_transport_error(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A transport ``httpx.HTTPError`` is logged, never raised (best-effort).
-
-    The PATCH is the read-path resume-fidelity write; a transport failure must
-    not crash the cold-start (which would strand a terminal with no reader), so
-    it is caught and surfaced as a warning only.
-    """
-    import omnigent.runner.app as runner_app_mod
-
-    class _BoomClient:
-        async def patch(self, _url: str, **_kwargs: Any) -> httpx.Response:
-            raise httpx.ConnectError("boom")
-
-    with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
-        await runner_app_mod._patch_agy_external_session_id(
-            cast(httpx.AsyncClient, _BoomClient()), "conv_x", "cascade_x"
-        )
-    assert "failed to PATCH external_session_id" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_patch_agy_external_session_id_logs_on_rejection(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A ``>= 400`` response is logged (not silently swallowed), never raised.
-
-    Mirrors the codex recorder PATCH: ``httpx`` does not raise on a 4xx/5xx
-    response unless asked, so the helper inspects ``status_code`` and warns when
-    the server rejects the write — otherwise the lost resume continuity would be
-    invisible.
-    """
-    import omnigent.runner.app as runner_app_mod
-
-    class _RejectClient:
-        async def patch(self, url: str, **_kwargs: Any) -> httpx.Response:
-            return httpx.Response(404, json={}, request=httpx.Request("PATCH", url))
-
-    with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
-        await runner_app_mod._patch_agy_external_session_id(
-            cast(httpx.AsyncClient, _RejectClient()), "conv_x", "cascade_x"
-        )
-    assert "rejected external_session_id PATCH (404)" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_antigravity_native.py
+++ b/tests/test_antigravity_native.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -939,16 +938,19 @@ def _seed_bridge_state(bridge_dir: Path, conversation_id: str) -> None:
     )
 
 
-async def test_cli_cold_start_mints_and_patches_external_session_id(
+async def test_cli_cold_start_mints_without_patching_external_session_id(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """
-    A placeholder-seeded CLI cold-start mints a real id, writes it, and PATCHes it.
+    A placeholder-seeded CLI cold-start mints a real id + writes it, but does NOT
+    record it as external_session_id.
 
-    The fresh-fallback path: bridge state holds the ``agy_conv_*`` placeholder, so
-    the cold-start ``StartCascade``s a real uuid4, persists it to bridge state
-    (replacing the placeholder), and PATCHes it onto the session as
-    ``external_session_id`` so a later ``--resume`` continues agy's conversation.
+    The cold-start cascade is the headless ``StartCascade`` bootstrap the agy TUI
+    never displays; recording it as ``external_session_id`` lost the whole
+    conversation on resume (a ``--resume`` loaded the empty phantom). The TUI
+    mints its OWN cascade on the first typed turn, which the read driver adopts
+    and records instead. So the cold-start ``StartCascade``s a real uuid4 and
+    persists it to bridge state (for the reader to bind), but issues NO PATCH.
     """
     monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
     bridge_dir = bridge_mod.bridge_dir_for_bridge_id("bridge_cs")
@@ -989,8 +991,9 @@ async def test_cli_cold_start_mints_and_patches_external_session_id(
     after = read_bridge_state(bridge_dir)
     assert after is not None
     assert after.conversation_id == minted_id
-    # The same id was PATCHed onto the session as external_session_id.
-    assert patches == [("/v1/sessions/conv_cs", {"external_session_id": minted_id})]
+    # NO external_session_id PATCH: the cold-start no longer records the headless
+    # phantom (the reader records the adopted TUI cascade instead) — #2 data-loss.
+    assert patches == []
 
 
 async def test_cli_cold_start_skips_when_conversation_already_real(
@@ -1030,53 +1033,6 @@ async def test_cli_cold_start_skips_when_conversation_already_real(
     after = read_bridge_state(bridge_dir)
     assert after is not None
     assert after.conversation_id == real_id
-
-
-async def test_cli_cold_start_logs_when_patch_rejected(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    """
-    A ``>= 400`` PATCH response is logged (best-effort) but never raised.
-
-    ``httpx`` does not raise on a 4xx/5xx response unless asked, so the cold-start
-    inspects ``status_code`` and warns when the server rejects the
-    ``external_session_id`` write — but the cascade id still reaches bridge state
-    (the chat mirror does not depend on the resume-fidelity PATCH).
-    """
-    monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
-    bridge_dir = bridge_mod.bridge_dir_for_bridge_id("bridge_cs_reject")
-    _seed_bridge_state(bridge_dir, "agy_conv_placeholder")
-
-    monkeypatch.setattr(_mod, "resolve_cold_start_agy_rpc_port", lambda _sock, _tgt: 52548)
-    started: list[tuple[int, str]] = []
-    monkeypatch.setattr(_mod, "start_cascade", lambda port, cid: started.append((port, cid)))
-
-    real_async_client = httpx.AsyncClient
-
-    def _reject_handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(404, json={})
-
-    def _mock_async_client(**kwargs: object) -> httpx.AsyncClient:
-        kwargs.pop("transport", None)
-        return real_async_client(transport=httpx.MockTransport(_reject_handler), **kwargs)
-
-    monkeypatch.setattr(_mod.httpx, "AsyncClient", _mock_async_client)
-
-    with caplog.at_level(logging.WARNING, logger="omnigent.antigravity_native"):
-        await _mod._cold_start_agy_conversation(
-            bridge_dir,
-            "conv_cs",
-            base_url="http://test",
-            headers={},
-            timeout_s=1.0,
-        )
-
-    # The cascade was still minted + persisted; only the resume-fidelity PATCH failed.
-    assert len(started) == 1
-    after = read_bridge_state(bridge_dir)
-    assert after is not None
-    assert after.conversation_id == started[0][1]
-    assert "rejected external_session_id PATCH (404)" in caplog.text
 
 
 async def test_cli_cold_start_scopes_to_pane_agy(

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -2939,8 +2939,14 @@ async def test_run_reader_with_bridge_adopts_first_cascade_in_place(
         rotate_calls.append("forked")  # must NOT happen on adopt-in-place
         return "conv_should_not_be_used"
 
+    recorded_external: list[tuple[str, str]] = []
+
+    async def _fake_record_external(client: object, session_id: str, cascade_id: str) -> None:
+        recorded_external.append((session_id, cascade_id))
+
     monkeypatch.setattr(reader, "supervise_reader", _fake_supervise)
     monkeypatch.setattr(reader, "_rotate_session_for_cascade", _fake_rotate)
+    monkeypatch.setattr(reader, "_record_external_session_id", _fake_record_external)
     monkeypatch.setattr(
         "omnigent.antigravity_native_interactions.bridge_interaction",
         lambda *a, **k: None,
@@ -2965,6 +2971,10 @@ async def test_run_reader_with_bridge_adopts_first_cascade_in_place(
     assert state is not None
     assert state.session_id == _SESSION_ID
     assert state.conversation_id == new_cascade
+    # The adopted cascade is recorded as external_session_id so a later --resume /
+    # server restart loads THIS conversation, not the headless cold-start phantom
+    # (#2 data-loss). It is recorded against the SAME session.
+    assert recorded_external == [(_SESSION_ID, new_cascade)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A fresh `antigravity-native` session recorded the **wrong** agy cascade for resume, so any **resume / omnigent-server-restart silently loaded an EMPTY conversation** — the whole chat history vanished, no error. (P1, data-loss; found in the post-#1166 bug-bash.)

**Root cause:** the cold-start `StartCascade`s a headless bootstrap cascade and PATCHed *that* id as the session's `external_session_id`. But the agy TUI mints its **own** cascade on the first typed turn (web turns are typed into the TUI since #1156/#1158), which the read driver **adopts in place** — and `external_session_id` is **set-once**, so the adopted (real) id could never replace the phantom. Resume launches `--conversation <external_session_id>` → the empty phantom.

**Fix:**
- The cold-start no longer records the phantom — runner `_cold_start_agy_conversation` (`runner/app.py`) **and** the CLI cold-start (`antigravity_native.py`).
- The reader records the **adopted** cascade as `external_session_id` on first-cascade adoption (`antigravity_native_reader._record_external_session_id`, best-effort, set-once-safe).

Now resume loads the conversation the TUI/web actually used — parity with claude-native's external-session mirroring.

## Verification

**Live** (agy 1.0.11): after a web turn, the session's `external_session_id` is the **adopted TUI cascade** (`04109bed…`), **not** the cold-start phantom (`169db340…`). The reader logs `adopted the first TUI-minted cascade in place (no fork)`.

**Unit/integration:** 332 antigravity + reader + executor + runner tests pass. The adopt-in-place reader test now asserts the `external_session_id` record; the cold-start tests assert no phantom PATCH; removed the now-dead cold-start-PATCH helper + its tests.

Found in a swarm bug-bash of antigravity-native; one of 13 confirmed issues (this is the P1 data-loss one).

This pull request and its description were written by Isaac.