### PR TITLE
feat(qwen,goose): record delegated fs I/O and gate it with result-phase policy

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -285,14 +285,16 @@ comments; this is the *what*, not the *how*.)
   bearer token is written through `_ensure_secure_bridge_dir` (the same
   owner-only ancestor validation the shared relay applies to token-bearing
   trees). Permission gating on qwen's *own* tool calls already works.
-- [ ] **File I/O recording / content policy.** Omnigent now *executes* delegated
+- [x] **File I/O recording / content policy.** Omnigent *executes* delegated
   file reads/writes through the `OSEnvironment` (see "File I/O delegation" in
   What works today), so the bytes flow through Omnigent and the sandbox roots are
-  enforced. Still missing on top of that: (a) emitting the I/O into Omnigent's
-  event stream (ToolCall-style records) so it shows in history, and (b) running
-  TOOL_RESULT-phase content policy on the read/written content. Both build on the
-  `_handle_fs_read` / `_handle_fs_write` handlers — the byte-level hook now
-  exists; this is wiring the recording/policy layers onto it.
+  enforced. On top of that the `_handle_fs_read` / `_handle_fs_write` handlers now
+  (a) emit ToolCall-style records onto the turn stream so the I/O shows in
+  history, and (b) run `PHASE_TOOL_RESULT` content policy on the read/written
+  bytes — an explicit deny refuses the op (a write is gated before it happens),
+  failing open otherwise. Result-phase policy here gates on content only: the
+  harness round-trip doesn't carry `request_data`, so the fs tool's identity
+  isn't surfaced to result-phase policy.
 
 > LLM-phase policy (`PHASE_LLM_REQUEST` / `PHASE_LLM_RESPONSE`) is intentionally
 > out of scope: qwen's model calls happen internally over ACP and are opaque to

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -50,6 +50,9 @@ from omnigent.inner.executor import (
     ExecutorEvent,
     Message,
     TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
     ToolSpec,
     TurnComplete,
 )
@@ -262,6 +265,10 @@ class GooseExecutor(Executor):
         self._tool_executor: _ToolExecutor | None = None
         self._mcp = OmnigentAcpMcp(label="goose")
         self._omnigent_tools: list[ToolSpec] = []
+
+        # ToolCall records for delegated fs ops; run_turn drains them onto the
+        # turn stream so the I/O shows in history.
+        self._fs_events: list[ExecutorEvent] = []
 
     # ------------------------------------------------------------------
     # Low-level ACP transport
@@ -614,17 +621,63 @@ class GooseExecutor(Executor):
             self._os_environment = env
         return self._os_environment
 
