### PR TITLE
fix(merge-ready): resolve fork PRs via search API (revert ineffective check_suite trigger)

### DIFF
--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -4,11 +4,9 @@ name: Merge Ready
 # required branch-protection check, backed by the REQUIRED list inside
 # this workflow. Triggers: `/merge` comment (write-access commenter only),
 # `pull_request_target` labeled (acts only with `automerge`),
-# `workflow_run` on CI completion (re-evaluates same-repo PRs),
-# `check_suite` completion (re-evaluates fork PRs -- their CI does not deliver
-# a usable workflow_run to this base-repo workflow), and `workflow_dispatch`
-# (programmatic/manual re-evaluation of one PR). Both ctx-resolve the PR from
-# the head SHA. Posted via the REST API (not the job's implicit
+# `workflow_run` on CI completion (same-repo AND fork PRs -- ctx resolves the
+# PR from the head SHA), and `workflow_dispatch` (programmatic/manual
+# re-evaluation of one PR). Posted via the REST API (not the job's implicit
 # check run) so the status lands on the PR head SHA, since these jobs run on
 # the default branch.
 #
@@ -22,21 +20,14 @@ name: Merge Ready
 # (branch protection has enforce_admins=false).
 
 on:
-  # `labeled` only; `workflow_run` re-evaluates same-repo PRs on CI completion.
+  # `labeled` only; `workflow_run` re-evaluates on CI completion for all PRs
+  # (same-repo and fork -- ctx resolves the PR from the head SHA).
   # pull_request_target (not pull_request) so this workflow always runs from
   # main -- a PR cannot modify the gate logic by editing this file.
   pull_request_target:
     types: [labeled]
   workflow_run:
     workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]
-    types: [completed]
-  # Fork-PR CI does not deliver a usable workflow_run to this base-repo
-  # workflow, so the gate never re-evaluated when a fork's tests finished
-  # (#1004 retired the fork-e2e mirror that used to bridge this). The
-  # github-actions check_suite DOES complete in the base repo for fork PRs --
-  # once, when all the suite's workflows finish -- and ctx resolves the PR
-  # from its head SHA, so it is the fork equivalent of the workflow_run path.
-  check_suite:
     types: [completed]
   issue_comment:
     types: [created]
@@ -57,7 +48,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.event.workflow_run.head_sha || github.event.check_suite.head_sha }}
+  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -80,10 +71,6 @@ jobs:
       (
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.event == 'pull_request'
-      ) ||
-      (
-        github.event_name == 'check_suite' &&
-        github.event.check_suite.app.slug == 'github-actions'
       ) ||
       github.event_name == 'workflow_dispatch' ||
       (
@@ -120,10 +107,14 @@ jobs:
           SHA_INPUT: ${{ inputs.sha }}
         run: |
           # Resolve the open PR from a head SHA -- fork-PR events leave the
-          # payload's pull_requests array empty (cross-repo).
+          # payload's pull_requests array empty (cross-repo). Use the search
+          # API, not GET /commits/{sha}/pulls: that endpoint does not associate
+          # a fork PR's head commit (it lives in the fork, not this repo), so it
+          # returns nothing for every fork PR and the gate silently skips them.
+          # The search index covers fork-PR head SHAs.
           resolve_pr_from_sha() {
-            gh api "repos/$REPO/commits/$1/pulls" \
-              --jq 'map(select(.state == "open")) | .[0].number // empty' 2>/dev/null || true
+            gh api "search/issues?q=repo:$REPO+type:pr+state:open+sha:$1" \
+              --jq '.items[0].number // empty' 2>/dev/null || true
           }
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             PR="${{ github.event.pull_request.number }}"
@@ -152,12 +143,11 @@ jobs:
             PR="${{ github.event.issue.number }}"
             SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
           else
-            # workflow_run (same-repo) or check_suite (fork) completion.
             PR=$(echo "$WF_PRS" | jq -r '.[0].number // empty')
-            SHA="${{ github.event.workflow_run.head_sha || github.event.check_suite.head_sha }}"
+            SHA="${{ github.event.workflow_run.head_sha }}"
             [[ -z "$PR" ]] && PR=$(resolve_pr_from_sha "$SHA")
             if [[ -z "$PR" ]]; then
-              echo "::notice::Skipped: CI completion has no associated open PR (push to main, etc)"
+              echo "::notice::Skipped: workflow_run has no associated PR (push to main, etc)"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -289,7 +279,6 @@ jobs:
         if: >-
           (
             github.event_name == 'workflow_run' ||
-            github.event_name == 'check_suite' ||
             github.event_name == 'workflow_dispatch'
           ) &&
           steps.ctx.outputs.skip != 'true' &&


### PR DESCRIPTION
## Related issue

N/A. Follow-up correcting #1354, which did not fix the fork-PR Merge Ready gate.

## Summary

#1354 mis-diagnosed why Merge Ready never posts for fork PRs and added a `check_suite` trigger. Both of its premises were wrong, and it changed nothing for forks.

What is actually true (all verified against live PRs):

- `workflow_run` DOES fire for fork-PR CI completions. Every one of fork PR #1339's CI completions is matched within ~2s by a merge-ready `workflow_run` run. The job runs; it just resolves no PR and skips every subsequent step.
- The `check_suite` trigger from #1354 is a no-op. GitHub does not deliver the github-actions app's own `check_suite` events to trigger workflows (recursion prevention), so the `app.slug == 'github-actions'` guard never matches. 80/80 `check_suite`-triggered runs created after #1354 merged skipped.

The real bug is PR resolution. Fork PRs carry an empty `workflow_run.pull_requests` array (cross-repo), so ctx falls back to `resolve_pr_from_sha`, which queried `GET /commits/{sha}/pulls`. That endpoint does not associate a fork PR's head commit (it lives in the fork, not this repo), so it returns nothing for every fork PR. ctx then sets `skip=true` and the gate silently skips. This regressed in #1004, which retired the fork-e2e mirror that used to push fork head SHAs onto a base-repo branch where `commits/{sha}/pulls` could find them.

Fix:
- `resolve_pr_from_sha` now uses the search API (`search/issues?q=repo:...+type:pr+state:open+sha:<sha>`), which does index fork-PR head SHAs.
- Revert the `check_suite` trigger and its supporting edits (concurrency key, job `if`, ctx SHA fallback, gate-red parity) from #1354. Net change vs the pre-#1354 baseline is just the resolver.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/merge-ready.yml'))"` parses cleanly; no `check_suite` references remain.
- Resolver verified live: old `commits/{sha}/pulls` returns empty for open fork PRs #1308 and #1339; the new search query returns `1308` and `1339`, and `1379` for an open same-repo PR.
- Repro of the bug under #1354: fork PR #1308 has all required checks green and its CI completed after #1354 merged, yet Merge Ready is still absent; its `workflow_run` merge-ready runs ran and skipped, and its `check_suite` runs all skipped.
- End-to-end confirmation still needs a live fork-PR CI completion after this lands (watch #1308 / #1339 / #1325).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Gate logic is otherwise unchanged; only the PR-resolution call and the reverted trigger differ. The resolver was verified directly against the live GitHub API for fork and same-repo PRs (see Test Plan). The trigger-delivery and end-to-end posting behavior is only observable on GitHub's runners, so final confirmation is a live fork-PR run after merge.