### PR TITLE
fix(antigravity): bidirectional elicitation sync for agy native (#1200)

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -815,3 +815,53 @@ def inject_user_message_via_tui(
             time.sleep(_TMUX_POLL_INTERVAL_S)
     time.sleep(_PASTE_SETTLE_S)
     _submit_and_verify(socket_path, tmux_target)
+
+
+def send_interaction_keys_via_tui(
+    bridge_dir: Path,
+    *keys: str,
+) -> None:
+    """
+    Send raw key arguments to the agy TUI pane to answer its in-process prompt.
+
+    The companion to :func:`inject_user_message_via_tui` for the OTHER thing the
+    attended agy TUI maintains in parallel with the RPC step state: its
+    **in-process permission / question prompt**. When agy runs attended (the
+    web/mobile path types every turn into the TUI), an approval surfaces in the
+    Omnigent web UI AND as agy's own numbered TUI prompt ("Do you want to
+    proceed?", 1.Yes … 4.No). Delivering the verdict over
+    :func:`omnigent.antigravity_native_rpc.handle_user_interaction` flips the
+    backend trajectory step to DONE and the command runs, but the **TUI prompt
+    for that interaction can stay open** — and the next typed turn then lands in
+    that stale prompt's filter/amend buffer instead of starting a fresh turn
+    (live-verified; see ``docs/claude/antigravity-rpc-spike-notes.md`` §"attended
+    TUI"). So the bridge ALSO types the selection into the pane to dismiss the
+    prompt, mirroring cursor-native's
+    :func:`omnigent.cursor_native_bridge.send_cursor_pane_keys`.
+
+    Each argument is a tmux ``send-keys`` key argument — a bare ``"1"`` / ``"4"``
+    selects a numbered option, ``"Enter"`` confirms, ``"Escape"`` cancels — sent
+    in order as ONE ``send-keys`` invocation so the digit and its Enter cannot be
+    reordered or split across the pane's input handling. Keys are interpreted by
+    tmux (no ``-l``), so named keys like ``Enter`` / ``Escape`` work.
+
+    :param bridge_dir: Native Antigravity bridge directory holding ``tmux.json``.
+    :param keys: Ordered tmux key arguments, e.g. ``("1", "Enter")`` to approve.
+    :returns: None.
+    :raises RuntimeError: When the tmux target is not advertised, the agy TUI has
+        exited, or the ``send-keys`` invocation fails.
+    """
+    if not keys:
+        raise RuntimeError("antigravity-native TUI selection requires at least one key")
+    info = read_tmux_info(bridge_dir)
+    if info is None:
+        raise RuntimeError(
+            "antigravity-native tmux target not advertised (is the agy terminal running?)"
+        )
+    socket_path = info["socket_path"]
+    tmux_target = info["tmux_target"]
+    if not _session_alive(socket_path, tmux_target):
+        raise RuntimeError(
+            "the agy terminal is no longer running (the TUI exited); restart the session"
+        )
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, *keys)

--- a/omnigent/antigravity_native_interactions.py
+++ b/omnigent/antigravity_native_interactions.py
@@ -35,6 +35,15 @@ Seam design (so the timeout logic is unit-testable without a live agy):
 * ``deliver`` — defaults to :func:`_deliver_via_rpc`, which offloads the blocking
   :func:`omnigent.antigravity_native_rpc.handle_user_interaction` to a worker
   thread (the function is synchronous); injectable so tests don't need a live agy.
+* ``inject_tui`` — defaults to :func:`_inject_via_tui`, which types the verdict's
+  key sequence into the agy TUI pane AFTER the RPC delivery. The attended agy TUI
+  keeps its OWN permission/question prompt open in parallel with the RPC step
+  (live-verified — ``docs/claude/antigravity-rpc-spike-notes.md`` §"attended
+  TUI"): the RPC flips the backend step to DONE, but the TUI prompt lingers, so a
+  web Approve/Reject would not advance the terminal (and the next typed turn would
+  fold into the stale prompt's buffer) without this keystroke (#1200). Injectable
+  so tests assert the key sequence without a live pane; mirrors cursor-native's
+  ``send_cursor_pane_keys`` approval drive.
 
 The deterministic elicitation id is derived from
 ``(cascade_id, trajectory_id, step_index)`` (mirrors
@@ -60,6 +69,7 @@ from omnigent.antigravity_native_steps import PendingInteraction, pending_intera
 from omnigent.server.routes._antigravity_elicitation import (
     to_elicitation_params,
     to_interaction_payload,
+    to_tui_selection_keys,
 )
 from omnigent.server.schemas import ElicitationRequestParams, ElicitationResult
 
@@ -120,6 +130,41 @@ class Deliver(Protocol):
     ) -> None:
         """Deliver one interaction answer to agy (see ``handle_user_interaction``)."""
         ...
+
+
+# Types the verdict's tmux key sequence into the agy TUI pane to dismiss its
+# in-process prompt (see ``_inject_via_tui`` / the module's "attended TUI" note).
+InjectTui = Callable[[list[str]], Awaitable[None]]
+
+
+async def _inject_via_tui(keys: list[str]) -> None:
+    """
+    Default :class:`InjectTui`: type the verdict keys into the agy TUI pane.
+
+    Offloads the blocking tmux ``send-keys`` (via
+    :func:`omnigent.antigravity_native_bridge.send_interaction_keys_via_tui`) to a
+    worker thread — the same pattern :func:`_deliver_via_rpc` uses for the RPC —
+    so the async bridge does not stall the event loop. The bridge directory is
+    resolved from the harness spawn env (the reader/CLI both run with it set), so
+    this seam takes only the keys.
+
+    A missing tmux target / exited pane raises ``RuntimeError`` from the bridge
+    primitive; the caller logs it and proceeds (the RPC delivery already advanced
+    the backend step — the keystroke is the belt-and-braces TUI dismissal).
+
+    :param keys: Ordered tmux key arguments (e.g. ``["1", "Enter"]`` to approve).
+    :returns: None.
+    :raises RuntimeError: Propagated from the bridge primitive (no target / pane
+        exited / send-keys failed).
+    """
+    # Lazy imports: keep this module importable from the lightweight CLI process
+    # without eagerly pulling the bridge env helpers, and resolve the bridge dir
+    # the same way the executor does.
+    from omnigent.antigravity_native_bridge import send_interaction_keys_via_tui
+    from omnigent.inner.antigravity_native_executor import _bridge_dir_from_env
+
+    bridge_dir = _bridge_dir_from_env()
+    await asyncio.to_thread(send_interaction_keys_via_tui, bridge_dir, *keys)
 
 
 def agy_elicitation_id(cascade_id: str, trajectory_id: str, step_index: int) -> str:
@@ -235,6 +280,7 @@ async def bridge_interaction(
     get_steps: GetSteps,
     request_elicitation: RequestElicitation,
     deliver: Deliver = _deliver_via_rpc,
+    inject_tui: InjectTui = _inject_via_tui,
     max_retries: int = _DEFAULT_MAX_RETRIES,
 ) -> None:
     """
@@ -271,6 +317,13 @@ async def bridge_interaction(
         :func:`_deliver_via_rpc`, which offloads the blocking
         :func:`omnigent.antigravity_native_rpc.handle_user_interaction` to a
         worker thread.
+    :param inject_tui: Types the verdict's key sequence into the agy TUI pane to
+        dismiss its in-process prompt AFTER a successful RPC delivery; defaults to
+        :func:`_inject_via_tui` (offloads ``send-keys`` to a worker thread). The
+        RPC flips the backend step, but the attended TUI keeps its own prompt open
+        in parallel — so the keystroke is required to actually advance the
+        terminal (#1200). A failure here is logged, not raised: the backend step
+        is already answered, so the turn proceeds regardless.
     :param max_retries: Upper bound on detect→deliver iterations.
     :returns: None. Never raises on the expected timeout/cancel/RPC-error paths —
         all are logged and end the loop so the long-lived caller stays alive.
@@ -321,6 +374,29 @@ async def bridge_interaction(
                 step_index=fresh["step_index"],
                 payload=payload,
             )
+            # The RPC flipped the backend trajectory step, but the attended agy
+            # TUI keeps its OWN permission/question prompt open in parallel
+            # (live-verified — see the module note / spike doc). Type the verdict's
+            # selection into the pane so the terminal actually advances (#1200) and
+            # the next typed turn does not land in the stale prompt's buffer. The
+            # backend is already answered, so a TUI-typing failure is logged, not
+            # raised — never undo a delivered verdict over a flaky pane.
+            keys = to_tui_selection_keys(current["kind"], result, current["spec"])
+            if keys:
+                try:
+                    await inject_tui(keys)
+                except Exception as tui_exc:
+                    # Best-effort TUI dismissal — the backend step is already
+                    # answered, so never undo a delivered verdict over a flaky pane.
+                    _logger.warning(
+                        "agy interaction delivered over RPC but TUI dismissal failed "
+                        "(cascade=%s, kind=%s, step=%d, keys=%r): %r",
+                        cascade_id,
+                        current["kind"],
+                        fresh["step_index"],
+                        keys,
+                        tui_exc,
+                    )
             return  # delivered successfully
         except AntigravityRpcError as exc:
             if _INPUT_NOT_REGISTERED not in str(exc).lower():

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -188,6 +188,19 @@ _StepKey = tuple[str | None, int | None, str | None]
 _EXTERNAL_SESSION_USAGE = "external_session_usage"
 _EXTERNAL_MODEL_CHANGE = "external_model_change"
 
+# Event that WITHDRAWS a surfaced elicitation whose WAITING step left WAITING
+# out-of-band (answered directly in the agy TUI, or agy timed out / auto-resolved
+# it). Posting it sets the server's parked-future ``resolved_elsewhere`` flag,
+# which (a) returns ``None`` from any in-flight ``request_elicitation`` long-poll
+# — so ``bridge_interaction`` does NOT then deliver a stale verdict — and (b)
+# clears the web approval card so the chat stops showing "Respond to the pending
+# request above to continue." Mirrors cursor-native's
+# ``_post_external_elicitation_resolved`` (#1200, direction 2). The reader's own
+# web→TUI delivery, by contrast, does NOT post this: the WAITING step there leaves
+# WAITING because the bridge ALREADY resolved the card (the human's verdict), so
+# the reader must not double-resolve it — see :func:`_maybe_withdraw_interaction`.
+_EXTERNAL_ELICITATION_RESOLVED = "external_elicitation_resolved"
+
 # Async callback handed each distinct WAITING interaction. It receives the SAME
 # ``cascade_id`` + connect-RPC ``port`` the reader discovered and is using, so the
 # Task 8 interaction bridge it drives targets agy's live conversation WITHOUT
@@ -1086,6 +1099,12 @@ class _ReaderState:
         a day); at most one runs at a time because the in-flight bridge owns agy's
         WAITING-timeout retries (a second would double-fire). Cancelled on reader
         teardown.
+    :param surfaced_elicitations: ``_StepKey`` → the deterministic elicitation id
+        published for that WAITING step. Populated when an interaction is handed to
+        the bridge; consumed by :func:`_maybe_withdraw_interaction` when the step
+        is later seen NO LONGER WAITING (answered in the agy TUI, or agy timed
+        out) to WITHDRAW the still-parked web card (#1200, direction 2). An entry
+        is removed once withdrawn so the withdraw posts at most once.
     """
 
     allocator: _ToolCallIdAllocator
@@ -1101,6 +1120,7 @@ class _ReaderState:
     cumulative_output_tokens: int = 0
     cumulative_cache_read_input_tokens: int = 0
     interaction_task: asyncio.Task[None] | None = None
+    surfaced_elicitations: dict[_StepKey, str] = field(default_factory=dict)
 
 
 async def _poll_loop(
@@ -1344,6 +1364,19 @@ async def _process_committed_step(
         cascade_id=cascade_id,
         state=state,
         on_pending_interaction=on_pending_interaction,
+    )
+    # Inverse of the above (#1200, direction 2): if a step we previously surfaced
+    # is now NO LONGER WAITING (answered in the agy TUI, or agy timed out), withdraw
+    # the parked web card so it does not linger. Runs unconditionally — including
+    # for an already-``seen`` step — because a WAITING step is not ``seen`` until it
+    # settles, so its terminal transition arrives as a fresh (not-yet-seen) step
+    # here; the dedup lives in ``surfaced_elicitations`` (popped on first withdraw).
+    await _maybe_withdraw_interaction(
+        step,
+        key=key,
+        client=client,
+        session_id=session_id,
+        state=state,
     )
 
 
@@ -1712,6 +1745,17 @@ def _maybe_handle_interaction(
         # WAITING-timeout retries, so don't double-fire on the retry step.
         return
     state.interacted.add(key)
+    # Record the deterministic elicitation id this WAITING step surfaces, so that
+    # if the step later leaves WAITING out-of-band (answered in the agy TUI, or
+    # agy timed it out) :func:`_maybe_withdraw_interaction` can WITHDRAW the parked
+    # web card (#1200, direction 2). ``agy_elicitation_id`` is lazily imported —
+    # like ``bridge_interaction`` — so the reader stays importable from the
+    # lightweight CLI process without eagerly pulling the server-route stack.
+    from omnigent.antigravity_native_interactions import agy_elicitation_id
+
+    state.surfaced_elicitations[key] = agy_elicitation_id(
+        cascade_id, pending["trajectory_id"], pending["step_index"]
+    )
 
     async def _run_bridge() -> None:
         await on_pending_interaction(cascade_id, state.port, pending)
@@ -1731,6 +1775,114 @@ def _maybe_handle_interaction(
     task = asyncio.create_task(_run_bridge(), name="antigravity-interaction-bridge")
     state.interaction_task = task
     task.add_done_callback(_clear_slot)
+
+
+async def _maybe_withdraw_interaction(
+    step: dict[str, object],
+    *,
+    key: _StepKey,
+    client: httpx.AsyncClient,
+    session_id: str,
+    state: _ReaderState,
+) -> None:
+    """
+    Withdraw a surfaced elicitation whose WAITING step left WAITING (#1200, dir 2).
+
+    The inverse of :func:`_maybe_handle_interaction`. The reader publishes an
+    elicitation when it first sees a WAITING permission/ask_question step; but a
+    step can stop being WAITING without the WEB card being answered — the user
+    types the answer directly in the agy TUI pane, or agy times out / auto-resolves
+    the interaction. Without this, the parked web card LINGERS forever, showing
+    "Respond to the pending request above to continue" while the agent has already
+    moved on.
+
+    So: when a step the reader previously surfaced is, on a later poll/frame, NO
+    LONGER WAITING, POST ``external_elicitation_resolved`` for its elicitation id.
+    Server-side this sets the parked future's ``resolved_elsewhere`` flag, which
+    (a) clears the web card, and (b) makes any in-flight ``request_elicitation``
+    long-poll return ``None`` — so a racing :func:`bridge_interaction` does NOT
+    then deliver a stale verdict (the await short-circuits cleanly). Mirrors
+    cursor-native's ``_post_external_elicitation_resolved``.
+
+    Idempotency / no double-resolve: the entry is popped from
+    ``surfaced_elicitations`` so the withdraw posts AT MOST ONCE per step. This is
+    safe even when the step left WAITING because the WEB verdict resolved it (the
+    bridge delivered): the server already consumed that parked future, so the
+    withdraw finds none and merely tombstones the id (harmless) — it can never
+    re-deliver, because the bridge's ``request_elicitation`` already returned the
+    real verdict and the elicitation id is unique per ``step_index``.
+
+    :param step: One RPC step dict (any status).
+    :param key: The step's identity key (already computed by the caller).
+    :param client: HTTP client for the Omnigent event POST.
+    :param session_id: Omnigent conversation id whose card to withdraw.
+    :param state: Per-run reader state — ``surfaced_elicitations`` is read/mutated.
+    :returns: None.
+    """
+    elicitation_id = state.surfaced_elicitations.get(key)
+    if elicitation_id is None:
+        return
+    # Still WAITING → the interaction is live; nothing to withdraw yet.
+    if pending_interaction(step) is not None:
+        return
+    # Left WAITING out-of-band (or the web verdict already advanced it): withdraw
+    # the card exactly once.
+    state.surfaced_elicitations.pop(key, None)
+    await _post_external_elicitation_resolved(client, session_id, elicitation_id)
+
+
+async def _post_external_elicitation_resolved(
+    client: httpx.AsyncClient,
+    session_id: str,
+    elicitation_id: str,
+) -> None:
+    """
+    Tell the server a surfaced agy elicitation was resolved/withdrawn out-of-band.
+
+    POSTs ``external_elicitation_resolved`` so the parked web card clears and any
+    in-flight ``request_elicitation`` long-poll returns ``None``. Best-effort: a
+    transport error or a non-2xx is logged, never raised — a failed withdraw must
+    not crash the reader loop (the next signal, or agy's own timeout, recovers).
+    Mirrors cursor-native's ``_post_external_elicitation_resolved``.
+
+    :param client: HTTP client for Omnigent event posts (the reader's client).
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param elicitation_id: The deterministic agy elicitation id to withdraw.
+    :returns: None.
+    """
+    try:
+        response = await client.post(
+            f"/v1/sessions/{url_component(session_id)}/events",
+            json={
+                "type": _EXTERNAL_ELICITATION_RESOLVED,
+                "data": {"elicitation_id": elicitation_id},
+            },
+        )
+    except httpx.HTTPError:
+        _logger.warning(
+            "agy external_elicitation_resolved POST failed; the web card may linger "
+            "until agy's own timeout: session=%s elicitation_id=%s",
+            session_id,
+            elicitation_id,
+            exc_info=True,
+        )
+        return
+    if response.status_code >= 400:
+        _logger.warning(
+            "agy external_elicitation_resolved rejected: session=%s elicitation_id=%s "
+            "status=%s body=%s",
+            session_id,
+            elicitation_id,
+            response.status_code,
+            response.text[:512],
+        )
+        return
+    _logger.info(
+        "agy withdrew a surfaced elicitation resolved out-of-band (TUI answer / "
+        "timeout): session=%s elicitation_id=%s",
+        session_id,
+        elicitation_id,
+    )
 
 
 async def _maybe_emit_session_usage(

--- a/omnigent/server/routes/_antigravity_elicitation.py
+++ b/omnigent/server/routes/_antigravity_elicitation.py
@@ -325,3 +325,92 @@ def _agy_permission_response(result: ElicitationResult) -> dict[str, Any]:
     :returns: ``{"permission": {"allow": <bool>}}``
     """
     return {"permission": {"allow": result.action == "accept"}}
+
+
+# agy's attended-TUI permission prompt is a numbered list: option 1 is the bare
+# "Yes" (approve once) and the LAST option is "No" (decline). The web card is a
+# binary Approve/Reject (the non-1:1 mapping with options 2/3 — the "always
+# allow" variants — is intentionally acceptable, #1200), so Approve drives the
+# always-safe "Yes" (1) and Reject drives "No" (4). These are the digits typed
+# into the pane, each followed by Enter to confirm the selection.
+_AGY_TUI_PERMISSION_APPROVE_OPTION = "1"
+_AGY_TUI_PERMISSION_REJECT_OPTION = "4"
+_AGY_TUI_CONFIRM_KEY = "Enter"
+
+
+def to_tui_selection_keys(
+    kind: str,
+    result: ElicitationResult,
+    spec: dict[str, Any],
+) -> list[str]:
+    """
+    Map an elicitation result to the tmux keys that answer agy's TUI prompt.
+
+    The attended agy TUI maintains its own permission / question prompt IN
+    PARALLEL with the RPC trajectory step (live-verified; see
+    ``docs/claude/antigravity-rpc-spike-notes.md``). Delivering the verdict over
+    ``HandleCascadeUserInteraction`` flips the backend step but can leave that TUI
+    prompt open, stranding the terminal (and folding the next typed turn into the
+    stale prompt's buffer — #1200). So the bridge ALSO types the selection into
+    the pane via
+    :func:`omnigent.antigravity_native_bridge.send_interaction_keys_via_tui`,
+    mirroring cursor-native. This is the pure shape-mapper for those keys.
+
+    * **permission** — Approve → option ``"1"`` ("Yes"), Reject → option ``"4"``
+      ("No"), each followed by ``Enter``. (The card is binary; the non-1:1 map
+      with the "always allow" variants 2/3 is intentionally acceptable, #1200.)
+    * **ask_question** — type the selected option id(s) ("1".."N") then ``Enter``;
+      agy's TUI numbers questions' options the same way its RPC ``selectedOptionIds``
+      do. A decline/cancel (or no usable selection) presses ``Escape`` to dismiss.
+
+    :param kind: Interaction kind — ``"ask_question"`` or ``"permission"``.
+    :param result: The web-submitted elicitation verdict.
+    :param spec: The original ``askQuestion`` / ``permission`` block (used to map
+        an ask_question answer's option labels back to ids).
+    :returns: Ordered tmux key arguments to send into the agy pane (possibly
+        empty when no keystroke is warranted, e.g. an unsupported kind).
+    :raises ValueError: When ``kind`` is not ``"ask_question"`` or ``"permission"``.
+    """
+    if kind == "permission":
+        option = (
+            _AGY_TUI_PERMISSION_APPROVE_OPTION
+            if result.action == "accept"
+            else _AGY_TUI_PERMISSION_REJECT_OPTION
+        )
+        return [option, _AGY_TUI_CONFIRM_KEY]
+    if kind == "ask_question":
+        return _agy_ask_question_tui_keys(result, spec)
+    raise ValueError(f"Unsupported agy interaction kind: {kind!r}")
+
+
+def _agy_ask_question_tui_keys(
+    result: ElicitationResult,
+    spec: dict[str, Any],
+) -> list[str]:
+    """
+    Map an ``ask_question`` result to the tmux keys answering agy's TUI prompt.
+
+    Reuses :func:`_agy_ask_question_response` to resolve the web answer back to
+    agy's option ids (``"1".."N"``), then types the FIRST question's selected
+    option id(s) followed by ``Enter``. agy's TUI shows one question's options as
+    a numbered list, so the option id is exactly the digit to press. A decline /
+    cancel — or any answer that resolves to no concrete option id — presses
+    ``Escape`` to dismiss the prompt (the RPC ``askQuestion`` skip already tells
+    the backend; the keystroke clears the TUI surface).
+
+    :param result: The web-submitted elicitation verdict.
+    :param spec: The ``askQuestion`` spec block (option id↔text map).
+    :returns: Ordered tmux key arguments (digits + ``Enter``, or ``["Escape"]``).
+    """
+    payload = _agy_ask_question_response(result, spec)
+    responses = payload.get("askQuestion", {}).get("responses", [])
+    selected: list[str] = []
+    if isinstance(responses, list) and responses:
+        first = responses[0]
+        if isinstance(first, dict):
+            ids = first.get("selectedOptionIds")
+            if isinstance(ids, list):
+                selected = [oid for oid in ids if isinstance(oid, str) and oid]
+    if not selected:
+        return ["Escape"]
+    return [*selected, _AGY_TUI_CONFIRM_KEY]

--- a/tests/server/test_antigravity_elicitation.py
+++ b/tests/server/test_antigravity_elicitation.py
@@ -10,6 +10,7 @@ import pytest
 from omnigent.server.routes._antigravity_elicitation import (
     to_elicitation_params,
     to_interaction_payload,
+    to_tui_selection_keys,
 )
 from omnigent.server.schemas import ElicitationResult
 
@@ -385,6 +386,78 @@ class TestToInteractionPayloadPermission:
         result = ElicitationResult(action="cancel")
         payload = to_interaction_payload("permission", result, self._spec())
         assert payload == {"permission": {"allow": False}}
+
+
+# ── to_tui_selection_keys: web verdict → agy TUI keystrokes (#1200) ──
+
+
+class TestToTuiSelectionKeysPermission:
+    """Tests for permission verdict → agy TUI numbered-prompt keystrokes."""
+
+    def _spec(self) -> dict[str, object]:
+        spec = _PERMISSION_PENDING["spec"]
+        assert isinstance(spec, dict)
+        return spec
+
+    def test_accept_types_option_1_then_enter(self) -> None:
+        """Approve → option 1 ("Yes") + Enter (the always-safe choice)."""
+        result = ElicitationResult(action="accept")
+        assert to_tui_selection_keys("permission", result, self._spec()) == ["1", "Enter"]
+
+    def test_decline_types_option_4_then_enter(self) -> None:
+        """Reject → option 4 ("No") + Enter."""
+        result = ElicitationResult(action="decline")
+        assert to_tui_selection_keys("permission", result, self._spec()) == ["4", "Enter"]
+
+    def test_cancel_types_option_4_then_enter(self) -> None:
+        """Cancel maps to the reject option, like the RPC ``allow: False`` path."""
+        result = ElicitationResult(action="cancel")
+        assert to_tui_selection_keys("permission", result, self._spec()) == ["4", "Enter"]
+
+
+class TestToTuiSelectionKeysAskQuestion:
+    """Tests for ask_question verdict → agy TUI numbered-prompt keystrokes."""
+
+    def _spec(self) -> dict[str, object]:
+        spec = _ASK_QUESTION_PENDING["spec"]
+        assert isinstance(spec, dict)
+        return spec
+
+    def test_accept_types_selected_option_id_then_enter(self) -> None:
+        """A single-select answer types its option id + Enter."""
+        result = ElicitationResult(action="accept", content={"0": "CLI tool"})
+        assert to_tui_selection_keys("ask_question", result, self._spec()) == ["2", "Enter"]
+
+    def test_multi_select_types_all_ids_then_enter(self) -> None:
+        """A multi-select answer types every selected option id, then Enter."""
+        spec = _MULTI_SELECT_PENDING["spec"]
+        assert isinstance(spec, dict)
+        result = ElicitationResult(action="accept", content={"0": ["React", "Angular"]})
+        assert to_tui_selection_keys("ask_question", result, spec) == ["1", "3", "Enter"]
+
+    def test_decline_types_escape(self) -> None:
+        """A decline (no concrete option id) dismisses the TUI prompt with Escape."""
+        result = ElicitationResult(action="decline")
+        assert to_tui_selection_keys("ask_question", result, self._spec()) == ["Escape"]
+
+    def test_write_in_only_answer_types_escape(self) -> None:
+        """An answer that is purely free-form (no matching option id) → Escape.
+
+        agy's TUI numbered prompt cannot accept a write-in by digit; the RPC
+        ``writeInResponse`` carries the text, so the keystroke just dismisses the
+        stale TUI surface.
+        """
+        result = ElicitationResult(action="accept", content={"0": "Something custom"})
+        assert to_tui_selection_keys("ask_question", result, self._spec()) == ["Escape"]
+
+
+class TestToTuiSelectionKeysUnknownKind:
+    """Guard against unknown interaction kinds in the TUI-key mapper."""
+
+    def test_unknown_kind_raises(self) -> None:
+        result = ElicitationResult(action="accept")
+        with pytest.raises(ValueError, match="unknown_kind"):
+            to_tui_selection_keys("unknown_kind", result, {})
 
 
 # ── unknown kind guard ───────────────────────────────────────────────

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -21,6 +21,7 @@ from omnigent.antigravity_native_bridge import (
     prepare_bridge_dir,
     read_bridge_state,
     read_tmux_info,
+    send_interaction_keys_via_tui,
     update_conversation_id,
     write_bridge_state,
     write_tmux_target,
@@ -1005,3 +1006,86 @@ def test_inject_user_message_via_tui_rejects_empty_content(tmp_path: Path) -> No
     """Empty content is a programming error, not something to type into the TUI."""
     with pytest.raises(RuntimeError, match="non-empty content"):
         inject_user_message_via_tui(tmp_path / "bridge", content="")
+
+
+# ---------------------------------------------------------------------------
+# Interaction-prompt TUI delivery (send_interaction_keys_via_tui) — #1200
+# ---------------------------------------------------------------------------
+
+
+def test_send_interaction_keys_via_tui_sends_one_send_keys_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The verdict keys go out as ONE ``send-keys`` so digit + Enter stay together."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+    captured: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "has-session" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        captured.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    send_interaction_keys_via_tui(bridge_dir, "1", "Enter")
+
+    assert captured == [
+        ["tmux", "-S", "/tmp/ex/tmux.sock", "send-keys", "-t", "main", "1", "Enter"]
+    ]
+
+
+def test_send_interaction_keys_via_tui_reject_sequence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reject verdict's ``4`` + Enter sequence is forwarded verbatim."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+    captured: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "has-session" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        captured.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    send_interaction_keys_via_tui(bridge_dir, "4", "Enter")
+
+    assert captured == [
+        ["tmux", "-S", "/tmp/ex/tmux.sock", "send-keys", "-t", "main", "4", "Enter"]
+    ]
+
+
+def test_send_interaction_keys_via_tui_raises_without_target(tmp_path: Path) -> None:
+    """No advertised tmux target → a clear RuntimeError (no silent drop)."""
+    with pytest.raises(RuntimeError, match="tmux target not advertised"):
+        send_interaction_keys_via_tui(tmp_path / "bridge", "1", "Enter")
+
+
+def test_send_interaction_keys_via_tui_raises_when_pane_gone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exited agy pane → RuntimeError so the bridge logs the best-effort miss."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        # has-session reports the pane is gone (non-zero exit).
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(RuntimeError, match="no longer running"):
+        send_interaction_keys_via_tui(bridge_dir, "1", "Enter")
+
+
+def test_send_interaction_keys_via_tui_rejects_empty_keys(tmp_path: Path) -> None:
+    """No keys is a programming error, not an empty send-keys call."""
+    with pytest.raises(RuntimeError, match="at least one key"):
+        send_interaction_keys_via_tui(tmp_path / "bridge")

--- a/tests/test_antigravity_native_interactions.py
+++ b/tests/test_antigravity_native_interactions.py
@@ -202,6 +202,31 @@ class _DeliverRecorder:
                 raise err
 
 
+class _InjectTuiRecorder:
+    """
+    Records every ``inject_tui`` call's key sequence (and optionally raises).
+
+    Stands in for :func:`_inject_via_tui` so a test can assert the EXACT tmux key
+    sequence the bridge types into the agy TUI pane after a successful RPC
+    delivery (#1200), without a live pane. Mirrors :class:`_DeliverRecorder`.
+    """
+
+    def __init__(self, *, error: Exception | None = None) -> None:
+        """
+        :param error: When not ``None``, raised on every call so a test can drive
+            the best-effort "TUI dismissal failed but the verdict still landed"
+            branch.
+        """
+        self.calls: list[list[str]] = []
+        self._error = error
+
+    async def __call__(self, keys: list[str]) -> None:
+        """Record one TUI key sequence, raising the scripted error if set."""
+        self.calls.append(list(keys))
+        if self._error is not None:
+            raise self._error
+
+
 def _steps_returner(*frames: list[dict[str, Any]]) -> Any:
     """
     Build a ``get_steps`` fake that returns successive snapshots per call.
@@ -259,6 +284,7 @@ async def test_happy_path_delivers_selected_option_to_fresh_step() -> None:
         ElicitationResult(action="accept", content={"0": "Second"})
     )
     deliver = _DeliverRecorder()
+    inject_tui = _InjectTuiRecorder()
 
     await bridge_interaction(
         _CASCADE,
@@ -267,6 +293,7 @@ async def test_happy_path_delivers_selected_option_to_fresh_step() -> None:
         get_steps=_steps_returner([waiting]),
         request_elicitation=request,
         deliver=deliver,
+        inject_tui=inject_tui,
     )
 
     assert len(deliver.calls) == 1
@@ -279,6 +306,8 @@ async def test_happy_path_delivers_selected_option_to_fresh_step() -> None:
     # The elicitation was published under the deterministic id for these ids.
     assert len(elicit_calls) == 1
     assert elicit_calls[0][0] == agy_elicitation_id(_CASCADE, _TRAJ, 3)
+    # The TUI prompt was dismissed by typing the selected option id + Enter.
+    assert inject_tui.calls == [["2", "Enter"]]
 
 
 # ---------------------------------------------------------------------------
@@ -371,6 +400,7 @@ async def test_permission_accept_delivers_allow_true() -> None:
     waiting = _permission_step(step_index=2)
     request, _ = _elicitation_returner(ElicitationResult(action="accept", content=None))
     deliver = _DeliverRecorder()
+    inject_tui = _InjectTuiRecorder()
 
     await bridge_interaction(
         _CASCADE,
@@ -379,11 +409,94 @@ async def test_permission_accept_delivers_allow_true() -> None:
         get_steps=_steps_returner([waiting]),
         request_elicitation=request,
         deliver=deliver,
+        inject_tui=inject_tui,
     )
 
     assert len(deliver.calls) == 1
     assert deliver.calls[0]["payload"] == {"permission": {"allow": True}}
     assert deliver.calls[0]["step_index"] == 2
+    # #1200: Approve drives agy's TUI prompt to option 1 ("Yes") + Enter, so the
+    # attended terminal advances (the RPC alone leaves the TUI prompt open).
+    assert inject_tui.calls == [["1", "Enter"]]
+
+
+@pytest.mark.asyncio
+async def test_permission_reject_delivers_allow_false_and_types_no() -> None:
+    """Permission rejected → deliver ``allow: False`` AND type option 4 ("No")."""
+    pending = _pending_permission(step_index=2)
+    waiting = _permission_step(step_index=2)
+    request, _ = _elicitation_returner(ElicitationResult(action="decline", content=None))
+    deliver = _DeliverRecorder()
+    inject_tui = _InjectTuiRecorder()
+
+    await bridge_interaction(
+        _CASCADE,
+        pending,
+        port=52548,
+        get_steps=_steps_returner([waiting]),
+        request_elicitation=request,
+        deliver=deliver,
+        inject_tui=inject_tui,
+    )
+
+    assert deliver.calls[0]["payload"] == {"permission": {"allow": False}}
+    # #1200: Reject drives agy's TUI prompt to option 4 ("No") + Enter.
+    assert inject_tui.calls == [["4", "Enter"]]
+
+
+@pytest.mark.asyncio
+async def test_tui_dismissal_failure_does_not_undo_delivered_verdict() -> None:
+    """A TUI send-keys failure is best-effort: the RPC verdict still stands.
+
+    The backend step is already answered by the time the keystroke is typed, so a
+    flaky/exited pane must NOT raise out of ``bridge_interaction`` (which would
+    look like the verdict failed). The delivery is recorded; the TUI error is
+    swallowed (logged).
+    """
+    pending = _pending_permission(step_index=2)
+    waiting = _permission_step(step_index=2)
+    request, _ = _elicitation_returner(ElicitationResult(action="accept", content=None))
+    deliver = _DeliverRecorder()
+    inject_tui = _InjectTuiRecorder(error=RuntimeError("the agy terminal exited"))
+
+    await bridge_interaction(
+        _CASCADE,
+        pending,
+        port=52548,
+        get_steps=_steps_returner([waiting]),
+        request_elicitation=request,
+        deliver=deliver,
+        inject_tui=inject_tui,
+    )
+
+    # The RPC verdict was delivered exactly once and the bridge returned cleanly
+    # despite the TUI keystroke raising.
+    assert len(deliver.calls) == 1
+    assert deliver.calls[0]["payload"] == {"permission": {"allow": True}}
+    assert inject_tui.calls == [["1", "Enter"]]
+
+
+@pytest.mark.asyncio
+async def test_no_tui_keystroke_when_nothing_delivered() -> None:
+    """When the elicitation returns None (timeout/cancel), no TUI key is typed."""
+    pending = _pending_permission(step_index=2)
+    waiting = _permission_step(step_index=2)
+    request, _ = _elicitation_returner(None)
+    deliver = _DeliverRecorder()
+    inject_tui = _InjectTuiRecorder()
+
+    await bridge_interaction(
+        _CASCADE,
+        pending,
+        port=52548,
+        get_steps=_steps_returner([waiting]),
+        request_elicitation=request,
+        deliver=deliver,
+        inject_tui=inject_tui,
+    )
+
+    assert deliver.calls == []
+    assert inject_tui.calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -773,6 +773,278 @@ async def test_reader_teardown_cancels_in_flight_interaction(
 
 
 # ---------------------------------------------------------------------------
+# #1200 direction 2: withdraw a surfaced elicitation resolved out-of-band
+# ---------------------------------------------------------------------------
+
+
+def _capturing_client() -> tuple[httpx.AsyncClient, list[dict[str, Any]]]:
+    """Build a real AsyncClient over a MockTransport that records every POST body.
+
+    ``_post_external_elicitation_resolved`` calls ``client.post`` directly (not
+    the post-retry sink), so a withdraw test needs a usable client. The transport
+    captures the JSON body of each POST and answers 200 so the reader proceeds.
+    """
+    captured: list[dict[str, Any]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.content:
+            captured.append(json.loads(request.content))
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.AsyncClient(base_url="http://test", transport=httpx.MockTransport(_handler))
+    return client, captured
+
+
+def _permission_waiting() -> dict[str, Any]:
+    """A WAITING command-permission step (the #1200 fixture)."""
+    return _load("run_command_waiting")
+
+
+def _permission_done() -> dict[str, Any]:
+    """The same permission step advanced to DONE (answered/timed out → no WAITING).
+
+    Built from the WAITING fixture by flipping the status and dropping the
+    ``requestedInteraction`` block, so ``pending_interaction`` returns ``None`` —
+    exactly what the reader sees once the step leaves WAITING.
+    """
+    step = copy.deepcopy(_load("run_command_waiting"))
+    step["status"] = "CORTEX_STEP_STATUS_DONE"
+    step.pop("requestedInteraction", None)
+    return step
+
+
+@pytest.mark.asyncio
+async def test_step_leaving_waiting_withdraws_surfaced_elicitation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """A surfaced WAITING step that later is NOT WAITING → withdraw the web card.
+
+    Models the terminal-answered / timed-out case: the reader surfaces the
+    permission elicitation, then on a later poll the step is DONE (no
+    ``requestedInteraction``). The reader must POST exactly one
+    ``external_elicitation_resolved`` for that step's deterministic elicitation id
+    so the lingering web card clears (#1200, direction 2).
+    """
+    from omnigent.antigravity_native_interactions import agy_elicitation_id
+
+    waiting = _permission_waiting()
+    done = _permission_done()
+    # WAITING twice (surface + dedup), then DONE (withdraw), then steady DONE.
+    script = _StepScript([[waiting], [waiting], [done], [done]])
+    sink = _PostSink()
+    client, captured = _capturing_client()
+
+    monkeypatch.setattr(
+        reader,
+        "stream_agent_state_updates",
+        _RaisingStream(httpx.ConnectError("stream disabled for poll test")),
+    )
+    monkeypatch.setattr(reader, "get_trajectory_steps", script)
+    monkeypatch.setattr(reader, "post_session_event_with_retry", sink)
+
+    async def _noop_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(reader, "_sleep", _noop_sleep)
+
+    async def _on_pending(_cascade_id: str, _port: int, _pending: PendingInteraction) -> None:
+        # Simulate a long-poll await that the terminal answer / timeout will
+        # short-circuit — it never returns a verdict here.
+        await asyncio.Event().wait()
+
+    async with client:
+        await asyncio.wait_for(
+            reader.supervise_reader(
+                _bridge_dir(tmp_path),
+                _SESSION_ID,
+                client=client,
+                on_pending_interaction=cast(Any, _on_pending),
+                poll_interval_s=0.0,
+                stop=_stop_after(4),
+            ),
+            timeout=5.0,
+        )
+
+    # Exactly one withdraw was posted, for THIS step's deterministic id.
+    expected_traj = waiting["metadata"]["sourceTrajectoryStepInfo"]["trajectoryId"]
+    expected_idx = waiting["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"]
+    expected_id = agy_elicitation_id(_CASCADE_ID, expected_traj, expected_idx)
+    withdraws = [body for body in captured if body.get("type") == "external_elicitation_resolved"]
+    assert len(withdraws) == 1
+    assert withdraws[0]["data"]["elicitation_id"] == expected_id
+
+
+@pytest.mark.asyncio
+async def test_still_waiting_does_not_withdraw(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """A still-WAITING step is NOT withdrawn (the interaction is still live)."""
+    waiting = _permission_waiting()
+    script = _StepScript([[waiting], [waiting], [waiting]])
+    sink = _PostSink()
+    client, captured = _capturing_client()
+
+    monkeypatch.setattr(
+        reader,
+        "stream_agent_state_updates",
+        _RaisingStream(httpx.ConnectError("stream disabled for poll test")),
+    )
+    monkeypatch.setattr(reader, "get_trajectory_steps", script)
+    monkeypatch.setattr(reader, "post_session_event_with_retry", sink)
+
+    async def _noop_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(reader, "_sleep", _noop_sleep)
+
+    async def _on_pending(_cascade_id: str, _port: int, _pending: PendingInteraction) -> None:
+        await asyncio.Event().wait()
+
+    async with client:
+        await asyncio.wait_for(
+            reader.supervise_reader(
+                _bridge_dir(tmp_path),
+                _SESSION_ID,
+                client=client,
+                on_pending_interaction=cast(Any, _on_pending),
+                poll_interval_s=0.0,
+                stop=_stop_after(3),
+            ),
+            timeout=5.0,
+        )
+
+    withdraws = [body for body in captured if body.get("type") == "external_elicitation_resolved"]
+    assert withdraws == []
+
+
+@pytest.mark.asyncio
+async def test_withdraw_posts_at_most_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """Even across many DONE re-reads, the withdraw is posted exactly once.
+
+    The dedup lives in ``surfaced_elicitations`` (popped on first withdraw), so a
+    steady-state poll that keeps returning the DONE step must not re-post.
+    """
+    waiting = _permission_waiting()
+    done = _permission_done()
+    script = _StepScript([[waiting], [done], [done], [done], [done]])
+    sink = _PostSink()
+    client, captured = _capturing_client()
+
+    monkeypatch.setattr(
+        reader,
+        "stream_agent_state_updates",
+        _RaisingStream(httpx.ConnectError("stream disabled for poll test")),
+    )
+    monkeypatch.setattr(reader, "get_trajectory_steps", script)
+    monkeypatch.setattr(reader, "post_session_event_with_retry", sink)
+
+    async def _noop_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(reader, "_sleep", _noop_sleep)
+
+    async def _on_pending(_cascade_id: str, _port: int, _pending: PendingInteraction) -> None:
+        await asyncio.Event().wait()
+
+    async with client:
+        await asyncio.wait_for(
+            reader.supervise_reader(
+                _bridge_dir(tmp_path),
+                _SESSION_ID,
+                client=client,
+                on_pending_interaction=cast(Any, _on_pending),
+                poll_interval_s=0.0,
+                stop=_stop_after(5),
+            ),
+            timeout=5.0,
+        )
+
+    withdraws = [body for body in captured if body.get("type") == "external_elicitation_resolved"]
+    assert len(withdraws) == 1
+
+
+@pytest.mark.asyncio
+async def test_withdraw_helper_pops_and_posts_once_directly() -> None:
+    """Unit-level: ``_maybe_withdraw_interaction`` posts once then no-ops.
+
+    Drives the helper directly with a surfaced id so the pop/no-double-post
+    contract is asserted without the full supervise loop.
+    """
+    from omnigent.antigravity_native_interactions import agy_elicitation_id
+
+    waiting = _permission_waiting()
+    done = _permission_done()
+    key = reader._step_key(waiting)
+    eid = agy_elicitation_id(
+        _CASCADE_ID,
+        waiting["metadata"]["sourceTrajectoryStepInfo"]["trajectoryId"],
+        waiting["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"],
+    )
+    state = reader._ReaderState(
+        allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+        seen=set(),
+        interacted=set(),
+        port=_PORT,
+    )
+    state.surfaced_elicitations[key] = eid
+    client, captured = _capturing_client()
+
+    async with client:
+        # First call on a DONE step → posts the withdraw and pops the entry.
+        await reader._maybe_withdraw_interaction(
+            done, key=key, client=client, session_id=_SESSION_ID, state=state
+        )
+        # Second call → entry gone, no further post.
+        await reader._maybe_withdraw_interaction(
+            done, key=key, client=client, session_id=_SESSION_ID, state=state
+        )
+
+    assert key not in state.surfaced_elicitations
+    withdraws = [b for b in captured if b.get("type") == "external_elicitation_resolved"]
+    assert len(withdraws) == 1
+    assert withdraws[0]["data"]["elicitation_id"] == eid
+
+
+@pytest.mark.asyncio
+async def test_withdraw_helper_noop_while_still_waiting() -> None:
+    """``_maybe_withdraw_interaction`` does nothing while the step is still WAITING."""
+    from omnigent.antigravity_native_interactions import agy_elicitation_id
+
+    waiting = _permission_waiting()
+    key = reader._step_key(waiting)
+    eid = agy_elicitation_id(
+        _CASCADE_ID,
+        waiting["metadata"]["sourceTrajectoryStepInfo"]["trajectoryId"],
+        waiting["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"],
+    )
+    state = reader._ReaderState(
+        allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+        seen=set(),
+        interacted=set(),
+        port=_PORT,
+    )
+    state.surfaced_elicitations[key] = eid
+    client, captured = _capturing_client()
+
+    async with client:
+        await reader._maybe_withdraw_interaction(
+            waiting, key=key, client=client, session_id=_SESSION_ID, state=state
+        )
+
+    # Still WAITING → entry retained, nothing posted.
+    assert state.surfaced_elicitations.get(key) == eid
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
 # Status edges: RUNNING on user turn, IDLE on assistant-text close
 # ---------------------------------------------------------------------------
 
@@ -1434,6 +1706,61 @@ async def test_stream_waiting_frame_invokes_callback_once(
     assert port == _PORT
     assert pending["kind"] == "ask_question"
     assert pending["trajectory_id"] == _CASCADE_ID
+
+
+@pytest.mark.asyncio
+async def test_stream_waiting_then_non_waiting_withdraws_elicitation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_discovery: None,
+) -> None:
+    """Over the STREAM path too, a WAITING step that goes DONE withdraws the card.
+
+    Confirms #1200 direction 2 is covered on the stream-primary path, not just the
+    poll fallback (a permission answered in the TUI / timed out surfaces as a
+    DONE frame after the WAITING frame).
+    """
+    from omnigent.antigravity_native_interactions import agy_elicitation_id
+
+    waiting = _permission_waiting()
+    done = _permission_done()
+    frames = [_frame([waiting]), _frame([done]), _frame([done])]
+    sink = _PostSink()
+    client, captured = _capturing_client()
+
+    monkeypatch.setattr(reader, "stream_agent_state_updates", _FrameScript(frames))
+    monkeypatch.setattr(reader, "get_trajectory_steps", _StepScript([[]]))
+    monkeypatch.setattr(reader, "post_session_event_with_retry", sink)
+
+    async def _noop_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(reader, "_sleep", _noop_sleep)
+
+    async def _on_pending(_cascade_id: str, _port: int, _pending: PendingInteraction) -> None:
+        await asyncio.Event().wait()
+
+    async with client:
+        await asyncio.wait_for(
+            reader.supervise_reader(
+                _bridge_dir(tmp_path),
+                _SESSION_ID,
+                client=client,
+                on_pending_interaction=cast(Any, _on_pending),
+                poll_interval_s=0.0,
+                stop=_stop_after(1),
+            ),
+            timeout=5.0,
+        )
+
+    expected_id = agy_elicitation_id(
+        _CASCADE_ID,
+        waiting["metadata"]["sourceTrajectoryStepInfo"]["trajectoryId"],
+        waiting["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"],
+    )
+    withdraws = [b for b in captured if b.get("type") == "external_elicitation_resolved"]
+    assert len(withdraws) == 1
+    assert withdraws[0]["data"]["elicitation_id"] == expected_id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes Antigravity (`agy`) command-permission / ask-question elicitations sync **both directions** between the Omnigent web Chat UI and the attended agy TUI. `Fixes #1200` (web→terminal), and adds the inverse (terminal→web withdrawal) so a card never lingers.

## Confirmed root cause

**Direction 1 — web → terminal (#1200).** The agy write path types **every** web turn into the *attended* agy TUI (`inject_user_message_via_tui`), so a permission gate surfaces as agy's own in-process numbered TUI prompt ("Do you want to proceed?" 1.Yes … 4.No). On Approve/Reject, `bridge_interaction` delivered the verdict over `HandleCascadeUserInteraction` RPC — which flips the backend trajectory step to `DONE` and runs the command, **but leaves the TUI's own prompt open in parallel**. This is explicitly the live-verified behavior in `docs/claude/antigravity-rpc-spike-notes.md` §"attended TUI": the terminal prompt does not advance, and the next typed turn lands in the stale prompt's filter/amend buffer. So the verdict "doesn't fully go through to the terminal." This is **hypothesis 1** from the brief — the bug is NOT a mapping typo (`_agy_permission_response` was correct) and NOT a verdict-delivery failure (a Reject reliably returns `action="decline"`, not `None`).

**Direction 2 — terminal → web.** The reader only *published* an elicitation on detecting a WAITING step and never *withdrew* it. If the user answers directly in the agy TUI, or agy times out / auto-resolves the step, the WAITING step advances but the web card lingers forever ("Respond to the pending request above to continue.").

## The fix

**Direction 1 — also type the selection into the TUI (mirrors cursor-native).** cursor-native is the sibling whose gate is likewise a TUI prompt with no hook; it resolves by typing a key into the pane (`send_cursor_pane_keys`). (claude-native uses a `PermissionRequest` hook that pre-empts the prompt — not available for agy.) After a successful RPC delivery, `bridge_interaction` now ALSO types the verdict into the agy pane:
- New bridge primitive `send_interaction_keys_via_tui(bridge_dir, *keys)` (mirrors `inject_user_message_via_tui`, reuses `_run_tmux`/`read_tmux_info`/`_session_alive`).
- New pure mapper `to_tui_selection_keys(kind, result, spec)` (next to `to_interaction_payload`): **permission** Approve → `["1","Enter"]` (Yes), Reject → `["4","Enter"]` (No); **ask_question** → the selected option id(s) + `Enter`, or `["Escape"]` on decline.
- TUI typing is best-effort (logged, not raised) — the backend step is already answered, so a flaky/exited pane never undoes a delivered verdict.

The 4-option↔Approve/Reject non-1:1 mapping is intentional/acceptable per the issue (Approve→the always-safe option 1, not the "always allow" variants 2/3).

**Direction 2 — withdraw on leaving WAITING (mirrors cursor-native).** The reader records each surfaced elicitation's deterministic id; when that step is later seen no longer WAITING, it POSTs `external_elicitation_resolved` (exactly cursor-native's `_post_external_elicitation_resolved`). Server-side this clears the web card AND sets the parked future's `resolved_elsewhere` → any in-flight `request_elicitation` long-poll returns `None`, so a racing `bridge_interaction` does **not** deliver a stale verdict (no deadlock, no double-deliver). Posted at most once per step; harmless when the web verdict already resolved it (no parked future → tombstone).

## Files changed
- `omnigent/antigravity_native_bridge.py` — `send_interaction_keys_via_tui` primitive.
- `omnigent/server/routes/_antigravity_elicitation.py` — `to_tui_selection_keys` pure mapper.
- `omnigent/antigravity_native_interactions.py` — `bridge_interaction` types the verdict into the TUI after RPC delivery (new injectable `inject_tui` seam + `_inject_via_tui` default).
- `omnigent/antigravity_native_reader.py` — track surfaced elicitations; `_maybe_withdraw_interaction` + `_post_external_elicitation_resolved` withdraw on leaving WAITING (wired into both poll and stream paths).
- Tests in `tests/test_antigravity_native_interactions.py`, `tests/server/test_antigravity_elicitation.py`, `tests/test_antigravity_native_bridge.py`, `tests/test_antigravity_native_reader.py`.

## Tests
All run from the worktree against this branch's code. **188 passed** across the four touched files (interactions / elicitation / bridge / reader); **181 passed** in the rest of the antigravity suite (no regressions). `ruff format` + `ruff check` clean; `mypy` clean on all touched modules.

Coverage of the full resolution, both directions:
- web Approve → RPC `allow:True` + types `["1","Enter"]`; Reject → `allow:False` + `["4","Enter"]`; ask → selected option ids + Enter.
- TUI-typing failure does NOT undo the delivered RPC verdict; no keystroke when nothing was delivered (None verdict).
- bridge primitive sends exactly `tmux … send-keys -t <target> <keys…>` as one invocation; raises on no target / exited pane / empty keys.
- a WAITING step that leaves WAITING (terminal-answered / timeout) clears the web card exactly once and is idempotent across re-reads; no withdraw while still WAITING; covered on BOTH poll and stream paths.

## Exact LIVE steps to confirm (orchestrator runs these)

**Direction 1 (web → terminal):**
1. Start an `omnigent antigravity` agent against the running server; open the agy TUI pane.
2. From the web Chat UI, send a turn that triggers a command permission (e.g. `echo "hi" && gh pr list ...`).
3. When the "Approval required · agy_native_permission" card appears, click **Approve**.
4. **Expect:** the agy TUI prompt advances (option 1 "Yes" selected + Enter), the command runs, the chat unblocks. Repeat with **Reject** → expect option 4 "No" selected.

**Direction 2 (terminal → web):**
1. Trigger a permission again so the web card appears.
2. Answer it **directly in the agy TUI pane** (type 1/2/3/4 + Enter) — do NOT click in the web UI.
3. **Expect:** the web card disappears on its own (within one reader poll) and the chat stops showing "Respond to the pending request above to continue."

This pull request and its description were written by Isaac.