### PR TITLE
fix(claude-sdk): real 1M context window (window resolution + [1m] API request)

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -47,6 +47,7 @@ from omnigent._platform import stable_user_id
 from omnigent.inner import _proc
 from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
+from omnigent.llms.context_window import claude_model_supports_1m
 from omnigent.onboarding.databricks_config import DATABRICKS_CLAUDE_DEFAULT_MODEL
 from omnigent.reasoning_effort import CLAUDE_EFFORTS, validate_effort
 from omnigent.spec.types import RetryPolicy
@@ -556,6 +557,39 @@ def _best_effort_close(resource: _Stream | _Process) -> None:
 # supplied directly), used when no spec/cfg model is set. On the ucode-cached
 # path the Omnigent producer resolves the model instead (see workflow.py).
 _DATABRICKS_CLAUDE_DEFAULT_MODEL = DATABRICKS_CLAUDE_DEFAULT_MODEL
+
+# Claude Code's "[1m]" model-id suffix opts a model into Anthropic's 1M-token
+# context window. The Agent SDK spawns the same `claude` CLI, which strips the
+# suffix from the wire model id (so a name-validating gateway still accepts the
+# bare name) and sends the "context-1m" beta. Without "[1m]" the CLI does NOT
+# send "context-1m", so first-party Anthropic caps the turn at the 200K base.
+# Verified through ClaudeSDKClient against a request-capture server, and it holds
+# under CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 (context-1m is not among the
+# betas that flag strips). The Databricks gateway serves 1M regardless (#1299),
+# so the suffix is harmless there. The 1M model set lives in
+# ``omnigent.llms.context_window`` (shared with the window override).
+_CLAUDE_1M_MODEL_SUFFIX = "[1m]"
+
+
+def _maybe_enable_1m_window(model: str | None) -> str | None:
+    """
+    Append the ``[1m]`` window suffix for a known 1M-context Claude model.
+
+    Makes the Claude CLI request the real 1M window instead of the 200K base.
+    Applied only to the id handed to ``options.model`` (the CLI ``--model``); the
+    bare id is kept for usage/pricing/window resolution. Idempotent; only known
+    1M Claude models (see :func:`claude_model_supports_1m`) are upgraded; ``None``
+    passes through.
+
+    :param model: Model id, e.g. ``"databricks-claude-opus-4-8"``, or ``None``.
+    :returns: ``model`` with ``[1m]`` appended when it is a known 1M Claude model
+        and not already suffixed; otherwise ``model`` unchanged.
+    """
+    if model is None or _CLAUDE_1M_MODEL_SUFFIX in model or not claude_model_supports_1m(model):
+        return model
+    logger.info("Claude SDK: requesting 1M context window for model %r", model)
+    return f"{model}{_CLAUDE_1M_MODEL_SUFFIX}"
+
 
 _CLAUDE_API_KEY_HELPER_ENV_KEY = "OMNIGENT_CLAUDE_API_KEY_HELPER"
 
@@ -2033,7 +2067,10 @@ class ClaudeSDKExecutor(Executor):
         if self._cli_path:
             options.cli_path = self._cli_path
         if model:
-            options.model = model
+            # Request the 1M window for known 1M Claude models (the CLI strips
+            # the [1m] suffix on the wire and sends context-1m). The bare `model`
+            # is kept for usage/pricing; only the CLI --model carries the suffix.
+            options.model = _maybe_enable_1m_window(model)
         if self._cwd:
             options.cwd = self._cwd
         # Install the unified can_use_tool gate. It runs the TOOL_CALL

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -74,6 +74,49 @@ _QWEN_CONTEXT_WINDOWS: dict[str, int] = {
 }
 
 
