### PR TITLE
feat(claude-native): persist compaction item on compaction completion

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -2428,6 +2428,22 @@ async def _forward_available_status_events(
                         compaction_status,
                         exc_info=True,
                     )
+                # Persist a compaction item so session resume knows
+                # the compaction boundary. Without this, rebuilding
+                # the transcript from the conversation DB loads the
+                # full pre-compaction history.
+                if compaction_status == "completed":
+                    try:
+                        await _persist_native_compaction_item(
+                            client,
+                            session_id=session_id,
+                        )
+                    except Exception:  # noqa: BLE001
+                        _logger.warning(
+                            "Failed to persist compaction item for %s",
+                            session_id,
+                            exc_info=True,
+                        )
                 durable = next_durable
                 await _write_hook_state_async(bridge_dir, durable)
                 continue
@@ -3408,6 +3424,47 @@ async def _post_external_compaction_status(
         json={
             "type": "external_compaction_status",
             "data": {"status": status},
+        },
+    )
+    resp.raise_for_status()
+
+
+async def _persist_native_compaction_item(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+) -> None:
+    """
+    Persist a compaction boundary item to the conversation store.
+
+    Called when the forwarder observes a compaction-completed signal
+    (``SessionStart source=compact``). Queries the latest conversation
+    item to use as ``last_item_id`` so session resume knows the
+    compaction boundary — items before this marker are summarized
+    and don't need to be loaded.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id.
+    """
+    # Find the last persisted item to use as the compaction boundary.
+    resp = await client.get(
+        f"/v1/sessions/{session_id}/items",
+        params={"limit": 1, "order": "desc"},
+    )
+    resp.raise_for_status()
+    items = resp.json().get("data", [])
+    last_item_id = items[0]["id"] if items else f"compact_boundary_{session_id}"
+
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "compaction",
+            "data": {
+                "summary": ("[Claude Code compaction — context was compacted in the terminal]"),
+                "last_item_id": last_item_id,
+                "model": "unknown",
+                "token_count": 0,
+            },
         },
     )
     resp.raise_for_status()

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -2437,6 +2437,7 @@ async def _forward_available_status_events(
                         await _persist_native_compaction_item(
                             client,
                             session_id=session_id,
+                            bridge_dir=bridge_dir,
                         )
                     except Exception:  # noqa: BLE001
                         _logger.warning(
@@ -3433,6 +3434,7 @@ async def _persist_native_compaction_item(
     client: httpx.AsyncClient,
     *,
     session_id: str,
+    bridge_dir: Path,
 ) -> None:
     """
     Persist a compaction boundary item to the conversation store.
@@ -3443,8 +3445,16 @@ async def _persist_native_compaction_item(
     compaction boundary — items before this marker are summarized
     and don't need to be loaded.
 
+    After writing the boundary, it also reads the post-compaction
+    transcript from Claude's own session state via
+    ``get_session_messages`` and includes them as ``compacted_messages``
+    so session resume in ephemeral environments can reconstruct context
+    without the CLI's local transcript files.
+
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: Bridge directory path used to look up the
+        Claude-native session id.
     """
     # Find the last persisted item to use as the compaction boundary.
     resp = await client.get(
@@ -3455,16 +3465,40 @@ async def _persist_native_compaction_item(
     items = resp.json().get("data", [])
     last_item_id = items[0]["id"] if items else f"compact_boundary_{session_id}"
 
+    # Read the post-compaction session messages so session resume can
+    # reconstruct context in ephemeral environments.
+    compacted_messages: list[dict[str, Any]] | None = None
+    try:
+        from claude_agent_sdk import get_session_messages
+
+        claude_sid = read_claude_session_id(bridge_dir)
+        if claude_sid:
+            msgs = get_session_messages(claude_sid)
+            compacted_messages = [
+                {"type": "message", "role": m.type, "content": m.message.get("content", [])}
+                for m in msgs
+                if isinstance(m.message, dict)
+            ]
+    except Exception:  # noqa: BLE001
+        _logger.debug(
+            "Failed to read Claude session messages for compaction persist",
+            exc_info=True,
+        )
+
+    event_data: dict[str, Any] = {
+        "summary": "[Claude Code compaction — context was compacted in the terminal]",
+        "last_item_id": last_item_id,
+        "model": "unknown",
+        "token_count": 0,
+    }
+    if compacted_messages is not None:
+        event_data["compacted_messages"] = compacted_messages
+
     resp = await client.post(
         f"/v1/sessions/{session_id}/events",
         json={
             "type": "compaction",
-            "data": {
-                "summary": ("[Claude Code compaction — context was compacted in the terminal]"),
-                "last_item_id": last_item_id,
-                "model": "unknown",
-                "token_count": 0,
-            },
+            "data": event_data,
         },
     )
     resp.raise_for_status()

--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -486,6 +486,29 @@ def compaction_to_history_items(
     assert isinstance(compaction_item.data, CompactionData)
     data = compaction_item.data
 
+    # Prefer compacted_messages when available — they carry the
+    # full compacted state (e.g. OpenAI's opaque compaction tokens
+    # or Claude's post-compaction transcript) that the harness can
+    # replay directly. Fall back to the synthetic summary pair for
+    # older compaction items that don't have compacted messages.
+    if data.compacted_messages:
+        items: list[ConversationItem] = []
+        for i, msg in enumerate(data.compacted_messages):
+            items.append(
+                ConversationItem(
+                    id=f"{compaction_item.id}_compacted_{i}",
+                    type=msg.get("type", "message"),
+                    status="completed",
+                    response_id=compaction_item.response_id,
+                    created_at=compaction_item.created_at,
+                    data=MessageData(
+                        role=msg.get("role", "user"),
+                        content=msg.get("content", []),
+                    ),
+                )
+            )
+        return items
+
     synthetic_user_content = (
         "[This is an automatically generated summary of the prior conversation "
         "context. The original messages are available but not included in this "

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -28,6 +29,7 @@ from omnigent.claude_native_bridge import (
     write_active_session_id,
 )
 from omnigent.claude_native_forwarder import (
+    _persist_native_compaction_item,
     forward_claude_transcript_to_session,
 )
 from omnigent.reasoning_effort import CLAUDE_EFFORTS, EFFORT_CLEAR_VALUES
@@ -5923,3 +5925,207 @@ async def test_forward_session_cost_tags_display_advance_with_model(
         estimate_box["value"] = 0.90
         await run()
         assert posted[-1] == {"policy_cost_usd": pytest.approx(0.90)}
+
+
+# ---------------------------------------------------------------------------
+# _persist_native_compaction_item tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persist_native_compaction_item_posts_compaction_event() -> None:
+    """
+    ``_persist_native_compaction_item`` queries the latest item and posts a compaction event.
+
+    The function GETs ``/v1/sessions/{id}/items?limit=1&order=desc`` to
+    find the most recent persisted item, then POSTs a ``compaction``
+    event using that item's id as ``last_item_id``.
+    """
+    get_response = MagicMock()
+    get_response.raise_for_status = MagicMock()
+    get_response.json.return_value = {"data": [{"id": "item_123"}]}
+
+    post_response = MagicMock()
+    post_response.raise_for_status = MagicMock()
+
+    client = AsyncMock()
+    client.get.return_value = get_response
+    client.post.return_value = post_response
+
+    await _persist_native_compaction_item(client, session_id="conv_test")
+
+    client.get.assert_called_once_with(
+        "/v1/sessions/conv_test/items",
+        params={"limit": 1, "order": "desc"},
+    )
+    client.post.assert_called_once()
+    post_call = client.post.call_args
+    assert post_call[0][0] == "/v1/sessions/conv_test/events"
+    body = post_call[1]["json"] if "json" in post_call[1] else post_call[0][1]
+    assert body["type"] == "compaction"
+    assert body["data"]["last_item_id"] == "item_123"
+    assert body["data"]["summary"] is not None
+    assert body["data"]["model"] == "unknown"
+    assert body["data"]["token_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_persist_native_compaction_item_empty_items_uses_fallback() -> None:
+    """
+    When no items exist, ``last_item_id`` falls back to a generated boundary id.
+
+    If the session has no persisted items yet (e.g. the very first turn
+    was compacted before anything was stored), the function generates
+    ``compact_boundary_{session_id}`` as the boundary marker instead of
+    crashing on an empty list.
+    """
+    get_response = MagicMock()
+    get_response.raise_for_status = MagicMock()
+    get_response.json.return_value = {"data": []}
+
+    post_response = MagicMock()
+    post_response.raise_for_status = MagicMock()
+
+    client = AsyncMock()
+    client.get.return_value = get_response
+    client.post.return_value = post_response
+
+    await _persist_native_compaction_item(client, session_id="conv_empty")
+
+    post_call = client.post.call_args
+    body = post_call[1]["json"] if "json" in post_call[1] else post_call[0][1]
+    assert body["data"]["last_item_id"].startswith("compact_boundary_")
+
+
+@pytest.mark.asyncio
+async def test_compaction_completed_triggers_persist(tmp_path: Path) -> None:
+    """
+    ``SessionStart source=compact`` triggers both status POST and item persistence.
+
+    When the forwarder processes a ``SessionStart source=compact`` record
+    (compaction completed), it must call ``_post_external_compaction_status``
+    to surface the status AND ``_persist_native_compaction_item`` to write
+    the compaction boundary item.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    # Initial SessionStart populates transcript_path.
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
+    # Post-compaction SessionStart — the completion signal.
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "source": "compact",
+            "session_id": "claude-session",
+        },
+    )
+    server, thread, base_url = _start_recording_server()
+    persist_called = asyncio.Event()
+
+    async def _persist_side_effect(*args: Any, **kwargs: Any) -> None:
+        persist_called.set()
+
+    persist_mock = AsyncMock(side_effect=_persist_side_effect)
+    with patch(
+        "omnigent.claude_native_forwarder._persist_native_compaction_item",
+        persist_mock,
+    ):
+        task = asyncio.create_task(
+            forward_claude_transcript_to_session(
+                base_url=base_url,
+                headers={},
+                session_id="conv_persist",
+                bridge_dir=bridge_dir,
+                agent_name="claude-native-ui",
+                start_at_end=False,
+                poll_interval_s=0.01,
+            )
+        )
+        try:
+            # Wait for the compaction status POST to arrive.
+            request = await _get_recorded_request(server)
+            # Wait for _persist_native_compaction_item to be called
+            # (it runs right after the POST in the same await chain).
+            await asyncio.wait_for(persist_called.wait(), timeout=5.0)
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5.0)
+
+    # The recording server captured the compaction status POST.
+    assert request["body"]["type"] == "external_compaction_status"
+    assert request["body"]["data"]["status"] == "completed"
+    # _persist_native_compaction_item was called with the right session id.
+    persist_mock.assert_called_once()
+    call_kwargs = persist_mock.call_args
+    assert call_kwargs[1]["session_id"] == "conv_persist"
+
+
+@pytest.mark.asyncio
+async def test_compaction_in_progress_does_not_persist(tmp_path: Path) -> None:
+    """
+    ``PreCompact`` (in_progress) does NOT call ``_persist_native_compaction_item``.
+
+    Only compaction *completion* (``SessionStart source=compact``) writes
+    the boundary item. ``PreCompact`` merely forwards the ``in_progress``
+    status so the UI shows a spinner — there is no boundary to persist yet.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "claude-session",
+            "transcript_path": str(transcript_path),
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {"hook_event_name": "PreCompact", "session_id": "claude-session"},
+    )
+    server, thread, base_url = _start_recording_server()
+    persist_mock = AsyncMock()
+    with patch(
+        "omnigent.claude_native_forwarder._persist_native_compaction_item",
+        persist_mock,
+    ):
+        task = asyncio.create_task(
+            forward_claude_transcript_to_session(
+                base_url=base_url,
+                headers={},
+                session_id="conv_no_persist",
+                bridge_dir=bridge_dir,
+                agent_name="claude-native-ui",
+                start_at_end=False,
+                poll_interval_s=0.01,
+            )
+        )
+        try:
+            # Wait for the in_progress status POST to arrive.
+            request = await _get_recorded_request(server)
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5.0)
+
+    assert request["body"]["type"] == "external_compaction_status"
+    assert request["body"]["data"]["status"] == "in_progress"
+    # _persist_native_compaction_item must NOT be called for in_progress.
+    persist_mock.assert_not_called()

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5933,13 +5933,15 @@ async def test_forward_session_cost_tags_display_advance_with_model(
 
 
 @pytest.mark.asyncio
-async def test_persist_native_compaction_item_posts_compaction_event() -> None:
+async def test_persist_native_compaction_item_posts_compaction_event(tmp_path: Path) -> None:
     """
     ``_persist_native_compaction_item`` queries the latest item and posts a compaction event.
 
     The function GETs ``/v1/sessions/{id}/items?limit=1&order=desc`` to
-    find the most recent persisted item, then POSTs a ``compaction``
-    event using that item's id as ``last_item_id``.
+    find the most recent persisted item, reads post-compaction messages
+    from the Claude session, then POSTs a ``compaction`` event using
+    that item's id as ``last_item_id`` and the messages as
+    ``compacted_messages``.
     """
     get_response = MagicMock()
     get_response.raise_for_status = MagicMock()
@@ -5952,7 +5954,26 @@ async def test_persist_native_compaction_item_posts_compaction_event() -> None:
     client.get.return_value = get_response
     client.post.return_value = post_response
 
-    await _persist_native_compaction_item(client, session_id="conv_test")
+    # Build a fake message returned by get_session_messages.
+    fake_msg = MagicMock()
+    fake_msg.type = "assistant"
+    fake_msg.message = {"content": [{"type": "text", "text": "hello"}]}
+
+    bridge_dir = tmp_path / "bridge"
+
+    with (
+        patch(
+            "omnigent.claude_native_forwarder.read_claude_session_id",
+            return_value="claude-uuid-1",
+        ),
+        patch(
+            "claude_agent_sdk.get_session_messages",
+            return_value=[fake_msg],
+        ),
+    ):
+        await _persist_native_compaction_item(
+            client, session_id="conv_test", bridge_dir=bridge_dir
+        )
 
     client.get.assert_called_once_with(
         "/v1/sessions/conv_test/items",
@@ -5967,10 +5988,14 @@ async def test_persist_native_compaction_item_posts_compaction_event() -> None:
     assert body["data"]["summary"] is not None
     assert body["data"]["model"] == "unknown"
     assert body["data"]["token_count"] == 0
+    # compacted_messages should contain the converted fake message.
+    assert body["data"]["compacted_messages"] == [
+        {"type": "message", "role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+    ]
 
 
 @pytest.mark.asyncio
-async def test_persist_native_compaction_item_empty_items_uses_fallback() -> None:
+async def test_persist_native_compaction_item_empty_items_uses_fallback(tmp_path: Path) -> None:
     """
     When no items exist, ``last_item_id`` falls back to a generated boundary id.
 
@@ -5990,11 +6015,23 @@ async def test_persist_native_compaction_item_empty_items_uses_fallback() -> Non
     client.get.return_value = get_response
     client.post.return_value = post_response
 
-    await _persist_native_compaction_item(client, session_id="conv_empty")
+    bridge_dir = tmp_path / "bridge"
+
+    with (
+        patch(
+            "omnigent.claude_native_forwarder.read_claude_session_id",
+            return_value=None,
+        ),
+    ):
+        await _persist_native_compaction_item(
+            client, session_id="conv_empty", bridge_dir=bridge_dir
+        )
 
     post_call = client.post.call_args
     body = post_call[1]["json"] if "json" in post_call[1] else post_call[0][1]
     assert body["data"]["last_item_id"].startswith("compact_boundary_")
+    # No compacted_messages when claude_sid is None.
+    assert "compacted_messages" not in body["data"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- When the claude-native forwarder observes compaction completion (`SessionStart source=compact`), it now persists a `compaction` item to the conversation store with the last item ID as boundary marker.
- Previously only UI spinner events (`external_compaction_status`) were published — no durable boundary was stored, so rebuilding the transcript from the conversation DB would load the full pre-compaction history.
- On session resume, `_load_initial_history` finds the compaction item and loads only items after the boundary, matching the CLI's own compacted context.

## Test plan

- [ ] Trigger compaction on a claude-native session (via `/compact` or automatic context overflow)
- [ ] Verify a `compaction` item appears in the conversation_items table
- [ ] Verify session resume after runner restart loads only post-compaction items

This pull request and its description were written by Isaac.