### PR TITLE
fix(ui): fold the pin button into the kebab menu on mobile

### DIFF
--- a/ap-web/src/shell/Sidebar.rowActions.test.tsx
+++ b/ap-web/src/shell/Sidebar.rowActions.test.tsx
@@ -1,6 +1,7 @@
 // Tests for the sidebar conversation-row quick actions:
-//   1. A pin/unpin button (the sole pin affordance — no longer in the kebab
-//      menu) that toggles the pin (ConversationRow's `quick-pin-conversation`).
+//   1. A desktop quick pin/unpin button (`quick-pin-conversation`) and a
+//      mobile-only kebab Pin item (`pin-conversation`) — two affordances for
+//      the same pin toggle, split by viewport (responsive Tailwind classes).
 //   2. Double-clicking a row to enter inline rename (ConversationRow's
 //      `onDoubleClick`), gated on edit permission.
 // See ConversationRow / ConversationEditRow in Sidebar.tsx.
@@ -135,16 +136,44 @@ describe("quick pin/unpin hover button", () => {
     expect(screen.queryByText("Pinned")).toBeNull();
   });
 
-  it("no longer offers Pin in the kebab menu (the quick button replaced it)", () => {
+  it("also offers Pin in the kebab menu (mobile affordance) and toggles the same pin state", () => {
     renderSidebar();
+
+    expect(screen.queryByText("Pinned")).toBeNull();
 
     // Radix DropdownMenu opens on pointerdown, not click.
     fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
 
-    // The menu opened (a sibling item is present) but the old Pin item is gone
-    // — pinning now lives only on the hover/quick button.
-    expect(screen.getByTestId("rename-conversation")).toBeInTheDocument();
-    expect(screen.queryByTestId("pin-conversation")).toBeNull();
+    // The kebab carries a Pin item (mobile-only via `md:hidden`, but always in
+    // the DOM since jsdom doesn't evaluate media queries). Clicking it drives
+    // the same pin state as the quick button — the row moves under "Pinned".
+    const pinItem = screen.getByTestId("pin-conversation");
+    expect(pinItem).toHaveTextContent("Pin");
+    fireEvent.click(pinItem);
+
+    const pinnedHeader = screen.getByText("Pinned");
+    const pinnedSection = pinnedHeader.closest("section")!;
+    expect(within(pinnedSection).getByText("My Session")).toBeInTheDocument();
+    expect(localStorage.getItem("omnigent:pinned-conversation-ids")).toContain("conv_1");
+  });
+
+  it("splits the two pin affordances by viewport via Tailwind responsive classes", () => {
+    // jsdom doesn't evaluate CSS media queries, so both affordances live in the
+    // DOM regardless of viewport — the mobile/desktop split is purely the
+    // responsive classes. Assert those classes directly: the kebab Pin item is
+    // hidden from `md` up (desktop), and the quick button is hidden below `md`
+    // (mobile) but shown from `md` up. Together they guarantee exactly one pin
+    // affordance is visible at any breakpoint.
+    renderSidebar();
+
+    // Desktop quick button: hidden on mobile, shown on desktop.
+    const quickButton = screen.getByTestId("quick-pin-conversation");
+    expect(quickButton).toHaveClass("hidden", "md:block");
+
+    // Kebab Pin item: present in the menu but hidden from `md` up, so it only
+    // surfaces on mobile.
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    expect(screen.getByTestId("pin-conversation")).toHaveClass("md:hidden");
   });
 });
 

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1080,6 +1080,7 @@ function ConversationRow({
           {relativeTime(conversation.updated_at * 1000)}
         </span>
       )}
+      {/* Pin button: desktop-only (hidden on mobile; use kebab menu instead). */}
       {!selectionMode && (
         <Button
           type="button"
@@ -1089,6 +1090,7 @@ function ConversationRow({
           data-testid="quick-pin-conversation"
           className={cn(
             "-translate-y-1/2 absolute top-1/2 right-9 transition-opacity",
+            "hidden md:block",
             "md:opacity-0 md:group-hover:opacity-100",
             "md:group-has-[:focus-visible]:opacity-100 md:group-has-[[aria-expanded=true]]:opacity-100",
           )}
@@ -1131,6 +1133,15 @@ function ConversationRow({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="min-w-36">
+            {/* Pin/Unpin — mobile-only; desktop has the quick-pin button. */}
+            <DropdownMenuItem
+              data-testid="pin-conversation"
+              className="md:hidden"
+              onSelect={() => onTogglePinned(conversation.id)}
+            >
+              {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
+              {isPinned ? "Unpin" : "Pin"}
+            </DropdownMenuItem>
             {isOwner ? (
               <DropdownMenuItem data-testid="archive-conversation" onSelect={runArchive}>
                 {isArchived ? (


### PR DESCRIPTION
## Problem

On mobile, the pin (thumbtack) button is permanently visible on every session row in the sidebar. On desktop it's gated behind row hover, but mobile has no hover state, so the button always shows — cluttering the list.

## Fix

- **Quick-pin button is now desktop-only** (`hidden md:block`) — unchanged hover behavior on desktop, gone on mobile.
- **Added a `Pin`/`Unpin` item to the kebab `⋯` menu** (`md:hidden`) — it surfaces only on mobile and calls the same `onTogglePinned` handler, so pin state, ordering, and localStorage persistence are identical.

Net result: exactly one pin affordance per breakpoint — hover button on desktop, kebab item on mobile.

## Tests

`Sidebar.rowActions.test.tsx`:
- Updated the test that asserted the kebab had *no* Pin item (old design); it now verifies the kebab Pin item exists and toggles the same pin state.
- Added a test asserting the responsive split via Tailwind classes: quick button has `hidden md:block`, kebab item has `md:hidden`.

> [!NOTE]
> jsdom doesn't evaluate CSS media queries, so the tests assert the responsive Tailwind classes (the mechanism) rather than true computed visibility — both elements are always in the test DOM. Genuine breakpoint-rendering coverage would need a real-browser e2e (Playwright with mobile/desktop viewports).

## Verification
- `npm test` — 3027 passed, 3 expected-fail, 2 skipped.
- `npm run build` — clean.