### PR TITLE
fix(cost-plan): trim verdict rationale by serialized length, preserving non-ASCII

### DIFF
--- a/omnigent/cost_plan.py
+++ b/omnigent/cost_plan.py
@@ -115,7 +115,11 @@ class AdvisorVerdict:
         turn (optimize mode, no user pin); ``False`` when the verdict was
         recorded but not applied (advise mode, or a user model pin won).
     :param rationale: One-sentence judge explanation, surfaced in the
-        UI and (optimize mode) in the in-turn system note.
+        UI and (optimize mode) in the in-turn system note. The judge
+        always produces a string (:mod:`omnigent.runner.cost_judge`
+        substitutes a fallback when the model returns none); ``None`` is
+        reserved for the serialize/parse round-trip's degenerate case,
+        where even an empty rationale would not fit the labels column.
     :param turn_anchor: Caller-supplied anchor tying the verdict to the
         turn that produced it (an item id or ISO timestamp), e.g.
         ``"2026-06-10T12:00:00+00:00"``. Callers sample the clock; this
@@ -126,7 +130,7 @@ class AdvisorVerdict:
     tier: str
     model: str
     applied: bool
-    rationale: str
+    rationale: str | None
     turn_anchor: str
 
 
@@ -134,15 +138,27 @@ class AdvisorVerdict:
 # than this are rejected wholesale by Postgres.
 _LABEL_VALUE_MAX_LEN = 256
 
+# Suffix marking a rationale trimmed to fit the labels column.
+_TRIM_MARKER = "..."
+
 
 def verdict_to_label_value(verdict: AdvisorVerdict) -> str:
     """
     Serialize a verdict into the :data:`COST_CONTROL_PLAN_LABEL` value.
 
     Long judge rationales are trimmed so the value fits the labels
-    column — an oversized value fails the whole write (the verdict then
-    never surfaces). The full rationale still reaches the UI via the
+    column (an oversized value fails the whole write, and the verdict
+    then never surfaces). The full rationale still reaches the UI via the
     ``routing_decision`` transcript item.
+
+    Trimming measures SERIALIZED length, not raw character count.
+    :func:`json.dumps` defaults to ``ensure_ascii=True``, so a non-ASCII
+    char escapes to ``\\uXXXX`` (6 chars) and a quote/backslash to 2;
+    counting raw chars dropped a short non-ASCII rationale wholesale (to
+    ``null``) even with column budget to spare. The trim keeps the
+    longest rationale prefix that fits, then appends
+    :data:`_TRIM_MARKER`; only the degenerate case (the other fields
+    alone overflow the column) yields a ``null`` rationale.
 
     :param verdict: The verdict to serialize.
     :returns: Compact JSON, e.g. ``'{"applied":true,"model":
@@ -159,17 +175,34 @@ def verdict_to_label_value(verdict: AdvisorVerdict) -> str:
         "turn_anchor": verdict.turn_anchor,
     }
     serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    overflow = len(serialized) - _LABEL_VALUE_MAX_LEN
-    if overflow > 0 and verdict.rationale:
-        # JSON escaping means a raw char can serialize to >1 char, so cutting
-        # overflow+3 raw chars (the "..." replaces them) always fits or more.
-        keep = max(0, len(verdict.rationale) - overflow - 3)
-        payload["rationale"] = (verdict.rationale[:keep] + "...") if keep > 0 else None
-        serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    if len(serialized) > _LABEL_VALUE_MAX_LEN:
-        payload["rationale"] = None
-        serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    return serialized
+    if len(serialized) <= _LABEL_VALUE_MAX_LEN or not verdict.rationale:
+        return serialized
+
+    # Serialized chars left for the rationale's escaped CONTENT, after the
+    # rest of the object and the trim marker take their share. base_len is
+    # measured with an empty rationale, so it already counts every other
+    # field's escaping plus the rationale value's two surrounding quotes.
+    base_payload = dict(payload)
+    base_payload["rationale"] = ""
+    base_len = len(json.dumps(base_payload, separators=(",", ":"), sort_keys=True))
+    budget = _LABEL_VALUE_MAX_LEN - base_len - len(_TRIM_MARKER)
+
+    kept = ""
+    if budget > 0:
+        # Largest prefix whose escaped content fits the budget. Escaped
+        # length is monotonic in prefix length, so binary-search it.
+        # ``json.dumps(s)`` wraps the value in quotes, hence the ``- 2``.
+        lo, hi = 0, len(verdict.rationale)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if len(json.dumps(verdict.rationale[:mid])) - 2 <= budget:
+                lo = mid
+            else:
+                hi = mid - 1
+        kept = verdict.rationale[:lo]
+
+    payload["rationale"] = (kept + _TRIM_MARKER) if kept else None
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
 
 
 def parse_verdict(labels: Mapping[str, str]) -> AdvisorVerdict | None:
@@ -186,9 +219,13 @@ def parse_verdict(labels: Mapping[str, str]) -> AdvisorVerdict | None:
     :param labels: The conversation's labels, e.g.
         ``{"cost_control.plan": '{"version": 3, ...}'}``.
     :returns: The parsed v3 verdict; ``None`` when the label is absent
-        (no advised turn yet) or is a tolerated legacy v2 label.
+        (no advised turn yet) or is a tolerated legacy v2 label. A parsed
+        verdict's ``rationale`` is ``None`` when the writer had to drop it
+        to fit the column (see :func:`verdict_to_label_value`).
     :raises ValueError: When a v3-shaped label is malformed (bad JSON,
-        wrong field types, unknown tier).
+        wrong field types, unknown tier). A ``null`` rationale is NOT
+        malformed: the writer emits it in the degenerate case, so it
+        round-trips rather than raising.
     """
     raw = labels.get(COST_CONTROL_PLAN_LABEL)
     if raw is None:
