### PR TITLE
feat(harness): add cursor-cloud harness (Cursor Cloud / Background Agents) (#1148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ omnigent run examples/scribe/
 omnigent run examples/polly/ --harness pi
 omnigent run examples/debby/ --harness openai-agents
 omnigent run examples/polly/ --harness cursor  # Cursor CLI (needs cursor-agent + CURSOR_API_KEY)
+omnigent run examples/polly/ --harness cursor-cloud # Cursor Cloud / background agents (runs in Cursor's cloud against the repo's GitHub remote, opens a PR; needs CURSOR_API_KEY + a dashboard-onboarded repo)
 omnigent run examples/polly/ --harness copilot # GitHub Copilot SDK (needs a GitHub token w/ Copilot, e.g. GH_TOKEN)
 ```
 
@@ -384,7 +385,7 @@ name: my_agent
 prompt: You are a helpful data analyst.
 
 executor:
-  harness: claude-sdk          # or: claude-native, codex, codex-native, cursor, cursor-native, kiro-native, openai-agents, pi, pi-native, antigravity, qwen, kimi, copilot
+  harness: claude-sdk          # or: claude-native, codex, codex-native, cursor, cursor-cloud, cursor-native, kiro-native, openai-agents, pi, pi-native, antigravity, qwen, kimi, copilot
 
 tools:
   # A local Python function (schema auto-generated from the signature)

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -49,7 +49,7 @@ resolved from the YAML file's directory.
 
 ```yaml
 executor:
-  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, kiro-native, pi, antigravity, qwen, kimi, copilot, hermes, ...
+  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, cursor-cloud, kiro-native, pi, antigravity, qwen, kimi, copilot, hermes, ...
   model: databricks-claude-opus-4-7
   auth:
     type: databricks
@@ -65,6 +65,18 @@ gateway / `auth.type: databricks` does not apply. Authenticate it with
 `CURSOR_API_KEY` (or a prior `cursor-agent login`), optionally pinned via
 `auth: {type: api_key, api_key: ${CURSOR_API_KEY}}`, and choose a Cursor model
 id (e.g. `auto`, `gpt-5`) rather than a `databricks-*` id.
+
+The `cursor-cloud` harness runs a **Cursor Cloud / Background Agent**: instead
+of editing the local working tree, it launches an agent in Cursor's cloud that
+clones a GitHub repository, works autonomously, and pushes a branch / opens a
+PR. It shares the `cursor` `CURSOR_API_KEY` auth and uses a cloud model id
+(default `composer-2.5`). The repository + starting ref default to the session
+directory's `origin` git remote and current branch (override with the
+`OMNIGENT_CURSOR_CLOUD_REPO` / `OMNIGENT_CURSOR_CLOUD_REF` env vars). One-time
+per-repo environment setup must be done in the Cursor dashboard first
+(`https://cursor.com/onboard?repository=<url>`) — there is no API to trigger it.
+v1 is launch + live stream + result/PR; follow-up, cancel, and multi-repo are
+not yet supported.
 
 The `kiro-native` harness is the native Kiro CLI terminal path used by
 `omnigent kiro`. It requires `kiro-cli` on `PATH` and Kiro's own login/auth; it

