### PR TITLE
feat(cursor-native): support /compact via cursor-agent /summarize

### DIFF
--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -754,7 +754,14 @@ async def forward_cursor_store_to_session(
                                 # only leaves the spinner lingering; unlike a
                                 # chat item it carries no content to lose, so we
                                 # never retry-wedge the mirror on it. Advance the
-                                # cursor either way.
+                                # cursor either way. NOTE: this also swallows
+                                # connection-level errors (a server blip at
+                                # exactly the rollup blob loses the completion
+                                # for good, since the cursor persists past it) —
+                                # strictly less resilient than the chat path,
+                                # which retries connection loss forever. Matches
+                                # the claude forwarder's best-effort posture and
+                                # never desyncs the mirror, so it is acceptable.
                                 try:
                                     await _post_external_compaction_status(
                                         client, session_id=session_id, status="completed"

--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -102,6 +102,16 @@ _USER_QUERY_RE = re.compile(r"<user_query>(.*?)</user_query>", re.DOTALL)
 # strip them from the mirrored bubble (the path is an internal bridge detail).
 _ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
 
+# When an in-pane ``/summarize`` finishes, cursor-agent collapses the prior
+# history into a single user blob whose plain-string ``content`` starts with
+# this marker (verified against ``~/.cursor/chats/.../store.db``). Real user
+# turns are a ``[{type:text}]`` list, never a bare string, so this prefix
+# unambiguously identifies the post-compaction rollup. It is the only durable
+# signal that the compaction the web UI requested has actually completed —
+# cursor-agent has no compaction hook the way Claude Code does — so the
+# forwarder maps it to an ``external_compaction_status`` "completed" edge.
+_COMPACTION_SUMMARY_PREFIX = "[Previous conversation summary]:"
+
 
 @dataclass
 class _ForwardState:
@@ -492,7 +502,19 @@ def _blob_to_item(rowid: int, blob_id: str, data: object, agent_name: str) -> _M
     role = obj.get("role")
     response_id = f"cursor:{blob_id}"[:_RESPONSE_ID_MAX_LEN]
     if role == "user":
-        prompt = _unwrap_user_query(_content_text(obj.get("content")))
+        content = obj.get("content")
+        # cursor writes the post-/summarize history rollup as a user blob with a
+        # plain-string content (real user turns are a ``[{type:text}]`` list).
+        # Surface it as a compaction-completed signal, not a chat bubble, so the
+        # forwarder can tell the web UI the compaction actually finished.
+        if isinstance(content, str) and content.startswith(_COMPACTION_SUMMARY_PREFIX):
+            return _MirrorItem(
+                rowid=rowid,
+                item_type="compaction_completed",
+                item_data={},
+                response_id=response_id,
+            )
+        prompt = _unwrap_user_query(_content_text(content))
         if not prompt:
             return None
         return _MirrorItem(
@@ -558,6 +580,34 @@ async def _post_conversation_item(
                 "item_data": item.item_data,
                 "response_id": item.response_id,
             },
+        },
+    )
+    resp.raise_for_status()
+
+
+async def _post_external_compaction_status(
+    client: httpx.AsyncClient, *, session_id: str, status: str
+) -> None:
+    """POST one ``external_compaction_status`` event to the Sessions API.
+
+    The server republishes this as the ``response.compaction.completed`` SSE the
+    web UI already renders, upgrading the "Compacting conversation…" spinner
+    (raised by the runner when it submitted ``/summarize``) to the permanent
+    "Conversation compacted" marker. Posting it only when the summary blob
+    actually appears is what makes the marker track cursor-agent's real
+    progress instead of firing the instant the command was submitted. Mirrors
+    :func:`omnigent.claude_native_forwarder._post_external_compaction_status`.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id.
+    :param status: Compaction status value, e.g. ``"completed"``.
+    :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
+    """
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_compaction_status",
+            "data": {"status": status},
         },
     )
     resp.raise_for_status()
@@ -697,6 +747,38 @@ async def forward_cursor_store_to_session(
                             _read_new_items, store_path, last_rowid, agent_name
                         )
                         for item in items:
