### PR TITLE
fix(antigravity-native): wire web Stop + Stop-session (kill pane / cancel cascade)

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -1082,6 +1082,49 @@ def inject_user_message_via_tui(
     _submit_and_verify(socket_path, tmux_target)
 
 
+def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
+    """Cancel the in-flight agy turn by sending ``Escape`` to the pane.
+
+    The agy TUI stops a running turn on ``Escape`` (the same key the footer's
+    ``esc to cancel`` hint advertises). The executor's ``run_turn`` returns right
+    after the TUI paste, so the runner's in-process cancel floor can't reach the
+    turn — this is the TUI-key analog of :func:`inject_user_message_via_tui` for
+    the web UI's Stop button. Mirrors
+    :func:`omnigent.cursor_native_bridge.inject_interrupt`.
+
+    The runner's interrupt handler prefers the connect-RPC ``CancelCascadeSteps``
+    path (and a WAITING-step DENY); this is the bridge-level fallback / hard
+    floor for a turn whose RPC port can't be resolved.
+
+    :param bridge_dir: Native Antigravity bridge directory holding ``tmux.json``.
+    :param timeout_s: Readiness budget for the advertised tmux target.
+    :returns: None.
+    :raises RuntimeError: If the tmux target is not advertised or send-keys fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    # No ``-l``: tmux must interpret ``Escape`` as a key name, not literal text.
+    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
+
+
+def kill_session(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
+    """Hard-stop the agy session by killing its tmux session.
+
+    Terminates the ``agy`` process and the pane outright — the analog of the user
+    manually exiting the attached TUI, for the web UI's "Stop session"
+    affordance. Without this the agy process + runner-owned pane leak (the
+    terminal panel keeps showing a live pane) until the host SIGTERMs or the
+    session is deleted. Mirrors
+    :func:`omnigent.cursor_native_bridge.kill_session`.
+
+    :param bridge_dir: Native Antigravity bridge directory holding ``tmux.json``.
+    :param timeout_s: Readiness budget for the advertised tmux target.
+    :returns: None.
+    :raises RuntimeError: If the tmux target is not advertised or kill-session fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    _run_tmux(info["socket_path"], "kill-session", "-t", info["tmux_target"])
+
+
 def send_interaction_keys_via_tui(
     bridge_dir: Path,
     *keys: str,

--- a/omnigent/antigravity_native_interactions.py
+++ b/omnigent/antigravity_native_interactions.py
@@ -272,6 +272,97 @@ def _freshest_waiting(
     return same_kind
 
 
+def _freshest_pending(steps: list[dict[str, object]]) -> PendingInteraction | None:
+    """
+    Return the highest-index WAITING interaction of ANY kind from *steps*.
+
+    Unlike :func:`_freshest_waiting` (which filters to a single ``kind`` for the
+    answer-round-trip path), the interrupt-DENY path doesn't know the kind up
+    front — it just wants the live WAITING step to refuse. agy keys delivery on
+    ``trajectoryId``+``stepIndex`` with no kind check, and the per-kind deny
+    payload is built from the matched step's own ``kind``, so taking the freshest
+    step of any kind is safe.
+
+    :param steps: A trajectory steps snapshot (from ``get_trajectory_steps``).
+    :returns: The highest-``step_index`` :class:`PendingInteraction`, or ``None``
+        when no step is WAITING.
+    """
+    freshest: PendingInteraction | None = None
+    for step in steps:
+        pending = pending_interaction(step)
+        if pending is None:
+            continue
+        if freshest is None or pending["step_index"] > freshest["step_index"]:
+            freshest = pending
+    return freshest
+
+
+async def deny_pending_interaction(
+    cascade_id: str,
+    *,
+    port: int,
+    get_steps: GetSteps,
+    deliver: Deliver = _deliver_via_rpc,
+) -> bool:
+    """
+    DENY the freshest WAITING agy interaction so a parked card clears.
+
+    ``CancelCascadeSteps`` is a NO-OP on a step that is WAITING for a user
+    interaction (ask-question / command-permission): agy returns HTTP 200 but
+    the WAITING step does not transition (see
+    :meth:`omnigent.inner.antigravity_native_executor.AntigravityNativeExecutor.interrupt_session`).
+    The only way to unblock such a step on an interrupt/stop is to deliver a
+    refusal through ``HandleCascadeUserInteraction``: an empty ``askQuestion``
+    responses list, or ``permission.allow=False``. This builds that deny payload
+    from a synthetic ``decline`` verdict (the same shape the web UI's decline
+    produces) and delivers it against the freshest WAITING step.
+
+    Best-effort and never raises on the expected RPC paths: a transport / shape
+    error is logged and swallowed so the interrupt handler always returns.
+
+    :param cascade_id: agy cascade id (equal to the conversation id).
+    :param port: Validated agy connect-RPC port.
+    :param get_steps: Re-reads the freshest trajectory steps (production wraps
+        :func:`omnigent.antigravity_native_rpc.get_trajectory_steps`).
+    :param deliver: Delivers the built deny payload to agy; defaults to
+        :func:`_deliver_via_rpc`.
+    :returns: ``True`` when a deny was delivered against a WAITING step; ``False``
+        when no step was WAITING or delivery failed.
+    """
+    pending = _freshest_pending(await get_steps())
+    if pending is None:
+        return False
+    payload = to_interaction_payload(
+        pending["kind"],
+        ElicitationResult(action="decline"),
+        pending["spec"],
+    )
+    try:
+        await deliver(
+            port,
+            cascade_id,
+            trajectory_id=pending["trajectory_id"],
+            step_index=pending["step_index"],
+            payload=payload,
+        )
+    except AntigravityRpcError as exc:
+        _logger.warning(
+            "agy interrupt deny failed (cascade=%s, step=%d, kind=%s): %s",
+            cascade_id,
+            pending["step_index"],
+            pending["kind"],
+            exc,
+        )
+        return False
+    _logger.info(
+        "agy interrupt: denied WAITING %s step %d (cascade=%s)",
+        pending["kind"],
+        pending["step_index"],
+        cascade_id,
+    )
+    return True
+
+
 async def bridge_interaction(
     cascade_id: str,
     pending: PendingInteraction,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5985,6 +5985,38 @@ async def _claude_native_bridge_id_for_session(
     return session_id
 
 
+async def _antigravity_native_bridge_id_for_session(
+    *,
+    server_client: httpx.AsyncClient,
+    session_id: str,
+) -> str:
+    """Resolve the bridge id label for an antigravity-native session.
+
+    Mirrors :func:`_claude_native_bridge_id_for_session`: the runner-owned agy
+    terminal's bridge dir is keyed by the session's bridge-id label (so a
+    ``--resume`` session lands in the right pane), falling back to *session_id*
+    for legacy single-session bridges. Matches the launch-time derivation in
+    ``_auto_create_antigravity_native_terminal``.
+
+    :param server_client: Omnigent server client used to fetch the session
+        snapshot.
+    :param session_id: Omnigent session/conversation id, e.g. ``"conv_abc123"``.
+    :returns: Opaque bridge id from
+        ``omnigent.antigravity_native.bridge_id`` when present, otherwise
+        *session_id*.
+    """
+    from omnigent.antigravity_native_bridge import ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY
+
+    labels = await _session_labels_for_runner_spawn(
+        server_client=server_client,
+        session_id=session_id,
+    )
+    bridge_id = labels.get(ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY)
+    if isinstance(bridge_id, str) and bridge_id:
+        return bridge_id
+    return session_id
+
+
 async def _claude_native_session_wants_rebuild(
     server_client: httpx.AsyncClient | None,
     session_id: str,
@@ -11391,6 +11423,236 @@ def create_runner_app(
             )
         return Response(status_code=204)
 
+    async def _clear_antigravity_native_pending_elicitation(
+        conv_id: str,
+        *,
+        cascade_id: str,
+        port: int,
+    ) -> None:
+        """Clear a parked agy elicitation card on interrupt/stop, best-effort.
+
+        A WAITING ask-question / permission prompt surfaces as an Omnigent
+        elicitation parked server-side; an interrupt/stop must release it or the
+        card lingers forever (the agy step is gone, but the web card has nothing
+        to resolve it). Computes the deterministic agy elicitation id for the
+        freshest WAITING step and POSTs ``external_elicitation_resolved`` so the
+        server resolves the parked future — the same release path cursor-native
+        uses when its TUI answers a prompt. Never raises.
+
+        :param conv_id: Session/conversation identifier.
+        :param cascade_id: agy cascade id (equal to the conversation id).
+        :param port: Validated agy connect-RPC port.
+        """
+        if server_client is None:
+            return
+        from omnigent.antigravity_native_interactions import (
+            _freshest_pending,
+            agy_elicitation_id,
+        )
+        from omnigent.antigravity_native_rpc import get_trajectory_steps
+
+        try:
+            steps = await asyncio.to_thread(get_trajectory_steps, port, cascade_id)
+        except (httpx.HTTPError, ValueError):
+            # A dead/relaunched pane (transport error) or a non-JSON 200; either
+            # way there's no live WAITING step to clear, so skip best-effort.
+            _logger.debug(
+                "antigravity-native interrupt: could not read steps to clear "
+                "pending elicitation; session=%s",
+                conv_id,
+                exc_info=True,
+            )
+            return
+        pending = _freshest_pending(steps)
+        if pending is None:
+            return
+        eid = agy_elicitation_id(cascade_id, pending["trajectory_id"], pending["step_index"])
+        try:
+            resp = await server_client.post(
+                f"/v1/sessions/{urllib.parse.quote(conv_id, safe='')}/events",
+                json={
+                    "type": "external_elicitation_resolved",
+                    "data": {"elicitation_id": eid},
+                },
+                timeout=10.0,
+            )
+            if resp.status_code >= 400:
+                _logger.warning(
+                    "antigravity-native external_elicitation_resolved rejected: "
+                    "status=%s session=%s",
+                    resp.status_code,
+                    conv_id,
+                )
+        except httpx.HTTPError:
+            _logger.warning(
+                "antigravity-native external_elicitation_resolved POST failed; session=%s",
+                conv_id,
+                exc_info=True,
+            )
+
+    async def _handle_antigravity_native_interrupt(conv_id: str) -> Response:
+        """Cancel the in-flight agy turn over connect-RPC (or DENY a WAITING step).
+
+        antigravity-native turns run inside the runner-owned agy TUI; the
+        executor's ``run_turn`` returns the instant the message is typed in, so
+        the in-process cancel floor has nothing to cancel (the turn task is
+        already ``.done()``). Unlike the other TUI harnesses, agy exposes a
+        connect-RPC ``CancelCascadeSteps`` that stops a RUNNING cascade cleanly,
+        so this drives that (the same path the executor's ``interrupt_session``
+        uses) rather than a blind Escape:
+
+        * Resolve the cascade id from bridge state and agy's connect-RPC port.
+        * If the current step is WAITING for a user interaction,
+          ``CancelCascadeSteps`` is a NO-OP (agy 200s but the step does not
+          transition — see the executor docstring), so DENY the WAITING step
+          through the interaction bridge instead and clear the parked card.
+        * Otherwise cancel the running cascade.
+
+        Falls back to a tmux Escape when no RPC port can be resolved (cold pane /
+        not-yet-bound cascade) so Stop is never a silent no-op.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 204 when an interrupt path ran; 503 if neither RPC nor the tmux
+            Escape fallback could reach the session.
+        """
+        from omnigent.antigravity_native_bridge import (
+            bridge_dir_for_bridge_id,
+            inject_interrupt,
+            is_placeholder_conversation_id,
+            read_bridge_state,
+        )
+        from omnigent.antigravity_native_interactions import deny_pending_interaction
+        from omnigent.antigravity_native_rpc import (
+            cancel_cascade_steps,
+            get_trajectory_steps,
+            resolve_language_server_port,
+        )
+
+        bridge_id = conv_id
+        if server_client is not None:
+            bridge_id = await _antigravity_native_bridge_id_for_session(
+                server_client=server_client,
+                session_id=conv_id,
+            )
+        bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+        state = await asyncio.to_thread(read_bridge_state, bridge_dir)
+        cascade_id = state.conversation_id if state is not None else None
+        port = None
+        if cascade_id is not None and not is_placeholder_conversation_id(cascade_id):
+            port = await asyncio.to_thread(resolve_language_server_port, cascade_id)
+
+        if cascade_id is not None and port is not None:
+
+            async def _get_steps() -> list[dict[str, object]]:
+                return await asyncio.to_thread(get_trajectory_steps, port, cascade_id)
+
+            # CancelCascadeSteps is a no-op on a WAITING step (ask-question /
+            # permission): refuse it through the interaction bridge instead, then
+            # clear the parked web card. A non-WAITING (generating) cascade is
+            # stopped by CancelCascadeSteps.
+            denied = await deny_pending_interaction(cascade_id, port=port, get_steps=_get_steps)
+            if denied:
+                await _clear_antigravity_native_pending_elicitation(
+                    conv_id, cascade_id=cascade_id, port=port
+                )
+            else:
+                await asyncio.to_thread(cancel_cascade_steps, port, cascade_id)
+            _wake_parent_after_native_interrupt(conv_id)
+            return Response(status_code=204)
+
+        # No live cascade/port (cold pane, placeholder id): fall back to a tmux
+        # Escape so Stop still reaches the agy TUI rather than no-op'ing.
+        try:
+            await asyncio.to_thread(inject_interrupt, bridge_dir, timeout_s=1.0)
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "antigravity_native_interrupt_failed",
+                    "detail": _client_safe_error_detail(
+                        exc, context="antigravity-native interrupt"
+                    ),
+                },
+            )
+        _wake_parent_after_native_interrupt(conv_id)
+        return Response(status_code=204)
+
+    async def _handle_antigravity_native_stop(conv_id: str) -> Response:
+        """Hard-stop an antigravity-native session by killing its tmux session.
+
+        Mirrors :func:`_handle_cursor_native_stop`: kill the pane (ends the
+        ``agy`` process — otherwise the process + runner-owned pane leak until
+        host SIGTERM / session delete), tear the terminal resource down so the
+        web UI stops showing a live terminal, cancel the RPC read driver (the
+        auto-forwarder), publish an explicit ``idle`` stop edge, clear any parked
+        elicitation card, and reclaim any sub-agent work entry.
+
+        NB: the codex/antigravity reader-owned idle suppression (the dispatch
+        guard that drops a reader's ``idle``) suppresses only the read driver's
+        own status edge; an explicit stop-edge ``idle`` published here is correct
+        — the spinner must clear on a hard stop.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 204 on success; 503 if the tmux target is unavailable.
+        """
+        from omnigent.antigravity_native_bridge import (
+            bridge_dir_for_bridge_id,
+            is_placeholder_conversation_id,
+            kill_session,
+            read_bridge_state,
+        )
+        from omnigent.antigravity_native_rpc import resolve_language_server_port
+
+        bridge_id = conv_id
+        if server_client is not None:
+            bridge_id = await _antigravity_native_bridge_id_for_session(
+                server_client=server_client,
+                session_id=conv_id,
+            )
+        bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+
+        # Release a parked elicitation card BEFORE the pane dies: once agy is
+        # killed its RPC port is gone and the freshest-WAITING step can't be read.
+        state = await asyncio.to_thread(read_bridge_state, bridge_dir)
+        cascade_id = state.conversation_id if state is not None else None
+        if cascade_id is not None and not is_placeholder_conversation_id(cascade_id):
+            port = await asyncio.to_thread(resolve_language_server_port, cascade_id)
+            if port is not None:
+                await _clear_antigravity_native_pending_elicitation(
+                    conv_id, cascade_id=cascade_id, port=port
+                )
+
+        try:
+            await asyncio.to_thread(kill_session, bridge_dir, timeout_s=1.0)
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "antigravity_native_stop_failed",
+                    "detail": _client_safe_error_detail(exc, context="antigravity-native stop"),
+                },
+            )
+        await _teardown_session_terminals(conv_id)
+        # Stop mirroring: cancel the RPC read driver so it isn't left polling a
+        # dead pane.
+        await _cancel_auto_forwarder_task(conv_id)
+        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
+        delivery_ack = _mark_subagent_terminal_and_wake(
+            conv_id,
+            status="cancelled",
+            output="[System: sub-agent stopped]",
+        )
+        if not delivery_ack.delivered and (
+            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
+        ):
+            _logger.warning(
+                "antigravity-native stop succeeded but sub-agent delivery was "
+                "not confirmed; session=%s reason=%s",
+                conv_id,
+                delivery_ack.reason,
+            )
+        return Response(status_code=204)
+
     async def _handle_claude_native_effort_change(
         conv_id: str,
         effort: str | None,
@@ -14796,6 +15058,10 @@ def create_runner_app(
             if _harness == "qwen-native":
                 # qwen turn lives in the qwen TUI; send Escape to stop it.
                 return await _handle_qwen_native_interrupt(conversation_id)
+            if _harness == "antigravity-native":
+                # agy turn lives in the runner-owned agy TUI; cancel the running
+                # cascade over connect-RPC (or DENY a WAITING interaction step).
+                return await _handle_antigravity_native_interrupt(conversation_id)
             if _harness == "kimi-native":
                 # kimi turn lives in the kimi TUI; send Escape to stop it.
                 return await _handle_kimi_native_interrupt(conversation_id)
@@ -14882,6 +15148,10 @@ def create_runner_app(
             if _harness == "qwen-native":
                 # Hard-kill the qwen tmux pane (the TUI is the runtime).
                 return await _handle_qwen_native_stop(conversation_id)
+            if _harness == "antigravity-native":
+                # Hard-kill the agy tmux pane (the TUI is the runtime) so the
+                # agy process + pane don't leak.
+                return await _handle_antigravity_native_stop(conversation_id)
             if _harness == "kimi-native":
                 # Hard-kill the kimi tmux pane (the TUI is the runtime).
                 return await _handle_kimi_native_stop(conversation_id)

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -27,6 +27,7 @@ import pytest
 from fastapi import FastAPI
 
 from omnigent import (
+    antigravity_native_bridge,
     claude_native_bridge,
     codex_native_bridge,
     cursor_native_bridge,
@@ -9813,6 +9814,349 @@ async def test_events_stop_session_on_native_returns_503_when_kill_fails(
         f"No session.status: idle should be enqueued when kill_session "
         f"failed; got {status_idle!r}."
     )
+
+
+@pytest.mark.asyncio
+async def test_events_stop_session_on_antigravity_native_kills_and_publishes_idle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    POST ``/events`` ``stop_session`` on an antigravity-native session kills the
+    agy pane, tears down terminals, and clears the spinner.
+
+    antigravity-native was the only native harness in neither the interrupt nor
+    the stop dispatch, so Stop session was a silent no-op — the agy process +
+    runner-owned pane leaked. The stop handler must mirror cursor-native:
+    ``kill_session`` (1.0s snappy timeout), then exactly one
+    ``session.status: idle`` so the web spinner clears, and NO interrupted
+    marker (a teardown is not a mid-turn interrupt).
+    """
+    from omnigent.runner.app import _session_event_queues_ref, _session_histories_ref
+
+    monkeypatch.setattr(antigravity_native_bridge, "_BRIDGE_ROOT", tmp_path / "agy-bridge")
+    captured_kill: list[Any] = []
+
+    def _fake_kill(bridge_dir: Any, *, timeout_s: float) -> None:
+        """Record the kill and return without touching tmux."""
+        captured_kill.append((bridge_dir, timeout_s))
+
+    monkeypatch.setattr(antigravity_native_bridge, "kill_session", _fake_kill)
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the antigravity-native spec for any agent_id."""
+        del agent_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_agy_stop", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        stop_resp = await client.post(
+            "/v1/sessions/conv_agy_stop/events",
+            json={"type": "stop_session"},
+        )
+
+        queue = _session_event_queues_ref.get("conv_agy_stop")
+        assert queue is not None
+        queued_events: list[dict[str, Any]] = []
+        while not queue.empty():
+            item = queue.get_nowait()
+            if isinstance(item, dict):
+                queued_events.append(item)
+        captured_history = list(_session_histories_ref.get("conv_agy_stop", []))
+
+    assert stop_resp.status_code == 204, (
+        f"antigravity-native stop_session must return 204 from /events (was a "
+        f"silent no-op fall-through); got {stop_resp.status_code}: {stop_resp.text}"
+    )
+    assert len(captured_kill) == 1, (
+        f"Expected one kill_session call routed by the antigravity-native stop "
+        f"dispatch branch, got {len(captured_kill)}."
+    )
+    _bridge_dir, timeout_s = captured_kill[0]
+    assert timeout_s == 1.0
+    status_idle = [
+        e for e in queued_events if e.get("type") == "session.status" and e.get("status") == "idle"
+    ]
+    assert len(status_idle) == 1, (
+        f"Expected exactly one explicit stop-edge session.status: idle, got "
+        f"{len(status_idle)}. Full queue: {queued_events!r}."
+    )
+    markers = [
+        h
+        for h in captured_history
+        if h.get("type") == "message"
+        and h.get("role") == "user"
+        and any("interrupted" in (b.get("text") or "").lower() for b in h.get("content", []))
+    ]
+    assert markers == [], f"stop_session must not append an interrupted marker; got {markers!r}."
+
+
+@pytest.mark.asyncio
+async def test_events_stop_session_on_antigravity_native_returns_503_when_kill_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """antigravity-native stop returns 503 (no idle) when ``kill_session`` fails."""
+    from omnigent.runner.app import _session_event_queues_ref
+
+    monkeypatch.setattr(antigravity_native_bridge, "_BRIDGE_ROOT", tmp_path / "agy-bridge")
+
+    def _fake_kill(bridge_dir: Any, *, timeout_s: float) -> None:
+        del bridge_dir, timeout_s
+        raise RuntimeError("tmux target is not advertised")
+
+    monkeypatch.setattr(antigravity_native_bridge, "kill_session", _fake_kill)
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_agy_stop_fail", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        stop_resp = await client.post(
+            "/v1/sessions/conv_agy_stop_fail/events",
+            json={"type": "stop_session"},
+        )
+        queue = _session_event_queues_ref.get("conv_agy_stop_fail")
+        assert queue is not None
+        queued_events = [queue.get_nowait() for _ in range(queue.qsize())]
+
+    assert stop_resp.status_code == 503, stop_resp.text
+    assert stop_resp.json().get("error") == "antigravity_native_stop_failed"
+    status_idle = [
+        e
+        for e in queued_events
+        if isinstance(e, dict) and e.get("type") == "session.status" and e.get("status") == "idle"
+    ]
+    assert status_idle == [], "No idle on the failed-kill path."
+
+
+@pytest.mark.asyncio
+async def test_events_interrupt_on_antigravity_native_cancels_running_cascade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    POST ``/events`` ``interrupt`` on antigravity-native cancels the running
+    cascade over connect-RPC.
+
+    The executor's ``run_turn`` returns the instant the message is typed into the
+    agy TUI, so the in-process cancel floor is a no-op; the interrupt must drive
+    agy's ``CancelCascadeSteps`` instead. With no WAITING step present, the
+    handler cancels the running cascade (not a deny).
+    """
+    import omnigent.antigravity_native_interactions as agy_interactions
+    import omnigent.antigravity_native_rpc as agy_rpc
+    from omnigent.antigravity_native_bridge import (
+        AntigravityNativeBridgeState,
+        bridge_dir_for_bridge_id,
+        prepare_bridge_dir,
+        write_bridge_state,
+    )
+
+    monkeypatch.setattr(antigravity_native_bridge, "_BRIDGE_ROOT", tmp_path / "agy-bridge")
+    # Real (non-placeholder) cascade id so the RPC interrupt path runs.
+    bridge_dir = prepare_bridge_dir("conv_agy_interrupt")
+    write_bridge_state(
+        bridge_dir,
+        AntigravityNativeBridgeState(
+            session_id="conv_agy_interrupt", conversation_id="real-cascade-uuid"
+        ),
+    )
+    assert bridge_dir == bridge_dir_for_bridge_id("conv_agy_interrupt")
+
+    monkeypatch.setattr(agy_rpc, "resolve_language_server_port", lambda cid: 52548)
+    # No WAITING step in the trajectory → the cancel branch (not deny) runs.
+    monkeypatch.setattr(agy_rpc, "get_trajectory_steps", lambda port, cid: [])
+    cancelled: list[tuple[int, str]] = []
+    monkeypatch.setattr(
+        agy_rpc,
+        "cancel_cascade_steps",
+        lambda port, cid: cancelled.append((port, cid)) or True,
+    )
+    denied: list[Any] = []
+    monkeypatch.setattr(
+        agy_interactions,
+        "handle_user_interaction",
+        lambda *a, **k: denied.append((a, k)),
+    )
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_agy_interrupt", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        resp = await client.post(
+            "/v1/sessions/conv_agy_interrupt/events",
+            json={"type": "interrupt"},
+        )
+
+    assert resp.status_code == 204, (
+        f"antigravity-native interrupt must 204 (was a no-op fall-through to the "
+        f"in-process cancel floor); got {resp.status_code}: {resp.text}"
+    )
+    assert cancelled == [(52548, "real-cascade-uuid")], (
+        f"interrupt must drive CancelCascadeSteps for the running cascade; got {cancelled!r}"
+    )
+    assert denied == [], "No deny should run when no step is WAITING."
+
+
+@pytest.mark.asyncio
+async def test_events_interrupt_on_antigravity_native_denies_waiting_step(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    POST ``/events`` ``interrupt`` on antigravity-native with a WAITING step
+    DENIES the interaction instead of (no-op) ``CancelCascadeSteps``.
+
+    ``CancelCascadeSteps`` is a no-op on a WAITING ask-question / permission
+    step (agy 200s but the step doesn't transition), so the interrupt must
+    deliver a refusal through ``HandleCascadeUserInteraction`` and clear the
+    parked card via ``external_elicitation_resolved``.
+    """
+    import omnigent.antigravity_native_interactions as agy_interactions
+    import omnigent.antigravity_native_rpc as agy_rpc
+    from omnigent.antigravity_native_bridge import (
+        AntigravityNativeBridgeState,
+        prepare_bridge_dir,
+        write_bridge_state,
+    )
+
+    monkeypatch.setattr(antigravity_native_bridge, "_BRIDGE_ROOT", tmp_path / "agy-bridge")
+    bridge_dir = prepare_bridge_dir("conv_agy_deny")
+    write_bridge_state(
+        bridge_dir,
+        AntigravityNativeBridgeState(
+            session_id="conv_agy_deny", conversation_id="real-cascade-uuid"
+        ),
+    )
+
+    waiting_permission_step = {
+        "type": "CORTEX_STEP_TYPE_RUN_COMMAND",
+        "status": "CORTEX_STEP_STATUS_WAITING",
+        "requestedInteraction": {
+            "permission": {
+                "resource": {"action": "command", "target": "rm -rf /"},
+                "actionDescription": "Dangerous",
+            }
+        },
+        "metadata": {
+            "sourceTrajectoryStepInfo": {
+                "trajectoryId": "traj-1",
+                "stepIndex": 2,
+                "cascadeId": "real-cascade-uuid",
+            }
+        },
+    }
+
+    monkeypatch.setattr(agy_rpc, "resolve_language_server_port", lambda cid: 52548)
+    monkeypatch.setattr(
+        agy_rpc, "get_trajectory_steps", lambda port, cid: [waiting_permission_step]
+    )
+    cancelled: list[Any] = []
+    monkeypatch.setattr(
+        agy_rpc, "cancel_cascade_steps", lambda port, cid: cancelled.append((port, cid)) or True
+    )
+    delivered: list[dict[str, Any]] = []
+
+    def _fake_handle(port: int, cascade_id: str, **kwargs: Any) -> None:
+        """Record the DENY delivery."""
+        delivered.append({"port": port, "cascade_id": cascade_id, **kwargs})
+
+    monkeypatch.setattr(agy_interactions, "handle_user_interaction", _fake_handle)
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_agy_deny", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        resp = await client.post(
+            "/v1/sessions/conv_agy_deny/events",
+            json={"type": "interrupt"},
+        )
+
+    assert resp.status_code == 204, resp.text
+    assert len(delivered) == 1, (
+        f"A WAITING step must be DENIED via HandleCascadeUserInteraction, not "
+        f"left to the no-op CancelCascadeSteps; got {delivered!r}"
+    )
+    call = delivered[0]
+    assert call["step_index"] == 2
+    assert call["payload"]["permission"]["allow"] is False
+    # CancelCascadeSteps must NOT run on the WAITING path (it's a no-op there).
+    assert cancelled == [], "CancelCascadeSteps must be skipped when a step is WAITING."
 
 
 @pytest.mark.asyncio

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -1014,6 +1014,70 @@ def test_inject_user_message_via_tui_rejects_empty_content(tmp_path: Path) -> No
 
 
 # ---------------------------------------------------------------------------
+# Interrupt / hard-stop tmux primitives (inject_interrupt / kill_session)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal ``subprocess.run`` result stand-in."""
+
+    def __init__(self, returncode: int = 0, stderr: str = "", stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+def test_inject_interrupt_sends_escape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The interrupt sends a bare ``Escape`` key to the advertised pane."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/a.sock"), tmux_target="sess:0.0")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        _mod.subprocess, "run", lambda cmd, **_k: captured.append(cmd) or _FakeProc(0)
+    )
+    _mod.inject_interrupt(bridge_dir, timeout_s=1.0)
+    # No ``-l``: tmux must interpret ``Escape`` as a key name, not literal text.
+    assert captured[0] == ["tmux", "-S", "/tmp/a.sock", "send-keys", "-t", "sess:0.0", "Escape"]
+
+
+def test_kill_session_kills_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hard-stop kills the advertised tmux session outright."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/a.sock"), tmux_target="sess:0.0")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        _mod.subprocess, "run", lambda cmd, **_k: captured.append(cmd) or _FakeProc(0)
+    )
+    _mod.kill_session(bridge_dir, timeout_s=1.0)
+    assert captured[0] == ["tmux", "-S", "/tmp/a.sock", "kill-session", "-t", "sess:0.0"]
+
+
+def test_inject_interrupt_raises_when_target_unadvertised(tmp_path: Path) -> None:
+    """No ``tmux.json`` → the readiness wait times out fast and raises."""
+    with pytest.raises(RuntimeError):
+        _mod.inject_interrupt(tmp_path / "bridge", timeout_s=0.05)
+
+
+def test_kill_session_raises_when_target_unadvertised(tmp_path: Path) -> None:
+    """No ``tmux.json`` → the readiness wait times out fast and raises."""
+    with pytest.raises(RuntimeError):
+        _mod.kill_session(tmp_path / "bridge", timeout_s=0.05)
+
+
+def test_kill_session_raises_on_tmux_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-zero tmux exit surfaces as a ``RuntimeError`` (not a silent no-op)."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/a.sock"), tmux_target="sess:0.0")
+    monkeypatch.setattr(
+        _mod.subprocess, "run", lambda *_a, **_k: _FakeProc(1, stderr="no such session")
+    )
+    with pytest.raises(RuntimeError, match="no such session"):
+        _mod.kill_session(bridge_dir, timeout_s=1.0)
+
+
+# ---------------------------------------------------------------------------
 # Omnigent MCP relay wiring (sys_* tools) — #1194
 # ---------------------------------------------------------------------------
 

