### PR TITLE
fix(web-ui): improve mobile Settings navigation

### DIFF
--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -137,6 +137,41 @@ describe("Sidebar session list", () => {
     );
   });
 
+  it("renders the footer Settings as an icon-only floating control on mobile", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    renderSidebar();
+
+    const settings = screen.getByTestId("settings-button");
+    // Accessible name survives even though the label is visually dropped on
+    // mobile (the icon stands alone there).
+    expect(settings).toHaveAttribute("aria-label", "Settings");
+    // Mobile: compact square icon button, out of flow at the bottom-left.
+    expect(settings.className).toContain("max-md:size-9");
+    // The text label is desktop-only.
+    const label = within(settings).getByText("Settings");
+    expect(label.className).toContain("max-md:hidden");
+  });
+
+  it("does NOT close the sidebar when the footer Settings is tapped", () => {
+    // No onNavClick on the footer Settings link: on mobile the overlay stays
+    // open and swaps to the settings section list rather than collapsing onto
+    // the default section's content.
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    const onClose = vi.fn();
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/"]}>
+            <Sidebar open onClose={onClose} />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+    fireEvent.click(screen.getByTestId("settings-button"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("keeps archived sessions out of the sidebar list (they live on the Settings page)", () => {
     mockConversations([
       conv("conv_active", "Claude Code"),

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -459,7 +459,10 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
             )}
           </div>
 
-          <nav className="relative flex-1 overflow-y-auto px-3 pb-3 [scrollbar-gutter:stable]">
+          {/* Mobile: extra bottom padding so the last session scrolls clear of
+          the floating Settings icon (which is absolutely positioned, out of
+          flow, over the bottom-left corner). */}
+          <nav className="relative flex-1 overflow-y-auto px-3 pb-3 max-md:pb-16 [scrollbar-gutter:stable]">
             <ConversationList
               conversationsQuery={conversationsQuery}
               onRowClick={onNavClick}
@@ -473,23 +476,41 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
             />
           </nav>
 
-          {/* Settings footer. Sibling *after* the flex-1 nav so it pins to the
-          bottom of the sidebar column. Always present (every deploy): the
-          full settings surface — appearance, keyboard shortcuts, archived
-          chats, and the account/sign-out controls when accounts auth is on —
-          lives behind this row on the /settings page. */}
-          <div className="shrink-0 px-3 pb-3">
-            {/* Match the New session / Inbox buttons (default size, no extra
-            padding) so the gear icon lines up with their leading icons. */}
+          {/* Settings entry. Always present (every deploy): the full settings
+          surface — appearance, keyboard shortcuts, archived chats, and the
+          account/sign-out controls when accounts auth is on — lives behind
+          this on the /settings page.
+
+          Desktop: a full-width footer row pinned below the flex-1 nav, the
+          gear aligned with the New session / Inbox icons.
+          Mobile: pulled OUT of flow (absolute, bottom-left) so it floats over
+          the conversation list as a compact icon instead of stealing a row's
+          height from the scroll area. */}
+          <div className="md:shrink-0 md:px-3 md:pb-3 max-md:absolute max-md:bottom-3 max-md:left-3 max-md:z-10">
             <Button
               asChild
               variant="ghost"
-              className="w-full justify-start gap-2 text-sm"
+              className={cn(
+                "gap-2 text-sm",
+                // Desktop: full-width row with label, matching New session /
+                // Inbox. Mobile: a small round icon-only button with its own
+                // surface (border + solid bg + shadow) so it reads as a
+                // floating control over the scrolling list beneath it.
+                "md:w-full md:justify-start",
+                "max-md:size-9 max-md:justify-center max-md:rounded-full max-md:border max-md:border-border max-md:bg-card-solid max-md:p-0 max-md:shadow-sm",
+              )}
               data-testid="settings-button"
             >
-              <Link to="/settings" onClick={onNavClick}>
+              {/* No onNavClick here: on mobile the sidebar is a full-screen
+              overlay, and entering settings swaps it to the section list
+              (SettingsSidebarBody). Closing the overlay would skip that list
+              and drop straight onto the default section's content — instead we
+              keep it open so mobile lands on the section list, then tapping a
+              section (which DOES use onNavClick) closes it to show content. */}
+              <Link to="/settings" aria-label="Settings">
                 <SettingsIcon className="size-4 text-muted-foreground" />
-                Settings
+                {/* Label is desktop-only; the icon stands alone on mobile. */}
+                <span className="max-md:hidden">Settings</span>
               </Link>
             </Button>
           </div>

--- a/ap-web/src/shell/settingsNav.test.tsx
+++ b/ap-web/src/shell/settingsNav.test.tsx
@@ -1,0 +1,83 @@
+// Tests for the Settings nav model + sidebar body (settingsNav).
+//
+// Covers the mobile-specific behavior: keyboard shortcuts is hidden on mobile
+// (max-md:hidden), and "Back to Omnigent" does NOT close the sidebar overlay
+// on a plain tap (no onNavClick) so mobile lands back on the conversation list
+// instead of the homepage. Section links still close it.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const mocks = vi.hoisted(() => ({ accountsEnabled: false }));
+
+vi.mock("@/lib/CapabilitiesContext", () => ({
+  useServerInfo: () => ({ accounts_enabled: mocks.accountsEnabled }),
+}));
+
+import { SettingsSidebarBody, settingsNavGroups } from "./settingsNav";
+
+function renderBody(opts: { onNavClick?: () => void; onClose?: () => void } = {}) {
+  const onNavClick = opts.onNavClick ?? vi.fn();
+  const onClose = opts.onClose ?? vi.fn();
+  render(
+    <TooltipProvider>
+      <MemoryRouter initialEntries={["/settings/appearance"]}>
+        <SettingsSidebarBody onNavClick={onNavClick} onClose={onClose} />
+      </MemoryRouter>
+    </TooltipProvider>,
+  );
+  return { onNavClick, onClose };
+}
+
+beforeEach(() => {
+  mocks.accountsEnabled = false;
+});
+afterEach(cleanup);
+
+describe("settingsNavGroups", () => {
+  it("flags Keyboard shortcuts as hidden on mobile, but not the other items", () => {
+    const items = settingsNavGroups(false).flatMap((g) => g.items);
+    const shortcuts = items.find((i) => i.id === "shortcuts");
+    expect(shortcuts?.hideOnMobile).toBe(true);
+    for (const item of items) {
+      if (item.id !== "shortcuts") expect(item.hideOnMobile).toBeFalsy();
+    }
+  });
+
+  it("includes Account (leading) only when accounts auth is enabled", () => {
+    expect(settingsNavGroups(false).flatMap((g) => g.items).map((i) => i.id)).not.toContain(
+      "account",
+    );
+    const withAccounts = settingsNavGroups(true).flatMap((g) => g.items).map((i) => i.id);
+    expect(withAccounts).toContain("account");
+    // Account leads its group — it's the most-visited section on accounts deploys.
+    expect(withAccounts[0]).toBe("account");
+  });
+});
+
+describe("SettingsSidebarBody", () => {
+  it("marks the Keyboard shortcuts nav item hidden on mobile via max-md:hidden", () => {
+    renderBody();
+    expect(screen.getByTestId("settings-nav-shortcuts").className).toContain("max-md:hidden");
+    // Sibling items stay visible on every viewport.
+    expect(screen.getByTestId("settings-nav-appearance").className).not.toContain("max-md:hidden");
+    expect(screen.getByTestId("settings-nav-archived").className).not.toContain("max-md:hidden");
+  });
+
+  it("does NOT close the sidebar when 'Back to Omnigent' is tapped", () => {
+    // No onNavClick on the back link: on mobile the overlay stays open so the
+    // sidebar swaps back to the conversation list rather than closing onto the
+    // homepage behind it.
+    const { onNavClick } = renderBody();
+    fireEvent.click(screen.getByRole("link", { name: /Back to Omnigent/ }));
+    expect(onNavClick).not.toHaveBeenCalled();
+  });
+
+  it("DOES close the sidebar when a section is tapped (drills into content)", () => {
+    const { onNavClick } = renderBody();
+    fireEvent.click(screen.getByTestId("settings-nav-appearance"));
+    expect(onNavClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ap-web/src/shell/settingsNav.test.tsx
+++ b/ap-web/src/shell/settingsNav.test.tsx
@@ -47,10 +47,14 @@ describe("settingsNavGroups", () => {
   });
 
   it("includes Account (leading) only when accounts auth is enabled", () => {
-    expect(settingsNavGroups(false).flatMap((g) => g.items).map((i) => i.id)).not.toContain(
-      "account",
-    );
-    const withAccounts = settingsNavGroups(true).flatMap((g) => g.items).map((i) => i.id);
+    expect(
+      settingsNavGroups(false)
+        .flatMap((g) => g.items)
+        .map((i) => i.id),
+    ).not.toContain("account");
+    const withAccounts = settingsNavGroups(true)
+      .flatMap((g) => g.items)
+      .map((i) => i.id);
     expect(withAccounts).toContain("account");
     // Account leads its group — it's the most-visited section on accounts deploys.
     expect(withAccounts[0]).toBe("account");

--- a/ap-web/src/shell/settingsNav.tsx
+++ b/ap-web/src/shell/settingsNav.tsx
@@ -33,6 +33,8 @@ interface SettingsNavItem {
   id: SettingsSectionId;
   label: string;
   icon: typeof PaletteIcon;
+  /** Hide this item on mobile (e.g. keyboard shortcuts on a touch device). */
+  hideOnMobile?: boolean;
 }
 
 interface SettingsNavGroup {
@@ -44,7 +46,7 @@ interface SettingsNavGroup {
 export function settingsNavGroups(accountsEnabled: boolean): SettingsNavGroup[] {
   const general: SettingsNavItem[] = [
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
-    { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon },
+    { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
   ];
   if (accountsEnabled) {
     // Account leads the group when present — it's the most-visited section
@@ -104,7 +106,13 @@ export function SettingsSidebarBody({
     <>
       <div className="flex items-center justify-between px-3 pt-3">
         <Button asChild variant="ghost" size="sm" className="gap-2 text-muted-foreground">
-          <Link to="/" onClick={onNavClick}>
+          {/* No onNavClick here: on mobile the sidebar is a full-screen
+          overlay. Navigating to "/" exits /settings, so the sidebar swaps
+          back to the conversation list — but we keep the overlay OPEN so
+          mobile lands on that list rather than closing onto the homepage
+          content behind it. On desktop onNavClick is a no-op (persistent
+          card), so dropping it changes nothing there. */}
+          <Link to="/">
             <ArrowLeftIcon className="size-4" />
             Back to Omnigent
           </Link>
@@ -142,6 +150,7 @@ export function SettingsSidebarBody({
                   className={cn(
                     "w-full justify-start gap-2 text-sm",
                     selected && "bg-muted font-semibold",
+                    item.hideOnMobile && "max-md:hidden",
                   )}
                 >
                   <Link


### PR DESCRIPTION
## What

Four mobile-only improvements to the Settings surface (the full-screen sidebar overlay). Desktop behavior is unchanged.

1. **Land on the section list, not Appearance.** Tapping **Settings** keeps the overlay open and swaps it to the settings section list (`SettingsSidebarBody`) instead of closing onto the default section's content.
2. **"Back to Omnigent" returns to the conversation list.** It no longer closes the overlay onto the homepage — it navigates to `/` (exiting `/settings`) while keeping the overlay open, so you land back on the conversation list.
3. **Floating Settings icon.** The footer Settings is now a compact icon-only control pulled out of flow at the bottom-left corner, so it no longer steals a row's height from the scrolling session list. The list gets extra bottom padding so the last session scrolls clear of the icon.
4. **Hide "Keyboard shortcuts" on mobile.** Not useful on a touch device, so it's hidden from the settings nav via a `hideOnMobile` flag.

## How

- `Sidebar.tsx`: footer Settings link drops `onNavClick` (no mobile close), gains responsive icon-only styling + absolute positioning on mobile; scroll area gains `max-md:pb-16`.
- `settingsNav.tsx`: "Back to Omnigent" link drops `onNavClick`; new `hideOnMobile` flag on nav items applies `max-md:hidden` to "Keyboard shortcuts".

## Tests

- New `settingsNav.test.tsx` (5): nav model, hide-on-mobile flag, and "Back to Omnigent" no-close vs section drill-down.
- Extended `Sidebar.test.tsx` (2): footer icon-only styling + no-close-on-tap.
- All passing; `SettingsPage.test.tsx` unaffected; lint clean.