### PR TITLE
fix: make iOS Connect button feel responsive while connecting

### DIFF
--- a/ap-web/ios/Omnigent/ConnectView.swift
+++ b/ap-web/ios/Omnigent/ConnectView.swift
@@ -55,25 +55,26 @@ struct ConnectView: View {
             }
             .submitLabel(.go)
             .onSubmit(connect)
+            .disabled(isConnecting)
         }
 
         Button(action: connect) {
           if isConnecting {
-            ProgressView()
-              .tint(primaryForeground)
+            HStack(spacing: 8) {
+              ProgressView()
+                .tint(primaryForeground)
+              Text("Connecting…")
+            }
           } else {
             Text("Connect")
           }
         }
-        .buttonStyle(.plain)
-        .font(.system(size: 14, weight: .medium))
-        .frame(maxWidth: .infinity)
-        .frame(height: 38)
-        .background(primary)
-        .foregroundStyle(primaryForeground)
-        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.radius))
+        .buttonStyle(PrimaryButtonStyle(background: primary, foreground: primaryForeground))
         .padding(.top, 16)
         .disabled(isConnecting)
+        // Fires the moment connect() flips isConnecting, so the tap is
+        // acknowledged by touch even before the spinner appears.
+        .sensoryFeedback(.impact(weight: .light), trigger: isConnecting)
 
         Text(message ?? "")
           .font(.system(size: 13))
@@ -110,6 +111,7 @@ struct ConnectView: View {
             }
           }
           .padding(.top, 12)
+          .disabled(isConnecting)
         }
       }
       .frame(maxWidth: 384)
@@ -149,6 +151,28 @@ struct ConnectView: View {
         }
       }
     }
+  }
+}
+
+// Primary (filled) button appearance plus an instant touch-down response.
+// `.buttonStyle(.plain)` gave no press feedback, so the tap felt dead until
+// the spinner swapped in; the opacity/scale here acknowledges the press the
+// moment the finger lands.
+private struct PrimaryButtonStyle: ButtonStyle {
+  let background: Color
+  let foreground: Color
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .font(.system(size: 14, weight: .medium))
+      .frame(maxWidth: .infinity)
+      .frame(height: 38)
+      .background(background)
+      .foregroundStyle(foreground)
+      .clipShape(RoundedRectangle(cornerRadius: DesignTokens.radius))
+      .opacity(configuration.isPressed ? 0.85 : 1)
+      .scaleEffect(configuration.isPressed ? 0.98 : 1)
+      .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
   }
 }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The iOS `ConnectView` Connect button felt unresponsive while it talked to the server. `connect()` runs `WorkspaceURLExpander.expandIfNeeded`, which issues a HEAD request with an 8s timeout, and the tap itself was never acknowledged because `.buttonStyle(.plain)` strips the default touch-down highlight.
- Added a `PrimaryButtonStyle` that keeps the existing filled look and adds an instant opacity+scale press response, so the tap registers the moment the finger lands.
- Added a light haptic via `.sensoryFeedback(.impact)` triggered on `isConnecting`, and a "Connecting…" label beside the spinner so the busy state reads clearly.
- Disabled the text field and recent-server rows while connecting so the whole form reflects the busy state. Connection logic is unchanged.

## Test Plan

- Built the iOS target via `xcodebuild -project Omnigent.xcodeproj -scheme Omnigent -destination 'generic/platform=iOS Simulator' -configuration Debug build CODE_SIGNING_ALLOWED=NO` — compiles clean (only a pre-existing unrelated warning in NativeNotificationManager).
- Manual: tap Connect against a slow/bare-https URL and confirm the button dims/scales on press, shows "Connecting…", disables the inputs, and still renders the red error message on failure. Haptic confirmed on a physical device.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by building the iOS target (compiles clean) and by manual inspection of the Connect flow in the simulator: press feedback, "Connecting…" label, disabled inputs during connection, and the error path. The change is presentation-only (button style, haptic, labels, disabled state) with no change to connection logic, so no automated tests were added.
