### PR TITLE
fix(runner): surface forwarder connectivity failures in idle-watchdog turn reason

### DIFF
--- a/omnigent/_native_forwarder_health.py
+++ b/omnigent/_native_forwarder_health.py
@@ -11,9 +11,13 @@ and otherwise lost, so the user only sees a generic "wedged LLM" reason.
 The forwarder records its last exhausted POST failure here so the watchdog can
 attach the connectivity cause to the turn-failure reason (issue #1119). The
 record is process-global rather than session-keyed because one subprocess
-serves exactly one conversation; it carries a monotonic timestamp so the
-watchdog only blames connectivity for a failure recent enough to plausibly be
-the cause of the stall.
+serves exactly one conversation AND runs one turn at a time (the native UI has
+a single active turn; the watchdog attributes the recorded failure to that
+turn). It carries a monotonic timestamp so the watchdog only blames
+connectivity for a failure recent enough to plausibly be the cause of the
+stall, and a successful POST clears the slot (:func:`note_post_success`) so a
+recovered connection can't have an old failure misattributed to a later,
+unrelated stall.
 """
 
 from __future__ import annotations
@@ -43,6 +47,23 @@ def record_post_failure(event_type: str, error: BaseException) -> None:
     :returns: None.
     """
     _state["last_post_failure"] = (time.monotonic(), f"{event_type}: {error!r}")
+
+
+def note_post_success() -> None:
+    """
+    Clear the failure record after a POST that reached the server.
+
+    Called whenever a forwarder POST receives any HTTP response (2xx or even a
+    4xx/5xx — receiving a status proves the server was reachable, so the prior
+    transport failure no longer reflects current connectivity). This bounds the
+    failure to "since the last successful round-trip": if the connection is
+    still down, subsequent POSTs keep failing and re-record, so the slot stays
+    populated; once it recovers, the next success empties it and the watchdog
+    won't blame a long-resolved failure for an unrelated later stall.
+
+    :returns: None.
+    """
+    _state["last_post_failure"] = None
 
 
 def recent_post_failure(within_s: float) -> str | None:

--- a/omnigent/_native_forwarder_health.py
+++ b/omnigent/_native_forwarder_health.py
@@ -1,0 +1,77 @@
+"""Process-local record of the most recent native-forwarder event-POST failure.
+
+A native-harness subprocess serves exactly one conversation (see
+``app.state.conversation_id`` in ``omnigent/runtime/harnesses/_scaffold.py``),
+and its transcript forwarder runs as an ``asyncio`` task in the SAME event loop
+as the harness idle-turn watchdog. When the watchdog fires after a stall, the
+real cause is often that the forwarder could not POST session events to the
+server (e.g. ``ConnectError: No route to host``) — which is logged separately
+and otherwise lost, so the user only sees a generic "wedged LLM" reason.
+
+The forwarder records its last exhausted POST failure here so the watchdog can
+attach the connectivity cause to the turn-failure reason (issue #1119). The
+record is process-global rather than session-keyed because one subprocess
+serves exactly one conversation; it carries a monotonic timestamp so the
+watchdog only blames connectivity for a failure recent enough to plausibly be
+the cause of the stall.
+"""
+
+from __future__ import annotations
+
+import time
+
+# Single-slot holder rather than a module global + ``global`` statement: one
+# conversation per subprocess means one "last failure" is unambiguous. The
+# tuple is ``(monotonic_timestamp, human_detail)``; ``None`` until a forwarder
+# POST exhausts its retries.
+_state: dict[str, tuple[float, str] | None] = {"last_post_failure": None}
+
+
+def record_post_failure(event_type: str, error: BaseException) -> None:
+    """
+    Record a native-forwarder event-POST failure that exhausted its retries.
+
+    Called from the forwarder's post path after all retries fail (a persistent
+    failure such as a connectivity outage — transient single failures that
+    recover are not recorded). Overwrites any prior record; only the most
+    recent failure is kept.
+
+    :param event_type: Session event type that failed to post, e.g.
+        ``"external_conversation_item"`` or ``"external_session_status"``.
+    :param error: The final transport error, e.g. an
+        ``httpx.ConnectError``. Rendered with ``repr`` into the detail string.
+    :returns: None.
+    """
+    _state["last_post_failure"] = (time.monotonic(), f"{event_type}: {error!r}")
+
+
+def recent_post_failure(within_s: float) -> str | None:
+    """
+    Return the most recent forwarder POST failure detail, if recent enough.
+
+    :param within_s: Recency window in seconds. A recorded failure older than
+        this is ignored so a long-resolved blip is not blamed for a fresh
+        stall. Pass the watchdog's idle window so only a failure that occurred
+        during the stall is surfaced.
+    :returns: A human-readable detail string (``"<event_type>: <repr>"``) when
+        a failure was recorded within *within_s* seconds, else ``None``.
+    """
+    record = _state["last_post_failure"]
+    if record is None:
+        return None
+    recorded_at, detail = record
+    if time.monotonic() - recorded_at > within_s:
+        return None
+    return detail
+
+
+def clear() -> None:
+    """
+    Forget any recorded forwarder POST failure.
+
+    Lets a test isolate from earlier records; harmless in production (the next
+    failure overwrites the slot regardless).
+
+    :returns: None.
+    """
+    _state["last_post_failure"] = None

--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -29,7 +29,12 @@ from pathlib import Path
 
 import httpx
 
-from omnigent._native_forwarder_health import record_post_failure as record_native_post_failure
+from omnigent._native_forwarder_health import (
+    note_post_success as note_native_post_success,
+)
+from omnigent._native_forwarder_health import (
+    record_post_failure as record_native_post_failure,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -231,6 +236,11 @@ async def post_session_event_with_retry(
                 return None
             await sleep(retry_delay(attempt))
             continue
+        # Reaching here means the POST got an HTTP response (no transport
+        # error), proving the server is reachable — clear any stale
+        # connectivity-failure record so the watchdog can't later misattribute
+        # it to an unrelated stall (issue #1119).
+        note_native_post_success()
         if response.status_code < 400:
             return response
         if response.status_code not in retry_status_codes:

--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -29,6 +29,8 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_forwarder_health import record_post_failure as record_native_post_failure
+
 _logger = logging.getLogger(__name__)
 
 # Dead-letter sink for permanently-undeliverable forward payloads (#1120).
@@ -221,6 +223,11 @@ async def post_session_event_with_retry(
                     max_attempts,
                     exc,
                 )
+                # Surface this connectivity failure to the harness idle-turn
+                # watchdog so a stall caused by unreachable-server posts is
+                # reported with its real cause, not a generic "wedged LLM"
+                # reason (issue #1119).
+                record_native_post_failure(event_type, exc)
                 return None
             await sleep(retry_delay(attempt))
             continue

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 
+from omnigent._native_forwarder_health import record_post_failure as record_native_post_failure
 from omnigent._native_post_delivery import (
     RepostResult,
     append_dead_letter,
@@ -5662,6 +5663,11 @@ def _log_post_transport_failure(event_type: str, exc: httpx.HTTPError, max_attem
         max_attempts,
         exc,
     )
+    # Surface this connectivity failure to the harness idle-turn watchdog: if
+    # the turn stalls because events can't reach the server, the watchdog
+    # attaches this cause to the failure reason instead of a generic
+    # "wedged LLM" message (issue #1119).
+    record_native_post_failure(event_type, exc)
 
 
 def _log_failed_session_event_post(

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -14,7 +14,12 @@ from typing import Any
 
 import httpx
 
-from omnigent._native_forwarder_health import record_post_failure as record_native_post_failure
+from omnigent._native_forwarder_health import (
+    note_post_success as note_native_post_success,
+)
+from omnigent._native_forwarder_health import (
+    record_post_failure as record_native_post_failure,
+)
 from omnigent._native_post_delivery import (
     RepostResult,
     append_dead_letter,
@@ -5614,6 +5619,11 @@ async def _post_session_event_inner(
                 return _PostResult(response=None, transport_error=type(exc).__name__)
             await _sleep(_post_retry_delay(attempt))
             continue
+        # An HTTP response (no transport error) proves the server is reachable,
+        # so clear any stale connectivity-failure record — otherwise a recovered
+        # connection could have an old failure misattributed to a later,
+        # unrelated idle-watchdog stall (issue #1119).
+        note_native_post_success()
         if _post_response_is_final(response, attempt, max_attempts):
             return _PostResult(response=response)
         await _sleep(_post_retry_delay(attempt))

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -50,6 +50,7 @@ from fastapi import APIRouter, FastAPI, Request, Response, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnigent import _native_forwarder_health as native_forwarder_health
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.policies.types import FAIL_CLOSED_PHASES
 from omnigent.runtime.tool_output import cap_tool_output
@@ -1483,10 +1484,26 @@ class HarnessApp:
                     ctx.response_id,
                     idle_timeout,
                 )
+                # A native forwarder that can't reach the server (e.g.
+                # ``No route to host``) starves the turn of progress events, so
+                # the idle watchdog — not the connectivity error — is what fails
+                # the turn. If such a POST failure was recorded recently, attach
+                # it so the user sees the real cause rather than a generic
+                # "wedged LLM" reason (issue #1119). The window is twice the
+                # idle timeout: the failure that began the stall is already
+                # ~idle_timeout old when the watchdog fires, so a window equal
+                # to the stall would race past it; 2x captures it while still
+                # ignoring a long-resolved earlier blip.
+                forwarder_failure = native_forwarder_health.recent_post_failure(idle_timeout * 2)
+                cause = (
+                    f"likely a wedged LLM or tool call; "
+                    f"recent forwarder POST failure ({forwarder_failure})"
+                    if forwarder_failure is not None
+                    else "likely a wedged LLM or tool call"
+                )
                 raise RuntimeError(
                     f"turn exceeded the {idle_timeout:.0f}s harness idle watchdog "
-                    f"(run_turn emitted no events for {idle_timeout:.0f}s; "
-                    f"likely a wedged LLM or tool call)"
+                    f"(run_turn emitted no events for {idle_timeout:.0f}s; {cause})"
                 ) from exc
             if absolute_wd.expired():
                 _logger.warning(

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -1720,3 +1720,63 @@ async def test_on_shutdown_hook_called_during_lifespan_teardown(
         assert content == "shutdown_called"
     finally:
         await mgr.shutdown()
+
+
+# ── Idle-watchdog surfaces forwarder connectivity cause (issue #1119) ──
+#
+# The pure-module unit test for ``_native_forwarder_health`` (record / recency
+# / clear) lives in ``tests/test_native_forwarder_health.py``. This file keeps
+# only the watchdog-integration test, which needs the harness scaffold.
+
+
+async def test_idle_watchdog_attaches_recent_forwarder_post_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Idle-watchdog failure names a recent forwarder connectivity error.
+
+    Regression for issue #1119: when a native forwarder can't reach the server
+    its event POSTs starve the turn of progress, so the idle watchdog — not the
+    connectivity error — fails the turn. The watchdog must attach that recorded
+    POST failure to the reason instead of only the generic "wedged LLM" text.
+
+    Fails on the unfixed watchdog (reason omits the forwarder cause); passes
+    once the watchdog reads ``_native_forwarder_health``.
+    """
+    from omnigent import _native_forwarder_health as health
+    from omnigent.runtime.harnesses import _scaffold
+
+    class _WedgedApp(HarnessApp):
+        async def run_turn(self, request: Any, ctx: TurnContext) -> None:
+            """Never emit progress, so the idle watchdog must fire."""
+            del request, ctx
+            await asyncio.Event().wait()
+
+    # Short idle window so the watchdog trips quickly; absolute kept high so the
+    # idle ceiling (not the absolute one) is what fails the turn. The reader's
+    # recency window is 2x the idle timeout, comfortably covering the record
+    # made just before run_turn started plus scheduling overhead.
+    monkeypatch.setattr(_scaffold, "_TURN_IDLE_TIMEOUT_S", 0.2)
+    monkeypatch.setattr(_scaffold, "_TURN_ABSOLUTE_TIMEOUT_S", 3600.0)
+
+    health.clear()
+    health.record_post_failure("external_session_status", httpx.ConnectError("No route to host"))
+
+    app = _WedgedApp()
+    ctx = TurnContext(
+        response_id="resp_watchdog_1119",
+        event_queue=asyncio.Queue(),
+        cancelled=asyncio.Event(),
+    )
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            await app._guarded_run_turn(None, ctx)  # type: ignore[arg-type]
+    finally:
+        health.clear()
+
+    message = str(excinfo.value)
+    # Names the idle ceiling (not the absolute one) so we know which watchdog
+    # fired, and carries the full recorded forwarder detail — both the event
+    # type and the connectivity error, not just a coincidental substring.
+    assert "idle watchdog" in message, message
+    assert "external_session_status" in message, message
+    assert "No route to host" in message, message

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1797,3 +1797,46 @@ async def test_post_session_event_inner_single_attempt_and_timeout() -> None:
     assert client.calls[0]["timeout"] == 5.0
     assert result.response is not None
     assert result.response.status_code == 503
+
+
+async def test_post_session_event_records_connectivity_failure_for_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex's exhausted-retry POST failure is recorded for the idle watchdog.
+
+    Writer half of issue #1119 for the codex forwarder: when every attempt to
+    POST a session event raises a connect error, ``_post_session_event`` must
+    record the failure in ``_native_forwarder_health`` (via
+    ``_log_post_transport_failure``) so the harness idle-turn watchdog can name
+    the connectivity cause instead of a generic "wedged LLM" reason.
+    """
+    from omnigent import _native_forwarder_health as health
+
+    class _AlwaysConnectError:
+        """Stub client whose every POST fails to connect."""
+
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            """Raise a connect error mimicking an unreachable server."""
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    async def _no_sleep(_seconds: float) -> None:
+        """No-op sleep so the retry loop doesn't add real delay."""
+
+    monkeypatch.setattr(fwd, "_sleep", _no_sleep)
+
+    health.clear()
+    try:
+        result = await fwd._post_session_event(
+            _AlwaysConnectError(),  # type: ignore[arg-type]
+            "conv_x",
+            event_type="external_session_status",
+            data={},
+        )
+        assert result is None
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert "external_session_status" in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()

--- a/tests/test_native_forwarder_health.py
+++ b/tests/test_native_forwarder_health.py
@@ -1,0 +1,76 @@
+"""Tests for the process-local native-forwarder POST-failure record.
+
+``omnigent/_native_forwarder_health.py`` is the small shared sink that lets a
+native forwarder report a connectivity failure to the harness idle-turn
+watchdog (issue #1119). These cover its record / recency / clear contract; the
+writer (forwarder retry loops) and reader (watchdog) integrations are tested in
+``tests/test_native_post_delivery.py``, ``tests/test_codex_native_forwarder.py``,
+and ``tests/runtime/harnesses/test_scaffold.py``.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from omnigent import _native_forwarder_health as health
+
+
+class _FakeClock:
+    """Controllable monotonic clock so recency is tested over real intervals."""
+
+    def __init__(self, start: float) -> None:
+        """Start the clock at *start* seconds."""
+        self.now = start
+
+    def monotonic(self) -> float:
+        """Return the current fake monotonic time."""
+        return self.now
+
+
+def test_recent_post_failure_round_trips_within_window() -> None:
+    """A recorded failure is returned, with its event type and error repr."""
+    health.clear()
+    try:
+        assert health.recent_post_failure(60.0) is None
+        health.record_post_failure(
+            "external_session_status", httpx.ConnectError("No route to host")
+        )
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert "external_session_status" in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()
+
+
+def test_recent_post_failure_respects_recency_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure older than the window is suppressed; one inside it is returned.
+
+    Uses a controlled clock so the boundary is exercised over a realistic
+    interval (record at t=1000, read 100s later) rather than a degenerate
+    zero-length window — pinning the actual ``elapsed > within_s`` comparison.
+    """
+    clock = _FakeClock(start=1000.0)
+    monkeypatch.setattr(health, "time", clock)
+    health.clear()
+    try:
+        health.record_post_failure(
+            "external_session_status", httpx.ConnectError("No route to host")
+        )
+        # 100s elapse before any read.
+        clock.now = 1100.0
+        # Window shorter than the elapsed gap → stale → suppressed.
+        assert health.recent_post_failure(60.0) is None
+        # Window longer than the gap → still surfaced, unchanged by the
+        # earlier stale read.
+        assert health.recent_post_failure(240.0) is not None
+    finally:
+        health.clear()
+
+
+def test_clear_forgets_the_record() -> None:
+    """``clear`` resets the slot so later reads see nothing."""
+    health.record_post_failure("external_session_status", httpx.ConnectError("boom"))
+    health.clear()
+    assert health.recent_post_failure(60.0) is None

--- a/tests/test_native_forwarder_health.py
+++ b/tests/test_native_forwarder_health.py
@@ -74,3 +74,20 @@ def test_clear_forgets_the_record() -> None:
     health.record_post_failure("external_session_status", httpx.ConnectError("boom"))
     health.clear()
     assert health.recent_post_failure(60.0) is None
+
+
+def test_note_post_success_clears_a_prior_failure() -> None:
+    """A successful POST clears the slot so a recovered connection isn't blamed.
+
+    Guards the misattribution fix: once connectivity returns and a POST gets a
+    response, the recorded failure must not survive to be attached to a later,
+    unrelated idle-watchdog stall.
+    """
+    health.clear()
+    try:
+        health.record_post_failure("external_session_status", httpx.ConnectError("boom"))
+        assert health.recent_post_failure(60.0) is not None
+        health.note_post_success()
+        assert health.recent_post_failure(60.0) is None
+    finally:
+        health.clear()

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -538,3 +538,48 @@ async def test_replay_preserves_malformed_lines(tmp_path: Path) -> None:
     # The parseable record was delivered and removed; the garbage line survives.
     remaining = current.read_text(encoding="utf-8").splitlines()
     assert remaining == ["not-json garbage line"]
+
+
+async def test_retry_loop_records_exhausted_connectivity_failure_for_watchdog() -> None:
+    """An exhausted-retry connectivity failure is recorded for the idle watchdog.
+
+    Writer half of issue #1119: when every POST attempt raises a connection
+    error (e.g. ``No route to host``), the shared retry loop must record the
+    failure in ``_native_forwarder_health`` so the harness idle-turn watchdog
+    can name the real cause. Fails before the recording call was added (the
+    health slot stays empty); passes after.
+    """
+    from omnigent import _native_forwarder_health as health
+    from omnigent._native_post_delivery import post_session_event_with_retry
+
+    class _AlwaysConnectError:
+        """Stub client whose every POST fails to connect."""
+
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            """Raise a connect error mimicking an unreachable server."""
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    async def _no_sleep(_: float) -> None:
+        """No-op sleep so retries don't add real delay."""
+
+    health.clear()
+    try:
+        result = await post_session_event_with_retry(
+            client=_AlwaysConnectError(),  # type: ignore[arg-type]
+            url="/v1/sessions/conv_x/events",
+            payload={"type": "external_session_status", "data": {}},
+            event_type="external_session_status",
+            max_attempts=2,
+            retry_status_codes=frozenset(),
+            sleep=_no_sleep,
+            retry_delay=lambda _attempt: 0.0,
+            logger_name="test.native_post_delivery",
+        )
+        assert result is None
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert "external_session_status" in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -583,3 +583,50 @@ async def test_retry_loop_records_exhausted_connectivity_failure_for_watchdog() 
         assert "No route to host" in detail
     finally:
         health.clear()
+
+
+async def test_retry_loop_success_clears_a_prior_connectivity_failure() -> None:
+    """A successful POST clears a previously recorded connectivity failure.
+
+    Misattribution guard for issue #1119: once the server is reachable again,
+    the retry loop must empty the failure slot so the idle watchdog can't blame
+    a long-resolved outage for a later, unrelated stall.
+    """
+    from omnigent import _native_forwarder_health as health
+    from omnigent._native_post_delivery import post_session_event_with_retry
+
+    class _Ok:
+        """Stub client whose POST always succeeds with 200."""
+
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            """Return a 200 response."""
+            del json
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+    async def _no_sleep(_: float) -> None:
+        """No-op sleep."""
+
+    health.clear()
+    try:
+        # Simulate an earlier outage still on record.
+        health.record_post_failure(
+            "external_session_status", httpx.ConnectError("No route to host")
+        )
+        assert health.recent_post_failure(60.0) is not None
+        response = await post_session_event_with_retry(
+            client=_Ok(),  # type: ignore[arg-type]
+            url="/v1/sessions/conv_x/events",
+            payload={"type": "external_session_status", "data": {}},
+            event_type="external_session_status",
+            max_attempts=2,
+            retry_status_codes=frozenset(),
+            sleep=_no_sleep,
+            retry_delay=lambda _attempt: 0.0,
+            logger_name="test.native_post_delivery",
+        )
+        assert response is not None
+        assert response.status_code == 200
+        # The successful round-trip must have cleared the stale failure.
+        assert health.recent_post_failure(60.0) is None
+    finally:
+        health.clear()


### PR DESCRIPTION
## Related issue

Closes #1119

## Summary

- When a native forwarder can't POST session events (e.g. `ConnectError: No route to host`), the turn stalls and the idle-turn watchdog fails it after 240s with a generic "likely a wedged LLM or tool call" reason — the real connectivity cause is logged separately and never reaches the user.
- Added a process-local record of the most recent native-forwarder POST failure (`omnigent/_native_forwarder_health.py`). A native-harness subprocess serves one conversation and runs one turn at a time, and its forwarder shares the watchdog's event loop, so a single timestamped slot is unambiguous.
- Writers: the codex forwarder's exhausted-retry path and the shared `_native_post_delivery.post_session_event_with_retry` final-failure path (used by codex and antigravity). Reader: the idle-watchdog branch in `_scaffold._guarded_run_turn` appends a recent failure (window = 2× idle timeout) to the turn-failure reason.
- Misattribution guard: a POST that gets any HTTP response proves the server is reachable, so it clears the record (`note_post_success`). The recorded failure therefore only reflects connectivity trouble since the last successful round-trip, and a recovered connection can't be blamed for a later, unrelated stall.

**ELI5:** If the program streaming your agent's progress loses its connection to the server, the turn looks "stuck" and gets killed after 4 minutes with a vague "the AI got wedged" message. We now remember the last network error and include it in the kill reason — so you see "couldn't reach the server" instead of a misleading guess. Once the connection comes back, the remembered error is cleared so it can't be blamed for a future unrelated stall.

## Known limitation / follow-up

Writer coverage is currently codex-native + antigravity-native (the forwarders that go through the shared retry helper). The other native forwarders (claude, cursor, goose, qwen, hermes, opencode) POST session events directly and don't yet record connectivity failures. Migrating them onto `post_session_event_with_retry` — which also consolidates duplicated retry logic — is tracked in #1230.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Reproduced the full writer→reader chain at unit level, each behavior verified failing-first:

- Module: `tests/test_native_forwarder_health.py` covers the record's round-trip, recency-window expiry (controlled clock), clear, and success-clears.
- Writer: `tests/test_native_post_delivery.py` and `tests/test_codex_native_forwarder.py` drive a real `httpx.ConnectError` through the shared and codex retry loops, exhaust retries, and assert the failure is recorded; a separate test asserts a successful POST clears a prior recorded failure (the misattribution guard).
- Reader: `tests/runtime/harnesses/test_scaffold.py` records a forwarder failure, drives a wedged `run_turn` to the idle timeout, and asserts the raised reason names the idle ceiling and the full connectivity detail.

Commands: `uv run --extra dev pytest tests/test_native_forwarder_health.py tests/test_native_post_delivery.py tests/test_codex_native_forwarder.py::test_post_session_event_records_connectivity_failure_for_watchdog tests/runtime/harnesses/test_scaffold.py::test_idle_watchdog_attaches_recent_forwarder_post_failure` → 15 passed. Existing codex forwarder post tests (14) and watchdog subprocess tests still pass. No live E2E (would require inducing a real `No route to host` against a host runner).

This pull request and its description were written by Isaac.