--- a/tests/test_antigravity_native_interactions.py
+++ b/tests/test_antigravity_native_interactions.py
@@ -35,9 +35,11 @@ from typing import Any
 import pytest
 
 from omnigent.antigravity_native_interactions import (
+    _freshest_pending,
     _freshest_waiting,
     agy_elicitation_id,
     bridge_interaction,
+    deny_pending_interaction,
 )
 from omnigent.antigravity_native_rpc import AntigravityRpcError
 from omnigent.antigravity_native_steps import PendingInteraction
@@ -675,3 +677,86 @@ def test_elicitation_id_is_deterministic_and_index_sensitive() -> None:
     assert a == b
     assert a != c
     assert a.startswith("elicit_agy_")
+
+
+# ---------------------------------------------------------------------------
+# deny_pending_interaction (interrupt DENY of a WAITING step)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deny_pending_interaction_denies_freshest_waiting_question() -> None:
+    """A WAITING ask_question is refused with an EMPTY responses payload."""
+    deliver = _DeliverRecorder()
+    denied = await deny_pending_interaction(
+        _CASCADE,
+        port=52548,
+        get_steps=_steps_returner([_question_step(step_index=2), _question_step(step_index=5)]),
+        deliver=deliver,
+    )
+    assert denied is True
+    assert len(deliver.calls) == 1
+    call = deliver.calls[0]
+    # Freshest (highest index) WAITING step is targeted.
+    assert call["step_index"] == 5
+    assert call["cascade_id"] == _CASCADE
+    # A decline yields an empty askQuestion responses list (no option selected).
+    assert call["payload"]["askQuestion"]["responses"] == []
+
+
+@pytest.mark.asyncio
+async def test_deny_pending_interaction_denies_permission_with_allow_false() -> None:
+    """A WAITING command-permission is refused with ``allow=False``."""
+    deliver = _DeliverRecorder()
+    denied = await deny_pending_interaction(
+        _CASCADE,
+        port=52548,
+        get_steps=_steps_returner([_permission_step(step_index=4)]),
+        deliver=deliver,
+    )
+    assert denied is True
+    assert deliver.calls[0]["payload"]["permission"]["allow"] is False
+    assert deliver.calls[0]["step_index"] == 4
+
+
+@pytest.mark.asyncio
+async def test_deny_pending_interaction_noop_when_no_waiting_step() -> None:
+    """No WAITING step → no delivery and a ``False`` return (cancel path runs)."""
+    deliver = _DeliverRecorder()
+    denied = await deny_pending_interaction(
+        _CASCADE,
+        port=52548,
+        # A DONE step carries an interaction block but is not WAITING.
+        get_steps=_steps_returner(
+            [_question_step(step_index=1, status="CORTEX_STEP_STATUS_DONE")]
+        ),
+        deliver=deliver,
+    )
+    assert denied is False
+    assert deliver.calls == []
+
+
+@pytest.mark.asyncio
+async def test_deny_pending_interaction_swallows_rpc_error() -> None:
+    """A delivery RPC error is logged and swallowed (returns ``False``)."""
+    deliver = _DeliverRecorder(errors=[AntigravityRpcError("boom")])
+    denied = await deny_pending_interaction(
+        _CASCADE,
+        port=52548,
+        get_steps=_steps_returner([_question_step(step_index=3)]),
+        deliver=deliver,
+    )
+    assert denied is False
+    assert len(deliver.calls) == 1
+
+
+def test_freshest_pending_picks_highest_index_any_kind() -> None:
+    """``_freshest_pending`` returns the highest-index WAITING step of any kind."""
+    fresh = _freshest_pending([_question_step(step_index=2), _permission_step(step_index=7)])
+    assert fresh is not None
+    assert fresh["step_index"] == 7
+    assert fresh["kind"] == "permission"
+    # No WAITING step → None.
+    assert (
+        _freshest_pending([_question_step(step_index=1, status="CORTEX_STEP_STATUS_DONE")]) is None
+    )


