### PR TITLE
fix(codex): apply reasoning effort via thread/settings/update, not turn/start (#1343)

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -1174,6 +1174,12 @@ class _CodexAppServerSession:
         self._loop: asyncio.AbstractEventLoop | None = None
         self.thread_id: str | None = None
         self.active_turn_id: str | None = None
+        # Last reasoning effort applied via ``thread/settings/update`` on the
+        # current thread. Effort is not part of the executor's session
+        # signature, so a change must be re-applied per turn; this is reset on
+        # a fresh thread so it is re-sent. ``turn/start`` carries no ``effort``
+        # field (it is silently dropped), hence the separate settings update.
+        self._applied_effort: str | None = None
         self._recent_stderr: list[str] = []
         self._recent_events: list[CodexMessage] = []
         self._process_cwd: Path | None = None
@@ -1439,6 +1445,9 @@ class _CodexAppServerSession:
             # below fails loud for a protocol violation instead of
             # silently carrying an empty-string thread id.
             self.thread_id = raw_thread_id if isinstance(raw_thread_id, str) else None
+            # Fresh thread: forget the prior thread's applied effort so the
+            # settings update below re-sends it for this thread.
+            self._applied_effort = None
 
         assert self.thread_id is not None
         prompt = _prompt_for_turn(messages, is_new_thread=is_new_thread)
@@ -1446,12 +1455,22 @@ class _CodexAppServerSession:
             turn_input = _to_codex_input_items(prompt)
         else:
             turn_input = [{"type": "text", "text": prompt}]
+        # Apply reasoning effort via ``thread/settings/update``: Codex's
+        # ``TurnStartParams`` has no ``effort`` field, so an ``effort`` set on
+        # ``turn/start`` is silently dropped by serde and never takes effect.
+        # ``ThreadSettingsUpdateParams`` is where ``model``/``effort`` live —
+        # the same path the TUI ``/model`` picker uses. Deduped against the
+        # last value applied on this thread to avoid a redundant per-turn RPC.
+        if reasoning_effort and reasoning_effort != self._applied_effort:
+            await self._request(
+                "thread/settings/update",
+                {"threadId": self.thread_id, "effort": reasoning_effort},
+            )
+            self._applied_effort = reasoning_effort
         turn_params: CodexParams = {
             "threadId": self.thread_id,
             "input": turn_input,
         }
-        if reasoning_effort:
-            turn_params["effort"] = reasoning_effort
         start_response = await self._request(
             "turn/start",
             turn_params,

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -566,18 +566,18 @@ class TestCodexExecutor(unittest.TestCase):
                 )
 
             inject_task = asyncio.create_task(_inject_turn_completed())
-            _ = [
-                event
-                async for event in session.run_turn(
-                    messages=[{"role": "user", "content": "hi"}],
-                    tools=[],
-                    system_prompt="",
-                    model="gpt-5.4-mini",
-                    cwd=".",
-                    sandbox="workspace-write",
-                    reasoning_effort="high",
-                )
-            ]
+            # Drive the turn to completion (consume the event stream for its
+            # side effects — the RPCs we assert on below).
+            async for _event in session.run_turn(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                system_prompt="",
+                model="gpt-5.4-mini",
+                cwd=".",
+                sandbox="workspace-write",
+                reasoning_effort="high",
+            ):
+                pass
             await inject_task
 
             methods = [call.args[0] for call in session._request.await_args_list]
@@ -619,18 +619,18 @@ class TestCodexExecutor(unittest.TestCase):
                 )
 
             inject_task = asyncio.create_task(_inject_turn_completed())
-            _ = [
-                event
-                async for event in session.run_turn(
-                    messages=[{"role": "user", "content": "again"}],
-                    tools=[],
-                    system_prompt="",
-                    model="gpt-5.4-mini",
-                    cwd=".",
-                    sandbox="workspace-write",
-                    reasoning_effort="high",
-                )
-            ]
+            # Drive the turn to completion (consume the event stream for its
+            # side effects — the RPCs we assert on below).
+            async for _event in session.run_turn(
+                messages=[{"role": "user", "content": "again"}],
+                tools=[],
+                system_prompt="",
+                model="gpt-5.4-mini",
+                cwd=".",
+                sandbox="workspace-write",
+                reasoning_effort="high",
+            ):
+                pass
             await inject_task
 
             methods = [call.args[0] for call in session._request.await_args_list]

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -532,6 +532,112 @@ class TestCodexExecutor(unittest.TestCase):
 
         _run(_t())
 