@@ -217,8 +254,10 @@ def parse_verdict(labels: Mapping[str, str]) -> AdvisorVerdict | None:
     if not isinstance(applied, bool):
         raise ValueError(f"{COST_CONTROL_PLAN_LABEL} verdict needs a boolean applied field")
     rationale = payload.get("rationale")
-    if not isinstance(rationale, str):
-        raise ValueError(f"{COST_CONTROL_PLAN_LABEL} verdict needs a string rationale field")
+    if rationale is not None and not isinstance(rationale, str):
+        raise ValueError(
+            f"{COST_CONTROL_PLAN_LABEL} verdict needs a string or null rationale field"
+        )
     turn_anchor = payload.get("turn_anchor")
     if not isinstance(turn_anchor, str):
         raise ValueError(f"{COST_CONTROL_PLAN_LABEL} verdict needs a string turn_anchor field")

--- a/tests/test_cost_plan.py
+++ b/tests/test_cost_plan.py
@@ -226,7 +226,7 @@ def test_describe_verdict_is_model_and_tier() -> None:
 
 def test_label_value_caps_long_rationale_at_column_limit() -> None:
     """An oversized judge rationale must trim to fit the varchar(256)
-    labels column — Postgres rejects the whole write otherwise (the
+    labels column (Postgres rejects the whole write otherwise, the
     haiku-shows/opus-doesn't bug)."""
     verdict = AdvisorVerdict(
         tier="expensive",
@@ -241,3 +241,99 @@ def test_label_value_caps_long_rationale_at_column_limit() -> None:
     assert parsed is not None
     assert parsed.model == verdict.model
     assert parsed.rationale is not None and parsed.rationale.endswith("...")
+
+
+def test_label_value_preserves_non_ascii_rationale_within_budget() -> None:
+    """A long non-ASCII rationale trims to a real prefix, not to null.
+
+    Regression guard for the encoding bug: ``json.dumps`` defaults to
+    ``ensure_ascii=True``, so each CJK char serializes to ``\\uXXXX``
+    (6 chars). The old trim counted raw chars against an overflow measured
+    on the escaped string, so a short non-ASCII rationale computed a
+    ``keep`` of zero and the serializer dropped it wholesale to
+    ``null`` (even with column budget to spare). The reader then raised on
+    that null. The trim must keep as much rationale as actually fits.
+    """
+    verdict = AdvisorVerdict(
+        tier="expensive",
+        model="databricks-claude-opus-4-8",
+        applied=True,
+        rationale="复杂重构任务" * 12,  # ~72 CJK chars, overflows the column
+        turn_anchor="2026-06-11T05:30:45.670436+00:00",
+    )
+    value = verdict_to_label_value(verdict)
+    assert len(value) <= 256
+    parsed = parse_verdict({COST_CONTROL_PLAN_LABEL: value})
+    assert parsed is not None
+    # The rationale survives as a trimmed prefix, not destroyed to null.
+    assert parsed.rationale is not None
+    assert parsed.rationale.endswith("...")
+    assert parsed.rationale.startswith("复杂重构")
+
+
+def test_label_value_keeps_short_non_ascii_rationale_verbatim() -> None:
+    """A non-ASCII rationale that fits is stored untouched (no trim)."""
+    verdict = AdvisorVerdict(
+        tier="cheap",
+        model="databricks-claude-haiku-4-5",
+        applied=False,
+        rationale="简单任务",
+        turn_anchor=_ANCHOR,
+    )
+    parsed = parse_verdict({COST_CONTROL_PLAN_LABEL: verdict_to_label_value(verdict)})
+    assert parsed is not None
+    assert parsed.rationale == "简单任务"
+
+
+def test_label_value_caps_escape_heavy_rationale() -> None:
+    """An all-quotes rationale (each char escapes to two) still fits 256."""
+    verdict = AdvisorVerdict(
+        tier="medium",
+        model="databricks-claude-sonnet-4-6",
+        applied=True,
+        rationale='"' * 600,
+        turn_anchor=_ANCHOR,
+    )
+    value = verdict_to_label_value(verdict)
+    assert len(value) <= 256
+    parsed = parse_verdict({COST_CONTROL_PLAN_LABEL: value})
+    assert parsed is not None
+    assert parsed.rationale is not None and parsed.rationale.endswith("...")
+
+
+def test_parse_verdict_tolerates_null_rationale() -> None:
+    """A serialized verdict carrying ``rationale: null`` parses, not raises.
+
+    ``verdict_to_label_value`` emits a null rationale in the degenerate
+    case where nothing fits, so the reader must accept it for the
+    serialize/parse round-trip to be total.
+    """
+    raw = json.dumps(
+        {
+            "version": 3,
+            "tier": "cheap",
+            "model": "databricks-claude-haiku-4-5",
+            "applied": True,
+            "rationale": None,
+            "turn_anchor": _ANCHOR,
+        }
+    )
+    parsed = parse_verdict({COST_CONTROL_PLAN_LABEL: raw})
+    assert parsed is not None
+    assert parsed.rationale is None
+
+
+def test_parse_verdict_non_string_non_null_rationale_raises() -> None:
+    """A numeric rationale is still corrupt and fails loud."""
+    raw = json.dumps(
+        {
+            "version": 3,
+            "tier": "cheap",
+            "model": "databricks-claude-haiku-4-5",
+            "applied": True,
+            "rationale": 123,
+            "turn_anchor": _ANCHOR,
+        }
+    )
+    with pytest.raises(ValueError, match="string or null rationale"):
+        parse_verdict({COST_CONTROL_PLAN_LABEL: raw})


### PR DESCRIPTION
## Related issue

Closes #1282

## Summary

- `verdict_to_label_value` (`omnigent/cost_plan.py`) trimmed a verdict's `rationale` to fit the `varchar(256)` `cost_control.plan` label by **raw character count**, subtracting an overflow that was measured on the **JSON-escaped** string. With `json.dumps(ensure_ascii=True)` a non-ASCII char escapes to `\uXXXX` (6 chars), so a short non-English rationale computed `keep <= 0` and was dropped wholesale to `"rationale": null`, even when most of the 256-char budget was free. The judge's explanation then vanished from the "Intelligent model router" popover.
- `parse_verdict` rejected the very `null` the serializer could emit, so the serialize/parse round-trip was internally inconsistent.
- Fix: trim by **serialized** length (binary-search the longest rationale prefix whose escaped form fits, then append the `...` marker), and tolerate a `null` rationale in `parse_verdict` and the `AdvisorVerdict.rationale` field so the round-trip is total. Behavior for ASCII rationales is unchanged.

ELI5: the code was measuring the rationale in "letters" but cutting against a budget measured in "bytes-after-escaping". For Chinese/emoji/quote-heavy text those differ a lot, so it threw the whole sentence away. Now it measures both in the same unit and keeps as much as actually fits.

Before vs after, for a 47-char Chinese rationale:

```
before: {"applied":true,"model":"databricks-claude-opus-4-8","rationale":null,...}   (150 chars, rationale lost)
after:  {"applied":true,"model":"databricks-claude-opus-4-8","rationale":"这是一个需要昂贵模型的复杂重构任务...",...}   (253 chars, 17 chars kept)
```

## Test Plan

- Added a failing-first regression test (`test_label_value_preserves_non_ascii_rationale_within_budget`) that today serializes to `null` and raises in `parse_verdict`; it is green after the fix.
- Added tests for: a short non-ASCII rationale preserved verbatim, an escape-heavy (all-quotes) rationale staying within 256, `parse_verdict` tolerating `null`, and `parse_verdict` still failing loud on a non-string non-null rationale.
- Commands:
  - `uv run pytest tests/test_cost_plan.py -q` -> 25 passed
  - `uv run pytest tests/runner/test_cost_advisor.py tests/runner/test_cost_judge.py tests/server/routes/test_sessions_cost_labels.py -q` -> 63 passed
  - `uv run ruff check omnigent/cost_plan.py tests/test_cost_plan.py` -> clean
  - `uv run ruff format --check` -> clean
  - `uvx pyrefly check omnigent/cost_plan.py omnigent/runner/cost_advisor.py omnigent/runner/cost_judge.py` -> 0 errors
- The existing ASCII cap test (`test_label_value_caps_long_rationale_at_column_limit`, 600 `x`) still passes unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the issue's reproduction script before the change (rationale dropped to `null`, `parse_verdict` raised) and after (rationale preserved as a trimmed prefix, label 253/256 chars, round-trips cleanly). The serialized-length trim is exercised by unit tests for non-ASCII, escape-heavy, and ASCII inputs, and the `varchar(256)` bound is asserted in each. The change is confined to `omnigent/cost_plan.py`, so a focused unit suite (per the contributing guide's area-mirroring) is the right level; no integration or e2e test is needed.
