### PR TITLE
fix(sandbox): honor env-var prefix in backgrounded managed host launch

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -382,8 +382,14 @@ class SandboxLauncher(ABC):
         """
         Start *command* as a detached background process in the sandbox.
 
-        The default wraps the command in ``setsid nohup … & echo launched``
-        so it survives the exec session ending. Providers where backgrounded
+        The default wraps the command in ``setsid nohup sh -c '…' & echo
+        launched`` so it survives the exec session ending. The ``sh -c`` wrapper
+        is load-bearing: callers pass env-prefixed commands (e.g.
+        ``"ENV=val omnigent host …"``), and ``nohup`` does NOT honor shell
+        ``VAR=val`` assignment syntax — ``nohup ENV=val cmd`` makes nohup try to
+        exec a program literally named ``ENV=val`` ("No such file or directory").
+        Re-parsing the command under ``sh -c`` lets the inner shell apply the
+        assignments before running the program. Providers where backgrounded
         processes are reaped on exec return (e.g. OpenShell) override this
         to hold the exec stream open instead.
 
@@ -397,7 +403,8 @@ class SandboxLauncher(ABC):
         """
         return self.run(
             sandbox_id,
-            f"setsid nohup {command} > {log_path} 2>&1 < /dev/null & echo launched",
+            f"setsid nohup sh -c {shlex.quote(command)} "
+            f"> {log_path} 2>&1 < /dev/null & echo launched",
         )
 
     def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:

