### PR TITLE
feat(hermes-native): add Omnigent policy enforcement, cost tracking, and interrupt

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -244,10 +244,19 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
         # bridge-owned directories below it.
         return _absolute_syntactic_path(qwen_root.parent.parent)
 
+    from omnigent.hermes_native_bridge import bridge_root as hermes_bridge_root
+
+    hermes_root = _absolute_syntactic_path(hermes_bridge_root())
+    if target.is_relative_to(hermes_root):
+        # Same shape as cursor-native ($TMPDIR/omnigent-<uid>/hermes-native): trust
+        # the uid-scoped temp dir's parent and validate/chmod the two
+        # bridge-owned directories below it.
+        return _absolute_syntactic_path(hermes_root.parent.parent)
+
     raise RuntimeError(
         f"bridge dir {target!s} is not under an allowed bridge root "
         f"({claude_root!s}, {codex_root!s}, {cursor_root!s}, "
-        f"{antigravity_root!s}, {qwen_root!s})"
+        f"{antigravity_root!s}, {qwen_root!s}, {hermes_root!s})"
     )
 
 

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -28,6 +28,7 @@ import hashlib
 import json
 import logging
 import os
+import secrets
 import shutil
 import subprocess
 import sys
@@ -126,17 +127,27 @@ def _load_user_hermes_config() -> dict:
         return {}
 
 
+_MCP_BRIDGE_CONFIG_FILE = "bridge.json"
+
+
 def write_policy_hook_config(
     bridge_dir: Path,
     server_url: str,
     session_id: str,
 ) -> Path:
-    """Write per-session ``HERMES_HOME`` with the Omnigent policy hook.
+    """Write per-session ``HERMES_HOME`` with Omnigent policy hook and MCP server.
 
-    Creates a ``config.yaml`` registering the ``pre_tool_call`` shell hook, a
-    wrapper script exporting ``_OMNIGENT_SERVER_URL`` and
-    ``_OMNIGENT_SESSION_ID``, and copies the user's auth/env files so the TUI
-    can still authenticate with its inference provider. Mirrors
+    Creates a ``config.yaml`` registering:
+
+    1. A ``pre_tool_call`` shell hook that evaluates tool calls against the
+       Omnigent policy engine (same hook the headless ``hermes`` harness uses).
+    2. An ``mcp_servers.omnigent`` entry that launches the Omnigent MCP stdio
+       server (``serve-mcp``), exposing Omnigent builtin tools
+       (``sys_session_*``, ``sys_agent_*``, ``load_skill``, ``web_fetch``, etc.)
+       to the Hermes model.
+
+    Also copies the user's auth/env files so the TUI can still authenticate
+    with its inference provider. Mirrors
     :func:`omnigent.inner.hermes_executor._populate_hermes_home`.
 
     :param bridge_dir: Per-session bridge dir (parent of the HERMES_HOME).
@@ -161,6 +172,9 @@ def write_policy_hook_config(
     )
     wrapper.chmod(0o755)
 
+    # Write bridge.json with an auth token for serve-mcp (idempotent).
+    _write_mcp_bridge_config(bridge_dir)
+
     # Merge user config so model/provider/auth settings carry over.
     user_cfg = _load_user_hermes_config()
     config: dict = {**user_cfg}
@@ -174,6 +188,20 @@ def write_policy_hook_config(
                 "timeout": 86400,
             },
         ],
+    }
+
+    # Register the Omnigent MCP stdio server so Hermes can call
+    # Omnigent builtin tools (sys_session_*, sys_agent_*, load_skill, etc.).
+    config["mcp_servers"] = {
+        **config.get("mcp_servers", {}),
+        "omnigent": {
+            "command": sys.executable,
+            "args": [
+                "-m", "omnigent.claude_native_bridge",
+                "serve-mcp",
+                "--bridge-dir", str(bridge_dir),
+            ],
+        },
     }
 
     config_path = hermes_home / "config.yaml"
