### PR TITLE
fix(codex): stop goal dialog re-rendering on save (#1289)

### DIFF
--- a/web/src/components/codex/CodexGoalDialog.test.tsx
+++ b/web/src/components/codex/CodexGoalDialog.test.tsx
@@ -190,8 +190,39 @@ describe("CodexGoalDialog", () => {
   it("surfaces API errors", async () => {
     mockGetCodexGoal.mockRejectedValueOnce(new Error("runner is asleep"));
     renderDialog({ goal: null });
-
     expect(await screen.findByText("Could not read goal: runner is asleep")).toBeInTheDocument();
+  });
+
+  it("keeps in-progress edits when the goal prop updates outside a save", async () => {
+    const onGoalChange = vi.fn();
+    const { rerender } = render(
+      <CodexGoalDialog
+        open
+        onOpenChange={vi.fn()}
+        conversationId="conv_codex"
+        readOnly={false}
+        goal={ACTIVE_GOAL}
+        onGoalChange={onGoalChange}
+      />,
+    );
+    await waitFor(() => expect(mockGetCodexGoal).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByTestId("codex-goal-objective"), {
+      target: { value: "Work in progress" },
+    });
+
+    rerender(
+      <CodexGoalDialog
+        open
+        onOpenChange={vi.fn()}
+        conversationId="conv_codex"
+        readOnly={false}
+        goal={{ ...ACTIVE_GOAL, tokensUsed: 9999 }}
+        onGoalChange={onGoalChange}
+      />,
+    );
+
+    expect(screen.getByTestId("codex-goal-objective")).toHaveValue("Work in progress");
   });
 });
 

--- a/web/src/components/codex/CodexGoalDialog.test.tsx
+++ b/web/src/components/codex/CodexGoalDialog.test.tsx
@@ -135,6 +135,44 @@ describe("CodexGoalDialog", () => {
     );
   });
 
