### PR TITLE
feat(qwen): mirror native-qwen tool approvals as web elicitation cards

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -93,35 +93,38 @@ comments; this is the *what*, not the *how*.)
   the `result`/`assistant` events is not yet emitted on `TurnComplete.usage`
   (see the status-line item below for the model/ring/cost consequences).
 
-- [ ] **Tool-approval elicitation card (TUI → web).** Today a tool call gates
-  only via qwen's **own in-terminal prompt** ("Apply this change? 1. Yes …") —
-  no approval card renders in the web chat, so a user on the Chat tab sees the
-  turn just hang. **Verified feasible** against a live session (and qwen
-  v0.18.1-preview.1): qwen emits a structured
-  `{"type":"control_request","request":{"subtype":"can_use_tool","tool_name",
-  "tool_use_id","input"},"request_id"}` on `--json-file` **and** accepts a
-  `{"type":"confirmation_response","request_id","allowed"}` on `--input-file`,
-  *coexisting* with its own TUI prompt (whichever answers first wins). The
-  forwarder currently just logs the `can_use_tool` (PR2 stub in
-  `qwen_native_forwarder.py`), so the request goes unanswered from the web side.
-  - **Template to copy:** cursor-native's approval mirror —
-    `omnigent/cursor_native_permissions.py` + `supervise_cursor_approval_mirror`
-    (wired in `runner/app.py::_auto_create_cursor_terminal`). qwen is *cleaner*:
-    read the structured `can_use_tool` from the event stream (no pane scraping)
-    and write `confirmation_response` to the input file (no keystrokes).
-  - **Reuse, don't add an endpoint:** POST the tool call to the existing
-    `/v1/sessions/{id}/policies/evaluate` (`_evaluate_tool_call_policy` in
-    `runner/app.py`) — it runs TOOL_CALL policy *and*, on ASK, parks a human
-    approval card (`response.elicitation_request`) and blocks for the verdict.
-    Map the verdict → `confirmation_response`. This delivers both the card and
-    the deferred policy gating in one shot.
-  - **Tricky edge (needs live E2E):** the user can answer in the **terminal**
-    *or* the **card**. The loser must be released — if qwen proceeds first
-    (a `tool_result` / next assistant event for that `tool_use_id` appears),
-    cancel the park via `external_elicitation_resolved` and skip the stale
-    `confirmation_response`; if the card answers first, write the response and
-    let the TUI prompt clear. Run the mirror as a supervised task alongside the
-    transcript forwarder in `_auto_create_qwen_terminal`.
+- [x] **Tool-approval elicitation card (TUI → web).** Implemented — qwen's
+  in-terminal tool-approval prompt now also renders as an approval card in the
+  web chat, and answering either surface resolves the other. qwen emits a
+  structured `{"type":"control_request","request":{"subtype":"can_use_tool",
+  "tool_name","tool_use_id","input"},"request_id"}` on `--json-file` **and**
+  accepts a `{"type":"confirmation_response","request_id","allowed"}` on
+  `--input-file`, *coexisting* with its own TUI prompt (whichever answers first
+  wins; qwen's `dual-output.md` confirms `control_request` is emitted whenever a
+  tool needs approval — the earlier "default mode doesn't emit these" note was
+  wrong).
+  - **Mirror:** `omnigent/qwen_native_permissions.py` —
+    `supervise_qwen_approval_mirror` tails the *same* `--json-file` the
+    transcript forwarder reads (seeded at EOF so only new prompts park), POSTs
+    each `can_use_tool` to the server's `qwen-permission-request` hook, and on
+    the web verdict writes `confirmation_response` to the input file (no
+    keystrokes). It's the structured analog of cursor-native's pane-scraping
+    mirror. Wired alongside the forwarder under one supervised task in
+    `runner/app.py::_auto_create_qwen_terminal` (`_supervise_qwen_native_bridges`).
+  - **Server hook:** `POST /v1/sessions/{id}/hooks/qwen-permission-request`
+    (`qwen_permission_request_hook`, modeled on the cursor hook) publishes the
+    standard `response.elicitation_request` (`policy_name=qwen_native_permission`,
+    `phase=pre_tool_use`) and parks via `_publish_and_wait_for_harness_elicitation`.
+    This always surfaces a card whenever the TUI prompts — the explicit goal —
+    rather than routing through `/policies/evaluate` (which would auto-resolve
+    and skip the card when no TOOL_CALL policy matches qwen's tool names).
+  - **Loser release:** qwen emits a `control_response` for a `request_id`
+    whether the TUI or an external `confirmation_response` answered. The mirror
+    watches for it: if it lands while the web card is still parked (TUI answered
+    first), it POSTs `external_elicitation_resolved` to clear the card and skips
+    the stale `confirmation_response`; if the card answered first, the task is
+    already done and the `control_response` just cleans up. Still worth a live
+    E2E to confirm timing under a real `qwen --acp` turn.
 
 - [ ] **Composer status line: real model + context ring (Web UI).** For
   native-qwen the composer's model/effort chip is currently **hidden** (web UI
@@ -177,6 +180,39 @@ comments; this is the *what*, not the *how*.)
   forced goose-native to start fresh.
 
 ### Medium
+
+- [ ] **Compaction / context-compression mirroring (TUI → web).** qwen calls
+  compaction *compression*: it auto-compresses when the context fills and exposes
+  a `/compress` command, rendering an inline item in its TUI
+  (`{type:"compression", compression:{isPending, originalTokenCount,
+  newTokenCount, compressionStatus}}` and an internal `chat_compressed` event).
+  Native-qwen does **not** surface any of this in the web UI today — during a
+  compression the Chat tab just shows the turn stall, and afterward the mirrored
+  token counts don't reflect the shrink. Omnigent already has the web-facing
+  primitives — `response.compaction.in_progress` / `.completed` / `.failed`
+  (`omnigent/runtime/compaction.py`, `omnigent/server/schemas.py:3158+`,
+  rendered by `ap-web` as the "Compacting…" spinner / compaction divider) — so
+  this is a *forwarder* change, not new UI.
+  - **Verify the wire shape first (live E2E):** confirm whether qwen emits a
+    structured compression marker on the `--json-file` dual-output stream (a
+    `compression`/`chat_compressed`-shaped event) the way it emits
+    `control_request` for approvals, or whether compression is TUI-only and must
+    be inferred (e.g. from a token-count drop between consecutive `assistant`
+    `usage` events, or a `system`-style notice). The `control_request` →
+    elicitation work proved the stream carries non-transcript control events, so
+    a compression event is plausible but unconfirmed — `permission_suggestions`
+    was null, so don't assume field richness.
+  - **Mirror it:** in `omnigent/qwen_native_forwarder.py`, on a
+    compression-in-progress marker publish `response.compaction.in_progress`
+    (POST to the session) so the spinner shows, and on completion publish
+    `response.compaction.completed` with the post-compression `total_tokens`
+    (pairs with the usage/context-ring work in the "Composer status line" item —
+    one usage path feeds the ring, cost, and the compaction token count). If the
+    stream has no compression event, scope this to "best-effort: emit completed
+    with the new token count when usage drops" and `log()` the limitation.
+  - **Note on the ACP `qwen` harness:** the in-process executor compresses
+    internally over ACP and is opaque to us (same boundary as the LLM-phase
+    policy exclusion below), so this item is **native-qwen only**.
 
 - [ ] **Provider routing: settings.json precedence + token refresh.** The
   base injection now works (see What works today), but two gaps remain before

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -185,8 +185,8 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
     Return the trusted parent for an allowed bridge directory.
 
     Claude-native files live below the uid-scoped temp bridge root.
