### PR TITLE
fix(antigravity-native): clean /quit no longer shows a spurious required_terminal_exited failed card

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6662,18 +6662,22 @@ def create_runner_app(
         if event.lifecycle != TerminalLifecycle.REQUIRED:
             return
 
-        # qwen-native: the user drives the qwen TUI directly, so quitting it
-        # (Ctrl+C / /quit) is a normal end-of-session, not a crash. The
-        # ``session_was_idle`` guard below is meant to catch a clean exit, but
-        # qwen's "powering down" redraw on quit trips the PTY-activity watcher
-        # and flips the status to ``running`` in the instant before the process
-        # exits — so the quit is misclassified as a crash and the scary
-        # ``required_terminal_exited`` card renders. Treat the qwen terminal's
-        # exit as a clean shutdown: genuine *boot* failures never reach here
-        # (they surface via ``_auto_create_qwen_terminal``'s error handler →
-        # ``_publish_native_terminal_start_error``), so a qwen required-terminal
-        # exit is always post-boot, i.e. user-initiated.
-        if event.terminal_name == "qwen" and event.session_key == "main":
+        # qwen-native / antigravity-native: the user drives the TUI directly, so
+        # quitting it (Ctrl+C / /quit) is a normal end-of-session, not a crash.
+        # The ``session_was_idle`` guard below is meant to catch a clean exit,
+        # but the exit-classification memo is never flipped to ``idle`` for these
+        # harnesses: qwen's "powering down" redraw on quit trips the PTY-activity
+        # watcher and flips the status to ``running`` in the instant before the
+        # process exits, and antigravity-native is deliberately excluded from the
+        # PTY ``emit_status`` role set (the RPC reader owns working-status, not
+        # PTY activity), so its memo stays ``running``. Either way the quit is
+        # misclassified as a crash and the scary ``required_terminal_exited`` card
+        # renders. Treat these terminals' exit as a clean shutdown: genuine *boot*
+        # failures never reach here (they surface via the respective
+        # ``_auto_create_*_terminal`` error handler →
+        # ``_publish_native_terminal_start_error``), so a qwen/antigravity
+        # required-terminal exit is always post-boot, i.e. user-initiated.
+        if event.terminal_name in ("qwen", "antigravity") and event.session_key == "main":
             # Publish a final ``idle`` to clear the web "Working…" spinner: the
             # powering-down redraw may have left the PTY watcher's last edge on
             # ``running``, and the watcher is gone once the pane dies, so without

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -9995,6 +9995,87 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
     assert pm.released == [conv_id]
 
 
+@pytest.mark.parametrize("terminal_name", ["qwen", "antigravity"])
+@pytest.mark.asyncio
+async def test_required_terminal_clean_quit_publishes_idle_not_failed(
+    terminal_name: str,
+) -> None:
+    """A clean ``/quit`` of qwen/antigravity-native is not a crash.
+
+    Both harnesses leave the exit-classification memo stuck on ``running`` at
+    quit time — qwen's "powering down" redraw trips the PTY-activity watcher,
+    and antigravity-native is deliberately excluded from the PTY ``emit_status``
+    role set (the RPC reader owns working-status). So ``session_was_idle`` is
+    ``False`` even though the user quit normally. The runner must special-case
+    these terminals: publish a final ``idle`` (to clear the web "Working…"
+    spinner) and release the harness, but never render the spurious red
+    ``required_terminal_exited`` failure card.
+
+    :param terminal_name: The native terminal that the user quit cleanly.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.runner.resource_registry import (
+        TerminalExitEvent,
+        TerminalLifecycle,
+    )
+
+    conv_id = f"conv_clean_quit_{terminal_name}_{uuid.uuid4().hex[:12]}"
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    pm._sessions.add(conv_id)
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    resource_registry = app.state.session_resource_registry
+    # Grab the runner's terminal-exit publisher (the branch under test) and
+    # drive it directly, mimicking the registry firing on a clean quit.
+    publish_exit = resource_registry._terminal_exit_publisher
+    assert callable(publish_exit)
+
+    try:
+        publish_exit(
+            TerminalExitEvent(
+                session_id=conv_id,
+                terminal_id=f"terminal_{terminal_name}_main",
+                terminal_name=terminal_name,
+                session_key="main",
+                lifecycle=TerminalLifecycle.REQUIRED,
+                # The memo never flipped to idle, so the generic guard would
+                # otherwise misclassify this normal quit as a crash.
+                session_was_idle=False,
+            )
+        )
+        queued_events: list[dict[str, Any]] = []
+        for _ in range(1000):
+            queued_events.extend(
+                _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+            )
+            if pm.released:
+                break
+            await asyncio.sleep(0)
+    finally:
+        _session_event_queues_ref.pop(conv_id, None)
+        runner_app.unregister_child_session(conv_id)
+
+    # The terminal resource is removed and a final idle clears the spinner...
+    assert {
+        "type": "session.resource.deleted",
+        "resource_id": f"terminal_{terminal_name}_main",
+        "resource_type": "terminal",
+        "session_id": conv_id,
+    } in queued_events
+    assert {"type": "session.status", "status": "idle"} in queued_events
+    # ...but no spurious failure card renders — the user quit normally.
+    assert [
+        event
+        for event in queued_events
+        if event.get("type") == "session.status" and event.get("status") == "failed"
+    ] == []
+    # The harness subprocess is still released — the terminal is gone.
+    assert pm.released == [conv_id]
+
+
 @pytest.mark.asyncio
 async def test_events_effort_change_on_native_session_types_slash_command(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

Quitting `agy` normally (`/quit`, Ctrl-C) from the Terminal panel rendered a red `required_terminal_exited` failure card and marked the session **failed** — a routine user action misclassified as a crash.

## Root cause

`antigravity-native` is **deliberately** excluded from the PTY `emit_status` role set: the RPC reader owns working-status, not PTY activity. Because of that exclusion, the exit-classification memo `_last_session_status` is never flipped to `idle` — it stays `running`. On a clean quit, `_publish_terminal_exit` (omnigent/runner/app.py) reaches its `session_was_idle` guard, which is `False` (memo stuck on `running`), so it falls through and emits a `failed` `required_terminal_exited` status + sub-agent failure.

qwen-native hit the exact same class of bug (its "powering down" redraw trips the PTY watcher to `running` at quit), and already has a clean-quit special-case at the top of `_publish_terminal_exit` (`if event.terminal_name == "qwen" and event.session_key == "main"` → publish `idle` + release, no failed card). That branch did not match `antigravity`.

## Fix

Extend the existing qwen clean-quit special-case to also match `antigravity`:

```python
if event.terminal_name in ("qwen", "antigravity") and event.session_key == "main":
```

This **mirrors qwen exactly** — publish a final `session.status: idle` (to clear the web "Working…" spinner, since the watcher is gone once the pane dies) and release the harness, with no `failed` card. Genuine *boot* failures never reach here: they surface via `_auto_create_antigravity_terminal`'s error handler → `_publish_native_terminal_start_error`. So a *post-boot* antigravity required-terminal exit is always user-initiated.

The intentional `emit_status` exclusion is left untouched (as designed).

## Tests

Adds a parametrized regression test (`qwen` + `antigravity`) in `tests/runner/test_app_sessions_native.py` that drives `_publish_terminal_exit` on a clean quit (`session_was_idle=False`) and asserts: a `session.resource.deleted` event, a final `idle` status, **no** `failed` card, and that the harness subprocess is released. Verified the test fails on `antigravity` without the one-line fix and passes with it.

```
5 passed, 202 deselected
```

This pull request and its description were written by Isaac.