### PR TITLE
fix(cursor-native): clear leftover composer draft on interrupt

### DIFF
--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -72,6 +72,18 @@ _PASTE_COMMIT_TIMEOUT_S = 5.0
 # first-run trust modal.
 _IDLE_MARKERS = ("Plan, search, build", "Add a follow-up")
 _TRUST_MARKER = "Trust this workspace"
+# Composer-clear (see _clear_composer): cursor-agent's input widget ignores the
+# readline Home/kill-line keys, so we delete with a Backspace flood instead.
+# Backspaces per round (one ``send-keys -N`` call) and a round cap; the loop
+# stops early once the pane stops changing (the draft is gone). The cap bounds a
+# pathological never-settles pane; ``_COMPOSER_CLEAR_CHUNK * _COMPOSER_CLEAR_MAX_ROUNDS``
+# deletions comfortably exceed any real draft.
+_COMPOSER_CLEAR_CHUNK = 200
+_COMPOSER_CLEAR_MAX_ROUNDS = 50
+# After a cancel, cursor-agent restores the interrupted prompt into the composer
+# slightly after the turn stops. Wait for the pane to stop changing (generation
+# ended and the draft settled) before clearing it, bounded by this timeout.
+_INTERRUPT_SETTLE_TIMEOUT_S = 2.0
 
 
 def bridge_dir_for_session_id(session_id: str) -> Path:
@@ -438,6 +450,38 @@ def _settle_pane(socket_path: str, tmux_target: str, *, timeout_s: float) -> Non
         time.sleep(_POLL_INTERVAL_S)
 
 
