### PR TITLE
fix(antigravity-native): wire omnigent MCP relay so agy gets the sys_* tools (#1194)

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -293,7 +293,10 @@ def _materialize_antigravity_agent_spec(tmpdir: Path) -> Path:
         "executor": {"harness": "antigravity-native"},
         # Opt the native session into the child-session spawn writes so the
         # wrapped agy can author agent configs and launch them as sub-agent
-        # sessions. The relay derives its advertised tool set from this spec.
+        # sessions. The Omnigent MCP relay (wired in #1194 — see
+        # ``antigravity_native_bridge.write_mcp_config`` and the runner's
+        # ``_ensure_comment_relay_started``) derives its advertised
+        # ``sys_session_*`` write surface from this ``spawn: true`` gate.
         "spawn": True,
         # Without an ``os_env`` block the runner's filesystem APIs 404 (see
         # ``_require_os_env`` in ``omnigent/runner/app.py``). agy already
@@ -305,9 +308,11 @@ def _materialize_antigravity_agent_spec(tmpdir: Path) -> Path:
             "cwd": ".",
             "sandbox": {"type": "none"},
         },
-        # Declare a default shell terminal so the relay advertises the
-        # ``sys_terminal_*`` family to the wrapped agy (the relay's gate is
-        # a non-empty ``terminals:`` block on this spec).
+        # Declare a default shell terminal so the Omnigent MCP relay advertises
+        # the ``sys_terminal_*`` family to the wrapped agy (the relay's gate is
+        # a non-empty ``terminals:`` block on this spec). This also feeds the
+        # web-UI new-terminal affordance (``server/routes/sessions.py``), so it
+        # is not inert even independent of the relay.
         "terminals": {
             "shell": {
                 "command": "bash",

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -7,11 +7,14 @@ import hashlib
 import json
 import logging
 import os
+import secrets
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 _logger = logging.getLogger(__name__)
 
@@ -239,6 +242,268 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
     bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(bridge_dir, 0o700)
     return bridge_dir
+
+
+# ── Omnigent MCP relay wiring (sys_* tools) ──────────────────────────────────
+#
+# agy is otherwise tool-isolated from Omnigent: unlike claude/codex/cursor it
+# wires no MCP relay, so the wrapped agy cannot reach any ``sys_*`` tool (spawn
+# sub-agent sessions, drive Omnigent terminals, list agents/models, ``sys_os_*``).
+# This section wires the SAME relay cursor #742 uses — the shared
+# ``omnigent.claude_native_bridge serve-mcp`` stdio server — into agy.
+#
+# THE CONFIG-SCOPING FOOTGUN. agy has no ``--mcp-config`` flag and ignores every
+# ``ANTIGRAVITY_*`` env knob; it loads MCP servers from a single HOME-GLOBAL file,
+# ``$HOME/.gemini/config/mcp_config.json`` — the *same* file the user's
+# interactive agy reads (verified empirically against agy 1.0.12). Writing that
+# file directly would (a) clobber/pollute the user's interactive agy config and
+# (b) be incorrect under concurrency: the relay command is bridge-dir-specific, so
+# two antigravity-native sessions (or a session + the user's interactive agy)
+# would fight over the one global file.
+#
+# CHOSEN DESIGN — per-session ISOLATED HOME. The runner launches agy with
+# ``HOME`` pointed at a per-bridge-dir tree (:func:`agy_home_dir`) seeded with a
+# COPY of the user's OAuth token + onboarding/migration markers and a
+# bridge-scoped ``config/mcp_config.json`` written by :func:`write_mcp_config`.
+# This (1) NEVER touches the user's real ``~/.gemini``, (2) gives each session its
+# own ``mcp_config.json`` so concurrent sessions never clobber one another, and
+# (3) was verified live: agy under the isolated HOME does NOT re-demand OAuth and
+# its ``/mcp`` panel shows ``✓ omnigent`` with the ``sys_*`` tools discovered. agy
+# resolves ``GeminiDir`` from ``$HOME/.gemini`` (its hardcoded default), so the
+# only thing the isolated HOME relocates is the *config + state* tree; auth still
+# works because the seeded token is a copy of the user's real one.
+_MCP_CONFIG_DIR = "config"
+_MCP_CONFIG_FILE = "mcp_config.json"
+_BRIDGE_CONFIG_FILE = "bridge.json"
+_MCP_SERVER_NAME = "omnigent"
+# agy auto-approves a relay tool when it is named in the server's ``enabledTools``
+# allowlist (agy's per-server MCP schema; mirrors cursor's ``autoApprove``).
+# Omnigent's own TOOL_CALL policy + elicitation gate still applies on the server
+# side, so auto-approving the agy-side MCP gate only avoids a hidden in-terminal
+# prompt blocking the call before Omnigent ever sees it.
+_AGY_ENABLED_TOOLS = [
+    "list_comments",
+    "sys_add_policy",
+    "sys_agent_download",
+    "sys_agent_get",
+    "sys_agent_list",
+    "sys_call_async",
+    "sys_cancel_async",
+    "sys_cancel_task",
+    "sys_list_models",
+    "sys_os_edit",
+    "sys_os_read",
+    "sys_os_shell",
+    "sys_os_write",
+    "sys_policy_registry",
+    "sys_session_close",
+    "sys_session_create",
+    "sys_session_get_history",
+    "sys_session_get_info",
+    "sys_session_list",
+    "sys_session_send",
+    "sys_terminal_close",
+    "sys_terminal_launch",
+    "sys_terminal_list",
+    "sys_terminal_read",
+    "sys_terminal_send",
+    "update_comment",
+]
+
+# Files copied from the user's real ``~/.gemini`` into the per-session isolated
+# HOME so agy does not re-run OAuth / onboarding. The OAuth token is the only
+# secret; it is COPIED (the real file is never moved or modified). Missing files
+# are skipped (agy regenerates onboarding/migration state, and a missing token
+# only means agy re-auths in that session — never a corruption of the real tree).
+_AGY_SEED_FILES = (
+    Path("antigravity-cli") / "antigravity-oauth-token",
+    Path("antigravity-cli") / "installation_id",
+)
+
+
+def agy_home_dir(bridge_dir: Path) -> Path:
+    """Return the per-session isolated ``HOME`` for an agy launch.
+
+    A subdirectory of *bridge_dir* so it is naturally per-session (the bridge dir
+    is hash-scoped to the bridge id) and torn down with the bridge. agy reads its
+    MCP config + state from ``$HOME/.gemini``; pinning ``HOME`` here keeps the
+    relay's ``mcp_config.json`` out of the user's real ``~/.gemini`` and prevents
+    two concurrent sessions from sharing one global config.
+
+    :param bridge_dir: Native Antigravity bridge directory.
+    :returns: Absolute path to this session's isolated agy HOME.
+    """
+    return bridge_dir / "agy-home"
+
+
+def build_mcp_config(
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> dict[str, Any]:
+    """Build agy's ``mcp_config.json`` payload for the Omnigent relay server.
+
+    Mirrors cursor #742's :func:`omnigent.cursor_native_bridge.build_mcp_config`
+    but emits agy's per-server MCP schema (lowercase ``command`` / ``args`` /
+    ``env`` keys plus ``enabledTools``, agy's auto-approve allowlist — verified
+    against agy 1.0.12's config struct) under the top-level ``mcpServers`` key.
+    The server command is the SAME shared relay claude/codex/cursor use:
+    ``<python> -I -m omnigent.claude_native_bridge serve-mcp --bridge-dir <dir>``.
+
+    **HOME pinning (critical for the isolated-HOME design).** agy spawns this relay
+    as a child, so the relay inherits agy's environment — including the per-session
+    isolated ``HOME`` agy runs under. But the relay validates its ``--bridge-dir``
+    against ``bridge_root()`` (``$HOME/.omnigent/antigravity-native``), which must
+    resolve to the RUNNER's real home where the bridge dir actually lives — not the
+    isolated agy HOME (a child of the bridge dir). So the relay's ``env`` pins
+    ``HOME`` back to the runner's real home. ``-I`` does not clear ``HOME``; it only
+    ignores ``PYTHON*`` vars and user site-packages, so this override takes effect.
+
+    :param bridge_dir: Native Antigravity bridge directory whose relay this
+        config points at.
+    :param python_executable: Python interpreter for the relay command;
+        defaults to the current interpreter (``sys.executable``).
+    :returns: The ``mcp_config.json`` payload as a dict.
+    """
+    python = python_executable or sys.executable
+    return {
+        "mcpServers": {
+            _MCP_SERVER_NAME: {
+                "command": python,
+                "args": [
+                    "-I",
+                    "-m",
+                    "omnigent.claude_native_bridge",
+                    "serve-mcp",
+                    "--bridge-dir",
+                    str(bridge_dir),
+                ],
+                "enabledTools": list(_AGY_ENABLED_TOOLS),
+                "env": {
+                    "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+                    # Pin the relay to the RUNNER's real home so its bridge-root
+                    # validation matches where the bridge dir lives (agy runs under
+                    # an isolated HOME; the relay must not inherit it). See docstring.
+                    "HOME": str(Path.home()),
+                },
+            }
+        }
+    }
+
+
+def write_mcp_bridge_config(bridge_dir: Path) -> None:
+    """Write the token config the shared Omnigent MCP relay requires.
+
+    The relay's ``serve-mcp`` reads ``<bridge_dir>/bridge.json`` for a token that
+    authorizes its localhost control endpoint. Idempotent: an existing token is
+    left untouched so a resume/clear does not rotate a live relay's token.
+    Mirrors :func:`omnigent.cursor_native_bridge.write_mcp_bridge_config`.
+
+    :param bridge_dir: Native Antigravity bridge directory.
+    :returns: None.
+    """
+    bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    config_path = bridge_dir / _BRIDGE_CONFIG_FILE
+    if config_path.exists():
+        return
+    payload = {"token": secrets.token_urlsafe(32)}
+    tmp = bridge_dir / (_BRIDGE_CONFIG_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, config_path)
+
+
+def write_mcp_config(
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> Path:
+    """Write the per-session agy MCP config + relay token into the isolated HOME.
+
+    Writes (1) ``bridge.json`` (the relay token) into *bridge_dir* and (2) the
+    ``mcp_config.json`` for the Omnigent relay into the per-session isolated agy
+    HOME at ``<agy_home>/.gemini/config/mcp_config.json`` — the path agy actually
+    loads MCP servers from. Because the HOME is per-session and never the user's
+    real ``~``, this never clobbers the user's interactive agy config and two
+    concurrent sessions never share one config. Mirrors cursor #742's
+    :func:`omnigent.cursor_native_bridge.write_mcp_config`, adapted to agy's
+    HOME-global config path + isolated-HOME scoping.
+
+    :param bridge_dir: Native Antigravity bridge directory (holds ``bridge.json``
+        and the isolated agy HOME).
+    :param python_executable: Python interpreter for the relay command;
+        defaults to the current interpreter.
+    :returns: Absolute path to the written ``mcp_config.json``.
+    """
+    write_mcp_bridge_config(bridge_dir)
+    config_dir = agy_home_dir(bridge_dir) / ".gemini" / _MCP_CONFIG_DIR
+    config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path = config_dir / _MCP_CONFIG_FILE
+    payload = build_mcp_config(bridge_dir, python_executable=python_executable)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+    return path
+
+
+def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
+    """Seed the per-session isolated agy HOME and return the launch env override.
+
+    Copies the user's real agy OAuth token + onboarding/migration state (NEVER
+    moving or modifying the real files) into ``<bridge_dir>/agy-home/.gemini`` so
+    a launch under this isolated HOME does not re-demand OAuth or re-run the
+    onboarding wizard. The relay's ``mcp_config.json`` is written separately by
+    :func:`write_mcp_config` so it lands in this same isolated tree rather than
+    the user's real ``~/.gemini`` (the footgun this whole design avoids).
+
+    Verified live (agy 1.0.12): under this isolated HOME agy logs in as the real
+    user from the seeded token and its ``/mcp`` panel shows ``✓ omnigent`` with the
+    ``sys_*`` tools discovered.
+
+    :param bridge_dir: Native Antigravity bridge directory.
+    :returns: An env-override mapping (``{"HOME": <iso_home>}``) to layer onto the
+        agy launch environment.
+    """
+    real_home = Path.home()
+    iso_home = agy_home_dir(bridge_dir)
+    iso_gemini = iso_home / ".gemini"
+    (iso_gemini / "antigravity-cli" / "cache").mkdir(mode=0o700, parents=True, exist_ok=True)
+    (iso_gemini / _MCP_CONFIG_DIR).mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    # Copy the auth token + installation id (best-effort: a missing token only
+    # means agy re-auths this session; the real files are never touched).
+    for rel in _AGY_SEED_FILES:
+        src = real_home / ".gemini" / rel
+        if not src.is_file():
+            continue
+        dst = iso_gemini / rel
+        dst.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with contextlib.suppress(OSError):
+            dst.write_bytes(src.read_bytes())
+            os.chmod(dst, 0o600)
+
+    # Seed the onboarding-complete marker so the first-run wizard never blocks a
+    # headless launch (same state ``ensure_agy_onboarding_complete`` writes).
+    onboarding = iso_gemini / "antigravity-cli" / "cache" / "onboarding.json"
+    with contextlib.suppress(OSError):
+        onboarding.write_text(
+            json.dumps(
+                {
+                    "consumerOnboardingComplete": True,
+                    "enterpriseOnboardingComplete": False,
+                    "onboardingComplete": True,
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    # Seed the migration marker so agy does not churn a from-scratch migration on
+    # first launch under the fresh HOME (cosmetic; agy creates it itself otherwise).
+    with contextlib.suppress(OSError):
+        (iso_gemini / _MCP_CONFIG_DIR / ".migrated").touch()
+
+    return {"HOME": str(iso_home)}
 
 
 def write_bridge_state(bridge_dir: Path, state: AntigravityNativeBridgeState) -> None:

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -217,9 +217,26 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
     if target.is_relative_to(cursor_root):
         return _absolute_syntactic_path(cursor_root.parent.parent)
 
+    from omnigent.antigravity_native_bridge import bridge_root as antigravity_bridge_root
+
+    # antigravity-native keeps its bridge files below ``~/.omnigent/antigravity-native``,
+    # the same ``$HOME/.omnigent/<harness>-native`` shape codex uses, so apply the
+    # identical anchor logic: in production trust ``$HOME`` and validate/chmod the
+    # two bridge-owned dirs below it (``.omnigent`` and ``antigravity-native``); in
+    # tests the monkeypatched root may differ, so trust the direct parent.
+    antigravity_root = _absolute_syntactic_path(antigravity_bridge_root())
+    if target.is_relative_to(antigravity_root):
+        trusted_parent = antigravity_root.parent
+        if (
+            antigravity_root.name == "antigravity-native"
+            and antigravity_root.parent.name == ".omnigent"
+        ):
+            trusted_parent = antigravity_root.parent.parent
+        return _absolute_syntactic_path(trusted_parent)
+
     raise RuntimeError(
         f"bridge dir {target!s} is not under an allowed bridge root "
-        f"({claude_root!s}, {codex_root!s}, {cursor_root!s})"
+        f"({claude_root!s}, {codex_root!s}, {cursor_root!s}, {antigravity_root!s})"
     )
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2974,6 +2974,7 @@ async def _auto_create_antigravity_terminal(
     publish_event: Callable[[str, dict[str, object]], None],
     *,
     server_client: httpx.AsyncClient | None = None,
+    ensure_comment_relay: Callable[..., Awaitable[None]] | None = None,
 ) -> SessionResourceView:
     """
     Auto-create the native Antigravity (agy) terminal for a session.
@@ -3023,6 +3024,11 @@ async def _auto_create_antigravity_terminal(
     :param server_client: Runner's Omnigent server HTTP client. Used to read
         the persisted workspace, launch args, and the discovered agy
         conversation id (``external_session_id``) for resume.
+    :param ensure_comment_relay: The runner's relay starter
+        (``_ensure_comment_relay_started``). When provided, the Omnigent MCP
+        relay is started against this session's bridge dir before launch so the
+        wrapped agy sees the ``sys_*`` tools (#1194). ``None`` skips relay wiring
+        (the ``_run_turn_bg`` first-turn fallback re-ensures it).
     :returns: The created terminal resource view.
     :raises RuntimeError: If the session snapshot or required runner env is
         unavailable.
@@ -3033,7 +3039,9 @@ async def _auto_create_antigravity_terminal(
         clear_bridge_state,
         ensure_agy_onboarding_complete,
         prepare_bridge_dir,
+        seed_isolated_agy_home,
         write_bridge_state,
+        write_mcp_config,
         write_tmux_target,
     )
     from omnigent.antigravity_native_launch import build_agy_launch
@@ -3118,6 +3126,36 @@ async def _auto_create_antigravity_terminal(
         headless=False,
         extra_args=terminal_launch_args,
     )
+
+    # Wire the Omnigent MCP relay so the wrapped agy gets the sys_* tools
+    # (spawn sub-agent sessions, drive Omnigent terminals, list agents/models,
+    # sys_os_*) — the only native harness that otherwise lacks them (#1194).
+    # agy has no --mcp-config flag and ignores ANTIGRAVITY_* env knobs; it loads
+    # MCP servers ONLY from the HOME-global ~/.gemini/config/mcp_config.json. To
+    # avoid clobbering the user's interactive agy config (and the concurrency
+    # footgun of a single shared file), launch agy under a per-session ISOLATED
+    # HOME seeded with a copy of the user's OAuth token + onboarding state and a
+    # bridge-scoped mcp_config.json. The relay subprocess is the same shared
+    # ``serve-mcp`` claude/codex/cursor use. Offloaded to a thread (file I/O) and
+    # done BEFORE the terminal launch so agy sees the config on its first MCP scan.
+    await asyncio.to_thread(write_mcp_config, bridge_dir)
+    env_overrides = {
+        **env_overrides,
+        **await asyncio.to_thread(seed_isolated_agy_home, bridge_dir),
+    }
+    # Start the shared comment/sys_* relay against THIS session's bridge dir before
+    # launch so its tool_relay.json is on disk when agy first scans the MCP server.
+    # ``await_notify=False``: agy starts its MCP client lazily, so awaiting the
+    # tools/list_changed notification would stall the launch (mirrors codex). The
+    # _run_turn_bg first-turn fallback re-ensures this for any session whose
+    # terminal was launched outside this path.
+    if ensure_comment_relay is not None:
+        await ensure_comment_relay(
+            session_id,
+            bridge_id=bridge_id,
+            explicit_bridge_dir=bridge_dir,
+            await_notify=False,
+        )
 
     _logger.info(
         "Antigravity terminal auto-create starting: session=%s workspace=%s resume=%s "
@@ -7919,6 +7957,7 @@ def create_runner_app(
                             resource_registry,
                             _publish_event,
                             server_client=server_client,
+                            ensure_comment_relay=_ensure_comment_relay_started,
                         )
                     except Exception as exc:
                         _logger.exception(
@@ -11670,6 +11709,29 @@ def create_runner_app(
             # _ensure_comment_relay_started docstring).
             await _ensure_comment_relay_started(
                 conv, explicit_bridge_dir=codex_bdir, await_notify=False
+            )
+        elif harness_name == "antigravity-native":
+            from omnigent.antigravity_native_bridge import (
+                ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY,
+                write_mcp_bridge_config,
+            )
+            from omnigent.antigravity_native_bridge import (
+                bridge_dir_for_bridge_id as antigravity_bridge_dir_for_id,
+            )
+
+            antigravity_labels = await _session_labels_for_runner_spawn(
+                server_client=server_client,
+                session_id=conv,
+            )
+            antigravity_bid = antigravity_labels.get(ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY)
+            antigravity_bdir = antigravity_bridge_dir_for_id(antigravity_bid or conv)
+            write_mcp_bridge_config(antigravity_bdir)
+            # Fallback for sessions not started via _auto_create_antigravity_terminal
+            # (which already started the relay + wrote agy's isolated-HOME mcp_config).
+            # await_notify=False: agy starts its MCP client lazily, so awaiting would
+            # stall the turn (see the _ensure_comment_relay_started docstring).
+            await _ensure_comment_relay_started(
+                conv, explicit_bridge_dir=antigravity_bdir, await_notify=False
             )
 
         try:

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -3378,6 +3378,132 @@ async def test_auto_create_antigravity_wires_reader_task_and_interaction_bridge(
         await runner_app_mod._cancel_auto_forwarder_task(session_id)
 
 
+@pytest.mark.asyncio
+async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-create wires the Omnigent MCP relay so agy gets the sys_* tools (#1194).
+
+    Asserts the three wiring points end-to-end against fakes:
+
+    * the relay starter (``ensure_comment_relay``) is invoked for THIS session's
+      bridge dir before launch, so its ``tool_relay.json`` is on disk when agy
+      first scans the MCP server;
+    * the relay ``mcp_config.json`` is written into the per-session ISOLATED agy
+      HOME (``<bridge_dir>/agy-home/.gemini/config``), NOT the user's real
+      ``~/.gemini`` — the config-scoping footgun the design avoids;
+    * the launch env carries ``HOME`` = that isolated home, so agy actually loads
+      the bridge-scoped config (and never the user's interactive agy config).
+    """
+    import omnigent.antigravity_native_bridge as bridge_mod
+    import omnigent.antigravity_native_launch as launch_mod
+    import omnigent.antigravity_native_reader as reader_mod
+    import omnigent.antigravity_native_rpc as rpc_mod
+    import omnigent.runner.app as runner_app_mod
+
+    session_id = "conv_agy_mcp"
+    monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    (tmp_path / "workspace").mkdir(parents=True, exist_ok=True)
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+    monkeypatch.setattr(bridge_mod, "ensure_agy_onboarding_complete", lambda: None)
+    monkeypatch.setattr(runner_app_mod, "_terminal_tmux_pane", lambda *_a, **_k: (None, None))
+    monkeypatch.setattr(rpc_mod, "_candidate_agy_rpc_ports", list)
+
+    # Capture the env build_agy_launch starts from so we can assert HOME is layered
+    # on top of it (the launch env is the captured spec's ``env`` below).
+    monkeypatch.setattr(
+        launch_mod, "build_agy_launch", lambda **_kwargs: (("agy",), {"AGY_ENV": "1"})
+    )
+
+    def _noop_reader(*_args: Any, **_kwargs: Any) -> Any:
+        async def _runner() -> None:
+            await asyncio.Event().wait()
+
+        return _runner()
+
+    monkeypatch.setattr(reader_mod, "supervise_reader", _noop_reader)
+
+    relay_calls: list[dict[str, Any]] = []
+
+    async def _recording_relay(session_id_arg: str, **kwargs: Any) -> None:
+        relay_calls.append({"session_id": session_id_arg, **kwargs})
+
+    captured_spec: dict[str, Any] = {}
+
+    snapshot = {"workspace": str(tmp_path / "workspace")}
+
+    class _SnapshotServerClient:
+        async def get(self, url: str, **_kwargs: Any) -> httpx.Response:
+            assert url == f"/v1/sessions/{session_id}"
+            return httpx.Response(200, json=snapshot, request=httpx.Request("GET", url))
+
+        async def patch(self, url: str, *, json: dict[str, Any], **_kwargs: Any) -> httpx.Response:
+            del json
+            return httpx.Response(200, json={}, request=httpx.Request("PATCH", url))
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            *,
+            resource_role: str | None = None,
+            **_kwargs: Any,
+        ) -> SessionResourceView:
+            captured_spec["env"] = dict(spec.env)
+            return SessionResourceView(
+                id="terminal_antigravity_main",
+                type="terminal",
+                session_id=session_id,
+                name="Antigravity",
+            )
+
+    try:
+        await _auto_create_antigravity_terminal(
+            session_id,
+            cast(SessionResourceRegistry, _FakeResourceRegistry()),
+            lambda _sid, _event: None,
+            server_client=cast(httpx.AsyncClient, _SnapshotServerClient()),
+            ensure_comment_relay=_recording_relay,
+        )
+        await asyncio.sleep(0)
+    finally:
+        await runner_app_mod._cancel_auto_forwarder_task(session_id)
+
+    bridge_dir = bridge_mod.bridge_dir_for_bridge_id(session_id)
+    iso_home = bridge_mod.agy_home_dir(bridge_dir)
+
+    # 1) The relay starter was invoked for this session's bridge dir.
+    assert len(relay_calls) == 1
+    assert relay_calls[0]["session_id"] == session_id
+    assert relay_calls[0]["explicit_bridge_dir"] == bridge_dir
+    assert relay_calls[0]["await_notify"] is False
+
+    # 2) The relay mcp_config.json landed in the ISOLATED agy HOME, not ~/.gemini.
+    mcp_config = iso_home / ".gemini" / "config" / "mcp_config.json"
+    assert mcp_config.is_file()
+    payload = json.loads(mcp_config.read_text(encoding="utf-8"))
+    server = payload["mcpServers"]["omnigent"]
+    assert server["args"][:4] == ["-I", "-m", "omnigent.claude_native_bridge", "serve-mcp"]
+    assert str(bridge_dir) in server["args"]
+    assert "sys_session_create" in server["enabledTools"]
+    # The bridge token the shared relay needs was written into the bridge dir.
+    assert (bridge_dir / "bridge.json").is_file()
+
+    # 3) The launch env carries HOME = the isolated home, layered over the
+    #    build_agy_launch base env.
+    assert captured_spec["env"]["HOME"] == str(iso_home)
+    assert captured_spec["env"]["AGY_ENV"] == "1"
+
+
 @pytest.mark.parametrize("parent_host_id", ["host_parent", None])
 @pytest.mark.asyncio
 async def test_codex_subagent_always_needs_runner_terminal(

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -14,15 +14,20 @@ from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
     ANTIGRAVITY_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     AntigravityNativeBridgeState,
+    agy_home_dir,
     build_antigravity_native_spawn_env,
+    build_mcp_config,
     clear_bridge_state,
     ensure_agy_onboarding_complete,
     inject_user_message_via_tui,
     prepare_bridge_dir,
     read_bridge_state,
     read_tmux_info,
+    seed_isolated_agy_home,
     update_conversation_id,
     write_bridge_state,
+    write_mcp_bridge_config,
+    write_mcp_config,
     write_tmux_target,
 )
 
@@ -1005,3 +1010,124 @@ def test_inject_user_message_via_tui_rejects_empty_content(tmp_path: Path) -> No
     """Empty content is a programming error, not something to type into the TUI."""
     with pytest.raises(RuntimeError, match="non-empty content"):
         inject_user_message_via_tui(tmp_path / "bridge", content="")
+
+
+# ---------------------------------------------------------------------------
+# Omnigent MCP relay wiring (sys_* tools) — #1194
+# ---------------------------------------------------------------------------
+
+
+def test_build_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
+    """build_mcp_config emits the shared serve-mcp relay command + enabledTools."""
+    config = build_mcp_config(tmp_path, python_executable="python-test")
+    server = config["mcpServers"]["omnigent"]
+    assert server["command"] == "python-test"
+    assert server["args"] == [
+        "-I",
+        "-m",
+        "omnigent.claude_native_bridge",
+        "serve-mcp",
+        "--bridge-dir",
+        str(tmp_path),
+    ]
+    # agy's auto-approve allowlist is the enabledTools key (not cursor's autoApprove).
+    assert "sys_session_send" in server["enabledTools"]
+    assert "sys_os_shell" in server["enabledTools"]
+    assert "sys_terminal_launch" in server["enabledTools"]
+    assert "sys_list_models" in server["enabledTools"]
+    assert server["enabledTools"] == sorted(server["enabledTools"])
+    assert server["env"]["TMPDIR"]
+    # The relay's HOME is pinned to the runner's real home so its bridge-root
+    # validation matches where the bridge dir lives — agy runs the relay under a
+    # per-session isolated HOME (a child of the bridge dir), which the relay must
+    # NOT inherit, or it would reject its own --bridge-dir.
+    assert server["env"]["HOME"] == str(Path.home())
+
+
+def test_build_mcp_config_defaults_python_to_current_interpreter(tmp_path: Path) -> None:
+    """Omitting python_executable uses sys.executable so the relay runs in our venv."""
+    import sys
+
+    server = build_mcp_config(tmp_path)["mcpServers"]["omnigent"]
+    assert server["command"] == sys.executable
+
+
+def test_write_mcp_config_targets_isolated_agy_home(tmp_path: Path) -> None:
+    """write_mcp_config writes into the per-session isolated agy HOME, not ~/.gemini."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    path = write_mcp_config(bridge_dir, python_executable="python-test")
+
+    # The config lands under the isolated HOME's ~/.gemini/config — the path agy
+    # actually loads MCP servers from — so the user's real ~/.gemini is untouched.
+    assert path == agy_home_dir(bridge_dir) / ".gemini" / "config" / "mcp_config.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["omnigent"]["command"] == "python-test"
+    # The bridge token the shared relay requires is written into the bridge dir.
+    assert json.loads((bridge_dir / "bridge.json").read_text(encoding="utf-8"))["token"]
+
+
+def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:
+    """A second write keeps the existing token so a live relay is not re-tokened."""
+    write_mcp_bridge_config(tmp_path)
+    first = (tmp_path / "bridge.json").read_text(encoding="utf-8")
+    write_mcp_bridge_config(tmp_path)
+    assert (tmp_path / "bridge.json").read_text(encoding="utf-8") == first
+
+
+def test_seed_isolated_agy_home_returns_home_override_and_seeds_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """seed_isolated_agy_home copies the OAuth token + markers and returns HOME."""
+    fake_home = tmp_path / "real-home"
+    (fake_home / ".gemini" / "antigravity-cli").mkdir(parents=True)
+    (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").write_text(
+        "real-token", encoding="utf-8"
+    )
+    (fake_home / ".gemini" / "antigravity-cli" / "installation_id").write_text(
+        "install-id", encoding="utf-8"
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    env = seed_isolated_agy_home(bridge_dir)
+
+    iso = agy_home_dir(bridge_dir)
+    assert env == {"HOME": str(iso)}
+    # OAuth token is COPIED (never moved) into the isolated tree.
+    token = iso / ".gemini" / "antigravity-cli" / "antigravity-oauth-token"
+    assert token.read_text(encoding="utf-8") == "real-token"
+    # The real token file is left in place.
+    assert (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").read_text(
+        encoding="utf-8"
+    ) == "real-token"
+    # Onboarding + migration markers seeded so a headless launch never blocks.
+    onboarding = iso / ".gemini" / "antigravity-cli" / "cache" / "onboarding.json"
+    assert json.loads(onboarding.read_text(encoding="utf-8"))["onboardingComplete"] is True
+    assert (iso / ".gemini" / "config" / ".migrated").is_file()
+
+
+def test_seed_isolated_agy_home_tolerates_missing_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing OAuth token only means agy re-auths — never a hard failure."""
+    fake_home = tmp_path / "real-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    env = seed_isolated_agy_home(bridge_dir)
+
+    iso = agy_home_dir(bridge_dir)
+    assert env == {"HOME": str(iso)}
+    # No token copied (none existed), but the isolated HOME + markers still exist.
+    assert not (iso / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").exists()
+    assert (iso / ".gemini" / "antigravity-cli" / "cache" / "onboarding.json").is_file()
+
+
+def test_agy_home_dir_is_under_bridge_dir(tmp_path: Path) -> None:
+    """The isolated HOME is a child of the (hash-scoped, per-session) bridge dir."""
+    bridge_dir = tmp_path / "bridge"
+    assert agy_home_dir(bridge_dir).parent == bridge_dir

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -3440,6 +3440,69 @@ async def test_start_tool_relay_accepts_codex_native_bridge_root(
 
 
 @pytest.mark.asyncio
+async def test_start_tool_relay_accepts_antigravity_native_bridge_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Relay startup accepts Antigravity-native's persistent bridge root (#1194).
+
+    Antigravity-native reuses the Claude MCP relay but stores bridge files in
+    ``~/.omnigent/antigravity-native`` (the same ``$HOME/.omnigent/<harness>``
+    shape codex uses). A regression in :func:`_trusted_parent_for_bridge_dir`
+    would reject the bridge dir, the relay would fail to write
+    ``tool_relay.json``, and the wrapped agy would get no ``sys_*`` tools.
+
+    :param tmp_path: Pytest temp directory used as an isolated user
+        state parent.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    from omnigent import antigravity_native_bridge
+
+    antigravity_root = tmp_path / ".omnigent" / "antigravity-native"
+    monkeypatch.setattr("omnigent.antigravity_native_bridge._BRIDGE_ROOT", antigravity_root)
+    bridge_dir = antigravity_native_bridge.prepare_bridge_dir("conv_agy")
+    relay_file = bridge_dir / claude_native_bridge._TOOL_RELAY_FILE
+
+    async def _executor(name: str, arguments: dict[str, object]) -> dict[str, object]:
+        """
+        Return an empty result for the unused relay tool callback.
+
+        :param name: Tool name, e.g. ``"sys_session_list"``.
+        :param arguments: Tool arguments.
+        :returns: Empty tool result.
+        """
+        del name, arguments
+        return {}
+
+    relay = None
+    try:
+        relay = start_tool_relay(
+            bridge_dir=bridge_dir,
+            tools=[
+                {
+                    "name": "sys_session_create",
+                    "description": "Spawn an Omnigent sub-agent session.",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+            tool_executor=_executor,
+            loop=asyncio.get_running_loop(),
+        )
+
+        assert relay_file.exists(), (
+            "Antigravity-native relay did not write tool_relay.json under the "
+            "persistent bridge root"
+        )
+        relay_info = json.loads(relay_file.read_text(encoding="utf-8"))
+        assert relay_info["tools"][0]["name"] == "sys_session_create"
+    finally:
+        if relay is not None:
+            relay.close()
+
+
+@pytest.mark.asyncio
 async def test_relay_close_keeps_advertisement_owned_by_newer_relay(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

`antigravity-native` (agy) was the **only** native harness with no omnigent MCP relay, so the wrapped agy could not use any `sys_*` tool — it could not spawn omnigent sub-agent sessions (`sys_session_*`), drive omnigent terminals (`sys_terminal_*`), list agents/models, or use the `sys_os_*` surface. cursor/claude/codex all wire a relay; agy did not. This PR wires the **same shared relay** (`omnigent.claude_native_bridge serve-mcp`) into antigravity-native, mirroring cursor #742 — **without clobbering the user's interactive agy config** (the footgun that deferred this as bug #11).

`Refs #1194`

## The config-scoping mechanism I confirmed (live)

agy has **no** `--mcp-config` / config-dir CLI flag and ignores `ANTIGRAVITY_*` env knobs. I confirmed empirically (agy v1.0.12, binary struct inspection + live runs):

- agy loads MCP servers from a single **HOME-global** file: `$HOME/.gemini/config/mcp_config.json`. The per-server schema uses **lowercase** keys (`command` / `args` / `env`) plus `enabledTools` / `disabledTools` (agy's auto-approve allowlist — the analog of cursor's `autoApprove`), under a top-level `mcpServers` map. (No `autoApprove` key; agy uses `enabledTools`.)
- `agy plugin` is marketplace-oriented and is **not** the mechanism for a local stdio relay (confirmed).
- agy resolves its `GeminiDir` from `$HOME/.gemini` (its hardcoded default). So relocating `HOME` relocates agy's entire config+state tree — including the MCP config.

## Chosen design: per-session ISOLATED HOME (+ why)

The runner launches agy with `HOME` pointed at a per-bridge-dir tree (`<bridge_dir>/agy-home`), seeded with:
- a **copy** of the user's OAuth token (`antigravity-cli/antigravity-oauth-token`) + `installation_id` (the real files are never moved or modified),
- the onboarding-complete + migration markers (so a headless launch never blocks on the first-run wizard),
- a bridge-scoped `config/mcp_config.json` written by `write_mcp_config`, pointing at this session's relay.

**Why this over the global file:**
- **Never touches the user's real `~/.gemini`** — the footgun (a) clobbering the user's interactive agy config is structurally impossible.
- **Concurrency-safe** — each session has its own HOME, so two antigravity-native sessions (or a session + the user's interactive agy) never share/fight over one `mcp_config.json`. The global-file approach was *incorrect* under concurrency because the relay command is bridge-dir-specific.
- **No re-auth** — verified live that agy under the isolated HOME logs in as the real user from the seeded token (no OAuth prompt).

**Critical subtlety caught during live e2e:** agy spawns the relay as a child, so the relay inherits agy's *isolated* HOME. But the relay validates its `--bridge-dir` against `bridge_root()` (= `$HOME/.omnigent/antigravity-native`), which must resolve to the **runner's real home** (where the bridge dir lives), not the isolated agy HOME (a child of the bridge dir). So `build_mcp_config` pins the relay's `env.HOME` back to the runner's real home. Without this, the relay would reject its own bridge dir in production. (`-I` does not clear `HOME` — it only ignores `PYTHON*` vars + user site-packages.)

**Tradeoff:** the isolated HOME does not share agy's conversation history with the user's interactive agy — acceptable (and correct) for a runner-owned, web-driven session; the omnigent conversation is the system-of-record (mirrored by the RPC reader).

## Mirror of cursor #742 (the relay itself)

- `antigravity_native_bridge.py`: `build_mcp_config` / `write_mcp_config` / `write_mcp_bridge_config` (the shared bridge-token pattern) + `seed_isolated_agy_home` / `agy_home_dir`. Relay command is the same `<python> -I -m omnigent.claude_native_bridge serve-mcp --bridge-dir <dir>`; `sys_*` tools auto-approved via `enabledTools`.
- `claude_native_bridge.py`: `_trusted_parent_for_bridge_dir` now accepts the antigravity-native bridge root (same `$HOME/.omnigent/<harness>-native` shape codex uses).
- `runner/app.py`: `_auto_create_antigravity_terminal` writes the isolated-HOME mcp_config + starts the relay (`_ensure_comment_relay_started`) **before** launch and threads `HOME` into the launch env; the `_run_turn_bg` first-turn relay fallback gets an `antigravity-native` branch (writes the bridge token + ensures the relay, mirroring codex).
- `antigravity_native.py`: the false spec comments claiming a relay already consumed `spawn:true` / `terminals:` are now accurate; `terminals:` is noted as still feeding the web-UI new-terminal affordance (so it is not fully inert).
- `del tools` in the executor is kept (tools reach agy via the launch-time MCP config, like other natives).

## Files changed

- `omnigent/antigravity_native_bridge.py` (+265) — MCP config builders + isolated-HOME seed
- `omnigent/claude_native_bridge.py` (+19) — accept antigravity bridge root
- `omnigent/runner/app.py` (+62) — relay wiring in auto-create + `_run_turn_bg` fallback
- `omnigent/antigravity_native.py` (+13) — fix false spec comments
- `tests/test_antigravity_native_bridge.py` (+126) — config build/write + seed unit tests
- `tests/test_claude_native_bridge.py` (+63) — relay accepts antigravity bridge root
- `tests/runner/test_app_sessions_native.py` (+126) — auto-create relay+config+HOME wiring

## Testing

**Unit/integration (all green, run from this worktree):**
```
.venv/bin/python -m pytest -q -p no:cacheprovider \
  tests/test_antigravity_native_bridge.py \
  tests/test_claude_native_bridge.py \
  tests/runner/test_app_sessions_native.py
```
- `tests/test_antigravity_native_bridge.py`: 52 → **60** passed (8 new — `build_mcp_config` emits the relay command + sorted `enabledTools` + HOME pin; `write_mcp_config` targets the isolated agy HOME and writes the bridge token; `seed_isolated_agy_home` copies the OAuth token without touching the real file and tolerates a missing credential; idempotent bridge token).
- `tests/test_claude_native_bridge.py`: new `test_start_tool_relay_accepts_antigravity_native_bridge_root` (relay writes `tool_relay.json` under the antigravity bridge root).
- `tests/runner/test_app_sessions_native.py`: new `test_auto_create_antigravity_wires_omnigent_mcp_relay` (relay started for the session's bridge dir; mcp_config written into the isolated HOME, not `~/.gemini`; `HOME` threaded into the launch env). The broader antigravity suite stays green (99 passed across the touched + antigravity suites).
- `ruff format` + `ruff check` clean on all touched files.

> Note: `test_required_terminal_exit_while_idle_does_not_fail_session` is a **pre-existing flake** (~10% on a clean `origin/main` checkout — a `sleep(0)`-spin event-drain race, unrelated to antigravity). Verified by running it 20× on the stashed clean base.

**Live e2e I ran (tool DISCOVERY — safe, no live server needed):**
- Generated the config with the **final** `write_mcp_config` + `seed_isolated_agy_home`, launched real `agy --dangerously-skip-permissions` in a tmux pane under the per-session isolated HOME (seeded with a copy of my real OAuth token).
- agy logged in as the real user (**no OAuth re-demand**), and its `/mcp` panel showed:
  ```
  ✓ omnigent  Tools: sys_session_create, sys_session_send, sys_terminal_launch, sys_os_shell, sys_list_models
  ```
- The relay wrote `server.json` (real port + token) into the bridge dir, proving the MCP `initialize` + `tools/list` handshake completed.
- The user's real `~/.gemini/config/mcp_config.json` stayed **0 bytes** (md5 unchanged) throughout — backed up and verified before/after every experiment; all live-test bridge dirs cleaned up.

**Live e2e the orchestrator must run (needs the running omnigent server):** agy actually **CALLING** a `sys_*` tool end-to-end through a real omnigent session. Steps:
1. Start a local omnigent server and create an `antigravity-native` session from the web UI (the runner auto-creates the agy terminal, which now wires the relay).
2. In the agy chat, ask it to call a sys_* tool, e.g. *"List the available omnigent models"* (`sys_list_models`) or *"Spawn an omnigent sub-agent session that echoes hello"* (`sys_session_create` → `sys_session_send`).
3. Confirm agy invokes the tool (it auto-approves via `enabledTools`), the call routes through omnigent's `/mcp` proxy (TOOL_CALL policy/elicitation still applies server-side), and the result returns into the agy conversation + the omnigent event stream.
4. Confirm the user's real `~/.gemini/config/mcp_config.json` is untouched and a second concurrent antigravity-native session gets its own relay (no clobber).

## Notes for reviewers

- PR #1207 also edits `antigravity_native_bridge.py`; this PR only **adds** functions (no reformatting) to minimize conflicts.
- Off `origin/main`; does not depend on PR #1185 (Stop).

This pull request and its description were written by Isaac.
