### PR TITLE
docs: add harness-integration-guide skill

### DIFF
--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -32,7 +32,7 @@ the vendor's tool-calling interface.
 | **Auth** | How credentials are obtained — API key, gateway token, vendor CLI login, OAuth, etc. |
 | **Streaming** | Harness forwards token-level or delta-level streaming to the Omnigent forwarder |
 | **Omnigent policies** | Harness enforces Omnigent-side tool policies — must support ALLOW, ASK, and DENY verdicts for both tool calls and tool results |
-| **Native elicitation (web)** | Harness surfaces tool-approval requests to the web UI — `canUseTool ASK`, `request_permission`, 2-stage cards |
+| **Native elicitation** | When a policy verdict is ASK, the harness surfaces the approval request in the Omnigent web UI so the user can approve or deny |
 | **Interrupt** | User can cancel a running turn mid-stream |
 | **Live queue (concurrent)** | Multiple turns can be queued and processed concurrently |
 | **Tool-boundary steer** | Omnigent can inject steering text at tool-call boundaries |
@@ -64,13 +64,12 @@ checkpoints:
 | **Tool call** (before execution) | Proceed silently | Surface approval request to user (via elicitation) | Block the call and return a policy-denied error to the model |
 | **Tool result** (after execution) | Return result to model | Surface result for user review before returning | Suppress the result and return a policy-denied error to the model |
 
-### Native elicitation strategies
+### Native elicitation
 
-| Strategy | How it works |
-|---|---|
-| `canUseTool ASK` | Omnigent asks the model whether a tool call should proceed; model responds with ASK to surface approval to the web UI |
-| `request_permission` | ACP-native permission request flow surfaced to the web UI |
-| 2-stage + card | Two-phase approval with a UI card |
+When a policy verdict is ASK, the harness must surface the pending tool call
+or tool result in the Omnigent web UI as an approval card, then relay the
+user's approve/deny decision back to the harness to continue or block
+execution.
 
 ### Resume / fork strategies
 
@@ -131,7 +130,7 @@ and relay the vendor's conversation into the Omnigent session.
 | **Auth** | Vendor login / config / token |
 | **Streaming (forwarder)** | `deltas` (token-level) vs `complete-only` (full response after completion) |
 | **Omnigent policies** | Whether the native harness enforces Omnigent-side tool policies — must support ALLOW, ASK, and DENY verdicts for both tool calls and tool results |
-| **Native elicitation (web)** | Whether the native harness surfaces tool-approval requests to the web UI — mirror+reply, permission.v2+reply |
+| **Native elicitation** | When a policy verdict is ASK, the native harness surfaces the approval request in the Omnigent web UI so the user can approve or deny |
 | **Interrupt** | User can abort a running turn |
 | **Bidirectional sync (TUI->Omni)** | TUI output mirrors into the Omnigent conversation |
 | **In-harness session-cmd sync** | Supports `clear`, `fork`, `resume`, `switch` commands from Omnigent |

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -117,15 +117,14 @@ All capabilities are **required** for a complete harness integration:
 ## Part 2 — Native harnesses
 
 Native harnesses wrap a vendor's own TUI or server and mirror output into
-Omnigent. They connect to the Omnigent MCP server via `stdio serve-mcp`
-and relay the vendor's conversation into the Omnigent session.
+Omnigent. They relay the vendor's conversation into the Omnigent session.
 
 ### Capability matrix
 
 | Capability | What it means |
 |---|---|
 | **Transport** | How the native harness communicates — tmux TUI, app server, HTTP/SSE, file-inject TUI |
-| **Connects to Omnigent MCP** | Whether the native harness connects via `stdio serve-mcp` |
+| **Connects to Omnigent MCP** | Whether the native harness connects to the Omnigent MCP server |
 | **Model override** | User can select a model at launch or per-prompt |
 | **Auth** | Vendor login / config / token |
 | **Streaming (forwarder)** | `deltas` (token-level) vs `complete-only` (full response after completion) |
@@ -144,7 +143,7 @@ and relay the vendor's conversation into the Omnigent session.
 All capabilities are **required** for a complete native harness integration:
 
 - [ ] Transport chosen and implemented (tmux TUI, app server, HTTP/SSE)
-- [ ] Connects to Omnigent MCP via `stdio serve-mcp`
+- [ ] Connects to Omnigent MCP
 - [ ] Model override works (or document vendor lock-in)
 - [ ] Auth configured (vendor login / config)
 - [ ] Streaming forwarder works (deltas preferred; complete-only acceptable)

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -1,34 +1,60 @@
 ---
 name: harness-integration-guide
-description: Reference guide for building new Omnigent harness integrations — covers the full feature matrix (MCP, model override, auth, streaming, policies, interrupt, concurrency, transcript resume, compaction, reasoning, images) with implementation notes and capability tiers.
+description: Reference guide for building new Omnigent harness integrations — covers SDK/subprocess harnesses and native harnesses as separate tracks, each with their own feature matrix, implementation patterns, and prioritized checklist.
 ---
 
 # Harness integration guide
 
 This skill describes the **feature matrix** every Omnigent harness must
-consider. Use it when planning, reviewing, or implementing a new harness
-(SDK in-process, CLI subprocess, or ACP subprocess).
+consider. Use it when planning, reviewing, or implementing a new harness.
 
-## Capability matrix
+Omnigent has two distinct harness tracks with different architectures and
+feature sets:
 
-Each harness is evaluated across the following dimensions:
+- **SDK/subprocess harnesses** — run the vendor model directly (in-process SDK,
+  CLI subprocess, or ACP subprocess). They own the model lifecycle.
+- **Native harnesses** — wrap a vendor's own TUI or server and mirror its
+  output into Omnigent. They observe and relay, rather than drive.
 
-| Capability | What it means | Priority |
-|---|---|---|
-| **Connects to Omnigent MCP** | Harness exposes/consumes tools via the MCP protocol (stdio `serve-mcp` or in-proc SDK MCP server) | P0 for SDK harnesses; native harnesses may use non-MCP bridges |
-| **Model override** | User can select a model via `--model` / config; some harnesses are vendor-locked (e.g. Claude-only, GPT-only, Gemini-only) | P0 |
-| **Auth** | How credentials are obtained — API key, gateway token, vendor CLI login, OAuth, etc. | P0 |
-| **Streaming** | Harness forwards token-level or delta-level streaming to the Omnigent forwarder | P0 |
-| **Policies / Elicitation** | How the harness gates tool use — `canUseTool ASK`, `request_permission`, 2-stage cards, pre-tool hooks, or policy DENY | P0 for web UI |
-| **Interrupt** | User can cancel a running turn mid-stream | P1 |
-| **Live queue (concurrent)** | Multiple turns can be queued and processed concurrently | P1 |
-| **Tool-boundary steer** | Omnigent can inject steering text at tool-call boundaries | P1 |
-| **Resume/fork from Omnigent transcript** | Rebuild a conversation from a stored Omnigent transcript (replay history, seed prompt, or vendor session ID) | P1 |
-| **Compaction** | Long conversations are compacted; harness surfaces `CompactionComplete` events | P2 |
-| **Reasoning** | Model reasoning/thinking tokens are forwarded | P2 |
-| **Images** | Image content (screenshots, diagrams) is forwarded — full binary, path reference, or text-flattened | P2 |
+---
 
