### PR TITLE
fix(codex-native): surface context-compaction status to the web UI (#1255)

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -61,6 +61,17 @@ _POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 _DELTA_FLUSH_INTERVAL_SECONDS = 0.05
 _DELTA_FLUSH_CHAR_THRESHOLD = 64
 _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE = "external_reasoning_effort_change"
+# Context-compaction progress edge. Publishes the same
+# ``response.compaction.in_progress`` / ``response.compaction.completed`` SSE
+# the AP-side compaction path emits, so the web UI shows its "Compacting
+# conversation…" spinner while Codex compacts. Payload: ``{"status": ...}``.
+_EXTERNAL_COMPACTION_STATUS_TYPE = "external_compaction_status"
+# Codex ThreadItem type for a context compaction, and the thread-level
+# notification Codex emits when compaction finishes. (Codex 5.1-Codex-Max+
+# auto-compacts mid-turn.) Sourced from the Codex app-server protocol enums;
+# handlers are harmless no-ops if a build spells these differently.
+_CODEX_COMPACTION_ITEM_TYPE = "contextCompaction"
+_CODEX_THREAD_COMPACTED_METHOD = "thread/compacted"
 _EXTERNAL_CODEX_COLLABORATION_MODE_CHANGE_TYPE = "external_codex_collaboration_mode_change"
 # Per-attempt client budget for the elicitation long-poll, slightly above
 # the server-side wait (``_CODEX_NATIVE_ELICITATION_HOOK_TIMEOUT_S``) so
@@ -276,6 +287,11 @@ class _CodexForwarderState:
     completed_plan_text_by_turn: dict[str, str] = field(default_factory=dict)
     plan_thread_by_turn: dict[str, str] = field(default_factory=dict)
     prompted_plan_turns: set[str] = field(default_factory=set)
+    # Last context-compaction status mirrored to Omnigent
+    # (``"in_progress"`` / ``"completed"``), used to dedupe consecutive
+    # identical posts when Codex signals completion via both a
+    # ``contextCompaction`` item and a ``thread/compacted`` notification.
+    compaction_status_posted: str | None = None
 
     def note_resume_response(self, response: CodexMessage) -> None:
         """
@@ -1996,6 +2012,11 @@ async def _handle_event(
         item = params.get("item")
         if isinstance(item, dict) and item.get("type") == _CODEX_COLLAB_AGENT_ITEM_TYPE:
             await _handle_collab_item(client, params, item, forwarder_state)
+        elif isinstance(item, dict) and item.get("type") == _CODEX_COMPACTION_ITEM_TYPE:
+            # Compaction started mid-turn — show the spinner.
+            await _post_compaction_status(
+                client, route_session_id, "in_progress", forwarder_state=forwarder_state
+            )
         elif isinstance(item, dict) and item.get("type") == "agentMessage":
             # Post the turn's user message NOW — before the assistant's text
             # deltas start streaming. The live ``userMessage`` event can be
@@ -2437,6 +2458,12 @@ async def _maybe_handle_turn_event(
             await delta_coalescer.flush()
         await _handle_turn_plan_updated(client, session_id, params)
         return True
+    if method == _CODEX_THREAD_COMPACTED_METHOD:
+        # Codex finished compacting the thread's context window.
+        await _post_compaction_status(
+            client, session_id, "completed", forwarder_state=forwarder_state
+        )
+        return True
     return False
 
 
@@ -2553,6 +2580,13 @@ async def _handle_terminal_turn_boundary(
     """
     if delta_coalescer is not None:
         await delta_coalescer.flush()
+    # Safety net: if a compaction was reported in progress but Codex never
+    # emitted a completion signal we recognize (e.g. a protocol-spelling
+    # drift), force the spinner closed at the turn boundary so it can't hang.
+    if forwarder_state is not None and forwarder_state.compaction_status_posted == "in_progress":
+        await _post_compaction_status(
+            client, session_id, "completed", forwarder_state=forwarder_state
+        )
     await _maybe_persist_interrupted_partial_text(
         client,
         session_id=session_id,
@@ -3321,6 +3355,14 @@ async def _handle_completed_item(
     if item_type == _CODEX_COLLAB_AGENT_ITEM_TYPE:
         if forwarder_state is not None:
             await _handle_collab_item(client, params, item, forwarder_state)
+        return
+    # A context-compaction item is a status edge, not transcript history:
+    # clear the compaction spinner. Handled before the dedup gate (it never
+    # appends an item).
+    if item_type == _CODEX_COMPACTION_ITEM_TYPE:
+        await _post_compaction_status(
+            client, session_id, "completed", forwarder_state=forwarder_state
+        )
         return
     if not _claim_completed_item(params, item, forwarder_state):
         return
@@ -4624,6 +4666,42 @@ async def _post_output_text_delta(
         data=data,
     )
     _log_failed_session_event_post("external_output_text_delta", response)
+
+
+async def _post_compaction_status(
+    client: httpx.AsyncClient,
+    session_id: str,
+    status: str,
+    *,
+    forwarder_state: _CodexForwarderState | None,
+) -> None:
+    """
+    Mirror a Codex context-compaction edge to Omnigent (#1255).
+
+    Publishes ``external_compaction_status`` so the web UI shows its
+    "Compacting conversation…" spinner while Codex compacts and clears it
+    when done — matching how claude-native brackets compaction. Consecutive
+    identical statuses are deduped because Codex may signal completion via
+    both a ``contextCompaction`` item and a ``thread/compacted``
+    notification.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param status: ``"in_progress"`` or ``"completed"``.
+    :param forwarder_state: Optional state carrying the dedupe baseline.
+    :returns: None.
+    """
+    if forwarder_state is not None and forwarder_state.compaction_status_posted == status:
+        return
+    response = await _post_session_event(
+        client,
+        session_id,
+        event_type=_EXTERNAL_COMPACTION_STATUS_TYPE,
+        data={"status": status},
+    )
+    _log_failed_session_event_post(_EXTERNAL_COMPACTION_STATUS_TYPE, response)
+    if forwarder_state is not None and response is not None and response.status_code < 400:
+        forwarder_state.compaction_status_posted = status
 
 
 async def _post_session_interrupted(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -8848,3 +8848,68 @@ def test_command_execution_leaves_normal_output_untouched() -> None:
     assert tool_call.output == "/repo\n"
     assert "Full access" not in tool_call.output
     assert "danger-full-access" not in tool_call.output
+
+
+def test_forwarder_mirrors_codex_context_compaction(tmp_path: Path) -> None:
+    """
+    Codex context-compaction surfaces as external_compaction_status (#1255).
+
+    A ``contextCompaction`` item/started shows the spinner (in_progress) and
+    the ``thread/compacted`` notification clears it (completed). Both signals
+    were previously dropped, so the web UI never indicated Codex compacted —
+    increasingly relevant with GPT-5.1-Codex-Max auto-compaction.
+    """
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_123",
+        ),
+    )
+    forwarder_state = codex_native_forwarder._CodexForwarderState()
+    posted: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Record /events bodies; 202 for events, 200 otherwise."""
+        if request.url.path.endswith("/events"):
+            posted.append(json.loads(request.content))
+            return httpx.Response(202, json={"queued": False})
+        return httpx.Response(200, json={})
+
+    async def run() -> None:
+        """Drive a compaction start item then the completion notification."""
+        async with httpx.AsyncClient(
+            base_url="http://127.0.0.1:8000",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            for event in [
+                {
+                    "method": "item/started",
+                    "params": {
+                        "threadId": "thread_123",
+                        "turnId": "turn_123",
+                        "item": {"type": "contextCompaction", "id": "item_c"},
+                    },
+                },
+                {"method": "thread/compacted", "params": {"threadId": "thread_123"}},
+            ]:
+                await codex_native_forwarder._handle_event(
+                    client,
+                    session_id="conv_123",
+                    bridge_dir=tmp_path,
+                    usage_coalescer=_usage_coalescer(client),
+                    elicitation_tracker=_elicitation_tracker(),
+                    event=event,
+                    forwarder_state=forwarder_state,
+                )
+
+    asyncio.run(run())
+
+    compaction = [p for p in posted if p.get("type") == "external_compaction_status"]
+    assert compaction == [
+        {"type": "external_compaction_status", "data": {"status": "in_progress"}},
+        {"type": "external_compaction_status", "data": {"status": "completed"}},
+    ]

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -667,3 +667,58 @@ async def test_elicitation_post_returns_none_when_budget_exhausted(
     # 1 = the deadline check stopped the loop before a second attempt
     # (backoff 1.0s > 0.5s budget); more means the budget is ignored.
     assert len(client.posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_compaction_status_posts_and_dedupes_consecutive() -> None:
+    """
+    Compaction status mirrors as external_compaction_status, deduped (#1255).
+
+    Codex may signal completion via both a ``contextCompaction`` item and a
+    ``thread/compacted`` notification; consecutive identical statuses must
+    not double-post (the spinner would flicker).
+    """
+    client = _RecordingClient()
+    state = fwd._CodexForwarderState()
+
+    await fwd._post_compaction_status(client, "conv_x", "in_progress", forwarder_state=state)
+    await fwd._post_compaction_status(client, "conv_x", "completed", forwarder_state=state)
+    # Duplicate completion (e.g. item then notification) is suppressed.
+    await fwd._post_compaction_status(client, "conv_x", "completed", forwarder_state=state)
+
+    assert [post[1] for post in client.posts] == [
+        {"type": "external_compaction_status", "data": {"status": "in_progress"}},
+        {"type": "external_compaction_status", "data": {"status": "completed"}},
+    ]
+    assert state.compaction_status_posted == "completed"
+
+
+@pytest.mark.asyncio
+async def test_completed_context_compaction_item_clears_spinner() -> None:
+    """
+    A completed ``contextCompaction`` item posts compaction-completed.
+
+    It is a status edge, not transcript history, so it must clear the
+    spinner without being appended as a conversation item.
+    """
+    client = _RecordingClient()
+    state = fwd._CodexForwarderState()
+    state.compaction_status_posted = "in_progress"
+
+    await fwd._handle_completed_item(
+        client,
+        "conv_x",
+        {
+            "threadId": "thread_1",
+            "turnId": "turn_1",
+            "item": {"type": "contextCompaction", "id": "item_c"},
+        },
+        forwarder_state=state,
+    )
+
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {"type": "external_compaction_status", "data": {"status": "completed"}},
+        )
+    ]


### PR DESCRIPTION
## Summary

Fixes **#1255**. The `codex-native` forwarder handled none of Codex's context-compaction signals, so the web UI never indicated the context window was compacted — increasingly common now that GPT-5.1-Codex-Max auto-compacts mid-turn.

## Change

`omnigent/codex_native_forwarder.py` — mirror compaction to the **existing** `external_compaction_status` event (the same one claude-native uses → `response.compaction.in_progress` / `response.compaction.completed` SSE, driving the web UI's "Compacting conversation…" spinner):
- `contextCompaction` `item/started` → `in_progress`
- `contextCompaction` `item/completed` **and** the `thread/compacted` notification → `completed`
- Consecutive identical statuses are deduped on `_CodexForwarderState.compaction_status_posted` (Codex may signal completion via both an item and a notification).
- **Safety net:** at the terminal turn boundary, if a compaction was left `in_progress`, force `completed` — so the spinner can't hang if a completion signal is missed.

## Note on signal strings

The Codex signal identifiers (`contextCompaction` item type, `thread/compacted` notification) are sourced from the Codex app-server protocol enums, not from an in-repo reference. The handlers are **harmless no-ops** if a Codex build spells them differently (nothing else keys on them). Worth a quick confirm against live Codex / an e2e before relying on it in prod.

## Tests

- `_post_compaction_status` posts and dedupes consecutive identical statuses (`tests/test_codex_native_forwarder.py`)
- a completed `contextCompaction` item clears the spinner without appending a transcript item
- integration: `item/started` → in_progress, `thread/compacted` → completed via `_handle_event` (`tests/test_codex_native.py`)

Full `test_codex_native_forwarder.py` + `test_codex_native.py` suites pass (183).
