### PR TITLE
fix(pi-native): select a cli-config Databricks gateway via shared selection

### DIFF
--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -816,26 +816,24 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
                 code=ErrorCode.INVALID_INPUT,
             )
         display_name_raw = raw.get("display_name")
-        cli_config_entry = ProviderEntry(
+        return ProviderEntry(
             name=name,
             kind=kind,
             cli=cli_raw,
             model_provider=model_provider_raw,
             display_name=display_name_raw if isinstance(display_name_raw, str) else None,
-        )
-        # A codex cli-config provider serves the openai surface, like a codex
-        # subscription. It may ALSO claim the pi scope when it is a Databricks
-        # AI Gateway (Pi speaks its Anthropic surface natively) — so a user can
-        # pin pi→Databricks with ``default: [openai, pi]``. We only run the
-        # (disk-reading) capability check when a ``default`` is actually
-        # declared, so the common no-default parse stays cheap and side-effect
-        # free; a non-Databricks cli-config remains pi-incapable (its
-        # ``default: pi`` is rejected at parse, parity with a subscription).
-        pi_capable = bool(default_raw) and _cli_config_serves_pi(cli_config_entry)
-        return replace(
-            cli_config_entry,
+            # A codex cli-config provider serves the openai surface, like a codex
+            # subscription. It may ALSO claim the pi scope (``default: [openai,
+            # pi]``) because a Databricks AI Gateway is pi-consumable (Pi speaks
+            # its Anthropic surface natively). This is allowed structurally —
+            # without reading the ambient ~/.codex/config.toml at parse — so a
+            # user can pin pi→Databricks; whether the pinned provider is a *real*
+            # Databricks gateway is validated at pi launch, which falls back to
+            # Pi's own login when it is not (see :func:`_cli_config_serves_pi`
+            # and ``resolve_pi_native_provider``). A codex subscription stays
+            # pi-incapable (its ``default: pi`` is still rejected at parse).
             default_families=_parse_default_families(
-                name, default_raw, {OPENAI_FAMILY}, pi_capable=pi_capable
+                name, default_raw, {OPENAI_FAMILY}, pi_capable=True
             ),
         )
 
@@ -1039,12 +1037,20 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
         if entry.cli == "claude":
             return frozenset({ANTHROPIC_FAMILY})
         if entry.cli == "codex":
-            # A codex cli-config provider that is a Databricks AI Gateway also
-            # serves pi — the gateway's Anthropic Messages surface is reusable
-            # by Pi (see :func:`_cli_config_serves_pi`). A codex *subscription*
-            # never does (a CLI login is unusable outside its own CLI), so the
-            # pi scope is gated on the cli-config Databricks-gateway capability.
-            if entry.kind == CLI_CONFIG_KIND and _cli_config_serves_pi(entry):
+            # A codex *cli-config* provider may ALSO serve pi: a Databricks AI
+            # Gateway exposes an Anthropic Messages surface Pi speaks natively
+            # (pi-native translates it via ``_cli_config_pi_provider``; the
+            # gateway-harness pi path routes it via
+            # ``configure_agent_harness_with_provider``). This is reported at the
+            # KIND level — structurally, without reading the ambient
+            # ~/.codex/config.toml — so ``provider_families`` stays pure (the
+            # setup menus / ``set_default_provider`` may offer/accept the pi
+            # scope for a codex cli-config). Whether the pinned provider is a
+            # *real* Databricks gateway is validated at resolution time
+            # (``default_provider_for_harness`` fallback + the pi launch), which
+            # falls back gracefully when it is not. A codex *subscription* never
+            # serves pi — a CLI login is unusable outside its own CLI.
+            if entry.kind == CLI_CONFIG_KIND:
                 return frozenset({OPENAI_FAMILY, PI_SURFACE})
             return frozenset({OPENAI_FAMILY})
         return frozenset()

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -816,15 +816,27 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
                 code=ErrorCode.INVALID_INPUT,
             )
         display_name_raw = raw.get("display_name")
