### PR TITLE
fix(infra): publish omnigent-server-openshell image and wire overlay to it

### DIFF
--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -123,16 +123,19 @@ jobs:
           set -euo pipefail
           IMAGE="ghcr.io/omnigent-ai/omnigent-server"
           HOST_IMAGE="ghcr.io/omnigent-ai/omnigent-host"
+          OPENSHELL_IMAGE="ghcr.io/omnigent-ai/omnigent-server-openshell"
           SHORT_SHA=$(git rev-parse --short HEAD)
 
           # Immutable per-commit pin, always.
           TAGS="${IMAGE}:sha-${SHORT_SHA}"
           HOST_TAGS="${HOST_IMAGE}:sha-${SHORT_SHA}"
+          OPENSHELL_TAGS="${OPENSHELL_IMAGE}:sha-${SHORT_SHA}"
 
-          # Append a floating/version tag to both images.
+          # Append a floating/version tag to all images.
           add_tag() {
             TAGS="${TAGS},${IMAGE}:$1"
             HOST_TAGS="${HOST_TAGS},${HOST_IMAGE}:$1"
+            OPENSHELL_TAGS="${OPENSHELL_TAGS},${OPENSHELL_IMAGE}:$1"
           }
 
           # Every qualifying main commit moves :latest-dev (bleeding edge).
@@ -171,6 +174,7 @@ jobs:
 
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "host_tags=${HOST_TAGS}" >> "$GITHUB_OUTPUT"
+          echo "openshell_tags=${OPENSHELL_TAGS}" >> "$GITHUB_OUTPUT"
 
       # No build-args: the Dockerfile ARGs default to public registries.
       # Multi-arch: each tag publishes as a manifest list spanning amd64 + arm64,
@@ -210,9 +214,30 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: false
           sbom: true
+
+      # OpenShell server variant: the default server image plus the
+      # openshell SDK extra (OMNIGENT_EXTRAS=openshell). Used by the
+      # deploy/kubernetes/overlays/openshell kustomize overlay. Reuses
+      # the shared builder-stage layers from the gha cache.
+      - name: Build and push openshell server image
+        id: build-openshell
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.tags.outputs.openshell_tags }}
+          build-args: |
+            OMNIGENT_EXTRAS=openshell
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: true
     outputs:
       server-digest: ${{ steps.build-server.outputs.digest }}
       host-digest: ${{ steps.build-host.outputs.digest }}
+      openshell-digest: ${{ steps.build-openshell.outputs.digest }}
 
   generate-sbom:
     # Runs in a separate job with read-only permissions so the Syft
@@ -249,6 +274,13 @@ jobs:
             -o cyclonedx-json=host-sbom.cdx.json \
             -o spdx-json=host-sbom.spdx.json
 
+      - name: Generate openshell server SBOM
+        run: |
+          set -euo pipefail
+          syft "ghcr.io/omnigent-ai/omnigent-server-openshell@${{ needs.build-and-push.outputs.openshell-digest }}" \
+            -o cyclonedx-json=openshell-sbom.cdx.json \
+            -o spdx-json=openshell-sbom.spdx.json
+
       - name: Upload SBOMs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
@@ -258,6 +290,8 @@ jobs:
             server-sbom.spdx.json
             host-sbom.cdx.json
             host-sbom.spdx.json
+            openshell-sbom.cdx.json
+            openshell-sbom.spdx.json
           retention-days: 90
 
   promote-nightly:
@@ -288,7 +322,7 @@ jobs:
           set -euo pipefail
           # crane tag points a new tag at an EXISTING manifest digest without
           # re-serializing it, so :latest-nightly keeps :latest-dev's exact digest.
-          for img in ghcr.io/omnigent-ai/omnigent-server ghcr.io/omnigent-ai/omnigent-host; do
+          for img in ghcr.io/omnigent-ai/omnigent-server ghcr.io/omnigent-ai/omnigent-host ghcr.io/omnigent-ai/omnigent-server-openshell; do
             if crane digest "${img}:latest-dev" >/dev/null 2>&1; then
               crane tag "${img}:latest-dev" latest-nightly
               echo "promoted ${img}:latest-dev -> :latest-nightly ($(crane digest "${img}:latest-nightly"))"
@@ -359,7 +393,7 @@ jobs:
             fi
           }
 
-          for img in ghcr.io/omnigent-ai/omnigent-server ghcr.io/omnigent-ai/omnigent-host; do
+          for img in ghcr.io/omnigent-ai/omnigent-server ghcr.io/omnigent-ai/omnigent-host ghcr.io/omnigent-ai/omnigent-server-openshell; do
             retag "${img}" "latest-rc" "${RC_TAG}"
             retag "${img}" "latest" "${LATEST_TAG}"
           done

--- a/deploy/kubernetes/overlays/openshell/kustomization.yaml
+++ b/deploy/kubernetes/overlays/openshell/kustomization.yaml
@@ -11,6 +11,12 @@ resources:
   - sandbox-clusterrole.yaml
   - sandbox-clusterrolebinding.yaml
 
+# Use the server image variant that includes the openshell SDK extra
+# (built by CI with OMNIGENT_EXTRAS=openshell).
+images:
+  - name: ghcr.io/omnigent-ai/omnigent-server
+    newName: ghcr.io/omnigent-ai/omnigent-server-openshell
+
 patches:
   - path: configmap-patch.yaml
   - path: secret-patch.yaml


### PR DESCRIPTION
## Related issue

Closes #1151

## Summary

- CI now builds and publishes a third image variant, `ghcr.io/omnigent-ai/omnigent-server-openshell`, using the existing `OMNIGENT_EXTRAS` Dockerfile build arg with `openshell`. It gets the same tag scheme (`:sha-*`, `:latest`, `:latest-dev`, etc.), SBOM generation, nightly promotion, and floating-tag reconciliation as the server and host images, and reuses the shared builder-stage GHA cache layers.
- The `deploy/kubernetes/overlays/openshell` kustomization now includes an `images:` transformer that swaps `omnigent-server` → `omnigent-server-openshell`, so deploying with the overlay automatically pulls the image that has the SDK.

**Note:** An upstream openshell issue ([NVIDIA/OpenShell#1705](https://github.com/NVIDIA/OpenShell/issues/1705)) means Linux wheels currently ship without the `_proto/` files. This PR ensures the image *installs* the extra correctly, but users may still hit an import error until the openshell team publishes a corrected Linux wheel.

## Test Plan

- [ ] Verified `kustomize build deploy/kubernetes/overlays/openshell/` resolves the image to `ghcr.io/omnigent-ai/omnigent-server-openshell:latest`
- [ ] Reviewed CI workflow diff to confirm tag computation, build step, SBOM generation, nightly promotion, and reconcile loops all include the new image

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the kustomize overlay output resolves to the correct image name. The CI workflow change is infrastructure-only (new build matrix entry + SBOM + tag promotion) and will be validated on the first merge to main.