-## Implementation patterns
+## Part 1 — SDK / subprocess harnesses
+
+These harnesses run the vendor model directly and bridge Omnigent tools into
+the vendor's tool-calling interface.
+
+### Capability matrix
+
+| Capability | What it means |
+|---|---|
+| **Connects to Omnigent MCP** | Harness exposes/consumes tools via the MCP protocol (in-proc SDK MCP server) |
+| **Model override** | User can select a model via `--model` / config; some harnesses are vendor-locked (e.g. Claude-only, GPT-only, Gemini-only) |
+| **Auth** | How credentials are obtained — API key, gateway token, vendor CLI login, OAuth, etc. |
+| **Streaming** | Harness forwards token-level or delta-level streaming to the Omnigent forwarder |
+| **Policies / Elicitation (web)** | How the harness gates tool use — `canUseTool ASK`, `request_permission`, 2-stage cards, pre-tool hooks, or policy DENY |
+| **Interrupt** | User can cancel a running turn mid-stream |
+| **Live queue (concurrent)** | Multiple turns can be queued and processed concurrently |
+| **Tool-boundary steer** | Omnigent can inject steering text at tool-call boundaries |
+| **Resume/fork from Omnigent transcript** | Rebuild a conversation from a stored Omnigent transcript (replay history, seed prompt, or vendor session ID) |
+| **Compaction** | Long conversations are compacted; harness surfaces `CompactionComplete` events |
+| **Reasoning** | Model reasoning/thinking tokens are forwarded |
+| **Images** | Image content (screenshots, diagrams) is forwarded — full binary, path reference, or text-flattened |
+
+### Current harness status
+
+| Harness | Implementation | MCP | Model override | Auth | Streaming | Policies | Interrupt | Concurrent | Steer | Resume/fork | Compaction | Reasoning | Images |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| claude-sdk | SDK in-process | yes | yes (Claude-only) | Anthropic key / Databricks gateway | yes | canUseTool ASK | yes | yes | yes | yes | yes (CompactionComplete) | yes | yes |
+| codex | CLI subprocess (app-server RPC) | no (dynamicTools RPC) | yes (GPT-only) | Databricks gateway / codex auth.json | yes | canUseTool ASK | yes | yes (turn/steer) | no | yes (full history replay) | no | yes | yes |
+| cursor | SDK in-process | no (SDK custom-tool) | ~(Cursor ids only) | Cursor API key | yes | 2-stage + card | yes (close) | no | no | yes (persistent agent replay) | no | yes | yes |
+| pi | CLI subprocess (JSONL RPC) | no (TCP socket) | yes (multi-model) | Databricks gateway / API keys | yes | policy + native gate | yes | yes | no | yes (history prefix replay) | no | yes | yes |
+| kimi | CLI subprocess (stream-json) | no | yes (-m multi) | kimi config | yes | no (vendor TUI gates) | yes | no | no | no (vendor session id) | no | ? | ~(dropped) |
+| qwen | ACP subprocess | no | yes (multi / gateway) | qwen config / Databricks gateway | yes | request_permission | yes | no | no | ~(text-prefix replay) | no | ? | no (markers) |
+| goose | ACP subprocess | no | yes (GOOSE_MODEL) | goose config / keyring | yes | request_permission | yes | no | no | ~(text-prefix replay) | no | ? | yes |
+| hermes | CLI subprocess | no (shell pre_tool_call hook) | yes (HARNESS_HERMES_MODEL) | hermes config | yes | ~(pre_tool_call hook DENY) | no | no | no | no (vendor session store) | no | ? | ? |
+| antigravity | SDK in-process (localharness binary) | no (SDK in-proc tools) | yes (Gemini-only) | Gemini key / Vertex AI | yes | ~(policy DENY) | yes | no | yes | yes (seeds history into prompt) | no | yes | ?(text-flattened) |
+| copilot | SDK in-process | no (SDK tool handlers) | ~(databricks-* -> auto) | GitHub token | yes | ~(pre-gated; native bypass) | yes | no | no | no (vendor CopilotSession) | no | yes | ~(flattened) |
+| openai-agents | SDK in-process | no (SDK FunctionTool) | yes (multi-model) | Databricks gateway / OpenAI key | yes | canUseTool ASK | yes | no | no | yes (full history via SDK session) | yes (CompactionComplete) | ~(emitted; not surfaced) | yes |
 
 ### Transport types
 
@@ -41,7 +67,6 @@ Each harness is evaluated across the following dimensions:
 ### MCP connectivity
 
 - **In-proc SDK MCP server** — the harness runs an MCP server in-process and the SDK connects to it directly (e.g. claude-sdk).
-- **stdio `serve-mcp`** — native harnesses connect via `stdio serve-mcp` to the Omnigent MCP server.
 - **Non-MCP bridges** — many harnesses use vendor-specific tool bridging: `dynamicTools` RPC (codex), SDK `custom_tools` (cursor), SDK `FunctionTool` (openai-agents), TCP socket (pi), shell hooks (hermes), SDK in-proc tools (antigravity), SDK tool handlers (copilot).
 
 ### Policies / elicitation strategies
@@ -51,7 +76,7 @@ Each harness is evaluated across the following dimensions:
 | `canUseTool ASK` | Omnigent asks the model whether a tool call should proceed; model responds with ASK to surface to user | claude-sdk, codex, openai-agents |
 | `request_permission` | ACP-native permission request flow | qwen, goose |
 | 2-stage + card | Two-phase approval with a UI card | cursor |
-| Pre-tool hook | Shell hook runs before each tool call; can DENY | hermes (non-native), pi-native, kimi-native |
+| Pre-tool hook | Shell hook runs before each tool call; can DENY | hermes |
 | Policy DENY | Omnigent policy engine denies disallowed calls | antigravity |
 | Pre-gated | Tools are pre-approved; native tools bypass gating | copilot |
 