+    async def _fs_call_policy_denies(self, tool_name: str, args: _AcpJsonObject) -> bool:
+        """Call-phase gate for a delegated fs side effect, evaluated before it runs."""
+        policy_eval = getattr(self, "_policy_evaluator", None)
+        if policy_eval is None:
+            return False
+        try:
+            verdict = await policy_eval("PHASE_TOOL_CALL", {"name": tool_name, "arguments": args})
+        except Exception as exc:  # noqa: BLE001 — call phase fails closed for side effects
+            logger.warning("goose TOOL_CALL policy eval failed for %s: %s", tool_name, exc)
+            return True
+        return getattr(verdict, "action", None) in ("POLICY_ACTION_DENY", "POLICY_ACTION_ASK")
+
+    async def _fs_result_policy_denies(self, tool_name: str, result: Any) -> bool:
+        """Result-phase check on delegated fs results before they reach the model."""
+        policy_eval = getattr(self, "_policy_evaluator", None)
+        if policy_eval is None:
+            return False
+        try:
+            verdict = await policy_eval("PHASE_TOOL_RESULT", {"result": result})
+        except Exception as exc:  # noqa: BLE001 — result phase fails open
+            logger.warning("goose TOOL_RESULT policy eval failed for %s: %s", tool_name, exc)
+            return False
+        return getattr(verdict, "action", None) == "POLICY_ACTION_DENY"
+
+    def _record_fs_op(
+        self,
+        tool_name: str,
+        args: _AcpJsonObject,
+        *,
+        status: ToolCallStatus,
+        result: Any = None,
+        error: str | None = None,
+    ) -> None:
+        """Buffer a paired ToolCallRequest + ToolCallComplete for a delegated fs op."""
+        call_id = f"fsacp_{secrets.token_hex(8)}"
+        self._fs_events.append(
+            ToolCallRequest(name=tool_name, args=args, metadata={"call_id": call_id})
+        )
+        self._fs_events.append(
+            ToolCallComplete(
+                name=tool_name,
+                status=status,
+                result=result,
+                error=error,
+                metadata={"call_id": call_id},
+            )
+        )
+
     async def _handle_fs_read(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/read_text_file`` by reading through the OSEnvironment.
 
-        ACP params ``{path, line?, limit?}`` (1-based start line, max line count;
-        both optional → whole file) map onto :meth:`OSEnvironment.read`.
-
-        :param params: The request params.
-        :returns: ``{"content": <text>}`` per the ACP response shape.
-        :raises _AcpRequestError: On a missing path arg, a non-text/binary file,
-            or a read failure (mapped to ENOENT when it looks like a missing
-            file so goose raises the right error to the model).
+        ACP params: ``{path, line?, limit?}`` where ``line`` is a 1-based start
+        line and ``limit`` a max line count (both optional → whole file). Maps
+        onto :meth:`OSEnvironment.read`'s ``offset`` / ``limit``. The op is
+        recorded onto the turn stream. Call-phase policy gates the read by path
+        before it runs, and the returned content runs through result-phase policy
+        before it reaches goose.
         """
         path = params.get("path")
         if not isinstance(path, str) or not path:
@@ -633,26 +686,55 @@ class GooseExecutor(Executor):
         limit = params.get("limit")
         offset = line if isinstance(line, int) and line >= 1 else 1
         read_limit = limit if isinstance(limit, int) and limit >= 1 else None
+        args: _AcpJsonObject = {"path": path}
+        if line is not None:
+            args["line"] = line
+        if limit is not None:
+            args["limit"] = limit
 
-        env = await self._ensure_os_environment()
-        result = await env.read(path, offset=offset, limit=read_limit)
-        if "error" in result:
-            message = str(result["error"])
-            code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
-            raise _AcpRequestError(code, message)
-        if result.get("encoding") != "utf-8":
-            raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
-        return {"content": result.get("content", "")}
+        if await self._fs_call_policy_denies("read_text_file", args):
+            self._record_fs_op(
+                "read_text_file", args, status=ToolCallStatus.BLOCKED, error="blocked by policy"
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by policy")
+
+        try:
+            env = await self._ensure_os_environment()
+            read_result = await env.read(path, offset=offset, limit=read_limit)
+            if "error" in read_result:
+                message = str(read_result["error"])
+                code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+                raise _AcpRequestError(code, message)
+            if read_result.get("encoding") != "utf-8":
+                raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
+        except _AcpRequestError as exc:
+            self._record_fs_op(
+                "read_text_file", args, status=ToolCallStatus.ERROR, error=exc.message
+            )
+            raise
+
+        content = read_result.get("content", "")
+        if await self._fs_result_policy_denies("read_text_file", content):
+            self._record_fs_op(
+                "read_text_file",
+                args,
+                status=ToolCallStatus.BLOCKED,
+                error="blocked by content policy",
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by content policy")
+        self._record_fs_op(
+            "read_text_file", args, status=ToolCallStatus.SUCCESS, result={"content": content}
+        )
+        return {"content": content}
 
     async def _handle_fs_write(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/write_text_file`` by writing through the OSEnvironment.
 
-        ACP params ``{path, content}``; the write goes through the helper so the
-        spec's sandbox write roots are enforced at the Python layer.
-
-        :param params: The request params.
-        :returns: An empty result object (ACP expects no payload on success).
-        :raises _AcpRequestError: On missing/invalid args or a write failure.
+        ACP params: ``{path, content}``. The write goes through the helper, so
+        the spec's sandbox write roots are enforced at the Python layer. The op
+        is recorded onto the turn stream, and call-phase policy gates the write
+        before it runs. Result-phase policy evaluates the write result after the
+        side effect; a denial refuses the response without undoing the write.
         """
         path = params.get("path")
         content = params.get("content")
@@ -660,11 +742,35 @@ class GooseExecutor(Executor):
             raise _AcpRequestError(-32602, "fs/write_text_file requires a string 'path'")
         if not isinstance(content, str):
             raise _AcpRequestError(-32602, "fs/write_text_file requires string 'content'")
+        args: _AcpJsonObject = {"path": path, "content": content}
 
-        env = await self._ensure_os_environment()
-        result = await env.write(path, content)
-        if "error" in result:
-            raise _AcpRequestError(-32603, str(result["error"]))
+        if await self._fs_call_policy_denies("write_text_file", args):
+            self._record_fs_op(
+                "write_text_file",
+                args,
+                status=ToolCallStatus.BLOCKED,
+                error="blocked by policy",
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by policy")
+        try:
+            env = await self._ensure_os_environment()
+            write_result = await env.write(path, content)
+            if "error" in write_result:
+                raise _AcpRequestError(-32603, str(write_result["error"]))
+        except _AcpRequestError as exc:
+            self._record_fs_op(
+                "write_text_file", args, status=ToolCallStatus.ERROR, error=exc.message
+            )
+            raise
+        if await self._fs_result_policy_denies("write_text_file", write_result):
+            self._record_fs_op(
+                "write_text_file",
+                args,
+                status=ToolCallStatus.BLOCKED,
+                error="blocked by result policy",
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by result policy")
+        self._record_fs_op("write_text_file", args, status=ToolCallStatus.SUCCESS, result=write_result)
         return {}
 
     @staticmethod
@@ -1050,6 +1156,11 @@ class GooseExecutor(Executor):
             if isinstance(stale, dict) and stale.get("id") is not None and stale.get("method"):
                 await self._respond_to_agent_request(stale)
 
+        # Answering a stale request above can run real fs I/O, so emit its ToolCall
+        # audit events into history rather than dropping them.
+        while self._fs_events:
+            yield self._fs_events.pop(0)
+
         self._rpc_id += 1
         req_id = self._rpc_id
         loop = asyncio.get_event_loop()
@@ -1129,6 +1240,10 @@ class GooseExecutor(Executor):
                 # Server-initiated request (session/request_permission): routes
                 # through policy + elicitation. Blocks while the human decides.
                 await self._respond_to_agent_request(notification)
+                # Surface any fs ToolCall events the handler buffered so the
+                # I/O shows in history.
+                while self._fs_events:
+                    yield self._fs_events.pop(0)
 
             # Inbound message = progress; reset the idle deadline (after the
             # approval block so a slow approval doesn't time out).

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -36,6 +36,7 @@ import contextlib
 import json
 import logging
 import os
+import secrets
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import Any, Protocol, TypeAlias
@@ -703,7 +704,9 @@ class GooseExecutor(Executor):
             read_result = await env.read(path, offset=offset, limit=read_limit)
             if "error" in read_result:
                 message = str(read_result["error"])
-                code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+                code = (
+                    _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+                )
                 raise _AcpRequestError(code, message)
             if read_result.get("encoding") != "utf-8":
                 raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
@@ -770,7 +773,9 @@ class GooseExecutor(Executor):
                 error="blocked by result policy",
             )
             raise _AcpRequestError(-32603, f"{path}: blocked by result policy")
-        self._record_fs_op("write_text_file", args, status=ToolCallStatus.SUCCESS, result=write_result)
+        self._record_fs_op(
+            "write_text_file", args, status=ToolCallStatus.SUCCESS, result=write_result
+        )
         return {}
 
     @staticmethod

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -42,6 +42,9 @@ from omnigent.inner.executor import (
     ExecutorEvent,
     Message,
     TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
     ToolSpec,
     TurnComplete,
 )
@@ -288,6 +291,10 @@ class QwenExecutor(Executor):
         self._tool_executor: _ToolExecutor | None = None
         self._mcp = OmnigentAcpMcp(label="qwen")
         self._omnigent_tools: list[ToolSpec] = []
+
+        # ToolCall records for delegated fs ops; run_turn drains them onto the
+        # turn stream so the I/O shows in history.
+        self._fs_events: list[ExecutorEvent] = []
 
     # ------------------------------------------------------------------
     # Low-level ACP helpers
@@ -742,18 +749,63 @@ class QwenExecutor(Executor):
             self._os_environment = env
         return self._os_environment
 
+    async def _fs_call_policy_denies(self, tool_name: str, args: _AcpJsonObject) -> bool:
+        """Call-phase gate for a delegated fs side effect, evaluated before it runs."""
+        policy_eval = getattr(self, "_policy_evaluator", None)
+        if policy_eval is None:
+            return False
+        try:
+            verdict = await policy_eval("PHASE_TOOL_CALL", {"name": tool_name, "arguments": args})
+        except Exception as exc:  # noqa: BLE001 — call phase fails closed for side effects
+            logger.warning("qwen TOOL_CALL policy eval failed for %s: %s", tool_name, exc)
+            return True
+        return getattr(verdict, "action", None) in ("POLICY_ACTION_DENY", "POLICY_ACTION_ASK")
+
+    async def _fs_result_policy_denies(self, tool_name: str, result: Any) -> bool:
+        """Result-phase check on delegated fs results before they reach the model."""
+        policy_eval = getattr(self, "_policy_evaluator", None)
+        if policy_eval is None:
+            return False
+        try:
+            verdict = await policy_eval("PHASE_TOOL_RESULT", {"result": result})
+        except Exception as exc:  # noqa: BLE001 — result phase fails open
+            logger.warning("qwen TOOL_RESULT policy eval failed for %s: %s", tool_name, exc)
+            return False
+        return getattr(verdict, "action", None) == "POLICY_ACTION_DENY"
+
+    def _record_fs_op(
+        self,
+        tool_name: str,
+        args: _AcpJsonObject,
+        *,
+        status: ToolCallStatus,
+        result: Any = None,
+        error: str | None = None,
+    ) -> None:
+        """Buffer a paired ToolCallRequest + ToolCallComplete for a delegated fs op."""
+        call_id = f"fsacp_{secrets.token_hex(8)}"
+        self._fs_events.append(
+            ToolCallRequest(name=tool_name, args=args, metadata={"call_id": call_id})
+        )
+        self._fs_events.append(
+            ToolCallComplete(
+                name=tool_name,
+                status=status,
+                result=result,
+                error=error,
+                metadata={"call_id": call_id},
+            )
+        )
+
     async def _handle_fs_read(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/read_text_file`` by reading through the OSEnvironment.
 
         ACP params: ``{path, line?, limit?}`` where ``line`` is a 1-based start
         line and ``limit`` a max line count (both optional → whole file). Maps
-        onto :meth:`OSEnvironment.read`'s ``offset`` / ``limit``.
-
-        :param params: The request params.
-        :returns: ``{"content": <text>}`` per the ACP response shape.
-        :raises _AcpRequestError: On a missing path arg, a non-text/binary file,
-            or a read failure (mapped to ENOENT when it looks like a missing
-            file so qwen raises the right error to the model).
+        onto :meth:`OSEnvironment.read`'s ``offset`` / ``limit``. The op is
+        recorded onto the turn stream. Call-phase policy gates the read by path
+        before it runs, and the returned content runs through result-phase policy
+        before it reaches qwen.
         """
         path = params.get("path")
         if not isinstance(path, str) or not path:
@@ -762,28 +814,55 @@ class QwenExecutor(Executor):
         limit = params.get("limit")
         offset = line if isinstance(line, int) and line >= 1 else 1
         read_limit = limit if isinstance(limit, int) and limit >= 1 else None
+        args: _AcpJsonObject = {"path": path}
+        if line is not None:
+            args["line"] = line
+        if limit is not None:
+            args["limit"] = limit
 
-        env = await self._ensure_os_environment()
-        result = await env.read(path, offset=offset, limit=read_limit)
-        if "error" in result:
-            message = str(result["error"])
-            code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
-            raise _AcpRequestError(code, message)
-        # A binary file comes back base64-encoded (or descriptor-only); ACP
-        # read_text_file is text-only, so refuse rather than hand back bytes.
-        if result.get("encoding") != "utf-8":
-            raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
-        return {"content": result.get("content", "")}
+        if await self._fs_call_policy_denies("read_text_file", args):
+            self._record_fs_op(
+                "read_text_file", args, status=ToolCallStatus.BLOCKED, error="blocked by policy"
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by policy")
+
+        try:
+            env = await self._ensure_os_environment()
+            read_result = await env.read(path, offset=offset, limit=read_limit)
+            if "error" in read_result:
+                message = str(read_result["error"])
+                code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+                raise _AcpRequestError(code, message)
+            if read_result.get("encoding") != "utf-8":
+                raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
+        except _AcpRequestError as exc:
+            self._record_fs_op(
+                "read_text_file", args, status=ToolCallStatus.ERROR, error=exc.message
+            )
+            raise
+
+        content = read_result.get("content", "")
+        if await self._fs_result_policy_denies("read_text_file", content):
+            self._record_fs_op(
+                "read_text_file",
+                args,
+                status=ToolCallStatus.BLOCKED,
+                error="blocked by content policy",
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by content policy")
+        self._record_fs_op(
+            "read_text_file", args, status=ToolCallStatus.SUCCESS, result={"content": content}
+        )
+        return {"content": content}
 
     async def _handle_fs_write(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/write_text_file`` by writing through the OSEnvironment.
 
         ACP params: ``{path, content}``. The write goes through the helper, so
-        the spec's sandbox write roots are enforced at the Python layer.
-
-        :param params: The request params.
-        :returns: An empty result object (ACP expects no payload on success).
-        :raises _AcpRequestError: On missing/invalid args or a write failure.
+        the spec's sandbox write roots are enforced at the Python layer. The op
+        is recorded onto the turn stream, and call-phase policy gates the write
+        before it runs. Result-phase policy evaluates the write result after the
+        side effect; a denial refuses the response without undoing the write.
         """
         path = params.get("path")
         content = params.get("content")
@@ -791,11 +870,35 @@ class QwenExecutor(Executor):
             raise _AcpRequestError(-32602, "fs/write_text_file requires a string 'path'")
         if not isinstance(content, str):
             raise _AcpRequestError(-32602, "fs/write_text_file requires string 'content'")
+        args: _AcpJsonObject = {"path": path, "content": content}
 
-        env = await self._ensure_os_environment()
-        result = await env.write(path, content)
-        if "error" in result:
-            raise _AcpRequestError(-32603, str(result["error"]))
+        if await self._fs_call_policy_denies("write_text_file", args):
+            self._record_fs_op(
+                "write_text_file",
+                args,
+                status=ToolCallStatus.BLOCKED,
+                error="blocked by policy",
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by policy")
+        try:
+            env = await self._ensure_os_environment()
+            write_result = await env.write(path, content)
+            if "error" in write_result:
+                raise _AcpRequestError(-32603, str(write_result["error"]))
+        except _AcpRequestError as exc:
+            self._record_fs_op(
+                "write_text_file", args, status=ToolCallStatus.ERROR, error=exc.message
+            )
+            raise
+        if await self._fs_result_policy_denies("write_text_file", write_result):
+            self._record_fs_op(
+                "write_text_file",
+                args,
+                status=ToolCallStatus.BLOCKED,
+                error="blocked by result policy",
+            )
+            raise _AcpRequestError(-32603, f"{path}: blocked by result policy")
+        self._record_fs_op("write_text_file", args, status=ToolCallStatus.SUCCESS, result=write_result)
         return {}
 
     @staticmethod
@@ -1200,6 +1303,11 @@ class QwenExecutor(Executor):
             if isinstance(stale, dict) and stale.get("id") is not None and stale.get("method"):
                 await self._respond_to_agent_request(stale)
 
+        # Answering a stale request above can run real fs I/O, so emit its ToolCall
+        # audit events into history rather than dropping them.
+        while self._fs_events:
+            yield self._fs_events.pop(0)
+
         # Send the turn — this is a JSON-RPC *request*, so we wait for
         # both streaming notifications AND the final response.
         self._rpc_id += 1
@@ -1311,6 +1419,10 @@ class QwenExecutor(Executor):
                 # permission goes through policy + elicitation; anything else
                 # gets method-not-found. Blocks while the human decides.
                 await self._respond_to_agent_request(notification)
+                # Surface any fs ToolCall events the handler buffered so the
+                # I/O shows in history.
+                while self._fs_events:
+                    yield self._fs_events.pop(0)
 
             # Inbound message = progress; reset the idle deadline. Runs after the
             # human-approval block above so a slow approval doesn't time out.

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -831,7 +831,9 @@ class QwenExecutor(Executor):
             read_result = await env.read(path, offset=offset, limit=read_limit)
             if "error" in read_result:
                 message = str(read_result["error"])
-                code = _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+                code = (
+                    _ACP_RESOURCE_NOT_FOUND_CODE if _looks_like_missing_file(message) else -32603
+                )
                 raise _AcpRequestError(code, message)
             if read_result.get("encoding") != "utf-8":
                 raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
@@ -898,7 +900,9 @@ class QwenExecutor(Executor):
                 error="blocked by result policy",
             )
             raise _AcpRequestError(-32603, f"{path}: blocked by result policy")
-        self._record_fs_op("write_text_file", args, status=ToolCallStatus.SUCCESS, result=write_result)
+        self._record_fs_op(
+            "write_text_file", args, status=ToolCallStatus.SUCCESS, result=write_result
+        )
         return {}
 
     @staticmethod

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -16,7 +16,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from omnigent.inner.executor import ExecutorError, TextChunk, TurnComplete
+from omnigent.inner.executor import (
+    ExecutorError,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
+    TurnComplete,
+)
 from omnigent.inner.goose_executor import GooseExecutor
 
 # ---------------------------------------------------------------------------
@@ -422,6 +429,158 @@ async def test_fs_unsupported_when_delegation_off() -> None:
     )
 
     assert sent[0]["error"]["code"] == -32601
+
+
+# ---------------------------------------------------------------------------
+# fs delegation — event recording + TOOL_RESULT-phase content policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fs_read_records_tool_call_events() -> None:
+    """A delegated read buffers a paired ToolCallRequest + ToolCallComplete."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "hello", "encoding": "utf-8"}
+    )
+    executor._send = AsyncMock()  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 3, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    req, done = executor._fs_events
+    assert isinstance(req, ToolCallRequest)
+    assert req.name == "read_text_file"
+    assert req.args == {"path": "a.txt"}
+    assert isinstance(done, ToolCallComplete)
+    assert done.status is ToolCallStatus.SUCCESS
+    assert done.result == {"content": "hello"}
+    assert req.metadata["call_id"] == done.metadata["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_fs_write_records_tool_call_events() -> None:
+    """A delegated write buffers a paired ToolCallRequest + ToolCallComplete."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(write_result={})  # type: ignore[assignment]
+    executor._send = AsyncMock()  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "abc"},
+        }
+    )
+
+    req, done = executor._fs_events
+    assert req.name == "write_text_file"
+    assert req.args == {"path": "out.txt", "content": "abc"}
+    assert done.status is ToolCallStatus.SUCCESS
+    assert req.metadata["call_id"] == done.metadata["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_fs_read_blocked_by_result_policy() -> None:
+    """A TOOL_RESULT-phase DENY refuses the read and records it BLOCKED."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "secret", "encoding": "utf-8"}
+    )
+    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+    executor._policy_evaluator = policy  # type: ignore[attr-defined]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 5, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    assert policy.await_args.args == ("PHASE_TOOL_RESULT", {"result": "secret"})
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_blocked_by_result_policy_prevents_write() -> None:
+    """A TOOL_RESULT-phase DENY prevents the write (content known up front)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={})
+    executor._os_environment = fake  # type: ignore[assignment]
+    executor._policy_evaluator = AsyncMock(  # type: ignore[attr-defined]
+        return_value=MagicMock(action="POLICY_ACTION_DENY")
+    )
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "secret"},
+        }
+    )
+
+    assert fake.write_calls == []  # the write never happened
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_run_turn_surfaces_delegated_fs_ops() -> None:
+    """run_turn drains recorded fs ops onto the turn stream as ToolCall events."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._initialized = True
+    executor._session_id = "s"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "hi", "encoding": "utf-8"}
+    )
+    loop = asyncio.get_event_loop()
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            req_id = msg["id"]
+            await executor._queue.put(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 77,
+                    "method": "fs/read_text_file",
+                    "params": {"path": "a.txt"},
+                }
+            )
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [e async for e in executor.run_turn([{"role": "user", "content": "go"}], [], "")]
+
+    assert [e.name for e in events if isinstance(e, ToolCallRequest)] == ["read_text_file"]
+    assert [e.status for e in events if isinstance(e, ToolCallComplete)] == [
+        ToolCallStatus.SUCCESS
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -487,15 +487,47 @@ async def test_fs_write_records_tool_call_events() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fs_read_blocked_by_call_policy() -> None:
+    """A TOOL_CALL-phase DENY refuses the read by path before it runs."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(read_result={"content": "secret", "encoding": "utf-8"})
+    executor._os_environment = fake  # type: ignore[assignment]
+    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+    executor._policy_evaluator = policy  # type: ignore[attr-defined]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 5, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    assert policy.await_args.args == (
+        "PHASE_TOOL_CALL",
+        {"name": "read_text_file", "arguments": {"path": "a.txt"}},
+    )
+    assert fake.read_calls == []  # denied before the read ran
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
 async def test_fs_read_blocked_by_result_policy() -> None:
