### PR TITLE
fix(inner): honor a plain OPENAI_API_KEY in databricks_executor._get_openai_client

### DIFF
--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -588,9 +588,10 @@ def _databrickscfg_profiles_for_host(host: str) -> list[str]:
 def _get_openai_client(profile: str | None = None) -> OpenAI:
     """Lazily import and construct the OpenAI client.
 
-    Supports two configuration modes (in priority order):
+    Supports three configuration modes (in priority order):
       1. Direct OpenAI-compatible: OPENAI_BASE_URL + OPENAI_API_KEY
-      2. Databricks config file: ~/.databrickscfg
+      2. Direct OpenAI default endpoint: OPENAI_API_KEY
+      3. Databricks config file: ~/.databrickscfg
     """
     try:
         from openai import OpenAI
@@ -609,6 +610,15 @@ def _get_openai_client(profile: str | None = None) -> OpenAI:
             # See _OPENAI_KEY_PLACEHOLDER docstring in open_responses_sdk.
             api_key=os.environ.get("OPENAI_API_KEY", _OPENAI_KEY_PLACEHOLDER),
         )
+
+    # Plain OpenAI key against the default api.openai.com endpoint. Use it
+    # directly rather than falling through to Databricks auth, which would
+    # otherwise raise a misleading "install databricks-sdk" error for a user
+    # who only configured OPENAI_API_KEY. Mirrors the sibling builder in
+    # open_responses_sdk._get_openai_client.
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        return OpenAI(api_key=api_key)
 
     from .open_responses_sdk import _OPENAI_KEY_PLACEHOLDER as _placeholder
 

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -803,6 +803,74 @@ def test_read_databrickscfg_missing_profile_falls_back_to_file_reader(
     assert creds.token == "dapi-fake-pat-token-for-unit-test"
 
 
+def test_get_openai_client_uses_plain_openai_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    clean_databricks_env: None,
+) -> None:
+    """A plain ``OPENAI_API_KEY`` (no ``OPENAI_BASE_URL``) builds an OpenAI
+    client against the default endpoint instead of falling through to
+    Databricks auth.
+
+    Before the fix, ``_get_openai_client`` only handled ``OPENAI_BASE_URL``
+    or a ``~/.databrickscfg`` profile, so a user who had configured only
+    ``OPENAI_API_KEY`` fell through to ``_resolve_databricks_auth`` and hit a
+    misleading "The 'databricks-sdk' package is required..." ImportError.
+    """
+    from omnigent.inner.databricks_executor import _get_openai_client
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_openai(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("openai.OpenAI", _fake_openai)
+
+    # The Databricks fallback must not be reached for a plain OpenAI key.
+    def _no_databricks(*_args: Any, **_kwargs: Any) -> object:
+        raise AssertionError(
+            "_resolve_databricks_auth must not be called when OPENAI_API_KEY is set"
+        )
+
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth",
+        _no_databricks,
+    )
+
+    _get_openai_client()
+
+    assert captured == {"api_key": "sk-test-key"}
+
+
+def test_get_openai_client_base_url_takes_precedence_over_plain_key(
+    monkeypatch: pytest.MonkeyPatch,
+    clean_databricks_env: None,
+) -> None:
+    """``OPENAI_BASE_URL`` still wins over a bare ``OPENAI_API_KEY`` so the
+    gateway/Databricks-serving path is unchanged by the new plain-key mode.
+    """
+    from omnigent.inner.databricks_executor import _get_openai_client
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_openai(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("openai.OpenAI", _fake_openai)
+
+    _get_openai_client()
+
+    assert captured["base_url"] == "https://gateway.example/v1"
+    assert captured["api_key"] == "sk-test-key"
+
+
 def test_read_databrickscfg_empty_config_file_returns_none(
     tmp_path: _Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

Related to #377 (does not fully close it — see Coverage notes).

## Summary

- `databricks_executor._get_openai_client` supported only two credential modes: `OPENAI_BASE_URL` (gateway) or a `~/.databrickscfg` profile. A user who configured **only** `OPENAI_API_KEY` (standard `api.openai.com`, no base URL) fell straight through to `_resolve_databricks_auth`, which raises a misleading `"The 'databricks-sdk' package is required for Databricks authentication"` ImportError instead of using the OpenAI key — the same class of error reported in #377.
- The sibling builder `open_responses_sdk._get_openai_client` already supports all three modes (gateway, plain key, Databricks). This change adds the missing plain-key mode to `databricks_executor._get_openai_client`, aligning the two implementations.
- `OPENAI_BASE_URL` still takes precedence, so the gateway / Databricks-serving path is unchanged.

## Test Plan

`uv run pytest tests/inner/test_databricks_executor.py tests/inner/test_open_responses_sdk.py` — **83 passed**.

New tests in `tests/inner/test_databricks_executor.py`:
- `test_get_openai_client_uses_plain_openai_api_key` — with only `OPENAI_API_KEY` set, the client is built from that key and `_resolve_databricks_auth` is **not** reached. Verified this test **fails before the fix** (it hits the Databricks fallback).
- `test_get_openai_client_base_url_takes_precedence_over_plain_key` — `OPENAI_BASE_URL` still wins over a bare key (precedence preserved).

Also: `ruff check` / `ruff format --check` clean on both files; `mypy` introduces no new errors (the pre-existing ones are unrelated to this diff).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Honest scope: the only caller of `databricks_executor._get_openai_client` is `DatabricksExecutor`, which is not currently instantiated on any production path (the live OpenAI executors — `OpenResponsesExecutor`, `OpenAIAgentsSDKExecutor` — already handle a plain `OPENAI_API_KEY`). So this is a robustness / consistency fix that removes a real footgun and aligns the two diverging `_get_openai_client` builders; it is **not** a guaranteed fix for the exact gpt-sub-agent crash in #377, which is why it is filed as "Related to" rather than "Closes". Verified manually by removing the new branch and observing the new plain-key test fail (reaching the Databricks fallback) before re-applying the fix. No secrets are included (the test key is a mocked dummy; `openai.OpenAI` is monkeypatched, so no network call is made).