@@ -63,7 +88,6 @@ Each harness is evaluated across the following dimensions:
 | History prefix replay | Replays a prefix of the history into a fresh session | pi |
 | Text-prefix replay | Injects a text summary/prefix of prior history | qwen, goose |
 | Prompt seeding | Seeds prior history into the system prompt on rebuild | antigravity |
-| Native rebuild | Vendor CLI natively supports resume/fork from transcript | claude-native, codex-native |
 | Vendor session ID | Relies on the vendor's own session persistence (no Omnigent-side rebuild) | kimi, hermes, copilot |
 
 ### Auth patterns
@@ -76,41 +100,86 @@ Each harness is evaluated across the following dimensions:
 | OAuth / GitHub token | copilot (GitHub PAT with Copilot permission) |
 | Gateway + fallback | codex (Databricks gateway / codex auth.json), pi (gateway / API keys) |
 
-## Native harness capabilities
+### Checklist for a new SDK/subprocess harness
+
+All capabilities are **required** for a complete harness integration:
+
+- [ ] Connects to Omnigent MCP (in-proc SDK MCP server or vendor-specific bridge)
+- [ ] Model override works (or document vendor lock-in)
+- [ ] Auth is configured and documented (setup flow in `omni setup`)
+- [ ] Streaming forwards to the Omnigent forwarder
+- [ ] Policy / elicitation strategy is implemented for web UI
+- [ ] Interrupt cancels the running turn
+- [ ] Live queue supports concurrent turns
+- [ ] Tool-boundary steering injects correctly
+- [ ] Resume/fork rebuilds conversation from Omnigent transcript
+- [ ] Compaction is surfaced (`CompactionComplete` events)
+- [ ] Reasoning tokens are forwarded
+- [ ] Images are forwarded (full binary preferred; path or text-flattened acceptable)
+- [ ] Unit tests cover tool bridging, auth, model routing
+- [ ] E2E skill exists for manual smoke-testing against a live server
+- [ ] Mock LLM tests cover the happy path without real API calls
+
+---
+
+## Part 2 — Native harnesses
 
 Native harnesses wrap a vendor's own TUI or server and mirror output into
-Omnigent. They have a separate feature set:
+Omnigent. They connect to the Omnigent MCP server via `stdio serve-mcp`
+and relay the vendor's conversation into the Omnigent session.
+
+### Capability matrix
 
 | Capability | What it means |
 |---|---|
 | **Transport** | How the native harness communicates — tmux TUI, app server, HTTP/SSE, file-inject TUI |
+| **Connects to Omnigent MCP** | Whether the native harness connects via `stdio serve-mcp` |
+| **Model override** | User can select a model at launch or per-prompt |
+| **Auth** | Vendor login / config / token |
 | **Streaming (forwarder)** | `deltas` (token-level) vs `complete-only` (full response after completion) |
-| **Bidirectional sync** | TUI output mirrors into Omnigent conversation |
-| **Session-cmd sync** | Supports `clear`, `fork`, `resume`, `switch` commands from Omnigent |
-| **Policies** | Whether the native harness can gate tool calls (mirror+reply, permission.v2, hook DENY, or none) |
+| **Policies / Elicitation** | Whether the native harness can gate tool calls — mirror+reply, permission.v2+reply, hook DENY, or none |
+| **Interrupt** | User can abort a running turn |
+| **Bidirectional sync (TUI->Omni)** | TUI output mirrors into the Omnigent conversation |
+| **In-harness session-cmd sync** | Supports `clear`, `fork`, `resume`, `switch` commands from Omnigent |
+| **Resume/fork from Omnigent transcript** | Can rebuild conversation from Omnigent transcript (native rebuild, or fresh launch) |
+| **Compaction** | Vendor-internal compaction status |
+| **Reasoning** | Model reasoning/thinking tokens are forwarded |
+| **Images** | Image content is forwarded — path reference, full binary, or text-flattened |
 
-## Checklist for a new harness
+### Current native harness status
 
-When implementing a new harness, ensure the following:
+| Harness | Owner | Transport | MCP | Model override | Auth | Streaming | Policies | Interrupt | Bidi sync | Session cmds | Resume/fork | Compaction | Reasoning | Images |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| claude-native | Daniel Lok | tmux TUI | yes (stdio serve-mcp) | yes (--model) | Claude CLI login | deltas | yes | yes | yes | clear/fork/resume | yes (native rebuild) | vendor-internal (status only) | ? | yes (path) |
+| codex-native | Zeyi Fan / Pat Sukprasert | app server | yes (stdio serve-mcp) | no (user-launched) | codex auth.json | deltas | yes (mirror+reply) | yes (turn/interrupt) | yes | yes (new/switch/fork) | yes (native fork-history rebuild) | yes | yes (in-term) | yes |
+| cursor-native | Serena Ruan / Corey Zumar | tmux TUI | yes (stdio serve-mcp) | no | cursor sub/key | complete-only | no (read-only mirror) | no | yes | no | no (fork launches fresh) | no | ? | yes (path) |
+| hermes-native | Tomu Hirata | tmux TUI | no | ?(set at launch) | hermes config | complete-only | no | no | yes | no | no (conversation in TUI) | no | ? | yes (path) |
+| opencode-native | Dhruv Gupta | native HTTP/SSE server | no | yes (per-prompt) | OpenCode native | complete-only | yes (permission.v2+reply) | yes (abort) | yes | no | no (relies on OpenCode server session) | no | ? | yes |
+| pi-native | Sabhya Chhabria | tmux TUI | no | no | pi config / managed dir | complete-only | ~(PreToolUse hook DENY) | ~(TUI only) | yes | no | no (fork launches fresh) | no | ? | yes (path) |
+| **0.3.0 Release CUT LINE** | | | | | | | | | | | | | | |
+| kimi-native | — | tmux TUI | no | no | kimi config | complete-only | ~(PreToolUse hook DENY) | ~(TUI only) | yes | no | no (conversation in TUI) | no | ? | yes (path) |
+| qwen-native | — | file-inject TUI | no | no (--model at launch) | qwen config | complete-only | no (TUI gates) | yes (tmux) | yes | no | no (conversation in TUI) | no | ? | ? |
+| goose-native | — | tmux TUI | no | no (--model at launch) | goose config | complete-only | no (GOOSE_MODE in-term) | yes (tmux) | yes | no | no (conversation in TUI) | no | ? | ? |
+| antigravity-native | — | tmux TUI (RPC) | no | — (agy self-selects) | inherited from agy | deltas | no | yes (CancelCascade RPC) | no | clear only | no (agy owns cascade history) | no | no (opaque) | ~(path marker) |
+| kiro-native | — | tmux TUI | no | ?(set at launch) | kiro config | complete-only | no | no | yes | no | no (conversation in TUI) | no | ? | yes (path) |
 
