### PR TITLE
#1319: Realign workspace cwd on resume for OpenCode Native

### DIFF
--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import shutil
 from dataclasses import dataclass
@@ -54,6 +55,9 @@ from omnigent.native_terminal import (
 )
 from omnigent.native_terminal import bind_session_runner as _bind_session_runner
 from omnigent.native_terminal import url_component
+from omnigent.opencode_native_state import read_launch_state, write_launch_state
+
+_logger = logging.getLogger(__name__)
 
 # Built-in native-UI agent name (matches the descriptor's
 # ``wrapper_agent_name`` and the ap-web native registry).
@@ -223,6 +227,8 @@ def _run_with_remote_server(  # pragma: no cover
         )
         if resolved_session_id is None and resume_picker and session_id is None:
             return
+        if resolved_session_id is not None:
+            _align_working_directory_with_session(resolved_session_id)
 
         async def _drive() -> None:
             with runner_startup_progress(initial_message="Preparing OpenCode...") as progress:
@@ -240,6 +246,8 @@ def _run_with_remote_server(  # pragma: no cover
                     workspace=str(Path.cwd().resolve()),
                     startup_progress=progress,
                 )
+            if resolved_session_id is None:
+                _record_launch_for_fresh_session(prepared.session_id)
             click.echo(f"Web UI: {conversation_url(base_url, prepared.session_id)}", err=True)
             open_conversation_link_if_enabled(
                 base_url=base_url,
@@ -429,6 +437,95 @@ async def _wait_for_opencode_terminal_ready(
     raise click.ClickException(
         f"The runner did not create the OpenCode terminal for {session_id!r} "
         f"within {timeout_s:.0f}s."
+    )
+
+
+# --- Resume workspace alignment: record launch cwd; realign it on resume ---
+
+_RESUME_ACTION_SWITCH = "switch"
+_RESUME_ACTION_CANCEL = "cancel"
+
+
+def _record_launch_for_fresh_session(session_id: str) -> None:
+    """
+    Persist the wrapper's current cwd as the OpenCode session launch state.
+
+    :param session_id: Newly created Omnigent conversation id, e.g.
+        ``"conv_abc123"``.
+    :returns: None.
+    """
+    try:
+        write_launch_state(session_id, str(Path.cwd().resolve()))
+    except OSError:
+        _logger.warning(
+            "failed to record opencode-native launch state for %s",
+            session_id,
+            exc_info=True,
+        )
+
+
+def _align_working_directory_with_session(session_id: str) -> None:
+    """
+    Resolve cwd mismatch before resuming an OpenCode-native session.
+
+    Native OpenCode state is workspace-scoped from the user's point of
+    view: the runner and ``opencode serve`` should reopen from the
+    directory where the session was created. If client-side launch
+    state points at a different existing directory, prompt whether to
+    switch there before the runner and ``opencode serve`` sample cwd.
+
+    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
+    :returns: None. Side-effect-only; may change process cwd.
+    :raises click.ClickException: If recorded state exists but the
+        recorded directory no longer exists, or if the user cancels.
+    """
+    state = read_launch_state(session_id)
+    if state is None:
+        return
+    current = Path.cwd().resolve()
+    recorded_path = Path(state.working_directory).resolve()
+    if current == recorded_path:
+        return
+    if not recorded_path.is_dir():
+        raise click.ClickException(
+            f"Session {session_id} was created in {recorded_path}, but that "
+            "directory no longer exists. Recreate or move the project back "
+            "before resuming OpenCode."
+        )
+    action = _prompt_opencode_resume_workspace_action(
+        recorded_path=recorded_path,
+        current=current,
+    )
+    if action == _RESUME_ACTION_SWITCH:
+        os.chdir(recorded_path)
+        click.echo(f"Switched to {recorded_path}.", err=True)
+        return
+    raise click.ClickException("Resume cancelled.")
+
+
+def _prompt_opencode_resume_workspace_action(
+    *,
+    recorded_path: Path,
+    current: Path,
+) -> str:
+    """
+    Ask how to handle an OpenCode resume cwd mismatch.
+
+    :param recorded_path: Recorded launch cwd, already resolved.
+    :param current: Current cwd, already resolved.
+    :returns: One of ``"switch"`` or ``"cancel"``.
+    """
+    click.echo(f"\nSession was started in: {recorded_path}", err=True)
+    click.echo(f"Current working directory: {current}", err=True)
+    click.echo("OpenCode resume is workspace-scoped. Choose an action:", err=True)
+    click.echo(f"  {_RESUME_ACTION_SWITCH:<6} - Switch working directory to {recorded_path}", err=True)
+    click.echo(f"  {_RESUME_ACTION_CANCEL:<6} - Cancel resume", err=True)
+    return click.prompt(
+        "Resume action",
+        type=click.Choice([_RESUME_ACTION_SWITCH, _RESUME_ACTION_CANCEL]),
+        default=_RESUME_ACTION_SWITCH,
+        show_choices=True,
+        err=True,
     )
 
 

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -518,7 +518,9 @@ def _prompt_opencode_resume_workspace_action(
     click.echo(f"\nSession was started in: {recorded_path}", err=True)
     click.echo(f"Current working directory: {current}", err=True)
     click.echo("OpenCode resume is workspace-scoped. Choose an action:", err=True)
-    click.echo(f"  {_RESUME_ACTION_SWITCH:<6} - Switch working directory to {recorded_path}", err=True)
+    click.echo(
+        f"  {_RESUME_ACTION_SWITCH:<6} - Switch working directory to {recorded_path}", err=True
+    )
     click.echo(f"  {_RESUME_ACTION_CANCEL:<6} - Cancel resume", err=True)
     return click.prompt(
         "Resume action",

--- a/tests/test_opencode_native.py
+++ b/tests/test_opencode_native.py
@@ -277,6 +277,7 @@ async def test_wait_for_terminal_times_out(monkeypatch: pytest.MonkeyPatch) -> N
     with pytest.raises(click.ClickException):
         await on._wait_for_opencode_terminal_ready(object(), "conv_1", timeout_s=0)  # type: ignore[arg-type]
 
+
 # --- Resume workspace alignment (launch.json record + cwd realign) ---
 def test_record_launch_for_fresh_session_persists_current_cwd(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_opencode_native.py
+++ b/tests/test_opencode_native.py
@@ -276,3 +276,390 @@ async def test_wait_for_terminal_times_out(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(on, "_find_running_opencode_terminal", _never)
     with pytest.raises(click.ClickException):
         await on._wait_for_opencode_terminal_ready(object(), "conv_1", timeout_s=0)  # type: ignore[arg-type]
+
+# --- Resume workspace alignment (launch.json record + cwd realign) ---
+def test_record_launch_for_fresh_session_persists_current_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A fresh session records its launch cwd for later resumes.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace and state root.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+    from omnigent.opencode_native_state import read_launch_state
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_NATIVE_STATE_DIR", str(tmp_path / "state"))
+
+    on._record_launch_for_fresh_session("conv_abc")
+
+    state = read_launch_state("conv_abc")
+    assert state is not None
+    assert state.working_directory == str(workspace.resolve())
+
+
+def test_record_launch_for_fresh_session_swallows_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A failed launch-state write warns rather than breaking the launch.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+
+    monkeypatch.chdir(tmp_path)
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(on, "write_launch_state", _raise)
+
+    # Best-effort recording: a write failure must not propagate.
+    on._record_launch_for_fresh_session("conv_abc")
+
+
+def test_align_no_recorded_state_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Resume with no recorded launch state neither prompts nor moves cwd.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace and state root.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_NATIVE_STATE_DIR", str(tmp_path / "state"))
+
+    def _fail_prompt(**_kwargs: object) -> str:
+        raise AssertionError("absent launch state should not prompt")
+
+    monkeypatch.setattr(on, "_prompt_opencode_resume_workspace_action", _fail_prompt)
+
+    on._align_working_directory_with_session("conv_missing")
+
+    assert Path.cwd().resolve() == tmp_path.resolve()
+
+
+def test_align_matching_cwd_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Resume from the recorded cwd must not prompt or move cwd.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace and state root.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+    from omnigent.opencode_native_state import write_launch_state
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    write_launch_state("conv_abc", str(tmp_path.resolve()))
+
+    def _fail_prompt(**_kwargs: object) -> str:
+        raise AssertionError("matching cwd should not prompt")
+
+    monkeypatch.setattr(on, "_prompt_opencode_resume_workspace_action", _fail_prompt)
+
+    on._align_working_directory_with_session("conv_abc")
+
+    assert Path.cwd().resolve() == tmp_path.resolve()
+
+
+def test_align_switches_to_recorded_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Choosing ``switch`` changes cwd to the recorded directory.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace and state root.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+    from omnigent.opencode_native_state import write_launch_state
+
+    recorded = tmp_path / "recorded"
+    current = tmp_path / "current"
+    recorded.mkdir()
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    write_launch_state("conv_abc", str(recorded.resolve()))
+    monkeypatch.setattr(
+        on,
+        "_prompt_opencode_resume_workspace_action",
+        lambda **_kwargs: "switch",
+    )
+
+    on._align_working_directory_with_session("conv_abc")
+
+    assert Path.cwd().resolve() == recorded.resolve()
+
+
+def test_align_cancel_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Choosing ``cancel`` aborts the resume without moving cwd.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace and state root.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+    from omnigent.opencode_native_state import write_launch_state
+
+    recorded = tmp_path / "recorded"
+    current = tmp_path / "current"
+    recorded.mkdir()
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    write_launch_state("conv_abc", str(recorded.resolve()))
+    monkeypatch.setattr(
+        on,
+        "_prompt_opencode_resume_workspace_action",
+        lambda **_kwargs: "cancel",
+    )
+
+    with pytest.raises(click.ClickException) as excinfo:
+        on._align_working_directory_with_session("conv_abc")
+
+    assert "cancel" in excinfo.value.message.lower()
+    assert Path.cwd().resolve() == current.resolve()
+
+
+def test_align_missing_recorded_cwd_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A recorded-but-missing cwd fails loud instead of resuming wrong.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace and state root.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+    from omnigent.opencode_native_state import write_launch_state
+
+    current = tmp_path / "current"
+    missing = tmp_path / "missing"
+    current.mkdir()
+    monkeypatch.chdir(current)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_NATIVE_STATE_DIR", str(tmp_path / "state"))
+    write_launch_state("conv_abc", str(missing))
+
+    def _fail_prompt(**_kwargs: object) -> str:
+        raise AssertionError("missing recorded dir should raise before prompting")
+
+    monkeypatch.setattr(on, "_prompt_opencode_resume_workspace_action", _fail_prompt)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        on._align_working_directory_with_session("conv_abc")
+
+    assert "conv_abc" in excinfo.value.message
+    assert str(missing.resolve()) in excinfo.value.message
+
+
+def test_prompt_offers_switch_and_cancel_choices(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    The cwd-mismatch prompt offers ``switch``/``cancel`` and defaults to switch.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary recorded/current paths.
+    :returns: None.
+    """
+    import omnigent.opencode_native as on
+
+    captured: dict[str, Any] = {}
+
+    def _fake_prompt(text: str, **kwargs: Any) -> str:
+        captured["text"] = text
+        captured["kwargs"] = kwargs
+        return "switch"
+
+    monkeypatch.setattr(click, "prompt", _fake_prompt)
+
+    result = on._prompt_opencode_resume_workspace_action(
+        recorded_path=tmp_path / "recorded",
+        current=tmp_path / "current",
+    )
+
+    assert result == "switch"
+    choice = captured["kwargs"]["type"]
+    assert isinstance(choice, click.Choice)
+    assert list(choice.choices) == ["switch", "cancel"]
+    assert captured["kwargs"]["default"] == "switch"
+
+
+# --- _run_with_remote_server control-flow (daemon/server mocked) ---
+def test_run_with_remote_server_aligns_cwd_before_daemon_prepare(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    Remote resume aligns cwd before the daemon prepare samples it.
+
+    Drives the real ``_run_with_remote_server`` with the daemon/server
+    mocked: asserts ``align`` runs first and the aligned cwd is the
+    workspace handed to prepare.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary start/aligned dirs.
+    :returns: None.
+    """
+    import os
+    from types import SimpleNamespace
+
+    import omnigent.chat as chat_mod
+    import omnigent.cli as cli_mod
+    import omnigent.host.identity as identity_mod
+    import omnigent.opencode_native as on
+    from omnigent._runner_startup import RunnerStartupProgress
+
+    start_dir = tmp_path / "start"
+    aligned_dir = tmp_path / "aligned"
+    start_dir.mkdir()
+    aligned_dir.mkdir()
+    monkeypatch.chdir(start_dir)
+
+    order: list[str] = []
+
+    def fake_align(_session_id: str) -> None:
+        order.append("align")
+        os.chdir(aligned_dir)
+
+    async def fake_prepare(**kwargs: Any) -> PreparedOpenCodeTerminal:
+        assert kwargs["host_id"] == "host_local"
+        assert kwargs["session_id"] == "conv_abc"
+        assert kwargs["workspace"] == str(aligned_dir.resolve())
+        assert isinstance(kwargs["startup_progress"], RunnerStartupProgress)
+        order.append("prepare")
+        return PreparedOpenCodeTerminal(
+            session_id="conv_abc",
+            terminal_id="term_main",
+            tmux_socket=None,
+            tmux_target=None,
+            reattached=True,
+        )
+
+    async def fake_attach(_prepared: object) -> None:
+        order.append("attach")
+
+    monkeypatch.setattr(chat_mod, "_remote_headers", lambda *_a, **_k: {})
+    monkeypatch.setattr(
+        cli_mod, "_ensure_host_daemon", lambda *_a, **_k: order.append("ensure-daemon")
+    )
+    monkeypatch.setattr(
+        identity_mod,
+        "load_or_create_host_identity",
+        lambda: SimpleNamespace(host_id="host_local"),
+    )
+    monkeypatch.setattr(on, "_resolve_session_id_for_resume", lambda **_k: "conv_abc")
+    monkeypatch.setattr(on, "_align_working_directory_with_session", fake_align)
+    monkeypatch.setattr(on, "_prepare_opencode_terminal_via_daemon", fake_prepare)
+    monkeypatch.setattr(on, "_attach_terminal_resource", fake_attach)
+    monkeypatch.setattr(on, "open_conversation_link_if_enabled", lambda **_k: None)
+
+    on._run_with_remote_server(
+        "http://server",
+        tmp_path / "spec.yaml",
+        session_id="conv_abc",
+        resume_picker=False,
+        opencode_args=(),
+    )
+
+    assert order == ["align", "ensure-daemon", "prepare", "attach"]
+
+
+def test_run_with_remote_server_records_launch_after_create(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A fresh remote session records its launch cwd after prepare (no align).
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary workspace.
+    :returns: None.
+    """
+    from types import SimpleNamespace
+
+    import omnigent.chat as chat_mod
+    import omnigent.cli as cli_mod
+    import omnigent.host.identity as identity_mod
+    import omnigent.opencode_native as on
+
+    monkeypatch.chdir(tmp_path)
+    order: list[str] = []
+
+    async def fake_prepare(**_k: Any) -> PreparedOpenCodeTerminal:
+        order.append("prepare")
+        return PreparedOpenCodeTerminal(
+            session_id="conv_new",
+            terminal_id="term_main",
+            tmux_socket=None,
+            tmux_target=None,
+            reattached=False,
+        )
+
+    async def fake_attach(_prepared: object) -> None:
+        order.append("attach")
+
+    def fake_record(session_id: str) -> None:
+        assert session_id == "conv_new"
+        order.append("record")
+
+    def fail_align(_session_id: str) -> None:
+        raise AssertionError("create path must not align cwd")
+
+    monkeypatch.setattr(chat_mod, "_remote_headers", lambda *_a, **_k: {})
+    monkeypatch.setattr(chat_mod, "_bundle_agent", lambda _spec: b"bundle")
+    monkeypatch.setattr(
+        cli_mod, "_ensure_host_daemon", lambda *_a, **_k: order.append("ensure-daemon")
+    )
+    monkeypatch.setattr(
+        identity_mod,
+        "load_or_create_host_identity",
+        lambda: SimpleNamespace(host_id="host_local"),
+    )
+    monkeypatch.setattr(on, "_resolve_session_id_for_resume", lambda **_k: None)
+    monkeypatch.setattr(on, "_align_working_directory_with_session", fail_align)
+    monkeypatch.setattr(on, "_prepare_opencode_terminal_via_daemon", fake_prepare)
+    monkeypatch.setattr(on, "_attach_terminal_resource", fake_attach)
+    monkeypatch.setattr(on, "_record_launch_for_fresh_session", fake_record)
+    monkeypatch.setattr(on, "open_conversation_link_if_enabled", lambda **_k: None)
+    monkeypatch.setattr(on, "echo_native_resume_hint", lambda **_k: None)
+
+    on._run_with_remote_server(
+        "http://server",
+        tmp_path / "spec.yaml",
+        session_id=None,
+        resume_picker=False,
+        opencode_args=(),
+    )
+
+    assert order == ["ensure-daemon", "prepare", "record", "attach"]


### PR DESCRIPTION
## Related issue

Closes https://github.com/omnigent-ai/omnigent/issues/1319

## Summary

`omni opencode --resume` relaunched OpenCode in the **current** directory, instead of re-aligning the workspace from launch.json. This wires the previously-unused `opencode_native_state` `launch.json`, bringing opencode-native to parity with codex-/claude-native:

- **`_record_launch_for_fresh_session`** — persist the launch cwd when a session is created.
- **`_align_working_directory_with_session`** — on resume, read it and, on a cwd mismatch, prompt **switch / cancel** (or fail loudly when the recorded directory is gone); `switch` `chdir`s so the runner relaunches in the recorded workspace.

### ELI5

If you start an OpenCode session in `~/proj` and later resume it from somewhere else, it used to reopen wherever you currently are. Now it remembers the folder you started in(logged in launch.json) and offers to put you back there before relaunching.

### Flow

```text
create:  omni opencode            (in ~/proj)  ─► write launch.json {workspace: ~/proj}

resume:  omni opencode --resume <conv>
           └─ read launch.json
               ├─ cwd == recorded   → continue silently
               ├─ cwd != recorded   → prompt: switch → chdir(~/proj) → relaunch there
               │                              cancel → abort
               └─ recorded missing  → error (don't relaunch in the wrong place)
```

## Test Plan

- `pytest tests/test_opencode_native.py` → **38 passed** (28 existing + 10 new).
- Manual live run on macOS with `opencode-ai` 1.17.11:
  1. `cd ~/proj && omni opencode` → created a session; confirmed `launch.json`
     written under `~/.omnigent/opencode-native/<hash>/` with the workspace.
  2. `cd ~ && omni opencode --resume <conv>` → got the switch/cancel prompt;
     `switch` relaunched in `~/proj`; `cancel` aborted cleanly.
  3. Renamed `~/proj` away, then resumed → failed loudly with the
     "directory no longer exists" error instead of relaunching in the wrong place.
     

### End-to-end test     
Before the change, no cwd change is suggested by the CLI:
<img width="525" height="64" alt="image" src="https://github.com/user-attachments/assets/451a832f-7535-4777-89fb-45459283094c" />
   
After the change, the CLI will show similar switch/cancel options like codex:
 A. Switch to original cwd:
<img width="706" height="163" alt="image" src="https://github.com/user-attachments/assets/f762e3bb-c5cb-4aca-beae-796bce5f26a0" />

B. Cancel switch: 
<img width="705" height="174" alt="WechatIMG110781" src="https://github.com/user-attachments/assets/c22be707-11dc-4de5-b4ad-aba60ea7ac38" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

10 new tests in `tests/test_opencode_native.py`: **8 unit** over the new helpers
(record persists cwd / swallows `OSError`; align no-state / matching-cwd / switch /
cancel / missing-dir; prompt offers `switch`/`cancel` and defaults to `switch`) and
**2 control-flow** that drive the real `_run_with_remote_server` with the daemon
mocked — asserting align-before-prepare on resume (and that the aligned cwd is the
workspace handed to the runner) and record-after-create. The daemon/tmux attach
plumbing is unchanged and stays covered by the live host e2e; manual verification
above covers the interactive switch/cancel/missing-dir paths a unit test can't.