### PR TITLE
fix(chat): tighten new session composer gutters on phones

### DIFF
--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1303,8 +1303,10 @@ export function NewChatLandingScreen() {
       data-testid="new-chat-landing"
     >
       {/* Padding lives inside the 840px cap, so the composer renders at
-          840 − 80 = 760px max. */}
-      <div className="flex w-full max-w-[840px] flex-col items-center gap-8 px-10 pt-8 pb-16">
+          840 − 80 = 760px max on desktop. px-4 on phones (16px gutters)
+          keeps the composer from feeling cramped against the viewport
+          edges; widens to the full px-10 at the md breakpoint and up. */}
+      <div className="flex w-full max-w-[840px] flex-col items-center gap-8 px-4 pt-8 pb-16 md:px-10">
         <div className="flex flex-col items-center gap-3.5 sm:flex-row">
           <OttoEyes className="h-18 w-auto shrink-0" />
           <h1 className="text-center text-3xl font-medium tracking-[-0.03em] text-foreground sm:text-left">


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The empty new-session page is rendered by NewChatDialog, not ChatPage's ConversationContent — so the earlier padding fix (422d190) edited the wrong component and had no visible effect.
- The composer + footer-chip container used `px-10` (40px gutters) at every breakpoint, leaving wide empty margins flanking the composer card on phones.
- Override to `px-4 md:px-10` so phones get 16px gutters and the composer no longer feels cramped against the viewport edges; desktop keeps the original 40px from the md breakpoint (768px) up.

## Test Plan

- Loaded the empty new-session landing page in a narrow (phone-width) viewport and confirmed the left/right gutters around the composer card and footer chips are 16px; verified they widen back to 40px at
  >=768px so desktop is unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified visually in the browser at phone and desktop widths: the new-session composer container gutters are 16px on phones and 40px at the md breakpoint and above. This is a Tailwind class-only change with no logic to unit-test.
