### PR TITLE
fix(claude-native): carry poison-event drop reason on external_session_status (#1113)

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -3374,6 +3374,7 @@ async def _post_external_session_status(
     *,
     session_id: str,
     status: str,
+    output: str | None = None,
 ) -> None:
     """
     Post one ``external_session_status`` event to the Sessions API.
@@ -3382,14 +3383,21 @@ async def _post_external_session_status(
     :param session_id: Omnigent session/conversation id.
     :param status: Session status value, e.g. ``"idle"`` or
         ``"failed"``.
+    :param output: Optional text attached to the event ``data``. On a
+        ``"failed"`` edge the server surfaces it as the session's failure
+        reason (``last_task_error``) so the UI renders a detail instead of
+        a bare "failed" (#1113). Ignored when falsy.
     :returns: None.
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
+    data: dict[str, Any] = {"status": status}
+    if output:
+        data["output"] = output
     resp = await client.post(
         f"/v1/sessions/{session_id}/events",
         json={
             "type": "external_session_status",
-            "data": {"status": status},
+            "data": data,
         },
     )
     resp.raise_for_status()
@@ -3596,7 +3604,9 @@ async def _post_forwarder_failed_status(
     :returns: None.
     """
     try:
-        await _post_external_session_status(client, session_id=session_id, status="failed")
+        await _post_external_session_status(
+            client, session_id=session_id, status="failed", output=reason
+        )
     except httpx.HTTPError:
         _logger.warning(
             "Failed to publish Claude forwarder failure status; "

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -2690,7 +2690,13 @@ async def test_forwarder_drops_poison_item_after_bounded_permanent_retries(
         "external_conversation_item",
         "external_session_status",
     ]
-    assert requests[-1]["data"] == {"status": "failed"}
+    # The failed edge carries the drop reason as ``output`` so the server
+    # surfaces it as the session's failure detail instead of a bare
+    # "failed" badge (#1113).
+    assert requests[-1]["data"] == {
+        "status": "failed",
+        "output": "transcript item poison-item:0:message rejected",
+    }
     assert first.byte_offset == 0
     assert second.byte_offset == transcript_path.stat().st_size
     assert second.line_cursor == 1
@@ -6166,3 +6172,38 @@ async def test_compaction_in_progress_does_not_persist(tmp_path: Path) -> None:
     assert request["body"]["data"]["status"] == "in_progress"
     # _persist_native_compaction_item must NOT be called for in_progress.
     persist_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_external_session_status_attaches_failure_reason() -> None:
+    """A failed status carries its reason as ``output`` in the payload (#1113).
+
+    The server's ``external_session_status`` handler surfaces a failed edge's
+    ``output`` as the session's failure detail, so threading the forwarder's
+    drop reason there makes the UI render it instead of a bare "failed".
+    """
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_x/events":
+            captured.append(json.loads(request.content))
+            return httpx.Response(204)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        await forwarder._post_external_session_status(
+            client,
+            session_id="conv_x",
+            status="failed",
+            output="transcript item item-1 rejected",
+        )
+        # No reason → no output field (e.g. a normal idle edge).
+        await forwarder._post_external_session_status(client, session_id="conv_x", status="idle")
+
+    assert captured[0]["type"] == "external_session_status"
+    assert captured[0]["data"] == {
+        "status": "failed",
+        "output": "transcript item item-1 rejected",
+    }
+    assert captured[1]["data"] == {"status": "idle"}


### PR DESCRIPTION
## Related issue

Contributes to #1113 (Gap 1). The main Gap-1 path (surfacing/persisting a failed edge's reason) landed independently on `main` via the codex-native error-surfacing work; this PR covers the remaining piece it doesn't — see "Scope".

## Summary

- When the claude-native transcript forwarder drops a permanently-rejected ("poison") item, it published `external_session_status: failed` with **no reason**, so the session rendered a bare "failed" badge with no explanation.
- The server's `external_session_status` handler already surfaces a failed edge's `data.output` as the session's failure detail (`last_task_error`) and persists it. This threads the drop reason the forwarder already has in scope into that `output` field, so it's surfaced and persisted instead of lost.
- `_post_external_session_status` gains an optional `output` param (default `None`, so its other call sites are unchanged); `_post_forwarder_failed_status` passes its `reason`.

## Scope

Originally this PR also added a server-side `external_status_error_detail` helper + handler change. While it was open, `main` independently added equivalent (and more complete — it persists labels) error-surfacing to the same handler. I rebased onto `main` and dropped the redundant server-side parts, keeping only the forwarder change that `main` does **not** cover: the poison-event drop reason. The broader Gap 2/3 reason-plumbing (runner-disconnect, idle-masking) remains for follow-up.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

- `tests/test_claude_native_forwarder.py::test_post_external_session_status_attaches_failure_reason` (new) — a failed post carries `data.output`; a no-reason post omits it.
- `tests/test_claude_native_forwarder.py::test_forwarder_drops_poison_item_after_bounded_permanent_retries` (updated) — the poison-drop failed edge now carries the drop reason as `output`.

Commands run (deps via the configured index):
- `pre-commit run` on the changed files (ruff format/check, test-quality lints, hygiene) — all pass.
- `pytest tests/test_claude_native_forwarder.py` — 99 passed; the new/updated tests verified to fail before the fix.

No E2E added: this is a forwarder payload change verified deterministically by unit tests, and the server handler that consumes `data.output` on a failed edge is already covered on `main`. Backward-compatible — the new `output` param defaults to `None`, so the forwarder's other `external_session_status` call sites are unchanged.