### PR TITLE
ci: ignore tests/e2e_ui/** in CI, Integration, and Windows workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    paths-ignore: ['ap-web/**']
+    paths-ignore: ['ap-web/**', 'tests/e2e_ui/**']
   push:
     branches:
       - main
-    paths-ignore: ['ap-web/**']
+    paths-ignore: ['ap-web/**', 'tests/e2e_ui/**']
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ on:
     # Security Gate via rerun-security-gate.yml, so label churn need not re-run
     # the heavy integration suite. (#399 added these for the gate; superseded.)
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore: ['ap-web/**']
+    paths-ignore: ['ap-web/**', 'tests/e2e_ui/**']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,11 +10,11 @@ name: Windows (native)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore: ['ap-web/**']
+    paths-ignore: ['ap-web/**', 'tests/e2e_ui/**']
   push:
     branches:
       - main
-    paths-ignore: ['ap-web/**']
+    paths-ignore: ['ap-web/**', 'tests/e2e_ui/**']
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Add `tests/e2e_ui/**` to `paths-ignore` in `ci.yml`, `integration.yml`, and `windows.yml`, alongside the existing `ap-web/**`. This matches what `e2e.yml` already does.

## Why

These workflows never exercise `tests/e2e_ui/`:
- `pyproject.toml` `addopts` already sets `--ignore=tests/e2e_ui`, so the default pytest run — including `ci.yml`'s `misc` catch-all — never collects it.
- `integration.yml` and `windows.yml` don't run it either.
- Those tests run **only** in `e2e-ui.yml` (left untouched).

So a PR touching only `tests/e2e_ui/**` was triggering these jobs for no coverage benefit.

## Merge gate safety

The `Merge Ready` required check handles the now-absent checks correctly:
- All `Pytest (*)` and `Integration (*)` required checks are in `ALLOW_SKIP` and are classified as legitimately path-ignored by `evaluate-checks.sh`.
- `windows.yml` is non-blocking (not in `REQUIRED`).
- `E2E UI Tests (shard *)` still runs and reports, since `e2e-ui.yml` is unchanged.
- `Pre-commit checks` (`lint.yml`) is intentionally left running — it has no `paths-ignore`.

A PR that touches `tests/e2e_ui/**` *and* other code still runs all jobs, since `paths-ignore` only suppresses when every changed path matches.