### PR TITLE
feat(kiro): add Kiro to the `omnigent setup` harness menu

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9853,6 +9853,64 @@ def _manage_hermes_harness() -> None:
                 status = "✗ hermes binary not found"
 
 
+def _manage_kiro_harness() -> None:
+    """Run the level-2 loop for Kiro: ensure the CLI is installed and signed in.
+
+    Kiro owns its own auth via ``kiro-cli login`` (Builder ID / social login /
+    Identity Center) and is installed via Kiro's curl installer — Omnigent stores
+    no Kiro credential. A missing CLI gates the drill-in; when installed, the
+    drill-in offers to launch ``kiro-cli login`` to sign in. Mirrors
+    :func:`_manage_hermes_harness`.
+
+    :returns: None. Side effects: may launch ``kiro-cli login``.
+    """
+    from omnigent.onboarding.harness_install import (
+        KIRO_KEY,
+        harness_cli_installed,
+        harness_install_spec,
+    )
+    from omnigent.onboarding.interactive import console, select
+
+    if not harness_cli_installed(KIRO_KEY):
+        spec = harness_install_spec(KIRO_KEY)
+        hint = (
+            spec.install_hint
+            if spec and spec.install_hint
+            else "curl -fsSL https://cli.kiro.dev/install | bash"
+        )
+        console.print(
+            f"  Kiro isn't installed. Install it with:\n    [bold]{hint}[/bold]\n"
+            "  then re-open this menu."
+        )
+        return
+
+    status: str | None = None
+    while True:
+        rows: list[_HarnessMenuRow] = [
+            _HarnessMenuRow("Run kiro-cli login (sign in)", action="login"),
+            _HarnessMenuRow("← Back", action="back"),
+        ]
+        idx = select(
+            "Kiro",
+            [r.label for r in rows],
+            clear_on_exit=True,
+            status=status,
+        )
+        if idx < 0:
+            return
+        action = rows[idx].action
+        if action == "back":
+            return
+        if action == "login":
+            import subprocess
+
+            try:
+                subprocess.run(["kiro-cli", "login"], check=False)
+                status = "✓ kiro-cli login completed"
+            except FileNotFoundError:
+                status = "✗ kiro-cli binary not found"
+
+
 def _prompt_install_copilot() -> str | None:
     """Offer to install the missing ``copilot`` extra; return a status line.
 
@@ -10572,6 +10630,7 @@ def _run_configure_harnesses_interactive() -> None:
         CURSOR_KEY,
         GOOSE_KEY,
         HERMES_KEY,
+        KIRO_KEY,
         OPENCODE_KEY,
         QWEN_KEY,
         harness_cli_installed,
@@ -10632,6 +10691,10 @@ def _run_configure_harnesses_interactive() -> None:
     # Sentinel marking the Hermes row — like Goose it owns its own auth via
     # ``hermes model`` and is installed via a curl installer.
     _HERMES = "\x00hermes"
+    # Sentinel marking the Kiro row — like Goose/Hermes it owns its own auth (via
+    # ``kiro-cli login``) and is installed via Kiro's curl installer, so it
+    # dispatches to its own drill-in rather than a provider family.
+    _KIRO = "\x00kiro"
     families = [ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE]
     while True:
         config = _load_global_config()
@@ -10873,6 +10936,27 @@ def _run_configure_harnesses_interactive() -> None:
         options.append(f"  {hermes_sub}")
         selectable.append(False)
         row_target.append(None)
+        # Kiro — native kiro-cli TUI (own auth via `kiro-cli login`, installed via
+        # Kiro's curl installer — no npm package or Omnigent credential).
+        kiro_installed = harness_cli_installed(KIRO_KEY)
+        options.append(f"{'  ' if kiro_installed else '[red]✗[/] '}Kiro")
+        selectable.append(True)
+        row_target.append(_KIRO)
+        if not kiro_installed:
+            from rich.markup import escape as _rich_escape
+
+            kiro_spec = harness_install_spec(KIRO_KEY)
+            kiro_hint = _rich_escape(
+                kiro_spec.install_hint
+                if kiro_spec and kiro_spec.install_hint
+                else "curl -fsSL https://cli.kiro.dev/install | bash"
+            )
+            kiro_sub = f"[dim]not installed — open to install ({kiro_hint})[/]"
+        else:
+            kiro_sub = "[green]✓[/] installed — sign in with `kiro-cli login`"
+        options.append(f"  {kiro_sub}")
+        selectable.append(False)
+        row_target.append(None)
         options.append("Quit")
         selectable.append(True)
         row_target.append(_QUIT)
@@ -10901,6 +10985,8 @@ def _run_configure_harnesses_interactive() -> None:
             _manage_goose_harness()
         elif target == _HERMES:
             _manage_hermes_harness()
+        elif target == _KIRO:
+            _manage_kiro_harness()
         else:  # Quit row (or, defensively, a non-family row)
             return
 

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1556,6 +1556,34 @@ def test_overview_marks_unconfigured_with_x_and_configured_without_checkmark(
     assert "no credential yet" in out
 
 
+def test_overview_lists_kiro_native_row(isolated_config, monkeypatch) -> None:
+    """Level 1: Kiro appears as an installable native harness row.
+
+    Kiro (``kiro-native``) is a native CLI harness with its own auth
+    (``kiro-cli login``), so — like Goose/Hermes — it belongs in the setup
+    overview. Absent the CLI it renders a red ✗ plus its curl install hint;
+    installed, it renders ready with the sign-in reminder. A regression that
+    drops the Kiro row (the gap this PR closes) fails here.
+    """
+    # CLI absent → Kiro row + the curl install hint. (The red ✗ marker carries an
+    # ANSI reset between the glyph and the name, so assert on the stable text.)
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_install.harness_cli_installed",
+        lambda family: False,
+    )
+    out = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="q\n").output
+    assert "Kiro" in out
+    assert "cli.kiro.dev/install" in out
+
+    # CLI present → ready row naming the sign-in step (no Omnigent credential).
+    monkeypatch.setattr(
+        "omnigent.onboarding.harness_install.harness_cli_installed",
+        lambda family: True,
+    )
+    out = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="q\n").output
+    assert "kiro-cli login" in out
+
+
 def test_drill_into_uninstalled_installs_then_proceeds(isolated_config, monkeypatch) -> None:
     """Selecting an uninstalled harness → 'Yes, install' runs the install and
     proceeds to credential setup.


