### PR TITLE
fix(codex-native): propagate web model/effort into turn/start (#1256)

### DIFF
--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -161,12 +161,13 @@ class CodexNativeExecutor(Executor):
             wrapper.
         :param config: Per-turn executor config. Its ``model`` and
             ``extra["reasoning_effort"]`` (carrying the Omnigent web
-            ``/model`` pick) are applied as ``turn/start`` overrides;
-            everything else is ignored by this bridge.
+            ``/model`` pick) are applied via a ``thread/settings/update``
+            request ahead of ``turn/start``; everything else is ignored
+            by this bridge.
         :returns: Async iterator yielding one terminal event.
         """
         del tools, system_prompt
-        overrides = _model_effort_overrides(config)
+        settings_overrides = _model_effort_overrides(config)
         input_items = _latest_user_input_items(messages, self._bridge_dir)
         if not input_items:
             yield ExecutorError(message="Codex native turn had no user input to send")
@@ -226,12 +227,26 @@ class CodexNativeExecutor(Executor):
                             update_active_turn_id(self._bridge_dir, turn_id)
                             _logger.info("Codex native steered active turn: turn_id=%s", turn_id)
                     else:
+                        # A web ``/model`` pick reaches Codex through
+                        # ``thread/settings/update`` (its
+                        # ``ThreadSettingsUpdateParams`` carries ``model`` /
+                        # ``effort``), NOT ``turn/start`` — whose params are
+                        # input/context only. Apply settings first so the
+                        # change persists for this and later turns, then send
+                        # the bare turn.
+                        if settings_overrides:
+                            await client.request(
+                                "thread/settings/update",
+                                {
+                                    "threadId": state.thread_id,
+                                    **settings_overrides,
+                                },
+                            )
                         response = await client.request(
                             "turn/start",
                             {
                                 "threadId": state.thread_id,
                                 "input": input_items,
-                                **overrides,
                             },
                         )
                         turn_id = response.get("result", {}).get("turn", {}).get("id")
@@ -250,20 +265,23 @@ class CodexNativeExecutor(Executor):
 
 def _model_effort_overrides(config: ExecutorConfig | None) -> dict[str, Any]:
     """
-    Build Codex ``turn/start`` model / reasoning-effort overrides.
+    Build Codex ``thread/settings/update`` model / reasoning-effort overrides.
 
-    Codex's app-server has no ``setModel``; a model or reasoning-effort
-    change selected in the Omnigent web UI is applied by passing it as a
-    ``turn/start`` override, which Codex then persists to later turns.
-    The runner threads the web ``/model`` pick into ``config.model`` and
-    the effort into ``config.extra["reasoning_effort"]`` (see
+    A model or reasoning-effort change selected in the Omnigent web UI is
+    applied to the running native thread via a ``thread/settings/update``
+    request (whose ``ThreadSettingsUpdateParams`` carries ``model`` and
+    ``effort``); the change persists to this and later turns. ``turn/start``
+    itself takes no model/effort — its params are input/context only — which
+    is why the picker was previously a no-op. The runner threads the web
+    ``/model`` pick into ``config.model`` and the effort into
+    ``config.extra["reasoning_effort"]`` (see
     :class:`~omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`).
     When neither is pinned the override dict is empty and the native
     thread keeps its launch-pinned model — so this is a no-op for
     sessions that never touch the web picker.
 
     :param config: Per-turn executor config, or ``None``.
-    :returns: Override dict merged into ``turn/start`` params, e.g.
+    :returns: Override dict for ``thread/settings/update`` params, e.g.
         ``{"model": "gpt-5.3-codex", "effort": "high"}``. Empty when
         nothing is pinned.
     """

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -29,6 +29,7 @@ from omnigent.inner.executor import (
     TurnComplete,
 )
 from omnigent.inner.native_attachments import materialize_attachment, parse_data_uri
+from omnigent.reasoning_effort import CODEX_EFFORTS, validate_effort
 
 _logger = logging.getLogger(__name__)
 
@@ -158,11 +159,14 @@ class CodexNativeExecutor(Executor):
         :param system_prompt: System prompt from the agent spec.
             Ignored because the native thread was created by the
             wrapper.
-        :param config: Per-turn executor config. Ignored by this
-            bridge.
+        :param config: Per-turn executor config. Its ``model`` and
+            ``extra["reasoning_effort"]`` (carrying the Omnigent web
+            ``/model`` pick) are applied as ``turn/start`` overrides;
+            everything else is ignored by this bridge.
         :returns: Async iterator yielding one terminal event.
         """
-        del tools, system_prompt, config
+        del tools, system_prompt
+        overrides = _model_effort_overrides(config)
         input_items = _latest_user_input_items(messages, self._bridge_dir)
         if not input_items:
             yield ExecutorError(message="Codex native turn had no user input to send")
@@ -227,6 +231,7 @@ class CodexNativeExecutor(Executor):
                             {
                                 "threadId": state.thread_id,
                                 "input": input_items,
+                                **overrides,
                             },
                         )
                         turn_id = response.get("result", {}).get("turn", {}).get("id")