-    """A TOOL_RESULT-phase DENY refuses the read and records it BLOCKED."""
+    """A TOOL_RESULT-phase DENY on read content refuses delivery and records BLOCKED."""
     from omnigent.inner.datamodel import OSEnvSpec
 
     executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
     executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
         read_result={"content": "secret", "encoding": "utf-8"}
     )
-    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+
+    async def _policy(phase: str, data: dict) -> MagicMock:  # type: ignore[type-arg]
+        # Allow the path at the call phase; deny the content at the result phase.
+        action = "POLICY_ACTION_DENY" if phase == "PHASE_TOOL_RESULT" else "POLICY_ACTION_ALLOW"
+        return MagicMock(action=action)
+
+    policy = AsyncMock(side_effect=_policy)
     executor._policy_evaluator = policy  # type: ignore[attr-defined]
     sent: list[dict] = []
     executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
@@ -510,15 +542,46 @@ async def test_fs_read_blocked_by_result_policy() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fs_write_blocked_by_result_policy_prevents_write() -> None:
-    """A TOOL_RESULT-phase DENY prevents the write (content known up front)."""
+async def test_fs_write_blocked_by_call_policy_prevents_write() -> None:
+    """A TOOL_CALL-phase DENY (path + content) prevents the write."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={})
+    executor._os_environment = fake  # type: ignore[assignment]
+    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+    executor._policy_evaluator = policy  # type: ignore[attr-defined]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "secret"},
+        }
+    )
+
+    assert policy.await_args.args == (
+        "PHASE_TOOL_CALL",
+        {"name": "write_text_file", "arguments": {"path": "out.txt", "content": "secret"}},
+    )
+    assert fake.write_calls == []  # the write never happened
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_call_policy_fails_closed() -> None:
+    """A TOOL_CALL-phase eval error prevents the write (fail closed for side effects)."""
     from omnigent.inner.datamodel import OSEnvSpec
 
     executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
     fake = _FakeOSEnv(write_result={})
     executor._os_environment = fake  # type: ignore[assignment]
     executor._policy_evaluator = AsyncMock(  # type: ignore[attr-defined]
-        return_value=MagicMock(action="POLICY_ACTION_DENY")
+        side_effect=RuntimeError("policy server unreachable")
     )
     sent: list[dict] = []
     executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
@@ -532,8 +595,34 @@ async def test_fs_write_blocked_by_result_policy_prevents_write() -> None:
         }
     )
 
-    assert fake.write_calls == []  # the write never happened
+    assert fake.write_calls == []  # an eval failure blocks the write, it does not allow it
     assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_call_policy_ask_blocks() -> None:
+    """A TOOL_CALL-phase ASK blocks the write (delegated fs has no elicitation path)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={})
+    executor._os_environment = fake  # type: ignore[assignment]
+    executor._policy_evaluator = AsyncMock(  # type: ignore[attr-defined]
+        return_value=MagicMock(action="POLICY_ACTION_ASK")
+    )
+    executor._send = AsyncMock()  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "secret"},
+        }
+    )
+
+    assert fake.write_calls == []  # ASK with no elicitation blocks the write
     assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
 
 