-        return ProviderEntry(
+        cli_config_entry = ProviderEntry(
             name=name,
             kind=kind,
             cli=cli_raw,
             model_provider=model_provider_raw,
             display_name=display_name_raw if isinstance(display_name_raw, str) else None,
-            # A codex cli-config provider serves the openai surface, like a
-            # codex subscription.
-            default_families=_parse_default_families(name, default_raw, {OPENAI_FAMILY}),
+        )
+        # A codex cli-config provider serves the openai surface, like a codex
+        # subscription. It may ALSO claim the pi scope when it is a Databricks
+        # AI Gateway (Pi speaks its Anthropic surface natively) — so a user can
+        # pin pi→Databricks with ``default: [openai, pi]``. We only run the
+        # (disk-reading) capability check when a ``default`` is actually
+        # declared, so the common no-default parse stays cheap and side-effect
+        # free; a non-Databricks cli-config remains pi-incapable (its
+        # ``default: pi`` is rejected at parse, parity with a subscription).
+        pi_capable = bool(default_raw) and _cli_config_serves_pi(cli_config_entry)
+        return replace(
+            cli_config_entry,
+            default_families=_parse_default_families(
+                name, default_raw, {OPENAI_FAMILY}, pi_capable=pi_capable
+            ),
         )
 
     if kind == DATABRICKS_KIND:
@@ -944,6 +956,34 @@ def harness_family(harness: str) -> str | None:
     return _HARNESS_FAMILY.get(harness)
 
 
+def _cli_config_serves_pi(entry: ProviderEntry) -> bool:
+    """Return whether a ``cli-config`` *entry* can drive the ``pi`` harness.
+
+    Most ``cli-config`` providers (a custom codex ``[model_providers.X]``) are
+    unusable outside their own CLI, so they never serve pi. The exception is a
+    Databricks AI Gateway: it exposes an Anthropic Messages surface Pi speaks
+    natively, and :func:`omnigent.pi_native_credentials._cli_config_pi_provider`
+    translates it into a Pi gateway config (and the gateway-harness pi path
+    routes it too — see ``configure_agent_harness_with_provider``). So a
+    cli-config provider serves pi *iff* it is a pi-consumable Databricks gateway.
+
+    The capability check lives in :mod:`omnigent.pi_native_credentials` (the
+    single source of truth, alongside the gateway-URL allowlist and the codex
+    transport reader). It is imported **lazily** here: ``pi_native_credentials``
+    imports this module at top level, so a top-level import back would cycle;
+    by call time both modules are fully loaded, so the lazy import is safe.
+
+    :param entry: The provider entry to classify.
+    :returns: ``True`` iff *entry* is a ``cli-config`` Databricks AI Gateway
+        Pi can route through.
+    """
+    if entry.kind != CLI_CONFIG_KIND:
+        return False
+    from omnigent.pi_native_credentials import cli_config_pi_provider_capable
+
+    return cli_config_pi_provider_capable(entry)
+
+
 def provider_families(entry: ProviderEntry) -> frozenset[str]:
     """Return the model families *entry* can serve.
 
@@ -999,6 +1039,13 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
         if entry.cli == "claude":
             return frozenset({ANTHROPIC_FAMILY})
         if entry.cli == "codex":
+            # A codex cli-config provider that is a Databricks AI Gateway also
+            # serves pi — the gateway's Anthropic Messages surface is reusable
+            # by Pi (see :func:`_cli_config_serves_pi`). A codex *subscription*
+            # never does (a CLI login is unusable outside its own CLI), so the
+            # pi scope is gated on the cli-config Databricks-gateway capability.
+            if entry.kind == CLI_CONFIG_KIND and _cli_config_serves_pi(entry):
+                return frozenset({OPENAI_FAMILY, PI_SURFACE})
             return frozenset({OPENAI_FAMILY})
         return frozenset()
     if entry.kind == DATABRICKS_KIND:
@@ -1099,18 +1146,26 @@ def default_provider_for_harness(config: dict[str, object], harness: str) -> Pro
     # excluded (a gemini key serves only the Gemini surface, never pi).
     for fam in _PI_FALLBACK_FAMILIES:
         provider = get_default_provider(config, fam)
-        # Subscription logins and cli-config provider pins live in the
-        # claude/codex CLI's own files, which an unmapped harness doesn't
-        # wrap; a bedrock provider is native-``omnigent claude`` only
-        # (configure_agent_harness_with_provider raises for it). None can
-        # serve pi, so skip them and fall through — otherwise a bedrock Claude
-        # default would turn a working pi run (own login) into a hard error.
-        if provider is not None and provider.kind not in (
-            SUBSCRIPTION_KIND,
-            CLI_CONFIG_KIND,
-            BEDROCK_KIND,
-        ):
-            return provider
+        if provider is None:
+            continue
+        # Subscription logins live in the claude/codex CLI's own login, which
+        # an unmapped harness doesn't wrap; a bedrock provider is
+        # native-``omnigent claude`` only (configure_agent_harness_with_provider
+        # raises for it). Neither can serve pi, so skip them and fall through —
+        # otherwise a bedrock Claude default would turn a working pi run (own
+        # login) into a hard error.
+        if provider.kind in (SUBSCRIPTION_KIND, BEDROCK_KIND):
+            continue
+        # A cli-config provider pins a model_provider in the codex CLI's own
+        # config.toml. Most such pins are unusable outside codex, BUT a
+        # Databricks AI Gateway exposes an Anthropic surface Pi speaks natively
+        # (translated by ``_cli_config_pi_provider`` for pi-native, and routed
+        # by ``configure_agent_harness_with_provider`` for the gateway-harness
+        # pi path). Route pi to it rather than skipping; a non-Databricks
+        # cli-config still falls through (it can't serve pi).
+        if provider.kind == CLI_CONFIG_KIND and not _cli_config_serves_pi(provider):
+            continue
+        return provider
     return None
 
 

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -80,11 +80,15 @@ _PI_FALLBACK_FAMILIES = (ANTHROPIC_FAMILY, OPENAI_FAMILY)
 # entry never carries a ``pi:`` block — but defaults are scoped per harness
 # surface, and pi consumes both families, so it gets its own scope name a
 # ``default:`` value may reference (``default: ["anthropic", "pi"]``).
-# Every provider kind except ``subscription`` can drive pi (a claude/codex
-# CLI login is unusable outside its own CLI), so only those kinds may claim
-# this scope. Resolution: an explicit pi default wins; otherwise pi falls
-# back to the anthropic then openai family default, skipping subscriptions
-# (see :func:`default_provider_for_harness`).
+# An inline key/gateway/local (with an anthropic/openai family) and a
+# databricks profile drive pi directly; a ``cli-config`` may claim the scope
+# too (a Databricks AI Gateway is pi-consumable — Pi speaks its Anthropic
+# surface), with the actual gateway capability validated at resolution time.
+# A ``subscription`` (CLI login, unusable outside its own CLI) and ``bedrock``
+# (native-``omnigent claude`` only) can never drive pi. Resolution: an
+# explicit pi default wins; otherwise pi falls back to the anthropic then
+# openai family default, skipping the non-pi kinds (see
+# :func:`default_provider_for_harness`).
 PI_SURFACE = "pi"
 
 # Accepted ``wire_api`` values. ``responses`` is the OpenAI Responses API;
@@ -1124,13 +1128,15 @@ def default_provider_for_harness(config: dict[str, object], harness: str) -> Pro
     default. The ``pi`` harness (and any unmapped harness) consumes both
     families: an explicit :data:`PI_SURFACE` default wins; otherwise it
     falls back to the ``anthropic`` then ``openai`` family default,
-    skipping ``subscription``, ``cli-config``, and ``bedrock`` defaults —
-    the first two live in the claude/codex CLI's own files an unmapped
-    harness can't read, and ``bedrock`` is native-``omnigent claude`` only.
-    Routing pi to any of them fails: ``configure_agent_harness_with_provider``
-    no-ops on subscription (spawning pi authless) and raises on cli-config
-    (non-codex) and bedrock. This mirrors :func:`provider_families`, which
-    never reports the :data:`PI_SURFACE` scope for these kinds.
+    skipping ``subscription`` and ``bedrock`` defaults (a CLI login is
+    unusable outside its own CLI, and ``bedrock`` is native-``omnigent
+    claude`` only — routing pi to either fails). A ``cli-config`` default is
+    skipped UNLESS it is a pi-consumable Databricks AI Gateway (see
+    :func:`_cli_config_serves_pi`): such a gateway exposes an Anthropic
+    surface Pi speaks natively, so pi-native translates it
+    (``_cli_config_pi_provider``) and the gateway-harness pi path routes it
+    (``configure_agent_harness_with_provider``). A non-Databricks cli-config
+    still falls through (it can't serve pi).
 
     :param config: The parsed config mapping (``providers:`` block).
     :param harness: The canonical harness name, e.g. ``"claude-sdk"`` or

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -29,17 +29,15 @@ from urllib.parse import urlparse
 
 from omnigent.model_override import normalize_model_for_provider
 from omnigent.onboarding.provider_config import (
-    ANTHROPIC_FAMILY,
     CHAT_WIRE_API,
     CLI_CONFIG_KIND,
     DATABRICKS_KIND,
     GATEWAY_KIND,
     KEY_KIND,
     LOCAL_KIND,
-    OPENAI_FAMILY,
     PI_SURFACE,
     ProviderEntry,
-    get_default_provider,
+    default_provider_for_harness,
     load_config,
 )
 
@@ -207,29 +205,20 @@ def _gateway_anthropic_base_url(codex_base_url: str) -> str:
     return f"{trimmed}{_DATABRICKS_GATEWAY_ANTHROPIC_SUFFIX}"
 
 
-def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
-    """Resolve a Codex ``cli-config`` Databricks-gateway provider into Pi config.
+def _cli_config_databricks_transport(entry: ProviderEntry) -> Any:
+    """Return the codex transport for a pi-consumable Databricks cli-config entry.
 
-    The common enterprise setup: ``isaac configure codex`` writes a custom
-    ``[model_providers.X]`` table (base_url + token-printing ``auth`` command)
-    into ``~/.codex/config.toml`` and ``omnigent setup`` adopts it as a
-    ``cli-config`` provider. Codex-native routes through that table; pi-native
-    used to return ``None`` here — silently falling back to Pi's own
-    ``/login`` (often stale creds) — which is the bug this fixes.
+    Shared core of :func:`_cli_config_pi_provider` and
+    :func:`cli_config_pi_provider_capable`: validates that *entry* is a codex
+    ``cli-config`` whose pinned ``[model_providers.X]`` table in
+    ``~/.codex/config.toml`` is a genuine Databricks AI Gateway carrying a
+    bearer-token command. Returns the resolved
+    :class:`~omnigent.onboarding.ambient.CodexConfigTransport` when so, else
+    ``None`` (logging the reason at INFO).
 
-    We read the *transport* (base URL + bearer-token command) from the codex
-    config table the entry pins, rewrite the base URL to the gateway's
-    Anthropic Messages surface (Pi speaks it natively), and emit a ``!command``
-    apiKey so Pi refreshes the gateway token per request — exactly like the
-    ``databricks`` kind path. The workspace-specific base URL and token path
-    are read from config, never hardcoded.
-
-    :param entry: The resolved default provider (``kind="cli-config"``,
-        ``cli="codex"``), carrying the ``model_provider`` id and display name.
-    :param model: Session model override, or ``None`` to use the default.
-    :returns: The Pi provider config, or ``None`` when the entry is not a
-        Databricks gateway, its codex provider table can't be resolved, or it
-        carries no token command (caller falls back to Pi's own login).
+    :param entry: The provider entry (expected ``kind="cli-config"``).
+    :returns: The codex transport when *entry* is a pi-consumable Databricks
+        AI Gateway, else ``None``.
     """
     # Only codex cli-config providers are model_provider-shaped today; a
     # claude analog would be a different mechanism entirely.
@@ -273,6 +262,55 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
             entry.name,
             entry.model_provider,
         )
