### PR TITLE
fix(web): surface opencode-native's live model in the session model pill

### DIFF
--- a/ap-web/src/pages/ChatPage.capabilities.test.ts
+++ b/ap-web/src/pages/ChatPage.capabilities.test.ts
@@ -57,6 +57,11 @@ describe("shouldShowModelPicker", () => {
     expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": "cursor-native-ui" } })).toBe(
       true,
     );
+    // opencode mirrors its live TUI model into model_override (like cursor), so
+    // the model indicator surfaces it and reflects in-TUI switches.
+    expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": "opencode-native-ui" } })).toBe(
+      true,
+    );
   });
 
   it("hides the picker for other wrappers and missing labels (fail closed)", () => {
@@ -88,6 +93,14 @@ describe("shouldShowEffortPicker", () => {
     // axis and a model switch resets it to that model's default, so a Web UI
     // dial would silently diverge from the TUI — dropped pending that fix.
     expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": "cursor-native-ui" } })).toBe(
+      false,
+    );
+  });
+
+  it("hides effort controls for opencode-native (model indicator only)", () => {
+    // WHY: opencode surfaces its live model read-only (switching stays in the
+    // opencode TUI); there is no Web UI effort dial for it.
+    expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": "opencode-native-ui" } })).toBe(
       false,
     );
   });

--- a/ap-web/src/pages/ChatPage.composer.test.tsx
+++ b/ap-web/src/pages/ChatPage.composer.test.tsx
@@ -364,6 +364,66 @@ describe("Composer slash-command submit routing", () => {
     expect(screen.getAllByTestId("model-picker-item").length).toBeGreaterThan(0);
   });
 
