### PR TITLE
fix(ap-web): only show session owner row when shared

### DIFF
--- a/ap-web/src/components/AgentInfo.test.tsx
+++ b/ap-web/src/components/AgentInfo.test.tsx
@@ -32,6 +32,10 @@ const registryData = { current: [] as unknown[] };
 // cost/id/usage tests untouched.
 const ownerData = { current: null as string | null | undefined };
 const viewerData = { current: null as string | null };
+// Grants the owner has handed out, returned by usePermissions. Only consulted
+// when the viewer owns the session; the owner row shows once it includes a
+// principal other than the viewer (a user or the __public__ sentinel).
+const grantsData = { current: undefined as { user_id: string }[] | undefined };
 vi.mock("@/hooks/usePolicies", () => ({
   usePolicies: () => ({ data: policiesData.current }),
   usePolicyRegistry: () => ({ data: registryData.current }),
@@ -45,6 +49,7 @@ vi.mock("@/hooks/useAgents", () => ({
 }));
 vi.mock("@/hooks/usePermissions", () => ({
   useSessionOwner: () => ({ data: ownerData.current }),
+  usePermissions: () => ({ data: grantsData.current }),
 }));
 vi.mock("@/lib/identity", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/identity")>()),
@@ -83,6 +88,7 @@ afterEach(() => {
   deleteMcpMutate.mockClear();
   ownerData.current = null;
   viewerData.current = null;
+  grantsData.current = undefined;
 });
 
 function renderButton(agent: Agent | undefined) {
@@ -288,24 +294,30 @@ describe("AgentInfoButton session id row", () => {
 });
 
 describe("AgentInfoButton session owner row", () => {
-  // The owner row lets a viewer see whose session a shared chat is. It reads
-  // the owner via useSessionOwner (mocked) and the viewer via getCurrentUserId
-  // (mocked); both reset to null in afterEach.
+  // The owner row lets a viewer see whose session a shared chat is, and is
+  // shown *only* when the session is actually shared. It reads the owner via
+  // useSessionOwner, the viewer via getCurrentUserId, and the owner's grants
+  // via usePermissions (all mocked); all reset between cases.
 
-  it("shows the session owner in the popover when one is known", () => {
+  it("shows the session owner when someone else owns the shared session", () => {
+    // A different owner means the session was shared with this viewer.
     ownerData.current = "alice@example.com";
+    viewerData.current = "bob@example.com";
     renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
     // Closed popover: the owner row is not mounted yet.
     expect(screen.queryByTestId("agent-info-session-owner")).toBeNull();
 
     fireEvent.click(screen.getByTestId("agent-info-trigger"));
 
-    expect(screen.getByTestId("agent-info-session-owner")).toHaveTextContent("alice@example.com");
+    const row = screen.getByTestId("agent-info-session-owner");
+    expect(row).toHaveTextContent("alice@example.com");
+    expect(row).not.toHaveTextContent("(you)");
   });
 
-  it("appends (you) when the viewer owns the session", () => {
+  it("shows the owner with (you) when the viewer owns it and shared with another user", () => {
     ownerData.current = "alice@example.com";
     viewerData.current = "alice@example.com";
+    grantsData.current = [{ user_id: "alice@example.com" }, { user_id: "bob@example.com" }];
     renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
     fireEvent.click(screen.getByTestId("agent-info-trigger"));
 
@@ -314,20 +326,29 @@ describe("AgentInfoButton session owner row", () => {
     expect(row).toHaveTextContent("(you)");
   });
 
-  it("omits (you) when someone else owns the session", () => {
+  it("shows the owner row when the viewer owns it and made it public", () => {
     ownerData.current = "alice@example.com";
-    viewerData.current = "bob@example.com";
+    viewerData.current = "alice@example.com";
+    grantsData.current = [{ user_id: "alice@example.com" }, { user_id: "__public__" }];
     renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
     fireEvent.click(screen.getByTestId("agent-info-trigger"));
 
-    const row = screen.getByTestId("agent-info-session-owner");
-    expect(row).toHaveTextContent("alice@example.com");
-    expect(row).not.toHaveTextContent("(you)");
+    expect(screen.getByTestId("agent-info-session-owner")).toHaveTextContent("alice@example.com");
+  });
+
+  it("omits the owner row for a private solo session (owner viewing, no other grants)", () => {
+    ownerData.current = "alice@example.com";
+    viewerData.current = "alice@example.com";
+    grantsData.current = [{ user_id: "alice@example.com" }];
+    renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
+    fireEvent.click(screen.getByTestId("agent-info-trigger"));
+    // The rest of the popover still renders (agent name proves it opened).
+    expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-info-session-owner")).toBeNull();
   });
 
   it("omits the owner row when no owner is known (permissions off / loading)", () => {
-    // owner null → no row at all, rather than an empty placeholder. The rest of
-    // the popover still renders (agent name proves it opened).
+    // owner null → no row at all, rather than an empty placeholder.
     renderButtonWithSession(AGENT_WITH_BOTH, "conv_owner");
     fireEvent.click(screen.getByTestId("agent-info-trigger"));
     expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();

--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -38,7 +38,8 @@ import {
   useDeletePolicy,
   type PolicyRegistryEntry,
 } from "@/hooks/usePolicies";
-import { useSessionOwner } from "@/hooks/usePermissions";
+import { usePermissions, useSessionOwner } from "@/hooks/usePermissions";
+import { isSessionSharedWithOthers } from "@/lib/permissionsApi";
 import { getCurrentUserId } from "@/lib/identity";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -1216,6 +1217,14 @@ export function AgentInfoContent({
   // (no mid-turn switch), so a model change is a fork that carries history.
   const showRestartWithModel = isCodexHarness(agent?.harness) && !!sessionId;
   const [restartOpen, setRestartOpen] = useState(false);
+  // Only surface the owner once the session is actually shared — a private
+  // solo session has no "owner" worth showing. A non-owner viewer already
+  // implies a share; the owner needs the grant list (manage-only, readable by
+  // the owner) to know they've granted access to anyone else or made it
+  // public. Mirrors the author-label gate in ChatPage.
+  const viewerOwnsSession = owner != null && owner === viewerId;
+  const { data: ownerGrants } = usePermissions(viewerOwnsSession ? (sessionId ?? null) : null);
+  const isSessionShared = isSessionSharedWithOthers(owner ?? null, viewerId, ownerGrants);
 
   useEffect(() => {
     return () => {
@@ -1246,7 +1255,7 @@ export function AgentInfoContent({
           )}
         </div>
       )}
-      {sessionId && owner && (
+      {sessionId && owner && isSessionShared && (
         <div className="flex flex-col gap-1.5">
           <SectionLabel>Owner</SectionLabel>
           <span

--- a/ap-web/src/lib/permissionsApi.ts
+++ b/ap-web/src/lib/permissionsApi.ts
@@ -66,6 +66,26 @@ export function derivePermissionLevel(
   return null;
 }
 
+/**
+ * Whether a session is visible to anyone other than the viewer: another
+ * principal owns it (so it's shared *with* the viewer), or the viewer owns
+ * it and granted access to a non-viewer principal (a user or the
+ * ``__public__`` sentinel). ``ownerGrants`` is ``undefined`` until loaded /
+ * when the viewer isn't the owner and can't read the manage-only grant list.
+ *
+ * Used to gate owner-attribution UI (author labels, the info popover's Owner
+ * row) so private solo sessions stay uncluttered.
+ */
+export function isSessionSharedWithOthers(
+  owner: string | null,
+  viewerId: string | null,
+  ownerGrants: readonly { user_id: string }[] | undefined,
+): boolean {
+  if (owner !== null && viewerId !== null && owner !== viewerId) return true;
+  const viewerOwnsSession = owner !== null && owner === viewerId;
+  return viewerOwnsSession && (ownerGrants ?? []).some((g) => g.user_id !== viewerId);
+}
+
 export interface Permission {
   user_id: string;
   conversation_id: string;

--- a/ap-web/src/pages/ChatPage.test.ts
+++ b/ap-web/src/pages/ChatPage.test.ts
@@ -3,6 +3,7 @@ import type { RenderItem } from "@/lib/renderItems";
 import type { ToolExecution } from "@/lib/blocks";
 import type { Bubble } from "@/lib/renderItems";
 import { BUILTIN_SLASH_COMMANDS, isSlashCommandText } from "@/components/SlashCommandMenu";
+import { isSessionSharedWithOthers } from "@/lib/permissionsApi";
 import {
   buildPendingBubbles,
   buildSlashCommandMap,
@@ -13,7 +14,6 @@ import {
   computeShowsWorking,
   containsMarkdownTable,
   dispatchInitialPrompt,
-  isSessionSharedWithOthers,
   isUnboundCodingFork,
   mergePendingBubbles,
   readOnlyReasonForSessionLabels,

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -85,7 +85,11 @@ import { usePromptHistory } from "@/hooks/usePromptHistory";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useIOSNativeKeyboardVisible } from "@/hooks/useIOSNativeKeyboardInset";
 import type { MessageContentBlock } from "@/lib/blocks";
-import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
+import {
+  derivePermissionLevel,
+  isOwnerLevel,
+  isSessionSharedWithOthers,
+} from "@/lib/permissionsApi";
 import {
   type Bubble,
   type RenderItem,
@@ -378,21 +382,6 @@ export function shouldShowAuthorBadge(
   isSessionShared: boolean,
 ): boolean {
   return isSessionShared && author !== undefined && author !== viewerId;
-}
-
-// Shared = someone other than the viewer can see the session: another
-// principal owns it (shared with the viewer), or the viewer owns it and
-// granted access to a non-viewer principal (a user or the __public__
-// sentinel). ownerGrants is undefined until loaded / when the viewer
-// isn't the owner and can't read the manage-only grant list.
-export function isSessionSharedWithOthers(
-  owner: string | null,
-  viewerId: string | null,
-  ownerGrants: readonly { user_id: string }[] | undefined,
-): boolean {
-  if (owner !== null && viewerId !== null && owner !== viewerId) return true;
-  const viewerOwnsSession = owner !== null && owner === viewerId;
-  return viewerOwnsSession && (ownerGrants ?? []).some((g) => g.user_id !== viewerId);
 }
 
 // Author labels render only in a shared session; ChatPage provides the


### PR DESCRIPTION
## What

The session info popover (header info-icon) showed an **Owner** field for every session, including private solo sessions where it just reads `local (you)` / your own id — noise with no value.

This gates the Owner row so it appears **only when the session is actually shared** with someone else or made public.

## How

- Moved the existing pure `isSessionSharedWithOthers(owner, viewerId, ownerGrants)` predicate from `ChatPage.tsx` into `permissionsApi.ts`, next to the permission types it reasons about, so both ChatPage's author-label gate and `AgentInfo` import it directly (no re-export shim).
- `AgentInfo` now computes sharing status the same way ChatPage does: it fetches the owner's grant list via `usePermissions` (only when the viewer owns the session — that list is manage-only) and gates the Owner row on the predicate.

A session counts as shared when another principal owns it (shared *with* you), or you own it and granted access to another user or the `__public__` sentinel.

## Test

- Updated `AgentInfo.test.tsx`: owner row shows when another user owns it, when the owner shared with another user, and when public; hidden for a private solo session or when no owner is known.
- `ChatPage.test.ts` imports the predicate from `permissionsApi`.
- `npm run type-check` and the affected vitest suites pass (166 tests).