### PR TITLE
feat(web-ui): show restart warning when MCP servers are edited

### DIFF
--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   CheckIcon,
   CopyIcon,
+  AlertTriangleIcon,
   PencilIcon,
   InfoIcon,
   PlusIcon,
@@ -730,11 +731,15 @@ function McpServerManagerDialog({
   servers,
   open,
   onOpenChange,
+  dirty,
+  onDirty,
 }: {
   sessionId: string;
   servers: McpServerSummary[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  dirty: boolean;
+  onDirty: () => void;
 }) {
   const [form, setForm] = useState<McpFormState>(EMPTY_MCP_FORM);
   const [formError, setFormError] = useState<string | null>(null);
@@ -751,6 +756,7 @@ function McpServerManagerDialog({
   }
 
   function notifyRestart() {
+    onDirty();
     showToast(
       <span className="text-sm">MCP servers updated. Restart the session to apply changes.</span>,
     );
@@ -797,6 +803,12 @@ function McpServerManagerDialog({
           <DialogTitle>Manage MCP Servers</DialogTitle>
           <DialogDescription>Add, edit, or remove MCP servers for this session.</DialogDescription>
         </DialogHeader>
+        {dirty && (
+          <div className="flex items-center gap-2 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
+            <AlertTriangleIcon className="size-4 shrink-0" />
+            Restart the session to apply your changes.
+          </div>
+        )}
         <div className="grid gap-4 pt-1 md:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
           <div className="flex min-w-0 flex-col gap-1.5">
             <SectionLabel>Servers</SectionLabel>
@@ -959,6 +971,16 @@ function McpServersSection({
   editable: boolean;
 }) {
   const [managerOpen, setManagerOpen] = useState(false);
+  const [mcpDirty, setMcpDirty] = useState(false);
+  const sessionStatus = useChatStore((s) => s.sessionStatus);
+  // Clear the dirty flag when the session restarts (launching picks up
+  // the updated MCP config) or when the user navigates to another session.
+  useEffect(() => {
+    if (sessionStatus === "launching") setMcpDirty(false);
+  }, [sessionStatus]);
+  useEffect(() => {
+    setMcpDirty(false);
+  }, [sessionId]);
   const canEdit = !!(sessionId && editable);
   const deleteServer = useDeleteMcpServer(canEdit ? sessionId : "");
   const showSection = servers.length > 0 || canEdit;
@@ -980,6 +1002,12 @@ function McpServersSection({
           </button>
         )}
       </div>
+      {mcpDirty && (
+        <p className="flex items-center gap-1 text-xs text-yellow-700 dark:text-yellow-400">
+          <AlertTriangleIcon className="size-3 shrink-0" />
+          Restart to apply changes
+        </p>
+      )}
       {servers.length > 0 ? (
         <McpServerList
           servers={servers}
@@ -987,12 +1015,14 @@ function McpServersSection({
             canEdit
               ? (name) =>
                   deleteServer.mutate(name, {
-                    onSuccess: () =>
+                    onSuccess: () => {
+                      setMcpDirty(true);
                       showToast(
                         <span className="text-sm">
                           MCP servers updated. Restart the session to apply changes.
                         </span>,
-                      ),
+                      );
+                    },
                   })
               : undefined
           }
@@ -1006,6 +1036,8 @@ function McpServersSection({
           servers={servers}
           open={managerOpen}
           onOpenChange={setManagerOpen}
+          dirty={mcpDirty}
+          onDirty={() => setMcpDirty(true)}
         />
       )}
     </div>

--- a/tests/e2e_ui/agents/test_agent_info_popover.py
+++ b/tests/e2e_ui/agents/test_agent_info_popover.py
@@ -250,6 +250,49 @@ def test_agent_info_mcp_server_add_and_remove(
     _wait_for(lambda: not _agent_mcp_names(base_url, session_id))
 
 
+def test_agent_info_mcp_dirty_warning_after_edit(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Restart warning appears in dialog and Tools section after MCP edit."""
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+
+    _open_popover(page)
+    page.get_by_role("button", name="Manage MCP servers").click()
+    dialog = page.get_by_role("dialog").filter(has=page.get_by_text("Manage MCP Servers"))
+    expect(dialog).to_be_visible(timeout=15_000)
+
+    # No warning before any edit.
+    expect(dialog.get_by_text("Restart the session to apply your changes.")).to_be_hidden()
+
+    # Add a server to trigger the dirty state.
+    dialog.get_by_label("Name").fill("dirty-test")
+    dialog.get_by_label("URL").fill("https://example.com/sse")
+    dialog.get_by_role("button", name="Save").click()
+    _wait_for(lambda: _agent_mcp_names(base_url, session_id) == {"dirty-test"})
+
+    # Warning should now appear inside the dialog.
+    expect(dialog.get_by_text("Restart the session to apply your changes.")).to_be_visible(
+        timeout=15_000
+    )
+
+    # Close the dialog; warning should also appear in the Tools section.
+    page.keyboard.press("Escape")
+    expect(dialog).to_be_hidden(timeout=5_000)
+    _open_popover(page)
+    expect(page.get_by_text("Restart to apply changes")).to_be_visible(timeout=15_000)
+
+    # Cleanup: delete the server.
+    page.get_by_role("button", name="Manage MCP servers").click()
+    dialog = page.get_by_role("dialog").filter(has=page.get_by_text("Manage MCP Servers"))
+    expect(dialog).to_be_visible(timeout=15_000)
+    dialog.get_by_role("button", name="Delete dirty-test").click()
+    _wait_for(lambda: not _agent_mcp_names(base_url, session_id))
+
+
 def test_agent_info_mcp_server_added_to_running_session_is_callable(
     page: Page,
     seeded_session: tuple[str, str],


### PR DESCRIPTION
## Summary
- Show a yellow warning banner in the Manage MCP Servers dialog and the Tools section when MCP server config has been modified but the session hasn't been restarted
- Dirty flag clears automatically when the session relaunches (`sessionStatus === "launching"`) or when the user navigates to a different session

## Test plan
- [ ] Open Manage MCP Servers dialog, add/edit/delete an MCP server — yellow warning appears in dialog and Tools section
- [ ] Stop and restart the session — warning clears
- [ ] Navigate to a different session — warning clears
- [ ] Verify warning styling in both light and dark mode

This pull request and its description were written by Isaac.