### PR TITLE
fix(cli): route every Databricks surface with the ?o= workspace selector

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -620,23 +620,38 @@ def _remote_headers(
         stored OIDC tokens, e.g. ``"http://localhost:6767"``.
     :returns: Headers to pass to httpx / OmnigentClient.
     """
+    # Resolve the bearer in the documented precedence order (one credential
+    # source per branch), then merge the workspace-routing header.
+    headers: dict[str, str] = {}
     token = os.environ.get(_REMOTE_AUTH_TOKEN_ENV)
     if token and (token := token.strip()):
-        return {"Authorization": f"Bearer {token}"}
-    # Check stored OIDC token from `omnigent login`.
-    if server_url:
+        # 1. Explicit env-var token.
+        headers["Authorization"] = f"Bearer {token}"
+    elif server_url:
         from omnigent.cli_auth import load_token
 
+        # 2. Stored OIDC session token from `omnigent login`.
         oidc_token = load_token(server_url)
         if oidc_token:
-            return {"Authorization": f"Bearer {oidc_token}"}
-        record_token = _stored_databricks_record_token(server_url)
-        if record_token:
-            return {"Authorization": f"Bearer {record_token}"}
-    creds = _read_databrickscfg(None)
-    if creds is None or not creds.token:
-        return {}
-    return {"Authorization": f"Bearer {creds.token}"}
+            headers["Authorization"] = f"Bearer {oidc_token}"
+        else:
+            # 3. Databricks Apps pointer record → mint a fresh workspace token.
+            record_token = _stored_databricks_record_token(server_url)
+            if record_token:
+                headers["Authorization"] = f"Bearer {record_token}"
+    if "Authorization" not in headers:
+        # 4. Ambient ~/.databrickscfg credentials.
+        creds = _read_databrickscfg(None)
+        if creds is not None and creds.token:
+            headers["Authorization"] = f"Bearer {creds.token}"
+    # Workspace routing: when a ?o= selector was recorded at login, name the
+    # workspace or the request routes to the account. Merged onto the result
+    # because these ad-hoc requests carry no httpx Auth.
+    if server_url:
+        from omnigent.cli_auth import databricks_org_id_headers
+
+        headers.update(databricks_org_id_headers(server_url))
+    return headers
 
 
 def _stored_databricks_record_token(server_url: str) -> str | None:
@@ -746,11 +761,19 @@ class _DatabricksTokenAuth(httpx.Auth):
 
         Static env-var token takes precedence, then stored OIDC token,
         then the reused Databricks SDK auth (which refreshes expired
-        OAuth tokens transparently).
+        OAuth tokens transparently). The stored ``X-Databricks-Org-Id``
+        selector (if any) is set first so the request routes to the
+        workspace, regardless of which credential branch sets the bearer.
 
         :param request: The outgoing httpx request.
         :yields: The request with auth header set.
         """
+        # Workspace routing (empty when none recorded); independent of the
+        # credential branch below.
+        if self._server_url:
+            from omnigent.cli_auth import databricks_org_id_headers
+
+            request.headers.update(databricks_org_id_headers(self._server_url))
         if self._static_token:
             request.headers["Authorization"] = f"Bearer {self._static_token}"
             yield request

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2395,7 +2395,11 @@ def _ensure_databricks_server_auth(server: str) -> None:
             f"HTTP {probe.status_code}). Run `{login_cmd}` and retry."
         )
     click.echo(f"Not signed in to {server} — running `{login_cmd}` first.")
-    _databricks_login(server, workspace_host)
+    # Recover the ``?o=`` selector from a prior login record so a re-login
+    # still targets the right workspace.
+    from omnigent.cli_auth import load_databricks_org_id
+
+    _databricks_login(server, workspace_host, org_id=load_databricks_org_id(server))
 
 
 def _ensure_backend(server: str | None) -> str:
