### PR TITLE
feat(ci): sync PR reviewer with linked-issue assignee

### DIFF
--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -19,6 +19,18 @@
 //
 // Only handles drawn from .github/reviewers are ever removed when reconciling,
 // so a manually-added reviewer outside that set is left untouched.
+//
+// Linked-issue sync: the PR's linked ("closes #N") issues are consulted so the
+// PR reviewer and the linked-issue assignee stay one and the same person.
+//   - If a linked issue is ALREADY assigned to a maintainer, that maintainer is
+//     adopted as the PR reviewer (overriding the load-balanced area pick) --
+//     "the person who owns the issue reviews the fix".
+//   - Whoever ends up the reviewer is then assigned onto any linked issue that
+//     has NO assignee yet, so an unowned issue inherits the PR's reviewer.
+// Only maintainers are adopted as reviewers (a non-maintainer assignee can't be
+// requested for review); the push-down direction assigns regardless. Existing
+// divergences on already-assigned issues are left untouched. Needs
+// issues:write (see auto-assign-reviewer.yml) to assign the linked issue.
 module.exports = async ({ github, context, core }) => {
   const fs = require("fs");
   const TARGET = 1;
@@ -99,6 +111,46 @@ module.exports = async ({ github, context, core }) => {
     return;
   }
 
+  // --- Linked ("closes #N") issues for this PR, via GraphQL (the REST PR
+  // payload doesn't carry them). Same-repo only. A failure here must not block
+  // reviewer assignment, so it degrades to "no linked issues".
+  let linkedIssues = []; // [{ number, assignees: [original-case logins] }]
+  try {
+    const data = await github.graphql(
+      `query($owner:String!, $repo:String!, $number:Int!) {
+        repository(owner:$owner, name:$repo) {
+          pullRequest(number:$number) {
+            closingIssuesReferences(first: 20) {
+              nodes {
+                number
+                repository { nameWithOwner }
+                assignees(first: 20) { nodes { login } }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, repo, number: pr.number }
+    );
+    const nodes =
+      data?.repository?.pullRequest?.closingIssuesReferences?.nodes || [];
+    linkedIssues = nodes
+      .filter((n) => n && n.repository?.nameWithOwner === `${owner}/${repo}`)
+      .map((n) => ({
+        number: n.number,
+        assignees: (n.assignees?.nodes || []).map((a) => a.login),
+      }));
+  } catch (e) {
+    core.warning(`Could not read linked issues; proceeding without them: ${e.message}`);
+  }
+
+  // Maintainers already assigned to a linked issue -> adopt as the reviewer.
+  // (A non-maintainer assignee can't be requested for review, so it's ignored
+  // here; the push-down below still keeps unassigned issues in sync.)
+  const issueReviewers = [
+    ...new Set(linkedIssues.flatMap((li) => li.assignees)),
+  ].filter((u) => maint.has(u.toLowerCase()) && u.toLowerCase() !== author);
+
   // --- Global open-review load (stateless fairness signal).
   const openPRs = await github.paginate(github.rest.pulls.list, {
     owner,
@@ -130,13 +182,21 @@ module.exports = async ({ github, context, core }) => {
     return out;
   };
 
-  // Desired = 1 lowest-load from candidates; top up from the full pool if an
-  // area has fewer than 1 owner.
-  let desired = takeLowest(candidates, TARGET);
-  if (desired.length < TARGET) {
-    const have = new Set(desired.map((u) => u.toLowerCase()).concat(author));
-    const filler = [...poolSet.values()].filter((u) => !have.has(u.toLowerCase()));
-    desired = desired.concat(takeLowest(filler, TARGET - desired.length));
+  // Desired reviewer. A maintainer already assigned to a linked issue wins
+  // (load-balanced if several), so the issue owner reviews the fix. Otherwise
+  // fall back to 1 lowest-load area candidate, topped up from the full pool if
+  // the area has no eligible owner.
+  let desired;
+  if (issueReviewers.length) {
+    desired = takeLowest(issueReviewers, TARGET);
+    core.info(`Adopting linked-issue assignee(s) [${issueReviewers.join(", ")}] as reviewer.`);
+  } else {
+    desired = takeLowest(candidates, TARGET);
+    if (desired.length < TARGET) {
+      const have = new Set(desired.map((u) => u.toLowerCase()).concat(author));
+      const filler = [...poolSet.values()].filter((u) => !have.has(u.toLowerCase()));
+      desired = desired.concat(takeLowest(filler, TARGET - desired.length));
+    }
   }
   const desiredLc = new Set(desired.map((u) => u.toLowerCase()));
 
@@ -183,9 +243,31 @@ module.exports = async ({ github, context, core }) => {
     });
   }
 
+  // --- Push-down: mirror the chosen reviewer onto any linked issue that has no
+  // assignee yet, so an unowned issue inherits the PR's reviewer. Already-
+  // assigned issues are left as-is (existing divergence is tolerated). Per-issue
+  // try/catch so one un-assignable issue can't abort the rest.
+  const syncedIssues = [];
+  if (desired.length) {
+    for (const li of linkedIssues) {
+      if (li.assignees.length) continue;
+      try {
+        await github.rest.issues.addAssignees({
+          owner, repo, issue_number: li.number, assignees: desired,
+        });
+        syncedIssues.push(li.number);
+      } catch (e) {
+        core.warning(`Could not assign linked issue #${li.number}: ${e.message}`);
+      }
+    }
+  }
+
   core.info(
     `Reviewers -> [${desired.join(", ")}]` +
       ` (area pool ${areaOwners.size || "∅→full"}, +${toAdd.length}/-${toRemove.length})` +
-      ` | Assignees +${toAddAssignees.length}/-${toRemoveAssignees.length}.`
+      ` | Assignees +${toAddAssignees.length}/-${toRemoveAssignees.length}` +
+      ` | Linked issues: ${linkedIssues.length || "none"}` +
+      `${issueReviewers.length ? ` (adopted owner)` : ""}` +
+      `${syncedIssues.length ? `, synced #${syncedIssues.join(", #")}` : ""}.`
   );
 };

