### PR TITLE
fix(e2e): raise REPL launch timeout above the CLI's own cold-start budget

### DIFF
--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -7,7 +7,8 @@ the agent responds after the user approves a policy ASK.
 This exercises the full Phase 10 path — prompt_toolkit's
 real input loop, the SSE stream consuming ``ElicitationRequest``
 events, the REPL's future-based approval wiring, and the
-server PATCHing the verdict back through DBOS.
+server PATCHing the verdict back through the durable
+session workflow.
 
 Unlike ``test_policies_e2e.py`` (polling API, background=True),
 this test drives the REPL through the actual streaming code
@@ -59,6 +60,32 @@ _LABEL_ASK_GATE_DIR = _FIXTURES_DIR / "e2e-label-ask-gate"
 _OUTPUT_GATE_DIR = _FIXTURES_DIR / "e2e-output-gate"
 _TOOL_RESULT_GATE_DIR = _FIXTURES_DIR / "e2e-tool-result-gate"
 _SUBAGENT_TOOL_GATE_DIR = _FIXTURES_DIR / "e2e-subagent-tool-gate"
+
+# Seconds to wait for ``omnigent run`` to reach an input-ready REPL —
+# the LAUNCH phase only (daemon spawn, local-server boot, agent upload,
+# runner bring-up, session attach, wrapper-redirect probe).
+#
+# This MUST exceed the CLI's own internal cold-start budget, which is
+# sequential on the critical path of every launch
+# (``_prepare_chat_session_via_daemon`` in omnigent/chat.py):
+#
+#   wait_for_host_online           up to 30s  (_DAEMON_CHAT_HOST_ONLINE_TIMEOUT_S)
+#   launch_or_reuse_daemon_runner  ~16.5s     (transient-409 host-reconnect retry)
+#   wait_for_runner_online         up to 60s  (_DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S)
+#                                  ≈ 106s worst case
+#
+# The old 60s sat *below* that budget, so on the rare slow path (loaded
+# CI runner, host-tunnel reconnect) the test aborted — still animating
+# the "Launching your agent…" spinner, before the approval path was
+# reached — before the CLI itself would have. This value tracks the
+# internal budget + margin, NOT an arbitrary inflation: the median
+# launch is a few seconds, so this ceiling only bites on the tail. To
+# lower it, first lower the internal timeouts above (they guard real
+# users on cold/slow hosts). Deliberately separate from the post-launch
+# assertion timeouts (approval, echo, turn-complete), which stay tight
+# so a real hang *after* launch still fails fast. Kept under the
+# ``--timeout=180`` per-test cap.
+_LAUNCH_TIMEOUT = 120
 
 # Regex to strip ANSI escape codes from pexpect output before
 # asserting. prompt_toolkit emits heavy styling — searching for
@@ -298,7 +325,7 @@ def _wait_for_prompt_ready(
     sleeping``) once prompt_toolkit's application is running
     and idle. Waiting for that after the banner makes the
     subsequent ``child.send(...)`` land in the live input
-    loop. Using a generous timeout — agent upload + DBOS boot
+    loop. Using a generous timeout — agent upload + server boot
     add latency on cold starts.
 
     :param child: Active pexpect child.
