### PR TITLE
feat(cursor-native): track session cost / token usage

### DIFF
--- a/docs/cursor-native-cost-tracking.md
+++ b/docs/cursor-native-cost-tracking.md
@@ -1,0 +1,154 @@
+# Cursor-native cost / token-usage tracking
+
+**Status:** Prototype (implemented; behind a live e2e validation)
+**Date:** 2026-06-25
+**Harness:** `cursor-native` (the `omnigent cursor` interactive TUI wrapper)
+
+## 1. Motivation
+
+The web UI already renders a **Session cost** badge and a per-model **token
+usage breakdown** (`AgentInfo.tsx` → `chatStore` → `session.usage` SSE event).
+claude-native and codex-native feed it; cursor-native did not — its info
+popover showed everything *except* cost/usage. This adds that feed.
+
+## 2. Why it was thought impossible (and what changed)
+
+The earlier investigation concluded cursor-native couldn't report usage:
+
+- **SQLite chat store** (`~/.cursor/chats/<md5(cwd)>/<chat-id>/store.db`,
+  tailed by `cursor_native_forwarder.py`) — message blobs only; **no** token or
+  cost data.
+- **`~/.cursor/projects/<ws>/agent-transcripts/<id>.jsonl`** — exists, but the
+  `turn_ended` record is just `{type, status}`; **no** usage.
+- **Headless `--print --output-format stream-json`** emits a `result.usage`
+  object — but that's the SDK/headless path, not the interactive TUI the
+  cursor-native harness drives.
+
+**What changed:** cursor-agent ships a Claude-Code-style **hooks** system, and
+the `stop` (and `afterAgentResponse`) hooks fire **in the interactive TUI** with
+per-turn token usage. Verified live against `cursor-agent 2026.06.24` by driving
+the real TUI through a PTY with a registered hook — captured `stop` payload:
+
+```json
+{
+  "conversation_id": "6eb5549f-…", "generation_id": "0b1b8c24-…",
+  "model": "claude-4-sonnet", "status": "completed", "loop_count": 0,
+  "input_tokens": 23666, "output_tokens": 5,
+  "cache_read_tokens": 23617, "cache_write_tokens": 47,
+  "session_id": "6eb5549f-…", "hook_event_name": "stop",
+  "transcript_path": "…/agent-transcripts/6eb5549f-….jsonl"
+}
+```
+
+> Note: Cursor's public hooks docs (cursor.com/docs/hooks) lag the binary — they
+> document `afterAgentResponse` as `{text}` only and omit `stop`. This CLI
+> version emits both with the token fields above. The forum confirms usage
+> shipped to the CLI ~Feb 2026.
+
+Hooks are delivered the payload as JSON on **stdin** and run only in the
+interactive loop (a `-p`/headless run does **not** fire them — also verified).
+
+## 3. Data flow
+
+```
+cursor-agent TUI  ── stop hook (per turn, JSON on stdin) ──▶
+  python -m omnigent.cursor_native_usage record-usage --bridge-dir <dir>
+      └─ appends one normalized line to <bridge_dir>/cursor_usage.jsonl
+          ▲
+          │  (runner-owned poll loop, ~0.7s)
+  supervise_cursor_usage_forwarder
+      └─ tails cursor_usage.jsonl, sums per-turn counts → cumulative totals
+      └─ POST /v1/sessions/{id}/events  type=external_session_usage
+              { cumulative_input_tokens, cumulative_output_tokens,
+                cumulative_cache_read_input_tokens, model }
+                  │
+  server _persist_external_session_usage (SET semantics, monotonic)
+      └─ prices tokens via fetch_model_pricing(model)  [if catalog-priced]
+      └─ broadcasts session.usage SSE  → chatStore → AgentInfo.tsx
+```
+
+This reuses the **exact** server contract claude/codex-native already use
+(`external_session_usage` → `_persist_native_cumulative_usage`), so **no server
+or frontend changes are required**.
+
+## 4. Components added
+
+| File | Change |
+|---|---|
+| `omnigent/cursor_native_usage.py` | **New.** Hook recorder (`record-usage`, stdlib-only) + cumulative accumulator + runner-owned poller/supervisor + `clear_cursor_usage_state`. |
+| `omnigent/cursor_native_bridge.py` | `build_hooks_config` / `write_hooks_config` — write `<workspace>/.cursor/hooks.json` registering the `stop` hook (sibling of `write_mcp_config`). |
+| `omnigent/runner/app.py` | In the cursor terminal setup: `write_hooks_config(...)`, `clear_cursor_usage_state(...)`, and `supervise_cursor_usage_forwarder(...)` added to the existing `_supervise_cursor_native_bridges` gather. |
+
+### Hook recorder (`record-usage`)
+- Reads the `stop` payload from stdin, normalizes to
+  `{generation_id, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens}`,
+  appends one line to `cursor_usage.jsonl` (`O_APPEND`).
+- **Always** prints `{}` and exits 0 — usage capture must never block/fail a
+  turn. Imports only the stdlib so the hook stays fast (cursor blocks turn-end
+  on it).
+
+### Accumulator semantics
+- cursor reports **per-turn** counts; session billing is their **sum** (each
+  turn is billed for the full context it re-sent, so summing per-turn
+  `input_tokens` — cache reads included — is the correct cumulative input).
+- Deduped by `generation_id`, so re-reading the append-only log every poll (and
+  after a supervisor restart) never double-counts. State persisted to
+  `<bridge_dir>/cursor_usage_forwarder.json`; written only **after** a
+  successful POST so a failed flush retries.
+
+### Token field mapping
+cursor's `input_tokens` is **inclusive** of cache-read + cache-write (the TUI
+subtracts them for display). We forward it inclusive as
+`cumulative_input_tokens` and pass `cumulative_cache_read_input_tokens`; the
+server splits the cache-read portion out and prices it at the cache-read rate.
+
+## 5. Cost vs. tokens (known limitation)
+
+`external_session_usage` prices tokens server-side via
+`fetch_model_pricing(model)`. The `model` from the hook is **cursor's id**
+(e.g. `claude-4-sonnet`, `composer-2.5`), which often does **not** match the
+MLflow catalog:
+
+| cursor model id | catalog resolves? | result |
+|---|---|---|
+| `claude-4-sonnet` | provider=anthropic, **no exact price** (catalog has `claude-sonnet-4-5`) | tokens shown, cost "—" |
+| `composer-2.5` | no provider (Cursor's own model) | tokens shown, cost "—" |
+| `gpt-5` | priced | tokens **and** cost |
+
+So **token usage always populates**; **dollar cost** appears only for models
+whose cursor id matches the catalog. We intentionally forward the **raw** cursor
+id rather than guess a version alias (a wrong version = wrong rate, which is
+worse than showing "—").
+
+**Follow-up for full cost:** add a cursor→catalog model alias map (e.g.
+`claude-4-sonnet → claude-sonnet-4-5`) — either in `cursor_native_usage` before
+POST, or as a cursor-aware branch in `fetch_model_pricing`. Out of scope for
+this prototype.
+
+## 6. Other caveats / follow-ups
+
+- **Cache-write tokens** aren't separately priced: the server's native
+  cumulative path splits out only `cache_read`, so cursor's `cache_write_tokens`
+  stay in the input bucket and price at the full input rate. Minor; matches the
+  field set the server accepts today.
+- **Same-workspace concurrent sessions:** `hooks.json` is workspace-scoped (like
+  `mcp.json`), so the last-launched session's `--bridge-dir` wins. Usage would
+  route to that session. Same limitation the MCP config already has; the store
+  forwarder's claim logic doesn't cover hooks.
+- **Trust gate:** project hooks load only in a trusted workspace. The
+  cursor-native flow already trusts the workspace (trust modal + cli-config), so
+  this is satisfied in practice — worth confirming in the e2e check.
+- **Hook latency:** cursor waits for the hook at turn-end. The recorder is a
+  short-lived `python -I -m …` (stdlib only); negligible, but a compiled
+  shim could remove the interpreter-spawn cost if it ever matters.
+
+## 7. Testing
+
+- **Unit/logic (done, offline):** drove the real `record-usage` CLI with two
+  captured `stop` payloads → correct `cursor_usage.jsonl`; accumulator produced
+  the expected cumulative POST body; verified dedup (re-read ≠ double-count) and
+  skip-empty.
+- **e2e (pending):** launch `omnigent cursor`, run a couple of turns, confirm
+  the Session-cost / token-usage popover updates in the web UI. The
+  `cursor-sdk-e2e-dev` skill spins up a live server; cursor-native needs the TUI
+  path (PTY-driven), so reuse the cursor-native e2e harness.

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -32,6 +32,7 @@ _BRIDGE_ROOT = Path(tempfile.gettempdir()) / f"omnigent-{stable_user_id()}" / "c
 _TMUX_FILE = "tmux.json"
 _BRIDGE_CONFIG_FILE = "bridge.json"
 _MCP_CONFIG_FILE = "mcp.json"
+_HOOKS_CONFIG_FILE = "hooks.json"
 _MCP_SERVER_NAME = "omnigent"
 _CURSOR_AUTO_APPROVE_TOOLS = [
     "list_comments",
@@ -191,6 +192,59 @@ def write_mcp_config(
     os.replace(tmp, path)
     enable_mcp_for_workspace(workspace)
     allow_mcp_tools_in_cli_config()
+    return path
+
+
+def build_hooks_config(
+    bridge_dir: Path, *, python_executable: str | None = None
+) -> dict[str, Any]:
+    """Build Cursor's ``.cursor/hooks.json`` registering the usage ``stop`` hook.
+
+    cursor-agent fires the ``stop`` hook once per completed turn with a JSON
+    payload (on stdin) carrying that turn's token usage — the only surface where
+    the interactive TUI exposes usage. The hook command runs
+    ``omnigent.cursor_native_usage record-usage``, which appends the usage to
+    ``<bridge_dir>/cursor_usage.jsonl`` for the runner's usage forwarder to tail
+    and post as ``external_session_usage`` (lighting up the web Session-cost
+    badge). Bakes the absolute ``--bridge-dir`` so the recorder writes where the
+    forwarder reads, regardless of the hook's working directory.
+    """
+    import shlex
+
+    python = python_executable or sys.executable
+    command = " ".join(
+        shlex.quote(part)
+        for part in (
+            python,
+            "-I",
+            "-m",
+            "omnigent.cursor_native_usage",
+            "record-usage",
+            "--bridge-dir",
+            str(bridge_dir),
+        )
+    )
+    return {"version": 1, "hooks": {"stop": [{"command": command}]}}
+
+
+def write_hooks_config(
+    workspace: Path,
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> Path:
+    """Write the workspace-scoped Cursor ``hooks.json`` capturing per-turn usage.
+
+    Sibling of :func:`write_mcp_config`: project-scoped Cursor config the TUI
+    loads on launch in a trusted workspace. Returns the written path.
+    """
+    cursor_dir = workspace / ".cursor"
+    cursor_dir.mkdir(parents=True, exist_ok=True)
+    path = cursor_dir / _HOOKS_CONFIG_FILE
+    payload = build_hooks_config(bridge_dir, python_executable=python_executable)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
     return path
 
 

--- a/omnigent/cursor_native_usage.py
+++ b/omnigent/cursor_native_usage.py
@@ -1,0 +1,368 @@
+"""Token-usage capture for the cursor-native harness.
+
+cursor-agent surfaces per-turn token usage ONLY through its lifecycle hooks —
+the SQLite chat store (tailed by :mod:`omnigent.cursor_native_forwarder`) and
+the on-disk ``agent-transcripts`` JSONL carry none, and the headless
+``result.usage`` is unavailable to the interactive TUI the harness drives. So we
+register a ``hooks.json`` ``stop`` hook (see
+:func:`omnigent.cursor_native_bridge.write_hooks_config`) whose command runs
+``record-usage`` here. cursor invokes it once per completed turn with a JSON
+payload on stdin:
+
+    {"generation_id": "...", "model": "claude-4-sonnet",
+     "input_tokens": 23666, "output_tokens": 5,
+     "cache_read_tokens": 23617, "cache_write_tokens": 47, ...}
+
+``record-usage`` appends one normalized line per turn to
+``<bridge_dir>/cursor_usage.jsonl``. The runner-owned poller
+(:func:`forward_cursor_usage_to_session`) tails that file, accumulates the
+per-turn counts into cumulative SESSION totals, and POSTs them as an
+``external_session_usage`` event — the SAME server contract claude-native and
+codex-native use, so the web UI's Session-cost badge and per-model token
+breakdown light up with no frontend changes.
+
+The recorder path imports only the stdlib so the hook stays fast (cursor blocks
+the turn end on the hook); ``httpx`` is imported lazily inside the poller.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+#: Append-only log of per-turn usage written by the ``stop`` hook recorder and
+#: tailed by the poller. One JSON object per line (per completed turn).
+USAGE_FILE = "cursor_usage.jsonl"
+
+#: Durable poller state (cumulative totals + processed generation ids), so a
+#: supervisor restart resumes without double-counting already-posted turns.
+_USAGE_STATE_FILE = "cursor_usage_forwarder.json"
+
+#: Per-turn usage fields we lift out of cursor's ``stop`` payload. cursor's
+#: ``input_tokens`` is INCLUSIVE of cache-read + cache-write (the TUI subtracts
+#: them for its own display); we forward it inclusive and let the server split
+#: the cache-read portion out via ``cumulative_cache_read_input_tokens``.
+_TOKEN_FIELDS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens")
+
+_DEFAULT_POLL_INTERVAL_S = 0.7
+_POST_TIMEOUT_S = 30.0
+
+# Supervisor backoff (mirrors cursor_native_forwarder.supervise_cursor_forwarder).
+_SUPERVISOR_INITIAL_BACKOFF_S = 1.0
+_SUPERVISOR_MAX_BACKOFF_S = 30.0
+_SUPERVISOR_HEALTHY_UPTIME_S = 60.0
+
+
+# --------------------------------------------------------------------------- #
+# Hook-side recorder (stdlib only — keep fast; cursor blocks the turn on it).
+# --------------------------------------------------------------------------- #
+
+
+def _coerce_int(value: object) -> int:
+    """Coerce a hook token field to a non-negative int (0 on anything odd)."""
+    try:
+        out = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+    return out if out >= 0 else 0
+
+
+def normalize_hook_payload(payload: object) -> dict[str, object] | None:
+    """Reduce a cursor ``stop`` hook payload to the usage line we persist.
+
+    :returns: ``{"generation_id", "model", <token fields>}`` when the payload
+        carries a generation id and at least one positive token count, else
+        ``None`` (skip — nothing to bill for this turn).
+    """
+    if not isinstance(payload, dict):
+        return None
+    gen_id = payload.get("generation_id") or payload.get("conversation_id")
+    if not isinstance(gen_id, str) or not gen_id:
+        return None
+    tokens = {field_name: _coerce_int(payload.get(field_name)) for field_name in _TOKEN_FIELDS}
+    if not any(tokens.values()):
+        return None
+    model = payload.get("model")
+    line: dict[str, object] = {"generation_id": gen_id}
+    if isinstance(model, str) and model:
+        line["model"] = model
+    line.update(tokens)
+    return line
+
+
+def record_usage_payload(bridge_dir: Path, payload: object) -> bool:
+    """Append a normalized usage line for one turn to ``cursor_usage.jsonl``.
+
+    :returns: ``True`` if a line was appended, ``False`` if the payload had no
+        billable usage (skipped).
+    """
+    line = normalize_hook_payload(payload)
+    if line is None:
+        return False
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    # O_APPEND keeps concurrent writers (a fast-firing hook) from interleaving
+    # within a single write() of one short JSON line.
+    with open(bridge_dir / USAGE_FILE, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(line, sort_keys=True) + "\n")
+    return True
+
+
+def _cli_record_usage(bridge_dir: Path) -> int:
+    """Hook entrypoint: read the JSON payload from stdin and append it.
+
+    Always emits ``{}`` (a no-op hook response cursor reads as "continue") and
+    exits 0 — a usage-capture failure must never block or fail the agent turn.
+    """
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+        record_usage_payload(bridge_dir, payload)
+    except Exception:  # noqa: BLE001 — never let usage capture break the turn
+        _logger.debug("cursor usage recorder failed", exc_info=True)
+    # cursor expects JSON on stdout; an empty object is the "continue" response.
+    sys.stdout.write("{}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Poller-side accumulator + forwarder (runner-owned).
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _UsageAccumulator:
+    """Cumulative session totals plus the generation ids already counted.
+
+    cursor reports PER-TURN counts; session billing is their sum (each turn is
+    billed for the full context it re-sent, so summing per-turn ``input_tokens``
+    — cache reads included — is the correct cumulative input). Dedup by
+    ``generation_id`` so a re-read of the append-only file (every poll, and
+    after a restart) never counts a turn twice.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    model: str | None = None
+    seen: set[str] = field(default_factory=set)
+
+    def add_line(self, line: dict[str, object]) -> bool:
+        """Fold one usage line in if unseen. Returns ``True`` when it counted."""
+        gen_id = line.get("generation_id")
+        if not isinstance(gen_id, str) or gen_id in self.seen:
+            return False
+        self.seen.add(gen_id)
+        self.input_tokens += _coerce_int(line.get("input_tokens"))
+        self.output_tokens += _coerce_int(line.get("output_tokens"))
+        self.cache_read_tokens += _coerce_int(line.get("cache_read_tokens"))
+        model = line.get("model")
+        if isinstance(model, str) and model:
+            self.model = model  # latest turn's model wins (mirrors a /model switch)
+        return True
+
+
+def _read_usage_state(bridge_dir: Path) -> _UsageAccumulator:
+    """Load the persisted accumulator, or a cold zero default."""
+    try:
+        data = json.loads((bridge_dir / _USAGE_STATE_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return _UsageAccumulator()
+    if not isinstance(data, dict):
+        return _UsageAccumulator()
+    seen = data.get("seen")
+    return _UsageAccumulator(
+        input_tokens=_coerce_int(data.get("input_tokens")),
+        output_tokens=_coerce_int(data.get("output_tokens")),
+        cache_read_tokens=_coerce_int(data.get("cache_read_tokens")),
+        model=data.get("model") if isinstance(data.get("model"), str) else None,
+        seen={s for s in seen if isinstance(s, str)} if isinstance(seen, list) else set(),
+    )
+
+
+def _write_usage_state(bridge_dir: Path, acc: _UsageAccumulator) -> None:
+    """Atomically persist the accumulator (tmp write + rename)."""
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    tmp = bridge_dir / (_USAGE_STATE_FILE + ".tmp")
+    tmp.write_text(
+        json.dumps(
+            {
+                "input_tokens": acc.input_tokens,
+                "output_tokens": acc.output_tokens,
+                "cache_read_tokens": acc.cache_read_tokens,
+                "model": acc.model,
+                "seen": sorted(acc.seen),
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.replace(tmp, bridge_dir / _USAGE_STATE_FILE)
+
+
+def _read_usage_lines(bridge_dir: Path) -> list[dict[str, object]]:
+    """Read every usage line currently in ``cursor_usage.jsonl`` (skip junk)."""
+    out: list[dict[str, object]] = []
+    try:
+        text = (bridge_dir / USAGE_FILE).read_text(encoding="utf-8")
+    except OSError:
+        return out
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def _usage_post_body(acc: _UsageAccumulator) -> dict[str, object]:
+    """Build the ``external_session_usage`` ``data`` payload from cumulative totals.
+
+    ``cumulative_input_tokens`` is sent INCLUSIVE of cache reads (cursor's
+    semantics); the server splits ``cumulative_cache_read_input_tokens`` back
+    out and prices it at the cache-read rate. ``model`` lets the server price
+    the tokens via the MLflow catalog (absent/unpriced models show tokens with
+    cost "—").
+    """
+    data: dict[str, object] = {
+        "cumulative_input_tokens": acc.input_tokens,
+        "cumulative_output_tokens": acc.output_tokens,
+        "cumulative_cache_read_input_tokens": acc.cache_read_tokens,
+    }
+    if acc.model:
+        data["model"] = acc.model
+    return data
+
+
+async def forward_cursor_usage_to_session(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    auth: object | None = None,
+) -> None:
+    """Tail ``cursor_usage.jsonl`` and POST cumulative usage to the AP session.
+
+    Each poll re-reads the append-only usage log, folds any unseen turns into
+    the cumulative accumulator (deduped by ``generation_id``), and — when the
+    totals advanced — POSTs an ``external_session_usage`` event. The accumulator
+    is persisted to ``bridge_dir`` so a supervisor restart resumes without
+    re-counting. Never returns normally; cancel the task to stop it.
+    """
+    import httpx
+
+    acc = _read_usage_state(bridge_dir)
+    timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=headers, auth=auth, timeout=timeout
+    ) as client:
+        while True:
+            try:
+                lines = await asyncio.to_thread(_read_usage_lines, bridge_dir)
+                changed = False
+                for line in lines:
+                    if acc.add_line(line):
+                        changed = True
+                if changed:
+                    resp = await client.post(
+                        f"/v1/sessions/{session_id}/events",
+                        json={"type": "external_session_usage", "data": _usage_post_body(acc)},
+                    )
+                    resp.raise_for_status()
+                    # Persist only after a successful POST so a failed flush is
+                    # retried (the unseen turns stay unseen until they land).
+                    await asyncio.to_thread(_write_usage_state, bridge_dir, acc)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "cursor usage forwarder poll failed; session=%s bridge_dir=%s",
+                    session_id,
+                    bridge_dir,
+                )
+            await asyncio.sleep(poll_interval_s)
+
+
+async def supervise_cursor_usage_forwarder(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    auth: object | None = None,
+) -> None:
+    """Run :func:`forward_cursor_usage_to_session` under a restart supervisor.
+
+    Mirrors :func:`omnigent.cursor_native_forwarder.supervise_cursor_forwarder`:
+    the poll loop swallows per-poll errors, but a crash in client setup would
+    otherwise stop usage updates for the session. Restart with bounded
+    exponential backoff; :class:`asyncio.CancelledError` propagates for clean
+    teardown. The persisted accumulator means restarts resume exactly.
+    """
+    backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+    while True:
+        run_started_at = time.monotonic()
+        crash_exc: Exception | None = None
+        try:
+            await forward_cursor_usage_to_session(
+                base_url=base_url,
+                headers=headers,
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                poll_interval_s=poll_interval_s,
+                auth=auth,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — supervisor restarts on any Exception
+            crash_exc = exc
+        if time.monotonic() - run_started_at >= _SUPERVISOR_HEALTHY_UPTIME_S:
+            backoff_s = _SUPERVISOR_INITIAL_BACKOFF_S
+        if crash_exc is not None:
+            _logger.error(
+                "cursor usage forwarder crashed; restarting in %.1fs; session=%s",
+                backoff_s,
+                session_id,
+                exc_info=crash_exc,
+            )
+        await asyncio.sleep(backoff_s)
+        backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)
+
+
+def clear_cursor_usage_state(bridge_dir: Path) -> None:
+    """Remove persisted usage state + log so a re-created terminal starts clean."""
+    for name in (_USAGE_STATE_FILE, USAGE_FILE):
+        with contextlib.suppress(OSError):
+            (bridge_dir / name).unlink()
+
+
+def _main(argv: list[str] | None = None) -> int:
+    """CLI used by the cursor ``stop`` hook: ``record-usage --bridge-dir <dir>``."""
+    parser = argparse.ArgumentParser(prog="omnigent.cursor_native_usage")
+    sub = parser.add_subparsers(dest="command", required=True)
+    rec = sub.add_parser("record-usage", help="Append a stop-hook usage payload (stdin JSON).")
+    rec.add_argument("--bridge-dir", required=True, type=Path)
+    args = parser.parse_args(argv)
+    if args.command == "record-usage":
+        return _cli_record_usage(args.bridge_dir)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1534,9 +1534,11 @@ async def _auto_create_cursor_terminal(
     from omnigent.cursor_native_bridge import (
         approve_mcp_server_for_workspace,
         bridge_dir_for_session_id,
+        write_hooks_config,
         write_mcp_config,
     )
     from omnigent.cursor_native_forwarder import clear_cursor_bridge_state, preseed_resume_state
+    from omnigent.cursor_native_usage import clear_cursor_usage_state
 
     bridge_dir = bridge_dir_for_session_id(session_id)
 
@@ -1581,6 +1583,10 @@ async def _auto_create_cursor_terminal(
     )
     if not preseeded:
         clear_cursor_bridge_state(bridge_dir)
+        # Drop any prior terminal's usage log/state so the new forwarder starts
+        # the cumulative count clean. Preserved across a preseeded resume (the
+        # accumulator's generation-id dedup makes re-reading the log safe).
+        clear_cursor_usage_state(bridge_dir)
         if resume_chat_id is not None:
             _logger.warning(
                 "cursor-native: could not pre-seed prior chat store for %r; "
@@ -1590,6 +1596,9 @@ async def _auto_create_cursor_terminal(
             )
             resume_chat_id = None
     write_mcp_config(Path(workspace), bridge_dir)
+    # Register the cursor ``stop`` hook that captures per-turn token usage into
+    # the bridge dir for the usage forwarder below (see cursor_native_usage).
+    write_hooks_config(Path(workspace), bridge_dir)
     cursor_command = resolve_cursor_executable()
     cursor_args = list(launch_config.terminal_launch_args or [])
     if "--approve-mcps" not in cursor_args:
@@ -1664,6 +1673,7 @@ async def _auto_create_cursor_terminal(
 
     from omnigent.cursor_native_forwarder import supervise_cursor_forwarder
     from omnigent.cursor_native_permissions import supervise_cursor_transcript_elicitations
+    from omnigent.cursor_native_usage import supervise_cursor_usage_forwarder
 
     if server_client is not None and ensure_comment_relay is not None:
         await ensure_comment_relay(
@@ -1684,7 +1694,9 @@ async def _auto_create_cursor_terminal(
         prompts as web elicitations by tailing the chat store for pending tool
         calls (see :mod:`omnigent.cursor_native_permissions`) — more reliable
         than scraping the rendered pane, which misses prompts whose wording
-        falls outside its regex.
+        falls outside its regex; the usage forwarder tails the ``stop``-hook
+        usage log and posts cumulative token usage / cost (see
+        :mod:`omnigent.cursor_native_usage`).
         """
         await asyncio.gather(
             supervise_cursor_forwarder(
@@ -1704,6 +1716,13 @@ async def _auto_create_cursor_terminal(
                 bridge_dir=bridge_dir,
                 workspace=workspace,
                 launch_epoch_ms=launch_epoch_ms,
+                auth=_runner_auth,
+            ),
+            supervise_cursor_usage_forwarder(
+                base_url=server_url,
+                headers={},
+                session_id=session_id,
+                bridge_dir=bridge_dir,
                 auth=_runner_auth,
             ),
         )

--- a/tests/test_cursor_native_bridge.py
+++ b/tests/test_cursor_native_bridge.py
@@ -242,3 +242,44 @@ class TestInjectModelGate:
             cursor_native_bridge.inject_model_command(bridge_dir, model="gpt-5.2")
 
         assert ["-t", _TARGET, "Enter"] not in _send_keys_calls(captured)
+
+
+class TestHooksConfig:
+    """The ``hooks.json`` that registers cursor's per-turn usage ``stop`` hook."""
+
+    def test_build_hooks_config_shape(self) -> None:
+        cfg = cursor_native_bridge.build_hooks_config(
+            Path("/tmp/bridge"), python_executable="/usr/bin/python3"
+        )
+        assert cfg["version"] == 1
+        hooks = cfg["hooks"]["stop"]
+        assert len(hooks) == 1
+        command = hooks[0]["command"]
+        # The recorder is invoked isolated (-I) on the usage module, with the
+        # absolute bridge dir baked in so it writes where the forwarder reads.
+        assert "-I" in command
+        assert "omnigent.cursor_native_usage" in command
+        assert "record-usage" in command
+        assert "/tmp/bridge" in command
+        assert command.startswith("/usr/bin/python3")
+
+    def test_build_hooks_config_quotes_spaced_paths(self) -> None:
+        cfg = cursor_native_bridge.build_hooks_config(
+            Path("/tmp/dir with space"), python_executable="/usr/bin/python3"
+        )
+        command = cfg["hooks"]["stop"][0]["command"]
+        # A shell-quoted path keeps the spaced bridge dir a single argv token.
+        assert "'/tmp/dir with space'" in command
+
+    def test_write_hooks_config_writes_project_scoped_file(self, tmp_path: Path) -> None:
+        import json
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        bridge_dir = tmp_path / "bridge"
+        path = cursor_native_bridge.write_hooks_config(workspace, bridge_dir)
+        assert path == workspace / ".cursor" / "hooks.json"
+        payload = json.loads(path.read_text())
+        assert payload["hooks"]["stop"][0]["command"].endswith(str(bridge_dir))
+        # No leftover temp file from the atomic write.
+        assert not (workspace / ".cursor" / "hooks.json.tmp").exists()

--- a/tests/test_cursor_native_usage.py
+++ b/tests/test_cursor_native_usage.py
@@ -124,8 +124,14 @@ class TestRecordUsageCli:
         # importable, mirroring the installed-package resolution in production.
         env = {"PYTHONPATH": str(Path(__file__).resolve().parents[1])}
         proc = subprocess.run(
-            [sys.executable, "-m", "omnigent.cursor_native_usage", "record-usage",
-             "--bridge-dir", str(tmp_path)],
+            [
+                sys.executable,
+                "-m",
+                "omnigent.cursor_native_usage",
+                "record-usage",
+                "--bridge-dir",
+                str(tmp_path),
+            ],
             input=json.dumps(_TURN1),
             capture_output=True,
             text=True,

--- a/tests/test_cursor_native_usage.py
+++ b/tests/test_cursor_native_usage.py
@@ -1,0 +1,342 @@
+"""Unit tests for cursor-native token-usage capture.
+
+Covers the pure pieces a live cursor-agent isn't needed for: normalizing the
+``stop``-hook payload, the append-only usage log + recorder CLI, the cumulative
+accumulator (per-turn sum + generation-id dedup), state round-trip, the
+``external_session_usage`` POST shape, and the poll loop (POST-on-change,
+no-repost-when-unchanged, persist-only-after-success). The live tmux +
+cursor-agent hook path is exercised by the e2e gate, not here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent import cursor_native_usage as usage
+
+# A representative cursor ``stop``-hook payload (live-captured field set).
+_TURN1 = {
+    "generation_id": "g1",
+    "model": "claude-4-sonnet",
+    "status": "completed",
+    "input_tokens": 23666,
+    "output_tokens": 5,
+    "cache_read_tokens": 23617,
+    "cache_write_tokens": 47,
+}
+_TURN2 = {
+    "generation_id": "g2",
+    "model": "claude-4-sonnet",
+    "status": "completed",
+    "input_tokens": 24010,
+    "output_tokens": 120,
+    "cache_read_tokens": 23700,
+    "cache_write_tokens": 60,
+}
+
+
+class TestNormalizeHookPayload:
+    def test_extracts_usage_fields(self) -> None:
+        line = usage.normalize_hook_payload(_TURN1)
+        assert line == {
+            "generation_id": "g1",
+            "model": "claude-4-sonnet",
+            "input_tokens": 23666,
+            "output_tokens": 5,
+            "cache_read_tokens": 23617,
+            "cache_write_tokens": 47,
+        }
+
+    def test_falls_back_to_conversation_id(self) -> None:
+        line = usage.normalize_hook_payload({"conversation_id": "c1", "output_tokens": 3})
+        assert line is not None and line["generation_id"] == "c1"
+
+    def test_skips_when_no_generation_id(self) -> None:
+        assert usage.normalize_hook_payload({"output_tokens": 3}) is None
+
+    def test_skips_when_all_tokens_zero(self) -> None:
+        payload = {"generation_id": "g", "input_tokens": 0, "output_tokens": 0}
+        assert usage.normalize_hook_payload(payload) is None
+
+    def test_omits_model_when_absent(self) -> None:
+        line = usage.normalize_hook_payload({"generation_id": "g", "output_tokens": 4})
+        assert line is not None and "model" not in line
+
+    def test_coerces_and_floors_negative_tokens(self) -> None:
+        line = usage.normalize_hook_payload(
+            {"generation_id": "g", "input_tokens": "7", "output_tokens": -3}
+        )
+        assert line is not None
+        assert line["input_tokens"] == 7  # coerced from str
+        assert line["output_tokens"] == 0  # negative floored
+
+    def test_non_dict_is_skipped(self) -> None:
+        assert usage.normalize_hook_payload("nope") is None
+
+
+class TestRecordUsagePayload:
+    def test_appends_one_line_per_turn(self, tmp_path: Path) -> None:
+        assert usage.record_usage_payload(tmp_path, _TURN1) is True
+        assert usage.record_usage_payload(tmp_path, _TURN2) is True
+        lines = (tmp_path / usage.USAGE_FILE).read_text().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["generation_id"] == "g1"
+
+    def test_non_billable_payload_is_skipped(self, tmp_path: Path) -> None:
+        assert usage.record_usage_payload(tmp_path, {"text": "hi"}) is False
+        assert not (tmp_path / usage.USAGE_FILE).exists()
+
+
+class TestRecordUsageCli:
+    def test_cli_reads_stdin_appends_and_emits_continue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        import io
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(_TURN1)))
+        rc = usage._cli_record_usage(tmp_path)
+        assert rc == 0
+        # cursor reads stdout as the hook response; "{}" means "continue".
+        assert capsys.readouterr().out == "{}"
+        assert (tmp_path / usage.USAGE_FILE).read_text().strip()
+
+    def test_cli_never_fails_on_garbage_stdin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        import io
+
+        monkeypatch.setattr("sys.stdin", io.StringIO("not json{{{"))
+        assert usage._cli_record_usage(tmp_path) == 0
+        assert capsys.readouterr().out == "{}"
+        assert not (tmp_path / usage.USAGE_FILE).exists()
+
+    def test_module_main_entrypoint(self, tmp_path: Path) -> None:
+        # End-to-end through the real CLI the hooks.json command invokes. ``-I``
+        # is dropped here (the worktree isn't pip-installed); PYTHONPATH makes it
+        # importable, mirroring the installed-package resolution in production.
+        env = {"PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+        proc = subprocess.run(
+            [sys.executable, "-m", "omnigent.cursor_native_usage", "record-usage",
+             "--bridge-dir", str(tmp_path)],
+            input=json.dumps(_TURN1),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout == "{}"
+        assert (tmp_path / usage.USAGE_FILE).read_text().strip()
+
+
+class TestUsageAccumulator:
+    def test_sums_per_turn_counts(self) -> None:
+        acc = usage._UsageAccumulator()
+        assert acc.add_line(usage.normalize_hook_payload(_TURN1)) is True  # type: ignore[arg-type]
+        assert acc.add_line(usage.normalize_hook_payload(_TURN2)) is True  # type: ignore[arg-type]
+        assert acc.input_tokens == 23666 + 24010
+        assert acc.output_tokens == 5 + 120
+        assert acc.cache_read_tokens == 23617 + 23700
+        assert acc.model == "claude-4-sonnet"
+
+    def test_dedups_by_generation_id(self) -> None:
+        acc = usage._UsageAccumulator()
+        line = usage.normalize_hook_payload(_TURN1)
+        assert acc.add_line(line) is True  # type: ignore[arg-type]
+        assert acc.add_line(line) is False  # type: ignore[arg-type] — same gen id, ignored
+        assert acc.output_tokens == 5  # not doubled
+
+    def test_latest_model_wins(self) -> None:
+        acc = usage._UsageAccumulator()
+        acc.add_line({"generation_id": "a", "model": "claude-4-sonnet", "output_tokens": 1})
+        acc.add_line({"generation_id": "b", "model": "gpt-5", "output_tokens": 1})
+        assert acc.model == "gpt-5"
+
+    def test_line_without_gen_id_is_ignored(self) -> None:
+        acc = usage._UsageAccumulator()
+        assert acc.add_line({"output_tokens": 9}) is False
+        assert acc.output_tokens == 0
+
+
+class TestStateRoundTrip:
+    def test_write_then_read_preserves_totals_and_seen(self, tmp_path: Path) -> None:
+        acc = usage._UsageAccumulator(
+            input_tokens=10, output_tokens=2, cache_read_tokens=4, model="gpt-5", seen={"g1"}
+        )
+        usage._write_usage_state(tmp_path, acc)
+        loaded = usage._read_usage_state(tmp_path)
+        assert loaded.input_tokens == 10
+        assert loaded.output_tokens == 2
+        assert loaded.cache_read_tokens == 4
+        assert loaded.model == "gpt-5"
+        assert loaded.seen == {"g1"}
+
+    def test_missing_state_is_cold_default(self, tmp_path: Path) -> None:
+        loaded = usage._read_usage_state(tmp_path)
+        assert (loaded.input_tokens, loaded.output_tokens, loaded.cache_read_tokens) == (0, 0, 0)
+        assert loaded.model is None and loaded.seen == set()
+
+
+class TestReadUsageLines:
+    def test_reads_valid_lines_and_skips_garbage(self, tmp_path: Path) -> None:
+        (tmp_path / usage.USAGE_FILE).write_text(
+            json.dumps({"generation_id": "g1", "output_tokens": 1})
+            + "\n\n"  # blank line tolerated
+            + "not json\n"  # garbage tolerated
+            + json.dumps({"generation_id": "g2", "output_tokens": 2})
+            + "\n"
+        )
+        lines = usage._read_usage_lines(tmp_path)
+        assert [line["generation_id"] for line in lines] == ["g1", "g2"]
+
+    def test_missing_file_is_empty(self, tmp_path: Path) -> None:
+        assert usage._read_usage_lines(tmp_path) == []
+
+
+class TestUsagePostBody:
+    def test_shape_with_model(self) -> None:
+        acc = usage._UsageAccumulator(
+            input_tokens=100, output_tokens=20, cache_read_tokens=80, model="gpt-5"
+        )
+        assert usage._usage_post_body(acc) == {
+            "cumulative_input_tokens": 100,
+            "cumulative_output_tokens": 20,
+            "cumulative_cache_read_input_tokens": 80,
+            "model": "gpt-5",
+        }
+
+    def test_omits_model_when_none(self) -> None:
+        body = usage._usage_post_body(usage._UsageAccumulator(output_tokens=5))
+        assert "model" not in body
+        assert body["cumulative_output_tokens"] == 5
+
+
+class TestClearUsageState:
+    def test_removes_log_and_state(self, tmp_path: Path) -> None:
+        usage.record_usage_payload(tmp_path, _TURN1)
+        usage._write_usage_state(tmp_path, usage._UsageAccumulator(output_tokens=1))
+        usage.clear_cursor_usage_state(tmp_path)
+        assert not (tmp_path / usage.USAGE_FILE).exists()
+        assert not (tmp_path / usage._USAGE_STATE_FILE).exists()
+
+    def test_noop_when_absent(self, tmp_path: Path) -> None:
+        usage.clear_cursor_usage_state(tmp_path)  # must not raise
+
+
+class _CtxRecordingClient:
+    """Async httpx-client stub (records POSTs, 200) usable as ``async with``."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict]] = []
+
+    async def __aenter__(self) -> _CtxRecordingClient:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def post(self, url: str, *, json: dict) -> httpx.Response:
+        self.posts.append((url, json))
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+
+async def _run_loop_until(
+    monkeypatch: pytest.MonkeyPatch,
+    bridge_dir: Path,
+    until,
+    *,
+    client: _CtxRecordingClient | None = None,
+    max_wait_s: float = 3.0,
+) -> _CtxRecordingClient:
+    """Run the real poll loop with a recording client until *until(client)* holds."""
+    client = client or _CtxRecordingClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: client)
+    task = asyncio.create_task(
+        usage.forward_cursor_usage_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv_1",
+            bridge_dir=bridge_dir,
+            poll_interval_s=0.01,
+        )
+    )
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max_wait_s
+    try:
+        while loop.time() < deadline:
+            if until(client):
+                return client
+            await asyncio.sleep(0.01)
+        raise AssertionError("loop condition was not met before timeout")
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+class TestForwardLoop:
+    async def test_posts_cumulative_usage_and_persists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        usage.record_usage_payload(tmp_path, _TURN1)
+        usage.record_usage_payload(tmp_path, _TURN2)
+        client = await _run_loop_until(monkeypatch, tmp_path, lambda c: len(c.posts) >= 1)
+        url, body = client.posts[0]
+        assert url == "/v1/sessions/conv_1/events"
+        assert body["type"] == "external_session_usage"
+        assert body["data"] == {
+            "cumulative_input_tokens": 23666 + 24010,
+            "cumulative_output_tokens": 5 + 120,
+            "cumulative_cache_read_input_tokens": 23617 + 23700,
+            "model": "claude-4-sonnet",
+        }
+        # State persisted after the successful POST so a restart resumes.
+        persisted = usage._read_usage_state(tmp_path)
+        assert persisted.seen == {"g1", "g2"}
+
+    async def test_no_repost_when_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        usage.record_usage_payload(tmp_path, _TURN1)
+        client = await _run_loop_until(monkeypatch, tmp_path, lambda c: len(c.posts) >= 1)
+        # Let several more polls run; with no new turns there must be no 2nd POST.
+        await asyncio.sleep(0.1)
+        assert len(client.posts) == 1
+
+    async def test_new_turn_triggers_followup_post(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        usage.record_usage_payload(tmp_path, _TURN1)
+        client = _CtxRecordingClient()
+        # First POST covers turn 1.
+        await _run_loop_until(monkeypatch, tmp_path, lambda c: len(c.posts) >= 1, client=client)
+        # Append a second turn and run again: a fresh cumulative POST must land.
+        usage.record_usage_payload(tmp_path, _TURN2)
+        await _run_loop_until(monkeypatch, tmp_path, lambda c: len(c.posts) >= 2, client=client)
+        _, body = client.posts[-1]
+        assert body["data"]["cumulative_output_tokens"] == 5 + 120
+
+    async def test_failed_post_is_not_persisted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _FailingClient(_CtxRecordingClient):
+            async def post(self, url: str, *, json: dict) -> httpx.Response:
+                self.posts.append((url, json))
+                raise httpx.ConnectError("boom")
+
+        usage.record_usage_payload(tmp_path, _TURN1)
+        client = await _run_loop_until(
+            monkeypatch, tmp_path, lambda c: len(c.posts) >= 1, client=_FailingClient()
+        )
+        assert len(client.posts) >= 1  # it tried
+        # A failed flush must NOT advance persisted state — the turn stays unseen
+        # so the next poll retries it (no silent loss).
+        assert usage._read_usage_state(tmp_path).seen == set()


### PR DESCRIPTION
## What

Adds **session cost / token-usage tracking** for the `cursor-native` harness, so the web UI's **Session cost** badge and per-model **token usage** breakdown populate for `omnigent cursor` sessions (they already worked for claude-native and codex-native).

## Why it was thought impossible — and what changed

cursor-agent surfaces per-turn token usage **only** through its lifecycle hooks:
- the SQLite chat store (tailed by `cursor_native_forwarder.py`) carries no usage,
- the on-disk `agent-transcripts/*.jsonl` `turn_ended` record is just `{type, status}`,
- and the headless `--print` `result.usage` is unavailable to the **interactive TUI** the harness drives.

The unlock: cursor-agent ships a Claude-Code-style **hooks** system, and the `stop` hook **fires in the interactive TUI** with per-turn token usage (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `model`). Verified live against `cursor-agent 2026.06.24` by driving the real TUI through a PTY. (Cursor's public hooks docs lag the binary — they document `afterAgentResponse` as `{text}` only and omit `stop`; this CLI version emits both with the token fields.)

## How

```
cursor-agent TUI -- stop hook (JSON on stdin, per turn) -->
  python -m omnigent.cursor_native_usage record-usage --bridge-dir <dir>
      append one line to <bridge_dir>/cursor_usage.jsonl
  supervise_cursor_usage_forwarder (runner-owned poll loop)
      sum per-turn counts -> cumulative totals (deduped by generation_id)
      POST external_session_usage { cumulative_input/output/cache_read_tokens, model }
  server _persist_external_session_usage -> session.usage SSE -> AgentInfo.tsx
```

Reuses the **exact** `external_session_usage` server contract claude/codex-native use, so **no server or frontend changes**.

- `omnigent/cursor_native_usage.py` (new) — stdlib-only hook recorder + cumulative accumulator + runner-owned poller/supervisor.
- `omnigent/cursor_native_bridge.py` — `build_hooks_config` / `write_hooks_config` (writes `<workspace>/.cursor/hooks.json`, sibling of `write_mcp_config`).
- `omnigent/runner/app.py` — wires `write_hooks_config`, `clear_cursor_usage_state`, and `supervise_cursor_usage_forwarder` into the existing cursor bridges setup.
- `docs/cursor-native-cost-tracking.md` (new) — full implementation doc.

## Known limitation (documented)

**Token usage always populates; dollar cost** resolves only for models whose cursor id matches the MLflow pricing catalog (`gpt-5` resolves; `claude-4-sonnet` and `composer-*` show tokens with cost "—"). We forward the **raw** cursor model id rather than guess a version alias (a wrong version = wrong rate). A cursor->catalog alias map is a documented follow-up.

## Testing

- `tests/test_cursor_native_usage.py` (new) — payload normalization, recorder + CLI, accumulator (per-turn sum + generation-id dedup), state round-trip, POST shape, and the poll loop (post-on-change, no-repost-when-unchanged, persist-only-after-success).
- `tests/test_cursor_native_bridge.py::TestHooksConfig` — `hooks.json` shape, shell-quoting, atomic project-scoped write.
- **38 tests pass**; `ruff check` clean. Live tmux + hook path left to the e2e gate.
