### PR TITLE
fix(spec): propagate inline MCP `tools:` whitelist to MCPServerConfig

### DIFF
--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -411,6 +411,7 @@ def _mcp_server_to_mcp_tool(config: MCPServerConfig) -> MCPTool:
             command=config.command,
             args=list(config.args) if config.args else None,
             env=dict(config.env) if config.env else None,
+            tools=list(config.tools) if config.tools else None,
         )
     if config.url is None:
         raise OmnigentError(
@@ -421,6 +422,7 @@ def _mcp_server_to_mcp_tool(config: MCPServerConfig) -> MCPTool:
     return MCPTool(
         url=config.url,
         headers=dict(config.headers) if config.headers else None,
+        tools=list(config.tools) if config.tools else None,
     )
 
 
@@ -1820,6 +1822,7 @@ def _translate_mcp_tool_from_def(
             url=tool.url,
             headers=dict(tool.headers) if tool.headers else {},
             databricks_profile=tool.profile,
+            tools=list(tool.tools) if tool.tools else None,
         )
     if tool.command is not None:
         return MCPServerConfig(
@@ -1828,6 +1831,7 @@ def _translate_mcp_tool_from_def(
             command=tool.command,
             args=list(tool.args) if tool.args else [],
             env=dict(tool.env) if tool.env else {},
+            tools=list(tool.tools) if tool.tools else None,
         )
     raise OmnigentError(
         f"omnigent MCP tool {tool_name!r} has neither 'url' nor "

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -1862,6 +1862,17 @@ def _parse_inline_mcp_servers(
                     code=ErrorCode.INVALID_INPUT,
                 )
             databricks_profile = str(raw_profile)
+        # Optional per-server tool allow-list (the YAML ``tools:`` whitelist) —
+        # only these tool names are exposed to the model; ``None`` exposes all.
+        # Mirrors ``MCPTool.tools`` and is filtered downstream in
+        # server/mcp_pool.py + runner/mcp_manager.py.
+        raw_allow = val.get("tools")
+        if raw_allow is not None and not isinstance(raw_allow, list):
+            raise OmnigentError(
+                f"Inline MCP server {name!r} 'tools' must be a list of tool names",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        tool_allowlist = [str(t) for t in raw_allow] if raw_allow else None
         servers.append(
             MCPServerConfig(
                 name=name,
@@ -1876,6 +1887,7 @@ def _parse_inline_mcp_servers(
                 headers=headers,
                 env=env,
                 databricks_profile=databricks_profile,
+                tools=tool_allowlist,
             )
         )
     return servers

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -918,6 +918,12 @@ class MCPServerConfig:
     command: str | None = None
     args: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict, repr=False)
+    # Optional per-server tool allow-list: only these tool names are exposed to
+    # the model; others are filtered at registration (server/mcp_pool.py,
+    # runner/mcp_manager.py). ``None`` exposes all. Applies to both transports
+    # and mirrors ``MCPTool.tools`` / the YAML ``tools:`` whitelist documented
+    # in docs/AGENT_YAML_SPEC.md.
+    tools: list[str] | None = None
     description: str | None = None
     # Per-tool timeout/retry overrides. None = inherit from
     # tools.timeout / tools.retry.

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -203,6 +203,49 @@ def test_parse_llm_connection_unresolved_var_raises(
         parse(tmp_path)
 
 
+def test_parse_inline_mcp_tools_whitelist(tmp_path: Path) -> None:
+    """A per-server ``tools:`` whitelist on an inline MCP tool propagates to
+    ``MCPServerConfig.tools`` (regression: it was silently dropped, so the
+    documented allow-list was a no-op and all tools were exposed)."""
+    config = {
+        "spec_version": 1,
+        "tools": {
+            "github": {
+                "type": "mcp",
+                "command": "npx",
+                "args": ["-y", "server-github"],
+                "tools": ["search_issues", "get_pull_request"],
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    cfg = next(m for m in spec.mcp_servers if m.name == "github")
+    assert cfg.tools == ["search_issues", "get_pull_request"]
+
+
+def test_parse_inline_mcp_tools_absent_is_none(tmp_path: Path) -> None:
+    """Omitting ``tools:`` leaves the allow-list as ``None`` (expose all)."""
+    config = {
+        "spec_version": 1,
+        "tools": {"github": {"type": "mcp", "command": "npx", "args": []}},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    cfg = next(m for m in parse(tmp_path).mcp_servers if m.name == "github")
+    assert cfg.tools is None
+
+
+def test_parse_inline_mcp_tools_non_list_raises(tmp_path: Path) -> None:
+    """A non-list ``tools:`` value is a clear error, not a silent type bug."""
+    config = {
+        "spec_version": 1,
+        "tools": {"github": {"type": "mcp", "command": "npx", "tools": "search_issues"}},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"'tools' must be a list"):
+        parse(tmp_path)
+
+
 def test_parse_expand_env_false_keeps_var_references(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem
The per-server `tools:` allow-list documented in `docs/AGENT_YAML_SPEC.md` is parsed onto `MCPTool.tools` but never carried to `MCPServerConfig`. The downstream registration filter (`server/mcp_pool.py`, `runner/mcp_manager.py`, which read `getattr(server.config, "tools", None)`) therefore always sees `None` and exposes **every** tool — the documented whitelist is a silent no-op.

## Fix
- add `tools: list[str] | None` to `MCPServerConfig` (`spec/types.py`)
- read + validate `tools:` in `_parse_inline_mcp_servers` (`spec/parser.py`) — the inline agent-YAML path that dropped it
- carry it through `_translate_mcp_tool_from_def` / `_mcp_server_to_mcp_tool` for def↔spec round-trip symmetry (`spec/omnigent.py`)
- regression tests in `tests/spec/test_parser.py`

## Testing
Regression tests added in `tests/spec/test_parser.py`.
