### PR TITLE
feat(ap-web): render Markdown (.md) files in the file preview pane

### DIFF
--- a/ap-web/src/lib/fileViewPreferences.ts
+++ b/ap-web/src/lib/fileViewPreferences.ts
@@ -28,7 +28,12 @@ const STORAGE_KEY = "omnigent:file-view-preferences";
 export const DEFAULT_FILE_VIEW_PREFERENCES: FileViewPreferences = {
   diffActive: false,
   diffLayout: "unified",
-  previewableViewMode: "editor",
+  // Default rendered view for previewable (markdown/html) files. "preview"
+  // opens both in their read-only render. Markdown additionally supports an
+  // editable "editor" mode and "source"; HTML has no editor and collapses
+  // "editor" → "preview" (see FileViewer). Flip this to "editor" to make .md
+  // open directly in the rich-text editor instead — HTML is unaffected.
+  previewableViewMode: "preview",
   hideWhitespace: false,
 };
 

--- a/ap-web/src/shell/CodeViewer.test.tsx
+++ b/ap-web/src/shell/CodeViewer.test.tsx
@@ -320,3 +320,28 @@ describe("CodeViewer image rendering", () => {
     expect(await screen.findByAltText("data.txt")).toBeDefined();
   });
 });
+
+describe("CodeViewer markdown preview (Streamdown)", () => {
+  it("renders Markdown via Streamdown in preview mode — headings + GFM task lists, not raw source or Monaco", () => {
+    const md = "# Title\n\n- [x] done\n- [ ] todo\n";
+    const { container } = renderViewer(md, true, "notes.md", { viewMode: "preview" });
+
+    // The heading is rendered as a Streamdown element, so the literal "# Title"
+    // source never appears — i.e. this is the rendered preview, not source.
+    const heading = container.querySelector('[data-streamdown="heading-1"]');
+    expect(heading?.textContent).toContain("Title");
+    expect(screen.queryByText("# Title")).toBeNull();
+
+    // GFM task list: remark-gfm tags each item `task-list-item` with a checkbox
+    // whose checked state reflects [x] vs [ ] (this is what PR #721's CSS targets).
+    const checkboxes = container.querySelectorAll<HTMLInputElement>(
+      '[data-streamdown="list-item"].task-list-item input[type="checkbox"]',
+    );
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0].checked).toBe(true);
+    expect(checkboxes[1].checked).toBe(false);
+
+    // Preview must not fall through to the Monaco source editor.
+    expect(screen.queryByTestId("monaco-editor-stub")).toBeNull();
+  });
+});

