### PR TITLE
fix(agy): drop literal markdown asterisks in permission card message

### DIFF
--- a/omnigent/server/routes/_antigravity_elicitation.py
+++ b/omnigent/server/routes/_antigravity_elicitation.py
@@ -172,7 +172,7 @@ def _agy_permission_params(
 
     message = "Antigravity wants to run a command"
     if command:
-        message = f"Antigravity wants to run **{command}**"
+        message = f"Antigravity wants to run: {command}"
 
     extras: dict[str, Any] = {
         "permission_spec": spec,

--- a/tests/server/test_antigravity_elicitation.py
+++ b/tests/server/test_antigravity_elicitation.py
@@ -230,6 +230,9 @@ class TestToElicitationParamsPermission:
     def test_message_contains_command(self) -> None:
         params = to_elicitation_params(_PERMISSION_PENDING)
         assert "pwd" in params.message
+        # The web ApprovalCard renders this message in a plain (non-markdown)
+        # span, so it must not carry literal markdown asterisks.
+        assert "**" not in params.message
 
     def test_phase_is_agy_permission(self) -> None:
         params = to_elicitation_params(_PERMISSION_PENDING)


### PR DESCRIPTION
## Bug

The Antigravity permission approval card rendered literal markdown asterisks (`**pwd**`) instead of bold text.

## Root cause

`_agy_permission_params` in `omnigent/server/routes/_antigravity_elicitation.py` set the elicitation message to `f"Antigravity wants to run **{command}**"` with `phase="agy_permission"`. The web ApprovalCard renders this message in a plain (non-markdown) `<span>`, so the `**` displayed literally. (Codex uses the same `**`-style message but renders it via a structured `codex_command_approval` branch, so its raw message is never shown — agy has no equivalent structured render.)

## Fix

Drop the markdown asterisks: the message is now `f"Antigravity wants to run: {command}"`, consistent with the no-command fallback wording (`"Antigravity wants to run a command"`). No frontend changes; `extras["command"]` is untouched.

## Tests

- `tests/server/test_antigravity_elicitation.py::TestToElicitationParamsPermission::test_message_contains_command` now also asserts the message contains no `**`.
- Full file passes: 37 passed.

This pull request and its description were written by Isaac.