+                            if item.item_type == "compaction_completed":
+                                # cursor finished /summarize: tell the web UI so
+                                # its "Compacting…" spinner upgrades to the
+                                # permanent marker. Best-effort — a failed post
+                                # only leaves the spinner lingering; unlike a
+                                # chat item it carries no content to lose, so we
+                                # never retry-wedge the mirror on it. Advance the
+                                # cursor either way.
+                                try:
+                                    await _post_external_compaction_status(
+                                        client, session_id=session_id, status="completed"
+                                    )
+                                except httpx.HTTPError:
+                                    _logger.warning(
+                                        "cursor forwarder could not post "
+                                        "compaction-completed; the web UI spinner "
+                                        "may linger; session=%s rowid=%s",
+                                        session_id,
+                                        item.rowid,
+                                        exc_info=True,
+                                    )
+                                failed_rowid = failed_attempts = 0
+                                last_rowid = item.rowid
+                                _write_state(
+                                    bridge_dir,
+                                    _ForwardState(
+                                        store_path=str(store_path),
+                                        last_rowid=last_rowid,
+                                        launch_epoch_ms=launch_epoch_ms,
+                                    ),
+                                )
+                                continue
                             if item.item_type:
                                 try:
                                     await _post_conversation_item(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10603,10 +10603,16 @@ def create_runner_app(
                 content="/summarize",
                 timeout_s=1.0,
             )
-        except (RuntimeError, ValueError) as exc:
+        except (RuntimeError, ValueError, OSError) as exc:
             # Dismiss the spinner the in_progress event raised — the history
             # was not compacted, so no permanent marker should be left, and no
             # summary blob will arrive for the forwarder to complete it.
+            #
+            # OSError is in scope (unlike the claude-native analog): cursor's
+            # ``inject_user_message`` writes the paste payload to a tempfile in
+            # ``bridge_dir`` first, so a filesystem fault (disk full, perms, dir
+            # gone) raises OSError. Without it here that escapes after in_progress
+            # already fired, stranding the spinner with no failed/completed edge.
             _publish_event(conv_id, {"type": "response.compaction.failed", "task_id": conv_id})
             return JSONResponse(
                 status_code=503,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10554,6 +10554,69 @@ def create_runner_app(
             )
         return Response(status_code=200)
 
+    async def _handle_cursor_native_compact(conv_id: str) -> Response:
+        """
+        Inject ``/summarize`` into the cursor-agent TUI pane.
+
+        cursor-native sessions manage their own context window inside the
+        cursor-agent TUI.  Explicit compaction must be handled there (via
+        cursor-agent's built-in ``/summarize`` slash command) rather than as
+        AP-side compaction, which would only summarise the transcript mirror
+        and desync the two context windows — the same rationale as
+        :func:`_handle_claude_native_compact`.
+
+        cursor-agent has no compaction hook (the way Claude Code's
+        ``PreCompact`` / ``SessionStart`` hooks drive claude-native's
+        ``external_compaction_status`` forwarding), so completion can't be
+        observed here — the summarization runs asynchronously in the pane after
+        we submit ``/summarize``.  This handler only *starts* it: publish
+        ``response.compaction.in_progress`` so the web UI raises its "Compacting
+        conversation…" spinner, then submit the command.  The matching
+        ``completed`` edge is emitted later by
+        :mod:`omnigent.cursor_native_forwarder` when it observes cursor write the
+        ``[Previous conversation summary]:`` rollup blob to its store — so the
+        permanent "Conversation compacted" marker tracks cursor's real progress
+        instead of firing the instant the command was submitted.  If the
+        injection fails we publish ``response.compaction.failed`` so the spinner
+        is dismissed rather than stranded (no summary blob will ever arrive to
+        complete it).  Returns 200 so the Omnigent server knows the control was
+        handled in the terminal and skips its own AP-side compaction.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 200 once ``/summarize`` has been submitted into the pane.
+            503 if the tmux target isn't yet advertised (the pane is not
+            attached, so there is nothing to compact).
+        """
+        from omnigent.cursor_native_bridge import bridge_dir_for_session_id, inject_user_message
+
+        bridge_dir = bridge_dir_for_session_id(conv_id)
+        _publish_event(conv_id, {"type": "response.compaction.in_progress", "task_id": conv_id})
+        try:
+            # inject_user_message uses bracketed paste, which bypasses cursor-agent's
+            # slash-command autocomplete dropdown. send-keys typing the literal
+            # ``/summarize`` opens that dropdown, and the single submit Enter then
+            # confirms the highlighted completion instead of submitting the command,
+            # so the command was never sent (the original bug).
+            await asyncio.to_thread(
+                inject_user_message,
+                bridge_dir,
+                content="/summarize",
+                timeout_s=1.0,
+            )
+        except (RuntimeError, ValueError) as exc:
+            # Dismiss the spinner the in_progress event raised — the history
+            # was not compacted, so no permanent marker should be left, and no
+            # summary blob will arrive for the forwarder to complete it.
+            _publish_event(conv_id, {"type": "response.compaction.failed", "task_id": conv_id})
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "cursor_native_compact_failed",
+                    "detail": _client_safe_error_detail(exc, context="cursor-native compact"),
+                },
+            )
+        return Response(status_code=200)
+
     def _inject_codex_compact(socket_path: str, target: str) -> None:
         """
         Blocking helper: type ``/compact`` into a codex tmux pane.
@@ -13427,6 +13490,8 @@ def create_runner_app(
                 return await _handle_claude_native_compact(conversation_id)
             if _session_harness_name(conversation_id) == "codex-native":
                 return await _handle_codex_native_compact(conversation_id)
+            if _session_harness_name(conversation_id) == "cursor-native":
+                return await _handle_cursor_native_compact(conversation_id)
             return Response(status_code=204)
 
         if body_type == "cost_approval_popup":

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -11057,6 +11057,206 @@ async def test_events_compact_on_codex_native_returns_503_on_tmux_failure(
 
 
 @pytest.mark.asyncio
+async def test_events_compact_on_cursor_native_pastes_summarize_and_raises_spinner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    POST ``/events`` with ``{"type":"compact"}`` on a cursor-native
+    session submits ``/summarize`` via bracketed paste, returns 200, and
+    raises the "Compacting…" spinner — but does NOT complete it.
+
+    cursor-agent manages its own context window in the TUI, so explicit
+    compaction must run there (its built-in ``/summarize`` command) rather
+    than as AP-side compaction — the same rationale as the claude-native
+    path.  The 200 (not 204) is load-bearing: the Omnigent server reads it to
+    skip its own ``_run_compact_locked`` (which 400s on the LLM-less native
+    pseudo-agent).
+
+    Two properties are pinned here:
+
+    1. **The command must go through the bracketed-paste path**
+       (``inject_user_message``), NOT a ``send-keys``-typed slash command.
+       Typing the literal ``/summarize`` opens cursor-agent's slash-command
+       autocomplete dropdown, and the single submit Enter then confirms the
+       highlighted completion instead of submitting the command — so the
+       command was never sent (the original bug, seen as ``/summarize`` left
+       sitting in the input box).
+    2. **The handler raises the spinner but must NOT complete it.** It publishes
+       ``response.compaction.in_progress`` (→ "Compacting conversation…") only.
+       cursor-agent runs the summarization asynchronously in the pane after the
+       submit, so completing here would flash "Conversation compacted" while
+       the TUI is still summarizing.  The ``completed`` edge is emitted later by
+       the cursor forwarder when it observes the summary blob (covered by
+       ``tests/test_cursor_native_forwarder.py``).
+    """
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.spec.types import ExecutorSpec
+
+    monkeypatch.setattr(cursor_native_bridge, "_BRIDGE_ROOT", tmp_path / "cursor-bridge")
+
+    captured: list[tuple[Any, str, float]] = []
+
+    def _fake_inject(bridge_dir: Any, *, content: str, timeout_s: float) -> None:
+        """Record the bracketed-paste call without touching tmux."""
+        captured.append((bridge_dir, content, timeout_s))
+
+    monkeypatch.setattr(cursor_native_bridge, "inject_user_message", _fake_inject)
+
+    cursor_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "cursor-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the cursor-native spec for any agent_id."""
+        del agent_id, session_id
+        return cursor_native_spec
+
+    conv_id = "conv_cursor_compact"
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        # Drain creation-time events so the drain below isolates only what
+        # /compact emits.
+        _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "compact"},
+        )
+
+        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+    # 200 = cursor-native dispatch routed to the compact handler and the paste
+    # succeeded. 204 would mean the dispatch fell through to the in-process
+    # no-op branch (the original gap) → Omnigent runs its own compaction and 400s.
+    assert resp.status_code == 200, (
+        f"Cursor-native compact must return 200 from /events; got {resp.status_code}: {resp.text}"
+    )
+    # Exactly one paste call. 0 = dispatch missed the cursor branch.
+    assert len(captured) == 1, (
+        f"Expected one inject_user_message call from cursor compact, got {len(captured)}."
+    )
+    bridge_dir, content, timeout_s = captured[0]
+    assert bridge_dir == cursor_native_bridge.bridge_dir_for_session_id(conv_id)
+    # The literal ``/summarize`` is cursor-agent's compaction command. It is
+    # delivered as *paste content*, not a typed slash command, so the
+    # autocomplete dropdown never opens and the submit Enter sends the command.
+    assert content == "/summarize", f"Expected '/summarize' paste content, got {content!r}."
+    # 1.0s short timeout: a missing tmux target means the pane isn't attached,
+    # so there is no live cursor TUI to compact.
+    assert timeout_s == 1.0
+
+    # The handler raises the spinner (in_progress) but must NOT complete it —
+    # completion is the forwarder's job once the summary blob actually lands.
+    # A regression re-adding ``completed`` here would flash the permanent
+    # "Conversation compacted" marker while the TUI is still summarizing.
+    compaction_types = [
+        e.get("type") for e in queued_events if str(e.get("type", "")).startswith("response.compaction")
+    ]
+    assert compaction_types == ["response.compaction.in_progress"], (
+        f"Handler must publish only in_progress (forwarder completes it); got {compaction_types!r}."
+    )
+    in_progress = next(e for e in queued_events if e.get("type") == "response.compaction.in_progress")
+    assert in_progress.get("task_id") == conv_id, (
+        f"in_progress must carry the session id as task_id; got {in_progress!r}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_events_compact_on_cursor_native_503_dismisses_spinner_when_bridge_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Bridge-not-ready RuntimeError surfaces as 503 and dismisses the spinner.
+
+    When the cursor TUI pane isn't attached there is no live cursor to
+    compact, so the handler returns 503 with ``cursor_native_compact_failed``.
+    Crucially it must also publish ``response.compaction.failed`` so the web
+    UI dismisses the "Compacting…" spinner the ``in_progress`` event raised —
+    otherwise the spinner is stranded forever — and must NOT publish
+    ``completed`` (the history was never compacted, so no permanent marker).
+    """
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.spec.types import ExecutorSpec
+
+    monkeypatch.setattr(cursor_native_bridge, "_BRIDGE_ROOT", tmp_path / "cursor-bridge")
+
+    def _fake_inject(bridge_dir: Any, *, content: str, timeout_s: float) -> None:
+        """Simulate the bridge-not-ready path (pane not attached)."""
+        del bridge_dir, content, timeout_s
+        raise RuntimeError("tmux target is not advertised")
+
+    monkeypatch.setattr(cursor_native_bridge, "inject_user_message", _fake_inject)
+
+    cursor_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "cursor-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the cursor-native spec for any agent_id."""
+        del agent_id, session_id
+        return cursor_native_spec
+
+    conv_id = "conv_cursor_compact_fail"
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "compact"},
+        )
+
+        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+    assert resp.status_code == 503, (
+        f"Cursor-native compact with no live pane must return 503; "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert body.get("error") == "cursor_native_compact_failed", (
+        f"503 body must carry the cursor bridge-failure error code; got {body!r}"
+    )
+
+    compaction_types = [
+        e.get("type") for e in queued_events if str(e.get("type", "")).startswith("response.compaction")
+    ]
+    # in_progress raised the spinner; failed must dismiss it. completed must
+    # never fire — the history was not compacted.
+    assert compaction_types == [
+        "response.compaction.in_progress",
+        "response.compaction.failed",
+    ], f"Expected in_progress then failed (no completed); got {compaction_types!r}."
+
+
+@pytest.mark.asyncio
 async def test_events_compact_on_non_native_session_is_204_noop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -11164,12 +11164,17 @@ async def test_events_compact_on_cursor_native_pastes_summarize_and_raises_spinn
     # A regression re-adding ``completed`` here would flash the permanent
     # "Conversation compacted" marker while the TUI is still summarizing.
     compaction_types = [
-        e.get("type") for e in queued_events if str(e.get("type", "")).startswith("response.compaction")
+        e.get("type")
+        for e in queued_events
+        if str(e.get("type", "")).startswith("response.compaction")
     ]
     assert compaction_types == ["response.compaction.in_progress"], (
-        f"Handler must publish only in_progress (forwarder completes it); got {compaction_types!r}."
+        f"Handler must publish only in_progress (forwarder completes it); "
+        f"got {compaction_types!r}."
     )
-    in_progress = next(e for e in queued_events if e.get("type") == "response.compaction.in_progress")
+    in_progress = next(
+        e for e in queued_events if e.get("type") == "response.compaction.in_progress"
+    )
     assert in_progress.get("task_id") == conv_id, (
         f"in_progress must carry the session id as task_id; got {in_progress!r}."
     )
@@ -11246,7 +11251,9 @@ async def test_events_compact_on_cursor_native_503_dismisses_spinner_when_bridge
     )
 
     compaction_types = [
-        e.get("type") for e in queued_events if str(e.get("type", "")).startswith("response.compaction")
+        e.get("type")
+        for e in queued_events
+        if str(e.get("type", "")).startswith("response.compaction")
     ]
     # in_progress raised the spinner; failed must dismiss it. completed must
     # never fire — the history was not compacted.

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -11181,19 +11181,34 @@ async def test_events_compact_on_cursor_native_pastes_summarize_and_raises_spinn
 
 
 @pytest.mark.asyncio