### PR DESCRIPTION
## What

Adds a **Kiro** row to the interactive `omnigent setup` harness overview.

## Why

The `kiro-native` harness (landed in #899) registers its install spec in `harness_install.py` but was never wired into the level-1 `omnigent setup` overview. As a result, Kiro couldn't be discovered or installed from the CLI setup flow — it only showed up in the web agent picker. Goose and Hermes (the other own-auth native CLIs installed via a shell script) already have rows there, so this closes a discoverability gap, not a functional one (`omnigent kiro` worked regardless).

## How

Mirrors the Hermes wiring in `_run_configure_harnesses_interactive`:
- a `_KIRO` row sentinel + `KIRO_KEY` import,
- a level-1 row that renders the curl install hint when `kiro-cli` is absent, and a sign-in reminder (`kiro-cli login`) when present,
- dispatch to a new `_manage_kiro_harness` drill-in that offers to run `kiro-cli login`.

Kiro owns its own auth (Builder ID / social login / Identity Center), so there is no Omnigent credential to configure — the drill-in just gates on the binary and surfaces sign-in.

## Test

`test_overview_lists_kiro_native_row` asserts the Kiro row + curl install hint render when the CLI is absent, and that the sign-in step is named when present. Full `tests/cli/test_configure_models.py` passes.

Follow-up to #899.

This pull request and its description were written by Isaac.