### PR TITLE
docs(harness-guide): tier native-harness capabilities (P0/P1/stretch) + add missing rows

### DIFF
--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -141,25 +141,46 @@ Omnigent. They relay the vendor's conversation into the Omnigent session.
 | **Reasoning** | Model reasoning/thinking tokens are forwarded |
 | **Images** | Image content is forwarded — path reference, full binary, or text-flattened |
 | **Cost tracking** | Native harness reports token usage and cost data back to Omnigent for each turn |
+| **Tool-output streaming** | Live incremental command/tool output (`outputDelta`) vs final aggregated output only |
+| **Working-tree diff** | The vendor's aggregated per-turn diff is surfaced (vs reconstructed from per-file edits) |
+| **Generated/viewed media** | Model-produced or model-viewed images are mirrored (distinct from user-supplied image input) |
+| **Vendor modes** | Vendor-specific modes (review mode, plan mode, etc.) are mirrored as status |
 
 ### Checklist for a new native harness
 
-All capabilities are **required** for a complete native harness integration:
+Capabilities are tiered by how essential they are. **P0** must work or the
+harness is non-functional. **P1** is required for a complete, parity-level
+integration — the web surface should match what the vendor TUI shows.
+**Stretch** items depend on vendor-specific signals and improve fidelity;
+they are optional and may legitimately be closed as wontfix when the vendor
+provides no signal or the data is redundant.
+
+**P0 — core (non-functional without these)**
 
 - [ ] Transport chosen and implemented (tmux TUI, app server, HTTP/SSE)
 - [ ] Connects to Omnigent MCP
-- [ ] Model override works (or document vendor lock-in)
 - [ ] Auth configured (vendor login / config)
 - [ ] Streaming forwarder works (deltas preferred; complete-only acceptable)
-- [ ] Omnigent policies enforce tool-use rules
+- [ ] Omnigent policies enforce tool-use rules (ALLOW / ASK / DENY at both tool call and tool result)
 - [ ] Native elicitation surfaces tool-approval requests to web UI
 - [ ] Interrupt aborts the running turn
 - [ ] Bidirectional sync mirrors TUI output into Omnigent conversation
-- [ ] Session commands (clear, fork, resume) work from Omnigent
-- [ ] Resume/fork rebuilds from Omnigent transcript
-- [ ] Compaction status is surfaced
-- [ ] Reasoning tokens are forwarded
-- [ ] Images are forwarded (path preferred; binary or text-flattened acceptable)
 - [ ] Cost tracking reports token usage and cost per turn
 - [ ] Unit tests cover forwarder, auth, transport
 - [ ] Mock LLM tests cover the happy path without real API calls
+
+**P1 — parity (required for a complete integration)**
+
+- [ ] Model override works at launch **and** per-prompt (or document vendor lock-in)
+- [ ] Session commands (clear, fork, resume) work from Omnigent
+- [ ] Resume/fork rebuilds from Omnigent transcript
+- [ ] Reasoning tokens are forwarded
+- [ ] Compaction status is surfaced
+- [ ] User-supplied images are forwarded (path preferred; binary or text-flattened acceptable)
+
+**Stretch — vendor-dependent fidelity**
+
+- [ ] Live tool/command output is streamed (`outputDelta`), not just final aggregated output
+- [ ] The vendor's aggregated working-tree diff is surfaced (if provided)
+- [ ] Generated/viewed media (model-produced or model-viewed images) is mirrored
+- [ ] Vendor-specific modes (review mode, plan mode, etc.) are mirrored as status


### PR DESCRIPTION
## What

Reworks **Part 2 (native harnesses)** of the harness-integration guide:

1. **Tiers the checklist** into **P0 — core** (non-functional without), **P1 — parity** (required for a complete integration; web surface should match the vendor TUI), and **Stretch — vendor-dependent fidelity** (optional; may be wontfix when the vendor gives no signal). It previously marked *all* capabilities flatly "required".
2. **Adds capability rows** surfaced by a codex-native audit: tool-output streaming granularity (`outputDelta` vs aggregated), working-tree diff, generated/viewed media, and vendor-specific modes.
3. Sharpens two existing items: model override now reads "at launch **and** per-prompt"; policies now spell out "ALLOW / ASK / DENY at both tool call and tool result".

## Why

The flat "all required" framing didn't match reality — even **codex-native**, one of the most complete native harnesses, fails several items (reasoning forwarding, compaction, per-prompt model override). A tiered model makes the guide an honest, usable yardstick and gives triage a vocabulary (P0/P1/stretch) for the gap issues below.

## Motivating gap issues (codex-native)

Filed from the same audit; the tiers here are chosen to match their suggested severities:

- #1254 — reasoning text not forwarded to web transcript (P1)
- #1255 — compaction status not surfaced (P1)
- #1256 — web model/effort picker doesn't propagate into the Codex thread (P1)
- #1257 — live command-execution output not streamed (stretch)
- #1258 — forwarder drops diff / output-images / review-mode item types (stretch)

## Notes / open questions for reviewers

- Scope is intentionally **Part 2 only**. Part 1 (SDK/subprocess) still says "all required"; happy to mirror the same tiering there in a follow-up if maintainers agree.
- Tier placement is a judgment call — reasoning/compaction are placed at **P1** (parity) rather than P0 since a harness is still usable without them. Adjust as you see fit.