+    def test_app_server_run_turn_applies_effort_via_thread_settings_update(self):
+        """Reasoning effort rides thread/settings/update, not turn/start.
+
+        Codex's ``TurnStartParams`` has no ``effort`` field, so an effort set
+        on ``turn/start`` is silently dropped by serde and never takes effect.
+        It must go through ``thread/settings/update`` (whose
+        ``ThreadSettingsUpdateParams`` carries ``effort``) — the same path the
+        TUI ``/model`` picker uses.
+        """
+
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            session._request = AsyncMock(
+                side_effect=[
+                    {"result": {"thread": {"id": "thread-1"}}},  # thread/start
+                    {"result": {}},  # thread/settings/update
+                    {"result": {"turn": {"id": "turn-1"}}},  # turn/start
+                ]
+            )
+
+            async def _inject_turn_completed() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {"method": "turn/completed", "params": {"turn": {"id": "turn-1"}}}
+                )
+
+            inject_task = asyncio.create_task(_inject_turn_completed())
+            _ = [
+                event
+                async for event in session.run_turn(
+                    messages=[{"role": "user", "content": "hi"}],
+                    tools=[],
+                    system_prompt="",
+                    model="gpt-5.4-mini",
+                    cwd=".",
+                    sandbox="workspace-write",
+                    reasoning_effort="high",
+                )
+            ]
+            await inject_task
+
+            methods = [call.args[0] for call in session._request.await_args_list]
+            # Settings update lands BEFORE the turn starts so the effort applies
+            # to this turn, and turn/start carries no (dropped) effort field.
+            self.assertEqual(methods, ["thread/start", "thread/settings/update", "turn/start"])
+            settings_params = session._request.await_args_list[1].args[1]
+            self.assertEqual(settings_params, {"threadId": "thread-1", "effort": "high"})
+            turn_params = session._request.await_args_list[2].args[1]
+            self.assertNotIn("effort", turn_params)
+
+        _run(_t())
+
+    def test_app_server_run_turn_dedupes_unchanged_effort(self):
+        """An unchanged effort is not re-sent on a later turn of one thread.
+
+        Effort persists on the thread once applied, so re-issuing
+        ``thread/settings/update`` every turn would be a redundant RPC.
+        """
+
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            # Existing thread (no thread/start) with effort already applied.
+            session.thread_id = "thread-1"
+            session._applied_effort = "high"
+            session._request = AsyncMock(side_effect=[{"result": {"turn": {"id": "turn-2"}}}])
+
+            async def _inject_turn_completed() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {"method": "turn/completed", "params": {"turn": {"id": "turn-2"}}}
+                )
+
+            inject_task = asyncio.create_task(_inject_turn_completed())
+            _ = [
+                event
+                async for event in session.run_turn(
+                    messages=[{"role": "user", "content": "again"}],
+                    tools=[],
+                    system_prompt="",
+                    model="gpt-5.4-mini",
+                    cwd=".",
+                    sandbox="workspace-write",
+                    reasoning_effort="high",
+                )
+            ]
+            await inject_task
+
+            methods = [call.args[0] for call in session._request.await_args_list]
+            self.assertEqual(methods, ["turn/start"])
+
+        _run(_t())
+
     def test_app_server_dynamic_tool_complete_carries_call_id_metadata(self):
         async def _t():
             session = _CodexAppServerSession(


### PR DESCRIPTION
## Summary

Fixes **#1343**. The SDK / non-native codex harness (`omnigent/inner/codex_executor.py`) set reasoning `effort` on `turn/start`, where Codex's app-server silently drops it — so a configured effort never took effect for `codex` (SDK) agents.

Ground-truth schema (extracted from the installed codex binary, 0.140.0-alpha.2): **`TurnStartParams` has no `effort`** — it lives on `ThreadSettingsUpdateParams`, sent via `thread/settings/update`. That's the same mechanism the codex-**native** fix (#1256 / #1274) and the TUI `/model` picker use; this brings the SDK harness in line.

## Change

`omnigent/inner/codex_executor.py` (`_CodexAppServerSession.run_turn`):
- Send `effort` via `thread/settings/update` (`{threadId, effort}`) **before** `turn/start`, so it applies to the turn.
- Removed `effort` from `turn/start` params (it was dropped anyway).
- Dedup: track `_applied_effort` on the session, only re-send when it changes; reset to `None` on a fresh thread so a new thread re-applies it. (Effort isn't part of the executor's session signature, so unlike `model` it isn't handled by session recreation — it must be applied per turn when it changes.)

`model` was already correct — set on `thread/start`, with model changes handled by session-signature recreation.

## Tests

`tests/inner/test_codex_executor.py`:
- effort rides `thread/settings/update` before `turn/start`; `turn/start` carries no `effort`
- an unchanged effort is not re-sent on a later turn of the same thread

Full `tests/inner/test_codex_executor.py` (85) passes; ruff format + check clean.

## Verification note

The schema is from a binary-string extraction, not a live capture of an SDK-codex turn. Worth confirming live that an SDK-codex agent with a non-default effort actually runs at that effort before fully relying on it.
