### PR TITLE
fix(antigravity-native): materialize web-turn attachments instead of dropping them

### DIFF
--- a/omnigent/inner/antigravity_native_executor.py
+++ b/omnigent/inner/antigravity_native_executor.py
@@ -53,8 +53,9 @@ stay informational on this write path — agy's own model selection determines t
 turn's model and thinking budget and cannot be overridden from here.
 
 Attachment note: the RPC turn text takes plain text, so an image/file attachment
-on a web turn is reduced to its text part (any prose the user typed). Inline
-image/file bytes are not forwarded to agy through this path.
+on a web turn is materialized to a file under the bridge dir and referenced by
+absolute path (``[Attached: <path>]``) so agy can open it with its Read tool —
+mirroring cursor-native. Any prose the user typed is sent alongside the marker.
 """
 
 from __future__ import annotations
@@ -153,7 +154,7 @@ class AntigravityNativeExecutor(Executor):
             when there was no text to send or delivery failed.
         """
         del session_key
-        text = _content_to_text(content)
+        text = _content_to_text(content, self._bridge_dir)
         if not text:
             return False
         outcome = await self._deliver(text)
@@ -250,7 +251,7 @@ class AntigravityNativeExecutor(Executor):
             except PermanentLLMError as exc:
                 yield ExecutorError(message=str(exc))
                 return
-        text = _latest_user_text(messages)
+        text = _latest_user_text(messages, self._bridge_dir)
         if not text:
             yield ExecutorError(message="Antigravity native turn had no user text to send")
             return
@@ -536,47 +537,60 @@ def _dig(obj: object, *keys: str) -> object:
     return current
 
 
-def _latest_user_text(messages: list[Message]) -> str:
+def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     """
     Extract the latest user message's text from the executor message list.
 
     :param messages: Executor message list.
+    :param bridge_dir: Bridge directory; image/file attachments are
+        materialized underneath it and referenced by path.
     :returns: The user's text (string + content-block shapes flattened), or
         ``""`` when there is no user text to send.
     """
     for message in reversed(messages):
         if message.get("role") == "user":
-            return _content_to_text(message.get("content"))
+            return _content_to_text(message.get("content"), bridge_dir)
     return ""
 
 
-def _content_to_text(content: EnqueuedContent) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """
     Flatten executor message content into plain text for the agy turn-send.
 
-    The RPC turn text carries only text, so this extracts the textual parts and
-    drops attachments. A plain string passes through. A list of content blocks
-    contributes every ``input_text`` / ``text`` block, joined by newlines;
-    ``input_image`` / ``input_file`` blocks are skipped (their bytes cannot be
-    sent through this path — at minimum the typed text is sent).
+    The RPC turn text carries only text. A plain string passes through. A list
+    of content blocks contributes every ``input_text`` / ``text`` block;
+    ``input_image`` / ``input_file`` blocks carrying a base64 data URI are
+    materialized to the bridge dir and referenced by absolute path
+    (``[Attached: <path>]``) so agy can open them with its Read tool — otherwise
+    web-UI attachments are silently dropped. Mirrors cursor-native.
 
     :param content: Message content — a string, a list of content blocks like
         ``{"type": "input_text", "text": "..."}``, or other.
+    :param bridge_dir: Bridge directory; attachments are materialized underneath
+        it and referenced by path.
     :returns: The flattened text, stripped of leading/trailing whitespace, or
         ``""`` when no text is present.
     """
     if isinstance(content, str):
         return content.strip()
     if isinstance(content, list):
-        parts: list[str] = []
+        from omnigent.inner.native_attachments import materialize_attachment
+
+        attachment_lines: list[str] = []
+        text_parts: list[str] = []
         for block in content:
             if not isinstance(block, dict):
                 continue
-            if block.get("type") in {"input_text", "text"}:
+            block_type = block.get("type", "")
+            if block_type in ("input_text", "text"):
                 text = block.get("text")
                 if isinstance(text, str) and text:
-                    parts.append(text)
-        return "\n".join(parts).strip()
+                    text_parts.append(text)
+            elif block_type in ("input_image", "input_file"):
+                path = materialize_attachment(block, bridge_dir)
+                if path is not None:
+                    attachment_lines.append(f"[Attached: {path}]")
+        return "\n".join(attachment_lines + text_parts).strip()
     if content is None:
         return ""
     return json.dumps(content, ensure_ascii=True)