--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -22,15 +22,19 @@
 //
 // Linked-issue sync: the PR's linked ("closes #N") issues are consulted so the
 // PR reviewer and the linked-issue assignee stay one and the same person.
-//   - If a linked issue is ALREADY assigned to a maintainer, that maintainer is
-//     adopted as the PR reviewer (overriding the load-balanced area pick) --
-//     "the person who owns the issue reviews the fix".
+//   - If a linked issue is ALREADY assigned to someone in the reviewers pool,
+//     that person is adopted as the PR reviewer (overriding the load-balanced
+//     area pick) -- "the person who owns the issue reviews the fix".
 //   - Whoever ends up the reviewer is then assigned onto any linked issue that
 //     has NO assignee yet, so an unowned issue inherits the PR's reviewer.
-// Only maintainers are adopted as reviewers (a non-maintainer assignee can't be
-// requested for review); the push-down direction assigns regardless. Existing
-// divergences on already-assigned issues are left untouched. Needs
-// issues:write (see auto-assign-reviewer.yml) to assign the linked issue.
+// Adoption is restricted to the managed reviewers pool (not the wider MAINTAINER
+// set) so an adopted reviewer is always removable by the reconcile step -- a
+// MAINTAINER not in the pool would be unremovable and could break the "exactly
+// 1 reviewer" invariant on a reopen. The push-down direction assigns regardless,
+// capped at MAX_PUSHDOWN issues since the fork-author-controlled PR body chooses
+// the linked issues. Existing divergences on already-assigned issues are left
+// untouched. Needs issues:write (see auto-assign-reviewer.yml) to assign the
+// linked issue.
 module.exports = async ({ github, context, core }) => {
   const fs = require("fs");
   const TARGET = 1;
@@ -144,12 +148,17 @@ module.exports = async ({ github, context, core }) => {
     core.warning(`Could not read linked issues; proceeding without them: ${e.message}`);
   }
 
-  // Maintainers already assigned to a linked issue -> adopt as the reviewer.
-  // (A non-maintainer assignee can't be requested for review, so it's ignored
-  // here; the push-down below still keeps unassigned issues in sync.)
+  // Linked-issue assignees who are in the .github/reviewers pool -> adopt as
+  // the reviewer. Restricted to the MANAGED pool (not the wider MAINTAINER set)
+  // on purpose: an adopted reviewer must be removable by the reconcile step
+  // below (which only touches `managed` handles), or a reopened PR could end up
+  // with two reviewers -- breaking the "exactly 1" invariant. Pool members are
+  // also known area reviewers (collaborators), so adoption can't route a fork PR
+  // to an arbitrary or non-collaborator maintainer. A maintainer assigned to the
+  // issue but in no area pool falls through to the normal area pick.
   const issueReviewers = [
     ...new Set(linkedIssues.flatMap((li) => li.assignees)),
-  ].filter((u) => maint.has(u.toLowerCase()) && u.toLowerCase() !== author);
+  ].filter((u) => managed.has(u.toLowerCase()) && u.toLowerCase() !== author);
 
   // --- Global open-review load (stateless fairness signal).
   const openPRs = await github.paginate(github.rest.pulls.list, {
@@ -213,9 +222,15 @@ module.exports = async ({ github, context, core }) => {
   );
 
   if (toAdd.length) {
-    await github.rest.pulls.requestReviewers({
-      owner, repo, pull_number: pr.number, reviewers: toAdd,
-    });
+    // Don't let a failed review request (e.g. a 422 for a non-collaborator)
+    // abort the assignee sync + push-down that follow.
+    try {
+      await github.rest.pulls.requestReviewers({
+        owner, repo, pull_number: pr.number, reviewers: toAdd,
+      });
+    } catch (e) {
+      core.warning(`Could not request reviewers [${toAdd.join(", ")}]: ${e.message}`);
+    }
   }
   if (toRemove.length) {
     await github.rest.pulls.removeRequestedReviewers({
@@ -245,17 +260,30 @@ module.exports = async ({ github, context, core }) => {
 
   // --- Push-down: mirror the chosen reviewer onto any linked issue that has no
   // assignee yet, so an unowned issue inherits the PR's reviewer. Already-
-  // assigned issues are left as-is (existing divergence is tolerated). Per-issue
-  // try/catch so one un-assignable issue can't abort the rest.
-  const syncedIssues = [];
+  // assigned issues are left as-is (existing divergence is tolerated).
+  //
+  // Bounded by MAX_PUSHDOWN: the PR body is fork-author-controlled, so a PR
+  // could list `closes #1..#20` to drive a maintainer onto many issues (bounded,
+  // reversible churn -- never an arbitrary user, same-repo only). The norm is one
+  // issue per PR, so a small cap blocks the abuse case without affecting real
+  // PRs; anything dropped is logged rather than silently skipped.
+  const MAX_PUSHDOWN = 5;
+  const unassignedLinked = linkedIssues.filter((li) => li.assignees.length === 0);
+  if (unassignedLinked.length > MAX_PUSHDOWN) {
+    core.warning(
+      `${unassignedLinked.length} unassigned linked issues; capping push-down at ` +
+        `${MAX_PUSHDOWN}. Skipped: #${unassignedLinked.slice(MAX_PUSHDOWN).map((li) => li.number).join(", #")}.`
+    );
+  }
+  // Per-issue try/catch so one un-assignable issue can't abort the rest.
+  const pushedIssues = [];
   if (desired.length) {
-    for (const li of linkedIssues) {
-      if (li.assignees.length) continue;
+    for (const li of unassignedLinked.slice(0, MAX_PUSHDOWN)) {
       try {
         await github.rest.issues.addAssignees({
           owner, repo, issue_number: li.number, assignees: desired,
         });
-        syncedIssues.push(li.number);
+        pushedIssues.push(li.number);
       } catch (e) {
         core.warning(`Could not assign linked issue #${li.number}: ${e.message}`);
       }
@@ -268,6 +296,8 @@ module.exports = async ({ github, context, core }) => {
       ` | Assignees +${toAddAssignees.length}/-${toRemoveAssignees.length}` +
       ` | Linked issues: ${linkedIssues.length || "none"}` +
       `${issueReviewers.length ? ` (adopted owner)` : ""}` +
-      `${syncedIssues.length ? `, synced #${syncedIssues.join(", #")}` : ""}.`
+      // addAssignees silently ignores users lacking push access, so this is
+      // "assignment requested", not a guaranteed landing.
+      `${pushedIssues.length ? `, push-down requested on #${pushedIssues.join(", #")}` : ""}.`
   );
 };

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -15,14 +15,37 @@ function mkOpenPRs(loadMap) {
 
 // author defaults to a non-maintainer; fork defaults to true -- so the scope
 // guard passes and the selection logic runs (the cases that assert on picks).
-async function run({ files, load = {}, current = [], currentAssignees = [], author = "someexternaldev", fork = true }) {
+// `linkedIssues` is [{ number, assignees: [logins], repo? }] -- the PR's
+// "closes #N" references, served back through the mocked GraphQL endpoint.
+async function run({
+  files, load = {}, current = [], currentAssignees = [],
+  author = "someexternaldev", fork = true, linkedIssues = [],
+}) {
   const listFiles = () => {}; listFiles._tag = "files";
   const list = () => {}; list._tag = "open";
-  const added = [], removed = [], assigned = [], unassigned = [];
+  const PR_NUMBER = 1;
+  const added = [], removed = [], unassigned = [];
+  // PR-assignee changes (issue_number === PR) vs linked-issue assignments are
+  // tracked separately so tests can assert the push-down direction in isolation.
+  const assigned = [];                 // assignees added to the PR itself
+  const issueAssigned = {};            // { issueNumber: [logins] } for linked issues
   const github = {
     paginate: async (fn) => (fn._tag === "files"
       ? files.map((f) => ({ filename: f }))
       : mkOpenPRs(load)),
+    graphql: async () => ({
+      repository: {
+        pullRequest: {
+          closingIssuesReferences: {
+            nodes: linkedIssues.map((li) => ({
+              number: li.number,
+              repository: { nameWithOwner: li.repo || "omnigent-ai/omnigent" },
+              assignees: { nodes: (li.assignees || []).map((login) => ({ login })) },
+            })),
+          },
+        },
+      },
+    }),
     rest: {
       pulls: {
         listFiles, list,
@@ -30,7 +53,10 @@ async function run({ files, load = {}, current = [], currentAssignees = [], auth
         removeRequestedReviewers: async ({ reviewers }) => removed.push(...reviewers),
       },
       issues: {
-        addAssignees: async ({ assignees }) => assigned.push(...assignees),
+        addAssignees: async ({ issue_number, assignees }) => {
+          if (issue_number === PR_NUMBER) assigned.push(...assignees);
+          else (issueAssigned[issue_number] ||= []).push(...assignees);
+        },
         removeAssignees: async ({ assignees }) => unassigned.push(...assignees),
       },
     },
@@ -38,7 +64,7 @@ async function run({ files, load = {}, current = [], currentAssignees = [], auth
   const context = {
     repo: { owner: "omnigent-ai", repo: "omnigent" },
     payload: { pull_request: {
-      number: 1, draft: false,
+      number: PR_NUMBER, draft: false,
       user: { login: author },
       // precise fork detection compares head vs base full_name
       head: { repo: { full_name: fork ? "external-contributor/omnigent" : "omnigent-ai/omnigent" } },
@@ -49,7 +75,11 @@ async function run({ files, load = {}, current = [], currentAssignees = [], auth
   };
   const core = { info: () => {}, warning: (m) => console.log("WARN", m) };
   await script({ github, context, core });
-  return { added: added.sort(), removed: removed.sort(), assigned: assigned.sort(), unassigned: unassigned.sort() };
+  return {
+    added: added.sort(), removed: removed.sort(),
+    assigned: assigned.sort(), unassigned: unassigned.sort(),
+    issueAssigned,
+  };
 }
 
 function assert(name, cond, detail) {
@@ -140,4 +170,69 @@ function assert(name, cond, detail) {
   // 9. scope guard: fork PR authored by a maintainer -> nothing assigned.
   r = await run({ files: ["omnigent/inner/foo.py"], author: "dhruv0811" });
   assert("maintainer-authored fork PR is skipped", r.added.length === 0 && r.removed.length === 0, JSON.stringify(r));
+
+  // 10. linked issue ALREADY assigned to a maintainer -> adopted as reviewer,
+  //     overriding the area pick (dhruv0811 would otherwise win on load here).
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    linkedIssues: [{ number: 42, assignees: ["TomeHirata"] }],
+  });
+  assert("linked-issue maintainer assignee is adopted as reviewer",
+    JSON.stringify(r.added) === JSON.stringify(["TomeHirata"]), JSON.stringify(r));
+  assert("adopted reviewer also mirrored onto the PR assignees",
+    JSON.stringify(r.assigned) === JSON.stringify(["TomeHirata"]), JSON.stringify(r));
+  assert("already-assigned linked issue is NOT re-assigned",
+    Object.keys(r.issueAssigned).length === 0, JSON.stringify(r.issueAssigned));
+
+  // 11. linked issue with NO assignee -> normal area pick, then pushed down onto
+  //     the issue so it inherits the PR's reviewer.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    linkedIssues: [{ number: 77, assignees: [] }],
+  });
+  assert("unassigned linked issue: reviewer is the area pick",
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
+  assert("unassigned linked issue inherits the chosen reviewer",
+    JSON.stringify(r.issueAssigned[77]) === JSON.stringify(["dhruv0811"]), JSON.stringify(r.issueAssigned));
+
+  // 12. linked issue assigned to a NON-maintainer -> not adopted (area pick
+  //     stands) and not re-assigned (it already has an assignee).
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    linkedIssues: [{ number: 88, assignees: ["someexternaldev"] }],
+  });
+  assert("non-maintainer issue assignee is NOT adopted as reviewer",
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
+  assert("issue with a (non-maintainer) assignee is left untouched",
+    Object.keys(r.issueAssigned).length === 0, JSON.stringify(r.issueAssigned));
+
+  // 13. two linked issues -- one assigned to a maintainer, one unassigned: the
+  //     maintainer is adopted AND mirrored onto the unassigned sibling.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    linkedIssues: [
+      { number: 10, assignees: ["TomeHirata"] },
+      { number: 11, assignees: [] },
+    ],
+  });
+  assert("two issues: maintainer adopted as reviewer",
+    JSON.stringify(r.added) === JSON.stringify(["TomeHirata"]), JSON.stringify(r));
+  assert("two issues: unassigned sibling inherits the same reviewer",
+    JSON.stringify(r.issueAssigned[11]) === JSON.stringify(["TomeHirata"]) &&
+    !(10 in r.issueAssigned), JSON.stringify(r.issueAssigned));
+
+  // 14. cross-repo linked issue is ignored (different nameWithOwner).
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    linkedIssues: [{ number: 99, assignees: ["TomeHirata"], repo: "other-org/other-repo" }],
+  });
+  assert("cross-repo linked issue does not affect the reviewer pick",
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
+  assert("cross-repo linked issue is not assigned",
+    Object.keys(r.issueAssigned).length === 0, JSON.stringify(r.issueAssigned));
 })();

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -73,12 +73,13 @@ async function run({
       assignees: currentAssignees.map((l) => ({ login: l })),
     } },
   };
-  const core = { info: () => {}, warning: (m) => console.log("WARN", m) };
+  const warnings = [];
+  const core = { info: () => {}, warning: (m) => warnings.push(m) };
   await script({ github, context, core });
   return {
     added: added.sort(), removed: removed.sort(),
     assigned: assigned.sort(), unassigned: unassigned.sort(),
-    issueAssigned,
+    issueAssigned, warnings,
   };
 }
 
@@ -235,4 +236,32 @@ function assert(name, cond, detail) {
     JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
   assert("cross-repo linked issue is not assigned",
     Object.keys(r.issueAssigned).length === 0, JSON.stringify(r.issueAssigned));
+
+  // 15. linked issue assigned to a maintainer who is NOT in the reviewers pool
+  //     (hzub is in .github/MAINTAINER but not .github/reviewers): NOT adopted
+  //     (adoption is restricted to the managed pool so the reviewer stays
+  //     removable), so the normal area pick stands. The issue already has an
+  //     assignee, so no push-down.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    linkedIssues: [{ number: 55, assignees: ["hzub"] }],
+  });
+  assert("non-pool maintainer issue assignee is NOT adopted as reviewer",
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
+  assert("non-pool maintainer issue is left untouched",
+    Object.keys(r.issueAssigned).length === 0, JSON.stringify(r.issueAssigned));
+
+  // 16. push-down is capped: 7 unassigned linked issues -> only MAX_PUSHDOWN (5)
+  //     get the reviewer; the overflow is logged, not silently dropped.
+  const manyIssues = [201, 202, 203, 204, 205, 206, 207].map((n) => ({ number: n, assignees: [] }));
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    linkedIssues: manyIssues,
+  });
+  assert("push-down capped at 5 issues",
+    Object.keys(r.issueAssigned).length === 5, JSON.stringify(Object.keys(r.issueAssigned)));
+  assert("capped overflow is warned",
+    r.warnings.some((w) => /capping push-down/.test(w)), JSON.stringify(r.warnings));
 })();

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -6,13 +6,17 @@ name: Auto-assign Reviewer
 # runtime -- a custom, non-magic path (NOT .github/CODEOWNERS), so GitHub's
 # native CODEOWNERS auto-request never fires and this action is the sole
 # assigner. Non-fork / collaborator / maintainer PRs are left alone.
-# See auto-assign-reviewer.js.
+# It also keeps the PR reviewer and any linked ("closes #N") issue's assignee in
+# sync: a maintainer already assigned to a linked issue is adopted as the
+# reviewer, and the chosen reviewer is assigned onto any still-unassigned linked
+# issue. See auto-assign-reviewer.js.
 #
 # pull_request_target so it can manage reviewers on fork PRs (a fork's
 # pull_request token is read-only). Safe: it checks out only the trusted default
 # branch (.github), never PR head, and runs no PR code -- it reads .github/
-# reviewers + .github/MAINTAINER + the changed-file list and calls the reviewers
-# API. The offline unit test (auto-assign-reviewer.test.js) covers the logic.
+# reviewers + .github/MAINTAINER + the changed-file list, queries the PR's linked
+# issues, and calls the reviewers / assignees API. The offline unit test
+# (auto-assign-reviewer.test.js) covers the logic.
 
 on:
   pull_request_target:
@@ -41,7 +45,8 @@ jobs:
       # Job-level permissions REPLACE the workflow-level block (they don't
       # merge), so contents:read must be restated here for actions/checkout.
       contents: read
-      pull-requests: write   # request reviewers
+      pull-requests: write   # request reviewers + assign the PR
+      issues: write          # assign the PR's linked ("closes #N") issues
     steps:
       # Trusted default branch only (.github sparse). Never the PR head, so no
       # PR-authored code runs.


### PR DESCRIPTION
## Related issue

N/A (CI/automation change, no associated issue)

## Summary

Makes the auto-assign-reviewer action linked-issue-aware so a PR and its linked (`closes #N`) issue end up with the same owner:

- If a linked issue is **already assigned to someone in the `.github/reviewers` pool**, that person is adopted as the PR reviewer, overriding the load-balanced area pick ("the person who owns the issue reviews the fix").
- Whoever becomes the reviewer is then assigned onto any linked issue that has **no assignee yet**, so an unowned issue inherits the PR's reviewer.
- Already-assigned issues are left untouched (existing divergence is tolerated).

Scope note: this only fires on the existing path, fork PRs authored by non-maintainers. Maintainer/internal PRs still pick their own reviewers. Adoption is restricted to the managed `.github/reviewers` pool (not the wider `.github/MAINTAINER` set) so an adopted reviewer is always removable by the reconcile step; otherwise a maintainer outside the pool could become an unremovable reviewer and break the "exactly 1 reviewer" invariant on a reopen. A maintainer assigned to the issue but in no area pool falls through to the normal area pick. The push-down direction assigns regardless, capped at 5 issues since the fork-author-controlled PR body chooses which issues are linked.

### ELI5

When an outside contributor opens a PR that says "closes #123", we want the same person on both #123 and the PR, instead of one human owning the issue and a different human reviewing the code.

So the bot checks the linked issue first:

- If one of our area reviewers is already assigned to the issue, that person becomes the PR reviewer (they already own the problem, so they review the fix).
- If nobody is on the issue yet, the bot picks a reviewer the normal way (by area + who is least busy) and then puts that same person on the issue too.

Either way, the issue and the PR end up with one shared owner. Issues that already have someone on them are left alone.

### Flowchart

```mermaid
flowchart TD
    A[Fork PR opened by non-maintainer] --> B[Fetch linked closes #N issues<br/>via GraphQL, same-repo only]
    B --> C{Any linked issue<br/>already assigned to a<br/>.github/reviewers pool member?}
    C -->|Yes| D[Adopt that person<br/>as the PR reviewer]
    C -->|No| E[Pick reviewer the normal way:<br/>area owner, least open reviews]
    D --> F[Set PR reviewer + PR assignee]
    E --> F
    F --> G{For each unassigned linked issue<br/>up to a cap of 5}
    G --> I[Assign the chosen reviewer<br/>onto the issue]
    F --> H[Already-assigned issues:<br/>leave untouched]
```

### How it works

Linked issues come from the PR's `closingIssuesReferences` via GraphQL (same-repo only, and a failure there degrades to "no linked issues" so reviewer assignment is never blocked). Assigning the linked issue needs `issues: write`, which is added to the job (the existing PR self-assign worked under `pull-requests: write` because a PR is an issue, but a separate issue is not).

Hardening (from review):

- Adoption is restricted to the managed `.github/reviewers` pool so an adopted reviewer is always removable by the reconcile step (no two-reviewer state on reopen), and a fork PR can't route review to a non-collaborator/arbitrary maintainer.
- The push-down is capped at 5 issues with an overflow warning, since the fork-author-controlled PR body chooses the linked issues (`closes #1..#N`).
- `requestReviewers` is wrapped in `try/catch` so a failed review request can't abort the assignee sync + push-down.

## Test Plan

Extended the offline unit test (`auto-assign-reviewer.test.js`, mocked GitHub client incl. `github.graphql`, no network) on top of the existing 12 assertions:

- linked issue already assigned to a pool reviewer is adopted (overrides area pick) and is not re-assigned
- unassigned linked issue inherits the chosen reviewer
- non-maintainer issue assignee is not adopted, and an already-assigned issue is left untouched
- two linked issues (one assigned, one not): pool reviewer adopted, unassigned sibling inherits the same reviewer
- cross-repo linked issue is ignored
- maintainer assigned to the issue but NOT in the reviewers pool is not adopted (falls back to the area pick)
- push-down is capped at 5 issues, with the overflow logged as a warning

Run: `node .github/workflows/auto-assign-reviewer.test.js` -> 27/27 assertions PASS.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The auto-assign workflow only triggers on fork PRs from non-maintainers, so it is covered by the offline unit test rather than an end-to-end run. The new linked-issue logic is exercised by the cases above against the real `.github/reviewers` and `.github/MAINTAINER` files.

This pull request and its description were written by Isaac.