-1. **P0 — must have for launch:**
-   - [ ] Model override works (or document vendor lock-in)
-   - [ ] Auth is configured and documented (setup flow in `omni setup`)
-   - [ ] Streaming forwards to the Omnigent forwarder
-   - [ ] Tool bridging works (MCP or vendor-specific)
-   - [ ] Policy / elicitation strategy is implemented for web UI
+### Checklist for a new native harness
 
-2. **P1 — expected for production use:**
-   - [ ] Interrupt cancels the running turn
-   - [ ] Tool-boundary steering injects correctly
-   - [ ] Resume/fork rebuilds conversation from Omnigent transcript
+All capabilities are **required** for a complete native harness integration:
 
-3. **P2 — nice to have:**
-   - [ ] Compaction is surfaced (`CompactionComplete` events)
-   - [ ] Reasoning tokens are forwarded
-   - [ ] Images are forwarded (full binary preferred; path or text-flattened acceptable)
-
-4. **Testing:**
-   - [ ] Unit tests cover tool bridging, auth, model routing
-   - [ ] E2E skill exists for manual smoke-testing against a live server
-   - [ ] Mock LLM tests cover the happy path without real API calls
+- [ ] Transport chosen and implemented (tmux TUI, app server, HTTP/SSE)
+- [ ] Connects to Omnigent MCP via `stdio serve-mcp`
+- [ ] Model override works (or document vendor lock-in)
+- [ ] Auth configured (vendor login / config)
+- [ ] Streaming forwarder works (deltas preferred; complete-only acceptable)
+- [ ] Policy / elicitation strategy gates tool calls in web UI
+- [ ] Interrupt aborts the running turn
+- [ ] Bidirectional sync mirrors TUI output into Omnigent conversation
+- [ ] Session commands (clear, fork, resume) work from Omnigent
+- [ ] Resume/fork rebuilds from Omnigent transcript
+- [ ] Compaction status is surfaced
+- [ ] Reasoning tokens are forwarded
+- [ ] Images are forwarded (path preferred; binary or text-flattened acceptable)
+- [ ] Unit tests cover forwarder, auth, transport
+- [ ] E2E skill exists for manual smoke-testing against a live server
+- [ ] Mock LLM tests cover the happy path without real API calls

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -40,29 +40,13 @@ the vendor's tool-calling interface.
 | **Reasoning** | Model reasoning/thinking tokens are forwarded |
 | **Images** | Image content (screenshots, diagrams) is forwarded — full binary, path reference, or text-flattened |
 
-### Current harness status
-
-| Harness | Implementation | MCP | Model override | Auth | Streaming | Policies | Interrupt | Concurrent | Steer | Resume/fork | Compaction | Reasoning | Images |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| claude-sdk | SDK in-process | yes | yes (Claude-only) | Anthropic key / Databricks gateway | yes | canUseTool ASK | yes | yes | yes | yes | yes (CompactionComplete) | yes | yes |
-| codex | CLI subprocess (app-server RPC) | no (dynamicTools RPC) | yes (GPT-only) | Databricks gateway / codex auth.json | yes | canUseTool ASK | yes | yes (turn/steer) | no | yes (full history replay) | no | yes | yes |
-| cursor | SDK in-process | no (SDK custom-tool) | ~(Cursor ids only) | Cursor API key | yes | 2-stage + card | yes (close) | no | no | yes (persistent agent replay) | no | yes | yes |
-| pi | CLI subprocess (JSONL RPC) | no (TCP socket) | yes (multi-model) | Databricks gateway / API keys | yes | policy + native gate | yes | yes | no | yes (history prefix replay) | no | yes | yes |
-| kimi | CLI subprocess (stream-json) | no | yes (-m multi) | kimi config | yes | no (vendor TUI gates) | yes | no | no | no (vendor session id) | no | ? | ~(dropped) |
-| qwen | ACP subprocess | no | yes (multi / gateway) | qwen config / Databricks gateway | yes | request_permission | yes | no | no | ~(text-prefix replay) | no | ? | no (markers) |
-| goose | ACP subprocess | no | yes (GOOSE_MODEL) | goose config / keyring | yes | request_permission | yes | no | no | ~(text-prefix replay) | no | ? | yes |
-| hermes | CLI subprocess | no (shell pre_tool_call hook) | yes (HARNESS_HERMES_MODEL) | hermes config | yes | ~(pre_tool_call hook DENY) | no | no | no | no (vendor session store) | no | ? | ? |
-| antigravity | SDK in-process (localharness binary) | no (SDK in-proc tools) | yes (Gemini-only) | Gemini key / Vertex AI | yes | ~(policy DENY) | yes | no | yes | yes (seeds history into prompt) | no | yes | ?(text-flattened) |
-| copilot | SDK in-process | no (SDK tool handlers) | ~(databricks-* -> auto) | GitHub token | yes | ~(pre-gated; native bypass) | yes | no | no | no (vendor CopilotSession) | no | yes | ~(flattened) |
-| openai-agents | SDK in-process | no (SDK FunctionTool) | yes (multi-model) | Databricks gateway / OpenAI key | yes | canUseTool ASK | yes | no | no | yes (full history via SDK session) | yes (CompactionComplete) | ~(emitted; not surfaced) | yes |
-
 ### Transport types
 
-| Type | Description | Examples |
-|---|---|---|
-| **SDK in-process** | Harness runs inside the Omnigent Python process via a vendor SDK | claude-sdk, cursor, antigravity, copilot, openai-agents |
-| **CLI subprocess** | Harness spawns a vendor CLI binary and communicates via stdout/stdin (JSONL, stream-json, or shell hooks) | codex, pi, kimi, hermes |
-| **ACP subprocess** | Harness uses the Agent Communication Protocol over a subprocess | qwen, goose |
+| Type | Description |
+|---|---|
+| **SDK in-process** | Harness runs inside the Omnigent Python process via a vendor SDK |
+| **CLI subprocess** | Harness spawns a vendor CLI binary and communicates via stdout/stdin (JSONL, stream-json, or shell hooks) |
+| **ACP subprocess** | Harness uses the Agent Communication Protocol over a subprocess |
 
 ### MCP connectivity
 
@@ -71,34 +55,34 @@ the vendor's tool-calling interface.
 
 ### Policies / elicitation strategies
 