### PR DESCRIPTION
## The bug (P1)

antigravity-native was the **only** native harness in **neither** the runner interrupt dispatch **nor** the `stop_session` dispatch, and its bridge had no kill/interrupt primitive (only `inject_user_message_via_tui`). As a result:

- **Soft Stop** during an agy turn did nothing — agy kept generating, tokens kept streaming, the spinner spun. The interrupt fell to `_cancel_inprocess_turn`, which early-returns because the executor yields `TurnComplete` the instant it types into the TUI (the turn task is already `.done()`), so `interrupt_session`/`cancel_cascade_steps` was never reached.
- **Hard "Stop session"** was a silent no-op fall-through: the agy process + runner-owned tmux pane were never killed (leaked until host SIGTERM / session delete), the terminal panel kept showing a live pane, and no idle edge was published.
- A pending elicitation card was never cleared by Stop, and an antigravity-driven sub-agent could never be stopped by its parent.

Siblings (claude / codex / cursor / goose / qwen-native) all have both an interrupt and a stop handler wired in. This mirrors **cursor-native** exactly.

## The fix — two parts

**(A) Bridge (`antigravity_native_bridge.py`)** — add `kill_session(bridge_dir)` and `inject_interrupt(bridge_dir)` built on the existing `_wait_for_tmux_info` / `_run_tmux` primitives, modeled on `cursor_native_bridge.py`.

