### PR TITLE
feat(web): add hide-whitespace toggle to diff viewer

### DIFF
--- a/ap-web/src/lib/fileViewPreferences.test.ts
+++ b/ap-web/src/lib/fileViewPreferences.test.ts
@@ -23,6 +23,7 @@ describe("fileViewPreferences", () => {
       diffActive: true,
       diffLayout: "split",
       previewableViewMode: "source",
+      hideWhitespace: true,
     });
     // The exact object written must come back — proves both the write
     // serialized and the read parsed/validated every field correctly.
@@ -30,6 +31,7 @@ describe("fileViewPreferences", () => {
       diffActive: true,
       diffLayout: "split",
       previewableViewMode: "source",
+      hideWhitespace: true,
     });
   });
 
@@ -57,6 +59,7 @@ describe("fileViewPreferences", () => {
       diffActive: true,
       diffLayout: "unified",
       previewableViewMode: "editor",
+      hideWhitespace: false,
     });
   });
 });

--- a/ap-web/src/lib/fileViewPreferences.ts
+++ b/ap-web/src/lib/fileViewPreferences.ts
@@ -19,6 +19,8 @@ export interface FileViewPreferences {
   diffLayout: "unified" | "split";
   /** Preferred mode for previewable (markdown/html) files. */
   previewableViewMode: "editor" | "preview" | "source";
+  /** Whether whitespace-only changes are hidden in the diff view. */
+  hideWhitespace: boolean;
 }
 
 const STORAGE_KEY = "omnigent:file-view-preferences";
@@ -27,6 +29,7 @@ export const DEFAULT_FILE_VIEW_PREFERENCES: FileViewPreferences = {
   diffActive: false,
   diffLayout: "unified",
   previewableViewMode: "editor",
+  hideWhitespace: false,
 };
 
 /**
@@ -54,6 +57,10 @@ export function readFileViewPreferences(): FileViewPreferences {
         p.previewableViewMode === "preview" || p.previewableViewMode === "source"
           ? p.previewableViewMode
           : "editor",
+      hideWhitespace:
+        typeof p.hideWhitespace === "boolean"
+          ? p.hideWhitespace
+          : DEFAULT_FILE_VIEW_PREFERENCES.hideWhitespace,
     };
   } catch {
     return DEFAULT_FILE_VIEW_PREFERENCES;

--- a/ap-web/src/shell/FileViewer.tsx
+++ b/ap-web/src/shell/FileViewer.tsx
@@ -31,6 +31,7 @@ import {
   Columns2Icon,
   DownloadIcon,
   EyeIcon,
+  EyeOffIcon,
   FileDiffIcon,
   Link2Icon,
   Loader2Icon,
@@ -602,6 +603,9 @@ function FileViewerBody({
   const [diffLayout, setDiffLayout] = useState<"unified" | "split">(
     () => persistedPrefsRef.current.diffLayout,
   );
+  const [hideWhitespace, setHideWhitespace] = useState(
+    () => persistedPrefsRef.current.hideWhitespace,
+  );
   const [previewableViewMode, setPreviewableViewMode] = useState<"editor" | "preview" | "source">(
     () => persistedPrefsRef.current.previewableViewMode,
   );
@@ -610,8 +614,8 @@ function FileViewerBody({
   // is intentionally excluded — it's contextual (per-open), not a sticky
   // preference. Idempotent on mount (writes back the seeded values).
   useEffect(() => {
-    writeFileViewPreferences({ diffActive, diffLayout, previewableViewMode });
-  }, [diffActive, diffLayout, previewableViewMode]);
+    writeFileViewPreferences({ diffActive, diffLayout, previewableViewMode, hideWhitespace });
+  }, [diffActive, diffLayout, previewableViewMode, hideWhitespace]);
   // Non-markdown previewable (HTML): "editor" falls back to "preview" — no rich-text mode.
   // Markdown: "preview" is removed; treat as "source" if somehow set (e.g. shared state from an HTML file).
   const fileViewMode: "editor" | "preview" | "source" = isPreviewable
@@ -766,6 +770,15 @@ function FileViewerBody({
           <RowsIcon className="size-4" />
         ),
       onSelect: () => setDiffLayout((l) => (l === "unified" ? "split" : "unified")),
+    });
+  }
+  if (viewMode === "diff") {
+    toolbarActions.push({
+      key: "hide-whitespace",
+      label: hideWhitespace ? "Show whitespace changes" : "Hide whitespace changes",
+      icon: hideWhitespace ? <EyeIcon className="size-4" /> : <EyeOffIcon className="size-4" />,
+      active: hideWhitespace,
+      onSelect: () => setHideWhitespace((prev) => !prev),
     });
   }
   toolbarActions.push({
@@ -1049,6 +1062,7 @@ function FileViewerBody({
                   after={diffQuery.data.after}
                   path={path}
                   layout={diffLayout}
+                  hideWhitespace={hideWhitespace}
                   conversationId={conversationId}
                   comments={openComments}
                   activeSelection={activeSelection}

--- a/ap-web/src/shell/MonacoDiffViewer.test.tsx
+++ b/ap-web/src/shell/MonacoDiffViewer.test.tsx
@@ -56,6 +56,7 @@ function renderDiff(props: {
   before: string | null;
   after: string | null;
   layout: "unified" | "split";
+  hideWhitespace?: boolean;
 }) {
   return render(
     <MonacoDiffViewer
@@ -63,6 +64,7 @@ function renderDiff(props: {
       after={props.after}
       path="src/a.ts"
       layout={props.layout}
+      hideWhitespace={props.hideWhitespace ?? false}
       conversationId="conv_1"
       comments={[]}
       activeSelection={null}

--- a/ap-web/src/shell/MonacoDiffViewer.tsx
+++ b/ap-web/src/shell/MonacoDiffViewer.tsx
@@ -31,6 +31,8 @@ interface MonacoDiffViewerProps {
   path: string;
   /** How hunks are rendered: side-by-side ("split") or inline ("unified"). */
   layout: "unified" | "split";