@@ -5956,7 +5960,10 @@ def _dispatch_run(
 
     if target is None:
         if server_from_cli and server is not None and harness is None:
-            base_url = server.rstrip("/")
+            # Normalize like every other entry point: expand a bare workspace
+            # URL to its /api/2.0/omnigent mount and strip any ?o= query. Else
+            # a direct ``--server`` request hits the root and bounces to /login.
+            base_url = _resolve_server_url(server)
             # Direct ``--server`` (no AGENT) has no local runner to bind, so an
             # interactive resume-by-id is an ATTACH: route it through the
             # `attach` pair (`_require_live_conversation` + `run_attach`), not
@@ -11701,6 +11708,14 @@ def _workspace_api_server_url(server: str) -> str:
 
     server = server.rstrip("/")
     parsed = urlsplit(server)
+    # Strip any ?o= selector / query / fragment before probing: callers append
+    # a path (``f"{base}/v1/..."``), so a query-bearing base would push that
+    # path into the query (``…/?o=123/v1/me``) and break the probe + expansion.
+    # The selector is carried separately (recorded at login, replayed as the
+    # X-Databricks-Org-Id header), never on the base URL.
+    if parsed.query or parsed.fragment:
+        server = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", "")).rstrip("/")
+        parsed = urlsplit(server)
     # The internal user guide hands out the workspace web-UI URL
     # (``https://<ws>/omnigent``) for browser access; accept it for login
     # too by expanding its bare root to the API mount. A root that does
@@ -11838,7 +11853,53 @@ def _databricks_workspace_login_target(server: str, probe: httpx.Response) -> st
     return None
 
 
-def _databricks_login(server: str, workspace_host: str) -> None:
+def _org_id_from_url(url: str) -> str | None:
+    """Extract the ``?o=<workspace-id>`` workspace selector from *url*.
+
+    A Databricks host can front many workspaces under one hostname, where
+    the bare host resolves to the account and ``?o=<workspace-id>`` picks
+    the workspace. The selector is threaded into both the login (to bind
+    the grant to the workspace) and every API request (to route to it).
+
+    :param url: A user-supplied server URL, possibly carrying ``?o=``,
+        e.g. ``"https://acme.databricks.com/?o=123"``.
+    :returns: The workspace id, e.g. ``"123"``, or ``None`` when absent.
+    """
+    from urllib.parse import parse_qs, urlsplit
+
+    values = parse_qs(urlsplit(url).query).get("o")
+    return values[0] if values and values[0] else None
+
+
+def _host_with_org(workspace_host: str, org_id: str | None) -> str:
+    """Append the ``?o=<org>`` workspace selector to *workspace_host*.
+
+    ``databricks auth login --host https://<ws>/?o=<org>`` makes the CLI
+    record ``workspace_id`` in the profile and bind the grant to that
+    workspace; without it the grant is account-scoped and the workspace
+    rejects it (HTTP 403). Returns *workspace_host* unchanged when no org
+    id is known, so single-workspace hosts are untouched.
+
+    :param workspace_host: The workspace host, e.g.
+        ``"https://example.databricks.com"``.
+    :param org_id: The workspace id from :func:`_org_id_from_url`, or
+        ``None``.
+    :returns: ``"https://<ws>/?o=<org>"`` when *org_id* is set, else
+        *workspace_host*.
+    """
+    if not org_id:
+        return workspace_host
+    # Encode (not interpolate) so a value with ``&``/``=`` can't inject extra
+    # query params onto the ``--host`` URL; keep the ``/?o=`` slash the CLI wants.
+    from urllib.parse import urlencode, urlsplit, urlunsplit
+
+    parsed = urlsplit(workspace_host.rstrip("/"))
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path or "/", urlencode({"o": org_id}), "")
+    )
+
+
+def _databricks_login(server: str, workspace_host: str, org_id: str | None = None) -> None:
     """Log in to a Databricks-fronted Omnigent server.
 
     Covers both Databricks Apps deployments and workspace-hosted
@@ -11857,6 +11918,10 @@ def _databricks_login(server: str, workspace_host: str) -> None:
         ``"https://myapp-123.aws.databricksapps.com"``.
     :param workspace_host: The Databricks workspace to authenticate
         against, e.g. ``"https://example.databricks.com"``.
+    :param org_id: The ``?o=`` workspace selector from the login URL
+        (see :func:`_org_id_from_url`). When set, the login binds the
+        grant to this workspace and the verify request routes to it —
+        needed where the bare host is the account, not a workspace.
     :raises click.ClickException: When the ``databricks`` extra or CLI
         binary is missing, the workspace login fails, or the server
         rejects the workspace token.
@@ -11879,13 +11944,13 @@ def _databricks_login(server: str, workspace_host: str) -> None:
     token = _databricks_workspace_token(workspace_host)
     fresh_login_done = False
     if token is None:
-        token = _login_and_mint_workspace_token(workspace_host)
+        token = _login_and_mint_workspace_token(workspace_host, org_id)
         fresh_login_done = True
 
     # Verify the workspace token actually gets through the edge to THIS
     # server (the user may lack access to it), and learn our identity
     # for the success message.
-    verify = _verify_databricks_server_token(server, token)
+    verify = _verify_databricks_server_token(server, token, org_id)
     if verify.status_code != 200 and not fresh_login_done:
         # A cached grant can be stale or minted for a different
         # workspace (the CLI token cache is host-keyed but not
@@ -11895,8 +11960,8 @@ def _databricks_login(server: str, workspace_host: str) -> None:
             f"The cached Databricks credentials were rejected by {server} "
             f"(HTTP {verify.status_code}) — refreshing the workspace login."
         )
-        token = _login_and_mint_workspace_token(workspace_host)
-        verify = _verify_databricks_server_token(server, token)
+        token = _login_and_mint_workspace_token(workspace_host, org_id)
+        verify = _verify_databricks_server_token(server, token, org_id)
     if verify.status_code != 200:
         raise click.ClickException(
             f"{workspace_host} accepted the login, but {server} rejected the token "
@@ -11913,9 +11978,10 @@ def _databricks_login(server: str, workspace_host: str) -> None:
         server,
         workspace_host,
         user_id=user_id,
-        # Workspace responses carry the org id; recorded so browser
-        # links can append the ``?o=<org>`` workspace selector.
-        org_id=verify.headers.get("x-databricks-org-id"),
+        # Recorded so later commands replay it as ``?o=`` to route requests
+        # and browser links append it. The login URL's selector wins; fall
+        # back to the org id the workspace stamps on responses.
+        org_id=org_id or verify.headers.get("x-databricks-org-id"),
     )
     who = f" as {user_id}" if user_id else ""
     click.echo(
@@ -11923,17 +11989,20 @@ def _databricks_login(server: str, workspace_host: str) -> None:
     )
 
 
-def _login_and_mint_workspace_token(workspace_host: str) -> str:
+def _login_and_mint_workspace_token(workspace_host: str, org_id: str | None = None) -> str:
     """Run the browser login for a workspace and mint a bearer from it.
 
     :param workspace_host: The workspace host, e.g.
         ``"https://example.databricks.com"``.
+    :param org_id: The ``?o=`` workspace selector (see
+        :func:`_org_id_from_url`); passed to the browser login so the
+        minted grant is bound to the workspace.
     :returns: A fresh bearer token for the workspace.
     :raises click.ClickException: When the Databricks CLI binary is
         missing, the login exits non-zero, or no token resolves after
         a successful login.
     """
-    _run_databricks_browser_login(workspace_host)
+    _run_databricks_browser_login(workspace_host, org_id)
     token = _databricks_workspace_token(workspace_host)
     if token is None:
         raise click.ClickException(
@@ -11943,11 +12012,16 @@ def _login_and_mint_workspace_token(workspace_host: str) -> str:
     return token
 
 
-def _run_databricks_browser_login(workspace_host: str) -> None:
+def _run_databricks_browser_login(workspace_host: str, org_id: str | None = None) -> None:
     """Run ``databricks auth login --host <workspace>`` (browser flow).
 
     :param workspace_host: The workspace host, e.g.
         ``"https://example.databricks.com"``.
