### PR TITLE
fix(pi-native): route cli-config Databricks gateway instead of falling back to Pi login

### DIFF
--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import socket
 import sys
 import time
@@ -377,6 +378,86 @@ def codex_config_custom_provider(config_path: Path) -> CodexConfigProvider | Non
     name = table.get("name")
     display_name = name if isinstance(name, str) and name.strip() else provider_id
     return CodexConfigProvider(provider_id=provider_id, display_name=display_name)
+
+
+@dataclass(frozen=True)
+class CodexConfigTransport:
+    """The base URL + auth command from a Codex ``[model_providers.X]`` table.
+
+    The runtime-routing counterpart of :class:`CodexConfigProvider` (which
+    only carries the id / display name for the setup menu). This reads the
+    fields a harness needs to actually talk to the provider — the ones
+    ``isaac configure codex`` writes for the Databricks AI Gateway.
+
+    :param base_url: The provider table's ``base_url``, e.g.
+        ``"https://<workspace>.ai-gateway.cloud.databricks.com/codex/v1"``.
+    :param auth_command: A single shell command string that prints a bearer
+        token to stdout, reconstructed from the table's ``[X.auth]``
+        ``command`` + ``args`` (e.g. ``"jq -r .access_token /path/token.json"``).
+        ``None`` when the table carries no ``[X.auth]`` token command (e.g. it
+        authenticates via a static header or AWS SigV4 instead).
+    """
+
+    base_url: str
+    auth_command: str | None
+
+
+def codex_config_provider_transport(
+    config_path: Path, provider_id: str
+) -> CodexConfigTransport | None:
+    """Read the base URL + auth command for one Codex ``[model_providers.X]``.
+
+    A harness that pinned a ``cli-config`` provider (e.g. pi-native routing the
+    user's Databricks AI Gateway) needs the *transport* — where to send
+    requests and how to authenticate — not just the id. This parses the named
+    ``[model_providers.<provider_id>]`` table out of ``config.toml`` and returns
+    its ``base_url`` plus a shell command (rebuilt from ``[X.auth]``
+    ``command`` + ``args``) that prints a bearer token.
+
+    Purely local and structural (parses one TOML file, runs nothing). Returns
+    ``None`` — rather than raising — for every "can't resolve" case so a caller
+    can fall back gracefully without crashing a launch.
+
+    :param config_path: Path to the Codex ``config.toml`` to inspect, e.g.
+        ``Path("~/.codex/config.toml").expanduser()``.
+    :param provider_id: The ``[model_providers.X]`` id to read, e.g.
+        ``"Databricks"``.
+    :returns: The :class:`CodexConfigTransport`, or ``None`` when the file is
+        missing / malformed, the table is absent, or it declares no
+        ``base_url``.
+    """
+    try:
+        raw = config_path.read_bytes()
+    except OSError:
+        return None
+    try:
+        config = tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return None
+
+    providers = config.get("model_providers")
+    if not isinstance(providers, dict):
+        return None
+    table = providers.get(provider_id)
+    if not isinstance(table, dict):
+        return None
+    base_url = table.get("base_url")
+    if not isinstance(base_url, str) or not base_url.strip():
+        return None
+
+    auth_command: str | None = None
+    auth = table.get("auth")
+    if isinstance(auth, dict):
+        command = auth.get("command")
+        args = auth.get("args")
+        if isinstance(command, str) and command.strip():
+            parts = [command]
+            if isinstance(args, list):
+                parts.extend(str(arg) for arg in args)
+            # shlex.join produces a single shell-safe string Pi can run as a
+            # "!command" apiKey (it shell-quotes the token file path etc.).
+            auth_command = shlex.join(parts)
+    return CodexConfigTransport(base_url=base_url.strip(), auth_command=auth_command)
 
 
 def codex_config_detection() -> DetectedProvider | None:

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -158,9 +158,7 @@ def _gateway_anthropic_base_url(codex_base_url: str) -> str:
     return f"{trimmed}{_DATABRICKS_GATEWAY_ANTHROPIC_SUFFIX}"
 
 
