### PR TITLE
fix(antigravity-native): price session cost + keep resume model faithful

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -342,6 +343,73 @@ def _resolve_display_name(model_enum: str, catalog: dict[str, object]) -> str:
             if isinstance(display, str) and display:
                 return display
     return model_enum
+
+
+# Gemini ids the Databricks model catalog prices (``databricks.json`` /
+# the MLflow ``databricks`` catalog). These are the ONLY pricing-resolvable
+# Gemini spellings: ``fetch_model_pricing`` infers provider ``google`` from a
+# bare ``gemini-`` id, but MLflow publishes no ``google`` catalog (404), so
+# only the gateway-prefixed ``databricks-gemini-*`` aliases resolve to non-None
+# pricing. Posting one of these (instead of the human displayName) is what lets
+# the server price the session and key the per-model TOKEN USAGE view. Keep in
+# sync with the ``databricks-gemini-*`` entries in
+# ``omnigent/onboarding/providers/model_catalog/databricks.json``.
+_PRICEABLE_GEMINI_IDS: frozenset[str] = frozenset(
+    {
+        "databricks-gemini-2-5-flash",
+        "databricks-gemini-2-5-pro",
+        "databricks-gemini-3-flash",
+        "databricks-gemini-3-pro",
+        "databricks-gemini-3-1-flash-lite",
+        "databricks-gemini-3-1-pro",
+        "databricks-gemini-3-5-flash",
+    }
+)
+
+
+def _resolve_pricing_id(model_enum: str, catalog: dict[str, object]) -> str:
+    """
+    Resolve a model enum to a PRICING-RESOLVABLE id (the dropdown / pricing key).
+
+    The server uses the ``model`` field on ``external_session_usage`` /
+    ``external_model_change`` for TWO things: as the :func:`fetch_model_pricing`
+    key (so the Session-cost badge and per-model TOKEN USAGE view get a cost) AND
+    as the per-model attribution bucket / web model dropdown value — exactly like
+    codex posts its raw pricing-valid model id (codex_native_forwarder.py). The
+    human ``displayName`` (``"Gemini 2.5 Flash"``) prices to ``None`` (its
+    capital-G/spaces shape fails ``_infer_provider``), so posting it left the
+    session unpriced and poisoned ``model_override`` with a non-slug label.
+
+    This resolves the (version-volatile) agy enum to its stable ``displayName``
+    via the catalog (:func:`_resolve_display_name`), then normalizes a Gemini
+    label (``"Gemini 3.5 Flash"`` → ``"databricks-gemini-3-5-flash"``) to the
+    matching priceable id in :data:`_PRICEABLE_GEMINI_IDS`. A trailing effort
+    parenthetical (``"Gemini 3.5 Flash (Medium)"``) is dropped first so the
+    effort-suffixed ``agy models`` spelling still maps.
+
+    Falls back to the resolved displayName (the human label) when the model is
+    not a recognized priceable Gemini — a non-Gemini model the agy catalog may
+    surface (Claude / GPT-OSS), or a future Gemini not yet in databricks.json.
+    Pricing won't resolve for that fallback, but the dropdown still shows a
+    sensible label and the value stays slug-shaped (no spaces only when the
+    enum itself resolved to a slug), mirroring the displayName-as-label contract
+    the UI already relied on.
+
+    :param model_enum: agy model enum string, e.g. ``"gemini-2.5-pro"`` or
+        ``"MODEL_PLACEHOLDER_M20"``.
+    :param catalog: Parsed response from ``GetAvailableModels``.
+    :returns: A priceable ``databricks-gemini-*`` id when the model maps to one,
+        else the resolved displayName (human label) as a fallback.
+    """
+    display = _resolve_display_name(model_enum, catalog)
+    # Drop a trailing effort parenthetical, e.g. "Gemini 3.5 Flash (Medium)".
+    label = re.sub(r"\s*\([^)]*\)\s*$", "", display).strip().lower()
+    if label.startswith("gemini"):
+        slug = re.sub(r"[^a-z0-9]+", "-", label.replace(".", "-")).strip("-")
+        candidate = f"databricks-{slug}"
+        if candidate in _PRICEABLE_GEMINI_IDS:
+            return candidate
+    return display
 
 
 def _parse_activity_timestamp(value: object) -> datetime | None:
