### PR TITLE
feat(web-ui): click-to-zoom image lightbox with full-screen zoom & pan

### DIFF
--- a/ap-web/src/components/ImageLightbox.test.tsx
+++ b/ap-web/src/components/ImageLightbox.test.tsx
@@ -1,0 +1,86 @@
+// Tests for the shared image lightbox: a ZoomableImage renders a button around
+// an <img>; activating it opens a full-screen Dialog showing the same source,
+// which closes via Escape or the "x" button.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// getEmbedRoot decides the Radix portal container; null → portal to body.
+vi.mock("@/lib/host", () => ({
+  getEmbedRoot: () => null,
+}));
+
+import { ImageLightboxProvider, ZoomableImage } from "./ImageLightbox";
+
+afterEach(cleanup);
+
+function renderWithProvider() {
+  return render(
+    <ImageLightboxProvider>
+      <ZoomableImage src="/pic.png" alt="diagram" className="size-10" />
+    </ImageLightboxProvider>,
+  );
+}
+
+describe("ZoomableImage + ImageLightboxProvider", () => {
+  it("renders a button wrapping an image (keeps the img role/name)", () => {
+    renderWithProvider();
+    expect(screen.getByRole("button", { name: "Zoom image: diagram" })).toBeInTheDocument();
+    // The inner <img> keeps its image role and alt-derived name.
+    const img = screen.getByRole("img", { name: "diagram" });
+    expect(img).toHaveAttribute("src", "/pic.png");
+    expect(img).toHaveClass("size-10");
+  });
+
+  it("does not render a dialog until the image is activated", () => {
+    renderWithProvider();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens a dialog showing the full image on click", () => {
+    renderWithProvider();
+    fireEvent.click(screen.getByRole("button", { name: "Zoom image: diagram" }));
+    const dialog = screen.getByRole("dialog");
+    // The dialog hosts its own copy of the image at the same source.
+    const dialogImg = screen.getAllByRole("img", { name: "diagram" }).at(-1)!;
+    expect(dialog).toContainElement(dialogImg);
+    expect(dialogImg).toHaveAttribute("src", "/pic.png");
+  });
+
+  it("closes the dialog with Escape", () => {
+    renderWithProvider();
+    fireEvent.click(screen.getByRole("button", { name: "Zoom image: diagram" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the dialog with the x button", () => {
+    renderWithProvider();
+    fireEvent.click(screen.getByRole("button", { name: "Zoom image: diagram" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("zooms in and out via the toolbar, updating the scale and label", () => {
+    renderWithProvider();
+    fireEvent.click(screen.getByRole("button", { name: "Zoom image: diagram" }));
+
+    // Starts at fit (100%); zoom-out disabled, the preview img is unscaled.
+    const previewImg = screen.getAllByRole("img", { name: "diagram" }).at(-1)!;
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toHaveTextContent("100%");
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeDisabled();
+    expect(previewImg).toHaveStyle({ transform: "translate(0px, 0px) scale(1)" });
+
+    // One zoom-in step is +0.5 → 150%, and the transform scales up.
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toHaveTextContent("150%");
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeEnabled();
+    expect(previewImg).toHaveStyle({ transform: "translate(0px, 0px) scale(1.5)" });
+
+    // The percentage acts as a reset back to fit.
+    fireEvent.click(screen.getByRole("button", { name: "Reset zoom" }));
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toHaveTextContent("100%");
+    expect(previewImg).toHaveStyle({ transform: "translate(0px, 0px) scale(1)" });
+  });
+});

--- a/ap-web/src/components/ImageLightbox.tsx
+++ b/ap-web/src/components/ImageLightbox.tsx
@@ -1,0 +1,262 @@
+import * as React from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { XIcon, ZoomInIcon, ZoomOutIcon } from "lucide-react";
+
+import { getEmbedRoot } from "@/lib/host";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+// Zoom bounds and step for the lightbox viewer. 1 = fit-to-card.
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 8;
+const ZOOM_STEP = 0.25;
+
+function clampZoom(z: number) {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z));
+}
+
+interface LightboxImage {
+  src: string;
+  alt: string;
+}
+
+interface LightboxContextValue {
+  open: (image: LightboxImage) => void;
+}
+
+// No-op fallback so image components keep working (just non-zoomable) when
+// rendered outside the provider — e.g. in isolated unit tests.
+const NOOP: LightboxContextValue = { open: () => {} };
+
+const LightboxContext = createContext<LightboxContextValue | null>(null);
+
+export function useLightbox(): LightboxContextValue {
+  return useContext(LightboxContext) ?? NOOP;
+}
+
+export interface ZoomableImageProps extends React.ComponentProps<"img"> {
+  /** Display source. May be undefined while the image is still resolving. */
+  src?: string;
+  alt: string;
+}
+
+/**
+ * An `<img>` wrapped in a `<button>` that opens it in the shared lightbox. The
+ * button carries the interaction (click + Enter/Space + focus ring, all native
+ * to a button); the inner `<img>` keeps its `role="img"` and alt-derived name,
+ * so screen readers and tests still see a real image. Activation is a no-op
+ * until `src` resolves. `className` styles the inner `<img>` (sizing,
+ * `object-contain`, etc.) — the button is a layout-transparent wrapper.
+ */
+export function ZoomableImage({ src, alt, className, ...imgProps }: ZoomableImageProps) {
+  const { open } = useLightbox();
+  return (
+    <button
+      type="button"
+      aria-label={alt ? `Zoom image: ${alt}` : "Zoom image"}
+      className="m-0 inline-flex max-w-full cursor-zoom-in appearance-none border-0 bg-transparent p-0 leading-none"
+      onClick={() => {
+        if (src) open({ src, alt });
+      }}
+    >
+      <img {...imgProps} src={src} alt={alt} className={className} />
+    </button>
+  );
+}
+
+/**
+ * The zoomable image inside the lightbox card. Holds its own zoom/pan state and
+ * is keyed by `src` in the provider so that state resets per image.
+ *
+ * Zoom: scroll wheel (anchored at the cursor), the +/- toolbar buttons, or
+ * double-click to toggle between fit and 2x. Pan: drag while zoomed in. The
+ * image is `object-contain` within a fixed-size viewport that clips overflow,
+ * so the zoomed image never escapes the card.
+ */
+function ZoomViewer({ image }: { image: LightboxImage }) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [zoom, setZoom] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  // Active pointer drag (panning); null when not dragging.
+  const dragRef = useRef<{ pointerId: number; startX: number; startY: number } | null>(null);
+
+  const resetView = useCallback(() => {
+    setZoom(1);
+    setOffset({ x: 0, y: 0 });
+  }, []);
+
+  const applyZoom = useCallback((next: number) => setZoom(clampZoom(next)), []);
+
+  // Wheel-to-zoom. Attached as a non-passive native listener so preventDefault
+  // works (React's onWheel is passive and would warn), keeping the page behind
+  // the modal from scrolling while zooming.
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      setZoom((z) => clampZoom(z - Math.sign(e.deltaY) * ZOOM_STEP * 2));
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
+  // Drop pan offset whenever zoom returns to fit.
+  useEffect(() => {
+    if (zoom === MIN_ZOOM) setOffset({ x: 0, y: 0 });
+  }, [zoom]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (zoom <= MIN_ZOOM) return;
+    dragRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX - offset.x,
+      startY: e.clientY - offset.y,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    setOffset({ x: e.clientX - drag.startX, y: e.clientY - drag.startY });
+  };
+  const endDrag = (e: React.PointerEvent) => {
+    if (dragRef.current?.pointerId === e.pointerId) dragRef.current = null;
+  };
+
+  const zoomed = zoom > MIN_ZOOM;
+
+  return (
+    <>
+      <div
+        ref={viewportRef}
+        className="absolute inset-0 flex items-center justify-center overflow-hidden"
+        onDoubleClick={() => applyZoom(zoomed ? MIN_ZOOM : 2)}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        style={{ cursor: zoomed ? (dragRef.current ? "grabbing" : "grab") : "zoom-in" }}
+      >
+        <img
+          src={image.src}
+          alt={image.alt}
+          draggable={false}
+          className="max-h-[92vh] max-w-[94vw] origin-center object-contain select-none"
+          style={{
+            transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`,
+            // Don't fight the drag with a transition while panning, but ease
+            // discrete zoom steps.
+            transition: dragRef.current ? "none" : "transform 120ms ease-out",
+          }}
+        />
+      </div>
+      {/* Zoom toolbar — bottom-center pill. */}
+      <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full bg-background/80 p-1 shadow-sm ring-1 ring-foreground/10 backdrop-blur-xs">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Zoom out"
+          disabled={zoom <= MIN_ZOOM}
+          onClick={() => applyZoom(zoom - ZOOM_STEP * 2)}
+        >
+          <ZoomOutIcon />
+        </Button>
+        <button
+          type="button"
+          aria-label="Reset zoom"
+          className="min-w-[3ch] cursor-pointer text-center text-xs tabular-nums text-muted-foreground hover:text-foreground"
+          onClick={resetView}
+        >
+          {Math.round(zoom * 100)}%
+        </button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Zoom in"
+          disabled={zoom >= MAX_ZOOM}
+          onClick={() => applyZoom(zoom + ZOOM_STEP * 2)}
+        >
+          <ZoomInIcon />
+        </Button>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Provides a single shared full-screen image viewer for the whole app. Any
+ * image wired with {@link useImageZoomProps} opens here. Built on the Radix
+ * Dialog primitive, so Escape closes it for free; an explicit "x" button gives
+ * the second close affordance. The content fills the viewport, so a click never
+ * lands "outside" — closing is Escape or the x only, by design.
+ */
+export function ImageLightboxProvider({ children }: { children: React.ReactNode }) {
+  const [image, setImage] = useState<LightboxImage | null>(null);
+
+  const open = useCallback((img: LightboxImage) => setImage(img), []);
+  const value = useMemo(() => ({ open }), [open]);
+
+  return (
+    <LightboxContext.Provider value={value}>
+      {children}
+      <DialogPrimitive.Root
+        open={image !== null}
+        onOpenChange={(next) => {
+          if (!next) setImage(null);
+        }}
+      >
+        <DialogPrimitive.Portal container={getEmbedRoot() ?? undefined}>
+          {/* Dark backdrop — dims the whole page to focus on the preview. */}
+          <DialogPrimitive.Overlay
+            className={cn(
+              "fixed inset-0 z-[60] bg-black/80 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+              "data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+            )}
+          />
+          {/* Full-screen stage (Slack-style): the image sits centered on the
+              dark backdrop and can zoom to fill the whole viewport, clipped to
+              the screen rather than to a small card. */}
+          <DialogPrimitive.Content
+            className={cn(
+              "fixed inset-0 z-[60] outline-none",
+              "duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+              "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+              "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            )}
+            // The image carries its own description; the title is for a11y only.
+            aria-describedby={undefined}
+            // Close is Escape or the "x" only — keep clicks on the backdrop
+            // (and elsewhere) from dismissing the preview.
+            onInteractOutside={(e) => e.preventDefault()}
+          >
+            <DialogPrimitive.Title className="sr-only">
+              {image?.alt || "Image preview"}
+            </DialogPrimitive.Title>
+            {/* key by src so zoom/pan state resets when a new image opens. */}
+            {image && <ZoomViewer key={image.src} image={image} />}
+            <DialogPrimitive.Close asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="absolute top-3 right-3 bg-background/70 hover:bg-background/90"
+              >
+                <XIcon />
+                <span className="sr-only">Close</span>
+              </Button>
+            </DialogPrimitive.Close>
+          </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
+    </LightboxContext.Provider>
+  );
+}

--- a/ap-web/src/components/SessionImage.tsx
+++ b/ap-web/src/components/SessionImage.tsx
@@ -3,6 +3,7 @@ import { ImageIcon } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { getOmnigentHostConfig, hostFetch } from "@/lib/host";
+import { ZoomableImage } from "@/components/ImageLightbox";
 
 export interface SessionImageProps {
   /**
@@ -28,7 +29,7 @@ export function SessionImage({ path, alt, className }: SessionImageProps) {
   // Host config is installed once at embed startup and never changes, so it's
   // safe to branch on it before any hooks. Hooks live in the embedded child.
   if (!getOmnigentHostConfig().fetcher) {
-    return <img src={path} alt={alt} className={className} />;
+    return <ZoomableImage src={path} alt={alt} className={className} />;
   }
   return <EmbeddedSessionImage path={path} alt={alt} className={className} />;
 }
@@ -98,5 +99,5 @@ function EmbeddedSessionImage({ path, alt, className }: SessionImageProps) {
     );
   }
 
-  return <img src={blobUrl} alt={alt} className={className} />;
+  return <ZoomableImage src={blobUrl} alt={alt} className={className} />;
 }

--- a/ap-web/src/components/ai-elements/image.tsx
+++ b/ap-web/src/components/ai-elements/image.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { ZoomableImage } from "@/components/ImageLightbox";
 import type { Experimental_GeneratedImage } from "ai";
 
 export type ImageProps = Experimental_GeneratedImage & {
@@ -7,9 +8,9 @@ export type ImageProps = Experimental_GeneratedImage & {
 };
 
 export const Image = ({ base64, uint8Array: _uint8Array, mediaType, ...props }: ImageProps) => (
-  <img
+  <ZoomableImage
     {...props}
-    alt={props.alt}
+    alt={props.alt ?? ""}
     className={cn("h-auto max-w-full overflow-hidden rounded-md", props.className)}
     src={`data:${mediaType};base64,${base64}`}
   />

--- a/ap-web/src/components/blocks/BlockRenderer.tsx
+++ b/ap-web/src/components/blocks/BlockRenderer.tsx
@@ -19,6 +19,7 @@ import type React from "react";
 import { defaultRemarkPlugins } from "streamdown";
 import remarkBreaks from "remark-breaks";
 import { MessageResponse } from "@/components/ai-elements/message";
+import { ZoomableImage } from "@/components/ImageLightbox";
 import { useThrottledValue } from "@/hooks/useThrottledValue";
 import type { RenderItem } from "@/lib/renderItems";
 import type { SessionStatus } from "@/lib/types";
@@ -133,9 +134,20 @@ function WorkspacePathInlineCode({
   );
 }
 
+// Markdown images open in the shared lightbox on click, matching uploaded and
+// generated images. (Remote `src`s are still gated by Streamdown's image
+// security; this only adds the zoom affordance to whatever does render.)
+function ZoomableMarkdownImage({ src, alt, ...props }: React.ComponentProps<"img">) {
+  const resolvedSrc = typeof src === "string" ? src : undefined;
+  return <ZoomableImage {...props} src={resolvedSrc} alt={alt ?? ""} />;
+}
+
 // Stable module-level override map so MessageResponse's memo (which ignores
 // `components` changes) never sees a new identity.
-const FILE_PATH_AWARE_COMPONENTS = { inlineCode: WorkspacePathInlineCode };
+const FILE_PATH_AWARE_COMPONENTS = {
+  inlineCode: WorkspacePathInlineCode,
+  img: ZoomableMarkdownImage,
+};
 
 // How often the live (growing) assistant bubble re-parses its markdown. The
 // store pump commits a new, longer text up to once per animation frame (~60/s);

--- a/ap-web/src/embed.tsx
+++ b/ap-web/src/embed.tsx
@@ -28,6 +28,7 @@ import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import App from "./App";
 import { TooltipProvider } from "./components/ui/tooltip";
+import { ImageLightboxProvider } from "./components/ImageLightbox";
 import { RunnerHealthProvider } from "./hooks/RunnerHealthProvider";
 import { CapabilitiesContext } from "./lib/CapabilitiesContext";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
@@ -199,15 +200,17 @@ function OmnigentProviders({
             disableTransitionOnChange
           >
             <TooltipProvider>
-              <RoutingProvider value={routing}>
-                <EmbedCapabilitiesProvider>
-                  <SessionUpdatesProvider>
-                    <RunnerHealthProvider>
-                      <App basename={basename} />
-                    </RunnerHealthProvider>
-                  </SessionUpdatesProvider>
-                </EmbedCapabilitiesProvider>
-              </RoutingProvider>
+              <ImageLightboxProvider>
+                <RoutingProvider value={routing}>
+                  <EmbedCapabilitiesProvider>
+                    <SessionUpdatesProvider>
+                      <RunnerHealthProvider>
+                        <App basename={basename} />
+                      </RunnerHealthProvider>
+                    </SessionUpdatesProvider>
+                  </EmbedCapabilitiesProvider>
+                </RoutingProvider>
+              </ImageLightboxProvider>
             </TooltipProvider>
           </NextThemesProvider>
         </EmbeddedProvider>

--- a/ap-web/src/main.tsx
+++ b/ap-web/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App.tsx";
 import { ThemeProvider } from "./components/theme/ThemeProvider";
 import { TooltipProvider } from "./components/ui/tooltip";
+import { ImageLightboxProvider } from "./components/ImageLightbox";
 import { RunnerHealthProvider } from "./hooks/RunnerHealthProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
@@ -73,13 +74,15 @@ void _bootProbe.then((info) => {
         <QueryClientProvider client={queryClient}>
           <ThemeProvider>
             <TooltipProvider>
-              <BrowserRouter>
-                <SessionUpdatesProvider>
-                  <RunnerHealthProvider>
-                    <App />
-                  </RunnerHealthProvider>
-                </SessionUpdatesProvider>
-              </BrowserRouter>
+              <ImageLightboxProvider>
+                <BrowserRouter>
+                  <SessionUpdatesProvider>
+                    <RunnerHealthProvider>
+                      <App />
+                    </RunnerHealthProvider>
+                  </SessionUpdatesProvider>
+                </BrowserRouter>
+              </ImageLightboxProvider>
             </TooltipProvider>
           </ThemeProvider>
         </QueryClientProvider>


### PR DESCRIPTION
## Summary

Images in chat messages are now clickable and open in a full-screen lightbox on a dark backdrop — like Slack's image viewer.

- **Open**: click any image in a message (or activate via keyboard).
- **Zoom**: scroll wheel, the `+` / `−` toolbar, or double-click to toggle fit ↔ 2×. The image scales across the whole viewport (clipped to the screen), not within a small box.
- **Pan**: drag while zoomed in; auto-recenters when back to fit.
- **Close**: `Escape` or the `×` button (backdrop clicks are intentionally ignored).

A single shared `ImageLightboxProvider` is mounted in both entry points (standalone `main.tsx` and embedded `embed.tsx`), and three render paths feed it via a `ZoomableImage` wrapper:

- `SessionImage` — user-uploaded images
- `ai-elements/Image` — AI-generated base64 images
- `BlockRenderer` — markdown `<img>` (added an `img` override to the Streamdown component map)

`ZoomableImage` renders a `<button>` around the `<img>` so it gets click + Enter/Space + focus-ring for free while the inner `<img>` keeps its `role="img"` / alt for screen readers. Markdown remote-image gating (Streamdown `allowedImagePrefixes: []`) is untouched — this only adds the zoom affordance to whatever already renders.

## Testing

- `tsc -b`, `oxlint`, `prettier` — clean
- New `ImageLightbox.test.tsx` (6 tests: button/img semantics, open-on-click, Escape/× close, toolbar zoom in/out + reset)
- Existing `SessionImage` + `BlockRenderer` tests pass