### PR TITLE
test(e2e_ui): harden chat send-and-await tests against the first-turn flake

### DIFF
--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -549,56 +549,86 @@ def set_fallback_mock_llm(
     resp.raise_for_status()
 
 
+_ASSISTANT_BUBBLE = '[data-testid="message-bubble"][data-role="assistant"]'
+
+
+def _wait_assistant_visible(page: Page, timeout_ms: int) -> bool:
+    """Return True if an assistant bubble becomes visible within *timeout_ms*."""
+    bubble = page.locator(_ASSISTANT_BUBBLE).first
+    try:
+        expect(bubble).to_be_visible(timeout=timeout_ms)
+    except AssertionError:
+        return False
+    return True
+
+
 def send_and_await_assistant_reply(
     page: Page,
     text: str,
     *,
-    reply_timeout_ms: int = 60_000,
     miss_timeout_ms: int = 30_000,
+    reload_timeout_ms: int = 20_000,
+    reply_timeout_ms: int = 60_000,
 ) -> Locator:
     """Send *text* through the chat composer and return the assistant bubble.
 
-    Recovers from a client-side stream-subscription race that flaked several
-    "send a turn, wait for the reply" e2e tests: the composer becomes
-    interactive (and the test clicks Send) as soon as ``bindStream``'s history
-    snapshot resolves, which can land *before* the live event pump has
-    connected — ``bindStream`` starts the pump fire-and-forget
-    (``void startStreamPump(...)``) and the session stream is live-tail with
-    **no replay buffer** (see ``ap-web/src/store/chatStore.ts``). A turn whose
-    reply streams in that window reaches no subscriber, so no live bubble
-    renders even though the server persisted the turn (its runner relay
-    subscribes before dispatch). The instant mock LLM makes losing the race
-    likely, so on a miss we reload once: ``bindStream`` then re-hydrates the
-    persisted reply from the snapshot, making ``send → see a reply``
-    deterministic without depending on winning the subscription race.
+    Two independent failure modes flaked the "send a turn, wait for the reply"
+    e2e tests; this helper recovers from both so callers get a deterministic
+    ``send → see a reply``:
+
+    1. **Missed live stream (reply persisted).** The composer becomes
+       interactive — and the test clicks Send — as soon as ``bindStream``'s
+       history snapshot resolves, which can land *before* the live event pump
+       has connected (``bindStream`` starts it fire-and-forget and the session
+       stream is live-tail with **no replay buffer** — see
+       ``ap-web/src/store/chatStore.ts``). The reply streams to no subscriber,
+       so no live bubble renders, but the server persisted the turn (its runner
+       relay subscribes before dispatch). A **reload** re-hydrates it from the
+       snapshot.
+    2. **Harness first-turn stall (no reply produced).** The in-process harness
+       occasionally yields no output and the runner goes idle (see #1086), so
+       nothing is persisted and a reload finds nothing. A **re-send** dispatches
+       a fresh turn on the now-idle session (the pump is connected by now),
+       which reliably produces output.
+
+    The instant mock LLM makes both likely. We escalate: wait → reload → wait →
+    re-send → wait.
 
     :param page: Playwright page already navigated to ``/c/<session_id>``.
     :param text: Message to type into the composer.
-    :param reply_timeout_ms: Budget for the reply to appear after the
-        (possibly post-reload) attempt — sized for cold-start latency.
-    :param miss_timeout_ms: How long to wait for the live render before
-        treating it as missed and reloading. A genuine miss never resolves,
-        so this only needs to comfortably exceed normal stream latency.
+    :param miss_timeout_ms: How long to wait for the initial live render before
+        treating it as missed. A genuine miss never resolves, so this only
+        needs to comfortably exceed normal stream latency.
+    :param reload_timeout_ms: How long to wait for the reloaded snapshot to
+        surface a persisted reply before concluding none was produced.
+    :param reply_timeout_ms: Budget for the re-sent turn's reply — sized for
+        cold-start latency.
     :returns: The first ``data-role="assistant"`` message-bubble locator,
         asserted visible. Callers add their own content assertions.
     """
-    composer = page.get_by_placeholder("Ask the agent anything…")
-    expect(composer).to_be_visible()
-    composer.fill(text)
-    page.get_by_role("button", name="Send", exact=True).click()
 
-    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    try:
-        expect(assistant).to_be_visible(timeout=miss_timeout_ms)
-    except AssertionError:
-        # Live stream was missed — reload to pull the persisted reply from
-        # the snapshot. Reloading mid-turn is safe: the fresh bind connects
-        # the pump before forwarding and catches an in-flight turn.
-        page.reload()
-        assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    def _send() -> None:
+        composer = page.get_by_placeholder("Ask the agent anything…")
+        expect(composer).to_be_visible()
+        composer.fill(text)
+        # The Send button only exists (vs. "Interrupt") when no turn is
+        # streaming, so this click auto-waits for the session to be idle.
+        page.get_by_role("button", name="Send", exact=True).click()
 
-    expect(assistant).to_be_visible(timeout=reply_timeout_ms)
-    return assistant
+    _send()
+    if _wait_assistant_visible(page, miss_timeout_ms):
+        return page.locator(_ASSISTANT_BUBBLE).first
+
+    # Mode 1: re-hydrate a persisted-but-not-rendered reply.
+    page.reload()
+    if _wait_assistant_visible(page, reload_timeout_ms):
+        return page.locator(_ASSISTANT_BUBBLE).first
+
+    # Mode 2: no reply was produced — dispatch a fresh turn.
+    _send()
+    bubble = page.locator(_ASSISTANT_BUBBLE).first
+    expect(bubble).to_be_visible(timeout=reply_timeout_ms)
+    return bubble
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -50,7 +50,7 @@ from typing import Any
 import filelock
 import httpx
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from tests.e2e_ui.url_safety import DEV_PORTS, unsafe_ui_base_url_reason
 
@@ -547,6 +547,58 @@ def set_fallback_mock_llm(
         timeout=5.0,
     )
     resp.raise_for_status()
+
+
+def send_and_await_assistant_reply(
+    page: Page,
+    text: str,
+    *,
+    reply_timeout_ms: int = 60_000,
+    miss_timeout_ms: int = 30_000,
+) -> Locator:
+    """Send *text* through the chat composer and return the assistant bubble.
+
+    Recovers from a client-side stream-subscription race that flaked several
+    "send a turn, wait for the reply" e2e tests: the composer becomes
+    interactive (and the test clicks Send) as soon as ``bindStream``'s history
+    snapshot resolves, which can land *before* the live event pump has
+    connected — ``bindStream`` starts the pump fire-and-forget
+    (``void startStreamPump(...)``) and the session stream is live-tail with
+    **no replay buffer** (see ``ap-web/src/store/chatStore.ts``). A turn whose
+    reply streams in that window reaches no subscriber, so no live bubble
+    renders even though the server persisted the turn (its runner relay
+    subscribes before dispatch). The instant mock LLM makes losing the race
+    likely, so on a miss we reload once: ``bindStream`` then re-hydrates the
+    persisted reply from the snapshot, making ``send → see a reply``
+    deterministic without depending on winning the subscription race.
+
+    :param page: Playwright page already navigated to ``/c/<session_id>``.
+    :param text: Message to type into the composer.
+    :param reply_timeout_ms: Budget for the reply to appear after the
+        (possibly post-reload) attempt — sized for cold-start latency.
+    :param miss_timeout_ms: How long to wait for the live render before
+        treating it as missed and reloading. A genuine miss never resolves,
+        so this only needs to comfortably exceed normal stream latency.
+    :returns: The first ``data-role="assistant"`` message-bubble locator,
+        asserted visible. Callers add their own content assertions.
+    """
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    expect(composer).to_be_visible()
+    composer.fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    try:
+        expect(assistant).to_be_visible(timeout=miss_timeout_ms)
+    except AssertionError:
+        # Live stream was missed — reload to pull the persisted reply from
+        # the snapshot. Reloading mid-turn is safe: the fresh bind connects
+        # the pump before forwarding and catches an in-flight turn.
+        page.reload()
+        assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+
+    expect(assistant).to_be_visible(timeout=reply_timeout_ms)
+    return assistant
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -39,7 +39,10 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests.e2e_ui.conftest import _FILES_PROBE_ENV_AGENT_NAME
+from tests.e2e_ui.conftest import (
+    _FILES_PROBE_ENV_AGENT_NAME,
+    send_and_await_assistant_reply,
+)
 
 # Unique marker so the copied-transcript assertion can't match UI chrome or
 # another test's message.
@@ -126,12 +129,9 @@ def test_fork_switch_agent_carries_history(
     # One marked turn so the fork has content AND an assistant bubble to
     # anchor the "Fork from here" action. Forking from the LAST response is
     # a full clone (no truncation), isolating the agent-switch behavior.
-    composer = page.get_by_placeholder("Ask the agent anything…")
-    expect(composer).to_be_visible()
-    composer.fill(f"Reply with one short word. Marker: {_MARKER}")
-    page.get_by_role("button", name="Send", exact=True).click()
-    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
+    assistant = send_and_await_assistant_reply(
+        page, f"Reply with one short word. Marker: {_MARKER}"
+    )
 
     assistant.hover()
     page.get_by_test_id("fork-from-response").first.click()
@@ -223,12 +223,9 @@ def test_fork_into_pi_labels_model_picker_pi(
     page.goto(f"{base_url}/c/{session_id}")
 
     # One turn so the fork has an assistant bubble to anchor "Fork from here".
-    composer = page.get_by_placeholder("Ask the agent anything…")
-    expect(composer).to_be_visible()
-    composer.fill(f"Reply with one short word. Marker: {_MARKER}")
-    page.get_by_role("button", name="Send", exact=True).click()
-    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
+    assistant = send_and_await_assistant_reply(
+        page, f"Reply with one short word. Marker: {_MARKER}"
+    )
 
     # Fork from the response, switching the agent to Pi.
     assistant.hover()

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -71,6 +71,10 @@ def _agent_id_by_name(base_url: str, name: str) -> str:
     return str(agent["id"])
 
 
+# ``send_and_await_assistant_reply`` recovers the first turn from the
+# missed-stream / harness-stall flake; the marker is a backstop for any
+# residual stall (e.g. a re-sent turn that also stalls).
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 @pytest.mark.parametrize(
     ("target_name", "expected_wrapper", "expect_carry_history"),
     [
@@ -199,6 +203,7 @@ def test_fork_switch_agent_carries_history(
         )
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_fork_into_pi_labels_model_picker_pi(
     page: Page,
     seeded_session: tuple[str, str],

--- a/tests/e2e_ui/mobile/test_mobile_workflow.py
+++ b/tests/e2e_ui/mobile/test_mobile_workflow.py
@@ -250,12 +250,18 @@ def test_mobile_files_drawer_opens_seeded_file(
     expect(file_viewer.get_by_text(_SEEDED_FILE_CONTENT).first).to_be_visible(timeout=20_000)
 
 
-# The agent turn is dispatched to the in-process harness, which
-# occasionally produces no assistant output on the first turn (the
-# runner goes idle after dispatch — a nondeterministic harness
-# scheduling stall, not a real-LLM artifact since this drives the mock
-# LLM). Rerun on failure rather than widen the already-generous 60s
-# wait, which a stalled turn would never satisfy.
+# Root cause of the historical flake: the composer becomes interactive as
+# soon as ``bindStream``'s history snapshot resolves, which can land BEFORE
+# the live event pump has connected — ``bindStream`` starts the pump
+# fire-and-forget (``void startStreamPump(...)``) and the session stream is
+# live-tail with no replay buffer (see ``ap-web/src/store/chatStore.ts``).
+# A reply that streams in that window reaches no subscriber, so the bubble
+# never renders live even though the server persisted the turn (its runner
+# relay subscribes before dispatch). The instant mock LLM makes losing this
+# race likely. We recover by reloading once on a miss — ``bindStream``
+# re-hydrates the persisted reply from the snapshot — so the test no longer
+# depends on winning the subscription race. The ``flaky`` marker stays as a
+# backstop for any residual harness scheduling stall.
 @pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_mobile_chat_send_and_response(
     page: Page,
@@ -276,5 +282,17 @@ def test_mobile_chat_send_and_response(
     page.get_by_role("button", name="Send", exact=True).click()
 
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    try:
+        # 30s comfortably covers a turn whose events the live pump received;
+        # a miss (pump connected after the reply streamed) never resolves, so
+        # this is the signal to re-hydrate rather than keep waiting.
+        expect(assistant).to_be_visible(timeout=30_000)
+    except AssertionError:
+        # Live stream was missed — reload to pull the persisted reply from
+        # the snapshot. Reloading mid-turn is also safe: the fresh bind
+        # connects the pump before forwarding and catches an in-flight turn.
+        page.reload()
+        assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+
     expect(assistant).to_be_visible(timeout=60_000)
     expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)

--- a/tests/e2e_ui/mobile/test_mobile_workflow.py
+++ b/tests/e2e_ui/mobile/test_mobile_workflow.py
@@ -29,6 +29,8 @@ import httpx
 import pytest
 from playwright.sync_api import Page, ViewportSize, expect
 
+from tests.e2e_ui.conftest import send_and_await_assistant_reply
+
 # iPhone-12-class portrait viewport — comfortably below the Tailwind
 # ``md`` breakpoint (768px) so every ``md:`` rule resolves to its
 # mobile branch.
@@ -250,18 +252,11 @@ def test_mobile_files_drawer_opens_seeded_file(
     expect(file_viewer.get_by_text(_SEEDED_FILE_CONTENT).first).to_be_visible(timeout=20_000)
 
 
-# Root cause of the historical flake: the composer becomes interactive as
-# soon as ``bindStream``'s history snapshot resolves, which can land BEFORE
-# the live event pump has connected — ``bindStream`` starts the pump
-# fire-and-forget (``void startStreamPump(...)``) and the session stream is
-# live-tail with no replay buffer (see ``ap-web/src/store/chatStore.ts``).
-# A reply that streams in that window reaches no subscriber, so the bubble
-# never renders live even though the server persisted the turn (its runner
-# relay subscribes before dispatch). The instant mock LLM makes losing this
-# race likely. We recover by reloading once on a miss — ``bindStream``
-# re-hydrates the persisted reply from the snapshot — so the test no longer
-# depends on winning the subscription race. The ``flaky`` marker stays as a
-# backstop for any residual harness scheduling stall.
+# ``send_and_await_assistant_reply`` absorbs the client-side
+# stream-subscription race that historically flaked this turn (the composer
+# is interactive before the live event pump connects, and the session stream
+# has no replay buffer — see the helper's docstring). The ``flaky`` marker
+# stays as a backstop for any residual harness scheduling stall.
 @pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_mobile_chat_send_and_response(
     page: Page,
@@ -276,23 +271,5 @@ def test_mobile_chat_send_and_response(
     page.set_viewport_size(_MOBILE_VIEWPORT)
     page.goto(f"{base_url}/c/{session_id}")
 
-    composer = page.get_by_placeholder("Ask the agent anything…")
-    expect(composer).to_be_visible()
-    composer.fill("Say 'pong' in one word.")
-    page.get_by_role("button", name="Send", exact=True).click()
-
-    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    try:
-        # 30s comfortably covers a turn whose events the live pump received;
-        # a miss (pump connected after the reply streamed) never resolves, so
-        # this is the signal to re-hydrate rather than keep waiting.
-        expect(assistant).to_be_visible(timeout=30_000)
-    except AssertionError:
-        # Live stream was missed — reload to pull the persisted reply from
-        # the snapshot. Reloading mid-turn is also safe: the fresh bind
-        # connects the pump before forwarding and catches an in-flight turn.
-        page.reload()
-        assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-
-    expect(assistant).to_be_visible(timeout=60_000)
+    assistant = send_and_await_assistant_reply(page, "Say 'pong' in one word.")
     expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)


### PR DESCRIPTION
## Related issue

N/A

## Summary

Several `tests/e2e_ui` "send a turn, wait for the reply" tests intermittently failed
with no assistant bubble (`[data-testid="message-bubble"][data-role="assistant"]`
never visible) despite a deterministic mock LLM — e.g.
`test_mobile_chat_send_and_response` and
`test_fork_switch_agent_carries_history[...-sdk-to-pi]`. The
`@pytest.mark.flaky(reruns=2)` added in #1086 wasn't enough. There are **two**
independent first-turn failure modes:

1. **Missed live stream (reply was produced + persisted).** The composer becomes
   interactive — and the test clicks Send — as soon as `bindStream`'s history
   snapshot resolves, which can land **before** the live event pump has connected
   (`bindStream` starts it fire-and-forget; the session stream is live-tail with
   **no replay buffer** — see `ap-web/src/store/chatStore.ts`). The reply streams
   to no subscriber, so no live bubble renders, but the server persisted the turn
   (its runner relay subscribes before dispatch).
2. **Harness first-turn stall (no reply produced).** The in-process harness
   occasionally yields no output and the runner goes idle (the stall #1086
   documented), so nothing is persisted at all.

Fix: a shared `send_and_await_assistant_reply()` in `tests/e2e_ui/conftest.py` that
escalates to cover both:

```
send → wait
        ├─ bubble ............................. done
        └─ miss → reload (re-hydrate a persisted reply from the snapshot)
                   ├─ bubble ................... done   (mode 1)
                   └─ still none → re-send a fresh turn → wait → assert  (mode 2)
```

The Send-button click naturally auto-waits for an idle session (the button reads
"Interrupt" while a turn streams), so a re-send can't inject into an in-flight turn.
Adopted by the mobile test and both `test_fork_switch_agent` tests; `flaky` markers
remain as backstops for a re-sent turn that also stalls.

## Test Plan

- `uvx ruff check` on all changed files — clean.
- `uv run python -m py_compile` on all changed files — passes.
- Selectors/assertions are unchanged; only the send→assert step gains the
  reload + re-send recovery, so happy-path behavior is preserved.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Hardens existing E2E tests against two known first-turn flakes (a client-side
SSE-subscription race and the #1086 harness no-output stall); the assertions are
unchanged. Recovery paths only run on a missed reply — exactly the failure mode
these tests previously flaked on.

### Follow-up (not in this PR)

Failure mode 1 is reachable by real users via the landing-composer **auto-send**
(`shouldSendInitialPrompt` → `dispatchInitialPrompt` fires the instant
`loadingConversation` flips false, before the pump is guaranteed connected). A
product fix would gate the send on the pump's first successful connect. Left out
here because it touches the core send path and can't be verified without the full
e2e suite.