### PR TITLE
fix(antigravity-native): surface a model/turn ERROR instead of a silent empty reply

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -135,6 +135,11 @@ _POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 # Session-status edge values (mirror the transcript forwarder's vocabulary).
 _STATUS_RUNNING = "running"
 _STATUS_IDLE = "idle"
+# Terminal-failure session status (a valid ``external_session_status``; see the
+# ``Literal["idle", "running", "failed"]`` schema). Emitted when an agy turn
+# closes on a model/turn ERROR so the web UI shows the turn FAILED instead of a
+# clean idle with a silent empty reply (#6).
+_STATUS_FAILED = "failed"
 
 # RPC step type/status constants needed for the status-transition heuristic. The
 # item-mapping constants live in the mapper; the driver only needs the few it
@@ -1632,9 +1637,27 @@ async def _emit_step(
 
     if _is_turn_close_step(step) and turn_active:
         turn_active = False
-        await _post_event(client, session_id, _status_event(_STATUS_IDLE))
+        # An ERROR planner closes the turn as FAILED, not a clean idle: a model /
+        # safety-policy / rate-limit / provider-overload error must surface as a
+        # failed turn (alongside the error item the mapper now emits), not a
+        # silent empty success that looks identical to a normal reply (#6).
+        close_status = _STATUS_FAILED if _step_is_error_planner(step) else _STATUS_IDLE
+        await _post_event(client, session_id, _status_event(close_status))
 
     return turn_active
+
+
+def _step_is_error_planner(step: dict[str, object]) -> bool:
+    """
+    Return whether a step is a PLANNER_RESPONSE that ended in ERROR.
+
+    Used to close the turn as ``failed`` (not ``idle``) so a model/turn error is
+    not mistaken for a clean empty reply.
+
+    :param step: One RPC step dict.
+    :returns: ``True`` for an ERROR-status planner step.
+    """
+    return step.get("type") == _TYPE_PLANNER_RESPONSE and step.get("status") == _STATUS_ERROR
 
 
 def _maybe_handle_interaction(

--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -651,6 +651,45 @@ def _user_message_event(*, text: str) -> OutboundEvent:
     )
 
 
+def _planner_error_event(
+    *, conversation_id: str, step_idx: int, step: dict[str, object]
+) -> OutboundEvent:
+    """
+    Build a committed assistant ``message`` item for an ERROR planner step.
+
+    A model/turn ERROR is otherwise dropped (the planner branch only commits at
+    DONE), so the turn looks like a silent empty reply. Surface a visible marker —
+    preferring any ``plannerResponse`` error text, falling back to a generic
+    message — mirroring the tool-level marker (:func:`_tool_error_output`). The
+    reader pairs this with a ``failed`` session-status edge.
+
+    :param conversation_id: agy conversation id (namespaces the response id).
+    :param step_idx: The ERROR planner step's index.
+    :param step: The ERROR PLANNER_RESPONSE step.
+    :returns: One ``external_conversation_item`` event (role ``"assistant"``).
+    """
+    detail = ""
+    planner = step.get("plannerResponse")
+    if isinstance(planner, dict):
+        err = planner.get("error") or planner.get("errorMessage")
+        if isinstance(err, str) and err.strip():
+            detail = f": {err.strip()}"
+    text = f"[antigravity: the model did not complete this turn (status ERROR){detail}]"
+    return OutboundEvent(
+        event_type="external_conversation_item",
+        data={
+            "item_type": "message",
+            "item_data": {
+                "role": "assistant",
+                "agent": _AGENT_NAME,
+                "content": [{"type": "output_text", "text": text}],
+            },
+            "response_id": _response_id(conversation_id, step_idx),
+        },
+        step_index=step_idx,
+    )
+
+
 def _function_call_events(
     *,
     conversation_id: str,
@@ -922,6 +961,20 @@ def map_step_to_events(
     # with the FINAL text, on both the stream and poll paths. ERROR/other non-DONE →
     # no committed item (any partial already streamed as deltas).
     if step_type == _TYPE_PLANNER_RESPONSE:
+        if status == _STATUS_ERROR:
+            # A model/turn ERROR (safety block, rate-limit, provider overload,
+            # internal error) must surface as a VISIBLE error item — otherwise the
+            # turn clears to idle with no text and is indistinguishable from a
+            # normal empty reply (the user sees nothing; no retry hint). Emit a
+            # committed error message (the reader also closes the turn as FAILED).
+            idx = _step_index(step)
+            return [
+                _planner_error_event(
+                    conversation_id=conversation_id,
+                    step_idx=idx if idx is not None else 0,
+                    step=step,
+                )
+            ]
         if status != _STATUS_DONE:
             return []
         # Treat absent stepIndex as 0 (proto omits zero-valued scalar).

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -832,23 +832,23 @@ async def test_status_not_idle_while_tools_running(
 
 
 @pytest.mark.asyncio
-async def test_status_idle_on_error_planner_close(
+async def test_status_failed_on_error_planner_close(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     patched_discovery: None,
 ) -> None:
-    """A turn that ends in a terminal-ERROR planner still emits IDLE.
+    """A turn that ends in a terminal-ERROR planner closes as FAILED (not idle).
 
-    Regression for the stuck-spinner bug: previously IDLE fired only on a DONE
-    planner with closing text, so a turn ending in an ERROR planner left
-    ``turn_active`` True forever (spinner stuck; next turn could not re-open
-    RUNNING). The IDLE here comes from the ERROR-terminal rule, not the
-    text-close rule (the planner carries no closing text).
+    A model/turn ERROR must surface as a failed turn — not a clean idle that
+    looks identical to a normal empty reply (#6). The turn still closes (the
+    spinner clears; ``turn_active`` resets so the next turn can re-open RUNNING),
+    but on the ``failed`` status edge, and the mapper commits a visible error
+    message item.
     """
     user = _load("user_input")
     error_planner = _load("planner_response_text")
     error_planner["status"] = "CORTEX_STEP_STATUS_ERROR"
-    # No closing text — prove the IDLE is from the ERROR-terminal rule.
+    # No closing text — prove the close is from the ERROR-terminal rule.
     error_planner["plannerResponse"] = {}
     script = _StepScript([[user], [user, error_planner], [user, error_planner]])
     sink = _PostSink()
@@ -861,7 +861,10 @@ async def test_status_idle_on_error_planner_close(
         iterations=3,
     )
 
-    assert sink.statuses() == ["running", "idle"]
+    # Closes as FAILED, not idle.
+    assert sink.statuses() == ["running", "failed"]
+    # The user message + a visible error item are committed (no silent empty reply).
+    assert sink.message_roles() == ["user", "assistant"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_antigravity_native_steps.py
+++ b/tests/test_antigravity_native_steps.py
@@ -197,6 +197,39 @@ class TestPlannerResponseText:
         assert events[0].data["response_id"] == f"agy_{_CID}_2"
 
 
+class TestPlannerResponseError:
+    """An ERROR PLANNER_RESPONSE emits a visible error item (not a silent drop)."""
+
+    def test_error_planner_emits_one_error_message(self) -> None:
+        """A terminal-ERROR planner yields one assistant ``message`` error marker.
+
+        Regression for #6: previously an ERROR planner returned ``[]`` (the branch
+        committed only at DONE), so a model/turn error looked identical to a normal
+        empty reply. It must surface a visible item.
+        """
+        step = _load("planner_response_text")
+        step["status"] = "CORTEX_STEP_STATUS_ERROR"
+        step["plannerResponse"] = {}  # no text/error detail -> generic marker
+        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.event_type == "external_conversation_item"
+        assert ev.data["item_type"] == "message"
+        item = ev.data["item_data"]
+        assert isinstance(item, dict)
+        assert item["role"] == "assistant"
+        text = item["content"][0]["text"]
+        assert "status ERROR" in text
+
+    def test_error_planner_includes_error_detail_when_present(self) -> None:
+        """Any ``plannerResponse.error`` text is folded into the marker."""
+        step = _load("planner_response_text")
+        step["status"] = "CORTEX_STEP_STATUS_ERROR"
+        step["plannerResponse"] = {"error": "model overloaded (503)"}
+        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        assert "model overloaded (503)" in events[0].data["item_data"]["content"][0]["text"]
+
+
 # ---------------------------------------------------------------------------
 # PLANNER_RESPONSE (tool_calls) → function_call events
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

An agy turn that ends in a model / safety-policy / rate-limit / provider-overload **ERROR** was indistinguishable from a normal empty reply: the step mapper committed nothing (its `PLANNER_RESPONSE` branch emits only at `DONE`) and the reader closed the turn on a plain `idle` edge. The user saw the spinner clear with **no text, no error card, no retry hint** — a silent failure. (P2; found in the antigravity-native bug-bash.)

**Fix:**
- **Mapper** (`antigravity_native_steps`): on a `CORTEX_STEP_STATUS_ERROR` planner, emit a visible assistant error item — preferring any `plannerResponse` error text, falling back to a generic marker (mirrors the existing tool-level error marker).
- **Reader** (`antigravity_native_reader`): close an ERROR turn on a `failed` session-status edge (a valid `external_session_status`) rather than `idle`, so the web UI shows the turn failed.

## Verification

**Unit/integration:** 159 antigravity steps + reader tests pass — incl. new `TestPlannerResponseError` mapper coverage (generic marker + folded error detail) and the reader test updated to assert close-as-`failed` + a committed error item. ruff clean.

A real model ERROR can't be triggered on demand, so this is unit-verified; the mapper + reader behavior is fully covered.

This pull request and its description were written by Isaac.