@@ -378,8 +405,8 @@ def test_repl_single_approval_allows_llm_response(
     end-to-end stack — prompt_toolkit's raw keystroke
     handling, the SDK's ``ElicitationRequest`` event routing,
     the server's ``response.elicitation_request`` emission, the
-    session ``approval`` event reply path, and DBOS wake
-    semantics — all cohere in production.
+    session ``approval`` event reply path, and the
+    server's durable-workflow wake semantics — all cohere in production.
 
     Load-bearing assertion: EXACTLY ONE approval prompt. The
     "three approvals for one message" bug (prior bug:
@@ -398,10 +425,10 @@ def test_repl_single_approval_allows_llm_response(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),  # rows, cols
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
-        _wait_for_prompt_ready(child, timeout=60)
+        _wait_for_prompt_ready(child, timeout=_LAUNCH_TIMEOUT)
 
         # Send the user message and wait for the approval
         # banner. 'approval required' is the human-readable
@@ -494,10 +521,10 @@ def test_repl_refusal_shows_deny_sentinel(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
-        _wait_for_prompt_ready(child, timeout=60)
+        _wait_for_prompt_ready(child, timeout=_LAUNCH_TIMEOUT)
 
         child.send("Hello deny-sentinel" + "\r")
         child.expect("approval required", timeout=30)
@@ -558,10 +585,10 @@ def test_repl_two_turns_fires_one_approval_per_turn(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
-        _wait_for_prompt_ready(child, timeout=60)
+        _wait_for_prompt_ready(child, timeout=_LAUNCH_TIMEOUT)
 
         # Turn 1: approve, wait for reply.
         child.send("Hello two-turns-guard" + "\r")
@@ -677,10 +704,10 @@ def test_repl_approve_always_caches_for_later_turns(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
-        _wait_for_prompt_ready(child, timeout=60)
+        _wait_for_prompt_ready(child, timeout=_LAUNCH_TIMEOUT)
 
         # Turn 1: approve always.
         child.send("Hello approve-cache" + "\r")
@@ -778,10 +805,10 @@ def test_repl_tool_call_approval_allows_tool_to_run(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
-        _wait_for_prompt_ready(child, timeout=60, welcome_pattern="e2e.tool.gate")
+        _wait_for_prompt_ready(child, timeout=_LAUNCH_TIMEOUT, welcome_pattern="e2e.tool.gate")
         child.send("testing123" + "\r")
         child.expect("approval required", timeout=45)
         banner_tail = _read_pending(child, seconds=1.0)
@@ -832,7 +859,7 @@ def test_repl_tool_call_refusal_blocks_tool(
     conversation — ``_enforce_tool_result_policy`` substitutes
     ``[Denied by policy: ...]``. This test is the end-to-end
     proof that the pre-persistence ordering holds under real
-    streaming + DBOS parking. The mock LLM is scripted to emit
+    streaming + durable-workflow parking. The mock LLM is scripted to emit
     the ``echo`` ``function_call`` so the TOOL_CALL ASK fires.
     """
     follow_up = "tool-call-refuse-followup-marker"
@@ -855,10 +882,10 @@ def test_repl_tool_call_refusal_blocks_tool(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
-        _wait_for_prompt_ready(child, timeout=60, welcome_pattern="e2e.tool.gate")
+        _wait_for_prompt_ready(child, timeout=_LAUNCH_TIMEOUT, welcome_pattern="e2e.tool.gate")
         child.send("testing456" + "\r")
         child.expect("approval required", timeout=45)
         child.send("n" + "\r")
@@ -1078,12 +1105,12 @@ def test_repl_label_driven_ask_approves(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
         _wait_for_prompt_ready(
             child,
-            timeout=60,
+            timeout=_LAUNCH_TIMEOUT,
             welcome_pattern="e2e.label.ask.gate",
         )
         # Turn 1: trigger taint — no ASK fires this turn
@@ -1159,12 +1186,12 @@ def test_repl_label_driven_ask_refuse_shows_sentinel(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
         _wait_for_prompt_ready(
             child,
-            timeout=60,
+            timeout=_LAUNCH_TIMEOUT,
             welcome_pattern="e2e.label.ask.gate",
         )
         # Turn 1: taint.
@@ -1240,12 +1267,12 @@ def test_repl_output_ask_does_not_prompt_in_repl(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
         _wait_for_prompt_ready(
             child,
-            timeout=60,
+            timeout=_LAUNCH_TIMEOUT,
             welcome_pattern="e2e.output.gate",
         )
         child.send("say hi output-noprompt" + "\r")
@@ -1303,12 +1330,12 @@ def test_repl_output_ask_passes_reply_through_no_sentinel(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
         _wait_for_prompt_ready(
             child,
-            timeout=60,
+            timeout=_LAUNCH_TIMEOUT,
             welcome_pattern="e2e.output.gate",
         )
         child.send("say hi output-passthru" + "\r")
@@ -1398,12 +1425,12 @@ def test_repl_tool_result_ask_does_not_prompt_in_repl(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
         _wait_for_prompt_ready(
             child,
-            timeout=60,
+            timeout=_LAUNCH_TIMEOUT,
             welcome_pattern="e2e.tool.result.gate",
         )
         child.send("pineapple" + "\r")
@@ -1486,12 +1513,12 @@ def test_repl_tool_result_ask_passes_output_through(
         encoding="utf-8",
         codec_errors="replace",
         dimensions=(40, 120),
-        timeout=60,
+        timeout=_LAUNCH_TIMEOUT,
     )
     try:
         _wait_for_prompt_ready(
             child,
-            timeout=60,
+            timeout=_LAUNCH_TIMEOUT,
             welcome_pattern="e2e.tool.result.gate",
         )
         child.send("mangosteen" + "\r")


### PR DESCRIPTION
## Problem

`tests/e2e/test_repl_approval_e2e.py::test_repl_single_approval_allows_llm_response` is flaky on CI:

```
pexpect.exceptions.TIMEOUT: Timeout exceeded.
buffer (last 100 chars): '…⠦ Launching your agent…'
searcher: re.compile('ask.demo')   timeout: 60
```

The test times out still **animating** the `Launching your agent…` spinner — i.e. the launch never completed, the approval path was never reached. The spinner was still painting new frames at the cut-off, so the process was alive and waiting, not hung: this is slow cold-start, not a deadlock.

## Root cause

The REPL tests spawn `omnigent run <agent>` under pexpect with a **60s** launch-phase timeout. The first test bears the one-time daemon + local-server cold boot for the module (subsequent tests reuse the persistent local daemon, paying only per-session runner bring-up).

But the CLI's **own internal cold-start budget** is sequential on the critical path of every launch (`_prepare_chat_session_via_daemon` in `omnigent/chat.py`) and sums to ~106s worst case:

| step | budget |
|---|---|
| `wait_for_host_online` | up to 30s (`_DAEMON_CHAT_HOST_ONLINE_TIMEOUT_S`) |
| `launch_or_reuse_daemon_runner` | ~16.5s (transient-409 host-reconnect retry) |
| `wait_for_runner_online` | up to 60s (`_DAEMON_CHAT_RUNNER_ONLINE_TIMEOUT_S`) |

A 60s test timeout sits **below** that budget, so on the rare slow path (loaded CI runner, host-tunnel reconnect) the test aborts *before the CLI itself would*. That's the flake.

## Fix

Lift the launch-phase timeout to a single `_LAUNCH_TIMEOUT = 120` constant — internal budget + margin, still under the `--timeout=180` per-test cap — applied at all 24 spawn / `_wait_for_prompt_ready` sites.

- The median launch is a few seconds, so this ceiling only bites on the tail.
- The **post-launch** assertion timeouts (approval, echo, turn-complete) stay tight, so a real hang *after* launch still fails fast.
- Also de-stales the docstrings' `DBOS` references (DBOS has been removed from the runtime).

This is not arbitrary padding: it aligns the test timeout with the system's own internal startup contract. To lower it, the internal budgets above would have to come down first (they guard real users on cold/slow hosts).

## Note on "just reuse the server"

The local daemon+server is already reused across the 14 REPL tests (persistent unit keyed on the shared module `HOME`). The flake is on the *first* test — the one that creates the shared server — so reuse can't make it cheaper. A follow-up option is a pre-warm fixture that boots the daemon before any assertion runs, which would let `_LAUNCH_TIMEOUT` shrink back toward ~20–30s; tracked separately.