### PR TITLE
fix(web-ui): prevent policy name overflow in agent info popover

### DIFF
--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -1062,15 +1062,17 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
                 <PopoverContent
                   side="top"
                   align="start"
-                  className="w-64"
+                  className="max-w-72"
                   onClick={(e) => e.stopPropagation()}
                 >
                   <div className="flex flex-col gap-2">
                     <div className="flex items-center gap-1.5">
                       <ShieldCheckIcon className="size-3.5 text-muted-foreground" />
-                      <span className="font-medium text-sm">{p.name}</span>
+                      <span className="min-w-0 break-all font-medium text-sm">{p.name}</span>
                     </div>
-                    {description && <p className="text-xs text-muted-foreground">{description}</p>}
+                    {description && (
+                      <p className="break-words text-xs text-muted-foreground">{description}</p>
+                    )}
                     <button
                       type="button"
                       onClick={() => p.id && deletePolicy.mutate(p.id)}


### PR DESCRIPTION
## Summary
- Long policy names (e.g. `require_approval_for_file_&_shell_operations`) were overflowing the policy popover in the agent info panel.
- Changed the popover from fixed `w-64` to `max-w-72`, added `break-all` on the policy name and `break-words` on the description so text wraps within bounds.

## Test plan
- [ ] Open agent info popover with a long policy name and verify text wraps correctly
- [ ] Verify short policy names still render cleanly

This pull request and its description were written by Isaac.