### PR TITLE
fix(antigravity-native): emit context_tokens/context_window so the context-occupancy ring renders

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -98,6 +98,7 @@ from omnigent.antigravity_native_steps import (
 )
 from omnigent.claude_native_bridge import url_component
 from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.llms.context_window import get_model_context_window
 from omnigent.server.schemas import ElicitationRequestParams, ElicitationResult
 
 _logger = logging.getLogger(__name__)
@@ -1093,6 +1094,12 @@ class _ReaderState:
     :param cumulative_output_tokens: Running session total of output tokens.
     :param cumulative_cache_read_input_tokens: Running session total of
         cache-read input tokens.
+    :param last_input_tokens: The LATEST per-call ``modelUsage.inputTokens`` seen
+        this run (the current-turn context occupancy, NOT the cumulative sum).
+        Drives ``external_session_usage.context_tokens`` so the web context-
+        occupancy ring renders. Mirrors codex's ``tokenUsage.last.inputTokens``
+        (the per-turn input incl. cache), versus the cumulative accumulators
+        above. ``0`` until the first DONE step carries usage.
     :param interaction_task: The single in-flight interaction-bridge task, or
         ``None`` when none is running. The bridge runs OFF the reader loop so
         streaming/mirroring continues while a human answers (a long-poll can last
@@ -1119,6 +1126,7 @@ class _ReaderState:
     cumulative_input_tokens: int = 0
     cumulative_output_tokens: int = 0
     cumulative_cache_read_input_tokens: int = 0
+    last_input_tokens: int = 0
     interaction_task: asyncio.Task[None] | None = None
     surfaced_elicitations: dict[_StepKey, str] = field(default_factory=dict)
 
@@ -1904,6 +1912,13 @@ async def _maybe_emit_session_usage(
     thread-wide counter, forwarded as SET values by
     :class:`~omnigent.codex_native_forwarder._SessionUsageCoalescer`).
 
+    Also forwards the context-occupancy ring fields (``context_tokens`` /
+    ``context_window``), mirroring codex-native. Codex reads both off its wire
+    (``tokenUsage.last.inputTokens`` / ``total.contextWindow``); agy's
+    ``modelUsage`` carries neither in ring-ready form, so ``context_tokens`` is
+    the LATEST per-call input (current-turn occupancy, NOT the cumulative sum)
+    and ``context_window`` is resolved from the model catalog (Gemini ⇒ ~1M).
+
     NOTE: ``state.cumulative_*`` accumulators are zeroed at reader-run start; a
     T-G /clear rotation rebinds with a fresh ``_ReaderState`` (``supervise_reader``
     is re-entered), so the new session's cost badge starts from 0 automatically.
@@ -1933,6 +1948,14 @@ async def _maybe_emit_session_usage(
     state.cumulative_cache_read_input_tokens += _int_field(
         per_call, "cumulative_cache_read_input_tokens"
     )
+    # Track the LATEST per-call input tokens for the context-occupancy ring.
+    # ``_model_usage_from_step`` reports ``modelUsage.inputTokens`` under the
+    # ``cumulative_input_tokens`` key (a per-CALL value at the wire, summed into
+    # the running total above) — the latest such value IS the current-turn
+    # context occupancy, mirroring codex's ``tokenUsage.last.inputTokens``.
+    this_call_input = _int_field(per_call, "cumulative_input_tokens")
+    if this_call_input > 0:
+        state.last_input_tokens = this_call_input
     # Resolve the raw model enum to a displayName if the catalog is available.
     model_enum = per_call.get("model")
     display_name: str | None = None
@@ -1949,6 +1972,21 @@ async def _maybe_emit_session_usage(
         payload["cumulative_cache_read_input_tokens"] = state.cumulative_cache_read_input_tokens
     if display_name is not None:
         payload["model"] = display_name
+    # Context-occupancy ring (web composer status line). The ring gate needs
+    # BOTH a numerator (``context_tokens`` = current-turn input occupancy) and a
+    # denominator (``context_window``). agy's ``modelUsage`` carries neither in a
+    # ring-ready shape — unlike codex, whose ``tokenUsage`` ships ``last`` and
+    # ``total.contextWindow`` on the wire — so we synthesize them here:
+    #   - ``context_tokens`` from the latest per-call input (above), and
+    #   - ``context_window`` resolved from the model's catalog window. agy runs
+    #     Gemini (~1M window); the curated Gemini table in ``context_window.py``
+    #     yields 1,048,576 rather than the 128K ``_DEFAULT_CONTEXT_WINDOW``.
+    if state.last_input_tokens > 0:
+        payload["context_tokens"] = state.last_input_tokens
+        if display_name is not None:
+            window = get_model_context_window(display_name)
+            if window > 0:
+                payload["context_window"] = window
     if not payload:
         return
     step_idx = _step_index(step) or 0

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -118,6 +118,53 @@ def _registry_context_window(model: str) -> int | None:
     return None
 
 
+# Curated context windows for the Gemini models the antigravity (``agy``) native
+# harness drives. Like Qwen, these are absent from litellm's bundled registry
+# (the antigravity model ids are agy displayNames such as ``"Gemini 2.5 Flash"``,
+# not the ``gemini/...`` ids litellm knows) and from the MLflow ``google``
+# catalog, so without this they fall back to the conservative 128K default — far
+# too small for Gemini, which serves a 1M-token window, leaving the antigravity
+# context-occupancy ring mis-sized (or, when it gated on the prior 128K, the
+# ring badly over-reading). Keyed by the *normalized* base id (provider prefix
+# and whitespace stripped, lowercased — see :func:`_gemini_context_window`).
+# Values are Google's published Gemini maxima (1,048,576 input tokens for the
+# 2.5 / 3 Pro and Flash families); an unrecognized Gemini id keeps the 128K
+# fallback (and a spec's ``executor.context_window`` always overrides this).
+_GEMINI_CONTEXT_WINDOWS: dict[str, int] = {
+    "gemini 3 pro": 1_048_576,
+    "gemini 3 flash": 1_048_576,
+    "gemini 3.5 flash": 1_048_576,
+    "gemini 2.5 pro": 1_048_576,
+    "gemini 2.5 flash": 1_048_576,
+    "gemini 1.5 pro": 1_048_576,
+    "gemini 1.5 flash": 1_048_576,
+    "gemini-3-pro": 1_048_576,
+    "gemini-3-flash": 1_048_576,
+    "gemini-3.5-flash": 1_048_576,
+    "gemini-2.5-pro": 1_048_576,
+    "gemini-2.5-flash": 1_048_576,
+    "gemini-1.5-pro": 1_048_576,
+    "gemini-1.5-flash": 1_048_576,
+}
+
+
+def _gemini_context_window(model: str) -> int | None:
+    """Look up a Gemini model's context window from the curated table.
+
+    Normalizes the id the way antigravity model strings reach us — an agy
+    ``displayName`` (``"Gemini 2.5 Flash"``) or a hyphenated id
+    (``"gemini-3.5-flash"``), possibly provider-prefixed — down to a
+    lowercased, prefix-stripped key before matching against
+    :data:`_GEMINI_CONTEXT_WINDOWS`.
+
+    :param model: The model identifier (any namespacing).
+    :returns: The context window in tokens, or ``None`` when the model isn't a
+        recognized Gemini entry (caller falls back to the 128K default).
+    """
+    bare = model.rsplit("/", 1)[-1].strip().lower()
+    return _GEMINI_CONTEXT_WINDOWS.get(bare)
+
+
 # Fallback cache pricing as a multiple of the plain input rate, used when the
 # catalog publishes no explicit cache rate for a model (e.g. ``databricks-*``
 # entries today omit them). Both providers we serve publish the same ratios:
@@ -303,7 +350,11 @@ def get_model_context_window(model: str) -> int:
        ``github.com/mlflow/mlflow/releases``. Covers models not yet
        in litellm's bundled registry, with a family-prefix fallback
        for newly released variants.
-    5. ``_DEFAULT_CONTEXT_WINDOW`` (128 K) — conservative fallback.
+    5. Curated Gemini table (:func:`_gemini_context_window`) — for the
+       antigravity (``agy``) native harness's Gemini ids (agy ``displayName``s
+       absent from both litellm and the MLflow ``google`` catalog) that serve
+       a 1M-token window. Qwen is already covered above by the registry.
+    6. ``_DEFAULT_CONTEXT_WINDOW`` (128 K) — conservative fallback.
 
     :param model: The model identifier, e.g. ``"openai/gpt-4o"`` or
         ``"databricks-gpt-5-5"``.
@@ -322,7 +373,11 @@ def get_model_context_window(model: str) -> int:
     try:
         import litellm
     except ImportError:
-        return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
+        return (
+            _fetch_context_window_from_mlflow(model)
+            or _gemini_context_window(model)
+            or _DEFAULT_CONTEXT_WINDOW
+        )
     try:
         info = litellm.get_model_info(model)
         if info:
@@ -340,7 +395,11 @@ def get_model_context_window(model: str) -> int:
                     return int(limit)
         except Exception:
             pass
-    return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
+    return (
+        _fetch_context_window_from_mlflow(model)
+        or _gemini_context_window(model)
+        or _DEFAULT_CONTEXT_WINDOW
+    )
 
 
 def resolve_effective_context_window(

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -15,6 +15,7 @@ import pytest
 from omnigent.llms import context_window
 from omnigent.llms.context_window import (
     ModelPricing,
+    _gemini_context_window,
     _registry_context_window,
     compute_llm_cost,
     fetch_model_pricing,
@@ -410,3 +411,34 @@ def test_get_model_context_window_uses_registry_first(monkeypatch: pytest.Monkey
     assert get_model_context_window("qwen3-coder-plus") == 1_048_576
     # A model the registry doesn't own still falls back to the conservative default.
     assert get_model_context_window("qwen-nonexistent-xyz") == 128_000
+
+
+def test_gemini_context_window_normalizes_id() -> None:
+    """The lookup strips provider prefixes and lowercases before matching.
+
+    Covers both the agy ``displayName`` shape (``"Gemini 2.5 Flash"``) and the
+    hyphenated id shape (``"gemini-3.5-flash"``) the antigravity native harness
+    drives.
+    """
+    assert _gemini_context_window("Gemini 2.5 Flash") == 1_048_576
+    assert _gemini_context_window("Gemini 2.5 Pro") == 1_048_576
+    assert _gemini_context_window("Gemini 3 Pro") == 1_048_576
+    assert _gemini_context_window("gemini-3.5-flash") == 1_048_576
+    assert _gemini_context_window("google/gemini-2.5-pro") == 1_048_576
+    assert _gemini_context_window("GEMINI 2.5 FLASH") == 1_048_576  # case-insensitive
+    # Unknown Gemini variant → None (caller falls back to the default).
+    assert _gemini_context_window("gemini-nonexistent-xyz") is None
+
+
+def test_get_model_context_window_uses_gemini_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A known Gemini model resolves to its curated 1M window, not the 128K default.
+
+    Catalog lookup is disabled so the resolution is hermetic (no network):
+    litellm has no agy displayName entry, MLflow is skipped, so the curated
+    Gemini table answers. This is what feeds the antigravity context ring.
+    """
+    monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
+    monkeypatch.delenv("AP_CONTEXT_WINDOW_OVERRIDE", raising=False)
+    assert get_model_context_window("Gemini 2.5 Flash") == 1_048_576
+    # An unrecognized Gemini model still falls back to the conservative default.
+    assert get_model_context_window("Gemini nonexistent xyz") == 128_000

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -2100,6 +2100,96 @@ async def test_planner_done_emits_session_usage(
     assert usage_data["cumulative_output_tokens"] == 100
     assert usage_data["cumulative_cache_read_input_tokens"] == 200
     assert usage_data["model"] == "Gemini 2.5 Flash"
+    # Context-occupancy ring fields (mirrors codex-native). The numerator is the
+    # current-turn input occupancy (the latest per-call inputTokens), and the
+    # denominator is the Gemini catalog window (~1M, not the 128K fallback).
+    assert usage_data["context_tokens"] == 1000
+    assert usage_data["context_window"] > 128_000
+
+
+@pytest.mark.asyncio
+async def test_usage_emits_context_ring_fields_for_web(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """The usage payload carries non-null ``context_tokens`` + a Gemini window.
+
+    Regression guard for the missing context-occupancy ring: the web ring gate
+    needs ``contextWindow > 0 && tokensUsed != null`` and is fed by
+    ``session.usage.contextTokens`` / ``contextWindow``. Before the fix the
+    reader posted only ``cumulative_*`` + ``model``, so the ring stayed gated
+    off. ``context_tokens`` must be the latest per-call input occupancy and
+    ``context_window`` must resolve to Gemini's ~1M window (not the 128K
+    ``_DEFAULT_CONTEXT_WINDOW`` fallback).
+    """
+    planner = _planner_with_model_usage(
+        input_tokens="4096",
+        output_tokens="100",
+        cache_read_tokens="512",
+        model_enum="MODEL_PLACEHOLDER_M20",
+    )
+    frames = [_frame([planner])]
+    sink = _PostSink()
+
+    await _run_with_telemetry(
+        bridge_dir=_bridge_dir(tmp_path),
+        sink=sink,
+        stream=_FrameScript(frames),
+        poll_steps=_StepScript([[]]),
+        monkeypatch=monkeypatch,
+        iterations=1,
+    )
+
+    usage_events = [(et, d) for et, d in sink.posts if et == "external_session_usage"]
+    assert len(usage_events) == 1, f"expected 1 usage event, got {len(usage_events)}"
+    _, usage_data = usage_events[0]
+    # Numerator: latest per-call input tokens (current-turn occupancy).
+    assert usage_data["context_tokens"] is not None
+    assert usage_data["context_tokens"] == 4096
+    # Denominator: Gemini's published ~1M window, well above the 128K fallback.
+    assert usage_data["context_window"] == 1_048_576
+
+
+@pytest.mark.asyncio
+async def test_context_tokens_tracks_latest_not_cumulative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """Across two turns, ``context_tokens`` follows the LATEST per-call input.
+
+    The cost badge accumulates (``cumulative_input_tokens`` sums to 3000), but
+    the ring must reflect current occupancy, so ``context_tokens`` is turn 2's
+    per-call input (2000), NOT the 3000 cumulative total — mirroring codex's
+    ``tokenUsage.last`` vs ``tokenUsage.total`` split.
+    """
+    planner_turn1 = _planner_with_model_usage(step_index=2, input_tokens="1000")
+    planner_turn2 = _planner_with_model_usage(step_index=6, input_tokens="2000")
+    frames = [
+        _frame([planner_turn1]),
+        _frame([planner_turn1, planner_turn2]),
+    ]
+    sink = _PostSink()
+
+    await _run_with_telemetry(
+        bridge_dir=_bridge_dir(tmp_path),
+        sink=sink,
+        stream=_FrameScript(frames),
+        poll_steps=_StepScript([[]]),
+        monkeypatch=monkeypatch,
+        iterations=1,
+    )
+
+    usage_events = [(et, d) for et, d in sink.posts if et == "external_session_usage"]
+    assert len(usage_events) == 2, f"expected 2 usage events, got {len(usage_events)}"
+    # Turn 1: per-call == cumulative on the first turn.
+    assert usage_events[0][1]["context_tokens"] == 1000
+    assert usage_events[0][1]["cumulative_input_tokens"] == 1000
+    # Turn 2: ring follows the latest per-call input, cost badge keeps summing.
+    assert usage_events[1][1]["context_tokens"] == 2000
+    assert usage_events[1][1]["cumulative_input_tokens"] == 3000
+    assert usage_events[1][1]["context_window"] == 1_048_576
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug (P2): context-window ring never renders in antigravity-native

**Symptom:** Antigravity-native web/mobile sessions never show the context-occupancy ring in the composer status line. Cumulative cost/token reporting still works; only the ring is missing.

**Root cause:** `omnigent/antigravity_native_reader.py` `_maybe_emit_session_usage` posted an `external_session_usage` payload with only `cumulative_*` + `model`. It never included `context_tokens` or `context_window`. The web ring gate needs `contextWindow > 0 && tokensUsed != null`, and `tokensUsed` is fed only by `session.usage.contextTokens` — which was never posted — so the ring stayed gated off.

## Fix (mirrors codex-native)

codex-native posts BOTH ring fields in its usage payload: `context_tokens` from `tokenUsage.last.inputTokens` (the current-turn occupancy, i.e. latest per-call input tokens incl. cache, NOT the cumulative accumulator) and `context_window` from `total.contextWindow` (read off its wire). agy's `modelUsage` carries neither in ring-ready form, so:

- **`context_tokens`** — track the LATEST per-call `modelUsage.inputTokens` in `_ReaderState` (`last_input_tokens`) and post it. `_model_usage_from_step` already parses `inputTokens`; we capture the last per-call value, mirroring codex's `tokenUsage.last`. The existing `cumulative_*` accumulators are unchanged (the cost badge keeps summing).
- **`context_window`** — resolve from the model catalog via `get_model_context_window(displayName)`. agy runs Gemini (~1M window), but the agy displayName ids (`"Gemini 2.5 Flash"`, …) are absent from litellm's registry and the MLflow `google` catalog, so resolution fell back to the conservative 128K `_DEFAULT_CONTEXT_WINDOW`. Mirroring the existing `_QWEN_CONTEXT_WINDOWS` curated table, this adds `_GEMINI_CONTEXT_WINDOWS` to `omnigent/llms/context_window.py` keyed by normalized Gemini id, yielding **1,048,576** (Google's published Gemini max-input window) instead of 128K.

The existing `cumulative_input_tokens` / `cumulative_output_tokens` / `cumulative_cache_read_input_tokens` / `model` fields are kept intact (SET semantics, accumulators untouched).

## Tests

- `tests/test_antigravity_native_reader.py`: extended `test_planner_done_emits_session_usage` to assert the ring fields; added `test_usage_emits_context_ring_fields_for_web` (non-null `context_tokens`, `context_window == 1_048_576`) and `test_context_tokens_tracks_latest_not_cumulative` (ring follows latest per-call input, cost badge keeps summing). 74 pass.
- `tests/llms/test_context_window.py`: added `test_gemini_context_window_normalizes_id` and `test_get_model_context_window_uses_gemini_fallback` (hermetic, catalog disabled).

This pull request and its description were written by Isaac.