### PR TITLE
fix(merge-ready): re-evaluate fork PRs on check_suite completion

### DIFF
--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -4,9 +4,11 @@ name: Merge Ready
 # required branch-protection check, backed by the REQUIRED list inside
 # this workflow. Triggers: `/merge` comment (write-access commenter only),
 # `pull_request_target` labeled (acts only with `automerge`),
-# `workflow_run` on CI completion (same-repo and fork PRs -- ctx resolves the
-# PR from the head SHA), and `workflow_dispatch` (programmatic/manual
-# re-evaluation of one PR). Posted via the REST API (not the job's implicit
+# `workflow_run` on CI completion (re-evaluates same-repo PRs),
+# `check_suite` completion (re-evaluates fork PRs -- their CI does not deliver
+# a usable workflow_run to this base-repo workflow), and `workflow_dispatch`
+# (programmatic/manual re-evaluation of one PR). Both ctx-resolve the PR from
+# the head SHA. Posted via the REST API (not the job's implicit
 # check run) so the status lands on the PR head SHA, since these jobs run on
 # the default branch.
 #
@@ -20,14 +22,21 @@ name: Merge Ready
 # (branch protection has enforce_admins=false).
 
 on:
-  # `labeled` only; `workflow_run` re-evaluates on CI completion for all PRs
-  # (same-repo and fork -- ctx resolves the PR from the head SHA).
+  # `labeled` only; `workflow_run` re-evaluates same-repo PRs on CI completion.
   # pull_request_target (not pull_request) so this workflow always runs from
   # main -- a PR cannot modify the gate logic by editing this file.
   pull_request_target:
     types: [labeled]
   workflow_run:
     workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]
+    types: [completed]
+  # Fork-PR CI does not deliver a usable workflow_run to this base-repo
+  # workflow, so the gate never re-evaluated when a fork's tests finished
+  # (#1004 retired the fork-e2e mirror that used to bridge this). The
+  # github-actions check_suite DOES complete in the base repo for fork PRs --
+  # once, when all the suite's workflows finish -- and ctx resolves the PR
+  # from its head SHA, so it is the fork equivalent of the workflow_run path.
+  check_suite:
     types: [completed]
   issue_comment:
     types: [created]
@@ -48,7 +57,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.event.workflow_run.head_sha }}
+  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.event.workflow_run.head_sha || github.event.check_suite.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -71,6 +80,10 @@ jobs:
       (
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.event == 'pull_request'
+      ) ||
+      (
+        github.event_name == 'check_suite' &&
+        github.event.check_suite.app.slug == 'github-actions'
       ) ||
       github.event_name == 'workflow_dispatch' ||
       (
@@ -139,11 +152,12 @@ jobs:
             PR="${{ github.event.issue.number }}"
             SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
           else
+            # workflow_run (same-repo) or check_suite (fork) completion.
             PR=$(echo "$WF_PRS" | jq -r '.[0].number // empty')
-            SHA="${{ github.event.workflow_run.head_sha }}"
+            SHA="${{ github.event.workflow_run.head_sha || github.event.check_suite.head_sha }}"
             [[ -z "$PR" ]] && PR=$(resolve_pr_from_sha "$SHA")
             if [[ -z "$PR" ]]; then
-              echo "::notice::Skipped: workflow_run has no associated PR (push to main, etc)"
+              echo "::notice::Skipped: CI completion has no associated open PR (push to main, etc)"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -275,6 +289,7 @@ jobs:
         if: >-
           (
             github.event_name == 'workflow_run' ||
+            github.event_name == 'check_suite' ||
             github.event_name == 'workflow_dispatch'
           ) &&
           steps.ctx.outputs.skip != 'true' &&


### PR DESCRIPTION
## Related issue

N/A. CI gate regression with no tracked issue (surfaced from triage of fork PRs stuck without a Merge Ready status).

## Summary

Merge Ready never updates for fork PRs. The gate's only re-evaluating trigger is `workflow_run` on CI completion, and that event is not delivered to this base-repo workflow for a fork's `pull_request` CI runs. The `automerge` label and `/merge` comment triggers are one-shot.

- Fork PR, no label: no `Merge Ready` status is ever posted (e.g. #1339, #1318, #1317, all checks green, no status).
- Fork PR with `automerge`: evaluated once at label-add time (before CI finishes, so red), never re-evaluated, so it stays red even after everything goes green (e.g. #1325, every check green but `Merge Ready=failure`).
- Same-repo PRs are unaffected (#1344 got `Merge Ready=success` with no label or comment, via `workflow_run`).

This used to work via the fork-e2e mirror (#406, push-event `workflow_run`). #1004 retired the mirror and the `check_suite` fallback, assuming forks re-evaluate via the direct `workflow_run`. That commit flagged the assumption as unverified, and it does not hold.

Fix: add a `check_suite: [completed]` trigger. The github-actions check_suite completes in the base repo for fork PRs (once, when the suite finishes), so it is the fork equivalent of the `workflow_run` path. ctx already resolves the PR from the head SHA (fork events carry an empty `pull_requests` array); the only new logic is reading the SHA from the check_suite payload. The concurrency key and the gate-red fail step gain `check_suite` for parity. Same-repo PRs hit both triggers but dedup via the shared head-SHA concurrency group.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/merge-ready.yml'))"` parses cleanly.
- Verified the `check_suite` branch of the ctx step locally: with `workflow_run` absent, `WF_PRS` is the string `null`, and `echo "null" | jq -r '.[0].number // empty'` yields empty, so PR resolution falls through to `resolve_pr_from_sha "$SHA"` with the SHA read from `github.event.check_suite.head_sha` (the fork path).
- Diagnosis confirmed against live PRs via `gh api repos/omnigent-ai/omnigent/commits/<sha>/status` (fork PRs above missing or stale; same-repo #1344 green).
- End-to-end requires a live fork-PR CI run (the `workflow_run` vs `check_suite` delivery difference cannot be exercised locally). Watch #1339 and #1325 once this lands.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Gate logic is unchanged; only the set of events that re-run the existing evaluation is broadened, so no new automated tests apply. Manual verification covered YAML validity, the ctx check_suite SHA-resolution branch, and reproduction of the bug against live fork vs same-repo PRs. The trigger-delivery behavior itself is only observable on GitHub's runners, so final confirmation is a live fork-PR run after merge.