-| Strategy | How it works | Harnesses |
-|---|---|---|
-| `canUseTool ASK` | Omnigent asks the model whether a tool call should proceed; model responds with ASK to surface to user | claude-sdk, codex, openai-agents |
-| `request_permission` | ACP-native permission request flow | qwen, goose |
-| 2-stage + card | Two-phase approval with a UI card | cursor |
-| Pre-tool hook | Shell hook runs before each tool call; can DENY | hermes |
-| Policy DENY | Omnigent policy engine denies disallowed calls | antigravity |
-| Pre-gated | Tools are pre-approved; native tools bypass gating | copilot |
+| Strategy | How it works |
+|---|---|
+| `canUseTool ASK` | Omnigent asks the model whether a tool call should proceed; model responds with ASK to surface to user |
+| `request_permission` | ACP-native permission request flow |
+| 2-stage + card | Two-phase approval with a UI card |
+| Pre-tool hook | Shell hook runs before each tool call; can DENY |
+| Policy DENY | Omnigent policy engine denies disallowed calls |
+| Pre-gated | Tools are pre-approved; native tools bypass gating |
 
 ### Resume / fork strategies
 
-| Strategy | How it works | Harnesses |
-|---|---|---|
-| Full history replay | Replays the entire message history into a fresh thread/session | codex, cursor, openai-agents |
-| History prefix replay | Replays a prefix of the history into a fresh session | pi |
-| Text-prefix replay | Injects a text summary/prefix of prior history | qwen, goose |
-| Prompt seeding | Seeds prior history into the system prompt on rebuild | antigravity |
-| Vendor session ID | Relies on the vendor's own session persistence (no Omnigent-side rebuild) | kimi, hermes, copilot |
+| Strategy | How it works |
+|---|---|
+| Full history replay | Replays the entire message history into a fresh thread/session |
+| History prefix replay | Replays a prefix of the history into a fresh session |
+| Text-prefix replay | Injects a text summary/prefix of prior history |
+| Prompt seeding | Seeds prior history into the system prompt on rebuild |
+| Vendor session ID | Relies on the vendor's own session persistence (no Omnigent-side rebuild) |
 
 ### Auth patterns
 
-| Pattern | Examples |
+| Pattern | Description |
 |---|---|
-| Anthropic API key / Databricks gateway | claude-sdk |
-| Vendor API key (direct) | cursor (Cursor API key), antigravity (Gemini key) |
-| Vendor CLI login / config file | hermes, kimi, goose, qwen, pi |
-| OAuth / GitHub token | copilot (GitHub PAT with Copilot permission) |
-| Gateway + fallback | codex (Databricks gateway / codex auth.json), pi (gateway / API keys) |
+| API key / Databricks gateway | Direct API key or routed through a Databricks gateway |
+| Vendor API key (direct) | Vendor-specific API key (e.g. Cursor, Gemini) |
+| Vendor CLI login / config file | Credentials stored in a vendor config file or managed via vendor CLI login |
+| OAuth / GitHub token | OAuth flow or platform token (e.g. GitHub PAT) |
+| Gateway + fallback | Primary gateway with fallback to vendor-native auth |
 
 ### Checklist for a new SDK/subprocess harness
 
@@ -145,23 +129,6 @@ and relay the vendor's conversation into the Omnigent session.
 | **Compaction** | Vendor-internal compaction status |
 | **Reasoning** | Model reasoning/thinking tokens are forwarded |
 | **Images** | Image content is forwarded — path reference, full binary, or text-flattened |
-
-### Current native harness status
-
-| Harness | Owner | Transport | MCP | Model override | Auth | Streaming | Policies | Interrupt | Bidi sync | Session cmds | Resume/fork | Compaction | Reasoning | Images |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| claude-native | Daniel Lok | tmux TUI | yes (stdio serve-mcp) | yes (--model) | Claude CLI login | deltas | yes | yes | yes | clear/fork/resume | yes (native rebuild) | vendor-internal (status only) | ? | yes (path) |
-| codex-native | Zeyi Fan / Pat Sukprasert | app server | yes (stdio serve-mcp) | no (user-launched) | codex auth.json | deltas | yes (mirror+reply) | yes (turn/interrupt) | yes | yes (new/switch/fork) | yes (native fork-history rebuild) | yes | yes (in-term) | yes |
-| cursor-native | Serena Ruan / Corey Zumar | tmux TUI | yes (stdio serve-mcp) | no | cursor sub/key | complete-only | no (read-only mirror) | no | yes | no | no (fork launches fresh) | no | ? | yes (path) |
-| hermes-native | Tomu Hirata | tmux TUI | no | ?(set at launch) | hermes config | complete-only | no | no | yes | no | no (conversation in TUI) | no | ? | yes (path) |
-| opencode-native | Dhruv Gupta | native HTTP/SSE server | no | yes (per-prompt) | OpenCode native | complete-only | yes (permission.v2+reply) | yes (abort) | yes | no | no (relies on OpenCode server session) | no | ? | yes |
-| pi-native | Sabhya Chhabria | tmux TUI | no | no | pi config / managed dir | complete-only | ~(PreToolUse hook DENY) | ~(TUI only) | yes | no | no (fork launches fresh) | no | ? | yes (path) |
-| **0.3.0 Release CUT LINE** | | | | | | | | | | | | | | |
-| kimi-native | — | tmux TUI | no | no | kimi config | complete-only | ~(PreToolUse hook DENY) | ~(TUI only) | yes | no | no (conversation in TUI) | no | ? | yes (path) |
-| qwen-native | — | file-inject TUI | no | no (--model at launch) | qwen config | complete-only | no (TUI gates) | yes (tmux) | yes | no | no (conversation in TUI) | no | ? | ? |
-| goose-native | — | tmux TUI | no | no (--model at launch) | goose config | complete-only | no (GOOSE_MODE in-term) | yes (tmux) | yes | no | no (conversation in TUI) | no | ? | ? |
-| antigravity-native | — | tmux TUI (RPC) | no | — (agy self-selects) | inherited from agy | deltas | no | yes (CancelCascade RPC) | no | clear only | no (agy owns cascade history) | no | no (opaque) | ~(path marker) |
-| kiro-native | — | tmux TUI | no | ?(set at launch) | kiro config | complete-only | no | no | yes | no | no (conversation in TUI) | no | ? | yes (path) |
 
 ### Checklist for a new native harness
 

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -113,7 +113,6 @@ All capabilities are **required** for a complete harness integration:
 - [ ] Images are forwarded (full binary preferred; path or text-flattened acceptable)
 - [ ] Cost tracking reports token usage and cost per turn
 - [ ] Unit tests cover tool bridging, auth, model routing
-- [ ] E2E skill exists for manual smoke-testing against a live server
 - [ ] Mock LLM tests cover the happy path without real API calls
 
 ---
@@ -163,5 +162,4 @@ All capabilities are **required** for a complete native harness integration:
 - [ ] Images are forwarded (path preferred; binary or text-flattened acceptable)
 - [ ] Cost tracking reports token usage and cost per turn
 - [ ] Unit tests cover forwarder, auth, transport
