### PR TITLE
fix(ap-web): use ReactElement instead of removed global JSX namespace

### DIFF
--- a/ap-web/src/components/SessionStateBadge.tsx
+++ b/ap-web/src/components/SessionStateBadge.tsx
@@ -2,6 +2,7 @@
 // it reads at a glance; running/unseen stay as compact dots. Verbose copy
 // (incl. the approval count) lives in the tooltip.
 
+import type { ReactElement } from "react";
 import { RunningDot } from "@/components/RunningDot";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -16,7 +17,7 @@ interface Visual {
   kind: SessionState["kind"];
   ariaLabel: string;
   tooltip: string;
-  render: () => JSX.Element;
+  render: () => ReactElement;
 }
 
 function describe(state: SessionState): Visual {

--- a/ap-web/src/shell/MarkdownCommentPlugin.tsx
+++ b/ap-web/src/shell/MarkdownCommentPlugin.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { MessageSquarePlusIcon } from "lucide-react";
 import type { Editor } from "@tiptap/react";
-import type { RefObject } from "react";
+import type { ReactElement, RefObject } from "react";
 import type { Comment } from "@/hooks/useComments";
 import type { ActiveSelection } from "./codeViewerHelpers";
 import { commentDecorationKey, type CommentDecorationState } from "./TipTapCommentExtension";
@@ -68,7 +68,7 @@ export function MarkdownCommentPlugin({
   onSetActiveSelection,
   pendingBodyRef,
   canEdit = true,
-}: MarkdownCommentPluginProps): JSX.Element | null {
+}: MarkdownCommentPluginProps): ReactElement | null {
   const [buttonPos, setButtonPos] = useState<{ top: number; left: number } | null>(null);
 
   // Stable refs so callbacks always see the latest values.


### PR DESCRIPTION
## Related issue

N/A — no associated issue (build fix).

## Summary

- `@types/react` v19 removed the global `JSX` namespace, so `tsc -b` fails with `error TS2503: Cannot find namespace 'JSX'` in `SessionStateBadge.tsx` and `MarkdownCommentPlugin.tsx`, which breaks `npm run build`.
- Switch both return-type annotations from the removed `JSX.Element` to the `ReactElement` type already imported from `"react"` elsewhere in the codebase. Type-only change with no runtime effect.

## Test Plan

From `ap-web/`:

- `npm run build` — now succeeds (`tsc -b && vite build`); previously failed with the two `TS2503` errors above.
- `npm run lint` — passes (exit 0); no new findings in the changed files.
- `npx vitest run src/components/SessionStateBadge.test.tsx src/shell/MarkdownCommentPlugin.test.tsx` — 2 files, 14 tests passing.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is a type-only annotation change with no runtime behaviour change, which CONTRIBUTING exempts from requiring a new test. Verified by running the production build (`tsc` type-check now passes), the linter, and the existing colocated Vitest suites for both touched files (14 tests pass).
