### PR TITLE
fix(os_env): wire createos fields in native parser + atexit cleanup

### DIFF
--- a/omnigent/inner/createos_os_env.py
+++ b/omnigent/inner/createos_os_env.py
@@ -14,6 +14,7 @@ Endpoints used:
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import shlex
@@ -149,12 +150,15 @@ class CreateosOSEnvironment(OSEnvironment):
             http.close()
             raise
 
-        return cls(
+        env = cls(
             spec=spec,
             cwd=Path(spec.cwd or "/root"),
             _sandbox_id=sandbox_id,
             _http=http,
         )
+        # __del__ may not run at interpreter exit; close() is idempotent.
+        atexit.register(env.close)
+        return env
 
     def _abs(self, path: str) -> str:
         p = Path(path)

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -839,6 +839,7 @@ def create_os_environment(spec: OSEnvSpec | None) -> OSEnvironment | None:
         return None
     if spec.type == "createos":
         from .createos_os_env import CreateosOSEnvironment
+
         return CreateosOSEnvironment.create_sync(spec)
     if spec.type != "caller_process":
         raise NotImplementedError(f"os_env type '{spec.type}' is not implemented")

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -698,6 +698,11 @@ def _parse_os_env(
         sandbox=sandbox,
         fork=fork,
         start_in_scratch=start_in_scratch,
+        # createos provider fields — keep in lockstep with loader._parse_os_env_spec
+        createos_base_url=str(raw["base_url"]) if raw.get("base_url") else None,
+        createos_api_key=str(raw["api_key"]) if raw.get("api_key") else None,
+        createos_shape=str(raw["shape"]) if raw.get("shape") else None,
+        createos_rootfs=str(raw["rootfs"]) if raw.get("rootfs") else None,
     )
 
 

--- a/tests/inner/test_createos_os_env.py
+++ b/tests/inner/test_createos_os_env.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 
+from omnigent.inner import createos_os_env as mod
 from omnigent.inner.createos_os_env import CreateosOSEnvironment, _Http
 from omnigent.inner.datamodel import OSEnvSpec
 
@@ -28,8 +30,6 @@ class _StubHttp:
     def get_bytes(self, path: str, params: dict[str, str]) -> bytes:
         key = params["path"]
         if key not in self.files:
-            import httpx
-
             req = httpx.Request("GET", "http://x")
             resp = httpx.Response(404, request=req)
             raise httpx.HTTPStatusError("not found", request=req, response=resp)
@@ -76,7 +76,7 @@ async def test_write_then_read_roundtrip() -> None:
     env = _env(http)
     w = await env.write("notes.txt", "line1\nline2\n")
     assert w["ok"] is True
-    assert w["bytes_written"] == len("line1\nline2\n".encode())
+    assert w["bytes_written"] == len(b"line1\nline2\n")
     assert http.files["/root/notes.txt"] == b"line1\nline2\n"
 
     r = await env.read("notes.txt")
@@ -153,9 +153,31 @@ def test_close_is_idempotent_and_destroys() -> None:
 
 
 def test_http_unwrap_jsend_envelope() -> None:
-    import httpx
-
     req = httpx.Request("GET", "http://x")
     resp = httpx.Response(200, json={"status": "success", "data": {"id": "z"}}, request=req)
     http = _Http("http://x", "k")
     assert http._unwrap(resp) == {"id": "z"}
+
+
+def test_create_sync_registers_atexit_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """create_sync registers close() with atexit so an interpreter exit
+    that skips __del__ still destroys the billable remote VM."""
+
+    class _FakeHttp:
+        def __init__(self, base_url: str, api_key: str) -> None:
+            pass
+
+        def post(self, path: str, body: Any = None) -> Any:
+            return {"id": "sbx_atexit"}
+
+        def close(self) -> None:
+            pass
+
+    registered: list[Any] = []
+    monkeypatch.setattr(mod, "_Http", _FakeHttp)
+    monkeypatch.setattr(mod, "_poll_until_running", lambda http, sandbox_id: None)
+    monkeypatch.setattr(mod.atexit, "register", lambda fn: registered.append(fn))
+
+    env = mod.CreateosOSEnvironment.create_sync(OSEnvSpec(type="createos", createos_api_key="k"))
+    assert env._sandbox_id == "sbx_atexit"
+    assert env.close in registered

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from omnigent.errors import OmnigentError
+from omnigent.inner.datamodel import OSEnvSpec
 from omnigent.spec.parser import discover_host_skills, parse
 from omnigent.spec.types import ApiKeyAuth, DatabricksAuth, ProviderAuth, SharePolicy
 
@@ -1399,6 +1400,53 @@ def test_parse_os_env_caller_process(tmp_path: Path) -> None:
     # Sandbox absent → None (the wrap then defaults appropriately).
     assert spec.os_env.sandbox is None
     assert spec.os_env.fork is False
+
+
+def test_parse_os_env_createos_populates_provider_fields(tmp_path: Path) -> None:
+    """The native parser wires the createos provider keys into the
+    ``createos_*`` fields, in lockstep with the legacy loader.
+
+    What breaks if this fails: an agent loaded via native YAML gets
+    ``type='createos'`` but base_url/api_key/shape/rootfs are silently
+    dropped, so the provider falls back to env vars / defaults only.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "with-createos",
+        "os_env": {
+            "type": "createos",
+            "base_url": "https://api.example.test",
+            "api_key": "sk-test",
+            "shape": "small",
+            "rootfs": "ubuntu-22.04",
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert isinstance(spec.os_env, OSEnvSpec)
+    assert spec.os_env.type == "createos"
+    assert spec.os_env.createos_base_url == "https://api.example.test"
+    assert spec.os_env.createos_api_key == "sk-test"
+    assert spec.os_env.createos_shape == "small"
+    assert spec.os_env.createos_rootfs == "ubuntu-22.04"
+
+
+def test_parse_os_env_createos_fields_default_none(tmp_path: Path) -> None:
+    """Absent createos keys leave the ``createos_*`` fields ``None`` so
+    the provider falls back to env vars / defaults.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "createos-bare",
+        "os_env": {"type": "createos"},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert isinstance(spec.os_env, OSEnvSpec)
+    assert spec.os_env.createos_base_url is None
+    assert spec.os_env.createos_api_key is None
+    assert spec.os_env.createos_shape is None
+    assert spec.os_env.createos_rootfs is None
 
 
 def test_parse_os_env_with_sandbox(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up to #452 (createos os_env provider), addressing the items noted there so they aren't lost. All changes are additive and opt-in to `type='createos'`.

## Fixes

1. **Native parser dropped createos config (correctness).** #452 wired `base_url`/`api_key`/`shape`/`rootfs` only into the legacy `omnigent/inner/loader.py:_parse_os_env_spec`. The native parser `omnigent/spec/parser.py:_parse_os_env` was untouched, so an agent loaded via native YAML got `type='createos'` but the `createos_*` fields were never populated — `api_key`/`base_url` resolved from env vars only and `shape`/`rootfs` always defaulted. This mirrors the wiring into the native parser, keeping the two loaders in lockstep.

2. **Remote VM could leak (cost).** `CreateosOSEnvironment.close()` was only reachable via `__del__`, which isn't guaranteed to run at interpreter shutdown. `create_sync` now does `atexit.register(self.close)` (mirroring `CallerProcessOSEnvironment`); `close()` is idempotent so an explicit close stays a no-op.

3. **Lint.** Blank line after the lazy import in `os_env.py` (ruff format) and a `b"..."` literal in the test (ruff check) — the two failures on #452.

## Tests
- `tests/spec/test_parser.py`: native parser populates `createos_*` from YAML, and leaves them `None` when absent.
- `tests/inner/test_createos_os_env.py`: `create_sync` registers `close()` with `atexit`.

All green locally (ruff check/format clean; 51 createos/os_env tests pass).

This pull request and its description were written by Isaac.
