### PR TITLE
fix(antigravity-native): scope response_id to the turn, not the step (#9)

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -1076,6 +1076,13 @@ class _ReaderState:
         committed ``message`` is posted (stream path only).
     :param turn_active: Whether a turn is currently considered open (a RUNNING
         edge fired and no closing IDLE edge yet).
+    :param turn_execution_id: The CURRENT turn's ``executionId`` — set from each
+        USER_INPUT step (its per-turn uuid) and held for every following step in
+        the turn. The mapper stamps it on each committed item's response_id so a
+        whole narrate→tool-call→answer turn groups into ONE assistant bubble
+        (#9). ``""`` until the first USER_INPUT is observed (e.g. a resumed
+        mid-turn snapshot whose opening USER_INPUT predates this run); the
+        mapper still produces a stable per-conversation id from it then.
     :param posted_model_enum: The last model enum already mirrored via
         ``external_model_change``. ``None`` = none posted yet.  Tracks the raw
         enum (NOT the displayName) so de-dup comparison is enum-stable.
@@ -1113,6 +1120,7 @@ class _ReaderState:
     prefixes: dict[int, str] = field(default_factory=dict)
     reasoning_prefixes: dict[int, str] = field(default_factory=dict)
     turn_active: bool = False
+    turn_execution_id: str = ""
     posted_model_enum: str | None = None
     model_catalog: dict[str, object] | None = None
     port: int = 0
@@ -1336,13 +1344,14 @@ async def _process_committed_step(
     if key not in state.seen:
         if _is_settled(step):
             state.seen.add(key)
-        state.turn_active = await _emit_step(
+        state.turn_active, state.turn_execution_id = await _emit_step(
             step,
             client=client,
             session_id=session_id,
             cascade_id=cascade_id,
             allocator=state.allocator,
             turn_active=state.turn_active,
+            turn_execution_id=state.turn_execution_id,
         )
         # Telemetry: model-change detection on USER_INPUT (design §10.4).
         await _maybe_emit_model_change(
@@ -1644,7 +1653,8 @@ async def _emit_step(
     cascade_id: str,
     allocator: _ToolCallIdAllocator,
     turn_active: bool,
-) -> bool:
+    turn_execution_id: str,
+) -> tuple[bool, str]:
     """
     Emit one new step's status edges + mapped conversation items.
 
@@ -1653,19 +1663,39 @@ async def _emit_step(
     this step closes the turn) AFTER them. Status edges fire only on a real
     transition, deduped via the ``turn_active`` flag threaded through the loop.
 
+    The turn's ``executionId`` is likewise threaded: a USER_INPUT step rebinds it
+    to that turn's per-turn uuid (:func:`_execution_discriminator`), and every
+    following step in the turn maps with it so all of a turn's committed items
+    carry ONE response_id and the SPA renders them in a single bubble (#9). A
+    USER_INPUT whose execution discriminator cannot be resolved keeps the prior
+    id rather than dropping to ``""`` mid-conversation.
+
     :param step: One new (not-yet-seen) RPC step dict.
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id to mirror into.
     :param cascade_id: agy cascade id (namespaces response/call ids).
     :param allocator: Per-run tool-call id allocator (fallback ids only).
     :param turn_active: Whether a turn is currently considered open on entry.
-    :returns: The updated ``turn_active`` flag after this step.
+    :param turn_execution_id: The current turn's ``executionId`` on entry (``""``
+        before the first USER_INPUT of the run).
+    :returns: The updated ``(turn_active, turn_execution_id)`` after this step.
     """
-    if _is_user_turn_step(step) and not turn_active:
-        turn_active = True
-        await _post_event(client, session_id, _status_event(_STATUS_RUNNING))
+    if _is_user_turn_step(step):
+        # A new user turn opens the turn-scoped response_id namespace: rebind the
+        # id to this turn so the following planner/tool steps group under it.
+        new_turn_id = _execution_discriminator(step)
+        if new_turn_id is not None:
+            turn_execution_id = new_turn_id
+        if not turn_active:
+            turn_active = True
+            await _post_event(client, session_id, _status_event(_STATUS_RUNNING))
 
-    for event in map_step_to_events(step, conversation_id=cascade_id, allocator=allocator):
+    for event in map_step_to_events(
+        step,
+        conversation_id=cascade_id,
+        turn_execution_id=turn_execution_id,
+        allocator=allocator,
+    ):
         await _post_event(client, session_id, event)
 
     if _is_turn_close_step(step) and turn_active:
@@ -1677,7 +1707,7 @@ async def _emit_step(
         close_status = _STATUS_FAILED if _step_is_error_planner(step) else _STATUS_IDLE
         await _post_event(client, session_id, _status_event(close_status))
 
-    return turn_active
+    return turn_active, turn_execution_id
 
 
 def _step_is_error_planner(step: dict[str, object]) -> bool:

--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -382,18 +382,25 @@ def pending_interaction(step: dict[str, object]) -> PendingInteraction | None:
     return None
 
 
-def _response_id(conversation_id: str, step_idx: int) -> str:
+def _response_id(conversation_id: str, turn_execution_id: str) -> str:
     """
-    Build a stable Omnigent response id for a RPC step.
+    Build a stable Omnigent response id scoped to one agy TURN.
 
-    Mirrors the forwarder's ``_response_id`` format so ids are consistent
-    across the transcript and RPC paths.
+    Keyed on the per-turn ``executionId`` (the USER_INPUT step's uuid) rather
+    than the conversation-monotonic ``stepIndex``, so every committed item
+    between two USER_INPUT boundaries — the narration ``message``, each
+    ``function_call``, the answer ``message`` — shares ONE response id and the
+    SPA renders them as a single assistant bubble. A per-``stepIndex`` id
+    instead fragmented a text→tool-call→answer turn into separate bubbles
+    (#9). This mirrors codex (``codex_<turnId>`` — one id per turn) and claude
+    (one ``current_response_id`` held across the turn).
 
     :param conversation_id: agy conversation id.
-    :param step_idx: Step index from ``sourceTrajectoryStepInfo.stepIndex``.
-    :returns: Response id, e.g. ``"agy_8ca97c49_2"``.
+    :param turn_execution_id: The turn's ``executionId`` (the USER_INPUT step's
+        per-turn uuid); see :func:`_execution_discriminator`.
+    :returns: Turn-scoped response id, e.g. ``"agy_8ca97c49_1df76a5f-..."``.
     """
-    return f"agy_{conversation_id}_{step_idx}"
+    return f"agy_{conversation_id}_{turn_execution_id}"
 
 
 def _json_string(value: dict[str, object]) -> str | None:
@@ -564,6 +571,7 @@ def _message_event(
     *,
     conversation_id: str,
     step_idx: int,
+    turn_execution_id: str,
     text: str,
 ) -> OutboundEvent:
     """
@@ -573,7 +581,10 @@ def _message_event(
     function; user turns are skipped by the caller.
 
     :param conversation_id: agy conversation id.
-    :param step_idx: Step index.
+    :param step_idx: Step index (carried on the envelope for ordering/debug).
+    :param turn_execution_id: The owning turn's ``executionId`` — the
+        response_id is scoped to it so all of a turn's items group into one
+        bubble (#9).
     :param text: Assistant text (``plannerResponse.modifiedResponse`` or
         ``plannerResponse.response``).
     :returns: One ``external_conversation_item`` event.
@@ -587,7 +598,7 @@ def _message_event(
                 "agent": _AGENT_NAME,
                 "content": [{"type": "output_text", "text": text}],
             },
-            "response_id": _response_id(conversation_id, step_idx),
+            "response_id": _response_id(conversation_id, turn_execution_id),
         },
         step_index=step_idx,
     )
@@ -694,6 +705,7 @@ def _function_call_events(
     *,
     conversation_id: str,
     step_idx: int,
+    turn_execution_id: str,
     tool_calls: list[object],
     allocator: _ToolCallIdAllocator,
 ) -> list[OutboundEvent]:
@@ -711,11 +723,14 @@ def _function_call_events(
 
     :param conversation_id: agy conversation id.
     :param step_idx: Owning step index.
+    :param turn_execution_id: The owning turn's ``executionId`` — every
+        function_call shares the turn-scoped response_id so it groups with the
+        surrounding narration/answer in one bubble (#9).
     :param tool_calls: ``plannerResponse.toolCalls`` list.
     :param allocator: Fallback call-id allocator when real id is absent.
     :returns: One ``external_conversation_item`` event per valid tool call.
     """
-    response_id = _response_id(conversation_id, step_idx)
+    response_id = _response_id(conversation_id, turn_execution_id)
     events: list[OutboundEvent] = []
     for entry in tool_calls:
         if not isinstance(entry, dict):
@@ -773,6 +788,7 @@ def _function_call_output_event(
     *,
     conversation_id: str,
     step_idx: int,
+    turn_execution_id: str,
     output: str,
     real_id: str | None,
     allocator: _ToolCallIdAllocator,
@@ -785,6 +801,9 @@ def _function_call_output_event(
 
     :param conversation_id: agy conversation id.
     :param step_idx: Tool-result step index.
+    :param turn_execution_id: The owning turn's ``executionId`` — the
+        response_id is scoped to it so the output groups with its invocation in
+        the same bubble (#9).
     :param output: Human-readable tool result text.
     :param real_id: agy-assigned call id from ``metadata.toolCall.id``, or
         ``None`` when absent.
@@ -797,7 +816,7 @@ def _function_call_output_event(
         data={
             "item_type": "function_call_output",
             "item_data": {"call_id": call_id, "output": output},
-            "response_id": _response_id(conversation_id, step_idx),
+            "response_id": _response_id(conversation_id, turn_execution_id),
         },
         step_index=step_idx,
     )
@@ -873,6 +892,7 @@ def map_step_to_events(
     step: dict[str, object],
     *,
     conversation_id: str,
+    turn_execution_id: str,
     allocator: _ToolCallIdAllocator,
 ) -> list[OutboundEvent]:
     """
@@ -922,6 +942,13 @@ def map_step_to_events(
     :param step: One step dict from ``GetCascadeTrajectorySteps``.
     :param conversation_id: agy conversation id (namespaces response ids and
         call ids).
+    :param turn_execution_id: The CURRENT turn's ``executionId`` (the open
+        turn's USER_INPUT step uuid). Every committed item this step emits is
+        stamped with the turn-scoped response_id ``agy_<conversation_id>_<turn
+        _execution_id>`` so a narrate→call-tool→answer turn renders as ONE
+        assistant bubble instead of one bubble per step (#9). The caller (the
+        reader) tracks it across the turn; USER_INPUT itself emits a user
+        ``message`` (no response_id) and does not consume this.
     :param allocator: Fallback tool-call id allocator, used only when a step
         lacks the real agy ``id`` field (resume-mid-turn case).
     :returns: Ordered events to POST for this step (possibly empty).
@@ -995,6 +1022,7 @@ def map_step_to_events(
                     _message_event(
                         conversation_id=conversation_id,
                         step_idx=step_idx,
+                        turn_execution_id=turn_execution_id,
                         text=text,
                     )
                 )
@@ -1004,6 +1032,7 @@ def map_step_to_events(
                     _function_call_events(
                         conversation_id=conversation_id,
                         step_idx=step_idx,
+                        turn_execution_id=turn_execution_id,
                         tool_calls=tool_calls,
                         allocator=allocator,
                     )
@@ -1064,6 +1093,7 @@ def map_step_to_events(
             _function_call_output_event(
                 conversation_id=conversation_id,
                 step_idx=step_idx,
+                turn_execution_id=turn_execution_id,
                 output=output,
                 real_id=result_call_id,
                 allocator=allocator,

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -130,6 +130,17 @@ class _PostSink:
                 out.append(role if isinstance(role, str) else "<none>")
         return out
 
+    def response_ids(self) -> list[str]:
+        """Return the ``response_id`` of every committed conversation item, in order."""
+        out: list[str] = []
+        for event_type, data in self.posts:
+            if event_type != "external_conversation_item":
+                continue
+            rid = data.get("response_id")
+            if isinstance(rid, str):
+                out.append(rid)
+        return out
+
     def deltas(self) -> list[dict[str, object]]:
         """Return the ``data`` payload of every ``external_output_text_delta``."""
         return [
@@ -2447,6 +2458,100 @@ async def test_two_real_wire_turns_each_emit_running_then_idle(
     # message — user-before-assistant ordering, per turn (#1155).
     assert sink.item_types() == ["message", "message", "message", "message"]
     assert sink.message_roles() == ["user", "assistant", "user", "assistant"]
+
+
+# ---------------------------------------------------------------------------
+# Turn-scoped response_id: one bubble per turn, distinct across turns (#9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_step_turn_items_share_one_response_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """A narrate→tool-call→answer turn commits items under ONE response_id (#9).
+
+    The turn is: USER_INPUT (opens it) → a tool-call PLANNER_RESPONSE
+    (``function_call``) → its RUN_COMMAND result (``function_call_output``) → a
+    text PLANNER_RESPONSE answer (``message``). These planner/result steps carry
+    DIFFERENT ``stepIndex`` values, so the old stepIndex-keyed id fragmented the
+    turn into several bubbles. With the turn-scoped id every committed assistant
+    item shares the SINGLE ``agy_<cascade>_<executionId>`` id (the user message
+    carries none — it is not an assistant response).
+    """
+    user = _user_input_real_wire(execution_id="exec-turn-1")
+    tool_call = _load("planner_response_tool_call_run_command")  # function_call, stepIndex 5
+    result = _load("run_command_done")  # function_call_output
+    answer = _done_planner("All done.", step_index=8)  # message
+    frames = [
+        _frame([user]),
+        _frame([user, tool_call]),
+        _frame([user, tool_call, result]),
+        _frame([user, tool_call, result, answer]),
+    ]
+    sink = _PostSink()
+
+    await _run_stream(
+        bridge_dir=_bridge_dir(tmp_path),
+        sink=sink,
+        stream=_FrameScript(frames),
+        poll_steps=_StepScript([[]]),
+        monkeypatch=monkeypatch,
+        iterations=1,
+    )
+
+    # function_call + function_call_output + assistant message, each once.
+    assert sink.item_types() == [
+        "message",  # user (no response_id)
+        "function_call",
+        "function_call_output",
+        "message",  # assistant answer
+    ]
+    # The three assistant-side items all carry the ONE turn-scoped id.
+    expected = f"agy_{_CASCADE_ID}_exec-turn-1"
+    assert sink.response_ids() == [expected, expected, expected]
+
+
+@pytest.mark.asyncio
+async def test_distinct_turns_get_distinct_response_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """Two turns (distinct ``executionId``) commit under DISTINCT response_ids (#9).
+
+    The complement of the single-turn grouping: a new USER_INPUT rebinds the
+    turn-scoped id, so turn 2's answer must NOT share turn 1's id (else the two
+    turns' replies would collapse into one bubble).
+    """
+    user1 = _user_input_real_wire(execution_id="exec-turn-1")
+    done1 = _done_planner("First answer.", step_index=2)
+    user2 = _user_input_real_wire(execution_id="exec-turn-2")
+    done2 = _done_planner("Second answer.", step_index=6)
+    frames = [
+        _frame([user1]),
+        _frame([user1, done1]),
+        _frame([user1, done1, user2]),
+        _frame([user1, done1, user2, done2]),
+    ]
+    sink = _PostSink()
+
+    await _run_stream(
+        bridge_dir=_bridge_dir(tmp_path),
+        sink=sink,
+        stream=_FrameScript(frames),
+        poll_steps=_StepScript([[]]),
+        monkeypatch=monkeypatch,
+        iterations=1,
+    )
+
+    # Only the two assistant answers carry a response_id (user messages do not).
+    id1 = f"agy_{_CASCADE_ID}_exec-turn-1"
+    id2 = f"agy_{_CASCADE_ID}_exec-turn-2"
+    assert sink.response_ids() == [id1, id2]
+    assert id1 != id2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_antigravity_native_steps.py
+++ b/tests/test_antigravity_native_steps.py
@@ -40,6 +40,10 @@ from omnigent.antigravity_native_steps import (
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "antigravity" / "steps"
 _CID = "test-conversation-id"
+# The current turn's ``executionId`` (the USER_INPUT step's per-turn uuid). The
+# mapper scopes every committed item's response_id to this turn id (#9), so the
+# tests drive it explicitly and assert ids of the form ``agy_<cid>_<turn>``.
+_TURN = "test-turn-exec-id"
 
 
 def _load(name: str) -> dict[str, Any]:
@@ -90,7 +94,9 @@ class TestUserInputCommitted:
     def test_user_input_commits_user_message(self) -> None:
         """USER_INPUT step → exactly one committed user ``message`` item."""
         step = _load("user_input")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         ev = events[0]
         assert ev.event_type == "external_conversation_item"
@@ -105,13 +111,17 @@ class TestUserInputCommitted:
     def test_user_input_no_delta(self) -> None:
         """USER_INPUT commits a message but emits no streaming delta events."""
         step = _load("user_input")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         _assert_no_delta(events)
 
     def test_user_input_without_text_is_skipped(self) -> None:
         """A USER_INPUT step with no recoverable text emits nothing (no empty bubble)."""
         step = {"type": "CORTEX_STEP_TYPE_USER_INPUT", "userInput": {}}
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events == []
 
 
@@ -131,25 +141,33 @@ class TestPlannerResponseText:
         message); the new mapper emits 1.
         """
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
 
     def test_event_type_is_conversation_item(self) -> None:
         """The single event has type ``external_conversation_item``."""
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].event_type == "external_conversation_item"
 
     def test_item_type_is_message(self) -> None:
         """The event's ``item_type`` is ``"message"``."""
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].data["item_type"] == "message"
 
     def test_message_role_is_assistant(self) -> None:
         """The ``message`` item has role ``"assistant"``."""
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         assert item_data["role"] == "assistant"
@@ -160,7 +178,9 @@ class TestPlannerResponseText:
         fixture's ``plannerResponse.response`` text.
         """
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         content = item_data["content"]
@@ -180,21 +200,31 @@ class TestPlannerResponseText:
         event before the message; the new mapper drops it entirely.
         """
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         _assert_no_delta(events)
 
     def test_step_index_from_fixture(self) -> None:
         """step_index on the event matches the fixture's sourceTrajectoryStepInfo.stepIndex."""
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         # planner_response_text.json has stepIndex=2
         assert events[0].step_index == 2
 
-    def test_response_id_stable(self) -> None:
-        """response_id is deterministic: ``agy_<conversation_id>_<stepIndex>``."""
+    def test_response_id_is_turn_scoped(self) -> None:
+        """response_id is turn-scoped: ``agy_<conversation_id>_<turn_execution_id>``.
+
+        Keyed on the turn's ``executionId``, NOT the step's ``stepIndex`` (#9),
+        so every item in a turn shares one id and renders as a single bubble.
+        """
         step = _load("planner_response_text")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
-        assert events[0].data["response_id"] == f"agy_{_CID}_2"
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
+        assert events[0].data["response_id"] == f"agy_{_CID}_{_TURN}"
 
 
 class TestPlannerResponseError:
@@ -241,14 +271,18 @@ class TestPlannerResponseToolCallRunCommand:
     def test_returns_one_function_call(self) -> None:
         """One tool call → one ``function_call`` event."""
         step = _load("planner_response_tool_call_run_command")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].data["item_type"] == "function_call"
 
     def test_function_call_name(self) -> None:
         """The function_call name matches the fixture's toolCall name."""
         step = _load("planner_response_tool_call_run_command")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         assert item_data["name"] == "run_command"
@@ -262,7 +296,9 @@ class TestPlannerResponseToolCallRunCommand:
         """
         alloc = _allocator()
         step = _load("planner_response_tool_call_run_command")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=alloc)
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         # Real agy id from the fixture
@@ -276,7 +312,9 @@ class TestPlannerResponseToolCallRunCommand:
         arguments; the real command args remain.
         """
         step = _load("planner_response_tool_call_run_command")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         args_text = item_data["arguments"]
@@ -290,13 +328,17 @@ class TestPlannerResponseToolCallRunCommand:
     def test_no_delta_event(self) -> None:
         """No delta event is emitted for a tool-call-only PLANNER_RESPONSE."""
         step = _load("planner_response_tool_call_run_command")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         _assert_no_delta(events)
 
     def test_step_index(self) -> None:
         """step_index matches fixture stepIndex=5."""
         step = _load("planner_response_tool_call_run_command")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].step_index == 5
 
 
@@ -306,14 +348,18 @@ class TestPlannerResponseToolCallAskQuestion:
     def test_returns_one_function_call(self) -> None:
         """One ask_question tool call → one ``function_call`` event."""
         step = _load("planner_response_tool_call_ask_question")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].data["item_type"] == "function_call"
 
     def test_function_call_name(self) -> None:
         """The function_call name is ``ask_question``."""
         step = _load("planner_response_tool_call_ask_question")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         assert item_data["name"] == "ask_question"
@@ -326,7 +372,9 @@ class TestPlannerResponseToolCallAskQuestion:
         """
         alloc = _allocator()
         step = _load("planner_response_tool_call_ask_question")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=alloc)
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         assert item_data["call_id"] == "jfizoalt"
@@ -344,19 +392,25 @@ class TestRunCommandDone:
     def test_returns_one_event(self) -> None:
         """One DONE run_command → one event."""
         step = _load("run_command_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
 
     def test_event_type_is_conversation_item(self) -> None:
         """event_type is ``external_conversation_item``."""
         step = _load("run_command_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].event_type == "external_conversation_item"
 
     def test_item_type_is_function_call_output(self) -> None:
         """item_type is ``function_call_output``."""
         step = _load("run_command_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].data["item_type"] == "function_call_output"
 
     def test_output_from_combined_output_full(self) -> None:
@@ -366,7 +420,9 @@ class TestRunCommandDone:
         The fixture has ``combinedOutput.full = '/Users/bryanli/...scratch\\n'``.
         """
         step = _load("run_command_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         assert item_data["output"] == "/Users/bryanli/.gemini/antigravity-cli/scratch\n"
@@ -381,7 +437,9 @@ class TestRunCommandDone:
         """
         step = _load("run_command_done")
         alloc = _allocator()
-        events = map_step_to_events(step, conversation_id=_CID, allocator=alloc)
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         assert item_data["call_id"] == "cbawg2v8"
@@ -391,7 +449,9 @@ class TestRunCommandDone:
     def test_step_index(self) -> None:
         """step_index matches fixture stepIndex=6."""
         step = _load("run_command_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].step_index == 6
 
 
@@ -412,13 +472,17 @@ class TestRunCommandWaiting:
     def test_waiting_emits_no_output_event(self) -> None:
         """WAITING run_command → empty list (no function_call_output)."""
         step = _load("run_command_waiting")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events == []
 
     def test_waiting_no_delta(self) -> None:
         """No delta event from a WAITING run_command."""
         step = _load("run_command_waiting")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         _assert_no_delta(events)
 
 
@@ -439,14 +503,18 @@ class TestRunCommandError:
     def test_error_emits_one_output_event(self) -> None:
         """A failed (ERROR-status) run_command emits one function_call_output."""
         step = _load("run_command_error")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].data["item_type"] == "function_call_output"
 
     def test_error_output_keyed_on_real_id(self) -> None:
         """The error output pairs by the real agy id (matches the invocation)."""
         step = _load("run_command_error")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = cast(dict[str, Any], events[0].data["item_data"])
         # Fixture carries toolCall.id="cbawg2v8" — the same id the planner
         # invocation emits, so the pair correlates.
@@ -455,7 +523,9 @@ class TestRunCommandError:
     def test_error_output_text_is_nonempty_marker(self) -> None:
         """The output is a non-empty error marker mentioning the ERROR status."""
         step = _load("run_command_error")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = cast(dict[str, Any], events[0].data["item_data"])
         output = item_data["output"]
         assert isinstance(output, str) and output
@@ -464,7 +534,9 @@ class TestRunCommandError:
     def test_error_step_index(self) -> None:
         """step_index matches fixture stepIndex=6."""
         step = _load("run_command_error")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].step_index == 6
 
 
@@ -489,7 +561,9 @@ class TestToolResultClosure:
         # Proto3 omits empty scalars: drop combinedOutput to simulate a
         # ``cd`` / ``mkdir`` / redirect that produced no captured output.
         step["runCommand"].pop("combinedOutput", None)
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].data["item_type"] == "function_call_output"
         item_data = cast(dict[str, Any], events[0].data["item_data"])
@@ -503,7 +577,9 @@ class TestToolResultClosure:
         # real toolCall.id so the pair still correlates.
         step["type"] = "CORTEX_STEP_TYPE_VIEW_FILE"
         step.pop("runCommand", None)
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].data["item_type"] == "function_call_output"
         item_data = cast(dict[str, Any], events[0].data["item_data"])
@@ -513,7 +589,9 @@ class TestToolResultClosure:
     def test_system_step_without_tool_id_is_skipped(self) -> None:
         """A non-tool step with no toolCall.id is NOT treated as a tool result."""
         step = _load("checkpoint")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events == []
 
 
@@ -528,14 +606,18 @@ class TestListDirectoryDone:
     def test_returns_one_function_call_output(self) -> None:
         """DONE list_directory → one function_call_output event."""
         step = _load("list_directory_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].data["item_type"] == "function_call_output"
 
     def test_call_id_is_real_agy_id(self) -> None:
         """call_id is the real agy-assigned id from metadata.toolCall.id."""
         step = _load("list_directory_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         # Fixture carries toolCall.id="h510vxi0"
@@ -544,7 +626,9 @@ class TestListDirectoryDone:
     def test_step_index(self) -> None:
         """step_index matches fixture stepIndex=10."""
         step = _load("list_directory_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].step_index == 10
 
 
@@ -564,7 +648,9 @@ class TestAskQuestionWaiting:
     def test_waiting_emits_no_event(self) -> None:
         """WAITING ask_question → empty list."""
         step = _load("ask_question_waiting")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events == []
 
 
@@ -579,14 +665,18 @@ class TestAskQuestionDone:
     def test_returns_function_call_output(self) -> None:
         """DONE ask_question → one function_call_output event."""
         step = _load("ask_question_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].data["item_type"] == "function_call_output"
 
     def test_call_id_is_real_agy_id(self) -> None:
         """call_id is the real agy-assigned id from metadata.toolCall.id."""
         step = _load("ask_question_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
         # Fixture carries toolCall.id="jfizoalt", matching the planner invocation
@@ -595,7 +685,9 @@ class TestAskQuestionDone:
     def test_step_index(self) -> None:
         """step_index matches fixture stepIndex=12."""
         step = _load("ask_question_done")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events[0].step_index == 12
 
 
@@ -610,13 +702,17 @@ class TestSystemStepsSkipped:
     def test_checkpoint_returns_empty(self) -> None:
         """CHECKPOINT step → ``[]``."""
         step = _load("checkpoint")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events == []
 
     def test_conversation_history_returns_empty(self) -> None:
         """CONVERSATION_HISTORY step → ``[]``."""
         step = _load("conversation_history")
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert events == []
 
 
@@ -643,7 +739,9 @@ class TestSlotZeroStepIndex:
         assert isinstance(traj_info, dict)
         traj_info.pop("stepIndex", None)
 
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].step_index == 0
 
@@ -657,7 +755,9 @@ class TestSlotZeroStepIndex:
         assert isinstance(traj_info, dict)
         traj_info["stepIndex"] = "2"  # String form
 
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         assert events[0].step_index == 2
 
@@ -691,7 +791,9 @@ class TestModifiedResponsePrecedence:
         planner["response"] = "Original text."
         planner["modifiedResponse"] = "Post-moderation text."
 
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
@@ -711,7 +813,9 @@ class TestModifiedResponsePrecedence:
         planner.pop("modifiedResponse", None)
         planner["response"] = "Fallback text."
 
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
@@ -730,7 +834,9 @@ class TestModifiedResponsePrecedence:
         planner["modifiedResponse"] = ""
         planner["response"] = "Non-empty response."
 
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
         assert len(events) == 1
         item_data = events[0].data["item_data"]
         assert isinstance(item_data, dict)
@@ -763,7 +869,9 @@ class TestRealIdPairing:
         """
         alloc = _allocator()
         planner_step = _load("planner_response_tool_call_run_command")
-        planner_events = map_step_to_events(planner_step, conversation_id=_CID, allocator=alloc)
+        planner_events = map_step_to_events(
+            planner_step, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         assert len(planner_events) == 1
         planner_item_data = planner_events[0].data["item_data"]
         assert isinstance(planner_item_data, dict)
@@ -771,7 +879,9 @@ class TestRealIdPairing:
         assert invocation_call_id == "cbawg2v8"
 
         result_step = _load("run_command_done")
-        result_events = map_step_to_events(result_step, conversation_id=_CID, allocator=alloc)
+        result_events = map_step_to_events(
+            result_step, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         assert len(result_events) == 1
         result_item = result_events[0].data["item_data"]
         assert isinstance(result_item, dict)
@@ -797,7 +907,9 @@ class TestRealIdPairing:
 
         # Emit PLANNER_RESPONSE for run_command (id="cbawg2v8")
         rc_planner = _load("planner_response_tool_call_run_command")
-        rc_planner_events = map_step_to_events(rc_planner, conversation_id=_CID, allocator=alloc)
+        rc_planner_events = map_step_to_events(
+            rc_planner, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         assert len(rc_planner_events) == 1
         rc_item = rc_planner_events[0].data["item_data"]
         assert isinstance(rc_item, dict)
@@ -805,7 +917,9 @@ class TestRealIdPairing:
 
         # Emit PLANNER_RESPONSE for ask_question (id="jfizoalt")
         aq_planner = _load("planner_response_tool_call_ask_question")
-        aq_planner_events = map_step_to_events(aq_planner, conversation_id=_CID, allocator=alloc)
+        aq_planner_events = map_step_to_events(
+            aq_planner, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         assert len(aq_planner_events) == 1
         aq_item = aq_planner_events[0].data["item_data"]
         assert isinstance(aq_item, dict)
@@ -813,7 +927,9 @@ class TestRealIdPairing:
 
         # Now deliver ask_question DONE result FIRST (out of order vs run_command)
         aq_done = _load("ask_question_done")
-        aq_result_events = map_step_to_events(aq_done, conversation_id=_CID, allocator=alloc)
+        aq_result_events = map_step_to_events(
+            aq_done, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         assert len(aq_result_events) == 1
         aq_result_item = aq_result_events[0].data["item_data"]
         assert isinstance(aq_result_item, dict)
@@ -822,7 +938,9 @@ class TestRealIdPairing:
 
         # Then deliver run_command DONE result
         rc_done = _load("run_command_done")
-        rc_result_events = map_step_to_events(rc_done, conversation_id=_CID, allocator=alloc)
+        rc_result_events = map_step_to_events(
+            rc_done, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+        )
         assert len(rc_result_events) == 1
         rc_result_item = rc_result_events[0].data["item_data"]
         assert isinstance(rc_result_item, dict)
@@ -832,6 +950,74 @@ class TestRealIdPairing:
         # Allocator must not have been used at all (all ids were real)
         assert alloc.invocation_count == 0
         assert alloc.orphan_output_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Turn-scoped response_id: one bubble per turn (#9)
+# ---------------------------------------------------------------------------
+
+
+class TestTurnScopedResponseId:
+    """
+    Every committed item in ONE turn shares ONE response_id; a new turn differs.
+
+    Bug #9: the response_id used to be keyed on the conversation-monotonic
+    ``stepIndex``, so a narrate→call-tool→answer turn (three different step
+    indices) fragmented into three assistant bubbles. Keying on the turn's
+    ``executionId`` instead groups the whole turn under one id (parity with
+    codex ``codex_<turnId>`` / claude's per-turn ``current_response_id``).
+    """
+
+    def _response_ids(self, events: list[OutboundEvent]) -> list[str]:
+        """Collect the ``response_id`` from every committed item (skip user/edges)."""
+        ids: list[str] = []
+        for ev in events:
+            rid = ev.data.get("response_id")
+            if isinstance(rid, str):
+                ids.append(rid)
+        return ids
+
+    def test_multi_step_turn_shares_one_response_id(self) -> None:
+        """text planner → tool call → tool result, same turn → ONE response_id.
+
+        The three steps carry DIFFERENT ``stepIndex`` values (2 / 5 / the
+        result's), so a stepIndex-keyed id would yield three distinct ids
+        (the #9 fragmentation). With a turn-scoped id they must all match.
+        """
+        alloc = _allocator()
+        text = _load("planner_response_text")  # stepIndex 2
+        tool_call = _load("planner_response_tool_call_run_command")  # stepIndex 5
+        result = _load("run_command_done")
+
+        ids: list[str] = []
+        for step in (text, tool_call, result):
+            events = map_step_to_events(
+                step, conversation_id=_CID, turn_execution_id=_TURN, allocator=alloc
+            )
+            ids.extend(self._response_ids(events))
+
+        # message + function_call + function_call_output all carry a response_id.
+        assert len(ids) == 3
+        # All three share the SINGLE turn-scoped id (not three stepIndex ids).
+        assert set(ids) == {f"agy_{_CID}_{_TURN}"}
+
+    def test_new_turn_gets_a_different_response_id(self) -> None:
+        """A second turn (new ``executionId``) yields a DIFFERENT response_id."""
+        alloc = _allocator()
+        text = _load("planner_response_text")
+
+        turn1 = map_step_to_events(
+            text, conversation_id=_CID, turn_execution_id="exec-turn-1", allocator=alloc
+        )
+        turn2 = map_step_to_events(
+            text, conversation_id=_CID, turn_execution_id="exec-turn-2", allocator=alloc
+        )
+
+        id1 = turn1[0].data["response_id"]
+        id2 = turn2[0].data["response_id"]
+        assert id1 == f"agy_{_CID}_exec-turn-1"
+        assert id2 == f"agy_{_CID}_exec-turn-2"
+        assert id1 != id2
 
 
 # ---------------------------------------------------------------------------
@@ -1207,7 +1393,9 @@ class TestMapStepEmitsNoReasoning:
         """
         step = _load("planner_response_text")
         cast(dict[str, Any], step["plannerResponse"])["thinking"] = "internal chain of thought"
-        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        events = map_step_to_events(
+            step, conversation_id=_CID, turn_execution_id=_TURN, allocator=_allocator()
+        )
 
         for event in events:
             assert event.event_type != "external_output_reasoning_delta"


### PR DESCRIPTION
## The bug (#9, P2)

Any non-trivial agy turn (narrate -> call a tool -> answer) rendered as several disconnected assistant bubbles instead of one. Not data loss — visual fragmentation that also broke per-turn UI affordances keyed on `responseId`.

## Root cause

`omnigent/antigravity_native_steps.py`'s `_response_id(conversation_id, step_idx)` returned `agy_<conv>_<stepIndex>` — keyed on the conversation-monotonic `stepIndex`. It was stamped on the committed `message`, every `function_call`, and every `function_call_output`. The SPA breaks the open assistant bubble whenever `responseId` changes, so a text -> tool-call -> answer turn (three different step indices) became three bubbles.

## Fix

Key `_response_id` on the TURN, not the step. The turn boundary already exists: the `USER_INPUT` step carries a per-turn `executionId` (the reader already uses it as its dedup discriminator via `_execution_discriminator`). The reader now holds the current turn's `executionId` in `_ReaderState.turn_execution_id`, rebinds it on each `USER_INPUT`, and threads it through `_emit_step` -> `map_step_to_events` -> `_message_event` / `_function_call_events` / `_function_call_output_event`. So every committed item between two `USER_INPUT` boundaries shares one `agy_<conv>_<executionId>` id.

This **mirrors the named siblings** — codex returns `codex_<turnId>` (one id per turn) and claude holds a single `current_response_id` across the whole turn.

The streaming `output_text_delta_event` keeps its per-step `planner_message_id` (the correct delta-coalescing key, independent of response_id) — only the COMMITTED item's response_id becomes turn-scoped.

## Tests

- Updated the per-stepIndex `response_id` assertions in `test_antigravity_native_steps.py` and added `TestTurnScopedResponseId`: a multi-step turn (text planner -> tool call -> result) emits items that all share ONE response_id, and a NEW turn id yields a DIFFERENT id.
- Added reader-level `test_multi_step_turn_items_share_one_response_id` and `test_distinct_turns_get_distinct_response_ids` in `test_antigravity_native_reader.py`, driving full turns end-to-end through the reader; existing per-step delta `message_id` assertion is unchanged.
- `pytest tests/test_antigravity_native_steps.py tests/test_antigravity_native_reader.py`: 161 passed. Lint clean (ruff format + check).

This pull request and its description were written by Isaac.