+# Curated context windows for Claude models whose serving backends UNDER-report
+# the window. Anthropic's 1M-context Claude models (opus-4-6/4-8, sonnet-4-6) are
+# served at 1M through the Databricks AI gateway, but litellm's bundled registry
+# (and, for newer ids, the MLflow catalog) report the 200K Anthropic base — which
+# left the UI context meter mis-sized and triggered proactive compaction ~5x too
+# early. Empirically verified against the gateway: a 375K-token prompt for
+# ``databricks-claude-opus-4-8`` is accepted (HTTP 200, ``input_tokens=375019``)
+# both with and without the ``context-1m`` beta — so 1M is not gateway-gated here.
+# Keyed by the *normalized* base id (provider / ``databricks-`` prefix, ``:tag``,
+# and ``[...]`` suffix stripped — see :func:`_claude_context_window_override`).
+# Aligns with the bundled model catalog's 1M Claude entries; a spec's
+# ``executor.context_window`` always overrides this.
+_CLAUDE_1M_TOKENS: int = 1_000_000
+_CLAUDE_CONTEXT_WINDOW_OVERRIDES: dict[str, int] = {
+    "claude-opus-4-8": _CLAUDE_1M_TOKENS,
+    "claude-opus-4-6": _CLAUDE_1M_TOKENS,
+    "claude-sonnet-4-6": _CLAUDE_1M_TOKENS,
+}
+
+
+def _claude_context_window_override(model: str) -> int | None:
+    """Return a curated context window for a known under-reported Claude model.
+
+    Normalizes the id the way model strings reach us — a provider prefix
+    (``anthropic/claude-opus-4-8``), the gateway ``databricks-`` prefix
+    (``databricks-claude-opus-4-8``), an OpenRouter-style ``:tag`` suffix, and a
+    Claude Code ``[1m]`` bracket alias (``claude-opus-4-8[1m]``) — down to the
+    bare base id before matching :data:`_CLAUDE_CONTEXT_WINDOW_OVERRIDES`.
+
+    Applied BEFORE litellm / the MLflow catalog (unlike :func:`_qwen_context_window`,
+    a post-lookup fallback) because those backends actively return the wrong (200K
+    base) value for these models, so a fallback would never be reached.
+
+    :param model: The model identifier (any namespacing).
+    :returns: The override window in tokens, or ``None`` when the model isn't a
+        recognized entry (caller continues the normal resolution chain).
+    """
+    bare = model.rsplit("/", 1)[-1].split(":", 1)[0].split("[", 1)[0].strip().lower()
+    if bare.startswith("databricks-"):
+        bare = bare[len("databricks-") :]
+    return _CLAUDE_CONTEXT_WINDOW_OVERRIDES.get(bare)
+
+
 def _qwen_context_window(model: str) -> int | None:
     """Look up a Qwen model's context window from the curated table.
 
@@ -265,13 +308,16 @@ def get_model_context_window(model: str) -> int:
 
     1. ``AP_CONTEXT_WINDOW_OVERRIDE`` env var — overrides everything.
        Supports custom/self-hosted models and e2e compaction tests.
-    2. ``litellm.get_model_info()`` — fast, local, no network. Also
+    2. Curated Claude overrides (:func:`_claude_context_window_override`) —
+       for 1M-context Claude models that litellm / the catalog under-report
+       as the 200K Anthropic base. Applied before litellm so it wins.
+    3. ``litellm.get_model_info()`` — fast, local, no network. Also
        tried with the ``databricks/`` prefix for Databricks models.
-    3. MLflow GitHub Release catalog — per-provider JSON fetched from
+    4. MLflow GitHub Release catalog — per-provider JSON fetched from
        ``github.com/mlflow/mlflow/releases``. Covers models not yet
        in litellm's bundled registry, with a family-prefix fallback
        for newly released variants.
-    4. ``_DEFAULT_CONTEXT_WINDOW`` (128 K) — conservative fallback.
+    5. ``_DEFAULT_CONTEXT_WINDOW`` (128 K) — conservative fallback.
 
     :param model: The model identifier, e.g. ``"openai/gpt-4o"`` or
         ``"databricks-gpt-5-5"``.
@@ -280,6 +326,9 @@ def get_model_context_window(model: str) -> int:
     override = os.environ.get("AP_CONTEXT_WINDOW_OVERRIDE")
     if override is not None:
         return int(override)
+    claude_override = _claude_context_window_override(model)
+    if claude_override is not None:
+        return claude_override
     try:
         import litellm
     except ImportError:

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -87,34 +87,65 @@ _QWEN_CONTEXT_WINDOWS: dict[str, int] = {
 # Aligns with the bundled model catalog's 1M Claude entries; a spec's
 # ``executor.context_window`` always overrides this.
 _CLAUDE_1M_TOKENS: int = 1_000_000
-_CLAUDE_CONTEXT_WINDOW_OVERRIDES: dict[str, int] = {
-    "claude-opus-4-8": _CLAUDE_1M_TOKENS,
-    "claude-opus-4-6": _CLAUDE_1M_TOKENS,
-    "claude-sonnet-4-6": _CLAUDE_1M_TOKENS,
-}
+# Canonical (bare, normalized) set of Claude models that serve a 1M context. The
+# single source of truth shared by the window override below AND the claude-sdk /
+# claude-native harnesses, which append Claude Code's ``[1m]`` model suffix for
+# these so the CLI requests 1M (it strips the suffix on the wire and sends the
+# ``context-1m`` beta). Aligns with the bundled model catalog's 1M Claude entries.
+CLAUDE_1M_MODELS: frozenset[str] = frozenset(
+    {"claude-opus-4-8", "claude-opus-4-6", "claude-sonnet-4-6"}
+)
+
+
+def _normalize_claude_model_id(model: str) -> str:
+    """Reduce a model id to its bare base form for 1M-set matching.
+
+    Strips a provider prefix (``anthropic/claude-opus-4-8``), the gateway
+    ``databricks-`` prefix, an OpenRouter-style ``:tag`` suffix, and a Claude
+    Code ``[1m]`` bracket alias; lowercased.
+
+    :param model: The model identifier (any namespacing).
+    :returns: The bare base id, e.g. ``"claude-opus-4-8"``.
+    """
+    bare = model.rsplit("/", 1)[-1].split(":", 1)[0].split("[", 1)[0].strip().lower()
+    if bare.startswith("databricks-"):
+        bare = bare[len("databricks-") :]
+    return bare
+
+
+def claude_model_supports_1m(model: str) -> bool:
+    """Whether *model* (any namespacing) is a known 1M-context Claude model.
+
+    Shared by the harnesses that opt a model into its 1M window via the ``[1m]``
+    suffix; mirrors :func:`_claude_context_window_override`'s own membership test.
+
+    :param model: The model identifier.
+    :returns: ``True`` if it normalizes to a member of :data:`CLAUDE_1M_MODELS`.
+    """
+    return _normalize_claude_model_id(model) in CLAUDE_1M_MODELS
 
 
 def _claude_context_window_override(model: str) -> int | None:
     """Return a curated context window for a known under-reported Claude model.
 