+def _clear_composer(socket_path: str, tmux_target: str) -> None:
+    """Empty the cursor-agent composer of any leftover draft before a paste.
+
+    cursor-agent restores the interrupted prompt back into the composer when a
+    turn is cancelled (Stop button -> :func:`inject_interrupt`), and its input
+    widget ignores the readline ``C-a``/``C-k``/``C-u`` keys we'd otherwise use
+    to clear a line — only ``Backspace`` deletes. So jump to the end (``End``)
+    and flood ``Backspace`` in ``send-keys -N`` bursts until the pane stops
+    changing (the draft is gone) or a generous round cap is hit. A burst against
+    an already-empty composer is a harmless no-op (unlike ``C-c``, which would
+    arm cursor-agent's exit), so this is safe to run before every injection.
+    """
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "End")
+    previous = _capture_pane(socket_path, tmux_target)
+    for _ in range(_COMPOSER_CLEAR_MAX_ROUNDS):
+        _run_tmux(
+            socket_path,
+            "send-keys",
+            "-t",
+            tmux_target,
+            "-N",
+            str(_COMPOSER_CLEAR_CHUNK),
+            "BSpace",
+        )
+        current = _capture_pane(socket_path, tmux_target)
+        # Once a burst no longer changes the pane, the composer is empty —
+        # further Backspaces are no-ops, so stop.
+        if current == previous:
+            return
+        previous = current
+
+
 def inject_user_message(
     bridge_dir: Path,
     *,
@@ -469,9 +513,9 @@ def inject_user_message(
             "cursor terminal is no longer running (the TUI exited); restart the session"
         )
     _settle_pane(socket_path, tmux_target, timeout_s=timeout_s)
-    # Clear any leftover draft: Home (C-a) + kill-to-end (C-k).
-    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
-    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
+    # Clear any leftover draft (e.g. the prompt cursor-agent restores into the
+    # composer after a cancelled turn) so it can't prepend the new message.
+    _clear_composer(socket_path, tmux_target)
     with tempfile.NamedTemporaryFile(
         dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
     ) as paste_file:
@@ -508,10 +552,30 @@ def inject_user_message(
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
 
 
-def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
-    """Cancel the in-flight Cursor turn by sending ``Escape`` to the pane.
+def _wait_for_pane_settle(socket_path: str, tmux_target: str, *, timeout_s: float) -> None:
+    """Best-effort wait until the pane stops changing across two captures.
 
-    cursor-agent stops a running turn on a single ``Escape`` (verified live).
+    Used after a cancel so the restored draft (and any final generation output)
+    has landed before we clear the composer. Falls through after *timeout_s*
+    rather than raising — the clear that follows is a no-op on an empty composer.
+    """
+    deadline = time.monotonic() + timeout_s
+    previous = _capture_pane(socket_path, tmux_target)
+    while time.monotonic() < deadline:
+        time.sleep(_POLL_INTERVAL_S)
+        current = _capture_pane(socket_path, tmux_target)
+        if current and current == previous:
+            return
+        previous = current
+
+
+def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
+    """Cancel the in-flight Cursor turn and clear the composer.
+
+    Sends ``Escape`` to stop the running turn, then clears the input box:
+    cursor-agent restores the interrupted prompt into the composer on cancel, so
+    without this the leftover prompt sits in the box and prepends the next
+    message (the web UI's Stop button would otherwise leave a half-sent draft).
     The harness ``run_turn`` returns right after the paste, so the runner's
     in-process cancel floor can't reach the turn — this is the analog of
     :func:`inject_user_message` for the web UI's Stop button.
@@ -519,8 +583,15 @@ def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT
     :raises RuntimeError: If the tmux target is not advertised or send-keys fails.
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    socket_path = info["socket_path"]
+    tmux_target = info["tmux_target"]
     # No ``-l``: tmux must interpret ``Escape`` as a key name.
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Escape")
+    # Let the cancel land and the restored draft settle, then clear it. The
+    # next injection also clears (defense in depth), but clearing here means the
+    # composer is empty the moment the user looks at the TUI after pressing Stop.
+    _wait_for_pane_settle(socket_path, tmux_target, timeout_s=_INTERRUPT_SETTLE_TIMEOUT_S)
+    _clear_composer(socket_path, tmux_target)
 
 
 def kill_session(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:

--- a/tests/test_cursor_native_bridge.py
+++ b/tests/test_cursor_native_bridge.py
@@ -1,0 +1,169 @@
+"""Unit tests for :mod:`omnigent.cursor_native_bridge` composer handling.
+
+Focused on the leftover-draft clear (:func:`_clear_composer`) and its use by
+:func:`inject_user_message`. cursor-agent restores the interrupted prompt into
+the composer when a turn is cancelled (web-UI Stop -> ``inject_interrupt`` sends
+``Escape``), and its input widget ignores the readline ``C-a``/``C-k`` keys the
+clear used to send — so the leftover survived and prepended the next message.
+The clear now floods ``Backspace`` until the pane stops changing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent import cursor_native_bridge
+from omnigent.cursor_native_bridge import write_tmux_target
+
+_SOCK = "/tmp/example/cursor.sock"
+_TARGET = "cursor:0.0"
+
+
+class _FakeCompleted:
+    """Minimal stand-in for ``subprocess.CompletedProcess``."""
+
+    def __init__(self, stdout: str = "") -> None:
+        self.returncode = 0
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _install_fake_tmux(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pane_captures: list[str],
+) -> list[list[str]]:
+    """Patch ``subprocess.run`` so tmux is mocked.
+
+    ``send-keys`` calls are recorded (and returned). ``capture-pane`` calls pop
+    the next value from *pane_captures* (the last value repeats once exhausted,
+    modelling a composer that has settled).
+
+    :returns: The list that accumulates every tmux argv invoked.
+    """
+    captured: list[list[str]] = []
+    remaining = list(pane_captures)
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+        del kwargs
+        captured.append(cmd)
+        if "capture-pane" in cmd:
+            value = remaining.pop(0) if len(remaining) > 1 else (remaining[0] if remaining else "")
+            return _FakeCompleted(stdout=value)
+        return _FakeCompleted()
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    return captured
+
+
+def _send_keys_calls(captured: list[list[str]]) -> list[list[str]]:
+    """The send-keys argv tails (everything after ``send-keys``)."""
+    return [cmd[cmd.index("send-keys") + 1 :] for cmd in captured if "send-keys" in cmd]
+
+
+def test_clear_composer_floods_backspace_until_pane_stable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The clear sends End, then Backspace bursts, stopping once the pane settles.
+
+    Two distinct captures (draft shrinking) then a repeat (empty) means three
+    bursts: the third sees no change and returns. It must never send the old
+    ``C-a``/``C-k`` keys, which cursor-agent's composer ignores.
+    """
+    # previous=capture#1 (draft); round1 sees #2 (empty, changed -> continue);
+    # round2 sees #3 (empty, unchanged -> stop).
+    captured = _install_fake_tmux(
+        monkeypatch,
+        pane_captures=["draft-content", "empty", "empty"],
+    )
+
+    cursor_native_bridge._clear_composer(_SOCK, _TARGET)
+
+    tails = _send_keys_calls(captured)
+    # End once, then one Backspace burst per round until stable.
+    assert tails[0] == ["-t", _TARGET, "End"]
+    bursts = [t for t in tails if "BSpace" in t]
+    assert all(
+        t == ["-t", _TARGET, "-N", str(cursor_native_bridge._COMPOSER_CLEAR_CHUNK), "BSpace"]
+        for t in bursts
+    )
+    assert len(bursts) == 2, f"expected to stop once the pane stabilized; got {len(bursts)}"
+    # The removed, ineffective readline clears must not come back.
+    assert not any("C-a" in t or "C-k" in t for t in tails)
+
+
+def test_clear_composer_terminates_on_empty_composer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already-empty composer settles immediately (one harmless burst).
+
+    A burst on empty input is a no-op (unlike ``C-c``, which would arm exit), so
+    the clear is safe to run before every injection. The pane never changes, so
+    the first burst's capture matches and the loop returns at once — never
+    reaching the round cap.
+    """
+    captured = _install_fake_tmux(monkeypatch, pane_captures=["idle-placeholder"])
+
+    cursor_native_bridge._clear_composer(_SOCK, _TARGET)
+
+    bursts = [t for t in _send_keys_calls(captured) if "BSpace" in t]
+    assert len(bursts) == 1, "empty composer should settle after a single burst"
+
+
+def test_clear_composer_is_bounded_when_pane_never_settles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pane that keeps changing is bounded by the round cap, not infinite."""
+
+    counter = {"n": 0}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+        del kwargs
+        if "capture-pane" in cmd:
+            counter["n"] += 1
+            return _FakeCompleted(stdout=f"ever-changing-{counter['n']}")
+        return _FakeCompleted()
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    cursor_native_bridge._clear_composer(_SOCK, _TARGET)
+
+    # One capture seeds `previous`, then one per round up to the cap.
+    assert counter["n"] == cursor_native_bridge._COMPOSER_CLEAR_MAX_ROUNDS + 1
+
+
+def test_inject_user_message_clears_before_pasting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The leftover-draft clear runs before the paste, so it can't survive it.
+
+    Regression for the reported bug: pressing Stop left the previous message in
+    the composer, which then prepended (blocked) the next web-UI message. The
+    Backspace flood must precede ``load-buffer``/``paste-buffer``.
+    """
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path(_SOCK),
+        tmux_target=_TARGET,
+    )
+    # Pane always reports an idle marker: _settle_pane returns immediately, the
+    # clear settles at once, and the paste-commit poll sees the needle.
+    captured = _install_fake_tmux(monkeypatch, pane_captures=["Add a follow-up hello marker"])
+    # Avoid real sleeps in the paste-commit settle.
+    monkeypatch.setattr(cursor_native_bridge.time, "sleep", lambda *_a, **_k: None)
+
+    cursor_native_bridge.inject_user_message(bridge_dir, content="hello marker")
+
+    first_backspace = next(
+        i for i, cmd in enumerate(captured) if "send-keys" in cmd and "BSpace" in cmd
+    )
+    first_paste = next(i for i, cmd in enumerate(captured) if "paste-buffer" in cmd)
+    assert first_backspace < first_paste, "draft must be cleared before the new paste"
+    # The old ineffective readline clear is gone.
+    assert not any("C-a" in cmd or "C-k" in cmd for cmd in captured)
+    # Submit still happens last.
+    assert any("send-keys" in cmd and "Enter" in cmd for cmd in captured)


### PR DESCRIPTION
## Problem

Pressing **Stop** in the web UI for a cursor-native session left the previous message sitting in the cursor-agent TUI composer, where it blocked / prepended the next message.

Root cause, confirmed by driving a real `cursor-agent` TUI:

1. The web-UI Stop button sends `Escape` to the pane (`inject_interrupt`), which cancels the turn — but cursor-agent **restores the interrupted prompt back into the composer**.
2. The existing draft-clear in `inject_user_message` used `C-a` + `C-k`. cursor-agent's composer **ignores** those readline keys (verified `C-a`/`C-k`/`C-u`/`Escape` all leave the text) — only `Backspace` deletes. So the restored prompt survived and merged with the next injected message.

## Fix

- **`_clear_composer`** replaces the dead `C-a`/`C-k` clear: jump to `End`, then flood `Backspace` via `send-keys -N` bursts until the pane stops changing. Handles inline text, multi-line drafts, and cursor-agent's collapsed `[Pasted text +N lines]` chips. A burst on an empty composer is a harmless no-op (unlike `C-c`, which would arm cursor-agent's exit).
- **`inject_interrupt`** now cancels, waits for the restored draft to settle, then clears the composer — so the input box is empty the moment you look at the TUI after Stop, not just before the next message. `inject_user_message` still clears before pasting (defense in depth).

## Testing

- New `tests/test_cursor_native_bridge.py` (4 tests): flood-until-stable, terminates on empty composer, bounded when the pane never settles, and a regression test that the clear runs before the paste.
- Verified end-to-end against a live `cursor-agent` TUI (`v2026.06.24`): leftover draft present before Stop → composer empty right after `inject_interrupt` → next message injects clean with no prepend.

## Note

On `cursor-agent v2026.06.24` a single `Escape` did not reliably *halt* generation (that build advertises `ctrl+c`); the leftover-clear here is version-agnostic, but making the stop key robust across cursor-agent versions is a possible follow-up.