### PR TITLE
fix(server+web): identify sub-agent heads by their own harness and name

### DIFF
--- a/ap-web/src/pages/ChatPage.statusLine.test.tsx
+++ b/ap-web/src/pages/ChatPage.statusLine.test.tsx
@@ -67,6 +67,7 @@ describe("Composer status line (branch + context ring)", () => {
       codexPlanMode: false,
       nativeVendorOwnsModel: false,
       sessionHarness: null,
+      subAgentName: null,
     });
   });
 
@@ -121,6 +122,17 @@ describe("Composer status line (branch + context ring)", () => {
     renderComposer({ agents: [{ id: "a1", name: "polly" }], selectedAgentId: "a1" });
 
     expect(screen.getByTestId("composer-harness")).toHaveTextContent("Polly (Pi)");
+  });
+
+  it("names the sub-agent head, not the bundle, for a head session", () => {
+    // A Debby GPT head session: the tray identifies the head being viewed
+    // ("Gpt"), not the bundle orchestrator ("Debby").
+    useChatStore.setState({ sessionHarness: "codex", subAgentName: "gpt" });
+    renderComposer({ agents: [{ id: "a1", name: "debby" }], selectedAgentId: "a1" });
+
+    const harness = screen.getByTestId("composer-harness");
+    expect(harness).toHaveTextContent("Gpt (Codex)");
+    expect(harness).not.toHaveTextContent("Debby");
   });
 
   it("no longer renders model/effort in the status tray (moved to the picker trigger)", () => {

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3408,9 +3408,13 @@ export function Composer({
   // Harness/agent identity shown in the status tray below the card. The
   // picker trigger owns model/effort now, so the identity moves here.
   const sessionHarness = useChatStore((s) => s.sessionHarness);
+  const subAgentName = useChatStore((s) => s.subAgentName);
   const harnessLabel = composerHarnessLabel(
     modelPickerKind,
-    agents?.find((a) => a.id === selectedAgentId)?.name ?? agents?.[0]?.name ?? null,
+    // For a sub-agent (head) session, identify the head family being viewed
+    // (e.g. the GPT head → "Gpt") rather than the bundle orchestrator
+    // ("Debby") — the bundle is already named in the breadcrumb / Agents rail.
+    subAgentName ?? agents?.find((a) => a.id === selectedAgentId)?.name ?? agents?.[0]?.name ?? null,
     sessionHarness,
   );
 

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3414,7 +3414,10 @@ export function Composer({
     // For a sub-agent (head) session, identify the head family being viewed
     // (e.g. the GPT head → "Gpt") rather than the bundle orchestrator
     // ("Debby") — the bundle is already named in the breadcrumb / Agents rail.
-    subAgentName ?? agents?.find((a) => a.id === selectedAgentId)?.name ?? agents?.[0]?.name ?? null,
+    subAgentName ??
+      agents?.find((a) => a.id === selectedAgentId)?.name ??
+      agents?.[0]?.name ??
+      null,
     sessionHarness,
   );
 

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -342,6 +342,12 @@ export interface ChatState {
    */
   sessionHarness: string | null;
   /**
+   * The active session's sub-agent head name (e.g. `"gpt"`), or null for a
+   * top-level session. Set from the snapshot on bind; lets a head sub-agent's
+   * composer identity name the head rather than the bundle orchestrator.
+   */
+  subAgentName: string | null;
+  /**
    * Context window size in tokens for the active session's model,
    * as looked up server-side. ``null`` before bind or when the
    * model is not in litellm's registry.
@@ -704,6 +710,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   flashItemId: null,
   llmModel: null,
   sessionHarness: null,
+  subAgentName: null,
   contextWindow: null,
   tokensUsed: null,
   sessionCostUsd: null,
@@ -1614,6 +1621,7 @@ function sessionBindingPatch(
   | "llmModel"
   | "sessionModelOverride"
   | "sessionHarness"
+  | "subAgentName"
   | "costControlModeOverride"
   | "codexPlanMode"
   | "contextWindow"
@@ -1636,6 +1644,7 @@ function sessionBindingPatch(
     llmModel: session.llmModel ?? null,
     sessionModelOverride: session.modelOverride ?? null,
     sessionHarness: session.harness ?? null,
+    subAgentName: session.subAgentName ?? null,
     costControlModeOverride: session.costControlModeOverride ?? null,
     codexPlanMode: codexPlanModeFromSession(session),
     contextWindow: session.contextWindow ?? null,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2608,7 +2608,22 @@ def _resolve_harness(conv: Conversation | None) -> str | None:
             agent.id, agent.bundle_location, expand_env=agent.session_id is None
         )
         executor = loaded.spec.executor
-        harness = executor.config.get("harness") or executor.type
+        # For a bundled-agent head sub-agent, report the HEAD's own harness,
+        # not the bundle brain's — `harness` is this session's provider family
+        # (a gpt head runs codex, not the claude-sdk brain). Falls back to the
+        # brain harness when the head declares none or can't be matched.
+        if conv.sub_agent_name:
+            sub = next(
+                (s for s in loaded.spec.sub_agents if s.name == conv.sub_agent_name),
+                None,
+            )
+            if sub is not None:
+                executor = sub.executor
+        harness = (
+            executor.config.get("harness")
+            or loaded.spec.executor.config.get("harness")
+            or executor.type
+        )
         return canonicalize_harness(harness) or harness
     except (KeyError, AttributeError, ValueError, ImportError, OSError):
         return None


### PR DESCRIPTION
## What

Viewing a bundled-agent **head sub-agent** (e.g. Debby's GPT head, `world-cup-winner-gpt`) showed the **bundle orchestrator's** identity — "Debby (Claude SDK)" — even though the head runs a different provider family. Both the harness and the name were wrong. This fixes both, so the GPT head reads **"Gpt (Codex)"**.

## Server — `_resolve_harness` (`omnigent/server/routes/sessions.py`)

For a sub-agent session (`conv.sub_agent_name` set), report the **head's own** executor harness — resolved from the matching `sub_agent` in the bundle spec — instead of the bundle brain's. Falls back to the brain harness when the head declares none or can't be matched. Top-level sessions are unchanged.

`harness` on the snapshot is documented as surfacing "the active credential for the correct provider *family*", so for a head that should be the head's family — this makes the existing field *truthful* (no new field; backwards-compatible). Verified live: a Debby GPT head now reports `harness=codex`, the Claude head stays `claude-sdk`, the top-level Debby session stays `claude-sdk`.

## Web — composer status tray (`ap-web/`)

- Surface `subAgentName` in the chat store on bind (mirrors `sessionHarness`).
- The composer-tray identity (`composerHarnessLabel`) now names the **head** (`subAgentName`, e.g. "Gpt") for a head session rather than the bundle agent ("Debby"). The bundle is still named in the breadcrumb / Agents rail.

## Tests

`ChatPage.statusLine.test.tsx`: a head session renders the head identity ("Gpt (Codex)"), never the bundle ("Debby"). All ap-web composer/status-line suites pass (74); `tsc` clean. Server behavior verified against a live server; happy to add a dedicated integration case if preferred.

## Result

| session | before | after |
|---|---|---|
| Debby **GPT head** | Debby (Claude SDK) | **Gpt (Codex)** |
| Debby Claude head | Debby (Claude SDK) | Claude (Claude SDK) |
| Debby (top-level) | Debby (Claude SDK) | Debby (Claude SDK) — unchanged |