+  /** Whether whitespace-only changes are hidden. */
+  hideWhitespace: boolean;
   conversationId: string;
   /** Saved comments — highlighted on the modified side. */
   comments: Comment[];
@@ -53,6 +55,7 @@ export function MonacoDiffViewer({
   after,
   path,
   layout,
+  hideWhitespace,
   conversationId,
   comments,
   activeSelection,
@@ -144,11 +147,12 @@ export function MonacoDiffViewer({
       fontSize: 12,
       automaticLayout: true,
       renderOverviewRuler: false,
+      ignoreTrimWhitespace: hideWhitespace,
       // Collapse long unchanged runs into expandable bands (like the old pierre
       // diff / GitHub) so only changed hunks + a few context lines are shown.
       hideUnchangedRegions: { enabled: true, contextLineCount: 3 },
     }),
-    [layout],
+    [layout, hideWhitespace],
   );
 
   return (


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a "Hide whitespace changes" toggle to the diff viewer toolbar, similar to GitHub's whitespace toggle when reviewing PRs
- The toggle appears only when the diff view is active and uses Monaco's `ignoreTrimWhitespace` option to filter out whitespace-only changes
- The preference is persisted to localStorage alongside other diff settings (layout, diff active) so it survives page refreshes and file navigation

## Test Plan

- Open a file with whitespace-only changes in the diff viewer
- Verify the hide-whitespace button (eye-off icon) appears in the toolbar when diff view is active
- Toggle the button and confirm whitespace-only diff hunks disappear/reappear
- Refresh the page and confirm the preference is preserved
- Verify the button does not appear outside of diff view

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: toggled the hide-whitespace button in the diff viewer toolbar and confirmed whitespace-only changes are properly hidden/shown. Verified the preference persists across page refreshes via localStorage.