+  it("shows the read-only model hint for bare /model on opencode-native", () => {
+    // opencode surfaces showModels (its pill mirrors the live TUI model) but
+    // has no web model options to populate a dropdown. The bare-/model intercept
+    // must NOT fire — opening an empty picker and swallowing the command was the
+    // regression. Instead it falls through to the builtin /model handler, which
+    // surfaces the current model as a read-only hint. ("/model <name>" still
+    // routes to setModel below — opencode reads model_override on the next turn,
+    // so a web switch is functional even though the picker list is empty.)
+    const setModel = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ setModel, llmModel: "openrouter/nemotron" });
+    const onSend = vi.fn();
+    render(
+      <Composer
+        {...composerProps({
+          onSend,
+          isTerminalFirst: true,
+          isNativeWrapper: true,
+          showModels: true,
+          modelPickerKind: "opencode",
+        })}
+      />,
+    );
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "/model " } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    // Not sent as plaintext, not a switch, and the (empty) web picker stays shut.
+    expect(onSend).not.toHaveBeenCalled();
+    expect(setModel).not.toHaveBeenCalled();
+    expect(screen.queryAllByTestId("model-picker-item")).toHaveLength(0);
+    // The builtin handler surfaced the current model as a read-only hint.
+    expect(screen.getByText(/openrouter\/nemotron/)).toBeTruthy();
+  });
+
+  it("routes /model <name> to setModel on opencode-native (functional switch)", () => {
+    // Even with an empty picker list, "/model <name>" must persist the override
+    // via setModel — the opencode executor reads model_override on the next
+    // web-injected turn. It must NOT leak to the agent as plaintext "/model …".
+    const setModel = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ setModel });
+    const onSend = vi.fn();
+    render(
+      <Composer
+        {...composerProps({
+          onSend,
+          isTerminalFirst: true,
+          isNativeWrapper: true,
+          showModels: true,
+          modelPickerKind: "opencode",
+        })}
+      />,
+    );
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "/model openrouter/llama-3.3-70b" } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(setModel).toHaveBeenCalledWith("openrouter/llama-3.3-70b");
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it("routes /model <name> to setModel on claude-native sessions", () => {
     // Sent as plaintext, "/model fable" would pop Claude's "Switch model?"
     // dialog inside the vendor TUI with nothing web-side to answer it —

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3152,6 +3152,7 @@ export function composerHarnessLabel(
   if (modelPickerKind === "claude") return "Claude";
   if (modelPickerKind === "codex") return "Codex";
   if (modelPickerKind === "cursor") return "Cursor";
+  if (modelPickerKind === "opencode") return "OpenCode";
   const display = agentName ? agentDisplayLabel(agentName) : null;
   const harness = sessionHarness ? (BRAIN_HARNESS_LABELS[sessionHarness] ?? null) : null;
   if (display && harness) return `${display} (${harness})`;
@@ -4445,7 +4446,7 @@ const EFFORT_LEVELS = ["low", "medium", "high"] as const;
 /** Anthropic-side efforts for claude-native sessions (matches ANTHROPIC_EFFORTS in reasoning_effort.py). */
 const CLAUDE_NATIVE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
-type NativeModelPickerKind = "claude" | "codex" | "cursor";
+type NativeModelPickerKind = "claude" | "codex" | "cursor" | "opencode";
 
 type LabelSource = { labels?: Record<string, string | null> | null } | null | undefined;
 
@@ -4509,6 +4510,11 @@ export function modelPickerKindForConv(
       return "codex";
     case "cursor-native-ui":
       return "cursor";
+    case "opencode-native-ui":
+      // Like cursor: a vendor-owns-model wrapper that mirrors its live TUI
+      // model into the session ``model_override`` (the forwarder's terminal→web
+      // mirror), so the picker surfaces that as the live model.
+      return "opencode";
     default:
       return null;
   }
@@ -4656,7 +4662,10 @@ function AgentPicker({
   // carried over from some other session) nor the meaningless `llmModel`
   // default. The other vendor-owns wrappers have no Omnigent-visible model and
   // stay null.
-  const pickerSelectedModel = modelPickerKind === "cursor" ? sessionModelOverride : selectedModel;
+  const pickerSelectedModel =
+    modelPickerKind === "cursor" || modelPickerKind === "opencode"
+      ? sessionModelOverride
+      : selectedModel;
   // SDK/bundle agents (no native picker) never have the cross-session sticky
   // applied to them, so their live model is the session's own — the applied
   // override or the bound default — never `selectedModel` (a pick carried over
@@ -4668,7 +4677,12 @@ function AgentPicker({
   const effectiveModel = nativeVendorOwnsModel
     ? modelPickerKind === "cursor"
       ? sessionModelOverride
-      : null
+      : modelPickerKind === "opencode"
+        ? // opencode mirrors its live TUI model into ``model_override`` (set at
+          // launch and updated by the forwarder on a TUI switch); show that,
+          // falling back to the launch-resolved model before any switch.
+          (sessionModelOverride ?? llmModel)
+        : null
     : nonNativeModel;
   const modelLabel = formatStatusModelLabel(effectiveModel, codexModelOptions);
   const effortTriggerLabel =

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3772,13 +3772,20 @@ export function Composer({
       const parts = trimmed.split(/\s+/);
       const cmd = parts[0].toLowerCase();
       const arg = parts[1] ?? "";
-      // Bare "/model" when the picker has a Models section (claude-native):
-      // sent as plaintext it would open Claude's interactive selector inside
-      // the vendor TUI, which the web UI can't render — the session just
-      // blocks. Open the composer's model picker instead and let the user
-      // choose there. "/model <name>" takes the builtin route below to
+      // Bare "/model" when the picker has a switchable Models section
+      // (claude-native): sent as plaintext it would open Claude's interactive
+      // selector inside the vendor TUI, which the web UI can't render — the
+      // session just blocks. Open the composer's model picker instead and let
+      // the user choose there. "/model <name>" takes the builtin route below to
       // setModel — the same write the picker makes.
-      if (cmd === "/model" && !arg && showModels) {
+      //
+      // opencode is excluded: it surfaces showModels (the pill mirrors its live
+      // TUI model) but ships no web model options, so intercepting bare "/model"
+      // would pop an empty dropdown and swallow the command. Fall through to the
+      // builtin "/model" handler below, which surfaces the current model as a
+      // read-only hint. ("/model <name>" still routes to setModel there —
+      // opencode reads model_override on the next web-injected turn.)
+      if (cmd === "/model" && !arg && showModels && modelPickerKind !== "opencode") {
         dirtyRef.current = true;
         setValue("");
         setCommandError(null);

--- a/tests/e2e_ui/chat/test_opencode_model_metadata.py
+++ b/tests/e2e_ui/chat/test_opencode_model_metadata.py
@@ -1,0 +1,94 @@
+"""E2E: opencode-native surfaces its live model as a read-only pill.
+
+opencode owns its model (the user switches it inside the opencode TUI), but it
+mirrors the live model into the session's ``model_override`` — set at launch and
+updated by the forwarder on every in-TUI switch. The web UI must surface *that*
+in the model pill so the indicator tracks the TUI, even though opencode ships no
+switchable web model list (the dropdown stays empty / display-only).
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+# Launch-resolved default the runner booted opencode with.
+LAUNCH_MODEL = "openrouter/nemotron"
+# The model the user switched to inside the opencode TUI; the forwarder mirrored
+# it into ``model_override``. This — not the launch default — must show.
+LIVE_TUI_MODEL = "openrouter/llama-3.3-70b-instruct"
+
+
+def _patch_session_as_opencode_native(page: Page, session_id: str) -> None:
+    """Patch the browser's session snapshot into an opencode-native response.
+
+    The server fixture seeds a normal ``hello_world`` session so the page can
+    boot against the real app/server. This route patch rewrites only the
+    ``GET /v1/sessions/{session_id}`` response as seen by the browser, mirroring
+    the AP snapshot after an opencode-native runner has mirrored its live TUI
+    model into ``model_override``. opencode exposes no switchable web model
+    list, so ``model_options`` stays absent.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    :returns: None.
+    """
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        parsed = urlparse(request.url)
+        if parsed.path != f"/v1/sessions/{session_id}" or request.method != "GET":
+            route.continue_()
+            return
+
+        response = route.fetch()
+        payload = response.json()
+        payload["labels"] = {
+            **payload.get("labels", {}),
+            "omnigent.wrapper": "opencode-native-ui",
+        }
+        payload["harness"] = "opencode"
+        payload["llm_model"] = LAUNCH_MODEL
+        payload["model_override"] = LIVE_TUI_MODEL
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def test_opencode_native_pill_shows_live_tui_model(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The model pill surfaces opencode's mirrored ``model_override``.
+
+    Covers the PR's user-facing path: an opencode-native session shows its live
+    model (the override the forwarder mirrors from the TUI), not the stale
+    launch default, and the harness identity reads "OpenCode".
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser snapshot is patched to opencode-native.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_session_as_opencode_native(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The pill mirrors the live TUI model (the override), NOT the launch default.
+    trigger = page.get_by_test_id("agent-picker-trigger")
+    expect(trigger).to_contain_text(LIVE_TUI_MODEL, timeout=15_000)
+    expect(trigger).not_to_contain_text(LAUNCH_MODEL)
+
+    # opencode is identified as its own native wrapper in the status tray.
+    expect(page.get_by_test_id("composer-harness")).to_contain_text("OpenCode")
+
+    # Display-only: opencode ships no switchable web model rows. (Switching
+    # stays in the opencode TUI; the web pill only reflects it.)
+    expect(page.locator('[data-testid="model-picker-item"]')).to_have_count(0)


### PR DESCRIPTION
## fix(web): surface opencode-native's live model in the session model pill

### Problem
For an `opencode-native` session, the web UI showed **no model** in the session pill, and an in-TUI `/model` switch wasn't reflected. (Follow-up to the merged opencode-native PR, which wired the model data + the terminal→web mirror server-side.)

### Root cause (it's purely frontend — the data was already there)
opencode-native is a vendor-owns-model wrapper, so `nativeVendorOwnsModel` is `true`. `effectiveModel` only surfaced `sessionModelOverride` for `cursor`; opencode fell through to `null` → nothing rendered. But opencode **mirrors its live model into `model_override`** exactly like cursor (set at launch + updated by the forwarder on a TUI switch), and the session API already returns `llm_model` + `model_override`. So the model was available; the picker just wasn't wired for this harness.

Verified live on a real session: the session API returns `llm_model`/`model_override = openrouter/...`, and switching the model in the TUI fires `session.next.model.switched` → `external_model_change` → `conv.model_override` updates (proven end-to-end).

### Fix
Treat `opencode-native` like `cursor` in `ChatPage`:
- add an `"opencode"` `NativeModelPickerKind`; map `opencode-native-ui` → it,
- surface `sessionModelOverride` (falling back to the launch-resolved `llmModel`) as the live model.

The pill now shows the opencode model and updates live on an in-TUI switch (the `session_model` stream handler already updates the store, un-gated by harness).

### Scope
**Display + reflect only.** Web-side *switching* needs opencode's available-model list piped into `model_options` (opencode's catalog is large/dynamic) — a follow-up. Switching stays in the opencode TUI, which the pill now reflects.

Tests: `shouldShowModelPicker` true for `opencode-native-ui`; effort picker stays hidden. Type-check + targeted vitest pass.

This pull request and its description were written by Isaac.
