### PR TITLE
test(runner): close bg-turn drain race in stream-failed test

### DIFF
--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -148,6 +148,28 @@ class _FakeHarnessStream:
             yield chunk
 
 
+async def _await_bg_turn_task(conv: str, *, timeout: float = 10.0) -> None:
+    """Await the fire-and-forget background turn task for *conv* before draining.
+
+    The ``POST /events`` background path returns 202 before its turn task
+    (named ``turn-{conv}``) finishes publishing the terminal ``session.status``.
+    Awaiting that task by name removes the race where a status-queue drain's
+    timeout expires under heavy CI load before the task completes. A task that
+    already finished is absent from ``asyncio.all_tasks()`` (it published its
+    terminal status synchronously on the way out), so a ``None`` lookup is a
+    safe no-op.
+
+    :param conv: Session/conversation identifier, e.g. ``"conv_abc123"``.
+    :param timeout: Hard cap in seconds for awaiting the task.
+    """
+    turn_task = next(
+        (t for t in asyncio.all_tasks() if t.get_name() == f"turn-{conv}"),
+        None,
+    )
+    if turn_task is not None:
+        await asyncio.wait_for(turn_task, timeout=timeout)
+
+
 async def _drain_published_statuses(
     conv: str,
     *,
@@ -1511,16 +1533,7 @@ async def test_runner_background_turn_emits_failed_when_spawn_env_build_raises(
             },
         )
         assert response.status_code == 202
-        # Await the background turn task directly so we know it has
-        # completed (and published its terminal status) before draining.
-        # This eliminates the race where the drain's timeout expires
-        # before the task finishes under heavy CI load.
-        turn_task = next(
-            (t for t in asyncio.all_tasks() if t.get_name() == f"turn-{conv}"),
-            None,
-        )
-        if turn_task is not None:
-            await asyncio.wait_for(turn_task, timeout=10.0)
+        await _await_bg_turn_task(conv)
         statuses = await _drain_published_statuses(conv, until="failed", timeout=2.0)
 
     # The turn published "running" then "failed" — it reached a terminal
@@ -1606,14 +1619,7 @@ async def test_runner_failed_status_carries_setup_error_message(
             },
         )
         assert response.status_code == 202
-        # Await the background turn task directly so we know it has
-        # completed (and published its terminal status) before draining.
-        turn_task = next(
-            (t for t in asyncio.all_tasks() if t.get_name() == f"turn-{conv}"),
-            None,
-        )
-        if turn_task is not None:
-            await asyncio.wait_for(turn_task, timeout=10.0)
+        await _await_bg_turn_task(conv)
         failed_event = await _drain_failed_status_event(conv, timeout=2.0)
 
     # The failed event must carry the real setup error message — not a
@@ -1794,7 +1800,11 @@ async def test_runner_publishes_terminal_failed_when_harness_stream_fails(
             },
         )
         assert response.status_code == 202
-        events = await _drain_status_events(conv, until=until, timeout=10.0)
+        # Await the background turn task directly so we know it has completed
+        # (and published its terminal status) before draining — the same race
+        # guard the sibling failed-status tests use.
+        await _await_bg_turn_task(conv)
+        events = await _drain_status_events(conv, until=until, timeout=2.0)
 
     statuses = [event.get("status") for event in events]
     # The turn must reach the parametrized terminal state. Without the fix,


### PR DESCRIPTION
## Related issue

N/A. Follow-up to #1332 (flaky test fix).

## Summary

- #1332 fixed the background-turn polling race in two `test_runner_dispatch.py` tests by awaiting the `turn-{conv}` task before draining the status queue, but `test_runner_publishes_terminal_failed_when_harness_stream_fails` kept the old fire-and-forget drain (`timeout=10.0`, no await).
- That test drives the same `POST /events` background path (the 202 returns before the turn task publishes its terminal `session.status`), so under heavy parallel CI load the drain can time out before the task finishes. Same flaky `['running'] == ['running', 'failed']` symptom #1332 addressed elsewhere.
- Factor the await-task-by-name guard into a shared `_await_bg_turn_task` helper and apply it at all three call sites (the previously-unguarded stream-failed test plus the two #1332 inlined), so the pattern can't drift back into a race.

## Test Plan

- `pytest tests/runner/test_runner_dispatch.py`, 130 passed.
- 10/10 repeated runs of `test_runner_publishes_terminal_failed_when_harness_stream_fails` (all 3 parametrized cases), green.
- `ruff check tests/runner/test_runner_dispatch.py` passes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Test-only change: a flaky timing guard in existing runner-dispatch tests. The
guard is exercised by the same tests it stabilizes, verified via the repeated
runs above.
