### PR TITLE
feat(pi-native): stream assistant text deltas for live web preview

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -323,6 +323,38 @@ module.exports = function (pi) {
   const postedReasoning = new Set();
   const toolCallsById = new Map();
   const pendingInterruptMs = 30_000;
+  // Live streaming state for assistant text deltas. Pi emits
+  // message_update events carrying an assistantMessageEvent of type
+  // "text_delta" (token chunk) / "text_end" (block complete) during a
+  // turn — see @earendil-works/pi-ai AssistantMessageEvent. We forward
+  // each token as a transient external_output_text_delta so the web UI
+  // paints a live preview before the final message lands.
+  //
+  // The preview is keyed by ASSISTANT MESSAGE, not per text block: the
+  // web UI (chatStore.pumpStreamEvents) finalizes the OLDEST in-flight
+  // "live:<message_id>" preview when the authoritative text_done arrives,
+  // FIFO, and message_end posts ONE combined external_conversation_item
+  // per assistant message (textFromMessage joins all text blocks). So a
+  // 1:1 message-scoped id keeps exactly one preview per item; a per-block
+  // id would orphan extra previews when a message has multiple text
+  // blocks (e.g. text → tool call → more text). All text blocks of a
+  // message share its id with a single monotonic chunk index, so the
+  // preview reads as one growing message — matching claude-native.
+  //
+  // Deltas are best-effort live preview: postEvent fails open, and the
+  // authoritative text still arrives via message_end regardless.
+  //
+  // streamingMessageOrdinal: bumped at each assistant message_end so the
+  // NEXT message of the turn gets a fresh, stable id distinct from earlier
+  // ones — see the message_end handler for why it advances there (not on
+  // message_start) so deltas and the finalize agree on the id.
+  let streamingMessageOrdinal = 0;
+  // streamedTextIndex: message_id -> next 0-based chunk index.
+  const streamedTextIndex = new Map();
+  // finalizedTextBlocks: message_ids whose final delta was already posted,
+  // so a duplicate text_end (or a stray text_delta after end) can't reopen
+  // or double-finalize the preview.
+  const finalizedTextBlocks = new Set();
 
   function rememberContext(ctx) {
     if (ctx) latestContext = ctx;
@@ -453,6 +485,63 @@ module.exports = function (pi) {
     });
   }
 
