### PR TITLE
ci(e2e-ui): cache Codex parity sidecar Rust build

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -143,6 +143,24 @@ jobs:
           sudo apt-get install -y bubblewrap tmux
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+      # Rust toolchain + target cache for the Codex parity sidecar. The
+      # mocked_native_codex_goal_session fixture builds tests/codex_parity/
+      # sidecar via `cargo build` (it pulls openai/codex's core_test_support
+      # crate, a multi-minute cold compile). Without this cache the build runs
+      # from scratch on whichever shard collects test_codex_goal_mode, adding
+      # ~9min to that shard. Mirrors ci.yml's codex-parity job: pin the
+      # toolchain for a stable cache fingerprint, key on the sidecar Cargo.lock.
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: .tmp-codex-parity-target
+          key: codex-parity-sidecar-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock') }}
+
       - name: Cache Playwright browsers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:


### PR DESCRIPTION
## Problem

e2e_ui CI jobs started taking >10 min per shard. The culprit is a single test:

`tests/e2e_ui/chat/test_codex_goal_mode.py::test_codex_goal_mode_with_mocked_responses`

In a recent run it took **8m53s** while every other test in the shard finished in <=34s. The time is almost entirely a **cold Rust compile**: its fixture (`mocked_native_codex_goal_session`) calls `build_sidecar_bin()`, which runs `cargo build` on `tests/codex_parity/sidecar`. That crate pulls `core_test_support` straight from `openai/codex.git`, dragging in the whole Codex Rust dependency tree -- a multi-minute debug compile on a 2-core runner.

`e2e-ui.yml` had **no Rust caching**, so whichever shard collected the test recompiled from scratch every run.

## Fix

Mirror `ci.yml`'s `codex-parity` job:
- Pin the Rust toolchain (`dtolnay/rust-toolchain` stable) for a stable cargo cache fingerprint.
- Cache `.tmp-codex-parity-target` (the `--target-dir` `build_sidecar_bin()` writes to), keyed on `tests/codex_parity/sidecar/Cargo.lock`.

The cache key is **identical** to `ci.yml`'s, and Actions caches are shared across workflows within a repo -- so e2e-ui can restore the cache `ci.yml`'s codex-parity job already populates, meaning the warm path should hit even on the first run.

## Expected impact

Warm `cargo build` is ~40-60s (measured across six `ci.yml` runs) vs the ~8min cold compile. The test should drop from ~9 min to roughly ~2 min, bringing the shard back under 10 min.