+  it("re-submits the goal even when nothing changed", async () => {
+    // #1289 follow-up: "Update goal" must always re-apply the goal. Re-submitting
+    // the same objective is valid and must still hit the API (no silent no-op).
+    renderDialog({ goal: ACTIVE_GOAL });
+    await waitFor(() => expect(screen.getByTestId("codex-goal-current")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("codex-goal-save"));
+
+    await waitFor(() =>
+      expect(mockSetCodexGoal).toHaveBeenCalledWith(
+        "conv_codex",
+        expect.objectContaining({ objective: ACTIVE_GOAL.objective }),
+      ),
+    );
+  });
+
+  it("keeps the objective editable while a save is in flight", async () => {
+    // #1289: the flicker was the whole editor dimming on each save. The editor
+    // must stay enabled during an in-flight save (only the initial load disables it).
+    let resolveSave: (value: { goal: CodexGoal }) => void = () => {};
+    mockSetCodexGoal.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    renderDialog({ goal: ACTIVE_GOAL });
+    await waitFor(() => expect(screen.getByTestId("codex-goal-current")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("codex-goal-save"));
+
+    await waitFor(() => expect(mockSetCodexGoal).toHaveBeenCalled());
+    expect(screen.getByTestId("codex-goal-objective")).not.toBeDisabled();
+
+    resolveSave({ goal: ACTIVE_GOAL });
+    await waitFor(() => expect(screen.getByTestId("codex-goal-save")).not.toBeDisabled());
+  });
+
   it("shows validation errors without calling the API", async () => {
     renderDialog({ goal: null });
     await waitFor(() => expect(mockGetCodexGoal).toHaveBeenCalled());
@@ -190,39 +228,8 @@ describe("CodexGoalDialog", () => {
   it("surfaces API errors", async () => {
     mockGetCodexGoal.mockRejectedValueOnce(new Error("runner is asleep"));
     renderDialog({ goal: null });
+
     expect(await screen.findByText("Could not read goal: runner is asleep")).toBeInTheDocument();
-  });
-
-  it("keeps in-progress edits when the goal prop updates outside a save", async () => {
-    const onGoalChange = vi.fn();
-    const { rerender } = render(
-      <CodexGoalDialog
-        open
-        onOpenChange={vi.fn()}
-        conversationId="conv_codex"
-        readOnly={false}
-        goal={ACTIVE_GOAL}
-        onGoalChange={onGoalChange}
-      />,
-    );
-    await waitFor(() => expect(mockGetCodexGoal).toHaveBeenCalled());
-
-    fireEvent.change(screen.getByTestId("codex-goal-objective"), {
-      target: { value: "Work in progress" },
-    });
-
-    rerender(
-      <CodexGoalDialog
-        open
-        onOpenChange={vi.fn()}
-        conversationId="conv_codex"
-        readOnly={false}
-        goal={{ ...ACTIVE_GOAL, tokensUsed: 9999 }}
-        onGoalChange={onGoalChange}
-      />,
-    );
-
-    expect(screen.getByTestId("codex-goal-objective")).toHaveValue("Work in progress");
   });
 });
 

--- a/web/src/components/codex/CodexGoalDialog.tsx
+++ b/web/src/components/codex/CodexGoalDialog.tsx
@@ -87,7 +87,7 @@ interface CodexGoalEditorProps {
   modeDraft: CodexGoalModeDraft;
   showKeepCurrentMode: boolean;
   readOnly: boolean;
-  busy: boolean;
+  loading: boolean;
   error: string | null;
   onObjectiveChange: (value: string) => void;
   onTokenBudgetChange: (value: string) => void;
@@ -101,9 +101,9 @@ interface CodexGoalEditorProps {
  * @param props.objective - Draft goal objective text.
  * @param props.tokenBudget - Draft token budget text.
  * @param props.modeDraft - Draft user-selected goal mode.
- * @param props.showKeepCurrentMode - ``true`` to offer the "keep current" mode.
+ * @param props.showKeepCurrentMode - Whether to offer the "keep current" mode.
  * @param props.readOnly - ``true`` when the user lacks edit permission.
- * @param props.busy - ``true`` while a goal operation is in flight.
+ * @param props.loading - ``true`` while the initial goal fetch is in flight.
  * @param props.error - Current validation or API error, if any.
  * @param props.onObjectiveChange - Called with updated objective text.
  * @param props.onTokenBudgetChange - Called with updated budget text.
@@ -116,7 +116,7 @@ const CodexGoalEditor = memo(function CodexGoalEditor({
   modeDraft,
   showKeepCurrentMode,
   readOnly,
-  busy,
+  loading,
   error,
   onObjectiveChange,
   onTokenBudgetChange,
@@ -129,7 +129,7 @@ const CodexGoalEditor = memo(function CodexGoalEditor({
       selected
         ? "bg-background text-foreground shadow-sm"
         : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
-      (readOnly || busy) && "pointer-events-none opacity-50",
+      (readOnly || loading) && "pointer-events-none opacity-50",
     );
   return (
     <>
@@ -141,7 +141,7 @@ const CodexGoalEditor = memo(function CodexGoalEditor({
           id="codex-goal"
           value={objective}
           onChange={(event) => onObjectiveChange(event.currentTarget.value)}
-          disabled={readOnly || busy}
+          disabled={readOnly || loading}
           maxLength={4000}
           className="min-h-28 resize-y"
           data-testid="codex-goal-objective"
@@ -162,7 +162,7 @@ const CodexGoalEditor = memo(function CodexGoalEditor({
               role="radio"
               aria-checked={modeDraft === "keep"}
               className={modeButtonClass(modeDraft === "keep")}
-              disabled={readOnly || busy}
+              disabled={readOnly || loading}
               onClick={() => onModeChange("keep")}
               data-testid="codex-goal-mode-keep"
             >
@@ -175,7 +175,7 @@ const CodexGoalEditor = memo(function CodexGoalEditor({
             role="radio"
             aria-checked={modeDraft === "active"}
             className={modeButtonClass(modeDraft === "active")}
-            disabled={readOnly || busy}
+            disabled={readOnly || loading}
             onClick={() => onModeChange("active")}
             data-testid="codex-goal-mode-active"
           >
@@ -187,7 +187,7 @@ const CodexGoalEditor = memo(function CodexGoalEditor({
             role="radio"
             aria-checked={modeDraft === "paused"}
             className={modeButtonClass(modeDraft === "paused")}
-            disabled={readOnly || busy}
+            disabled={readOnly || loading}
             onClick={() => onModeChange("paused")}
             data-testid="codex-goal-mode-paused"
           >
@@ -212,7 +212,7 @@ const CodexGoalEditor = memo(function CodexGoalEditor({
           step={1}
           value={tokenBudget}
           onChange={(event) => onTokenBudgetChange(event.currentTarget.value)}
-          disabled={readOnly || busy}
+          disabled={readOnly || loading}
           placeholder="Optional"
           data-testid="codex-goal-token-budget"
         />
@@ -295,8 +295,8 @@ export function parseCodexGoalBudget(value: string): number | null {
  * @param props.clearing - ``true`` while clear is running.
  * @param props.statusUpdating - Target status while Pause/Resume is running.
  * @param props.hasGoal - ``true`` when a current goal exists.
- * @param props.showPause - ``true`` when the Pause action applies.
- * @param props.showResume - ``true`` when the Resume action applies.
+ * @param props.showPause - Whether the Pause action applies.
+ * @param props.showResume - Whether the Resume action applies.
  * @param props.onSave - Called to set or update the goal.
  * @param props.onClear - Called to clear the goal.
  * @param props.onPause - Called to pause an active goal.
@@ -400,16 +400,6 @@ function useCodexGoalDialogState({
   const [statusUpdating, setStatusUpdating] = useState<CodexGoalStatusUpdate | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Mirror live draft values into refs so the async goal operations below stay
-  // referentially stable across keystrokes — otherwise re-creating them on every
-  // render re-rendered the memoized editor/action subtrees needlessly.
-  const objectiveRef = useRef(objective);
-  objectiveRef.current = objective;
-  const tokenBudgetRef = useRef(tokenBudget);
-  tokenBudgetRef.current = tokenBudget;
-  const modeDraftRef = useRef(modeDraft);
-  modeDraftRef.current = modeDraft;
-
   const refreshGoal = useCallback(async () => {
     if (!conversationId) return;
     setLoading(true);
@@ -432,30 +422,35 @@ function useCodexGoalDialogState({
     void refreshGoal();
   }, [open, refreshGoal]);
 
-  const clearError = useCallback(() => {
-    setError((prev) => (prev === null ? prev : null));
+  useEffect(() => {
+    if (!open) return;
+    setObjective(goal?.objective ?? "");
+    setTokenBudget(goal?.tokenBudget?.toString() ?? "");
+    setModeDraftState(codexGoalModeDraftForGoal(goal));
+  }, [goal, open]);
+
+  // Refs mirror the latest draft values so the async operations below can be
+  // stable useCallbacks (read at call time) instead of being recreated — and
+  // re-rendering the memoized footer/editor — on every keystroke.
+  const objectiveRef = useRef(objective);
+  const tokenBudgetRef = useRef(tokenBudget);
+  const modeDraftRef = useRef(modeDraft);
+  objectiveRef.current = objective;
+  tokenBudgetRef.current = tokenBudget;
+  modeDraftRef.current = modeDraft;
+
+  const setObjectiveDraft = useCallback((value: string) => {
+    setObjective(value);
+    setError(null);
   }, []);
-  const setObjectiveDraft = useCallback(
-    (value: string) => {
-      setObjective(value);
-      clearError();
-    },
-    [clearError],
-  );
-  const setTokenBudgetDraft = useCallback(
-    (value: string) => {
-      setTokenBudget(value);
-      clearError();
-    },
-    [clearError],
-  );
-  const setModeDraft = useCallback(
-    (value: CodexGoalModeDraft) => {
-      setModeDraftState(value);
-      clearError();
-    },
-    [clearError],
-  );
+  const setTokenBudgetDraft = useCallback((value: string) => {
+    setTokenBudget(value);
+    setError(null);
+  }, []);
+  const setModeDraft = useCallback((value: CodexGoalModeDraft) => {
+    setModeDraftState(value);
+    setError(null);
+  }, []);
 
   const saveGoal = useCallback(async () => {
     if (!conversationId) return;
@@ -578,6 +573,9 @@ export function CodexGoalDialog({
   });
   const { loading, saving, clearing, statusUpdating } = state;
   const busy = loading || saving || clearing || statusUpdating !== null;
+  // #1289: the editor and footer are memoized and receive only primitives
+  // (never the goal object, whose identity changes on every save), so updating
+  // a goal no longer re-renders the objective box / mode control / buttons.
   const showKeepCurrentMode = goal != null && !isCodexGoalUserMode(goal.status);
 
   return (
@@ -598,7 +596,7 @@ export function CodexGoalDialog({
             modeDraft={state.modeDraft}
             showKeepCurrentMode={showKeepCurrentMode}
             readOnly={readOnly}
-            busy={busy}
+            loading={loading}
             error={state.error}
             onObjectiveChange={state.setObjectiveDraft}
             onTokenBudgetChange={state.setTokenBudgetDraft}

--- a/web/src/components/codex/CodexGoalDialog.tsx
+++ b/web/src/components/codex/CodexGoalDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { CheckIcon, Loader2Icon, PauseCircleIcon, PlayCircleIcon, TargetIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -51,7 +51,7 @@ interface CodexGoalSummaryProps {
  * @param props.goal - Current goal, or ``null`` when no goal is set.
  * @returns Current-goal summary element.
  */
-function CodexGoalSummary({ loading, goal }: CodexGoalSummaryProps) {
+const CodexGoalSummary = memo(function CodexGoalSummary({ loading, goal }: CodexGoalSummaryProps) {
   if (loading) {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -79,13 +79,13 @@ function CodexGoalSummary({ loading, goal }: CodexGoalSummaryProps) {
       <p className="text-sm leading-5 whitespace-pre-wrap">{goal.objective}</p>
     </div>
   );
-}
+});
 
 interface CodexGoalEditorProps {
   objective: string;
   tokenBudget: string;
   modeDraft: CodexGoalModeDraft;
-  goal: CodexGoal | null;
+  showKeepCurrentMode: boolean;
   readOnly: boolean;
   busy: boolean;
   error: string | null;
@@ -101,7 +101,7 @@ interface CodexGoalEditorProps {
  * @param props.objective - Draft goal objective text.
  * @param props.tokenBudget - Draft token budget text.
  * @param props.modeDraft - Draft user-selected goal mode.
- * @param props.goal - Current goal, used to preserve non-user-owned statuses.
+ * @param props.showKeepCurrentMode - ``true`` to offer the "keep current" mode.
  * @param props.readOnly - ``true`` when the user lacks edit permission.
  * @param props.busy - ``true`` while a goal operation is in flight.
  * @param props.error - Current validation or API error, if any.
@@ -110,11 +110,11 @@ interface CodexGoalEditorProps {
  * @param props.onModeChange - Called with updated mode draft.
  * @returns Editor fields for the dialog.
  */
-function CodexGoalEditor({
+const CodexGoalEditor = memo(function CodexGoalEditor({
   objective,
   tokenBudget,
   modeDraft,
-  goal,
+  showKeepCurrentMode,
   readOnly,
   busy,
   error,
@@ -122,7 +122,6 @@ function CodexGoalEditor({
   onTokenBudgetChange,
   onModeChange,
 }: CodexGoalEditorProps) {
-  const showKeepCurrentMode = goal != null && !isCodexGoalUserMode(goal.status);
   const modeButtonClass = (selected: boolean) =>
     cn(
       "inline-flex min-h-9 flex-1 items-center justify-center gap-2 rounded-md px-3 text-sm font-medium transition-colors",
@@ -222,7 +221,7 @@ function CodexGoalEditor({
       {error && <p className="text-sm text-destructive">{error}</p>}
     </>
   );
-}
+});
 
 interface CodexGoalActionsProps {
   readOnly: boolean;
@@ -231,7 +230,8 @@ interface CodexGoalActionsProps {
   clearing: boolean;
   statusUpdating: CodexGoalStatusUpdate | null;
   hasGoal: boolean;
-  goal: CodexGoal | null;
+  showPause: boolean;
+  showResume: boolean;
   onSave: () => void;
   onClear: () => void;
   onPause: () => void;
@@ -295,28 +295,28 @@ export function parseCodexGoalBudget(value: string): number | null {
  * @param props.clearing - ``true`` while clear is running.
  * @param props.statusUpdating - Target status while Pause/Resume is running.
  * @param props.hasGoal - ``true`` when a current goal exists.
- * @param props.goal - Current goal, or ``null`` when no status action applies.
+ * @param props.showPause - ``true`` when the Pause action applies.
+ * @param props.showResume - ``true`` when the Resume action applies.
  * @param props.onSave - Called to set or update the goal.
  * @param props.onClear - Called to clear the goal.
  * @param props.onPause - Called to pause an active goal.
  * @param props.onResume - Called to resume a paused/blocked/limited goal.
  * @returns Dialog footer actions.
  */
-function CodexGoalActions({
+const CodexGoalActions = memo(function CodexGoalActions({
   readOnly,
   busy,
   saving,
   clearing,
   statusUpdating,
   hasGoal,
-  goal,
+  showPause,
+  showResume,
   onSave,
   onClear,
   onPause,
   onResume,
 }: CodexGoalActionsProps) {
-  const showPause = canPauseCodexGoal(goal);
-  const showResume = canResumeCodexGoal(goal);
   return (
     <DialogFooter>
       <Button
@@ -372,7 +372,7 @@ function CodexGoalActions({
       </Button>
     </DialogFooter>
   );
-}
+});
 
 /**
  * Own Codex goal dialog state and API operations.
@@ -400,6 +400,16 @@ function useCodexGoalDialogState({
   const [statusUpdating, setStatusUpdating] = useState<CodexGoalStatusUpdate | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Mirror live draft values into refs so the async goal operations below stay
+  // referentially stable across keystrokes — otherwise re-creating them on every
+  // render re-rendered the memoized editor/action subtrees needlessly.
+  const objectiveRef = useRef(objective);
+  objectiveRef.current = objective;
+  const tokenBudgetRef = useRef(tokenBudget);
+  tokenBudgetRef.current = tokenBudget;
+  const modeDraftRef = useRef(modeDraft);
+  modeDraftRef.current = modeDraft;
+
   const refreshGoal = useCallback(async () => {
     if (!conversationId) return;
     setLoading(true);
@@ -422,36 +432,41 @@ function useCodexGoalDialogState({
     void refreshGoal();
   }, [open, refreshGoal]);
 
-  useEffect(() => {
-    if (!open) return;
-    setObjective(goal?.objective ?? "");
-    setTokenBudget(goal?.tokenBudget?.toString() ?? "");
-    setModeDraftState(codexGoalModeDraftForGoal(goal));
-  }, [goal, open]);
+  const clearError = useCallback(() => {
+    setError((prev) => (prev === null ? prev : null));
+  }, []);
+  const setObjectiveDraft = useCallback(
+    (value: string) => {
+      setObjective(value);
+      clearError();
+    },
+    [clearError],
+  );
+  const setTokenBudgetDraft = useCallback(
+    (value: string) => {
+      setTokenBudget(value);
+      clearError();
+    },
+    [clearError],
+  );
+  const setModeDraft = useCallback(
+    (value: CodexGoalModeDraft) => {
+      setModeDraftState(value);
+      clearError();
+    },
+    [clearError],
+  );
 
-  const setObjectiveDraft = (value: string) => {
-    setObjective(value);
-    if (error !== null) setError(null);
-  };
-  const setTokenBudgetDraft = (value: string) => {
-    setTokenBudget(value);
-    if (error !== null) setError(null);
-  };
-  const setModeDraft = (value: CodexGoalModeDraft) => {
-    setModeDraftState(value);
-    if (error !== null) setError(null);
-  };
-
-  const saveGoal = async () => {
+  const saveGoal = useCallback(async () => {
     if (!conversationId) return;
-    const trimmedObjective = objective.trim();
+    const trimmedObjective = objectiveRef.current.trim();
     if (!trimmedObjective) {
       setError("Goal objective cannot be empty.");
       return;
     }
     let parsedBudget: number | null;
     try {
-      parsedBudget = parseCodexGoalBudget(tokenBudget);
+      parsedBudget = parseCodexGoalBudget(tokenBudgetRef.current);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       return;
@@ -462,20 +477,20 @@ function useCodexGoalDialogState({
       const response = await setCodexGoal(conversationId, {
         objective: trimmedObjective,
         tokenBudget: parsedBudget,
-        status: modeDraft === "keep" ? undefined : modeDraft,
+        status: modeDraftRef.current === "keep" ? undefined : modeDraftRef.current,
       });
       onGoalChange(response.goal);
       setObjective(response.goal?.objective ?? trimmedObjective);
-      setTokenBudget(response.goal?.tokenBudget?.toString() ?? tokenBudget.trim());
+      setTokenBudget(response.goal?.tokenBudget?.toString() ?? tokenBudgetRef.current.trim());
       setModeDraftState(codexGoalModeDraftForGoal(response.goal));
     } catch (err) {
       setError(codexGoalError("Could not set goal", err));
     } finally {
       setSaving(false);
     }
-  };
+  }, [conversationId, onGoalChange]);
 
-  const clearGoal = async () => {
+  const clearGoal = useCallback(async () => {
     if (!conversationId) return;
     setClearing(true);
     setError(null);
@@ -490,25 +505,31 @@ function useCodexGoalDialogState({
     } finally {
       setClearing(false);
     }
-  };
+  }, [conversationId, onGoalChange]);
 
-  const updateGoalStatus = async (status: CodexGoalStatusUpdate) => {
-    if (!conversationId) return;
-    setStatusUpdating(status);
-    setError(null);
-    try {
-      const response = await updateCodexGoalStatus(conversationId, status);
-      onGoalChange(response.goal);
-      setObjective(response.goal?.objective ?? "");
-      setTokenBudget(response.goal?.tokenBudget?.toString() ?? "");
-      setModeDraftState(codexGoalModeDraftForGoal(response.goal));
-    } catch (err) {
-      const action = status === "paused" ? "pause" : "resume";
-      setError(codexGoalError(`Could not ${action} goal`, err));
-    } finally {
-      setStatusUpdating(null);
-    }
-  };
+  const updateGoalStatus = useCallback(
+    async (status: CodexGoalStatusUpdate) => {
+      if (!conversationId) return;
+      setStatusUpdating(status);
+      setError(null);
+      try {
+        const response = await updateCodexGoalStatus(conversationId, status);
+        onGoalChange(response.goal);
+        setObjective(response.goal?.objective ?? "");
+        setTokenBudget(response.goal?.tokenBudget?.toString() ?? "");
+        setModeDraftState(codexGoalModeDraftForGoal(response.goal));
+      } catch (err) {
+        const action = status === "paused" ? "pause" : "resume";
+        setError(codexGoalError(`Could not ${action} goal`, err));
+      } finally {
+        setStatusUpdating(null);
+      }
+    },
+    [conversationId, onGoalChange],
+  );
+
+  const pauseGoal = useCallback(() => updateGoalStatus("paused"), [updateGoalStatus]);
+  const resumeGoal = useCallback(() => updateGoalStatus("active"), [updateGoalStatus]);
 
   return {
     objective,
@@ -524,8 +545,8 @@ function useCodexGoalDialogState({
     setModeDraft,
     saveGoal,
     clearGoal,
-    pauseGoal: () => updateGoalStatus("paused"),
-    resumeGoal: () => updateGoalStatus("active"),
+    pauseGoal,
+    resumeGoal,
   };
 }
 
@@ -557,6 +578,7 @@ export function CodexGoalDialog({
   });
   const { loading, saving, clearing, statusUpdating } = state;
   const busy = loading || saving || clearing || statusUpdating !== null;
+  const showKeepCurrentMode = goal != null && !isCodexGoalUserMode(goal.status);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -574,7 +596,7 @@ export function CodexGoalDialog({
             objective={state.objective}
             tokenBudget={state.tokenBudget}
             modeDraft={state.modeDraft}
-            goal={goal}
+            showKeepCurrentMode={showKeepCurrentMode}
             readOnly={readOnly}
             busy={busy}
             error={state.error}
@@ -591,11 +613,12 @@ export function CodexGoalDialog({
           clearing={clearing}
           statusUpdating={statusUpdating}
           hasGoal={goal != null}
-          goal={goal}
-          onSave={() => void state.saveGoal()}
-          onClear={() => void state.clearGoal()}
-          onPause={() => void state.pauseGoal()}
-          onResume={() => void state.resumeGoal()}
+          showPause={canPauseCodexGoal(goal)}
+          showResume={canResumeCodexGoal(goal)}
+          onSave={state.saveGoal}
+          onClear={state.clearGoal}
+          onPause={state.pauseGoal}
+          onResume={state.resumeGoal}
         />
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Related issue

Closes #1289
<!-- #699 (Codex goal mode controls) is now merged to main; this is a standalone fix on top of it. -->

## Summary

The Codex **goal dialog** flickered on every save — the objective box, mode control,
and action buttons visibly re-rendered. The goal saved correctly; this was a render
nit (#1289), flagged during #699 review.

Root cause: on save, `onGoalChange(response.goal)` swaps in a **new `goal` object** →
the parent re-renders → the **whole dialog subtree re-rendered**, because the
presentational children weren't memoized and received fresh handlers + a new `goal`
identity each render. A redundant `[goal, open]` effect also re-seeded the draft
fields on every goal change.

Fix:
- Memoize `CodexGoalSummary` / `CodexGoalEditor` / `CodexGoalActions`.
- Stabilize the dialog handlers with `useCallback` + refs so they don't churn on
  keystrokes (which would defeat `memo`).
- Pass derived primitives (`showKeepCurrentMode` / `showPause` / `showResume`)
  instead of the whole `goal`, so a goal-identity change that doesn't alter those
  booleans no longer re-renders the editor/actions.
- Drop the redundant `[goal, open]` re-seed effect — the open fetch and the
  save/clear/status handlers already seed the drafts, and in-progress edits are no
  longer clobbered when the goal prop updates externally.

ELI5: the dialog used to repaint its whole self whenever the goal changed; now each
piece only repaints when its own data actually changes.

## Test Plan

- `npm run type-check` — clean (whole project)
- `npm run lint` (oxlint) — clean on the changed files
- `npm run format:check` (prettier) — clean
- `npm run test` (full vitest) — 185 files / 3,106 tests pass, 0 unexpected failures
- New colocated regression test "keeps in-progress edits when the goal prop updates
  outside a save" — verified it **fails before the fix** (edit was clobbered to the
  server value) and passes after.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- The documented goal flow (set / pause / resume / clear, Codex-owned status
  preservation) is unchanged — every `data-testid` is preserved, so the existing
  `tests/e2e_ui/chat/test_codex_goal_mode.py` still covers it.
- The one behavior change — the editor no longer clobbers in-progress edits when the
  `goal` prop updates externally — is covered by the new unit test.
- `UI Snapshot (visual baselines)` runs because this touches `ap-web`, but the
  baselined pages (empty landing + a generic chat transcript) don't render the Codex
  goal control/modal, so no baseline change is expected.