-- [ ] E2E skill exists for manual smoke-testing against a live server
 - [ ] Mock LLM tests cover the happy path without real API calls

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -44,8 +44,18 @@ the vendor's tool-calling interface.
 
 ### MCP connectivity
 
-- **In-proc SDK MCP server** — the harness runs an MCP server in-process and the SDK connects to it directly (e.g. claude-sdk).
-- **Non-MCP bridges** — many harnesses use vendor-specific tool bridging: `dynamicTools` RPC (codex), SDK `custom_tools` (cursor), SDK `FunctionTool` (openai-agents), TCP socket (pi), shell hooks (hermes), SDK in-proc tools (antigravity), SDK tool handlers (copilot).
+The harness must bridge Omnigent's builtin MCP tools so the model can call
+them. These tools provide session management, agent orchestration, policy
+control, and web access:
+
+- `sys_session_get_info`, `sys_session_list`, `sys_session_get_history`
+- `sys_agent_get`, `sys_agent_list`, `sys_agent_download`
+- `sys_call_async`, `sys_cancel_async`, `sys_cancel_task`
+- `sys_read_inbox`
+- `sys_add_policy`, `sys_policy_registry`
+- `load_skill`
+- `list_comments`, `update_comment`
+- `web_fetch`, `web_search`
 
 ### Omnigent policies
 

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: harness-integration-guide
+description: Reference guide for building new Omnigent harness integrations — covers the full feature matrix (MCP, model override, auth, streaming, policies, interrupt, concurrency, transcript resume, compaction, reasoning, images) with implementation notes and capability tiers.
+---
+
+# Harness integration guide
+
+This skill describes the **feature matrix** every Omnigent harness must
+consider. Use it when planning, reviewing, or implementing a new harness
+(SDK in-process, CLI subprocess, or ACP subprocess).
+
+## Capability matrix
+
+Each harness is evaluated across the following dimensions:
+
+| Capability | What it means | Priority |
+|---|---|---|
+| **Connects to Omnigent MCP** | Harness exposes/consumes tools via the MCP protocol (stdio `serve-mcp` or in-proc SDK MCP server) | P0 for SDK harnesses; native harnesses may use non-MCP bridges |
+| **Model override** | User can select a model via `--model` / config; some harnesses are vendor-locked (e.g. Claude-only, GPT-only, Gemini-only) | P0 |
+| **Auth** | How credentials are obtained — API key, gateway token, vendor CLI login, OAuth, etc. | P0 |
+| **Streaming** | Harness forwards token-level or delta-level streaming to the Omnigent forwarder | P0 |
+| **Policies / Elicitation** | How the harness gates tool use — `canUseTool ASK`, `request_permission`, 2-stage cards, pre-tool hooks, or policy DENY | P0 for web UI |
+| **Interrupt** | User can cancel a running turn mid-stream | P1 |
+| **Live queue (concurrent)** | Multiple turns can be queued and processed concurrently | P1 |
+| **Tool-boundary steer** | Omnigent can inject steering text at tool-call boundaries | P1 |
+| **Resume/fork from Omnigent transcript** | Rebuild a conversation from a stored Omnigent transcript (replay history, seed prompt, or vendor session ID) | P1 |
+| **Compaction** | Long conversations are compacted; harness surfaces `CompactionComplete` events | P2 |
+| **Reasoning** | Model reasoning/thinking tokens are forwarded | P2 |
+| **Images** | Image content (screenshots, diagrams) is forwarded — full binary, path reference, or text-flattened | P2 |
+
+## Implementation patterns
+
+### Transport types
+
+| Type | Description | Examples |
+|---|---|---|
+| **SDK in-process** | Harness runs inside the Omnigent Python process via a vendor SDK | claude-sdk, cursor, antigravity, copilot, openai-agents |
+| **CLI subprocess** | Harness spawns a vendor CLI binary and communicates via stdout/stdin (JSONL, stream-json, or shell hooks) | codex, pi, kimi, hermes |
+| **ACP subprocess** | Harness uses the Agent Communication Protocol over a subprocess | qwen, goose |
+
+### MCP connectivity
+
+- **In-proc SDK MCP server** — the harness runs an MCP server in-process and the SDK connects to it directly (e.g. claude-sdk).
+- **stdio `serve-mcp`** — native harnesses connect via `stdio serve-mcp` to the Omnigent MCP server.
+- **Non-MCP bridges** — many harnesses use vendor-specific tool bridging: `dynamicTools` RPC (codex), SDK `custom_tools` (cursor), SDK `FunctionTool` (openai-agents), TCP socket (pi), shell hooks (hermes), SDK in-proc tools (antigravity), SDK tool handlers (copilot).
+
+### Policies / elicitation strategies
+
+| Strategy | How it works | Harnesses |
+|---|---|---|
+| `canUseTool ASK` | Omnigent asks the model whether a tool call should proceed; model responds with ASK to surface to user | claude-sdk, codex, openai-agents |
+| `request_permission` | ACP-native permission request flow | qwen, goose |
+| 2-stage + card | Two-phase approval with a UI card | cursor |
+| Pre-tool hook | Shell hook runs before each tool call; can DENY | hermes (non-native), pi-native, kimi-native |
+| Policy DENY | Omnigent policy engine denies disallowed calls | antigravity |
+| Pre-gated | Tools are pre-approved; native tools bypass gating | copilot |
+
+### Resume / fork strategies
+
+| Strategy | How it works | Harnesses |
+|---|---|---|
+| Full history replay | Replays the entire message history into a fresh thread/session | codex, cursor, openai-agents |
+| History prefix replay | Replays a prefix of the history into a fresh session | pi |
+| Text-prefix replay | Injects a text summary/prefix of prior history | qwen, goose |
+| Prompt seeding | Seeds prior history into the system prompt on rebuild | antigravity |
+| Native rebuild | Vendor CLI natively supports resume/fork from transcript | claude-native, codex-native |
+| Vendor session ID | Relies on the vendor's own session persistence (no Omnigent-side rebuild) | kimi, hermes, copilot |
+
+### Auth patterns
+
+| Pattern | Examples |
+|---|---|
+| Anthropic API key / Databricks gateway | claude-sdk |
+| Vendor API key (direct) | cursor (Cursor API key), antigravity (Gemini key) |
+| Vendor CLI login / config file | hermes, kimi, goose, qwen, pi |
+| OAuth / GitHub token | copilot (GitHub PAT with Copilot permission) |
+| Gateway + fallback | codex (Databricks gateway / codex auth.json), pi (gateway / API keys) |
+
+## Native harness capabilities
+
+Native harnesses wrap a vendor's own TUI or server and mirror output into
+Omnigent. They have a separate feature set:
+
+| Capability | What it means |
+|---|---|
+| **Transport** | How the native harness communicates — tmux TUI, app server, HTTP/SSE, file-inject TUI |
+| **Streaming (forwarder)** | `deltas` (token-level) vs `complete-only` (full response after completion) |
+| **Bidirectional sync** | TUI output mirrors into Omnigent conversation |
+| **Session-cmd sync** | Supports `clear`, `fork`, `resume`, `switch` commands from Omnigent |
+| **Policies** | Whether the native harness can gate tool calls (mirror+reply, permission.v2, hook DENY, or none) |
+
+## Checklist for a new harness
+
+When implementing a new harness, ensure the following:
+
+1. **P0 — must have for launch:**
+   - [ ] Model override works (or document vendor lock-in)
+   - [ ] Auth is configured and documented (setup flow in `omni setup`)
+   - [ ] Streaming forwards to the Omnigent forwarder
+   - [ ] Tool bridging works (MCP or vendor-specific)
+   - [ ] Policy / elicitation strategy is implemented for web UI
+
+2. **P1 — expected for production use:**
+   - [ ] Interrupt cancels the running turn
+   - [ ] Tool-boundary steering injects correctly
+   - [ ] Resume/fork rebuilds conversation from Omnigent transcript
+
+3. **P2 — nice to have:**
+   - [ ] Compaction is surfaced (`CompactionComplete` events)
+   - [ ] Reasoning tokens are forwarded
+   - [ ] Images are forwarded (full binary preferred; path or text-flattened acceptable)
+
+4. **Testing:**
+   - [ ] Unit tests cover tool bridging, auth, model routing
+   - [ ] E2E skill exists for manual smoke-testing against a live server
+   - [ ] Mock LLM tests cover the happy path without real API calls

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -31,7 +31,8 @@ the vendor's tool-calling interface.
 | **Model override** | User can select a model via `--model` / config; some harnesses are vendor-locked (e.g. Claude-only, GPT-only, Gemini-only) |
 | **Auth** | How credentials are obtained — API key, gateway token, vendor CLI login, OAuth, etc. |
 | **Streaming** | Harness forwards token-level or delta-level streaming to the Omnigent forwarder |
