### PR TITLE
test(codex-native): live e2e guard for web model/effort override

### DIFF
--- a/tests/e2e/test_host_codex_native_e2e.py
+++ b/tests/e2e/test_host_codex_native_e2e.py
@@ -203,6 +203,34 @@ def _content_types(item: dict[str, object]) -> list[object]:
     return [block.get("type") for block in content if isinstance(block, dict)]
 
 
+def _send_user_text(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    text: str,
+) -> None:
+    """
+    Post a user text message to a session (the web "send" action).
+
+    :param client: HTTP client pointed at the test server.
+    :param session_id: Session/conversation id.
+    :param text: User message text to deliver to the agent.
+    :returns: None.
+    """
+    resp = client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+
+
 def _poll_for_assistant_marker(
     client: httpx.Client,
     *,
@@ -1193,6 +1221,142 @@ def test_codex_native_image_only_persists_user_bubble_and_does_not_bleed(
             "the later text-only message absorbed the earlier image — the "
             "image-only turn's pending entry leaked and was folded into the "
             f"next message. content_types={_content_types(text_user_items[0])}"
+        )
+    finally:
+        daemon.send_signal(signal.SIGTERM)
+        try:
+            daemon.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+            daemon.wait()
+
+
+@pytest.mark.skipif(
+    os.environ.get("OMNIGENT_E2E_CODEX_NATIVE") != "1" or shutil.which("codex") is None,
+    reason=(
+        "codex-native model/effort override e2e needs `codex` on PATH and "
+        "OMNIGENT_E2E_CODEX_NATIVE=1 to run"
+    ),
+)
+def test_codex_native_web_model_effort_override_survives_turn(
+    live_server: str,
+    http_client: httpx.Client,
+    tmp_path: Path,
+) -> None:
+    """
+    A web model/effort pick applied mid-session does not break the turn.
+
+    Regression for #1256 / PR #1274. A model or reasoning-effort change
+    made in the Omnigent web picker reaches the runner as
+    ``ExecutorConfig.model`` / ``extra["reasoning_effort"]``, and
+    ``CodexNativeExecutor.run_turn`` now applies it via a
+    ``thread/settings/update`` request (whose ``ThreadSettingsUpdateParams``
+    carries ``model`` / ``effort``) ahead of a bare ``turn/start``.
+
+    The original fix tried to send ``model``/``effort`` ON ``turn/start`` —
+    where the app-server schema does not accept them. If those fields are
+    rejected by the real app-server (``client.request`` raises ->
+    ``ExecutorError``), *every web turn after a picker change fails*. This
+    test exercises the real codex app-server: it switches the model and
+    reasoning effort via ``PATCH /v1/sessions`` (exactly what the SPA does),
+    then sends a turn and asserts it runs to a reply. A reply proves the
+    app-server accepted the ``thread/settings/update`` the override path
+    emits — i.e. the catastrophic "every web turn fails" mode is gone.
+
+    The exact RPC shape (``thread/settings/update`` precedes a bare
+    ``turn/start``, with overrides omitted when unset and invalid effort
+    dropped) is pinned deterministically by
+    ``tests/inner/test_codex_native_executor.py``; this is the live
+    counterpart that the unit fake cannot provide — that the override is
+    *honored*, not rejected.
+
+    The target model defaults to the session's own running model (always a
+    valid id, profile-independent) so the override path is exercised on any
+    profile; set ``OMNIGENT_E2E_CODEX_SWITCH_MODEL`` to a different valid
+    codex model to drive a genuine cross-model switch.
+
+    :param live_server: Test server URL.
+    :param http_client: HTTP client pointed at the test server.
+    :param tmp_path: Per-test temp dir for the workspace and daemon log.
+    :returns: None.
+    """
+    workspace = tmp_path / "codex_ws"
+    workspace.mkdir()
+    boot_marker = f"BOOT_{uuid.uuid4().hex[:6].upper()}"
+    switched_marker = f"CODEX_{uuid.uuid4().hex[:6].upper()}"
+
+    daemon = _spawn_host_daemon(tmp_path=tmp_path, live_server=live_server)
+    try:
+        host_id = _online_host_id(http_client, timeout=30.0)
+        agent_id = _codex_native_agent_id(http_client)
+        session_id = _create_codex_host_session(
+            http_client,
+            agent_id=agent_id,
+            host_id=host_id,
+            workspace=str(workspace),
+        )
+
+        # Turn 1 establishes the native thread on its launch-pinned model,
+        # so the override below is a genuine mid-session change (the only
+        # path that must ride thread/settings/update — a fresh thread could
+        # otherwise be launch-pinned).
+        _send_user_text(
+            http_client,
+            session_id=session_id,
+            text=f"Reply with exactly one word: {boot_marker}",
+        )
+        _poll_for_assistant_marker(
+            http_client, session_id=session_id, marker=boot_marker, timeout=180.0
+        )
+
+        # Resolve a valid target model: an explicit env override, else the
+        # session's current running model (guaranteed valid on any profile).
+        session = http_client.get(f"/v1/sessions/{session_id}")
+        session.raise_for_status()
+        session_data = session.json()
+        current_model = session_data.get("model_override") or session_data.get("llm_model")
+        target_model = os.environ.get("OMNIGENT_E2E_CODEX_SWITCH_MODEL") or current_model
+        assert target_model, (
+            "could not resolve a model to override with — the session reported "
+            f"neither model_override nor llm_model: {session_data!r}"
+        )
+
+        # The web picker action: PATCH the session's model + reasoning effort.
+        # "high" is a valid codex effort (CODEX_EFFORTS) and a real settings
+        # change, so run_turn emits thread/settings/update with both fields.
+        patch = http_client.patch(
+            f"/v1/sessions/{session_id}",
+            json={"model_override": target_model, "reasoning_effort": "high"},
+            timeout=30.0,
+        )
+        patch.raise_for_status()
+
+        # Turn 2 carries the override. run_turn sends thread/settings/update
+        # {model, effort} before turn/start; if the app-server rejected those
+        # fields (the pre-fix turn-path behavior), this turn would raise an
+        # ExecutorError and the marker would never arrive.
+        _send_user_text(
+            http_client,
+            session_id=session_id,
+            text=f"Reply with exactly one word: {switched_marker}",
+        )
+        text = _poll_for_assistant_marker(
+            http_client, session_id=session_id, marker=switched_marker, timeout=180.0
+        )
+        assert switched_marker in text, (
+            f"override turn produced no marker {switched_marker!r} — the web "
+            "model/effort pick broke the turn. response: "
+            f"{text!r}"
+        )
+
+        # The picked model persisted on the session (keeps the web dropdown
+        # and the cost gate in sync). With target == the running model, the
+        # inbound forwarder mirror re-affirms the same id, so this is stable.
+        after = http_client.get(f"/v1/sessions/{session_id}")
+        after.raise_for_status()
+        assert after.json().get("model_override") == target_model, (
+            "model_override did not persist after the override turn; got "
+            f"{after.json().get('model_override')!r}, expected {target_model!r}"
         )
     finally:
         daemon.send_signal(signal.SIGTERM)


### PR DESCRIPTION
## Summary

Follow-up to #1274 (already merged). Adds a **live** e2e regression guard for the web model/reasoning-effort override on `codex-native`.

#1274 moved the override off `turn/start` (whose `TurnStartParams` schema accepts only input/context fields) onto `thread/settings/update` (whose `ThreadSettingsUpdateParams` carries `model` / `effort`). The unit tests in `tests/inner/test_codex_native_executor.py` pin the exact RPC shape, but a fake client can only prove the request is *sent* — not that the real Codex app-server *honors* it. That gap is exactly where the original bug lived: had `model`/`effort` been rejected on the turn path, **every web turn after a picker change would fail**.

## Test

`test_codex_native_web_model_effort_override_survives_turn`:
- establishes a native thread on its launch-pinned model (turn 1),
- switches the model + reasoning effort via `PATCH /v1/sessions` — exactly what the web picker does,
- sends turn 2 and asserts it runs to a reply.

A reply proves the app-server accepted the `thread/settings/update` the override path emits, i.e. the catastrophic "every web turn fails" mode is gone. Profile-independent: the target model defaults to the session's own running model (always valid); set `OMNIGENT_E2E_CODEX_SWITCH_MODEL` to drive a genuine cross-model switch. Guarded by `OMNIGENT_E2E_CODEX_NATIVE=1` + `codex` on PATH, like the rest of the suite.

Verified passing live on the oss profile (~31s).

This pull request and its description were written by Isaac.