+    :param org_id: The ``?o=`` workspace selector (see
+        :func:`_org_id_from_url`). When set, ``?o=<org_id>`` is appended
+        to ``--host`` so the CLI records ``workspace_id`` and binds the
+        grant to that workspace (else the grant is account-scoped and
+        the workspace rejects it).
     :raises click.ClickException: When the Databricks CLI binary is
         missing or the login exits non-zero.
     """
@@ -11957,25 +12031,32 @@ def _run_databricks_browser_login(workspace_host: str) -> None:
             "The Databricks CLI is required to log in to a workspace. "
             "Install it first: https://docs.databricks.com/dev-tools/cli/install.html"
         )
-    click.echo(f"Opening browser to log in to {workspace_host} ...")
+    login_host = _host_with_org(workspace_host, org_id)
+    click.echo(f"Opening browser to log in to {login_host} ...")
     result = subprocess.run(
-        [databricks_bin, "auth", "login", "--host", workspace_host],
+        [databricks_bin, "auth", "login", "--host", login_host],
         check=False,
     )
     if result.returncode != 0:
         raise click.ClickException(
-            f"`databricks auth login --host {workspace_host}` failed "
+            f"`databricks auth login --host {login_host}` failed "
             f"(exit {result.returncode}). If the workspace is unreachable from "
             "this machine (VPN / IP access lists), resolve that and retry."
         )
 
 
-def _verify_databricks_server_token(server: str, token: str) -> httpx.Response:
+def _verify_databricks_server_token(
+    server: str, token: str, org_id: str | None = None
+) -> httpx.Response:
     """Probe ``GET /v1/me`` on *server* with a workspace bearer.
 
     :param server: The server URL, e.g.
         ``"https://myapp-123.aws.databricksapps.com"``.
     :param token: The workspace bearer token to present.
+    :param org_id: The ``?o=`` workspace selector (see
+        :func:`_org_id_from_url`). When set, the probe carries
+        ``?o=<org_id>`` so the request routes to the workspace rather
+        than defaulting to the account (which answers HTTP 503).
     :returns: The probe response (200 means the token is accepted and
         the body carries ``user_id``).
     :raises click.ClickException: When the server is unreachable.
@@ -11986,6 +12067,7 @@ def _verify_databricks_server_token(server: str, token: str) -> httpx.Response:
         return _httpx.get(
             f"{server}/v1/me",
             headers={"Authorization": f"Bearer {token}"},
+            params={"o": org_id} if org_id else None,
             timeout=10.0,
         )
     except _httpx.HTTPError as exc:
@@ -12081,6 +12163,9 @@ def login(server_url: str) -> None:
     import httpx as _httpx
 
     server = _resolve_server_url(server_url)
+    # Read the ``?o=`` selector from the raw input: normalization strips the
+    # query when expanding to the API mount.
+    org_id = _org_id_from_url(server_url)
 
     # ── Step 0: Probe the server's auth mode. ──────────────────
     # /v1/me returns a JSON ``login_url`` on 401 — "/login" for
@@ -12098,7 +12183,7 @@ def login(server_url: str) -> None:
 
     databricks_workspace = _databricks_workspace_login_target(server, probe)
     if databricks_workspace is not None:
-        _databricks_login(server, databricks_workspace)
+        _databricks_login(server, databricks_workspace, org_id=org_id)
         _remember_default_server(server)
         return
 

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -220,6 +220,55 @@ def load_databricks_org_id(server_url: str) -> str | None:
     return org_id if isinstance(org_id, str) and org_id else None
 
 
+# Workspace-routing header. When a Databricks host fronts many workspaces
+# under one hostname, the bare host is the account; the API proxy routes a
+# workspace request by this header (equivalently to the ``?o=`` query param).
+DATABRICKS_ORG_ID_HEADER = "X-Databricks-Org-Id"
+
+
+def databricks_org_id_headers(server_url: str) -> dict[str, str]:
+    """Return the workspace-routing header for *server_url*, or ``{}``.
+
+    ``omnigent login https://<host>/?o=<id>`` records the ``?o=`` selector;
+    this surfaces it as the :data:`DATABRICKS_ORG_ID_HEADER` so requests
+    route to the workspace instead of the account. Empty when no selector
+    is recorded (single-workspace / non-Databricks hosts), so those callers
+    are unaffected.
+
+    :param server_url: The server URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``.
+    :returns: ``{"X-Databricks-Org-Id": "<id>"}`` when a selector is
+        recorded for *server_url*, otherwise ``{}``.
+    """
+    org_id = load_databricks_org_id(server_url)
+    return {DATABRICKS_ORG_ID_HEADER: org_id} if org_id else {}
+
+
+def databricks_auth_headers(server_url: str, bearer_token: str | None) -> dict[str, str]:
+    """Mint the bearer and the workspace-routing header together.
+
+    Pairs ``Authorization`` with :data:`DATABRICKS_ORG_ID_HEADER` in one
+    call so a hand-built header dict can't carry the bearer without the
+    routing header. Use it where a static dict is constructed (the
+    WebSocket handshakes, the hook-config replay) instead of writing the
+    ``Authorization`` entry inline; the long-lived httpx clients set both
+    in their ``auth_flow``. Either value is omitted when absent, so
+    single-workspace and unauthenticated callers are unaffected.
+
+    :param server_url: The server URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``.
+    :param bearer_token: The workspace bearer token, or ``None`` to omit
+        the ``Authorization`` header (local unauthenticated runs).
+    :returns: A header dict carrying ``Authorization`` and/or
+        ``X-Databricks-Org-Id`` as available, possibly empty.
+    """
+    headers: dict[str, str] = {}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    headers.update(databricks_org_id_headers(server_url))
+    return headers
+
+
 def clear_token(server_url: str) -> None:
     """Remove a stored token for a server.
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1396,6 +1396,12 @@ class HostProcess:
         # is not a browser. Seeded before either auth branch so it is sent
         # on both the managed-token and Bearer paths.
         headers: dict[str, str] = {"Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
+        # Workspace routing: the tunnel handshake must name the workspace or
+        # it routes to the account. Empty for single-workspace and managed
+        # hosts (no recorded selector), so neither is affected.
+        from omnigent.cli_auth import databricks_org_id_headers
+
+        headers.update(databricks_org_id_headers(self._server_url))
 
         managed_token = os.environ.get(HOST_TOKEN_ENV_VAR)
         if managed_token:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -171,14 +171,23 @@ class _RunnerDatabricksAuth(httpx.Auth):
     unauthenticated servers), the auth flow is a no-op.
     """
 