@@ -199,6 +227,29 @@ def write_policy_hook_config(
     allowlist_path.write_text(json.dumps(allowlist_data, indent=2) + "\n")
 
     return hermes_home
+
+
+def _write_mcp_bridge_config(bridge_dir: Path) -> None:
+    """Write ``bridge.json`` with an auth token for ``serve-mcp``.
+
+    Idempotent: skips if a config already exists (avoids overwriting a token
+    that the relay HTTP server was started with). Mirrors
+    :func:`omnigent.codex_native_bridge.write_mcp_bridge_config`.
+    """
+    config_path = bridge_dir / _MCP_BRIDGE_CONFIG_FILE
+    if config_path.exists():
+        return
+    bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = {"token": secrets.token_urlsafe(32)}
+    fd, tmp_name = tempfile.mkstemp(prefix=f"{_MCP_BRIDGE_CONFIG_FILE}.", dir=str(bridge_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_name, config_path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
 
 
 def inject_compress_command(bridge_dir: Path, *, timeout_s: float = 5.0) -> None:

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -8,9 +8,15 @@ analog of the goose-native tmux bridge. This is what wires the web-UI chat box t
 the running Hermes TUI (and, since the web UI embeds that pane, the message shows
 in both surfaces).
 
-The native TUI uses the user's own ``~/.hermes`` (model/provider/tools) and its
-own tool-approval prompt; Omnigent writes no vendor config here. That prompt is
-surfaced to the web UI as a synced approval card by the runner-side mirror
+When Omnigent policies are configured the runner writes a per-session
+``HERMES_HOME`` with a ``pre_tool_call`` hook (via :func:`write_policy_hook_config`)
+that evaluates tool calls against the Omnigent policy engine — the same hook used
+by the headless ``hermes`` harness (:mod:`omnigent.inner.hermes_executor`). The
+``HERMES_HOME`` env var in :func:`build_hermes_native_spawn_env` points the TUI at
+this per-session dir so the hook fires alongside Hermes' own approval prompt.
+
+The native TUI's own tool-approval prompt is surfaced to the web UI as a synced
+approval card by the runner-side mirror
 (:mod:`omnigent.hermes_native_permissions`), which reads the pane via
 :func:`capture_hermes_pane` and answers it via :func:`send_hermes_pane_keys`.
 """
@@ -20,12 +26,17 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import json
+import logging
 import os
+import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_HERMES_NATIVE_BRIDGE_DIR"
@@ -70,16 +81,136 @@ def build_hermes_native_spawn_env(session_id: str) -> dict[str, str]:
 
     Publishes the per-session bridge dir so the
     :class:`~omnigent.inner.hermes_native_executor.HermesNativeExecutor` can find
-    the tmux target advertised by the runner. Unlike the headless ``hermes``
-    harness this sets no model/provider env — the native TUI uses the user's own
-    ``hermes`` configuration (``hermes model``), left untouched.
+    the tmux target advertised by the runner. If a per-session ``HERMES_HOME``
+    was written by :func:`write_policy_hook_config`, the env includes
+    ``HERMES_HOME`` so the TUI picks up the policy hook.
 
     :param session_id: The Omnigent session id (keys the bridge dir).
     :returns: Env-var overrides for the harness executor spawn.
     """
     bridge_dir = bridge_dir_for_session_id(session_id)
     _ensure_dir(bridge_dir)
-    return {BRIDGE_DIR_ENV_VAR: str(bridge_dir)}
+    env: dict[str, str] = {BRIDGE_DIR_ENV_VAR: str(bridge_dir)}
+    hermes_home = read_hermes_home(bridge_dir)
+    if hermes_home is not None:
+        env["HERMES_HOME"] = str(hermes_home)
+    return env
+
+
+# Keys from the user's ``~/.hermes/config.yaml`` that the per-session
+# HERMES_HOME needs in order to authenticate with the inference provider.
+_USER_CONFIG_KEYS = frozenset(
+    {
+        "model",
+        "providers",
+        "fallback_providers",
+        "credential_pool_strategies",
+    }
+)
+
+_HERMES_HOME_SUBDIR = "hermes_home"
+
+
+def _load_user_hermes_config() -> dict:
+    """Load inference-relevant keys from the user's ``~/.hermes/config.yaml``."""
+    user_config = Path.home() / ".hermes" / "config.yaml"
+    if not user_config.is_file():
+        return {}
+    try:
+        import yaml
+
+        full = yaml.safe_load(user_config.read_text()) or {}
+        return {k: v for k, v in full.items() if k in _USER_CONFIG_KEYS}
+    except Exception:  # noqa: BLE001
+        _logger.debug("Failed to load user Hermes config at %s", user_config, exc_info=True)
+        return {}
+
+
+def write_policy_hook_config(
+    bridge_dir: Path,
+    server_url: str,
+    session_id: str,
+) -> Path:
+    """Write per-session ``HERMES_HOME`` with the Omnigent policy hook.
+
+    Creates a ``config.yaml`` registering the ``pre_tool_call`` shell hook, a
+    wrapper script exporting ``_OMNIGENT_SERVER_URL`` and
+    ``_OMNIGENT_SESSION_ID``, and copies the user's auth/env files so the TUI
+    can still authenticate with its inference provider. Mirrors
+    :func:`omnigent.inner.hermes_executor._populate_hermes_home`.
+
+    :param bridge_dir: Per-session bridge dir (parent of the HERMES_HOME).
+    :param server_url: Omnigent server base URL.
+    :param session_id: Omnigent session / conversation ID.
+    :returns: The HERMES_HOME path.
+    """
+    hermes_home = bridge_dir / _HERMES_HOME_SUBDIR
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    hook_script_path = str(
+        Path(__file__).resolve().parent / "inner" / "hermes_policy_hook.py"
+    )
+
+    # Wrapper shell script: sets env vars and execs the Python hook.
+    wrapper = hermes_home / "omnigent-policy-hook.sh"
+    wrapper.write_text(
+        f"#!/bin/sh\n"
+        f"export _OMNIGENT_SERVER_URL='{server_url}'\n"
+        f"export _OMNIGENT_SESSION_ID='{session_id}'\n"
+        f"exec '{sys.executable}' '{hook_script_path}'\n"
+    )
+    wrapper.chmod(0o755)
+
+    # Merge user config so model/provider/auth settings carry over.
+    user_cfg = _load_user_hermes_config()
+    config: dict = {**user_cfg}
+
+    config["hooks_auto_accept"] = True
+    config["hooks"] = {
+        **config.get("hooks", {}),
+        "pre_tool_call": [
+            {
+                "command": str(wrapper),
+                "timeout": 86400,
+            },
+        ],
+    }
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+
+    # Copy user's .env (API keys).
+    user_env = Path.home() / ".hermes" / ".env"
+    if user_env.is_file():
+        shutil.copy2(user_env, hermes_home / ".env")
+
+    # Copy user's auth.json (provider credentials).
+    user_auth = Path.home() / ".hermes" / "auth.json"
+    if user_auth.is_file():
+        shutil.copy2(user_auth, hermes_home / "auth.json")
+
+    # Pre-populate the allowlist so Hermes doesn't prompt for hook consent.
+    allowlist_path = hermes_home / "shell-hooks-allowlist.json"
+    allowlist_data = {
+        "approvals": [
+            {"event": "pre_tool_call", "command": str(wrapper)},
+        ],
+    }
+    allowlist_path.write_text(json.dumps(allowlist_data, indent=2) + "\n")
+
+    return hermes_home
+
+
+def read_hermes_home(bridge_dir: Path) -> Path | None:
+    """Return the per-session HERMES_HOME if it was previously written.
+
+    :param bridge_dir: Per-session bridge dir.
+    :returns: The HERMES_HOME path, or ``None`` if it doesn't exist.
+    """
+    hermes_home = bridge_dir / _HERMES_HOME_SUBDIR
+    if hermes_home.is_dir():
+        return hermes_home
+    return None
 
 
 def write_tmux_target(

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -515,17 +515,17 @@ def inject_user_message(
 
 
 def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:
-    """Cancel the in-flight Hermes turn by sending ``Escape`` to the pane.
+    """Cancel the in-flight Hermes turn by sending ``C-c`` to the pane.
 
-    The harness ``run_turn`` returns right after the paste, so the runner's
-    in-process cancel floor can't reach the turn — this is the analog of
-    :func:`inject_user_message` for the web UI's Stop button.
+    Hermes uses Ctrl+C to interrupt a running turn (double-press within 2s
+    forces exit). The harness ``run_turn`` returns right after the paste, so
+    the runner's in-process cancel floor can't reach the turn — this is the
+    analog of :func:`inject_user_message` for the web UI's Stop button.
 
     :raises RuntimeError: If the tmux target is not advertised or send-keys fails.
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    # No ``-l``: tmux must interpret ``Escape`` as a key name.
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
+    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-c")
 
 
 def kill_session(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -158,9 +158,7 @@ def write_policy_hook_config(
     hermes_home = bridge_dir / _HERMES_HOME_SUBDIR
     hermes_home.mkdir(parents=True, exist_ok=True)
 
-    hook_script_path = str(
-        Path(__file__).resolve().parent / "inner" / "hermes_policy_hook.py"
-    )
+    hook_script_path = str(Path(__file__).resolve().parent / "inner" / "hermes_policy_hook.py")
 
     # Wrapper shell script: sets env vars and execs the Python hook.
     wrapper = hermes_home / "omnigent-policy-hook.sh"
@@ -197,9 +195,11 @@ def write_policy_hook_config(
         "omnigent": {
             "command": sys.executable,
             "args": [
-                "-m", "omnigent.claude_native_bridge",
+                "-m",
+                "omnigent.claude_native_bridge",
                 "serve-mcp",
-                "--bridge-dir", str(bridge_dir),
+                "--bridge-dir",
+                str(bridge_dir),
             ],
         },
     }

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -201,6 +201,28 @@ def write_policy_hook_config(
     return hermes_home
 
 
+def inject_compress_command(bridge_dir: Path, *, timeout_s: float = 5.0) -> None:
+    """Type ``/compress`` into the Hermes TUI pane.
+
+    Hermes' ``/compress`` slash command compacts the conversation context,
+    analogous to Claude Code's ``/compact``. This clears any draft the user
+    is mid-typing, pastes ``/compress`` literally, and submits with Enter.
+
+    :param bridge_dir: Per-session bridge dir holding ``tmux.json``.
+    :param timeout_s: How long to wait for ``tmux.json`` to appear.
+    :raises RuntimeError: If the tmux target is not advertised or send-keys fails.
+    """
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    socket_path = info["socket_path"]
+    target = info["tmux_target"]
+    # Clear any draft the user is mid-typing.
+    _run_tmux(socket_path, "send-keys", "-t", target, "C-u")
+    # Paste ``/compress`` literally.
+    _run_tmux(socket_path, "send-keys", "-l", "-t", target, "/compress")
+    # Submit.
+    _run_tmux(socket_path, "send-keys", "-t", target, "Enter")
+
+
 def read_hermes_home(bridge_dir: Path) -> Path | None:
     """Return the per-session HERMES_HOME if it was previously written.
 

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -393,43 +393,101 @@ class _MirrorItem:
     response_id: str
 
 
-def _message_to_item(
-    msg_id: int, role: object, content: object, agent_name: str
-) -> _MirrorItem | None:
-    """Convert one ``messages`` row to a mirror item, or ``None`` to skip it.
+def _message_to_items(
+    msg_id: int,
+    role: object,
+    content: object,
+    tool_calls: object,
+    tool_call_id: object,
+    tool_name: object,  # noqa: ARG001 — reserved for future use (e.g. logging)
+    agent_name: str,
+) -> list[_MirrorItem]:
+    """Convert one ``messages`` row to mirror items.
 
-    Hermes stores ``content`` as plain text (not JSON), so the body is used
-    directly after stripping bridge attachment markers.
+    An assistant row with ``tool_calls`` emits a ``function_call`` item per
+    call, followed by a ``message`` item if it also has prose content. A tool
+    row emits a ``function_call_output`` item. Returns an empty list to skip.
     """
     if not isinstance(role, str):
-        return None
+        return []
     text = ""
     if isinstance(content, str):
         text = _ATTACHMENT_MARKER_RE.sub("", content).strip()
     response_id = f"hermes:{msg_id}"
+
     if role == "user":
         if not text:
-            return None
-        return _MirrorItem(
-            msg_id=msg_id,
-            item_type="message",
-            item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
-            response_id=response_id,
-        )
+            return []
+        return [
+            _MirrorItem(
+                msg_id=msg_id,
+                item_type="message",
+                item_data={"role": "user", "content": [{"type": "input_text", "text": text}]},
+                response_id=response_id,
+            )
+        ]
+
     if role == "assistant":
-        if not text:
-            return None  # tool-only / reasoning-only turn with no prose
-        return _MirrorItem(
-            msg_id=msg_id,
-            item_type="message",
-            item_data={
-                "role": "assistant",
-                "agent": agent_name,
-                "content": [{"type": "output_text", "text": text}],
-            },
-            response_id=response_id,
-        )
-    return None  # tool / system / other scaffolding
+        items: list[_MirrorItem] = []
+        # Parse tool_calls JSON — assistant rows may include tool call requests.
+        if isinstance(tool_calls, str) and tool_calls:
+            try:
+                calls = json.loads(tool_calls)
+            except (json.JSONDecodeError, ValueError):
+                calls = []
+            if isinstance(calls, list):
+                for call in calls:
+                    if not isinstance(call, dict):
+                        continue
+                    call_id = call.get("call_id") or call.get("id") or ""
+                    func = call.get("function", {})
+                    name = func.get("name", "") if isinstance(func, dict) else ""
+                    arguments = func.get("arguments", "{}") if isinstance(func, dict) else "{}"
+                    if call_id and name:
+                        items.append(
+                            _MirrorItem(
+                                msg_id=msg_id,
+                                item_type="function_call",
+                                item_data={
+                                    "agent": agent_name,
+                                    "name": name,
+                                    "arguments": arguments,
+                                    "call_id": call_id,
+                                },
+                                response_id=response_id,
+                            )
+                        )
+        # Also emit a message item if there's prose content.
+        if text:
+            items.append(
+                _MirrorItem(
+                    msg_id=msg_id,
+                    item_type="message",
+                    item_data={
+                        "role": "assistant",
+                        "agent": agent_name,
+                        "content": [{"type": "output_text", "text": text}],
+                    },
+                    response_id=response_id,
+                )
+            )
+        return items
+
+    if role == "tool":
+        # Tool result row — emit function_call_output.
+        if isinstance(tool_call_id, str) and tool_call_id:
+            output = text or ""
+            return [
+                _MirrorItem(
+                    msg_id=msg_id,
+                    item_type="function_call_output",
+                    item_data={"call_id": tool_call_id, "output": output},
+                    response_id=response_id,
+                )
+            ]
+        return []
+
+    return []
 
 
 def _read_new_items(
@@ -445,7 +503,8 @@ def _read_new_items(
         return []
     try:
         rows = con.execute(
-            "SELECT id, role, content FROM messages "
+            "SELECT id, role, content, tool_calls, tool_call_id, tool_name "
+            "FROM messages "
             "WHERE session_id = ? AND id > ? AND active = 1 ORDER BY id",
             (hermes_session_id, last_id),
         ).fetchall()
@@ -455,10 +514,12 @@ def _read_new_items(
     finally:
         con.close()
     items: list[_MirrorItem] = []
-    for msg_id, role, content in rows:
-        item = _message_to_item(msg_id, role, content, agent_name)
-        if item is not None:
-            items.append(item)
+    for msg_id, role, content, tool_calls_json, tool_call_id, tool_name_val in rows:
+        converted = _message_to_items(
+            msg_id, role, content, tool_calls_json, tool_call_id, tool_name_val, agent_name
+        )
+        if converted:
+            items.extend(converted)
         else:
             items.append(_MirrorItem(msg_id=msg_id, item_type="", item_data={}, response_id=""))
     return items

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -93,6 +93,84 @@ def _warn_sqlite_once(context: str, exc: sqlite3.Error) -> None:
 _ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
 
 
+def _read_model_from_hermes_config(bridge_dir: Path) -> str | None:
+    """Best-effort read of the model name from the per-session HERMES_HOME config.
+
+    Falls back to the user's ``~/.hermes/config.yaml`` if no per-session config
+    exists. Returns ``None`` when the model cannot be determined.
+    """
+    candidates = [
+        bridge_dir / "hermes_home" / "config.yaml",
+        Path.home() / ".hermes" / "config.yaml",
+    ]
+    for config_path in candidates:
+        if not config_path.is_file():
+            continue
+        try:
+            import yaml
+
+            data = yaml.safe_load(config_path.read_text()) or {}
+            model = data.get("model")
+            if isinstance(model, str) and model:
+                return model
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+class _HermesUsageTracker:
+    """Post ``external_session_usage`` events for a hermes-native session.
+
+    Hermes' SQLite ``state.db`` does not expose per-message token counts, so
+    this tracker posts only the model name to the server — enough for the
+    server to associate the model for display and (eventually) pricing.
+
+    Follows the :class:`omnigent.codex_native_forwarder._SessionUsageCoalescer`
+    pattern: deduplicates (only posts when the model changes) and is flushed
+    from the poll loop.
+
+    TODO: Token-level cost tracking (input_tokens, output_tokens, total_tokens)
+    requires Hermes to expose usage data in its state.db or session transcript.
+    """
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        session_id: str,
+        bridge_dir: Path,
+    ) -> None:
+        self._client = client
+        self._session_id = session_id
+        self._bridge_dir = bridge_dir
+        self._model: str | None = None
+        self._posted_model: str | None = None
+
+    async def flush(self) -> None:
+        """Post the model name if it changed since the last flush."""
+        if self._model is None:
+            self._model = await asyncio.to_thread(
+                _read_model_from_hermes_config, self._bridge_dir
+            )
+        if not self._model or self._model == self._posted_model:
+            return
+        try:
+            resp = await self._client.post(
+                f"/v1/sessions/{self._session_id}/events",
+                json={
+                    "type": "external_session_usage",
+                    "data": {"model": self._model},
+                },
+            )
+            if resp.status_code < 400:
+                self._posted_model = self._model
+            else:
+                _logger.warning(
+                    "hermes usage tracker POST failed: status=%s", resp.status_code
+                )
+        except httpx.HTTPError:
+            _logger.debug("hermes usage tracker POST failed", exc_info=True)
+
+
 def _hermes_home() -> Path:
     """Return Hermes' home dir for this process (``$HERMES_HOME`` or ``~/.hermes``)."""
     raw = os.environ.get("HERMES_HOME", "").strip()
@@ -449,6 +527,7 @@ async def forward_hermes_store_to_session(
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
+        usage_tracker = _HermesUsageTracker(client, session_id, bridge_dir)
         while True:
             try:
                 if hermes_session_id is None:
@@ -501,6 +580,8 @@ async def forward_hermes_store_to_session(
                                     launch_epoch_s=launch_epoch_s,
                                 ),
                             )
+                        # Post model/usage data after mirroring messages.
+                        await usage_tracker.flush()
                         # Refresh the claim heartbeat every poll (even with no new
                         # items) so an idle owner keeps its claim.
                         _write_state(

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -148,9 +148,7 @@ class _HermesUsageTracker:
     async def flush(self) -> None:
         """Post the model name if it changed since the last flush."""
         if self._model is None:
-            self._model = await asyncio.to_thread(
-                _read_model_from_hermes_config, self._bridge_dir
-            )
+            self._model = await asyncio.to_thread(_read_model_from_hermes_config, self._bridge_dir)
         if not self._model or self._model == self._posted_model:
             return
         try:
@@ -164,9 +162,7 @@ class _HermesUsageTracker:
             if resp.status_code < 400:
                 self._posted_model = self._model
             else:
-                _logger.warning(
-                    "hermes usage tracker POST failed: status=%s", resp.status_code
-                )
+                _logger.warning("hermes usage tracker POST failed: status=%s", resp.status_code)
         except httpx.HTTPError:
             _logger.debug("hermes usage tracker POST failed", exc_info=True)
 

--- a/omnigent/inner/hermes_native_executor.py
+++ b/omnigent/inner/hermes_native_executor.py
@@ -18,7 +18,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-from omnigent.hermes_native_bridge import BRIDGE_DIR_ENV_VAR, inject_user_message
+from omnigent.hermes_native_bridge import BRIDGE_DIR_ENV_VAR, inject_interrupt, inject_user_message
 from omnigent.inner.executor import (
     Executor,
     ExecutorConfig,
@@ -91,6 +91,19 @@ class HermesNativeExecutor(Executor):
             yield ExecutorError(message=str(exc))
             return
         yield TurnComplete(response=None)
+
+    async def interrupt_session(self, session_key: str) -> bool:
+        """Cancel the in-flight Hermes turn by sending Escape to the TUI pane.
+
+        :param session_key: Unused (single-session TUI).
+        :returns: ``True`` if the interrupt was sent, ``False`` on failure.
+        """
+        del session_key
+        try:
+            await asyncio.to_thread(inject_interrupt, self._bridge_dir)
+        except RuntimeError:
+            return False
+        return True
 
 
 def _bridge_dir_from_env() -> Path:

--- a/omnigent/inner/hermes_native_harness.py
+++ b/omnigent/inner/hermes_native_harness.py
@@ -10,11 +10,12 @@ injects web-UI messages into the running ``hermes`` TUI (launched by
 ``omnigent hermes`` in the session terminal) via tmux. The bridge dir is read from
 :data:`~omnigent.hermes_native_bridge.BRIDGE_DIR_ENV_VAR` in the spawn env.
 
-Tool policies: Omnigent's PreToolUse/PostToolUse policy gates (which the headless
-``hermes`` harness enforces via Hermes' ``pre_tool_call`` shell hook) do NOT apply
-to hermes-native — ``hermes`` runs its tools inside its own TUI and gates them with
-its own in-terminal approval prompts, which Omnigent does not intercept. Treat the
-Hermes TUI's own approval as the sole tool gate (same stance as goose-native).
+Tool policies: Omnigent policies are enforced via a per-session ``HERMES_HOME``
+that registers a ``pre_tool_call`` shell hook (the same hook the headless
+``hermes`` harness uses). The runner writes this before launching the TUI (see
+:func:`omnigent.hermes_native_bridge.write_policy_hook_config`). Hermes' own
+in-terminal approval prompt still fires for dangerous commands and is mirrored
+to the web UI by :mod:`omnigent.hermes_native_permissions`.
 """
 
 from __future__ import annotations

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1939,11 +1939,21 @@ async def _auto_create_hermes_terminal(
     # re-creating, so old and new tasks can't both mirror (double-posting), and
     # drop the prior terminal's stale forward cursor.
     await _cancel_auto_forwarder_task(session_id)
-    from omnigent.hermes_native_bridge import bridge_dir_for_session_id, write_tmux_target
+    from omnigent.hermes_native_bridge import (
+        bridge_dir_for_session_id,
+        read_hermes_home,
+        write_policy_hook_config,
+        write_tmux_target,
+    )
     from omnigent.hermes_native_forwarder import clear_hermes_bridge_state
 
     bridge_dir = bridge_dir_for_session_id(session_id)
     clear_hermes_bridge_state(bridge_dir)
+
+    # Write a per-session HERMES_HOME with the Omnigent policy hook so the
+    # native TUI evaluates tool calls against Omnigent policies.
+    _hermes_server_url = _required_runner_env("RUNNER_SERVER_URL")
+    write_policy_hook_config(bridge_dir, _hermes_server_url, session_id)
 
     # ``_pi_native_launch_config`` is a generic session-snapshot reader
     # (workspace + terminal_launch_args); reused here, not Pi-specific.
@@ -1959,6 +1969,12 @@ async def _auto_create_hermes_terminal(
     # cursor (clear_hermes_bridge_state above) starts it at that row's first row.
     launch_epoch_s = time.time()
     hermes_args = [*(launch_config.terminal_launch_args or [])]
+    # If a per-session HERMES_HOME was written (policy hook), pass it via env
+    # so the TUI picks up the hook config alongside its own approval prompt.
+    _hermes_terminal_env: dict[str, str] = {}
+    _hermes_home_path = read_hermes_home(bridge_dir)
+    if _hermes_home_path is not None:
+        _hermes_terminal_env["HERMES_HOME"] = str(_hermes_home_path)
     terminal_view = await resource_registry.launch_required_terminal(
         session_id=session_id,
         terminal_name="hermes",
@@ -1968,13 +1984,7 @@ async def _auto_create_hermes_terminal(
             os_env=OSEnvSpec(type="caller_process", cwd=workspace),
             command=hermes_command,
             args=hermes_args,
-            # No env overrides: Hermes uses the user's own ~/.hermes (model,
-            # provider, tools, and its native tool-approval prompt — which appears
-            # in the TUI and the web's embedded terminal). No NO_COLOR (an earlier
-            # NO_COLOR=1 rendered the gold TUI white); no HERMES_YOLO_MODE (that
-            # suppressed Hermes' own approval). The bridge captures the pane with
-            # ``tmux capture-pane -p`` (ANSI stripped), so colour never interferes.
-            env={},
+            env=_hermes_terminal_env,
             scrollback=100_000,
             tmux_allow_passthrough=True,
             tmux_start_on_attach=False,
@@ -7833,8 +7843,18 @@ def create_runner_app(
 
                 spawn_env = build_goose_native_spawn_env(session_id)
             if harness_name == "hermes-native" and spawn_env is None:
-                from omnigent.hermes_native_bridge import build_hermes_native_spawn_env
+                from omnigent.hermes_native_bridge import (
+                    bridge_dir_for_session_id as _hermes_bridge_dir,
+                    build_hermes_native_spawn_env,
+                    write_policy_hook_config,
+                )
 
+                _h_server_url = os.environ.get(
+                    "RUNNER_SERVER_URL", "http://localhost:6767"
+                ).rstrip("/")
+                write_policy_hook_config(
+                    _hermes_bridge_dir(session_id), _h_server_url, session_id
+                )
                 spawn_env = build_hermes_native_spawn_env(session_id)
             if harness_name == "qwen-native" and spawn_env is None:
                 from omnigent.qwen_native_bridge import build_qwen_native_spawn_env
@@ -12526,8 +12546,18 @@ def create_runner_app(
 
             spawn_env = build_goose_native_spawn_env(conv_id)
         if harness_name == "hermes-native" and spawn_env is None:
-            from omnigent.hermes_native_bridge import build_hermes_native_spawn_env
+            from omnigent.hermes_native_bridge import (
+                bridge_dir_for_session_id as _hermes_bridge_dir2,
+                build_hermes_native_spawn_env,
+                write_policy_hook_config,
+            )
 
+            _h_server_url2 = os.environ.get(
+                "RUNNER_SERVER_URL", "http://localhost:6767"
+            ).rstrip("/")
+            write_policy_hook_config(
+                _hermes_bridge_dir2(conv_id), _h_server_url2, conv_id
+            )
             spawn_env = build_hermes_native_spawn_env(conv_id)
         if harness_name == "qwen-native" and spawn_env is None:
             from omnigent.qwen_native_bridge import build_qwen_native_spawn_env

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2018,6 +2018,7 @@ async def _auto_create_hermes_terminal(
     server_url = _required_runner_env("RUNNER_SERVER_URL")
     _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
 
+    from omnigent.hermes_native_bridge import read_hermes_home
     from omnigent.hermes_native_forwarder import supervise_hermes_forwarder
     from omnigent.hermes_native_permissions import supervise_hermes_approval_mirror
 
@@ -2037,6 +2038,11 @@ async def _auto_create_hermes_terminal(
         the approval mirror surfaces Hermes' dangerous-command prompt as a web
         elicitation (see :mod:`omnigent.hermes_native_permissions`).
         """
+        # When a per-session HERMES_HOME is configured (policy hooks / MCP),
+        # Hermes writes its state.db there, not ~/.hermes.  Point the
+        # forwarder at the right database so it can discover the session.
+        _hermes_home = read_hermes_home(bridge_dir)
+        _state_db = _hermes_home / "state.db" if _hermes_home is not None else None
         await asyncio.gather(
             supervise_hermes_forwarder(
                 base_url=server_url,
@@ -2046,8 +2052,7 @@ async def _auto_create_hermes_terminal(
                 agent_name="hermes-native-ui",
                 workspace=workspace,
                 launch_epoch_s=launch_epoch_s,
-                # The native TUI uses the user's ~/.hermes, so the forwarder tails
-                # the default store there (default_state_db()).
+                db_path=_state_db,
                 auth=_runner_auth,
             ),
             supervise_hermes_approval_mirror(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7845,6 +7845,8 @@ def create_runner_app(
             if harness_name == "hermes-native" and spawn_env is None:
                 from omnigent.hermes_native_bridge import (
                     bridge_dir_for_session_id as _hermes_bridge_dir,
+                )
+                from omnigent.hermes_native_bridge import (
                     build_hermes_native_spawn_env,
                     write_policy_hook_config,
                 )
@@ -7852,9 +7854,7 @@ def create_runner_app(
                 _h_server_url = os.environ.get(
                     "RUNNER_SERVER_URL", "http://localhost:6767"
                 ).rstrip("/")
-                write_policy_hook_config(
-                    _hermes_bridge_dir(session_id), _h_server_url, session_id
-                )
+                write_policy_hook_config(_hermes_bridge_dir(session_id), _h_server_url, session_id)
                 spawn_env = build_hermes_native_spawn_env(session_id)
             if harness_name == "qwen-native" and spawn_env is None:
                 from omnigent.qwen_native_bridge import build_qwen_native_spawn_env
@@ -12578,16 +12578,16 @@ def create_runner_app(
         if harness_name == "hermes-native" and spawn_env is None:
             from omnigent.hermes_native_bridge import (
                 bridge_dir_for_session_id as _hermes_bridge_dir2,
+            )
+            from omnigent.hermes_native_bridge import (
                 build_hermes_native_spawn_env,
                 write_policy_hook_config,
             )
 
-            _h_server_url2 = os.environ.get(
-                "RUNNER_SERVER_URL", "http://localhost:6767"
-            ).rstrip("/")
-            write_policy_hook_config(
-                _hermes_bridge_dir2(conv_id), _h_server_url2, conv_id
+            _h_server_url2 = os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767").rstrip(
+                "/"
             )
+            write_policy_hook_config(_hermes_bridge_dir2(conv_id), _h_server_url2, conv_id)
             spawn_env = build_hermes_native_spawn_env(conv_id)
         if harness_name == "qwen-native" and spawn_env is None:
             from omnigent.qwen_native_bridge import build_qwen_native_spawn_env

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10777,6 +10777,36 @@ def create_runner_app(
         # Submit.
         _run_tmux(socket_path, "send-keys", "-t", target, "Enter")
 
+    async def _handle_hermes_native_compact(conv_id: str) -> Response:
+        """Type ``/compress`` into the Hermes TUI pane.
+
+        Hermes' ``/compress`` slash command compacts the conversation context,
+        analogous to Claude Code's ``/compact``. Returns 200 on successful
+        injection so the Omnigent server knows the control was handled in the
+        terminal and skips its own AP-side compaction.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 200 once ``/compress`` has been typed into the pane.
+            503 if the tmux target isn't yet advertised.
+        """
+        from omnigent.hermes_native_bridge import (
+            bridge_dir_for_session_id,
+            inject_compress_command,
+        )
+
+        bridge_dir = bridge_dir_for_session_id(conv_id)
+        try:
+            await asyncio.to_thread(inject_compress_command, bridge_dir, timeout_s=1.0)
+        except (RuntimeError, ValueError) as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "hermes_native_compact_failed",
+                    "detail": _client_safe_error_detail(exc, context="hermes-native compact"),
+                },
+            )
+        return Response(status_code=200)
+
     async def _handle_claude_native_cost_popup(
         conv_id: str,
         elicitation_id: str,
@@ -13681,6 +13711,8 @@ def create_runner_app(
                 return await _handle_codex_native_compact(conversation_id)
             if _session_harness_name(conversation_id) == "cursor-native":
                 return await _handle_cursor_native_compact(conversation_id)
+            if _session_harness_name(conversation_id) == "hermes-native":
+                return await _handle_hermes_native_compact(conversation_id)
             return Response(status_code=204)
 
         if body_type == "cost_approval_popup":

--- a/tests/inner/test_hermes_native_executor.py
+++ b/tests/inner/test_hermes_native_executor.py
@@ -67,3 +67,22 @@ async def test_enqueue_session_message_injects(tmp_path: Path, monkeypatch) -> N
     assert seen == ["steer"]
     # Empty content is a no-op (no injection).
     assert await ex.enqueue_session_message("main", "") is False
+
+
+async def test_interrupt_session_success(tmp_path: Path, monkeypatch) -> None:
+    called: list[Path] = []
+    monkeypatch.setattr(
+        hne, "inject_interrupt", lambda bridge_dir, **kw: called.append(bridge_dir)
+    )
+    ex = hne.HermesNativeExecutor(bridge_dir=tmp_path)
+    assert await ex.interrupt_session("main") is True
+    assert called == [tmp_path]
+
+
+async def test_interrupt_session_failure(tmp_path: Path, monkeypatch) -> None:
+    def _fail(bridge_dir, **kw):
+        raise RuntimeError("tmux not available")
+
+    monkeypatch.setattr(hne, "inject_interrupt", _fail)
+    ex = hne.HermesNativeExecutor(bridge_dir=tmp_path)
+    assert await ex.interrupt_session("main") is False

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -210,6 +210,18 @@ def test_write_policy_hook_config_creates_expected_files(tmp_path) -> None:
     assert allowlist["approvals"][0]["event"] == "pre_tool_call"
     assert allowlist["approvals"][0]["command"] == str(wrapper)
 
+    # MCP server registered.
+    mcp = config["mcp_servers"]["omnigent"]
+    assert mcp["command"] == sys.executable
+    assert "serve-mcp" in mcp["args"]
+    assert "--bridge-dir" in mcp["args"]
+    assert str(bridge_dir) in mcp["args"]
+
+    # bridge.json written with auth token.
+    bridge_config = json.loads((bridge_dir / "bridge.json").read_text())
+    assert isinstance(bridge_config["token"], str)
+    assert len(bridge_config["token"]) > 0
+
 
 def test_write_policy_hook_config_copies_user_files(tmp_path, monkeypatch) -> None:
     bridge_dir = tmp_path / "bridge"

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -92,14 +92,14 @@ def test_inject_user_message_dead_pane_raises(tmp_path, monkeypatch) -> None:
         b.inject_user_message(tmp_path, content="hi")
 
 
-def test_inject_interrupt_sends_escape(tmp_path, monkeypatch) -> None:
+def test_inject_interrupt_sends_ctrl_c(tmp_path, monkeypatch) -> None:
     calls: list[tuple[str, ...]] = []
     monkeypatch.setattr(
         b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
     )
     monkeypatch.setattr(b, "_run_tmux", lambda _sock, *args: calls.append(args))
     b.inject_interrupt(tmp_path)
-    assert calls == [("send-keys", "-t", "t", "Escape")]
+    assert calls == [("send-keys", "-t", "t", "C-c")]
 
 
 def test_kill_session_kills_target(tmp_path, monkeypatch) -> None:

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -138,3 +140,104 @@ def test_send_pane_keys_raises_without_target(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(b, "read_tmux_info", lambda _d: None)
     with pytest.raises(RuntimeError, match="not advertised"):
         b.send_hermes_pane_keys(tmp_path, "1")
+
+
+# -- Policy hook config tests --
+
+
+def test_write_policy_hook_config_creates_expected_files(tmp_path) -> None:
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    hermes_home = b.write_policy_hook_config(
+        bridge_dir, "http://localhost:6767", "session-123"
+    )
+
+    assert hermes_home == bridge_dir / "hermes_home"
+    assert hermes_home.is_dir()
+
+    # Wrapper shell script exists and is executable.
+    wrapper = hermes_home / "omnigent-policy-hook.sh"
+    assert wrapper.is_file()
+    assert wrapper.stat().st_mode & 0o111
+    wrapper_text = wrapper.read_text()
+    assert "_OMNIGENT_SERVER_URL='http://localhost:6767'" in wrapper_text
+    assert "_OMNIGENT_SESSION_ID='session-123'" in wrapper_text
+    assert sys.executable in wrapper_text
+    assert "hermes_policy_hook.py" in wrapper_text
+
+    # config.yaml with hook registered.
+    config = json.loads((hermes_home / "config.yaml").read_text())
+    assert config["hooks_auto_accept"] is True
+    hooks = config["hooks"]["pre_tool_call"]
+    assert len(hooks) == 1
+    assert hooks[0]["command"] == str(wrapper)
+    assert hooks[0]["timeout"] == 86400
+
+    # Allowlist.
+    allowlist = json.loads((hermes_home / "shell-hooks-allowlist.json").read_text())
+    assert allowlist["approvals"][0]["event"] == "pre_tool_call"
+    assert allowlist["approvals"][0]["command"] == str(wrapper)
+
+
+def test_write_policy_hook_config_copies_user_files(tmp_path, monkeypatch) -> None:
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    user_hermes = tmp_path / ".hermes"
+    user_hermes.mkdir()
+    (user_hermes / ".env").write_text("API_KEY=secret")
+    (user_hermes / "auth.json").write_text('{"token": "abc"}')
+
+    monkeypatch.setattr(b.Path, "home", staticmethod(lambda: tmp_path))
+
+    hermes_home = b.write_policy_hook_config(bridge_dir, "http://localhost:6767", "s1")
+    assert (hermes_home / ".env").read_text() == "API_KEY=secret"
+    assert (hermes_home / "auth.json").read_text() == '{"token": "abc"}'
+
+
+def test_write_policy_hook_config_merges_user_model(tmp_path, monkeypatch) -> None:
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    user_hermes = tmp_path / ".hermes"
+    user_hermes.mkdir()
+
+    import yaml
+
+    (user_hermes / "config.yaml").write_text(
+        yaml.dump({"model": "claude-sonnet-4-20250514", "providers": {"anthropic": {}}})
+    )
+
+    monkeypatch.setattr(b.Path, "home", staticmethod(lambda: tmp_path))
+
+    hermes_home = b.write_policy_hook_config(bridge_dir, "http://localhost:6767", "s2")
+    config = json.loads((hermes_home / "config.yaml").read_text())
+    assert config["model"] == "claude-sonnet-4-20250514"
+    assert config["providers"] == {"anthropic": {}}
+    assert config["hooks_auto_accept"] is True
+
+
+def test_read_hermes_home_returns_path_when_exists(tmp_path) -> None:
+    (tmp_path / "hermes_home").mkdir()
+    assert b.read_hermes_home(tmp_path) == tmp_path / "hermes_home"
+
+
+def test_read_hermes_home_returns_none_when_missing(tmp_path) -> None:
+    assert b.read_hermes_home(tmp_path) is None
+
+
+def test_build_spawn_env_includes_hermes_home_when_policy_written(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(b, "_BRIDGE_ROOT", tmp_path / "hermes-native")
+    bridge_dir = b.bridge_dir_for_session_id("test-session")
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    b.write_policy_hook_config(bridge_dir, "http://localhost:6767", "test-session")
+
+    env = b.build_hermes_native_spawn_env("test-session")
+    assert env["HERMES_HOME"] == str(bridge_dir / "hermes_home")
+
+
+def test_build_spawn_env_no_hermes_home_without_policy(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(b, "_BRIDGE_ROOT", tmp_path / "hermes-native")
+    env = b.build_hermes_native_spawn_env("test-no-policy")
+    assert "HERMES_HOME" not in env

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -142,6 +142,37 @@ def test_send_pane_keys_raises_without_target(tmp_path, monkeypatch) -> None:
         b.send_hermes_pane_keys(tmp_path, "1")
 
 
+# -- Compress command injection tests --
+
+
+def test_inject_compress_command_sends_keys(tmp_path, monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def _fake_tmux(_socket_path, *args):
+        calls.append(args)
+
+    monkeypatch.setattr(b, "_run_tmux", _fake_tmux)
+    monkeypatch.setattr(
+        b, "read_tmux_info", lambda _d: {"socket_path": "/s", "tmux_target": "t"}
+    )
+    # _wait_for_tmux_info calls read_tmux_info internally, so patch it.
+    monkeypatch.setattr(
+        b, "_wait_for_tmux_info", lambda _d, timeout_s=30: {"socket_path": "/s", "tmux_target": "t"}
+    )
+    b.inject_compress_command(tmp_path)
+    assert calls == [
+        ("send-keys", "-t", "t", "C-u"),
+        ("send-keys", "-l", "-t", "t", "/compress"),
+        ("send-keys", "-t", "t", "Enter"),
+    ]
+
+
+def test_inject_compress_command_raises_without_target(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(b, "read_tmux_info", lambda _d: None)
+    with pytest.raises(RuntimeError):
+        b.inject_compress_command(tmp_path, timeout_s=0.1)
+
+
 # -- Policy hook config tests --
 
 

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -152,12 +151,12 @@ def test_inject_compress_command_sends_keys(tmp_path, monkeypatch) -> None:
         calls.append(args)
 
     monkeypatch.setattr(b, "_run_tmux", _fake_tmux)
-    monkeypatch.setattr(
-        b, "read_tmux_info", lambda _d: {"socket_path": "/s", "tmux_target": "t"}
-    )
+    monkeypatch.setattr(b, "read_tmux_info", lambda _d: {"socket_path": "/s", "tmux_target": "t"})
     # _wait_for_tmux_info calls read_tmux_info internally, so patch it.
     monkeypatch.setattr(
-        b, "_wait_for_tmux_info", lambda _d, timeout_s=30: {"socket_path": "/s", "tmux_target": "t"}
+        b,
+        "_wait_for_tmux_info",
+        lambda _d, timeout_s=30: {"socket_path": "/s", "tmux_target": "t"},
     )
     b.inject_compress_command(tmp_path)
     assert calls == [
@@ -180,9 +179,7 @@ def test_write_policy_hook_config_creates_expected_files(tmp_path) -> None:
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
 
-    hermes_home = b.write_policy_hook_config(
-        bridge_dir, "http://localhost:6767", "session-123"
-    )
+    hermes_home = b.write_policy_hook_config(bridge_dir, "http://localhost:6767", "session-123")
 
     assert hermes_home == bridge_dir / "hermes_home"
     assert hermes_home.is_dir()
@@ -268,9 +265,7 @@ def test_read_hermes_home_returns_none_when_missing(tmp_path) -> None:
     assert b.read_hermes_home(tmp_path) is None
 
 
-def test_build_spawn_env_includes_hermes_home_when_policy_written(
-    tmp_path, monkeypatch
-) -> None:
+def test_build_spawn_env_includes_hermes_home_when_policy_written(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(b, "_BRIDGE_ROOT", tmp_path / "hermes-native")
     bridge_dir = b.bridge_dir_for_session_id("test-session")
     bridge_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -29,6 +29,9 @@ CREATE TABLE messages (
     session_id TEXT NOT NULL,
     role TEXT NOT NULL,
     content TEXT,
+    tool_call_id TEXT,
+    tool_calls TEXT,
+    tool_name TEXT,
     active INTEGER NOT NULL DEFAULT 1
 );
 """
@@ -41,15 +44,17 @@ def _seed_db(path: Path, *, cwd: str, started_at: float, session_id: str = "2026
         "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
         (session_id, "cli", cwd, started_at),
     )
+    # (session_id, role, content, tool_call_id, tool_calls, tool_name, active)
     rows = [
-        (session_id, "user", "hi [Attached: /x.png]", 1),
-        (session_id, "assistant", "hello", 1),
-        (session_id, "tool", "{tool-result}", 1),
-        (session_id, "assistant", "", 1),  # reasoning/tool-only: no prose -> skipped
-        (session_id, "user", "soft-deleted", 0),  # inactive -> skipped
+        (session_id, "user", "hi [Attached: /x.png]", None, None, None, 1),
+        (session_id, "assistant", "hello", None, None, None, 1),
+        (session_id, "tool", "{tool-result}", None, None, None, 1),  # no tool_call_id -> skipped
+        (session_id, "assistant", "", None, None, None, 1),  # no prose, no tool_calls -> skipped
+        (session_id, "user", "soft-deleted", None, None, None, 0),  # inactive -> skipped
     ]
     con.executemany(
-        "INSERT INTO messages(session_id, role, content, active) VALUES (?,?,?,?)",
+        "INSERT INTO messages(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        " VALUES (?,?,?,?,?,?,?)",
         rows,
     )
     con.commit()
@@ -104,6 +109,48 @@ def test_read_new_items_maps_roles_and_strips_attachments(tmp_path: Path) -> Non
     assert posted[1].item_data["role"] == "assistant"
     assert posted[1].item_data["agent"] == "hermes-native-ui"
     assert posted[1].item_data["content"] == [{"type": "output_text", "text": "hello"}]
+
+
+def test_read_new_items_mirrors_tool_calls(tmp_path: Path) -> None:
+    """Tool calls on assistant rows become function_call items; tool rows become outputs."""
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.execute(
+        "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
+        ("s1", "cli", str(tmp_path), 1000.0),
+    )
+    import json
+
+    tool_calls_json = json.dumps([
+        {
+            "id": "call_abc",
+            "call_id": "call_abc",
+            "type": "function",
+            "function": {"name": "search_files", "arguments": '{"pattern": "*"}'},
+        }
+    ])
+    rows = [
+        ("s1", "assistant", "", None, tool_calls_json, None, 1),
+        ("s1", "tool", "found 3 files", "call_abc", None, "search_files", 1),
+    ]
+    con.executemany(
+        "INSERT INTO messages(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        " VALUES (?,?,?,?,?,?,?)",
+        rows,
+    )
+    con.commit()
+    con.close()
+
+    items = f._read_new_items(db, "s1", 0, "agent")
+    posted = [i for i in items if i.item_type]
+    assert len(posted) == 2
+    assert posted[0].item_type == "function_call"
+    assert posted[0].item_data["name"] == "search_files"
+    assert posted[0].item_data["call_id"] == "call_abc"
+    assert posted[1].item_type == "function_call_output"
+    assert posted[1].item_data["call_id"] == "call_abc"
+    assert posted[1].item_data["output"] == "found 3 files"
 
 
 def test_read_new_items_idempotent_past_high_water(tmp_path: Path) -> None:

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -223,3 +223,64 @@ async def test_forward_loop_discovers_and_mirrors_new_messages(tmp_path, monkeyp
     assert roles == ["user", "assistant"]
     # High-water cursor persisted so a restart resumes without re-posting.
     assert f._read_state(tmp_path).hermes_session_id == "20260620_1"
+
+
+# --- Usage tracker tests ---------------------------------------------------
+
+
+async def test_usage_tracker_posts_model_on_first_flush(tmp_path, monkeypatch) -> None:
+    """The tracker reads the model from the bridge config and posts it."""
+    # Write a per-session config with a model.
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    import yaml
+
+    (hermes_home / "config.yaml").write_text(yaml.dump({"model": "claude-sonnet-4-20250514"}))
+
+    client = _FakeClient()
+    tracker = f._HermesUsageTracker(client, "conv_usage", tmp_path)
+    await tracker.flush()
+
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url == "/v1/sessions/conv_usage/events"
+    assert body["type"] == "external_session_usage"
+    assert body["data"]["model"] == "claude-sonnet-4-20250514"
+
+
+async def test_usage_tracker_deduplicates(tmp_path, monkeypatch) -> None:
+    """Consecutive flushes with the same model do not re-post."""
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    import yaml
+
+    (hermes_home / "config.yaml").write_text(yaml.dump({"model": "gpt-4o"}))
+
+    client = _FakeClient()
+    tracker = f._HermesUsageTracker(client, "conv_dedup", tmp_path)
+    await tracker.flush()
+    await tracker.flush()
+    await tracker.flush()
+
+    assert len(client.posts) == 1  # only the first flush posts
+
+
+async def test_usage_tracker_no_post_when_no_model(tmp_path) -> None:
+    """No config / no model -> nothing posted."""
+    client = _FakeClient()
+    tracker = f._HermesUsageTracker(client, "conv_none", tmp_path)
+    await tracker.flush()
+    assert len(client.posts) == 0
+
+
+async def test_read_model_from_hermes_config_fallback(tmp_path, monkeypatch) -> None:
+    """Falls back to ~/.hermes/config.yaml when no per-session config exists."""
+    user_hermes = tmp_path / ".hermes"
+    user_hermes.mkdir()
+    import yaml
+
+    (user_hermes / "config.yaml").write_text(yaml.dump({"model": "from-user-config"}))
+    monkeypatch.setattr(f.Path, "home", staticmethod(lambda: tmp_path))
+
+    model = f._read_model_from_hermes_config(tmp_path / "nonexistent")
+    assert model == "from-user-config"

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -53,7 +53,8 @@ def _seed_db(path: Path, *, cwd: str, started_at: float, session_id: str = "2026
         (session_id, "user", "soft-deleted", None, None, None, 0),  # inactive -> skipped
     ]
     con.executemany(
-        "INSERT INTO messages(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        "INSERT INTO messages"
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
         " VALUES (?,?,?,?,?,?,?)",
         rows,
     )
@@ -137,7 +138,8 @@ def test_read_new_items_mirrors_tool_calls(tmp_path: Path) -> None:
         ("s1", "tool", "found 3 files", "call_abc", None, "search_files", 1),
     ]
     con.executemany(
-        "INSERT INTO messages(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        "INSERT INTO messages"
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
         " VALUES (?,?,?,?,?,?,?)",
         rows,
     )

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -122,14 +122,16 @@ def test_read_new_items_mirrors_tool_calls(tmp_path: Path) -> None:
     )
     import json
 
-    tool_calls_json = json.dumps([
-        {
-            "id": "call_abc",
-            "call_id": "call_abc",
-            "type": "function",
-            "function": {"name": "search_files", "arguments": '{"pattern": "*"}'},
-        }
-    ])
+    tool_calls_json = json.dumps(
+        [
+            {
+                "id": "call_abc",
+                "call_id": "call_abc",
+                "type": "function",
+                "function": {"name": "search_files", "arguments": '{"pattern": "*"}'},
+            }
+        ]
+    )
     rows = [
         ("s1", "assistant", "", None, tool_calls_json, None, 1),
         ("s1", "tool", "found 3 files", "call_abc", None, "search_files", 1),


### PR DESCRIPTION
## Summary
- **Omnigent policies**: Wire up the existing `hermes_policy_hook.py` (used by headless hermes) for hermes-native. The runner writes a per-session `HERMES_HOME` with a `pre_tool_call` shell hook that evaluates tool calls against `POST /v1/sessions/{id}/policies/evaluate` — supporting ALLOW, ASK (parks for web-UI approval), and DENY verdicts. Hermes' own TUI approval prompt still fires alongside and is mirrored to the web UI.
- **Cost tracking**: Add `_HermesUsageTracker` to the forwarder that posts `external_session_usage` events with the model name (read from per-session or user Hermes config). Token-level cost tracking requires Hermes to expose usage data in its state.db (tracked as TODO).
- **Interrupt**: Wire `interrupt_session()` in the executor, calling `inject_interrupt()` (sends Escape to TUI pane).

<img width="879" height="528" alt="image" src="https://github.com/user-attachments/assets/3154c3dc-413f-4679-bd2d-c72b197f13e8" />
