### PR TITLE
fix(runtime): hide temp files from git changed-files results

### DIFF
--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -711,6 +711,8 @@ class GitFilesystemRegistry(FilesystemRegistry):
             rel_path = self._git_to_rel(git_path)
             if rel_path is None:
                 continue
+            if _is_ephemeral(rel_path):
+                continue
             # Skip runner-internal and build directories (e.g. terminals/,
             # node_modules/).  These are never agent-edited source files.
             first_component = Path(rel_path).parts[0] if Path(rel_path).parts else ""
@@ -734,6 +736,8 @@ class GitFilesystemRegistry(FilesystemRegistry):
         """
         norm = _normalize_path(path, self._cwd)
         if norm is None:
+            return None
+        if _is_ephemeral(norm):
             return None
         try:
             cwd_prefix = self._cwd.relative_to(self._git_root)

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -473,6 +473,55 @@ def test_git_list_changed_files_excludes_terminals_dir(tmp_path: Path) -> None:
     )
 
 
+def test_git_changed_files_suppress_ephemeral_files(tmp_path: Path) -> None:
+    """Git-backed changed files must hide temp/editor artifacts.
+
+    The non-git registry already suppresses these names when agent tools record
+    changes.  Git workspaces should behave the same way even though they read
+    from ``git status`` instead of recorded agent events.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    ephemeral_files = [
+        "pyproject.toml.tmp.12345",
+        "pyproject.toml.tmp",
+        "notes.md~",
+        ".main.py.swp",
+        ".main.py.swo",
+        "#README.md#",
+    ]
+    for file_path in ephemeral_files:
+        (tmp_path / file_path).write_text("temporary artifact")
+    (tmp_path / "real_change.py").write_text("agent wrote this")
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    results = reg.list_changed_files("any-conv", limit=100)
+
+    paths = [r["path"] for r in results]
+    assert paths == ["real_change.py"], (
+        f"Expected only 'real_change.py', got {paths}. "
+        "Git-backed changed files should suppress temp/editor artifacts."
+    )
+    for file_path in ephemeral_files:
+        result = reg.get_changed_file("any-conv", file_path)
+        assert result is None, (
+            f"Expected get_changed_file to hide {file_path!r}, got {result!r}. "
+            "Direct file lookup should match the changed-files list."
+        )
+
+    real_result = reg.get_changed_file("any-conv", "real_change.py")
+    assert real_result is not None
+    assert real_result["status"] == "created"
+
+
 def test_git_list_changed_files_expands_untracked_nested_dir(tmp_path: Path) -> None:
     """A new file in a brand-new untracked directory tree returns its full path.
 


### PR DESCRIPTION
## Summary

This fixes a backend bug in the git-backed changed-files registry.

The non-git registry already hides temp/editor artifact files like `*.tmp`, `*.tmp.*`, `*~`, `*.swp`, `*.swo`, and `#*#`.

But the git-backed registry reads from `git status`, and it was not applying that same filter. Because of that, files like `notes.md~` or `pyproject.toml.tmp.12345` could show up as real changed files.

## What changed

- Skip ephemeral temp/editor files in `GitFilesystemRegistry.list_changed_files()`.
- Return `None` for those files in `GitFilesystemRegistry.get_changed_file()`.
- Added a regression test using a real git repo.

## Why

These files are not real source changes. They are usually created by editors, package managers, or write-temp flows.

Showing them in changed-files results adds noise and can make the Files panel look like there are extra changes that do not matter.

## Testing

- `uv run pytest tests/runtime/test_filesystem_registry.py -q`
- `uv run ruff check omnigent/runtime/filesystem_registry.py tests/runtime/test_filesystem_registry.py`
- `uv run ruff format --check omnigent/runtime/filesystem_registry.py tests/runtime/test_filesystem_registry.py`
- `git diff --check`