### PR TITLE
fix(ios): reveal server switcher when the page never speaks over the JS bridge

### DIFF
--- a/ap-web/ios/Omnigent/OmnigentWebView.swift
+++ b/ap-web/ios/Omnigent/OmnigentWebView.swift
@@ -251,6 +251,7 @@ struct OmnigentWebView: UIViewRepresentable {
     }
 
     func detach() {
+      parent.model.cancelServerSwitcherWatchdog()
       webView = nil
     }
 
@@ -305,6 +306,9 @@ struct OmnigentWebView: UIViewRepresentable {
       _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
     ) {
       guard isTrustedBridgeMessage(message) else { return }
+      // Any trusted message proves the page is alive and driving the bridge, so
+      // stand down the liveness watchdog — the page owns the switcher from here.
+      parent.model.cancelServerSwitcherWatchdog()
       guard let body = message.body as? [String: Any],
         let method = body["method"] as? String
       else { return }
@@ -343,6 +347,7 @@ struct OmnigentWebView: UIViewRepresentable {
       parent.model.isLoading = true
       parent.model.currentURL = webView.url ?? parent.model.currentURL
       parent.model.serverSwitcherHidden = true
+      parent.model.armServerSwitcherWatchdog()
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
@@ -489,6 +494,7 @@ struct OmnigentWebView: UIViewRepresentable {
       let nsError = error as NSError
       guard nsError.code != NSURLErrorCancelled else { return }
       parent.model.isLoading = false
+      parent.model.cancelServerSwitcherWatchdog()
 
       let failedURL = failedURL(from: nsError) ?? webView.url ?? pinnedURL ?? parent.initialURL
       guard failedURL.omnigentOrigin == pinnedOrigin else { return }

--- a/ap-web/ios/Omnigent/WebViewModel.swift
+++ b/ap-web/ios/Omnigent/WebViewModel.swift
@@ -24,8 +24,37 @@ final class WebViewModel: ObservableObject {
 
   weak var webView: WKWebView?
 
+  /// How long, after a navigation begins, we wait for the web app to prove it's
+  /// alive by talking over the JS bridge. If the page never speaks within this
+  /// window — a blank render, crashed JS, or a hang that never reaches
+  /// `didFinish` — we surface the server switcher so the user is never stranded
+  /// on a broken page with no way back to server selection.
+  private static let bridgeLivenessTimeout: TimeInterval = 6
+
+  private var serverSwitcherWatchdog: Task<Void, Never>?
+
   func reload() {
     webView?.reload()
+  }
+
+  /// Arm (or re-arm) the liveness watchdog. Called whenever a navigation
+  /// begins. The switcher has just been hidden for the load; if the page never
+  /// claims it back over the bridge, the watchdog reveals it as an escape hatch.
+  func armServerSwitcherWatchdog() {
+    serverSwitcherWatchdog?.cancel()
+    serverSwitcherWatchdog = Task { @MainActor [weak self] in
+      try? await Task.sleep(nanoseconds: UInt64(Self.bridgeLivenessTimeout * 1_000_000_000))
+      guard !Task.isCancelled, let self else { return }
+      self.serverSwitcherHidden = false
+      self.serverSwitcherWatchdog = nil
+    }
+  }
+
+  /// Stand the watchdog down. Called the moment the page proves it's alive over
+  /// the bridge, and when a load fails (we route to server selection anyway).
+  func cancelServerSwitcherWatchdog() {
+    serverSwitcherWatchdog?.cancel()
+    serverSwitcherWatchdog = nil
   }
 
   func emitNotificationActivation(_ path: String) {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The iOS server switcher visibility is entirely web-driven: it is hidden on every navigation start and only revealed when the web app calls `setServerSwitcherHidden(false)` over the JS bridge. `didFailProvisionalNavigation` only catches transport failures (DNS/TLS/connection), so a page that loads HTTP-200 but renders blank, crashes its JS before the mount effect runs, or hangs without reaching `didFinish` leaves the switcher hidden forever — stranding the user with no way back to server selection.
- Add a bridge-liveness watchdog in `WebViewModel`: a 6s timer armed on navigation start (`didStartProvisionalNavigation`) that forces the switcher visible if it fires. The first trusted bridge message of any kind cancels it — the page has proven it is alive and owns the switcher state from there. The watchdog is also cancelled on load failure (we route to server selection anyway) and on coordinator teardown.
- This keys the escape hatch on the page actually using the bridge, so there is no pill flash on healthy loads, and a genuinely-alive page that wants the switcher hidden still gets its way.

## Test Plan

- Manual reasoning over the navigation lifecycle: healthy load → first bridge call cancels the watchdog before it fires; blank/crashed/hung page → no bridge call → switcher appears after 6s; transport failure → routes to ConnectView with the watchdog cancelled; fullscreen page calling `setServerSwitcherHidden(true)` → that call cancels the watchdog so it stays hidden.
- `swift format` run clean on both edited files. Not built against a simulator in this environment — recommend a local `xcodebuild` before merge.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by tracing the navigation-delegate and bridge-message paths: the watchdog is armed on every navigation start, cancelled by the first trusted bridge message, by load failure, and by coordinator teardown; on expiry it sets `serverSwitcherHidden = false`. No automated iOS UI test harness exists for the WebView shell, so coverage is manual reasoning plus `swift format`. A simulator build/run is recommended locally before merge.