@@ -563,6 +652,50 @@ async def test_run_turn_surfaces_delegated_fs_ops() -> None:
                     "params": {"path": "a.txt"},
                 }
             )
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [e async for e in executor.run_turn([{"role": "user", "content": "go"}], [], "")]
+
+    assert [e.name for e in events if isinstance(e, ToolCallRequest)] == ["read_text_file"]
+    assert [e.status for e in events if isinstance(e, ToolCallComplete)] == [
+        ToolCallStatus.SUCCESS
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_records_stale_fs_op_from_prior_turn() -> None:
+    """A stale server fs request answered at turn start is still audited, not dropped."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._initialized = True
+    executor._session_id = "s"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "hi", "encoding": "utf-8"}
+    )
+    loop = asyncio.get_event_loop()
+
+    # A leftover fs request from a prior turn, sitting on the queue before this
+    # turn starts. It runs real I/O when answered, so its audit events must survive.
+    await executor._queue.put(
+        {"jsonrpc": "2.0", "id": 77, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            req_id = msg["id"]
 
             def _resolve() -> None:
                 fut = executor._pending.get(req_id)

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -466,8 +466,9 @@ async def test_fs_write_records_tool_call_events() -> None:
     """A delegated write buffers a paired ToolCallRequest + ToolCallComplete."""
     from omnigent.inner.datamodel import OSEnvSpec
 
+    write_result = {"bytes": 3}
     executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
-    executor._os_environment = _FakeOSEnv(write_result={})  # type: ignore[assignment]
+    executor._os_environment = _FakeOSEnv(write_result=write_result)  # type: ignore[assignment]
     executor._send = AsyncMock()  # type: ignore[method-assign]
 
     await executor._respond_to_agent_request(
@@ -483,6 +484,7 @@ async def test_fs_write_records_tool_call_events() -> None:
     assert req.name == "write_text_file"
     assert req.args == {"path": "out.txt", "content": "abc"}
     assert done.status is ToolCallStatus.SUCCESS
+    assert done.result == write_result
     assert req.metadata["call_id"] == done.metadata["call_id"]
 
 
@@ -537,6 +539,38 @@ async def test_fs_read_blocked_by_result_policy() -> None:
     )
 
     assert policy.await_args.args == ("PHASE_TOOL_RESULT", {"result": "secret"})
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_blocked_by_result_policy() -> None:
+    """A TOOL_RESULT-phase DENY on the write result records BLOCKED."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    write_result = {"path": "out.txt", "bytes": 3, "marker": "actual"}
+    executor = GooseExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(write_result=write_result)  # type: ignore[attr-defined]
+
+    async def _policy(phase: str, data: dict) -> MagicMock:  # type: ignore[type-arg]
+        action = "POLICY_ACTION_DENY" if phase == "PHASE_TOOL_RESULT" else "POLICY_ACTION_ALLOW"
+        return MagicMock(action=action)
+
+    policy = AsyncMock(side_effect=_policy)
+    executor._policy_evaluator = policy  # type: ignore[attr-defined]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "abc"},
+        }
+    )
+
+    assert policy.await_args_list[-1].args == ("PHASE_TOOL_RESULT", {"result": write_result})
     assert "error" in sent[0]
     assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
 

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -21,7 +21,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from omnigent.inner.executor import ExecutorError, TextChunk, TurnComplete
+from omnigent.inner.executor import (
+    ExecutorError,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
+    TurnComplete,
+)
 from omnigent.inner.qwen_executor import QwenExecutor
 
 # ---------------------------------------------------------------------------