-async def test_events_compact_on_cursor_native_503_dismisses_spinner_when_bridge_not_ready(
+@pytest.mark.parametrize(
+    ("inject_exc", "label"),
+    [
+        # Pane not attached: _wait_for_tmux_info / _run_tmux raise RuntimeError.
+        (RuntimeError("tmux target is not advertised"), "runtime"),
+        # Filesystem fault writing the paste tempfile into bridge_dir (disk
+        # full, perms, dir removed). cursor's inject_user_message has this
+        # surface; the claude-native analog does not. A narrow
+        # ``except (RuntimeError, ValueError)`` would let this escape AFTER
+        # in_progress fired, stranding the spinner with no failed edge.
+        (OSError("No space left on device"), "oserror"),
+    ],
+)
+async def test_events_compact_on_cursor_native_503_dismisses_spinner_on_inject_failure(
+    inject_exc: Exception,
+    label: str,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """
-    Bridge-not-ready RuntimeError surfaces as 503 and dismisses the spinner.
+    An injection failure surfaces as 503 AND dismisses the spinner.
 
-    When the cursor TUI pane isn't attached there is no live cursor to
-    compact, so the handler returns 503 with ``cursor_native_compact_failed``.
-    Crucially it must also publish ``response.compaction.failed`` so the web
-    UI dismisses the "Compacting…" spinner the ``in_progress`` event raised —
-    otherwise the spinner is stranded forever — and must NOT publish
-    ``completed`` (the history was never compacted, so no permanent marker).
+    The handler publishes ``response.compaction.in_progress`` before injecting,
+    so every failure path must publish ``response.compaction.failed`` to
+    dismiss the "Compacting…" spinner — otherwise it is stranded forever — and
+    must NOT publish ``completed`` (the history was never compacted). Covers
+    both the tmux ``RuntimeError`` and the tempfile ``OSError`` surfaces; the
+    latter is unique to cursor's bracketed-paste path.
     """
     from omnigent.runner.app import _session_event_queues_ref
     from omnigent.spec.types import ExecutorSpec
@@ -11201,9 +11216,9 @@ async def test_events_compact_on_cursor_native_503_dismisses_spinner_when_bridge
     monkeypatch.setattr(cursor_native_bridge, "_BRIDGE_ROOT", tmp_path / "cursor-bridge")
 
     def _fake_inject(bridge_dir: Any, *, content: str, timeout_s: float) -> None:
-        """Simulate the bridge-not-ready path (pane not attached)."""
+        """Simulate an injection failure (tmux down, or tempfile write fault)."""
         del bridge_dir, content, timeout_s
-        raise RuntimeError("tmux target is not advertised")
+        raise inject_exc
 
     monkeypatch.setattr(cursor_native_bridge, "inject_user_message", _fake_inject)
 
@@ -11218,7 +11233,7 @@ async def test_events_compact_on_cursor_native_503_dismisses_spinner_when_bridge
         del agent_id, session_id
         return cursor_native_spec
 
-    conv_id = "conv_cursor_compact_fail"
+    conv_id = f"conv_cursor_compact_fail_{label}"
     pm = _FakeProcessManager(_ScriptedHarnessClient([]))
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -158,6 +158,27 @@ class TestBlobToItem:
     def test_binary_merkle_node_is_skipped(self) -> None:
         assert fwd._blob_to_item(3, "bid", b"\n \x92\xc0\xa6w\xef&", "a") is None
 
+    def test_summary_rollup_becomes_compaction_completed(self) -> None:
+        # After /summarize finishes, cursor collapses the prior history into a
+        # user blob whose content is a plain STRING (not a [{type:text}] list)
+        # starting with the marker. It must surface as a compaction-completed
+        # signal — the only durable cue that the in-pane compaction finished —
+        # not as a chat bubble.
+        blob = self._blob(
+            {"role": "user", "content": f"{fwd._COMPACTION_SUMMARY_PREFIX} Summary:\n1. ..."}
+        )
+        item = fwd._blob_to_item(12, "bid", blob, "cursor-native-ui")
+        assert item is not None
+        assert item.item_type == "compaction_completed"
+        assert item.item_data == {}
+
+    def test_plain_string_user_without_marker_is_skipped(self) -> None:
+        # A bare-string user content that ISN'T the summary rollup has no
+        # <user_query> wrapper, so it is neither a chat bubble nor a compaction
+        # signal — skipped, exactly as before.
+        blob = self._blob({"role": "user", "content": "just some unwrapped context"})
+        assert fwd._blob_to_item(2, "bid", blob, "a") is None
+
 
 class TestReadNewItems:
     def test_reads_live_wal_store(self, tmp_path: Path) -> None:
@@ -866,3 +887,104 @@ class TestForwardLoopExternalSessionId:
             await asyncio.gather(task, return_exceptions=True)
 
         assert patch_count == 1
+
+
+class TestCompactionCompletedForwarding:
+    """The forwarder maps cursor's post-/summarize rollup blob to a
+    ``external_compaction_status`` 'completed' edge.
+
+    The runner raises the web UI's "Compacting…" spinner when it submits
+    ``/summarize`` but cannot tell when cursor actually finishes (cursor-agent
+    has no compaction hook). The forwarder closes that gap: when it tails the
+    summary rollup blob out of the store it posts the completion, so the
+    permanent "Conversation compacted" marker tracks cursor's real progress
+    instead of flashing the instant the command was submitted.
+    """
+
+    @pytest.mark.asyncio
+    async def test_summary_blob_posts_compaction_completed_not_a_bubble(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Store: a normal user turn (rowid 1) then the post-/summarize rollup
+        # (rowid 2, a plain-string user blob with the marker prefix).
+        store = tmp_path / "store.db"
+        writer = _make_store(
+            store,
+            [
+                ("b1", _user("<user_query>\nhi\n</user_query>")),
+                (
+                    "b2",
+                    {
+                        "role": "user",
+                        "content": f"{fwd._COMPACTION_SUMMARY_PREFIX} Summary:\n1. ...",
+                    },
+                ),
+            ],
+        )
+        writer.close()
+
+        completions: list[str] = []
+
+        async def _fake_compaction(client: object, *, session_id: str, status: str) -> None:
+            completions.append(status)
+
+        monkeypatch.setattr(fwd, "_post_external_compaction_status", _fake_compaction)
+
+        poster = _FakePoster(lambda item: None)
+        bridge = await _drive_forwarder(
+            monkeypatch,
+            tmp_path,
+            store,
+            poster,
+            until=lambda b: bool(completions) and fwd._read_state(b).last_rowid >= 2,
+        )
+
+        # The rollup fired exactly one 'completed' edge — the web UI marker.
+        assert completions == ["completed"]
+        # It was NOT mirrored as a chat bubble (only the real user turn was).
+        assert [it.rowid for it in poster.delivered] == [1]
+        assert all(it.item_type == "message" for it in poster.delivered)
+        # The cursor advanced past the rollup so it never re-fires completion.
+        assert fwd._read_state(bridge).last_rowid == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_completion_post_does_not_wedge_the_mirror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A failed completion POST must not wedge the loop: unlike a chat item it
+        # carries no content to lose, so the cursor advances past it regardless
+        # (the spinner just lingers). A later message must still mirror.
+        store = tmp_path / "store.db"
+        writer = _make_store(
+            store,
+            [
+                (
+                    "b1",
+                    {
+                        "role": "user",
+                        "content": f"{fwd._COMPACTION_SUMMARY_PREFIX} Summary:\n1. ...",
+                    },
+                ),
+                ("b2", _user("<user_query>\nnext\n</user_query>")),
+            ],
+        )
+        writer.close()
+
+        async def _failing_compaction(client: object, *, session_id: str, status: str) -> None:
+            raise _http_status_error(500)
+
+        monkeypatch.setattr(fwd, "_post_external_compaction_status", _failing_compaction)
+
+        poster = _FakePoster(lambda item: None)
+        bridge = await _drive_forwarder(
+            monkeypatch,
+            tmp_path,
+            store,
+            poster,
+            until=lambda b: fwd._read_state(b).last_rowid >= 2,
+        )
+
+        # The message after the (failed) completion still mirrored, and the
+        # cursor advanced past both — no wedge, no infinite re-post.
+        assert [it.rowid for it in poster.delivered] == [2]
+        assert fwd._read_state(bridge).last_rowid == 2


### PR DESCRIPTION
## What

Wire the web UI's **compact** control to cursor-native sessions, with a "Compacting…" → "Conversation compacted" indicator that tracks cursor-agent's real progress.

Previously the runner's `/events` compact dispatch had no cursor-native branch, so `/compact` returned a 204 no-op. The server then fell through to its own AP-side compaction, which 400s on the LLM-less native pseudo-agent — explicit compaction must run inside the cursor-agent TUI (it owns its own context window).

## How

**Runner (`omnigent/runner/app.py`)** — add `_handle_cursor_native_compact`:
- Submits `/summarize` (cursor-agent's compaction command) into the TUI pane via **bracketed paste** (`inject_user_message`). This is load-bearing: typing the literal command with `send-keys` opens cursor's slash-command autocomplete dropdown, and the single submit Enter then confirms the dropdown instead of sending the command — so it never lands (the first bug we hit).
- Publishes `response.compaction.in_progress` to raise the web UI spinner, and `response.compaction.failed` on injection error to dismiss it (no summary will ever arrive to complete it).
- Returns 200 so the server knows the control was handled in the terminal and skips its own compaction.

**Forwarder (`omnigent/cursor_native_forwarder.py`)** — emit `completed` only when compaction *actually* finishes:
- cursor-agent has no compaction hook (unlike Claude Code's PreCompact/SessionStart). But after `/summarize`, cursor writes the rolled-up history to its chat store as a `role:"user"` blob whose **plain-string** content starts with `[Previous conversation summary]:` (real user turns are always a `[{type:text}]` list, so the prefix is unambiguous).
- The store-tailing forwarder maps that blob to an `external_compaction_status` `completed` edge (the same server path claude-native uses), so "Conversation compacted" only shows once the summary exists — not the instant the command was submitted.

## Testing

- `tests/runner/test_app_sessions_native.py`: handler returns 200, pastes `/summarize`, raises the spinner but does **not** complete it; 503 path dismisses the spinner via `failed`.
- `tests/test_cursor_native_forwarder.py`: `_blob_to_item` detects the summary rollup (and still skips plain unwrapped strings); loop-level test posts `completed` exactly once (not as a chat bubble, cursor advances past it); a failed completion post does not wedge the mirror.

All cursor-native suites pass.