### PR TITLE
feat(cursor): add --mode support for native cursor sessions

### DIFF
--- a/ap-web/src/lib/nativeCodingAgents.ts
+++ b/ap-web/src/lib/nativeCodingAgents.ts
@@ -16,7 +16,7 @@ export type NativeCodingAgentIconKind =
   | "antigravity"
   | "kimi"
   | "hermes";
-export type NativeCodingAgentCapability = "permissionMode" | "approvalMode";
+export type NativeCodingAgentCapability = "permissionMode" | "approvalMode" | "cursorMode";
 
 export interface NativeCodingAgentSpec {
   key: NativeCodingAgentIconKind;
@@ -68,6 +68,7 @@ export const NATIVE_CODING_AGENTS = [
     displayName: "Cursor",
     iconKind: "cursor",
     sortRank: 30,
+    capabilities: ["cursorMode"],
   },
   {
     key: "pi",

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -113,6 +113,47 @@ const CLAUDE_NATIVE_PERMISSION_MODES: { value: string; label: string; descriptio
   },
 ];
 
+// Cursor execution modes. "default" sends no flags; other values map to CLI
+// args passed via terminal_launch_args. Keep in sync with `cursor-agent --help`.
+const CURSOR_NATIVE_DEFAULT_EXEC_MODE = "default";
+const CURSOR_NATIVE_EXEC_MODES: {
+  value: string;
+  label: string;
+  description: string;
+  args: string[];
+}[] = [
+  {
+    value: "default",
+    label: "Default",
+    description: "Normal agent mode; prompts before running commands",
+    args: [],
+  },
+  {
+    value: "auto-review",
+    label: "Auto-review",
+    description: "Smart Auto: auto-runs safe tool calls and prompts for the rest",
+    args: ["--auto-review"],
+  },
+  {
+    value: "plan",
+    label: "Plan",
+    description: "Read-only planning; analyzes and proposes plans, no edits",
+    args: ["--mode", "plan"],
+  },
+  {
+    value: "ask",
+    label: "Ask",
+    description: "Q&A style; explains and answers questions (read-only)",
+    args: ["--mode", "ask"],
+  },
+  {
+    value: "yolo",
+    label: "Yolo",
+    description: "Runs everything without prompts or safety checks",
+    args: ["--yolo"],
+  },
+];
+
 // Codex approval presets matching the `/permissions` TUI popup.
 // Each preset bundles a sandbox profile + approval policy, mirroring
 // codex-rs/utils/approval-presets/src/lib.rs. "default" is the auto
@@ -615,6 +656,52 @@ function ApprovalModeOptions({
 }
 
 /**
+ * Cursor execution-mode radio rows, rendered inside the Advanced settings
+ * menu in the composer footer. Mirror of {@link PermissionModeOptions}
+ * for the Cursor native agent.
+ *
+ * @param value Currently selected mode, e.g. ``"default"``.
+ * @param onValueChange Selection callback (receives the mode value).
+ */
+function CursorModeOptions({
+  value,
+  onValueChange,
+}: {
+  value: string;
+  onValueChange: (mode: string) => void;
+}) {
+  const [previewed, setPreviewed] = useState<string | null>(null);
+  const detail = CURSOR_NATIVE_EXEC_MODES.find(
+    (m) => m.value === (previewed ?? value),
+  )?.description;
+  return (
+    <>
+      <DropdownMenuRadioGroup value={value} onValueChange={onValueChange}>
+        {CURSOR_NATIVE_EXEC_MODES.map((mode) => (
+          <DropdownMenuRadioItem
+            key={mode.value}
+            value={mode.value}
+            data-testid={`new-chat-landing-cursor-mode-${mode.value}`}
+            onFocus={() => setPreviewed(mode.value)}
+            onPointerEnter={() => setPreviewed(mode.value)}
+            className="rounded-sm pl-2 py-1 text-xs"
+          >
+            {mode.label}
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
+      <DropdownMenuSeparator />
+      <p
+        data-testid="new-chat-landing-cursor-mode-detail"
+        className="min-h-5 px-2 pt-0.5 pb-1 text-xs leading-relaxed text-muted-foreground"
+      >
+        {detail}
+      </p>
+    </>
+  );
+}
+
+/**
  * Brain-harness radio rows for an overridable bundle agent, rendered
  * inside the Advanced settings menu in the composer footer.
  *
@@ -803,6 +890,9 @@ export function NewChatLandingScreen() {
   // the codex-native wrapper; ignored otherwise. Lives in the footer
   // tray's Advanced settings menu.
   const [approvalMode, setApprovalMode] = useState<string>(CODEX_NATIVE_DEFAULT_APPROVAL_MODE);
+  // Execution mode for Cursor (cursor-agent --mode / --yolo). Only meaningful
+  // for the cursor-native wrapper; ignored otherwise.
+  const [cursorExecMode, setCursorExecMode] = useState<string>(CURSOR_NATIVE_DEFAULT_EXEC_MODE);
   // Per-session brain-harness override for bundle agents (polly / debby).
   // null = the agent spec's declared harness (no override sent); cleared on
   // every agent switch so a pick never leaks across agents.
@@ -893,6 +983,7 @@ export function NewChatLandingScreen() {
       : agentList.find((a) => a.id === effectiveAgentId);
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
+  const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
   // Native-terminal agents interpret slash commands inside their own CLI
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
@@ -1044,6 +1135,8 @@ export function NewChatLandingScreen() {
     CLAUDE_NATIVE_PERMISSION_MODES.find((m) => m.value === permissionMode)?.label ?? permissionMode;
   const approvalModeLabel =
     CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.label ?? approvalMode;
+  const cursorExecModeLabel =
+    CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === cursorExecMode)?.label ?? cursorExecMode;
   // Effective brain harness for the selected agent: the user's pick, else
   // the spec's declared harness. null for non-overridable agents (native
   // wrappers, agents whose spec failed to load).
@@ -1060,9 +1153,11 @@ export function NewChatLandingScreen() {
       ? `${selectedAgent.display_name} (${permissionModeLabel})`
       : supportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
         ? `${selectedAgent.display_name} (${approvalModeLabel})`
-        : pickedHarness != null
-          ? `${selectedAgent.display_name} (${BRAIN_HARNESS_LABELS[pickedHarness] ?? pickedHarness})`
-          : selectedAgent.display_name
+        : supportsCursorMode && cursorExecMode !== CURSOR_NATIVE_DEFAULT_EXEC_MODE
+          ? `${selectedAgent.display_name} (${cursorExecModeLabel})`
+          : pickedHarness != null
+            ? `${selectedAgent.display_name} (${BRAIN_HARNESS_LABELS[pickedHarness] ?? pickedHarness})`
+            : selectedAgent.display_name
     : "Select agent";
 
   /**
@@ -1162,6 +1257,7 @@ export function NewChatLandingScreen() {
       const nativeLabels = nativeWrapperLabelsForAgent(agent);
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
       const agentSupportsApprovalMode = nativeAgentHasCapability(agent, "approvalMode");
+      const agentSupportsCursorMode = nativeAgentHasCapability(agent, "cursorMode");
 
       let data: { id: string };
 
@@ -1218,7 +1314,7 @@ export function NewChatLandingScreen() {
             // The values are the registered wrapper ids the runner keys off —
             // they must match the wrapper registry, not the agent display name.
             labels: nativeLabels,
-            // Permission / approval mode → CLI flag pair, persisted as
+            // Permission / approval / cursor mode → CLI flag pair, persisted as
             // terminal_launch_args. Omitted for the default and non-native agents.
             terminal_launch_args:
               agentSupportsPermissionMode &&
@@ -1226,7 +1322,9 @@ export function NewChatLandingScreen() {
                 ? ["--permission-mode", permissionMode]
                 : agentSupportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
                   ? (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.args ?? [])
-                  : undefined,
+                  : agentSupportsCursorMode && cursorExecMode !== CURSOR_NATIVE_DEFAULT_EXEC_MODE
+                    ? (CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === cursorExecMode)?.args ?? [])
+                    : undefined,
             // Cost-control switch from the "Cost Optimized" pill; polly-only
             // (cost control is a polly feature) and omitted when unset so the
             // session defers to the spec default.
@@ -1901,11 +1999,12 @@ export function NewChatLandingScreen() {
 
               {/* Advanced settings chip — per-agent knobs that don't warrant
                 their own chip: the brain-harness override (bundle agents),
-                Claude Code's permission mode, and Codex's approval mode.
-                Hidden when the selected agent has none. */}
+                Claude Code's permission mode, Codex's approval mode, and
+                Cursor's execution mode. Hidden when the selected agent has none. */}
               {(selectedAgentDefaultHarness != null ||
                 supportsPermissionMode ||
-                supportsApprovalMode) && (
+                supportsApprovalMode ||
+                supportsCursorMode) && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
@@ -1960,6 +2059,23 @@ export function NewChatLandingScreen() {
                           Approval mode
                         </div>
                         <ApprovalModeOptions value={approvalMode} onValueChange={setApprovalMode} />
+                      </>
+                    )}
+                    {/* Execution mode (Cursor only) — cursor-native has no
+                      overridable harness, so the two sections never co-render
+                      today; the separator covers a future agent with both. */}
+                    {supportsCursorMode && (
+                      <>
+                        {(selectedAgentDefaultHarness != null ||
+                          supportsPermissionMode ||
+                          supportsApprovalMode) && <DropdownMenuSeparator />}
+                        <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
+                          Execution mode
+                        </div>
+                        <CursorModeOptions
+                          value={cursorExecMode}
+                          onValueChange={setCursorExecMode}
+                        />
                       </>
                     )}
                   </DropdownMenuContent>

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4650,11 +4650,23 @@ def _ensure_bundled_agent_brain_credential(name: str) -> None:
     hidden=True,
     help="Deprecated alias for ``--resume <id>``; kept for one release.",
 )
+@click.option(
+    "--mode",
+    "mode",
+    default=None,
+    type=click.Choice(["plan", "ask"]),
+    help=(
+        "Start cursor-agent in the given execution mode. "
+        "``plan``: read-only/planning (analyze, propose plans, no edits). "
+        "``ask``: Q&A style for explanations and questions (read-only)."
+    ),
+)
 @click.argument("cursor_args", nargs=-1, type=click.UNPROCESSED)
 def cursor(
     server: str | None,
     resume: str | None,
     session_id: str | None,
+    mode: str | None,
     cursor_args: tuple[str, ...],
 ) -> None:
     """Launch the Cursor TUI in an Omnigent terminal.
@@ -4664,6 +4676,8 @@ def cursor(
       omnigent cursor
       omnigent cursor --resume conv_abc123
       omnigent cursor --resume                 # interactive picker
+      omnigent cursor --mode plan              # start in plan (read-only) mode
+      omnigent cursor --mode ask               # start in ask (Q&A) mode
     """
     choice = _split_resume_value(resume)
     if session_id is not None and (choice.picker or choice.conversation_id is not None):
@@ -4690,6 +4704,7 @@ def cursor(
         resume_picker=choice.picker,
         cursor_args=cursor_args,
         auto_open_conversation=auto_open_conversation,
+        mode=mode,
     )
 
 

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -152,6 +152,22 @@ def build_cursor_launch(
     return NativeCursorLaunch(executable=executable, argv=[executable, *cursor_args])
 
 
+def _inject_mode_arg(
+    cursor_args: tuple[str, ...],
+    mode: str | None,
+) -> tuple[str, ...]:
+    """Return *cursor_args* with ``--mode <mode>`` prepended when appropriate.
+
+    No-op when *mode* is ``None`` or ``--mode`` / ``--plan`` is already present
+    in *cursor_args* (user-supplied value wins).
+    """
+    if mode is None:
+        return cursor_args
+    if any(arg in ("--mode", "--plan") or arg.startswith("--mode=") for arg in cursor_args):
+        return cursor_args
+    return ("--mode", mode) + cursor_args
+
+
 def run_cursor_native(
     *,
     server: str | None,
@@ -159,6 +175,7 @@ def run_cursor_native(
     cursor_args: tuple[str, ...],
     resume_picker: bool = False,
     auto_open_conversation: bool = False,
+    mode: str | None = None,
 ) -> None:
     """
     Launch the Cursor TUI in an Omnigent terminal.
@@ -169,6 +186,8 @@ def run_cursor_native(
     :param resume_picker: ``True`` runs the cursor-native picker.
     :param auto_open_conversation: When ``True``, open the browser
         conversation URL after launch.
+    :param mode: Optional cursor-agent execution mode (``"plan"`` or ``"ask"``).
+        Injected as ``--mode <mode>`` unless already present in *cursor_args*.
     :returns: None after the terminal attach session ends.
     """
     _preflight_local_tools()
@@ -177,6 +196,7 @@ def run_cursor_native(
             "Cursor requires a resolved Omnigent server URL. The CLI should call "
             "_ensure_backend before run_cursor_native."
         )
+    effective_cursor_args = _inject_mode_arg(cursor_args, mode)
     with TemporaryDirectory(prefix="omnigent-cursor-native-") as tmpdir:
         spec_path = _materialize_cursor_agent_spec(Path(tmpdir))
         _run_with_remote_server(
@@ -184,7 +204,7 @@ def run_cursor_native(
             spec_path,
             session_id=session_id,
             resume_picker=resume_picker,
-            cursor_args=cursor_args,
+            cursor_args=effective_cursor_args,
             auto_open_conversation=auto_open_conversation,
         )
 

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -165,7 +165,7 @@ def _inject_mode_arg(
         return cursor_args
     if any(arg in ("--mode", "--plan") or arg.startswith("--mode=") for arg in cursor_args):
         return cursor_args
-    return ("--mode", mode) + cursor_args
+    return ("--mode", mode, *cursor_args)
 
 
 def run_cursor_native(


### PR DESCRIPTION
## Related issue

N/A

## Summary

Cursor's native agent had no way to select an execution mode at session start — unlike Claude Code (permission mode) and Codex (approval mode), which both expose per-session knobs in the Advanced settings menu. This adds first-class mode support across the CLI and web UI.

- **`omnigent cursor --mode [plan|ask]`** — new CLI option that injects `--mode <value>` into `cursor-agent`'s argv; a `_inject_mode_arg` helper skips injection if the user already passed `--mode`/`--plan` directly in passthrough args so there's no conflict
- **Web UI Advanced settings** — new `CursorModeOptions` radio component (Default / Auto-review / Plan / Ask / Yolo) follows the same pattern as `PermissionModeOptions` and `ApprovalModeOptions`; the selected mode is shown in the agent picker label and persisted as `terminal_launch_args` on session create, mapping each choice to its `cursor-agent` CLI args (`--auto-review`, `--mode plan`, `--mode ask`, `--yolo`)
- `cursorMode` added to `NativeCodingAgentCapability` and declared on the cursor agent spec so the Advanced chip appears only for Cursor sessions

## Test Plan

- [x] `omnigent cursor --help` shows `--mode [plan|ask]` with descriptions
- [x] `_inject_mode_arg` unit assertions: mode injected when absent, no-op when `--mode`/`--plan`/`--mode=` already present, no-op when mode is `None`
- [x] TypeScript type-check (`tsc -b`) passes clean
- [x] Manual inspection: Advanced settings chip appears for Cursor agent, shows Default / Auto-review / Plan / Ask / Yolo options with hover descriptions; agent picker label updates to e.g. `Cursor (Plan)` on non-default picks

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The `_inject_mode_arg` helper was verified inline with assertions. The web UI changes follow the established pattern for `PermissionModeOptions`/`ApprovalModeOptions` and were verified via TypeScript type-check. E2E UI coverage is tracked separately (the e2e-ui runner has no workspace access for native-terminal session flows).