--- a/tests/inner/test_antigravity_native_executor.py
+++ b/tests/inner/test_antigravity_native_executor.py
@@ -205,7 +205,8 @@ def test_run_turn_flattens_content_blocks(tmp_path: Path, injected: dict[str, ob
                         "role": "user",
                         "content": [
                             {"type": "input_text", "text": "line one"},
-                            {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                            # malformed data URI (no comma) -> not materialized
+                            {"type": "input_image", "image_url": "data:image/png;base64"},
                             {"type": "input_text", "text": "line two"},
                         ],
                     }
@@ -260,6 +261,76 @@ def test_run_turn_no_user_text_errors(tmp_path: Path, injected: dict[str, object
     assert _injected(injected) == []
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
+
+
+# a tiny valid base64 PNG data URI (1x1 pixel), materialized to disk + referenced
+_PNG_DATA_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def test_run_turn_image_attachment_materialized(
+    tmp_path: Path, injected: dict[str, object]
+) -> None:
+    """An image block is written to the bridge dir and referenced by path."""
+    _seed_state(tmp_path)
+
+    async def _drive() -> list[ExecutorEvent]:
+        return [
+            event
+            async for event in _executor(tmp_path).run_turn(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_image", "image_url": _PNG_DATA_URI},
+                            {"type": "input_text", "text": "describe this"},
+                        ],
+                    }
+                ],
+                tools=[],
+                system_prompt="",
+            )
+        ]
+
+    events = asyncio.run(_drive())
+    content = _injected(injected)[0]["content"]
+    assert isinstance(content, str)
+    # attachment marker is prepended ahead of the typed text
+    assert content.startswith("[Attached: ")
+    assert str(tmp_path) in content
+    assert content.endswith("describe this")
+    assert isinstance(events[0], TurnComplete)
+
+
+def test_run_turn_attachment_only_no_longer_errors(
+    tmp_path: Path, injected: dict[str, object]
+) -> None:
+    """An attachment-only turn injects the marker instead of hard-erroring."""
+    _seed_state(tmp_path)
+
+    async def _drive() -> list[ExecutorEvent]:
+        return [
+            event
+            async for event in _executor(tmp_path).run_turn(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_image", "image_url": _PNG_DATA_URI}],
+                    }
+                ],
+                tools=[],
+                system_prompt="",
+            )
+        ]
+
+    events = asyncio.run(_drive())
+    content = _injected(injected)[0]["content"]
+    assert isinstance(content, str)
+    assert content.startswith("[Attached: ")
+    assert isinstance(events[0], TurnComplete)
+    assert not any(isinstance(event, ExecutorError) for event in events)
 
 
 # ---------------------------------------------------------------------------
@@ -653,28 +724,30 @@ def test_run_turn_unsupported_effort_surfaces_error(
 # ---------------------------------------------------------------------------
 
 
-def test_content_to_text_handles_string_blocks_none_and_other() -> None:
+def test_content_to_text_handles_string_blocks_none_and_other(tmp_path: Path) -> None:
     """
     Flattening covers every content shape the executor may receive.
 
     A plain string passes through; ``input_text``/``text`` blocks join by newline
-    while image/file blocks are dropped (the text turn is text-only); ``None``
+    while an unmaterializable image/file block contributes nothing; ``None``
     yields ``""``; any other shape falls back to a JSON encoding rather than
     crashing.
     """
     from omnigent.inner.antigravity_native_executor import _content_to_text
 
-    assert _content_to_text("  hello  ") == "hello"
+    assert _content_to_text("  hello  ", tmp_path) == "hello"
     assert (
         _content_to_text(
             [
                 {"type": "input_text", "text": "a"},
-                {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                # malformed data URI (no comma) -> not materialized
+                {"type": "input_image", "image_url": "data:image/png;base64"},
                 {"type": "text", "text": "b"},
-            ]
+            ],
+            tmp_path,
         )
         == "a\nb"
     )
-    assert _content_to_text(None) == ""
+    assert _content_to_text(None, tmp_path) == ""
     # Defensive fallback for an unexpected shape: encoded, not crashed.
-    assert _content_to_text(123) == "123"
+    assert _content_to_text(123, tmp_path) == "123"


### PR DESCRIPTION
## The bug (P2)

A web/mobile user who attaches an image/file to an `omnigent antigravity` (antigravity-native) turn loses it with zero feedback: the bytes are never persisted, no path marker is typed into agy, and no warning is logged. **Attachment-only turns are worse** — they hard-error with `Antigravity native turn had no user text to send`. Text-only turns are unaffected.

## Root cause

`omnigent/inner/antigravity_native_executor.py::_content_to_text` only collected `input_text`/`text` blocks. `input_image`/`input_file` blocks were silently skipped, so attachment bytes were dropped on the floor. `_latest_user_text` then returned `""` for attachment-only turns, and `run_turn` raised `ExecutorError`.

## Fix — mirror cursor-native

Antigravity-native was the lone holdout among the terminal-native executors. cursor-native (the closest analog — it also types into a vendor TUI over tmux), along with claude/qwen/goose/pi-native, already materialize attachments via the shared `omnigent.inner.native_attachments.materialize_attachment` helper and reference them by absolute path. This change mirrors that pattern exactly:

- Thread `self._bridge_dir` into `_content_to_text` / `_latest_user_text`.
- In the block loop, decode `input_image` / `input_file` data URIs to a file under the bridge dir's `uploads/` and prepend `[Attached: <path>]` (attachment lines first, then the typed text) so agy can open the file with its Read tool.
- Attachment-only turns now yield the marker text instead of hard-erroring.
- Delete the now-stale docstring claims that "bytes cannot be sent through this path" — the TUI-typing transport carries a file-path marker exactly like cursor.

## Tests

`tests/inner/test_antigravity_native_executor.py` (mirrors cursor's coverage):
- `test_run_turn_image_attachment_materialized` — an `input_image` block is written to the bridge dir and the injected text starts with `[Attached: ...]`, with the typed prose appended.
- `test_run_turn_attachment_only_no_longer_errors` — an attachment-only turn injects the marker and completes (no `ExecutorError`).
- Updated existing helper/flatten tests to pass `bridge_dir` and use unmaterializable URIs where the assertion is about text joining.

All 33 tests in the file pass; `ruff format` + `ruff check` clean.

This pull request and its description were written by Isaac.