--- a/tests/onboarding/sandboxes/test_base.py
+++ b/tests/onboarding/sandboxes/test_base.py
@@ -1,0 +1,101 @@
+"""Provider-agnostic tests for the :class:`SandboxLauncher` base behavior.
+
+The exec-model defaults (``run_background`` / ``start_host``) are shared by
+every provider whose sandbox is a bare box the server execs into (Modal,
+Daytona, E2B, Boxlite, Islo, …), so they are tested once here against a
+minimal recording launcher rather than per provider.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import ClassVar
+
+from omnigent.onboarding.sandboxes.base import RemoteCommandResult, SandboxLauncher
+
+
+class _RecordingLauncher(SandboxLauncher):
+    """Minimal exec-model launcher that records every ``run`` command."""
+
+    provider: ClassVar[str] = "recording"
+
+    def __init__(self, home: str = "/root") -> None:
+        self.commands: list[str] = []
+        self.backgrounded: list[str] = []
+        self._home = home
+
+    def prepare(self) -> None:  # pragma: no cover - unused preflight stub
+        pass
+
+    def provision(self, name: str) -> str:  # pragma: no cover - unused stub
+        return "sb-1"
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        self.commands.append(command)
+        # start_host probes $HOME first; everything else returns empty.
+        stdout = self._home if command == 'printf %s "$HOME"' else ""
+        return RemoteCommandResult(returncode=0, stdout=stdout, stderr="")
+
+    def run_background(
+        self, sandbox_id: str, command: str, *, log_path: str = "/tmp/omnigent-host.log"
+    ) -> RemoteCommandResult:
+        # Capture the raw (pre-wrap) command so a test can prove a real shell
+        # honors its env prefix, independent of the setsid/nohup wrapper.
+        self.backgrounded.append(command)
+        return super().run_background(sandbox_id, command, log_path=log_path)
+
+
+def test_run_background_wraps_command_in_sh_c() -> None:
+    """
+    ``run_background`` must wrap the command in ``sh -c`` so env-var prefixes
+    survive ``nohup``. ``nohup ENV=val cmd`` makes nohup try to exec a program
+    literally named ``ENV=val`` ("No such file or directory") — re-parsing under
+    ``sh -c`` lets the inner shell apply the assignment before running ``cmd``.
+    Regression: managed Daytona/Modal hosts never came online because the
+    in-sandbox ``omnigent host`` launch died on its ``OMNIGENT_HOST_TOKEN=…``
+    prefix.
+    """
+    launcher = _RecordingLauncher()
+
+    launcher.run_background("sb-1", "FOO=bar omnigent host --server https://srv")
+
+    [cmd] = launcher.commands
+    assert cmd == (
+        "setsid nohup sh -c 'FOO=bar omnigent host --server https://srv' "
+        "> /tmp/omnigent-host.log 2>&1 < /dev/null & echo launched"
+    )
+
+
+def test_start_host_env_prefix_is_honored_by_a_real_shell() -> None:
+    """
+    The env-prefixed command ``start_host`` hands to ``run_background`` must
+    apply its ``OMNIGENT_HOST_*`` assignments when re-parsed by a shell — the
+    exact thing the ``sh -c`` wrapper restores. Run the raw command through a
+    real ``sh -c`` (the inner shell of the wrapper) with ``omnigent host``
+    swapped for a probe that echoes the injected vars; the broken bare-``nohup``
+    form would never reach this assignment-honoring shell.
+    """
+    launcher = _RecordingLauncher()
+
+    workspace = launcher.start_host(
+        "sb-1",
+        token="tok-123",
+        host_id="host_abc",
+        host_name="managed-abc",
+        server_url="https://srv",
+    )
+    assert workspace == "/root/workspace"
+
+    [raw] = launcher.backgrounded
+    # A nested `sh -c` reads the *inherited* env (a bare `$VAR` in the same
+    # simple command would expand in the parent shell, before the temporary
+    # assignment takes effect — and print empty).
+    probe = raw.replace(
+        "omnigent host --server https://srv",
+        "sh -c 'printf %s:%s:%s "
+        '"$OMNIGENT_HOST_TOKEN" "$OMNIGENT_HOST_ID" "$OMNIGENT_HOST_NAME"\'',
+    )
+    out = subprocess.run(
+        ["sh", "-c", probe], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert out == "tok-123:host_abc:managed-abc"


### PR DESCRIPTION
## Problem

Launching a managed cloud sandbox host (reproduced with **Daytona**, but affects all exec-model providers) fails with:

```
Sandbox launch failed: managed host did not come online within 120s — check /tmp/omnigent-host.log inside the sandbox
```

`/tmp/omnigent-host.log` inside the sandbox reveals the real cause:

```
nohup: failed to run command 'OMNIGENT_HOST_TOKEN=eLw8...': No such file or directory
```

## Root cause

`SandboxLauncher.start_host` starts the in-sandbox host with an env-var prefix:

```
OMNIGENT_HOST_TOKEN=… OMNIGENT_HOST_ID=… OMNIGENT_HOST_NAME=… omnigent host --server https://…
```

and `SandboxLauncher.run_background` backgrounded it as `setsid nohup <command> …`. `nohup` does **not** honor shell `VAR=val` assignment syntax: after `setsid nohup`, the `OMNIGENT_HOST_TOKEN=…` token is no longer at the start of a simple command, so the shell passes it as a literal argument and `nohup` tries to `exec` a program *named* `OMNIGENT_HOST_TOKEN=…` → "No such file or directory". The host process never starts, never dials back, and the managed launch times out at 120s.

Reproduce locally:

```
$ nohup FOO=bar echo hello
nohup: FOO=bar: No such file or directory
```

Because the sandbox itself provisions fine, the failure surfaces as a generic online-timeout rather than a clear error.

## Fix

Wrap the backgrounded command in `sh -c` so a real shell re-parses it and applies the env assignments before exec — the same `setsid nohup sh -c '…'` form the cwsandbox smoke test already uses:

```python
f"setsid nohup sh -c {shlex.quote(command)} > {log_path} 2>&1 < /dev/null & echo launched"
```

Affects every exec-model provider sharing the base `run_background` (Daytona, Modal, E2B, Boxlite, Islo, cwsandbox). Providers that override `run_background` (OpenShell) and entrypoint-model providers (Kubernetes) are unaffected.

## Tests

New `tests/onboarding/sandboxes/test_base.py`:
- pins the exact `sh -c`-wrapped command shape
- proves a real shell honors the injected `OMNIGENT_HOST_*` prefix end to end

Full sandbox + managed-host suite: 341 passed.

Fixes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)