-    def __init__(self, factory: Callable[[], str | None] | None) -> None:
+    def __init__(
+        self,
+        factory: Callable[[], str | None] | None,
+        server_url: str | None = None,
+    ) -> None:
         """
         :param factory: Sync callable that returns a fresh bearer
             token, e.g. the return value of
             :func:`_make_auth_token_factory`. ``None`` disables
             auth (local unauthenticated servers).
+        :param server_url: Omnigent server URL used to look up the ``?o=``
+            workspace selector for the ``X-Databricks-Org-Id`` routing
+            header. Defaults to ``RUNNER_SERVER_URL`` so existing callers
+            (which pass only the factory) need no change.
         """
         self._factory = factory
+        self._server_url = server_url or os.environ.get(_RUNNER_SERVER_URL_ENV_VAR)
 
     def auth_flow(
         self,
@@ -207,6 +216,13 @@ class _RunnerDatabricksAuth(httpx.Auth):
         :raises httpx.RequestError: When the factory is configured
             but returns no token.
         """
+        # Workspace routing: name the workspace or the request routes to the
+        # account (the forwarder's POST /events otherwise 403s). Empty when
+        # none recorded. Set once here; it persists across the retry yield.
+        if self._server_url:
+            from omnigent.cli_auth import databricks_org_id_headers
+
+            request.headers.update(databricks_org_id_headers(self._server_url))
         if self._factory is not None:
             token = self._factory()
             if not token:
@@ -654,6 +670,7 @@ def create_app(
         a second time during runner boot.
     :returns: A runner FastAPI app exposing the harness-contract subset.
     """
+    from omnigent.cli_auth import databricks_org_id_headers
     from omnigent.runner.app import create_runner_app
     from omnigent.runner.identity import (
         OMNIGENT_INTERNAL_WS_ORIGIN,
@@ -707,7 +724,10 @@ def create_app(
         # — both reached from tool_dispatch over this client) requires a
         # trusted Origin; the runner sends none otherwise, so the sentinel is
         # what lets sys_session_create / sys_upload_file through.
-        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+        #
+        # The workspace-routing header (empty unless a ?o= selector was
+        # recorded for this server) routes these callbacks to the workspace.
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN, **databricks_org_id_headers(server_url)},
         timeout=httpx.Timeout(5.0, read=None),
         # NOTE: ``follow_redirects`` deliberately stays False.
         # ``_RunnerDatabricksAuth.auth_flow`` needs to *see* the

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2712,7 +2712,12 @@ async def _auto_create_kimi_terminal(
     server_url = os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767").rstrip("/")
     _auth_factory = _make_auth_token_factory()
     _auth_token = _auth_factory() if _auth_factory is not None else None
-    _runner_headers = {"Authorization": f"Bearer {_auth_token}"} if _auth_token else {}
+    # The hook subprocess replays these static headers from its config (no
+    # refresh-capable httpx.Auth of its own); the helper pairs the bearer with
+    # the workspace-routing header so neither is dropped.
+    from omnigent.cli_auth import databricks_auth_headers
+
+    _runner_headers = databricks_auth_headers(server_url, _auth_token)
     write_hook_config(
         bridge_dir,
         server_url=server_url,
@@ -3070,9 +3075,12 @@ async def _auto_create_codex_terminal(
 
     _policy_auth_factory = _make_auth_token_factory()
     _policy_auth_token = _policy_auth_factory() if _policy_auth_factory is not None else None
-    policy_headers = (
-        {"Authorization": f"Bearer {_policy_auth_token}"} if _policy_auth_token else {}
-    )
+    # The codex policy hook subprocess replays these static headers from its
+    # config (no refresh-capable auth of its own); the helper pairs the bearer
+    # with the workspace-routing header so neither is dropped.
+    from omnigent.cli_auth import databricks_auth_headers
+
+    policy_headers = databricks_auth_headers(launch_config.policy_server_url, _policy_auth_token)
 
     app_server = build_codex_native_server(
         socket_path=socket_path,
@@ -4779,7 +4787,12 @@ async def _auto_create_claude_terminal(
     # stop forwarding after the token lapses. ``_RunnerDatabricksAuth``
     # with a ``None`` factory is a safe no-op (local unauthenticated).
     _auth_token = _auth_factory() if _auth_factory is not None else None
-    _runner_headers = {"Authorization": f"Bearer {_auth_token}"} if _auth_token else {}
+    # The hook subprocess replays these static headers from its config (no
+    # refresh-capable auth of its own); the helper pairs the bearer with the
+    # workspace-routing header so neither is dropped.
+    from omnigent.cli_auth import databricks_auth_headers
+
+    _runner_headers = databricks_auth_headers(server_url, _auth_token)
     _runner_auth = _RunnerDatabricksAuth(_auth_factory)
 
     from omnigent.claude_native import (

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -295,6 +295,7 @@ async def serve_tunnel(
             await _serve_tunnel_once(
                 app,
                 tunnel_url=tunnel_url,
+                server_url=server_url,
                 runner_id=runner_id,
                 runner_version=runner_version,
                 auth_token=auth_token,
@@ -494,6 +495,7 @@ async def _serve_tunnel_once(
     app: _ASGIApp,
     *,
     tunnel_url: str,
+    server_url: str,
     runner_id: str,
     runner_version: str,
     auth_token: str | None = None,
@@ -505,6 +507,10 @@ async def _serve_tunnel_once(
     :param app: Runner ASGI application.
     :param tunnel_url: WebSocket URL to connect to, e.g.
         ``"ws://127.0.0.1:6767/v1/runners/runner_abc/tunnel"``.
+    :param server_url: HTTP(S) server base URL the tunnel belongs to,
+        e.g. ``"https://example.databricks.com/api/2.0/omnigent"``. Used
+        to look up the workspace-routing header (keyed by server URL, not
+        the ws tunnel URL).
     :param runner_id: Stable runner id, e.g. ``"runner_abc"``.
     :param runner_version: Runner version string for the hello
         frame, e.g. ``"0.1.0"``.
@@ -525,9 +531,13 @@ async def _serve_tunnel_once(
     # guard (CSWSH protection) allows the handshake — this runner is not a
     # browser and would otherwise rely on the permissive missing-origin
     # branch.
+    # Pair the bearer with the workspace-routing header: the handshake must
+    # name the workspace or it routes to the account. Both empty for
+    # single-workspace hosts / local unauthenticated runs.
+    from omnigent.cli_auth import databricks_auth_headers
+
     headers: dict[str, str] = {"Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
-    if auth_token:
-        headers["Authorization"] = f"Bearer {auth_token}"
+    headers.update(databricks_auth_headers(server_url, auth_token))
     if tunnel_token:
         headers[RUNNER_TUNNEL_TOKEN_HEADER] = tunnel_token
     async with websockets.connect(

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1391,11 +1391,11 @@ def _patch_auth_preflight(
     monkeypatch.setattr(cli, "_workspace_api_server_url", lambda server: server.rstrip("/"))
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: tty)
     login_calls: list[str] = []
-    monkeypatch.setattr(
-        cli,
-        "_databricks_login",
-        lambda server, workspace_host: login_calls.append(f"{server} {workspace_host}"),
-    )
+
+    def _capture_login(server: str, workspace_host: str, org_id: str | None = None) -> None:
+        login_calls.append(f"{server} {workspace_host}")
+
+    monkeypatch.setattr(cli, "_databricks_login", _capture_login)
     return login_calls
 
 

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2300,6 +2300,48 @@ def test_remote_headers_falls_back_to_ambient_databricks_creds(
     assert read_calls == [None]
 
 
+def test_remote_headers_adds_org_id_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A recorded ?o= selector rides every ad-hoc request.
+
+    These probes (session info, agent pick, runner status, native
+    forwarders) carry no httpx Auth, so the workspace-routing header must be
+    added here or the request routes to the account. It accompanies
+    whichever bearer the resolution chain produced.
+    """
+    monkeypatch.delenv("OMNIGENT_REMOTE_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(chat_module, "_stored_databricks_record_token", lambda _url: "rec-tok")
+    monkeypatch.setattr(
+        "omnigent.cli_auth.load_databricks_org_id", lambda _url: "2850744067564480"
+    )
+
+    headers = _remote_headers(server_url="https://acme.databricks.com/api/2.0/omnigent")
+
+    assert headers == {
+        "Authorization": "Bearer rec-tok",
+        "X-Databricks-Org-Id": "2850744067564480",
+    }
+
+
+def test_remote_headers_omits_org_when_no_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No recorded ?o= selector → the request URL/headers carry no org header.
+
+    Guards the "unchanged when nothing recorded" claim: a single-workspace
+    or Databricks Apps server (no stored org id) must produce only the
+    bearer, so the runtime replay never appends a routing header where none
+    was recorded.
+    """
+    monkeypatch.delenv("OMNIGENT_REMOTE_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(chat_module, "_stored_databricks_record_token", lambda _url: "rec-tok")
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda _url: None)
+
+    headers = _remote_headers(server_url="https://single.databricks.com/api/2.0/omnigent")
+
+    assert headers == {"Authorization": "Bearer rec-tok"}
+    assert "X-Databricks-Org-Id" not in headers
+
+
 def test_server_headers_do_not_encode_runner_affinity() -> None:
     """Runner affinity is persisted by PATCH /v1/sessions, not headers."""
     headers = chat_module._server_headers(runner_id="runner_local_test")
@@ -2817,6 +2859,38 @@ def test_databricks_token_auth_resolves_sdk_once(
     # authenticate() runs per request (4) — cheap in-memory SDK cache hits,
     # NOT CLI shell-outs. That's the behavior the fix preserves.
     assert cfg.authenticate_calls == 4
+
+
+def test_databricks_token_auth_sets_org_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every SDK-client request carries the workspace-routing header.
+
+    The header is set at the top of ``auth_flow`` — independent of which
+    credential branch runs — so the workspace-routing signal rides even when
+    a request carries no bearer.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.delenv(chat_module._REMOTE_AUTH_TOKEN_ENV, raising=False)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(
+        "omnigent.cli_auth.databricks_org_id_headers",
+        lambda _url: {"X-Databricks-Org-Id": "2850744067564480"},
+    )
+    # Isolate from real Databricks SDK resolution: the bearer is irrelevant
+    # here — only the routing header is under test.
+    monkeypatch.setattr(chat_module._DatabricksTokenAuth, "_sdk_token", lambda self: None)
+
+    auth = chat_module._DatabricksTokenAuth(
+        server_url="https://acme.databricks.com/api/2.0/omnigent"
+    )
+    flow = auth.auth_flow(
+        httpx.Request("GET", "https://acme.databricks.com/api/2.0/omnigent/v1/sessions")
+    )
+    request = next(flow)
+    flow.close()
+
+    assert request.headers["X-Databricks-Org-Id"] == "2850744067564480"
 
 
 # ── _spec_used_families (startup-header creds line) ──────

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -228,6 +228,60 @@ def test_store_and_load_databricks_record(token_dir) -> None:
     )
 
 
+def test_databricks_org_id_headers_from_record(token_dir) -> None:
+    """A recorded ?o= selector surfaces as the workspace-routing header.
+
+    When the bare host is the account, the request routes by this header
+    (equivalently to ``?o=``). A record with no org id (single-workspace
+    host) yields no header, so those callers are unaffected.
+    """
+    from omnigent.cli_auth import databricks_org_id_headers, store_databricks_auth
+
+    store_databricks_auth(
+        server_url="https://acme.databricks.com/api/2.0/omnigent",
+        workspace_host="https://acme.databricks.com",
+        org_id="2850744067564480",
+    )
+    assert databricks_org_id_headers("https://acme.databricks.com/api/2.0/omnigent") == {
+        "X-Databricks-Org-Id": "2850744067564480"
+    }
+
+    store_databricks_auth(
+        server_url="https://single.databricks.com/api/2.0/omnigent",
+        workspace_host="https://single.databricks.com",
+    )
+    assert databricks_org_id_headers("https://single.databricks.com/api/2.0/omnigent") == {}
+
+
+def test_databricks_auth_headers_pairs_bearer_and_org(token_dir) -> None:
+    """The paired minter always emits the bearer and the ?o= header together.
+
+    The static-dict seams (WS handshakes, hook-config replay) call this so a
+    workspace request can never carry ``Authorization`` without the routing
+    header. A missing token or selector is omitted, so single-workspace and
+    local-unauthenticated callers are unaffected.
+    """
+    from omnigent.cli_auth import databricks_auth_headers, store_databricks_auth
+
+    store_databricks_auth(
+        server_url="https://acme.databricks.com/api/2.0/omnigent",
+        workspace_host="https://acme.databricks.com",
+        org_id="2850744067564480",
+    )
+    recorded = "https://acme.databricks.com/api/2.0/omnigent"
+    # Bearer + org travel together.
+    assert databricks_auth_headers(recorded, "tok") == {
+        "Authorization": "Bearer tok",
+        "X-Databricks-Org-Id": "2850744067564480",
+    }
+    # Recorded selector but no token (local/unauth): org still rides, no bearer.
+    assert databricks_auth_headers(recorded, None) == {"X-Databricks-Org-Id": "2850744067564480"}
+    # No record (unknown server): bearer only, no routing header.
+    assert databricks_auth_headers("https://other.example.com", "tok") == {
+        "Authorization": "Bearer tok"
+    }
+
+
 def test_load_token_returns_none_for_databricks_record(token_dir) -> None:
     """A Databricks pointer record carries NO bearer — load_token must miss.
 

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -52,7 +52,7 @@ class _FakeHttpx:
         """
         headers = kwargs.get("headers")
         auth = headers.get("Authorization") if isinstance(headers, dict) else None
-        self.requests.append({"url": url, "authorization": auth})
+        self.requests.append({"url": url, "authorization": auth, "params": kwargs.get("params")})
         return self.responses.pop(0)
 
 
@@ -351,6 +351,98 @@ def test_login_stale_cached_grant_triggers_fresh_login_and_retry(
     # The retry verify presented the freshly minted token, not the stale one.
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"
     assert load_databricks_workspace_host(_APPS_URL) == _WORKSPACE
+
+
+# ── ?o= workspace selector ──────────────────────────────────────────
+
+_ORG_ID = "2850744067564480"
+# A login URL where the bare host is the account and ``?o=`` picks the workspace.
+_SELECTOR_URL = f"{_WORKSPACE}/?o={_ORG_ID}"
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (_SELECTOR_URL, _ORG_ID),
+        (f"{_WORKSPACE_API_URL}?o={_ORG_ID}", _ORG_ID),
+        # Selector among other params is still found.
+        (f"{_WORKSPACE}/?foo=bar&o={_ORG_ID}", _ORG_ID),
+        # No selector → None (the single-workspace / Apps case).
+        (_WORKSPACE, None),
+        (_APPS_URL, None),
+        (f"{_WORKSPACE}/?o=", None),
+    ],
+)
+def test_org_id_from_url(url: str, expected: str | None) -> None:
+    """``?o=<workspace-id>`` is extracted from a login URL, else ``None``.
+
+    The selector is the only signal that names the workspace when the bare
+    host is the account; an absent or empty ``o`` must read as ``None`` so
+    single-workspace and Apps URLs keep their current behavior.
+    """
+    assert cli_mod._org_id_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    ("workspace_host", "org_id", "expected"),
+    [
+        (_WORKSPACE, "2850744067564480", f"{_WORKSPACE}/?o=2850744067564480"),
+        # No org id → host returned untouched (single-workspace / Apps).
+        (_WORKSPACE, None, _WORKSPACE),
+        # A selector carrying & / = is encoded, not interpolated, so it can't
+        # inject extra query params onto the `databricks auth login --host` URL.
+        (_WORKSPACE, "123&foo=bar", f"{_WORKSPACE}/?o=123%26foo%3Dbar"),
+    ],
+)
+def test_host_with_org_encodes_selector(
+    workspace_host: str, org_id: str | None, expected: str
+) -> None:
+    """``_host_with_org`` appends an URL-encoded ?o= selector (no injection).
+
+    The value is passed straight to ``databricks auth login --host``; encoding
+    it (vs string interpolation) keeps a value with ``&``/``=`` from expanding
+    into extra query params on that URL.
+    """
+    assert cli_mod._host_with_org(workspace_host, org_id) == expected
+
+
+def test_login_threads_org_id_through_workspace_login_and_verify(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """A ``?o=`` login binds the grant to the workspace and routes the verify.
+
+    When the bare host is the account, the browser login must carry ``?o=``
+    so the CLI records ``workspace_id`` (else the grant is account-scoped →
+    HTTP 403), and the verify request must carry ``?o=`` so it routes to the
+    workspace (else it defaults to the account → HTTP 503). The selector is
+    also persisted so later commands replay it.
+    """
+    from omnigent.cli_auth import load_databricks_org_id, load_databricks_workspace_host
+
+    fake = _FakeHttpx(
+        responses=[
+            _response(401, headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'}),
+            _response(200, body={"user_id": "alice@example.com"}),
+        ]
+    )
+    login_calls = _patch_login_env(
+        monkeypatch,
+        fake_httpx=fake,
+        # Force the browser login so the --host argv is observable.
+        cached_tokens=[None, "tok-fresh"],
+    )
+
+    result = CliRunner().invoke(cli_group, ["login", _SELECTOR_URL])
+
+    assert result.exit_code == 0, result.output
+    # The browser login carries the selector so the profile is workspace-scoped.
+    assert login_calls == [f"auth login --host {_WORKSPACE}/?o={_ORG_ID}"]
+    # The verify request routes to the workspace via ?o= (and used the token).
+    assert fake.requests[-1]["params"] == {"o": _ORG_ID}
+    assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"
+    # The selector is persisted (from the URL, authoritative over any header).
+    assert load_databricks_org_id(_SELECTOR_URL) == _ORG_ID
+    assert load_databricks_workspace_host(_SELECTOR_URL) == _WORKSPACE
 
 
 # ── login sets the default server ───────────────────────────────────
@@ -827,6 +919,50 @@ def test_resolve_server_url_defaults_scheme_and_expands(
 
     assert cli_mod._resolve_server_url("example.databricks.com") == _WORKSPACE_API_URL
     assert cli_mod._resolve_server_url("example.databricks.com/omnigent") == _WORKSPACE_API_URL
+
+
+def test_resolve_server_url_strips_query_and_expands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare workspace URL carrying ``?o=`` still expands to the API mount.
+
+    The ``?o=`` selector on the input must not corrupt the probe or defeat
+    expansion — ``omnigent run --server https://<ws>/?o=<id>`` has to reach
+    ``/api/2.0/omnigent`` (the selector rides via the login record /
+    ``X-Databricks-Org-Id``, never the base URL). A regression sends every
+    request to the workspace root, which bounces to ``/login``.
+    """
+    probed = _scripted_normalizer_httpx(
+        monkeypatch,
+        {
+            f"{_WORKSPACE}/v1/me": _response(404, headers={"server": "databricks"}),
+            f"{_WORKSPACE_API_URL}/v1/me": _response(
+                401, headers={"www-authenticate": 'Bearer realm="DatabricksRealm"'}
+            ),
+        },
+    )
+
+    assert cli_mod._resolve_server_url(f"{_WORKSPACE}/?o=2850744067564480") == _WORKSPACE_API_URL
+    # The probes hit the CLEAN root/mount — never a ?o=-corrupted URL (which
+    # would push the path into the query string, e.g. ``…/?o=123/v1/me``).
+    assert probed and all("o=" not in url and "%2F" not in url for url in probed)
+
+
+def test_resolve_server_url_strips_query_on_full_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full ``/api/2.0/omnigent?o=`` URL returns the clean mount with no probe.
+
+    When the user already passes the mount path, only the ``?o=`` needs
+    stripping — the path-carrying URL is returned untouched (no network probe).
+    """
+    probed = _scripted_normalizer_httpx(monkeypatch, {})  # any probe fails the test
+
+    assert (
+        cli_mod._resolve_server_url(f"{_WORKSPACE_API_URL}?o=2850744067564480")
+        == _WORKSPACE_API_URL
+    )
+    assert probed == []
 
 
 def test_workspace_url_expands_web_ui_path_to_api_mount(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1812,6 +1812,31 @@ def _host(
     return HostProcess(identity, server_url)
 
 
+def test_build_connect_headers_adds_org_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A recorded ?o= selector rides the tunnel handshake.
+
+    The WS upgrade must name the workspace via ``X-Databricks-Org-Id`` or it
+    routes to the account. The header rides alongside the Origin sentinel,
+    independent of the bearer/managed-token branch.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import omnigent.runner._entry as entry_mod
+
+    # No managed token + no real Databricks creds: isolate the bearer
+    # branch so only the routing header is under test.
+    monkeypatch.delenv("OMNIGENT_HOST_TOKEN", raising=False)
+    monkeypatch.setattr(entry_mod, "_make_auth_token_factory", lambda *, server_url=None: None)
+    monkeypatch.setattr(
+        "omnigent.cli_auth.load_databricks_org_id", lambda _url: "2850744067564480"
+    )
+
+    headers = _host("https://acme.databricks.com/api/2.0/omnigent")._build_connect_headers()
+
+    assert headers["X-Databricks-Org-Id"] == "2850744067564480"
+
+
 async def test_run_retries_on_login_redirect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -114,6 +114,7 @@ async def test_serve_tunnel_backs_off_after_clean_close(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -174,6 +175,7 @@ async def test_serve_tunnel_resets_backoff_after_successful_connection(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -238,6 +240,7 @@ async def test_serve_tunnel_fails_loud_on_protocol_rejection(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -281,6 +284,7 @@ async def test_serve_tunnel_fails_loud_on_http_auth_rejection(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -393,6 +397,7 @@ async def test_serve_tunnel_fails_loud_on_auth_redirect(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -537,10 +542,14 @@ async def test_serve_tunnel_once_sends_bearer_header(
         return _ConnectContext()
 
     monkeypatch.setattr(websockets, "connect", _fake_connect)
+    # No recorded ?o= selector, so no workspace-routing header rides the
+    # handshake (keeps the asserted header set exact).
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda _server_url: None)
 
     await _serve_tunnel_once(
         _noop_app,
         tunnel_url="wss://example.databricksapps.com/v1/runners/runner_auth/tunnel",
+        server_url="https://example.databricksapps.com",
         runner_id="runner_auth",
         runner_version="0.1.0",
         auth_token="tok-auth",
@@ -561,6 +570,62 @@ async def test_serve_tunnel_once_sends_bearer_header(
         "max_size": serve_module.RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
     }
     assert isinstance(captured["sent"], str)
+
+
+async def test_serve_tunnel_once_sends_org_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recorded ?o= selector rides the tunnel handshake.
+
+    The WS upgrade must name the workspace via ``X-Databricks-Org-Id`` or it
+    routes to the account. The selector is keyed by the server URL, not the
+    ws tunnel URL, so the handshake resolves it from *server_url*.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import websockets
+
+    captured: dict[str, object] = {}
+
+    class _FakeWS:
+        async def send(self, data: str) -> None:
+            del data
+
+        def __aiter__(self) -> _FakeWS:
+            return self
+
+        async def __anext__(self) -> str:
+            raise StopAsyncIteration
+
+    class _Ctx:
+        async def __aenter__(self) -> _FakeWS:
+            return _FakeWS()
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    def _fake_connect(url: str, **kwargs: object) -> _Ctx:
+        captured["headers"] = kwargs.get("additional_headers")
+        return _Ctx()
+
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+    monkeypatch.setattr(
+        "omnigent.cli_auth.load_databricks_org_id", lambda _server_url: "2850744067564480"
+    )
+
+    await _serve_tunnel_once(
+        _noop_app,
+        tunnel_url="wss://acme.databricks.com/v1/runners/r/tunnel",
+        server_url="https://acme.databricks.com/api/2.0/omnigent",
+        runner_id="r",
+        runner_version="0.1.0",
+        auth_token="tok",
+    )
+
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers["X-Databricks-Org-Id"] == "2850744067564480"
 
 
 @pytest.mark.parametrize(
@@ -810,6 +875,7 @@ async def test_serve_tunnel_calls_factory_on_each_reconnect(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -882,6 +948,7 @@ async def test_serve_tunnel_401_with_factory_retries(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -947,6 +1014,7 @@ async def test_serve_tunnel_401_without_factory_is_fatal(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -1003,6 +1071,7 @@ async def test_serve_tunnel_403_remains_fatal_with_factory(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,
@@ -1077,6 +1146,7 @@ async def test_serve_tunnel_reconnect_uses_fresh_token_not_stale(
         app: Any,
         *,
         tunnel_url: str,
+        server_url: str = "",
         runner_id: str,
         runner_version: str,
         auth_token: str | None = None,


### PR DESCRIPTION
## Problem

A Databricks host can front many workspaces under one hostname: the bare host
resolves to the **account**, and `?o=<workspace-id>` names the workspace. A
request that omits the selector routes to the account, not the workspace — so:

- `omnigent login https://<host>/?o=<id>` mints an **account-scoped** grant the
  workspace rejects (**HTTP 403**), and
- runtime requests miss the workspace mount (**HTTP 403/503**).

The CLI parsed `?o=` out of the login URL and discarded it, so neither login
nor any later request named the workspace.

## Fix

Thread the `?o=<workspace-id>` selector through every surface that talks to the
workspace:

- **login (mint)** — `databricks auth login --host https://<host>/?o=<org>` binds
  the grant to the workspace; the selector is URL-encoded onto `--host`.
- **login (verify + persist)** — the verify probe carries `?o=`; the selector is
  recorded (authoritative over the `x-databricks-org-id` response header).
- **URL normalization** — `_resolve_server_url` strips `?o=` before probing and
  expands a bare workspace URL to `/api/2.0/omnigent`; the direct `--server`
  `run` path now resolves like every other entry point (was hitting the root →
  303 `/login`).
- **runtime** — every request and WebSocket handshake carries
  `X-Databricks-Org-Id`, from the recorded selector:
  - client SDK / AsyncClient (`_DatabricksTokenAuth.auth_flow`)
  - ad-hoc probes / native forwarders (`_remote_headers`)
  - host tunnel WS handshake (`HostProcess._build_connect_headers`)
  - runner HTTP (`create_app`) + runner WS tunnel (`_serve_tunnel_once`)
  - runner auth for all native forwarders + permission/usage supervisors
    (`_RunnerDatabricksAuth.auth_flow`)
  - runner hook-config headers replayed by the claude/kimi/codex hooks

The httpx.Auth paths set the bearer and the routing header in the same
`auth_flow`; the static-dict seams (WS handshakes, hook-config replay) mint both
through one helper, `databricks_auth_headers()`, so a workspace request can't
carry `Authorization` without the routing header.

The helpers are empty when no selector is recorded, so single-workspace,
Databricks Apps, and non-Databricks servers are unaffected.

## Verified

- Live against a Databricks workspace: header-only and `?o=`-only both return
  200 on `/v1/me`; `omnigent run` and `omnigent host` both connect.
- Per-surface unit tests; `ruff` clean; all Pytest + non-UI E2E green.

> The failing UI/pre-commit/npm jobs are an `npm install` `ETIMEDOUT` to the
> Databricks npm proxy (infra), not this change — it's Python-only and every
> Pytest job passes.

This pull request and its description were written by Isaac.
