### PR TITLE
fix(e2e): wait for turn dispatch before treating idle as terminal

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1657,20 +1657,28 @@ def poll_session_until_terminal(
     """
     deadline = time.monotonic() + timeout
     last_body: dict[str, Any] = {}
+    # A queued turn reads ``idle`` until the runner dispatches it, so accept
+    # ``idle`` as terminal only once the turn has started — seen as a
+    # running/waiting edge, or as real output (a non-user, non-resource_event
+    # item) for turns that finish between polls. ``failed`` is always terminal.
+    seen_running = False
     while time.monotonic() < deadline:
         resp = client.get(f"/v1/sessions/{session_id}")
         resp.raise_for_status()
         last_body = resp.json()
         status = last_body.get("status")
-        if status in ("idle", "failed"):
-            output = [
-                flattened
-                for item in last_body.get("items", [])
-                if not (
-                    (flattened := _flatten_session_item(item)).get("type") == "message"
-                    and flattened.get("role") == "user"
-                )
-            ]
+        if status in ("running", "waiting"):
+            seen_running = True
+        output = [
+            flattened
+            for item in last_body.get("items", [])
+            if not (
+                (flattened := _flatten_session_item(item)).get("type") == "message"
+                and flattened.get("role") == "user"
+            )
+        ]
+        has_turn_output = any(item.get("type") != "resource_event" for item in output)
+        if status == "failed" or (status == "idle" and (seen_running or has_turn_output)):
             return {
                 "id": response_id,
                 "status": "completed" if status == "idle" else "failed",


### PR DESCRIPTION
## Related issue

N/A. Flaky E2E test fix.

## Summary

- `tests/e2e/test_os_env_write_boundary_e2e.py::test_sys_os_write_inside_workspace_allowed` flaked with `sys_os_write produced no tool result`. The snapshot held only the startup terminal `resource_event`.
- Root cause: `poll_session_until_terminal` returned on the first `idle` it saw. A turn queued via `POST /events` isn't yet in the runner's `_active_turns`, so the snapshot reads `idle` (cache miss becomes `idle`; the runner live-status fallback is also `idle` until dispatch). At `POLL_INTERVAL_S` = 0.1s the first GET wins that race. This affected every caller of the helper.
- Fix: accept `idle` as terminal only once the turn has started, seen as a `running`/`waiting` edge, or (for turns finishing between polls) when real output is present (a non-user, non-`resource_event` item). `failed` stays immediately terminal. Mirrors `test_steering`'s `_wait_for_session_running` guard.

## Test Plan

- 15/15 serial runs of `test_os_env_write_boundary_e2e.py`, all green.
- 5/5 parallel runs (`-n 6 --dist=loadscope`) alongside `test_tool_call_policy_e2e` and `test_decorated_tools_e2e` to recreate the runner contention that widens the race window, all green.
- `ruff check tests/e2e/conftest.py` passes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Change is confined to a shared E2E poll helper; the existing E2E tests that
call it (the flaky one plus `test_tool_call_policy_e2e` /
`test_decorated_tools_e2e`) exercise the fixed path, verified via the
serial + parallel stress runs above.
