### PR TITLE
fix(cost): clamp self-reported session cost monotonic to harden budget gate

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -3001,8 +3001,18 @@ def _persist_native_cumulative_usage(
     current = dict(conv.session_usage) if conv and conv.session_usage else {}
     # Native usage is cumulative (SET semantics), so the per-turn delta
     # for the daily rollup is new_total - old_total. Capture the old
-    # cumulative cost before the fields below overwrite it.
+    # cumulative + enforcement costs before the fields below overwrite them.
+    # Both are clamped MONOTONIC below (a write may only raise them): the
+    # ``external_session_usage`` event is posted with the session owner's own
+    # bearer token (the forwarder uses no privileged identity), so a client
+    # could otherwise replay it with a falsified low cost to reset the gate's
+    # cost to ~0 (disabling the budget DENY/ASK) and drive the daily rollup
+    # delta negative (clawing back already-spent budget). Monotonicity makes a
+    # downward report a no-op, so the worst a forged post can do is leave the
+    # figure unchanged. (See also the runner-token guard on cost_control.*
+    # label writes in ``cost_advisor`` — usage was the missing half.)
     old_cost = float(current.get("total_cost_usd", 0.0) or 0.0)
+    old_policy_cost = float(current.get("policy_cost_usd", 0.0) or 0.0)
     if cin is not None:
         # The reported input total is INCLUSIVE of cached tokens (codex's
         # ``inputTokens`` counts cache reads). Split the cached portion into
@@ -3051,7 +3061,8 @@ def _persist_native_cumulative_usage(
         else None
     )
     if cost is not None:
-        current["total_cost_usd"] = float(cost)
+        # Monotonic: a reported total below the persisted one is ignored.
+        current["total_cost_usd"] = max(old_cost, float(cost))
     elif has_tokens:
         if isinstance(model_name, str) and model_name:
             from omnigent.llms.context_window import compute_llm_cost, fetch_model_pricing
@@ -3064,7 +3075,10 @@ def _persist_native_cumulative_usage(
                 # cache reads at their own rate; it falls back to the input
                 # rate for cache tokens when the catalog omits a cache price
                 # (e.g. ``databricks-*`` entries today).
-                current["total_cost_usd"] = compute_llm_cost(current, pricing)
+                # Monotonic, like the explicit-cost branch: token totals are
+                # also client-SET, so a lowered token report can't drop the
+                # priced cost below the persisted figure.
+                current["total_cost_usd"] = max(old_cost, compute_llm_cost(current, pricing))
 
     # Per-model attribution (SET). Native harnesses report cumulative SESSION
     # totals, not per-model splits, so attribute the running cumulative buckets
@@ -3087,9 +3101,13 @@ def _persist_native_cumulative_usage(
     # Enforcement value (claude-native display/policy split). Stored
     # separately from the displayed ``total_cost_usd`` so the gate can read
     # the real-time figure (incl. in-flight sub-agent spend) while the badge
-    # shows the frozen statusLine total. SET semantics, like the rest.
+    # shows the frozen statusLine total. Monotonic, like total_cost_usd: this
+    # is the value the cost-budget gate actually reads, so a forged low report
+    # must never lower it. When an in-flight estimate later resolves below a
+    # prior peak the clamp keeps the peak — conservative (the gate errs toward
+    # MORE enforcement, never less), which is the safe direction for a budget.
     if policy_cost is not None:
-        current["policy_cost_usd"] = float(policy_cost)
+        current["policy_cost_usd"] = max(old_policy_cost, float(policy_cost))
 
     conversation_store.set_session_usage(session_id, current)
     # Per-user daily rollup. Native reports cumulative totals, so the turn's
@@ -3097,7 +3115,9 @@ def _persist_native_cumulative_usage(
     # ``total_cost_usd`` (= statusLine S), NOT ``policy_cost_usd`` — the
     # daily report must reflect real spend, not the real-time gate estimate.
     new_cost = float(current.get("total_cost_usd", 0.0) or 0.0)
-    _record_daily_cost(conv, new_cost - old_cost, conversation_store)
+    # Non-negative by the monotonic clamp above; ``max(0.0, ...)`` keeps the
+    # daily rollup from ever being clawed back even if that invariant changes.
+    _record_daily_cost(conv, max(0.0, new_cost - old_cost), conversation_store)
     return _priced_cost_for_display(current)
 
 

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3849,6 +3849,48 @@ async def test_external_session_usage_cumulative_cost_is_set_not_added(
     assert usage.get("total_cost_usd") == 0.90
 
 
+async def test_external_session_usage_cost_is_monotonic(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    A cumulative-usage post may only RAISE the persisted costs, never lower them.
+
+    The ``external_session_usage`` event carries the session owner's own bearer
+    token (the forwarder uses no privileged identity), so an owner could replay
+    it with a falsified low cost. Both the display cost (``total_cost_usd``) and
+    the enforcement cost (``policy_cost_usd``, which the cost-budget gate reads)
+    are clamped monotonic so such a post is a no-op — it can't reset the gate to
+    ~0 and re-enable spending past the budget. A regression (the low value
+    landing) would re-open the budget-bypass.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    high = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_session_usage",
+            "data": {"cumulative_cost_usd": 0.90, "policy_cost_usd": 0.95},
+        },
+    )
+    assert high.status_code == 202, high.text
+
+    # Falsified low report — must be ignored, not stored.
+    low = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_session_usage",
+            "data": {"cumulative_cost_usd": 0.0, "policy_cost_usd": 0.0},
+        },
+    )
+    assert low.status_code == 202, low.text
+
+    usage = _read_session_usage(db_uri, session["id"])
+    assert usage.get("total_cost_usd") == 0.90
+    assert usage.get("policy_cost_usd") == 0.95
+
+
 async def test_external_session_usage_codex_tokens_priced(
     client: httpx.AsyncClient,
     db_uri: str,


### PR DESCRIPTION
## Summary

Hardens the cost-budget gate against a self-reporting bypass surfaced by a customer report (they could "edit webpage headers to override budget constraints and turn off cost limitations").

The cost-budget policy enforces `DENY`/`ASK` against the session's persisted usage — `total_cost_usd` (display) and `policy_cost_usd` (the value the gate actually reads). Those fields are written by the `external_session_usage` event using **pure SET semantics**. That event is accepted with only `LEVEL_EDIT` (which a session **owner** has) and is posted by the native forwarder using the **owner's own bearer token** — no privileged runner identity. So an owner can replay the request with a falsified cost:

- **Reset / bypass:** SET a low `cumulative_cost_usd` / `policy_cost_usd` → the gate's cost drops to ~0 → the budget `DENY`/`ASK` never trips.
- **Daily claw-back:** the per-user daily rollup uses `new - old` as the delta, so a lower report makes the delta **negative**, refunding already-spent daily budget.

Contrast: the related `cost_control.*` **label** write is already guarded by a runner-token identity check (`cost_advisor`). The `session_usage` write — the half that actually drives enforcement — was not.

## Change

In `_persist_native_cumulative_usage` (`omnigent/server/routes/sessions.py`):

- Clamp `total_cost_usd` to `max(old, new)` in both the explicit-cost and token-priced branches.
- Clamp the enforcement `policy_cost_usd` to `max(old, new)`.
- Floor the daily-rollup delta at `0`.

Cumulative billed cost only ever rises within a session, so this is a no-op for legitimate reports; a forged downward report becomes a no-op instead of a bypass. When an in-flight estimate later resolves below a prior peak the clamp keeps the peak — conservative (the gate errs toward more enforcement, never less), which is the safe direction for a budget.

## Scope / limitations

This is a **Tier-1 partial mitigation**. It closes the reset and daily-claw-back vectors. It does **not** stop a user who controls the reporting process itself (e.g. a forwarder running on a user-controlled machine) from simply under-reporting or never advancing cost — closing that fully requires **server-side metering** of actual LLM spend rather than trusting the self-reported figure. Follow-up tracked separately.

## Test

- New regression `test_external_session_usage_cost_is_monotonic`: a high report followed by a falsified zero report leaves both `total_cost_usd` and `policy_cost_usd` unchanged.
- `tests/server/integration/test_sessions_endpoints.py -k external_session_usage` → 23 passed.
- `tests/policies/builtins/test_cost.py`, `tests/runtime/policies/test_builder.py`, `tests/runtime/policies/test_session_cost_ask_routing.py` → 75 passed.