### PR TITLE
feat(web-ui): global command palette (Cmd/Ctrl+K)

### DIFF
--- a/tests/e2e_ui/sessions/test_command_palette.py
+++ b/tests/e2e_ui/sessions/test_command_palette.py
@@ -1,0 +1,77 @@
+"""E2E: ⌘/Ctrl+K opens the command palette and jumps to a session.
+
+Covers the command palette added in ``ap-web/src/shell/CommandPalette.tsx`` and
+its global hotkey (``useCommandPaletteHotkey``, ⌘/Ctrl+K, bound in
+``AppShell``). The palette lists sessions from the same server-search source as
+the sidebar and navigates to the picked one.
+
+The flow: open the palette from a focused composer (proving the window-level
+hotkey fires regardless of focus, like the session-switch hotkey), then select
+the *other* seeded session from the palette's list and assert the route changes
+to it.
+
+No LLM turn is needed — this is pure client-side keyboard + routing — so it
+skips the nightly/real-agent markers the approval suites carry. Two runner-bound
+sessions come from the ``seeded_session_pair`` fixture; both are recent and
+non-archived, so both appear in the palette's default (empty-query) list.
+
+Server-side search-query *filtering* is left to the Vitest unit tests
+(``CommandPalette.test.tsx``): the server's search reindex is asynchronous (see
+``useConversations.ts``), which would make a "type then expect filtered" e2e
+assertion timing-dependent. Selecting from the listed sessions exercises the
+same open → select → navigate path deterministically.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+
+
+def _set_title(base_url: str, session_id: str, title: str) -> None:
+    """Title a session via ``PATCH /v1/sessions/{id}`` so its row is legible."""
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def test_command_palette_opens_and_switches_session(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """⌘/Ctrl+K opens the palette; picking session B navigates to it."""
+    base_url, session_a, session_b = seeded_session_pair
+    _set_title(base_url, session_a, "e2e-palette-a")
+    _set_title(base_url, session_b, "e2e-palette-b")
+
+    page.goto(f"{base_url}/c/{session_a}")
+
+    # Both sessions must be loaded so the palette's session list holds them.
+    expect(page.locator(f'a[href="/c/{session_a}"]')).to_be_visible(timeout=30_000)
+    expect(page.locator(f'a[href="/c/{session_b}"]')).to_be_visible()
+
+    # Focus the composer first — the hotkey is window-level and must fire even
+    # from a focused text field (same contract as the session-switch hotkey).
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible()
+    composer.click()
+
+    # Open the palette. CI runs Linux chromium → Control; the hook also accepts
+    # Cmd via metaKey on macOS.
+    page.keyboard.press("Control+k")
+
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible(timeout=10_000)
+    expect(page.get_by_test_id("command-palette-input")).to_be_focused()
+
+    # Pick the other session from inside the palette and assert we navigate to it.
+    dialog.get_by_text("e2e-palette-b").click()
+
+    expect(page).to_have_url(f"{base_url}/c/{session_b}", timeout=10_000)
+    # The palette closes on select.
+    expect(page.get_by_test_id("command-palette-input")).to_have_count(0)

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -32,6 +32,7 @@ describe("KeyboardShortcutsDialog", () => {
 
     expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
     // General / In chats / Navigation / View / Slash commands — one each.
+    expect(screen.getByText("Open command palette")).toBeTruthy();
     expect(screen.getByText("Show keyboard shortcuts")).toBeTruthy();
     expect(screen.getByText("Send message")).toBeTruthy();
     expect(screen.getByText("Recall previous prompt")).toBeTruthy();

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -65,7 +65,10 @@ interface ShortcutGroup {
 const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "General",
-    items: [{ label: "Show keyboard shortcuts", keys: [MOD_KEY, "/"] }],
+    items: [
+      { label: "Open command palette", keys: [MOD_KEY, "K"] },
+      { label: "Show keyboard shortcuts", keys: [MOD_KEY, "/"] },
+    ],
   },
   {
     title: "In chats",

--- a/web/src/hooks/useCommandPaletteHotkey.test.tsx
+++ b/web/src/hooks/useCommandPaletteHotkey.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isCommandPaletteHotkey, useCommandPaletteHotkey } from "./useCommandPaletteHotkey";
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+function press(init: KeyboardEventInit): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+  window.dispatchEvent(e);
+  return e;
+}
+
+describe("isCommandPaletteHotkey", () => {
+  it("matches Cmd+K and Ctrl+K", () => {
+    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "k", metaKey: true }))).toBe(
+      true,
+    );
+    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "k", ctrlKey: true }))).toBe(
+      true,
+    );
+    // Uppercase (some layouts report "K" with the modifier).
+    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "K", metaKey: true }))).toBe(
+      true,
+    );
+  });
+
+  it("rejects plain k, and k with Alt or Shift held", () => {
+    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "k" }))).toBe(false);
+    expect(
+      isCommandPaletteHotkey(
+        new KeyboardEvent("keydown", { key: "k", metaKey: true, altKey: true }),
+      ),
+    ).toBe(false);
+    expect(
+      isCommandPaletteHotkey(
+        new KeyboardEvent("keydown", { key: "k", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects other keys with the modifier", () => {
+    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "j", metaKey: true }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("useCommandPaletteHotkey", () => {
+  it("toggles on Cmd+K and prevents the browser default", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle));
+
+    const e = press({ key: "k", metaKey: true });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("ignores auto-repeat", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle));
+
+    press({ key: "k", metaKey: true, repeat: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when disabled", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle, false));
+
+    const e = press({ key: "k", metaKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("bails when focus sits inside a terminal or code editor", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle));
+
+    const term = document.createElement("div");
+    term.className = "xterm";
+    const input = document.createElement("input");
+    term.appendChild(input);
+    document.body.appendChild(term);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    press({ key: "k", metaKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("unbinds on unmount", () => {
+    const onToggle = vi.fn();
+    const { unmount } = renderHook(() => useCommandPaletteHotkey(onToggle));
+    unmount();
+
+    press({ key: "k", metaKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useCommandPaletteHotkey.ts
+++ b/web/src/hooks/useCommandPaletteHotkey.ts
@@ -1,0 +1,66 @@
+// ⌘K (Ctrl+K on Win/Linux) toggles the global command palette. Sibling to the
+// session-switch (⌘↑/↓) and sidebar-toggle (⌘⌥[ / ⌘⌥]) hotkeys; like them it's
+// bound ONCE at the app shell, where the palette's open-state lives.
+//
+// Why ⌘K: it's the de-facto command-palette key across developer tools, and
+// issue #1059 / PR #1064 deliberately reserved it for this (PR #1064 took ⌘⇧F
+// for sidebar search precisely to leave ⌘K free). The browser binds Ctrl+K to
+// the address bar, so we preventDefault to claim it.
+//
+// Two surfaces own ⌘K themselves and must keep it: xterm terminals (forward it
+// to the PTY) and the Monaco editor (⌘K is a chord prefix). When focus sits in
+// one of those, we bail and let the keystroke through.
+
+import { useEffect, useRef } from "react";
+
+/** Selector for surfaces that own ⌘K and must keep it (terminals, code editor). */
+const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor";
+
+/** True when the event is the command-palette chord: Cmd/Ctrl+K, no Alt/Shift. */
+export function isCommandPaletteHotkey(e: globalThis.KeyboardEvent): boolean {
+  if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return false;
+  // AltGr reports as Ctrl+Alt on some layouts; the altKey check above already
+  // rejects it, but guard explicitly so intl typing never triggers the palette.
+  if (e.getModifierState("AltGraph")) return false;
+  // Match the letter, not a physical code — ⌘ doesn't remap "k" across layouts.
+  return e.key === "k" || e.key === "K";
+}
+
+/** Does focus sit inside a surface that owns ⌘K (xterm / Monaco)? */
+function focusOwnsHotkey(): boolean {
+  const el = document.activeElement;
+  return el instanceof Element && el.closest(HOTKEY_OWNING_SURFACES) !== null;
+}
+
+/**
+ * Bind ⌘/Ctrl+K to toggle the command palette. Bind ONCE.
+ *
+ * @param onToggle Flip the palette open/closed.
+ * @param enabled  Pass `false` to disable the hotkey (e.g. embedded mode, where
+ *   ⌘K belongs to the host page). Defaults to enabled.
+ */
+export function useCommandPaletteHotkey(onToggle: () => void, enabled: boolean = true): void {
+  // Held in a ref so the bound handler always calls the latest closure without
+  // re-registering on every render.
+  const latest = useRef(onToggle);
+  latest.current = onToggle;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: globalThis.KeyboardEvent): void => {
+      // Ignore auto-repeat: holding the chord would flap the palette.
+      if (e.repeat) return;
+      if (!isCommandPaletteHotkey(e)) return;
+      // Leave ⌘K to terminals/editors that bind it themselves.
+      if (focusOwnsHotkey()) return;
+      // Claim the chord: preventDefault drops the browser default (Ctrl+K
+      // focuses the address bar). stopPropagation mirrors the sibling hotkey
+      // hooks; no other listener binds ⌘K, so it's belt-and-suspenders.
+      e.preventDefault();
+      e.stopPropagation();
+      latest.current();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled]);
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -5,6 +5,8 @@ import { useConversations } from "@/hooks/useConversations";
 import { useSessionAgent } from "@/hooks/useAgents";
 import { useApproveHotkey } from "@/hooks/useApproveHotkey";
 import { useSidebarToggleHotkeys } from "@/hooks/useSidebarToggleHotkeys";
+import { useCommandPaletteHotkey } from "@/hooks/useCommandPaletteHotkey";
+import { useIsEmbedded } from "@/lib/embedded";
 import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
 import { useSeedReadState } from "@/hooks/useUnseenConversations";
@@ -70,6 +72,7 @@ import { TerminalsPanel } from "./TerminalsPanel";
 import { TodoPanel } from "./TodoPanel";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
+import { CommandPalette } from "./CommandPalette";
 import { Toaster } from "@/components/ui/toast";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { ForkDialogContextProvider, type ForkDialogContextValue } from "./ForkDialogContext";
@@ -777,6 +780,12 @@ export function AppShell() {
     onToggleRight: toggleRightPanel,
   });
 
+  // ⌘K (Ctrl+K) toggles the command palette. Disabled embedded, where ⌘K is the
+  // host page's. Bound here where the palette's open-state lives.
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const isEmbedded = useIsEmbedded();
+  useCommandPaletteHotkey(() => setCommandPaletteOpen((prev) => !prev), !isEmbedded);
+
   // Mobile back button: close the open file and return to the files/changes
   // list. On mobile the tab strip is hidden, so a "back" should fully drop the
   // file (remove it from openFiles) rather than leaving an orphan tab the user
@@ -1334,6 +1343,16 @@ export function AppShell() {
           {/* Keyboard-shortcuts reference. Self-contained (owns its open state +
               ⌘/Ctrl+/ opener); ungated so it works on every route. */}
           <KeyboardShortcutsDialog />
+          {/* Global command palette (⌘K). Ungated so it works on every route;
+              the hotkey itself is disabled in embedded mode. */}
+          {!isEmbedded && (
+            <CommandPalette
+              open={commandPaletteOpen}
+              onOpenChange={setCommandPaletteOpen}
+              onToggleLeftSidebar={() => setSidebarOpen((prev) => !prev)}
+              onToggleRightSidebar={toggleRightPanel}
+            />
+          )}
           {/* Transient toasts (e.g. "session archived"). Mounted once here so
               any surface can fire one via showToast(). */}
           <Toaster />

--- a/web/src/shell/CommandPalette.test.tsx
+++ b/web/src/shell/CommandPalette.test.tsx
@@ -1,0 +1,176 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+
+import { CommandPalette } from "./CommandPalette";
+
+const navigate = vi.fn();
+vi.mock("@/lib/routing", () => ({
+  useNavigate: () => navigate,
+}));
+
+const useConversations = vi.fn();
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: (...args: unknown[]) => useConversations(...args),
+}));
+
+const openKeyboardShortcuts = vi.fn();
+vi.mock("@/components/KeyboardShortcutsDialog", () => ({
+  openKeyboardShortcuts: () => openKeyboardShortcuts(),
+}));
+
+function conv(id: string, title: string | null, agent_name: string | null = null) {
+  return { id, title, agent_name, archived: false };
+}
+
+function setSessions(sessions: ReturnType<typeof conv>[], isFetching = false) {
+  useConversations.mockReturnValue({ data: { pages: [{ data: sessions }] }, isFetching });
+}
+
+function renderPalette(overrides: Partial<ComponentProps<typeof CommandPalette>> = {}) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    onToggleLeftSidebar: vi.fn(),
+    onToggleRightSidebar: vi.fn(),
+    ...overrides,
+  };
+  render(<CommandPalette {...props} />);
+  return props;
+}
+
+beforeEach(() => {
+  navigate.mockClear();
+  openKeyboardShortcuts.mockClear();
+  useConversations.mockReset();
+  setSessions([]);
+});
+afterEach(cleanup);
+
+describe("CommandPalette — sessions", () => {
+  it("lists sessions by display label with their agent type", () => {
+    setSessions([conv("c1", "Fix the parser", "research-agent"), conv("c2", null)]);
+    renderPalette();
+
+    expect(screen.getByText("Fix the parser")).toBeTruthy();
+    expect(screen.getByText("research-agent")).toBeTruthy();
+    // Null title → conversationDisplayLabel's "New session" fallback.
+    expect(screen.getByText("New session")).toBeTruthy();
+  });
+
+  it("navigates to the session and closes when an item is selected", () => {
+    setSessions([conv("c1", "Fix the parser")]);
+    const onOpenChange = vi.fn();
+    renderPalette({ onOpenChange });
+
+    fireEvent.click(screen.getByText("Fix the parser"));
+
+    expect(navigate).toHaveBeenCalledWith("/c/c1");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("debounces the typed query into a server search (archived excluded)", () => {
+    vi.useFakeTimers();
+    try {
+      setSessions([conv("c1", "Fix the parser")]);
+      renderPalette();
+
+      // Empty query on mount → shares AppShell's `["conversations","",false]` entry.
+      expect(useConversations).toHaveBeenCalledWith("", false);
+
+      fireEvent.change(screen.getByTestId("command-palette-input"), {
+        target: { value: "deploy" },
+      });
+      // Before the debounce elapses the query has NOT yet reached the hook.
+      expect(useConversations).not.toHaveBeenCalledWith("deploy", false);
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      // After the 300ms debounce, the typed query drives a server search with
+      // archived excluded — proving the palette searches the server, not a page.
+      expect(useConversations).toHaveBeenCalledWith("deploy", false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dedupes sessions that appear on overlapping pages", () => {
+    useConversations.mockReturnValue({
+      data: {
+        pages: [{ data: [conv("c1", "One")] }, { data: [conv("c1", "One"), conv("c2", "Two")] }],
+      },
+      isFetching: false,
+    });
+    renderPalette();
+
+    expect(screen.getAllByText("One")).toHaveLength(1);
+    expect(screen.getByText("Two")).toBeTruthy();
+  });
+});
+
+describe("CommandPalette — actions", () => {
+  it("lists the built-in action commands", () => {
+    renderPalette();
+
+    expect(screen.getByText("New chat")).toBeTruthy();
+    expect(screen.getByText("Go to Inbox")).toBeTruthy();
+    expect(screen.getByText("Go to Settings")).toBeTruthy();
+    expect(screen.getByText("Toggle conversations sidebar")).toBeTruthy();
+    expect(screen.getByText("Toggle workspace sidebar")).toBeTruthy();
+    expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
+  });
+
+  it("runs a navigation action and closes the palette", () => {
+    const onOpenChange = vi.fn();
+    renderPalette({ onOpenChange });
+
+    fireEvent.click(screen.getByText("Go to Settings"));
+
+    expect(navigate).toHaveBeenCalledWith("/settings");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("invokes the sidebar-toggle callbacks", () => {
+    const onToggleLeftSidebar = vi.fn();
+    const onToggleRightSidebar = vi.fn();
+    renderPalette({ onToggleLeftSidebar, onToggleRightSidebar });
+
+    fireEvent.click(screen.getByText("Toggle conversations sidebar"));
+    expect(onToggleLeftSidebar).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("Toggle workspace sidebar"));
+    expect(onToggleRightSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the keyboard-shortcuts dialog", () => {
+    renderPalette();
+    fireEvent.click(screen.getByText("Keyboard shortcuts"));
+    expect(openKeyboardShortcuts).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters actions client-side against the query", () => {
+    renderPalette();
+
+    fireEvent.change(screen.getByTestId("command-palette-input"), {
+      target: { value: "settings" },
+    });
+
+    expect(screen.getByText("Go to Settings")).toBeTruthy();
+    expect(screen.queryByText("New chat")).toBeNull();
+  });
+});
+
+describe("CommandPalette — empty state", () => {
+  it("shows an empty state when nothing matches", () => {
+    setSessions([]);
+    renderPalette();
+
+    // A query that matches no action and no session.
+    fireEvent.change(screen.getByTestId("command-palette-input"), {
+      target: { value: "zzzznomatch" },
+    });
+
+    expect(screen.getByText("No results found")).toBeTruthy();
+  });
+});

--- a/web/src/shell/CommandPalette.test.tsx
+++ b/web/src/shell/CommandPalette.test.tsx
@@ -14,11 +14,6 @@ vi.mock("@/hooks/useConversations", () => ({
   useConversations: (...args: unknown[]) => useConversations(...args),
 }));
 
-const openKeyboardShortcuts = vi.fn();
-vi.mock("@/components/KeyboardShortcutsDialog", () => ({
-  openKeyboardShortcuts: () => openKeyboardShortcuts(),
-}));
-
 function conv(id: string, title: string | null, agent_name: string | null = null) {
   return { id, title, agent_name, archived: false };
 }
@@ -41,7 +36,6 @@ function renderPalette(overrides: Partial<ComponentProps<typeof CommandPalette>>
 
 beforeEach(() => {
   navigate.mockClear();
-  openKeyboardShortcuts.mockClear();
   useConversations.mockReset();
   setSessions([]);
 });
@@ -118,7 +112,6 @@ describe("CommandPalette — actions", () => {
     expect(screen.getByText("Go to Settings")).toBeTruthy();
     expect(screen.getByText("Toggle conversations sidebar")).toBeTruthy();
     expect(screen.getByText("Toggle workspace sidebar")).toBeTruthy();
-    expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
   });
 
   it("runs a navigation action and closes the palette", () => {
@@ -141,12 +134,6 @@ describe("CommandPalette — actions", () => {
 
     fireEvent.click(screen.getByText("Toggle workspace sidebar"));
     expect(onToggleRightSidebar).toHaveBeenCalledTimes(1);
-  });
-
-  it("opens the keyboard-shortcuts dialog", () => {
-    renderPalette();
-    fireEvent.click(screen.getByText("Keyboard shortcuts"));
-    expect(openKeyboardShortcuts).toHaveBeenCalledTimes(1);
   });
 
   it("filters actions client-side against the query", () => {

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -1,0 +1,203 @@
+// Global command palette (⌘K). Two command groups:
+//
+//   • Actions — static app commands (new chat, navigate, toggle panels,
+//     keyboard shortcuts). Filtered client-side against the live query.
+//   • Sessions — fuzzy session switching from the SAME server-search source the
+//     sidebar uses (`useConversations(query)` → `GET /v1/sessions?search_query=`),
+//     debounced. Not a static first page: a user with hundreds of sessions must
+//     find any of them, which client-side filtering over one page cannot do.
+//
+// cmdk's own filtering is disabled (`shouldFilter={false}`): the server filters
+// sessions, and we filter the (tiny, static) action list ourselves so both
+// groups react to the same input.
+
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "@/lib/routing";
+import { useConversations } from "@/hooks/useConversations";
+import { openKeyboardShortcuts } from "@/components/KeyboardShortcutsDialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { conversationDisplayLabel, getConversationAgentType } from "./sidebarNav";
+
+export interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Flip the left (Conversations) sidebar — owned by AppShell. */
+  onToggleLeftSidebar: () => void;
+  /** Flip the right (Workspace) sidebar — owned by AppShell. */
+  onToggleRightSidebar: () => void;
+}
+
+interface ActionCommand {
+  id: string;
+  label: string;
+  /** Extra terms the client-side filter matches against (beyond the label). */
+  keywords: string[];
+  run: () => void;
+}
+
+/** Debounce matches the sidebar search (300ms) so keystrokes don't each fetch. */
+const SEARCH_DEBOUNCE_MS = 300;
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+  onToggleLeftSidebar,
+  onToggleRightSidebar,
+}: CommandPaletteProps) {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  // Reset the query when the palette closes so it reopens clean.
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setDebouncedQuery("");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const close = (): void => onOpenChange(false);
+
+  const actions = useMemo<ActionCommand[]>(
+    () => [
+      {
+        id: "new-chat",
+        label: "New chat",
+        keywords: ["compose", "start", "new session"],
+        run: () => navigate("/"),
+      },
+      {
+        id: "go-inbox",
+        label: "Go to Inbox",
+        keywords: ["notifications", "comments", "needs response"],
+        run: () => navigate("/inbox"),
+      },
+      {
+        id: "go-settings",
+        label: "Go to Settings",
+        keywords: ["preferences", "configuration", "account"],
+        run: () => navigate("/settings"),
+      },
+      {
+        id: "toggle-left-sidebar",
+        label: "Toggle conversations sidebar",
+        keywords: ["panel", "left", "sessions list"],
+        run: onToggleLeftSidebar,
+      },
+      {
+        id: "toggle-right-sidebar",
+        label: "Toggle workspace sidebar",
+        keywords: ["panel", "right", "files", "terminal"],
+        run: onToggleRightSidebar,
+      },
+      {
+        id: "keyboard-shortcuts",
+        label: "Keyboard shortcuts",
+        keywords: ["help", "keys", "hotkeys"],
+        run: openKeyboardShortcuts,
+      },
+    ],
+    [navigate, onToggleLeftSidebar, onToggleRightSidebar],
+  );
+
+  const filteredActions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (q === "") return actions;
+    return actions.filter(
+      (a) =>
+        a.label.toLowerCase().includes(q) || a.keywords.some((k) => k.toLowerCase().includes(q)),
+    );
+  }, [actions, query]);
+
+  // Archived excluded (matches the sidebar default). With an empty query this
+  // shares AppShell's existing `useConversations()` cache entry, so an idle
+  // palette costs no extra fetch; a search keys its own entry.
+  const { data, isFetching } = useConversations(debouncedQuery, false);
+
+  const sessions = useMemo(() => {
+    const seen = new Set<string>();
+    const out: { id: string; label: string; agent: string }[] = [];
+    for (const page of data?.pages ?? []) {
+      for (const c of page.data) {
+        if (seen.has(c.id)) continue;
+        seen.add(c.id);
+        out.push({
+          id: c.id,
+          label: conversationDisplayLabel(c),
+          agent: getConversationAgentType(c),
+        });
+      }
+    }
+    return out;
+  }, [data]);
+
+  const runAction = (action: ActionCommand): void => {
+    close();
+    action.run();
+  };
+
+  const goToSession = (id: string): void => {
+    close();
+    navigate(`/c/${id}`);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        aria-describedby={undefined}
+        className="top-1/4 translate-y-0 overflow-hidden p-0"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        {/* shouldFilter=false: the server filters sessions and we filter actions
+            (see file header). vimBindings=false: keep Ctrl+K/J from doubling as
+            list-nav on Win/Linux, where Ctrl+K is also the opener. */}
+        <Command shouldFilter={false} vimBindings={false} label="Command palette">
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder="Search commands and sessions…"
+            data-testid="command-palette-input"
+          />
+          <CommandList>
+            <CommandEmpty>
+              {isFetching && debouncedQuery ? "Searching…" : "No results found"}
+            </CommandEmpty>
+            {filteredActions.length > 0 && (
+              <CommandGroup heading="Actions">
+                {filteredActions.map((a) => (
+                  <CommandItem key={a.id} value={`action:${a.id}`} onSelect={() => runAction(a)}>
+                    <span className="flex-1 truncate text-left">{a.label}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {sessions.length > 0 && (
+              <CommandGroup heading="Sessions">
+                {sessions.map((s) => (
+                  <CommandItem key={s.id} value={s.id} onSelect={() => goToSession(s.id)}>
+                    <span className="flex-1 truncate text-left">{s.label}</span>
+                    <span className="ml-2 shrink-0 text-xs text-muted-foreground">{s.agent}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -1,7 +1,7 @@
 // Global command palette (⌘K). Two command groups:
 //
-//   • Actions — static app commands (new chat, navigate, toggle panels,
-//     keyboard shortcuts). Filtered client-side against the live query.
+//   • Actions — static app commands (new chat, navigate, toggle panels).
+//     Filtered client-side against the live query.
 //   • Sessions — fuzzy session switching from the SAME server-search source the
 //     sidebar uses (`useConversations(query)` → `GET /v1/sessions?search_query=`),
 //     debounced. Not a static first page: a user with hundreds of sessions must
@@ -12,9 +12,16 @@
 // groups react to the same input.
 
 import { useEffect, useMemo, useState } from "react";
+import {
+  InboxIcon,
+  type LucideIcon,
+  PanelLeftIcon,
+  PanelRightIcon,
+  SettingsIcon,
+  SquarePenIcon,
+} from "lucide-react";
 import { useNavigate } from "@/lib/routing";
 import { useConversations } from "@/hooks/useConversations";
-import { openKeyboardShortcuts } from "@/components/KeyboardShortcutsDialog";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
   Command,
@@ -38,6 +45,8 @@ export interface CommandPaletteProps {
 interface ActionCommand {
   id: string;
   label: string;
+  /** Mirrors the icon on the equivalent button elsewhere in the UI. */
+  icon: LucideIcon;
   /** Extra terms the client-side filter matches against (beyond the label). */
   keywords: string[];
   run: () => void;
@@ -76,38 +85,37 @@ export function CommandPalette({
       {
         id: "new-chat",
         label: "New chat",
+        icon: SquarePenIcon,
         keywords: ["compose", "start", "new session"],
         run: () => navigate("/"),
       },
       {
         id: "go-inbox",
         label: "Go to Inbox",
+        icon: InboxIcon,
         keywords: ["notifications", "comments", "needs response"],
         run: () => navigate("/inbox"),
       },
       {
         id: "go-settings",
         label: "Go to Settings",
+        icon: SettingsIcon,
         keywords: ["preferences", "configuration", "account"],
         run: () => navigate("/settings"),
       },
       {
         id: "toggle-left-sidebar",
         label: "Toggle conversations sidebar",
+        icon: PanelLeftIcon,
         keywords: ["panel", "left", "sessions list"],
         run: onToggleLeftSidebar,
       },
       {
         id: "toggle-right-sidebar",
         label: "Toggle workspace sidebar",
+        icon: PanelRightIcon,
         keywords: ["panel", "right", "files", "terminal"],
         run: onToggleRightSidebar,
-      },
-      {
-        id: "keyboard-shortcuts",
-        label: "Keyboard shortcuts",
-        keywords: ["help", "keys", "hotkeys"],
-        run: openKeyboardShortcuts,
       },
     ],
     [navigate, onToggleLeftSidebar, onToggleRightSidebar],
@@ -158,7 +166,7 @@ export function CommandPalette({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         aria-describedby={undefined}
-        className="top-1/4 translate-y-0 overflow-hidden p-0"
+        className="top-1/4 translate-y-0 overflow-hidden p-0 sm:max-w-2xl"
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">Command palette</DialogTitle>
@@ -178,11 +186,15 @@ export function CommandPalette({
             </CommandEmpty>
             {filteredActions.length > 0 && (
               <CommandGroup heading="Actions">
-                {filteredActions.map((a) => (
-                  <CommandItem key={a.id} value={`action:${a.id}`} onSelect={() => runAction(a)}>
-                    <span className="flex-1 truncate text-left">{a.label}</span>
-                  </CommandItem>
-                ))}
+                {filteredActions.map((a) => {
+                  const Icon = a.icon;
+                  return (
+                    <CommandItem key={a.id} value={`action:${a.id}`} onSelect={() => runAction(a)}>
+                      <Icon />
+                      <span className="flex-1 truncate text-left">{a.label}</span>
+                    </CommandItem>
+                  );
+                })}
               </CommandGroup>
             )}
             {sessions.length > 0 && (

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -67,6 +67,17 @@ if (!("IntersectionObserver" in globalThis)) {
   });
 }
 
+// cmdk (the command-palette primitive) constructs a ResizeObserver on mount,
+// which jsdom doesn't implement. A no-op stub lets command-palette/selector
+// component tests render without throwing.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+}
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: (query: string) => ({


### PR DESCRIPTION
## Related issue

Closes #1385

## Summary

Add a global command palette opened with Cmd+K (Ctrl+K on Windows/Linux), available across the web UI and the desktop (Electron) app. It has two groups:

* **Actions**: New chat, Go to Inbox, Go to Settings, Toggle conversations sidebar, Toggle workspace sidebar, Open keyboard shortcuts. Filtered client-side as you type.
* **Sessions**: fuzzy session switching from the same server-search source the sidebar uses (`useConversations` -> `GET /v1/sessions?search_query=`, debounced), so it finds sessions beyond the first page rather than client-filtering a single page. Archived sessions excluded, matching the sidebar default.

The hotkey is bound once in `AppShell`. It does not fire when focus is inside an xterm terminal or the Monaco editor (both own Cmd/Ctrl+K), and is disabled in embedded mode where Cmd/Ctrl+K belongs to the host page. The desktop app loads the same SPA and binds only Cmd/Ctrl+N and Cmd/Ctrl+F natively, so Cmd/Ctrl+K reaches the renderer unchanged. Adds an "Open command palette" row to the keyboard-shortcuts dialog.

Complements PR #1064 (Cmd/Ctrl+Shift+F sidebar search): that PR reserved Cmd/Ctrl+K for exactly this palette. The two are additive and the palette coexists with the existing sidebar search.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Vitest unit tests:

* `useCommandPaletteHotkey.test.tsx`: the chord predicate (Cmd/Ctrl+K, rejecting Alt/Shift/AltGraph/other keys), auto-repeat ignore, disabled mode, bail when focus is in an xterm/Monaco surface, and listener cleanup on unmount.
* `CommandPalette.test.tsx`: action commands render, run, and close the palette (navigation, sidebar-toggle callbacks, keyboard-shortcuts); client-side action filtering; session list mapping with the "New session" fallback; debounced server search (archived excluded); page dedupe; and the empty state.
* `KeyboardShortcutsDialog.test.tsx`: the new "Open command palette" row.

Playwright e2e (`tests/e2e_ui/sessions/test_command_palette.py`): Cmd/Ctrl+K opens the palette from a focused composer, selecting a session navigates to it, and the palette closes. It selects from the default session list rather than typing-to-filter, because the server search reindex is asynchronous and would make a type-then-filter assertion timing-dependent (search filtering is covered by the unit tests).

Also adds a no-op `ResizeObserver` polyfill to `test-setup.ts` (cmdk constructs one on mount; jsdom does not implement it), guarded so it never clobbers a real implementation or the per-test stubs other suites set.

Validated locally (from `ap-web/`):

* `npm run type-check`
* `npm test` (3158 passed, 3 expected fail, 2 skipped)
* `npm run build`
* `npx oxlint` on the touched files (clean; full `npm run lint` reports pre-existing errors outside this change)

E2E (repo root, venv active): `python -m pytest tests/e2e_ui/sessions/test_command_palette.py --ui-skip-build` (passes). Manually verified in a real browser and in the desktop app.