@@ -1457,6 +1464,158 @@ async def test_fs_write_rejects_missing_args() -> None:
     )
 
     assert sent[0]["error"]["code"] == -32602
+
+
+# ---------------------------------------------------------------------------
+# fs delegation — event recording + TOOL_RESULT-phase content policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fs_read_records_tool_call_events() -> None:
+    """A delegated read buffers a paired ToolCallRequest + ToolCallComplete."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "hello", "encoding": "utf-8"}
+    )
+    executor._send = AsyncMock()  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 3, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    req, done = executor._fs_events
+    assert isinstance(req, ToolCallRequest)
+    assert req.name == "read_text_file"
+    assert req.args == {"path": "a.txt"}
+    assert isinstance(done, ToolCallComplete)
+    assert done.status is ToolCallStatus.SUCCESS
+    assert done.result == {"content": "hello"}
+    assert req.metadata["call_id"] == done.metadata["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_fs_write_records_tool_call_events() -> None:
+    """A delegated write buffers a paired ToolCallRequest + ToolCallComplete."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(write_result={})  # type: ignore[assignment]
+    executor._send = AsyncMock()  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "abc"},
+        }
+    )
+
+    req, done = executor._fs_events
+    assert req.name == "write_text_file"
+    assert req.args == {"path": "out.txt", "content": "abc"}
+    assert done.status is ToolCallStatus.SUCCESS
+    assert req.metadata["call_id"] == done.metadata["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_fs_read_blocked_by_result_policy() -> None:
+    """A TOOL_RESULT-phase DENY refuses the read and records it BLOCKED."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "secret", "encoding": "utf-8"}
+    )
+    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+    executor._policy_evaluator = policy  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 5, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    assert policy.await_args.args == ("PHASE_TOOL_RESULT", {"result": "secret"})
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_blocked_by_result_policy_prevents_write() -> None:
+    """A TOOL_RESULT-phase DENY prevents the write (content known up front)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={})
+    executor._os_environment = fake  # type: ignore[assignment]
+    executor._policy_evaluator = AsyncMock(  # type: ignore[assignment]
+        return_value=MagicMock(action="POLICY_ACTION_DENY")
+    )
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "secret"},
+        }
+    )
+
+    assert fake.write_calls == []  # the write never happened
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_run_turn_surfaces_delegated_fs_ops() -> None:
+    """run_turn drains recorded fs ops onto the turn stream as ToolCall events."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._initialized = True
+    executor._session_id = "s"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "hi", "encoding": "utf-8"}
+    )
+    loop = asyncio.get_event_loop()
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            req_id = msg["id"]
+            await executor._queue.put(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 77,
+                    "method": "fs/read_text_file",
+                    "params": {"path": "a.txt"},
+                }
+            )
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [e async for e in executor.run_turn([{"role": "user", "content": "go"}], [], "")]
+
+    assert [e.name for e in events if isinstance(e, ToolCallRequest)] == ["read_text_file"]
+    assert [e.status for e in events if isinstance(e, ToolCallComplete)] == [
+        ToolCallStatus.SUCCESS
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -1501,8 +1501,9 @@ async def test_fs_write_records_tool_call_events() -> None:
     """A delegated write buffers a paired ToolCallRequest + ToolCallComplete."""
     from omnigent.inner.datamodel import OSEnvSpec
 
+    write_result = {"bytes": 3}
     executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
-    executor._os_environment = _FakeOSEnv(write_result={})  # type: ignore[assignment]
+    executor._os_environment = _FakeOSEnv(write_result=write_result)  # type: ignore[assignment]
     executor._send = AsyncMock()  # type: ignore[method-assign]
 
     await executor._respond_to_agent_request(
@@ -1518,6 +1519,7 @@ async def test_fs_write_records_tool_call_events() -> None:
     assert req.name == "write_text_file"
     assert req.args == {"path": "out.txt", "content": "abc"}
     assert done.status is ToolCallStatus.SUCCESS
+    assert done.result == write_result
     assert req.metadata["call_id"] == done.metadata["call_id"]
 
 
@@ -1572,6 +1574,38 @@ async def test_fs_read_blocked_by_result_policy() -> None:
     )
 
     assert policy.await_args.args == ("PHASE_TOOL_RESULT", {"result": "secret"})
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_blocked_by_result_policy() -> None:
+    """A TOOL_RESULT-phase DENY on the write result records BLOCKED."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    write_result = {"path": "out.txt", "bytes": 3, "marker": "actual"}
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._os_environment = _FakeOSEnv(write_result=write_result)  # type: ignore[assignment]
+
+    async def _policy(phase: str, data: dict) -> MagicMock:  # type: ignore[type-arg]
+        action = "POLICY_ACTION_DENY" if phase == "PHASE_TOOL_RESULT" else "POLICY_ACTION_ALLOW"
+        return MagicMock(action=action)
+
+    policy = AsyncMock(side_effect=_policy)
+    executor._policy_evaluator = policy  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "abc"},
+        }
+    )
+
+    assert policy.await_args_list[-1].args == ("PHASE_TOOL_RESULT", {"result": write_result})
     assert "error" in sent[0]
     assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
 

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -1522,15 +1522,47 @@ async def test_fs_write_records_tool_call_events() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fs_read_blocked_by_call_policy() -> None:
+    """A TOOL_CALL-phase DENY refuses the read by path before it runs."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(read_result={"content": "secret", "encoding": "utf-8"})
+    executor._os_environment = fake  # type: ignore[assignment]
+    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+    executor._policy_evaluator = policy  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {"jsonrpc": "2.0", "id": 5, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    assert policy.await_args.args == (
+        "PHASE_TOOL_CALL",
+        {"name": "read_text_file", "arguments": {"path": "a.txt"}},
+    )
+    assert fake.read_calls == []  # denied before the read ran
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
 async def test_fs_read_blocked_by_result_policy() -> None:
-    """A TOOL_RESULT-phase DENY refuses the read and records it BLOCKED."""
+    """A TOOL_RESULT-phase DENY on read content refuses delivery and records BLOCKED."""
     from omnigent.inner.datamodel import OSEnvSpec
 
     executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
     executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
         read_result={"content": "secret", "encoding": "utf-8"}
     )
-    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+
+    async def _policy(phase: str, data: dict) -> MagicMock:  # type: ignore[type-arg]
+        # Allow the path at the call phase; deny the content at the result phase.
+        action = "POLICY_ACTION_DENY" if phase == "PHASE_TOOL_RESULT" else "POLICY_ACTION_ALLOW"
+        return MagicMock(action=action)
+
+    policy = AsyncMock(side_effect=_policy)
     executor._policy_evaluator = policy  # type: ignore[assignment]
     sent: list[dict] = []
     executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
@@ -1545,15 +1577,46 @@ async def test_fs_read_blocked_by_result_policy() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fs_write_blocked_by_result_policy_prevents_write() -> None:
-    """A TOOL_RESULT-phase DENY prevents the write (content known up front)."""
+async def test_fs_write_blocked_by_call_policy_prevents_write() -> None:
+    """A TOOL_CALL-phase DENY (path + content) prevents the write."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={})
+    executor._os_environment = fake  # type: ignore[assignment]
+    policy = AsyncMock(return_value=MagicMock(action="POLICY_ACTION_DENY"))
+    executor._policy_evaluator = policy  # type: ignore[assignment]
+    sent: list[dict] = []
+    executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "secret"},
+        }
+    )
+
+    assert policy.await_args.args == (
+        "PHASE_TOOL_CALL",
+        {"name": "write_text_file", "arguments": {"path": "out.txt", "content": "secret"}},
+    )
+    assert fake.write_calls == []  # the write never happened
+    assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_call_policy_fails_closed() -> None:
+    """A TOOL_CALL-phase eval error prevents the write (fail closed for side effects)."""
     from omnigent.inner.datamodel import OSEnvSpec
 
     executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
     fake = _FakeOSEnv(write_result={})
     executor._os_environment = fake  # type: ignore[assignment]
     executor._policy_evaluator = AsyncMock(  # type: ignore[assignment]
-        return_value=MagicMock(action="POLICY_ACTION_DENY")
+        side_effect=RuntimeError("policy server unreachable")
     )
     sent: list[dict] = []
     executor._send = AsyncMock(side_effect=lambda m: sent.append(m))  # type: ignore[method-assign]