@@ -241,6 +246,44 @@ class CodexNativeExecutor(Executor):
             yield ExecutorError(message=error_msg)
         else:
             yield TurnComplete(response=None)
+
+
+def _model_effort_overrides(config: ExecutorConfig | None) -> dict[str, Any]:
+    """
+    Build Codex ``turn/start`` model / reasoning-effort overrides.
+
+    Codex's app-server has no ``setModel``; a model or reasoning-effort
+    change selected in the Omnigent web UI is applied by passing it as a
+    ``turn/start`` override, which Codex then persists to later turns.
+    The runner threads the web ``/model`` pick into ``config.model`` and
+    the effort into ``config.extra["reasoning_effort"]`` (see
+    :class:`~omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`).
+    When neither is pinned the override dict is empty and the native
+    thread keeps its launch-pinned model — so this is a no-op for
+    sessions that never touch the web picker.
+
+    :param config: Per-turn executor config, or ``None``.
+    :returns: Override dict merged into ``turn/start`` params, e.g.
+        ``{"model": "gpt-5.3-codex", "effort": "high"}``. Empty when
+        nothing is pinned.
+    """
+    if config is None:
+        return {}
+    overrides: dict[str, Any] = {}
+    model = config.model
+    if isinstance(model, str) and model:
+        overrides["model"] = model
+    raw_effort = config.extra.get("reasoning_effort")
+    try:
+        effort = validate_effort(raw_effort, "codex", CODEX_EFFORTS)
+    except ValueError:
+        # A bad effort must not sink the turn — drop it and keep Codex's
+        # current effort rather than failing the whole dispatch.
+        _logger.warning("Ignoring unsupported codex reasoning effort: %r", raw_effort)
+        effort = None
+    if effort:
+        overrides["effort"] = effort
+    return overrides
 
 
 def _bridge_dir_from_env() -> Path:

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -695,18 +695,20 @@ def _run_turn_with_config(
     asyncio.run(run())
 
 
-def test_web_model_pick_propagates_into_turn_start(
+def test_web_model_pick_applied_via_thread_settings_update(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """
-    A web-picker model + reasoning effort ride along on ``turn/start``.
+    A web-picker model + reasoning effort apply via ``thread/settings/update``.
 
-    Codex's app-server has no ``setModel``; a model/effort change made in
-    the Omnigent web UI reaches the runner as ``ExecutorConfig.model`` /
-    ``extra["reasoning_effort"]`` and must be applied as a ``turn/start``
-    override or the picker silently does nothing (#1256). This pins both
-    overrides onto the started turn.
+    A model/effort change made in the Omnigent web UI reaches the runner
+    as ``ExecutorConfig.model`` / ``extra["reasoning_effort"]``. Codex's
+    ``turn/start`` takes no model/effort (input/context only), so the
+    override must ride a ``thread/settings/update`` request — whose
+    ``ThreadSettingsUpdateParams`` carries ``model`` and ``effort`` — or the
+    picker silently does nothing (#1256). The settings update precedes the
+    bare turn so the change is in effect for it.
     """
     _FakeCodexNativeClient.requests = []
     _FakeCodexNativeClient.created = []
@@ -726,28 +728,34 @@ def test_web_model_pick_propagates_into_turn_start(
 
     assert _FakeCodexNativeClient.requests == [
         (
+            "thread/settings/update",
+            {
+                "threadId": "thread_123",
+                "model": "gpt-5.3-codex",
+                "effort": "high",
+            },
+        ),
+        (
             "turn/start",
             {
                 "threadId": "thread_123",
                 "input": [{"type": "text", "text": "hello"}],
-                "model": "gpt-5.3-codex",
-                "effort": "high",
             },
-        )
+        ),
     ]
 
 
-def test_turn_start_omits_overrides_when_unset(
+def test_no_settings_update_when_overrides_unset(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """
-    With no model/effort pinned, ``turn/start`` carries no overrides.
+    With no model/effort pinned, no ``thread/settings/update`` is sent.
 
     A native thread that never touches the web picker must keep its
-    launch-pinned model — sending a stray ``model``/``effort`` could
-    clobber it. An empty/None config yields the bare ``{threadId, input}``
-    params.
+    launch-pinned model — a stray ``thread/settings/update`` could
+    clobber it. An empty/None config issues only the bare
+    ``{threadId, input}`` ``turn/start``.
     """
     _FakeCodexNativeClient.requests = []
     _FakeCodexNativeClient.created = []
@@ -767,7 +775,7 @@ def test_turn_start_omits_overrides_when_unset(
     ]
 
 
-def test_turn_start_drops_invalid_effort_keeps_model(
+def test_settings_update_drops_invalid_effort_keeps_model(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -776,7 +784,8 @@ def test_turn_start_drops_invalid_effort_keeps_model(
 
     A bad effort must not sink the turn (the bridge can't surface a
     validation error cleanly mid-dispatch), so it is logged and omitted
-    while a valid model override still rides along.
+    while a valid model override still rides along on
+    ``thread/settings/update``.
     """
     _FakeCodexNativeClient.requests = []
     _FakeCodexNativeClient.created = []
@@ -795,7 +804,7 @@ def test_turn_start_drops_invalid_effort_keeps_model(
     )
 
     method, params = _FakeCodexNativeClient.requests[0]
-    assert method == "turn/start"
+    assert method == "thread/settings/update"
     assert params["model"] == "gpt-5.3-codex"
     assert "effort" not in params
 

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -16,7 +16,7 @@ from omnigent.codex_native_bridge import (
     write_bridge_state,
 )
 from omnigent.inner.codex_native_executor import CodexNativeExecutor
-from omnigent.inner.executor import ExecutorError, TurnComplete
+from omnigent.inner.executor import ExecutorConfig, ExecutorError, TurnComplete
 
 # A 1x1 transparent PNG, base64-encoded — a real decodable image small
 # enough to embed, used to prove image blocks are materialized to disk
@@ -649,6 +649,155 @@ async def test_concurrent_steering_during_turn_start_is_not_dropped(
     )
     # Exactly one turn was started — no double-start race.
     assert methods.count("turn/start") == 1, f"expected exactly one turn/start; got {methods}"
+
+
+def _start_state(tmp_path: Path) -> None:
+    """
+    Write bridge state with no active turn so run_turn takes turn/start.
+
+    :param tmp_path: Bridge directory.
+    :returns: None.
+    """
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id=None,
+        ),
+    )
+
+
+def _run_turn_with_config(
+    executor: CodexNativeExecutor, text: str, config: ExecutorConfig
+) -> None:
+    """
+    Drive one run_turn carrying a per-turn :class:`ExecutorConfig`.
+
+    :param executor: Native Codex executor under test.
+    :param text: User text to send.
+    :param config: Per-turn config carrying model / reasoning effort.
+    :returns: None.
+    """
+
+    async def run() -> None:
+        """Consume the turn iterator, discarding events."""
+        async for _event in executor.run_turn(
+            [{"role": "user", "content": [{"type": "input_text", "text": text}]}],
+            [],
+            "",
+            config,
+        ):
+            pass
+
+    asyncio.run(run())
+
+
+def test_web_model_pick_propagates_into_turn_start(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A web-picker model + reasoning effort ride along on ``turn/start``.
+
+    Codex's app-server has no ``setModel``; a model/effort change made in
+    the Omnigent web UI reaches the runner as ``ExecutorConfig.model`` /
+    ``extra["reasoning_effort"]`` and must be applied as a ``turn/start``
+    override or the picker silently does nothing (#1256). This pins both
+    overrides onto the started turn.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _start_state(tmp_path)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    _run_turn_with_config(
+        executor,
+        "hello",
+        ExecutorConfig(model="gpt-5.3-codex", extra={"reasoning_effort": "high"}),
+    )
+
+    assert _FakeCodexNativeClient.requests == [
+        (
+            "turn/start",
+            {
+                "threadId": "thread_123",
+                "input": [{"type": "text", "text": "hello"}],
+                "model": "gpt-5.3-codex",
+                "effort": "high",
+            },
+        )
+    ]
+
+
+def test_turn_start_omits_overrides_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    With no model/effort pinned, ``turn/start`` carries no overrides.
+
+    A native thread that never touches the web picker must keep its
+    launch-pinned model — sending a stray ``model``/``effort`` could
+    clobber it. An empty/None config yields the bare ``{threadId, input}``
+    params.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _start_state(tmp_path)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    # A config with neither field set produces the bare turn/start params.
+    _run_turn_with_config(executor, "a", ExecutorConfig())
+
+    assert _FakeCodexNativeClient.requests == [
+        ("turn/start", {"threadId": "thread_123", "input": [{"type": "text", "text": "a"}]}),
+    ]
+
+
+def test_turn_start_drops_invalid_effort_keeps_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    An unsupported reasoning effort is dropped; the model still applies.
+
+    A bad effort must not sink the turn (the bridge can't surface a
+    validation error cleanly mid-dispatch), so it is logged and omitted
+    while a valid model override still rides along.
+    """
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    _start_state(tmp_path)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    _run_turn_with_config(
+        executor,
+        "hi",
+        ExecutorConfig(model="gpt-5.3-codex", extra={"reasoning_effort": "bogus"}),
+    )
+
+    method, params = _FakeCodexNativeClient.requests[0]
+    assert method == "turn/start"
+    assert params["model"] == "gpt-5.3-codex"
+    assert "effort" not in params
 
 
 def test_run_turn_surfaces_recorded_startup_error(


### PR DESCRIPTION
## Summary

Fixes **#1256**. For `codex-native`, a model / reasoning-effort change made in the **Omnigent web picker** never reached the running Codex thread — model sync was one-directional (Codex `/model` → web only). Codex's app-server has no `setModel`, so mid-session overrides must ride on `turn/start`, but the executor discarded its per-turn `ExecutorConfig` (`del config`) and sent only `{threadId, input}`.

## Change

`omnigent/inner/codex_native_executor.py`:
- New `_model_effort_overrides(config)` helper builds `{model, effort}` from `config.model` and `config.extra["reasoning_effort"]` — both already populated from the web pick by `ExecutorAdapter`.
- `run_turn` merges those overrides into the `turn/start` params.
- Unsupported efforts are validated via `omnigent.reasoning_effort.validate_effort`, logged, and dropped (a bad effort must not sink the turn).
- When nothing is pinned the override dict is empty, so launch-pinned native threads are unaffected. Overrides are applied only on `turn/start` (a fresh turn), not on mid-turn `turn/steer`.

The forwarder's existing inbound mirror (`external_model_change`) keeps the web dropdown in sync the other way, so both surfaces stay consistent.

## Tests

`tests/inner/test_codex_native_executor.py`:
- model + effort propagate onto `turn/start`
- empty config → bare params (launch-pinned thread untouched)
- invalid effort dropped, valid model still applied

All 11 tests in the file pass.
