### PR TITLE
fix(antigravity-native): apply web /model switch live by typing /model into the agy TUI

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -1082,6 +1082,69 @@ def inject_user_message_via_tui(
     _submit_and_verify(socket_path, tmux_target)
 
 
+def inject_slash_command(
+    bridge_dir: Path,
+    *,
+    command: str,
+    timeout_s: float = _TMUX_READY_TIMEOUT_S,
+    auto_confirm: bool = False,
+) -> None:
+    """
+    Type an agy TUI slash command into the tmux pane and submit it.
+
+    A live control (e.g. ``/model``) that agy reads only from its TUI — never
+    from a config file at turn boundaries — must be typed into the running pane,
+    not delivered over agy's connect-RPC. This mirrors
+    :func:`omnigent.claude_native_bridge.inject_slash_command`, but uses agy's
+    own clear primitive (Home + kill-to-end, as :func:`inject_user_message_via_tui`
+    does) rather than Claude Code's ``C-u``, since the two TUIs bind their input
+    boxes differently.
+
+    A slash command is a single short line with no interior newline, so it is
+    sent literally (``send-keys -l``) instead of streamed through the paste
+    buffer the way a multi-line user message is.
+
+    :param bridge_dir: Native Antigravity bridge directory holding ``tmux.json``.
+    :param command: Single-line slash command including the leading ``/``, e.g.
+        ``"/model gemini-2.5-pro"``.
+    :param timeout_s: Seconds to wait for ``tmux.json`` to be advertised, e.g.
+        ``30.0``.
+    :param auto_confirm: If ``True``, send an extra ``Enter`` after a short delay
+        to accept the default option of any TUI confirmation dialog the command
+        may pop. When no dialog appears the extra Enter falls on an empty prompt
+        and is a no-op. Callers that don't trigger confirmations should leave
+        this ``False``.
+    :returns: None.
+    :raises ValueError: If *command* is empty, does not start with ``/``, or
+        contains a newline.
+    :raises RuntimeError: If the tmux target is not advertised within *timeout_s*,
+        or if a ``tmux send-keys`` invocation fails.
+    """
+    if not command or not command.startswith("/"):
+        raise ValueError(f"slash command must start with '/'; got {command!r}")
+    if "\n" in command:
+        raise ValueError("slash command must be a single line")
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    socket_path = info["socket_path"]
+    tmux_target = info["tmux_target"]
+    # Clear any leftover draft before typing: Home (C-a) + kill-to-end (C-k) —
+    # otherwise the literal send below concatenates with the user's in-progress
+    # text and the Enter submits ``<their-draft>/model ...`` as a turn. This is
+    # agy's clear primitive (see :func:`inject_user_message_via_tui`); Claude's
+    # bridge uses ``C-u`` because its input box binds the kill differently.
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
+    # ``-l`` types ``/`` and spaces literally; the trailing Enter submits.
+    _run_tmux(socket_path, "send-keys", "-l", "-t", tmux_target, command)
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+    if auto_confirm:
+        # Give the TUI time to render its confirmation dialog before the
+        # auto-Enter arrives; otherwise the keystroke races the prompt and gets
+        # dropped.
+        time.sleep(0.3)
+        _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+
+
 def send_interaction_keys_via_tui(
     bridge_dir: Path,
     *keys: str,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11586,6 +11586,77 @@ def create_runner_app(
             )
         return Response(status_code=204)
 
+    async def _handle_antigravity_native_model_change(
+        conv_id: str,
+        model: str | None,
+    ) -> Response:
+        """
+        Type ``/model <name>`` into agy's tmux pane.
+
+        Antigravity-native sessions can't read the persisted ``model_override``
+        field at turn boundaries — the executor's ``run_turn`` never consults
+        ``config.model``, and the ``--model`` flag on the ``agy`` binary is baked
+        in at spawn. To propagate a live change without restarting the pane, this
+        helper types agy's built-in slash command into the terminal, mirroring
+        :func:`_handle_claude_native_model_change`. The model id is passed through
+        verbatim: the launch path forwards ``model_override`` straight to
+        ``--model`` (see ``antigravity_native_launch``), so the same id is what
+        agy's ``/model`` expects.
+
+        Skipped silently when *model* is ``None`` or empty / whitespace only —
+        there is no slash form for "use the spawn default", so a clear only takes
+        effect on the next spawn.
+
+        :param conv_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
+        :param model: New persisted model identifier, e.g. ``"gemini-2.5-pro"``;
+            ``None`` when the user cleared the override.
+        :returns: 204 on success or skip (caller treats both the same — the
+            persisted value is the authoritative fallback). 503 if the tmux
+            target isn't yet advertised (best-effort failure).
+        """
+        from omnigent.antigravity_native_bridge import (
+            ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY,
+            bridge_dir_for_bridge_id,
+            inject_slash_command,
+        )
+
+        if model is None or not model.strip():
+            # Persistence already happened on the Omnigent server; the next
+            # spawn will pick up the new value via ``--model``.
+            return Response(status_code=204)
+        # Resolve the bridge id from the session's labels so ``/clear``
+        # rotations (where bridge_id != conv_id) land in the right tmux pane.
+        # Falls back to ``conv_id`` for legacy single-session bridges — the same
+        # pattern :func:`_antigravity_native_terminal_arrives_via_transfer` uses.
+        labels = await _session_labels_for_runner_spawn(
+            server_client=server_client,
+            session_id=conv_id,
+        )
+        bridge_id = labels.get(ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY) or conv_id
+        bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+        command = f"/model {model.strip()}"
+        try:
+            # Short timeout: missing tmux.json means the pane isn't attached;
+            # the persisted model still applies on the next spawn.
+            await asyncio.to_thread(
+                inject_slash_command,
+                bridge_dir,
+                command=command,
+                timeout_s=1.0,
+                auto_confirm=True,
+            )
+        except (RuntimeError, ValueError) as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "antigravity_native_model_failed",
+                    "detail": _client_safe_error_detail(
+                        exc, context="antigravity-native model change"
+                    ),
+                },
+            )
+        return Response(status_code=204)
+
     async def _handle_claude_native_compact(conv_id: str) -> Response:
         """
         Type ``/compact`` into Claude's tmux pane.
@@ -14926,12 +14997,22 @@ def create_runner_app(
             # Omnigent server forwards the persisted model_override here so
             # harnesses that can't re-read it from store at turn
             # boundaries can propagate it live. Claude-native and
-            # cursor-native type ``/model`` into their tmux pane;
-            # codex-native queues a Codex app-server next-turn settings
-            # update. Other harnesses pick up the persisted value on the
-            # next turn and 204 here.
+            # cursor-native, opencode-native, and antigravity-native type
+            # ``/model`` into their tmux pane; codex-native queues a Codex
+            # app-server next-turn settings update. Antigravity-native must
+            # type it because its executor's ``run_turn`` never consults
+            # ``config.model`` — the persisted value would otherwise only
+            # apply on a fresh spawn (via ``--model``), making a mid-session
+            # switch a silent no-op. Other harnesses re-read the persisted
+            # value on the next turn and 204 here.
             harness = _session_harness_name(conversation_id)
-            if harness in ("claude-native", "codex-native", "cursor-native", "opencode-native"):
+            if harness in (
+                "claude-native",
+                "codex-native",
+                "cursor-native",
+                "opencode-native",
+                "antigravity-native",
+            ):
                 model = body.get("model") if isinstance(body, dict) else None
                 if model is not None and not isinstance(model, str):
                     return JSONResponse(
@@ -14955,6 +15036,11 @@ def create_runner_app(
                     )
                 if harness == "opencode-native":
                     return await _handle_opencode_native_model_change(
+                        conversation_id,
+                        model,
+                    )
+                if harness == "antigravity-native":
+                    return await _handle_antigravity_native_model_change(
                         conversation_id,
                         model,
                     )

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -27,6 +27,7 @@ import pytest
 from fastapi import FastAPI
 
 from omnigent import (
+    antigravity_native_bridge,
     claude_native_bridge,
     codex_native_bridge,
     cursor_native_bridge,
@@ -12783,6 +12784,240 @@ async def test_events_model_change_on_cursor_native_session_returns_503_when_not
     body = resp.json()
     assert body.get("error") == "cursor_native_model_failed", (
         f"503 body must carry the cursor bridge-failure error code; got {body!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_events_model_change_on_antigravity_native_session_types_slash_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    POST ``/events`` with ``{"type":"model_change","model":"gemini-2.5-pro"}``
+    on an antigravity-native session injects ``/model gemini-2.5-pro`` into tmux.
+
+    Mirrors the claude-native model_change happy-path. Pins that the runner
+    dispatch routes antigravity-native model_change to its own handler — not the
+    204 no-op it used to fall through to — and assembles the right slash command.
+    The agy executor's ``run_turn`` never reads ``config.model``, so without this
+    a mid-session web ``/model`` switch would never reach the running agy.
+    """
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.spec.types import ExecutorSpec
+
+    captured: list[Any] = []
+
+    def _fake_inject(
+        bridge_dir: Any,
+        *,
+        command: str,
+        timeout_s: float,
+        auto_confirm: bool = False,
+    ) -> None:
+        """Record the call and return without touching tmux."""
+        captured.append((bridge_dir, command, timeout_s, auto_confirm))
+
+    monkeypatch.setattr(antigravity_native_bridge, "inject_slash_command", _fake_inject)
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the antigravity-native spec for any agent_id."""
+        del agent_id, session_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_agy_model", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        # Drain creation-time events (antigravity-native auto-create may
+        # enqueue terminal_pending / a failure with no real workspace) so the
+        # drain below isolates only what model_change emits.
+        _drain_session_event_queue(_session_event_queues_ref.get("conv_agy_model"))
+
+        resp = await client.post(
+            "/v1/sessions/conv_agy_model/events",
+            json={"type": "model_change", "model": "gemini-2.5-pro"},
+        )
+
+        # model_change is a control signal, not a state change — no events
+        # should land on the SSE queue.
+        queue = _session_event_queues_ref.get("conv_agy_model")
+        queued_events: list[dict[str, Any]] = []
+        if queue is not None:
+            while not queue.empty():
+                item = queue.get_nowait()
+                if isinstance(item, dict):
+                    queued_events.append(item)
+
+    assert resp.status_code == 204, (
+        f"Antigravity-native model_change must return 204 from /events; "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert len(captured) == 1, (
+        f"Expected one inject_slash_command call from antigravity-native "
+        f"model_change, got {len(captured)}."
+    )
+    _bridge_dir, command, timeout_s, auto_confirm = captured[0]
+    assert command == "/model gemini-2.5-pro", (
+        f"Expected '/model gemini-2.5-pro' literal, got {command!r}."
+    )
+    assert timeout_s == 1.0
+    assert auto_confirm is True, "agy's /model can pop a confirm dialog; auto_confirm must be set."
+    assert queued_events == [], (
+        f"model_change must not publish session events; got {queued_events!r}."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_value",
+    # There is no slash form for "use the spawn default", so ``None`` (clear)
+    # must skip injection. Empty / whitespace-only strings must also skip —
+    # typing ``/model `` with nothing after would land as a TUI error.
+    [None, "", "   "],
+)
+async def test_events_model_change_on_antigravity_native_session_skips_inject_for_empty_or_null(
+    monkeypatch: pytest.MonkeyPatch,
+    model_value: str | None,
+) -> None:
+    """
+    Null / empty / whitespace-only model values 204 without typing.
+
+    Pins that the empty-value guard lives in the antigravity-native handler,
+    matching the claude-native handler's behavior.
+    """
+    from omnigent.spec.types import ExecutorSpec
+
+    def _fake_inject(
+        bridge_dir: Any,
+        *,
+        command: str,
+        timeout_s: float,
+        auto_confirm: bool = False,
+    ) -> None:
+        """Fail the test if the runner reaches inject for an empty value."""
+        del bridge_dir, command, timeout_s, auto_confirm
+        raise AssertionError(
+            f"inject_slash_command must not be called for model={model_value!r}; "
+            f"the antigravity-native handler should skip empty / null values."
+        )
+
+    monkeypatch.setattr(antigravity_native_bridge, "inject_slash_command", _fake_inject)
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the antigravity-native spec for any agent_id."""
+        del agent_id, session_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_agy_model_skip", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        resp = await client.post(
+            "/v1/sessions/conv_agy_model_skip/events",
+            json={"type": "model_change", "model": model_value},
+        )
+
+    assert resp.status_code == 204, (
+        f"Antigravity-native model_change with empty / null value must return "
+        f"204 (no-op); got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_events_model_change_on_antigravity_native_returns_503_when_bridge_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Bridge-not-ready RuntimeError surfaces as 503 from /events.
+
+    Sister to the happy-path test. Pins that the failure mode of the
+    antigravity-native model dispatch (tmux pane gone / bridge dir not yet
+    advertised) returns 503. The Omnigent server's PATCH swallows this 503 and
+    still returns 200 with the persisted value — the next spawn applies the new
+    model via ``--model``.
+    """
+    from omnigent.spec.types import ExecutorSpec
+
+    def _fake_inject(
+        bridge_dir: Any,
+        *,
+        command: str,
+        timeout_s: float,
+        auto_confirm: bool = False,
+    ) -> None:
+        """Simulate the bridge-not-ready path."""
+        del bridge_dir, command, timeout_s, auto_confirm
+        raise RuntimeError("antigravity-native tmux target was not advertised")
+
+    monkeypatch.setattr(antigravity_native_bridge, "inject_slash_command", _fake_inject)
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the antigravity-native spec for any agent_id."""
+        del agent_id, session_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_agy_model_fail", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        resp = await client.post(
+            "/v1/sessions/conv_agy_model_fail/events",
+            json={"type": "model_change", "model": "gemini-2.5-pro"},
+        )
+
+    assert resp.status_code == 503, (
+        f"Antigravity-native model_change with inject failure must return 503; "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert body.get("error") == "antigravity_native_model_failed", (
+        f"503 body must carry the bridge-failure error code; got {body!r}"
     )
 
 

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -19,6 +19,7 @@ from omnigent.antigravity_native_bridge import (
     build_mcp_config,
     clear_bridge_state,
     ensure_agy_onboarding_complete,
+    inject_slash_command,
     inject_user_message_via_tui,
     prepare_bridge_dir,
     read_bridge_state,
@@ -1011,6 +1012,136 @@ def test_inject_user_message_via_tui_rejects_empty_content(tmp_path: Path) -> No
     """Empty content is a programming error, not something to type into the TUI."""
     with pytest.raises(RuntimeError, match="non-empty content"):
         inject_user_message_via_tui(tmp_path / "bridge", content="")
+
+
+# ---------------------------------------------------------------------------
+# Live-control slash commands (inject_slash_command)
+# ---------------------------------------------------------------------------
+
+
+def test_inject_slash_command_clears_draft_sends_literal_then_enter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Slash commands flow via C-a + C-k (clear) + literal send + Enter.
+
+    The clear kills any draft the user is mid-typing — otherwise the literal
+    send concatenates and Enter submits ``<draft>/model ...`` as a turn. ``-l``
+    is required so tmux sends ``/`` and spaces literally; the trailing Enter
+    submits.
+    """
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+
+    captured: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """Record one tmux invocation; return rc=0."""
+        del kwargs
+        captured.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    inject_slash_command(bridge_dir, command="/model gemini-2.5-pro")
+
+    # Four tmux calls in order: C-a, C-k (clear), literal send, Enter.
+    assert len(captured) == 4, (
+        f"Expected 4 tmux send-keys calls (C-a + C-k + literal + Enter), got {captured}"
+    )
+    clear_home, clear_kill, literal, submit = captured
+    assert clear_home == ["tmux", "-S", "/tmp/ex/tmux.sock", "send-keys", "-t", "main", "C-a"]
+    assert clear_kill == ["tmux", "-S", "/tmp/ex/tmux.sock", "send-keys", "-t", "main", "C-k"]
+    assert literal == [
+        "tmux",
+        "-S",
+        "/tmp/ex/tmux.sock",
+        "send-keys",
+        "-l",
+        "-t",
+        "main",
+        "/model gemini-2.5-pro",
+    ]
+    assert submit == ["tmux", "-S", "/tmp/ex/tmux.sock", "send-keys", "-t", "main", "Enter"]
+
+
+def test_inject_slash_command_auto_confirm_sends_extra_enter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``auto_confirm=True`` sends a second Enter to accept a TUI confirm dialog.
+
+    ``/model`` can pop a confirmation prompt the chat UI can't render; the extra
+    Enter accepts its default. When no dialog appears the keystroke is a no-op.
+    """
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    enters = {"n": 0}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """Count Enter sends; return rc=0."""
+        del kwargs
+        if cmd[-1] == "Enter":
+            enters["n"] += 1
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    inject_slash_command(bridge_dir, command="/model gemini-2.5-pro", auto_confirm=True)
+
+    assert enters["n"] == 2, "auto_confirm must send the submit Enter plus a confirm Enter"
+
+
+@pytest.mark.parametrize(
+    "bad_command",
+    [
+        "",
+        "model gemini-2.5-pro",  # missing leading slash
+        "/model x\nrm -rf /",  # multi-line
+    ],
+)
+def test_inject_slash_command_rejects_invalid_commands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bad_command: str,
+) -> None:
+    """
+    Malformed slash commands raise ValueError before touching tmux.
+
+    No leading ``/`` would type as plain text; a stray newline would chain a
+    second command. Validation must fire before the tmux call so the route
+    returns 4xx instead of silently appearing to succeed.
+    """
+    bridge_dir = tmp_path / "bridge"
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """Fail the test if tmux is invoked for an invalid command."""
+        del cmd, kwargs
+        raise AssertionError("subprocess.run must not be called for invalid commands")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(ValueError):
+        inject_slash_command(bridge_dir, command=bad_command)
+
+
+def test_inject_slash_command_raises_when_tmux_target_never_advertised(
+    tmp_path: Path,
+) -> None:
+    """
+    Missing tmux.json surfaces RuntimeError, mirroring inject_user_message_via_tui.
+
+    The runner route catches and returns 503, so the Omnigent server's PATCH
+    still succeeds (model persisted) and the next spawn picks it up via
+    ``--model``.
+    """
+    with pytest.raises(RuntimeError, match="tmux target was not advertised"):
+        inject_slash_command(
+            tmp_path / "bridge",
+            command="/model gemini-2.5-pro",
+            timeout_s=0.0,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

Changing the model from the web picker mid-session was a **silent no-op** for antigravity-native. The running `agy` kept its current model until the session was restarted (a fresh spawn *does* apply the new model via `--model`). The change was persisted (`model_override`) and the web UI updated, but the live `agy` never switched.

## Root cause

The runner's `model_change` dispatch in `omnigent/runner/app.py` handled only `claude-native` and `codex-native`; **antigravity-native fell through to a 204 no-op**. And the executor's `run_turn` only ever reads `config.extra["reasoning_effort"]` — it never consults `config.model` — so the persisted value can only take effect on the *next* spawn (via `--model`), making a mid-session switch invisible to the running cascade.

## The fix (mirrors claude-native exactly)

claude-native already solves the identical problem by typing `/model <name>` into its tmux pane. This change does the same for `agy`:

- **`omnigent/runner/app.py`**: add `_handle_antigravity_native_model_change`, modeled on `_handle_claude_native_model_change` (resolves the bridge id from session labels so `/clear` rotations land in the right pane, skips `None`/empty/whitespace, 503 on bridge-not-ready), and wire an `antigravity-native` branch into the `model_change` dispatch.
- **`omnigent/antigravity_native_bridge.py`**: add `inject_slash_command(bridge_dir, *, command, timeout_s, auto_confirm)`, matching `claude_native_bridge.inject_slash_command`'s signature. It uses agy's own clear primitive (`C-a` + `C-k`, as `inject_user_message_via_tui` does) rather than Claude's `C-u`, then `send-keys -l` the literal `/model <name>` and submits with Enter. `auto_confirm` sends an extra Enter to accept any TUI confirmation dialog.
- **Model id**: passed through verbatim. The launch path already forwards `model_override` straight to `--model` (`antigravity_native_launch`), so the same id is exactly what agy's `/model` expects.
- Fix the misleading dispatch comment that claimed other harnesses pick up the persisted value on the next turn — false for antigravity, which is precisely why we type `/model`.

`_resolve_plan_model` / `_latest_requested_model` in the executor (dead code) were not touched.

## Tests

- **Bridge** (`tests/test_antigravity_native_bridge.py`): `inject_slash_command` clears the draft and sends the literal command + Enter; `auto_confirm` sends the extra Enter; invalid commands raise `ValueError` before touching tmux; missing `tmux.json` raises `RuntimeError`.
- **Dispatch/handler** (`tests/runner/test_app_sessions_native.py`): an antigravity-native `model_change` types `/model gemini-2.5-pro` with `auto_confirm=True` and 204s; null/empty/whitespace skip injection and 204; bridge-not-ready surfaces 503 with `antigravity_native_model_failed`.

All 261 tests in both touched files pass. `ruff format` + `ruff check` clean.

This pull request and its description were written by Isaac.