### PR TITLE
fix(codex-native): surface degraded forward sync instead of silent loss (#1120)

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -4713,7 +4713,116 @@ def _session_usage_data_from_params(params: dict[str, Any]) -> dict[str, int] | 
     return data
 
 
+@dataclass
+class _ForwardHealth:
+    """
+    Process-level health of Omnigent session-event forwarding (#1120).
+
+    Network failures (connect timeouts, 503s, resets) make
+    ``_post_session_event`` drop transcript/usage events after its bounded
+    retries, previously visible only as scattered per-item warnings. This
+    tracks consecutive permanent failures so a sustained outage escalates
+    to a single loud signal instead of staying effectively silent.
+
+    :param consecutive_failures: Permanent post failures since the last
+        success.
+    :param degraded_logged: Whether the degraded-sync edge has already
+        been logged for the current outage (so it logs once, not per item).
+    """
+
+    consecutive_failures: int = 0
+    degraded_logged: bool = False
+
+
+# After this many consecutive permanent forward failures, sync is treated as
+# degraded and escalated once to ERROR. Small enough to fire during a real
+# outage, large enough to ride out a transient blip the retries already cover.
+_FORWARD_DEGRADED_THRESHOLD = 5
+_forward_health = _ForwardHealth()
+
+
+def _reset_forward_health() -> None:
+    """
+    Reset forward-health tracking (test seam / new forwarder lifetime).
+
+    :returns: None.
+    """
+    global _forward_health
+    _forward_health = _ForwardHealth()
+
+
+def _note_forward_success() -> None:
+    """
+    Record a successful forward, clearing any degraded-sync state.
+
+    :returns: None.
+    """
+    if _forward_health.degraded_logged:
+        _logger.info(
+            "codex-native forward sync recovered after %d consecutive failures",
+            _forward_health.consecutive_failures,
+        )
+    _forward_health.consecutive_failures = 0
+    _forward_health.degraded_logged = False
+
+
+def _note_forward_failure(event_type: str) -> None:
+    """
+    Record a permanent forward failure; escalate once when sync degrades.
+
+    :param event_type: Session event type that failed to post, e.g.
+        ``"external_conversation_item"``.
+    :returns: None.
+    """
+    _forward_health.consecutive_failures += 1
+    if (
+        _forward_health.consecutive_failures >= _FORWARD_DEGRADED_THRESHOLD
+        and not _forward_health.degraded_logged
+    ):
+        _logger.error(
+            "codex-native forward sync degraded: %d consecutive Omnigent "
+            "event-post failures; transcript/usage mirroring may be incomplete "
+            "(latest type=%s)",
+            _forward_health.consecutive_failures,
+            event_type,
+        )
+        _forward_health.degraded_logged = True
+
+
 async def _post_session_event(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    event_type: str,
+    data: dict[str, Any],
+) -> httpx.Response | None:
+    """
+    Post one Omnigent session event, tracking forward-sync health (#1120).
+
+    Thin wrapper over :func:`_post_session_event_inner` that classifies the
+    outcome — a sub-400 response is a success; ``None`` or a >=400 final
+    response is a permanent failure — and updates :data:`_forward_health`
+    so a sustained outage escalates to a single ERROR instead of silently
+    dropping events.
+
+    :param client: HTTP client for Omnigent event posts.
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :param event_type: Session event type, e.g.
+        ``"external_conversation_item"``.
+    :param data: Event data payload, e.g. ``{"status": "running"}``.
+    :returns: The same value as :func:`_post_session_event_inner`.
+    """
+    response = await _post_session_event_inner(
+        client, session_id, event_type=event_type, data=data
+    )
+    if response is not None and response.status_code < 400:
+        _note_forward_success()
+    else:
+        _note_forward_failure(event_type)
+    return response
+
+
+async def _post_session_event_inner(
     client: httpx.AsyncClient,
     session_id: str,
     *,

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -667,3 +667,83 @@ async def test_elicitation_post_returns_none_when_budget_exhausted(
     # 1 = the deadline check stopped the loop before a second attempt
     # (backoff 1.0s > 0.5s budget); more means the budget is ignored.
     assert len(client.posts) == 1
+
+
+class _StatusClient:
+    """httpx client stub whose ``post`` returns a fixed status code."""
+
+    def __init__(self, status_code: int) -> None:
+        """:param status_code: Status to return from every post, e.g. ``400``."""
+        self.status_code = status_code
+        self.posts = 0
+
+    async def post(self, url: str, *, json: dict) -> httpx.Response:
+        """Return the configured status; never raises."""
+        del json
+        self.posts += 1
+        return httpx.Response(self.status_code, request=httpx.Request("POST", url))
+
+
+def test_forward_failures_escalate_to_degraded_once() -> None:
+    """
+    Sustained forward failures flip the degraded latch exactly once (#1120).
+
+    Network drops previously surfaced only as scattered per-item warnings;
+    the latch turns a real outage into a single loud signal and does not
+    re-fire per dropped item.
+    """
+    fwd._reset_forward_health()
+
+    for _ in range(fwd._FORWARD_DEGRADED_THRESHOLD - 1):
+        fwd._note_forward_failure("external_output_text_delta")
+    # Below threshold: not yet degraded.
+    assert fwd._forward_health.degraded_logged is False
+
+    fwd._note_forward_failure("external_output_text_delta")  # crosses threshold
+    assert fwd._forward_health.degraded_logged is True
+    assert fwd._forward_health.consecutive_failures == fwd._FORWARD_DEGRADED_THRESHOLD
+
+    # The latch holds — further failures keep counting but don't re-escalate.
+    fwd._note_forward_failure("external_output_text_delta")
+    assert fwd._forward_health.degraded_logged is True
+    assert fwd._forward_health.consecutive_failures == fwd._FORWARD_DEGRADED_THRESHOLD + 1
+
+
+def test_forward_success_resets_degraded_state() -> None:
+    """
+    A successful forward clears the failure count and degraded latch.
+
+    Recovery must re-arm the indicator so a later outage escalates again.
+    """
+    fwd._reset_forward_health()
+    for _ in range(fwd._FORWARD_DEGRADED_THRESHOLD):
+        fwd._note_forward_failure("external_session_usage")
+    assert fwd._forward_health.degraded_logged is True
+
+    fwd._note_forward_success()
+
+    assert fwd._forward_health.consecutive_failures == 0
+    assert fwd._forward_health.degraded_logged is False
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_tracks_success_and_failure() -> None:
+    """
+    _post_session_event classifies each outcome into forward health (#1120).
+
+    A 2xx clears the failure run; a permanent 4xx counts as a failure so a
+    sustained outage can escalate.
+    """
+    fwd._reset_forward_health()
+
+    # A permanent 4xx is a failure.
+    await fwd._post_session_event(
+        _StatusClient(400), "conv_x", event_type="external_session_status", data={"status": "idle"}
+    )
+    assert fwd._forward_health.consecutive_failures == 1
+
+    # A 2xx resets the run.
+    await fwd._post_session_event(
+        _RecordingClient(), "conv_x", event_type="external_session_status", data={"status": "idle"}
+    )
+    assert fwd._forward_health.consecutive_failures == 0


### PR DESCRIPTION
## Summary

Addresses **#1120**. Native-forwarder POSTs fail under network trouble (connect timeouts, 503s, resets) and, after bounded retries, drop transcript/usage events. Previously this surfaced only as scattered per-item WARNINGs — a sustained outage was effectively silent (the issue's core complaint).

## Change

`omnigent/codex_native_forwarder.py`:
- Renamed the retry loop to `_post_session_event_inner`; `_post_session_event` is now a thin wrapper that classifies each outcome into a process-level `_ForwardHealth` — a sub-400 response is a success (clears the run); `None` or a >=400 final response is a permanent failure.
- After `_FORWARD_DEGRADED_THRESHOLD` (5) consecutive failures, sync escalates **once** to a single ERROR: *"forward sync degraded … transcript/usage mirroring may be incomplete."* Recovery logs an INFO and re-arms the indicator.
- The `degraded_logged` latch guarantees one signal per outage, not one per dropped item.

## Scope

This delivers the **degraded-sync indicator** (the issue's first fix clause), converting silent loss into a loud, operator-visible signal — matching the issue's log-based evidence. **On-disk dead-letter + replay is a deliberate follow-up**: it needs a persistence path + retention policy and (for replay) ordering guarantees, which are a separate design decision. Happy to do that next if wanted.

Scoped to the codex-native forwarder (our issue set). The same wrapper pattern applies to `claude_native_forwarder.py` and the other native forwarders named in #1120 — can follow up across them, or extract a shared helper.

## Tests

`tests/test_codex_native_forwarder.py`:
- consecutive failures flip the degraded latch exactly once (no per-item re-fire)
- a success resets the count and re-arms the latch
- `_post_session_event` classifies a permanent 4xx as failure and a 2xx as success

Full `test_codex_native_forwarder.py` (28) and `test_codex_native.py` (155) suites pass.