+  function streamingMessageId(responseId) {
+    // Stable per-assistant-message id across all of the message's text
+    // chunks. The web UI keys an in-flight "live:<message_id>" preview off
+    // this, appends each chunk in `index` order, and reconciles it against
+    // the authoritative assistant item by FIFO retirement. responseId
+    // scopes it to this turn and the ordinal distinguishes successive
+    // assistant messages within the turn, so a finalized message's id is
+    // never reused by a later one.
+    return `${responseId}:msg:${streamingMessageOrdinal}`;
+  }
+
+  async function postOutputTextDelta(messageId, delta, options) {
+    // Transient assistant-text chunk for live preview (Responses-style
+    // response.output_text.delta on the wire). Not persisted; the
+    // authoritative final text arrives separately via
+    // external_conversation_item. A blank, non-final delta carries no
+    // signal — skip it so an empty token can't churn the UI buffer.
+    const final = !!(options && options.final);
+    if (typeof delta !== "string") return;
+    if (!delta && !final) return;
+    const index = streamedTextIndex.get(messageId) || 0;
+    streamedTextIndex.set(messageId, index + 1);
+    await postEvent(config, {
+      type: "external_output_text_delta",
+      data: {
+        delta,
+        message_id: messageId,
+        index,
+        final,
+      },
+    });
+  }
+
+  async function postTextDelta(update, responseId) {
+    // assistantMessageEvent of type "text_delta": one streamed token of
+    // the current assistant message. All text blocks of the message share
+    // its id, so the preview reads as one growing message.
+    if (!update || typeof update.delta !== "string" || !update.delta) return;
+    const messageId = streamingMessageId(responseId);
+    if (finalizedTextBlocks.has(messageId)) return;
+    await postOutputTextDelta(messageId, update.delta);
+  }
+
+  async function finalizeStreamingMessage(responseId) {
+    // Emit a final-marker delta so the web UI knows no further chunks will
+    // arrive for this message_id and can stop the live buffer. The marker
+    // carries no new text (the running preview already holds the full
+    // message); message_end posts the authoritative item that replaces the
+    // preview in place. Only finalize a message we actually streamed (a
+    // message with no text_delta has no live preview to close).
+    const messageId = streamingMessageId(responseId);
+    if (finalizedTextBlocks.has(messageId)) return;
+    if (!streamedTextIndex.has(messageId)) return;
+    finalizedTextBlocks.add(messageId);
+    await postOutputTextDelta(messageId, "", { final: true });
+  }
+
   async function mirrorAssistantMessage(message, responseId) {
     const blocks = contentBlocks(message);
     for (let index = 0; index < blocks.length; index += 1) {
@@ -508,6 +597,9 @@ module.exports = function (pi) {
     postedToolResults.clear();
     postedReasoning.clear();
     toolCallsById.clear();
+    streamedTextIndex.clear();
+    finalizedTextBlocks.clear();
+    streamingMessageOrdinal = 0;
     await postEvent(config, {
       type: "external_session_status",
       data: {
@@ -546,6 +638,10 @@ module.exports = function (pi) {
     const responseId = currentResponseId();
     const update = event ? event.assistantMessageEvent : undefined;
     if (!update || typeof update !== "object") return;
+    if (update.type === "text_delta") {
+      await postTextDelta(update, responseId);
+      return;
+    }
     if (update.type === "toolcall_end") {
       await postToolCall(update.toolCall, responseId);
       return;
@@ -629,9 +725,20 @@ module.exports = function (pi) {
     const role = messageRole(message);
     if (role !== "assistant") return;
     const responseId = currentResponseId();
+    // Close the live preview for this message (no-op if nothing streamed),
+    // then bump the ordinal so the NEXT assistant message of this turn
+    // streams under a fresh, distinct id and never reuses this one's. The
+    // ordinal advances here (not on message_start) so the deltas just
+    // posted and this finalize agree on the id regardless of whether Pi
+    // fires message_start.
+    await finalizeStreamingMessage(responseId);
+    streamingMessageOrdinal += 1;
     await mirrorAssistantMessage(message, responseId);
     const text = textFromMessage(message);
     if (!text) return;
+    // The authoritative assistant item. The web UI retires + replaces the
+    // oldest in-flight live preview in place with this (FIFO; one preview
+    // per message), so the streamed partials never duplicate the final.
     await postEvent(config, {
       type: "external_conversation_item",
       data: {

--- a/tests/test_pi_native_extension.py
+++ b/tests/test_pi_native_extension.py
@@ -251,7 +251,9 @@ def test_text_deltas_post_incrementally_with_stable_id() -> None:
     the streamed text, a final marker closes the stream, and the authoritative
     assistant item carries the full text exactly once (no duplication).
     """
-    script = _STREAMING_HARNESS + r"""
+    script = (
+        _STREAMING_HARNESS
+        + r"""
 (async () => {
   await handlers.agent_start({}, ctx);
   await handlers.turn_start({ turnIndex: 1 }, ctx);
@@ -293,6 +295,7 @@ def test_text_deltas_post_incrementally_with_stable_id() -> None:
   assert.equal(assistantText(assistantItems[0]), chunks.join(""));
 })().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
 """
+    )
     result = _run_node(script, str(_extension_path()), "/tmp")
     assert result.returncode == 0, result.stdout + result.stderr
 
@@ -306,7 +309,9 @@ def test_multiple_text_blocks_share_one_message_preview(tmp_path: Path) -> None:
     preview is orphaned. Asserts both blocks' chunks share one ``message_id``
     with a single monotonic index.
     """
-    script = _STREAMING_HARNESS + r"""
+    script = (
+        _STREAMING_HARNESS
+        + r"""
 (async () => {
   await handlers.agent_start({}, ctx);
   await handlers.turn_start({ turnIndex: 1 }, ctx);
@@ -335,6 +340,7 @@ def test_multiple_text_blocks_share_one_message_preview(tmp_path: Path) -> None:
   );
 })().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
 """
+    )
     result = _run_node(script, str(_extension_path()), str(tmp_path))
     assert result.returncode == 0, result.stdout + result.stderr
 
@@ -347,7 +353,9 @@ def test_successive_messages_in_turn_get_distinct_ids(tmp_path: Path) -> None:
     the new text into the already-committed first bubble. Asserts the second
     message's deltas carry a different ``message_id`` whose index restarts at 0.
     """
-    script = _STREAMING_HARNESS + r"""
+    script = (
+        _STREAMING_HARNESS
+        + r"""
 (async () => {
   await handlers.agent_start({}, ctx);
   await handlers.turn_start({ turnIndex: 1 }, ctx);
@@ -384,6 +392,7 @@ def test_successive_messages_in_turn_get_distinct_ids(tmp_path: Path) -> None:
   assert.equal(assistantText(assistantItems[1]), "Done");
 })().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
 """
+    )
     result = _run_node(script, str(_extension_path()), str(tmp_path))
     assert result.returncode == 0, result.stdout + result.stderr
 
@@ -395,7 +404,9 @@ def test_message_without_streamed_text_posts_no_delta(tmp_path: Path) -> None:
     stray final marker — there is no live preview to close, so a spurious delta
     could create an empty preview bubble in the web UI.
     """
-    script = _STREAMING_HARNESS + r"""
+    script = (
+        _STREAMING_HARNESS
+        + r"""
 (async () => {
   await handlers.agent_start({}, ctx);
   await handlers.turn_start({ turnIndex: 1 }, ctx);
@@ -406,5 +417,6 @@ def test_message_without_streamed_text_posts_no_delta(tmp_path: Path) -> None:
   assert.equal(deltas().length, 0, JSON.stringify(deltas()));
 })().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
 """
+    )
     result = _run_node(script, str(_extension_path()), str(tmp_path))
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_pi_native_extension.py
+++ b/tests/test_pi_native_extension.py
@@ -148,3 +148,263 @@ require(extensionPath)(pi);
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _extension_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "omnigent"
+        / "resources"
+        / "pi_native"
+        / "omnigent_pi_native_extension.js"
+    )
+
+
+def _run_node(script: str, *args: str) -> subprocess.CompletedProcess[str]:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+    return subprocess.run(
+        [node, "-e", script, *args],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+
+
+# Shared Node preamble: load the real extension with mocked fetch/setInterval/pi,
+# drive its event handlers, and expose the posted event bodies.
+_STREAMING_HARNESS = r"""
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+
+const extensionPath = process.argv[1];
+const tmpDir = process.argv[2];
+const configPath = path.join(tmpDir, "config.json");
+
+fs.writeFileSync(
+  configPath,
+  JSON.stringify({ serverUrl: "http://omnigent.test", sessionId: "session-1" }),
+);
+process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
+
+const posted = [];
+global.fetch = async (_url, request) => {
+  posted.push(JSON.parse(request.body));
+  return { ok: true, async json() { return { result: "" }; } };
+};
+global.setInterval = () => ({ fakeInterval: true });
+
+const handlers = {};
+const pi = {
+  registerCommand() {},
+  on(name, handler) { handlers[name] = handler; },
+  sendUserMessage() {},
+};
+
+require(extensionPath)(pi);
+
+const ctx = { isIdle: () => false, ui: { setTitle() {}, setStatus() {}, notify() {} } };
+
+// Helpers to build the Pi AssistantMessageEvent shapes the extension consumes.
+function textDelta(contentIndex, delta) {
+  return { type: "text_delta", contentIndex, delta, partial: {} };
+}
+function textEnd(contentIndex, content) {
+  return { type: "text_end", contentIndex, content, partial: {} };
+}
+async function feed(assistantMessageEvent) {
+  await handlers.message_update({ assistantMessageEvent }, ctx);
+}
+async function endMessage(text) {
+  await handlers.message_end(
+    {
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text }],
+      },
+    },
+    ctx,
+  );
+}
+
+function deltas() {
+  return posted.filter((e) => e.type === "external_output_text_delta");
+}
+function items() {
+  return posted.filter((e) => e.type === "external_conversation_item");
+}
+function assistantText(item) {
+  return item.data.item_data.content.map((b) => b.text).join("");
+}
+"""
+
+
+def test_text_deltas_post_incrementally_with_stable_id() -> None:
+    """Each token posts as an external_output_text_delta with a stable id.
+
+    Drives the real extension with a sequence of Pi ``text_delta`` events for
+    one assistant message, then ``message_end``. Asserts: every chunk shares one
+    ``message_id``, chunk ``index`` is monotonic from 0, the joined deltas equal
+    the streamed text, a final marker closes the stream, and the authoritative
+    assistant item carries the full text exactly once (no duplication).
+    """
+    script = _STREAMING_HARNESS + r"""
+(async () => {
+  await handlers.agent_start({}, ctx);
+  await handlers.turn_start({ turnIndex: 1 }, ctx);
+
+  const chunks = ["Hello", ", ", "world", "!"];
+  for (const c of chunks) await feed(textDelta(0, c));
+  await feed(textEnd(0, chunks.join("")));
+  await endMessage(chunks.join(""));
+
+  const ds = deltas();
+  // One text chunk per delta plus a single final marker.
+  const textChunks = ds.filter((d) => d.data.delta !== "");
+  const finals = ds.filter((d) => d.data.final === true);
+  assert.equal(textChunks.length, chunks.length, JSON.stringify(ds));
+  assert.equal(finals.length, 1, JSON.stringify(ds));
+
+  // Stable message_id across every chunk and the final marker.
+  const ids = new Set(ds.map((d) => d.data.message_id));
+  assert.equal(ids.size, 1, "expected one stable message_id: " + JSON.stringify([...ids]));
+  const messageId = [...ids][0];
+  assert.ok(typeof messageId === "string" && messageId.length > 0);
+
+  // Monotonic, gapless index from 0.
+  const indices = ds.map((d) => d.data.index);
+  assert.deepEqual(indices, indices.map((_, i) => i), JSON.stringify(indices));
+
+  // Joined streamed deltas equal the streamed text.
+  assert.equal(textChunks.map((d) => d.data.delta).join(""), chunks.join(""));
+
+  // The final marker is last and carries no new text.
+  assert.equal(ds[ds.length - 1].data.final, true);
+  assert.equal(ds[ds.length - 1].data.delta, "");
+
+  // Exactly one authoritative assistant item, carrying the full text once.
+  const assistantItems = items().filter(
+    (i) => i.data.item_type === "message" && i.data.item_data.role === "assistant",
+  );
+  assert.equal(assistantItems.length, 1, JSON.stringify(assistantItems));
+  assert.equal(assistantText(assistantItems[0]), chunks.join(""));
+})().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
+"""
+    result = _run_node(script, str(_extension_path()), "/tmp")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_multiple_text_blocks_share_one_message_preview(tmp_path: Path) -> None:
+    """Multiple text blocks in one message stream under one message_id.
+
+    The web UI finalizes the oldest live preview per authoritative item (FIFO,
+    one item per message), so a message with two text blocks (e.g. text → tool
+    call → text) must stream as ONE growing preview — not two — or the second
+    preview is orphaned. Asserts both blocks' chunks share one ``message_id``
+    with a single monotonic index.
+    """
+    script = _STREAMING_HARNESS + r"""
+(async () => {
+  await handlers.agent_start({}, ctx);
+  await handlers.turn_start({ turnIndex: 1 }, ctx);
+
+  // Text block 0, a tool call at index 1, then text block 2.
+  await feed(textDelta(0, "First "));
+  await feed(textDelta(0, "part."));
+  await feed(textEnd(0, "First part."));
+  await feed(textDelta(2, " Second "));
+  await feed(textDelta(2, "part."));
+  await feed(textEnd(2, " Second part."));
+  await endMessage("First part. Second part.");
+
+  const ds = deltas();
+  const ids = new Set(ds.map((d) => d.data.message_id));
+  assert.equal(ids.size, 1, "both blocks must share one id: " + JSON.stringify([...ids]));
+
+  const textChunks = ds.filter((d) => d.data.delta !== "");
+  assert.equal(textChunks.length, 4, JSON.stringify(ds));
+  // Single monotonic index spanning both blocks.
+  const indices = ds.map((d) => d.data.index);
+  assert.deepEqual(indices, indices.map((_, i) => i), JSON.stringify(indices));
+  assert.equal(
+    textChunks.map((d) => d.data.delta).join(""),
+    "First part. Second part.",
+  );
+})().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
+"""
+    result = _run_node(script, str(_extension_path()), str(tmp_path))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_successive_messages_in_turn_get_distinct_ids(tmp_path: Path) -> None:
+    """Two assistant messages in one turn stream under distinct message_ids.
+
+    After a tool round-trip Pi begins a fresh assistant message. Its preview
+    must NOT reuse the first message's (finalized) id, or the web UI would fold
+    the new text into the already-committed first bubble. Asserts the second
+    message's deltas carry a different ``message_id`` whose index restarts at 0.
+    """
+    script = _STREAMING_HARNESS + r"""
+(async () => {
+  await handlers.agent_start({}, ctx);
+  await handlers.turn_start({ turnIndex: 1 }, ctx);
+
+  await feed(textDelta(0, "Looking"));
+  await feed(textEnd(0, "Looking"));
+  await endMessage("Looking");
+
+  // Second assistant message (after a tool round-trip) in the same turn.
+  await feed(textDelta(0, "Done"));
+  await feed(textEnd(0, "Done"));
+  await endMessage("Done");
+
+  const ds = deltas();
+  const ids = [...new Set(ds.map((d) => d.data.message_id))];
+  assert.equal(ids.size === undefined ? ids.length : ids.length, 2, JSON.stringify(ids));
+
+  // Group indices per id; each must restart at 0 and be monotonic.
+  const byId = new Map();
+  for (const d of ds) {
+    if (!byId.has(d.data.message_id)) byId.set(d.data.message_id, []);
+    byId.get(d.data.message_id).push(d.data.index);
+  }
+  for (const [, idxs] of byId) {
+    assert.deepEqual(idxs, idxs.map((_, i) => i), JSON.stringify(idxs));
+  }
+
+  // Two authoritative items, one per message, no cross-contamination.
+  const assistantItems = items().filter(
+    (i) => i.data.item_type === "message" && i.data.item_data.role === "assistant",
+  );
+  assert.equal(assistantItems.length, 2);
+  assert.equal(assistantText(assistantItems[0]), "Looking");
+  assert.equal(assistantText(assistantItems[1]), "Done");
+})().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
+"""
+    result = _run_node(script, str(_extension_path()), str(tmp_path))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_message_without_streamed_text_posts_no_delta(tmp_path: Path) -> None:
+    """A message_end with no preceding text_delta emits no delta events.
+
+    A tool-only assistant message (or a non-streaming path) must not post a
+    stray final marker — there is no live preview to close, so a spurious delta
+    could create an empty preview bubble in the web UI.
+    """
+    script = _STREAMING_HARNESS + r"""
+(async () => {
+  await handlers.agent_start({}, ctx);
+  await handlers.turn_start({ turnIndex: 1 }, ctx);
+
+  // No text_delta at all — just the authoritative item.
+  await endMessage("");
+
+  assert.equal(deltas().length, 0, JSON.stringify(deltas()));
+})().catch((e) => { console.error(e && e.stack ? e.stack : e); process.exit(1); });
+"""
+    result = _run_node(script, str(_extension_path()), str(tmp_path))
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## What

Moves the **pi-native** harness from complete-only mirroring to **streaming deltas**, so the web UI paints assistant text incrementally DURING a Pi turn — parity with claude-native / codex-native.

Previously the Pi bridge extension POSTed the full assistant message as an `external_conversation_item` only at `message_end`, so the web bubble stayed empty until the turn's text was finished.

## Does Pi's API actually support deltas? Yes.

A Pi `message_update` event carries an `assistantMessageEvent` of type `text_delta` (token chunk), `text_end` (block complete), `thinking_delta`, `toolcall_delta`, etc. — see `@earendil-works/pi-ai` `AssistantMessageEvent`. The extension already hooked `message_update` for `toolcall_end` / `thinking_end` but ignored `text_delta`. So token-by-token streaming was available; this wires it up.

## How

Each `text_delta` is forwarded as a transient `external_output_text_delta` — the same `response.output_text.delta` wire shape claude/codex-native use (`delta` + stable `message_id` + monotonic `index` + `final`). The server already accepts and broadcasts this event on `GET /v1/sessions/{id}/stream`, and the web store (`chatStore.pumpStreamEvents`) already renders a `live:<message_id>` preview and retires+replaces it with the authoritative item. pi-native is already registered as a native-terminal wrapper (`pi-native-ui` in `nativeCodingAgents`), so that finalization path applies unchanged — **no server or web changes were needed**, only the extension.

### Key design choice: preview keyed per assistant MESSAGE, not per text block

The web UI finalizes the **oldest** in-flight preview (FIFO) when the single combined item per message arrives. So all of a message's text blocks share **one** `message_id` with a single monotonic index — a per-block id would orphan extra previews when a message has multiple text blocks (text → tool call → more text). The ordinal advances at `message_end` (not `message_start`) so the deltas just posted and the finalize agree on the id regardless of whether Pi fires `message_start`.

The existing complete-message post is unchanged and stays authoritative, so streamed partials never duplicate the final — the UI replaces the preview in place.

## Tests

Four new Node-execution tests in `tests/test_pi_native_extension.py` drive the **real** extension JS under Node and assert:
- partial deltas post incrementally with a stable `message_id`, gapless monotonic `index` from 0, joined text == streamed text, exactly one final marker, and one authoritative item (no duplication);
- a multi-text-block message coalesces into ONE preview (one shared id);
- successive messages in a turn get distinct ids whose index restarts at 0;
- a text-less (tool-only) message posts no stray delta.

All pi-native python tests pass (17), and the existing interrupt/replay JS test still passes (14 assertions).

## Live verification

Verified end-to-end against a live local server (port 6784): the real extension POSTing to `/v1/sessions/{id}/events` produced **9 incremental `response.output_text.delta` events** (one stable `message_id`, gapless index `0..9`) observed on the same `GET /v1/sessions/{id}/stream` SSE endpoint the web UI consumes, followed by the authoritative full-text item — proving the full server→SSE pipeline the web consumes.

**Limitation (honest):** a real Pi-model turn was NOT runnable in this environment — the `pi` CLI works under node v22, and the harness does launch it with the generated extension, but no Pi credentials / Anthropic egress are configured here, so a live model turn stalls at launch. The Pi `text_delta` event sequence was therefore replayed through the genuine extension code rather than produced by a live model. The streaming wiring, event shape, server acceptance, and SSE broadcast are all verified live; only the upstream Pi model call is unexercised.

This pull request and its description were written by Isaac.