### PR TITLE
fix(claude-sdk): context-aware auth error messages for non-Databricks users

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2467,7 +2467,8 @@ class ClaudeSDKExecutor(Executor):
                             if error_status == 404:
                                 if self._gateway:
                                     endpoint_hint = (
-                                        "Check ANTHROPIC_BASE_URL / gateway endpoint configuration."
+                                        "Check ANTHROPIC_BASE_URL / gateway endpoint "
+                                        "configuration."
                                     )
                                 else:
                                     endpoint_hint = (

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2443,18 +2443,40 @@ class ClaudeSDKExecutor(Executor):
                                 error_status in {401, 403}
                                 or retry_error == "authentication_failed"
                             ):
+                                if self._gateway_uses_databricks_profile:
+                                    auth_hint = (
+                                        "Check your selected ~/.databrickscfg profile."
+                                    )
+                                elif self._gateway:
+                                    auth_hint = (
+                                        "Check your provider's base URL and auth command "
+                                        "(ANTHROPIC_BASE_URL / gateway auth)."
+                                    )
+                                else:
+                                    auth_hint = (
+                                        "Check your Claude CLI login status "
+                                        "(`claude /status`) or API key configuration."
+                                    )
                                 terminal_error = (
                                     "Claude SDK provider authentication failed"
                                     f" ({retry_error}, status={error_status}). "
-                                    "Check your selected ~/.databrickscfg profile."
+                                    f"{auth_hint}"
                                 )
                                 break
 
                             if error_status == 404:
+                                if self._gateway:
+                                    endpoint_hint = (
+                                        "Check ANTHROPIC_BASE_URL / gateway endpoint configuration."
+                                    )
+                                else:
+                                    endpoint_hint = (
+                                        "Check ANTHROPIC_BASE_URL configuration."
+                                    )
                                 terminal_error = (
                                     "Claude SDK provider endpoint was not found "
                                     f"({retry_error}, status={error_status}). "
-                                    "Check ANTHROPIC_BASE_URL / Databricks endpoint configuration."
+                                    f"{endpoint_hint}"
                                 )
                                 break
                         elif getattr(system_msg, "hook_event_name", None) == "PreCompact":

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2444,9 +2444,7 @@ class ClaudeSDKExecutor(Executor):
                                 or retry_error == "authentication_failed"
                             ):
                                 if self._gateway_uses_databricks_profile:
-                                    auth_hint = (
-                                        "Check your selected ~/.databrickscfg profile."
-                                    )
+                                    auth_hint = "Check your selected ~/.databrickscfg profile."
                                 elif self._gateway:
                                     auth_hint = (
                                         "Check your provider's base URL and auth command "
@@ -2471,9 +2469,7 @@ class ClaudeSDKExecutor(Executor):
                                         "configuration."
                                     )
                                 else:
-                                    endpoint_hint = (
-                                        "Check ANTHROPIC_BASE_URL configuration."
-                                    )
+                                    endpoint_hint = "Check ANTHROPIC_BASE_URL configuration."
                                 terminal_error = (
                                     "Claude SDK provider endpoint was not found "
                                     f"({retry_error}, status={error_status}). "

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1175,6 +1175,96 @@ class TestSystemMessages(unittest.TestCase):
             self.assertIsInstance(events[0], ExecutorError)
             self.assertIn("authentication failed", events[0].message)
             self.assertIn("401", events[0].message)
+            # Non-gateway executor should suggest checking CLI login, not databrickscfg
+            self.assertIn("claude /status", events[0].message)
+            self.assertNotIn("databrickscfg", events[0].message)
+
+        _run(_t())
+
+    def test_auth_retry_databricks_gateway_mentions_databrickscfg(self):
+        """Databricks-profile gateway auth errors should mention ~/.databrickscfg."""
+        from claude_agent_sdk.types import (
+            ClaudeAgentOptions as SDKClaudeAgentOptions,
+        )
+        from claude_agent_sdk.types import (
+            StreamEvent as SDKStreamEvent,
+        )
+        from claude_agent_sdk.types import (
+            SystemMessage as SDKSystemMessage,
+        )
+
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        class _Sentinel:
+            pass
+
+        class _FakeSDK:
+            AssistantMessage = _Sentinel
+            ResultMessage = _Sentinel
+            UserMessage = _Sentinel
+            SystemMessage = SDKSystemMessage
+            StreamEvent = SDKStreamEvent
+            ClaudeAgentOptions = SDKClaudeAgentOptions
+            messages = [
+                SDKSystemMessage(
+                    subtype="api_retry",
+                    data={
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "attempt": 1,
+                        "max_retries": 10,
+                        "retry_delay_ms": 500,
+                        "error_status": 401,
+                        "error": "authentication_failed",
+                    },
+                )
+            ]
+
+            class ClaudeSDKClient:
+                def __init__(self, options):
+                    self.options = options
+
+                async def connect(self):
+                    return None
+
+                async def query(self, prompt, session_id="default"):
+                    return None
+
+                async def receive_response(self):
+                    for message in _FakeSDK.messages:
+                        yield message
+
+                async def disconnect(self):
+                    return None
+
+        async def _t():
+            # Create a gateway executor that uses a Databricks profile path.
+            # gateway=True + no host/base_url overrides → _gateway_uses_databricks_profile is True.
+            # Patch _resolve_gateway_env to avoid needing a real ~/.databrickscfg.
+            with patch(
+                "omnigent.inner.claude_sdk_executor._resolve_gateway_env",
+                return_value={
+                    "ANTHROPIC_BASE_URL": "https://host/ai-gateway/anthropic",
+                    "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "900000",
+                    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+                    "OMNIGENT_CLAUDE_API_KEY_HELPER": "databricks auth token ...",
+                },
+            ):
+                executor = ClaudeSDKExecutor(gateway=True)
+            with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=_FakeSDK):
+                events = [
+                    e
+                    async for e in executor.run_turn(
+                        [{"role": "user", "content": "hello"}],
+                        [],
+                        "",
+                    )
+                ]
+            self.assertEqual(len(events), 1)
+            self.assertIsInstance(events[0], ExecutorError)
+            self.assertIn("authentication failed", events[0].message)
+            # Databricks gateway should mention databrickscfg
+            self.assertIn("databrickscfg", events[0].message)
 
         _run(_t())
 


### PR DESCRIPTION
## Summary

Closes #1058

- The 401/403 auth error in `ClaudeSDKExecutor` was hardcoded to say *"Check your selected ~/.databrickscfg profile"* regardless of the actual auth method. Subscription users (no Databricks at all) saw a misleading reference to a file that doesn't exist on their machine.
- The error message now adapts based on the executor's auth mode:
  - **Databricks profile gateway** → mentions `~/.databrickscfg`
  - **Generic provider gateway** → mentions base URL / auth command
  - **Non-gateway (subscription/direct)** → suggests `claude /status` or API key check
- The 404 endpoint-not-found error also adapts (gateway vs. non-gateway).

## Test plan

- [x] Existing `test_auth_retry_surfaces_executor_error` updated to assert the non-gateway hint (`claude /status`) and no `databrickscfg` mention
- [x] New `test_auth_retry_databricks_gateway_mentions_databrickscfg` verifies the Databricks gateway path still shows the `databrickscfg` hint
- [x] Full `test_claude_sdk_executor.py` suite passes (101 tests)

This pull request and its description were written by Isaac.