### PR TITLE
fix(native-claude): use Claude's 1M context window for gateway 1M models

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -149,6 +149,24 @@ _UCODE_CLAUDE_TIER_TO_ENV: dict[str, str] = {
     "haiku": _ANTHROPIC_DEFAULT_HAIKU_MODEL_ENV,
 }
 _DEFAULT_UCODE_AUTH_REFRESH_INTERVAL_MS = 900_000
+
+# Claude Code's "[1m]" model-id suffix opts a model into Anthropic's 1M-token
+# context window: Claude Code strips the suffix from the wire model id and
+# sends the "context-1m" beta header. The Databricks AI gateway serves these
+# models at 1M unconditionally (verified in #1299: a 375K-token
+# databricks-claude-opus-4-8 request is accepted with AND without the beta).
+# Without "[1m]", Claude Code reports the model's 200K Anthropic base as its
+# window and so its own context meter / proactive compaction run ~5x too
+# early; appending "[1m]" makes Claude Code use the real 1M window.
+_CLAUDE_1M_MODEL_SUFFIX = "[1m]"
+# Bare (normalized) Claude model ids that serve a 1M context window. Mirrors
+# the 1M Claude set in omnigent.llms.context_window (#1299/#1300, which fixes
+# the same under-reporting for the in-process / claude-sdk path); keep the two
+# in sync until they are consolidated behind one shared helper.
+_CLAUDE_1M_MODELS: frozenset[str] = frozenset(
+    {"claude-opus-4-8", "claude-opus-4-6", "claude-sonnet-4-6"}
+)
+
 _SESSION_LABELS = {
     "omnigent.ui": "terminal",
     _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
@@ -1378,6 +1396,46 @@ def _strip_resume_from_claude_args(args: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(out)
 
 
+def _model_supports_1m_window(model: str) -> bool:
+    """
+    Return whether a model id denotes a Claude model that serves 1M context.
+
+    Normalizes the id the way model strings reach us — a provider prefix
+    (``anthropic/claude-opus-4-8``), the gateway ``databricks-`` prefix
+    (``databricks-claude-opus-4-8``), an OpenRouter-style ``:tag`` suffix, and
+    an existing ``[1m]`` bracket alias — down to the bare base id before
+    matching :data:`_CLAUDE_1M_MODELS`.
+
+    :param model: The model identifier (any namespacing), e.g.
+        ``"databricks-claude-opus-4-8"``.
+    :returns: ``True`` if the model is a known 1M-context Claude model.
+    """
+    bare = model.rsplit("/", 1)[-1].split(":", 1)[0].split("[", 1)[0].strip().lower()
+    if bare.startswith("databricks-"):
+        bare = bare[len("databricks-") :]
+    return bare in _CLAUDE_1M_MODELS
+
+
+def _maybe_enable_1m_window(model: str) -> str:
+    """
+    Append the ``[1m]`` window suffix for a known 1M-context Claude model.
+
+    Native Claude through a Databricks gateway otherwise reports the model's
+    200K Anthropic base as its window — the gateway serves 1M regardless (see
+    #1299) — so Claude Code's own context meter and proactive compaction run
+    ~5x too early. Appending ``[1m]`` makes Claude Code use the real 1M
+    window. Idempotent; only known 1M Claude models are upgraded.
+
+    :param model: Gateway model id, e.g. ``"databricks-claude-opus-4-8"``.
+    :returns: ``model`` with ``[1m]`` appended when it is a known 1M Claude
+        model and not already suffixed, otherwise ``model`` unchanged.
+    """
+    if _CLAUDE_1M_MODEL_SUFFIX in model or not _model_supports_1m_window(model):
+        return model
+    _logger.info("native-claude: requesting 1M context window for model %r", model)
+    return f"{model}{_CLAUDE_1M_MODEL_SUFFIX}"
+
+
 def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | None:
     """
     Resolve native Claude Code launch config from ucode state.
@@ -1450,10 +1508,15 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
             env[env_var] = model_id
     # When ucode caches no model, default it so Claude Code doesn't fall back
     # to its host-config model (an Anthropic-direct id the gateway rejects).
+    model = agent_state.model or DATABRICKS_CLAUDE_DEFAULT_MODEL
+    # Opt the active model into the 1M context window when it is a known
+    # 1M-context Claude model, so Claude Code's own context meter and
+    # compaction use the real window instead of the 200K Anthropic base.
+    model = _maybe_enable_1m_window(model)
     return ClaudeNativeUcodeConfig(
         env=env,
         api_key_helper=agent_state.auth_command,
-        model=agent_state.model or DATABRICKS_CLAUDE_DEFAULT_MODEL,
+        model=model,
     )
 
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -411,8 +411,9 @@ def test_ucode_config_for_profile_defaults_model_when_ucode_omits_it(
     config = claude_native._ucode_config_for_profile("test-profile")
 
     assert config is not None
-    # The verified routable gateway endpoint name, not the CLI's own default.
-    assert config.model == "databricks-claude-opus-4-8"
+    # The verified routable gateway endpoint name (with the [1m] suffix, since
+    # opus-4-8 is a known 1M model), not the CLI's own Anthropic-direct default.
+    assert config.model == "databricks-claude-opus-4-8[1m]"
 
 
 def test_ucode_config_for_profile_fails_loud_on_malformed_claude_state(
@@ -436,6 +437,105 @@ def test_ucode_config_for_profile_fails_loud_on_malformed_claude_state(
 
     with pytest.raises(click.ClickException, match="missing Claude base URL"):
         claude_native._ucode_config_for_profile("test-profile")
+
+
+@pytest.mark.parametrize(
+    "ident",
+    [
+        "claude-opus-4-8",
+        "databricks-claude-opus-4-8",
+        "anthropic/claude-opus-4-8",
+        "databricks/databricks-claude-opus-4-8",
+        "claude-opus-4-8[1m]",
+        "Databricks-Claude-Opus-4-8",
+        "claude-opus-4-8:beta",
+        "databricks-claude-opus-4-6",
+        "databricks-claude-sonnet-4-6",
+    ],
+)
+def test_model_supports_1m_window_true_for_known_1m_models(ident: str) -> None:
+    """Every naming a 1M Claude id reaches us in is recognized as 1M-capable.
+
+    Covers the gateway ``databricks-`` prefix, provider prefix, an existing
+    ``[1m]`` alias, a ``:tag`` suffix, and mixed case.
+    """
+    assert claude_native._model_supports_1m_window(ident) is True
+
+
+@pytest.mark.parametrize(
+    "ident",
+    [
+        "databricks-claude-sonnet-4-5",  # real Claude model, but 200K base
+        "databricks-claude-haiku-4-5",  # not a 1M model
+        "databricks-gpt-5-5",  # not Claude
+        "claude-3-opus-20240229",  # older Claude, 200K
+    ],
+)
+def test_model_supports_1m_window_false_for_non_1m_models(ident: str) -> None:
+    """Non-1M / non-Claude models are not flagged (no [1m] gets appended)."""
+    assert claude_native._model_supports_1m_window(ident) is False
+
+
+def test_maybe_enable_1m_window_appends_for_known_1m_model() -> None:
+    """A known 1M Claude model gets the [1m] suffix so Claude Code uses 1M."""
+    assert (
+        claude_native._maybe_enable_1m_window("databricks-claude-opus-4-8")
+        == "databricks-claude-opus-4-8[1m]"
+    )
+
+
+def test_maybe_enable_1m_window_bare_for_non_1m_model() -> None:
+    """A non-1M model is returned unchanged (no spurious 1M claim)."""
+    # haiku is not a 1M model — appending [1m] would mis-size its window.
+    assert (
+        claude_native._maybe_enable_1m_window("databricks-claude-haiku-4-5")
+        == "databricks-claude-haiku-4-5"
+    )
+
+
+def test_maybe_enable_1m_window_idempotent_when_already_1m() -> None:
+    """A model already carrying [1m] is returned unchanged (no double suffix)."""
+    assert (
+        claude_native._maybe_enable_1m_window("databricks-claude-opus-4-8[1m]")
+        == "databricks-claude-opus-4-8[1m]"
+    )
+
+
+def test_ucode_config_for_profile_appends_1m_for_opus_4_8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    End to end: a 1M Claude model resolves to a [1m] launch model.
+
+    Proves the resolved ``--model`` Claude Code is launched with carries the
+    1M alias for opus-4-8, which is what makes Claude Code's own context meter
+    and compaction use the real 1M window instead of the 200K base.
+    """
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    workspace_state = UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        agents={
+            "claude": UcodeAgentState(
+                model="databricks-claude-opus-4-8",
+                base_url="https://example.databricks.com/ai-gateway/anthropic",
+                auth_command="printf token",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: workspace_state,
+    )
+
+    config = claude_native._ucode_config_for_profile("test-profile")
+
+    assert config is not None
+    assert config.model == "databricks-claude-opus-4-8[1m]"
 
 
 def test_attach_url_encodes_path_components() -> None:


### PR DESCRIPTION
## Summary

Native Claude routed through the Databricks AI gateway reported the model's **200K** Anthropic base as its context window, so Claude Code's own context meter and proactive compaction sized to 200K and auto-compacted ~5× too early. The same workspace under a direct-Anthropic harness (1M window) sits at ~16%.

The gateway is **not** the cap — verified in #1299 (a 375K-token `databricks-claude-opus-4-8` request is accepted with *and without* the `context-1m` beta). The defect is that Claude Code, given a bare gateway model id (`databricks-claude-opus-4-8`), falls back to the 200K Anthropic base. This appends Claude Code's `[1m]` suffix in the ucode native-claude config for the **known 1M Claude models** (opus-4-8/4-6, sonnet-4-6), so Claude Code uses the real 1M window (it strips the suffix on the wire and sends the `context-1m` beta). Non-1M models are untouched.

Complements #1300: that PR fixes the same 200K under-reporting on the **in-process / claude-sdk** path (omnigent's `get_model_context_window`); this PR covers the **claude-native** path, where Claude Code self-determines its own window and #1300's resolver does not apply. The 1M model set here mirrors #1300's curated set — worth consolidating behind one shared helper once both land.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

`tests/test_claude_native.py`: new unit tests for `_model_supports_1m_window` (id normalization across the gateway `databricks-` prefix, provider prefix, `[1m]` alias, `:tag`, and case → True for opus-4-8/4-6 and sonnet-4-6; False for sonnet-4-5, haiku, and non-Claude ids), `_maybe_enable_1m_window` (appends for a known 1M model, leaves non-1M models bare, idempotent when already `[1m]`), and `_ucode_config_for_profile` end-to-end resolving `databricks-claude-opus-4-8[1m]`. Existing ucode-config tests updated for the new behavior. Ran `PYTHONPATH=. .venv/bin/python -m pytest tests/test_claude_native.py -k "ucode_config or model_supports_1m or maybe_enable_1m"` → 23 passed; mypy and ruff clean on both files.

Manual verification: `_ucode_config_for_profile(<gateway profile>)` resolves `databricks-claude-opus-4-8[1m]` against a live Databricks AI gateway; a probe confirmed the gateway accepts the `context-1m` beta (HTTP 200) and (per #1299) serves a 375K-token prompt with and without the beta.

This pull request and its description were written by Isaac.
