### PR TITLE
Warn clearly on Layer 2 compaction auth failures

### DIFF
--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -735,6 +735,39 @@ def _history_idx_to_msg_idx(
     return msg_idx
 
 
+def _exception_status_code(exc: BaseException) -> int | None:
+    """
+    Return the first HTTP-like status code attached to *exc*.
+
+    Provider SDKs and runner calls surface auth failures through
+    different exception shapes (``response.status_code``,
+    ``status_code``, or string ``code``). Walk the exception chain so
+    wrapped OpenAI/httpx errors still classify correctly.
+
+    :param exc: Exception raised during summarization.
+    :returns: HTTP status code, e.g. ``401``, or ``None``.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        response = getattr(current, "response", None)
+        response_status = getattr(response, "status_code", None)
+        if isinstance(response_status, int):
+            return response_status
+        status_code = getattr(current, "status_code", None)
+        if isinstance(status_code, int):
+            return status_code
+        code = getattr(current, "code", None)
+        if isinstance(code, int):
+            return code
+        if isinstance(code, str) and code.isdigit():
+            return int(code)
+        next_exc = current.__cause__ or current.__context__
+        current = next_exc if isinstance(next_exc, BaseException) else None
+    return None
+
+
 async def _run_layer2(
     messages: list[dict[str, Any]],
     history: list[ConversationItem],
@@ -799,12 +832,21 @@ async def _run_layer2(
             model,
             **summarize_kwargs,
         )
-    except Exception:
-        _logger.warning(
-            "Layer 2 summarisation failed for task %s — falling back to Layer 3",
-            task_id,
-            exc_info=True,
-        )
+    except Exception as exc:
+        if _exception_status_code(exc) == 401:
+            _logger.warning(
+                "Layer 2 summarisation received HTTP 401 Unauthorized for task %s; "
+                "check the configured LLM credentials/base URL before relying on "
+                "Layer 3 truncation fallback",
+                task_id,
+                exc_info=True,
+            )
+        else:
+            _logger.warning(
+                "Layer 2 summarisation failed for task %s — falling back to Layer 3",
+                task_id,
+                exc_info=True,
+            )
         if fail_on_error:
             raise
         return None

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -743,6 +744,53 @@ async def test_layer2_failure_falls_back_to_layer3(monkeypatch: pytest.MonkeyPat
     )
     # Some messages must have been returned (Layer 3 truncated, not emptied).
     assert len(result.messages) > 0
+
+
+@pytest.mark.asyncio
+async def test_layer2_401_logs_auth_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A 401 during Layer 2 should name the auth/config problem before
+    falling back to Layer 3.
+    """
+    call_idx = [0]
+
+    def mock_count_tokens(msgs: list[dict[str, Any]], model: str) -> int:
+        """
+        Trigger Layer 2, then let Layer 3 finish after one truncation pass.
+        """
+        call_idx[0] += 1
+        return 10001 if call_idx[0] <= 2 else 50
+
+    monkeypatch.setattr("omnigent.runtime.compaction.count_tokens", mock_count_tokens)
+
+    async def _raise_unauthorized(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Raise an LLM error shaped like a provider HTTP 401."""
+        raise RetryableLLMError("Unauthorized", code="401")
+
+    monkeypatch.setattr(
+        "omnigent.runtime.compaction.summarize_history",
+        _raise_unauthorized,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.runtime.compaction"):
+        result = await compact(
+            [_user_msg_dict("first"), _assistant_msg_dict()],
+            [_user_msg("msg_u1"), _assistant_msg("msg_a1")],
+            config=CompactionConfig(trigger_threshold=0.8, recent_window=1),
+            context_window=12500,
+            system_token_budget=0,
+            model="openai/gpt-4o",
+            task_id="task_401",
+            llm_client=_RaisesIfCalled(),
+        )
+
+    assert result.summary_metadata is None
+    assert "HTTP 401 Unauthorized" in caplog.text
+    assert "configured LLM credentials/base URL" in caplog.text
+    assert "task_401" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- detect HTTP-like 401 errors raised during Layer 2 compaction summarization
- log a clear credentials/base URL warning before falling back to Layer 3
- add regression coverage for the 401 warning path

## Tests
- python3 -m pytest tests/runtime/test_compaction.py -k 'layer2_failure_falls_back_to_layer3 or layer2_401_logs_auth_warning' *(fails locally: pytest is not installed)*
- uv run pytest tests/runtime/test_compaction.py -k 'layer2_failure_falls_back_to_layer3 or layer2_401_logs_auth_warning' *(fails locally: uv is not installed)*