### PR TITLE
feat(cursor-native): carry conversation history into forks

### DIFF
--- a/ap-web/src/lib/forkHarness.test.ts
+++ b/ap-web/src/lib/forkHarness.test.ts
@@ -39,6 +39,8 @@ describe("isNativeHarness", () => {
     ["native-claude", true],
     ["codex-native", true],
     ["native-codex", true],
+    ["cursor-native", true],
+    ["native-cursor", true],
     ["pi-native", true],
     ["native-pi", true],
     // Antigravity-native spellings are native too — aligned with Python
@@ -87,6 +89,10 @@ describe("forkTargetCarriesHistory", () => {
     ["native-claude"],
     ["codex-native"],
     ["native-codex"],
+    // Cursor is native but server-backed: a fork carries history as a text
+    // preamble (text-prefix replay), so it must be offered in the picker too.
+    ["cursor-native"],
+    ["native-cursor"],
     // Pi is native but multi-family (no single harnessFamily) — it must
     // still be offered, or the fork/switch-agent pickers silently drop it.
     ["pi-native"],

--- a/ap-web/src/lib/forkHarness.ts
+++ b/ap-web/src/lib/forkHarness.ts
@@ -9,6 +9,11 @@
 //     the source's native transcript when the source is same-family native,
 //     else building one from the copied Omnigent items (a format-agnostic
 //     conversion, so the source harness doesn't matter).
+//   - Cursor is native but server-backed: a synthesized local store is NOT
+//     loaded by `cursor-agent --resume`, so the runner replays the prior turns
+//     as a text preamble on the fork's first message (text-prefix replay). The
+//     turns appear as one context block in the Cursor TUI rather than as
+//     reconstructed bubbles, but the agent gets the full prior context.
 //
 // Native targets carry history from any source: the rollout synthesizer
 // writes the session_meta fields codex ≥ 0.133 requires (timestamp,
@@ -49,10 +54,11 @@ export function harnessFamily(
 }
 
 /**
- * Whether a harness is a native CLI harness (Claude Code / Codex / Pi /
- * Antigravity). Mirrors Python `NATIVE_HARNESSES` (`omnigent/harness_aliases.py`)
- * — including both native-antigravity spellings (the in-process `antigravity`
- * SDK harness is NOT native) — so both sides classify the same set.
+ * Whether a harness is a native CLI harness (Claude Code / Codex / Cursor /
+ * Pi / Antigravity). Mirrors Python `NATIVE_HARNESSES`
+ * (`omnigent/harness_aliases.py`) — including both native-antigravity spellings
+ * (the in-process `antigravity` SDK harness is NOT native) — so both sides
+ * classify the same set.
  */
 export function isNativeHarness(harness: string | null | undefined): boolean {
   return (
@@ -60,6 +66,8 @@ export function isNativeHarness(harness: string | null | undefined): boolean {
     harness === "native-claude" ||
     harness === "codex-native" ||
     harness === "native-codex" ||
+    harness === "cursor-native" ||
+    harness === "native-cursor" ||
     harness === "pi-native" ||
     harness === "native-pi" ||
     harness === "antigravity-native" ||

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -144,23 +144,34 @@ def write_fork_preamble(bridge_dir: Path, preamble: str) -> None:
     (bridge_dir / _FORK_PREAMBLE_FILE).write_text(preamble, encoding="utf-8")
 
 
-def take_fork_preamble(bridge_dir: Path) -> str | None:
-    """Read and remove the fork preamble, returning it once (else ``None``).
+def read_fork_preamble(bridge_dir: Path) -> str | None:
+    """Read the fork preamble WITHOUT consuming it (else ``None``).
 
-    The file is deleted on read so the history rides only the FIRST injected
-    message; subsequent turns inject the plain user text.
+    Read and clear are deliberately split: the executor reads the preamble,
+    injects it, and only calls :func:`clear_fork_preamble` on a SUCCESSFUL
+    injection. Consuming on read would lose the forked history permanently if
+    the first injection fails (e.g. the TUI exited) and the turn is retried.
 
     :param bridge_dir: The session's cursor-native bridge dir.
     :returns: The preamble text, or ``None`` when absent/empty.
     """
-    path = bridge_dir / _FORK_PREAMBLE_FILE
     try:
-        text = path.read_text(encoding="utf-8")
+        text = (bridge_dir / _FORK_PREAMBLE_FILE).read_text(encoding="utf-8")
     except (OSError, ValueError):
         return None
-    with contextlib.suppress(OSError):
-        path.unlink()
     return text or None
+
+
+def clear_fork_preamble(bridge_dir: Path) -> None:
+    """Remove the fork preamble so it rides only the FIRST injected message.
+
+    Called by the executor only after a turn's injection succeeds; subsequent
+    turns then inject the plain user text. A no-op when the file is absent.
+
+    :param bridge_dir: The session's cursor-native bridge dir.
+    """
+    with contextlib.suppress(OSError):
+        (bridge_dir / _FORK_PREAMBLE_FILE).unlink()
 
 
 #: Human-readable lead-in / sign-off framing the replayed transcript inside the

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -182,6 +182,26 @@ _FORK_HISTORY_HEADER = "This session was forked. Here is the conversation so far
 _FORK_HISTORY_FOOTER = "(End of prior conversation. Please continue from here.)"
 
 
+def _neutralize_fork_sentinels(text: str) -> str:
+    """Defang any literal fork sentinel tags inside replayed transcript text.
+
+    The preamble is rendered from prior user/assistant turns verbatim, so a turn
+    could literally contain ``<omnigent_fork_history>`` /
+    ``</omnigent_fork_history>`` (a user typed it, pasted logs, etc.). If left
+    intact, an embedded close tag would let the forwarder's strip stop early and
+    leak the rest of the transcript into the mirrored web bubble. Replacing the
+    angle brackets guarantees the framed block contains exactly ONE real
+    open/close pair, so the (non-greedy) strip is unambiguous. The bracketed form
+    stays readable for the cursor agent.
+
+    :param text: Rendered transcript text.
+    :returns: The text with any literal sentinel tags defanged.
+    """
+    return text.replace(FORK_HISTORY_OPEN_TAG, "[omnigent_fork_history]").replace(
+        FORK_HISTORY_CLOSE_TAG, "[/omnigent_fork_history]"
+    )
+
+
 def wrap_fork_preamble(preamble: str, user_text: str) -> str:
     """Combine a fork preamble with the latest user text for one injection.
 
@@ -193,6 +213,13 @@ def wrap_fork_preamble(preamble: str, user_text: str) -> str:
     sentinel block from the mirrored user turn so the copied history isn't
     duplicated in the Omnigent timeline.
 
+    Any literal sentinel tags inside *preamble* are defanged
+    (:func:`_neutralize_fork_sentinels`) so the framed block holds exactly one
+    real open/close pair — this keeps the forwarder's non-greedy strip
+    unambiguous and prevents embedded tags from leaking history. *user_text* is
+    left untouched (it sits after the close tag; the non-greedy strip stops at
+    the real close, so a tag in the user's own message is preserved).
+
     :param preamble: Rendered prior-conversation transcript.
     :param user_text: The user's first message in the fork.
     :returns: The framed, fenced transcript followed by the user text.
@@ -200,7 +227,7 @@ def wrap_fork_preamble(preamble: str, user_text: str) -> str:
     return (
         f"{FORK_HISTORY_OPEN_TAG}\n"
         f"{_FORK_HISTORY_HEADER}\n\n"
-        f"{preamble}\n\n"
+        f"{_neutralize_fork_sentinels(preamble)}\n\n"
         f"{_FORK_HISTORY_FOOTER}\n"
         f"{FORK_HISTORY_CLOSE_TAG}\n\n"
         f"{user_text}"

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -118,6 +118,84 @@ def _ensure_dir(path: Path) -> None:
         os.chmod(path, 0o700)
 
 
+#: File the runner drops into a fork's bridge dir holding the prior-conversation
+#: text preamble, consumed once by the executor on the first injected message.
+#: cursor's conversation is server-backed (a synthesized local store.db is NOT
+#: loaded by ``cursor-agent --resume``), so a fork carries history by replaying
+#: the prior turns as a text prefix on the first message (text-prefix replay).
+_FORK_PREAMBLE_FILE = "fork_preamble.txt"
+#: Sentinel framing the replayed history inside the first injected message. The
+#: cursor agent reads the wrapped context, but the forwarder strips this block
+#: when mirroring the user turn back to Omnigent so the copied history isn't
+#: duplicated in the timeline (see cursor_native_forwarder._unwrap_user_query).
+FORK_HISTORY_OPEN_TAG = "<omnigent_fork_history>"
+FORK_HISTORY_CLOSE_TAG = "</omnigent_fork_history>"
+
+
+def write_fork_preamble(bridge_dir: Path, preamble: str) -> None:
+    """Persist a fork's prior-conversation preamble for the executor to consume.
+
+    :param bridge_dir: The session's cursor-native bridge dir.
+    :param preamble: Rendered prior-conversation text (``""`` is not written).
+    """
+    if not preamble:
+        return
+    _ensure_dir(bridge_dir)
+    (bridge_dir / _FORK_PREAMBLE_FILE).write_text(preamble, encoding="utf-8")
+
+
+def take_fork_preamble(bridge_dir: Path) -> str | None:
+    """Read and remove the fork preamble, returning it once (else ``None``).
+
+    The file is deleted on read so the history rides only the FIRST injected
+    message; subsequent turns inject the plain user text.
+
+    :param bridge_dir: The session's cursor-native bridge dir.
+    :returns: The preamble text, or ``None`` when absent/empty.
+    """
+    path = bridge_dir / _FORK_PREAMBLE_FILE
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    with contextlib.suppress(OSError):
+        path.unlink()
+    return text or None
+
+
+#: Human-readable lead-in / sign-off framing the replayed transcript inside the
+#: sentinel, so the block reads as a contained "here's the prior conversation"
+#: note rather than a raw dump. The cursor agent sees this context; the forwarder
+#: strips the whole sentinel block from the mirrored web bubble.
+_FORK_HISTORY_HEADER = "This session was forked. Here is the conversation so far:"
+_FORK_HISTORY_FOOTER = "(End of prior conversation. Please continue from here.)"
+
+
+def wrap_fork_preamble(preamble: str, user_text: str) -> str:
+    """Combine a fork preamble with the latest user text for one injection.
+
+    The transcript is framed by a human lead-in / sign-off and fenced in
+    :data:`FORK_HISTORY_OPEN_TAG` / :data:`FORK_HISTORY_CLOSE_TAG`. cursor can't
+    reconstruct native chat bubbles from a fork (its conversation is
+    server-backed), so this is the closest single-message analog: the agent
+    reads the framed transcript as context, and the forwarder strips the whole
+    sentinel block from the mirrored user turn so the copied history isn't
+    duplicated in the Omnigent timeline.
+
+    :param preamble: Rendered prior-conversation transcript.
+    :param user_text: The user's first message in the fork.
+    :returns: The framed, fenced transcript followed by the user text.
+    """
+    return (
+        f"{FORK_HISTORY_OPEN_TAG}\n"
+        f"{_FORK_HISTORY_HEADER}\n\n"
+        f"{preamble}\n\n"
+        f"{_FORK_HISTORY_FOOTER}\n"
+        f"{FORK_HISTORY_CLOSE_TAG}\n\n"
+        f"{user_text}"
+    )
+
+
 def build_cursor_native_spawn_env(session_id: str) -> dict[str, str]:
     """Build the ``HARNESS_CURSOR_NATIVE_*`` env the harness executor reads."""
     bridge_dir = bridge_dir_for_session_id(session_id)

--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -42,6 +42,7 @@ from pathlib import Path
 import httpx
 
 from omnigent._native_post_delivery import post_may_have_been_delivered
+from omnigent.cursor_native_bridge import FORK_HISTORY_CLOSE_TAG, FORK_HISTORY_OPEN_TAG
 
 _logger = logging.getLogger(__name__)
 
@@ -101,6 +102,16 @@ _USER_QUERY_RE = re.compile(r"<user_query>(.*?)</user_query>", re.DOTALL)
 # before pasting into the TUI; cursor stores them inside the user_query, so
 # strip them from the mirrored bubble (the path is an internal bridge detail).
 _ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
+# On a fork into cursor, the executor prepends the prior conversation to the
+# first user message, fenced in <omnigent_fork_history>…</omnigent_fork_history>
+# (cursor_native_bridge.wrap_fork_preamble). cursor stores it inside the
+# user_query; strip the whole block so the mirrored bubble shows only the user's
+# real text — the copied history already lives in the Omnigent timeline, so
+# echoing it here would duplicate it.
+_FORK_HISTORY_RE = re.compile(
+    rf"{re.escape(FORK_HISTORY_OPEN_TAG)}.*?{re.escape(FORK_HISTORY_CLOSE_TAG)}",
+    re.DOTALL,
+)
 
 # When an in-pane ``/summarize`` finishes, cursor-agent collapses the prior
 # history into a single user blob whose plain-string ``content`` starts with
@@ -434,7 +445,8 @@ def _unwrap_user_query(text: str) -> str | None:
     match = _USER_QUERY_RE.search(text)
     if match is None:
         return None
-    inner = _ATTACHMENT_MARKER_RE.sub("", _strip_control_chars(match.group(1)))
+    inner = _FORK_HISTORY_RE.sub("", _strip_control_chars(match.group(1)))
+    inner = _ATTACHMENT_MARKER_RE.sub("", inner)
     return inner.strip() or None
 
 

--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -108,8 +108,17 @@ _ATTACHMENT_MARKER_RE = re.compile(r"\[Attached:[^\]]*\]")
 # user_query; strip the whole block so the mirrored bubble shows only the user's
 # real text — the copied history already lives in the Omnigent timeline, so
 # echoing it here would duplicate it.
+#
+# The match is non-greedy so it stops at the FIRST close tag: that is always the
+# real one, because wrap_fork_preamble defangs any literal sentinels inside the
+# replayed transcript (so the block holds exactly one real open/close pair), and
+# stopping at the first close preserves a tag in the user's own message that
+# sits after it. The trailing alternative strips an UNTERMINATED open block (a
+# truncated paste with no close tag) to end-of-text, so it degrades gracefully
+# instead of mirroring the whole raw block.
 _FORK_HISTORY_RE = re.compile(
-    rf"{re.escape(FORK_HISTORY_OPEN_TAG)}.*?{re.escape(FORK_HISTORY_CLOSE_TAG)}",
+    rf"{re.escape(FORK_HISTORY_OPEN_TAG)}.*?{re.escape(FORK_HISTORY_CLOSE_TAG)}"
+    rf"|{re.escape(FORK_HISTORY_OPEN_TAG)}.*",
     re.DOTALL,
 )
 

--- a/omnigent/inner/cursor_native_executor.py
+++ b/omnigent/inner/cursor_native_executor.py
@@ -19,8 +19,9 @@ from typing import Any
 
 from omnigent.cursor_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
+    clear_fork_preamble,
     inject_user_message,
-    take_fork_preamble,
+    read_fork_preamble,
     wrap_fork_preamble,
 )
 from omnigent.inner.executor import (
@@ -91,11 +92,13 @@ class CursorNativeExecutor(Executor):
         # A fork into cursor carries history as a text preamble: cursor's
         # conversation is server-backed (no local store to seed for --resume), so
         # the runner stashed the prior turns and we prepend them to the FIRST
-        # injected message. ``take_fork_preamble`` consumes the file, so later
-        # turns inject the plain user text. The forwarder strips the sentinel
+        # injected message. We READ the preamble here but only CLEAR it after a
+        # successful injection (below) — consuming it up front would lose the
+        # forked history permanently if this injection fails (e.g. the TUI
+        # exited) and the turn is retried. The forwarder strips the sentinel
         # block when mirroring this turn back, so the copied history isn't
         # duplicated in the Omnigent timeline.
-        preamble = take_fork_preamble(self._bridge_dir)
+        preamble = read_fork_preamble(self._bridge_dir)
         if preamble:
             text = wrap_fork_preamble(preamble, text)
         try:
@@ -104,6 +107,10 @@ class CursorNativeExecutor(Executor):
         except RuntimeError as exc:
             yield ExecutorError(message=str(exc))
             return
+        # Injection landed — now it's safe to consume the preamble so later
+        # turns inject the plain user text.
+        if preamble:
+            clear_fork_preamble(self._bridge_dir)
         yield TurnComplete(response=None)
 
 

--- a/omnigent/inner/cursor_native_executor.py
+++ b/omnigent/inner/cursor_native_executor.py
@@ -17,7 +17,12 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-from omnigent.cursor_native_bridge import BRIDGE_DIR_ENV_VAR, inject_user_message
+from omnigent.cursor_native_bridge import (
+    BRIDGE_DIR_ENV_VAR,
+    inject_user_message,
+    take_fork_preamble,
+    wrap_fork_preamble,
+)
 from omnigent.inner.executor import (
     Executor,
     ExecutorConfig,
@@ -83,6 +88,16 @@ class CursorNativeExecutor(Executor):
         if not text:
             yield ExecutorError(message="cursor native turn had no user text to send")
             return
+        # A fork into cursor carries history as a text preamble: cursor's
+        # conversation is server-backed (no local store to seed for --resume), so
+        # the runner stashed the prior turns and we prepend them to the FIRST
+        # injected message. ``take_fork_preamble`` consumes the file, so later
+        # turns inject the plain user text. The forwarder strips the sentinel
+        # block when mirroring this turn back, so the copied history isn't
+        # duplicated in the Omnigent timeline.
+        preamble = take_fork_preamble(self._bridge_dir)
+        if preamble:
+            text = wrap_fork_preamble(preamble, text)
         try:
             async with self._inject_lock:
                 await asyncio.to_thread(inject_user_message, self._bridge_dir, content=text)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -508,6 +508,10 @@ class _PiNativeLaunchConfig:
     :param model_override: Persisted per-session ``/model`` override, e.g.
         ``"claude-4.6-sonnet-medium"``; ``None`` when unset. Consumed by the
         cursor-native launch (``--model``), ignored by pi-native.
+    :param fork_carry_history: ``True`` when the session is a fork bound to a
+        carry-history native target (``omnigent.fork.carry_history``). Consumed
+        by the cursor-native launch to replay prior turns as a text preamble on
+        the first message; ignored by pi-native.
     """
 
     workspace: Path
@@ -515,6 +519,7 @@ class _PiNativeLaunchConfig:
     terminal_launch_args: list[str] | None
     external_session_id: str | None
     model_override: str | None = None
+    fork_carry_history: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -712,12 +717,19 @@ async def _pi_native_launch_config(
             raise RuntimeError(
                 f"Invalid model_override for session {session_id!r}: {exc}"
             ) from exc
+    from omnigent.stores.conversation_store import FORK_CARRY_HISTORY_LABEL_KEY
+
+    labels = snapshot.get("labels")
+    fork_carry_history = (
+        isinstance(labels, dict) and labels.get(FORK_CARRY_HISTORY_LABEL_KEY) == "1"
+    )
     return _PiNativeLaunchConfig(
         workspace=_pi_session_workspace(session_workspace),
         server_url=os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767").rstrip("/"),
         terminal_launch_args=terminal_launch_args,
         external_session_id=external_session_id,
         model_override=model_override,
+        fork_carry_history=fork_carry_history,
     )
 
 
@@ -1534,6 +1546,7 @@ async def _auto_create_cursor_terminal(
     from omnigent.cursor_native_bridge import (
         approve_mcp_server_for_workspace,
         bridge_dir_for_session_id,
+        write_fork_preamble,
         write_hooks_config,
         write_mcp_config,
     )
@@ -1595,6 +1608,26 @@ async def _auto_create_cursor_terminal(
                 session_id,
             )
             resume_chat_id = None
+    # A fork bound to cursor carries history as a text preamble: cursor's
+    # conversation is server-backed, so there's no local store to seed for
+    # ``--resume`` (a fresh fork has no prior chat anyway → ``not preseeded``).
+    # Render the copied Omnigent items once and stash them; the executor prepends
+    # them to the fork's first injected message. Best-effort — a failure just
+    # starts the cursor turn without the prior context.
+    if launch_config.fork_carry_history and not preseeded and server_client is not None:
+        try:
+            from omnigent.claude_native import _fetch_all_session_items_for_claude_resume
+
+            fork_items = await _fetch_all_session_items_for_claude_resume(
+                server_client, session_id
+            )
+            write_fork_preamble(bridge_dir, _cursor_fork_history_preamble(fork_items))
+        except Exception:  # noqa: BLE001 — context carry-over is best-effort
+            _logger.warning(
+                "cursor-native: could not build fork history preamble (session=%s).",
+                session_id,
+                exc_info=True,
+            )
     write_mcp_config(Path(workspace), bridge_dir)
     # Register the cursor ``stop`` hook that captures per-turn token usage into
     # the bridge dir for the usage forwarder below (see cursor_native_usage).
@@ -4015,6 +4048,66 @@ def _cursor_native_resume_args(chat_id: str | None, existing_args: list[str]) ->
     if any(arg == "--resume" or arg.startswith("--resume=") for arg in existing_args):
         return []
     return ["--resume", chat_id]
+
+
+def _cursor_message_item_text(content: Any) -> str:
+    """Join the text of a session message item's content blocks.
+
+    :param content: A message item's ``content`` — a plain string or a list of
+        ``{"type": "input_text"|"output_text"|"text", "text": ...}`` blocks.
+    :returns: The concatenated block text (stripped), or ``""``.
+    """
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") in ("input_text", "output_text", "text"):
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+    return "".join(parts).strip()
+
+
+#: Transcript role labels for the fork preamble. cursor's TUI can't reconstruct
+#: native user/assistant bubbles (its conversation is server-backed), so the
+#: replayed history reads as close to that as a single text block allows:
+#: capitalized speaker labels, blank-line-separated turns.
+_CURSOR_FORK_ROLE_LABELS = {"user": "You", "assistant": "Assistant"}
+
+
+def _cursor_fork_history_preamble(items: list[dict[str, Any]]) -> str:
+    """Render copied fork items as a readable conversation transcript.
+
+    cursor's conversation is server-backed, so a fork can't seed a local store
+    for ``--resume`` to load; instead the prior turns are replayed as a text
+    prefix on the fork's first message (text-prefix replay). Only user/assistant
+    message text is replayed — cursor's TUI has no surface to import tool-call
+    history or reconstruct native bubbles, so this formats the turns as a clean
+    speaker-labelled transcript (the closest single-block analog), mirroring the
+    antigravity executor's documented text-prefix fallback. The human framing +
+    strip sentinel are added by
+    :func:`omnigent.cursor_native_bridge.wrap_fork_preamble`.
+
+    :param items: Committed Omnigent items (``GET /v1/sessions/{id}/items``),
+        chronological.
+    :returns: A blank-line-separated transcript like ``"You: …\\n\\nAssistant:
+        …"``, or ``""`` when no replayable user/assistant text exists.
+    """
+    turns: list[str] = []
+    for item in items:
+        if item.get("type") != "message":
+            continue
+        role = item.get("role")
+        if role not in _CURSOR_FORK_ROLE_LABELS:
+            continue
+        text = _cursor_message_item_text(item.get("content"))
+        if text:
+            turns.append(f"{_CURSOR_FORK_ROLE_LABELS[role]}: {text}")
+    return "\n\n".join(turns)
 
 
 def _agent_os_env_from_spec(agent_spec: AgentSpec | ResolvedSpec | None) -> Any | None:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9695,29 +9695,42 @@ def _agent_is_native(agent: Agent) -> bool:
     return is_native_harness(spec.executor.harness_kind)
 
 
-# Native harnesses that record a resumable session and can rebuild a fork's
-# transcript from copied Omnigent items. Both spellings are listed because
-# canonicalize_harness passes the reversed native ids through unchanged (only
-# "native-pi" is aliased) — same reasoning as model_override._CLAUDE_FAMILY_HARNESSES.
-# cursor/pi native are intentionally absent: they can't replay fork history.
+# Native harnesses that rebuild a resumable on-disk transcript from the copied
+# Omnigent items and relaunch the CLI with --resume, so prior turns reappear as
+# native chat history. Used by BOTH fork and switch-agent. Both spellings are
+# listed because canonicalize_harness passes the reversed native ids through
+# unchanged (only "native-pi" is aliased) — same reasoning as
+# model_override._CLAUDE_FAMILY_HARNESSES.
+#
+# cursor is intentionally absent here: its conversation is server-backed (a
+# synthesized/cloned local store.db is NOT loaded by `cursor-agent --resume`),
+# so it can't rebuild a transcript. Instead a FORK carries cursor history as a
+# text preamble (see _CURSOR_FORK_HISTORY_HARNESSES below) — switch-agent keeps
+# the current fresh-launch behavior. pi has no carry-history path yet.
 _FORK_HISTORY_NATIVE_HARNESSES: frozenset[str] = frozenset(
     {"claude-native", "native-claude", "codex-native", "native-codex"}
 )
 
+# Native harnesses that carry FORK history as a text preamble (text-prefix
+# replay) instead of a rebuilt transcript. Fork-only — switch-agent does not
+# use this set, so switching into cursor still launches fresh. The runner
+# branches on the harness to choose preamble vs transcript rebuild (see
+# _auto_create_cursor_terminal / cursor_native_executor).
+_CURSOR_FORK_HISTORY_HARNESSES: frozenset[str] = frozenset({"cursor-native", "native-cursor"})
+
 
 def _agent_carries_native_fork_history(agent: Agent) -> bool:
-    """Return whether *agent*'s native harness can replay fork history.
+    """Return whether *agent*'s native harness rebuilds a fork's transcript.
 
-    Only claude-native / codex-native record a resumable native session and
-    can rebuild a fork's transcript from the copied Omnigent items. cursor-
-    native and pi-native are native CLIs but cannot carry chat history into a
-    fork (no resumable external_session_id and their TUIs can't import a
-    transcript), so stamping ``carry_history_into_native`` for them would be a
-    false promise — the fork launches fresh regardless. Returns ``False`` when
-    the bundle can't be loaded (treated as non-carrying).
+    Only claude-native / codex-native record a resumable native session and can
+    rebuild a fork's transcript from the copied Omnigent items. Used by both
+    fork and switch-agent. cursor carries fork history a different way (a text
+    preamble, fork-only — see :func:`_agent_carries_cursor_fork_history`); pi has
+    no carry-history path yet. Returns ``False`` when the bundle can't be loaded
+    (treated as non-carrying).
 
     :param agent: The agent whose harness to classify.
-    :returns: ``True`` only for fork-history-capable native harnesses.
+    :returns: ``True`` only for transcript-rebuild native harnesses.
     """
     from omnigent.harness_aliases import canonicalize_harness
 
@@ -9730,6 +9743,31 @@ def _agent_carries_native_fork_history(agent: Agent) -> bool:
     except Exception:  # noqa: BLE001 — unloadable bundle → treat as non-carrying
         return False
     return canonicalize_harness(spec.executor.harness_kind) in _FORK_HISTORY_NATIVE_HARNESSES
+
+
+def _agent_carries_cursor_fork_history(agent: Agent) -> bool:
+    """Return whether *agent* is cursor-native (carries FORK history via preamble).
+
+    Cursor's conversation is server-backed, so a fork can't seed a local store
+    for ``--resume``; instead the runner replays the prior turns as a text
+    preamble on the fork's first message. Fork-only — switch-agent does not call
+    this, so switching into cursor still launches fresh. Returns ``False`` when
+    the bundle can't be loaded.
+
+    :param agent: The agent whose harness to classify.
+    :returns: ``True`` only for the cursor-native harness (either spelling).
+    """
+    from omnigent.harness_aliases import canonicalize_harness
+
+    try:
+        spec = (
+            get_agent_cache()
+            .load(agent.id, agent.bundle_location, expand_env=agent.session_id is None)
+            .spec
+        )
+    except Exception:  # noqa: BLE001 — unloadable bundle → treat as non-carrying
+        return False
+    return canonicalize_harness(spec.executor.harness_kind) in _CURSOR_FORK_HISTORY_HARNESSES
 
 
 def _native_coding_agent_for_agent(agent: Agent) -> NativeCodingAgent | None:
@@ -14478,18 +14516,26 @@ def create_sessions_router(
         # items (the converters consume Omnigent's normalized item shape, so
         # the source harness doesn't matter). SDK targets replay the
         # transcript as context regardless, so the marker is inert for them.
-        # Only claude/codex native can replay fork history; cursor/pi native
-        # can't (no resumable session, TUI can't import a transcript), so don't
-        # stamp a carry-history promise they'd silently break with a fresh launch.
-        carry_history_into_native = await asyncio.to_thread(
+        # claude/codex native rebuild the transcript; cursor native instead
+        # replays prior turns as a text preamble (its conversation is
+        # server-backed, so a local store can't be seeded — fork-only, see
+        # _agent_carries_cursor_fork_history). pi has no carry path yet, so don't
+        # stamp a promise it would break with a fresh launch. The single
+        # FORK_CARRY_HISTORY label drives both; the runner branches on harness.
+        target_is_cursor = await asyncio.to_thread(_agent_carries_cursor_fork_history, base_agent)
+        carry_history_into_native = target_is_cursor or await asyncio.to_thread(
             _agent_carries_native_fork_history, base_agent
         )
         # The source's native session id is only resumable by a target in the
         # SAME provider family — a Claude target can't clone a Codex rollout.
         # Cross-family, the store must skip the fork-source directive so the
         # runner takes the rebuild path instead of a doomed clone attempt
-        # (a failed clone launches fresh, losing history).
-        resume_source_native_session = not switching_agent or copy_model_settings
+        # (a failed clone launches fresh, losing history). cursor never clones a
+        # native session (server-backed; it carries history via the preamble),
+        # so it always skips the source directive too.
+        resume_source_native_session = (
+            not switching_agent or copy_model_settings
+        ) and not target_is_cursor
 
         # On an agent switch, recompute the Web UI presentation labels for
         # the TARGET harness so the clone isn't left in the source's UI mode

--- a/tests/inner/test_cursor_native_executor.py
+++ b/tests/inner/test_cursor_native_executor.py
@@ -118,6 +118,16 @@ class TestForkPreamble:
         assert wrapped.endswith("do it")
         assert wrapped.index(FORK_HISTORY_CLOSE_TAG) < wrapped.index("do it")
 
+    def test_wrap_defangs_sentinels_inside_preamble(self) -> None:
+        # A literal close tag in the replayed transcript must not produce a second
+        # real close tag inside the block (which would let the forwarder's strip
+        # stop early and leak history). The framed block holds exactly one pair.
+        wrapped = wrap_fork_preamble(f"You: see {FORK_HISTORY_CLOSE_TAG} here", "go")
+        assert wrapped.count(FORK_HISTORY_CLOSE_TAG) == 1
+        assert wrapped.count(FORK_HISTORY_OPEN_TAG) == 1
+        # The defanged form stays readable.
+        assert "[/omnigent_fork_history]" in wrapped
+
 
 class TestRunTurnPreambleInjection:
     """run_turn prepends the fork preamble to the FIRST injected message only."""

--- a/tests/inner/test_cursor_native_executor.py
+++ b/tests/inner/test_cursor_native_executor.py
@@ -16,6 +16,8 @@ import pytest
 
 from omnigent.cursor_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
+    FORK_HISTORY_CLOSE_TAG,
+    FORK_HISTORY_OPEN_TAG,
     _paste_payload_bytes,
     allow_mcp_tools_in_cli_config,
     approve_mcp_server_for_workspace,
@@ -25,10 +27,14 @@ from omnigent.cursor_native_bridge import (
     cursor_project_key,
     enable_mcp_for_workspace,
     read_tmux_info,
+    take_fork_preamble,
+    wrap_fork_preamble,
+    write_fork_preamble,
     write_mcp_bridge_config,
     write_mcp_config,
     write_tmux_target,
 )
+from omnigent.inner import cursor_native_executor as cne
 from omnigent.inner.cursor_native_executor import (
     CursorNativeExecutor,
     _content_to_text,
@@ -80,6 +86,75 @@ class TestExecutorCapabilities:
         assert ex.supports_streaming() is False
         # Web-UI messages can be injected mid-turn (steering).
         assert ex.supports_live_message_queue() is True
+
+
+class TestForkPreamble:
+    """The fork preamble file + sentinel framing (text-prefix replay)."""
+
+    def test_write_take_round_trip_is_once_only(self, tmp_path: Path) -> None:
+        write_fork_preamble(tmp_path, "Conversation so far:\nuser: hi")
+        # First read returns it; the file is consumed so the second read is None.
+        assert take_fork_preamble(tmp_path) == "Conversation so far:\nuser: hi"
+        assert take_fork_preamble(tmp_path) is None
+
+    def test_empty_preamble_is_not_written(self, tmp_path: Path) -> None:
+        write_fork_preamble(tmp_path, "")
+        assert take_fork_preamble(tmp_path) is None
+
+    def test_take_missing_is_none(self, tmp_path: Path) -> None:
+        assert take_fork_preamble(tmp_path) is None
+
+    def test_wrap_fences_preamble_before_user_text(self) -> None:
+        wrapped = wrap_fork_preamble("Conversation so far:\nuser: hi", "do it")
+        assert wrapped.startswith(FORK_HISTORY_OPEN_TAG)
+        assert FORK_HISTORY_CLOSE_TAG in wrapped
+        # The user's real text follows the fenced block.
+        assert wrapped.endswith("do it")
+        assert wrapped.index(FORK_HISTORY_CLOSE_TAG) < wrapped.index("do it")
+
+
+class TestRunTurnPreambleInjection:
+    """run_turn prepends the fork preamble to the FIRST injected message only."""
+
+    @pytest.mark.asyncio
+    async def test_first_turn_injects_preamble_then_consumes_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        injected: list[str] = []
+        monkeypatch.setattr(
+            cne,
+            "inject_user_message",
+            lambda bridge_dir, content: injected.append(content),
+        )
+        write_fork_preamble(tmp_path, "You: earlier")
+        ex = CursorNativeExecutor(bridge_dir=tmp_path)
+
+        # First turn: the preamble rides into the injected text, fenced.
+        async for _ in ex.run_turn([{"role": "user", "content": "first"}], [], ""):
+            pass
+        assert FORK_HISTORY_OPEN_TAG in injected[0]
+        assert "You: earlier" in injected[0]
+        assert injected[0].endswith("first")
+
+        # Second turn: preamble consumed -> plain user text only.
+        async for _ in ex.run_turn([{"role": "user", "content": "second"}], [], ""):
+            pass
+        assert injected[1] == "second"
+
+    @pytest.mark.asyncio
+    async def test_no_preamble_injects_plain_text(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        injected: list[str] = []
+        monkeypatch.setattr(
+            cne,
+            "inject_user_message",
+            lambda bridge_dir, content: injected.append(content),
+        )
+        ex = CursorNativeExecutor(bridge_dir=tmp_path)
+        async for _ in ex.run_turn([{"role": "user", "content": "hello"}], [], ""):
+            pass
+        assert injected == ["hello"]
 
 
 class TestPastePayload:

--- a/tests/inner/test_cursor_native_executor.py
+++ b/tests/inner/test_cursor_native_executor.py
@@ -24,10 +24,11 @@ from omnigent.cursor_native_bridge import (
     bridge_dir_for_session_id,
     build_cursor_native_spawn_env,
     build_mcp_config,
+    clear_fork_preamble,
     cursor_project_key,
     enable_mcp_for_workspace,
+    read_fork_preamble,
     read_tmux_info,
-    take_fork_preamble,
     wrap_fork_preamble,
     write_fork_preamble,
     write_mcp_bridge_config,
@@ -40,6 +41,7 @@ from omnigent.inner.cursor_native_executor import (
     _content_to_text,
     _latest_user_text,
 )
+from omnigent.inner.executor import ExecutorError
 
 
 class TestContentExtraction:
@@ -91,18 +93,22 @@ class TestExecutorCapabilities:
 class TestForkPreamble:
     """The fork preamble file + sentinel framing (text-prefix replay)."""
 
-    def test_write_take_round_trip_is_once_only(self, tmp_path: Path) -> None:
-        write_fork_preamble(tmp_path, "Conversation so far:\nuser: hi")
-        # First read returns it; the file is consumed so the second read is None.
-        assert take_fork_preamble(tmp_path) == "Conversation so far:\nuser: hi"
-        assert take_fork_preamble(tmp_path) is None
+    def test_read_does_not_consume_clear_does(self, tmp_path: Path) -> None:
+        write_fork_preamble(tmp_path, "You: hi")
+        # Read is idempotent (the file survives) so a failed/retried injection
+        # can re-read it; only clear consumes.
+        assert read_fork_preamble(tmp_path) == "You: hi"
+        assert read_fork_preamble(tmp_path) == "You: hi"
+        clear_fork_preamble(tmp_path)
+        assert read_fork_preamble(tmp_path) is None
 
     def test_empty_preamble_is_not_written(self, tmp_path: Path) -> None:
         write_fork_preamble(tmp_path, "")
-        assert take_fork_preamble(tmp_path) is None
+        assert read_fork_preamble(tmp_path) is None
 
-    def test_take_missing_is_none(self, tmp_path: Path) -> None:
-        assert take_fork_preamble(tmp_path) is None
+    def test_read_missing_is_none_and_clear_is_noop(self, tmp_path: Path) -> None:
+        assert read_fork_preamble(tmp_path) is None
+        clear_fork_preamble(tmp_path)  # no file -> no error
 
     def test_wrap_fences_preamble_before_user_text(self) -> None:
         wrapped = wrap_fork_preamble("Conversation so far:\nuser: hi", "do it")
@@ -140,6 +146,37 @@ class TestRunTurnPreambleInjection:
         async for _ in ex.run_turn([{"role": "user", "content": "second"}], [], ""):
             pass
         assert injected[1] == "second"
+
+    @pytest.mark.asyncio
+    async def test_failed_injection_preserves_preamble_for_retry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If the FIRST injection fails (e.g. the TUI exited), the preamble must
+        # NOT be consumed — otherwise the forked history is lost permanently and
+        # a retried first turn launches with no prior context.
+        injected: list[str] = []
+        calls = {"n": 0}
+
+        def fake_inject(bridge_dir: Path, content: str) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("tmux target not advertised")
+            injected.append(content)
+
+        monkeypatch.setattr(cne, "inject_user_message", fake_inject)
+        write_fork_preamble(tmp_path, "You: earlier")
+        ex = CursorNativeExecutor(bridge_dir=tmp_path)
+
+        # First turn: injection fails -> ExecutorError, preamble still on disk.
+        events = [e async for e in ex.run_turn([{"role": "user", "content": "first"}], [], "")]
+        assert any(isinstance(e, ExecutorError) for e in events)
+        assert read_fork_preamble(tmp_path) == "You: earlier"
+
+        # Retry: injection succeeds, history rides along, THEN it's consumed.
+        async for _ in ex.run_turn([{"role": "user", "content": "first"}], [], ""):
+            pass
+        assert "You: earlier" in injected[0]
+        assert read_fork_preamble(tmp_path) is None
 
     @pytest.mark.asyncio
     async def test_no_preamble_injects_plain_text(

--- a/tests/runner/test_app_cursor_native_model.py
+++ b/tests/runner/test_app_cursor_native_model.py
@@ -13,7 +13,11 @@ import logging
 
 import pytest
 
-from omnigent.runner.app import _cursor_native_model_from_spec
+from omnigent.runner.app import (
+    _cursor_fork_history_preamble,
+    _cursor_message_item_text,
+    _cursor_native_model_from_spec,
+)
 from omnigent.spec.types import AgentSpec, ExecutorSpec
 
 
@@ -61,3 +65,53 @@ def test_cursor_native_model_from_spec_warns_on_dropped_model(
     with caplog.at_level(logging.WARNING):
         assert _cursor_native_model_from_spec(_spec("databricks-claude-opus")) is None
     assert any("databricks-claude-opus" in rec.getMessage() for rec in caplog.records)
+
+
+def _msg(role: str, text: str) -> dict:
+    """A message item as returned by GET /v1/sessions/{id}/items."""
+    block = "input_text" if role == "user" else "output_text"
+    return {"type": "message", "role": role, "content": [{"type": block, "text": text}]}
+
+
+class TestCursorMessageItemText:
+    def test_string_content(self) -> None:
+        assert _cursor_message_item_text("hi") == "hi"
+
+    def test_joins_text_blocks(self) -> None:
+        content = [
+            {"type": "input_text", "text": "one "},
+            {"type": "text", "text": "two"},
+            {"type": "input_image", "image_url": "data:..."},  # non-text -> skipped
+        ]
+        assert _cursor_message_item_text(content) == "one two"
+
+    def test_non_text_is_empty(self) -> None:
+        assert _cursor_message_item_text(None) == ""
+        assert _cursor_message_item_text([{"type": "input_image"}]) == ""
+
+
+class TestCursorForkHistoryPreamble:
+    def test_renders_user_and_assistant_turns(self) -> None:
+        items = [
+            _msg("user", "add hello.txt"),
+            _msg("assistant", "done"),
+            _msg("user", "now delete it"),
+        ]
+        # Turns render as a speaker-labelled transcript, blank-line separated —
+        # the closest single-block analog to claude/codex native bubbles.
+        assert _cursor_fork_history_preamble(items) == (
+            "You: add hello.txt\n\nAssistant: done\n\nYou: now delete it"
+        )
+
+    def test_skips_non_message_and_empty_items(self) -> None:
+        items = [
+            {"type": "function_call", "name": "sys_os_write"},  # tool call -> skipped
+            _msg("assistant", ""),  # empty text -> skipped
+            {"type": "message", "role": "system", "content": [{"text": "x"}]},  # system
+            _msg("user", "real"),
+        ]
+        assert _cursor_fork_history_preamble(items) == "You: real"
+
+    def test_no_replayable_text_yields_empty(self) -> None:
+        assert _cursor_fork_history_preamble([]) == ""
+        assert _cursor_fork_history_preamble([{"type": "function_call"}]) == ""

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -796,17 +796,20 @@ async def test_fork_switch_404_unknown_target() -> None:
             False,
             {"omnigent.ui": "terminal", "omnigent.wrapper": "codex-native-ui"},
         ),
-        # cursor/pi targets are native terminal-first harnesses, but they
-        # cannot replay fork history (no resumable native session and no TUI
-        # transcript import), so do not stamp carry_history_into_native.
+        # cursor target carries history via a text preamble (its conversation
+        # is server-backed, so the runner can't seed a local store for --resume),
+        # so carry_history_into_native IS stamped — the runner branches on the
+        # harness to choose preamble vs transcript rebuild.
         (
             "claude_sdk",
             "cursor-native",
             False,
-            False,
+            True,
             False,
             {"omnigent.ui": "terminal", "omnigent.wrapper": "cursor-native-ui"},
         ),
+        # pi target is native terminal-first but has no carry-history path yet,
+        # so it launches fresh — do not stamp carry_history_into_native.
         (
             "claude_sdk",
             "pi-native",
@@ -846,10 +849,11 @@ async def test_fork_switch_model_and_carry_gating(
     """The switch gates model copy + native carry + UI mode on the target.
 
     A model id is provider-bound, so ``copy_model_settings`` must be True
-    only within a family. ``carry_history_into_native`` must be True only for
-    native targets that can replay fork history (claude/codex); cursor/pi
-    targets are terminal-first but launch fresh, and SDK targets replay
-    history themselves so they never set it. ``resume_source_native_session``
+    only within a family. ``carry_history_into_native`` must be True for
+    native targets that carry fork history (claude/codex rebuild a transcript,
+    cursor replays a text preamble); pi is terminal-first but launches fresh,
+    and SDK targets replay history themselves so they never set it.
+    ``resume_source_native_session``
     must be False on a cross-family switch so the store skips the fork-source
     directive (the source's native transcript is the wrong format; a clone
     attempt would fail and launch fresh). ``presentation_labels`` must reflect the TARGET
@@ -937,19 +941,25 @@ async def test_fork_no_switch_native_source_carries_history(
     )
 
 
-@pytest.mark.parametrize("harness", ["cursor-native", "pi-native"])
+@pytest.mark.parametrize(
+    "harness,expect_carry",
+    [
+        # cursor carries history via a text preamble the runner replays on the
+        # first message (its conversation is server-backed, so no local store to
+        # seed for --resume) — so a same-agent fork DOES mark native carry.
+        ("cursor-native", True),
+        # pi has no carry-history path yet, so it launches fresh — stamping the
+        # directive would be a false promise the runner can't keep.
+        ("pi-native", False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_fork_cursor_native_does_not_carry_history(
+async def test_fork_cursor_pi_native_carry_gating(
     monkeypatch: pytest.MonkeyPatch,
     harness: str,
+    expect_carry: bool,
 ) -> None:
-    """A fork of a cursor/pi native source must NOT mark native carry.
-
-    Unlike claude/codex native, the cursor and pi harnesses record no
-    resumable native session and their TUIs can't import a transcript, so
-    ``carry_history_into_native`` must be False — stamping it would be a
-    false promise the runner can't keep (the fork launches fresh anyway).
-    """
+    """A same-agent fork marks native carry for cursor (preamble) but not pi."""
     conv = _make_conversation()
     conv_store = _ConversationStore(
         conversations={"conv_src": conv},
@@ -965,9 +975,8 @@ async def test_fork_cursor_native_does_not_carry_history(
 
     assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
     fork_call = conv_store.fork_calls[0]
-    assert fork_call["carry_history_into_native"] is False, (
-        f"A {harness} fork must not mark native carry — that harness can't "
-        "replay fork history, so the directive would be a false promise."
+    assert fork_call["carry_history_into_native"] is expect_carry, (
+        f"A {harness} fork should set carry_history_into_native={expect_carry}."
     )
 
 
@@ -978,10 +987,10 @@ async def test_fork_cursor_native_does_not_carry_history(
         # valid harness ids that canonicalize_harness passes through unchanged,
         # so the carry gate must recognize them just like their canonical
         # spellings — otherwise an identically-behaving agent silently loses
-        # fork history. cursor/pi (either spelling) still must NOT carry.
+        # fork history. cursor carries (preamble); pi (either spelling) does not.
         ("native-claude", True),
         ("native-codex", True),
-        ("native-cursor", False),
+        ("native-cursor", True),
         ("native-pi", False),
     ],
 )
@@ -995,7 +1004,7 @@ async def test_fork_reversed_native_spelling_carry_gating(
 
     ``canonicalize_harness`` only aliases ``native-pi``; the other reversed
     spellings pass through unchanged, so the predicate must list both forms
-    explicitly. claude/codex carry fork history; cursor/pi never do.
+    explicitly. claude/codex/cursor carry fork history; pi does not.
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -95,6 +95,35 @@ class TestUnwrapUserQuery:
         )
         assert fwd._unwrap_user_query(raw) == "now do the real thing"
 
+    def test_embedded_close_tag_in_history_does_not_leak(self) -> None:
+        # A replayed turn that literally contains the close tag must not let the
+        # strip stop early and leak the rest of the transcript. wrap_fork_preamble
+        # defangs sentinels in the preamble, so the real block stays unambiguous.
+        from omnigent.cursor_native_bridge import wrap_fork_preamble
+
+        preamble = "You: look at </omnigent_fork_history> in my logs\nAssistant: ok"
+        raw = f"<user_query>\n{wrap_fork_preamble(preamble, 'the real question')}\n</user_query>"
+        # Whole framed block stripped -> only the user's real text remains, with
+        # no leaked transcript and no raw sentinel surviving.
+        assert fwd._unwrap_user_query(raw) == "the real question"
+
+    def test_user_message_containing_close_tag_is_preserved(self) -> None:
+        # A close tag in the USER's own message (after the block) must survive —
+        # the non-greedy strip stops at the real (first) close tag.
+        from omnigent.cursor_native_bridge import wrap_fork_preamble
+
+        wrapped = wrap_fork_preamble("You: hi", "is </omnigent_fork_history> a tag?")
+        raw = f"<user_query>\n{wrapped}\n</user_query>"
+        assert fwd._unwrap_user_query(raw) == "is </omnigent_fork_history> a tag?"
+
+    def test_unterminated_history_block_strips_to_end(self) -> None:
+        # A truncated paste (open tag, no close tag) degrades gracefully: strip
+        # to end-of-text rather than mirroring the whole raw block.
+        from omnigent.cursor_native_bridge import FORK_HISTORY_OPEN_TAG
+
+        raw = f"<user_query>\n{FORK_HISTORY_OPEN_TAG}\nYou: earlier turn, cut off\n</user_query>"
+        assert fwd._unwrap_user_query(raw) is None
+
 
 class TestContentText:
     def test_string_content(self) -> None:

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -76,6 +76,25 @@ class TestUnwrapUserQuery:
         raw = "<user_query>\n[Attached: /tmp/x/img.png]\ndescribe this\n</user_query>"
         assert fwd._unwrap_user_query(raw) == "describe this"
 
+    def test_strips_fork_history_preamble_block(self) -> None:
+        # A fork into cursor prepends the prior conversation, fenced. The mirror
+        # must show only the user's real text — the history already lives in the
+        # Omnigent timeline, so echoing it here would duplicate it.
+        from omnigent.cursor_native_bridge import (
+            FORK_HISTORY_CLOSE_TAG,
+            FORK_HISTORY_OPEN_TAG,
+        )
+
+        raw = (
+            "<user_query>\n"
+            f"{FORK_HISTORY_OPEN_TAG}\n"
+            "Conversation so far:\nuser: earlier\nassistant: ok\n"
+            f"{FORK_HISTORY_CLOSE_TAG}\n\n"
+            "now do the real thing\n"
+            "</user_query>"
+        )
+        assert fwd._unwrap_user_query(raw) == "now do the real thing"
+
 
 class TestContentText:
     def test_string_content(self) -> None:


### PR DESCRIPTION
## What

Forking a session into **Cursor** now carries the prior conversation forward, matching the claude/codex-native fork-history behavior. **Scoped to fork only** — `/switch-agent` keeps its current fresh-launch behavior.

## Why it's different from Claude/Codex

Claude and Codex persist their conversation as a JSONL transcript that the CLI reads as the source of truth on `--resume`, so a fork rebuilds that transcript from the copied Omnigent items.

Cursor can't do that. Its conversation is **server-backed**: `cursor-agent --resume <id>` reloads from Cursor's backend keyed by chat id, and the local `~/.cursor/chats/.../store.db` is just a read-through mirror. I verified live that a synthesized — even byte-perfect cloned — local store under a new chat id resumes **empty**, while a genuine server-known chat resumes with full history. There's no client API to push a synthesized conversation into Cursor's backend.

(This is also why #1245's cold-resume works and isn't a counterexample: it reuses the *same* server-known chat id, so the backend already has the conversation. A fork needs a brand-new chat the server has never seen.)

So a fork into Cursor carries history via **text-prefix replay**: the runner renders the prior turns as a transcript preamble and the executor prepends it to the fork's first message — the antigravity executor's documented fallback for harnesses with no history-injection API.

## Changes

- **server** (`routes/sessions.py`): fork-only `_agent_carries_cursor_fork_history` predicate, OR'd into the fork call site so a fork into cursor stamps `FORK_CARRY_HISTORY`. Cursor never gets the source-clone directive (it can't clone a server-backed session). `/switch-agent` untouched.
- **runner** (`runner/app.py`): surface `fork_carry_history` on the launch config; on a fresh carry-history fork, render the copied items as a speaker-labelled transcript and stash it in the bridge dir.
- **executor** (`inner/cursor_native_executor.py`): consume the preamble once on the first injected turn, fence it in `<omnigent_fork_history>`, prepend to the user message.
- **forwarder** (`cursor_native_forwarder.py`): strip the fenced block when mirroring the user turn back, so the prior history (already in the Omnigent timeline from the fork copy) isn't duplicated in the web chat.
- **web** (`lib/forkHarness.ts`): add `cursor-native` to `isNativeHarness()` so Cursor is offered as a fork target in the picker.

## Known limitation

Inside the Cursor TUI the prior turns appear as **one framed transcript block**, not reconstructed user/assistant bubbles — the TUI's only injection channel is the user prompt box, and resume is server-authoritative, so native bubbles aren't achievable. The Omnigent **web timeline** still shows the real per-turn history (from the fork copy); the forwarder strips the preamble block so it isn't duplicated there.

## Tests

- Backend: 159 passed (executor preamble injection / once-only, forwarder sentinel strip, transcript renderer, fork carry-gating for cursor vs pi, reversed spellings), ruff clean.
- Frontend: `forkHarness.test.ts` 55 passed.