+        return None
+    return transport
+
+
+def cli_config_pi_provider_capable(entry: ProviderEntry) -> bool:
+    """Return whether a ``cli-config`` *entry* is pi-consumable.
+
+    A codex ``cli-config`` provider IS reusable by Pi exactly when
+    :func:`_cli_config_pi_provider` would resolve — i.e. its pinned
+    ``[model_providers.X]`` table is a genuine Databricks AI Gateway with a
+    bearer-token command. This is the capability predicate the selection layer
+    (:mod:`omnigent.onboarding.provider_config`) consults to decide whether a
+    cli-config provider may serve / default the ``pi`` surface, keeping the
+    single source of truth here (and avoiding an import cycle —
+    ``provider_config`` lazy-imports this rather than the reverse).
+
+    :param entry: The provider entry to classify (expected
+        ``kind="cli-config"``; any other kind returns ``False``).
+    :returns: ``True`` iff Pi can route through this cli-config provider.
+    """
+    return _cli_config_databricks_transport(entry) is not None
+
+
+def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
+    """Resolve a Codex ``cli-config`` Databricks-gateway provider into Pi config.
+
+    The common enterprise setup: ``isaac configure codex`` writes a custom
+    ``[model_providers.X]`` table (base_url + token-printing ``auth`` command)
+    into ``~/.codex/config.toml`` and ``omnigent setup`` adopts it as a
+    ``cli-config`` provider. Codex-native routes through that table; pi-native
+    used to return ``None`` here — silently falling back to Pi's own
+    ``/login`` (often stale creds) — which is the bug this fixes.
+
+    We read the *transport* (base URL + bearer-token command) from the codex
+    config table the entry pins, rewrite the base URL to the gateway's
+    Anthropic Messages surface (Pi speaks it natively), and emit a ``!command``
+    apiKey so Pi refreshes the gateway token per request — exactly like the
+    ``databricks`` kind path. The workspace-specific base URL and token path
+    are read from config, never hardcoded.
+
+    :param entry: The resolved default provider (``kind="cli-config"``,
+        ``cli="codex"``), carrying the ``model_provider`` id and display name.
+    :param model: Session model override, or ``None`` to use the default.
+    :returns: The Pi provider config, or ``None`` when the entry is not a
+        Databricks gateway, its codex provider table can't be resolved, or it
+        carries no token command (caller falls back to Pi's own login).
+    """
+    transport = _cli_config_databricks_transport(entry)
+    if transport is None:
         return None
     return PiProviderConfig(
         provider_id=_PI_PROVIDER_ID,
@@ -369,13 +407,14 @@ def resolve_pi_native_provider(
     try:
         config = config_loader()
         # Pi is multi-family; ``omnigent setup`` marks defaults per family, not
-        # for ``pi``. Prefer an explicit pi default, then Anthropic (Pi's native
-        # surface), then OpenAI.
-        entry = (
-            get_default_provider(config, PI_SURFACE)
-            or get_default_provider(config, ANTHROPIC_FAMILY)
-            or get_default_provider(config, OPENAI_FAMILY)
-        )
+        # for ``pi``. Use the shared house-pattern selection so pi resolves its
+        # default exactly like the rest of the codebase — an explicit pi default
+        # wins, else the anthropic (Pi's native surface) then openai family
+        # default, skipping kinds that can't drive pi. Crucially this now lets a
+        # cli-config Databricks AI Gateway through (it is pi-consumable via
+        # ``_cli_config_pi_provider``), so an unrelated anthropic-family default
+        # no longer shadows it.
+        entry = default_provider_for_harness(config, PI_SURFACE)
         if entry is None:
             _LOGGER.info(
                 "pi-native: no omnigent-configured provider for the pi/anthropic/openai "

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -24,7 +24,7 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from omnigent.model_override import normalize_model_for_provider
@@ -40,6 +40,12 @@ from omnigent.onboarding.provider_config import (
     default_provider_for_harness,
     load_config,
 )
+
+if TYPE_CHECKING:
+    # Annotation-only import (the runtime import is lazy inside the function,
+    # since ``ambient`` pulls in onboarding-only deps this module avoids on the
+    # runner's session-create hot path).
+    from omnigent.onboarding.ambient import CodexConfigTransport
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -205,7 +211,7 @@ def _gateway_anthropic_base_url(codex_base_url: str) -> str:
     return f"{trimmed}{_DATABRICKS_GATEWAY_ANTHROPIC_SUFFIX}"
 
 
-def _cli_config_databricks_transport(entry: ProviderEntry) -> Any:
+def _cli_config_databricks_transport(entry: ProviderEntry) -> CodexConfigTransport | None:
     """Return the codex transport for a pi-consumable Databricks cli-config entry.
 
     Shared core of :func:`_cli_config_pi_provider` and

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -595,6 +595,16 @@ def configure_agent_harness_with_provider(
         return
 
     if entry.kind == CLI_CONFIG_KIND:
+        # The pi harness consumes both families and can route a cli-config
+        # Databricks AI Gateway (the gateway's Anthropic Messages surface is one
+        # Pi speaks natively) — the same provider pi-native routes via
+        # ``_cli_config_pi_provider``. Translate it into the pi gateway
+        # transport rather than failing loud; a non-Databricks cli-config is
+        # never selected for pi (see ``default_provider_for_harness``), so it
+        # won't reach here.
+        if harness_type == "pi":
+            _apply_cli_config_databricks_to_pi(env, entry)
+            return
         # A custom model provider defined (and authenticated) by the codex
         # CLI's own config.toml: pin it by name; the executor's bridged
         # config.toml carries the provider table + credential. Only the
@@ -883,6 +893,59 @@ def _apply_provider_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:
             "~/.omnigent/config.yaml.",
             code=ErrorCode.INVALID_INPUT,
         )
+
+
+def _apply_cli_config_databricks_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:
+    """Apply a cli-config Databricks AI Gateway to the pi (gateway-harness) path.
+
+    The gateway-harness pi launch (``omnigent run`` / agents) and pi-native
+    (the terminal) both resolve the same default provider
+    (:func:`default_provider_for_harness`), so when that default is a
+    ``cli-config`` Databricks AI Gateway, this path must route it rather than
+    fail loud. We reuse the pi-native translation
+    (:func:`omnigent.pi_native_credentials._cli_config_pi_provider`) — which
+    reads the codex ``[model_providers.X]`` transport, rewrites the base URL to
+    the gateway's Anthropic Messages surface (``/anthropic``) Pi speaks
+    natively, and builds the per-request bearer-token ``!command`` apiKey — then
+    maps its fields onto the ``HARNESS_PI_GATEWAY_*`` env vars the pi harness
+    wrap reads (the same vars :func:`_apply_provider_to_pi` emits).
+
+    :param env: Mutable spawn-env dict, modified in place.
+    :param entry: The resolved ``cli-config`` provider entry (a Databricks
+        gateway — selection guarantees a non-Databricks cli-config never
+        reaches here).
+    :raises OmnigentError: If the cli-config entry cannot be translated into a
+        Pi gateway provider (its codex table can't be resolved or it is not a
+        recognized Databricks AI Gateway) — selection should prevent this, so a
+        failure here is a real misconfiguration worth surfacing.
+    """
+    # Imported lazily: pi_native_credentials is on the runner's session-create
+    # hot path and pulls onboarding-only deps; keep this off workflow import.
+    from omnigent.pi_native_credentials import _cli_config_pi_provider
+
+    # The spec model (if any) is already in HARNESS_PI_MODEL; thread it so the
+    # gateway translation honors an explicit override, else its default.
+    model_override = env.get("HARNESS_PI_MODEL")
+    provider = _cli_config_pi_provider(entry, model=model_override)
+    if provider is None:
+        raise OmnigentError(
+            f"provider {entry.name!r} (kind 'cli-config') was selected for the 'pi' "
+            "harness but its codex [model_providers] table could not be resolved as a "
+            "Databricks AI Gateway. Check the [model_providers] base_url + auth in "
+            "~/.codex/config.toml, or configure a key/gateway provider for pi in "
+            "~/.omnigent/config.yaml.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    # Pi speaks the gateway's Anthropic Messages surface — register it under
+    # pi's "claude" family key (mirrors _apply_provider_to_pi's anthropic path).
+    base_urls = {_PI_FAMILY_KEY[ANTHROPIC_FAMILY]: provider.base_url}
+    env[_HARNESS_GATEWAY_FLAG["pi"]] = "true"
+    env["HARNESS_PI_GATEWAY_BASE_URLS"] = json.dumps(base_urls, sort_keys=True)
+    env["HARNESS_PI_GATEWAY_HOST"] = _origin_of(provider.base_url)
+    # provider.api_key is a "!command" form (Pi's models.json convention); the
+    # gateway transport env var wants the bare shell command, so strip the "!".
+    env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] = provider.api_key.lstrip("!")
+    env["HARNESS_PI_MODEL"] = provider.model
 
 
 def _synthesize_databricks_provider(profile: str | None) -> ProviderEntry:

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from omnigent.errors import OmnigentError
@@ -131,34 +133,102 @@ def test_default_provider_for_pi_none_when_only_subscriptions() -> None:
     assert default_provider_for_harness(config, "pi") is None
 
 
-def test_default_provider_for_pi_skips_cli_config_defaults() -> None:
-    """For the unmapped ``pi`` harness, a cli-config default is skipped.
+_DATABRICKS_CODEX_CONFIG_TOML = """
+model_provider = "Databricks"
 
-    A cli-config entry pins a provider table in ~/.codex/config.toml (e.g.
-    isaac's Databricks AI Gateway); only the codex harness bridges that file,
-    and ``configure_agent_harness_with_provider`` raises for any other
-    harness. A regression here makes the resolver hand pi the codex-only
-    gateway: the REPL startup header then shows "Pi → ⚙️ Databricks AI
-    Gateway" while ``setup`` (which filters via ``provider_families``)
-    correctly shows pi as credential-less, and an actual pi spawn fails.
+[model_providers.Databricks]
+name = "Databricks AI Gateway"
+base_url = "https://1965859176160743.ai-gateway.cloud.databricks.com/codex/v1"
+wire_api = "responses"
+
+[model_providers.Databricks.auth]
+command = "jq"
+args = ["-r", ".access_token", "/Users/me/.databricks/model-serving-token.json"]
+timeout_ms = 5000
+"""
+
+
+def _write_codex_toml(home: Path, body: str) -> None:
+    """Write a ``~/.codex/config.toml`` under *home* (resolver reads $HOME)."""
+    codex_dir = home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "config.toml").write_text(body, encoding="utf-8")
+
+
+def test_default_provider_for_pi_selects_cli_config_databricks_gateway(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """For the unmapped ``pi`` harness, a cli-config Databricks gateway IS selected.
+
+    A cli-config entry pins a provider table in ~/.codex/config.toml. PR #1251
+    made a Databricks AI Gateway cli-config pi-consumable (Pi speaks its
+    Anthropic surface natively), and pi resolution now routes it (pi-native
+    translates it; the gateway-harness pi path translates it too). So when the
+    pinned ``[model_providers.X]`` resolves to a real Databricks gateway, the
+    shared selection returns it for pi — the previous "skip all cli-config for
+    pi" behavior was the bug.
     """
+    _write_codex_toml(tmp_path, _DATABRICKS_CODEX_CONFIG_TOML)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
     config = {
         "providers": {
             "codex-databricks": {
                 "kind": "cli-config",
                 "default": True,
                 "cli": "codex",
-                "model_provider": "databricks",
+                "model_provider": "Databricks",
             },
         }
     }
-    # With only the codex-pinned gateway configured, pi must resolve no
-    # default — the gateway's credential lives in codex's config.toml,
-    # which pi cannot read. A non-None result means the fallback regressed
-    # to accepting cli-config and the header/setup readouts diverge again.
+    pi_default = default_provider_for_harness(config, "pi")
+    assert pi_default is not None
+    assert pi_default.name == "codex-databricks"
+    # The codex harness still takes the cli-config default — it is exactly the
+    # CLI whose config.toml carries the provider table.
+    assert default_provider_for_harness(config, "codex").name == "codex-databricks"
+
+
+def test_default_provider_for_pi_skips_non_databricks_cli_config_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A NON-Databricks (or unresolvable) cli-config default is still skipped for pi.
+
+    Selecting a non-Databricks cli-config for pi would just drop to Pi's own
+    login (``_cli_config_pi_provider`` returns None for it), so the pi fallback
+    must skip it. Here the pinned table points at a generic proxy, so pi
+    resolves no default (the REPL header / setup must show pi credential-less),
+    while codex still takes it.
+    """
+    _write_codex_toml(
+        tmp_path,
+        """
+model_provider = "Databricks"
+
+[model_providers.Databricks]
+name = "Some Other Proxy"
+base_url = "https://proxy.example.com/v1"
+
+[model_providers.Databricks.auth]
+command = "printf"
+args = ["%s", "sk-static"]
+""",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    config = {
+        "providers": {
+            "codex-databricks": {
+                "kind": "cli-config",
+                "default": True,
+                "cli": "codex",
+                "model_provider": "Databricks",
+            },
+        }
+    }
+    # A non-Databricks cli-config is not pi-consumable → pi falls back to None.
     assert default_provider_for_harness(config, "pi") is None
-    # The codex harness itself still takes the cli-config default — it is
-    # exactly the CLI whose config.toml carries the provider table.
+    # The codex harness still takes the cli-config default.
     assert default_provider_for_harness(config, "codex").name == "codex-databricks"
 
 
@@ -572,8 +642,12 @@ def test_parse_cli_config_entry() -> None:
     assert entry.cli == "codex"
     assert entry.model_provider == "Databricks"
     assert entry.display_name == "Databricks AI Gateway"
-    # Serves (and can default) exactly the codex/openai surface.
-    assert provider_families(entry) == frozenset({OPENAI_FAMILY})
+    # A codex cli-config serves the openai surface AND is structurally
+    # pi-capable: a Databricks AI Gateway is reusable by Pi (its Anthropic
+    # surface), so it can claim the pi scope. (``default: true`` deliberately
+    # never expands to pi — only an explicit ``pi`` does — so default_families
+    # stays openai-only here.)
+    assert provider_families(entry) == frozenset({OPENAI_FAMILY, PI_SURFACE})
     assert entry.default_families == frozenset({OPENAI_FAMILY})
 
 

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -1081,6 +1081,39 @@ def test_openai_agents_cli_config_default_fails_loud(config_home: Path) -> None:
         _build_openai_agents_sdk_spawn_env(spec)
 
 
+def test_pi_cli_config_databricks_default_routes_gateway(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cli-config Databricks gateway default routes the pi (gateway) harness.
+
+    Unlike openai-agents (which fails loud), pi CAN consume a cli-config
+    Databricks AI Gateway — the gateway's Anthropic Messages surface is one Pi
+    speaks. The gateway-harness pi path must translate it into the
+    ``HARNESS_PI_GATEWAY_*`` transport (the same vars an inline gateway emits),
+    pointing at the gateway's ``/anthropic`` surface — NOT raise the
+    "can only drive the 'codex' harness" error.
+    """
+    _isolate_home_with_codex_config(config_home, monkeypatch)
+    _write_config(config_home, _cli_config_default_config())
+    spec = _make_spec(harness="pi")
+
+    env = _build_pi_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_PI_GATEWAY"] == "true"
+    # The gateway's codex /codex/v1 base_url is rewritten to the /anthropic
+    # surface Pi speaks natively, registered under pi's "claude" family key.
+    assert env["HARNESS_PI_GATEWAY_BASE_URLS"] == (
+        '{"claude": "https://example.ai-gateway.cloud.databricks.com/anthropic"}'
+    )
+    assert env["HARNESS_PI_GATEWAY_HOST"] == "https://example.ai-gateway.cloud.databricks.com"
+    # The bearer-token command comes from the codex [model_providers.X.auth]
+    # table (the "!" Pi-models.json prefix is stripped for the transport var).
+    # The fixture's [auth] declares command="jq" with no args, so it is "jq".
+    assert env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] == "jq"
+    # Default model is the Databricks gateway default (no spec/override model).
+    assert env["HARNESS_PI_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
 _DISMISSIBLE_CODEX_CONFIG_TOML = """
 model_provider = "Databricks"
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -497,6 +497,119 @@ def test_real_gateway_still_resolves_after_hardening(
     )
 
 
+# ── Cross-surface selection: a cli-config Databricks gateway must be reachable
+#    and selectable for pi (the bug: the old pi filter excluded all cli-config) ──
+
+
+def _cli_config_databricks_pinned_pi() -> dict[str, object]:
+    """A config where the cli-config Databricks gateway is pinned ``default: [openai, pi]``.
+
+    Alongside an anthropic key that defaults only the anthropic surface, the
+    Databricks gateway explicitly claims the pi scope — which the parser now
+    accepts for a Databricks cli-config gateway. ``resolve_pi_native_provider``
+    must select the gateway (its explicit pi default wins the shared
+    selection), NOT api.anthropic.com.
+    """
+    return {
+        "providers": {
+            "anthropic": {
+                "kind": "key",
+                "default": "anthropic",
+                "anthropic": {
+                    "base_url": "https://api.anthropic.com",
+                    "api_key": "sk-test-literal",
+                },
+            },
+            "codex-databricks": {
+                "kind": "cli-config",
+                "default": ["openai", "pi"],
+                "cli": "codex",
+                "model_provider": "Databricks",
+                "display_name": "Databricks AI Gateway",
+            },
+        }
+    }
+
+
+def test_explicit_pi_pin_selects_cli_config_databricks_over_anthropic_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An explicit ``default: pi`` on a cli-config Databricks gateway wins for pi.
+
+    Even with an anthropic key present (its own anthropic-surface default), the
+    Databricks gateway pinned to the pi scope must be the pi selection — proving
+    the parser accepts ``default: [openai, pi]`` for a Databricks cli-config AND
+    the shared selection routes pi to it (base_url is the gateway's /anthropic
+    surface, NOT api.anthropic.com).
+    """
+    _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_pinned_pi)
+
+    assert provider is not None
+    assert (
+        provider.base_url == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
+    )
+    assert provider.api == "anthropic-messages"
+    assert provider.auth_header is True
+    assert provider.api_key == (
+        "!jq -r .access_token /Users/me/.databricks/model-serving-token.json"
+    )
+    # NOT the anthropic key endpoint.
+    assert provider.base_url != "https://api.anthropic.com"
+
+
+def test_cli_config_databricks_as_sole_default_selected_for_pi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config Databricks gateway as the only openai default is selected for pi.
+
+    No explicit pi default and no anthropic default: the shared pi fallback
+    reaches the openai default, and because it is a pi-consumable Databricks
+    gateway, selection no longer skips it (the bug: the old filter excluded all
+    cli-config from pi). Pi routes to the gateway's /anthropic surface.
+    """
+    _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
+
+    assert provider is not None
+    assert (
+        provider.base_url == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
+    )
+
+
+def test_non_databricks_cli_config_not_selected_for_pi_via_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A NON-Databricks cli-config openai default is NOT selected for pi (falls back).
+
+    A generic (non-Databricks) cli-config provider cannot serve pi, so the pi
+    fallback must skip it rather than select it (selecting it would just drop to
+    Pi's own login). With no other pi-consumable default, resolution returns
+    None.
+    """
+    _write_codex_config(
+        tmp_path,
+        """
+model_provider = "Databricks"
+
+[model_providers.Databricks]
+name = "Some Other Proxy"
+base_url = "https://proxy.example.com/v1"
+
+[model_providers.Databricks.auth]
+command = "printf"
+args = ["%s", "sk-static"]
+""",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # codex-databricks here points at a non-Databricks proxy → not pi-consumable.
+    assert creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config) is None
+
+
 @pytest.mark.parametrize(
     "gateway_url",
     [


### PR DESCRIPTION
## Problem

pi-native is supposed to be able to use a Databricks AI Gateway configured as a `cli-config` provider (the common `codex-databricks` setup). PR #1251 added `_cli_config_pi_provider` so pi *can* translate such a provider into a Pi `models.json` gateway config — but selection never reached it:

1. `resolve_pi_native_provider` picked the provider with its own inline chain (`get_default_provider(PI) or get_default_provider(ANTHROPIC) or get_default_provider(OPENAI)`), bypassing the shared house-pattern selection.
2. The shared selection `default_provider_for_harness(config, "pi")` explicitly **excluded all `cli-config` providers** from the pi surface (comment: cli-config "can't serve pi") — now stale for the Databricks-gateway case.
3. The parser rejected marking a `cli-config` provider as a `pi` default, so a user couldn't pin pi -> Databricks.

## What changed

- **Unify selection (A):** `resolve_pi_native_provider` now calls `default_provider_for_harness(config, "pi")` — pi resolves its default exactly like the rest of the codebase. The existing per-`kind` dispatch (databricks / cli-config / key / gateway / local) is unchanged.
- **Allow a pi-consumable cli-config Databricks gateway through the pi filter (B):** `default_provider_for_harness` and `provider_families` now let a `cli-config` provider serve / default pi **iff** it is a Databricks AI Gateway `_cli_config_pi_provider` can actually translate. `subscription`, `bedrock`, and non-Databricks `cli-config` are still excluded. The capability predicate `cli_config_pi_provider_capable` lives in `pi_native_credentials` (single source of truth, alongside the gateway-URL allowlist and the codex transport reader) and is **lazily imported** by `provider_config` to avoid an import cycle.
- **Parser (C):** a Databricks `cli-config` gateway may now claim the pi scope (`default: [openai, pi]`), so a user can pin pi -> Databricks explicitly. The (disk-reading) capability check runs only when a `default` is declared; a non-Databricks cli-config remains pi-incapable (its `default: pi` is rejected at parse, parity with a subscription).
- **Gateway-harness pi path:** `configure_agent_harness_with_provider(..., harness_type="pi")` now translates a cli-config Databricks gateway into the `HARNESS_PI_GATEWAY_*` env vars (reusing the pi-native translation) instead of raising — so `omnigent run` / agent pi launches route the gateway too, not just the pi-native terminal.

## Caller-impact analysis

`default_provider_for_harness` / `surface_default_provider` / `provider_families` are shared. The change is gated on `entry.kind == CLI_CONFIG_KIND` + the Databricks-gateway capability check, so:
- codex / claude / cursor / opencode / hermes selection is unaffected (their family resolution never hits the new cli-config-for-pi branch).
- the setup harness menus and REPL startup header only see the new pi scope for a real Databricks cli-config gateway.

## Tests

- New `tests/test_pi_native_credentials.py` cases: explicit pi pin selects the Databricks gateway over an anthropic key; a sole cli-config Databricks openai default is selected for pi; a non-Databricks cli-config is NOT selected for pi (falls back). Existing pi-native + provider-config + other-harness selection tests pass.

This pull request and its description were written by Isaac.