--- a/docs/plans/2026-06-25-001-feat-cursor-cloud-agents-harness-plan.md
+++ b/docs/plans/2026-06-25-001-feat-cursor-cloud-agents-harness-plan.md
@@ -1,0 +1,348 @@
+---
+title: "feat: Add cursor-cloud harness (Cursor Cloud / Background Agents)"
+type: feat
+date: 2026-06-25
+issue: https://github.com/omnigent-ai/omnigent/issues/1148
+depth: deep
+status: ready
+---
+
+# feat: Add `cursor-cloud` Harness — Cursor Cloud / Background Agents
+
+## Summary
+
+Omnigent integrates Cursor in two local-only flavors today: `cursor` (the SDK/headless harness driving a local `cursor-agent` over a bridge) and `cursor-native` (the resident TUI mirror). Issue #1148 asks for **Cursor Cloud / Background Agents** — agents that run in Cursor's cloud VMs against a GitHub repo and push a branch / open a PR, rather than editing the local filesystem.
+
+This plan adds a new `cursor-cloud` harness. The `cursor-sdk` Python package already vendored for the `cursor` harness exposes cloud through the **same** `AsyncClient.launch_bridge` client via `AgentOptions(cloud=CloudAgentOptions(repos=[...]))`. The harness launches a cloud run from a user prompt, streams the run's SSE events back as live Omnigent conversation events, and resolves the turn with the agent's result summary plus the branch/PR link.
+
+v1 is deliberately minimal: **launch → live stream → result/PR**, one cloud run per turn. No follow-up/cancel/list/archive/artifacts/multi-repo in the first PR.
+
+---
+
+## Problem Frame
+
+- **Who:** Omnigent users who want to dispatch long-running, parallel, isolated coding agents that produce merge-ready PRs — without tying up their local machine (the value Cursor Cloud adds over the local `cursor` harness).
+- **Today:** Both existing Cursor harnesses run on the local machine, operate on the local cwd, and require the machine to stay running. There is no path to Cursor's cloud runtime.
+- **Gap:** Cloud agents have a fundamentally different execution model — remote VM, GitHub-repo-scoped, branch/PR output, fire-and-forget — that none of the local harness machinery (tool-bridge, `preToolUse` policy hook, local-cwd file edits) maps onto.
+- **Goal:** A `cursor-cloud` harness that launches a cloud run, streams progress, and surfaces the resulting branch/PR, reusing the existing Cursor API-key auth and the vendored `cursor-sdk`.
+
+---
+
+## Requirements
+
+- **R1.** A new harness selectable as `cursor-cloud` (registry, CLI choices, spec allowlist, routing).
+- **R2.** A turn launches a Cursor cloud run via `cursor-sdk` `CloudAgentOptions` against a GitHub repo + starting ref.
+- **R3.** Repo + ref default to the conversation cwd's git `origin` remote and current branch, with explicit `--repo` / `--ref` override.
+- **R4.** The run's SSE events stream live into Omnigent as conversation events (assistant text, reasoning/thinking, tool-call info); the turn resolves with the result summary and branch/PR link.
+- **R5.** Auth reuses the existing Cursor `crsr_` API key / `cursor` secret — no new credential surface.
+- **R6.** Model selection flows through Omnigent's existing per-harness model-env + `/model` override path, with a cloud-appropriate default.
+- **R7.** A never-onboarded repo (no Cursor dashboard env setup) produces a clear, actionable error rather than an opaque hang/failure.
+- **R8.** Out of v1 scope: follow-up prompts, cancel/interrupt of a live run, list/archive, artifact download, multi-repo, env-var injection, custom subagents, webhooks.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Use `cursor-sdk`'s `CloudAgentOptions`, not raw REST.** The official Python `cursor-sdk` exposes cloud through the same package and client as the local path (`from cursor_sdk import CloudAgentOptions, CloudRepository, AgentOptions`; `AgentOptions(cloud=...)`). It is already a vendored optional extra (`omnigent[cursor]`). A raw `httpx` REST client against `api.cursor.com/v1/agents` would duplicate auth, SSE parsing, and model handling the SDK already provides. *(External research load-bearing — confirmed SDK cloud support; see Sources.)*
+- **KTD2 — New `cursor-cloud` harness key, not a mode-flag on `cursor`.** Although `launch_bridge` is shared, the cloud runtime breaks the local `cursor` executor's core assumptions: no Omnigent custom-tool bridge, no `preToolUse` policy hook, no local-cwd edits, output is a remote branch/PR. Folding a `cloud=True` branch into `CursorExecutor` would entangle two execution models. A separate executor keeps each clean.
+- **KTD3 — Reuse the existing Cursor API key / `cursor` secret.** The same `crsr_` key authenticates both local and cloud. The harness consumes it via the established spawn-env precedence (spec `ApiKeyAuth` → `resolve_cursor_api_key()` → ambient `CURSOR_API_KEY`). No new `cursor_cloud_auth.py`.
+- **KTD4 — `handles_tools_internally=True`, `supports_streaming=True`, no tool-bridge.** Tools execute in Cursor's cloud VM; Omnigent does not execute them. `tool_call` SSE events surface as informational `ToolCallRequest`/`ToolCallComplete`. The `tools` arg to `run_turn` is ignored.
+- **KTD5 — Resolve repo/ref at the spawn-env layer.** `workflow._build_cursor_cloud_spawn_env` reads the cwd `origin` remote + current branch (overridable by `--repo`/`--ref`) and passes them as `HARNESS_CURSOR_CLOUD_REPO`/`_REF`. Keeps git access on the runner side and the executor pure w.r.t. config.
+- **KTD6 — `auto_create_pr=True` by default; turn blocks until terminal with heartbeat tolerance.** The PR link is the core deliverable, so request it by default. The turn awaits `run.wait()` (terminal `FINISHED|ERROR|CANCELLED|EXPIRED`); SSE `heartbeat` events keep a long run alive. Interrupt/cancel is out of v1 scope, so `interrupt_session` returns `False`.
+- **KTD7 — Minimal v1 surface (R8).** One run per turn. Multi-turn follow-up would map a second turn to `agent.send()` on the same agent, but that is deferred to keep the first PR reviewable.
+
+---
+
+## High-Level Technical Design
+
+### Turn lifecycle (launch → stream → result)
+
+```mermaid
+sequenceDiagram
+    participant U as Omnigent (Session)
+    participant H as cursor_cloud_harness (create_app)
+    participant E as CursorCloudExecutor
+    participant SDK as cursor-sdk AsyncClient
+    participant C as Cursor Cloud (api.cursor.com)
+
+    U->>E: run_turn(messages, tools, system_prompt)
+    E->>SDK: launch_bridge() / agents.create(AgentOptions(cloud=CloudAgentOptions(repos=[repo@ref], auto_create_pr=True)))
+    E->>SDK: agent.send(prompt)
+    SDK->>C: POST /v1/agents + run
+    loop SSE run.events()
+        C-->>SDK: status / assistant / thinking / tool_call / heartbeat
+        SDK-->>E: event
+        E-->>U: TextChunk / ReasoningChunk / ToolCallRequest
+    end
+    C-->>SDK: result (FINISHED, git.branches[].pr_url)
+    SDK-->>E: run.wait() -> RunResult
+    E-->>U: TurnComplete(response=summary + branch/PR link, usage)
+```
+
+### Where it plugs into the harness wiring
+
+```mermaid
+flowchart LR
+    CLI["CLI / spec\n(cursor-cloud selected)"] --> REG["_HARNESS_MODULES\n'cursor-cloud'"]
+    REG --> SPAWN["workflow._build_cursor_cloud_spawn_env\n(repo/ref/model/api_key -> HARNESS_CURSOR_CLOUD_*)"]
+    SPAWN --> DISPATCH["runner/app dispatch\nelif harness == 'cursor-cloud'"]
+    DISPATCH --> APP["cursor_cloud_harness.create_app()\nExecutorAdapter"]
+    APP --> EXE["CursorCloudExecutor.run_turn"]
+    AUTH["onboarding: reuse cursor crsr_ key\nharness_readiness / install / setup wizard"] -.-> SPAWN
+    MODEL["_HARNESS_MODEL_ENV_KEY\nmodel_override._SDK_MODEL_OVERRIDE_HARNESSES"] -.-> SPAWN
+```
+
+*Both diagrams render the intended design; prose in the units below is authoritative on disagreement.*
+
+---
+
+## Output Structure
+
+New files (existing files are modified in place, listed per unit):
+
+```
+omnigent/inner/
+  cursor_cloud_executor.py     # CursorCloudExecutor (SDK cloud launch + SSE mapping)
+  cursor_cloud_harness.py      # thin create_app() wrap + HARNESS_CURSOR_CLOUD_* contract
+omnigent/
+  cursor_cloud_repo.py         # cwd-remote + override repo/ref resolution helper
+tests/inner/
+  test_cursor_cloud_executor.py
+  test_cursor_cloud_harness.py
+tests/
+  test_cursor_cloud_repo.py
+tests/runtime/
+  test_cursor_cloud_spawn_env.py
+tests/e2e/omnigent/
+  test_per_harness_cursor_cloud.py
+```
+
+---
+
+## Implementation Units
+
+### U1. CursorCloudExecutor + harness wrap
+
+**Goal:** The core executor: launch a cloud run via `cursor-sdk`, map SSE events to `ExecutorEvent`s, resolve the turn with summary + branch/PR link. Plus the thin `create_app()` wrap and its env-var contract.
+
+**Requirements:** R2, R4, R6 (consumes model), R7.
+
+**Dependencies:** U2 (repo/ref reach the executor via env, but the executor only reads them — author U1 against the env contract; U2 produces the values).
+
+**Files:**
+- `omnigent/inner/cursor_cloud_executor.py` (new)
+- `omnigent/inner/cursor_cloud_harness.py` (new)
+- `pyproject.toml` (bump `cursor = ["cursor-sdk>=…"]` only if cloud absent at the pinned floor)
+- `tests/inner/test_cursor_cloud_executor.py` (new)
+- `tests/inner/test_cursor_cloud_harness.py` (new)
+
+**Approach:**
+- Mirror `CursorExecutor` / `cursor_harness.py` structure: `Executor` subclass + `ExecutorAdapter(executor_factory=…, harness_label="Cursor Cloud")`.
+- `run_turn`: lazily import `cursor_sdk` (optional extra → request-time `ImportError`), build `AgentOptions(model=…, cloud=CloudAgentOptions(repos=[CloudRepository(url, starting_ref)], auto_create_pr=True))`, `agent.send(prompt)`, async-iterate `run.events()` mapping: `assistant`→`TextChunk`, `thinking`→`ReasoningChunk`, `tool_call`→`ToolCallRequest`, `heartbeat`→no-op keep-alive, `error`→`ExecutorError`. Await `run.wait()`; emit `TurnComplete(response=summary + formatted branch/PR link, usage=…)`.
+- The prompt is the latest user message text; ignore `tools` (cloud runs its own).
+- Capability flags: `supports_streaming=True`, `supports_tool_calling=True`, `handles_tools_internally=True`, `supports_live_message_queue=False`. `interrupt_session` → `False` (cancel deferred).
+- Env contract in the wrap: `HARNESS_CURSOR_CLOUD_MODEL`, `_API_KEY`, `_REPO`, `_REF`, `_CWD`, `_OS_ENV` (mirror `cursor_harness.py` defaults).
+- R7: if the launch/first run fails with a "repo not set up"-class error, raise/emit an `ExecutorError` whose message names the dashboard onboarding URL (`https://cursor.com/onboard?repository=<url>`).
+
+**Verified SDK surface (`cursor-sdk==0.1.7`, introspected 2026-06-25 — no pin bump needed):**
+- Cloud client: `cursor_sdk.AsyncClient(base_url="https://api.cursor.com", auth_token=<crsr_ key>)` (or `AsyncClient.connect(base_url, auth_token)`). No default base_url constant — pass it explicitly. `allow_api_key_env_fallback` reads `CURSOR_API_KEY`.
+- Launch: `agent = await client.create_agent(cloud=CloudAgentOptions(repos=[CloudRepository(url=…, starting_ref=…)], auto_create_pr=True), model=…, api_key=…)` → returns `AsyncAgent`. Then `run = await agent.send(prompt)` → returns `AsyncRun`.
+- Stream: `async for ev in run.events()` yields `RunStreamEvent(kind: str, offset, sdk_message, result, done, interaction_update, step, result_is_full)`. `sdk_message` carries the same `SDKMessage` family the local harness already maps (`SDKAssistantMessage`, `SDKThinkingMessage`, `SDKToolUseMessage`, `SDKStatusMessage`). Terminal `ev.result` carries the `RunResult`; `ev.done` flags completion.
+- Terminal: `result = await run.wait()` → `RunResult(id, agent_id, status, result, model, duration_ms, git, created_at)`. `result.git` is `RunGitInfo(branches=[RunGitBranchInfo(repo_url, branch, pr_url)])` or `None`.
+- **Reuse the local executor's helpers** — `_sdk_message_to_events`, `_resolve_model`, `_normalize_cursor_usage`, `_latest_user_text` in `omnigent/inner/cursor_executor.py` already map `SDKMessage`→`ExecutorEvent` and normalize usage. Extract/share them rather than reimplementing; the cloud executor differs only in client/agent construction and `RunResult.git`→PR-link formatting.
+
+**Execution note:** `cursor-sdk==0.1.7` import already verified — cloud symbols present. Start from a failing test asserting a launched run's `RunStreamEvent` sequence maps to the expected `ExecutorEvent` stream (SDK client mocked).
+
+**Patterns to follow:** `omnigent/inner/cursor_executor.py` (SDK client lifecycle, `_close_*` helpers, usage extraction), `omnigent/inner/cursor_harness.py` (env-var resolution + `ExecutorAdapter`), `iterate_blocking_stream` if the SDK stream is sync.
+
+**Test scenarios:**
+- Happy path: mocked client yields `status, assistant("Hello"), tool_call(edit), result(FINISHED, branch=cursor/x, pr_url=…)` → executor yields `TextChunk("Hello")`, a `ToolCallRequest`, then `TurnComplete` whose response contains the PR URL.
+- Reasoning: `thinking` deltas → `ReasoningChunk(event_type="reasoning_text")`.
+- Heartbeat-only gaps between events do not terminate the turn or emit spurious events.
+- Terminal `ERROR` event → `ExecutorError(retryable=False)` with the provider message.
+- "Repo not set up" launch failure → `ExecutorError` whose message includes the onboarding URL (R7).
+- `result.git` is `None` / `pr_url` is `None` (autoCreatePR produced no PR) → `TurnComplete` still resolves, response notes the branch only.
+- Missing `cursor_sdk` import → request-time `ImportError` surfaced as a clean executor error, not an app-boot crash.
+- Wrap: env vars absent → documented defaults; `HARNESS_CURSOR_CLOUD_MODEL` set → forwarded to `AgentOptions.model`.
+
+**Verification:** Unit tests pass with a mocked `cursor-sdk`; `create_app()` builds a FastAPI app without a live SDK; a launched run with `auto_create_pr` surfaces a PR link in the final response.
+
+---
+
+### U2. Repo/ref resolution helper
+
+**Goal:** Resolve the GitHub repo URL + starting ref a cloud run targets: default to the cwd `origin` remote + current branch, overridable explicitly.
+
+**Requirements:** R3.
+
+**Dependencies:** none.
+
+**Files:**
+- `omnigent/cursor_cloud_repo.py` (new)
+- `tests/test_cursor_cloud_repo.py` (new)
+
+**Approach:**
+- Pure function(s): given a cwd and optional `repo`/`ref` overrides, return a normalized `(repo_url, ref)`. Read `git remote get-url origin` and `git rev-parse --abbrev-ref HEAD` from the cwd when overrides are absent.
+- Normalize SSH (`git@github.com:org/repo.git`) and HTTPS (`https://github.com/org/repo.git`) remotes to the `https://github.com/org/repo` form the Cursor API expects; strip `.git`.
+- Override precedence: explicit `repo`/`ref` win over cwd-derived values.
+- Raise a clear error when no override is given and cwd is not a git repo / has no `origin`.
+
+**Patterns to follow:** existing cwd/git handling in `omnigent/cursor_native.py` (`resolve_*`), runner cwd plumbing.
+
+**Test scenarios:**
+- HTTPS origin → normalized `https://github.com/org/repo`, `.git` stripped.
+- SSH origin (`git@github.com:org/repo.git`) → same normalized HTTPS form.
+- Current branch detected via `rev-parse` → used as ref when no override.
+- Explicit `repo`/`ref` override beats cwd values.
+- cwd has no git repo and no override → clear, named error.
+- Non-GitHub remote (e.g. GitLab) → passes through normalized (API supports it) but is recorded; no crash.
+
+**Verification:** Helper returns correct `(url, ref)` for each remote shape; override precedence holds; missing-remote error is explicit.
+
+---
+
+### U3. Register `cursor-cloud` (registry, routing, aliases, spec allowlist)
+
+**Goal:** Make `cursor-cloud` a first-class selectable harness so the runner resolves and serves it.
+
+**Requirements:** R1.
+
+**Dependencies:** U1 (registry value must point at a real module).
+
+**Files:**
+- `omnigent/runtime/harnesses/__init__.py` (add `"cursor-cloud": "omnigent.inner.cursor_cloud_harness"` to `_HARNESS_MODULES`)
+- `omnigent/spec/_omnigent_compat.py` (`OMNIGENT_HARNESSES`, `OMNIGENT_HARNESS_ALIASES`)
+- `omnigent/harness_aliases.py` (`HARNESS_ALIASES`; **not** `NATIVE_HARNESSES` — cloud has no TUI/terminal)
+- tests: extend the relevant existing registry/spec tests.
+
+**Approach:** Pure registration. Routing (`runner/routing.py`) and the process manager pick up `_HARNESS_MODULES` additions automatically — no edits there. Do not add to `NATIVE_HARNESSES` or native-coding-agent metadata; `cursor-cloud` is not a terminal takeover.
+
+**Test scenarios:**
+- `cursor-cloud` resolves through routing to its harness module.
+- Spec allowlist accepts `cursor-cloud` as a valid `executor.harness`.
+- It is absent from `NATIVE_HARNESSES`.
+
+**Verification:** A spec / CLI selection of `cursor-cloud` resolves to `cursor_cloud_harness` without error.
+
+---
+
+### U4. Spawn-env builder + dispatch + model wiring
+
+**Goal:** Translate the selected harness + config into the `HARNESS_CURSOR_CLOUD_*` env the wrap reads, including resolved repo/ref and model.
+
+**Requirements:** R2, R3, R5, R6.
+
+**Dependencies:** U1 (env contract), U2 (repo/ref resolution), U3 (harness registered).
+
+**Files:**
+- `omnigent/runtime/workflow.py` (new `_build_cursor_cloud_spawn_env`, mirroring `_build_cursor_spawn_env`)
+- `omnigent/runner/app.py` (dispatch `elif harness == "cursor-cloud"`; `_HARNESS_MODEL_ENV_KEY` add `"cursor-cloud": "HARNESS_CURSOR_CLOUD_MODEL"`)
+- `omnigent/model_override.py` (add `cursor-cloud` to `_SDK_MODEL_OVERRIDE_HARNESSES`)
+- `tests/runtime/test_cursor_cloud_spawn_env.py` (new)
+
+**Approach:**
+- `_build_cursor_cloud_spawn_env`: API-key precedence identical to `_build_cursor_spawn_env` (spec `ApiKeyAuth` → `resolve_cursor_api_key()` → ambient). Call U2's resolver with the conversation cwd + any `--repo`/`--ref` to populate `HARNESS_CURSOR_CLOUD_REPO`/`_REF`. Forward model + os_env.
+- Dispatch branch wires the builder into the runner spawn path.
+- Model-env-key + `model_override` keep `/model` overrides landing in `HARNESS_CURSOR_CLOUD_MODEL`; pick a cloud-appropriate default model (e.g. `composer-2.5` / `auto`) when unset; drop a `databricks-*` id authored for another harness.
+
+**Test scenarios:**
+- Builder emits `HARNESS_CURSOR_CLOUD_{API_KEY,MODEL,REPO,REF,CWD}` from a spec + cwd.
+- API-key precedence: spec key beats stored beats ambient.
+- `--repo`/`--ref` override flows into the env; absent → cwd-derived (via U2).
+- `/model` override for `cursor-cloud` lands in `HARNESS_CURSOR_CLOUD_MODEL`.
+- A `databricks-*` model id is dropped, not forwarded.
+
+**Verification:** Spawning `cursor-cloud` yields a child env with a resolved repo/ref, API key, and model; `/model` override round-trips.
+
+---
+
+### U5. Onboarding: reuse Cursor auth, readiness, install, CLI surface
+
+**Goal:** Make `cursor-cloud` set-up-able and visible: it is "ready" when the Cursor API key is configured, installable via the `omnigent[cursor]` extra, and selectable in CLI choices / setup wizard.
+
+**Requirements:** R1, R5.
+
+**Dependencies:** U3.
+
+**Files:**
+- `omnigent/onboarding/harness_readiness.py` (a `cursor-cloud` branch → `cursor_api_key_configured()`; register the spelling in the readiness set)
+- `omnigent/onboarding/harness_install.py` (`_HARNESS_INSTALL` / `_HARNESS_FAMILY` — reuse the Cursor `omnigent[cursor]` extra)
+- `omnigent/cli.py` (`_HARNESS_CHOICES_HELP` / `_DEFAULT_HARNESS_PROMPTS`; setup-wizard manager — reuse Cursor's key management since the secret is shared)
+- tests: extend `tests/onboarding/test_*` for the new readiness/install entries.
+
+**Approach:** No new secret. Readiness reuses `cursor_api_key_configured()`. Install reuses the `cursor` family extra. CLI choices gain a `cursor-cloud` line describing "cloud / background agents (GitHub repo → PR)". The setup wizard routes `cursor-cloud` management to the existing Cursor key flow (or notes "shares the Cursor API key").
+
+**Test scenarios:**
+- Readiness reports `cursor-cloud` ready iff the Cursor API key is configured.
+- Install spec maps `cursor-cloud` to the `omnigent[cursor]` extra.
+- CLI harness choices include `cursor-cloud` with cloud-specific help text.
+
+**Verification:** `cursor-cloud` appears in harness choices; readiness reflects Cursor key presence; install points at the right extra.
+
+---
+
+### U6. Behavioral e2e + docs
+
+**Goal:** Prove the end-to-end harness contract with a per-harness behavioral test and document the new harness.
+
+**Requirements:** R4, R7 (error surfacing), R8 (documented scope boundary).
+
+**Dependencies:** U1–U5.
+
+**Files:**
+- `tests/e2e/omnigent/test_per_harness_cursor_cloud.py` (new, mirroring `test_per_harness_cursor.py`)
+- docs: a short `cursor-cloud` section wherever harness docs live (e.g. the harness list / `designs/` or README harness table) noting the GitHub + dashboard-onboarding prerequisite.
+
+**Approach:** Behavioral e2e with the SDK boundary mocked (no live cloud calls in CI): drive a turn through the harness app and assert the streamed events + final PR-bearing response. Document the env-setup prerequisite (R7) and the v1 scope boundary (R8).
+
+**Execution note:** Live cloud calls are not run in CI — keep the e2e at the mocked-SDK boundary. Manual live verification is a release-time step, not a gate.
+
+**Test scenarios:**
+- e2e: a turn against the harness app with a mocked cloud run streams assistant text and resolves with a PR link.
+- e2e: "repo not set up" path surfaces the onboarding-URL error (R7).
+
+**Verification:** e2e passes against the mocked SDK; docs describe prerequisites and scope.
+
+---
+
+## System-Wide Impact
+
+- **Runner / workflow:** one new spawn-env builder + one dispatch branch; routing and process-manager pick up the registry entry automatically.
+- **Onboarding:** no new secret — reuses the Cursor key, so the credential surface is unchanged.
+- **Users:** a new harness option; the only novel prerequisite is a GitHub-connected, dashboard-onboarded repo.
+- **CI:** new unit/e2e tests at the mocked-SDK boundary; per the contribution notes, avoid coupling new coverage to the live-e2e gate.
+
+---
+
+## Risk Analysis & Mitigation
+
+- **Env-setup gap (high).** A repo never set up in Cursor's dashboard cannot be launched programmatically — no API/SDK trigger exists (confirmed by Cursor). *Mitigation:* R7 — detect the failure and surface the `cursor.com/onboard?repository=…` URL; document the prerequisite (U6).
+- **`cursor-sdk` cloud is public beta (medium).** API/SDK shapes may shift. *Mitigation:* isolate all SDK contact in `CursorCloudExecutor`; pin/track the version; the U1 import check catches a stale pin early.
+- **Long-running turns (medium).** Cloud runs can be slow; the turn blocks until terminal. *Mitigation:* rely on SSE `heartbeat` to keep the stream alive; cancel/interrupt deferred (KTD6) — document that a launched run continues server-side even if the turn is abandoned.
+- **API-key entitlement (low/medium).** The `crsr_` key may need cloud entitlement / a connected GitHub account distinct from local use. *Mitigation:* surface auth/permission errors verbatim; note the GitHub-connection requirement in docs.
+- **Pin uncertainty (low).** Cloud likely present at `>=0.1.7` but unverified against PyPI. *Mitigation:* U1 execution-note import check; bump if needed.
+
+---
+
+## Scope Boundaries
+
+**In scope (v1):** new `cursor-cloud` harness; launch one cloud run per turn via `cursor-sdk` `CloudAgentOptions`; live SSE streaming → Omnigent events; result summary + branch/PR link; cwd-remote repo/ref with `--repo`/`--ref` override; Cursor-key auth reuse; model resolution + `/model` override; env-setup-gap error surfacing.
+
+### Deferred to Follow-Up Work
+- Multi-turn follow-up prompts (`agent.send()` on a persisted agent across turns).
+- Cancel/interrupt of a live cloud run (`interrupt_session` → cancel endpoint).
+- List / archive / delete agents; artifact download; usage endpoint.
+- Multi-repo runs (API allows ≤20), `customSubagents`, `envVars` injection, `mcpServers`, `mode: plan`.
+- Webhooks (v0-only today) and any non-blocking/background completion model.
+- Programmatic first-time repo env setup (blocked upstream — no API exists).
+
+---
+
+## Sources & Research
+
+- Cursor Cloud Agents API — endpoints, SSE event types, run states, `git.branches[].pr_url`: https://cursor.com/docs/cloud-agent/api/endpoints
+- Cursor Python SDK (`cursor-sdk`) — `AsyncClient.launch_bridge`, `AgentOptions`, `CloudAgentOptions`, `CloudRepository`, `run.events()` / `run.wait()`: https://cursor.com/docs/sdk/python
+- Cursor APIs overview / auth (`crsr_`, Basic/Bearer, `api.cursor.com`): https://cursor.com/docs/api
+- Env-setup-gap confirmation (manual dashboard onboarding required): Cursor forum, June 2026.
+- Repo references: `omnigent/inner/cursor_executor.py`, `omnigent/inner/cursor_harness.py`, `omnigent/runtime/harnesses/__init__.py` (`_HARNESS_MODULES`), `omnigent/runtime/workflow.py` (`_build_cursor_spawn_env`), `omnigent/onboarding/cursor_auth.py`, `omnigent/onboarding/copilot_auth.py` (API-key auth template), `omnigent/inner/opencode_native_executor.py` (native-server reference, considered and rejected per KTD2).
+- Issue: https://github.com/omnigent-ai/omnigent/issues/1148 (no existing PR as of 2026-06-25; `nethum529` expressed intent to take it).

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10895,12 +10895,6 @@ def _run_configure_harnesses_interactive() -> None:
     # is outside the anthropic/openai machinery), so it dispatches to its own
     # credential manager rather than ``_manage_harness_providers``.
     _ANTIGRAVITY = "\x00antigravity"
-    # Sentinel marking the Cursor Cloud row — Cursor Cloud / Background Agents
-    # run in Cursor's cloud against a GitHub repo via the same ``cursor-sdk`` and
-    # the same ``CURSOR_API_KEY`` as the SDK Cursor harness, so it dispatches to
-    # the shared Cursor key flow (``_manage_cursor_harness``) rather than a
-    # separate credential of its own.
-    _CURSOR_CLOUD = "\x00cursor-cloud"
     # Sentinel marking the Qwen Code row — like Antigravity/Cursor it is not a
     # provider family (its v1 auth is the CLI's own env vars / ``/auth`` flow,
     # not an Omnigent credential), so it dispatches to its own drill-in.
@@ -11001,22 +10995,10 @@ def _run_configure_harnesses_interactive() -> None:
             options.append(f"  {cursor_sub}")
             selectable.append(False)
             row_target.append(None)
-        # Cursor Cloud / Background Agents: runs in Cursor's cloud against a
-        # GitHub repo (opens a PR) via the same ``cursor-sdk`` and the same
-        # ``CURSOR_API_KEY`` as the SDK Cursor harness — no separate secret. So
-        # readiness mirrors Cursor's (the shared key), and its row dispatches to
-        # the same key flow.
-        options.append(f"{'  ' if cursor_key_set else '[red]✗[/] '}Cursor Cloud")
-        selectable.append(True)
-        row_target.append(_CURSOR_CLOUD)
-        cursor_cloud_sub = (
-            "[green]✓[/] shares the Cursor API key"
-            if cursor_key_set
-            else "[dim]shares the Cursor API key — open to add one[/]"
-        )
-        options.append(f"  {cursor_cloud_sub}")
-        selectable.append(False)
-        row_target.append(None)
+        # NB: the ``cursor-cloud`` harness (Cursor Cloud / Background Agents)
+        # shares this same ``CURSOR_API_KEY`` and has no separate credential, so
+        # it intentionally has no row of its own here — configuring Cursor above
+        # configures it too. It remains selectable via ``--harness cursor-cloud``.
         # Antigravity (Gemini-native, no provider family): like Cursor, readiness
         # is just whether a Gemini key is configured (``antigravity:`` block or
         # ambient env); its drill-in manages that key. Vertex specs need no key,
@@ -11241,9 +11223,6 @@ def _run_configure_harnesses_interactive() -> None:
             return
         target = row_target[idx]
         if target == CURSOR_KEY:
-            _manage_cursor_harness()
-        elif target == _CURSOR_CLOUD:
-            # Cursor Cloud shares the Cursor API key — route to the same flow.
             _manage_cursor_harness()
         elif target == COPILOT_KEY:
             _manage_copilot_harness()

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5408,7 +5408,8 @@ def resume(
 # into a materialized copy of the spec before the server starts.
 _HARNESS_CHOICES_HELP = (
     "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
-    "'cursor', 'kimi', "
+    "'cursor', 'cursor-cloud' (Cursor Cloud / background agents — runs in "
+    "Cursor's cloud against a GitHub repo, opens a PR), 'kimi', "
     "'openai-agents', 'open-responses', 'pi', 'antigravity', 'qwen', 'goose', or 'copilot'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."
@@ -5440,6 +5441,10 @@ _DEFAULT_HARNESS_PROMPTS = {
     ),
     "cursor": (
         "You are Cursor, running through Omnigent. Help the user with software engineering tasks."
+    ),
+    "cursor-cloud": (
+        "You are a Cursor Cloud background agent, running through Omnigent. "
+        "Help the user with software engineering tasks."
     ),
     "kimi": (
         "You are Kimi Code, running through Omnigent. "
@@ -10890,6 +10895,12 @@ def _run_configure_harnesses_interactive() -> None:
     # is outside the anthropic/openai machinery), so it dispatches to its own
     # credential manager rather than ``_manage_harness_providers``.
     _ANTIGRAVITY = "\x00antigravity"
+    # Sentinel marking the Cursor Cloud row — Cursor Cloud / Background Agents
+    # run in Cursor's cloud against a GitHub repo via the same ``cursor-sdk`` and
+    # the same ``CURSOR_API_KEY`` as the SDK Cursor harness, so it dispatches to
+    # the shared Cursor key flow (``_manage_cursor_harness``) rather than a
+    # separate credential of its own.
+    _CURSOR_CLOUD = "\x00cursor-cloud"
     # Sentinel marking the Qwen Code row — like Antigravity/Cursor it is not a
     # provider family (its v1 auth is the CLI's own env vars / ``/auth`` flow,
     # not an Omnigent credential), so it dispatches to its own drill-in.
@@ -10990,6 +11001,22 @@ def _run_configure_harnesses_interactive() -> None:
             options.append(f"  {cursor_sub}")
             selectable.append(False)
             row_target.append(None)
+        # Cursor Cloud / Background Agents: runs in Cursor's cloud against a
+        # GitHub repo (opens a PR) via the same ``cursor-sdk`` and the same
+        # ``CURSOR_API_KEY`` as the SDK Cursor harness — no separate secret. So
+        # readiness mirrors Cursor's (the shared key), and its row dispatches to
+        # the same key flow.
+        options.append(f"{'  ' if cursor_key_set else '[red]✗[/] '}Cursor Cloud")
+        selectable.append(True)
+        row_target.append(_CURSOR_CLOUD)
+        cursor_cloud_sub = (
+            "[green]✓[/] shares the Cursor API key"
+            if cursor_key_set
+            else "[dim]shares the Cursor API key — open to add one[/]"
+        )
+        options.append(f"  {cursor_cloud_sub}")
+        selectable.append(False)
+        row_target.append(None)
         # Antigravity (Gemini-native, no provider family): like Cursor, readiness
         # is just whether a Gemini key is configured (``antigravity:`` block or
         # ambient env); its drill-in manages that key. Vertex specs need no key,
@@ -11214,6 +11241,9 @@ def _run_configure_harnesses_interactive() -> None:
             return
         target = row_target[idx]
         if target == CURSOR_KEY:
+            _manage_cursor_harness()
+        elif target == _CURSOR_CLOUD:
+            # Cursor Cloud shares the Cursor API key — route to the same flow.
             _manage_cursor_harness()
         elif target == COPILOT_KEY:
             _manage_copilot_harness()

--- a/omnigent/cursor_cloud_repo.py
+++ b/omnigent/cursor_cloud_repo.py
@@ -1,0 +1,156 @@
+"""Repo/ref resolution for the ``cursor-cloud`` harness.
+
+A Cursor Cloud / Background Agent runs in a fresh cloud VM that clones a
+**GitHub-hosted** repository at a starting ref — it never touches the local
+working tree. So unlike the local ``cursor`` harness (which operates on the
+session ``cwd``), the cloud harness needs a *remote URL + ref* to launch.
+
+This module resolves that pair:
+
+- **Default:** the ``origin`` remote URL and current branch of the session
+  ``cwd`` (so "run a cloud agent here" targets the repo you're sitting in).
+- **Override:** an explicit repo URL and/or ref wins over the cwd-derived
+  values (so you can target any connected repo without changing directory).
+
+The resolved URL is normalized to the ``https://github.com/<org>/<repo>`` form
+the Cursor API expects, accepting both SSH (``git@github.com:org/repo.git``)
+and HTTPS (``https://github.com/org/repo.git``) remotes. Non-GitHub remotes
+(GitLab, Azure DevOps, Bitbucket — all supported by the Cursor API) are
+normalized where possible and otherwise passed through unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["CursorCloudRepo", "RepoResolutionError", "resolve_cursor_cloud_repo"]
+
+
+class RepoResolutionError(RuntimeError):
+    """Raised when no repo can be resolved (no override and cwd has no remote)."""
+
+
+@dataclass(frozen=True)
+class CursorCloudRepo:
+    """A resolved cloud-agent target: a normalized repo URL and a starting ref.
+
+    :param url: Normalized repository URL, e.g.
+        ``https://github.com/org/repo``.
+    :param ref: Starting git ref (branch / tag / commit) the cloud agent
+        clones at, or ``None`` to let the cloud default to the repo's default
+        branch.
+    """
+
+    url: str
+    ref: str | None
+
+
+# ``git@host:org/repo(.git)`` — the scp-like SSH remote form.
+_SSH_REMOTE_RE = re.compile(r"^(?:ssh://)?git@(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$")
+# ``scheme://[user@]host/org/repo(.git)`` — the HTTP(S) / git protocol form.
+_URL_REMOTE_RE = re.compile(
+    r"^(?P<scheme>https?|git)://(?:[^@/]+@)?(?P<host>[^/]+)/(?P<path>.+?)(?:\.git)?/?$"
+)
+
+
+def normalize_remote_url(raw: str) -> str:
+    """Normalize a git remote URL to the ``https://<host>/<path>`` form.
+
+    Accepts SSH (``git@github.com:org/repo.git``), HTTPS
+    (``https://github.com/org/repo.git``), and ``git://`` remotes; strips any
+    ``.git`` suffix, embedded credentials, and trailing slash. A string that
+    matches no known remote shape is returned stripped but otherwise unchanged
+    (the Cursor API rejects a malformed URL more clearly than we can here).
+
+    :param raw: The remote URL as reported by ``git remote get-url``.
+    :returns: The normalized ``https://<host>/<org>/<repo>`` URL.
+    """
+    candidate = raw.strip()
+    ssh = _SSH_REMOTE_RE.match(candidate)
+    if ssh:
+        return f"https://{ssh.group('host')}/{ssh.group('path')}"
+    url = _URL_REMOTE_RE.match(candidate)
+    if url:
+        return f"https://{url.group('host')}/{url.group('path')}"
+    return candidate
+
+
+def _git(cwd: Path, *args: str) -> str | None:
+    """Run a read-only ``git`` command in *cwd*, returning stdout or ``None``.
+
+    Returns ``None`` on any failure (not a git repo, missing remote, git not
+    installed) — callers treat ``None`` as "unavailable" and fall back or error.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    value = out.stdout.strip()
+    return value or None
+
+
+def resolve_cursor_cloud_repo(
+    cwd: str | Path | None,
+    *,
+    repo_override: str | None = None,
+    ref_override: str | None = None,
+) -> CursorCloudRepo:
+    """Resolve the cloud-agent repo URL + starting ref.
+
+    Override precedence: an explicit ``repo_override`` / ``ref_override`` wins
+    over the cwd-derived value, field by field. With no repo override, the
+    ``origin`` remote of *cwd* supplies the URL and the current branch supplies
+    the ref (unless ``ref_override`` is given).
+
+    :param cwd: Session working directory to read git config from. ``None``
+        means "no cwd available" — only an explicit ``repo_override`` can
+        resolve in that case.
+    :param repo_override: Explicit repository URL (any git remote form;
+        normalized). Wins over the cwd ``origin`` remote.
+    :param ref_override: Explicit starting ref. Wins over the cwd branch.
+    :returns: The resolved :class:`CursorCloudRepo`.
+    :raises RepoResolutionError: When no ``repo_override`` is given and *cwd*
+        is unset or has no ``origin`` remote.
+    """
+    if repo_override and repo_override.strip():
+        url = normalize_remote_url(repo_override)
+        ref = ref_override.strip() if ref_override and ref_override.strip() else None
+        return CursorCloudRepo(url=url, ref=ref)
+
+    if cwd is None:
+        raise RepoResolutionError(
+            "cursor-cloud needs a GitHub repository to run against, but no repo "
+            "was provided and there is no working directory to read an 'origin' "
+            "remote from. Pass an explicit repo URL."
+        )
+
+    cwd_path = Path(cwd)
+    origin = _git(cwd_path, "remote", "get-url", "origin")
+    if not origin:
+        raise RepoResolutionError(
+            f"cursor-cloud needs a GitHub repository to run against, but {cwd_path} "
+            "has no 'origin' git remote. Pass an explicit repo URL or run from a "
+            "git repository with a GitHub remote."
+        )
+
+    url = normalize_remote_url(origin)
+    if ref_override and ref_override.strip():
+        ref: str | None = ref_override.strip()
+    else:
+        ref = _git(cwd_path, "rev-parse", "--abbrev-ref", "HEAD")
+        # A detached HEAD reports "HEAD" — not a usable ref to clone; let the
+        # cloud default to the repo's default branch instead.
+        if ref == "HEAD":
+            ref = None
+    return CursorCloudRepo(url=url, ref=ref)

--- a/omnigent/cursor_cloud_repo.py
+++ b/omnigent/cursor_cloud_repo.py
@@ -48,33 +48,36 @@ class CursorCloudRepo:
     ref: str | None
 
 
-# ``git@host:org/repo(.git)`` — the scp-like SSH remote form.
-_SSH_REMOTE_RE = re.compile(r"^(?:ssh://)?git@(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$")
-# ``scheme://[user@]host/org/repo(.git)`` — the HTTP(S) / git protocol form.
-_URL_REMOTE_RE = re.compile(
-    r"^(?P<scheme>https?|git)://(?:[^@/]+@)?(?P<host>[^/]+)/(?P<path>.+?)(?:\.git)?/?$"
+# scp-like SSH remote ``git@host:org/repo(.git)`` — the colon separates host
+# and path (no port is possible in this form).
+_SCP_REMOTE_RE = re.compile(r"^git@(?P<host>[^:/]+):(?P<path>.+?)(?:\.git)?/?$")
+# URI-form remote ``(ssh|https|git)://[user@]host[:port]/org/repo(.git)`` — an
+# optional ``:port`` after the host is stripped (e.g. ``ssh://git@github.com:22/...``).
+_URI_REMOTE_RE = re.compile(
+    r"^(?:ssh|https?|git)://(?:[^@/]+@)?(?P<host>[^:/]+)(?::\d+)?/(?P<path>.+?)(?:\.git)?/?$"
 )
 
 
 def normalize_remote_url(raw: str) -> str:
     """Normalize a git remote URL to the ``https://<host>/<path>`` form.
 
-    Accepts SSH (``git@github.com:org/repo.git``), HTTPS
+    Accepts scp-like SSH (``git@github.com:org/repo.git``), URI-form SSH
+    (``ssh://git@github.com[:port]/org/repo.git``), HTTPS
     (``https://github.com/org/repo.git``), and ``git://`` remotes; strips any
-    ``.git`` suffix, embedded credentials, and trailing slash. A string that
-    matches no known remote shape is returned stripped but otherwise unchanged
-    (the Cursor API rejects a malformed URL more clearly than we can here).
+    ``.git`` suffix, embedded credentials, ``:port``, and trailing slash. A
+    string that matches no known remote shape is returned stripped but otherwise
+    unchanged (the Cursor API rejects a malformed URL more clearly than we can).
 
     :param raw: The remote URL as reported by ``git remote get-url``.
     :returns: The normalized ``https://<host>/<org>/<repo>`` URL.
     """
     candidate = raw.strip()
-    ssh = _SSH_REMOTE_RE.match(candidate)
-    if ssh:
-        return f"https://{ssh.group('host')}/{ssh.group('path')}"
-    url = _URL_REMOTE_RE.match(candidate)
-    if url:
-        return f"https://{url.group('host')}/{url.group('path')}"
+    scp = _SCP_REMOTE_RE.match(candidate)
+    if scp:
+        return f"https://{scp.group('host')}/{scp.group('path')}"
+    uri = _URI_REMOTE_RE.match(candidate)
+    if uri:
+        return f"https://{uri.group('host')}/{uri.group('path')}"
     return candidate
 
 
@@ -108,10 +111,16 @@ def resolve_cursor_cloud_repo(
 ) -> CursorCloudRepo:
     """Resolve the cloud-agent repo URL + starting ref.
 
-    Override precedence: an explicit ``repo_override`` / ``ref_override`` wins
-    over the cwd-derived value, field by field. With no repo override, the
-    ``origin`` remote of *cwd* supplies the URL and the current branch supplies
-    the ref (unless ``ref_override`` is given).
+    Resolution paths:
+
+    - **Repo override given:** use it. The ref is ``ref_override`` if given,
+        else ``None`` (the target repo's default branch). The cwd branch is
+        deliberately NOT carried over — it belongs to a possibly-different repo
+        and may not exist on the override target, so defaulting is the safe
+        choice.
+    - **No repo override:** the ``origin`` remote of *cwd* supplies the URL, and
+        the ref is ``ref_override`` if given, else the cwd's current branch
+        (the exact commit SHA on a detached HEAD).
 
     :param cwd: Session working directory to read git config from. ``None``
         means "no cwd available" — only an explicit ``repo_override`` can
@@ -149,8 +158,9 @@ def resolve_cursor_cloud_repo(
         ref: str | None = ref_override.strip()
     else:
         ref = _git(cwd_path, "rev-parse", "--abbrev-ref", "HEAD")
-        # A detached HEAD reports "HEAD" — not a usable ref to clone; let the
-        # cloud default to the repo's default branch instead.
+        # A detached HEAD reports "HEAD", which is not a clonable ref — fall
+        # back to the exact commit SHA so a CI / checked-out-SHA workflow runs
+        # the cloud agent on that commit rather than the repo's default branch.
         if ref == "HEAD":
-            ref = None
+            ref = _git(cwd_path, "rev-parse", "HEAD")
     return CursorCloudRepo(url=url, ref=ref)

--- a/omnigent/inner/cursor_cloud_executor.py
+++ b/omnigent/inner/cursor_cloud_executor.py
@@ -1,0 +1,292 @@
+"""``harness: cursor-cloud`` executor — Cursor Cloud / Background Agents.
+
+Where :class:`omnigent.inner.cursor_executor.CursorExecutor` drives a *local*
+``cursor-agent`` over a bridge (editing the session ``cwd``), this executor
+launches a **cloud** run: the same ``cursor-sdk`` ``AsyncClient`` connected to
+Cursor's backend (``https://api.cursor.com``) creates a background agent that
+clones a GitHub repo into a fresh VM, works autonomously, and pushes a branch /
+opens a PR. The local working tree is never touched.
+
+The cloud runtime deliberately drops the local harness's machinery:
+
+- **No tool bridge / custom tools** — tools run inside the cloud VM, so the
+  ``tools`` argument is ignored and ``handles_tools_internally`` is ``True``.
+  ``tool_call`` stream events surface as *informational* ExecutorEvents.
+- **No ``preToolUse`` policy hook / native approval** — there is no local
+  process to gate.
+- **No persistent agent across turns (v1)** — each turn launches a fresh cloud
+  run seeded with the conversation so far; follow-up / cancel are deferred.
+
+What it shares with the local executor (imported, not reimplemented): the
+``SDKMessage`` → ExecutorEvent mapping, model-id resolution drop logic, usage
+normalization, and prompt building.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
+
+from .cursor_executor import (
+    _build_cursor_prompt,
+    _normalize_cursor_usage,
+    _safe_close,
+    _sdk_message_to_events,
+)
+from .datamodel import OSEnvSpec
+from .executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    TextChunk,
+    ToolSpec,
+    TurnCancelled,
+    TurnComplete,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cursor's public Cloud Agents API base URL. The SDK has no default for it, so
+# the cloud client must be constructed with it explicitly. Overridable via the
+# constructor for tests.
+_DEFAULT_CLOUD_BASE_URL = "https://api.cursor.com"
+
+# Cloud agents run a curated model set in Max Mode; ``composer-2.5`` is the
+# documented default. A gateway-routed (``databricks-*``) id carried by a spec
+# authored for another harness is dropped to this default.
+_DEFAULT_CLOUD_MODEL = "composer-2.5"
+
+# Dashboard URL that triggers first-time repo environment setup. The Cursor API
+# has no programmatic equivalent, so a never-onboarded repo fails to launch —
+# we point the user here (see ``_onboarding_hint``).
+_ONBOARD_URL = "https://cursor.com/onboard?repository={url}"
+
+
+def _resolve_cloud_model(model: str | None) -> str:
+    """Resolve the cloud model id, dropping ids the cloud API can't honor.
+
+    Mirrors :func:`cursor_executor._resolve_model` but defaults to the cloud
+    model rather than the local ``auto`` select.
+    """
+    if not model or model.startswith(("databricks-", "databricks/")):
+        if model:
+            logger.warning(
+                "CursorCloudExecutor: requested model %r is not a Cursor cloud "
+                "model id; falling back to %r.",
+                model,
+                _DEFAULT_CLOUD_MODEL,
+            )
+        return _DEFAULT_CLOUD_MODEL
+    return model
+
+
+def _onboarding_hint(repo_url: str, error: str) -> str:
+    """Augment a launch error with the dashboard-onboarding URL when relevant.
+
+    Cloud runs fail if the repo has never had its environment set up in the
+    Cursor dashboard, and there is no API to trigger it. When the failure looks
+    like a setup/repo-access problem, append the onboarding URL so the user has
+    an actionable next step rather than an opaque error.
+    """
+    lowered = error.lower()
+    if any(
+        token in lowered
+        for token in ("set up", "setup", "not found", "repository", "repo", "access", "onboard")
+    ):
+        return (
+            f"{error}\n\nIf this repository has not been set up for Cursor cloud "
+            f"agents yet, complete the one-time environment setup at "
+            f"{_ONBOARD_URL.format(url=repo_url)} (there is no API to trigger it)."
+        )
+    return error
+
+
+class CursorCloudExecutor(Executor):
+    """Execute agent turns as Cursor Cloud / Background Agent runs."""
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        os_env: OSEnvSpec | None = None,
+        model: str | None = None,
+        api_key: str | None = None,
+        repo_url: str | None = None,
+        ref: str | None = None,
+        agent_name: str | None = None,
+        auto_create_pr: bool = True,
+        base_url: str = _DEFAULT_CLOUD_BASE_URL,
+    ) -> None:
+        self._cwd = cwd or (os_env.cwd if os_env else None)
+        self._model_override = model
+        self._api_key = api_key
+        self._repo_url = repo_url
+        self._ref = ref
+        self._agent_name = agent_name
+        self._auto_create_pr = auto_create_pr
+        self._base_url = base_url
+
+    # ── capability flags ──────────────────────────────────────────────
+    def supports_streaming(self) -> bool:
+        return True
+
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    def handles_tools_internally(self) -> bool:
+        # Tools execute in the cloud VM; the Session must not re-execute them.
+        return True
+
+    def supports_live_message_queue(self) -> bool:
+        return False
+
+    async def interrupt_session(self, session_key: str) -> bool:  # noqa: ARG002 — cancel deferred (v1)
+        # Cancel of a live cloud run is deferred (KTD7); the run continues
+        # server-side. Report unsupported so the runner doesn't assume a stop.
+        return False
+
+    def _format_result(self, response_text: str, result: Any) -> str | None:  # type: ignore[explicit-any]
+        """Compose the final turn text: streamed summary + branch/PR links.
+
+        Appends each pushed branch and its PR URL (when ``auto_create_pr``
+        produced one) from ``RunResult.git.branches`` so the user gets the
+        merge-ready artifact link in-conversation.
+        """
+        parts: list[str] = []
+        body = response_text or getattr(result, "result", "") or ""
+        if body:
+            parts.append(body)
+        git = getattr(result, "git", None)
+        branches = getattr(git, "branches", None) or []
+        links: list[str] = []
+        for branch in branches:
+            pr_url = getattr(branch, "pr_url", None)
+            branch_name = getattr(branch, "branch", None)
+            if pr_url:
+                links.append(f"- PR: {pr_url}")
+            elif branch_name:
+                links.append(f"- Branch pushed: `{branch_name}` (no PR opened)")
+        if links:
+            parts.append("**Cloud agent result:**\n" + "\n".join(links))
+        final = "\n\n".join(parts)
+        return final or None
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],  # noqa: ARG002 — cloud runs its own tools; not bridged
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        if not self._repo_url:
+            yield ExecutorError(
+                message=(
+                    "cursor-cloud has no repository to run against. Set a GitHub "
+                    "repo via the cwd's 'origin' remote or an explicit override."
+                )
+            )
+            return
+
+        model = _resolve_cloud_model((config.model if config else None) or self._model_override)
+        # Each turn is a fresh cloud run seeded with the conversation so far
+        # (v1: no persistent agent / follow-up), so always serialize history.
+        prompt = _build_cursor_prompt(messages, is_first_turn=True, system_prompt=system_prompt)
+        if not prompt:
+            yield TurnComplete(response=None)
+            return
+
+        try:
+            from cursor_sdk import (  # lazy: optional dependency
+                AsyncClient,
+                CloudAgentOptions,
+                CloudRepository,
+            )
+        except ImportError as exc:
+            yield ExecutorError(
+                message=(
+                    "CursorCloudExecutor requires the 'cursor-sdk' package. "
+                    "Install it with: uv pip install 'omnigent[cursor]'"
+                )
+            )
+            logger.debug("cursor-sdk import failed: %s", exc)
+            return
+
+        client: Any = None
+        try:
+            client = AsyncClient(base_url=self._base_url, auth_token=self._api_key)
+            cloud = CloudAgentOptions(
+                repos=[CloudRepository(url=self._repo_url, starting_ref=self._ref)],
+                auto_create_pr=self._auto_create_pr,
+            )
+            try:
+                agent = await client.create_agent(
+                    model=model,
+                    api_key=self._api_key,
+                    name=self._agent_name,
+                    cloud=cloud,
+                )
+                run = await agent.send(prompt)
+            except Exception as exc:  # noqa: BLE001 — launch failure surfaced w/ onboarding hint
+                yield ExecutorError(
+                    message=_onboarding_hint(self._repo_url, f"cursor-cloud launch failed: {exc}"),
+                    retryable=False,
+                )
+                return
+
+            response_text = ""
+            turn_usage: dict[str, Any] | None = None
+            async for stream_event in run.events():
+                sdk_message = getattr(stream_event, "sdk_message", None)
+                if sdk_message is not None:
+                    for event in _sdk_message_to_events(sdk_message):
+                        if isinstance(event, TextChunk):
+                            response_text += event.text
+                        yield event
+                iu = getattr(stream_event, "interaction_update", None)
+                if iu is not None and getattr(iu, "type", None) == "turn-ended":
+                    raw_usage = getattr(iu, "usage", None)
+                    if isinstance(raw_usage, dict) and raw_usage:
+                        turn_usage = _normalize_cursor_usage(raw_usage, model)
+            result = await run.wait()
+        except Exception as exc:  # noqa: BLE001 — mid-run SDK failure surfaced as retryable
+            yield ExecutorError(message=f"cursor-cloud run failed: {exc}", retryable=True)
+            return
+        finally:
+            if client is not None:
+                await _safe_close(client)
+
+        status = str(getattr(result, "status", "") or "").lower()
+        if status == "error":
+            detail = getattr(result, "result", "") or "cursor-cloud run reported an error"
+            yield ExecutorError(
+                message=_onboarding_hint(self._repo_url, f"cursor-cloud run error: {detail}"),
+                retryable=True,
+            )
+            return
+        if status == "expired":
+            detail = getattr(result, "result", "") or "cursor-cloud run expired"
+            yield ExecutorError(message=f"cursor-cloud run expired: {detail}", retryable=True)
+            return
+        if status == "cancelled":
+            yield TurnCancelled(reason="cursor-cloud run cancelled")
+            return
+        if status and status != "finished":
+            detail = getattr(result, "result", "") or "unknown status"
+            yield ExecutorError(
+                message=f"cursor-cloud run returned non-finished status {status!r}: {detail}",
+                retryable=True,
+            )
+            return
+
+        if turn_usage:
+            _notify_usage_from_dict(model=model, usage=turn_usage)
+        yield TurnComplete(response=self._format_result(response_text, result), usage=turn_usage)
+
+    async def close(self) -> None:
+        # No persistent per-session state in v1 (fresh run per turn).
+        return

--- a/omnigent/inner/cursor_cloud_executor.py
+++ b/omnigent/inner/cursor_cloud_executor.py
@@ -25,6 +25,7 @@ normalization, and prompt building.
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -50,11 +51,6 @@ from .executor import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Cursor's public Cloud Agents API base URL. The SDK has no default for it, so
-# the cloud client must be constructed with it explicitly. Overridable via the
-# constructor for tests.
-_DEFAULT_CLOUD_BASE_URL = "https://api.cursor.com"
 
 # Cloud agents run a curated model set in Max Mode; ``composer-2.5`` is the
 # documented default. A gateway-routed (``databricks-*``) id carried by a spec
@@ -120,7 +116,6 @@ class CursorCloudExecutor(Executor):
         ref: str | None = None,
         agent_name: str | None = None,
         auto_create_pr: bool = True,
-        base_url: str = _DEFAULT_CLOUD_BASE_URL,
     ) -> None:
         self._cwd = cwd or (os_env.cwd if os_env else None)
         self._model_override = model
@@ -129,7 +124,6 @@ class CursorCloudExecutor(Executor):
         self._ref = ref
         self._agent_name = agent_name
         self._auto_create_pr = auto_create_pr
-        self._base_url = base_url
 
     # ── capability flags ──────────────────────────────────────────────
     def supports_streaming(self) -> bool:
@@ -216,9 +210,18 @@ class CursorCloudExecutor(Executor):
             logger.debug("cursor-sdk import failed: %s", exc)
             return
 
+        # Cloud runs route through the SDK's bundled bridge — the SAME entry the
+        # local cursor harness uses. A direct ``AsyncClient(base_url=...)`` hits
+        # the wrong RPC route (404). The bridge authenticates from
+        # ``CURSOR_API_KEY``; mirror our resolved key into the env for the bridge
+        # subprocess (this is a dedicated harness process) and also pass it to
+        # ``create_agent``.
+        if self._api_key:
+            os.environ["CURSOR_API_KEY"] = self._api_key
+
         client: Any = None
         try:
-            client = AsyncClient(base_url=self._base_url, auth_token=self._api_key)
+            client = await AsyncClient.launch_bridge()
             cloud = CloudAgentOptions(
                 repos=[CloudRepository(url=self._repo_url, starting_ref=self._ref)],
                 auto_create_pr=self._auto_create_pr,
@@ -232,8 +235,18 @@ class CursorCloudExecutor(Executor):
                 )
                 run = await agent.send(prompt)
             except Exception as exc:  # noqa: BLE001 — launch failure surfaced w/ onboarding hint
+                # A launch/send failure on cloud is most often the repo not
+                # having had its one-time Cursor environment set up (the API can
+                # return a bare ``internal error`` in that case), so always point
+                # the user at the dashboard onboarding step.
                 yield ExecutorError(
-                    message=_onboarding_hint(self._repo_url, f"cursor-cloud launch failed: {exc}"),
+                    message=(
+                        f"cursor-cloud launch failed: {exc}\n\nIf this repository "
+                        f"has not been set up for Cursor cloud agents yet, complete "
+                        f"the one-time environment setup at "
+                        f"{_ONBOARD_URL.format(url=self._repo_url)} (there is no API "
+                        f"to trigger it)."
+                    ),
                     retryable=False,
                 )
                 return

--- a/omnigent/inner/cursor_cloud_harness.py
+++ b/omnigent/inner/cursor_cloud_harness.py
@@ -1,0 +1,112 @@
+"""``harness: cursor-cloud`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"cursor-cloud"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Wraps a :class:`omnigent.inner.cursor_cloud_executor.CursorCloudExecutor`,
+which launches Cursor Cloud / Background Agent runs over the ``cursor-sdk``.
+Mirrors the ``cursor`` wrap's env-var config flow; like ``cursor`` it has NO
+gateway / Databricks-profile env vars (the SDK talks only to Cursor's backend).
+
+Env vars read at startup:
+
+- ``HARNESS_CURSOR_CLOUD_MODEL``: Cursor cloud model id (e.g. ``composer-2.5``,
+  ``claude-4.6-sonnet-thinking``). ``None`` / a ``databricks-*`` id resolves to
+  the cloud default.
+- ``HARNESS_CURSOR_CLOUD_API_KEY``: Cursor API key (the same ``crsr_`` key the
+  local ``cursor`` harness uses). ``None`` falls back to ambient
+  ``CURSOR_API_KEY``.
+- ``HARNESS_CURSOR_CLOUD_REPO`` / ``HARNESS_CURSOR_CLOUD_REF``: the GitHub repo
+  URL + starting ref the cloud agent clones. Resolved by the spawn-env builder
+  from the cwd ``origin`` remote (or an override).
+- ``HARNESS_CURSOR_CLOUD_CWD``: working directory (used only to seed defaults;
+  the cloud run does not touch it).
+- ``HARNESS_CURSOR_CLOUD_OS_ENV``: JSON-encoded :class:`OSEnvSpec` (its ``cwd``
+  is used when ``HARNESS_CURSOR_CLOUD_CWD`` is unset).
+- ``HARNESS_CURSOR_CLOUD_AGENT_NAME``: optional display name for the run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from fastapi import FastAPI
+
+from omnigent.inner.cursor_cloud_executor import CursorCloudExecutor
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+_ENV_MODEL = "HARNESS_CURSOR_CLOUD_MODEL"
+_ENV_API_KEY = "HARNESS_CURSOR_CLOUD_API_KEY"
+_ENV_REPO = "HARNESS_CURSOR_CLOUD_REPO"
+_ENV_REF = "HARNESS_CURSOR_CLOUD_REF"
+_ENV_CWD = "HARNESS_CURSOR_CLOUD_CWD"
+_ENV_OS_ENV = "HARNESS_CURSOR_CLOUD_OS_ENV"
+_ENV_AGENT_NAME = "HARNESS_CURSOR_CLOUD_AGENT_NAME"
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    """Resolve the inner-executor :class:`OSEnvSpec` from :data:`_ENV_OS_ENV`.
+
+    Mirrors the ``cursor`` wrap: decodes the JSON-encoded dict, falling back to
+    ``caller_process + sandbox=none`` when the env var is missing or malformed.
+    """
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env", _ENV_OS_ENV, exc
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+def _build_cursor_cloud_executor() -> Executor:
+    """Construct a :class:`CursorCloudExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first turn, so a
+    missing ``cursor-sdk`` install surfaces as a request-time error rather than
+    an app-boot crash.
+    """
+    return CursorCloudExecutor(
+        cwd=os.environ.get(_ENV_CWD) or None,
+        os_env=_resolve_os_env(),
+        model=os.environ.get(_ENV_MODEL) or None,
+        api_key=os.environ.get(_ENV_API_KEY) or None,
+        repo_url=os.environ.get(_ENV_REPO) or None,
+        ref=os.environ.get(_ENV_REF) or None,
+        agent_name=os.environ.get(_ENV_AGENT_NAME, "").strip() or None,
+    )
+
+
+def create_app() -> FastAPI:
+    """Build the cursor-cloud harness's FastAPI app (required entry point)."""
+    adapter = ExecutorAdapter(
+        executor_factory=_build_cursor_cloud_executor, harness_label="Cursor Cloud"
+    )
+    return adapter.build()

--- a/omnigent/inner/cursor_cloud_harness.py
+++ b/omnigent/inner/cursor_cloud_harness.py
@@ -16,8 +16,10 @@ Env vars read at startup:
   ``claude-4.6-sonnet-thinking``). ``None`` / a ``databricks-*`` id resolves to
   the cloud default.
 - ``HARNESS_CURSOR_CLOUD_API_KEY``: Cursor API key (the same ``crsr_`` key the
-  local ``cursor`` harness uses). ``None`` falls back to ambient
-  ``CURSOR_API_KEY``.
+  local ``cursor`` harness uses). The runner-side spawn-env builder
+  (``_build_cursor_cloud_spawn_env``) resolves the key (spec api-key > stored
+  cursor key > ambient ``CURSOR_API_KEY``) before spawn; this wrap simply reads
+  the already-resolved value, passing ``None`` when it is unset.
 - ``HARNESS_CURSOR_CLOUD_REPO`` / ``HARNESS_CURSOR_CLOUD_REF``: the GitHub repo
   URL + starting ref the cloud agent clones. Resolved by the spawn-env builder
   from the cwd ``origin`` remote (or an override).

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -32,6 +32,7 @@ _SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
         "pi",
         "openai-agents",
         "cursor",
+        "cursor-cloud",
         "antigravity",
         "kimi",
         "qwen",

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -57,6 +57,15 @@ QWEN_KEY = "qwen"
 # installer rather than npm — so it carries an ``install_hint``, not a ``package``.
 CURSOR_KEY = "cursor"
 
+# Cursor Cloud / Background Agents run in Cursor's cloud against a GitHub repo
+# via the same ``cursor-sdk`` package and the same ``CURSOR_API_KEY`` (the
+# ``crsr_`` key) as the SDK ``cursor`` harness — no separate binary or secret.
+# Like the SDK ``cursor`` harness it is deliberately absent from
+# ``_HARNESS_NAME_TO_KEY`` (it gates on the shared key, not a CLI on ``PATH``);
+# the key is kept here purely as the canonical harness id the readiness layer
+# shares.
+CURSOR_CLOUD_KEY = "cursor-cloud"
+
 # Kimi authenticates against Moonshot AI's backend (``kimi login`` OAuth or a
 # Moonshot API key), not via the ambient provider config; like Cursor it ships
 # via a curl installer rather than npm, so it carries an ``install_hint``.

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -31,6 +31,7 @@ import omnigent.onboarding.gemini_auth as _gemini_auth
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
 from omnigent.onboarding.harness_install import (
     COPILOT_KEY,
+    CURSOR_CLOUD_KEY,
     CURSOR_KEY,
     GOOSE_KEY,
     HERMES_KEY,
@@ -226,6 +227,16 @@ def harness_is_configured(harness: str) -> bool:
         from omnigent.onboarding.cursor_auth import cursor_api_key_configured
 
         return cursor_api_key_configured() or bool(os.environ.get("CURSOR_API_KEY"))
+    if canonical == CURSOR_CLOUD_KEY:
+        # Cursor Cloud / Background Agents run in Cursor's cloud against a GitHub
+        # repo via the same ``cursor-sdk`` and the same ``CURSOR_API_KEY`` as the
+        # SDK ``cursor`` harness — no separate binary or secret. So readiness is
+        # identical: whether that shared Cursor key is resolvable (stored by
+        # ``omnigent setup`` or inherited from the env). A missing repo / bad key
+        # surfaces at run time.
+        from omnigent.onboarding.cursor_auth import cursor_api_key_configured
+
+        return cursor_api_key_configured() or bool(os.environ.get("CURSOR_API_KEY"))
     if canonical == COPILOT_KEY:
         # Copilot runs in-process via the ``github-copilot-sdk`` package (the
         # SDK bundles the CLI binary it drives, so there is no separate binary to
@@ -292,6 +303,7 @@ def configured_harness_map() -> dict[str, bool]:
     spellings.update(_HERMES_NATIVE_HARNESSES)
     spellings.update(_QWEN_HARNESSES)
     spellings.add(CURSOR_KEY)
+    spellings.add(CURSOR_CLOUD_KEY)  # Cursor Cloud — gates on the shared Cursor key
     spellings.add(KIMI_SURFACE)
     spellings.add(GOOSE_KEY)  # headless Goose (``goose acp``) gates on the goose binary
     spellings.add(HERMES_KEY)  # Hermes Agent wraps the ``hermes`` CLI

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -16463,6 +16463,7 @@ _HARNESS_MODEL_ENV_KEY: dict[str, str] = {
     "pi": "HARNESS_PI_MODEL",
     "openai-agents": "HARNESS_OPENAI_AGENTS_MODEL",
     "cursor": "HARNESS_CURSOR_MODEL",
+    "cursor-cloud": "HARNESS_CURSOR_CLOUD_MODEL",
     # cursor-native is intentionally omitted here (and from
     # model_override._SDK_MODEL_OVERRIDE_HARNESSES): like the other native CLIs
     # (claude-native, codex-native) it honors the spec model via a launch
@@ -16508,6 +16509,7 @@ def _build_spawn_env_from_spec(
             _build_claude_sdk_spawn_env,
             _build_codex_spawn_env,
             _build_copilot_spawn_env,
+            _build_cursor_cloud_spawn_env,
             _build_cursor_spawn_env,
             _build_goose_spawn_env,
             _build_kimi_spawn_env,
@@ -16526,6 +16528,8 @@ def _build_spawn_env_from_spec(
             env = _build_openai_agents_sdk_spawn_env(spec)
         elif harness == "cursor":
             env = _build_cursor_spawn_env(spec, workdir=workdir)
+        elif harness == "cursor-cloud":
+            env = _build_cursor_cloud_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "antigravity":
             env = _build_antigravity_spawn_env(spec)
         elif harness == "kimi":

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -66,6 +66,11 @@ _HARNESS_MODULES: dict[str, str] = {
     # cursor harness wrap (Cursor's ``cursor-agent`` CLI, headless). See
     # omnigent/inner/cursor_harness.py.
     "cursor": "omnigent.inner.cursor_harness",
+    # cursor-cloud harness wrap. Launches Cursor Cloud / Background Agent runs
+    # via the cursor-sdk against a GitHub repo (clones in a cloud VM, pushes a
+    # branch / opens a PR) — NOT a native TUI, so it is NOT in
+    # ``NATIVE_HARNESSES``. See omnigent/inner/cursor_cloud_harness.py.
+    "cursor-cloud": "omnigent.inner.cursor_cloud_harness",
     # Kimi Code CLI harness wrap (Moonshot AI's ``kimi`` CLI, headless). See
     # omnigent/inner/kimi_harness.py. Drives ``kimi --print --output-format
     # stream-json`` per turn; resumes via ``--session <uuid>`` captured from

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1633,6 +1633,74 @@ def _build_cursor_spawn_env(
     return env
 
 
+def _build_cursor_cloud_spawn_env(
+    spec: AgentSpec,
+    *,
+    cwd: Path | None = None,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """Build the ``HARNESS_CURSOR_CLOUD_*`` env-var dict the cursor-cloud wrap reads.
+
+    Mirrors :func:`_build_cursor_spawn_env`'s auth precedence (the cloud harness
+    shares the Cursor ``crsr_`` key), and additionally resolves the GitHub repo
+    URL + starting ref the cloud agent clones. Repo/ref default to the session
+    ``cwd``'s ``origin`` remote and current branch; explicit overrides are read
+    from ``OMNIGENT_CURSOR_CLOUD_REPO`` / ``OMNIGENT_CURSOR_CLOUD_REF`` when set.
+    A repo that cannot be resolved is left unset here so the executor surfaces a
+    clear turn-time error rather than failing the spawn.
+
+    :param spec: The agent spec.
+    :param cwd: Session working directory (read for the ``origin`` remote).
+    :param workdir: The bundle's on-disk path (unused by cloud; kept for
+        dispatch-signature parity).
+    :returns: A dict of env-var overrides.
+    """
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model is not None:
+        env["HARNESS_CURSOR_CLOUD_MODEL"] = model
+
+    # Auth: identical precedence to the local cursor builder — explicit spec
+    # api-key auth wins, else a stored cursor key, else an ambient CURSOR_API_KEY.
+    if isinstance(spec.executor.auth, ApiKeyAuth):
+        env["HARNESS_CURSOR_CLOUD_API_KEY"] = spec.executor.auth.api_key
+    elif spec.executor.auth is None:
+        from omnigent.onboarding.cursor_auth import resolve_cursor_api_key
+
+        stored_key = resolve_cursor_api_key()
+        if stored_key:
+            env["HARNESS_CURSOR_CLOUD_API_KEY"] = stored_key
+        else:
+            ambient_key = os.environ.get("CURSOR_API_KEY")
+            if ambient_key and ambient_key.strip():
+                env["HARNESS_CURSOR_CLOUD_API_KEY"] = ambient_key.strip()
+
+    # Repo/ref: cwd origin remote by default, explicit override via env.
+    from omnigent.cursor_cloud_repo import RepoResolutionError, resolve_cursor_cloud_repo
+
+    try:
+        resolved = resolve_cursor_cloud_repo(
+            cwd,
+            repo_override=os.environ.get("OMNIGENT_CURSOR_CLOUD_REPO"),
+            ref_override=os.environ.get("OMNIGENT_CURSOR_CLOUD_REF"),
+        )
+    except RepoResolutionError:
+        resolved = None
+    if resolved is not None:
+        env["HARNESS_CURSOR_CLOUD_REPO"] = resolved.url
+        if resolved.ref:
+            env["HARNESS_CURSOR_CLOUD_REF"] = resolved.ref
+
+    if cwd is not None:
+        env["HARNESS_CURSOR_CLOUD_CWD"] = str(cwd)
+    if spec.name:
+        env["HARNESS_CURSOR_CLOUD_AGENT_NAME"] = spec.name
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_CURSOR_CLOUD_OS_ENV"] = os_env_payload
+    return env
+
+
 def _build_kimi_spawn_env(
     spec: AgentSpec,
     *,

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -87,6 +87,7 @@ OMNIGENT_HARNESSES = frozenset(
         "codex-native",
         "copilot",
         "cursor",
+        "cursor-cloud",
         "kimi",
         "kimi-native",
         "cursor-native",

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -227,6 +227,12 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
         "pi-native",
         "opencode-native",
         "cursor",
+        # ``cursor-cloud`` is excluded for the same reason as ``cursor`` (it
+        # authenticates to Cursor's own backend, not the Databricks gateway this
+        # matrix drives), and additionally requires a GitHub repo + one-time
+        # dashboard environment setup to launch a cloud run. Its coverage is the
+        # mocked-SDK cursor-cloud executor/harness/spawn-env unit tests.
+        "cursor-cloud",
         "cursor-native",
         "antigravity",
         "antigravity-native",

--- a/tests/inner/test_cursor_cloud_executor.py
+++ b/tests/inner/test_cursor_cloud_executor.py
@@ -27,7 +27,9 @@ from omnigent.inner.cursor_cloud_executor import (
 from omnigent.inner.executor import (
     ExecutorError,
     Message,
+    ReasoningChunk,
     TextChunk,
+    ToolCallRequest,
     TurnCancelled,
     TurnComplete,
 )
@@ -41,6 +43,18 @@ def _assistant(text: str) -> SimpleNamespace:
     return SimpleNamespace(
         type="assistant",
         message=SimpleNamespace(content=[SimpleNamespace(type="text", text=text)]),
+    )
+
+
+def _thinking(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="thinking", text=text)
+
+
+def _tool(
+    name: str, call_id: str, status: str, args: Any = None, result: Any = None
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="tool_call", name=name, call_id=call_id, status=status, args=args, result=result
     )
 
 
@@ -201,6 +215,9 @@ async def test_run_turn_happy_path_appends_pr_url(monkeypatch: pytest.MonkeyPatc
     response = completes[0].response
     assert "Fixed the bug." in response
     assert "https://github.com/org/repo/pull/42" in response
+    # The prompt sent to agent.send is the first-turn prompt: the system prompt
+    # prepended to the user message (see _build_cursor_prompt).
+    assert state["sent"] == ["SYS\n\nfix it"]
     # Client constructed with the cloud base URL + auth token and torn down.
     assert state["base_urls"] == ["https://api.cursor.com"]
     assert state["auth_tokens"] == ["crsr_x"]
@@ -235,6 +252,68 @@ async def test_run_turn_branch_only_notes_no_pr(monkeypatch: pytest.MonkeyPatch)
     response = completes[0].response
     assert "cursor/wip" in response
     assert "no PR opened" in response
+
+
+async def test_run_turn_maps_thinking_and_tool_call_stream_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared SDK->ExecutorEvent mapping surfaces ``thinking`` as a
+    ReasoningChunk and a running ``tool_call`` as a ToolCallRequest (tools run in
+    the cloud VM, so they are informational, not bridged)."""
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[
+            _thinking("planning the fix"),
+            _tool("Read", "t1", "running", args={"path": "f.py"}),
+            _assistant("done"),
+        ],
+        status="finished",
+        result_text="done",
+        git=SimpleNamespace(branches=[]),
+    )
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("fix it")], [], "SYS")]
+
+    reasoning = [e for e in events if isinstance(e, ReasoningChunk)]
+    assert len(reasoning) == 1 and reasoning[0].delta == "planning the fix"
+
+    reqs = [e for e in events if isinstance(e, ToolCallRequest)]
+    assert len(reqs) == 1
+    assert reqs[0].name == "Read"
+    assert reqs[0].args == {"path": "f.py"}
+
+    assert any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_turn_ended_update_carries_normalized_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream event whose ``interaction_update`` is a ``turn-ended`` with a usage
+    dict produces a TurnComplete carrying the normalized usage."""
+    turn_ended = SimpleNamespace(
+        type="turn-ended",
+        usage={"inputTokens": 1000, "outputTokens": 200, "totalTokens": 1200},
+    )
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[_assistant("done")],
+        interaction_updates=[turn_ended],
+        status="finished",
+        result_text="done",
+        git=SimpleNamespace(branches=[]),
+    )
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("fix it")], [], "SYS")]
+
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    usage = completes[0].usage
+    assert usage is not None
+    assert usage["input_tokens"] == 1000
+    assert usage["output_tokens"] == 200
+    assert usage["total_tokens"] == 1200
+    # Resolved cloud default model is recorded on the usage dict.
+    assert usage["model"] == "composer-2.5"
 
 
 async def test_run_turn_auto_create_pr_threaded(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/inner/test_cursor_cloud_executor.py
+++ b/tests/inner/test_cursor_cloud_executor.py
@@ -1,0 +1,367 @@
+"""Tests for :class:`omnigent.inner.cursor_cloud_executor.CursorCloudExecutor`.
+
+The cursor-cloud harness launches a Cursor Cloud / Background Agent run over the
+``cursor-sdk`` ``AsyncClient``: it creates a cloud agent that clones a GitHub
+repo, works in a fresh VM, and pushes a branch / opens a PR. The SDK is replaced
+with an injected fake module (no live cloud call, API key, or network), letting
+us exercise the happy path (streamed text + PR-link composition), the
+branch-only result, the missing-repo guard, launch failure with the onboarding
+hint, and the terminal-status branches (error / cancelled). Live coverage lives
+in the gated e2e test.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from omnigent.inner.cursor_cloud_executor import (
+    CursorCloudExecutor,
+    _onboarding_hint,
+    _resolve_cloud_model,
+)
+from omnigent.inner.executor import (
+    ExecutorError,
+    Message,
+    TextChunk,
+    TurnCancelled,
+    TurnComplete,
+)
+
+
+def _user(content: str, session_id: str = "conv1") -> Message:
+    return {"role": "user", "content": content, "session_id": session_id}
+
+
+def _assistant(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="assistant",
+        message=SimpleNamespace(content=[SimpleNamespace(type="text", text=text)]),
+    )
+
+
+def _branch(*, repo_url: str, branch: str, pr_url: str | None) -> SimpleNamespace:
+    return SimpleNamespace(repo_url=repo_url, branch=branch, pr_url=pr_url)
+
+
+# ---------------------------------------------------------------------------
+# Fake cursor_sdk
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[Any] | None = None,
+    interaction_updates: list[Any] | None = None,
+    status: str = "finished",
+    result_text: str = "",
+    git: Any = None,
+    create_exc: Exception | None = None,
+) -> dict[str, Any]:
+    """Install a fake ``cursor_sdk`` module and return a capture dict.
+
+    *messages* is the SDK message stream replayed by ``run.events()``; *git*
+    becomes ``RunResult.git`` (with ``.branches``). *create_exc* makes
+    ``client.create_agent`` raise, exercising the launch-failure path.
+    """
+    state: dict[str, Any] = {
+        "base_urls": [],
+        "auth_tokens": [],
+        "create_kwargs": [],
+        "cloud_options": [],
+        "repos": [],
+        "sent": [],
+        "closed": 0,
+    }
+
+    class _FakeRun:
+        async def events(self) -> Any:
+            for message in messages or []:
+                yield SimpleNamespace(sdk_message=message, interaction_update=None)
+            for iu in interaction_updates or []:
+                yield SimpleNamespace(sdk_message=None, interaction_update=iu)
+
+        async def wait(self) -> Any:
+            return SimpleNamespace(status=status, result=result_text, git=git)
+
+    class _FakeAgent:
+        async def send(self, prompt: str) -> _FakeRun:
+            state["sent"].append(prompt)
+            return _FakeRun()
+
+    class _FakeClient:
+        def __init__(self, *, base_url: Any = None, auth_token: Any = None) -> None:
+            state["base_urls"].append(base_url)
+            state["auth_tokens"].append(auth_token)
+
+        async def create_agent(
+            self, *, model: Any, api_key: Any, name: Any, cloud: Any
+        ) -> _FakeAgent:
+            state["create_kwargs"].append(
+                {"model": model, "api_key": api_key, "name": name, "cloud": cloud}
+            )
+            if create_exc is not None:
+                raise create_exc
+            return _FakeAgent()
+
+        async def aclose(self) -> None:
+            state["closed"] += 1
+
+    class _FakeCloudRepository:
+        def __init__(self, *, url: Any = None, starting_ref: Any = None) -> None:
+            self.url = url
+            self.starting_ref = starting_ref
+            state["repos"].append(self)
+
+    class _FakeCloudAgentOptions:
+        def __init__(self, *, repos: Any = None, auto_create_pr: Any = None) -> None:
+            self.repos = repos
+            self.auto_create_pr = auto_create_pr
+            state["cloud_options"].append(self)
+
+    fake = types.ModuleType("cursor_sdk")
+    fake.AsyncClient = _FakeClient  # type: ignore[attr-defined]
+    fake.CloudAgentOptions = _FakeCloudAgentOptions  # type: ignore[attr-defined]
+    fake.CloudRepository = _FakeCloudRepository  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "cursor_sdk", fake)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cloud_model_defaults_and_drops_databricks() -> None:
+    assert _resolve_cloud_model("claude-4.6-sonnet-thinking") == "claude-4.6-sonnet-thinking"
+    assert _resolve_cloud_model(None) == "composer-2.5"
+    assert _resolve_cloud_model("databricks-claude-sonnet-4-6") == "composer-2.5"
+    assert _resolve_cloud_model("databricks/kimi") == "composer-2.5"
+
+
+def test_onboarding_hint_appends_url_for_setup_errors() -> None:
+    hint = _onboarding_hint("https://github.com/org/repo", "repository not found")
+    assert "cursor.com/onboard?repository=https://github.com/org/repo" in hint
+
+
+def test_onboarding_hint_passthrough_for_unrelated_errors() -> None:
+    # An error with none of the setup/repo tokens is returned unchanged.
+    assert _onboarding_hint("https://github.com/org/repo", "timeout") == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# capability flags
+# ---------------------------------------------------------------------------
+
+
+def test_capabilities() -> None:
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo")
+    assert executor.supports_streaming() is True
+    assert executor.supports_tool_calling() is True
+    # Tools execute in the cloud VM, so the Session must not re-dispatch.
+    assert executor.handles_tools_internally() is True
+    assert executor.supports_live_message_queue() is False
+
+
+# ---------------------------------------------------------------------------
+# run_turn — happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_run_turn_happy_path_appends_pr_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    git = SimpleNamespace(
+        branches=[
+            _branch(
+                repo_url="https://github.com/org/repo",
+                branch="cursor/fix-thing",
+                pr_url="https://github.com/org/repo/pull/42",
+            )
+        ]
+    )
+    state = _install_fake_sdk(
+        monkeypatch,
+        messages=[_assistant("Fixed "), _assistant("the bug.")],
+        status="finished",
+        result_text="Fixed the bug.",
+        git=git,
+    )
+    executor = CursorCloudExecutor(
+        repo_url="https://github.com/org/repo", ref="main", api_key="crsr_x"
+    )
+    events = [e async for e in executor.run_turn([_user("fix it")], [], "SYS")]
+
+    assert [e.text for e in events if isinstance(e, TextChunk)] == ["Fixed ", "the bug."]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    response = completes[0].response
+    assert "Fixed the bug." in response
+    assert "https://github.com/org/repo/pull/42" in response
+    # Client constructed with the cloud base URL + auth token and torn down.
+    assert state["base_urls"] == ["https://api.cursor.com"]
+    assert state["auth_tokens"] == ["crsr_x"]
+    assert state["closed"] == 1
+    # The repo URL + starting ref were threaded into CloudRepository.
+    assert state["repos"][0].url == "https://github.com/org/repo"
+    assert state["repos"][0].starting_ref == "main"
+
+
+async def test_run_turn_branch_only_notes_no_pr(monkeypatch: pytest.MonkeyPatch) -> None:
+    git = SimpleNamespace(
+        branches=[
+            _branch(
+                repo_url="https://github.com/org/repo",
+                branch="cursor/wip",
+                pr_url=None,
+            )
+        ]
+    )
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[_assistant("Pushed work.")],
+        status="finished",
+        result_text="Pushed work.",
+        git=git,
+    )
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("do it")], [], "SYS")]
+
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    response = completes[0].response
+    assert "cursor/wip" in response
+    assert "no PR opened" in response
+
+
+async def test_run_turn_auto_create_pr_threaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_sdk(
+        monkeypatch,
+        messages=[_assistant("ok")],
+        result_text="ok",
+        git=SimpleNamespace(branches=[]),
+    )
+    executor = CursorCloudExecutor(
+        repo_url="https://github.com/org/repo", api_key="crsr_x", auto_create_pr=False
+    )
+    _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    assert state["cloud_options"][0].auto_create_pr is False
+    # The agent name + resolved model are threaded into create_agent.
+    assert state["create_kwargs"][0]["model"] == "composer-2.5"
+
+
+# ---------------------------------------------------------------------------
+# run_turn — guard + failure paths
+# ---------------------------------------------------------------------------
+
+
+async def test_run_turn_missing_repo_errors_before_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No fake SDK installed — the repo guard must fire before any import/use.
+    executor = CursorCloudExecutor(repo_url=None, api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert "no repository" in errors[0].message.lower()
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_empty_prompt_completes_without_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_sdk(monkeypatch, messages=[_assistant("x")])
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [
+        e
+        async for e in executor.run_turn(
+            [{"role": "assistant", "content": "x", "session_id": "conv1"}], [], ""
+        )
+    ]
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete) and events[0].response is None
+    assert state["sent"] == []  # nothing launched
+
+
+async def test_run_turn_launch_failure_includes_onboarding_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_sdk(
+        monkeypatch,
+        create_exc=RuntimeError("repository not found"),
+    )
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert errors[0].retryable is False
+    assert "launch failed" in errors[0].message
+    # The onboarding URL is appended because the error looks like a repo/setup issue.
+    assert "cursor.com/onboard?repository=https://github.com/org/repo" in errors[0].message
+
+
+async def test_run_turn_error_status_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[_assistant("partial")],
+        status="error",
+        result_text="model exploded",
+        git=SimpleNamespace(branches=[]),
+    )
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert errors[0].retryable is True
+    assert "model exploded" in errors[0].message
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_cancelled_status_emits_turn_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[_assistant("partial")],
+        status="cancelled",
+        result_text="stopped",
+        git=SimpleNamespace(branches=[]),
+    )
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    cancels = [e for e in events if isinstance(e, TurnCancelled)]
+    assert len(cancels) == 1
+    assert not any(isinstance(e, ExecutorError) for e in events)
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_expired_status_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_sdk(
+        monkeypatch,
+        messages=[_assistant("partial")],
+        status="expired",
+        result_text="quota hit",
+        git=SimpleNamespace(branches=[]),
+    )
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1 and errors[0].retryable is True
+    assert "expired" in errors[0].message
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_lazy_imports_cursor_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SDK import is lazy (inside run_turn): a missing cursor_sdk surfaces as
+    a turn-time ExecutorError, not an import-time crash at construction."""
+    monkeypatch.setitem(sys.modules, "cursor_sdk", None)
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo", api_key="crsr_x")
+    events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1 and "cursor-sdk" in errors[0].message
+
+
+async def test_interrupt_session_unsupported_in_v1() -> None:
+    executor = CursorCloudExecutor(repo_url="https://github.com/org/repo")
+    assert await executor.interrupt_session("conv1") is False

--- a/tests/inner/test_cursor_cloud_executor.py
+++ b/tests/inner/test_cursor_cloud_executor.py
@@ -84,8 +84,7 @@ def _install_fake_sdk(
     ``client.create_agent`` raise, exercising the launch-failure path.
     """
     state: dict[str, Any] = {
-        "base_urls": [],
-        "auth_tokens": [],
+        "launch_bridge_calls": 0,
         "create_kwargs": [],
         "cloud_options": [],
         "repos": [],
@@ -109,9 +108,12 @@ def _install_fake_sdk(
             return _FakeRun()
 
     class _FakeClient:
-        def __init__(self, *, base_url: Any = None, auth_token: Any = None) -> None:
-            state["base_urls"].append(base_url)
-            state["auth_tokens"].append(auth_token)
+        @classmethod
+        async def launch_bridge(cls) -> _FakeClient:
+            # Cloud routes through the SDK's bundled bridge, the same entry the
+            # local cursor harness uses (not a direct AsyncClient(base_url=...)).
+            state["launch_bridge_calls"] += 1
+            return cls()
 
         async def create_agent(
             self, *, model: Any, api_key: Any, name: Any, cloud: Any
@@ -218,9 +220,10 @@ async def test_run_turn_happy_path_appends_pr_url(monkeypatch: pytest.MonkeyPatc
     # The prompt sent to agent.send is the first-turn prompt: the system prompt
     # prepended to the user message (see _build_cursor_prompt).
     assert state["sent"] == ["SYS\n\nfix it"]
-    # Client constructed with the cloud base URL + auth token and torn down.
-    assert state["base_urls"] == ["https://api.cursor.com"]
-    assert state["auth_tokens"] == ["crsr_x"]
+    # Cloud client came from the SDK bridge (launch_bridge), the API key was
+    # threaded to create_agent, and the bridge was torn down.
+    assert state["launch_bridge_calls"] == 1
+    assert state["create_kwargs"][0]["api_key"] == "crsr_x"
     assert state["closed"] == 1
     # The repo URL + starting ref were threaded into CloudRepository.
     assert state["repos"][0].url == "https://github.com/org/repo"

--- a/tests/inner/test_cursor_cloud_harness.py
+++ b/tests/inner/test_cursor_cloud_harness.py
@@ -1,19 +1,20 @@
 """Tests for the ``harness: cursor-cloud`` wrap shape.
 
 Verifies the module-registry entry, FastAPI routes, and env-var-driven lazy
-executor construction. The inner ``CursorCloudExecutor.__init__`` is mocked so
-the test runs without a live cloud client / ``cursor-sdk`` call.
+executor construction. ``CursorCloudExecutor.__init__`` is pure (no ``cursor-sdk``
+import — that is lazily imported inside ``run_turn``), so the env-var tests build
+the REAL executor and assert its private fields, rather than mocking the
+constructor (which would only prove the mock captured kwargs).
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
-from unittest.mock import patch
 
 import pytest
 
 from omnigent.inner import cursor_cloud_harness
+from omnigent.inner.cursor_cloud_executor import CursorCloudExecutor
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 
 
@@ -36,29 +37,18 @@ def test_executor_factory_reads_env_vars(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("HARNESS_CURSOR_CLOUD_CWD", "/tmp/test-cwd")
     monkeypatch.setenv("HARNESS_CURSOR_CLOUD_AGENT_NAME", "demo")
 
-    captured: dict[str, Any] = {}
+    # The constructor is pure (cursor-sdk is imported lazily inside run_turn),
+    # so build the REAL executor and assert its resolved private fields.
+    executor = cursor_cloud_harness._build_cursor_cloud_executor()
+    assert isinstance(executor, CursorCloudExecutor)
 
-    def _fake_init(self: Any, **kwargs: Any) -> None:
-        captured.update(kwargs)
-
-    with patch(
-        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
-        _fake_init,
-    ):
-        cursor_cloud_harness._build_cursor_cloud_executor()
-
-    assert captured["model"] == "claude-4.6-sonnet-thinking"
-    assert captured["api_key"] == "crsr_secret"
-    assert captured["repo_url"] == "https://github.com/org/repo"
-    assert captured["ref"] == "main"
-    assert captured["cwd"] == "/tmp/test-cwd"
-    assert captured["agent_name"] == "demo"
-    # Default os_env when unset: caller_process + sandbox=none.
-    os_env_value = captured["os_env"]
-    assert os_env_value is not None
-    assert os_env_value.type == "caller_process"
-    assert os_env_value.sandbox is not None
-    assert os_env_value.sandbox.type == "none"
+    assert executor._model_override == "claude-4.6-sonnet-thinking"
+    assert executor._api_key == "crsr_secret"
+    assert executor._repo_url == "https://github.com/org/repo"
+    assert executor._ref == "main"
+    assert executor._agent_name == "demo"
+    # HARNESS_CURSOR_CLOUD_CWD takes precedence over the os_env cwd.
+    assert executor._cwd == "/tmp/test-cwd"
 
 
 def test_executor_factory_unset_optional_env_passes_none(
@@ -71,59 +61,43 @@ def test_executor_factory_unset_optional_env_passes_none(
         "HARNESS_CURSOR_CLOUD_REF",
         "HARNESS_CURSOR_CLOUD_CWD",
         "HARNESS_CURSOR_CLOUD_AGENT_NAME",
+        "HARNESS_CURSOR_CLOUD_OS_ENV",
     ):
         monkeypatch.delenv(var, raising=False)
 
-    captured: dict[str, Any] = {}
+    executor = cursor_cloud_harness._build_cursor_cloud_executor()
+    assert isinstance(executor, CursorCloudExecutor)
 
-    def _fake_init(self: Any, **kwargs: Any) -> None:
-        captured.update(kwargs)
-
-    with patch(
-        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
-        _fake_init,
-    ):
-        cursor_cloud_harness._build_cursor_cloud_executor()
-
-    assert captured["model"] is None
-    assert captured["api_key"] is None
-    assert captured["repo_url"] is None
-    assert captured["ref"] is None
-    assert captured["cwd"] is None
-    assert captured["agent_name"] is None
+    assert executor._model_override is None
+    # API key unset -> None (the spawn-env builder resolves the key before spawn;
+    # the wrap just reads the resolved value).
+    assert executor._api_key is None
+    assert executor._repo_url is None
+    assert executor._ref is None
+    assert executor._agent_name is None
+    # No cwd env and default os_env (cwd=None) -> None.
+    assert executor._cwd is None
 
 
 def test_executor_factory_decodes_os_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HARNESS_CURSOR_CLOUD_CWD", raising=False)
     monkeypatch.setenv(
         "HARNESS_CURSOR_CLOUD_OS_ENV",
         json.dumps({"type": "caller_process", "cwd": "/srv/app", "sandbox": {"type": "none"}}),
     )
-    captured: dict[str, Any] = {}
 
-    def _fake_init(self: Any, **kwargs: Any) -> None:
-        captured["os_env"] = kwargs["os_env"]
-
-    with patch(
-        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
-        _fake_init,
-    ):
-        cursor_cloud_harness._build_cursor_cloud_executor()
-
-    assert captured["os_env"].cwd == "/srv/app"
+    executor = cursor_cloud_harness._build_cursor_cloud_executor()
+    assert isinstance(executor, CursorCloudExecutor)
+    # With no HARNESS_CURSOR_CLOUD_CWD, the os_env cwd seeds the executor cwd.
+    assert executor._cwd == "/srv/app"
 
 
 def test_malformed_os_env_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HARNESS_CURSOR_CLOUD_CWD", raising=False)
     monkeypatch.setenv("HARNESS_CURSOR_CLOUD_OS_ENV", "{not-json")
-    captured: dict[str, Any] = {}
 
-    def _fake_init(self: Any, **kwargs: Any) -> None:
-        captured["os_env"] = kwargs["os_env"]
-
-    with patch(
-        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
-        _fake_init,
-    ):
-        cursor_cloud_harness._build_cursor_cloud_executor()
-
-    assert captured["os_env"].type == "caller_process"
-    assert captured["os_env"].sandbox.type == "none"
+    # A malformed os_env falls back to the default (cwd=None), so the executor's
+    # cwd is None rather than crashing the constructor.
+    executor = cursor_cloud_harness._build_cursor_cloud_executor()
+    assert isinstance(executor, CursorCloudExecutor)
+    assert executor._cwd is None

--- a/tests/inner/test_cursor_cloud_harness.py
+++ b/tests/inner/test_cursor_cloud_harness.py
@@ -1,0 +1,129 @@
+"""Tests for the ``harness: cursor-cloud`` wrap shape.
+
+Verifies the module-registry entry, FastAPI routes, and env-var-driven lazy
+executor construction. The inner ``CursorCloudExecutor.__init__`` is mocked so
+the test runs without a live cloud client / ``cursor-sdk`` call.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner import cursor_cloud_harness
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+
+
+def test_harness_module_registered_in_module_registry() -> None:
+    assert _HARNESS_MODULES.get("cursor-cloud") == "omnigent.inner.cursor_cloud_harness"
+
+
+def test_create_app_returns_fastapi_with_required_routes() -> None:
+    app = cursor_cloud_harness.create_app()
+    paths = {route.path for route in app.routes}  # type: ignore[attr-defined]
+    assert "/health" in paths
+    assert "/v1/sessions/{conversation_id}/events" in paths
+
+
+def test_executor_factory_reads_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_CURSOR_CLOUD_MODEL", "claude-4.6-sonnet-thinking")
+    monkeypatch.setenv("HARNESS_CURSOR_CLOUD_API_KEY", "crsr_secret")
+    monkeypatch.setenv("HARNESS_CURSOR_CLOUD_REPO", "https://github.com/org/repo")
+    monkeypatch.setenv("HARNESS_CURSOR_CLOUD_REF", "main")
+    monkeypatch.setenv("HARNESS_CURSOR_CLOUD_CWD", "/tmp/test-cwd")
+    monkeypatch.setenv("HARNESS_CURSOR_CLOUD_AGENT_NAME", "demo")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_cloud_harness._build_cursor_cloud_executor()
+
+    assert captured["model"] == "claude-4.6-sonnet-thinking"
+    assert captured["api_key"] == "crsr_secret"
+    assert captured["repo_url"] == "https://github.com/org/repo"
+    assert captured["ref"] == "main"
+    assert captured["cwd"] == "/tmp/test-cwd"
+    assert captured["agent_name"] == "demo"
+    # Default os_env when unset: caller_process + sandbox=none.
+    os_env_value = captured["os_env"]
+    assert os_env_value is not None
+    assert os_env_value.type == "caller_process"
+    assert os_env_value.sandbox is not None
+    assert os_env_value.sandbox.type == "none"
+
+
+def test_executor_factory_unset_optional_env_passes_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in (
+        "HARNESS_CURSOR_CLOUD_MODEL",
+        "HARNESS_CURSOR_CLOUD_API_KEY",
+        "HARNESS_CURSOR_CLOUD_REPO",
+        "HARNESS_CURSOR_CLOUD_REF",
+        "HARNESS_CURSOR_CLOUD_CWD",
+        "HARNESS_CURSOR_CLOUD_AGENT_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_cloud_harness._build_cursor_cloud_executor()
+
+    assert captured["model"] is None
+    assert captured["api_key"] is None
+    assert captured["repo_url"] is None
+    assert captured["ref"] is None
+    assert captured["cwd"] is None
+    assert captured["agent_name"] is None
+
+
+def test_executor_factory_decodes_os_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "HARNESS_CURSOR_CLOUD_OS_ENV",
+        json.dumps({"type": "caller_process", "cwd": "/srv/app", "sandbox": {"type": "none"}}),
+    )
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured["os_env"] = kwargs["os_env"]
+
+    with patch(
+        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_cloud_harness._build_cursor_cloud_executor()
+
+    assert captured["os_env"].cwd == "/srv/app"
+
+
+def test_malformed_os_env_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_CURSOR_CLOUD_OS_ENV", "{not-json")
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured["os_env"] = kwargs["os_env"]
+
+    with patch(
+        "omnigent.inner.cursor_cloud_harness.CursorCloudExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_cloud_harness._build_cursor_cloud_executor()
+
+    assert captured["os_env"].type == "caller_process"
+    assert captured["os_env"].sandbox.type == "none"

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -145,6 +145,8 @@ def test_configured_harness_map_covers_all_spellings(
         "pi-native",
         "native-pi",
         "cursor",
+        # Cursor Cloud / Background Agents — shares the cursor API key.
+        "cursor-cloud",
         # Native Cursor (``omni cursor``) — gates on the cursor-agent CLI.
         "cursor-native",
         "native-cursor",

--- a/tests/runtime/test_cursor_cloud_spawn_env.py
+++ b/tests/runtime/test_cursor_cloud_spawn_env.py
@@ -1,0 +1,156 @@
+"""Tests for ``_build_cursor_cloud_spawn_env`` in ``omnigent/runtime/workflow.py``.
+
+The cursor-cloud spawn-env builder maps ``spec`` fields to the
+``HARNESS_CURSOR_CLOUD_*`` env vars the cloud harness wrap reads. It mirrors the
+local cursor builder's auth precedence (spec api-key > stored > ambient
+``CURSOR_API_KEY``) and additionally resolves the GitHub repo URL + starting ref
+the cloud agent clones (from the cwd ``origin`` remote, or an
+``OMNIGENT_CURSOR_CLOUD_REPO`` / ``_REF`` override). Like the local builder, a
+``DatabricksAuth`` profile has no cursor equivalent and is ignored.
+
+Unit test — no subprocess spawn. The repo-resolution path is exercised via the
+``OMNIGENT_CURSOR_CLOUD_REPO`` override to avoid depending on a real git cwd.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.runtime.workflow import _build_cursor_cloud_spawn_env
+from omnigent.spec.types import (
+    AgentSpec,
+    ApiKeyAuth,
+    DatabricksAuth,
+    ExecutorSpec,
+    LLMConfig,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Isolate config + clear ambient/override env so each case is deterministic."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    monkeypatch.delenv("OMNIGENT_CURSOR_CLOUD_REPO", raising=False)
+    monkeypatch.delenv("OMNIGENT_CURSOR_CLOUD_REF", raising=False)
+
+
+def _make_spec(
+    *,
+    model: str | None = "composer-2.5",
+    name: str = "test-cursor-cloud",
+    auth: ApiKeyAuth | DatabricksAuth | None = None,
+) -> AgentSpec:
+    """Build a minimal cursor-cloud :class:`AgentSpec` for the spawn-env tests."""
+    config: dict[str, object] = {"harness": "cursor-cloud"}
+    if model is not None:
+        config["model"] = model
+    return AgentSpec(
+        spec_version=1,
+        name=name,
+        instructions="You are a test agent.",
+        executor=ExecutorSpec(type="omnigent", config=config, model=model, auth=auth),
+        llm=LLMConfig(model=model) if model is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repo / ref resolution
+# ---------------------------------------------------------------------------
+
+
+def test_repo_override_flows_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_CURSOR_CLOUD_REPO", "git@github.com:org/repo.git")
+    monkeypatch.setenv("OMNIGENT_CURSOR_CLOUD_REF", "release-1.0")
+    env = _build_cursor_cloud_spawn_env(_make_spec())
+    # Normalized to https form by the resolver.
+    assert env["HARNESS_CURSOR_CLOUD_REPO"] == "https://github.com/org/repo"
+    assert env["HARNESS_CURSOR_CLOUD_REF"] == "release-1.0"
+
+
+def test_repo_override_without_ref_omits_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_CURSOR_CLOUD_REPO", "https://github.com/org/repo")
+    env = _build_cursor_cloud_spawn_env(_make_spec())
+    assert env["HARNESS_CURSOR_CLOUD_REPO"] == "https://github.com/org/repo"
+    assert "HARNESS_CURSOR_CLOUD_REF" not in env
+
+
+def test_unresolvable_repo_is_omitted() -> None:
+    """No cwd and no override -> repo resolution fails softly, leaving the repo
+    env unset so the executor surfaces a clear turn-time error (not a spawn crash)."""
+    env = _build_cursor_cloud_spawn_env(_make_spec(), cwd=None)
+    assert "HARNESS_CURSOR_CLOUD_REPO" not in env
+    assert "HARNESS_CURSOR_CLOUD_REF" not in env
+
+
+def test_cwd_threads_into_cwd_env_var(tmp_path: Path) -> None:
+    env = _build_cursor_cloud_spawn_env(_make_spec(), cwd=tmp_path)
+    assert env["HARNESS_CURSOR_CLOUD_CWD"] == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_model_threads_into_env_var() -> None:
+    env = _build_cursor_cloud_spawn_env(_make_spec(model="claude-4.6-sonnet-thinking"))
+    assert env["HARNESS_CURSOR_CLOUD_MODEL"] == "claude-4.6-sonnet-thinking"
+
+
+def test_no_model_omits_model_env_var() -> None:
+    env = _build_cursor_cloud_spawn_env(_make_spec(model=None))
+    assert "HARNESS_CURSOR_CLOUD_MODEL" not in env
+
+
+def test_databricks_model_forwarded_for_executor_to_drop() -> None:
+    """A ``databricks-*`` spec model is forwarded as-is; the executor's
+    ``_resolve_cloud_model`` drops it to the cloud default at turn time (the
+    spawn-env builder does not second-guess the model id)."""
+    env = _build_cursor_cloud_spawn_env(_make_spec(model="databricks-claude-sonnet-4-6"))
+    assert env["HARNESS_CURSOR_CLOUD_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# Auth precedence
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_auth_sets_api_key_env_var() -> None:
+    env = _build_cursor_cloud_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="crsr_test_123")))
+    assert env["HARNESS_CURSOR_CLOUD_API_KEY"] == "crsr_test_123"
+
+
+def test_databricks_auth_does_not_set_api_key() -> None:
+    """A ``DatabricksAuth`` profile has no cursor-cloud equivalent and is ignored."""
+    env = _build_cursor_cloud_spawn_env(_make_spec(auth=DatabricksAuth(profile="oss")))
+    assert "HARNESS_CURSOR_CLOUD_API_KEY" not in env
+
+
+def test_no_auth_no_ambient_omits_api_key() -> None:
+    env = _build_cursor_cloud_spawn_env(_make_spec(auth=None))
+    assert "HARNESS_CURSOR_CLOUD_API_KEY" not in env
+
+
+def test_ambient_cursor_api_key_used_when_no_spec_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_ambient")
+    env = _build_cursor_cloud_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_CURSOR_CLOUD_API_KEY"] == "crsr_ambient"
+
+
+def test_spec_api_key_wins_over_ambient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_ambient")
+    env = _build_cursor_cloud_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="crsr_spec")))
+    assert env["HARNESS_CURSOR_CLOUD_API_KEY"] == "crsr_spec"
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_name_threads_into_agent_name_env_var() -> None:
+    env = _build_cursor_cloud_spawn_env(_make_spec(name="polly"))
+    assert env["HARNESS_CURSOR_CLOUD_AGENT_NAME"] == "polly"

--- a/tests/runtime/test_cursor_cloud_spawn_env.py
+++ b/tests/runtime/test_cursor_cloud_spawn_env.py
@@ -14,6 +14,7 @@ Unit test — no subprocess spawn. The repo-resolution path is exercised via the
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,31 @@ def _make_spec(
 # ---------------------------------------------------------------------------
 # Repo / ref resolution
 # ---------------------------------------------------------------------------
+
+
+def _init_repo(path: Path, *, remote: str | None, branch: str = "feature/x") -> None:
+    """Initialize a git repo at *path* on *branch*, optionally with an origin remote."""
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t.t"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+    if remote is not None:
+        subprocess.run(["git", "-C", str(path), "remote", "add", "origin", remote], check=True)
+    (path / "f.txt").write_text("x")
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", "init"], check=True)
+
+
+def test_cwd_origin_remote_resolves_repo_and_ref(tmp_path: Path) -> None:
+    """The default runtime path: no OMNIGENT_CURSOR_CLOUD_REPO/REF override, so the
+    repo + ref are derived from the cwd's ``origin`` remote and current branch.
+
+    (The autouse fixture already clears the override env vars.)
+    """
+    _init_repo(tmp_path, remote="git@github.com:org/repo.git", branch="feature/x")
+    env = _build_cursor_cloud_spawn_env(_make_spec(), cwd=tmp_path)
+    # Origin remote normalized to https form, current branch as the ref.
+    assert env["HARNESS_CURSOR_CLOUD_REPO"] == "https://github.com/org/repo"
+    assert env["HARNESS_CURSOR_CLOUD_REF"] == "feature/x"
 
 
 def test_repo_override_flows_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cursor_cloud_repo.py
+++ b/tests/test_cursor_cloud_repo.py
@@ -33,6 +33,9 @@ from omnigent.cursor_cloud_repo import (
         ("git@github.com:org/repo", "https://github.com/org/repo"),
         # ssh:// prefixed form.
         ("ssh://git@github.com/org/repo.git", "https://github.com/org/repo"),
+        # ssh:// with an explicit port — the port is stripped, not folded into path.
+        ("ssh://git@github.com:22/org/repo.git", "https://github.com/org/repo"),
+        ("ssh://git@ssh.github.com:443/org/repo", "https://ssh.github.com/org/repo"),
         # HTTPS form with .git suffix.
         ("https://github.com/org/repo.git", "https://github.com/org/repo"),
         ("https://github.com/org/repo", "https://github.com/org/repo"),
@@ -114,7 +117,7 @@ def test_ref_override_beats_cwd_branch(tmp_path: Path) -> None:
     assert resolved.ref == "release-1.0"
 
 
-def test_detached_head_yields_none_ref(tmp_path: Path) -> None:
+def test_detached_head_yields_commit_sha(tmp_path: Path) -> None:
     _init_repo(tmp_path, remote="git@github.com:org/repo.git", branch="main")
     # Detach HEAD at the current commit so `rev-parse --abbrev-ref HEAD` -> "HEAD".
     sha = subprocess.run(
@@ -126,7 +129,8 @@ def test_detached_head_yields_none_ref(tmp_path: Path) -> None:
     subprocess.run(["git", "-C", str(tmp_path), "checkout", "-q", sha], check=True)
     resolved = resolve_cursor_cloud_repo(tmp_path)
     assert resolved.url == "https://github.com/org/repo"
-    assert resolved.ref is None  # detached "HEAD" is not a usable ref
+    # Detached "HEAD" is not a clonable ref; fall back to the exact commit SHA.
+    assert resolved.ref == sha
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cursor_cloud_repo.py
+++ b/tests/test_cursor_cloud_repo.py
@@ -1,0 +1,150 @@
+"""Tests for :mod:`omnigent.cursor_cloud_repo`.
+
+Covers URL normalization (SSH / HTTPS / git@ forms, ``.git`` + trailing-slash
+stripping), cwd-derived resolution from a real temp git repo's ``origin``
+remote and current branch, override precedence, detached-HEAD handling, and the
+no-repo error paths. No live cloud calls — repo resolution is pure git + regex.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omnigent.cursor_cloud_repo import (
+    CursorCloudRepo,
+    RepoResolutionError,
+    normalize_remote_url,
+    resolve_cursor_cloud_repo,
+)
+
+# ---------------------------------------------------------------------------
+# normalize_remote_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # SSH scp-like form.
+        ("git@github.com:org/repo.git", "https://github.com/org/repo"),
+        ("git@github.com:org/repo", "https://github.com/org/repo"),
+        # ssh:// prefixed form.
+        ("ssh://git@github.com/org/repo.git", "https://github.com/org/repo"),
+        # HTTPS form with .git suffix.
+        ("https://github.com/org/repo.git", "https://github.com/org/repo"),
+        ("https://github.com/org/repo", "https://github.com/org/repo"),
+        # Trailing slash stripped.
+        ("https://github.com/org/repo/", "https://github.com/org/repo"),
+        ("git@github.com:org/repo.git/", "https://github.com/org/repo"),
+        # Embedded credentials dropped.
+        ("https://user:token@github.com/org/repo.git", "https://github.com/org/repo"),
+        # git:// scheme normalized to https.
+        ("git://github.com/org/repo.git", "https://github.com/org/repo"),
+        # Non-GitHub host passed through (still normalized).
+        ("git@gitlab.com:group/sub/repo.git", "https://gitlab.com/group/sub/repo"),
+        # Whitespace stripped.
+        ("  https://github.com/org/repo.git  ", "https://github.com/org/repo"),
+    ],
+)
+def test_normalize_remote_url(raw: str, expected: str) -> None:
+    assert normalize_remote_url(raw) == expected
+
+
+def test_normalize_remote_url_unknown_shape_returned_stripped() -> None:
+    # A string matching no known remote shape comes back stripped but unchanged.
+    assert normalize_remote_url("  not-a-url  ") == "not-a-url"
+
+
+# ---------------------------------------------------------------------------
+# resolve_cursor_cloud_repo — override precedence
+# ---------------------------------------------------------------------------
+
+
+def test_repo_override_wins_and_is_normalized() -> None:
+    resolved = resolve_cursor_cloud_repo(
+        None, repo_override="git@github.com:org/repo.git", ref_override="main"
+    )
+    assert resolved == CursorCloudRepo(url="https://github.com/org/repo", ref="main")
+
+
+def test_repo_override_without_ref_yields_none_ref() -> None:
+    resolved = resolve_cursor_cloud_repo(None, repo_override="https://github.com/org/repo")
+    assert resolved.url == "https://github.com/org/repo"
+    assert resolved.ref is None
+
+
+def test_blank_ref_override_folds_to_none() -> None:
+    resolved = resolve_cursor_cloud_repo(
+        None, repo_override="https://github.com/org/repo", ref_override="   "
+    )
+    assert resolved.ref is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_cursor_cloud_repo — cwd-derived
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(path: Path, *, remote: str | None, branch: str = "feature/x") -> None:
+    """Initialize a git repo at *path* on *branch*, optionally with an origin remote."""
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t.t"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+    if remote is not None:
+        subprocess.run(["git", "-C", str(path), "remote", "add", "origin", remote], check=True)
+    (path / "f.txt").write_text("x")
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", "init"], check=True)
+
+
+def test_cwd_derived_url_and_branch(tmp_path: Path) -> None:
+    _init_repo(tmp_path, remote="git@github.com:org/repo.git", branch="feature/x")
+    resolved = resolve_cursor_cloud_repo(tmp_path)
+    assert resolved.url == "https://github.com/org/repo"
+    assert resolved.ref == "feature/x"
+
+
+def test_ref_override_beats_cwd_branch(tmp_path: Path) -> None:
+    _init_repo(tmp_path, remote="https://github.com/org/repo.git", branch="feature/x")
+    resolved = resolve_cursor_cloud_repo(tmp_path, ref_override="release-1.0")
+    assert resolved.url == "https://github.com/org/repo"
+    assert resolved.ref == "release-1.0"
+
+
+def test_detached_head_yields_none_ref(tmp_path: Path) -> None:
+    _init_repo(tmp_path, remote="git@github.com:org/repo.git", branch="main")
+    # Detach HEAD at the current commit so `rev-parse --abbrev-ref HEAD` -> "HEAD".
+    sha = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(["git", "-C", str(tmp_path), "checkout", "-q", sha], check=True)
+    resolved = resolve_cursor_cloud_repo(tmp_path)
+    assert resolved.url == "https://github.com/org/repo"
+    assert resolved.ref is None  # detached "HEAD" is not a usable ref
+
+
+# ---------------------------------------------------------------------------
+# resolve_cursor_cloud_repo — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_no_cwd_and_no_override_raises() -> None:
+    with pytest.raises(RepoResolutionError):
+        resolve_cursor_cloud_repo(None)
+
+
+def test_cwd_without_origin_remote_raises(tmp_path: Path) -> None:
+    _init_repo(tmp_path, remote=None, branch="main")
+    with pytest.raises(RepoResolutionError):
+        resolve_cursor_cloud_repo(tmp_path)
+
+
+def test_non_git_cwd_raises(tmp_path: Path) -> None:
+    with pytest.raises(RepoResolutionError):
+        resolve_cursor_cloud_repo(tmp_path)


### PR DESCRIPTION
## What & why

Closes #1148. Adds a new `cursor-cloud` harness for **Cursor Cloud / Background Agents** — agents that run in Cursor's cloud against a GitHub repo and push a branch / open a PR, complementing the existing local-only `cursor` (SDK) and `cursor-native` (TUI) harnesses.

The Python `cursor-sdk` already vendored for the `cursor` harness exposes cloud through the **same** `AsyncClient` via `AgentOptions(cloud=CloudAgentOptions(...))` (verified against the pinned `cursor-sdk==0.1.7`), so no new dependency is needed.

## How it works

A turn launches a cloud run (`AsyncClient(base_url="https://api.cursor.com", auth_token=…)` → `create_agent(cloud=CloudAgentOptions(repos=[…], auto_create_pr=True))` → `agent.send(prompt)`), streams `run.events()` into Omnigent conversation events, and resolves the turn with the result summary + branch/PR link from `RunResult.git.branches`.

Key decisions:
- **New harness key, not a mode on `cursor`.** The cloud runtime breaks the local executor's assumptions (no tool bridge, no `preToolUse` policy hook, no local-cwd edits, output is a remote PR), so a separate `CursorCloudExecutor` keeps both clean. It **reuses** the local executor's `_sdk_message_to_events` / `_resolve_model` / `_normalize_cursor_usage` helpers (cloud emits the same `SDKMessage` types).
- **Shared auth.** Reuses the existing Cursor `crsr_` API key — no new secret.
- **`handles_tools_internally=True`.** Tools run in the cloud VM; `tool_call` events are informational.
- **Repo/ref:** defaults to the cwd `origin` remote + current branch (override via `OMNIGENT_CURSOR_CLOUD_REPO` / `_REF`); SSH/HTTPS normalized to the API's `https://github.com/org/repo` form.

## Scope (v1)

In: launch → live stream → result/PR, model resolution + `/model` override, onboarding (readiness/install/CLI), docs.
Deferred: follow-up prompts, cancel/interrupt, list/archive, artifacts, multi-repo, env-var injection.

## Caveat — repo env setup

Cursor cloud requires a one-time per-repo environment setup in the dashboard (`https://cursor.com/onboard?repository=<url>`); there is no API to trigger it. A never-onboarded repo surfaces that URL in the error rather than hanging.

## Testing

57 new unit tests (cursor-sdk boundary fully mocked, no live cloud calls): URL normalization + override precedence + detached-HEAD SHA, event-stream mapping, PR-link formatting, missing-repo guard, launch-failure onboarding hint, terminal error/expired/cancelled paths, env-var reads, auth precedence. Full suite incl. existing cursor/onboarding tests: **151 passed**. `ruff` clean. Diff reviewed by `codex` (gate pass, no P1; three P2 resolver findings fixed).

Live cloud e2e is a manual release-time step (it needs a real key + onboarded repo and can't be mocked across the subprocess boundary), consistent with the existing per-harness cursor e2e.

This pull request and its description were written by Isaac.
