### PR TITLE
fix(pi-native): fall back to fresh session when cold-resume builds no file

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1454,8 +1454,9 @@ async def _resolve_pi_resume_session(
 
     # Case 1: cold resume of a session that already has a captured Pi id.
     if launch_config.external_session_id is not None:
+        built: Path | None = None
         try:
-            await ensure_local_pi_resume_session(
+            built = await ensure_local_pi_resume_session(
                 server_client,
                 session_id=session_id,
                 external_session_id=launch_config.external_session_id,
@@ -1464,11 +1465,26 @@ async def _resolve_pi_resume_session(
                 model=model,
             )
         except Exception:  # noqa: BLE001 — best-effort; launch fresh on failure
+            built = None
             _logger.warning(
-                "Could not synthesize Pi resume session for %s; launching without history",
+                "Could not synthesize Pi resume session for %s; launching fresh",
                 session_id,
                 exc_info=True,
             )
+        # Only launch with ``--session <id>`` when a session file actually
+        # exists/was written. ``ensure_local_pi_resume_session`` returns
+        # ``None`` when nothing resumable was produced (missing/cleared bridge
+        # dir, empty history, or a transient fetch/write failure caught above).
+        # Returning the captured id regardless would emit ``pi --session <id>``
+        # for a file that does not exist — Pi then exits instead of launching,
+        # defeating the best-effort fallback this function promises. Fall back
+        # to a fresh session (return ``None``) in that case.
+        if built is None:
+            _logger.info(
+                "Pi cold-resume produced no local session file for %s; launching fresh",
+                session_id,
+            )
+            return None
         return launch_config.external_session_id
 
     # Case 2: forked clone bound to a pi-native target with no captured session

--- a/tests/runner/test_pi_native_resume_wiring.py
+++ b/tests/runner/test_pi_native_resume_wiring.py
@@ -147,6 +147,32 @@ async def test_resolve_cold_resume_builds_and_returns_captured_id(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_resolve_cold_resume_no_resumable_history_launches_fresh(tmp_path: Path) -> None:
+    """Cold resume with a captured id but no resumable history launches fresh.
+
+    Regression: ``_resolve_pi_resume_session`` used to return the captured
+    ``external_session_id`` unconditionally, even when
+    ``ensure_local_pi_resume_session`` produced no file (empty/cleared bridge
+    dir, empty history, or a transient fetch/write failure). That id is then
+    emitted as ``pi --session <id>``, which Pi treats as "open an existing
+    session file" and exits when the file is absent — failing the launch
+    instead of falling back to a fresh session. With no resumable items, the
+    cold-resume path must return ``None`` (no ``--session``) and write no file.
+    """
+    config = _config(workspace=tmp_path, external_session_id=_EXTERNAL_ID)
+    async with _items_only_client([]) as client:
+        out = await _resolve_pi_resume_session(
+            session_id="conv_1",
+            launch_config=config,
+            session_dir=tmp_path,
+            workspace=tmp_path,
+            server_client=client,
+        )
+    assert out is None
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+@pytest.mark.asyncio
 async def test_resolve_fork_rebuild_mints_id_and_patches(tmp_path: Path) -> None:
     config = _config(workspace=tmp_path, fork_carry_history=True)
     patched: dict[str, Any] = {}


### PR DESCRIPTION
## Context

Follow-up to #1240 (merged). [This review comment](https://github.com/omnigent-ai/omnigent/pull/1240#issuecomment-4802623962) flagged a launch-edge regression that landed with the merge.

## The bug

`_resolve_pi_resume_session()`'s **cold-resume** branch (Case 1) returned `launch_config.external_session_id` **unconditionally**, even when `ensure_local_pi_resume_session()` returned `None` (missing/cleared bridge dir, cross-machine, empty history) or raised a transient fetch/write error.

That id is later emitted as `pi --session <id>`. Pi's CLI treats `--session` as "resolve an existing session file" and **exits when the file is not found** — so the terminal fails to launch instead of falling back to a fresh Pi session, contradicting the helper's own docstring and logging.

## The fix

Capture the `Path | None` returned by `ensure_local_pi_resume_session()` and return the captured id **only when a file actually exists/was written**; on `None` or exception, return `None` so `_build_pi_native_args()` omits `--session` and Pi launches fresh. This mirrors how Case 2 (fork rebuild) already guards on its `built` result.

## Tests

Adds `test_resolve_cold_resume_no_resumable_history_launches_fresh` — cold resume with a captured id but empty history returns `None` and writes no file. Verified it **fails without the fix** and passes with it. Full `test_pi_native_resume_wiring.py` suite: 8 passed. ruff clean.

This pull request and its description were written by Isaac.