### PR TITLE
Hide sidebar Load more for collapsed sections

### DIFF
--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -320,6 +320,31 @@ describe("Sidebar load-more vs collapsed Recent", () => {
     fireEvent.click(screen.getByRole("button", { name: "Recent" }));
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
   });
+
+  it("hides Load more when the only paginated section is collapsed", () => {
+    const rows = [conv("conv_shared", "Claude Code", { permission_level: 2 })];
+    useConvMock.mockImplementation(
+      () =>
+        ({
+          data: {
+            pages: [{ data: rows, first_id: rows[0]!.id, last_id: rows[0]!.id, has_more: true }],
+            pageParams: [undefined],
+          },
+          isLoading: false,
+          isError: false,
+          error: null,
+          fetchNextPage: vi.fn(),
+          hasNextPage: true,
+          isFetchingNextPage: false,
+        }) as unknown as ReturnType<typeof useConversations>,
+    );
+    renderSidebar();
+
+    expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Shared with me" }));
+    expect(screen.queryByText("conv_shared")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
 });
 
 describe("Sidebar mobile overlay background", () => {

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -675,6 +675,9 @@ function ConversationList({
   // Archived sessions are surfaced on the Settings page, not here, so they
   // don't count toward the sidebar's empty-state threshold.
   const totalVisible = sections.pinned.length + sections.sessions.length + sections.shared.length;
+  const hasExpandedPaginatedSection =
+    (sections.sessions.length > 0 && !effectiveCollapsedSections.includes("Recent")) ||
+    (sections.shared.length > 0 && !effectiveCollapsedSections.includes("Shared with me"));
 
   // Section structure comes from the muted micro-headers + whitespace
   // alone (Linear-style) — no divider rules between groups.
@@ -728,9 +731,9 @@ function ConversationList({
           )}
           {/* Archived sessions are no longer listed here — they live on the
               Settings page ("Archived chats"), reachable from the footer. */}
-          {/* Pagination extends the Recent list, so the button hides with
-              it — a Load more under a collapsed group reads orphaned. */}
-          {hasMorePages && !effectiveCollapsedSections.includes("Recent") && (
+          {/* Pagination extends the loaded session sections, so the button
+              hides when every pagination target is collapsed. */}
+          {hasMorePages && hasExpandedPaginatedSection && (
             <button
               type="button"
               disabled={conversationsQuery.isFetchingNextPage}


### PR DESCRIPTION
## Summary
- only show the sidebar Load more button when at least one paginated session section is expanded
- add coverage for the button hiding when the only paginated section is collapsed

## Tests
- npm test -- Sidebar.test.tsx *(fails locally: ap-web/node_modules is missing, vitest not found)*