### PR TITLE
fix(electron): unconditionally hide workspace nav bar in desktop app

### DIFF
--- a/ap-web/electron/src/main.js
+++ b/ap-web/electron/src/main.js
@@ -31,7 +31,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 const { registerLocalhostCors } = require("./localhost_cors");
-const { normalizeUrl, expandDatabricksWorkspaceUrl, WORKSPACE_UI_PATH } = require("./url");
+const { normalizeUrl, expandDatabricksWorkspaceUrl } = require("./url");
 
 /** Absolute path to the bundled setup page (the "connect to server" form). */
 const SETUP_PAGE = path.join(__dirname, "..", "setup", "index.html");
@@ -862,15 +862,7 @@ function createWindow(targetUrl, opts = {}) {
   // is a fresh document); the SPA's own client-side routing keeps the same
   // document, so the injected stylesheet persists across in-app navigation.
   win.webContents.on("did-finish-load", () => {
-    let pathname = "";
-    try {
-      pathname = new URL(win.webContents.getURL()).pathname;
-    } catch {
-      return;
-    }
-    if (pathname.startsWith(WORKSPACE_UI_PATH)) {
-      void win.webContents.insertCSS(WORKSPACE_CHROME_HIDE_CSS);
-    }
+    void win.webContents.insertCSS(WORKSPACE_CHROME_HIDE_CSS);
   });
 
   win.on("closed", () => {

--- a/ap-web/electron/src/main.js
+++ b/ap-web/electron/src/main.js
@@ -32,6 +32,7 @@ const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 const { registerLocalhostCors } = require("./localhost_cors");
 const { normalizeUrl, expandDatabricksWorkspaceUrl } = require("./url");
+const { registerWorkspaceChromeHide } = require("./workspace-chrome");
 
 /** Absolute path to the bundled setup page (the "connect to server" form). */
 const SETUP_PAGE = path.join(__dirname, "..", "setup", "index.html");
@@ -597,29 +598,6 @@ function rememberRecentServer(settings, url) {
   ].slice(0, MAX_RECENT_SERVERS);
 }
 
-/**
- * CSS that hides the Databricks workspace navigation chrome around a
- * workspace-hosted Omnigent SPA.
- *
- * On a workspace the SPA is mounted as a workspace *page*, so Databricks wraps
- * it in its top-nav shell (the dark bar with the workspace switcher). In a
- * dedicated desktop window that chrome is just noise. We promote Omnigent's
- * own root — ``.omnigent-app``, the wrapper ap-web's embed entry sets
- * (``ap-web/src/embed.tsx``) — to a full-viewport overlay so it paints over
- * the workspace bar. Keying on Omnigent's wrapper (defined in THIS repo)
- * rather than the monolith-owned, unstable workspace nav markup keeps this
- * from silently breaking when Databricks reshuffles its chrome; on a
- * standalone (non-embed) build there is no ``.omnigent-app``, so the rule is
- * a harmless no-op.
- */
-const WORKSPACE_CHROME_HIDE_CSS = `
-  .omnigent-app {
-    position: fixed !important;
-    inset: 0 !important;
-    z-index: 2147483647 !important;
-  }
-`;
-
 // ---------------------------------------------------------------------------
 // Window + navigation
 // ---------------------------------------------------------------------------
@@ -858,12 +836,8 @@ function createWindow(targetUrl, opts = {}) {
   // Databricks workspace-hosted Omnigent renders inside the workspace's
   // top-nav chrome (the SPA is a workspace page). On a dedicated desktop
   // window, hide it by overlaying Omnigent's own root — see
-  // WORKSPACE_CHROME_HIDE_CSS. Re-applied on every full load (a server switch
-  // is a fresh document); the SPA's own client-side routing keeps the same
-  // document, so the injected stylesheet persists across in-app navigation.
-  win.webContents.on("did-finish-load", () => {
-    void win.webContents.insertCSS(WORKSPACE_CHROME_HIDE_CSS);
-  });
+  // registerWorkspaceChromeHide, which wires the inject-on-did-finish-load.
+  registerWorkspaceChromeHide(win.webContents);
 
   win.on("closed", () => {
     windows.delete(win);

--- a/ap-web/electron/src/workspace-chrome.js
+++ b/ap-web/electron/src/workspace-chrome.js
@@ -1,0 +1,66 @@
+// Hiding the Databricks workspace navigation chrome around a workspace-hosted
+// Omnigent SPA. Kept in its own Electron-free module so the injection logic is
+// unit-testable (test/workspace-chrome.test.js calls applyWorkspaceChromeHideCss
+// with a fake webContents) without requiring main.js, which boots the app.
+
+/**
+ * CSS that hides the Databricks workspace navigation chrome.
+ *
+ * On a workspace the SPA is mounted as a workspace *page*, so Databricks wraps
+ * it in its top-nav shell (the dark bar with the workspace switcher). In a
+ * dedicated desktop window that chrome is just noise. We promote Omnigent's
+ * own root — ``.omnigent-app``, the wrapper ap-web's embed entry sets
+ * (``ap-web/src/embed.tsx``) — to a full-viewport overlay so it paints over
+ * the workspace bar. Keying on Omnigent's wrapper (defined in THIS repo)
+ * rather than the monolith-owned, unstable workspace nav markup keeps this
+ * from silently breaking when Databricks reshuffles its chrome; on a
+ * standalone (non-embed) build there is no ``.omnigent-app``, so the rule is
+ * a harmless no-op.
+ */
+const WORKSPACE_CHROME_HIDE_CSS = `
+  .omnigent-app {
+    position: fixed !important;
+    inset: 0 !important;
+    z-index: 2147483647 !important;
+  }
+`;
+
+/**
+ * Inject the chrome-hide CSS into a finished-loading webContents.
+ *
+ * Injection is UNCONDITIONAL by design. An earlier version gated this behind
+ * ``pathname.startsWith(WORKSPACE_UI_PATH)``, which silently skipped injection
+ * whenever the loaded URL didn't match the mount path (auth redirects, path
+ * variants) and left the workspace switcher visible. Because the CSS only
+ * targets ``.omnigent-app`` — which exists solely in the workspace-embedded
+ * build — injecting on every load is a harmless no-op on standalone servers.
+ * Do not reintroduce a URL/path guard here.
+ *
+ * @param {{ insertCSS: (css: string) => Promise<unknown> }} webContents
+ */
+function applyWorkspaceChromeHideCss(webContents) {
+  void webContents.insertCSS(WORKSPACE_CHROME_HIDE_CSS);
+}
+
+/**
+ * Wire chrome-hide injection to a window's webContents.
+ *
+ * The CSS is (re)injected on every ``did-finish-load`` — a full document load
+ * such as the initial navigation or a server switch. The SPA's own client-side
+ * routing keeps the same document, so the injected stylesheet persists across
+ * in-app navigation without re-firing.
+ *
+ * @param {{ on: (event: string, listener: () => void) => void,
+ *           insertCSS: (css: string) => Promise<unknown> }} webContents
+ */
+function registerWorkspaceChromeHide(webContents) {
+  webContents.on("did-finish-load", () => {
+    applyWorkspaceChromeHideCss(webContents);
+  });
+}
+
+module.exports = {
+  WORKSPACE_CHROME_HIDE_CSS,
+  applyWorkspaceChromeHideCss,
+  registerWorkspaceChromeHide,
+};

--- a/ap-web/electron/test/main.test.js
+++ b/ap-web/electron/test/main.test.js
@@ -1,11 +1,19 @@
-// Regression guard for the workspace-chrome CSS injection in src/main.js, run
-// with `node --test` (no extra deps). The bug: a `pathname.startsWith(
-// WORKSPACE_UI_PATH)` guard around insertCSS silently skipped injection when
-// the loaded URL didn't match the mount path (auth redirects, path variants),
-// leaving the Databricks workspace chrome visible. The CSS targets
-// `.omnigent-app`, which only exists in the workspace-embedded build, so
-// injecting unconditionally is a harmless no-op on standalone servers. This
-// guard fails if the path condition is reintroduced.
+// Regression guard for how src/main.js WIRES workspace-chrome injection, run
+// with `node --test` (no extra deps). The wiring itself lives in
+// src/workspace-chrome.js (registerWorkspaceChromeHide registers a
+// did-finish-load listener that injects the chrome-hide CSS) and its BEHAVIOR is
+// unit-tested in workspace-chrome.test.js. This guards the complementary half
+// that no behavior test can see: that main.js still actually INVOKES
+// registerWorkspaceChromeHide(win.webContents) as live code — not removed, not
+// commented out.
+//
+// A naive source-string match would pass even if the call were commented out
+// (the text still appears in the comment), so we strip comments from the source
+// before asserting. URL slashes (`https://`) are preserved by only treating a
+// `//` NOT preceded by `:` as a line comment. (This cannot prove the call runs
+// at runtime — only an Electron launch could — but it does catch the call being
+// removed or commented out, which the behavior test in workspace-chrome.test.js
+// cannot, because that test never touches main.js.)
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
@@ -14,20 +22,38 @@ const path = require("node:path");
 
 const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
 
-describe("workspace chrome CSS injection (src/main.js)", () => {
-  it("injects WORKSPACE_CHROME_HIDE_CSS from the did-finish-load handler", () => {
-    const handler = mainSource.match(/did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/);
-    assert.ok(handler, "did-finish-load handler not found in main.js");
-    assert.match(handler[1], /insertCSS\(WORKSPACE_CHROME_HIDE_CSS\)/);
+// Strip block comments, then line comments (leaving `://` in URLs intact).
+const liveCode = mainSource
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+describe("workspace chrome injection wiring (src/main.js)", () => {
+  it("invokes registerWorkspaceChromeHide(win.webContents) as live code", () => {
+    assert.match(
+      liveCode,
+      /registerWorkspaceChromeHide\(win\.webContents\)/,
+      [
+        "src/main.js no longer has a live registerWorkspaceChromeHide(win.webContents)",
+        "call (it was removed or commented out). That call wires the did-finish-load",
+        "listener that injects WORKSPACE_CHROME_HIDE_CSS to hide the Databricks workspace",
+        "top-nav/switcher in the desktop window. Without it the switcher reappears and users",
+        "can navigate out of Omnigent into other workspace apps. Re-add the call (the wiring",
+        "is defined in src/workspace-chrome.js); do not delete this test.",
+      ].join(" "),
+    );
   });
 
-  it("does not gate injection behind a WORKSPACE_UI_PATH check", () => {
-    const handler = mainSource.match(/did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/);
-    assert.ok(handler, "did-finish-load handler not found in main.js");
+  it("does not gate the wiring behind a URL/path check", () => {
     assert.doesNotMatch(
-      handler[1],
-      /WORKSPACE_UI_PATH/,
-      "path guard reintroduced — CSS injection must be unconditional",
+      liveCode,
+      /registerWorkspaceChromeHide[\s\S]{0,200}(WORKSPACE_UI_PATH|pathname|startsWith)/,
+      [
+        "A URL/path gate was reintroduced around the chrome-hide wiring. It must stay",
+        "UNCONDITIONAL: the original bug gated on pathname.startsWith(WORKSPACE_UI_PATH),",
+        "which skipped injection on auth redirects and path variants and left the workspace",
+        "switcher visible. The CSS targets .omnigent-app (workspace-embedded build only), so",
+        "injecting on every load is a safe no-op elsewhere. See src/workspace-chrome.js.",
+      ].join(" "),
     );
   });
 });

--- a/ap-web/electron/test/main.test.js
+++ b/ap-web/electron/test/main.test.js
@@ -23,9 +23,7 @@ const path = require("node:path");
 const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
 
 // Strip block comments, then line comments (leaving `://` in URLs intact).
-const liveCode = mainSource
-  .replace(/\/\*[\s\S]*?\*\//g, "")
-  .replace(/(^|[^:])\/\/.*$/gm, "$1");
+const liveCode = mainSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
 
 describe("workspace chrome injection wiring (src/main.js)", () => {
   it("invokes registerWorkspaceChromeHide(win.webContents) as live code", () => {

--- a/ap-web/electron/test/main.test.js
+++ b/ap-web/electron/test/main.test.js
@@ -1,0 +1,37 @@
+// Regression guard for the workspace-chrome CSS injection in src/main.js, run
+// with `node --test` (no extra deps). The bug: a `pathname.startsWith(
+// WORKSPACE_UI_PATH)` guard around insertCSS silently skipped injection when
+// the loaded URL didn't match the mount path (auth redirects, path variants),
+// leaving the Databricks workspace chrome visible. The CSS targets
+// `.omnigent-app`, which only exists in the workspace-embedded build, so
+// injecting unconditionally is a harmless no-op on standalone servers. This
+// guard fails if the path condition is reintroduced.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const path = require("node:path");
+
+const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
+
+describe("workspace chrome CSS injection (src/main.js)", () => {
+  it("injects WORKSPACE_CHROME_HIDE_CSS from the did-finish-load handler", () => {
+    const handler = mainSource.match(
+      /did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/,
+    );
+    assert.ok(handler, "did-finish-load handler not found in main.js");
+    assert.match(handler[1], /insertCSS\(WORKSPACE_CHROME_HIDE_CSS\)/);
+  });
+
+  it("does not gate injection behind a WORKSPACE_UI_PATH check", () => {
+    const handler = mainSource.match(
+      /did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/,
+    );
+    assert.ok(handler, "did-finish-load handler not found in main.js");
+    assert.doesNotMatch(
+      handler[1],
+      /WORKSPACE_UI_PATH/,
+      "path guard reintroduced — CSS injection must be unconditional",
+    );
+  });
+});

--- a/ap-web/electron/test/main.test.js
+++ b/ap-web/electron/test/main.test.js
@@ -16,17 +16,13 @@ const mainSource = readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
 
 describe("workspace chrome CSS injection (src/main.js)", () => {
   it("injects WORKSPACE_CHROME_HIDE_CSS from the did-finish-load handler", () => {
-    const handler = mainSource.match(
-      /did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/,
-    );
+    const handler = mainSource.match(/did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/);
     assert.ok(handler, "did-finish-load handler not found in main.js");
     assert.match(handler[1], /insertCSS\(WORKSPACE_CHROME_HIDE_CSS\)/);
   });
 
   it("does not gate injection behind a WORKSPACE_UI_PATH check", () => {
-    const handler = mainSource.match(
-      /did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/,
-    );
+    const handler = mainSource.match(/did-finish-load"\s*,\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*\)\s*;/);
     assert.ok(handler, "did-finish-load handler not found in main.js");
     assert.doesNotMatch(
       handler[1],

--- a/ap-web/electron/test/workspace-chrome.test.js
+++ b/ap-web/electron/test/workspace-chrome.test.js
@@ -1,0 +1,109 @@
+// Unit test for the workspace-chrome CSS injection (src/workspace-chrome.js),
+// run with `node --test` (no extra deps). It calls the REAL function that
+// main.js wires to the webContents `did-finish-load` event, passing a fake
+// webContents whose URL is NOT under the workspace mount path.
+//
+// The original bug gated injection behind `pathname.startsWith(
+// WORKSPACE_UI_PATH)`, so on such URLs (auth redirects, path variants) the CSS
+// never landed and the Databricks workspace switcher stayed visible.
+// Reintroducing any URL/path guard inside applyWorkspaceChromeHideCss stops
+// insertCSS from firing here, failing this test.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  applyWorkspaceChromeHideCss,
+  registerWorkspaceChromeHide,
+  WORKSPACE_CHROME_HIDE_CSS,
+} = require("../src/workspace-chrome");
+
+describe("applyWorkspaceChromeHideCss", () => {
+  it("injects the chrome-hide CSS even when the URL is not under the workspace path", () => {
+    const injected = [];
+    const webContents = {
+      // A path variant the old guard would have skipped (not /ml/omnigents).
+      getURL: () => "https://dbc-x.cloud.databricks.com/dashboard",
+      insertCSS: (css) => {
+        injected.push(css);
+        return Promise.resolve();
+      },
+    };
+
+    applyWorkspaceChromeHideCss(webContents);
+
+    assert.deepEqual(
+      injected,
+      [WORKSPACE_CHROME_HIDE_CSS],
+      [
+        "applyWorkspaceChromeHideCss must inject WORKSPACE_CHROME_HIDE_CSS for ANY loaded",
+        "URL, but it did not fire for a non-/ml/omnigents path. A URL/path guard has likely",
+        "been reintroduced. That is the original bug: gating injection by path left the",
+        "Databricks workspace switcher visible on auth redirects and path variants. Injection",
+        "must stay unconditional — the CSS only targets .omnigent-app (workspace-embedded",
+        "build), so it is a harmless no-op elsewhere.",
+      ].join(" "),
+    );
+  });
+});
+
+describe("registerWorkspaceChromeHide", () => {
+  // This is the behavior half of the guard. main.test.js proves main.js still
+  // CALLS registerWorkspaceChromeHide; this proves the function, once called,
+  // injects exactly once per full document load. We hand it a fake webContents
+  // that captures the listener registered via `.on(eventName, listener)`, then
+  // fire the event ourselves and assert the CSS landed.
+  function fakeWebContents() {
+    const listeners = new Map();
+    const injected = [];
+    return {
+      injected,
+      emit(eventName) {
+        const listener = listeners.get(eventName);
+        if (listener) listener();
+      },
+      on: (eventName, listener) => {
+        listeners.set(eventName, listener);
+      },
+      insertCSS: (css) => {
+        injected.push(css);
+        return Promise.resolve();
+      },
+    };
+  }
+
+  it("injects nothing until a full load fires", () => {
+    const webContents = fakeWebContents();
+
+    registerWorkspaceChromeHide(webContents);
+
+    assert.deepEqual(
+      webContents.injected,
+      [],
+      [
+        "registerWorkspaceChromeHide injected CSS at wiring time instead of waiting for a",
+        "load event. It must only register a listener; injecting before the document is",
+        "ready can no-op against a blank page and leave the workspace chrome visible.",
+      ].join(" "),
+    );
+  });
+
+  it("injects the chrome-hide CSS once when did-finish-load fires", () => {
+    const webContents = fakeWebContents();
+
+    registerWorkspaceChromeHide(webContents);
+    webContents.emit("did-finish-load");
+
+    assert.deepEqual(
+      webContents.injected,
+      [WORKSPACE_CHROME_HIDE_CSS],
+      [
+        "registerWorkspaceChromeHide did not inject WORKSPACE_CHROME_HIDE_CSS exactly once",
+        "after did-finish-load fired. Likely the event name was changed (it must stay",
+        "'did-finish-load', the full-document-load event), the listener was not registered,",
+        "or the injection was dropped. Without this, the Databricks workspace top-nav/switcher",
+        "stays visible in the desktop window and users can navigate out of Omnigent.",
+      ].join(" "),
+    );
+  });
+});


### PR DESCRIPTION
## What was broken

In the desktop app, the Databricks workspace nav bar (top chrome + app switcher) was supposed to be hidden so users stay inside Omnigent. The CSS that hides it (`WORKSPACE_CHROME_HIDE_CSS`) was injected on `did-finish-load` — **but only when the loaded URL's path started with `WORKSPACE_UI_PATH` (`/ml/omnigents`)**.

That guard backfired: on any other URL — auth redirects, path variants — the injection was skipped, the workspace nav bar stayed visible, and users could click out of Omnigent into other workspace apps.

## The fix

Inject the CSS **unconditionally** on every full page load. This is safe because the CSS only targets `.omnigent-app` — the root wrapper that exists solely in the workspace-embedded build (`ap-web/src/embed.tsx`). On a standalone server there's no such element, so the rule is a harmless no-op. The dead `WORKSPACE_UI_PATH` import is removed.

## Why the refactor

The injection logic couldn't be imported and tested directly, because `main.js` boots Electron the moment it's required. So the wiring was pulled into a small Electron-free module, `ap-web/electron/src/workspace-chrome.js`, exposing:

- `applyWorkspaceChromeHideCss(webContents)` — injects the CSS once.
- `registerWorkspaceChromeHide(webContents)` — registers the `did-finish-load` listener that calls it.

`main.js` now just calls `registerWorkspaceChromeHide(win.webContents)`.

## Test coverage

Two complementary layers, because no single cheap test can cover everything:

1. **Behavior** (`workspace-chrome.test.js`) — drives the real functions against a fake `webContents`: asserts injection is unconditional (fires on a non-`/ml/omnigents` URL), that nothing injects before a load, and that exactly one injection happens when `did-finish-load` fires. This catches a reintroduced path guard or a changed event name.
2. **Wiring** (`main.test.js`) — a comment-aware source check that `main.js` still makes a live, uncommented `registerWorkspaceChromeHide(win.webContents)` call. This catches the call being deleted or commented out — the one thing the behavior test can't see, since it never touches `main.js`.

The only thing left to a real Electron launch is proving the listener fires at runtime; the wiring check stands in for that.

## Test plan

- [x] `npm test` in `ap-web/electron` — 25/25 pass.
- [x] Verified the guards bite: removing/commenting the `main.js` call fails the wiring test; changing the event name fails the behavior test.
- [x] Built and launched the desktop app locally; nav bar stays hidden across navigation and server switches.
