### PR TITLE
Add Databricks support to agents SDK extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ omnigent run examples/debby/ --harness openai-agents
 omnigent run examples/polly/ --harness cursor  # Cursor CLI (needs cursor-agent + CURSOR_API_KEY)
 ```
 
+When using the OpenAI Agents SDK harness, set `OPENAI_API_KEY` before launching.
+If you are pointing the SDK at a custom OpenAI-compatible endpoint, such as a
+gateway, also set `OPENAI_BASE_URL`. Databricks-backed OpenAI Agents SDK runs
+should install the SDK path with `uv tool install "omnigent[agents-sdk]"`, which
+includes the Databricks SDK needed for workspace auth.
+
 **🐙 Polly** is a multi-agent coding orchestrator who writes no code herself.
 She's the tech lead: she plans, delegates the work to coding sub-agents
 (Claude Code, Codex, or Pi) in parallel git worktrees, then routes each diff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ openshell = ["openshell>=0.0.7,<1"]
 tracing = ["mlflow>=3,<4"]
 agents-sdk = [
     "openai-agents>=0.1,<1",
+    "databricks-sdk>=0.56.0,<1",
     "opentelemetry-instrumentation-openai-agents-v2>=0.1",
 ]
 # Google Antigravity SDK harness (`harness: antigravity`). Optional: the

--- a/uv.lock
+++ b/uv.lock
@@ -2757,6 +2757,7 @@ dependencies = [
 
 [package.optional-dependencies]
 agents-sdk = [
+    { name = "databricks-sdk" },
     { name = "openai-agents" },
     { name = "opentelemetry-instrumentation-openai-agents-v2" },
 ]
@@ -2849,6 +2850,7 @@ requires-dist = [
     { name = "cursor-sdk", marker = "extra == 'cursor'", specifier = ">=0.1.7" },
     { name = "cwsandbox", marker = "extra == 'cwsandbox'", specifier = ">=0.24,<1" },
     { name = "databricks-mcp", marker = "extra == 'databricks'", specifier = ">=0.1.0" },
+    { name = "databricks-sdk", marker = "extra == 'agents-sdk'", specifier = ">=0.56.0,<1" },
     { name = "databricks-sdk", marker = "extra == 'all'", specifier = ">=0.56.0,<1" },
     { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.56.0,<1" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.180,<1" },


### PR DESCRIPTION
## Summary
- add `databricks-sdk` to the `agents-sdk` optional dependency path and refresh `uv.lock`
- document `OPENAI_API_KEY` and optional `OPENAI_BASE_URL` setup for OpenAI Agents SDK launches
- call out the `omnigent[agents-sdk]` install path for Databricks-backed OpenAI Agents SDK runs

## Security audit
- Checked Polly configs/docs for literal API keys, tokens, secrets, and passwords. No hardcoded secret material was found in `examples/polly` or `omnigent/resources/examples/polly`.
- `examples/polly/agents/gpt_worker/config.yaml` is not present on this branch or current `origin/main`. No remediation commit was needed because no Polly secret exposure exists in this PR diff.

## Validation
- `uv lock` — resolved 250 packages
- `uv lock --check` — resolved 250 packages in 2ms
- `uv run --extra agents-sdk python -c "import databricks.sdk; import agents; print('agents-sdk extra imports ok')"` — passed
- `test ! -e examples/polly/agents/gpt_worker/config.yaml && echo 'examples/polly/agents/gpt_worker/config.yaml not present'` — passed
- `rg -n -e "sk-[A-Za-z0-9_-]{8,}" -e "ghp_[A-Za-z0-9_]+" -e "github_pat_[A-Za-z0-9_]+" -e "xox[baprs]-[A-Za-z0-9-]+" -e "(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*\\\"?[A-Za-z0-9_./+=-]{12,}" examples/polly omnigent/resources/examples/polly || true` — no matches
- `uv run --extra dev pytest tests/onboarding/test_databricks_config.py tests/onboarding/test_harness_readiness.py tests/onboarding/test_harness_install.py` — 87 passed in 0.10s