### PR TITLE
fix(ios): respect safe-area inset for the Jump to top button

### DIFF
--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -2023,10 +2023,14 @@ export function JumpToTopButton({
 
   return (
     <div
+      // top 50px centers the pill on the chat-scroll-fade border (the mask ramps
+      // 48px→80px), just below the h-14 ChatHeader. z-40 > header z-30. On the
+      // iOS shell the header and fade border shift down by the safe-area inset
+      // (see .chat-scroll-fade in index.css), so add --omnigent-inset-top here
+      // too to keep the pill centered on the border. The var is 0px off-shell.
+      style={{ top: "calc(50px + var(--omnigent-inset-top))" }}
       className={cn(
-        // top-[50px]: centers the pill on the chat-scroll-fade border (the mask
-        // ramps 48px→80px), just below the h-14 ChatHeader. z-40 > header z-30.
-        "pointer-events-none absolute inset-x-0 top-[50px] z-40 flex justify-center transition-opacity duration-150",
+        "pointer-events-none absolute inset-x-0 z-40 flex justify-center transition-opacity duration-150",
         visible ? "opacity-100" : "opacity-0",
       )}
     >


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The "Jump to top" pill was pinned at a hardcoded `top-[50px]`, but on the iOS shell the ChatHeader and the `.chat-scroll-fade` mask border both shift down by `var(--omnigent-inset-top)` (the safe-area inset). The pill stayed put, so on notched devices it drifted off the fade border and overlapped the header.
- Move the offset to an inline style and add the inset: `top: calc(50px + var(--omnigent-inset-top))`. This mirrors the established inset pattern (`.chat-scroll-fade`, `.chat-conversation-content`, `PageScroll`). The var resolves to `0px` off-shell, so browser and Electron behavior is unchanged.

## Test Plan

- Reviewed the diff against the existing inset system in `index.css` (`--omnigent-inset-top`, `.chat-scroll-fade` mask).
- Verified the var defaults to `0px` outside the iOS shell, keeping non-iOS positioning identical to before.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CSS-only positioning change with no test hooks. Verified by reasoning against the shared inset variables: `--omnigent-inset-top` is `env(safe-area-inset-top, 0px)`, so the pill now tracks the fade border on iOS and is unchanged (50px) in the browser and Electron.