--- a/ap-web/src/shell/CodeViewer.tsx
+++ b/ap-web/src/shell/CodeViewer.tsx
@@ -30,8 +30,7 @@ import {
 } from "lucide-react";
 import type { BundledLanguage, ThemedToken } from "shiki";
 import { highlightCode } from "@/components/ai-elements/code-block";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { MessageResponse } from "@/components/ai-elements/message";
 import { type Comment } from "@/hooks/useComments";
 import {
   type FileContentResponse,
@@ -65,16 +64,23 @@ const MonacoCodeEditor = lazy(() =>
 );
 
 // ---------------------------------------------------------------------------
-// MarkdownPreview — read-only render of Markdown content via react-markdown + GFM
+// MarkdownPreview — read-only render of Markdown content
 // ---------------------------------------------------------------------------
 
 // Width of the line-number gutter — must match the `w-12` Tailwind class on the gutter div.
 const GUTTER_WIDTH = 48;
 
+// Reuse the chat message renderer (Streamdown + remark-gfm, hardened rehype
+// plugins, code highlighting, mermaid/math/CJK) so a previewed .md file looks
+// exactly like the same Markdown rendered in chat — task lists, tables, fenced
+// code, emoji — and inherits the shared `[data-streamdown="*"]` styling in
+// index.css. Because Streamdown emits plain DOM (no iframe, unlike the HTML
+// preview), this also renders inside the iOS WKWebView shell, where the
+// sandboxed HTML preview cannot. Text sizing mirrors chat's MessageContent.
 function MarkdownPreview({ content }: { content: string }) {
   return (
-    <div className="px-6 py-4 overflow-auto h-full prose dark:prose-invert prose-sm max-w-none">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    <div className="h-full overflow-auto px-6 py-4 text-[0.9375rem] leading-6">
+      <MessageResponse>{content}</MessageResponse>
     </div>
   );
 }

--- a/ap-web/src/shell/FileViewer.test.tsx
+++ b/ap-web/src/shell/FileViewer.test.tsx
@@ -23,7 +23,12 @@ import type { Comment } from "@/hooks/useComments";
 // ── Mock heavy child components ───────────────────────────────────────────────
 
 vi.mock("./CodeViewer", () => ({
-  CodeViewer: () => <div data-testid="code-viewer" />,
+  // Surface the resolved viewMode so the view-mode tests can assert how
+  // FileViewer routed a given file/preference without pulling in the real
+  // (Monaco/Streamdown/TipTap) viewer tree.
+  CodeViewer: ({ viewMode }: { viewMode?: string }) => (
+    <div data-testid="code-viewer" data-view-mode={viewMode} />
+  ),
 }));
 
 vi.mock("./CommentsPanel", () => ({
@@ -1005,5 +1010,46 @@ describe("FileViewer keyboard shortcut — Alt+← / Alt+→", () => {
     expect(onNavigateTo).not.toHaveBeenCalled();
 
     document.body.removeChild(input);
+  });
+});
+
+describe("FileViewer markdown/HTML view modes", () => {
+  function currentViewMode(): string | null {
+    return screen.getByTestId("code-viewer").getAttribute("data-view-mode");
+  }
+
+  it("opens a .md file in read-only preview by default", () => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    renderViewer({ open: true, path: "notes.md" });
+    expect(currentViewMode()).toBe("preview");
+  });
+
+  it("cycles markdown preview → editor → source → preview via the toolbar toggle", () => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    renderViewer({ open: true, path: "notes.md" });
+    expect(currentViewMode()).toBe("preview");
+
+    // The toggle button's accessible name describes the destination mode.
+    fireEvent.click(screen.getByRole("button", { name: "Rich text editor" }));
+    expect(currentViewMode()).toBe("editor");
+
+    fireEvent.click(screen.getByRole("button", { name: "View source" }));
+    expect(currentViewMode()).toBe("source");
+
+    fireEvent.click(screen.getByRole("button", { name: "View preview" }));
+    expect(currentViewMode()).toBe("preview");
+  });
+
+  it("toggles HTML between preview and source only (no rich-text editor mode)", () => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+    renderViewer({ open: true, path: "page.html" });
+    expect(currentViewMode()).toBe("preview");
+
+    fireEvent.click(screen.getByRole("button", { name: "View source" }));
+    expect(currentViewMode()).toBe("source");
+
+    // Back to preview — never enters "editor" (which markdown has but HTML lacks).
+    fireEvent.click(screen.getByRole("button", { name: "View preview" }));
+    expect(currentViewMode()).toBe("preview");
   });
 });