-    Normalizes the id the way model strings reach us — a provider prefix
-    (``anthropic/claude-opus-4-8``), the gateway ``databricks-`` prefix
-    (``databricks-claude-opus-4-8``), an OpenRouter-style ``:tag`` suffix, and a
-    Claude Code ``[1m]`` bracket alias (``claude-opus-4-8[1m]``) — down to the
-    bare base id before matching :data:`_CLAUDE_CONTEXT_WINDOW_OVERRIDES`.
+    The 1M-context Claude models are served at 1M through the Databricks AI
+    gateway, but litellm's bundled registry (and, for newer ids, the MLflow
+    catalog) report the 200K Anthropic base — which left the UI context meter
+    mis-sized and triggered proactive compaction ~5x too early. Empirically
+    verified against the gateway: a 375K-token ``databricks-claude-opus-4-8``
+    request is accepted (HTTP 200, ``input_tokens=375019``) with and without the
+    ``context-1m`` beta — so 1M is not gateway-gated here.
 
     Applied BEFORE litellm / the MLflow catalog (unlike :func:`_qwen_context_window`,
     a post-lookup fallback) because those backends actively return the wrong (200K
-    base) value for these models, so a fallback would never be reached.
+    base) value for these models, so a fallback would never be reached. A spec's
+    ``executor.context_window`` always overrides this.
 
     :param model: The model identifier (any namespacing).