@@ -1567,8 +1630,34 @@ async def test_fs_write_blocked_by_result_policy_prevents_write() -> None:
         }
     )
 
-    assert fake.write_calls == []  # the write never happened
+    assert fake.write_calls == []  # an eval failure blocks the write, it does not allow it
     assert "error" in sent[0]
+    assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_fs_write_call_policy_ask_blocks() -> None:
+    """A TOOL_CALL-phase ASK blocks the write (delegated fs has no elicitation path)."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    fake = _FakeOSEnv(write_result={})
+    executor._os_environment = fake  # type: ignore[assignment]
+    executor._policy_evaluator = AsyncMock(  # type: ignore[assignment]
+        return_value=MagicMock(action="POLICY_ACTION_ASK")
+    )
+    executor._send = AsyncMock()  # type: ignore[method-assign]
+
+    await executor._respond_to_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "fs/write_text_file",
+            "params": {"path": "out.txt", "content": "secret"},
+        }
+    )
+
+    assert fake.write_calls == []  # ASK with no elicitation blocks the write
     assert executor._fs_events[-1].status is ToolCallStatus.BLOCKED
 
 
@@ -1598,6 +1687,50 @@ async def test_run_turn_surfaces_delegated_fs_ops() -> None:
                     "params": {"path": "a.txt"},
                 }
             )
+
+            def _resolve() -> None:
+                fut = executor._pending.get(req_id)
+                if fut and not fut.done():
+                    fut.set_result(
+                        {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}}
+                    )
+
+            loop.call_soon(_resolve)
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [e async for e in executor.run_turn([{"role": "user", "content": "go"}], [], "")]
+
+    assert [e.name for e in events if isinstance(e, ToolCallRequest)] == ["read_text_file"]
+    assert [e.status for e in events if isinstance(e, ToolCallComplete)] == [
+        ToolCallStatus.SUCCESS
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_records_stale_fs_op_from_prior_turn() -> None:
+    """A stale server fs request answered at turn start is still audited, not dropped."""
+    from omnigent.inner.datamodel import OSEnvSpec
+
+    executor = QwenExecutor(os_env=OSEnvSpec(type="caller_process"))
+    executor._initialized = True
+    executor._session_id = "s"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    executor._os_environment = _FakeOSEnv(  # type: ignore[assignment]
+        read_result={"content": "hi", "encoding": "utf-8"}
+    )
+    loop = asyncio.get_event_loop()
+
+    # A leftover fs request from a prior turn, sitting on the queue before this
+    # turn starts. It runs real I/O when answered, so its audit events must survive.
+    await executor._queue.put(
+        {"jsonrpc": "2.0", "id": 77, "method": "fs/read_text_file", "params": {"path": "a.txt"}}
+    )
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            req_id = msg["id"]
 
             def _resolve() -> None:
                 fut = executor._pending.get(req_id)


### PR DESCRIPTION
## Related issue

N/A. This completes the deferred follow-up from #1100, tracked in `docs/QWEN_FOLLOWUPS.md` ("File I/O recording / content policy"). No separate issue.

## Summary

#1100 routed the ACP harnesses' file reads/writes back through Omnigent's `OSEnvironment` but left two layers as documented follow-ups: the delegated I/O was invisible in history and no content policy ran on it. This wires both onto the existing `_handle_fs_read` / `_handle_fs_write` handlers, in **qwen** and **goose**:

- **History recording.** Each delegated read/write emits a paired `ToolCallRequest` + `ToolCallComplete` onto the turn stream, which the harness adapter already renders as observed `function_call` / `function_call_output` items. The handlers buffer the records and `run_turn` drains them right after dispatching the request; the buffer is reset per turn so a prior turn's ops don't leak in.
- **Result-phase content policy.** The read/written bytes run through `PHASE_TOOL_RESULT` policy. An explicit `POLICY_ACTION_DENY` refuses the op (read: the bytes never reach the agent; write: evaluated before `OSEnvironment.write`, so the write never happens). It fails open otherwise (policy unwired, an eval error, or any non-deny verdict), matching `PHASE_TOOL_RESULT`'s advisory semantics (`FAIL_CLOSED_PHASES` is `PHASE_TOOL_CALL` only). Result policy here gates on content only: the server reads result-phase tool identity from `request_data`, which the harness policy round-trip doesn't carry, so the payload is `{"result": content}` (matching the existing producer in `runner/tool_dispatch.py`). A real read/write failure records `ERROR`, a denial records `BLOCKED`, success records `SUCCESS`; malformed requests still raise before any record.

Applied to both ACP harnesses since they share the identical dispatch pattern (same as #1100 and the history-replay change). `docs/QWEN_FOLLOWUPS.md` is updated to check the item off and note the content-only scope.

## Test Plan

- 10 new tests (5 per harness): a delegated read and write each emit a paired `ToolCallRequest` + `ToolCallComplete` with a shared `call_id`; a `PHASE_TOOL_RESULT` deny refuses a read and records it `BLOCKED`; a deny prevents a write (the `OSEnvironment.write` is never called) and records `BLOCKED`; `run_turn` surfaces a delegated op's records onto the turn stream.
- Each new test fails on the unfixed code (verified by stashing the production change).
- `pytest tests/inner/test_qwen_executor.py tests/inner/test_goose_executor.py tests/inner/test_qwen_agent_integration.py` — 155 passed.
- `ruff check` + `ruff format --check` clean; no lock-file changes.
- The `e2e_ui` / per-harness e2e suites are gateway-bound and were not run locally.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit tests drive the real dispatch (`_respond_to_agent_request`) and the real `run_turn` loop with a fake `OSEnvironment` and a fake policy evaluator, so they cover both the recording and the deny/fail-open paths without a live qwen/goose binary. Two design calls worth a look: (1) for writes I run result-phase policy before `OSEnvironment.write` so an explicit deny actually prevents the write. That bends "result phase = after the side effect," but the content is known up front and blocking a not-yet-incurred write is the useful behavior. (2) Result-phase policy is content-only here, because the harness policy round-trip (`evaluate_policy(phase, data)`) carries no `request_data`, so the server can't see the fs tool's name for the result phase. Happy to adjust either if you would rather keep the phase semantics strict or thread `request_data` through the round-trip.