-| **Policies / Elicitation (web)** | How the harness gates tool use — `canUseTool ASK`, `request_permission`, 2-stage cards, pre-tool hooks, or policy DENY |
+| **Omnigent policies** | Harness enforces Omnigent-side tool policies — policy DENY, pre-gated allow-lists, pre-tool hooks |
+| **Native elicitation (web)** | Harness surfaces tool-approval requests to the web UI — `canUseTool ASK`, `request_permission`, 2-stage cards |
 | **Interrupt** | User can cancel a running turn mid-stream |
 | **Live queue (concurrent)** | Multiple turns can be queued and processed concurrently |
 | **Tool-boundary steer** | Omnigent can inject steering text at tool-call boundaries |
@@ -53,16 +54,21 @@ the vendor's tool-calling interface.
 - **In-proc SDK MCP server** — the harness runs an MCP server in-process and the SDK connects to it directly (e.g. claude-sdk).
 - **Non-MCP bridges** — many harnesses use vendor-specific tool bridging: `dynamicTools` RPC (codex), SDK `custom_tools` (cursor), SDK `FunctionTool` (openai-agents), TCP socket (pi), shell hooks (hermes), SDK in-proc tools (antigravity), SDK tool handlers (copilot).
 
-### Policies / elicitation strategies
+### Omnigent policy strategies
 
 | Strategy | How it works |
 |---|---|
-| `canUseTool ASK` | Omnigent asks the model whether a tool call should proceed; model responds with ASK to surface to user |
-| `request_permission` | ACP-native permission request flow |
-| 2-stage + card | Two-phase approval with a UI card |
-| Pre-tool hook | Shell hook runs before each tool call; can DENY |
 | Policy DENY | Omnigent policy engine denies disallowed calls |
-| Pre-gated | Tools are pre-approved; native tools bypass gating |
+| Pre-gated | Tools are pre-approved via allow-lists; bypass gating |
+| Pre-tool hook | Shell hook runs before each tool call; can DENY |
+
+### Native elicitation strategies
+
+| Strategy | How it works |
+|---|---|
+| `canUseTool ASK` | Omnigent asks the model whether a tool call should proceed; model responds with ASK to surface approval to the web UI |
+| `request_permission` | ACP-native permission request flow surfaced to the web UI |
+| 2-stage + card | Two-phase approval with a UI card |
 
 ### Resume / fork strategies
 
@@ -92,7 +98,8 @@ All capabilities are **required** for a complete harness integration:
 - [ ] Model override works (or document vendor lock-in)
 - [ ] Auth is configured and documented (setup flow in `omni setup`)
 - [ ] Streaming forwards to the Omnigent forwarder
-- [ ] Policy / elicitation strategy is implemented for web UI
+- [ ] Omnigent policies enforce tool-use rules
+- [ ] Native elicitation surfaces tool-approval requests to web UI
 - [ ] Interrupt cancels the running turn
 - [ ] Live queue supports concurrent turns
 - [ ] Tool-boundary steering injects correctly
@@ -121,7 +128,8 @@ and relay the vendor's conversation into the Omnigent session.
 | **Model override** | User can select a model at launch or per-prompt |
 | **Auth** | Vendor login / config / token |
 | **Streaming (forwarder)** | `deltas` (token-level) vs `complete-only` (full response after completion) |
-| **Policies / Elicitation** | Whether the native harness can gate tool calls — mirror+reply, permission.v2+reply, hook DENY, or none |
+| **Omnigent policies** | Whether the native harness enforces Omnigent-side tool policies — hook DENY, policy engine |
+| **Native elicitation (web)** | Whether the native harness surfaces tool-approval requests to the web UI — mirror+reply, permission.v2+reply |
 | **Interrupt** | User can abort a running turn |
 | **Bidirectional sync (TUI->Omni)** | TUI output mirrors into the Omnigent conversation |
 | **In-harness session-cmd sync** | Supports `clear`, `fork`, `resume`, `switch` commands from Omnigent |
@@ -139,7 +147,8 @@ All capabilities are **required** for a complete native harness integration:
 - [ ] Model override works (or document vendor lock-in)
 - [ ] Auth configured (vendor login / config)
 - [ ] Streaming forwarder works (deltas preferred; complete-only acceptable)