-    :returns: The override window in tokens, or ``None`` when the model isn't a
-        recognized entry (caller continues the normal resolution chain).
+    :returns: 1M when *model* is a known 1M Claude model, else ``None`` (caller
+        continues the normal resolution chain).
     """
-    bare = model.rsplit("/", 1)[-1].split(":", 1)[0].split("[", 1)[0].strip().lower()
-    if bare.startswith("databricks-"):
-        bare = bare[len("databricks-") :]
-    return _CLAUDE_CONTEXT_WINDOW_OVERRIDES.get(bare)
+    return _CLAUDE_1M_TOKENS if claude_model_supports_1m(model) else None
 
 
 def _qwen_context_window(model: str) -> int | None:

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -3564,3 +3564,96 @@ def test_no_precompact_no_compaction_event() -> None:
         assert len(compaction_events) == 0
 
     _run(_t())
+
+
+# ---------------------------------------------------------------------------
+# Tests: 1M context-window opt-in ([1m] model suffix)
+# ---------------------------------------------------------------------------
+
+
+def test_claude_sdk_maybe_enable_1m_window() -> None:
+    """`_maybe_enable_1m_window` appends [1m] for known 1M models only."""
+    from omnigent.inner.claude_sdk_executor import _maybe_enable_1m_window as m
+
+    assert m("databricks-claude-opus-4-8") == "databricks-claude-opus-4-8[1m]"
+    assert m("claude-opus-4-8") == "claude-opus-4-8[1m]"
+    assert m("claude-sonnet-4-6") == "claude-sonnet-4-6[1m]"
+    assert m("claude-opus-4-8[1m]") == "claude-opus-4-8[1m]"  # idempotent
+    assert m("claude-sonnet-4-5") == "claude-sonnet-4-5"  # non-1M untouched
+    assert m("databricks-gpt-5-5") == "databricks-gpt-5-5"
+    assert m(None) is None
+
+
+def _run_turn_capture_options_model(model: str) -> str | None:
+    """Run one turn with cfg.model=*model*; return the ``options.model`` the
+    executor handed Claude Code (captured at connect)."""
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+    from omnigent.inner.executor import ExecutorConfig
+
+    captured: list = []
+
+    class _ResultMessage:
+        def __init__(self, session_id):
+            self.session_id = session_id
+            self.result = "ok"
+            self.content = []
+            self.model = "claude-test"
+            self.usage = type("U", (), {"input_tokens": 1, "output_tokens": 1})()
+
+    class _FakeSDK:
+        AssistantMessage = type("AssistantMessage", (), {})
+        UserMessage = type("UserMessage", (), {})
+        SystemMessage = type("SystemMessage", (), {})
+        ResultMessage = _ResultMessage
+        StreamEvent = type("StreamEvent", (), {})
+        ClaudeAgentOptions = type(
+            "ClaudeAgentOptions",
+            (),
+            {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+        )
+        messages: list = []
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+
+            async def connect(self):
+                captured.append(getattr(self.options, "model", None))
+
+            async def query(self, prompt, session_id="default"):
+                _FakeSDK.messages = [_ResultMessage(f"claude-{session_id}")]
+
+            async def receive_response(self):
+                for message in _FakeSDK.messages:
+                    yield message
+
+            async def disconnect(self):
+                return None
+
+    async def _t():
+        executor = ClaudeSDKExecutor()
+        with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=_FakeSDK):
+            async for _ in executor.run_turn(
+                [{"role": "user", "content": "hi", "session_id": "s1"}],
+                [],
+                "",
+                ExecutorConfig(model=model),
+            ):
+                pass
+
+    _run(_t())
+    return captured[0] if captured else None
+
+
+def test_run_turn_appends_1m_suffix_for_known_model() -> None:
+    """A known 1M model is handed to Claude Code with the [1m] suffix."""
+    assert _run_turn_capture_options_model("databricks-claude-opus-4-8") == (
+        "databricks-claude-opus-4-8[1m]"
+    )
+
+
+def test_run_turn_keeps_bare_model_for_non_1m() -> None:
+    """A non-1M model is handed to Claude Code unchanged (no spurious 1M)."""
+    assert _run_turn_capture_options_model("databricks-claude-sonnet-4-5") == (
+        "databricks-claude-sonnet-4-5"
+    )

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -429,3 +429,24 @@ def test_get_model_context_window_uses_qwen_fallback(monkeypatch: pytest.MonkeyP
     assert get_model_context_window("qwen3-coder-plus") == 1_048_576
     # An unrecognized qwen model still falls back to the conservative default.
     assert get_model_context_window("qwen-nonexistent-xyz") == 128_000
+
+
+def test_claude_model_supports_1m_shared_helper() -> None:
+    """The shared 1M-model predicate (used by the harnesses' [1m]-append)
+    recognizes the same set as the window override, across all id namings."""
+    from omnigent.llms.context_window import CLAUDE_1M_MODELS, claude_model_supports_1m
+
+    assert "claude-opus-4-8" in CLAUDE_1M_MODELS
+    for ident in (
+        "claude-opus-4-8",
+        "databricks-claude-opus-4-8",
+        "anthropic/claude-opus-4-8",
+        "claude-opus-4-8[1m]",
+        "Claude-Opus-4-8",
+        "claude-opus-4-8:beta",
+        "claude-sonnet-4-6",
+        "claude-opus-4-6",
+    ):
+        assert claude_model_supports_1m(ident) is True, ident
+    for ident in ("claude-sonnet-4-5", "claude-haiku-4-5", "databricks-gpt-5-5"):
+        assert claude_model_supports_1m(ident) is False, ident

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -99,6 +99,53 @@ def test_resolve_effective_context_window_declared_window_wins_without_override(
     )
 
 
+def test_claude_context_window_override_normalizes_id() -> None:
+    """The curated Claude override matches across all the namings the model id
+    reaches us in — gateway ``databricks-`` prefix, provider prefix, ``[1m]``
+    bracket alias, ``:tag`` suffix, and case."""
+    from omnigent.llms.context_window import _claude_context_window_override as ov
+
+    for ident in (
+        "claude-opus-4-8",
+        "databricks-claude-opus-4-8",
+        "anthropic/claude-opus-4-8",
+        "databricks/databricks-claude-opus-4-8",
+        "claude-opus-4-8[1m]",
+        "Databricks-Claude-Opus-4-8",
+        "claude-opus-4-8:beta",
+    ):
+        assert ov(ident) == 1_000_000, ident
+    # Other current 1M Claude models are covered too.
+    assert ov("databricks-claude-sonnet-4-6") == 1_000_000
+    assert ov("databricks-claude-opus-4-6") == 1_000_000
+    # Non-1M / unknown models are NOT overridden (caller continues the chain).
+    assert ov("databricks-claude-sonnet-4-5") is None
+    assert ov("databricks-gpt-5-5") is None
+    assert ov("claude-3-opus-20240229") is None
+
+
+def test_get_model_context_window_claude_1m_override_wins() -> None:
+    """A 1M Claude model resolves to 1M — the override runs before litellm /
+    the catalog (which report the 200K Anthropic base), so it wins regardless
+    of those backends."""
+    assert get_model_context_window("databricks-claude-opus-4-8") == 1_000_000
+    assert get_model_context_window("claude-opus-4-8") == 1_000_000
+
+
+def test_env_override_still_beats_claude_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AP_CONTEXT_WINDOW_OVERRIDE`` outranks the curated Claude override."""
+    monkeypatch.setenv("AP_CONTEXT_WINDOW_OVERRIDE", "12345")
+    assert get_model_context_window("databricks-claude-opus-4-8") == 12345
+
+
+def test_resolve_effective_window_opus_4_8_defaults_to_1m() -> None:
+    """With no declared window, opus-4-8 resolves to 1M via the override; an
+    explicit spec window still wins over it."""
+    assert resolve_effective_context_window(None, "databricks-claude-opus-4-8") == 1_000_000
+    # Author-declared window is authoritative (e.g. intentionally smaller).
+    assert resolve_effective_context_window(200_000, "databricks-claude-opus-4-8") == 200_000
+
+
 def test_compute_llm_cost_prices_cache_tokens_at_their_own_rates() -> None:
     """
     Cache reads/writes are billed at their own rates, not the input rate.


### PR DESCRIPTION
## Related issue

Closes #1299

## Summary

Gives **claude-sdk** a real 1M context window for Anthropic's 1M-context Claude models (opus-4-8/4-6, sonnet-4-6). Two complementary halves:

1. **omnigent's window** (`get_model_context_window`): these models resolved to the **200K** Anthropic base because litellm's bundled registry reports 200K for `claude-opus-4-*` (consulted before the catalog). That mis-sized the UI context ring and made proactive compaction fire at `0.8 * 200K ≈ 160K` — ~5× too early. Added a curated override consulted **before** litellm.

2. **the API request** (`claude_sdk_executor`): even with the window sized right, the SDK handed Claude Code the **bare** model id, so its CLI sent no `context-1m` beta and first-party Anthropic capped the turn at 200K. Now `options.model = _maybe_enable_1m_window(model)` appends Claude Code's `[1m]` suffix for the known 1M models — the CLI **strips it on the wire** (so a name-validating gateway still accepts the bare id) **and** sends `context-1m`. The bare `model` is kept for usage/pricing/window; only the CLI `--model` carries the suffix.

The 1M model set is shared (`CLAUDE_1M_MODELS` / `claude_model_supports_1m` in `llms/context_window.py`) between the window override and the executor `[1m]`-append — one source of truth.

**Empirically verified** against the Databricks AI gateway and via `ClaudeSDKClient` + a request-capture server:
- Gateway accepts a 375K-token `databricks-claude-opus-4-8` request (HTTP 200, `input_tokens=375019`) **with and without** `context-1m` — so 1M is not gateway-gated; the gateway also rejects the literal `[1m]` *name*, which is why the CLI's on-the-wire stripping matters.
- `options.model="…[1m]"` → wire model is the **bare** id **and** `context-1m` is sent; bare model → no `context-1m`. Holds under `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` (the executor's gateway env), since `context-1m` is not among the betas that flag strips.

**claude-native** is covered separately by #1306 (the ucode/gateway path); its first-party sub-path and the shared 1M set are noted for **consolidation with this PR** once both land.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

`uv run python -m pytest tests/llms/test_context_window.py tests/inner/test_claude_sdk_executor.py -q` — passes. New tests: the shared `claude_model_supports_1m` / `CLAUDE_1M_MODELS` predicate (id normalization across gateway/provider prefix, `[1m]`, `:tag`, case); `get_model_context_window` resolving 1M for the override models and env-override precedence; `resolve_effective_context_window` defaulting opus-4-8 to 1M while a declared spec window still wins; and executor tests asserting `options.model` gets `[1m]` for a known 1M model and stays bare otherwise.

Manual: Databricks gateway probe (375K accepted, with/without `context-1m`; `[1m]` *name* 400s — confirming the CLI must strip it) and a `ClaudeSDKClient` request-capture confirming the bare-vs-`[1m]` wire behavior above.

This pull request and its description were written by Isaac.
