### PR TITLE
Add auth-aware Codex availability

### DIFF
--- a/ap-web/src/hooks/useHosts.ts
+++ b/ap-web/src/hooks/useHosts.ts
@@ -14,11 +14,11 @@ export interface Host {
   sandbox_provider?: string | null;
   /**
    * Per-harness readiness reported by the host's last connect, e.g.
-   * `{"claude-sdk": true, "codex": false}`. `null`/absent means the
+   * `{"claude-sdk": true, "codex": "needs-auth"}`. `null`/absent means the
    * host has never reported it (older host build) — unknown, never
    * "nothing configured".
    */
-  configured_harnesses?: Record<string, boolean> | null;
+  configured_harnesses?: Record<string, boolean | string> | null;
 }
 
 interface HostsResponse {

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -8,6 +8,7 @@ import {
   deriveHomeDir,
   deriveRepoName,
   describeCreateError,
+  harnessUnavailableReasonOnHost,
   harnessUnconfiguredOnHost,
   isValidSandboxRepoUrl,
   isValidWorkspace,
@@ -375,7 +376,7 @@ describe("describeCreateError", () => {
 });
 
 describe("harnessUnconfiguredOnHost", () => {
-  const hostWith = (configured: Record<string, boolean> | null | undefined): Host =>
+  const hostWith = (configured: Record<string, boolean | string> | null | undefined): Host =>
     ({
       host_id: "host_1",
       name: "laptop",
@@ -385,10 +386,17 @@ describe("harnessUnconfiguredOnHost", () => {
     }) as Host;
 
   it("warns only on an explicit false from the host", () => {
-    const host = hostWith({ "claude-sdk": true, codex: false });
+    const testHost = hostWith({ "claude-sdk": true, codex: false });
     // Explicit false → warn; explicit true → no warning.
-    expect(harnessUnconfiguredOnHost("codex", host)).toBe(true);
-    expect(harnessUnconfiguredOnHost("claude-sdk", host)).toBe(false);
+    expect(harnessUnconfiguredOnHost("codex", testHost)).toBe(true);
+    expect(harnessUnconfiguredOnHost("claude-sdk", testHost)).toBe(false);
+  });
+
+  it("surfaces structured codex unavailable reasons", () => {
+    const testHost = hostWith({ codex: "needs-auth", "codex-native": "binary-missing" });
+    expect(harnessUnconfiguredOnHost("codex", testHost)).toBe(true);
+    expect(harnessUnavailableReasonOnHost("codex", testHost)).toBe("needs-auth");
+    expect(harnessUnavailableReasonOnHost("codex-native", testHost)).toBe("binary-missing");
   });
 
   it("never warns when readiness is unknown", () => {

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -10,6 +10,8 @@ import {
   describeCreateError,
   harnessUnavailableReasonOnHost,
   harnessUnconfiguredOnHost,
+  harnessWarningBadgeText,
+  harnessWarningMessageText,
   isValidSandboxRepoUrl,
   isValidWorkspace,
   matchSkillInvocation,
@@ -392,11 +394,35 @@ describe("harnessUnconfiguredOnHost", () => {
     expect(harnessUnconfiguredOnHost("claude-sdk", testHost)).toBe(false);
   });
 
+  it("keeps legacy non-codex false availability generic", () => {
+    const testHost = hostWith({ "claude-native": false });
+    const reason = harnessUnavailableReasonOnHost("claude-native", testHost);
+    expect(reason).toBe("unconfigured");
+    expect(harnessWarningBadgeText(reason)).toBe("needs setup");
+    expect(harnessWarningMessageText("Claude Code", "laptop", reason)).toBe(
+      "Claude Code isn't configured on laptop — run omnigent setup on that machine.",
+    );
+  });
+
   it("surfaces structured codex unavailable reasons", () => {
     const testHost = hostWith({ codex: "needs-auth", "codex-native": "binary-missing" });
     expect(harnessUnconfiguredOnHost("codex", testHost)).toBe(true);
     expect(harnessUnavailableReasonOnHost("codex", testHost)).toBe("needs-auth");
     expect(harnessUnavailableReasonOnHost("codex-native", testHost)).toBe("binary-missing");
+    expect(harnessWarningBadgeText("needs-auth")).toBe("needs auth");
+    expect(harnessWarningMessageText("Codex", "laptop", "needs-auth")).toBe(
+      "Codex needs Codex authentication on laptop — run codex login on that machine.",
+    );
+    expect(harnessWarningBadgeText("binary-missing")).toBe("binary missing");
+    expect(harnessWarningMessageText("Codex", "laptop", "binary-missing")).toBe(
+      "Codex is missing the Codex binary on laptop — run omnigent setup on that machine.",
+    );
+  });
+
+  it("ignores unknown future reason strings", () => {
+    expect(harnessUnavailableReasonOnHost("codex", hostWith({ codex: "future-reason" }))).toBe(
+      null,
+    );
   });
 
   it("never warns when readiness is unknown", () => {

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1,4 +1,4 @@
-import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type DragEvent, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@/lib/routing";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -414,8 +414,53 @@ export function harnessUnconfiguredOnHost(
   harness: string | null | undefined,
   host: Host | undefined | null,
 ): boolean {
-  if (!harness || !host?.configured_harnesses) return false;
-  return host.configured_harnesses[harness] === false;
+  return harnessUnavailableReasonOnHost(harness, host) !== null;
+}
+
+export function harnessUnavailableReasonOnHost(
+  harness: string | null | undefined,
+  host: Host | undefined | null,
+): string | null {
+  if (!harness || !host?.configured_harnesses) return null;
+  const availability = host.configured_harnesses[harness];
+  if (availability === false) return "binary-missing";
+  if (availability === "binary-missing" || availability === "needs-auth") return availability;
+  return null;
+}
+
+function harnessWarningBadgeText(reason: string | null): string {
+  if (reason === "binary-missing") return "binary missing";
+  if (reason === "needs-auth") return "needs auth";
+  return "needs setup";
+}
+
+function harnessWarningMessage(
+  agentName: string | undefined,
+  hostName: string | undefined,
+  reason: string | null,
+): ReactNode {
+  if (reason === "needs-auth") {
+    return (
+      <>
+        {agentName} needs Codex authentication on {hostName} — run <code>codex login</code> on that
+        machine.
+      </>
+    );
+  }
+  if (reason === "binary-missing") {
+    return (
+      <>
+        {agentName} is missing the Codex binary on {hostName} — run <code>omnigent setup</code> on
+        that machine.
+      </>
+    );
+  }
+  return (
+    <>
+      {agentName} isn&apos;t configured on {hostName} — run <code>omnigent setup</code> on that
+      machine.
+    </>
+  );
 }
 
 /**
@@ -742,7 +787,7 @@ function BrainHarnessOptions({
                 className="border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
                 data-testid={`new-chat-landing-harness-warning-${id}`}
               >
-                needs setup
+                {harnessWarningBadgeText(harnessUnavailableReasonOnHost(id, host))}
               </Badge>
             )}
           </DropdownMenuRadioItem>
@@ -998,6 +1043,10 @@ export function NewChatLandingScreen() {
     selectedAgent?.harness,
     harnessWarningHost,
   );
+  const selectedAgentUnavailableReason = harnessUnavailableReasonOnHost(
+    selectedAgent?.harness,
+    harnessWarningHost,
+  );
   const workspaceTrimmed = workspace.trim();
   const workspaceValid = isValidWorkspace(workspace);
   const isCloudHost =
@@ -1211,7 +1260,9 @@ export function NewChatLandingScreen() {
             className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
             data-testid={`new-chat-landing-agent-warning-${agent.id}`}
           >
-            needs setup
+            {harnessWarningBadgeText(
+              harnessUnavailableReasonOnHost(agent.harness, harnessWarningHost),
+            )}
           </Badge>
         )}
       </DropdownMenuItem>
@@ -2096,8 +2147,11 @@ export function NewChatLandingScreen() {
             >
               <TriangleAlertIcon className="size-3.5 shrink-0" />
               <span>
-                {selectedAgent?.display_name} isn&apos;t configured on {harnessWarningHost?.name} —
-                run <code>omnigent setup</code> on that machine.
+                {harnessWarningMessage(
+                  selectedAgent?.display_name,
+                  harnessWarningHost?.name,
+                  selectedAgentUnavailableReason,
+                )}
               </span>
             </p>
           )}

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -417,21 +417,45 @@ export function harnessUnconfiguredOnHost(
   return harnessUnavailableReasonOnHost(harness, host) !== null;
 }
 
+function isCodexHarness(harness: string): boolean {
+  return harness === "codex" || harness === "codex-native" || harness === "native-codex";
+}
+
 export function harnessUnavailableReasonOnHost(
   harness: string | null | undefined,
   host: Host | undefined | null,
 ): string | null {
   if (!harness || !host?.configured_harnesses) return null;
   const availability = host.configured_harnesses[harness];
-  if (availability === false) return "binary-missing";
-  if (availability === "binary-missing" || availability === "needs-auth") return availability;
+  if (availability === false) return isCodexHarness(harness) ? "binary-missing" : "unconfigured";
+  if (
+    isCodexHarness(harness) &&
+    (availability === "binary-missing" || availability === "needs-auth")
+  ) {
+    return availability;
+  }
+  // Unknown future reason strings fall through to no warning until the UI knows their copy.
   return null;
 }
 
-function harnessWarningBadgeText(reason: string | null): string {
+export function harnessWarningBadgeText(reason: string | null): string {
   if (reason === "binary-missing") return "binary missing";
   if (reason === "needs-auth") return "needs auth";
   return "needs setup";
+}
+
+export function harnessWarningMessageText(
+  agentName: string | undefined,
+  hostName: string | undefined,
+  reason: string | null,
+): string {
+  if (reason === "needs-auth") {
+    return `${agentName} needs Codex authentication on ${hostName} — run codex login on that machine.`;
+  }
+  if (reason === "binary-missing") {
+    return `${agentName} is missing the Codex binary on ${hostName} — run omnigent setup on that machine.`;
+  }
+  return `${agentName} isn't configured on ${hostName} — run omnigent setup on that machine.`;
 }
 
 function harnessWarningMessage(

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -133,27 +133,32 @@ def _resolve_codex_auth_source() -> _CodexAuthSource:
     return _CodexAuthSource(auth_path=_codex_home_config_source_from_env() / "auth.json")
 
 
-def _codex_expiry_timestamp(value: object) -> float | None:
-    """Parse a Codex auth expiry value into epoch seconds, when possible."""
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, (int, float)):
-        # Codex-adjacent auth files commonly use either seconds or millis.
-        return float(value) / 1000 if value > 10_000_000_000 else float(value)
-    if isinstance(value, str):
-        stripped = value.strip()
-        if not stripped:
-            return None
-        with contextlib.suppress(ValueError):
-            numeric = float(stripped)
-            return numeric / 1000 if numeric > 10_000_000_000 else numeric
-        with contextlib.suppress(ValueError):
-            return datetime.fromisoformat(stripped.replace("Z", "+00:00")).timestamp()
-    return None
-
-
 def _codex_auth_json_has_available_credential(auth_path: Path) -> bool:
-    """Return whether ``auth.json`` parses and carries an unexpired credential."""
+    """Return whether ``auth.json`` parses and carries a usable credential.
+
+    Presence-based by design. A real Codex ``auth.json`` (see the openai/codex
+    ``AuthDotJson`` shape) is one of:
+
+    * **API-key** auth — a top-level ``OPENAI_API_KEY`` (or a
+      ``personal_access_token`` from ``codex login --with-access-token``).
+    * **ChatGPT / OAuth** auth — a ``tokens`` object holding ``access_token`` /
+      ``refresh_token`` (and an ``id_token``).
+
+    There is intentionally **no expiry judgement**. Codex stores no top-level
+    expiry field; ChatGPT-mode access tokens are short-lived JWTs that Codex
+    silently refreshes via the long-lived ``refresh_token`` (recorded in
+    ``last_refresh``), so an "expired" ``access_token`` is the normal
+    between-refresh state, not a deauth. Whether the ``refresh_token`` itself is
+    still valid is server-side and opaque, so this local-only, side-effect-free
+    check only asks whether a credential is *configured* — not whether it would
+    authenticate. A revoked/truly-expired session can therefore still surface as
+    available and fail at run time; catching that needs a network probe, which
+    is out of scope here.
+
+    :param auth_path: Path to the Codex ``auth.json``.
+    :returns: ``True`` when the file parses and contains a credential field;
+        ``False`` when it is missing, malformed, or carries no credential.
+    """
     try:
         raw = auth_path.read_text(encoding="utf-8")
     except OSError:
@@ -165,31 +170,11 @@ def _codex_auth_json_has_available_credential(auth_path: Path) -> bool:
     if not isinstance(data, dict):
         return False
 
-    credential_containers = [data]
+    for key in ("OPENAI_API_KEY", "personal_access_token"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
     tokens = data.get("tokens")
-    if isinstance(tokens, dict):
-        credential_containers.append(tokens)
-
-    expiry_keys = ("expires_at", "expiresAt", "expiry", "expires_on", "expiration")
-    now = time.time()
-    for container in credential_containers:
-        for key in expiry_keys:
-            if key not in container:
-                continue
-            # Absence is allowed: real ChatGPT-login auth.json stores expiry
-            # inside the id_token JWT, which this local-only check intentionally
-            # does not parse. If an explicit expiry key is present but
-            # unparseable, fail closed to needs-auth.
-            timestamp = _codex_expiry_timestamp(container[key])
-            if timestamp is None or timestamp <= now:
-                return False
-
-    api_key = data.get("OPENAI_API_KEY")
-    if isinstance(api_key, str) and api_key.strip():
-        return True
-    personal_access_token = data.get("personal_access_token")
-    if isinstance(personal_access_token, str) and personal_access_token.strip():
-        return True
     if isinstance(tokens, dict):
         for field in ("access_token", "refresh_token"):
             value = tokens.get(field)
@@ -207,8 +192,10 @@ def _codex_auth_unavailable_reason() -> str | None:
     ``codex login``, shells out to a status command, or performs a network probe.
 
     :returns: ``"binary-missing"`` when the CLI is absent, ``"needs-auth"``
-        when the CLI exists but ``auth.json`` is missing, malformed, empty, or
-        expired, and ``None`` when a usable unexpired credential is present.
+        when the CLI exists but ``auth.json`` is missing, malformed, or carries
+        no credential, and ``None`` when a credential is configured. Token
+        *validity* (revoked/expired refresh) is not judged locally — see
+        :func:`_codex_auth_json_has_available_credential`.
     """
     if shutil.which(_DEFAULT_CODEX_COMMAND) is None:
         return _CODEX_AUTH_UNAVAILABLE_BINARY_MISSING

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -105,6 +105,113 @@ _UNBOUND_RUNNER_MESSAGE_FRAGMENT = "not bound to a runner"
 # hex + hyphens keeps it safe to interpolate into a rollout filename and a
 # ``codex resume`` argument (no path separators / traversal).
 _CODEX_THREAD_ID_RE = re.compile(r"^[0-9a-fA-F-]+$")
+_CODEX_AUTH_UNAVAILABLE_BINARY_MISSING = "binary-missing"
+_CODEX_AUTH_UNAVAILABLE_NEEDS_AUTH = "needs-auth"
+
+
+@dataclass(frozen=True)
+class _CodexAuthSource:
+    """Resolved source for Codex authentication material."""
+
+    auth_path: Path
+
+
+def _resolve_codex_auth_source() -> _CodexAuthSource:
+    """
+    Resolve the local Codex auth source used for availability checks.
+
+    This is the seam for future managed credentials: once Omnigent can provide
+    centrally managed Codex credentials, this resolver can return that source
+    instead. For now it deliberately defaults to Codex's local ``auth.json`` via
+    the same ``CODEX_HOME`` source resolver used when launching native Codex, so
+    inherited private Omnigent homes map back to the user's real Codex home.
+
+    :returns: Local Codex auth source to inspect synchronously.
+    """
+    from omnigent.inner.codex_executor import _codex_home_config_source_from_env
+
+    return _CodexAuthSource(auth_path=_codex_home_config_source_from_env() / "auth.json")
+
+
+def _codex_expiry_timestamp(value: object) -> float | None:
+    """Parse a Codex auth expiry value into epoch seconds, when possible."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        # Codex-adjacent auth files commonly use either seconds or millis.
+        return float(value) / 1000 if value > 10_000_000_000 else float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        with contextlib.suppress(ValueError):
+            numeric = float(stripped)
+            return numeric / 1000 if numeric > 10_000_000_000 else numeric
+        with contextlib.suppress(ValueError):
+            return datetime.fromisoformat(stripped.replace("Z", "+00:00")).timestamp()
+    return None
+
+
+def _codex_auth_json_has_available_credential(auth_path: Path) -> bool:
+    """Return whether ``auth.json`` parses and carries an unexpired credential."""
+    try:
+        raw = auth_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(data, dict):
+        return False
+
+    credential_containers = [data]
+    tokens = data.get("tokens")
+    if isinstance(tokens, dict):
+        credential_containers.append(tokens)
+
+    expiry_keys = ("expires_at", "expiresAt", "expiry", "expires_on", "expiration")
+    now = time.time()
+    for container in credential_containers:
+        for key in expiry_keys:
+            if key not in container:
+                continue
+            timestamp = _codex_expiry_timestamp(container[key])
+            if timestamp is None or timestamp <= now:
+                return False
+
+    api_key = data.get("OPENAI_API_KEY")
+    if isinstance(api_key, str) and api_key.strip():
+        return True
+    personal_access_token = data.get("personal_access_token")
+    if isinstance(personal_access_token, str) and personal_access_token.strip():
+        return True
+    if isinstance(tokens, dict):
+        for field in ("access_token", "refresh_token"):
+            value = tokens.get(field)
+            if isinstance(value, str) and value.strip():
+                return True
+    return False
+
+
+def _codex_auth_unavailable_reason() -> str | None:
+    """
+    Return why local Codex is unavailable, or ``None`` when available.
+
+    The check is synchronous, side-effect free, and local-only: it only checks
+    the ``codex`` binary and the resolved local auth source. It never runs
+    ``codex login``, shells out to a status command, or performs a network probe.
+
+    :returns: ``"binary-missing"`` when the CLI is absent, ``"needs-auth"``
+        when the CLI exists but ``auth.json`` is missing, malformed, empty, or
+        expired, and ``None`` when a usable unexpired credential is present.
+    """
+    if shutil.which(_DEFAULT_CODEX_COMMAND) is None:
+        return _CODEX_AUTH_UNAVAILABLE_BINARY_MISSING
+    source = _resolve_codex_auth_source()
+    if not _codex_auth_json_has_available_credential(source.auth_path):
+        return _CODEX_AUTH_UNAVAILABLE_NEEDS_AUTH
+    return None
 
 
 def _update_startup_progress(

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -176,6 +176,10 @@ def _codex_auth_json_has_available_credential(auth_path: Path) -> bool:
         for key in expiry_keys:
             if key not in container:
                 continue
+            # Absence is allowed: real ChatGPT-login auth.json stores expiry
+            # inside the id_token JWT, which this local-only check intentionally
+            # does not parse. If an explicit expiry key is present but
+            # unparseable, fail closed to needs-auth.
             timestamp = _codex_expiry_timestamp(container[key])
             if timestamp is None or timestamp <= now:
                 return False

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+HarnessAvailability = bool | str
+
 # Structured error code carried in ``HostLaunchRunnerResultFrame.error_code``
 # when the host refuses a launch because the session's harness is not
 # configured on that machine (CLI missing or no default credential). Shared
@@ -81,7 +83,7 @@ class HostHelloFrame:
     frame_protocol_version: int
     name: str
     runners: list[str] = field(default_factory=list)
-    configured_harnesses: dict[str, bool] | None = None
+    configured_harnesses: dict[str, HarnessAvailability] | None = None
 
 
 @dataclass
@@ -774,7 +776,7 @@ def _decode_host_hello(msg: dict[str, Any]) -> HostHelloFrame:
         frame_protocol_version=_required_int(msg, "frame_protocol_version"),
         name=_required_str(msg, "name"),
         runners=_optional_str_list(msg, "runners"),
-        configured_harnesses=_optional_str_bool_map(msg, "configured_harnesses"),
+        configured_harnesses=_optional_str_availability_map(msg, "configured_harnesses"),
     )
 
 
@@ -1091,23 +1093,25 @@ def _optional_str_list(msg: dict[str, Any], key: str) -> list[str]:
     return list(val)
 
 
-def _optional_str_bool_map(msg: dict[str, Any], key: str) -> dict[str, bool] | None:
-    """Return an optional string→bool mapping field.
+def _optional_str_availability_map(
+    msg: dict[str, Any], key: str
+) -> dict[str, HarnessAvailability] | None:
+    """Return an optional string→availability mapping field.
 
     Tolerant by design: absent, null, or non-mapping values all decode
     to ``None`` ("unknown") rather than raising, so an older or newer
     peer's hello never breaks the tunnel handshake. Entries with a
-    non-string key or non-bool value are dropped for the same reason.
+    non-string key or non-bool/string value are dropped for the same reason.
 
     :param msg: Decoded frame object.
     :param key: Field name, e.g. ``"configured_harnesses"``.
-    :returns: The mapping, e.g. ``{"claude-sdk": True}``, or ``None``
+    :returns: The mapping, e.g. ``{"claude-sdk": True, "codex": "needs-auth"}``, or ``None``
         when absent / null / not a JSON object.
     """
     val = msg.get(key)
     if not isinstance(val, dict):
         return None
-    return {k: v for k, v in val.items() if isinstance(k, str) and isinstance(v, bool)}
+    return {k: v for k, v in val.items() if isinstance(k, str) and isinstance(v, (bool, str))}
 
 
 def _optional_nullable_str(msg: dict[str, Any], key: str) -> str | None:

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -45,8 +45,11 @@ from omnigent.onboarding.provider_config import (
     _EXECUTOR_TYPE_HARNESS_ALIASES,
     _HARNESS_FAMILY,
     GEMINI_FAMILY,
+    OPENAI_FAMILY,
     PI_SURFACE,
 )
+
+HarnessAvailability = bool | str
 
 # In-process SDK harnesses: no CLI binary, credentials resolved at runtime
 # from ambient/spec sources the daemon can't see. Never gated. Includes both
@@ -267,17 +270,30 @@ def harness_is_configured(harness: str) -> bool:
     return True
 
 
-def configured_harness_map() -> dict[str, bool]:
+def _harness_availability(canonical: str) -> HarnessAvailability:
+    """Return picker-facing availability for one canonical harness spelling."""
+    if (
+        canonical in {"codex", "codex-native", "native-codex"}
+        and _HARNESS_FAMILY.get(canonical) == OPENAI_FAMILY
+    ):
+        from omnigent.codex_native import _codex_auth_unavailable_reason
+
+        return _codex_auth_unavailable_reason() or True
+    return harness_is_configured(canonical)
+
+
+def configured_harness_map() -> dict[str, HarnessAvailability]:
     """Return per-harness readiness for every accepted harness spelling.
 
     Built so the server/web UI can do a plain dict lookup with whatever
     spelling it holds — canonical ids, executor-type spellings, the
     ``claude`` alias, and ``pi``. SDK and unknown harnesses map to
     ``True`` (never gated); CLI-wrapping harnesses map to whether their
-    binary is on ``PATH``.
+    binary is on ``PATH``. Codex entries use a structured string reason when
+    unavailable: ``"binary-missing"`` or ``"needs-auth"``.
 
     :returns: Mapping of harness spelling to readiness, e.g.
-        ``{"claude-native": False, "codex-native": False,
+        ``{"claude-native": False, "codex-native": "needs-auth",
         "claude-sdk": True, "openai-agents": True, "pi": True, "qwen": True}``.
     """
     spellings: set[str] = set(_HARNESS_FAMILY)
@@ -296,4 +312,6 @@ def configured_harness_map() -> dict[str, bool]:
     spellings.add(GOOSE_KEY)  # headless Goose (``goose acp``) gates on the goose binary
     spellings.add(HERMES_KEY)  # Hermes Agent wraps the ``hermes`` CLI
     spellings.add(COPILOT_KEY)
-    return {spelling: harness_is_configured(spelling) for spelling in spellings}
+    return {
+        spelling: _harness_availability(_canonical_harness(spelling)) for spelling in spellings
+    }

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -33,6 +33,7 @@ from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, 
 # (PING_INTERVAL_S * PING_MISS_THRESHOLD) so a healthy host that is
 # still heart-beating is never falsely aged out.
 HOST_LIVENESS_TTL_S = 90
+HarnessAvailability = bool | str
 
 
 @dataclass
@@ -73,7 +74,7 @@ class Host:
     updated_at: int
     sandbox_provider: str | None = None
     sandbox_id: str | None = None
-    configured_harnesses: dict[str, bool] | None = None
+    configured_harnesses: dict[str, HarnessAvailability] | None = None
 
 
 def host_is_live(host: Host, now: int | None = None) -> bool:
@@ -100,14 +101,14 @@ def host_is_live(host: Host, now: int | None = None) -> bool:
 _logger = logging.getLogger(__name__)
 
 
-def _parse_configured_harnesses(raw: str | None) -> dict[str, bool] | None:
+def _parse_configured_harnesses(raw: str | None) -> dict[str, HarnessAvailability] | None:
     """
     Parse the JSON-encoded ``hosts.configured_harnesses`` column.
 
     Tolerant: ``NULL``, malformed JSON, or a non-object payload all
     map to ``None`` ("unknown") — a corrupt column value must degrade
     to no-warning in the UI, never break host listing. Entries with a
-    non-bool value are dropped for the same reason.
+    non-bool/string value are dropped for the same reason.
 
     :param raw: The raw column value, e.g.
         ``'{"claude-sdk": true, "codex": false}'`` or ``None``.
@@ -122,7 +123,7 @@ def _parse_configured_harnesses(raw: str | None) -> dict[str, bool] | None:
         return None
     if not isinstance(parsed, dict):
         return None
-    return {k: v for k, v in parsed.items() if isinstance(v, bool)}
+    return {k: v for k, v in parsed.items() if isinstance(k, str) and isinstance(v, (bool, str))}
 
 
 def _row_to_host(row: SqlHost) -> Host:
@@ -186,7 +187,7 @@ class HostStore:
         owner: str,
         *,
         allow_host_id_reown: bool = False,
-        configured_harnesses: dict[str, bool] | None = None,
+        configured_harnesses: dict[str, HarnessAvailability] | None = None,
     ) -> Host:
         """
         Register or update a host on WebSocket connect.

--- a/tests/e2e_ui/chat/test_codex_auth_availability.py
+++ b/tests/e2e_ui/chat/test_codex_auth_availability.py
@@ -1,0 +1,325 @@
+"""E2E: auth-aware Codex availability in the New Chat landing screen.
+
+The landing composer (``NewChatLandingScreen`` in
+``ap-web/src/shell/NewChatDialog.tsx``) warns — but does not block — when the
+selected agent's harness is not ready on the selected host. For Codex the
+readiness signal is structured: the host's ``host.hello`` readiness map flows
+through ``host_store`` and ``GET /v1/hosts`` as a per-harness
+``configured_harnesses`` value of ``"needs-auth"``, ``"binary-missing"``, or
+available (absent / ``true``). This PR makes the picker render that distinction:
+
+* the **needs-auth message** under the composer
+  (``new-chat-landing-harness-warning``):
+  ``"<agent> needs Codex authentication on <host> — run codex login on that
+  machine."`` — shown for any selected Codex agent (native or brain harness).
+* the **needs-auth badge** (``new-chat-landing-harness-warning-codex``,
+  text ``"needs auth"``) on the Codex row inside a bundle agent's Advanced
+  "Agent Harness" menu.
+
+Why the ``page.route`` stubbing (mirrors
+``start_session/test_start_session.py``): the e2e harness's runner tunnels
+directly into the server and registers no *host*, so ``GET /v1/hosts`` has
+nothing real to return and there is no seam to inject a per-harness readiness
+reason server-side. Faking ``/v1/hosts`` (with ``configured_harnesses``) and
+``/v1/agents`` is the established way these tests drive the landing picker; it
+is also exactly the wire shape the host readiness map produces, so the stub
+exercises the real availability/reason → picker rendering path.
+
+The async-in-a-fresh-thread shape is inherited from
+``start_session/test_start_session.py`` for the reason documented there: once a
+pytest-playwright *sync* test has run in the session, pytest-asyncio can't start
+a loop on the main thread, so each async body runs in its own thread via
+:func:`asyncio.run`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+# Stubbed host the composer auto-selects (the tunneled runner registers no
+# host). Keyed identically in the recent-workspaces localStorage seed.
+_HOST_ID = "host_e2e"
+_HOST_NAME = "e2e-host"
+# Bare create endpoint: ``/v1/sessions`` with an optional query, but NOT
+# ``/v1/sessions/{id}/...`` — so the GET conversation list and the
+# agent-discovery scan pass through to the real server.
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* to completion in a dedicated thread with its own event loop.
+
+    The e2e_ui suite runs many pytest-playwright **sync** tests in the same
+    session; once one has run, pytest-asyncio can't start a loop on the main
+    thread. Running the coroutine from a fresh thread via :func:`asyncio.run`
+    sidesteps that. Any exception (including assertion failures) is captured
+    and re-raised on the calling thread so the test fails normally.
+
+    :param coro: The coroutine to run to completion.
+    :raises Exception: Whatever the coroutine raised, re-raised here.
+    """
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+def _hosts_body(configured_harnesses: dict[str, Any] | None) -> str:
+    """Stub body for ``GET /v1/hosts``: one online host the composer picks.
+
+    :param configured_harnesses: The host's per-harness readiness map, mirroring
+        what the ``host.hello`` readiness map produces (e.g.
+        ``{"codex-native": "needs-auth"}``). ``None`` omits the field, modelling
+        an older host that never reported readiness ("unknown" — never warns).
+    """
+    host: dict[str, Any] = {
+        "host_id": _HOST_ID,
+        "name": _HOST_NAME,
+        "owner": "e2e",
+        "status": "online",
+    }
+    if configured_harnesses is not None:
+        host["configured_harnesses"] = configured_harnesses
+    return json.dumps({"hosts": [host]})
+
+
+def _codex_native_agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: the native Codex agent.
+
+    ``codex-native-ui`` + ``harness: "codex-native"`` is what the frontend treats
+    as a Codex harness (``isCodexHarness``), so a host readiness reason of
+    ``"needs-auth"`` for that harness drives the under-composer warning message.
+    Sole agent, so it auto-selects and no explicit pick is needed.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_codex_e2e",
+                    "name": "codex-native-ui",
+                    "display_name": "Codex",
+                    "description": "OpenAI's coding agent",
+                    "harness": "codex-native",
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+def _polly_codex_agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: a bundle agent on the codex brain harness.
+
+    Polly is a multi-agent bundle (not a native terminal wrapper), so its
+    Advanced menu renders the **Agent Harness** radio group with a row per brain
+    harness (including ``codex``). That row carries the readiness *badge* when the
+    host reports the harness unavailable — the second selector under test. Sole
+    agent, so it auto-selects.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_polly_e2e",
+                    "name": "polly",
+                    "display_name": "Polly",
+                    "description": "Multi-agent coding",
+                    "harness": "codex",
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+async def _register_routes(
+    page,
+    *,
+    agents_body: str,
+    configured_harnesses: dict[str, Any] | None,
+) -> None:
+    """Register the host/agent stubs and neutralize agent discovery.
+
+    :param page: The Playwright page to install routes on.
+    :param agents_body: Body for the ``GET /v1/agents`` stub.
+    :param configured_harnesses: Readiness map for the stubbed host's
+        ``configured_harnesses`` (see :func:`_hosts_body`).
+    """
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=_hosts_body(configured_harnesses),
+        )
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=agents_body)
+
+    async def handle_agent_scan(route: Route) -> None:
+        # Neutralize agent discovery so only the stubbed agent feeds the picker.
+        # On the shared e2e_ui server, sessions other tests left behind would
+        # otherwise leak in and — ranking ahead — auto-select, swapping the
+        # selected harness out from under the warning assertion.
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"data": []}),
+        )
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    # Registered after the broad globs so it wins the kind=any discovery scan;
+    # the bare conversation-list GET still falls through to the real server.
+    await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+
+def test_codex_needs_auth_warns_and_clears_when_available(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A needs-auth Codex host warns to run ``codex login``; an available host doesn't.
+
+    Drives the auth-aware availability the PR adds end to end against the
+    rendered landing screen:
+
+    1. **needs-auth** — the stubbed host reports ``configured_harnesses:
+       {"codex-native": "needs-auth"}`` for the selected Codex agent. The picker
+       shows the under-composer warning naming the host and telling the user to
+       ``run codex login`` on that machine.
+    2. **available** — when the same host omits the reason (Codex ready), the
+       warning is absent. Proves the warning is reason-driven, not always-on.
+    """
+    base_url, session_id = seeded_session
+    del session_id  # this flow never creates a session — only reads the picker
+    _run_in_fresh_loop(_drive_codex_needs_auth(base_url))
+
+
+async def _drive_codex_needs_auth(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            # needs-auth: the host reports the Codex harness as needing auth.
+            await _register_routes(
+                page,
+                agents_body=_codex_native_agents_body(),
+                configured_harnesses={"codex-native": "needs-auth"},
+            )
+            # Seed a recent working directory so the composer auto-fills (it
+            # never has to touch the host-less file browser).
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Codex auto-selects (sole agent) on the needs-auth host, so the
+            # under-composer warning renders, names the host, and tells the user
+            # to run `codex login` (rendered as a <code> element inside the
+            # message, so we match the surrounding copy).
+            warning = page.get_by_test_id("new-chat-landing-harness-warning")
+            await expect(warning).to_be_visible(timeout=30_000)
+            await expect(warning).to_contain_text("needs Codex authentication")
+            await expect(warning).to_contain_text(_HOST_NAME)
+            await expect(warning).to_contain_text("codex login")
+        finally:
+            await browser.close()
+
+    # available: the same host with Codex ready — no reason, no warning.
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(
+                page,
+                agents_body=_codex_native_agents_body(),
+                # Codex available (None / absent reason) — the picker must not warn.
+                configured_harnesses={"codex-native": True},
+            )
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            # The input is up and Codex has auto-selected; an available host
+            # leaves no warning. count()==0 (not "not visible") because the
+            # element is conditionally rendered, never just hidden.
+            await expect(page.get_by_test_id("new-chat-landing-harness-warning")).to_have_count(0)
+        finally:
+            await browser.close()
+
+
+def test_codex_needs_auth_badge_in_harness_menu(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A bundle agent's Advanced "Agent Harness" menu badges the Codex row "needs auth".
+
+    For a brain-harness bundle agent (Polly), the Advanced menu lists each brain
+    harness as a radio row. When the selected host reports the ``codex`` harness
+    as ``needs-auth``, that row carries the warning badge
+    (``new-chat-landing-harness-warning-codex``) reading "needs auth" — the
+    per-row counterpart to the under-composer message.
+    """
+    base_url, session_id = seeded_session
+    del session_id
+    _run_in_fresh_loop(_drive_codex_badge(base_url))
+
+
+async def _drive_codex_badge(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(
+                page,
+                agents_body=_polly_codex_agents_body(),
+                configured_harnesses={"codex": "needs-auth"},
+            )
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Polly auto-selects (sole agent), so the Advanced chip opens the
+            # brain-harness radio group.
+            await page.get_by_test_id("new-chat-landing-advanced-chip").click()
+            badge = page.get_by_test_id("new-chat-landing-harness-warning-codex")
+            await expect(badge).to_be_visible(timeout=30_000)
+            await expect(badge).to_contain_text("needs auth")
+        finally:
+            await browser.close()

--- a/tests/e2e_ui/chat/test_codex_auth_availability.py
+++ b/tests/e2e_ui/chat/test_codex_auth_availability.py
@@ -47,10 +47,6 @@ from playwright.async_api import Route, async_playwright, expect
 # host). Keyed identically in the recent-workspaces localStorage seed.
 _HOST_ID = "host_e2e"
 _HOST_NAME = "e2e-host"
-# Bare create endpoint: ``/v1/sessions`` with an optional query, but NOT
-# ``/v1/sessions/{id}/...`` — so the GET conversation list and the
-# agent-discovery scan pass through to the real server.
-_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
 
 
 def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -142,13 +142,13 @@ def test_hello_frame_configured_harnesses_round_trip() -> None:
         version="0.1.0",
         frame_protocol_version=1,
         name="corey-laptop",
-        configured_harnesses={"claude-sdk": True, "codex": False},
+        configured_harnesses={"claude-sdk": True, "codex": "needs-auth"},
     )
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
     # Exact map equality: both the True and the False must survive —
     # False is the actionable "warn the user" value.
-    assert decoded.configured_harnesses == {"claude-sdk": True, "codex": False}
+    assert decoded.configured_harnesses == {"claude-sdk": True, "codex": "needs-auth"}
 
 
 def test_hello_frame_legacy_payload_decodes_unknown_harnesses() -> None:

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -224,9 +224,6 @@ def test_configured_harness_map_gates_only_cli_harnesses(
     for cli in (
         "claude-native",
         "native-claude",
-        "codex",
-        "codex-native",
-        "native-codex",
         "pi",
         "kimi",
         "cursor-native",
@@ -241,6 +238,8 @@ def test_configured_harness_map_gates_only_cli_harnesses(
         "hermes",
     ):
         assert result[cli] is False, f"{cli} should be gated on its CLI binary"
+    for codex in ("codex", "codex-native", "native-codex"):
+        assert result[codex] == "binary-missing", f"{codex} should name the missing Codex binary"
 
 
 def test_configured_harness_map_all_true_with_clis(
@@ -258,6 +257,10 @@ def test_configured_harness_map_all_true_with_clis(
     import omnigent.onboarding.gemini_auth as _ga
 
     _all_clis_installed(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.codex_native._codex_auth_unavailable_reason",
+        lambda: None,
+    )
     monkeypatch.setenv("CURSOR_API_KEY", "crsr_ready")
     # antigravity-native also needs a credential (not just the ``agy`` binary).
     monkeypatch.setattr(_ga, "gemini_login_detected", lambda: True)

--- a/tests/server/integration/test_hosts_api.py
+++ b/tests/server/integration/test_hosts_api.py
@@ -56,7 +56,7 @@ def _websocket_scope(path: str) -> dict[str, object]:
 
 def _make_hello(
     name: str = "test-laptop",
-    configured_harnesses: dict[str, bool] | None = None,
+    configured_harnesses: dict[str, bool | str] | None = None,
 ) -> str:
     """Encode a HostHelloFrame for tests.
 
@@ -105,7 +105,7 @@ async def _connect_host(
     registry: HostRegistry,
     host_id: str = _HOST_ID,
     name: str = "test-laptop",
-    configured_harnesses: dict[str, bool] | None = None,
+    configured_harnesses: dict[str, bool | str] | None = None,
 ) -> ApplicationCommunicator:
     """Connect a mock host via WebSocket tunnel.
 
@@ -259,7 +259,7 @@ async def test_hosts_api_surfaces_configured_harnesses(
     _comm = await _connect_host(
         app,
         registry,
-        configured_harnesses={"claude-sdk": True, "codex": False},
+        configured_harnesses={"claude-sdk": True, "codex": "needs-auth"},
     )
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -271,10 +271,10 @@ async def test_hosts_api_surfaces_configured_harnesses(
     # picker warning; a lossy encode/persist would drop it.
     assert listing.json()["hosts"][0]["configured_harnesses"] == {
         "claude-sdk": True,
-        "codex": False,
+        "codex": "needs-auth",
     }
     assert single.status_code == 200
-    assert single.json()["configured_harnesses"] == {"claude-sdk": True, "codex": False}
+    assert single.json()["configured_harnesses"] == {"claude-sdk": True, "codex": "needs-auth"}
 
 
 async def test_hosts_api_configured_harnesses_null_for_older_host(

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -115,13 +115,13 @@ def test_upsert_persists_configured_harnesses(host_store: HostStore) -> None:
         host_id="host_ch1",
         name="laptop",
         owner="alice@example.com",
-        configured_harnesses={"claude-sdk": True, "codex": False},
+        configured_harnesses={"claude-sdk": True, "codex": "needs-auth"},
     )
 
     fetched = host_store.get_host("host_ch1")
     assert fetched is not None
     # Exact equality: the False bit is the actionable "warn" value.
-    assert fetched.configured_harnesses == {"claude-sdk": True, "codex": False}
+    assert fetched.configured_harnesses == {"claude-sdk": True, "codex": "needs-auth"}
 
 
 def test_upsert_reconnect_overwrites_and_nulls_configured_harnesses(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -28,6 +28,88 @@ from omnigent.codex_native_elicitation import codex_elicitation_id
 from omnigent.spec import load
 
 
+def _write_codex_auth(path: Path, payload: object) -> None:
+    """Write a test Codex auth.json payload."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _point_codex_auth_check_at(
+    monkeypatch: pytest.MonkeyPatch, auth_path: Path, *, binary_present: bool
+) -> None:
+    """Redirect Codex availability checks away from the real machine state."""
+    monkeypatch.setattr(
+        codex_native,
+        "_resolve_codex_auth_source",
+        lambda: codex_native._CodexAuthSource(auth_path=auth_path),
+    )
+    monkeypatch.setattr(
+        codex_native.shutil,
+        "which",
+        lambda name: f"/tmp/{name}" if binary_present else None,
+    )
+
+
+def test_codex_auth_unavailable_reason_binary_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing codex binary reports binary-missing before reading auth.json."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=False)
+
+    assert codex_native._codex_auth_unavailable_reason() == "binary-missing"
+
+
+def test_codex_auth_unavailable_reason_absent_auth_json_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Installed codex without auth.json reports needs-auth."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_valid_unexpired_auth_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Installed codex with unexpired auth.json is available."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+    _write_codex_auth(
+        auth_path,
+        {"tokens": {"access_token": "tok", "expires_at": codex_native.time.time() + 3600}},
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_expired_auth_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Installed codex with expired auth.json reports needs-auth."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+    _write_codex_auth(
+        auth_path,
+        {"tokens": {"access_token": "tok", "expires_at": codex_native.time.time() - 1}},
+    )
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_malformed_auth_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Installed codex with malformed auth.json reports needs-auth."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text("{not json", encoding="utf-8")
+
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
 class _FakeTerminalClient:
     """
     Minimal async client for terminal-launch helper tests.

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -70,30 +70,58 @@ def test_codex_auth_unavailable_reason_absent_auth_json_needs_auth(
     assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
 
 
-def test_codex_auth_unavailable_reason_valid_unexpired_auth_available(
+def test_codex_auth_unavailable_reason_chatgpt_tokens_available(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Installed codex with unexpired auth.json is available."""
+    """A real ChatGPT/OAuth auth.json (tokens block) is available.
+
+    Mirrors the openai/codex ``AuthDotJson`` shape: ``auth_mode=chatgpt`` with a
+    ``tokens`` object. There is no top-level expiry field — access-token expiry
+    lives in the JWT and is refreshed via ``refresh_token`` — so presence of the
+    tokens is what marks the credential configured.
+    """
     auth_path = tmp_path / "codex-home" / "auth.json"
     _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
     _write_codex_auth(
         auth_path,
-        {"tokens": {"access_token": "tok", "expires_at": codex_native.time.time() + 3600}},
+        {
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "id_token": "header.payload.sig",
+                "access_token": "header.payload.sig",
+                "refresh_token": "opaque-refresh",
+                "account_id": "org_test",
+            },
+            "last_refresh": "2026-06-25T15:04:05Z",
+        },
     )
 
     assert codex_native._codex_auth_unavailable_reason() is None
 
 
-def test_codex_auth_unavailable_reason_expired_auth_needs_auth(
+def test_codex_auth_unavailable_reason_api_key_available(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Installed codex with expired auth.json reports needs-auth."""
+    """A real API-key auth.json (``auth_mode=api``) is available."""
     auth_path = tmp_path / "codex-home" / "auth.json"
     _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
-    _write_codex_auth(
-        auth_path,
-        {"tokens": {"access_token": "tok", "expires_at": codex_native.time.time() - 1}},
-    )
+    _write_codex_auth(auth_path, {"auth_mode": "api", "OPENAI_API_KEY": "sk-test"})
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_no_credential_needs_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A parseable auth.json with no credential field reports needs-auth.
+
+    e.g. a stub that records ``auth_mode`` but carries neither an
+    ``OPENAI_API_KEY`` nor a ``tokens`` block — there is nothing to authenticate
+    with, so the picker should warn rather than show Codex as ready.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+    _write_codex_auth(auth_path, {"auth_mode": "chatgpt"})
 
     assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
 


### PR DESCRIPTION
## Summary

Implements Workstream B for #152: Codex availability is now auth-aware for the picker while staying synchronous and local-only.

## Acceptance coverage

- Adds `_codex_auth_unavailable_reason()` with structured states:
  - `binary-missing` when the `codex` CLI is absent
  - `needs-auth` when the CLI exists but `auth.json` is missing, malformed, invalid, or expired
  - `None` for available
- Reuses the existing Codex home/source resolver instead of hardcoding `~/.codex`.
- Adds `_resolve_codex_auth_source()` as the documented seam for future managed credentials; it defaults to local `auth.json`.
- Wires Codex reason strings through the host hello readiness map, persistence, API, and New Chat picker badges/messages while preserving legacy boolean handling for other harnesses.
- Keeps the check side-effect free: no login command, no status subprocess, no network probe.

## Tests / gates

- `pytest tests/test_codex_native.py tests/onboarding/test_harness_readiness.py tests/host/test_frames.py tests/stores/test_host_store.py tests/server/integration/test_hosts_api.py -q` — 290 passed
- `npm --prefix ap-web test -- NewChatDialog.test.tsx -t harnessUnconfiguredOnHost` — 3 passed, 98 skipped
- `npm --prefix ap-web run type-check` — passed
- `uv run --frozen --extra dev pre-commit run --all-files --show-diff-on-failure` — passed
- `cd ap-web && npx npm@11.12.1 install --package-lock-only --legacy-peer-deps --no-audit --no-fund && git diff --exit-code package-lock.json` — passed

Note: full `npm --prefix ap-web test -- NewChatDialog.test.tsx` still hits an existing local environment issue (`localStorage.clear is not a function`) outside the helper tests touched here.
