### PR TITLE
Clarify /compact unavailable for model-less harnesses

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10494,8 +10494,12 @@ async def _run_compact_locked(
 
         llm_config = LLMConfig(model=spec.executor.model, connection=spec.executor.connection)
     else:
+        harness = spec.executor.harness_kind
         raise OmnigentError(
-            "Compaction requires a configured LLM model",
+            f"/compact is unavailable for this {harness} session because the agent "
+            "does not declare an LLM model for server-side compaction. Configure "
+            "`llm.model` or `executor.model`, or use a harness-native compaction "
+            "control when one is available.",
             code=ErrorCode.INVALID_INPUT,
         )
     task_id = f"compact_{int(time.time() * 1000)}"

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -622,6 +622,7 @@ def build_agent_bundle(
     skills: list[dict[str, str]] | None = None,
     guardrails: dict[str, Any] | None = None,
     terminals: dict[str, Any] | None = None,
+    include_llm: bool = True,
 ) -> bytes:
     """
     Build a minimal valid agent bundle (tar.gz) for testing.
@@ -655,6 +656,8 @@ def build_agent_bundle(
     :param terminals: Optional ``terminals:`` block written verbatim
         into the spec, e.g. ``{"shell": {"command": "bash"}}``.
         ``None`` omits it (the agent has no terminal access).
+    :param include_llm: Whether to include the default ``llm:`` block.
+        Set ``False`` for model-less harness tests.
     :returns: A gzipped tar archive containing the generated
         ``config.yaml`` plus optional sub-agent and skill files.
     """
@@ -662,15 +665,16 @@ def build_agent_bundle(
     config: dict[str, Any] = {
         "spec_version": 1,
         "name": name,
+    }
+    if include_llm:
         # LLM config is required for the real workflow to execute.
         # The model value must match the agent name used by tests.
-        "llm": {
+        config["llm"] = {
             "model": name,
             # api_key is required by spec validation; the workflow
             # uses the mock LLM client so it's never actually sent.
             "connection": {"api_key": "test-key"},
-        },
-    }
+        }
     if description is not None:
         config["description"] = description
     if guardrails is not None:
@@ -753,6 +757,7 @@ async def create_test_agent(
     skills: list[dict[str, str]] | None = None,
     user: str | None = None,
     guardrails: dict[str, Any] | None = None,
+    include_llm: bool = True,
 ) -> dict[str, Any]:
     """
     Create an agent via multipart session create and return the agent JSON.
@@ -778,6 +783,8 @@ async def create_test_agent(
     :param guardrails: Optional ``guardrails:`` block for the agent
         spec (e.g. a ``cost_budget`` policy). Passed verbatim to
         :func:`build_agent_bundle`. ``None`` omits guardrails.
+    :param include_llm: Whether to include the default ``llm:`` block.
+        Set ``False`` for model-less harness tests.
     :returns: Parsed agent response body from the session agent
         endpoint, with an extra ``_session_id`` key for the owning
         session.
@@ -789,6 +796,7 @@ async def create_test_agent(
         executor=executor,
         skills=skills,
         guardrails=guardrails,
+        include_llm=include_llm,
     )
     metadata: dict[str, Any] = {}
     headers: dict[str, str] = {}

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -204,6 +204,33 @@ async def test_compact_runs_omnigent_compaction_when_runner_noops(
     )
 
 
+async def test_compact_model_less_sdk_harness_returns_clear_unavailable_message(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A model-less SDK-style harness should not expose the raw server-side
+    compaction model requirement.
+    """
+    agent = await create_test_agent(
+        client,
+        name="model-less-sdk",
+        executor={"type": "agents_sdk"},
+        include_llm=False,
+    )
+    sid = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "compact", "data": {}},
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert "/compact is unavailable" in resp.text
+    assert "agents_sdk" in resp.text
+    assert "llm.model" in resp.text
+    assert "executor.model" in resp.text
+
+
 async def test_compact_errors_when_runner_injection_fails(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -214,7 +214,10 @@ async def test_compact_model_less_sdk_harness_returns_clear_unavailable_message(
     agent = await create_test_agent(
         client,
         name="model-less-sdk",
-        executor={"type": "agents_sdk"},
+        # Explicit harness: build_agent_bundle defaults config.harness to
+        # "claude-sdk", which harness_kind would echo instead of the real
+        # model-less SDK harness under test.
+        executor={"type": "omnigent", "config": {"harness": "openai-agents"}},
         include_llm=False,
     )
     sid = await _create_session(client, agent["id"])
@@ -226,7 +229,7 @@ async def test_compact_model_less_sdk_harness_returns_clear_unavailable_message(
 
     assert resp.status_code == 400, resp.text
     assert "/compact is unavailable" in resp.text
-    assert "agents_sdk" in resp.text
+    assert "openai-agents" in resp.text
     assert "llm.model" in resp.text
     assert "executor.model" in resp.text
 


### PR DESCRIPTION
## Summary
- replace the raw model requirement error with a harness-specific /compact unavailable message
- allow test bundles to omit the default llm block for model-less harness coverage
- add integration coverage for a model-less agents_sdk session

## Tests
- python3 -m compileall omnigent/server/routes/sessions.py tests/server/helpers.py tests/server/integration/test_sessions_compact.py
- python3 -m pytest tests/server/integration/test_sessions_compact.py -k model_less_sdk *(not run: pytest is not installed in this checkout)*