--- a/ap-web/src/shell/FileViewer.tsx
+++ b/ap-web/src/shell/FileViewer.tsx
@@ -616,15 +616,16 @@ function FileViewerBody({
   useEffect(() => {
     writeFileViewPreferences({ diffActive, diffLayout, previewableViewMode, hideWhitespace });
   }, [diffActive, diffLayout, previewableViewMode, hideWhitespace]);
-  // Non-markdown previewable (HTML): "editor" falls back to "preview" — no rich-text mode.
-  // Markdown: "preview" is removed; treat as "source" if somehow set (e.g. shared state from an HTML file).
-  const fileViewMode: "editor" | "preview" | "source" = isPreviewable
-    ? lang !== "markdown" && previewableViewMode === "editor"
-      ? "preview"
-      : lang === "markdown" && previewableViewMode === "preview"
-        ? "source"
-        : previewableViewMode
-    : "source";
+  // Markdown supports all three modes (preview / editor / source). HTML has no
+  // rich-text editor, so "editor" collapses to "preview". Non-previewable files
+  // always render as source.
+  const fileViewMode: "editor" | "preview" | "source" = !isPreviewable
+    ? "source"
+    : lang === "markdown"
+      ? previewableViewMode
+      : previewableViewMode === "editor"
+        ? "preview"
+        : previewableViewMode;
   // Derived effective view mode — diff takes priority when active and available.
   const viewMode: "editor" | "preview" | "source" | "diff" =
     diffActive && isDiffAvailable ? "diff" : fileViewMode;
@@ -695,38 +696,32 @@ function FileViewerBody({
   };
   const toolbarActions: ToolbarAction[] = [];
   if (isPreviewable && viewMode !== "diff") {
-    const previewLabel =
+    // The button advances to the next view mode; its icon/label describe that
+    // destination. Markdown cycles through all three (preview → editor → source
+    // → preview); HTML has no rich-text editor, so it toggles preview ↔ source.
+    const nextMode: "editor" | "preview" | "source" =
       lang === "markdown"
-        ? viewMode === "editor"
-          ? "Source view"
-          : "Rich text editor"
+        ? viewMode === "preview"
+          ? "editor"
+          : viewMode === "editor"
+            ? "source"
+            : "preview"
         : viewMode === "preview"
-          ? "View source"
-          : "View preview";
+          ? "source"
+          : "preview";
+    const nextModeMeta: Record<
+      "editor" | "preview" | "source",
+      { label: string; icon: ReactNode }
+    > = {
+      preview: { label: "View preview", icon: <EyeIcon className="size-4" /> },
+      editor: { label: "Rich text editor", icon: <PencilLineIcon className="size-4" /> },
+      source: { label: "View source", icon: <CodeIcon className="size-4" /> },
+    };
     toolbarActions.push({
       key: "preview",
-      label: previewLabel,
-      icon:
-        lang === "markdown" ? (
-          viewMode === "editor" ? (
-            <CodeIcon className="size-4" />
-          ) : (
-            <PencilLineIcon className="size-4" />
-          )
-        ) : viewMode === "preview" ? (
-          <CodeIcon className="size-4" />
-        ) : (
-          <EyeIcon className="size-4" />
-        ),
-      onSelect: () => {
-        if (lang === "markdown") {
-          guardDirty(() =>
-            setPreviewableViewMode((mode) => (mode === "editor" ? "source" : "editor")),
-          );
-        } else {
-          setPreviewableViewMode((mode) => (mode === "preview" ? "source" : "preview"));
-        }
-      },
+      label: nextModeMeta[nextMode].label,
+      icon: nextModeMeta[nextMode].icon,
+      onSelect: () => guardDirty(() => setPreviewableViewMode(nextMode)),
     });
   }
   // HTML artifacts can be popped out into their own browser tab for full-window


### PR DESCRIPTION
## What & why

Closes #970. Markdown files now get a **read-only rendered preview** in the file viewer, the same way HTML files already do. Markdown is a common agent output format (docs, summaries), and previously a `.md` file could only be viewed as the editable TipTap rich-text editor or as raw source — there was no clean rendered preview.

## How

- **Render with the chat's Streamdown renderer.** The preview reuses `MessageResponse` (Streamdown + remark-gfm, hardened rehype plugins, code highlighting, mermaid/math/CJK) so a previewed `.md` looks identical to the same Markdown in chat — task lists, GFM tables, fenced code, emoji — and inherits the shared `[data-streamdown="*"]` styling (including the task-list fix from #721). This replaces a dead, unreachable `react-markdown` preview that `FileViewer` never routed to.
- **Markdown now has all three view modes.** The toolbar toggle cycles **preview → editor → source → preview**. HTML is unchanged (preview ↔ source; it has no rich-text editor).
- **Default to `preview`** so `.md` opens rendered. This is a single constant in `fileViewPreferences.ts` — flip it back to `"editor"` to restore the old default (HTML is unaffected either way).

## Web + mobile in one change

The iOS app (`ap-web/ios`) is a thin WKWebView shell that loads the same server-served SPA. Because Streamdown emits **plain DOM (no iframe)** — unlike the sandboxed HTML preview, which WKWebView blocks (see #968) — this markdown preview renders on **both web and the iOS app** from a single web change, which is exactly the parity #970 asks for. (The HTML-iframe mobile gaps in #968/#969 remain separate.)

## Tests

- `CodeViewer.test.tsx`: preview mode renders Streamdown output (heading + GFM task-list checkboxes), not raw source or Monaco.
- `FileViewer.test.tsx`: `.md` opens in preview by default; the toggle cycles preview → editor → source → preview; HTML toggles preview ↔ source only.
- `tsc`, `oxlint`, and `prettier --check` clean on changed files.

## Note

`react-markdown` is now unused in `ap-web` (this was its last importer) but is left in `package.json` to avoid lockfile churn — easy follow-up cleanup if desired.

This pull request and its description were written by Isaac.