**(B) Runner (`runner/app.py`)**:
- **INTERRUPT** — new `_handle_antigravity_native_interrupt` resolves the cascade id (from bridge state) + connect-RPC port and drives `CancelCascadeSteps` (the same path the executor's `interrupt_session` uses). Per the executor docstring, `CancelCascadeSteps` is a **no-op on a WAITING** (ask-question / permission) step — so when the current step is WAITING it instead **DENIES** through the interaction bridge (`deny_pending_interaction`) and clears the parked elicitation card. Falls back to a tmux `Escape` when no RPC port is resolvable, so Stop is never a no-op.
- **STOP** — new `_handle_antigravity_native_stop` modeled on `_handle_cursor_native_stop`: `kill_session` → `_teardown_session_terminals` → `_cancel_auto_forwarder_task` (stops the RPC reader) → publish an explicit `session.status: idle` stop edge → `_mark_subagent_terminal_and_wake`, clearing the parked elicitation first (before the pane dies and the RPC port is gone).
- New `deny_pending_interaction` helper in `antigravity_native_interactions.py` for the WAITING-step DENY path.

This lives in **runner dispatch** (like cursor), not the adapter (the base adapter interrupt path 404s when no turn is in flight).

## Tests

- Bridge: `kill_session` / `inject_interrupt` send the right tmux args, raise when the target is unadvertised, and surface tmux failures.
- `deny_pending_interaction`: denies the freshest WAITING question (empty responses) / permission (`allow=False`), no-ops with no WAITING step, swallows RPC errors.
- Dispatch: interrupt drives `CancelCascadeSteps` for a running cascade and **DENIES** (not cancels) when a step is WAITING; `stop_session` kills + tears down + publishes exactly one idle (and 503s with no idle on kill failure).

All touched test files pass; lint clean.

This pull request and its description were written by Isaac.