### PR TITLE
fix(runtime): tolerate missing lsof in orphan sweep

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1222,13 +1222,16 @@ async def _pids_holding_socket(socket_path: Path) -> list[int]:
     :returns: List of holding PIDs (often a single one — the
         bound runner).
     """
-    proc = await asyncio.create_subprocess_exec(
-        "lsof",
-        "-t",
-        str(socket_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "lsof",
+            "-t",
+            str(socket_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except OSError:
+        return []
     stdout, _ = await proc.communicate()
     if proc.returncode != 0:
         return []

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -595,6 +595,21 @@ async def test_pids_holding_socket_returns_empty_for_missing(
     assert pids == []
 
 
+async def test_pids_holding_socket_returns_empty_when_lsof_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    short_tmp_parent: Path,
+) -> None:
+    """Missing ``lsof`` is best-effort cleanup noise, not a boot failure."""
+
+    async def missing_lsof(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError(2, "No such file or directory", "lsof")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", missing_lsof)
+
+    pids = await _pids_holding_socket(short_tmp_parent / "conv-stale.sock")
+    assert pids == []
+
+
 # ── Per-spawn env override ─────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #1265

## Summary

- Treat spawn-time `lsof` failures as best-effort orphan-cleanup misses in `_pids_holding_socket`.
- Add a deterministic regression test for `FileNotFoundError` when `lsof` is unavailable.

## Test Plan

- Red before fix: `uv run pytest -q tests/runtime/harnesses/test_process_manager.py::test_pids_holding_socket_returns_empty_when_lsof_is_missing` failed with `FileNotFoundError: lsof`.
- `uv sync --extra all --extra dev`
- `uv run pytest -q tests/runtime/harnesses/test_process_manager.py::test_pids_holding_socket_returns_empty_for_missing tests/runtime/harnesses/test_process_manager.py::test_pids_holding_socket_returns_empty_when_lsof_is_missing`
- `uv run pytest -q tests/runtime/harnesses/test_process_manager.py`
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pre-commit run --all-files`
- Attempted full gate: `uv run pytest -v` currently fails during collection on upstream `main` with `ImportError: cannot import name 'update_versions' from 'scripts' (/.../tests/scripts/__init__.py)`. This happens before this change-specific suite is reached.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the pre-fix failure with the new unit test and verified the fixed helper returns `[]` when `lsof` cannot be spawned.