### PR TITLE
feat(cursor-native): surface tool-approval + AskQuestion elicitations via the chat store

### DIFF
--- a/ap-web/src/components/blocks/ApprovalCard.test.tsx
+++ b/ap-web/src/components/blocks/ApprovalCard.test.tsx
@@ -655,6 +655,37 @@ describe("ApprovalCard — AskUserQuestion form (parsed from content_preview)", 
     expect(screen.queryByText("Claude has questions")).toBeNull();
   });
 
+  it("labels Cursor structured input prompts as Cursor prompts", () => {
+    // Cursor's AskQuestion reuses the same AskUserQuestion renderer (the
+    // runner translates it into the preview shape), so the title must reflect
+    // the producer rather than defaulting to "Claude has questions".
+    render(
+      <ApprovalCard
+        elicitationId="elic_cursor_label"
+        message="AskQuestion Demo"
+        phase="pre_tool_use"
+        policyName="cursor_native_permission"
+        contentPreview=""
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+        askUserQuestion={{
+          questions: [
+            {
+              id: "demo_topic",
+              question: "What kind of example would you like to see?",
+              options: [{ label: "A coding-related question" }, { label: "A workflow question" }],
+              multiSelect: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Cursor has questions")).toBeDefined();
+    expect(screen.queryByText("Claude has questions")).toBeNull();
+  });
+
   it("submits multi-select answers as an array", () => {
     const submitSpy = vi.fn().mockResolvedValue(undefined);
     useChatStore.setState({ submitApproval: submitSpy } as Partial<

--- a/ap-web/src/components/blocks/ApprovalCard.tsx
+++ b/ap-web/src/components/blocks/ApprovalCard.tsx
@@ -250,7 +250,9 @@ export function ApprovalCard({
       ? "Antigravity needs your input"
       : policyName.startsWith("codex_") || phase.startsWith("codex_")
         ? "Codex needs input"
-        : "Claude has questions";
+        : policyName.startsWith("cursor_") || phase.startsWith("cursor_")
+          ? "Cursor has questions"
+          : "Claude has questions";
 
   // Hide the raw JSON preview for AskUserQuestion (the form already
   // renders the questions + options structurally) and for option-

--- a/docs/cursor-native-elicitation.md
+++ b/docs/cursor-native-elicitation.md
@@ -1,0 +1,150 @@
+# Cursor-native Elicitation — Transcript-based Surfacing
+
+**Status:** implemented
+**Supersedes:** [`cursor-native-tui-mirror-plan.md`](./cursor-native-tui-mirror-plan.md) (pane-scrape design)
+**Code:** `omnigent/cursor_native_permissions.py`, the `cursor-permission-request` hook in
+`omnigent/server/routes/sessions.py`, runner wiring in `omnigent/runner/app.py`,
+`ap-web/.../ApprovalCard.tsx`.
+
+## Goal / behavior
+
+Surface an Omnigent **elicitation card whenever the `cursor-agent` TUI gates a tool call or
+asks a question**, answerable from the web **or** the embedded TUI. Cursor's own native gate
+stays the source of truth — **no `--force`, no JS-bundle modification**. The failure mode is
+benign: if detection ever breaks, the embedded TUI prompt still works and the user answers
+there.
+
+Two interaction kinds are surfaced (both ride cursor's per-call "pending" mechanism):
+
+1. **Tool-approval gates** — shell commands, file edit/create (`ApplyPatch`), `Delete`, MCP
+   tools, etc. Rendered as an approve/reject card; answered with a keystroke.
+2. **`AskQuestion`** — cursor's structured multiple-choice tool. Rendered as the existing
+   `AskUserQuestion` form; answered by driving the TUI picker.
+
+## Approach: detect in the transcript, deliver via the pane
+
+```
+cursor chat store.db (~/.cursor/chats/<md5(cwd)>/<chat-id>/store.db)
+   │  pending tool call written as an assistant `tool-call` content part with
+   │  providerOptions.cursor.pendingToolCallStartedAtMs and no matching tool-result
+   ▼
+[runner] supervise_cursor_transcript_elicitations  (tails the SAME store the forwarder mirrors)
+   │  read_cursor_pending_tool_calls → settle-debounce → POST /hooks/cursor-permission-request
+   ▼
+[server] publish response.elicitation_request → PARK   (_publish_and_wait_for_harness_elicitation)
+   ▼
+[web]    ApprovalCard / AskUserQuestionForm renders → user answers
+   ▼
+[server] return the verdict to the parked POST
+   ▼
+[runner] send tmux keystrokes into the pane:
+            approval → `y` / `Escape`(+`Enter` to submit the rejection reason)
+            question → picker navigation (Down × index, Space, Enter), or type into "Other"
+```
+
+If the pending call vanishes from the store while still parked (the user answered in the TUI,
+or it executed), the runner POSTs `external_elicitation_resolved` to clear the card.
+
+### Detection signal (the key fact)
+
+Each `toolCallId` is classified by how its `tool-call` part appears in the store:
+
+- **pending** — appears in an object **with** `providerOptions.cursor.pendingToolCallStartedAtMs`
+  (cursor is blocking on it),
+- **committed** — appears **without** the marker (cursor finalized it to run — auto-approved,
+  or approved and now executing),
+- **resolved** — has a `tool-result`.
+
+> **active elicitation = pending AND NOT committed AND NOT resolved.**
+
+The committed exclusion is the structural discriminator that removes the auto-approve flash
+*without a timing guess*: empirically a call genuinely blocked on the human appears **only**
+with the marker until answered (verified — a pending `Delete`: marker-only, zero no-marker
+appearances), while an auto-approved/committed call appears without it. The pending call lives
+**only inside cursor's binary protobuf checkpoint frames** — not as a plain-JSON `blobs` row —
+so the reader (`read_cursor_pending_tool_calls`) byte-scans each blob for embedded JSON objects
+rather than `json.loads`-ing the whole row.
+
+### Settle / debounce (small backstop)
+
+With the committed-exclusion above doing the real work, the settle window is just a short
+backstop (`_ELICITATION_SETTLE_S` = 0.5s) for the sub-poll race where cursor's marker frame is
+observed a tick before its committed frame. It is intentionally short so a genuinely-gated
+prompt that resolves quickly — e.g. a cursor **Auto-review retry** — still surfaces a card
+rather than being suppressed. (An earlier 1.5s window suppressed exactly such a retry; the
+discriminator is what let it shrink safely.)
+
+### Keystroke delivery
+
+The pane is still used to *deliver* the verdict. Two gotchas, both handled in
+`_send_cursor_keys`:
+
+- **Send keys one at a time** with a short gap and a longer settle before `Enter` — the cursor
+  TUI re-renders between keys and **drops a back-to-back burst** sent in one `tmux send-keys`
+  call. (Single-key approvals were unaffected, which is why this only surfaced with the
+  multi-key `AskQuestion` picker.)
+- **Reject is a two-step.** Cursor's tool-reject doesn't dismiss on the decline key alone — it
+  opens a *"Reason for rejection (Enter to submit, Esc to cancel)"* sub-prompt. The approval
+  decline path sends the decline key **then `Enter`** to submit an empty reason, so the TUI
+  doesn't park at the reason input. (The `AskQuestion` picker's "Esc to skip" dismisses
+  cleanly, so the question decline is a single key.)
+
+### AskQuestion specifics
+
+- Rendered via the existing web form: the runner stamps the full questions as the **structured
+  `ask_user_question` hook field** (uncapped), with an `AskUserQuestion(...)` `content_preview`
+  as the ≤1024-char legacy fallback. cursor's `prompt`/`label` are mapped to the web's
+  `question`/`label`; each question `id` is preserved.
+- Answered by translating the chosen option labels (keyed by question `id`) into picker
+  keystrokes; a value matching no option targets the trailing "Other (type to answer)" row.
+
+## Why this replaced the pane-scrape plan
+
+The original plan (`cursor-native-tui-mirror-plan.md`) chose to **scrape the rendered TUI pane**
+and answer with keystrokes. Its central justification:
+
+> "The transcript JSONL and the chat `store.db` contain only the user message while an approval
+> is pending (the decision lives in memory), so a clean file-tail channel is not available —
+> scraping the pane is required."
+
+**That premise was incorrect — and it was an investigation gap, not a cursor-version change.**
+Empirically, cursor chat stores from **June 18–19** (the same `2026.06.19` era the plan was
+written against) already contain `pendingToolCallStartedAtMs` — the exact signal this design
+keys on. The pending decision *is* persisted; it just lives inside the **binary protobuf
+checkpoint frames**, which don't decode as a plain-JSON blob. An inspection that reads the
+store the way the forwarder does (`_blob_to_item` → `json.loads`, skipping binary blobs as
+"Merkle-tree node, not a message") sees only the user message and concludes the decision is
+in-memory. Byte-scanning the frames for embedded JSON reveals the pending tool call.
+
+### What the transcript channel wins over pane-scraping
+
+- **No prompt-wording allowlist.** Pane-scraping recognized prompts by verb regex
+  (`run|allow|approve|…`), so it silently missed prompts whose accept verb fell outside it —
+  e.g. the file-deletion gate *"Delete this file? → Delete (y) / Keep (n)"* (the bug that
+  motivated this rewrite). The transcript path captures **every** gated tool kind uniformly.
+- **Solves the plan's "tricky part" (dedup).** The plan flagged identity for identical
+  consecutive commands as the hard problem and pointed at a "hook-assisted hybrid" to borrow a
+  stable `tool_use_id`. The transcript gives us cursor's stable `toolCallId` directly — used as
+  the dedup key and to mint the elicitation id — so that edge case disappears.
+- **Structured data** (`toolName` + `args`) instead of regex-parsed pane text.
+
+### What we kept from the plan
+
+- Cursor's native gate remains authoritative; no bundle modification; benign failure mode.
+- The pane is still the delivery channel for the verdict keystroke.
+- The server hook, parking machinery (`_publish_and_wait_for_harness_elicitation`),
+  `external_elicitation_resolved`, and the web `ApprovalCard` are reused unchanged (the
+  `AskQuestion` form reuses Claude's `AskUserQuestion` renderer).
+
+## Known gaps / follow-ups
+
+- **Duplicate cursor sessions in one cwd.** The forwarder arbitrates a single owner
+  (`_chat_claimed_by_other`); the elicitation detector does not, so two same-cwd sessions could
+  double-surface. Low likelihood; not yet addressed.
+- **Store schema is private and version-sensitive.** Confirmed against cursor-agent 2026.06.24
+  (and the marker present back to 2026.06.18). Failure stays benign (TUI gate authoritative).
+- **Keystroke delivery assumes the pane still shows the prompt** and the picker's key bindings
+  (`Down`/`Space`/`Enter`, highlight resets per question). Verified live; re-check on cursor
+  upgrades.
+- **Workspace-trust modal** (first-run) is not a tool call, so it isn't surfaced — answerable
+  only in the TUI.

--- a/docs/cursor-native-tui-mirror-plan.md
+++ b/docs/cursor-native-tui-mirror-plan.md
@@ -1,6 +1,22 @@
 # Cursor-native TUI Mirror — Elicitation Plan
 
-**Status:** proposed
+> **⚠️ SUPERSEDED — historical.** The shipped implementation uses **transcript-based**
+> detection (tailing cursor's chat `store.db` for pending tool calls), not pane scraping. See
+> [`cursor-native-elicitation.md`](./cursor-native-elicitation.md) for the current design.
+>
+> This plan's core premise — *"the `store.db` contains only the user message while an approval
+> is pending (the decision lives in memory)"* (see "Why this approach") — turned out to be
+> **incorrect, and it was an investigation gap rather than a cursor-version difference.** The
+> pending tool call *is* persisted (carrying `providerOptions.cursor.pendingToolCallStartedAtMs`),
+> but inside cursor's **binary protobuf checkpoint frames**, which don't decode as a plain-JSON
+> `blobs` row — so an inspection that only reads clean-JSON blobs (as the forwarder does) sees
+> just the user message. Empirically, that marker is present in chat stores back to 2026.06.18
+> (this plan's `2026.06.19` era). The transcript channel is more reliable than pane-scraping
+> (no prompt-wording allowlist) and gives a stable `toolCallId`, which solves the dedup problem
+> this plan flagged as "the tricky part." Kept from this plan: native gate stays authoritative,
+> no bundle modification, tmux keystroke delivery, benign failure mode.
+
+**Status:** superseded (was: proposed)
 **Baseline:** `origin/main`
 **Tracking issue:** omnigent-ai/omnigent#1032 (cursor-native tool-call elicitations not surfaced in web UI)
 

--- a/omnigent/cursor_native_permissions.py
+++ b/omnigent/cursor_native_permissions.py
@@ -1,41 +1,50 @@
-"""Cursor-native tool-approval mirror (TUI → web elicitation).
+"""Cursor-native tool-approval + question surfacing (TUI → web elicitation).
 
-The ``cursor-agent`` TUI gates its own tool calls (shell, file write, …) with an
-in-terminal approval prompt that lives only in cursor's in-memory state — there
-is no public event or hook for it, and it is not written to cursor's transcript
-or chat store while pending. To surface those approvals in the Omnigent web UI
-(so a user can answer from the chat view, not just inside the embedded
-terminal), the runner watches the cursor pane:
+The ``cursor-agent`` TUI gates its own tool calls (shell, file write/delete, MCP,
+…) with an in-terminal approval prompt, and asks structured questions via its
+``AskQuestion`` tool. To surface both in the Omnigent web UI (so a user can
+answer from the chat view, not just inside the embedded terminal), the runner
+tails cursor's chat ``store.db`` — the SAME store the forwarder mirrors — for
+*pending tool calls* and drives the TUI to deliver the web verdict:
 
-1. poll ``capture-pane`` and detect an approval block (the bordered
-   "Run this command? … (y) … (esc or n)" widget),
-2. POST it to the server's ``cursor-permission-request`` hook, which publishes
-   the standard ``response.elicitation_request`` event and parks for the web
-   verdict (the same machinery codex-native uses),
-3. on the verdict, drive the cursor TUI by sending the advertised keystroke
-   (``y`` to approve, ``Escape`` to reject),
-4. if the prompt instead disappears on its own (the user answered inside the
-   embedded terminal), POST ``external_elicitation_resolved`` so the parked web
-   card clears.
+1. detect a pending tool call (an assistant ``tool-call`` content part carrying
+   ``providerOptions.cursor.pendingToolCallStartedAtMs`` with no matching
+   ``tool-result`` yet — see :func:`read_cursor_pending_tool_calls`),
+2. after a short settle (auto-approved calls resolve inside it and never
+   surface), POST it to the server's ``cursor-permission-request`` hook, which
+   publishes ``response.elicitation_request`` and parks for the web verdict,
+3. on the verdict, drive the cursor TUI by sending keystrokes into the pane
+   (``y``/``Escape`` for an approval; the picker navigation for a question),
+4. if the pending call instead disappears on its own (the user answered in the
+   embedded terminal), POST ``external_elicitation_resolved`` to clear the card.
 
-This deliberately does NOT modify cursor's JS bundle and does NOT suppress
-cursor's native gate; cursor's own prompt remains the source of truth and the
-fallback if pane detection ever fails (the user can still answer in the
-terminal). See ``docs/cursor-native-tui-mirror-plan.md``.
+Detection lives in the transcript (keyed on the stable ``toolCallId``), NOT in
+pane scraping — which silently missed any prompt whose wording fell outside a
+regex. The pane is still used only to *deliver* the keystroke verdict. This does
+NOT modify cursor's JS bundle and does NOT suppress cursor's native gate; the
+TUI prompt remains the source of truth and the benign fallback if store
+detection ever fails. See ``docs/cursor-native-elicitation.md`` (and the
+superseded ``docs/cursor-native-tui-mirror-plan.md`` for the original pane-scrape
+design and why the transcript channel replaced it).
 """
 
 from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
-import re
 from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
 
-from omnigent.cursor_native_bridge import capture_cursor_pane, send_cursor_pane_keys
+from omnigent.cursor_native_bridge import send_cursor_pane_keys
+
+# Reuse the forwarder's store discovery and WAL-aware blob reader so the
+# transcript-based detector binds to the SAME cursor chat the forwarder mirrors
+# (one chat per workspace) and reads the live ``-wal`` state correctly.
+from omnigent.cursor_native_forwarder import _discover_store, _read_blob_rows
 
 _logger = logging.getLogger(__name__)
 
@@ -44,203 +53,93 @@ _POLL_INTERVAL_S = 0.3
 # past any realistic wait, so the runner's POST never abandons a live prompt.
 _POST_TIMEOUT_S = 86400.0
 
-# Markers used to recognise an approval block in the rendered pane. Cursor's
-# per-tool prompt advertises keys in PARENTHESES ("(y)", "(esc or n)"); the
-# first-run Workspace-Trust modal uses BRACKETS ("[a] Trust this workspace"),
-# so keying on parenthesised options cleanly excludes the trust modal.
-_ACCEPT_VERB_RE = re.compile(r"\b(run|allow|approve|apply|accept|yes)\b", re.IGNORECASE)
-_DECLINE_VERB_RE = re.compile(r"\b(skip|reject|deny|cancel|no)\b", re.IGNORECASE)
-_PAREN_KEY_RE = re.compile(r"\(([^)]*)\)")
-_TITLE_SCAN_LINES = 12
-
 
 @dataclass(frozen=True)
 class CursorApprovalPrompt:
-    """A parsed cursor-agent approval prompt.
+    """A cursor tool-approval prompt to surface as a web elicitation.
 
-    :param title: The prompt's question line, e.g. ``"Run this command?"``.
-    :param subject: The operation detail, e.g. ``"echo hi > out.txt"`` (the
-        ``$``-prefixed command for shell ops), or ``""``.
-    :param operation_type: Coarse type, ``"shell"`` when a command subject was
-        found, else ``"tool"``.
+    Built from a transcript-detected pending tool call (see
+    :func:`_prompt_from_pending`) and consumed by :func:`_run_one_approval` to
+    render the card and drive the verdict keystroke.
+
+    :param operation_type: Coarse type, ``"shell"`` for a command, else
+        ``"tool"`` — a label only.
     :param message: Human-readable card message.
-    :param preview: Compact preview for the card (the command/subject).
+    :param preview: Compact preview for the card (the command / path / args).
     :param accept_key: tmux key to approve, e.g. ``"y"``.
     :param decline_key: tmux key to reject, e.g. ``"Escape"``.
-    :param block_hash: Stable hash of (title, subject) used to dedupe a prompt
-        across polls and to mint a stable elicitation id.
     """
 
-    title: str
-    subject: str
     operation_type: str
     message: str
     preview: str
     accept_key: str
     decline_key: str
-    block_hash: str
 
 
-def cursor_permission_elicitation_id(session_id: str, block_hash: str) -> str:
-    """Return the deterministic Omnigent elicitation id for a cursor prompt."""
-    return f"elicit_cursor_{session_id}_{block_hash}"
-
-
-def _paren_key(line: str) -> str | None:
-    """Extract a single-letter key from the last ``(…)`` group on *line*."""
-    groups = _PAREN_KEY_RE.findall(line)
-    if not groups:
-        return None
-    candidate = groups[-1].strip().lower()
-    return candidate if re.fullmatch(r"[a-z]", candidate) else None
-
-
-def _clean_subject(line: str) -> str:
-    """Normalise a ``$``-prefixed command line into a bare command string."""
-    text = line.strip().lstrip("$").strip()
-    text = text.replace("Waiting for approval...", "").strip()
-    # Strip a trailing " in <cwd>" hint that cursor appends to the command.
-    text = re.sub(r"\s+in\s+\S+$", "", text).strip()
-    return text[:1024]
-
-
-def parse_cursor_approval_prompt(pane: str) -> CursorApprovalPrompt | None:
-    """
-    Parse a cursor-agent approval block out of rendered pane text.
-
-    Returns ``None`` when no approval prompt is visible (including the
-    Workspace-Trust modal, which uses ``[key]`` brackets rather than the
-    ``(key)`` parentheses of a tool-approval prompt). Requires BOTH a
-    parenthesised accept option and a decline option to avoid false positives.
-
-    :param pane: Visible pane text from ``capture-pane -p``.
-    :returns: The parsed prompt, or ``None``.
-    """
-    if not pane:
-        return None
-    lines = pane.splitlines()
-
-    accept_idx: int | None = None
-    for i, line in enumerate(lines):
-        if "(y)" not in line.lower():
-            continue
-        if _ACCEPT_VERB_RE.search(line) and "everything" not in line.lower():
-            accept_idx = i
-            break
-    if accept_idx is None:
-        return None
-
-    decline_key: str | None = None
-    for line in lines[accept_idx : accept_idx + 5]:
-        low = line.lower()
-        if "(esc" in low or "(n)" in low or _DECLINE_VERB_RE.search(line):
-            decline_key = "Escape" if "esc" in low else (_paren_key(line) or "Escape")
-            break
-    if decline_key is None:
-        return None
-
-    accept_key = _paren_key(lines[accept_idx]) or "y"
-
-    title = ""
-    subject = ""
-    start = max(0, accept_idx - _TITLE_SCAN_LINES)
-    for line in reversed(lines[start:accept_idx]):
-        stripped = line.strip()
-        if not subject and stripped.startswith("$"):
-            subject = _clean_subject(stripped)
-        if not title and stripped.endswith("?"):
-            title = stripped
-    if not title and not subject:
-        return None
-
-    operation_type = "shell" if subject else "tool"
-    message = title or "Cursor wants approval to run a tool"
-    preview = subject or title
-    block_hash = hashlib.sha256(f"{title}\n{subject}".encode()).hexdigest()[:16]
-    return CursorApprovalPrompt(
-        title=title,
-        subject=subject,
-        operation_type=operation_type,
-        message=message,
-        preview=preview,
-        accept_key=accept_key,
-        decline_key=decline_key,
-        block_hash=block_hash,
-    )
-
-
-async def supervise_cursor_approval_mirror(
+async def _park_cursor_elicitation(
+    client: httpx.AsyncClient,
     *,
-    base_url: str,
-    headers: dict[str, str],
     session_id: str,
-    bridge_dir: Path,
-    auth: httpx.Auth | None = None,
-    poll_interval_s: float = _POLL_INTERVAL_S,
-) -> None:
-    """
-    Poll the cursor pane and mirror its approval prompts to web elicitations.
+    payload: dict[str, object],
+) -> dict | None:
+    """POST the cursor permission hook and return the web verdict, or ``None``.
 
-    Runs for the session's lifetime (cancelled on teardown). At most one prompt
-    is active at a time (cursor shows them sequentially): a new block spawns a
-    task that parks on the server and, on the web verdict, sends the keystroke;
-    a block that vanishes while still parked means the user answered in the TUI,
-    so the parked card is released via ``external_elicitation_resolved``.
-
-    :param base_url: Server base URL.
-    :param headers: Auth/routing headers for the runner's requests.
-    :param session_id: Omnigent conversation id.
-    :param bridge_dir: The cursor-native bridge dir holding ``tmux.json``.
-    :param auth: Optional httpx auth for the runner's requests.
-    :param poll_interval_s: Pane poll cadence in seconds.
+    ``None`` covers every "no keystroke" outcome: an empty 2xx (resolved in the
+    TUI / timed out), an HTTP error, or a non-dict body — all logged here so the
+    callers (approval and question) only deal with a real verdict dict.
     """
-    active: dict[str, object] | None = None
-    timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
-        while True:
-            try:
-                pane = await asyncio.to_thread(capture_cursor_pane, bridge_dir)
-                prompt = parse_cursor_approval_prompt(pane) if pane else None
-                if prompt is not None:
-                    if active is None or active["key"] != prompt.block_hash:
-                        elicitation_id = cursor_permission_elicitation_id(
-                            session_id, prompt.block_hash
-                        )
-                        task = asyncio.create_task(
-                            _run_one_approval(
-                                client,
-                                session_id=session_id,
-                                bridge_dir=bridge_dir,
-                                prompt=prompt,
-                                elicitation_id=elicitation_id,
-                            ),
-                            name=f"cursor-approval-{prompt.block_hash}",
-                        )
-                        active = {
-                            "key": prompt.block_hash,
-                            "elicitation_id": elicitation_id,
-                            "task": task,
-                        }
-                elif active is not None:
-                    task = active["task"]
-                    if isinstance(task, asyncio.Task) and not task.done():
-                        # Vanished while still parked → answered in the TUI;
-                        # release the web card.
-                        await _post_external_elicitation_resolved(
-                            client, session_id, str(active["elicitation_id"])
-                        )
-                    active = None
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                _logger.exception(
-                    "cursor approval mirror poll failed; session=%s bridge_dir=%s",
-                    session_id,
-                    bridge_dir,
-                )
-            await asyncio.sleep(poll_interval_s)
+    try:
+        response = await client.post(
+            f"/v1/sessions/{session_id}/hooks/cursor-permission-request",
+            json=payload,
+        )
+    except httpx.HTTPError:
+        _logger.exception("cursor permission hook POST failed; session=%s", session_id)
+        return None
+    if response.status_code >= 400:
+        _logger.warning(
+            "cursor permission hook rejected: status=%s body=%s",
+            response.status_code,
+            response.text[:512],
+        )
+        return None
+    if not response.content:
+        # Empty 2xx → resolved elsewhere (TUI answered) or timeout: no keystroke.
+        return None
+    try:
+        result = response.json()
+    except ValueError:
+        _logger.warning("cursor permission hook returned non-JSON: %s", response.text[:512])
+        return None
+    return result if isinstance(result, dict) else None
+
+
+async def _send_cursor_keys(bridge_dir: Path, session_id: str, *keys: str) -> None:
+    """Send tmux keys to the cursor pane ONE AT A TIME, with settle pauses.
+
+    A multi-key sequence (the ``AskQuestion`` picker: ``Down``/``Space``/
+    ``Enter``) must NOT be sent as a single ``send-keys`` call — the cursor TUI
+    drops keys delivered back-to-back and needs a brief beat before it registers
+    ``Enter`` (it re-renders the picker between keys). So send each key in its
+    own call, pause between them, and pause a little longer before ``Enter``.
+    A single-key approval (``y`` / ``Escape``) just sends once. Delivery failure
+    is logged and aborts the rest of the sequence.
+    """
+    if not keys:
+        return
+    for key in keys:
+        if key == "Enter":
+            await asyncio.sleep(_KEY_ENTER_SETTLE_S)
+        try:
+            await asyncio.to_thread(send_cursor_pane_keys, bridge_dir, key)
+        except RuntimeError:
+            _logger.exception(
+                "failed to send cursor keystroke %r (of %r); session=%s", key, keys, session_id
+            )
+            return
+        await asyncio.sleep(_KEY_INTERVAL_S)
+    _logger.debug("cursor keystrokes sent: %r; session=%s", keys, session_id)
 
 
 async def _run_one_approval(
@@ -251,49 +150,79 @@ async def _run_one_approval(
     prompt: CursorApprovalPrompt,
     elicitation_id: str,
 ) -> None:
-    """Park one cursor prompt on the server and send the verdict keystroke."""
-    payload = {
-        "elicitation_id": elicitation_id,
-        "operation_type": prompt.operation_type,
-        "message": prompt.message,
-        "content_preview": prompt.preview,
-    }
-    try:
-        response = await client.post(
-            f"/v1/sessions/{session_id}/hooks/cursor-permission-request",
-            json=payload,
-        )
-    except httpx.HTTPError:
-        _logger.exception("cursor permission hook POST failed; session=%s", session_id)
+    """Park one cursor approval prompt on the server and send the verdict key."""
+    result = await _park_cursor_elicitation(
+        client,
+        session_id=session_id,
+        payload={
+            "elicitation_id": elicitation_id,
+            "operation_type": prompt.operation_type,
+            "message": prompt.message,
+            "content_preview": prompt.preview,
+        },
+    )
+    if result is None:
         return
-    if response.status_code >= 400:
-        _logger.warning(
-            "cursor permission hook rejected: status=%s body=%s",
-            response.status_code,
-            response.text[:512],
-        )
-        return
-    if not response.content:
-        # Empty 2xx → resolved elsewhere (TUI answered) or timeout: no keystroke.
-        return
-    try:
-        result = response.json()
-    except ValueError:
-        _logger.warning("cursor permission hook returned non-JSON: %s", response.text[:512])
-        return
-    action = result.get("action") if isinstance(result, dict) else None
-    key = None
+    action = result.get("action")
     if action == "accept":
-        key = prompt.accept_key
+        await _send_cursor_keys(bridge_dir, session_id, prompt.accept_key)
     elif action in {"decline", "cancel"}:
-        key = prompt.decline_key
-    if key is None:
+        # Cursor's tool-reject doesn't dismiss on the decline key alone — it
+        # opens a "Reason for rejection (Enter to submit, Esc to cancel)"
+        # sub-prompt and waits there. Follow the decline key with Enter to
+        # submit an empty reason so the rejection completes, instead of leaving
+        # the TUI parked at the reason input (which the user then has to clear
+        # by hand). The settle pause before Enter (see _send_cursor_keys) gives
+        # the reason prompt time to render first.
+        await _send_cursor_keys(bridge_dir, session_id, prompt.decline_key, "Enter")
+
+
+async def _run_one_question(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    call: CursorPendingToolCall,
+    elicitation_id: str,
+) -> None:
+    """Park one cursor ``AskQuestion`` on the server and drive the TUI picker.
+
+    Renders as the structured multiple-choice form (not an approve/reject card)
+    by sending an ``AskUserQuestion(...)`` ``content_preview`` the web UI already
+    knows how to parse. On the web verdict, translates the chosen option labels
+    into the TUI picker's key sequence (navigate → ``Space`` select → ``Enter``
+    advance/submit); a decline sends ``Escape`` to skip the question.
+    """
+    result = await _park_cursor_elicitation(
+        client,
+        session_id=session_id,
+        payload={
+            "elicitation_id": elicitation_id,
+            "operation_type": "question",
+            "message": _askquestion_message(call.args),
+            # Structured payload is the authoritative source the web UI renders
+            # (no length cap); content_preview is the ≤1024-char legacy fallback.
+            "ask_user_question": _askquestion_payload(call.args),
+            "content_preview": _askquestion_preview(call.args),
+        },
+    )
+    if result is None:
         return
-    try:
-        await asyncio.to_thread(send_cursor_pane_keys, bridge_dir, key)
-    except RuntimeError:
-        _logger.exception(
-            "failed to send cursor approval keystroke %r; session=%s", key, session_id
+    action = result.get("action")
+    if action == "accept":
+        content = result.get("content")
+        keys = _askquestion_keystrokes(call.args, content if isinstance(content, dict) else {})
+        _logger.debug(
+            "cursor question accept; session=%s content=%r keys=%r", session_id, content, keys
+        )
+        await _send_cursor_keys(bridge_dir, session_id, *keys)
+    elif action in {"decline", "cancel"}:
+        # The question picker's "Esc to skip" dismisses cleanly (no rejection-
+        # reason sub-prompt like the tool-approval gate has), so a single key.
+        await _send_cursor_keys(bridge_dir, session_id, _TRANSCRIPT_DECLINE_KEY)
+    else:
+        _logger.warning(
+            "cursor question verdict: unexpected action=%r; session=%s", action, session_id
         )
 
 
@@ -318,3 +247,506 @@ async def _post_external_elicitation_resolved(
             )
     except httpx.HTTPError:
         _logger.exception("cursor external_elicitation_resolved POST failed")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transcript-based elicitation detection (preferred over pane scraping)
+#
+# Pane scraping (above) recognises a prompt by its rendered wording, so it
+# silently misses any prompt whose verb/keys fall outside the regex (e.g. the
+# file-deletion prompt "Delete this file? → Delete (y) / Keep (n)", whose accept
+# verb "Delete" is not in the run/allow/approve allowlist). The cursor chat
+# ``store.db`` — the same store the forwarder tails — records the gated tool call
+# itself the moment cursor blocks on it, which is a far more reliable signal:
+#
+#   • A blocked tool call is written as an assistant ``tool-call`` content part
+#     carrying ``providerOptions.cursor.pendingToolCallStartedAtMs`` (an
+#     auto-run call has the part but NOT the marker). The pending call lives
+#     only inside cursor's binary protobuf *checkpoint* frame (not yet flushed
+#     as a plain-JSON ``blobs`` row), so we scan each blob's raw bytes for
+#     embedded JSON objects rather than ``json.loads``-ing the whole row.
+#   • When the call is answered (in the web UI or the TUI), cursor appends a
+#     ``tool-result`` content part with the SAME ``toolCallId``. So an active
+#     elicitation is exactly a pending ``tool-call`` whose ``toolCallId`` has no
+#     matching ``tool-result`` yet.
+#
+# This captures EVERY gated tool (Delete, Write, shell, …) with structured
+# ``toolName`` + ``args``, with the ``toolCallId`` as a stable correlation key —
+# no prompt-wording allowlist. The pane is still used to DELIVER the verdict
+# (send-keys ``y`` / ``Escape``); only DETECTION moves to the transcript.
+#
+# Verified against cursor-agent 2026.06.24; the store schema is private and
+# version-sensitive, so this remains a best-effort channel — cursor's own TUI
+# gate stays authoritative, exactly as the pane mirror's contract.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# tmux keys for the verdict. The transcript records WHAT cursor is asking but
+# not the advertised hot-keys; cursor's per-tool gate uniformly accepts ``y``
+# and rejects on ``Escape`` (empirically true across tool kinds), so map the
+# web verdict onto those rather than reading the pane for key hints.
+_TRANSCRIPT_ACCEPT_KEY = "y"
+_TRANSCRIPT_DECLINE_KEY = "Escape"
+
+# Inter-key pacing when driving the multi-step AskQuestion picker. The cursor
+# TUI re-renders between keys and drops a back-to-back burst, so keys go one at
+# a time with a short gap, and a longer settle precedes ``Enter`` (which commits
+# a question / submits) so the prior selection has rendered first.
+_KEY_INTERVAL_S = 0.15
+_KEY_ENTER_SETTLE_S = 0.4
+
+# Tool names cursor treats as shell-ish, for the card's coarse operation_type.
+_SHELL_TOOL_NAMES = frozenset({"shell", "run", "runterminalcmd", "terminal", "bash"})
+
+# Tool names that are structured multiple-choice questions, not approval gates.
+# These surface as an interactive question form (not approve/reject) and are
+# answered by driving the TUI picker rather than a single y/Escape keystroke.
+_QUESTION_TOOL_NAMES = frozenset({"askquestion"})
+
+# Short settle before surfacing a pending call. The auto-approve flash is now
+# excluded *structurally* (see read_cursor_pending_tool_calls: a committed call
+# appears without the marker), so this is only a small backstop for the sub-poll
+# race where cursor's marker frame is observed a tick before its committed frame.
+# Kept short so a genuinely-gated prompt that resolves quickly (e.g. an
+# Auto-review retry) still surfaces a card rather than being suppressed.
+_ELICITATION_SETTLE_S = 0.5
+
+
+@dataclass(frozen=True)
+class CursorPendingToolCall:
+    """One gated cursor tool call awaiting approval, parsed from ``store.db``.
+
+    :param tool_call_id: cursor's ``toolCallId`` (a stable per-call id; note it
+        may embed a newline). The correlation key between the pending
+        ``tool-call`` and its eventual ``tool-result``.
+    :param tool_name: The gated tool, e.g. ``"Delete"`` / ``"Write"`` /
+        ``"Shell"``.
+    :param args: The tool arguments, e.g. ``{"path": "…/hello.txt"}``.
+    """
+
+    tool_call_id: str
+    tool_name: str
+    args: dict[str, object]
+
+
+def cursor_tool_call_elicitation_id(session_id: str, tool_call_id: str) -> str:
+    """Return the deterministic Omnigent elicitation id for a gated tool call.
+
+    Keyed by ``toolCallId`` (hashed for a clean, fixed-width id) so the same
+    pending call maps to the same elicitation across polls and supervisor
+    restarts — the transcript analog of :func:`cursor_permission_elicitation_id`.
+    """
+    digest = hashlib.sha256(tool_call_id.encode("utf-8")).hexdigest()[:16]
+    return f"elicit_cursor_{session_id}_{digest}"
+
+
+def _iter_embedded_json_objects(raw: bytes) -> list[dict]:
+    """Extract top-level JSON objects embedded anywhere in a blob's raw bytes.
+
+    A pending tool call lives inside cursor's binary protobuf checkpoint frame
+    with the JSON message embedded (and binary protobuf before/after it), so a
+    whole-row ``json.loads`` fails. Decode as latin-1 (1 byte → 1 char, keeping
+    indices aligned; JSON is ASCII regardless) and brace-match each ``{`` while
+    tracking string state + escapes so braces inside strings don't miscount. A
+    candidate ``{`` in surrounding binary that fails to balance or parse is
+    skipped without abandoning the rest of the row.
+
+    :param raw: The raw ``blobs.data`` bytes.
+    :returns: Every successfully parsed JSON object (dicts only), in order.
+    """
+    text = raw.decode("latin-1")
+    objects: list[dict] = []
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] != "{":
+            i += 1
+            continue
+        depth = 0
+        in_str = False
+        esc = False
+        matched = False
+        j = i
+        while j < n:
+            ch = text[j]
+            if in_str:
+                if esc:
+                    esc = False
+                elif ch == "\\":
+                    esc = True
+                elif ch == '"':
+                    in_str = False
+            elif ch == '"':
+                in_str = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        obj = json.loads(text[i : j + 1])
+                    except ValueError:
+                        obj = None
+                    if isinstance(obj, dict):
+                        objects.append(obj)
+                    matched = True
+                    break
+            j += 1
+        # Advance past a matched object; otherwise step one char past this brace
+        # so binary noise containing a stray "{" can't abort the whole scan.
+        i = (j + 1) if matched else (i + 1)
+    return objects
+
+
+def _pending_started_ms(obj: dict) -> int | None:
+    """Return ``providerOptions.cursor.pendingToolCallStartedAtMs`` or ``None``."""
+    provider = obj.get("providerOptions")
+    if not isinstance(provider, dict):
+        return None
+    cursor = provider.get("cursor")
+    if not isinstance(cursor, dict):
+        return None
+    marker = cursor.get("pendingToolCallStartedAtMs")
+    return marker if isinstance(marker, int) else None
+
+
+def read_cursor_pending_tool_calls(store_path: Path) -> list[CursorPendingToolCall]:
+    """Return the gated tool calls currently awaiting a human in *store_path*.
+
+    Scans every blob for embedded JSON messages and classifies each
+    ``toolCallId`` by how its ``tool-call`` part appears:
+
+    * **pending** — appears in an object WITH ``pendingToolCallStartedAtMs``
+      (cursor is blocking on it),
+    * **committed** — appears in an object WITHOUT the marker (cursor finalized
+      it to run: either auto-approved, or approved and now executing),
+    * **resolved** — has a ``tool-result``.
+
+    A call is *awaiting a human* exactly when it is pending and NOT (committed or
+    resolved). Empirically a call that's genuinely blocked on the human appears
+    ONLY with the marker (never committed) until answered, while an
+    auto-approved / committed call appears without it — so this excludes the
+    auto-approve flash structurally, with no timing heuristic. Pure / read-only,
+    so it is safe to run alongside the forwarder tailing the same store.
+
+    :param store_path: This session's cursor ``store.db``.
+    :returns: Active pending tool calls (cursor shows them one at a time, but the
+        list supports more than one defensively), in first-seen order.
+    """
+    pending: dict[str, CursorPendingToolCall] = {}
+    committed: set[str] = set()
+    resolved: set[str] = set()
+    for _rowid, _blob_id, data in _read_blob_rows(store_path, 0):
+        raw = bytes(data) if isinstance(data, (bytes, bytearray)) else str(data).encode("utf-8")
+        for obj in _iter_embedded_json_objects(raw):
+            content = obj.get("content")
+            if not isinstance(content, list):
+                continue
+            marker = _pending_started_ms(obj)
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                part_type = part.get("type")
+                tool_call_id = part.get("toolCallId")
+                if not isinstance(tool_call_id, str):
+                    continue
+                if part_type == "tool-call":
+                    if marker is not None:
+                        tool_name = part.get("toolName")
+                        args = part.get("args")
+                        pending[tool_call_id] = CursorPendingToolCall(
+                            tool_call_id=tool_call_id,
+                            tool_name=tool_name if isinstance(tool_name, str) else "tool",
+                            args=args if isinstance(args, dict) else {},
+                        )
+                    else:
+                        committed.add(tool_call_id)
+                elif part_type == "tool-result":
+                    resolved.add(tool_call_id)
+    return [
+        call for tcid, call in pending.items() if tcid not in committed and tcid not in resolved
+    ]
+
+
+def _preview_for_args(args: dict[str, object]) -> str:
+    """Build a compact human preview from a gated tool call's args."""
+    for key in ("command", "path", "file_path", "filePath", "target"):
+        value = args.get(key)
+        if isinstance(value, str) and value:
+            return value[:1024]
+    try:
+        return json.dumps(args, ensure_ascii=False)[:1024]
+    except (TypeError, ValueError):
+        return str(args)[:1024]
+
+
+def _prompt_from_pending(call: CursorPendingToolCall) -> CursorApprovalPrompt:
+    """Adapt a transcript-detected pending call to the existing card payload.
+
+    Reuses :class:`CursorApprovalPrompt` (and thus :func:`_run_one_approval`)
+    so the server hook, card rendering and keystroke path are unchanged — only
+    the detection source differs.
+    """
+    preview = _preview_for_args(call.args)
+    operation_type = "shell" if call.tool_name.lower() in _SHELL_TOOL_NAMES else "tool"
+    return CursorApprovalPrompt(
+        operation_type=operation_type,
+        message=f"Cursor wants to run {call.tool_name}",
+        preview=preview,
+        accept_key=_TRANSCRIPT_ACCEPT_KEY,
+        decline_key=_TRANSCRIPT_DECLINE_KEY,
+    )
+
+
+def _is_question_call(call: CursorPendingToolCall) -> bool:
+    """Whether a pending call is a structured question rather than a gate."""
+    return call.tool_name.lower() in _QUESTION_TOOL_NAMES
+
+
+def _iter_askquestion_questions(args: dict[str, object]) -> list[dict]:
+    """Return the well-formed question dicts from an ``AskQuestion`` args blob."""
+    questions = args.get("questions")
+    if not isinstance(questions, list):
+        return []
+    return [q for q in questions if isinstance(q, dict)]
+
+
+def _askquestion_message(args: dict[str, object]) -> str:
+    """Card title for an ``AskQuestion`` (its ``title``, else a generic label)."""
+    title = args.get("title")
+    return title if isinstance(title, str) and title else "Cursor is asking a question"
+
+
+def _askquestion_payload(args: dict[str, object]) -> dict[str, object]:
+    """Translate cursor ``AskQuestion`` args into the web ``AskUserQuestion`` shape.
+
+    The web UI renders the multiple-choice form from a ``{"questions": [...]}``
+    structure (see ``ap-web`` ``askUserQuestion`` lib). cursor's field names
+    differ — its question text is ``prompt`` (vs ``question``) and it has no
+    ``multiSelect`` — so map them across, preserving each question ``id`` we'll
+    need to interpret the answer.
+    """
+    web_questions: list[dict[str, object]] = []
+    for question in _iter_askquestion_questions(args):
+        prompt = question.get("prompt") or question.get("question")
+        options = question.get("options")
+        if not isinstance(prompt, str) or not prompt or not isinstance(options, list):
+            continue
+        web_options = [
+            {"label": opt["label"]}
+            for opt in options
+            if isinstance(opt, dict) and isinstance(opt.get("label"), str) and opt["label"]
+        ]
+        if not web_options:
+            continue
+        web_question: dict[str, object] = {
+            "question": prompt,
+            "options": web_options,
+            "multiSelect": question.get("multiSelect") is True,
+        }
+        qid = question.get("id")
+        if isinstance(qid, str) and qid:
+            web_question["id"] = qid
+        web_questions.append(web_question)
+    return {"questions": web_questions}
+
+
+def _askquestion_preview(args: dict[str, object]) -> str:
+    """``AskUserQuestion(...)`` preview string — the legacy ≤1024-char fallback.
+
+    The structured ``ask_user_question`` hook field (see :func:`_run_one_question`)
+    is the authoritative source the web UI consumes; this preview is the
+    binary-card fallback for when that field is absent or truncated.
+    """
+    return "AskUserQuestion(" + json.dumps(_askquestion_payload(args)) + ")"
+
+
+def _askquestion_keystrokes(args: dict[str, object], content: dict) -> list[str]:
+    """Compute the TUI key sequence that enters ``content`` and submits.
+
+    cursor's picker: ``↑/↓`` move within a question's options, ``Space`` toggles
+    the highlighted option, ``Enter`` advances to the next question (or submits
+    on the last); the highlight resets to the first option of each question. The
+    web form answers (``content``) are keyed by question ``id`` (else question
+    text) with the chosen option *label(s)* as the value. For each question, in
+    order, we move down to each chosen option, ``Space``-select it, then press
+    ``Enter`` to advance/submit.
+
+    A chosen value not matching any predefined option is treated as a free-form
+    answer: navigate to the trailing "Other (type to answer)" row and type it.
+    """
+    keys: list[str] = []
+    for question in _iter_askquestion_questions(args):
+        prompt = question.get("prompt") or question.get("question")
+        qid = question.get("id")
+        answer_key = qid if isinstance(qid, str) and qid else prompt
+        labels = [opt.get("label") for opt in question.get("options", []) if isinstance(opt, dict)]
+        answer = content.get(answer_key) if isinstance(answer_key, str) else None
+        if isinstance(answer, list):
+            chosen: list[object] = answer
+        elif isinstance(answer, str):
+            chosen = [answer]
+        else:
+            chosen = []
+        # The "Other" row sits just past the predefined options.
+        other_index = len(labels)
+        # Map each chosen value to a target row, keeping ascending order so the
+        # ``Down`` navigation is monotonic; custom values target the Other row.
+        targets: list[tuple[int, str | None]] = []
+        for value in chosen:
+            if value in labels:
+                targets.append((labels.index(value), None))
+            elif isinstance(value, str) and value:
+                targets.append((other_index, value))
+        pos = 0
+        for index, custom_text in sorted(targets, key=lambda t: t[0]):
+            keys.extend(["Down"] * (index - pos))
+            pos = index
+            if custom_text is not None:
+                # Typing into the Other row implicitly selects it.
+                keys.append(custom_text)
+            else:
+                keys.append("Space")
+        keys.append("Enter")  # advance to the next question / submit on the last
+    return keys
+
+
+async def supervise_cursor_transcript_elicitations(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    workspace: str,
+    launch_epoch_ms: int,
+    auth: httpx.Auth | None = None,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+    settle_s: float = _ELICITATION_SETTLE_S,
+) -> None:
+    """Mirror cursor's gated tool calls to web elicitations via the chat store.
+
+    The transcript counterpart of :func:`supervise_cursor_approval_mirror`:
+    instead of scraping the rendered pane, it tails this session's cursor
+    ``store.db`` for pending tool calls (see
+    :func:`read_cursor_pending_tool_calls`). A call is surfaced only once it has
+    stayed continuously pending for ``settle_s`` — auto-approved calls resolve
+    inside cursor's gate-decision window and so never produce a (flashing) card,
+    while a call that truly waits on a human persists well past it. A surfaced
+    call is parked on the server hook exactly as the pane mirror does; on the web
+    verdict it sends the ``y`` / ``Escape`` keystroke into the pane, and when a
+    surfaced call later vanishes from the store while still parked (answered in
+    the TUI, or executed after approval) it releases the card via
+    ``external_elicitation_resolved``.
+
+    Store discovery reuses the forwarder's logic, so this binds to the same chat
+    the forwarder mirrors. Detection is keyed by ``toolCallId`` (stable across
+    polls and restarts), capturing every gated tool kind without a
+    prompt-wording allowlist.
+
+    :param base_url: Server base URL.
+    :param headers: Auth/routing headers for the runner's requests.
+    :param session_id: Omnigent conversation id.
+    :param bridge_dir: The cursor-native bridge dir holding ``tmux.json``.
+    :param workspace: The session's working directory (cursor's chat-dir key).
+    :param launch_epoch_ms: Wall-clock ms when this terminal launched.
+    :param auth: Optional httpx auth for the runner's requests.
+    :param poll_interval_s: Store poll cadence in seconds.
+    :param settle_s: How long a call must stay pending before it is surfaced.
+    """
+    # tool_call_id → {"elicitation_id": str, "task": asyncio.Task} for SURFACED
+    # (parked) calls; tool_call_id → loop-time first seen pending, for calls
+    # still inside the settle window (not yet surfaced).
+    active: dict[str, dict[str, object]] = {}
+    first_seen: dict[str, float] = {}
+    store_path: Path | None = None
+    loop = asyncio.get_running_loop()
+    timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=headers, auth=auth, timeout=timeout
+    ) as client:
+        while True:
+            try:
+                if store_path is None or not store_path.exists():
+                    store_path = await asyncio.to_thread(
+                        _discover_store, workspace, launch_epoch_ms
+                    )
+                pending_calls = (
+                    await asyncio.to_thread(read_cursor_pending_tool_calls, store_path)
+                    if store_path is not None
+                    else []
+                )
+                seen_ids = {call.tool_call_id for call in pending_calls}
+                now = loop.time()
+                # Surfaced calls whose pending entry vanished → answered in the
+                # TUI (or executed after approval): release the web card.
+                for tool_call_id in [tcid for tcid in active if tcid not in seen_ids]:
+                    entry = active.pop(tool_call_id)
+                    task = entry["task"]
+                    if isinstance(task, asyncio.Task) and not task.done():
+                        await _post_external_elicitation_resolved(
+                            client, session_id, str(entry["elicitation_id"])
+                        )
+                # Calls that vanished before settling were auto-approved — drop
+                # their debounce timer silently (no card was ever shown).
+                for tool_call_id in [tcid for tcid in first_seen if tcid not in seen_ids]:
+                    pending_for = now - first_seen.pop(tool_call_id, now)
+                    _logger.debug(
+                        "cursor elicitation: pending call resolved within settle window "
+                        "(%.2fs) — no card; session=%s tool_call_id=%s",
+                        pending_for,
+                        session_id,
+                        tool_call_id.splitlines()[0],
+                    )
+                # Surface calls that have now stayed pending past the settle window.
+                for call in pending_calls:
+                    if call.tool_call_id in active:
+                        continue
+                    is_new = call.tool_call_id not in first_seen
+                    first = first_seen.setdefault(call.tool_call_id, now)
+                    if is_new:
+                        _logger.debug(
+                            "cursor elicitation: pending %s detected, settling %.1fs; "
+                            "session=%s tool_call_id=%s",
+                            call.tool_name,
+                            settle_s,
+                            session_id,
+                            call.tool_call_id.splitlines()[0],
+                        )
+                    if now - first < settle_s:
+                        continue
+                    elicitation_id = cursor_tool_call_elicitation_id(session_id, call.tool_call_id)
+                    _logger.debug(
+                        "cursor elicitation: surfacing %s; session=%s tool_call_id=%s",
+                        call.tool_name,
+                        session_id,
+                        call.tool_call_id.splitlines()[0],
+                    )
+                    if _is_question_call(call):
+                        coro = _run_one_question(
+                            client,
+                            session_id=session_id,
+                            bridge_dir=bridge_dir,
+                            call=call,
+                            elicitation_id=elicitation_id,
+                        )
+                    else:
+                        coro = _run_one_approval(
+                            client,
+                            session_id=session_id,
+                            bridge_dir=bridge_dir,
+                            prompt=_prompt_from_pending(call),
+                            elicitation_id=elicitation_id,
+                        )
+                    task = asyncio.create_task(coro, name=f"cursor-approval-{elicitation_id}")
+                    active[call.tool_call_id] = {
+                        "elicitation_id": elicitation_id,
+                        "task": task,
+                    }
+                    first_seen.pop(call.tool_call_id, None)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "cursor transcript elicitation poll failed; session=%s bridge_dir=%s",
+                    session_id,
+                    bridge_dir,
+                )
+            await asyncio.sleep(poll_interval_s)

--- a/omnigent/cursor_native_permissions.py
+++ b/omnigent/cursor_native_permissions.py
@@ -357,13 +357,23 @@ def _iter_embedded_json_objects(raw: bytes) -> list[dict]:
     objects: list[dict] = []
     i, n = 0, len(text)
     while i < n:
+        # Only attempt at a plausible object opener: ``{`` then (whitespace) ``"``.
+        # Every message/part object we care about is keyed (``{"type"``, ``{"role"``,
+        # ``{"args":{"…``), so this skips the stray ``{`` bytes that pepper the
+        # surrounding binary protobuf — cheaply and without false starts.
         if text[i] != "{":
+            i += 1
+            continue
+        k = i + 1
+        while k < n and text[k] in " \t\r\n":
+            k += 1
+        if k >= n or text[k] != '"':
             i += 1
             continue
         depth = 0
         in_str = False
         esc = False
-        matched = False
+        parsed_ok = False
         j = i
         while j < n:
             ch = text[j]
@@ -387,12 +397,14 @@ def _iter_embedded_json_objects(raw: bytes) -> list[dict]:
                         obj = None
                     if isinstance(obj, dict):
                         objects.append(obj)
-                    matched = True
+                        parsed_ok = True
                     break
             j += 1
-        # Advance past a matched object; otherwise step one char past this brace
-        # so binary noise containing a stray "{" can't abort the whole scan.
-        i = (j + 1) if matched else (i + 1)
+        # Jump past the object ONLY when it parsed; a balanced-but-invalid span
+        # (a stray opener whose braces happened to balance around real JSON) must
+        # advance by one so the genuine object nested inside still gets scanned —
+        # otherwise a large binary checkpoint frame can swallow a real tool-call.
+        i = (j + 1) if parsed_ok else (i + 1)
     return objects
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1663,7 +1663,7 @@ async def _auto_create_cursor_terminal(
     _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
 
     from omnigent.cursor_native_forwarder import supervise_cursor_forwarder
-    from omnigent.cursor_native_permissions import supervise_cursor_approval_mirror
+    from omnigent.cursor_native_permissions import supervise_cursor_transcript_elicitations
 
     if server_client is not None and ensure_comment_relay is not None:
         await ensure_comment_relay(
@@ -1680,8 +1680,11 @@ async def _auto_create_cursor_terminal(
         them under one task keeps a single registration/cancellation handle
         (:func:`_register_auto_forwarder_task`) for session teardown. The
         forwarder mirrors cursor-agent's replies onto the conversation; the
-        approval mirror surfaces cursor's native tool-approval prompts as web
-        elicitations (see :mod:`omnigent.cursor_native_permissions`).
+        transcript elicitation detector surfaces cursor's native tool-approval
+        prompts as web elicitations by tailing the chat store for pending tool
+        calls (see :mod:`omnigent.cursor_native_permissions`) — more reliable
+        than scraping the rendered pane, which misses prompts whose wording
+        falls outside its regex.
         """
         await asyncio.gather(
             supervise_cursor_forwarder(
@@ -1694,11 +1697,13 @@ async def _auto_create_cursor_terminal(
                 launch_epoch_ms=launch_epoch_ms,
                 auth=_runner_auth,
             ),
-            supervise_cursor_approval_mirror(
+            supervise_cursor_transcript_elicitations(
                 base_url=server_url,
                 headers={},
                 session_id=session_id,
                 bridge_dir=bridge_dir,
+                workspace=workspace,
+                launch_epoch_ms=launch_epoch_ms,
                 auth=_runner_auth,
             ),
         )

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -15296,6 +15296,18 @@ def create_sessions_router(
         operation_type = payload.get("operation_type")
         if not isinstance(operation_type, str) or not operation_type:
             operation_type = "tool"
+        # Structured AskQuestion payload (cursor's multiple-choice tool): when
+        # present, stamp it as the ``ask_user_question`` extra so the web UI
+        # renders the interactive form from it directly. ``content_preview`` is
+        # hard-capped at 1024 chars, which truncates a multi-question payload and
+        # breaks the preview-parse fallback — the structured field has no such
+        # cap and is the authoritative source the UI consumes when present.
+        extras: dict[str, Any] = {}
+        ask_user_question = payload.get("ask_user_question")
+        if isinstance(ask_user_question, dict) and isinstance(
+            ask_user_question.get("questions"), list
+        ):
+            extras["ask_user_question"] = ask_user_question
         params = ElicitationRequestParams(
             mode="form",
             message=message,
@@ -15304,6 +15316,7 @@ def create_sessions_router(
             phase="pre_tool_use",
             policy_name="cursor_native_permission",
             content_preview=content_preview,
+            **extras,
         )
         result = await _publish_and_wait_for_harness_elicitation(
             request,

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -341,6 +341,62 @@ async def test_qwen_permission_request_hook_allow_round_trip(
     assert resp.json() == {"action": "accept"}
 
 
+async def test_cursor_permission_request_hook_stamps_ask_user_question_extra(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    cursor ``AskQuestion`` → the structured ``ask_user_question`` extra is
+    published on the elicitation params (uncapped), so the web UI renders the
+    interactive form from it rather than parsing the ≤1024-char content_preview.
+
+    Catches: a multi-question payload silently dropped (web falls back to the
+    raw approve/reject card); the extra not surviving the params round-trip.
+    """
+    agent = await create_test_agent(client, "test-cursor-askquestion")
+    session_id = await _create_session(client, agent["id"])
+    elicitation_id = f"elicit_cursor_{session_id}_q1"
+    ask_user_question = {
+        "questions": [
+            {
+                "id": "demo_topic",
+                "question": "What kind of example would you like to see?",
+                "options": [
+                    {"label": "A coding-related question"},
+                    {"label": "A workflow question"},
+                ],
+                "multiSelect": False,
+            }
+        ]
+    }
+    payload = {
+        "elicitation_id": elicitation_id,
+        "operation_type": "question",
+        "message": "AskQuestion Demo",
+        "content_preview": "AskUserQuestion({...})",
+        "ask_user_question": ask_user_question,
+    }
+
+    drain_task = asyncio.create_task(_drain_until_elicitation(session_id))
+    await asyncio.sleep(0.05)
+    hook_task = asyncio.create_task(
+        client.post(
+            f"/v1/sessions/{session_id}/hooks/cursor-permission-request",
+            json=payload,
+        )
+    )
+
+    event = await drain_task
+    params = event["params"]
+    assert params["policy_name"] == "cursor_native_permission"
+    # The structured payload rode through verbatim as the params extra.
+    assert params["ask_user_question"] == ask_user_question
+
+    verdict = await _post_approval(client, session_id, elicitation_id, "accept")
+    assert verdict.status_code == 202, verdict.text
+    resp = await hook_task
+    assert resp.status_code == 200, resp.text
+
+
 async def test_top_level_elicitations_route_is_not_mounted(
     app: FastAPI,
     client: httpx.AsyncClient,

--- a/tests/test_cursor_native_permissions.py
+++ b/tests/test_cursor_native_permissions.py
@@ -1,17 +1,16 @@
-"""Unit tests for the cursor-native tool-approval mirror.
+"""Unit tests for cursor-native elicitation surfacing.
 
-Covers everything a live cursor-agent isn't needed for, with the tmux + HTTP
-boundaries faked:
+Covers everything a live cursor-agent isn't needed for, with the store + tmux +
+HTTP boundaries faked:
 
-* **Parser** — parsing an approval block out of rendered pane text
-  (subject/title/keys/operation type), rejecting non-approval panes (notably
-  the first-run Workspace-Trust modal, which uses ``[key]`` brackets rather
-  than the ``(key)`` parentheses of a tool-approval prompt), dedup-hash
-  stability, and the elicitation-id format.
-* **Mirror supervisor** — ``_run_one_approval`` (park → verdict → keystroke),
-  ``_post_external_elicitation_resolved`` (un-park on TUI-side answer), and
-  ``supervise_cursor_approval_mirror`` (detect → spawn → release) driven with a
-  fake pane capture, fake send-keys, and a stub async client.
+* **Transcript detection** — reading pending tool calls out of the chat
+  ``store.db`` (incl. binary checkpoint frames), suppressing resolved/auto-run
+  calls, and the stable elicitation-id format.
+* **Supervisor** — surfacing a settled pending call, the debounce that drops
+  auto-approved calls, and the TUI-resolved release.
+* **Verdict delivery** — ``_run_one_approval`` (park → verdict → keystroke,
+  incl. the reject → reason-prompt → Enter two-step) and ``_run_one_question``
+  (AskQuestion form → picker keystrokes).
 * **Bridge helpers** — ``capture_cursor_pane`` / ``send_cursor_pane_keys`` with
   the tmux primitives monkeypatched.
 
@@ -23,6 +22,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json as _json
+import sqlite3 as _sqlite3
 from pathlib import Path
 
 import httpx
@@ -31,88 +32,11 @@ import pytest
 from omnigent import cursor_native_bridge as cnb
 from omnigent import cursor_native_permissions as cnp
 from omnigent.cursor_native_permissions import (
-    cursor_permission_elicitation_id,
-    parse_cursor_approval_prompt,
+    CursorApprovalPrompt,
+    CursorPendingToolCall,
+    cursor_tool_call_elicitation_id,
+    read_cursor_pending_tool_calls,
 )
-
-# A faithful capture of cursor-agent's shell approval block (the widget the
-# mirror keys on), as rendered by ``tmux capture-pane -p``.
-_SHELL_PANE = """ $  echo omnigent_probe > out.txt in .
-
- Run this command?
- Shell allowlist is empty
-  → Run (once) (y)
-    Run Everything (shift+tab)
-    Skip (esc or n)
-"""
-
-# The first-run Workspace-Trust modal — must NOT be mistaken for a tool prompt.
-_TRUST_PANE = """  │  ⚠ Workspace Trust Required
-  │  Do you trust the contents of this directory?
-  │    [a] Trust this workspace
-  │    [q] Quit
-"""
-
-
-def test_parse_shell_approval_extracts_subject_title_and_keys() -> None:
-    """A shell approval block yields the command, title, and advertised keys."""
-    prompt = parse_cursor_approval_prompt(_SHELL_PANE)
-
-    assert prompt is not None
-    assert prompt.title == "Run this command?"
-    assert prompt.subject == "echo omnigent_probe > out.txt"
-    assert prompt.operation_type == "shell"
-    assert prompt.accept_key == "y"
-    assert prompt.decline_key == "Escape"
-    # The card renders the command for the user to review.
-    assert "echo omnigent_probe > out.txt" in prompt.preview
-    assert prompt.message
-
-
-@pytest.mark.parametrize(
-    "pane",
-    [
-        pytest.param("", id="empty"),
-        pytest.param("idle\n> Add a follow-up", id="idle-input"),
-        pytest.param(_TRUST_PANE, id="workspace-trust-modal"),
-        pytest.param(
-            " Run this command?\n  → Run (once) [y]\n    Skip [n]\n",
-            id="bracket-keys-not-parens",
-        ),
-    ],
-)
-def test_parse_returns_none_for_non_approval_panes(pane: str) -> None:
-    """Non-approval panes (incl. the trust modal) are not parsed as prompts."""
-    assert parse_cursor_approval_prompt(pane) is None
-
-
-def test_block_hash_is_stable_across_identical_captures() -> None:
-    """The same prompt seen on two polls dedupes to the same hash and id."""
-    first = parse_cursor_approval_prompt(_SHELL_PANE)
-    second = parse_cursor_approval_prompt(_SHELL_PANE)
-
-    assert first is not None and second is not None
-    assert first.block_hash == second.block_hash
-
-
-def test_block_hash_differs_for_a_different_command() -> None:
-    """A different command produces a different dedup hash (a new prompt)."""
-    other_pane = _SHELL_PANE.replace("echo omnigent_probe", "rm -rf build")
-    first = parse_cursor_approval_prompt(_SHELL_PANE)
-    other = parse_cursor_approval_prompt(other_pane)
-
-    assert first is not None and other is not None
-    assert first.block_hash != other.block_hash
-
-
-def test_elicitation_id_is_deterministic_and_session_scoped() -> None:
-    """The elicitation id is stable for a (session, block) and carries both."""
-    eid = cursor_permission_elicitation_id("conv_abc", "deadbeef")
-
-    assert eid == cursor_permission_elicitation_id("conv_abc", "deadbeef")
-    assert eid != cursor_permission_elicitation_id("conv_xyz", "deadbeef")
-    assert "conv_abc" in eid
-    assert eid.startswith("elicit_cursor_")
 
 
 class _QueueClient:
@@ -128,35 +52,45 @@ class _QueueClient:
 
 
 @pytest.mark.parametrize(
-    ("response", "expected_key"),
+    ("response", "expected_keys"),
     [
-        pytest.param(httpx.Response(200, json={"action": "accept"}), "y", id="accept->y"),
-        pytest.param(httpx.Response(200, json={"action": "decline"}), "Escape", id="decline->esc"),
-        pytest.param(httpx.Response(200, json={"action": "cancel"}), "Escape", id="cancel->esc"),
-        pytest.param(httpx.Response(200), None, id="empty-200->no-key"),
-        pytest.param(httpx.Response(400, text="nope"), None, id="rejected->no-key"),
-        pytest.param(httpx.Response(200, content=b"not-json"), None, id="non-json->no-key"),
+        pytest.param(httpx.Response(200, json={"action": "accept"}), ["y"], id="accept->y"),
+        # Decline/cancel: the decline key opens cursor's "Reason for rejection"
+        # sub-prompt, so a follow-up Enter submits an empty reason to complete it.
         pytest.param(
-            httpx.Response(200, json={"action": "??"}), None, id="unknown-action->no-key"
+            httpx.Response(200, json={"action": "decline"}), ["Escape", "Enter"], id="decline->esc"
         ),
+        pytest.param(
+            httpx.Response(200, json={"action": "cancel"}), ["Escape", "Enter"], id="cancel->esc"
+        ),
+        pytest.param(httpx.Response(200), [], id="empty-200->no-key"),
+        pytest.param(httpx.Response(400, text="nope"), [], id="rejected->no-key"),
+        pytest.param(httpx.Response(200, content=b"not-json"), [], id="non-json->no-key"),
+        pytest.param(httpx.Response(200, json={"action": "??"}), [], id="unknown-action->no-key"),
     ],
 )
 @pytest.mark.asyncio
 async def test_run_one_approval_posts_then_sends_verdict_keystroke(
     response: httpx.Response,
-    expected_key: str | None,
+    expected_keys: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Park a prompt on the server, then drive the TUI with the verdict key.
+    """Park a prompt on the server, then drive the TUI with the verdict key(s).
 
     The hook POST always carries the renderable fields; a keystroke is sent ONLY
-    for a concrete accept (``accept_key``) or decline/cancel (``decline_key``)
-    verdict — an empty 2xx (answered in the TUI / timeout), a rejection, a
-    non-JSON body, or an unknown action sends nothing.
+    for a concrete accept (``accept_key``) or decline/cancel (``decline_key`` +
+    ``Enter`` to submit the empty rejection reason) verdict — an empty 2xx
+    (answered in the TUI / timeout), a rejection, a non-JSON body, or an unknown
+    action sends nothing.
     """
-    prompt = parse_cursor_approval_prompt(_SHELL_PANE)
-    assert prompt is not None
+    prompt = CursorApprovalPrompt(
+        operation_type="shell",
+        message="Cursor wants to run Shell",
+        preview="echo omnigent_probe > out.txt",
+        accept_key="y",
+        decline_key="Escape",
+    )
     sent: list[tuple[Path, tuple[str, ...]]] = []
     monkeypatch.setattr(cnp, "send_cursor_pane_keys", lambda d, *keys: sent.append((d, keys)))
     client = _QueueClient([response])
@@ -177,7 +111,8 @@ async def test_run_one_approval_posts_then_sends_verdict_keystroke(
         "message": prompt.message,
         "content_preview": prompt.preview,
     }
-    assert sent == ([] if expected_key is None else [(tmp_path, (expected_key,))])
+    # Keys are sent one per call (see _send_cursor_keys), so each is its own tuple.
+    assert sent == [(tmp_path, (key,)) for key in expected_keys]
 
 
 @pytest.mark.asyncio
@@ -191,83 +126,6 @@ async def test_post_external_elicitation_resolved_shape() -> None:
         "type": "external_elicitation_resolved",
         "data": {"elicitation_id": "elic_9"},
     }
-
-
-@pytest.mark.asyncio
-async def test_supervise_mirror_parks_new_prompt_then_releases_on_vanish(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Detect → spawn a park task → release it when the prompt vanishes unanswered.
-
-    Drives one full cycle: the first poll sees the shell prompt (spawns the park
-    task), the next sees an empty pane while that task is still parked — the
-    user answered in the TUI — so the supervisor posts
-    ``external_elicitation_resolved`` to clear the web card.
-    """
-    created: list[object] = []
-
-    class _FakeAsyncClient:
-        def __init__(self, **_kw: object) -> None:
-            self.posts: list[tuple[str, dict]] = []
-            created.append(self)
-
-        async def __aenter__(self) -> _FakeAsyncClient:
-            return self
-
-        async def __aexit__(self, *_a: object) -> bool:
-            return False
-
-        async def post(self, url: str, *, json: dict, **_kw: object) -> httpx.Response:
-            self.posts.append((url, json))
-            return httpx.Response(200, request=httpx.Request("POST", url))
-
-    monkeypatch.setattr(cnp.httpx, "AsyncClient", _FakeAsyncClient)
-
-    # Pane: the prompt on the first poll, gone thereafter.
-    panes = iter([_SHELL_PANE])
-    monkeypatch.setattr(cnp, "capture_cursor_pane", lambda _d: next(panes, ""))
-
-    # Hold the park task pending so the vanish path takes the release branch
-    # (a completed task means the verdict already landed → no release needed).
-    started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def _fake_run_one(_client: object, **_kw: object) -> None:
-        started.set()
-        await release.wait()
-
-    monkeypatch.setattr(cnp, "_run_one_approval", _fake_run_one)
-
-    task = asyncio.create_task(
-        cnp.supervise_cursor_approval_mirror(
-            base_url="http://t",
-            headers={},
-            session_id="conv_3",
-            bridge_dir=tmp_path,
-            poll_interval_s=0.001,
-        )
-    )
-    try:
-        await asyncio.wait_for(started.wait(), 2.0)
-        for _ in range(400):
-            if created and getattr(created[0], "posts", None):
-                break
-            await asyncio.sleep(0.005)
-        assert created, "supervisor never opened a client"
-        url, body = created[0].posts[0]  # type: ignore[attr-defined]
-        assert url == "/v1/sessions/conv_3/events"
-        assert body["type"] == "external_elicitation_resolved"
-        prompt = parse_cursor_approval_prompt(_SHELL_PANE)
-        assert prompt is not None
-        assert body["data"]["elicitation_id"] == cursor_permission_elicitation_id(
-            "conv_3", prompt.block_hash
-        )
-    finally:
-        release.set()
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
 
 def test_capture_cursor_pane_returns_pane_or_none(
@@ -310,3 +168,474 @@ def test_send_cursor_pane_keys_raises_without_target(
     monkeypatch.setattr(cnb, "read_tmux_info", lambda _d: None)
     with pytest.raises(RuntimeError):
         cnb.send_cursor_pane_keys(tmp_path, "y")
+
+
+# ── Transcript-based detector ────────────────────────────────────────────────
+#
+# These cover the chat-store detection path that replaced pane scraping as the
+# primary signal. A pending (approval-gated) tool call is recorded as an
+# assistant ``tool-call`` content part carrying
+# ``providerOptions.cursor.pendingToolCallStartedAtMs``, embedded inside a
+# binary protobuf checkpoint frame; it is "answered" when a ``tool-result`` with
+# the same ``toolCallId`` is appended. The fixtures below mirror the real
+# store-blob shapes verified against cursor-agent 2026.06.24.
+
+
+def _write_store(path: Path, blobs: list[bytes]) -> None:
+    """Create a minimal cursor-shaped ``store.db`` with the given raw blobs."""
+    con = _sqlite3.connect(str(path))
+    try:
+        con.execute("CREATE TABLE blobs (id TEXT, data BLOB)")
+        con.executemany(
+            "INSERT INTO blobs (id, data) VALUES (?, ?)",
+            [(f"blob{i}", data) for i, data in enumerate(blobs)],
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _framed(obj: dict) -> bytes:
+    """Wrap a JSON message in fake binary protobuf noise, as cursor checkpoints do.
+
+    The real pending tool-call blob is a protobuf frame with the JSON embedded
+    and arbitrary binary (including stray ``{`` / ``"`` bytes) before and after
+    it — the case the scanner must survive without aborting the row.
+    """
+    prefix = b"\n \x16\xa0\x815\x13b\xc6mt2\x90{ noise \xff\x00"  # incl. a stray "{"
+    suffix = b"*\x8e\x02\x08\xff\x01 trailing \x00\xfe"
+    return prefix + _json.dumps(obj).encode("utf-8") + suffix
+
+
+def _pending_tool_call_obj(tool_call_id: str, tool_name: str, args: dict) -> dict:
+    return {
+        "id": "1",
+        "role": "assistant",
+        "content": [
+            {"type": "tool-call", "toolCallId": tool_call_id, "toolName": tool_name, "args": args}
+        ],
+        "providerOptions": {"cursor": {"pendingToolCallStartedAtMs": 1782373529662}},
+    }
+
+
+def _tool_result_obj(tool_call_id: str) -> dict:
+    return {
+        "role": "tool",
+        "content": [{"type": "tool-result", "toolCallId": tool_call_id, "result": "ok"}],
+    }
+
+
+def test_read_pending_detects_framed_gated_tool_call(tmp_path: Path) -> None:
+    """A pending tool-call embedded in a binary frame is detected with its args.
+
+    This is the exact failure the pane parser missed: a file-deletion gate whose
+    accept verb ("Delete") is outside the pane regex's allowlist.
+    """
+    store = tmp_path / "store.db"
+    _write_store(
+        store,
+        [
+            b'{"role":"user","content":"<user_query>delete it</user_query>"}',
+            _framed(_pending_tool_call_obj("call_abc\nfc_1", "Delete", {"path": "/x/hello.txt"})),
+        ],
+    )
+    calls = read_cursor_pending_tool_calls(store)
+    assert len(calls) == 1
+    assert calls[0] == CursorPendingToolCall(
+        tool_call_id="call_abc\nfc_1", tool_name="Delete", args={"path": "/x/hello.txt"}
+    )
+
+
+def test_read_pending_suppresses_resolved_call(tmp_path: Path) -> None:
+    """A pending call whose tool-result has landed is no longer active."""
+    store = tmp_path / "store.db"
+    _write_store(
+        store,
+        [
+            _framed(_pending_tool_call_obj("call_done\nfc_2", "Read", {"path": "/x/a"})),
+            _json.dumps(_tool_result_obj("call_done\nfc_2")).encode("utf-8"),
+        ],
+    )
+    assert read_cursor_pending_tool_calls(store) == []
+
+
+def test_read_pending_excludes_committed_call(tmp_path: Path) -> None:
+    """A marker'd call that ALSO appears committed (no-marker tool-call) is excluded.
+
+    This is the auto-approve case: cursor stamps the pending marker while deciding,
+    then finalizes the call to run — writing the same tool-call WITHOUT the marker.
+    The committed (no-marker) appearance means cursor is no longer blocked on the
+    human, so it must not surface a card even before the tool-result lands.
+    """
+    store = tmp_path / "store.db"
+    committed = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool-call",
+                "toolCallId": "call_w\nfc",
+                "toolName": "Write",
+                "args": {"path": "/x"},
+            }
+        ],
+        "providerOptions": {"cursor": {"modelProviderMessageId": "m1"}},
+    }
+    _write_store(
+        store,
+        [
+            _framed(_pending_tool_call_obj("call_w\nfc", "Write", {"path": "/x"})),
+            _json.dumps(committed).encode("utf-8"),
+        ],
+    )
+    assert read_cursor_pending_tool_calls(store) == []
+
+
+def test_read_pending_ignores_autorun_call_without_marker(tmp_path: Path) -> None:
+    """A clean-JSON tool-call lacking the pending marker (auto-ran) is ignored."""
+    store = tmp_path / "store.db"
+    autorun = {
+        "role": "assistant",
+        "content": [
+            {"type": "tool-call", "toolCallId": "call_auto", "toolName": "Read", "args": {}}
+        ],
+        "providerOptions": {"cursor": {"modelProviderMessageId": "m1"}},
+    }
+    _write_store(store, [_json.dumps(autorun).encode("utf-8")])
+    assert read_cursor_pending_tool_calls(store) == []
+
+
+def test_read_pending_detects_multiple_distinct_gated_calls(tmp_path: Path) -> None:
+    """Two distinct pending calls are both surfaced; a resolved one is dropped."""
+    store = tmp_path / "store.db"
+    _write_store(
+        store,
+        [
+            _framed(_pending_tool_call_obj("call_1\nfc", "Delete", {"path": "/a"})),
+            _framed(_pending_tool_call_obj("call_2\nfc", "Write", {"path": "/b"})),
+            _framed(_pending_tool_call_obj("call_3\nfc", "Read", {"path": "/c"})),
+            _json.dumps(_tool_result_obj("call_3\nfc")).encode("utf-8"),
+        ],
+    )
+    names = sorted(c.tool_name for c in read_cursor_pending_tool_calls(store))
+    assert names == ["Delete", "Write"]
+
+
+def test_tool_call_elicitation_id_is_stable_and_scoped(tmp_path: Path) -> None:
+    """The id is deterministic per (session, toolCallId) and embeds the session."""
+    a = cursor_tool_call_elicitation_id("conv_x", "call_1\nfc")
+    b = cursor_tool_call_elicitation_id("conv_x", "call_1\nfc")
+    c = cursor_tool_call_elicitation_id("conv_y", "call_1\nfc")
+    assert a == b and a != c
+    assert a.startswith("elicit_cursor_conv_x_")
+
+
+async def test_supervise_transcript_parks_new_call_then_releases_on_resolve(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """detect pending → POST hook; on resolve (call vanishes) → POST resolved."""
+    posts: list[tuple[str, dict]] = []
+
+    pending_now = [
+        CursorPendingToolCall(tool_call_id="call_z\nfc", tool_name="Delete", args={"path": "/x"})
+    ]
+
+    monkeypatch.setattr(cnp, "_discover_store", lambda *_a, **_k: tmp_path / "store.db")
+    (tmp_path / "store.db").write_bytes(b"")  # exists() check
+    monkeypatch.setattr(cnp, "read_cursor_pending_tool_calls", lambda _s: list(pending_now))
+    # Keystroke + park boundaries faked.
+    monkeypatch.setattr(cnp, "send_cursor_pane_keys", lambda *_a, **_k: None)
+
+    class _Resp:
+        status_code = 200
+        content = b""
+
+        def json(self) -> dict:
+            return {}
+
+    release = asyncio.Event()
+
+    class _Client:
+        async def post(self, url: str, json: dict | None = None, **_k):
+            posts.append((url, json or {}))
+            if "hooks/cursor-permission-request" in url:
+                # Simulate a parked hook (no web verdict yet): stay open until
+                # released, so the call is still "active" when it vanishes from
+                # the store — exercising the TUI-answered release path.
+                await release.wait()
+            return _Resp()
+
+    monkeypatch.setattr(cnp.httpx, "AsyncClient", lambda **_k: _FakeAsyncCM(_Client()))
+
+    task = asyncio.create_task(
+        cnp.supervise_cursor_transcript_elicitations(
+            base_url="http://x",
+            headers={},
+            session_id="conv_z",
+            bridge_dir=tmp_path,
+            workspace="/ws",
+            launch_epoch_ms=0,
+            poll_interval_s=0.01,
+            settle_s=0.0,  # surface immediately; debounce covered separately
+        )
+    )
+    # Let it detect + park the pending call.
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if any("hooks/cursor-permission-request" in u for u, _ in posts):
+            break
+    # Now the call disappears (answered in TUI) → expect a resolved POST.
+    pending_now.clear()
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if any(j.get("type") == "external_elicitation_resolved" for _, j in posts):
+            break
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert any("hooks/cursor-permission-request" in u for u, _ in posts)
+    assert any(j.get("type") == "external_elicitation_resolved" for _, j in posts)
+
+
+async def test_supervise_transcript_debounces_autoapproved_call(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A call that resolves within the settle window surfaces NO card at all.
+
+    This is the auto-approve case: cursor stamps the pending marker while it
+    decides, then auto-approves and executes before a human is ever asked. With
+    a settle window, the detector must neither park a hook nor post a resolved
+    event — otherwise the web UI flashes a card that flips to "resolved
+    elsewhere" for a call no human saw.
+    """
+    posts: list[tuple[str, dict]] = []
+
+    pending_now = [
+        CursorPendingToolCall(tool_call_id="call_auto\nfc", tool_name="Write", args={"path": "/x"})
+    ]
+
+    monkeypatch.setattr(cnp, "_discover_store", lambda *_a, **_k: tmp_path / "store.db")
+    (tmp_path / "store.db").write_bytes(b"")
+    monkeypatch.setattr(cnp, "read_cursor_pending_tool_calls", lambda _s: list(pending_now))
+    monkeypatch.setattr(cnp, "send_cursor_pane_keys", lambda *_a, **_k: None)
+
+    class _Resp:
+        status_code = 200
+        content = b""
+
+        def json(self) -> dict:
+            return {}
+
+    class _Client:
+        async def post(self, url: str, json: dict | None = None, **_k):
+            posts.append((url, json or {}))
+            return _Resp()
+
+    monkeypatch.setattr(cnp.httpx, "AsyncClient", lambda **_k: _FakeAsyncCM(_Client()))
+
+    task = asyncio.create_task(
+        cnp.supervise_cursor_transcript_elicitations(
+            base_url="http://x",
+            headers={},
+            session_id="conv_a",
+            bridge_dir=tmp_path,
+            workspace="/ws",
+            launch_epoch_ms=0,
+            poll_interval_s=0.01,
+            settle_s=0.2,  # long enough to span several polls before we resolve
+        )
+    )
+    # Let a few polls run while the call is pending (still inside settle window).
+    await asyncio.sleep(0.1)
+    # Auto-approved: the call resolves (vanishes) before the settle window ends.
+    pending_now.clear()
+    await asyncio.sleep(0.2)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert not any("hooks/cursor-permission-request" in u for u, _ in posts), posts
+    assert not any(j.get("type") == "external_elicitation_resolved" for _, j in posts), posts
+
+
+# ── AskQuestion (structured multiple-choice) ─────────────────────────────────
+#
+# cursor's ``AskQuestion`` tool is NOT an approval gate — it is a multi-question
+# picker. It surfaces with the pending marker like any gated call, but must
+# render as the web ``AskUserQuestion`` form (not approve/reject) and be answered
+# by driving the TUI picker. Args shape verified against cursor-agent 2026.06.24.
+
+_ASKQUESTION_ARGS = {
+    "title": "AskQuestion Demo",
+    "questions": [
+        {
+            "id": "demo_topic",
+            "prompt": "What kind of example would you like to see?",
+            "options": [
+                {"id": "coding", "label": "A coding-related question (Recommended)"},
+                {"id": "workflow", "label": "A workflow/planning question"},
+                {"id": "fun", "label": "A fun preference question"},
+            ],
+        },
+        {
+            "id": "demo_depth",
+            "prompt": "How detailed should the follow-up be?",
+            "options": [
+                {"id": "brief", "label": "Brief (Recommended)"},
+                {"id": "detailed", "label": "Detailed"},
+            ],
+        },
+    ],
+}
+
+
+def test_is_question_call_distinguishes_askquestion() -> None:
+    """``AskQuestion`` routes to the question path; other tools to approval."""
+    assert cnp._is_question_call(CursorPendingToolCall("t", "AskQuestion", _ASKQUESTION_ARGS))
+    assert not cnp._is_question_call(CursorPendingToolCall("t", "Delete", {"path": "/x"}))
+    assert not cnp._is_question_call(CursorPendingToolCall("t", "Shell", {"command": "ls"}))
+
+
+def test_askquestion_preview_translates_to_web_form_shape() -> None:
+    """cursor args → the ``AskUserQuestion(...)`` preview the web UI parses.
+
+    cursor's ``prompt`` becomes ``question``; options keep only ``label``; each
+    question ``id`` is preserved (the answer comes back keyed by it).
+    """
+    preview = cnp._askquestion_preview(_ASKQUESTION_ARGS)
+    assert preview.startswith("AskUserQuestion(") and preview.endswith(")")
+    payload = _json.loads(preview[len("AskUserQuestion(") : -1])
+    assert [q["question"] for q in payload["questions"]] == [
+        "What kind of example would you like to see?",
+        "How detailed should the follow-up be?",
+    ]
+    assert [q["id"] for q in payload["questions"]] == ["demo_topic", "demo_depth"]
+    assert payload["questions"][0]["options"] == [
+        {"label": "A coding-related question (Recommended)"},
+        {"label": "A workflow/planning question"},
+        {"label": "A fun preference question"},
+    ]
+    assert all(q["multiSelect"] is False for q in payload["questions"])
+
+
+def test_askquestion_keystrokes_navigate_to_chosen_options() -> None:
+    """Chosen labels map to Down-navigation + Space + Enter per question."""
+    # First option of each question (index 0): just Space + Enter.
+    keys = cnp._askquestion_keystrokes(
+        _ASKQUESTION_ARGS,
+        {
+            "demo_topic": "A coding-related question (Recommended)",
+            "demo_depth": "Brief (Recommended)",
+        },
+    )
+    assert keys == ["Space", "Enter", "Space", "Enter"]
+
+    # Second option of each (index 1): one Down, Space, Enter — per question.
+    keys = cnp._askquestion_keystrokes(
+        _ASKQUESTION_ARGS,
+        {"demo_topic": "A workflow/planning question", "demo_depth": "Detailed"},
+    )
+    assert keys == ["Down", "Space", "Enter", "Down", "Space", "Enter"]
+
+
+def test_askquestion_keystrokes_types_into_other_row_for_custom_answer() -> None:
+    """A value matching no predefined option targets the trailing Other row."""
+    keys = cnp._askquestion_keystrokes(
+        _ASKQUESTION_ARGS,
+        {"demo_topic": "something custom", "demo_depth": "Detailed"},
+    )
+    # Q1 has 3 options → Other row at index 3: Down×3 then type the text.
+    assert keys == ["Down", "Down", "Down", "something custom", "Enter", "Down", "Space", "Enter"]
+
+
+async def test_run_one_question_renders_form_then_drives_picker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The hook gets an AskUserQuestion preview; the verdict drives the picker."""
+    posts: list[tuple[str, dict]] = []
+    sent_keys: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(cnp, "send_cursor_pane_keys", lambda _d, *keys: sent_keys.append(keys))
+
+    class _Resp:
+        status_code = 200
+        # Web verdict: accept with the user's selected labels, keyed by question id.
+        content = b"x"
+
+        def json(self) -> dict:
+            return {
+                "action": "accept",
+                "content": {
+                    "demo_topic": "A workflow/planning question",
+                    "demo_depth": "Detailed",
+                },
+            }
+
+    class _Client:
+        async def post(self, url: str, json: dict | None = None, **_k):
+            posts.append((url, json or {}))
+            return _Resp()
+
+    await cnp._run_one_question(
+        _Client(),
+        session_id="conv_q",
+        bridge_dir=tmp_path,
+        call=CursorPendingToolCall("tc\nq", "AskQuestion", _ASKQUESTION_ARGS),
+        elicitation_id="elicit_cursor_conv_q_abc",
+    )
+
+    # 1) The hook payload carries the AskUserQuestion form preview, not raw JSON.
+    assert len(posts) == 1
+    url, body = posts[0]
+    assert "hooks/cursor-permission-request" in url
+    assert body["operation_type"] == "question"
+    assert body["content_preview"].startswith("AskUserQuestion(")
+    # Structured payload (uncapped) is the authoritative source the web renders.
+    assert body["ask_user_question"]["questions"][0]["id"] == "demo_topic"
+    assert body["ask_user_question"]["questions"][0]["question"] == (
+        "What kind of example would you like to see?"
+    )
+    # 2) The verdict drove the picker to the chosen options (index 1 in each).
+    flat = [k for group in sent_keys for k in group]
+    assert flat == ["Down", "Space", "Enter", "Down", "Space", "Enter"]
+
+
+async def test_run_one_question_decline_skips_via_escape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A declined question sends Escape (skip), not an option selection."""
+    sent_keys: list[tuple[str, ...]] = []
+    monkeypatch.setattr(cnp, "send_cursor_pane_keys", lambda _d, *keys: sent_keys.append(keys))
+
+    class _Resp:
+        status_code = 200
+        content = b"x"
+
+        def json(self) -> dict:
+            return {"action": "decline"}
+
+    class _Client:
+        async def post(self, url: str, json: dict | None = None, **_k):
+            return _Resp()
+
+    await cnp._run_one_question(
+        _Client(),
+        session_id="conv_q",
+        bridge_dir=tmp_path,
+        call=CursorPendingToolCall("tc", "AskQuestion", _ASKQUESTION_ARGS),
+        elicitation_id="e",
+    )
+    assert [k for group in sent_keys for k in group] == ["Escape"]
+
+
+class _FakeAsyncCM:
+    """Minimal async-context-manager wrapper around a fake client."""
+
+    def __init__(self, client: object) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> object:
+        return self._client
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False

--- a/tests/test_cursor_native_permissions.py
+++ b/tests/test_cursor_native_permissions.py
@@ -225,6 +225,29 @@ def _tool_result_obj(tool_call_id: str) -> dict:
     }
 
 
+def test_iter_embedded_json_recovers_from_enclosing_garbage() -> None:
+    """A stray opener whose braces balance AROUND the real object must not hide it.
+
+    Large cursor checkpoint frames contain binary that can form a ``{ … }`` span
+    enclosing a real message object while itself being invalid JSON. The scanner
+    must keep going (advance by one) and still extract the inner object — not
+    jump past the whole failed span (which dropped genuinely-pending tool calls,
+    e.g. MCP, in big frames).
+    """
+    inner = _json.dumps(_pending_tool_call_obj("call_mcp\nfc", "omnigent-list_comments", {"x": 1}))
+    # Leading "{"k": … <inner> … bad}" balances at the trailing brace but fails
+    # to parse; the genuine object is nested inside it.
+    raw = b'{"k": ' + inner.encode("utf-8") + b" trailing-bad}"
+    objs = cnp._iter_embedded_json_objects(raw)
+    names = [
+        p.get("toolName")
+        for o in objs
+        for p in (o.get("content") or [])
+        if isinstance(p, dict) and p.get("type") == "tool-call"
+    ]
+    assert "omnigent-list_comments" in names
+
+
 def test_read_pending_detects_framed_gated_tool_call(tmp_path: Path) -> None:
     """A pending tool-call embedded in a binary frame is detected with its args.
 


### PR DESCRIPTION
## What

Surfaces cursor-agent's native **tool-approval gates** and **`AskQuestion`** prompts as Omnigent web elicitation cards, answerable from the web UI or the embedded TUI — for every gated tool kind (shell, `Delete`, `Write`/`ApplyPatch`, MCP, …), not just the ones whose prompt wording matched a regex.

## Verified demo

https://github.com/user-attachments/assets/3acba60c-4521-4cfe-8378-05b909210a07

## How

Detection moves from **scraping the rendered TUI pane** to **tailing the cursor chat `store.db`** (the same store the forwarder mirrors):

- A pending call is an assistant `tool-call` part carrying `providerOptions.cursor.pendingToolCallStartedAtMs` (inside cursor's binary protobuf checkpoint frames) with no matching `tool-result`.
- It's excluded once the same `toolCallId` appears **without** the marker (committed / auto-approved) or gets a `tool-result`. This **structural discriminator** removes the auto-approve flash with no timing heuristic; the settle window is now just a 0.5s sub-poll-race backstop.
- The stable `toolCallId` is the dedup + elicitation-id key — solving the identical-consecutive-commands problem the old plan flagged as "the tricky part."

The pane is still used only to **deliver** the verdict keystroke:
- Keys are sent **one at a time** with a settle before `Enter` (the TUI drops a back-to-back burst).
- Approval **reject** sends the decline key then `Enter` to submit cursor's empty "Reason for rejection" sub-prompt (otherwise the TUI parks there).
- **`AskQuestion`** renders as the existing `AskUserQuestion` form (via a structured, uncapped `ask_user_question` hook extra) and is answered by driving the picker (`Down`/`Space`/`Enter`, plus the "Other" type row).

The web card labels cursor prompts **"Cursor has questions"**.

The now-dead pane-scraping path (parser + mirror supervisor) is removed.

## Docs

Adds `docs/cursor-native-elicitation.md` and supersedes `docs/cursor-native-tui-mirror-plan.md`. Notably: the old plan's premise that "the store has only the user message while pending" was an **investigation gap, not a cursor-version difference** — the pending marker is present in stores back to 2026.06.18; it just lives in binary frames that don't `json.loads` as a plain blob.

## Testing

- `tests/test_cursor_native_permissions.py` (25): transcript detection, committed-exclusion discriminator, AskQuestion preview/keystrokes/form-flow, reject two-step, debounce.
- `tests/server/integration/test_sessions_permission_request_hook.py`: the `ask_user_question` extra round-trip.
- `ap-web` `ApprovalCard.test.tsx` (36): the "Cursor has questions" label.
- Manually verified end-to-end live (cursor-agent 2026.06.24): Delete/Shell/MCP approvals (approve + reject), auto-approve suppression, and multi-question AskQuestion with non-default + custom answers.

This pull request and its description were written by Isaac.