### PR TITLE
ci: drop the redundant merge-ready-rerun job from e2e/e2e-ui/integration

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -313,37 +313,3 @@ jobs:
               echo "- 📜 server.log: _no artifact uploaded (glob matched nothing)_"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-
-  # Explicitly re-dispatch Merge Ready for same-repo PRs: the workflow_run hop
-  # is brittle and was dropped on #751/#792. Fork PRs are NOT re-dispatched here
-  # -- their pull_request GITHUB_TOKEN is read-only (actions:write is not
-  # granted), so `gh workflow run` would 403; they re-evaluate via
-  # merge-ready.yml's own workflow_run trigger instead. No checkout,
-  # actions:write only; GITHUB_TOKEN workflow_dispatch is exempt from recursion.
-  merge-ready-rerun:
-    name: Merge Ready rerun
-    needs: e2e-ui
-    if: >-
-      always()
-      && needs.e2e-ui.result != 'skipped'
-      && github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      actions: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    steps:
-      - name: Re-dispatch Merge Ready
-        run: |
-          set -euo pipefail
-          PR="$PR_NUMBER"
-          if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
-            echo "::notice::could not resolve PR number; nothing to do."
-            exit 0
-          fi
-          echo "Re-dispatching merge-ready.yml for PR #$PR after $GITHUB_WORKFLOW."
-          gh workflow run merge-ready.yml --repo "$REPO" -f pr="$PR"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,37 +122,3 @@ jobs:
           num_shards: ${{ matrix.num_shards }}
           parallelism: ${{ github.event.inputs.parallelism || '2' }}
           nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-
-  # Explicitly re-dispatch Merge Ready for same-repo PRs: the workflow_run hop
-  # is brittle and was dropped on #751/#792. Fork PRs are NOT re-dispatched here
-  # -- their pull_request GITHUB_TOKEN is read-only (actions:write is not
-  # granted), so `gh workflow run` would 403; they re-evaluate via
-  # merge-ready.yml's own workflow_run trigger instead. No checkout,
-  # actions:write only; GITHUB_TOKEN workflow_dispatch is exempt from recursion.
-  merge-ready-rerun:
-    name: Merge Ready rerun
-    needs: e2e
-    if: >-
-      always()
-      && needs.e2e.result != 'skipped'
-      && github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      actions: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    steps:
-      - name: Re-dispatch Merge Ready
-        run: |
-          set -euo pipefail
-          PR="$PR_NUMBER"
-          if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
-            echo "::notice::could not resolve PR number; nothing to do."
-            exit 0
-          fi
-          echo "Re-dispatching merge-ready.yml for PR #$PR after $GITHUB_WORKFLOW."
-          gh workflow run merge-ready.yml --repo "$REPO" -f pr="$PR"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -104,37 +104,3 @@ jobs:
           harness: ${{ matrix.harness }}
           model: ${{ matrix.model }}
           workers: ${{ matrix.workers }}
-
-  # Explicitly re-dispatch Merge Ready for same-repo PRs: the workflow_run hop
-  # is brittle and was dropped on #751/#792. Fork PRs are NOT re-dispatched here
-  # -- their pull_request GITHUB_TOKEN is read-only (actions:write is not
-  # granted), so `gh workflow run` would 403; they re-evaluate via
-  # merge-ready.yml's own workflow_run trigger instead. No checkout,
-  # actions:write only; GITHUB_TOKEN workflow_dispatch is exempt from recursion.
-  merge-ready-rerun:
-    name: Merge Ready rerun
-    needs: integration
-    if: >-
-      always()
-      && needs.integration.result != 'skipped'
-      && github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      actions: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    steps:
-      - name: Re-dispatch Merge Ready
-        run: |
-          set -euo pipefail
-          PR="$PR_NUMBER"
-          if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
-            echo "::notice::could not resolve PR number; nothing to do."
-            exit 0
-          fi
-          echo "Re-dispatching merge-ready.yml for PR #$PR after $GITHUB_WORKFLOW."
-          gh workflow run merge-ready.yml --repo "$REPO" -f pr="$PR"


### PR DESCRIPTION
## What

Removes the `merge-ready-rerun` job from `e2e.yml`, `e2e-ui.yml`, and `integration.yml` (−102 lines).

## Why it's safe / redundant

- `merge-ready.yml` **already triggers on `workflow_run` completion** of `[PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]` — so the gate re-evaluates automatically when these finish.
- `ci.yml` has **never** had a `merge-ready-rerun` job — it relies solely on that `workflow_run` hop and works. That's proof the explicit re-dispatch isn't needed for same-repo PRs.
- The explicit rerun existed mainly to paper over the **fork/mirror push** path's brittle `workflow_run` association (#751/#792). #1004 **retired the fork-e2e mirror** and restricted the rerun to same-repo PRs — so it had become a no-op duplicate of the `workflow_run` trigger.

## Fallbacks retained

If the `workflow_run` hop ever misses, the `Merge Ready` gate can still be re-evaluated via a `/merge` comment or its `workflow_dispatch` entry point.

## Verification

- All three workflows still parse; remaining jobs are `gate` / `setup` / `{e2e,e2e-ui,integration}`.
- No dangling references to `merge-ready-rerun` anywhere in `.github/`.
- `merge-ready.yml`'s `workflow_run` trigger still lists all three workflows.