### PR TITLE
fix(cursor-native): resume TUI with prior conversation on cold restart

### DIFF
--- a/omnigent/_native_resume_hint.py
+++ b/omnigent/_native_resume_hint.py
@@ -60,22 +60,34 @@ def echo_native_resume_hint(
 def echo_native_cold_resume_hint(
     *,
     agent_label: str = "Cursor",
+    restored: bool = False,
 ) -> None:
     """
-    Warn that a cold resume is starting a fresh session, not restoring one.
+    Tell the user a cold resume is relaunching the agent's TUI.
 
-    Some native wrappers (notably Cursor) cannot reattach to a prior
-    chat once the session terminal has exited: the TUI records no
-    resumable chat id, so ``--resume`` relaunches a *fresh* agent with
-    none of the prior turns. The reattach-to-a-live-terminal path is
-    unaffected; this hint only fires when the terminal is gone and we
-    are cold-starting a new TUI, so the user is not misled into
-    thinking their earlier conversation came back.
+    Fires only when the session terminal has exited and we are
+    cold-starting a new TUI (the reattach-to-a-live-terminal path is
+    unaffected). Two outcomes, selected by *restored*:
+
+    - ``restored=False`` (default): the wrapper cannot reattach to the
+      prior chat, so ``--resume`` relaunches a *fresh* agent with none of
+      the prior turns. Used by wrappers that record no resumable chat id.
+    - ``restored=True``: the wrapper captured a resumable chat id and is
+      reloading the prior conversation into the new TUI (e.g. Cursor,
+      which reuses its chat store across ``cursor-agent --resume``).
 
     :param agent_label: Human-readable agent name for the message,
         e.g. ``"Cursor"``.
+    :param restored: Whether the prior conversation is being reloaded.
     :returns: None.
     """
+    if restored:
+        click.echo(
+            f"Terminal not running - relaunching {agent_label} and "
+            "resuming the prior conversation.",
+            err=True,
+        )
+        return
     click.echo(
         f"Terminal not running - starting a fresh {agent_label} session "
         "(prior chat not restored).",

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import shutil
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -54,6 +55,27 @@ from omnigent.native_terminal import url_component
 
 _DEFAULT_CURSOR_COMMAND = "cursor-agent"
 _CURSOR_PATH_ENV = "OMNIGENT_CURSOR_PATH"
+#: cursor chat ids (used as ``external_session_id``) are canonical UUIDs, e.g.
+#: ``0ef42bbf-3b80-4bec-ac39-ca46531cbc47``. This id flows into two untrusted
+#: sinks — a filesystem path component (the cursor chat-store dir) and the
+#: ``cursor-agent --resume`` argv — so both callers validate against this strict
+#: 8-4-4-4-12 shape before use (stricter than codex's loose hex+dash guard,
+#: because we know cursor mints full UUIDs). Anything else can never reach a path
+#: or argv.
+_CURSOR_CHAT_ID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def is_valid_cursor_chat_id(chat_id: str | None) -> bool:
+    """Return whether *chat_id* is a well-formed cursor chat id (UUID shape).
+
+    Used to gate the persisted ``external_session_id`` before it is used as a
+    cursor store-path component or passed to ``cursor-agent --resume``.
+    """
+    return bool(chat_id) and _CURSOR_CHAT_ID_RE.fullmatch(chat_id) is not None
+
+
 _AGENT_NAME = "cursor-native-ui"
 _TERMINAL_NAME = "cursor"
 _TERMINAL_SESSION_KEY = "main"
@@ -109,6 +131,11 @@ class PreparedCursorTerminal:
     tmux_target: str | None
     reattached: bool
     cold_resumed: bool = False
+    #: The validated cursor chat id captured for this session, when a cold
+    #: resume will actually reload prior turns. ``None`` when no resumable id
+    #: was captured (first run, or the forwarder never persisted one), so the
+    #: cold resume genuinely starts a fresh chat — drives the honest hint.
+    resume_chat_id: str | None = None
 
 
 def _configured_cursor_command(env: Mapping[str, str]) -> str:
@@ -286,10 +313,15 @@ def _run_with_remote_server(
                 warn=lambda message: click.echo(message, err=True),
             )
             if prepared.cold_resumed:
-                # cursor reuses its chat store across ``cursor-agent --resume``
-                # and the runner injects ``--resume <chatId>`` on cold resume, so
-                # the prior conversation is reloaded rather than lost.
-                echo_native_cold_resume_hint(agent_label="Cursor", restored=True)
+                # Only promise restoration when a valid chat id was actually
+                # captured: then the runner injects ``--resume <chatId>`` and
+                # cursor (which reuses its chat store across ``--resume``)
+                # reloads the prior turns. With no captured id the runner injects
+                # nothing and cursor starts fresh, so the hint must say so.
+                echo_native_cold_resume_hint(
+                    agent_label="Cursor",
+                    restored=prepared.resume_chat_id is not None,
+                )
             await _attach_terminal_resource(prepared)
             if resolved_session_id is None:
                 echo_native_resume_hint(
@@ -332,6 +364,7 @@ async def _prepare_cursor_terminal_via_daemon(
         # running terminal below, so default both flags off here.
         reattached = False
         cold_resumed = False
+        resume_chat_id: str | None = None
         if session_id is None:
             if session_bundle is None:
                 raise click.ClickException("Creating a Cursor session requires a session bundle.")
@@ -379,6 +412,14 @@ async def _prepare_cursor_terminal_via_daemon(
             # independent). Safe because cursor never uses reattached for
             # teardown ownership.
             cold_resumed = True
+            # The hint below should only promise "prior conversation resumed"
+            # when a valid chat id was actually captured; otherwise the runner
+            # injects no ``--resume`` and cursor starts fresh. Read it from the
+            # same session payload and validate it (the runner re-validates
+            # before use; this keeps the user-facing message honest).
+            ext = payload.get("external_session_id") if isinstance(payload, dict) else None
+            if isinstance(ext, str) and is_valid_cursor_chat_id(ext):
+                resume_chat_id = ext
             if persist_args:
                 _update_startup_progress(startup_progress, "Updating Cursor session...")
                 resp = await client.patch(
@@ -417,6 +458,7 @@ async def _prepare_cursor_terminal_via_daemon(
         tmux_target=terminal.tmux_target,
         reattached=reattached,
         cold_resumed=cold_resumed,
+        resume_chat_id=resume_chat_id,
     )
 
 

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -88,12 +88,14 @@ class PreparedCursorTerminal:
         terminal was reused (the live-reattach path: prior chat is
         intact).
     :param cold_resumed: ``True`` when resuming an existing Omnigent
-        session whose terminal had already exited, so a *fresh*
-        ``cursor-agent`` TUI was launched with none of the prior turns.
-        Cursor records no resumable chat id, so this is genuinely a new
-        chat - distinct from a brand-new session (``resolved_session_id
-        is None``) and from a live reattach. Drives the honest
-        cold-resume stderr hint. Note: cursor deliberately treats
+        session whose terminal had already exited, so a new
+        ``cursor-agent`` TUI is launched. The forwarder persisted the
+        cursor chat id as ``external_session_id``, so the runner relaunches
+        with ``--resume <chatId>`` and the prior conversation is reloaded
+        (cursor reuses its chat store across ``--resume``). Distinct from a
+        brand-new session (``resolved_session_id is None``) and from a live
+        reattach. Drives the cold-resume stderr hint. Note: cursor
+        deliberately treats
         ``cold_resumed`` and ``reattached`` as mutually exclusive (the
         cold-resume path leaves ``reattached`` at its ``False`` default)
         - unlike ``claude_native`` which models them independently. This
@@ -284,7 +286,10 @@ def _run_with_remote_server(
                 warn=lambda message: click.echo(message, err=True),
             )
             if prepared.cold_resumed:
-                echo_native_cold_resume_hint(agent_label="Cursor")
+                # cursor reuses its chat store across ``cursor-agent --resume``
+                # and the runner injects ``--resume <chatId>`` on cold resume, so
+                # the prior conversation is reloaded rather than lost.
+                echo_native_cold_resume_hint(agent_label="Cursor", restored=True)
             await _attach_terminal_resource(prepared)
             if resolved_session_id is None:
                 echo_native_resume_hint(

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -363,13 +363,16 @@ async def _prepare_cursor_terminal_via_daemon(
                     tmux_target=existing_terminal.tmux_target,
                     reattached=True,
                 )
-            # Session exists but its terminal has exited. Cursor records no
-            # resumable chat id, so the launch below starts a fresh TUI with
-            # no prior turns. Flag it so the caller can say so honestly.
-            # Mutually exclusive with the reattach path above: we leave
-            # reattached at False here (unlike claude_native, which treats
-            # cold_resumed/reattached as independent). Safe because cursor
-            # never uses reattached for teardown ownership.
+            # Session exists but its terminal has exited. The forwarder
+            # persists the cursor chat id as external_session_id, so the
+            # runner's _auto_create_cursor_terminal will pass
+            # ``--resume <chatId>`` to cursor-agent and the TUI reloads
+            # the prior conversation. Flag cold_resumed so the caller can
+            # show an honest hint. Mutually exclusive with the reattach
+            # path above: we leave reattached at False here (unlike
+            # claude_native, which treats cold_resumed/reattached as
+            # independent). Safe because cursor never uses reattached for
+            # teardown ownership.
             cold_resumed = True
             if persist_args:
                 _update_startup_progress(startup_progress, "Updating Cursor session...")

--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -265,6 +265,14 @@ def preseed_resume_state(
     Writing the known store path + current rowid here lets the forwarder skip
     discovery entirely and start tailing only messages posted after the resume.
 
+    External contract (verified empirically against the current cursor build):
+    ``cursor-agent --resume`` reuses the SAME chat store and *appends* new turns
+    at higher rowids — it does not re-write prior turns as new blobs. Seeding
+    ``last_rowid`` to the current max therefore mirrors only post-resume turns,
+    with no duplicate-history re-post. If a future cursor build re-appended the
+    prior conversation at rowids past the seed, those would be re-mirrored as
+    duplicates — the e2e gate (cursor-sdk-e2e-dev) is the guard for that drift.
+
     :param bridge_dir: Per-session bridge directory (``bridge_dir_for_session_id``).
     :param workspace: Realpath-normalised workspace (must match the cursor TUI cwd
         so the store hash aligns).

--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -231,6 +231,64 @@ def _chat_claimed_by_other(bridge_dir: Path, store_path: Path, my_launch_ms: int
     return False
 
 
+def _get_current_rowid(store_path: Path) -> int:
+    """Return the highest rowid currently in *store_path*, or 0 on any error."""
+    sql = "SELECT MAX(rowid) FROM blobs"
+    for uri, kw in ((f"file:{store_path}?mode=ro", {"uri": True}), (str(store_path), {})):
+        try:
+            con = sqlite3.connect(uri, timeout=5.0, **kw)
+        except sqlite3.Error:
+            continue
+        try:
+            row = con.execute(sql).fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+        except sqlite3.Error:
+            continue
+        finally:
+            con.close()
+    return 0
+
+
+def preseed_resume_state(
+    bridge_dir: Path,
+    workspace: str,
+    chat_id: str,
+    launch_epoch_ms: int,
+) -> bool:
+    """Pre-seed the bridge state for a cold resume of a cursor-native session.
+
+    On cold resume ``cursor-agent --resume <chatId>`` loads an existing chat
+    store whose ``meta.json`` creation timestamp predates this launch.
+    ``_discover_store``'s recency filter would therefore miss it, leaving the
+    forwarder stuck in an empty-discovery loop and new messages unmirrored.
+
+    Writing the known store path + current rowid here lets the forwarder skip
+    discovery entirely and start tailing only messages posted after the resume.
+
+    :param bridge_dir: Per-session bridge directory (``bridge_dir_for_session_id``).
+    :param workspace: Realpath-normalised workspace (must match the cursor TUI cwd
+        so the store hash aligns).
+    :param chat_id: The cursor chat id (``external_session_id``).
+    :param launch_epoch_ms: Wall-clock ms of this terminal launch (used for the
+        claim-ownership heartbeat).
+    :returns: ``True`` when the store was found and state was written; ``False``
+        when the store doesn't exist yet (unlikely on resume, but safe to handle).
+    """
+    store_path = _cursor_chats_root() / _workspace_hash(workspace) / chat_id / "store.db"
+    if not store_path.exists():
+        return False
+    last_rowid = _get_current_rowid(store_path)
+    _write_state(
+        bridge_dir,
+        _ForwardState(
+            store_path=str(store_path),
+            last_rowid=last_rowid,
+            launch_epoch_ms=launch_epoch_ms,
+        ),
+    )
+    return True
+
+
 def _cursor_chats_root() -> Path:
     """Return ``~/.cursor/chats`` for the process's HOME (shared with the TUI)."""
     return Path.home() / ".cursor" / "chats"
@@ -556,34 +614,60 @@ async def forward_cursor_store_to_session(
         while True:
             try:
                 if store_path is None or not store_path.exists():
-                    resolved = await asyncio.to_thread(_discover_store, workspace, launch_epoch_ms)
-                    if resolved is not None and not await asyncio.to_thread(
-                        _chat_claimed_by_other, bridge_dir, resolved, launch_epoch_ms
-                    ):
-                        store_path = resolved
-                        if persisted.store_path == str(resolved):
-                            last_rowid = persisted.last_rowid
-                        else:
-                            last_rowid = 0
+                    # On cold resume the runner pre-seeds the bridge state with
+                    # the known store path (see ``preseed_resume_state``), so we
+                    # use it directly rather than running ``_discover_store`` whose
+                    # launch-recency filter would miss a store created before this
+                    # launch. For a normal fresh start the persisted path is absent
+                    # (bridge state was cleared) and we fall through to discovery.
+                    if persisted.store_path and Path(persisted.store_path).exists():
+                        store_path = Path(persisted.store_path)
+                        last_rowid = persisted.last_rowid
                         _write_state(
                             bridge_dir,
                             _ForwardState(
-                                store_path=str(resolved),
+                                store_path=str(store_path),
                                 last_rowid=last_rowid,
                                 launch_epoch_ms=launch_epoch_ms,
                             ),
                         )
                         persisted = _ForwardState()  # consumed
-                        # Persist the cursor chat id as external_session_id so a
-                        # later cold resume can pass ``--resume <chatId>`` to the
-                        # cursor-agent TUI. The chat_id is the UUID directory that
-                        # contains ``store.db`` (i.e. store_path.parent.name).
                         if not chat_id_patched:
-                            chat_id = store_path.parent.name
+                            chat_id_val = store_path.parent.name
                             await _patch_external_session_id(
-                                client, session_id=session_id, chat_id=chat_id
+                                client, session_id=session_id, chat_id=chat_id_val
                             )
                             chat_id_patched = True
+                    else:
+                        resolved = await asyncio.to_thread(
+                            _discover_store, workspace, launch_epoch_ms
+                        )
+                        if resolved is not None and not await asyncio.to_thread(
+                            _chat_claimed_by_other, bridge_dir, resolved, launch_epoch_ms
+                        ):
+                            store_path = resolved
+                            if persisted.store_path == str(resolved):
+                                last_rowid = persisted.last_rowid
+                            else:
+                                last_rowid = 0
+                            _write_state(
+                                bridge_dir,
+                                _ForwardState(
+                                    store_path=str(resolved),
+                                    last_rowid=last_rowid,
+                                    launch_epoch_ms=launch_epoch_ms,
+                                ),
+                            )
+                            persisted = _ForwardState()  # consumed
+                            # Persist the cursor chat id as external_session_id so
+                            # a later cold resume can pass ``--resume <chatId>``
+                            # to the cursor-agent TUI.
+                            if not chat_id_patched:
+                                chat_id_val = store_path.parent.name
+                                await _patch_external_session_id(
+                                    client, session_id=session_id, chat_id=chat_id_val
+                                )
+                                chat_id_patched = True
                 if store_path is not None and store_path.exists():
                     # cursor keeps ONE chat per working dir, so two cursor-native
                     # sessions launched in the same cwd discover the same store.

--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -452,6 +452,33 @@ def _blob_to_item(rowid: int, blob_id: str, data: object, agent_name: str) -> _M
     return None  # system or other scaffolding
 
 
+async def _patch_external_session_id(
+    client: httpx.AsyncClient, *, session_id: str, chat_id: str
+) -> None:
+    """PATCH the Omnigent session with the cursor chat id for cold-resume.
+
+    Best-effort: logs on failure but does not raise so the forwarder loop
+    continues mirroring even if the PATCH can't be delivered.
+    """
+    try:
+        resp = await client.patch(
+            f"/v1/sessions/{session_id}",
+            json={"external_session_id": chat_id},
+        )
+        if resp.status_code >= 400:
+            _logger.warning(
+                "AP rejected external_session_id PATCH (%s); session=%s chat_id=%s",
+                resp.status_code,
+                session_id,
+                chat_id,
+            )
+    except httpx.HTTPError:
+        _logger.warning(
+            "Transient error PATCHing external_session_id; session=%s — will not retry",
+            session_id,
+        )
+
+
 async def _post_conversation_item(
     client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
 ) -> None:
@@ -519,6 +546,9 @@ async def forward_cursor_store_to_session(
     # has seen. Reset whenever the cursor advances past an item.
     failed_rowid = 0
     failed_attempts = 0
+    # Track whether the cursor chat id has been persisted as external_session_id
+    # so the cold-resume path can pass ``--resume <chatId>`` to cursor-agent.
+    chat_id_patched = False
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
@@ -544,6 +574,16 @@ async def forward_cursor_store_to_session(
                             ),
                         )
                         persisted = _ForwardState()  # consumed
+                        # Persist the cursor chat id as external_session_id so a
+                        # later cold resume can pass ``--resume <chatId>`` to the
+                        # cursor-agent TUI. The chat_id is the UUID directory that
+                        # contains ``store.db`` (i.e. store_path.parent.name).
+                        if not chat_id_patched:
+                            chat_id = store_path.parent.name
+                            await _patch_external_session_id(
+                                client, session_id=session_id, chat_id=chat_id
+                            )
+                            chat_id_patched = True
                 if store_path is not None and store_path.exists():
                     # cursor keeps ONE chat per working dir, so two cursor-native
                     # sessions launched in the same cwd discover the same store.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1546,9 +1546,7 @@ async def _auto_create_cursor_terminal(
     # reloads the prior conversation. ``external_session_id`` is set by the
     # forwarder the first time it discovers the cursor chat store; absent on a
     # brand-new session, so no ``--resume`` is injected and cursor starts fresh.
-    cursor_args.extend(
-        _cursor_native_resume_args(launch_config.external_session_id, cursor_args)
-    )
+    cursor_args.extend(_cursor_native_resume_args(launch_config.external_session_id, cursor_args))
     # Honor the spec's pinned model (``--model`` flag / config.yaml ``model:``)
     # by launching cursor-agent with ``--model <model>``. An explicit model in
     # the passthrough launch args (``omnigent cursor -- --model X`` or the joined

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1507,6 +1507,7 @@ async def _auto_create_cursor_terminal(
     # and drop the prior terminal's stale forward cursor so the new forwarder
     # can't resume the wrong chat / a stale rowid (mirrors codex's clear_bridge_state).
     await _cancel_auto_forwarder_task(session_id)
+    from omnigent.cursor_native import is_valid_cursor_chat_id
     from omnigent.cursor_native_bridge import (
         approve_mcp_server_for_workspace,
         bridge_dir_for_session_id,
@@ -1526,12 +1527,25 @@ async def _auto_create_cursor_terminal(
     # cursor TUI's cwd and the forwarder hash the SAME path — cursor keys its
     # chat store dir on ``md5(cwd)``, and a mismatch would hide the store.
     workspace = os.path.realpath(str(launch_config.workspace))
+    # Validate the persisted chat id ONCE, up front. It feeds two untrusted
+    # sinks below — the cursor store path in preseed_resume_state (filesystem)
+    # and the ``--resume`` argv in _cursor_native_resume_args — so a malformed
+    # value must reach neither (defense-in-depth). cursor mints UUID chat ids;
+    # anything else is dropped here and the session starts fresh.
+    resume_chat_id = launch_config.external_session_id
+    if resume_chat_id and not is_valid_cursor_chat_id(resume_chat_id):
+        _logger.warning(
+            "cursor-native: persisted chat id %r is not a well-formed cursor "
+            "chat id; ignoring it for resume (session=%s).",
+            resume_chat_id,
+            session_id,
+        )
+        resume_chat_id = None
     # On cold resume, pre-seed the bridge state with the known store path and
     # current rowid so the forwarder skips launch-recency discovery (the existing
     # chat store predates this launch and would fail _discover_store's floor check).
     # On a fresh start, clear any stale state from a prior terminal so the old
     # and new forwarders can't double-post the same chat.
-    resume_chat_id = launch_config.external_session_id
     if resume_chat_id and preseed_resume_state(
         bridge_dir, workspace, resume_chat_id, launch_epoch_ms
     ):
@@ -1544,10 +1558,9 @@ async def _auto_create_cursor_terminal(
     if "--approve-mcps" not in cursor_args:
         cursor_args.append("--approve-mcps")
     # On cold resume, pass ``--resume <chatId>`` to cursor-agent so the TUI
-    # reloads the prior conversation. ``external_session_id`` is set by the
-    # forwarder the first time it discovers the cursor chat store; absent on a
+    # reloads the prior conversation. The id was validated above; ``None`` on a
     # brand-new session, so no ``--resume`` is injected and cursor starts fresh.
-    cursor_args.extend(_cursor_native_resume_args(launch_config.external_session_id, cursor_args))
+    cursor_args.extend(_cursor_native_resume_args(resume_chat_id, cursor_args))
     # Honor the spec's pinned model (``--model`` flag / config.yaml ``model:``)
     # by launching cursor-agent with ``--model <model>``. An explicit model in
     # the passthrough launch args (``omnigent cursor -- --model X`` or the joined
@@ -3890,14 +3903,6 @@ def _cursor_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) 
     return model
 
 
-#: cursor chat ids are UUIDs (hex + dashes). Validate the persisted
-#: ``external_session_id`` against this shape before feeding it back to
-#: ``cursor-agent --resume`` / storing it durably — defense-in-depth mirroring
-#: codex's ``_CODEX_THREAD_ID_RE`` guard, so a malformed discovery result can
-#: never reach the argv or pin the session to a junk id.
-_CURSOR_CHAT_ID_RE = re.compile(r"^[0-9a-fA-F-]+$")
-
-
 def _cursor_native_resume_args(chat_id: str | None, existing_args: list[str]) -> list[str]:
     """Return ``["--resume", chat_id]`` for a cursor-native cold resume, or ``[]``.
 
@@ -3907,6 +3912,9 @@ def _cursor_native_resume_args(chat_id: str | None, existing_args: list[str]) ->
     cursor-agent reuses the same chat id/store across ``--resume`` (verified
     empirically), so the persisted id stays valid for the life of the session.
 
+    Re-validates the chat id (callers should already have, but this stays
+    self-defensive so a malformed id can never reach the argv directly).
+
     :param chat_id: The cursor chat id stored as ``external_session_id``, or
         ``None`` for a brand-new session where the forwarder hasn't run yet.
     :param existing_args: Already-built cursor-agent args; ``--resume`` is
@@ -3914,14 +3922,9 @@ def _cursor_native_resume_args(chat_id: str | None, existing_args: list[str]) ->
         ``--resume=X`` form) via passthrough launch args.
     :returns: ``["--resume", chat_id]`` or ``[]``.
     """
-    if not chat_id:
-        return []
-    if not _CURSOR_CHAT_ID_RE.fullmatch(chat_id):
-        _logger.warning(
-            "cursor-native: persisted chat id %r is not a well-formed cursor "
-            "chat id; not injecting --resume.",
-            chat_id,
-        )
+    from omnigent.cursor_native import is_valid_cursor_chat_id
+
+    if not is_valid_cursor_chat_id(chat_id):
         return []
     if any(arg == "--resume" or arg.startswith("--resume=") for arg in existing_args):
         return []

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1546,12 +1546,26 @@ async def _auto_create_cursor_terminal(
     # chat store predates this launch and would fail _discover_store's floor check).
     # On a fresh start, clear any stale state from a prior terminal so the old
     # and new forwarders can't double-post the same chat.
-    if resume_chat_id and preseed_resume_state(
+    #
+    # Tie the ``--resume`` decision to preseed success: only resume when we
+    # actually pre-seeded the prior store. If preseed fails (the store dir is
+    # gone), injecting ``--resume`` anyway would reload that store in the TUI
+    # while the cleared forwarder falls back to discovery — whose recency floor
+    # excludes the pre-launch store — so the relaunched chat would go unmirrored.
+    # Dropping resume here starts a genuinely fresh chat that discovery can find.
+    preseeded = bool(resume_chat_id) and preseed_resume_state(
         bridge_dir, workspace, resume_chat_id, launch_epoch_ms
-    ):
-        pass  # forwarder will pick up the pre-seeded store path
-    else:
+    )
+    if not preseeded:
         clear_cursor_bridge_state(bridge_dir)
+        if resume_chat_id is not None:
+            _logger.warning(
+                "cursor-native: could not pre-seed prior chat store for %r; "
+                "starting a fresh chat (session=%s).",
+                resume_chat_id,
+                session_id,
+            )
+            resume_chat_id = None
     write_mcp_config(Path(workspace), bridge_dir)
     cursor_command = resolve_cursor_executable()
     cursor_args = list(launch_config.terminal_launch_args or [])

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1511,10 +1511,9 @@ async def _auto_create_cursor_terminal(
         bridge_dir_for_session_id,
         write_mcp_config,
     )
-    from omnigent.cursor_native_forwarder import clear_cursor_bridge_state
+    from omnigent.cursor_native_forwarder import clear_cursor_bridge_state, preseed_resume_state
 
     bridge_dir = bridge_dir_for_session_id(session_id)
-    clear_cursor_bridge_state(bridge_dir)
 
     # ``_pi_native_launch_config`` is a generic session-snapshot reader
     # (workspace + terminal_launch_args); reused here, not Pi-specific.
@@ -1526,6 +1525,18 @@ async def _auto_create_cursor_terminal(
     # cursor TUI's cwd and the forwarder hash the SAME path — cursor keys its
     # chat store dir on ``md5(cwd)``, and a mismatch would hide the store.
     workspace = os.path.realpath(str(launch_config.workspace))
+    # On cold resume, pre-seed the bridge state with the known store path and
+    # current rowid so the forwarder skips launch-recency discovery (the existing
+    # chat store predates this launch and would fail _discover_store's floor check).
+    # On a fresh start, clear any stale state from a prior terminal so the old
+    # and new forwarders can't double-post the same chat.
+    resume_chat_id = launch_config.external_session_id
+    if resume_chat_id and preseed_resume_state(
+        bridge_dir, workspace, resume_chat_id, launch_epoch_ms
+    ):
+        pass  # forwarder will pick up the pre-seeded store path
+    else:
+        clear_cursor_bridge_state(bridge_dir)
     write_mcp_config(Path(workspace), bridge_dir)
     cursor_command = resolve_cursor_executable()
     cursor_args = list(launch_config.terminal_launch_args or [])

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1531,6 +1531,13 @@ async def _auto_create_cursor_terminal(
     cursor_args = list(launch_config.terminal_launch_args or [])
     if "--approve-mcps" not in cursor_args:
         cursor_args.append("--approve-mcps")
+    # On cold resume, pass ``--resume <chatId>`` to cursor-agent so the TUI
+    # reloads the prior conversation. ``external_session_id`` is set by the
+    # forwarder the first time it discovers the cursor chat store; absent on a
+    # brand-new session, so no ``--resume`` is injected and cursor starts fresh.
+    cursor_args.extend(
+        _cursor_native_resume_args(launch_config.external_session_id, cursor_args)
+    )
     # Honor the spec's pinned model (``--model`` flag / config.yaml ``model:``)
     # by launching cursor-agent with ``--model <model>``. An explicit model in
     # the passthrough launch args (``omnigent cursor -- --model X`` or the joined
@@ -3871,6 +3878,24 @@ def _cursor_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) 
         )
         return None
     return model
+
+
+def _cursor_native_resume_args(chat_id: str | None, existing_args: list[str]) -> list[str]:
+    """Return ``["--resume", chat_id]`` for a cursor-native cold resume, or ``[]``.
+
+    The forwarder persists the cursor chat id as ``external_session_id`` after
+    it first discovers the chat store. On a cold resume (terminal has exited)
+    this id is injected here so cursor-agent reloads the prior conversation.
+
+    :param chat_id: The cursor chat id stored as ``external_session_id``, or
+        ``None`` for a brand-new session where the forwarder hasn't run yet.
+    :param existing_args: Already-built cursor-agent args; ``--resume`` is
+        skipped when the user already passed one via passthrough launch args.
+    :returns: ``["--resume", chat_id]`` or ``[]``.
+    """
+    if chat_id and "--resume" not in existing_args:
+        return ["--resume", chat_id]
+    return []
 
 
 def _agent_os_env_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -> Any | None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -15,6 +15,7 @@ import json
 import logging
 import mimetypes
 import os
+import re
 import sys
 import tempfile
 import time
@@ -3889,22 +3890,42 @@ def _cursor_native_model_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) 
     return model
 
 
+#: cursor chat ids are UUIDs (hex + dashes). Validate the persisted
+#: ``external_session_id`` against this shape before feeding it back to
+#: ``cursor-agent --resume`` / storing it durably — defense-in-depth mirroring
+#: codex's ``_CODEX_THREAD_ID_RE`` guard, so a malformed discovery result can
+#: never reach the argv or pin the session to a junk id.
+_CURSOR_CHAT_ID_RE = re.compile(r"^[0-9a-fA-F-]+$")
+
+
 def _cursor_native_resume_args(chat_id: str | None, existing_args: list[str]) -> list[str]:
     """Return ``["--resume", chat_id]`` for a cursor-native cold resume, or ``[]``.
 
     The forwarder persists the cursor chat id as ``external_session_id`` after
     it first discovers the chat store. On a cold resume (terminal has exited)
     this id is injected here so cursor-agent reloads the prior conversation.
+    cursor-agent reuses the same chat id/store across ``--resume`` (verified
+    empirically), so the persisted id stays valid for the life of the session.
 
     :param chat_id: The cursor chat id stored as ``external_session_id``, or
         ``None`` for a brand-new session where the forwarder hasn't run yet.
     :param existing_args: Already-built cursor-agent args; ``--resume`` is
-        skipped when the user already passed one via passthrough launch args.
+        skipped when the user already passed one (``--resume X`` or the joined
+        ``--resume=X`` form) via passthrough launch args.
     :returns: ``["--resume", chat_id]`` or ``[]``.
     """
-    if chat_id and "--resume" not in existing_args:
-        return ["--resume", chat_id]
-    return []
+    if not chat_id:
+        return []
+    if not _CURSOR_CHAT_ID_RE.fullmatch(chat_id):
+        _logger.warning(
+            "cursor-native: persisted chat id %r is not a well-formed cursor "
+            "chat id; not injecting --resume.",
+            chat_id,
+        )
+        return []
+    if any(arg == "--resume" or arg.startswith("--resume=") for arg in existing_args):
+        return []
+    return ["--resume", chat_id]
 
 
 def _agent_os_env_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -> Any | None:
@@ -5679,8 +5700,6 @@ def _is_context_overflow_error(event: dict[str, Any]) -> tuple[int, int] | None:
     msg = str(error.get("message", "")).lower()
     if not any(pat in msg for pat in _CONTEXT_OVERFLOW_PATTERNS):
         return None
-    import re
-
     actual_gt_max = re.search(r"(\d{4,})\D*>\D*(\d{4,})", msg)
     if actual_gt_max is not None:
         return int(actual_gt_max.group(2)), int(actual_gt_max.group(1))

--- a/tests/runner/test_app_cursor_native_resume.py
+++ b/tests/runner/test_app_cursor_native_resume.py
@@ -1,0 +1,45 @@
+"""Tests for cursor-native cold-resume arg injection.
+
+``_cursor_native_resume_args`` builds the ``["--resume", chat_id]`` suffix
+that ``_auto_create_cursor_terminal`` appends to cursor-agent's launch args
+when the Omnigent session already has an ``external_session_id`` (set by the
+forwarder the first time it discovers the cursor chat store). A missing or
+empty id means a brand-new session — no ``--resume`` is injected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.runner.app import _cursor_native_resume_args
+
+
+@pytest.mark.parametrize(
+    ("chat_id", "existing_args", "expected"),
+    [
+        # Brand-new session — forwarder hasn't written external_session_id yet.
+        (None, [], []),
+        ("", [], []),
+        # Cold resume with a valid chat_id and no prior --resume in args.
+        ("chat-uuid-abc123", [], ["--resume", "chat-uuid-abc123"]),
+        ("chat-uuid-abc123", ["--approve-mcps"], ["--resume", "chat-uuid-abc123"]),
+        # User already passed --resume via passthrough args — don't duplicate it.
+        ("chat-uuid-abc123", ["--resume", "other-id"], []),
+        # --resume combined with other flags.
+        ("chat-uuid-abc123", ["--approve-mcps", "--resume", "other-id"], []),
+    ],
+    ids=[
+        "no-chat-id-none",
+        "no-chat-id-empty",
+        "fresh-args",
+        "with-other-flags",
+        "resume-already-present",
+        "resume-present-with-other-flags",
+    ],
+)
+def test_cursor_native_resume_args(
+    chat_id: str | None,
+    existing_args: list[str],
+    expected: list[str],
+) -> None:
+    assert _cursor_native_resume_args(chat_id, existing_args) == expected

--- a/tests/runner/test_app_cursor_native_resume.py
+++ b/tests/runner/test_app_cursor_native_resume.py
@@ -4,14 +4,20 @@
 that ``_auto_create_cursor_terminal`` appends to cursor-agent's launch args
 when the Omnigent session already has an ``external_session_id`` (set by the
 forwarder the first time it discovers the cursor chat store). A missing or
-empty id means a brand-new session — no ``--resume`` is injected.
+empty id means a brand-new session — no ``--resume`` is injected. A malformed
+id (not a UUID-shaped hex+dash string) is rejected defensively.
 """
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from omnigent.runner.app import _cursor_native_resume_args
+
+# A real cursor chat id is a UUID (hex + dashes).
+_CHAT = "0ef42bbf-3b80-4bec-ac39-ca46531cbc47"
 
 
 @pytest.mark.parametrize(
@@ -21,12 +27,14 @@ from omnigent.runner.app import _cursor_native_resume_args
         (None, [], []),
         ("", [], []),
         # Cold resume with a valid chat_id and no prior --resume in args.
-        ("chat-uuid-abc123", [], ["--resume", "chat-uuid-abc123"]),
-        ("chat-uuid-abc123", ["--approve-mcps"], ["--resume", "chat-uuid-abc123"]),
+        (_CHAT, [], ["--resume", _CHAT]),
+        (_CHAT, ["--approve-mcps"], ["--resume", _CHAT]),
         # User already passed --resume via passthrough args — don't duplicate it.
-        ("chat-uuid-abc123", ["--resume", "other-id"], []),
-        # --resume combined with other flags.
-        ("chat-uuid-abc123", ["--approve-mcps", "--resume", "other-id"], []),
+        (_CHAT, ["--resume", "other-id"], []),
+        (_CHAT, ["--approve-mcps", "--resume", "other-id"], []),
+        # The joined ``--resume=<id>`` passthrough form must also dedup.
+        (_CHAT, ["--resume=other-id"], []),
+        (_CHAT, ["--approve-mcps", "--resume=other-id"], []),
     ],
     ids=[
         "no-chat-id-none",
@@ -35,6 +43,8 @@ from omnigent.runner.app import _cursor_native_resume_args
         "with-other-flags",
         "resume-already-present",
         "resume-present-with-other-flags",
+        "resume-equals-form",
+        "resume-equals-form-with-other-flags",
     ],
 )
 def test_cursor_native_resume_args(
@@ -43,3 +53,21 @@ def test_cursor_native_resume_args(
     expected: list[str],
 ) -> None:
     assert _cursor_native_resume_args(chat_id, existing_args) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "chat-uuid-abc123",  # contains non-hex letters
+        "../../etc/passwd",  # path traversal shape
+        "id with spaces",
+        "$(rm -rf /)",
+        "0ef42bbf;reboot",
+    ],
+    ids=["non-hex", "traversal", "spaces", "shell", "semicolon"],
+)
+def test_malformed_chat_id_is_rejected(bad_id: str, caplog: pytest.LogCaptureFixture) -> None:
+    """A chat id that isn't UUID-shaped is never injected, and is logged."""
+    with caplog.at_level(logging.WARNING):
+        assert _cursor_native_resume_args(bad_id, []) == []
+    assert any(bad_id in rec.getMessage() for rec in caplog.records)

--- a/tests/runner/test_app_cursor_native_resume.py
+++ b/tests/runner/test_app_cursor_native_resume.py
@@ -10,8 +10,6 @@ id (not a UUID-shaped hex+dash string) is rejected defensively.
 
 from __future__ import annotations
 
-import logging
-
 import pytest
 
 from omnigent.runner.app import _cursor_native_resume_args
@@ -59,15 +57,33 @@ def test_cursor_native_resume_args(
     "bad_id",
     [
         "chat-uuid-abc123",  # contains non-hex letters
+        "deadbeef",  # hex but not UUID-shaped
+        "----",  # dashes only
+        "0",  # single digit
         "../../etc/passwd",  # path traversal shape
         "id with spaces",
         "$(rm -rf /)",
         "0ef42bbf;reboot",
+        "0ef42bbf-3b80-4bec-ac39-ca46531cbc47x",  # trailing junk
     ],
-    ids=["non-hex", "traversal", "spaces", "shell", "semicolon"],
+    ids=[
+        "non-hex",
+        "short-hex",
+        "dashes-only",
+        "single-digit",
+        "traversal",
+        "spaces",
+        "shell",
+        "semicolon",
+        "trailing-junk",
+    ],
 )
-def test_malformed_chat_id_is_rejected(bad_id: str, caplog: pytest.LogCaptureFixture) -> None:
-    """A chat id that isn't UUID-shaped is never injected, and is logged."""
-    with caplog.at_level(logging.WARNING):
-        assert _cursor_native_resume_args(bad_id, []) == []
-    assert any(bad_id in rec.getMessage() for rec in caplog.records)
+def test_malformed_chat_id_is_rejected(bad_id: str) -> None:
+    """A chat id that isn't UUID-shaped is never injected as a --resume arg.
+
+    The strict UUID guard (shared with the runner / CLI via
+    ``is_valid_cursor_chat_id``) keeps a malformed id out of the argv. The
+    runner logs the rejection at its single validation site; this function
+    just returns no args.
+    """
+    assert _cursor_native_resume_args(bad_id, []) == []

--- a/tests/test_cursor_native.py
+++ b/tests/test_cursor_native.py
@@ -137,3 +137,35 @@ async def _async_noop(*_: object, **__: object) -> None:
 
 async def _launch_runner(*_: object, **__: object) -> str:
     return "runner_1"
+
+
+class TestIsValidCursorChatId:
+    """``is_valid_cursor_chat_id`` gates the persisted external_session_id."""
+
+    @pytest.mark.parametrize(
+        "chat_id",
+        [
+            "0ef42bbf-3b80-4bec-ac39-ca46531cbc47",
+            "00000000-0000-0000-0000-000000000000",
+            "0EF42BBF-3B80-4BEC-AC39-CA46531CBC47",  # uppercase hex
+        ],
+    )
+    def test_accepts_well_formed_uuids(self, chat_id: str) -> None:
+        assert cursor_native.is_valid_cursor_chat_id(chat_id) is True
+
+    @pytest.mark.parametrize(
+        "chat_id",
+        [
+            None,
+            "",
+            "deadbeef",  # hex but not UUID-shaped
+            "chat-uuid-abc123",  # non-hex letters
+            "----",
+            "../../etc/passwd",  # path traversal shape
+            "0ef42bbf;reboot",  # shell metachar
+            "0ef42bbf-3b80-4bec-ac39-ca46531cbc47x",  # trailing junk
+            "0ef42bbf-3b80-4bec-ac39-ca46531cbc4",  # one short in last group
+        ],
+    )
+    def test_rejects_malformed_or_empty(self, chat_id: str | None) -> None:
+        assert cursor_native.is_valid_cursor_chat_id(chat_id) is False

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -623,9 +623,7 @@ async def test_patch_external_session_id_http_error_logs_but_does_not_raise(
 class TestPreseedResumeState:
     """``preseed_resume_state`` pre-seeds bridge state for cold resume."""
 
-    def _seed_chat(
-        self, chats_root: Path, workspace: str, chat_id: str, rows: int = 3
-    ) -> Path:
+    def _seed_chat(self, chats_root: Path, workspace: str, chat_id: str, rows: int = 3) -> Path:
         import hashlib
 
         ws_hash = hashlib.md5(workspace.encode()).hexdigest()
@@ -710,7 +708,7 @@ class TestForwardLoopPreseedResume:
 
         def _no_discover(workspace: str, launch_ms: int) -> None:
             discover_calls.append((workspace, launch_ms))
-            return None  # should never be reached
+            return  # should never be reached
 
         monkeypatch.setattr(fwd, "_discover_store", _no_discover)
         monkeypatch.setattr(fwd, "_chat_claimed_by_other", lambda *a, **k: False)

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -22,6 +22,14 @@ import pytest
 
 from omnigent import cursor_native_forwarder as fwd
 
+# Real cursor chat ids are UUIDs. Use UUID-shaped ids in fixtures so the
+# persist side (forwarder) and the resume side (runner's strict
+# ``is_valid_cursor_chat_id`` guard) agree on the same id shape — exercising the
+# persist→resume path with values the resume side would actually accept.
+_CHAT_ID = "0ef42bbf-3b80-4bec-ac39-ca46531cbc47"
+_CHAT_ID_2 = "1a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d"
+_CHAT_ID_ABSENT = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+
 
 def _make_store(
     path: Path, rows: list[tuple[str, object]], *, wal: bool = False
@@ -583,11 +591,11 @@ class _PatchRecordingClient:
 async def test_patch_external_session_id_request_shape() -> None:
     """PATCH carries the correct URL and JSON body."""
     client = _PatchRecordingClient()
-    await fwd._patch_external_session_id(client, session_id="conv_abc", chat_id="chat-uuid-123")  # type: ignore[arg-type]
+    await fwd._patch_external_session_id(client, session_id="conv_abc", chat_id=_CHAT_ID)  # type: ignore[arg-type]
     assert len(client.patches) == 1
     url, body = client.patches[0]
     assert url == "/v1/sessions/conv_abc"
-    assert body == {"external_session_id": "chat-uuid-123"}
+    assert body == {"external_session_id": _CHAT_ID}
 
 
 @pytest.mark.asyncio
@@ -643,7 +651,7 @@ class TestPreseedResumeState:
         monkeypatch.setattr(fwd, "_cursor_chats_root", lambda: tmp_path / "chats")
         bridge_dir = tmp_path / "bridge"
         bridge_dir.mkdir()
-        result = fwd.preseed_resume_state(bridge_dir, "/ws", "no-such-chat", 1_000)
+        result = fwd.preseed_resume_state(bridge_dir, "/ws", _CHAT_ID_ABSENT, 1_000)
         assert result is False
         assert fwd._read_state(bridge_dir).store_path is None
 
@@ -651,11 +659,11 @@ class TestPreseedResumeState:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(fwd, "_cursor_chats_root", lambda: tmp_path / "chats")
-        store = self._seed_chat(tmp_path / "chats", "/ws", "chat-abc", rows=5)
+        store = self._seed_chat(tmp_path / "chats", "/ws", _CHAT_ID, rows=5)
         bridge_dir = tmp_path / "bridge"
         bridge_dir.mkdir()
 
-        result = fwd.preseed_resume_state(bridge_dir, "/ws", "chat-abc", launch_epoch_ms=99_000)
+        result = fwd.preseed_resume_state(bridge_dir, "/ws", _CHAT_ID, launch_epoch_ms=99_000)
 
         assert result is True
         state = fwd._read_state(bridge_dir)
@@ -667,11 +675,11 @@ class TestPreseedResumeState:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(fwd, "_cursor_chats_root", lambda: tmp_path / "chats")
-        self._seed_chat(tmp_path / "chats", "/ws", "chat-empty", rows=0)
+        self._seed_chat(tmp_path / "chats", "/ws", _CHAT_ID_2, rows=0)
         bridge_dir = tmp_path / "bridge"
         bridge_dir.mkdir()
 
-        fwd.preseed_resume_state(bridge_dir, "/ws", "chat-empty", launch_epoch_ms=1_000)
+        fwd.preseed_resume_state(bridge_dir, "/ws", _CHAT_ID_2, launch_epoch_ms=1_000)
 
         assert fwd._read_state(bridge_dir).last_rowid == 0
 
@@ -684,7 +692,7 @@ class TestForwardLoopPreseedResume:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """When bridge state is pre-seeded, forwarder skips _discover_store."""
-        chat_id = "preseeded-chat-uuid"
+        chat_id = _CHAT_ID
         store = tmp_path / chat_id / "store.db"
         store.parent.mkdir(parents=True)
         writer = _make_store(
@@ -764,7 +772,7 @@ class TestForwardLoopExternalSessionId:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The forwarder PATCHes external_session_id with the cursor chat_id."""
-        store = tmp_path / "chat-uuid-abc123" / "store.db"
+        store = tmp_path / _CHAT_ID / "store.db"
         store.parent.mkdir(parents=True)
         self._seed(store)
 
@@ -807,14 +815,14 @@ class TestForwardLoopExternalSessionId:
         assert len(patches) == 1
         session_id, chat_id = patches[0]
         assert session_id == "conv_1"
-        assert chat_id == "chat-uuid-abc123"
+        assert chat_id == _CHAT_ID
 
     @pytest.mark.asyncio
     async def test_patches_only_once_across_multiple_polls(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """external_session_id is patched exactly once, not on every poll tick."""
-        store = tmp_path / "chat-uuid-xyz" / "store.db"
+        store = tmp_path / _CHAT_ID_2 / "store.db"
         store.parent.mkdir(parents=True)
         self._seed(store)
 

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -4,8 +4,9 @@ Covers the pure pieces a live cursor-agent isn't needed for: reading the
 content-addressed SQLite chat store (including the live-WAL layout that the
 ``immutable=1`` open mode silently missed), unwrapping cursor's
 ``<user_query>`` framing, building conversation items, rowid-based dedup,
-store discovery by ``md5(cwd)`` + launch recency, and the POST shapes. The live
-tmux + cursor-agent path is exercised by the e2e gate, not here.
+store discovery by ``md5(cwd)`` + launch recency, the POST shapes, and the
+``external_session_id`` patch that enables cold resume. The live tmux +
+cursor-agent path is exercised by the e2e gate, not here.
 """
 
 from __future__ import annotations
@@ -559,3 +560,172 @@ class TestForwardLoopPostFailures:
         # Retried well past the skip bound, yet never advanced — not quarantined.
         assert fwd._read_state(bridge).last_rowid == 0
         assert not poster.delivered
+
+
+# ---------------------------------------------------------------------------
+# external_session_id patching (cold-resume support)
+# ---------------------------------------------------------------------------
+
+
+class _PatchRecordingClient:
+    """Async stub that records PATCH calls and allows injecting a failure response."""
+
+    def __init__(self, status: int = 200) -> None:
+        self.patches: list[tuple[str, dict]] = []
+        self._status = status
+
+    async def patch(self, url: str, *, json: dict) -> httpx.Response:
+        self.patches.append((url, json))
+        return httpx.Response(self._status, request=httpx.Request("PATCH", url))
+
+
+@pytest.mark.asyncio
+async def test_patch_external_session_id_request_shape() -> None:
+    """PATCH carries the correct URL and JSON body."""
+    client = _PatchRecordingClient()
+    await fwd._patch_external_session_id(client, session_id="conv_abc", chat_id="chat-uuid-123")  # type: ignore[arg-type]
+    assert len(client.patches) == 1
+    url, body = client.patches[0]
+    assert url == "/v1/sessions/conv_abc"
+    assert body == {"external_session_id": "chat-uuid-123"}
+
+
+@pytest.mark.asyncio
+async def test_patch_external_session_id_4xx_logs_but_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A 4xx rejection from the server is logged but must not propagate."""
+    client = _PatchRecordingClient(status=400)
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        await fwd._patch_external_session_id(client, session_id="conv_x", chat_id="cid")  # type: ignore[arg-type]
+    assert any("400" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_patch_external_session_id_http_error_logs_but_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A transport error is logged and swallowed so the forwarder loop continues."""
+
+    class _ErrorClient:
+        async def patch(self, url: str, *, json: dict) -> httpx.Response:
+            raise httpx.ConnectError("refused", request=httpx.Request("PATCH", url))
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        await fwd._patch_external_session_id(_ErrorClient(), session_id="conv_x", chat_id="cid")  # type: ignore[arg-type]
+    assert caplog.records
+
+
+class TestForwardLoopExternalSessionId:
+    """The poll loop patches external_session_id once when the store is found."""
+
+    @staticmethod
+    def _seed(store: Path, text: str = "hello") -> None:
+        writer = _make_store(
+            store, [("u", _user(f"<user_query>\n{text}\n</user_query>"))]
+        )
+        writer.close()
+
+    @pytest.mark.asyncio
+    async def test_patches_chat_id_on_first_store_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The forwarder PATCHes external_session_id with the cursor chat_id."""
+        store = tmp_path / "chat-uuid-abc123" / "store.db"
+        store.parent.mkdir(parents=True)
+        self._seed(store)
+
+        patches: list[tuple[str, dict]] = []
+
+        async def _fake_patch(client: object, *, session_id: str, chat_id: str) -> None:
+            patches.append((session_id, chat_id))
+
+        monkeypatch.setattr(fwd, "_patch_external_session_id", _fake_patch)
+        monkeypatch.setattr(fwd, "_post_conversation_item", _FakePoster(lambda _: None))
+
+        bridge_dir = tmp_path / "cursor-native" / "sess"
+        bridge_dir.mkdir(parents=True)
+        monkeypatch.setattr(fwd, "_discover_store", lambda ws, launch_ms: store)
+        monkeypatch.setattr(fwd, "_chat_claimed_by_other", lambda *a, **k: False)
+
+        task = asyncio.create_task(
+            fwd.forward_cursor_store_to_session(
+                base_url="http://test",
+                headers={},
+                session_id="conv_1",
+                bridge_dir=bridge_dir,
+                agent_name="cursor-native-ui",
+                workspace="/ws",
+                launch_epoch_ms=1_000,
+                poll_interval_s=0.001,
+            )
+        )
+        try:
+            for _ in range(2000):
+                if patches:
+                    break
+                await asyncio.sleep(0.001)
+            else:
+                raise AssertionError("external_session_id patch was never called")
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert len(patches) == 1
+        session_id, chat_id = patches[0]
+        assert session_id == "conv_1"
+        assert chat_id == "chat-uuid-abc123"
+
+    @pytest.mark.asyncio
+    async def test_patches_only_once_across_multiple_polls(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """external_session_id is patched exactly once, not on every poll tick."""
+        store = tmp_path / "chat-uuid-xyz" / "store.db"
+        store.parent.mkdir(parents=True)
+        self._seed(store)
+
+        patch_count = 0
+
+        async def _count_patches(client: object, *, session_id: str, chat_id: str) -> None:
+            nonlocal patch_count
+            patch_count += 1
+
+        monkeypatch.setattr(fwd, "_patch_external_session_id", _count_patches)
+        monkeypatch.setattr(fwd, "_post_conversation_item", _FakePoster(lambda _: None))
+
+        bridge_dir = tmp_path / "cursor-native" / "sess"
+        bridge_dir.mkdir(parents=True)
+        monkeypatch.setattr(fwd, "_discover_store", lambda ws, launch_ms: store)
+        monkeypatch.setattr(fwd, "_chat_claimed_by_other", lambda *a, **k: False)
+
+        task = asyncio.create_task(
+            fwd.forward_cursor_store_to_session(
+                base_url="http://test",
+                headers={},
+                session_id="conv_2",
+                bridge_dir=bridge_dir,
+                agent_name="cursor-native-ui",
+                workspace="/ws",
+                launch_epoch_ms=1_000,
+                poll_interval_s=0.001,
+            )
+        )
+        try:
+            # Let the loop run for several ticks after the patch fires.
+            for _ in range(2000):
+                if patch_count >= 1:
+                    break
+                await asyncio.sleep(0.001)
+            # Extra ticks to confirm it doesn't re-patch.
+            for _ in range(50):
+                await asyncio.sleep(0.001)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert patch_count == 1

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -756,9 +756,7 @@ class TestForwardLoopExternalSessionId:
 
     @staticmethod
     def _seed(store: Path, text: str = "hello") -> None:
-        writer = _make_store(
-            store, [("u", _user(f"<user_query>\n{text}\n</user_query>"))]
-        )
+        writer = _make_store(store, [("u", _user(f"<user_query>\n{text}\n</user_query>"))])
         writer.close()
 
     @pytest.mark.asyncio

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -620,6 +620,139 @@ async def test_patch_external_session_id_http_error_logs_but_does_not_raise(
     assert caplog.records
 
 
+class TestPreseedResumeState:
+    """``preseed_resume_state`` pre-seeds bridge state for cold resume."""
+
+    def _seed_chat(
+        self, chats_root: Path, workspace: str, chat_id: str, rows: int = 3
+    ) -> Path:
+        import hashlib
+
+        ws_hash = hashlib.md5(workspace.encode()).hexdigest()
+        chat_dir = chats_root / ws_hash / chat_id
+        chat_dir.mkdir(parents=True)
+        store = chat_dir / "store.db"
+        writer = _make_store(
+            store,
+            [(f"b{i}", _user(f"<user_query>\nmsg{i}\n</user_query>")) for i in range(rows)],
+        )
+        writer.close()
+        return store
+
+    def test_returns_false_when_store_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(fwd, "_cursor_chats_root", lambda: tmp_path / "chats")
+        bridge_dir = tmp_path / "bridge"
+        bridge_dir.mkdir()
+        result = fwd.preseed_resume_state(bridge_dir, "/ws", "no-such-chat", 1_000)
+        assert result is False
+        assert fwd._read_state(bridge_dir).store_path is None
+
+    def test_writes_store_path_and_current_rowid(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(fwd, "_cursor_chats_root", lambda: tmp_path / "chats")
+        store = self._seed_chat(tmp_path / "chats", "/ws", "chat-abc", rows=5)
+        bridge_dir = tmp_path / "bridge"
+        bridge_dir.mkdir()
+
+        result = fwd.preseed_resume_state(bridge_dir, "/ws", "chat-abc", launch_epoch_ms=99_000)
+
+        assert result is True
+        state = fwd._read_state(bridge_dir)
+        assert state.store_path == str(store)
+        assert state.last_rowid == 5  # all 5 rows already in store
+        assert state.launch_epoch_ms == 99_000
+
+    def test_empty_store_seeds_rowid_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(fwd, "_cursor_chats_root", lambda: tmp_path / "chats")
+        self._seed_chat(tmp_path / "chats", "/ws", "chat-empty", rows=0)
+        bridge_dir = tmp_path / "bridge"
+        bridge_dir.mkdir()
+
+        fwd.preseed_resume_state(bridge_dir, "/ws", "chat-empty", launch_epoch_ms=1_000)
+
+        assert fwd._read_state(bridge_dir).last_rowid == 0
+
+
+class TestForwardLoopPreseedResume:
+    """Forwarder uses pre-seeded bridge state on cold resume, skipping discovery."""
+
+    @pytest.mark.asyncio
+    async def test_uses_preseed_store_without_discover(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When bridge state is pre-seeded, forwarder skips _discover_store."""
+        chat_id = "preseeded-chat-uuid"
+        store = tmp_path / chat_id / "store.db"
+        store.parent.mkdir(parents=True)
+        writer = _make_store(
+            store,
+            [
+                ("old", _user("<user_query>\nold message\n</user_query>")),  # rowid 1 (pre-resume)
+                ("new", _user("<user_query>\nnew message\n</user_query>")),  # rowid 2 (new)
+            ],
+        )
+        writer.close()
+
+        bridge_dir = tmp_path / "cursor-native" / "sess"
+        bridge_dir.mkdir(parents=True)
+        # Pre-seed: rowid 1 already mirrored (old history), start from there.
+        fwd._write_state(
+            bridge_dir,
+            fwd._ForwardState(store_path=str(store), last_rowid=1, launch_epoch_ms=999_000),
+        )
+
+        discover_calls: list = []
+
+        def _no_discover(workspace: str, launch_ms: int) -> None:
+            discover_calls.append((workspace, launch_ms))
+            return None  # should never be reached
+
+        monkeypatch.setattr(fwd, "_discover_store", _no_discover)
+        monkeypatch.setattr(fwd, "_chat_claimed_by_other", lambda *a, **k: False)
+
+        delivered: list[fwd._MirrorItem] = []
+
+        async def _collect(client: object, *, session_id: str, item: fwd._MirrorItem) -> None:
+            delivered.append(item)
+
+        monkeypatch.setattr(fwd, "_post_conversation_item", _collect)
+        monkeypatch.setattr(fwd, "_patch_external_session_id", lambda *a, **k: None)
+
+        task = asyncio.create_task(
+            fwd.forward_cursor_store_to_session(
+                base_url="http://test",
+                headers={},
+                session_id="conv_1",
+                bridge_dir=bridge_dir,
+                agent_name="cursor-native-ui",
+                workspace="/ws",
+                launch_epoch_ms=1_000_000,  # far future — discovery would find nothing
+                poll_interval_s=0.001,
+            )
+        )
+        try:
+            for _ in range(2000):
+                if delivered:
+                    break
+                await asyncio.sleep(0.001)
+            else:
+                raise AssertionError("forwarder never mirrored the new message")
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        # Only the NEW message (rowid 2) was mirrored; old history was skipped.
+        assert len(delivered) == 1
+        assert delivered[0].item_data["content"][0]["text"] == "new message"
+        # _discover_store was never called (pre-seed took the fast path).
+        assert not discover_calls
+
+
 class TestForwardLoopExternalSessionId:
     """The poll loop patches external_session_id once when the store is found."""
 

--- a/tests/test_native_resume_hint.py
+++ b/tests/test_native_resume_hint.py
@@ -31,23 +31,43 @@ def test_format_native_resume_command_includes_remote_context() -> None:
     assert command == ("omnigent claude --server https://example.databricks.com --resume conv_abc")
 
 
-def test_cold_resume_hint_is_honest_on_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+def test_cold_resume_hint_not_restored_is_honest_on_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """
-    The cold-resume hint must tell the user, on stderr, that prior turns
-    are gone.
+    The default (``restored=False``) hint must say prior turns are gone.
 
-    Cursor cannot reattach to a chat once its terminal exits, so resume
-    cold-starts a fresh TUI. If the hint were silent (or printed an
-    upbeat "resumed!" line), the user would reasonably assume their
-    earlier conversation came back and be misled. The message therefore
-    has to state both facts: the terminal was not running, and the prior
-    chat was not restored. It must go to stderr so it never pollutes the
-    TUI's stdout.
+    Wrappers that record no resumable chat id (e.g. Hermes/qwen/kimi)
+    cold-start a fresh TUI on resume. If the hint were silent (or printed
+    an upbeat "resumed!" line), the user would assume their earlier
+    conversation came back and be misled. The message states both facts:
+    the terminal was not running, and the prior chat was not restored. It
+    must go to stderr so it never pollutes the TUI's stdout.
     """
-    echo_native_cold_resume_hint(agent_label="Cursor")
+    echo_native_cold_resume_hint(agent_label="Hermes")
 
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "Terminal not running" in captured.err
-    assert "fresh Cursor session" in captured.err
+    assert "fresh Hermes session" in captured.err
     assert "prior chat not restored" in captured.err
+
+
+def test_cold_resume_hint_restored_reports_reload(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    With ``restored=True`` the hint says the prior conversation is reloaded.
+
+    Cursor reuses its chat store across ``cursor-agent --resume``, so a cold
+    resume relaunches the TUI *with* the prior turns. The message must not
+    claim the chat was lost (that would now be the misleading case), and must
+    stay on stderr.
+    """
+    echo_native_cold_resume_hint(agent_label="Cursor", restored=True)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Terminal not running" in captured.err
+    assert "resuming the prior conversation" in captured.err
+    assert "not restored" not in captured.err


### PR DESCRIPTION
## Related issue

N/A

## Summary

When `cursor-agent`'s terminal has exited and the user runs `omni cursor --resume <conv_id>`, a fresh TUI was launched with no prior history even though the web UI showed the full conversation. The root cause was two missing pieces in the cold-resume path:

1. **No chat id was persisted.** The cursor forwarder tails `~/.cursor/chats/<md5(cwd)>/<chat-id>/store.db` to mirror messages into Omnigent, but it never recorded the `chat_id` (the UUID directory name) as `external_session_id` on the Omnigent session — so there was nothing to resume from, unlike Claude/Codex which both persist their native session id through the same field.

2. **`external_session_id` was fetched but not used.** `_auto_create_cursor_terminal` already calls `_pi_native_launch_config` which reads `external_session_id` from the session snapshot, but the value was silently ignored rather than forwarded to the `cursor-agent` launch args.

The fix wires both ends:

- `cursor_native_forwarder.py`: adds `_patch_external_session_id`, called once when the store is first discovered, which PATCHes the Omnigent session with the cursor `chat_id`. Best-effort — logs on failure, never raises, so a transient error doesn't interrupt mirroring.
- `runner/app.py`: adds `_cursor_native_resume_args` (extracted for testability, analogous to `_cursor_native_model_from_spec`) and calls it in `_auto_create_cursor_terminal` to inject `--resume <chatId>` into the cursor-agent launch args when `external_session_id` is set. Skipped on first-ever launch (no id yet) and when the user already passed `--resume` in their passthrough args.

## Test Plan

- [x] Unit tests added for `_patch_external_session_id`: request shape, 4xx-logs-but-doesn't-raise, transport-error-logs-but-doesn't-raise
- [x] Forwarder loop tests: verifies patch fires with the correct `session_id` and `chat_id` on store discovery; verifies `chat_id_patched` guard prevents re-patching across subsequent poll ticks
- [x] Parametrized tests for `_cursor_native_resume_args`: no chat id (new session), valid id injects `--resume`, user passthrough already contains `--resume` (no duplication)
- [x] All 41 tests (35 pre-existing + 6 new) pass

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The live tmux + cursor-agent cold-resume path (terminal exited, user re-runs `omni cursor --resume`) requires a running server and cursor-agent binary, so it is covered by the e2e gate rather than unit tests. The unit tests cover the two added seams directly: the forwarder's PATCH call and the runner's args injection.