### PR TITLE
feat(hermes-native): support resume via --resume

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -580,6 +580,9 @@ async def forward_hermes_store_to_session(
     persisted = _read_state(bridge_dir)
     hermes_session_id: str | None = persisted.hermes_session_id
     last_id = persisted.last_id if hermes_session_id is not None else 0
+    # Track whether we have already PATCHed the external_session_id to the
+    # Omnigent server so we do it at most once per forwarder lifetime.
+    _external_id_synced = False
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
@@ -605,6 +608,24 @@ async def forward_hermes_store_to_session(
                                 last_id=last_id,
                                 launch_epoch_s=launch_epoch_s,
                             ),
+                        )
+                # PATCH the external_session_id once so the server
+                # knows which Hermes session backs this conversation
+                # (needed for fork/resume).
+                if hermes_session_id is not None and not _external_id_synced:
+                    try:
+                        resp = await client.patch(
+                            f"/v1/sessions/{session_id}",
+                            json={"external_session_id": hermes_session_id},
+                        )
+                        resp.raise_for_status()
+                        _external_id_synced = True
+                    except httpx.HTTPError:
+                        _logger.debug(
+                            "hermes forwarder failed to PATCH external_session_id; "
+                            "will retry next poll; session=%s",
+                            session_id,
+                            exc_info=True,
                         )
                 if hermes_session_id is not None:
                     # Yield to an earlier-launched live session rather than mirror

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2393,6 +2393,10 @@ async def _auto_create_hermes_terminal(
     # cursor (clear_hermes_bridge_state above) starts it at that row's first row.
     launch_epoch_s = time.time()
     hermes_args = [*(launch_config.terminal_launch_args or [])]
+    # Fork with history: resume the source Hermes session so the TUI
+    # loads the prior conversation context.
+    if launch_config.fork_carry_history and launch_config.fork_source_external_id:
+        hermes_args.extend(["--resume", launch_config.fork_source_external_id])
     # If a per-session HERMES_HOME was written (policy hook), pass it via env
     # so the TUI picks up the hook config alongside its own approval prompt.
     _hermes_terminal_env: dict[str, str] = {}

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9773,7 +9773,15 @@ def _agent_is_native(agent: Agent) -> bool:
 # text preamble (see _CURSOR_FORK_HISTORY_HARNESSES below) — switch-agent keeps
 # the current fresh-launch behavior.
 _FORK_HISTORY_NATIVE_HARNESSES: frozenset[str] = frozenset(
-    {"claude-native", "native-claude", "codex-native", "native-codex", "pi-native"}
+    {
+        "claude-native",
+        "native-claude",
+        "codex-native",
+        "native-codex",
+        "hermes-native",
+        "native-hermes",
+        "pi-native",
+    }
 )
 
 # Native harnesses that carry FORK history as a text preamble (text-prefix

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -216,9 +216,14 @@ class _Resp:
 class _FakeClient:
     def __init__(self) -> None:
         self.posts: list[tuple[str, dict]] = []
+        self.patches: list[tuple[str, dict]] = []
 
     async def post(self, url, json=None, **_kwargs):
         self.posts.append((url, json or {}))
+        return _Resp()
+
+    async def patch(self, url, json=None, **_kwargs):
+        self.patches.append((url, json or {}))
         return _Resp()
 
 
@@ -274,6 +279,97 @@ async def test_forward_loop_discovers_and_mirrors_new_messages(tmp_path, monkeyp
     assert roles == ["user", "assistant"]
     # High-water cursor persisted so a restart resumes without re-posting.
     assert f._read_state(tmp_path).hermes_session_id == "20260620_1"
+
+
+async def test_forward_loop_patches_external_session_id_once(tmp_path, monkeypatch) -> None:
+    """The forwarder PATCHes external_session_id when it first discovers the Hermes session.
+
+    Runs the full forward loop with all HTTP calls intercepted at the
+    ``httpx.AsyncClient`` level (constructor replaced by a fake async-context-
+    manager). The first ``test_forward_loop_discovers_and_mirrors_new_messages``
+    test creates a *real* ``httpx.AsyncClient`` which can interfere with
+    class-level patches on subsequent tests, so we replace the constructor
+    entirely to stay fully in-process.
+    """
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    _seed_db(db, cwd=workspace, started_at=1000.0)
+
+    patched_calls: list[tuple[str, dict]] = []
+
+    async def _fake_post(_client, *, session_id, item):
+        pass  # ignore mirrored items for this test
+
+    monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
+
+    iteration = {"n": 0}
+
+    # Build a self-contained fake client + constructor so the forward loop
+    # never touches real httpx internals.
+    class _Client:
+        async def post(self, url, json=None, **_kw):
+            return _Resp()
+
+        async def patch(self, url, json=None, **_kw):
+            patched_calls.append((url, json or {}))
+            return _Resp()
+
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def _make_client(**_kw):
+        yield _Client()
+
+    # Patch the module attribute that ``forward_hermes_store_to_session`` reads
+    # at call time (``httpx.AsyncClient``).  Using ``monkeypatch.setattr`` on
+    # the *module* object the forwarder imports (``f.httpx``) guarantees the
+    # right target and automatic undo.
+    monkeypatch.setattr(
+        f,
+        "httpx",
+        type(
+            "_httpx",
+            (),
+            {
+                "AsyncClient": _make_client,
+                "Timeout": lambda *a, **kw: None,
+                "Auth": None,
+                "HTTPError": Exception,
+            },
+        ),
+    )
+
+    async def _sleep(_s):
+        iteration["n"] += 1
+        if iteration["n"] >= 3:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+    # Use a subdirectory for bridge_dir so the claim guard doesn't see
+    # sibling test directories (which may contain state from earlier tests
+    # that used the same hermes session id).
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv_patch",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    # The PATCH should have been called exactly once even though we ran 3 iterations.
+    patch_calls = [(url, body) for url, body in patched_calls if "external_session_id" in body]
+    assert len(patch_calls) == 1
+    url, body = patch_calls[0]
+    assert url == "/v1/sessions/conv_patch"
+    assert body["external_session_id"] == "20260620_1"
 
 
 # --- Usage tracker tests ---------------------------------------------------


### PR DESCRIPTION
## Summary
- **Forwarder PATCHes `external_session_id`**: When the forwarder discovers the Hermes session ID from `state.db`, it PATCHes it to the Omnigent server so fork knows the source's native session ID.
- **Resume with `--resume`**: When resuming a hermes-native session with carry-history, `_auto_create_hermes_terminal` passes `--resume <source_hermes_session_id>` to the new TUI so Hermes loads the full prior conversation.

<img width="718" height="676" alt="image" src="https://github.com/user-attachments/assets/62390830-4545-4977-b462-a998db3fc20f" />