@@ -1933,12 +2001,17 @@ async def _maybe_emit_session_usage(
     state.cumulative_cache_read_input_tokens += _int_field(
         per_call, "cumulative_cache_read_input_tokens"
     )
-    # Resolve the raw model enum to a displayName if the catalog is available.
+    # Resolve the raw model enum to a PRICING-RESOLVABLE id (a priceable
+    # ``databricks-gemini-*`` when the model maps to one, else the human
+    # displayName) if the catalog is available. The server keys
+    # ``fetch_model_pricing`` AND the per-model TOKEN USAGE bucket on this field,
+    # so posting the bare displayName left the session unpriced — see
+    # :func:`_resolve_pricing_id`.
     model_enum = per_call.get("model")
-    display_name: str | None = None
+    pricing_id: str | None = None
     if isinstance(model_enum, str) and model_enum:
         catalog = await _ensure_catalog(state)
-        display_name = _resolve_display_name(model_enum, catalog)
+        pricing_id = _resolve_pricing_id(model_enum, catalog)
     # Build the cumulative payload (SET-semantics running totals).
     payload: dict[str, object] = {}
     if state.cumulative_input_tokens > 0:
@@ -1947,8 +2020,8 @@ async def _maybe_emit_session_usage(
         payload["cumulative_output_tokens"] = state.cumulative_output_tokens
     if state.cumulative_cache_read_input_tokens > 0:
         payload["cumulative_cache_read_input_tokens"] = state.cumulative_cache_read_input_tokens
-    if display_name is not None:
-        payload["model"] = display_name
+    if pricing_id is not None:
+        payload["model"] = pricing_id
     if not payload:
         return
     step_idx = _step_index(step) or 0
@@ -1994,14 +2067,20 @@ async def _maybe_emit_model_change(
     if model_enum == state.posted_model_enum:
         return
     catalog = await _ensure_catalog(state)
-    display_name = _resolve_display_name(model_enum, catalog)
+    # Post a PRICING-RESOLVABLE id (priceable ``databricks-gemini-*`` when the
+    # model maps to one, else the human displayName) — never the raw human
+    # displayName. The server persists this into ``conv.model_override``, which
+    # is re-validated and passed to ``agy --model`` on resume; a non-slug label
+    # ("Gemini 2.5 Flash") is unfaithfully resumed and fails
+    # ``validate_model_override``. See :func:`_resolve_pricing_id`.
+    pricing_id = _resolve_pricing_id(model_enum, catalog)
     step_idx = _step_index(step) or 0
     await _post_event(
         client,
         session_id,
         OutboundEvent(
             event_type=_EXTERNAL_MODEL_CHANGE,
-            data={"model": display_name},
+            data={"model": pricing_id},
             step_index=step_idx,
         ),
     )

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4138,9 +4138,20 @@ async def _auto_create_antigravity_terminal(
         raise RuntimeError(f"Invalid external_session_id for Antigravity session {session_id!r}.")
     resume = bool(external_session_id)
 
-    # agy model label from the session's model_override (None lets agy default).
+    # agy model id from the session's model_override (None lets agy default).
     _model_override = snapshot.get("model_override")
     model = _model_override if isinstance(_model_override, str) and _model_override else None
+    if model is not None:
+        # Defense-in-depth: re-validate the persisted override at the runner
+        # boundary so a value that somehow bypassed server-side validation can
+        # never reach the agy ``--model`` argv as shell- or flag-shaped input
+        # (mirrors the Codex spawn-boundary re-validation above).
+        try:
+            validate_model_override(model)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Invalid model_override for Antigravity session {session_id!r}: {exc}"
+            ) from exc
 
     # Bridge id mirrors the CLI/harness derivation: the session's bridge-id
     # label when present (so the spawn env built by

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -3364,7 +3364,19 @@ async def _persist_external_model_change(
             "external_model_change requires data.model to be a non-empty string",
             code=ErrorCode.INVALID_INPUT,
         )
-    model = raw_model.strip()
+    # This value is persisted into ``model_override`` and later crosses the
+    # spawn boundary as a ``--model`` argv element (codex ``config.toml`` /
+    # agy ``--model``), so reject anything shell- or flag-shaped — and, in
+    # particular, the human displayName an external harness might mistakenly
+    # report (``"Gemini 2.5 Flash"`` has spaces, which the model-id charset
+    # rejects). Mirrors the runner's defense-in-depth re-validation at spawn.
+    try:
+        model = validate_model_override(raw_model)
+    except ValueError as exc:
+        raise OmnigentError(
+            f"external_model_change data.model is not a valid model id: {exc}",
+            code=ErrorCode.INVALID_INPUT,
+        ) from exc
     if conv.model_override == model:
         return
     await asyncio.to_thread(

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -2979,6 +2979,30 @@ async def test_auto_create_antigravity_cold_starts_real_conversation(
 
 
 @pytest.mark.asyncio
+async def test_auto_create_antigravity_rejects_invalid_model_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A persisted ``model_override`` that fails validation raises at spawn.
+
+    Defense-in-depth re-validation at the runner boundary (mirrors the Codex
+    spawn-boundary check): a human displayName ("Gemini 2.5 Flash") has spaces,
+    which ``validate_model_override`` rejects, so it can never reach the agy
+    ``--model`` argv as a value agy cannot faithfully resume. Fails loud rather
+    than launching agy with a poisoned model id.
+    """
+    with pytest.raises(RuntimeError, match="Invalid model_override for Antigravity"):
+        await _run_antigravity_auto_create(
+            tmp_path,
+            monkeypatch,
+            session_id="conv_agy_badmodel",
+            snapshot={"model_override": "Gemini 2.5 Flash"},
+            candidate_ports=[52548],
+        )
+
+
+@pytest.mark.asyncio
 async def test_auto_create_antigravity_cold_start_scopes_to_pane_agy(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -5072,6 +5072,35 @@ async def test_post_external_model_change_rejects_empty_model(
     assert "external_model_change" in resp.text
 
 
+@pytest.mark.asyncio
+async def test_post_external_model_change_rejects_displayname(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A human displayName (``"Gemini 2.5 Flash"``) 400s and is NOT persisted.
+
+    The persisted ``model_override`` crosses the spawn boundary as a
+    ``--model`` argv element, so it must be a valid (slug-shaped) model id.
+    The displayName has spaces, which ``validate_model_override`` rejects —
+    guarding against an external harness mistakenly reporting the dropdown
+    label (the antigravity-native pricing/resume bug) and poisoning the
+    override with a value ``agy --model`` cannot faithfully resume.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_model_change", "data": {"model": "Gemini 2.5 Flash"}},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "external_model_change" in resp.text
+
+    # The override was not persisted.
+    snapshot = await client.get(f"/v1/sessions/{session['id']}")
+    assert snapshot.json()["model_override"] is None
+
+
 async def test_post_external_model_change_does_not_forward_to_runner(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -2073,7 +2073,9 @@ async def test_planner_done_emits_session_usage(
     - cumulative_input_tokens = inputTokens (int)
     - cumulative_output_tokens = outputTokens (int)
     - cumulative_cache_read_input_tokens = cacheReadTokens (int)
-    - model = the displayName from the catalog (not the raw enum)
+    - model = a PRICING-RESOLVABLE ``databricks-gemini-*`` id derived from the
+      catalog displayName (NOT the raw enum and NOT the human displayName) — the
+      server keys ``fetch_model_pricing`` on it, so it must be a priceable id.
     """
     planner = _planner_with_model_usage(
         input_tokens="1000",
@@ -2099,7 +2101,13 @@ async def test_planner_done_emits_session_usage(
     assert usage_data["cumulative_input_tokens"] == 1000
     assert usage_data["cumulative_output_tokens"] == 100
     assert usage_data["cumulative_cache_read_input_tokens"] == 200
-    assert usage_data["model"] == "Gemini 2.5 Flash"
+    # "Gemini 2.5 Flash" (M20's displayName) maps to the priceable id, NOT the
+    # raw enum or the human displayName. Membership in the curated priceable set
+    # is the offline-safe proxy for "fetch_model_pricing resolves it" (every id
+    # in the set is a databricks.json entry; verified non-None at fix time).
+    assert usage_data["model"] == "databricks-gemini-2-5-flash"
+    assert usage_data["model"] in reader._PRICEABLE_GEMINI_IDS
+    assert " " not in usage_data["model"]  # never the human displayName
 
 
 @pytest.mark.asyncio
@@ -2172,7 +2180,9 @@ async def test_first_turn_emits_model_change(
 ) -> None:
     """The first USER_INPUT step with a new model enum emits external_model_change.
 
-    The event data must carry the resolved displayName, NOT the raw enum.
+    The event data must carry a PRICING-RESOLVABLE ``databricks-gemini-*`` id
+    (the value the server persists into ``model_override`` and later passes to
+    ``agy --model`` on resume), NOT the raw enum and NOT the human displayName.
     """
     user = _user_input_with_model("MODEL_PLACEHOLDER_M20")
     frames = [_frame([user])]
@@ -2192,7 +2202,14 @@ async def test_first_turn_emits_model_change(
         f"expected 1 model_change event, got {len(model_change_events)}"
     )
     _, mc_data = model_change_events[0]
-    assert mc_data["model"] == "Gemini 2.5 Flash"
+    assert mc_data["model"] == "databricks-gemini-2-5-flash"
+    assert mc_data["model"] in reader._PRICEABLE_GEMINI_IDS
+    # The persisted model_override must survive validate_model_override (the
+    # human displayName "Gemini 2.5 Flash" has spaces and would NOT) so it can
+    # cross the spawn boundary to ``agy --model`` faithfully on resume.
+    from omnigent.model_override import validate_model_override
+
+    assert validate_model_override(mc_data["model"]) == mc_data["model"]
 
 
 @pytest.mark.asyncio
@@ -2249,8 +2266,8 @@ async def test_model_switch_mid_session_emits_new_model_change(
     assert len(model_change_events) == 2, (
         f"expected 2 model_change events (one per distinct model), got {len(model_change_events)}"
     )
-    assert model_change_events[0][1]["model"] == "Gemini 2.5 Flash"
-    assert model_change_events[1][1]["model"] == "Gemini 2.5 Pro"
+    assert model_change_events[0][1]["model"] == "databricks-gemini-2-5-flash"
+    assert model_change_events[1][1]["model"] == "databricks-gemini-2-5-pro"
 
 
 @pytest.mark.asyncio
@@ -2319,6 +2336,70 @@ def test_requested_model_enum_from_step_falls_back_to_requested_model() -> None:
         },
     }
     assert reader._requested_model_enum_from_step(legacy_step) == "MODEL_PLACEHOLDER_M20"
+
+
+def test_resolve_pricing_id_maps_gemini_displayname_to_priceable_id() -> None:
+    """A Gemini enum resolves to a priceable ``databricks-gemini-*`` id.
+
+    The catalog maps the enum to a human displayName ("Gemini 2.5 Flash"), which
+    the resolver normalizes to the gateway-prefixed id the server can price with
+    ``fetch_model_pricing``. Every mapped id must be in the curated priceable
+    set (the offline-safe proxy for "fetch_model_pricing resolves it").
+    """
+    assert (
+        reader._resolve_pricing_id("MODEL_PLACEHOLDER_M20", _FAKE_CATALOG)
+        == "databricks-gemini-2-5-flash"
+    )
+    assert (
+        reader._resolve_pricing_id("MODEL_PLACEHOLDER_M132", _FAKE_CATALOG)
+        == "databricks-gemini-2-5-pro"
+    )
+    assert reader._resolve_pricing_id("MODEL_PLACEHOLDER_M20", _FAKE_CATALOG) in (
+        reader._PRICEABLE_GEMINI_IDS
+    )
+
+
+def test_resolve_pricing_id_handles_effort_suffix_and_other_gemini_versions() -> None:
+    """The resolver drops a trailing effort parenthetical and maps newer Geminis.
+
+    The RPC catalog displayName is clean ("Gemini 3.5 Flash"), but the ``agy
+    models`` listing suffixes effort ("Gemini 3.5 Flash (Medium)"); both must map
+    to the same priceable id so a future agy that includes the suffix still
+    prices. Covers the 3.x family that exists in databricks.json.
+    """
+    catalog: dict[str, object] = {
+        "models": {
+            "a": {"model": "ENUM_FLASH35", "displayName": "Gemini 3.5 Flash (Medium)"},
+            "b": {"model": "ENUM_PRO31", "displayName": "Gemini 3.1 Pro"},
+            "c": {"model": "ENUM_FLASHLITE", "displayName": "Gemini 3.1 Flash Lite"},
+        }
+    }
+    assert reader._resolve_pricing_id("ENUM_FLASH35", catalog) == "databricks-gemini-3-5-flash"
+    assert reader._resolve_pricing_id("ENUM_PRO31", catalog) == "databricks-gemini-3-1-pro"
+    assert (
+        reader._resolve_pricing_id("ENUM_FLASHLITE", catalog) == "databricks-gemini-3-1-flash-lite"
+    )
+
+
+def test_resolve_pricing_id_falls_back_to_displayname_for_non_gemini() -> None:
+    """A non-Gemini / unknown model falls back to the displayname (or raw enum).
+
+    The agy catalog can surface Claude / GPT-OSS models that have no
+    ``databricks-gemini-*`` counterpart; the resolver must not invent one. It
+    returns the human displayName (a sensible dropdown label), and an enum
+    absent from the catalog returns the raw enum unchanged — preserving the
+    existing "unknown enum is reported, never dropped" behavior.
+    """
+    catalog: dict[str, object] = {
+        "models": {
+            "x": {"model": "ENUM_CLAUDE", "displayName": "Claude Sonnet 4.6 (Thinking)"},
+        }
+    }
+    assert reader._resolve_pricing_id("ENUM_CLAUDE", catalog) == "Claude Sonnet 4.6 (Thinking)"
+    # Absent from the catalog → raw enum (matches _resolve_display_name fallback).
+    assert reader._resolve_pricing_id("MODEL_PLACEHOLDER_M999", _FAKE_CATALOG) == (
+        "MODEL_PLACEHOLDER_M999"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The antigravity-native reader posted the human **displayName** (`"Gemini 2.5 Flash"`) as the `model` field on **both** `external_session_usage` (`antigravity_native_reader.py` `_maybe_emit_session_usage`) and `external_model_change` (`_maybe_emit_model_change`), via `_resolve_display_name`. That broke two things:

1. **Session cost is never priced.** The server's `_persist_native_cumulative_usage` keys `fetch_model_pricing(data["model"])`. `_infer_provider` does prefix matching, and `"Gemini 2.5 Flash"` (capital G, spaces) matches no prefix → provider `None` → pricing `None`. The Session-cost badge stays `—` for the whole conversation and the per-model TOKEN USAGE view shows no cost (tokens *were* still tracked). The `model_override` fallback in the server's resolution chain was *also* the displayName, so it failed too.
2. **Resume is poisoned.** `_persist_external_model_change` persisted the displayName verbatim into `conv.model_override` (unvalidated). On resume the runner runs `agy --model "Gemini 2.5 Flash"` — a label agy can't faithfully resume (it wants a slug), so the chosen model isn't restored.

Sibling harnesses don't have this bug: codex posts its raw pricing-valid model id as `data["model"]` (simultaneously the `fetch_model_pricing` key AND the dropdown value), and re-validates `model_override` at its spawn boundary (`runner/app.py:671-684`). antigravity did neither.

## Fix

**Post a pricing-resolvable id, not the displayName, on both events.** Added `_resolve_pricing_id(model_enum, catalog)` to the reader (parallel to `_resolve_display_name`):
- Resolves the version-volatile agy enum to its stable catalog `displayName`, then normalizes a Gemini label to the matching priceable `databricks-gemini-*` id (dropping a trailing effort parenthetical like `(Medium)` first).
- Falls back to the resolved displayName for non-Gemini models the agy catalog can surface (Claude / GPT-OSS) or a future Gemini not yet in databricks.json — so the dropdown still shows a sensible label.

**Why `databricks-gemini-*` is the only priceable spelling:** `fetch_model_pricing` infers provider `google` from a bare `gemini-` id, but MLflow publishes no `google` catalog (404) → pricing `None`. The `databricks-` prefix (`context_window.py:44`) routes to the `databricks` catalog, whose `databricks-gemini-*` entries (in `databricks.json`) carry real pricing. The `model` field doubles as the per-model attribution bucket key / web model dropdown value, so posting the slug mirrors how codex/claude post their pricing-valid id.

The enum→id mapping (derived from the catalog displayName, verified against `databricks.json` and `fetch_model_pricing`):

| catalog displayName | posted id (priceable) |
| --- | --- |
| Gemini 2.5 Flash | `databricks-gemini-2-5-flash` |
| Gemini 2.5 Pro | `databricks-gemini-2-5-pro` |
| Gemini 3 Flash | `databricks-gemini-3-flash` |
| Gemini 3 Pro | `databricks-gemini-3-pro` |
| Gemini 3.1 Flash Lite | `databricks-gemini-3-1-flash-lite` |
| Gemini 3.1 Pro | `databricks-gemini-3-1-pro` |
| Gemini 3.5 Flash | `databricks-gemini-3-5-flash` |

**Validate `model_override` at both boundaries:**
- `_persist_external_model_change` now runs `validate_model_override` — its `_MODEL_ID_RE` charset has no spaces, so a displayName is rejected and never persisted.
- Added codex-style defense-in-depth re-validation at the antigravity spawn boundary (`runner/app.py` `_auto_create_antigravity_terminal`, mirroring the Codex check) so a poisoned value can never reach the `agy --model` argv.

## Tests

- `tests/test_antigravity_native_reader.py`: the reader now posts a priceable `databricks-gemini-*` id (asserted in `_PRICEABLE_GEMINI_IDS`, never a displayName); the persisted value survives `validate_model_override`; new units for `_resolve_pricing_id` (gemini mapping, effort-suffix stripping, non-gemini/unknown fallback).
- `tests/server/integration/test_sessions_endpoints.py`: `external_model_change` with a displayName 400s and is not persisted.
- `tests/runner/test_app_sessions_native.py`: the antigravity spawn boundary rejects a poisoned `model_override`.

All touched suites pass; ruff clean.

This pull request and its description were written by Isaac.