-- [ ] Policy / elicitation strategy gates tool calls in web UI
+- [ ] Omnigent policies enforce tool-use rules
+- [ ] Native elicitation surfaces tool-approval requests to web UI
 - [ ] Interrupt aborts the running turn
 - [ ] Bidirectional sync mirrors TUI output into Omnigent conversation
 - [ ] Session commands (clear, fork, resume) work from Omnigent

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -31,7 +31,7 @@ the vendor's tool-calling interface.
 | **Model override** | User can select a model via `--model` / config; some harnesses are vendor-locked (e.g. Claude-only, GPT-only, Gemini-only) |
 | **Auth** | How credentials are obtained — API key, gateway token, vendor CLI login, OAuth, etc. |
 | **Streaming** | Harness forwards token-level or delta-level streaming to the Omnigent forwarder |
-| **Omnigent policies** | Harness enforces Omnigent-side tool policies — policy DENY, pre-gated allow-lists, pre-tool hooks |
+| **Omnigent policies** | Harness enforces Omnigent-side tool policies — must support ALLOW, ASK, and DENY verdicts for both tool calls and tool results |
 | **Native elicitation (web)** | Harness surfaces tool-approval requests to the web UI — `canUseTool ASK`, `request_permission`, 2-stage cards |
 | **Interrupt** | User can cancel a running turn mid-stream |
 | **Live queue (concurrent)** | Multiple turns can be queued and processed concurrently |
@@ -54,13 +54,15 @@ the vendor's tool-calling interface.
 - **In-proc SDK MCP server** — the harness runs an MCP server in-process and the SDK connects to it directly (e.g. claude-sdk).
 - **Non-MCP bridges** — many harnesses use vendor-specific tool bridging: `dynamicTools` RPC (codex), SDK `custom_tools` (cursor), SDK `FunctionTool` (openai-agents), TCP socket (pi), shell hooks (hermes), SDK in-proc tools (antigravity), SDK tool handlers (copilot).
 
-### Omnigent policy strategies
+### Omnigent policies
 
-| Strategy | How it works |
-|---|---|
-| Policy DENY | Omnigent policy engine denies disallowed calls |
-| Pre-gated | Tools are pre-approved via allow-lists; bypass gating |
-| Pre-tool hook | Shell hook runs before each tool call; can DENY |
+The harness must support the Omnigent policy engine's three verdicts at two
+checkpoints:
+
+| Checkpoint | ALLOW | ASK | DENY |
+|---|---|---|---|
+| **Tool call** (before execution) | Proceed silently | Surface approval request to user (via elicitation) | Block the call and return a policy-denied error to the model |
+| **Tool result** (after execution) | Return result to model | Surface result for user review before returning | Suppress the result and return a policy-denied error to the model |
 
 ### Native elicitation strategies
 
@@ -128,7 +130,7 @@ and relay the vendor's conversation into the Omnigent session.
 | **Model override** | User can select a model at launch or per-prompt |
 | **Auth** | Vendor login / config / token |
 | **Streaming (forwarder)** | `deltas` (token-level) vs `complete-only` (full response after completion) |
-| **Omnigent policies** | Whether the native harness enforces Omnigent-side tool policies — hook DENY, policy engine |
+| **Omnigent policies** | Whether the native harness enforces Omnigent-side tool policies — must support ALLOW, ASK, and DENY verdicts for both tool calls and tool results |
 | **Native elicitation (web)** | Whether the native harness surfaces tool-approval requests to the web UI — mirror+reply, permission.v2+reply |
 | **Interrupt** | User can abort a running turn |
 | **Bidirectional sync (TUI->Omni)** | TUI output mirrors into the Omnigent conversation |

--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -40,14 +40,7 @@ the vendor's tool-calling interface.
 | **Compaction** | Long conversations are compacted; harness surfaces `CompactionComplete` events |
 | **Reasoning** | Model reasoning/thinking tokens are forwarded |
 | **Images** | Image content (screenshots, diagrams) is forwarded — full binary, path reference, or text-flattened |
-
-### Transport types
-
-| Type | Description |
-|---|---|
-| **SDK in-process** | Harness runs inside the Omnigent Python process via a vendor SDK |
-| **CLI subprocess** | Harness spawns a vendor CLI binary and communicates via stdout/stdin (JSONL, stream-json, or shell hooks) |
-| **ACP subprocess** | Harness uses the Agent Communication Protocol over a subprocess |
+| **Cost tracking** | Harness reports token usage and cost data back to Omnigent for each turn |
 
 ### MCP connectivity
 
@@ -108,6 +101,7 @@ All capabilities are **required** for a complete harness integration:
 - [ ] Compaction is surfaced (`CompactionComplete` events)
 - [ ] Reasoning tokens are forwarded
 - [ ] Images are forwarded (full binary preferred; path or text-flattened acceptable)
+- [ ] Cost tracking reports token usage and cost per turn
 - [ ] Unit tests cover tool bridging, auth, model routing
 - [ ] E2E skill exists for manual smoke-testing against a live server
 - [ ] Mock LLM tests cover the happy path without real API calls
@@ -137,6 +131,7 @@ Omnigent. They relay the vendor's conversation into the Omnigent session.
 | **Compaction** | Vendor-internal compaction status |
 | **Reasoning** | Model reasoning/thinking tokens are forwarded |
 | **Images** | Image content is forwarded — path reference, full binary, or text-flattened |
+| **Cost tracking** | Native harness reports token usage and cost data back to Omnigent for each turn |
 
 ### Checklist for a new native harness
 
@@ -156,6 +151,7 @@ All capabilities are **required** for a complete native harness integration:
 - [ ] Compaction status is surfaced
 - [ ] Reasoning tokens are forwarded
 - [ ] Images are forwarded (path preferred; binary or text-flattened acceptable)
+- [ ] Cost tracking reports token usage and cost per turn
 - [ ] Unit tests cover forwarder, auth, transport
 - [ ] E2E skill exists for manual smoke-testing against a live server
 - [ ] Mock LLM tests cover the happy path without real API calls


### PR DESCRIPTION
## Summary
- Adds a new `.claude/skills/harness-integration-guide` skill that documents the full harness feature matrix, implementation patterns (transport, MCP, policies, resume/fork, auth), and a prioritized checklist for building new integrations.
- Sourced from the team's [harness feature matrix spreadsheet](https://docs.google.com/spreadsheets/d/1TAfjAUzBK9f_s0T81JeDcQr0kXRVsQ5wJ-GOirwzH6I/edit?gid=1955804515#gid=1955804515).

## Test plan
- [ ] Verify `/harness-integration-guide` loads the skill content in Claude Code
- [ ] Confirm the capability matrix, implementation patterns, and checklist are accurate

This pull request and its description were written by Isaac.