### PR TITLE
fix(server): don't yield the SSE [DONE] sentinel during GeneratorExit teardown

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10386,11 +10386,17 @@ async def _stream_live_events(
     reconcile pre-subscribe state via the snapshot endpoint
     (``GET /v1/sessions/{id}``) and dedupe by item id.
 
-    On client disconnect the subscribe loop breaks; the
-    ``finally`` block emits a ``[DONE]`` sentinel so well-behaved
-    SSE consumers see a clean stream termination. The pub-sub
-    layer auto-cleans this generator's subscriber slot in its own
-    ``finally`` when iteration exits.
+    On a graceful close — the subscribe loop returns, or this route
+    detects a disconnect and breaks — a ``[DONE]`` sentinel is emitted
+    after the loop so well-behaved SSE consumers see a clean stream
+    termination. The sentinel is deliberately NOT in the ``finally``
+    block: a hard disconnect makes the ASGI server ``aclose()`` this
+    generator, and yielding during the resulting ``GeneratorExit``
+    teardown raises ``RuntimeError: async generator ignored
+    GeneratorExit`` (issue #1117). The ``finally`` does only
+    synchronous presence cleanup. The pub-sub layer auto-cleans this
+    generator's subscriber slot in its own ``finally`` when iteration
+    exits.
 
     Each emitted dict is validated against
     :data:`ServerStreamEvent` at the wire boundary so a runtime
@@ -10472,16 +10478,31 @@ async def _stream_live_events(
                 )
             validated = _SERVER_STREAM_EVENT_ADAPTER.validate_python(event)
             yield _format_sse(event_type, validated.model_dump())
+        # Graceful termination only: the subscribe loop returned (its own
+        # ``[DONE]`` sentinel) or we broke out after detecting a disconnect.
+        # The sentinel is emitted HERE, not in ``finally``, on purpose. A
+        # hard client disconnect makes the ASGI server call ``aclose()`` on
+        # this generator, which throws ``GeneratorExit`` into the suspended
+        # ``yield`` above. Yielding again while that ``GeneratorExit`` is
+        # propagating — which a ``yield`` in ``finally`` would do — raises
+        # ``RuntimeError: async generator ignored GeneratorExit`` and leaves
+        # an orphaned ``athrow`` task whose exception is never retrieved
+        # (issue #1117). Keeping the sentinel outside ``finally`` lets the
+        # forced teardown unwind cleanly while still emitting ``[DONE]`` on
+        # every graceful close.
+        yield "data: [DONE]\n\n"
     finally:
-        # The non-None checks besides presence_token's are type
-        # narrowing only: a minted token implies both were set above.
+        # Synchronous-only cleanup: it must run on both graceful close and
+        # forced ``GeneratorExit`` teardown, so it cannot ``yield`` or
+        # ``await`` anything (see above). The non-None checks besides
+        # presence_token's are type narrowing only: a minted token implies
+        # both were set above.
         if (
             presence_token is not None
             and viewer_user_id is not None
             and presence_root_id is not None
         ):
             presence.disconnect(presence_root_id, viewer_user_id, presence_token)
-        yield "data: [DONE]\n\n"
 
 
 # Bounds for per-session native-terminal pass-through args

--- a/tests/server/test_stream_events.py
+++ b/tests/server/test_stream_events.py
@@ -470,3 +470,51 @@ def test_session_created_event_payload_shape() -> None:
     assert parsed.conversation_id == "conv_parent"
     assert parsed.child_session_id == "conv_child"
     assert parsed.agent_id == "agent_xyz"
+
+
+class _FakeConnectedRequest:
+    """Minimal Request stub: never reports the client as disconnected."""
+
+    async def is_disconnected(self) -> bool:
+        """:returns: ``False`` — the client stays connected for the test."""
+        return False
+
+
+async def test_stream_live_events_aclose_during_yield_does_not_orphan_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forced ``aclose()`` mid-stream tears down without a RuntimeError.
+
+    Regression for issue #1117: on a hard client disconnect the ASGI server
+    calls ``aclose()`` on the SSE generator, which throws ``GeneratorExit``
+    into the suspended live-tail ``yield``. When the ``[DONE]`` sentinel sat
+    in the ``finally`` block, that ``yield`` ran during ``GeneratorExit``
+    teardown and raised ``RuntimeError: async generator ignored
+    GeneratorExit``, orphaning the ``athrow`` task. The sentinel now lives
+    after the loop (graceful close only), so the forced teardown unwinds
+    cleanly.
+
+    Fails on the unfixed generator (``aclose()`` re-raises the RuntimeError);
+    passes once the sentinel is moved out of ``finally``.
+    """
+    import asyncio
+
+    from omnigent.server.routes import sessions as sessions_routes
+
+    async def _fake_subscribe(conversation_id: str, **kwargs: Any) -> Any:
+        """Yield one valid event, then block so the generator suspends mid-tail."""
+        del conversation_id, kwargs
+        yield {"type": "session.heartbeat"}
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(sessions_routes.session_stream, "subscribe", _fake_subscribe)
+
+    gen = sessions_routes._stream_live_events(_FakeConnectedRequest(), "conv_x")
+    # Advance to the first live-tail event; the generator is now suspended at
+    # the ``yield _format_sse(...)`` inside the ``try`` — the exact point a
+    # client-disconnect ``aclose()`` injects ``GeneratorExit``.
+    first = await gen.__anext__()
+    assert "session.heartbeat" in first
+
+    # Must not raise ``RuntimeError: async generator ignored GeneratorExit``.
+    await gen.aclose()


### PR DESCRIPTION
## Related issue

Closes #1117

## Summary

- `_stream_live_events` emitted its `data: [DONE]` sentinel from a `finally` block. On a hard client disconnect the ASGI server calls `aclose()`, which throws `GeneratorExit` into the suspended live-tail `yield`; the `finally` then tried to `yield` again, raising `RuntimeError: async generator ignored GeneratorExit` and orphaning the `athrow` task (silent resource leak; can mask real teardown errors).
- Moved the sentinel out of `finally` to the normal post-loop path, so it's emitted only on graceful termination. The `finally` now does only synchronous presence cleanup (safe during forced teardown).

**ELI5:** When a browser tab watching the live stream closes abruptly, Python tells the streaming function to shut down. The old code tried to send one last "stream done" message *while shutting down*, which Python forbids — it blew up with a hidden error and leaked a background task. We now send that final message only when the stream ends normally, and do nothing but quiet cleanup during an abrupt close.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `test_stream_live_events_aclose_during_yield_does_not_orphan_task` in `tests/server/test_stream_events.py`. It drives the real `_stream_live_events` generator to a suspended live-tail `yield`, then calls `aclose()` (exactly what the ASGI server does on client disconnect).

Verified failing-first per the bug-fix protocol:
- On the unfixed generator: `1 failed` with `RuntimeError: async generator ignored GeneratorExit` (the issue's exact error).
- After the fix: `1 passed`.
- Full file: `uv run --extra dev pytest tests/server/test_stream_events.py` → `17 passed`.

This pull request and its description were written by Isaac.