-    Codex- and Cursor-native reuse the relay/MCP implementation but keep bridge
-    files below their own bridge roots. All roots use the same
+    Codex-, Cursor-, and Qwen-native reuse the relay/MCP implementation but keep
+    bridge files below their own bridge roots. All roots use the same
     owner-only ancestor validation; only the trusted anchor differs.
 
     :param target: Normalized bridge directory path being created or validated,
@@ -234,9 +234,19 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
             trusted_parent = antigravity_root.parent.parent
         return _absolute_syntactic_path(trusted_parent)
 
+    from omnigent.qwen_native_bridge import bridge_root as qwen_bridge_root
+
+    qwen_root = _absolute_syntactic_path(qwen_bridge_root())
+    if target.is_relative_to(qwen_root):
+        # Same shape as cursor-native ($TMPDIR/omnigent-<uid>/qwen-native): trust
+        # the uid-scoped temp dir's parent and validate/chmod the two
+        # bridge-owned directories below it.
+        return _absolute_syntactic_path(qwen_root.parent.parent)
+
     raise RuntimeError(
         f"bridge dir {target!s} is not under an allowed bridge root "
-        f"({claude_root!s}, {codex_root!s}, {cursor_root!s}, {antigravity_root!s})"
+        f"({claude_root!s}, {codex_root!s}, {cursor_root!s}, "
+        f"{antigravity_root!s}, {qwen_root!s})"
     )
 
 

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -20,9 +20,11 @@ Event shapes consumed (others are ignored defensively):
 - ``{"type":"assistant","message":{"role":"assistant","content":[{"type":"text"|
   "thinking"|"tool_use",...}]}}`` — only ``text`` blocks are mirrored.
 - ``{"type":"control_request","request":{"subtype":"can_use_tool",...},
-  "request_id":...}`` — recognized and logged; Omnigent-side policy gating
-  (answer via ``confirmation_response``) is the documented follow-up. With the
-  default in-terminal approval mode qwen does not emit these.
+  "request_id":...}`` and the matching ``control_response`` — the permission
+  control plane. NOT handled here: the tool-approval mirror
+  (:mod:`omnigent.qwen_native_permissions`) tails the same stream and surfaces
+  these as web elicitation cards. This forwarder ignores them (they carry no
+  transcript prose to mirror).
 
 Status (``running``/``idle``) is intentionally NOT posted here: the runner's
 PTY-activity watcher owns those edges for qwen-native (see
@@ -157,15 +159,9 @@ def _event_to_item(event: dict[str, object], agent_name: str) -> _MirrorItem | N
     """Convert one qwen stream-json event to a mirror item, or ``None`` to skip it."""
     etype = event.get("type")
     if etype not in ("user", "assistant"):
-        if etype == "control_request":
-            request = event.get("request")
-            subtype = request.get("subtype") if isinstance(request, dict) else None
-            if subtype == "can_use_tool":
-                # Recognized but not yet gated through Omnigent's policy engine —
-                # qwen's in-terminal approval is the gate for now. Wiring
-                # confirmation_response back through TOOL_CALL policy is the
-                # documented follow-up (see module docstring / design doc).
-                _logger.debug("qwen forwarder saw can_use_tool control_request (in-terminal gate)")
+        # control_request / control_response (the permission control plane) carry
+        # no transcript prose; the tool-approval mirror
+        # (omnigent.qwen_native_permissions) owns them off the same stream.
         return None
     uuid = event.get("uuid")
     if not isinstance(uuid, str) or not uuid:

--- a/omnigent/qwen_native_permissions.py
+++ b/omnigent/qwen_native_permissions.py
@@ -261,9 +261,21 @@ async def supervise_qwen_approval_mirror(
                 events, offset = await asyncio.to_thread(
                     _read_new_control_events, events_file, offset
                 )
+                # A request whose control_response is already in THIS same batch
+                # was answered (in the TUI or auto) within one poll window, before
+                # we could park it. Parking it now would race its own response: the
+                # response branch runs against a freshly-created task that hasn't
+                # POSTed yet, so it can't release the card, which would then linger
+                # until the server-side park times out. The decision is already
+                # made — skip the card entirely.
+                resolved_in_batch = {ev.request_id for ev in events if ev.kind == "response"}
                 for ev in events:
                     if ev.kind == "request":
-                        if ev.request_id in pending or ev.approval is None:
+                        if (
+                            ev.request_id in pending
+                            or ev.approval is None
+                            or ev.request_id in resolved_in_batch
+                        ):
                             continue
                         elicitation_id = qwen_permission_elicitation_id(session_id, ev.request_id)
                         task = asyncio.create_task(

--- a/omnigent/qwen_native_permissions.py
+++ b/omnigent/qwen_native_permissions.py
@@ -1,0 +1,387 @@
+"""Qwen-native tool-approval mirror (TUI → web elicitation).
+
+The ``qwen`` TUI gates its own tool calls (shell, file write, …) with an
+in-terminal approval prompt. Unlike cursor-native — where the prompt lives only
+in the TUI's in-memory state and has to be scraped off the pane — qwen exposes a
+structured **permission control plane** on its dual-output stream: whenever a
+tool needs approval it emits a ``control_request`` / ``can_use_tool`` event on
+``--json-file`` (coexisting with the in-terminal prompt) and accepts a
+``confirmation_response`` on ``--input-file`` (whichever side answers first
+wins, the loser is harmlessly dropped). See qwen's ``dual-output.md``.
+
+So to surface those approvals in the Omnigent web UI (so a user on the Chat tab
+can answer from the chat view, not just inside the embedded terminal), the runner
+tails the same event stream the transcript forwarder uses:
+
+1. read a ``control_request`` / ``can_use_tool`` off ``--json-file`` (structured,
+   no pane scraping),
+2. POST it to the server's generic ``native-permission-request`` hook (shared
+   with the hermes-/goose-native mirrors; ``agent="qwen"`` labels the card),
+   which publishes the standard ``response.elicitation_request`` event and parks
+   for the web verdict (the same machinery cursor-/codex-native use),
+3. on the verdict, answer qwen by appending a ``confirmation_response`` to
+   ``--input-file`` (``allowed=True`` on accept, ``False`` on decline/cancel) —
+   no keystrokes,
+4. if instead a ``control_response`` for that ``request_id`` appears while the
+   card is still parked (the user answered inside the embedded terminal, or qwen
+   auto-resolved), POST ``external_elicitation_resolved`` so the parked web card
+   clears and skip the now-stale ``confirmation_response``.
+
+This deliberately does NOT suppress qwen's native gate; qwen's own prompt remains
+the source of truth and the fallback if the mirror ever misses a request (the
+user can still answer in the terminal). It is the cleaner, structured analog of
+:mod:`omnigent.cursor_native_permissions`. See ``docs/QWEN_NATIVE_DESIGN.md`` and
+``docs/QWEN_FOLLOWUPS.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from omnigent.qwen_native_bridge import events_file_path, submit_confirmation
+
+_logger = logging.getLogger(__name__)
+
+#: Event-file poll cadence. Matches the transcript forwarder so a pending
+#: approval surfaces in the web UI within a step of the terminal prompt.
+_POLL_INTERVAL_S = 0.4
+# The approval hook parks server-side until a human answers; allow a day, well
+# past any realistic wait, so the runner's POST never abandons a live prompt.
+_POST_TIMEOUT_S = 86400.0
+#: Cap on a preview string POSTed to the card (server truncates too).
+_PREVIEW_MAX = 1024
+
+
+@dataclass(frozen=True)
+class QwenApprovalRequest:
+    """A parsed qwen ``can_use_tool`` control request.
+
+    :param request_id: qwen's ``request_id`` for the control request — the
+        correlation key answered via ``confirmation_response`` and matched
+        against a later ``control_response``.
+    :param tool_name: The tool qwen wants to run, e.g. ``"run_shell_command"``.
+    :param message: Human-readable card message.
+    :param preview: Compact preview for the card (the shell command, or the
+        JSON-encoded tool input).
+    """
+
+    request_id: str
+    tool_name: str
+    message: str
+    preview: str
+
+
+@dataclass(frozen=True)
+class _ControlEvent:
+    """One parsed control-plane event from ``--json-file``.
+
+    :param kind: ``"request"`` (a ``can_use_tool`` to park) or ``"response"``
+        (a resolution to release the loser).
+    :param request_id: The control request's id (correlates request ↔ response).
+    :param approval: The parsed request when ``kind == "request"``, else ``None``.
+    """
+
+    kind: str
+    request_id: str
+    approval: QwenApprovalRequest | None
+
+
+def qwen_permission_elicitation_id(session_id: str, request_id: str) -> str:
+    """Return the deterministic Omnigent elicitation id for a qwen control request.
+
+    qwen's ``request_id`` is already unique per pending tool call, so it keys the
+    elicitation directly — stable across polls and recomputable for the
+    loser-release path.
+    """
+    return f"elicit_qwen_{session_id}_{request_id}"
+
+
+def _preview_for(tool_name: str, tool_input: object) -> str:
+    """Render a compact card preview from a qwen tool input.
+
+    A shell tool's ``command`` is the most useful single line; otherwise the
+    JSON-encoded input, falling back to the bare tool name.
+    """
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str) and command.strip():
+            return command.strip()[:_PREVIEW_MAX]
+        try:
+            return json.dumps(tool_input, ensure_ascii=False)[:_PREVIEW_MAX]
+        except (TypeError, ValueError):
+            pass
+    return tool_name[:_PREVIEW_MAX]
+
+
+def parse_can_use_tool(event: dict[str, object]) -> QwenApprovalRequest | None:
+    """Parse a ``control_request`` / ``can_use_tool`` event, or ``None`` to skip.
+
+    Tolerant of odd shapes: a missing ``tool_name`` degrades to ``"tool"`` and a
+    non-dict ``input`` to an empty preview rather than dropping the request.
+
+    :param event: One decoded ``--json-file`` event.
+    :returns: The parsed approval request, or ``None`` when *event* is not a
+        ``can_use_tool`` control request.
+    """
+    if event.get("type") != "control_request":
+        return None
+    request = event.get("request")
+    if not isinstance(request, dict) or request.get("subtype") != "can_use_tool":
+        return None
+    request_id = event.get("request_id")
+    if not isinstance(request_id, str) or not request_id:
+        return None
+    raw_name = request.get("tool_name")
+    tool_name = raw_name if isinstance(raw_name, str) and raw_name else "tool"
+    preview = _preview_for(tool_name, request.get("input"))
+    return QwenApprovalRequest(
+        request_id=request_id,
+        tool_name=tool_name,
+        message=f"qwen wants to run {tool_name}",
+        preview=preview,
+    )
+
+
+def _control_response_request_id(event: dict[str, object]) -> str | None:
+    """Return the ``request_id`` of a ``control_response`` event, or ``None``.
+
+    qwen emits ``control_response`` whether the decision was made in the TUI or
+    by an external ``confirmation_response`` — either way it marks the request
+    resolved, which is the signal to release a still-parked web card.
+    """
+    if event.get("type") != "control_response":
+        return None
+    response = event.get("response")
+    if not isinstance(response, dict):
+        return None
+    request_id = response.get("request_id")
+    return request_id if isinstance(request_id, str) and request_id else None
+
+
+def _read_new_control_events(events_file: Path, offset: int) -> tuple[list[_ControlEvent], int]:
+    """Read NDJSON lines past *offset*, returning control events + the new offset.
+
+    Mirrors :func:`omnigent.qwen_native_forwarder._read_new_events`: detects a
+    truncated/recreated file (``size < offset`` → rewind to 0), consumes only
+    fully terminated lines, and leaves a trailing partial line for the next poll.
+    Only control-plane events (``control_request`` / ``control_response``) are
+    returned; user/assistant transcript events are the forwarder's concern.
+    """
+    try:
+        size = events_file.stat().st_size
+    except OSError:
+        return [], offset
+    if size < offset:
+        offset = 0  # file truncated by a relaunched terminal
+    if size == offset:
+        return [], offset
+    try:
+        with open(events_file, "rb") as fh:
+            fh.seek(offset)
+            data = fh.read(size - offset)
+    except OSError:
+        return [], offset
+    last_nl = data.rfind(b"\n")
+    if last_nl == -1:
+        return [], offset  # no complete line yet
+    consumed = data[: last_nl + 1]
+    new_offset = offset + len(consumed)
+    events: list[_ControlEvent] = []
+    for raw in consumed.split(b"\n"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            continue  # tolerate a malformed line rather than stalling the tail
+        if not isinstance(event, dict):
+            continue
+        approval = parse_can_use_tool(event)
+        if approval is not None:
+            events.append(_ControlEvent("request", approval.request_id, approval))
+            continue
+        response_id = _control_response_request_id(event)
+        if response_id is not None:
+            events.append(_ControlEvent("response", response_id, None))
+    return events, new_offset
+
+
+async def supervise_qwen_approval_mirror(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    auth: httpx.Auth | None = None,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+) -> None:
+    """
+    Tail qwen's ``--json-file`` and mirror its approval prompts to web elicitations.
+
+    Runs for the session's lifetime (cancelled on teardown; any other exception
+    is logged and the loop continues, so a transient failure never abandons the
+    gate). Seeds the read offset at the current end of file so only *new* control
+    requests are parked — history was already resolved, and re-parking it would
+    flash stale cards. Several tool calls can be parked at once (qwen tags each
+    with its own ``request_id``); a ``control_response`` for a still-parked
+    request means it was answered in the TUI (or auto-resolved), so the web card
+    is released via ``external_elicitation_resolved``.
+
+    :param base_url: Server base URL.
+    :param headers: Auth/routing headers for the runner's requests.
+    :param session_id: Omnigent conversation id.
+    :param bridge_dir: The qwen-native bridge dir holding the event/input files.
+    :param auth: Optional httpx auth for the runner's requests.
+    :param poll_interval_s: Event-file poll cadence in seconds.
+    """
+    events_file = events_file_path(bridge_dir)
+    # Start watching from "now": only act on prompts emitted after launch. A
+    # request already in the file was either resolved (has a control_response) or
+    # is still showing in the TUI as the fallback; either way re-parking it would
+    # be wrong. Matches cursor-native's "the terminal is the fallback" stance.
+    try:
+        offset = events_file.stat().st_size
+    except OSError:
+        offset = 0
+    # request_id -> {"elicitation_id": str, "task": asyncio.Task}
+    pending: dict[str, dict[str, object]] = {}
+    timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=headers, auth=auth, timeout=timeout
+    ) as client:
+        while True:
+            try:
+                events, offset = await asyncio.to_thread(
+                    _read_new_control_events, events_file, offset
+                )
+                for ev in events:
+                    if ev.kind == "request":
+                        if ev.request_id in pending or ev.approval is None:
+                            continue
+                        elicitation_id = qwen_permission_elicitation_id(session_id, ev.request_id)
+                        task = asyncio.create_task(
+                            _run_one_approval(
+                                client,
+                                session_id=session_id,
+                                bridge_dir=bridge_dir,
+                                approval=ev.approval,
+                                elicitation_id=elicitation_id,
+                            ),
+                            name=f"qwen-approval-{ev.request_id}",
+                        )
+                        pending[ev.request_id] = {
+                            "elicitation_id": elicitation_id,
+                            "task": task,
+                        }
+                    else:  # "response": the request was resolved
+                        entry = pending.pop(ev.request_id, None)
+                        if entry is None:
+                            continue
+                        task = entry["task"]
+                        if isinstance(task, asyncio.Task) and not task.done():
+                            # Resolved in the TUI (or auto) before the web card
+                            # answered → release the parked card.
+                            await _post_external_elicitation_resolved(
+                                client, session_id, str(entry["elicitation_id"])
+                            )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "qwen approval mirror poll failed; session=%s bridge_dir=%s",
+                    session_id,
+                    bridge_dir,
+                )
+            await asyncio.sleep(poll_interval_s)
+
+
+async def _run_one_approval(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    approval: QwenApprovalRequest,
+    elicitation_id: str,
+) -> None:
+    """Park one qwen control request on the server and answer with the verdict."""
+    # Reuse the vendor-agnostic native-permission hook (shared with the hermes-
+    # and goose-native mirrors); ``agent`` labels the card and ``policy_name``
+    # keeps the qwen flavor.
+    payload = {
+        "elicitation_id": elicitation_id,
+        "agent": "qwen",
+        "policy_name": "qwen_native_permission",
+        "operation_type": approval.tool_name,
+        "message": approval.message,
+        "content_preview": approval.preview,
+    }
+    try:
+        response = await client.post(
+            f"/v1/sessions/{session_id}/hooks/native-permission-request",
+            json=payload,
+        )
+    except httpx.HTTPError:
+        _logger.exception("qwen permission hook POST failed; session=%s", session_id)
+        return
+    if response.status_code >= 400:
+        _logger.warning(
+            "qwen permission hook rejected: status=%s body=%s",
+            response.status_code,
+            response.text[:512],
+        )
+        return
+    if not response.content:
+        # Empty 2xx → resolved elsewhere (TUI answered) or timeout: no response.
+        return
+    try:
+        result = response.json()
+    except ValueError:
+        _logger.warning("qwen permission hook returned non-JSON: %s", response.text[:512])
+        return
+    action = result.get("action") if isinstance(result, dict) else None
+    if action == "accept":
+        allowed = True
+    elif action in {"decline", "cancel"}:
+        allowed = False
+    else:
+        return
+    try:
+        await asyncio.to_thread(
+            submit_confirmation, bridge_dir, request_id=approval.request_id, allowed=allowed
+        )
+    except RuntimeError:
+        _logger.exception(
+            "failed to write qwen confirmation_response for %s; session=%s",
+            approval.request_id,
+            session_id,
+        )
+
+
+async def _post_external_elicitation_resolved(
+    client: httpx.AsyncClient, session_id: str, elicitation_id: str
+) -> None:
+    """Tell the server the native TUI answered a pending qwen prompt."""
+    try:
+        response = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "external_elicitation_resolved",
+                "data": {"elicitation_id": elicitation_id},
+            },
+            timeout=10.0,
+        )
+        if response.status_code >= 400:
+            _logger.warning(
+                "qwen external_elicitation_resolved rejected: status=%s body=%s",
+                response.status_code,
+                response.text[:512],
+            )
+    except httpx.HTTPError:
+        _logger.exception("qwen external_elicitation_resolved POST failed")

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2251,6 +2251,7 @@ async def _auto_create_qwen_terminal(
     _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
 
     from omnigent.qwen_native_forwarder import supervise_qwen_forwarder
+    from omnigent.qwen_native_permissions import supervise_qwen_approval_mirror
 
     if server_client is not None and ensure_comment_relay is not None:
         await ensure_comment_relay(
@@ -2259,20 +2260,42 @@ async def _auto_create_qwen_terminal(
             await_notify=False,
         )
 
+    async def _supervise_qwen_native_bridges() -> None:
+        """Run the transcript forwarder and the approval mirror together.
+
+        Both are per-session, runner-owned, and self-healing (they catch and
+        log their own failures rather than exiting); gathering them under one
+        task keeps a single registration/cancellation handle
+        (:func:`_register_auto_forwarder_task`) for session teardown. The
+        forwarder mirrors qwen's replies onto the conversation; the approval
+        mirror surfaces qwen's native ``can_use_tool`` prompts as web
+        elicitations (see :mod:`omnigent.qwen_native_permissions`).
+        """
+        await asyncio.gather(
+            supervise_qwen_forwarder(
+                base_url=server_url,
+                headers={},
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                agent_name="qwen-native-ui",
+                auth=_runner_auth,
+            ),
+            supervise_qwen_approval_mirror(
+                base_url=server_url,
+                headers={},
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                auth=_runner_auth,
+            ),
+        )
+
     _forwarder_task = asyncio.create_task(
-        supervise_qwen_forwarder(
-            base_url=server_url,
-            headers={},
-            session_id=session_id,
-            bridge_dir=bridge_dir,
-            agent_name="qwen-native-ui",
-            auth=_runner_auth,
-        ),
-        name=f"qwen-forwarder-{session_id}",
+        _supervise_qwen_native_bridges(),
+        name=f"qwen-bridges-{session_id}",
     )
     _register_auto_forwarder_task(session_id, _forwarder_task)
     _logger.info(
-        "Auto-created qwen terminal + forwarder for session %s; forwarder_task=%s",
+        "Auto-created qwen terminal + forwarder/approval-mirror for session %s; task=%s",
         session_id,
         _forwarder_task.get_name(),
     )

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -287,6 +287,60 @@ async def test_cursor_permission_request_hook_allow_round_trip(
     assert resp.json() == {"action": "accept"}
 
 
+async def test_qwen_permission_request_hook_allow_round_trip(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    qwen-native TUI ``can_use_tool`` → web ApprovalCard → accept → verdict.
+
+    The runner-side mirror (``omnigent.qwen_native_permissions``) reads a
+    ``can_use_tool`` control request off qwen's ``--json-file`` and POSTs it to
+    the generic ``/hooks/native-permission-request`` (shared with hermes-/goose-
+    native) with ``agent="qwen"`` + ``policy_name="qwen_native_permission"``; the
+    route publishes a ``response.elicitation_request`` (phase ``pre_tool_use``,
+    the qwen policy name, carrying the runner-minted elicitation id and the
+    rendered tool preview) and parks on the same harness-elicitation registry the
+    Claude/Cursor hooks use, then returns the MCP ``ElicitationResult`` once the
+    UI answers. The qwen-native analog of
+    ``test_cursor_permission_request_hook_allow_round_trip``.
+    """
+    agent = await create_test_agent(client, "test-qwen-permission-allow")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = f"elicit_qwen_{session_id}_r1"
+    payload = {
+        "elicitation_id": elicitation_id,
+        "agent": "qwen",
+        "policy_name": "qwen_native_permission",
+        "operation_type": "run_shell_command",
+        "message": "qwen wants to run run_shell_command",
+        "content_preview": "echo hi > out.txt",
+    }
+
+    drain_task = asyncio.create_task(_drain_until_elicitation(session_id))
+    await asyncio.sleep(0.05)
+    hook_task = asyncio.create_task(
+        client.post(
+            f"/v1/sessions/{session_id}/hooks/native-permission-request",
+            json=payload,
+        )
+    )
+
+    event = await drain_task
+    assert event["elicitation_id"] == elicitation_id
+    params = event["params"]
+    assert params["message"] == "qwen wants to run run_shell_command"
+    assert params["phase"] == "pre_tool_use"
+    assert params["policy_name"] == "qwen_native_permission"
+    assert params["content_preview"] == "echo hi > out.txt"
+
+    verdict = await _post_approval(client, session_id, elicitation_id, "accept")
+    assert verdict.status_code == 202, verdict.text
+
+    resp = await hook_task
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"action": "accept"}
+
+
 async def test_top_level_elicitations_route_is_not_mounted(
     app: FastAPI,
     client: httpx.AsyncClient,

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -336,6 +336,59 @@ def test_prepare_bridge_dir_refuses_symlinked_ancestor(
     assert not (attacker_dir / "bridge.json").exists()
 
 
+def test_trusted_parent_accepts_qwen_native_bridge_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The relay's bridge-root allowlist accepts qwen-native bridge dirs.
+
+    The comment relay (``start_tool_relay`` → ``_ensure_secure_dir`` →
+    ``_trusted_parent_for_bridge_dir``) writes its JSON file under the
+    harness's bridge dir, validating it lives below a known bridge root.
+    qwen-native reuses this relay but keeps files under its own root
+    (``$TMPDIR/omnigent-<uid>/qwen-native``); if that root is missing from the
+    allowlist, every qwen-native session raises ``not under an allowed bridge
+    root`` and the relay never starts (observed in a live runner log). This
+    pins the qwen-native branch so the regression can't return.
+    """
+    from omnigent import qwen_native_bridge
+
+    # Distinct claude root so the qwen target can't match the claude branch
+    # first (the autouse fixture points the claude root at ``tmp_path``).
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native")
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    # qwen root mirrors production shape: <uid-scoped temp>/qwen-native.
+    qwen_root = tmp_path / "omnigent-test" / "qwen-native"
+    monkeypatch.setattr(qwen_native_bridge, "_BRIDGE_ROOT", qwen_root)
+
+    target = claude_native_bridge._absolute_syntactic_path(qwen_root / "abc123")
+    trusted = claude_native_bridge._trusted_parent_for_bridge_dir(target)
+
+    # Same anchor as cursor-native: the uid-scoped temp dir's parent.
+    assert trusted == claude_native_bridge._absolute_syntactic_path(qwen_root.parent.parent)
+
+
+def test_trusted_parent_rejects_path_outside_all_roots_and_names_qwen(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A path under no known root is refused, and the error names the qwen root."""
+    from omnigent import qwen_native_bridge
+
+    # Distinct claude root so ``outside`` below isn't swept under it (the autouse
+    # fixture points the claude root at ``tmp_path``).
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native")
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    qwen_root = tmp_path / "omnigent-test" / "qwen-native"
+    monkeypatch.setattr(qwen_native_bridge, "_BRIDGE_ROOT", qwen_root)
+
+    outside = claude_native_bridge._absolute_syntactic_path(tmp_path / "somewhere-else" / "x")
+    with pytest.raises(RuntimeError, match="not under an allowed bridge root") as exc:
+        claude_native_bridge._trusted_parent_for_bridge_dir(outside)
+    assert "qwen-native" in str(exc.value)
+
+
 def test_record_hook_event_updates_transcript_state(tmp_path: Path) -> None:
     """
     Hook records expose Claude's JSONL transcript path to the executor.

--- a/tests/test_qwen_native_permissions.py
+++ b/tests/test_qwen_native_permissions.py
@@ -1,0 +1,335 @@
+"""Unit tests for the qwen-native tool-approval mirror.
+
+Covers everything a live ``qwen`` TUI isn't needed for, with the file + HTTP
+boundaries faked:
+
+* **Parser** — pulling a ``can_use_tool`` control request out of a ``--json-file``
+  event (tool name / shell-command preview / request id), ignoring non-approval
+  events, extracting a ``control_response`` request id, and the elicitation-id
+  format.
+* **Reader** — ``_read_new_control_events`` incremental byte-offset tailing,
+  partial-line handling, and truncation rewind (the analog of the forwarder's
+  ``_read_new_events``, but for the control plane).
+* **Mirror supervisor** — ``_run_one_approval`` (park → verdict →
+  ``confirmation_response``), ``_post_external_elicitation_resolved`` (un-park on
+  a TUI-side answer), and ``supervise_qwen_approval_mirror`` (park a new request,
+  then release it when its ``control_response`` arrives unanswered).
+
+The event shapes are pinned to qwen's dual-output protocol (see
+``docs/QWEN_NATIVE_DESIGN.md`` and qwen's ``dual-output.md``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent import qwen_native_permissions as qnp
+from omnigent.qwen_native_bridge import events_file_path, input_file_path
+from omnigent.qwen_native_permissions import (
+    parse_can_use_tool,
+    qwen_permission_elicitation_id,
+)
+
+
+def _can_use_tool_ev(
+    request_id: str, *, tool_name: str = "run_shell_command", command: str = "ls"
+) -> dict:
+    return {
+        "type": "control_request",
+        "request_id": request_id,
+        "request": {
+            "subtype": "can_use_tool",
+            "tool_name": tool_name,
+            "tool_use_id": f"tu_{request_id}",
+            "input": {"command": command},
+        },
+    }
+
+
+def _control_response_ev(request_id: str, *, allowed: bool = True) -> dict:
+    return {
+        "type": "control_response",
+        "response": {
+            "subtype": "success",
+            "request_id": request_id,
+            "response": {"allowed": allowed},
+        },
+    }
+
+
+def _ev_bytes(obj: dict) -> bytes:
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+# ── Parser ───────────────────────────────────────────────────────
+
+
+def test_parse_can_use_tool_extracts_request_id_name_and_command_preview() -> None:
+    req = parse_can_use_tool(_can_use_tool_ev("r1", command="rm -rf build"))
+    assert req is not None
+    assert req.request_id == "r1"
+    assert req.tool_name == "run_shell_command"
+    assert req.preview == "rm -rf build"
+    assert req.message
+
+
+def test_parse_can_use_tool_non_shell_input_falls_back_to_json_preview() -> None:
+    ev = {
+        "type": "control_request",
+        "request_id": "r2",
+        "request": {"subtype": "can_use_tool", "tool_name": "write_file", "input": {"path": "/x"}},
+    }
+    req = parse_can_use_tool(ev)
+    assert req is not None
+    assert req.tool_name == "write_file"
+    assert json.loads(req.preview) == {"path": "/x"}
+
+
+def test_parse_can_use_tool_missing_name_degrades_to_tool() -> None:
+    ev = {"type": "control_request", "request_id": "r3", "request": {"subtype": "can_use_tool"}}
+    req = parse_can_use_tool(ev)
+    assert req is not None
+    assert req.tool_name == "tool"
+    assert req.preview == "tool"
+
+
+@pytest.mark.parametrize(
+    "ev",
+    [
+        pytest.param({"type": "assistant", "uuid": "a1"}, id="assistant"),
+        pytest.param({"type": "system", "subtype": "session_start"}, id="system"),
+        pytest.param(
+            {"type": "control_request", "request": {"subtype": "other"}, "request_id": "x"},
+            id="other-control-subtype",
+        ),
+        pytest.param(
+            {"type": "control_request", "request": {"subtype": "can_use_tool"}},
+            id="missing-request-id",
+        ),
+    ],
+)
+def test_parse_can_use_tool_returns_none_for_non_approval_events(ev: dict) -> None:
+    assert parse_can_use_tool(ev) is None
+
+
+def test_control_response_request_id_extraction() -> None:
+    assert qnp._control_response_request_id(_control_response_ev("r9")) == "r9"
+    assert qnp._control_response_request_id({"type": "control_request"}) is None
+    assert qnp._control_response_request_id({"type": "control_response", "response": {}}) is None
+
+
+def test_elicitation_id_is_deterministic_and_session_scoped() -> None:
+    eid = qwen_permission_elicitation_id("conv_abc", "r1")
+    assert eid == qwen_permission_elicitation_id("conv_abc", "r1")
+    assert eid != qwen_permission_elicitation_id("conv_xyz", "r1")
+    assert "conv_abc" in eid
+    assert eid.startswith("elicit_qwen_")
+
+
+# ── Reader ───────────────────────────────────────────────────────
+
+
+def test_read_new_control_events_incremental_and_partial_line(tmp_path: Path) -> None:
+    f = tmp_path / "out.ndjson"
+    f.write_bytes(_ev_bytes(_can_use_tool_ev("r1")))
+    events, off = qnp._read_new_control_events(f, 0)
+    assert [e.kind for e in events] == ["request"]
+    assert events[0].request_id == "r1"
+
+    # Append a complete response line plus a trailing partial line; only the
+    # complete one is consumed, offset stops before the partial.
+    with open(f, "ab") as fh:
+        fh.write(_ev_bytes(_control_response_ev("r1")))
+        fh.write(b'{"type":"control_request","request_id":"r2"')  # no newline
+    events2, off2 = qnp._read_new_control_events(f, off)
+    assert [(e.kind, e.request_id) for e in events2] == [("response", "r1")]
+    assert off2 == off + len(_ev_bytes(_control_response_ev("r1")))
+
+
+def test_read_new_control_events_rewinds_on_truncation(tmp_path: Path) -> None:
+    f = tmp_path / "out.ndjson"
+    f.write_bytes(_ev_bytes(_can_use_tool_ev("r1")) * 3)
+    _events, off = qnp._read_new_control_events(f, 0)
+    assert off > 0
+    # Terminal relaunch truncates the file; a stale offset past EOF rewinds to 0.
+    f.write_bytes(_ev_bytes(_can_use_tool_ev("r2")))
+    events, new_off = qnp._read_new_control_events(f, off)
+    assert [e.request_id for e in events] == ["r2"]
+    assert new_off == len(_ev_bytes(_can_use_tool_ev("r2")))
+
+
+def test_read_new_control_events_ignores_transcript_and_malformed(tmp_path: Path) -> None:
+    f = tmp_path / "out.ndjson"
+    f.write_bytes(
+        _ev_bytes({"type": "assistant", "uuid": "a1", "message": {"content": []}})
+        + b"not-json\n"
+        + _ev_bytes(_can_use_tool_ev("r1"))
+    )
+    events, _off = qnp._read_new_control_events(f, 0)
+    assert [(e.kind, e.request_id) for e in events] == [("request", "r1")]
+
+
+# ── Mirror supervisor ────────────────────────────────────────────
+
+
+class _QueueClient:
+    """Async httpx-client stub: records POSTs, returns queued responses in order."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self.posts: list[tuple[str, dict]] = []
+        self._responses = list(responses)
+
+    async def post(self, url: str, *, json: dict, **_kw: object) -> httpx.Response:
+        self.posts.append((url, json))
+        return self._responses.pop(0)
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_allowed"),
+    [
+        pytest.param(httpx.Response(200, json={"action": "accept"}), True, id="accept->allow"),
+        pytest.param(httpx.Response(200, json={"action": "decline"}), False, id="decline->deny"),
+        pytest.param(httpx.Response(200, json={"action": "cancel"}), False, id="cancel->deny"),
+        pytest.param(httpx.Response(200), None, id="empty-200->no-write"),
+        pytest.param(httpx.Response(400, text="nope"), None, id="rejected->no-write"),
+        pytest.param(httpx.Response(200, content=b"not-json"), None, id="non-json->no-write"),
+        pytest.param(
+            httpx.Response(200, json={"action": "??"}), None, id="unknown-action->no-write"
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_one_approval_posts_then_writes_confirmation(
+    response: httpx.Response,
+    expected_allowed: bool | None,
+    tmp_path: Path,
+) -> None:
+    """Park a request on the server, then answer qwen with a confirmation line.
+
+    A ``confirmation_response`` is written ONLY for a concrete accept/decline/
+    cancel verdict; an empty 2xx (TUI answered / timeout), a rejection, a
+    non-JSON body, or an unknown action writes nothing to the input file.
+    """
+    req = parse_can_use_tool(_can_use_tool_ev("r1", command="ls -la"))
+    assert req is not None
+    client = _QueueClient([response])
+
+    await qnp._run_one_approval(
+        client,  # type: ignore[arg-type]
+        session_id="conv_1",
+        bridge_dir=tmp_path,
+        approval=req,
+        elicitation_id="elic_1",
+    )
+
+    url, body = client.posts[0]
+    assert url == "/v1/sessions/conv_1/hooks/native-permission-request"
+    assert body == {
+        "elicitation_id": "elic_1",
+        "agent": "qwen",
+        "policy_name": "qwen_native_permission",
+        "operation_type": "run_shell_command",
+        "message": req.message,
+        "content_preview": "ls -la",
+    }
+
+    in_path = input_file_path(tmp_path)
+    if expected_allowed is None:
+        assert not in_path.exists() or in_path.read_text() == ""
+    else:
+        lines = [json.loads(ln) for ln in in_path.read_text().splitlines() if ln.strip()]
+        assert lines == [
+            {"type": "confirmation_response", "request_id": "r1", "allowed": expected_allowed}
+        ]
+
+
+@pytest.mark.asyncio
+async def test_post_external_elicitation_resolved_shape() -> None:
+    client = _QueueClient([httpx.Response(200)])
+    await qnp._post_external_elicitation_resolved(client, "conv_2", "elic_9")  # type: ignore[arg-type]
+    url, body = client.posts[0]
+    assert url == "/v1/sessions/conv_2/events"
+    assert body == {"type": "external_elicitation_resolved", "data": {"elicitation_id": "elic_9"}}
+
+
+@pytest.mark.asyncio
+async def test_supervise_mirror_parks_then_releases_on_control_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Park a new ``can_use_tool``, then release it when its ``control_response``
+    arrives while the web card is still parked (the user answered in the TUI).
+    """
+    created: list[object] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, **_kw: object) -> None:
+            self.posts: list[tuple[str, dict]] = []
+            created.append(self)
+
+        async def __aenter__(self) -> _FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *_a: object) -> bool:
+            return False
+
+        async def post(self, url: str, *, json: dict, **_kw: object) -> httpx.Response:
+            self.posts.append((url, json))
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(qnp.httpx, "AsyncClient", _FakeAsyncClient)
+
+    # Hold the park task pending so the release branch is taken (a completed task
+    # means the web verdict already landed → no release needed).
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _fake_run_one(_client: object, **_kw: object) -> None:
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(qnp, "_run_one_approval", _fake_run_one)
+
+    events_file = events_file_path(tmp_path)
+    events_file.write_bytes(b"")  # mirror seeds offset at EOF (==0 here)
+
+    task = asyncio.create_task(
+        qnp.supervise_qwen_approval_mirror(
+            base_url="http://t",
+            headers={},
+            session_id="conv_3",
+            bridge_dir=tmp_path,
+            poll_interval_s=0.001,
+        )
+    )
+    try:
+        # Let the mirror seed its read offset at EOF (empty file) first, so the
+        # request below is seen as NEW — the real fresh-terminal flow.
+        await asyncio.sleep(0.05)
+        # First a control_request appears → park task spawns.
+        with open(events_file, "ab") as fh:
+            fh.write(_ev_bytes(_can_use_tool_ev("r1")))
+        await asyncio.wait_for(started.wait(), 2.0)
+        # Then its control_response (answered in the TUI) → release the card.
+        with open(events_file, "ab") as fh:
+            fh.write(_ev_bytes(_control_response_ev("r1")))
+        for _ in range(400):
+            if created and getattr(created[0], "posts", None):
+                break
+            await asyncio.sleep(0.005)
+        assert created, "supervisor never opened a client"
+        url, body = created[0].posts[0]  # type: ignore[attr-defined]
+        assert url == "/v1/sessions/conv_3/events"
+        assert body["type"] == "external_elicitation_resolved"
+        assert body["data"]["elicitation_id"] == qwen_permission_elicitation_id("conv_3", "r1")
+    finally:
+        release.set()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/test_qwen_native_permissions.py
+++ b/tests/test_qwen_native_permissions.py
@@ -333,3 +333,73 @@ async def test_supervise_mirror_parks_then_releases_on_control_response(
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+
+@pytest.mark.asyncio
+async def test_supervise_mirror_skips_request_resolved_in_same_poll_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A request + its control_response in ONE poll batch never parks a card.
+
+    The decision was made (TUI/auto) within a single poll window, before the
+    mirror could park it. Parking now would race its own response — the response
+    branch would run against a freshly-created task that hasn't POSTed yet and so
+    couldn't release the card, leaving it stuck until the server-side timeout. So
+    the mirror must spawn no approval task and post nothing for that request.
+    """
+    created: list[object] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, **_kw: object) -> None:
+            self.posts: list[tuple[str, dict]] = []
+            created.append(self)
+
+        async def __aenter__(self) -> _FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *_a: object) -> bool:
+            return False
+
+        async def post(self, url: str, *, json: dict, **_kw: object) -> httpx.Response:
+            self.posts.append((url, json))
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(qnp.httpx, "AsyncClient", _FakeAsyncClient)
+
+    run_one_calls: list[str] = []
+
+    async def _fake_run_one(_client: object, *, approval: object, **_kw: object) -> None:
+        run_one_calls.append(approval.request_id)  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(qnp, "_run_one_approval", _fake_run_one)
+
+    events_file = events_file_path(tmp_path)
+    events_file.write_bytes(b"")  # mirror seeds offset at EOF (==0 here)
+
+    task = asyncio.create_task(
+        qnp.supervise_qwen_approval_mirror(
+            base_url="http://t",
+            headers={},
+            session_id="conv_4",
+            bridge_dir=tmp_path,
+            poll_interval_s=0.02,
+        )
+    )
+    try:
+        # Let the mirror seed its offset at EOF and enter its sleep, then write
+        # BOTH events in a single atomic write so the next poll reads them as one
+        # batch (the file is empty until this one syscall completes, so a poll
+        # can only see neither line or both — never just the request).
+        await asyncio.sleep(0.08)
+        with open(events_file, "ab") as fh:
+            fh.write(_ev_bytes(_can_use_tool_ev("r1")) + _ev_bytes(_control_response_ev("r1")))
+        # Give the supervisor several poll cycles to consume the batch.
+        await asyncio.sleep(0.2)
+        assert run_one_calls == [], "should not park a request already resolved in-batch"
+        assert created, "supervisor never opened a client"
+        assert created[0].posts == [], "should not post external_elicitation_resolved"  # type: ignore[attr-defined]
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task


### PR DESCRIPTION
## Summary

Follow-up to #1134. Makes tool-approval **elicitation work for native-qwen**: when the embedded qwen TUI prompts for tool approval, the same approval now renders as a card in the web chat, and answering **either** surface resolves the other.

qwen's dual-output stream emits a structured `control_request`/`can_use_tool` whenever a tool needs approval (coexisting with its in-terminal prompt), accepts a `confirmation_response` on the input file, and emits a `control_response` on resolution either way (verified against qwen v0.18.2 + its `dual-output.md`). This is the structured analog of cursor-native's pane-scraping approval mirror — no keystrokes, no ANSI scraping.

### How it works

```
qwen TUI --json-file ──▶ mirror ──▶ POST /hooks/native-permission-request ──▶ web ApprovalCard
   ▲                       │              (publishes response.elicitation_request, parks)
   └── confirmation_response ◀── web verdict (accept→allowed:true / decline|cancel→false)

control_response (TUI answered first) ──▶ mirror POSTs external_elicitation_resolved ──▶ card clears
```

- **`omnigent/qwen_native_permissions.py`** (new): `supervise_qwen_approval_mirror` tails the same `--json-file` the transcript forwarder reads (seeded at EOF so only new prompts park), parks each request on the server, writes `confirmation_response` on the web verdict, and releases the card via `external_elicitation_resolved` when the TUI answers first.
- **Reuses the generic `POST /v1/sessions/{id}/hooks/native-permission-request`** hook (the vendor-agnostic one shared with the hermes-/goose-native mirrors, landed on `main` after this branch forked) with `agent="qwen"` + `policy_name="qwen_native_permission"`, so the card is qwen-labelled and a card always shows when the TUI prompts.
- **`omnigent/runner/app.py`**: forwarder + approval mirror run together under one supervised task in `_auto_create_qwen_terminal`.
- **`omnigent/qwen_native_forwarder.py`**: corrected the now-inaccurate `can_use_tool` stub comments (the mirror owns the control plane).

Verified end-to-end on a live session — matching `request_id` across `control_request` → our `confirmation_response` → `control_response`.

### Drive-by fix

The comment relay's bridge-root allowlist (`claude_native_bridge._trusted_parent_for_bridge_dir`) omitted `qwen-native`, so `ensure_comment_relay` threw `not under an allowed bridge root` for **every** native-qwen session (seen in a live runner log). Added the `qwen-native` branch (same shape as cursor-native).

### Docs

- Marked the elicitation follow-up done in `docs/QWEN_FOLLOWUPS.md`.
- Added a Medium follow-up: compaction/compression mirroring (TUI → web).

## Tests

- `tests/test_qwen_native_permissions.py` (new): parser, control-event reader (incremental/partial-line/truncation), `_run_one_approval` verdict→confirmation matrix, and the park→release-on-`control_response` cycle.
- `tests/server/integration/test_sessions_permission_request_hook.py`: qwen-flavored native-permission hook round-trip.
- `tests/test_claude_native_bridge.py`: two trusted-parent regression tests for the bridge-root fix (the accept case fails without the fix).

All added/impacted tests pass.

> Note: `test_top_level_elicitations_route_is_not_mounted` (in the hook integration file) fails on this branch with **405 vs 404** — verified pre-existing and unrelated (it fails identically on a clean tree with all changes stashed); it's environment/ordering-sensitive around whether the SPA catch-all route is mounted.

## Notes / known limitations

- The web card is binary **Approve/Reject**, which is faithful: qwen's external `confirmation_response` is boolean (`allowed`), which qwen collapses to `proceed_once`/`cancel`. The TUI's "Always allow project/user" options are keyboard-only and not exposed on the stream (`permission_suggestions` is null). Users can still pick them in the embedded pane; the mirror's loser-release keeps both surfaces consistent.
- A live E2E confirming the terminal-vs-card race timing under real latency is still worth doing (bridge-level pieces are unit-covered).