### PR TITLE
fix(ui): toggle arrow indicator when expanding token usage dropdown

### DIFF
--- a/ap-web/src/components/AgentInfo.test.tsx
+++ b/ap-web/src/components/AgentInfo.test.tsx
@@ -246,6 +246,42 @@ describe("AgentInfoButton per-model usage breakdown", () => {
     expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();
     expect(screen.queryByTestId("agent-info-usage-by-model")).toBeNull();
   });
+
+  it("toggles the arrow indicator when expanding/collapsing the details", () => {
+    useChatStore.setState({
+      sessionUsageByModel: {
+        "claude-sonnet-4-6": {
+          inputTokens: 1000,
+          outputTokens: 500,
+          totalTokens: 1500,
+          cacheReadInputTokens: null,
+          cacheCreationInputTokens: null,
+          totalCostUsd: 0.1,
+        },
+      },
+    });
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_arrow");
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+
+    const details = screen.getByTestId("agent-info-usage-by-model") as HTMLDetailsElement;
+    const summary = details.querySelector("summary")!;
+
+    // Initially collapsed — arrow points right.
+    expect(summary).toHaveTextContent("▶");
+    expect(summary).not.toHaveTextContent("▼");
+
+    // Expand the details by setting the open attribute and firing toggle.
+    details.open = true;
+    fireEvent(details, new Event("toggle"));
+    expect(summary).toHaveTextContent("▼");
+    expect(summary).not.toHaveTextContent("▶");
+
+    // Collapse again.
+    details.open = false;
+    fireEvent(details, new Event("toggle"));
+    expect(summary).toHaveTextContent("▶");
+    expect(summary).not.toHaveTextContent("▼");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -128,18 +128,22 @@ const MODEL_TOKEN_ROWS: ReadonlyArray<{ key: keyof ModelUsage; label: string }> 
  * @param usageByModel - Map of raw harness model id to its cumulative usage.
  */
 function ModelUsageBreakdown({ usageByModel }: { usageByModel: Record<string, ModelUsage> }) {
+  const [isOpen, setIsOpen] = useState(false);
   // Stable display order: most total tokens first, so the dominant model
   // leads. Falls back to 0 for models that haven't recorded a total yet.
   const models = Object.entries(usageByModel).sort(
     ([, a], [, b]) => (b.totalTokens ?? 0) - (a.totalTokens ?? 0),
   );
   return (
-    <details data-testid="agent-info-usage-by-model">
+    <details
+      data-testid="agent-info-usage-by-model"
+      onToggle={(e) => setIsOpen(e.currentTarget.open)}
+    >
       <summary className="cursor-pointer select-none list-none">
         <SectionLabel>
           <span className="inline-flex items-center gap-1">
             Token usage
-            <span className="text-[9px]">▶</span>
+            <span className="text-[9px]">{isOpen ? "▼" : "▶"}</span>
           </span>
         </SectionLabel>
       </summary>


### PR DESCRIPTION
## Summary
- Fixed the token usage dropdown arrow indicator to change from ▶ to ▼ when expanded
- Added state tracking via `useState` and `onToggle` handler on the `<details>` element
- Added test to verify arrow toggles correctly on expand/collapse

## Test plan
- [x] Verified UI manually - arrow now changes direction when clicking to expand/collapse
- [x] `npm test` passes (2992 tests)
- [x] `npm run build` passes

This pull request and its description were written by Isaac.