-def _cli_config_pi_provider(
-    entry: ProviderEntry, *, model: str | None
-) -> PiProviderConfig | None:
+def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
     """Resolve a Codex ``cli-config`` Databricks-gateway provider into Pi config.
 
     The common enterprise setup: ``isaac configure codex`` writes a custom

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -19,6 +19,7 @@ The managed config dir is per-session (like codex-native's managed
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -28,6 +29,7 @@ from typing import Any
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
     CHAT_WIRE_API,
+    CLI_CONFIG_KIND,
     DATABRICKS_KIND,
     GATEWAY_KIND,
     KEY_KIND,
@@ -38,6 +40,8 @@ from omnigent.onboarding.provider_config import (
     get_default_provider,
     load_config,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 # Env var the ``pi`` CLI reads to relocate its config dir (default
 # ``~/.pi/agent``). Setting it per session gives Pi a managed, isolated
@@ -57,6 +61,13 @@ _DATABRICKS_PI_DEFAULT_MODEL = "databricks-claude-sonnet-4-6"
 # natively (``api: anthropic-messages``); the gateway authenticates with a
 # workspace bearer token, so we set ``authHeader`` (Authorization: Bearer).
 _DATABRICKS_ANTHROPIC_GATEWAY_PATH = "/ai-gateway/anthropic"
+
+# The Databricks AI Gateway exposes one surface per protocol under the same
+# workspace origin: Codex/OpenAI-Responses at ``/codex/v1`` and Anthropic
+# Messages at ``/anthropic``. ``isaac configure codex`` writes the Codex
+# base_url; pi-native rewrites it to the Anthropic surface Pi speaks natively.
+_DATABRICKS_GATEWAY_CODEX_SUFFIX = "/codex/v1"
+_DATABRICKS_GATEWAY_ANTHROPIC_SUFFIX = "/anthropic"
 
 
 @dataclass(frozen=True)
@@ -122,6 +133,109 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         # bearer token is refreshed per request (the auth command itself
         # force-refreshes), matching codex-native's refresh semantics.
         api_key=f"!{auth_command}",
+        auth_header=True,
+    )
+
+
+def _gateway_anthropic_base_url(codex_base_url: str) -> str:
+    """Rewrite a Codex gateway base URL to the Anthropic Messages surface.
+
+    The Databricks AI Gateway serves each protocol under the same workspace
+    origin: ``.../codex/v1`` (OpenAI Responses) and ``.../anthropic``
+    (Anthropic Messages). ``isaac configure codex`` records the Codex URL;
+    Pi speaks Anthropic Messages natively, so we point it at ``/anthropic``.
+
+    :param codex_base_url: The provider table's ``base_url``, e.g.
+        ``"https://<workspace>.ai-gateway.cloud.databricks.com/codex/v1"``.
+    :returns: The Anthropic-surface base URL, e.g.
+        ``"https://<workspace>.ai-gateway.cloud.databricks.com/anthropic"``.
+    """
+    trimmed = codex_base_url.rstrip("/")
+    if trimmed.endswith(_DATABRICKS_GATEWAY_CODEX_SUFFIX):
+        trimmed = trimmed[: -len(_DATABRICKS_GATEWAY_CODEX_SUFFIX)]
+    if trimmed.endswith(_DATABRICKS_GATEWAY_ANTHROPIC_SUFFIX):
+        return trimmed
+    return f"{trimmed}{_DATABRICKS_GATEWAY_ANTHROPIC_SUFFIX}"
+
+
+def _cli_config_pi_provider(
+    entry: ProviderEntry, *, model: str | None
+) -> PiProviderConfig | None:
+    """Resolve a Codex ``cli-config`` Databricks-gateway provider into Pi config.
+
+    The common enterprise setup: ``isaac configure codex`` writes a custom
+    ``[model_providers.X]`` table (base_url + token-printing ``auth`` command)
+    into ``~/.codex/config.toml`` and ``omnigent setup`` adopts it as a
+    ``cli-config`` provider. Codex-native routes through that table; pi-native
+    used to return ``None`` here — silently falling back to Pi's own
+    ``/login`` (often stale creds) — which is the bug this fixes.
+
+    We read the *transport* (base URL + bearer-token command) from the codex
+    config table the entry pins, rewrite the base URL to the gateway's
+    Anthropic Messages surface (Pi speaks it natively), and emit a ``!command``
+    apiKey so Pi refreshes the gateway token per request — exactly like the
+    ``databricks`` kind path. The workspace-specific base URL and token path
+    are read from config, never hardcoded.
+
+    :param entry: The resolved default provider (``kind="cli-config"``,
+        ``cli="codex"``), carrying the ``model_provider`` id and display name.
+    :param model: Session model override, or ``None`` to use the default.
+    :returns: The Pi provider config, or ``None`` when the entry is not a
+        Databricks gateway, its codex provider table can't be resolved, or it
+        carries no token command (caller falls back to Pi's own login).
+    """
+    # Only codex cli-config providers are model_provider-shaped today; a
+    # claude analog would be a different mechanism entirely.
+    if entry.cli != "codex" or not entry.model_provider:
+        return None
+    # Imported lazily: ambient pulls in onboarding-only deps, and this module
+    # is imported on the runner's session-create hot path.
+    from omnigent.onboarding.ambient import (
+        _codex_config_path,
+        codex_config_provider_transport,
+    )
+
+    transport = codex_config_provider_transport(_codex_config_path(), entry.model_provider)
+    if transport is None:
+        _LOGGER.info(
+            "pi-native: cli-config provider %r (model_provider %r) has no resolvable "
+            "[model_providers.%s] base_url in ~/.codex/config.toml; Pi will use its own login.",
+            entry.name,
+            entry.model_provider,
+            entry.model_provider,
+        )
+        return None
+    # Identify the Databricks AI Gateway robustly (not by workspace id): the
+    # codex base_url points at the AI Gateway host. We accept any gateway-shaped
+    # base_url — the canonical Databricks form is "*.ai-gateway.*databricks*".
+    host = transport.base_url
+    is_databricks_gateway = "databricks" in host.lower() and "ai-gateway" in host.lower()
+    if not is_databricks_gateway:
+        _LOGGER.info(
+            "pi-native: cli-config provider %r (model_provider %r, base_url %r) is not a "
+            "recognized Databricks AI Gateway; Pi will use its own login.",
+            entry.name,
+            entry.model_provider,
+            transport.base_url,
+        )
+        return None
+    if not transport.auth_command:
+        _LOGGER.info(
+            "pi-native: Databricks cli-config provider %r carries no [model_providers.%s.auth] "
+            "token command; Pi will use its own login.",
+            entry.name,
+            entry.model_provider,
+        )
+        return None
+    return PiProviderConfig(
+        provider_id=_PI_PROVIDER_ID,
+        base_url=_gateway_anthropic_base_url(transport.base_url),
+        api="anthropic-messages",
+        model=model or _DATABRICKS_PI_DEFAULT_MODEL,
+        # Pi resolves a "!command" apiKey at request time, so the gateway
+        # bearer token (the codex auth command prints it) is refreshed per
+        # request — matching codex-native's refresh semantics.
+        api_key=f"!{transport.auth_command}",
         auth_header=True,
     )
 
@@ -205,18 +319,53 @@ def resolve_pi_native_provider(
             or get_default_provider(config, OPENAI_FAMILY)
         )
         if entry is None:
+            _LOGGER.info(
+                "pi-native: no omnigent-configured provider for the pi/anthropic/openai "
+                "surface; Pi will use its own login."
+            )
             return None
         if entry.kind == DATABRICKS_KIND:
-            return _databricks_pi_provider(entry, model=model)
-        if entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
-            return _inline_family_pi_provider(entry, model=model)
-        # subscription / cli-config: a CLI's own login can't be reused outside
-        # that CLI — let Pi use its own login.
-        return None
+            resolved = _databricks_pi_provider(entry, model=model)
+        elif entry.kind == CLI_CONFIG_KIND:
+            # A Codex cli-config provider whose [model_providers.X] table is the
+            # Databricks AI Gateway IS reusable by Pi (the gateway exposes an
+            # Anthropic surface Pi speaks). Translate it rather than dropping to
+            # Pi's own login — the bug this module fixes.
+            resolved = _cli_config_pi_provider(entry, model=model)
+        elif entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+            resolved = _inline_family_pi_provider(entry, model=model)
+        else:
+            # subscription (a CLI's own login can't be reused outside that CLI):
+            # let Pi use its own login.
+            _LOGGER.info(
+                "pi-native: configured provider %r (kind %r) cannot drive Pi; "
+                "Pi will use its own login.",
+                entry.name,
+                entry.kind,
+            )
+            return None
+        if resolved is None:
+            # The provider matched a translatable kind but its details could not
+            # be resolved (e.g. a Databricks gateway whose codex config table is
+            # missing). Don't swallow it silently — a future user mystified by an
+            # "OpenRouter auth error despite configuring Databricks" needs this.
+            _LOGGER.warning(
+                "pi-native: configured provider %r (kind %r) could not be translated "
+                "into native Pi config; Pi will use its own login (which may hold "
+                "unrelated/stale credentials).",
+                entry.name,
+                entry.kind,
+            )
+        return resolved
     except Exception:  # noqa: BLE001 — any resolution failure must not break launch
         # Any failure (malformed config, duplicate per-family default, or an
         # unresolved ``api_key: $VAR``) falls back to Pi's own login rather than
         # failing the terminal launch.
+        _LOGGER.warning(
+            "pi-native: failed to resolve the omnigent-configured provider; Pi will "
+            "use its own login.",
+            exc_info=True,
+        )
         return None
 
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -25,6 +25,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
@@ -68,6 +69,53 @@ _DATABRICKS_ANTHROPIC_GATEWAY_PATH = "/ai-gateway/anthropic"
 # base_url; pi-native rewrites it to the Anthropic surface Pi speaks natively.
 _DATABRICKS_GATEWAY_CODEX_SUFFIX = "/codex/v1"
 _DATABRICKS_GATEWAY_ANTHROPIC_SUFFIX = "/anthropic"
+
+# Trusted parent domain suffixes for a Databricks-owned host. The AI Gateway
+# lives under a per-workspace subdomain of one of these (the canonical form is
+# ``<workspace>.ai-gateway.cloud.databricks.com``); the Azure / GCP control
+# planes serve workspaces under their own parent domains. We anchor on the
+# leading "." so a look-alike like ``...cloud.databricks.com.evil.test`` (which
+# ends in ``.evil.test``) is rejected.
+_DATABRICKS_TRUSTED_HOST_SUFFIXES = (
+    ".cloud.databricks.com",  # AWS workspaces + ai-gateway (incl. *.staging.cloud.databricks.com)
+    ".azuredatabricks.net",  # Azure Databricks
+    ".gcp.databricks.com",  # GCP Databricks
+)
+
+# A genuine AI Gateway host carries the ``ai-gateway`` DNS label; we require it
+# (alongside a trusted suffix) so a non-gateway Databricks host isn't routed as
+# the gateway's Anthropic surface.
+_DATABRICKS_AI_GATEWAY_LABEL = "ai-gateway"
+
+
+def _is_databricks_ai_gateway_url(base_url: str) -> bool:
+    """Return ``True`` only for a genuine Databricks AI Gateway base URL.
+
+    Hardens the old substring scan over the whole base_url (scheme+host+path),
+    which look-alikes such as ``https://databricks-ai-gateway.evil.test/...``,
+    ``https://x.cloud.databricks.com.evil.test/...`` or
+    ``https://evil.test/databricks/ai-gateway/v1`` all defeated — leaking the
+    workspace bearer token to an attacker-controlled host. We parse the URL and
+    validate the *hostname* (not the raw string): require an ``https`` scheme, a
+    resolvable hostname carrying the ``ai-gateway`` DNS label, and a hostname
+    that ends with a trusted Databricks-owned parent domain suffix.
+
+    :param base_url: The codex provider table's ``base_url``.
+    :returns: ``True`` iff the URL is an https Databricks AI Gateway endpoint.
+    """
+    parsed = urlparse(base_url)
+    if parsed.scheme != "https":
+        return False
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    hostname = hostname.lower()
+    # ``ai-gateway`` must be a full DNS label, not a substring of one (so
+    # ``databricks-ai-gateway.evil.test`` does not qualify on the label alone).
+    labels = hostname.split(".")
+    if _DATABRICKS_AI_GATEWAY_LABEL not in labels:
+        return False
+    return any(hostname.endswith(suffix) for suffix in _DATABRICKS_TRUSTED_HOST_SUFFIXES)
 
 
 @dataclass(frozen=True)
@@ -203,12 +251,12 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
             entry.model_provider,
         )
         return None
-    # Identify the Databricks AI Gateway robustly (not by workspace id): the
-    # codex base_url points at the AI Gateway host. We accept any gateway-shaped
-    # base_url — the canonical Databricks form is "*.ai-gateway.*databricks*".
-    host = transport.base_url
-    is_databricks_gateway = "databricks" in host.lower() and "ai-gateway" in host.lower()
-    if not is_databricks_gateway:
+    # Identify the Databricks AI Gateway robustly (not by workspace id): parse
+    # the codex base_url and validate its *hostname* against a trusted
+    # Databricks domain suffix allowlist plus the ``ai-gateway`` DNS label — a
+    # substring scan over the whole base_url would forward the workspace bearer
+    # token to look-alike hosts (e.g. ``databricks-ai-gateway.evil.test``).
+    if not _is_databricks_ai_gateway_url(transport.base_url):
         _LOGGER.info(
             "pi-native: cli-config provider %r (model_provider %r, base_url %r) is not a "
             "recognized Databricks AI Gateway; Pi will use its own login.",

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -461,6 +461,40 @@ def test_codex_config_custom_provider_detected(clean_env) -> None:
     assert detect_providers() == [_ISAAC_STYLE_DETECTION]
 
 
+def test_codex_config_provider_transport_reads_base_url_and_auth(clean_env) -> None:
+    """``codex_config_provider_transport`` returns base_url + a shell auth command.
+
+    The runtime-routing counterpart of the detection: pi-native reads this to
+    point Pi at the user's Databricks gateway. The ``[X.auth]`` command + args
+    are rebuilt into a single shell-safe string.
+    """
+    from omnigent.onboarding.ambient import (
+        _codex_config_path,
+        codex_config_provider_transport,
+    )
+
+    _write_codex_config(clean_env, _ISAAC_STYLE_CODEX_CONFIG)
+    transport = codex_config_provider_transport(_codex_config_path(), "Databricks")
+    assert transport is not None
+    assert transport.base_url == "https://example.ai-gateway.cloud.databricks.com/codex/v1"
+    assert transport.auth_command == (
+        "jq -r .access_token /home/user/.databricks/model-serving-token.json"
+    )
+
+
+def test_codex_config_provider_transport_missing_table_returns_none(clean_env) -> None:
+    """An absent / unnamed ``[model_providers.X]`` table → ``None``."""
+    from omnigent.onboarding.ambient import (
+        _codex_config_path,
+        codex_config_provider_transport,
+    )
+
+    _write_codex_config(clean_env, 'model_provider = "Databricks"\n')
+    assert codex_config_provider_transport(_codex_config_path(), "Databricks") is None
+    # Missing file is also graceful.
+    assert codex_config_provider_transport(clean_env / "nope.toml", "Databricks") is None
+
+
 def test_codex_config_detected_before_codex_login(clean_env) -> None:
     """With BOTH a custom config provider and a codex login, config wins priority.
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -335,8 +335,7 @@ def test_cli_config_databricks_resolves_to_anthropic_gateway(
     assert provider.api == "anthropic-messages"
     # /codex/v1 rewritten to the /anthropic surface Pi speaks natively.
     assert (
-        provider.base_url
-        == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
+        provider.base_url == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
     )
     assert provider.model == "databricks-claude-sonnet-4-6"
     assert provider.auth_header is True
@@ -361,8 +360,7 @@ def test_cli_config_databricks_respects_model_override(
     assert provider is not None
     assert provider.model == "databricks-claude-opus-4-8"
     assert (
-        provider.base_url
-        == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
+        provider.base_url == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
     )
 
 
@@ -415,8 +413,7 @@ def test_cli_config_databricks_warns_on_unresolvable(
 
     with caplog.at_level(logging.INFO, logger="omnigent.pi_native_credentials"):
         assert (
-            creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
-            is None
+            creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config) is None
         )
     assert any("codex-databricks" in rec.getMessage() for rec in caplog.records)
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -278,6 +278,149 @@ def test_openai_responses_wire_api_explicit() -> None:
     assert provider.model == "gpt-4o"
 
 
+def _cli_config_databricks_config() -> dict[str, object]:
+    """A config whose default is a cli-config Databricks gateway (openai surface)."""
+    return {
+        "providers": {
+            "codex-databricks": {
+                "kind": "cli-config",
+                "default": True,
+                "cli": "codex",
+                "model_provider": "Databricks",
+                "display_name": "Databricks AI Gateway",
+            },
+        }
+    }
+
+
+def _write_codex_config(home: Path, body: str) -> None:
+    """Write a ``~/.codex/config.toml`` under *home* (the resolver reads $HOME)."""
+    codex_dir = home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "config.toml").write_text(body, encoding="utf-8")
+
+
+_DATABRICKS_CODEX_CONFIG = """
+model_provider = "Databricks"
+
+[model_providers.Databricks]
+name = "Databricks AI Gateway"
+base_url = "https://1965859176160743.ai-gateway.cloud.databricks.com/codex/v1"
+wire_api = "responses"
+
+[model_providers.Databricks.auth]
+command = "jq"
+args = ["-r", ".access_token", "/Users/me/.databricks/model-serving-token.json"]
+timeout_ms = 5000
+"""
+
+
+def test_cli_config_databricks_resolves_to_anthropic_gateway(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config Databricks default → Pi anthropic-messages gateway provider.
+
+    The bug this fixes: previously the resolver returned ``None`` for
+    ``cli-config``, silently dropping Pi to its own login. Now it reads the
+    transport (base_url + auth command) from the pinned ``[model_providers.X]``
+    table in ``~/.codex/config.toml``, rewrites the Codex base URL to the
+    gateway's Anthropic surface, and emits a ``!command`` apiKey.
+    """
+    _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
+
+    assert provider is not None
+    assert provider.api == "anthropic-messages"
+    # /codex/v1 rewritten to the /anthropic surface Pi speaks natively.
+    assert (
+        provider.base_url
+        == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
+    )
+    assert provider.model == "databricks-claude-sonnet-4-6"
+    assert provider.auth_header is True
+    # apiKey is a "!command" rebuilt from the table's [X.auth] command + args
+    # so Pi refreshes the gateway token per request.
+    assert provider.api_key == (
+        "!jq -r .access_token /Users/me/.databricks/model-serving-token.json"
+    )
+
+
+def test_cli_config_databricks_respects_model_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A session model override wins over the cli-config Databricks default."""
+    _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    provider = creds.resolve_pi_native_provider(
+        model="databricks-claude-opus-4-8",
+        config_loader=_cli_config_databricks_config,
+    )
+    assert provider is not None
+    assert provider.model == "databricks-claude-opus-4-8"
+    assert (
+        provider.base_url
+        == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
+    )
+
+
+def test_cli_config_missing_codex_table_returns_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config entry whose codex table is absent → None (graceful fallback)."""
+    # config.toml exists but defines no [model_providers.Databricks] table.
+    _write_codex_config(tmp_path, 'model_provider = "Databricks"\n')
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config) is None
+
+
+def test_cli_config_non_databricks_gateway_returns_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config provider that is NOT a Databricks gateway → None.
+
+    Gateway detection is by base_url shape (``*.ai-gateway.*databricks*``), so a
+    generic custom provider pointing elsewhere falls back to Pi's own login
+    rather than being mistranslated as the Databricks Anthropic surface.
+    """
+    _write_codex_config(
+        tmp_path,
+        """
+model_provider = "Databricks"
+
+[model_providers.Databricks]
+name = "Some Other Proxy"
+base_url = "https://proxy.example.com/v1"
+
+[model_providers.Databricks.auth]
+command = "printf"
+args = ["%s", "sk-static"]
+""",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config) is None
+
+
+def test_cli_config_databricks_warns_on_unresolvable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unresolvable cli-config Databricks logs a clear reason (not silent)."""
+    _write_codex_config(tmp_path, 'model_provider = "Databricks"\n')
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="omnigent.pi_native_credentials"):
+        assert (
+            creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
+            is None
+        )
+    assert any("codex-databricks" in rec.getMessage() for rec in caplog.records)
+
+
 def test_anthropic_family_ignores_wire_api() -> None:
     """The Anthropic family always uses anthropic-messages, ignoring wire_api.
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -418,6 +418,122 @@ def test_cli_config_databricks_warns_on_unresolvable(
     assert any("codex-databricks" in rec.getMessage() for rec in caplog.records)
 
 
+def _codex_config_with_base_url(base_url: str) -> str:
+    """A codex config.toml whose Databricks table points at *base_url*."""
+    return f"""
+model_provider = "Databricks"
+
+[model_providers.Databricks]
+name = "Databricks AI Gateway"
+base_url = "{base_url}"
+wire_api = "responses"
+
+[model_providers.Databricks.auth]
+command = "jq"
+args = ["-r", ".access_token", "/Users/me/.databricks/model-serving-token.json"]
+timeout_ms = 5000
+"""
+
+
+# Look-alike base URLs from the security finding: each embeds the "databricks"
+# and "ai-gateway" substrings somewhere in scheme+host+path, defeating the old
+# substring scan, but NONE is a real Databricks AI Gateway host. Routing any of
+# them would leak the workspace bearer token to an attacker-controlled host.
+_LOOKALIKE_GATEWAY_URLS = [
+    # "ai-gateway" + "databricks" labels, but the real host is evil.test.
+    "https://databricks-ai-gateway.evil.test/codex/v1",
+    # Trusted suffix appears mid-host; the actual parent domain is .evil.test.
+    "https://x.ai-gateway.cloud.databricks.com.evil.test/codex/v1",
+    # Both substrings live in the path, not the host.
+    "https://evil.test/databricks/ai-gateway/v1",
+    # Right host shape but plaintext http (token must never go over http).
+    "http://1965859176160743.ai-gateway.cloud.databricks.com/codex/v1",
+]
+
+
+@pytest.mark.parametrize("gateway_url", _LOOKALIKE_GATEWAY_URLS)
+def test_cli_config_lookalike_gateway_returns_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, gateway_url: str
+) -> None:
+    """A look-alike (non-Databricks) gateway URL → None, never forwards the token.
+
+    The old detector matched the "databricks" and "ai-gateway" substrings
+    anywhere in the full base_url, so these look-alikes all passed and the code
+    would emit the workspace bearer token as the apiKey for an attacker host.
+    The hardened detector parses the URL and validates the *hostname* against a
+    trusted Databricks domain suffix allowlist, so each falls back to Pi login.
+    """
+    _write_codex_config(tmp_path, _codex_config_with_base_url(gateway_url))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config) is None
+
+
+def test_real_gateway_still_resolves_after_hardening(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The proven real gateway URL still resolves end-to-end after hardening.
+
+    Guards against over-tightening: the canonical
+    ``<workspace>.ai-gateway.cloud.databricks.com`` host must still translate to
+    the Anthropic surface with the ``!command`` apiKey.
+    """
+    _write_codex_config(
+        tmp_path,
+        _codex_config_with_base_url(
+            "https://1965859176160743.ai-gateway.cloud.databricks.com/codex/v1"
+        ),
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
+
+    assert provider is not None
+    assert (
+        provider.base_url == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
+    )
+    assert provider.api == "anthropic-messages"
+    assert provider.api_key == (
+        "!jq -r .access_token /Users/me/.databricks/model-serving-token.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "gateway_url",
+    [
+        # Canonical AWS gateway.
+        "https://1965859176160743.ai-gateway.cloud.databricks.com/codex/v1",
+        # Staging variant (still ends in .cloud.databricks.com).
+        "https://wkspc.ai-gateway.staging.cloud.databricks.com/codex/v1",
+        # Azure / GCP parent domains carrying the ai-gateway label.
+        "https://wkspc.ai-gateway.azuredatabricks.net/codex/v1",
+        "https://wkspc.ai-gateway.gcp.databricks.com/codex/v1",
+    ],
+)
+def test_is_databricks_ai_gateway_url_accepts_real_hosts(gateway_url: str) -> None:
+    """The hardened detector accepts genuine Databricks AI Gateway hosts."""
+    assert creds._is_databricks_ai_gateway_url(gateway_url) is True
+
+
+@pytest.mark.parametrize(
+    "gateway_url",
+    [
+        *_LOOKALIKE_GATEWAY_URLS,
+        # ai-gateway label, databricks substring, but non-databricks suffix.
+        "https://ai-gateway.databricks.evil.test/codex/v1",
+        # Trusted suffix but no ai-gateway label (a non-gateway Databricks host).
+        "https://wkspc.cloud.databricks.com/codex/v1",
+        # ai-gateway only as a substring of a label, not a full label.
+        "https://my-ai-gateway-proxy.cloud.databricks.com/codex/v1",
+        # Garbage / no hostname.
+        "not-a-url",
+        "",
+    ],
+)
+def test_is_databricks_ai_gateway_url_rejects_lookalikes(gateway_url: str) -> None:
+    """The hardened detector rejects look-alike and malformed URLs."""
+    assert creds._is_databricks_ai_gateway_url(gateway_url) is False
+
+
 def test_anthropic_family_ignores_wire_api() -> None:
     """The Anthropic family always uses anthropic-messages, ignoring wire_api.
 


### PR DESCRIPTION
## Root cause

`omnigent/pi_native_credentials.py:resolve_pi_native_provider` resolves the
default provider for the Pi surface, then dispatches on `entry.kind`. The
`cli-config` kind returned **None**, so the runner wrote no `models.json`,
never set `PI_CODING_AGENT_DIR`, and Pi fell back to its own `~/.pi/agent`
login (often stale OpenRouter creds).

The common enterprise setup registers the Databricks AI Gateway in
`~/.omnigent/config.yaml` as a `cli-config` provider (`codex-databricks`,
`model_provider: Databricks`), whose actual definition + credential live in
`~/.codex/config.toml`'s `[model_providers.Databricks]` table. So pi-native
never used Databricks — producing the confusing "OpenRouter auth error
despite configuring Databricks" failures.

## Fix

- New `_cli_config_pi_provider`: when the resolved default is a `cli-config`
  Databricks gateway, read its transport (base_url + token-printing auth
  command) from the codex config table, rewrite the Codex base URL
  (`.../codex/v1`) to the gateway's Anthropic Messages surface (`.../anthropic`)
  that Pi speaks natively, and emit a `!command` apiKey so Pi refreshes the
  bearer per request — matching codex-native's refresh semantics.
- New `codex_config_provider_transport` in `onboarding/ambient.py` reads one
  `[model_providers.X]` table's `base_url` + `[X.auth]` command/args (rebuilt
  via `shlex.join`). Workspace id and token path are **read from config**,
  never hardcoded.
- Robust gateway detection (base_url is `*.ai-gateway.*databricks*`), not a
  hardcoded workspace id.
- Observability: every fall-back-to-None path now logs a clear reason
  instead of silently swallowing it.

## Tests
- Extended `tests/test_pi_native_credentials.py` (see commits).

## Live e2e
- Resolver-produced `models.json` authenticates against the real Databricks
  AI Gateway: a real `pi` turn returns the completion (`PONG`), base_url is
  the Databricks `/anthropic` surface (not OpenRouter, not api.anthropic.com).

This pull request and its description were written by Isaac.