### PR TITLE
feat(qwen-native): support /compact via qwen /compress

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -140,9 +140,13 @@ comments; this is the *what*, not the *how*.)
   metadata. The forwarder (`omnigent/qwen_native_forwarder.py`) could parse it
   and report it onto the session so the chip reflects qwen's reality.
   - **Context ring + cost tracking also missing**, same root cause: native-qwen
-    emits no token usage, so `tokensUsed` / `contextWindow` stay null (the ring
-    renders only when `contextWindow > 0 && tokensUsed != null`) and the session
-    cost stays $0 (cost is derived from per-turn usage × model price). The ACP
+    doesn't yet parse/forward token usage, so `tokensUsed` / `contextWindow` stay
+    null (the ring renders only when `contextWindow > 0 && tokensUsed != null`)
+    and the session cost stays $0 (cost is derived from per-turn usage × model
+    price). The usage *is* on the stream, though — verified live (`qwen`
+    v0.18.2): each turn's final `assistant` event carries `message.usage`
+    (`{input_tokens, output_tokens, cache_read_input_tokens, total_tokens}`), so
+    the forwarder could parse it and POST `external_session_usage`. The ACP
     `qwen` harness already does this — see "Cost / token tracking" in *What works
     today* (`_accumulate_usage`); native-qwen needs the equivalent off the
     `--json-file` stream. Parse `result.usage` (`input_tokens` / `output_tokens`
@@ -181,38 +185,41 @@ comments; this is the *what*, not the *how*.)
 
 ### Medium
 
-- [ ] **Compaction / context-compression mirroring (TUI → web).** qwen calls
-  compaction *compression*: it auto-compresses when the context fills and exposes
-  a `/compress` command, rendering an inline item in its TUI
-  (`{type:"compression", compression:{isPending, originalTokenCount,
-  newTokenCount, compressionStatus}}` and an internal `chat_compressed` event).
-  Native-qwen does **not** surface any of this in the web UI today — during a
-  compression the Chat tab just shows the turn stall, and afterward the mirrored
-  token counts don't reflect the shrink. Omnigent already has the web-facing
-  primitives — `response.compaction.in_progress` / `.completed` / `.failed`
-  (`omnigent/runtime/compaction.py`, `omnigent/server/schemas.py:3158+`,
-  rendered by `ap-web` as the "Compacting…" spinner / compaction divider) — so
-  this is a *forwarder* change, not new UI.
-  - **Verify the wire shape first (live E2E):** confirm whether qwen emits a
-    structured compression marker on the `--json-file` dual-output stream (a
-    `compression`/`chat_compressed`-shaped event) the way it emits
-    `control_request` for approvals, or whether compression is TUI-only and must
-    be inferred (e.g. from a token-count drop between consecutive `assistant`
-    `usage` events, or a `system`-style notice). The `control_request` →
-    elicitation work proved the stream carries non-transcript control events, so
-    a compression event is plausible but unconfirmed — `permission_suggestions`
-    was null, so don't assume field richness.
-  - **Mirror it:** in `omnigent/qwen_native_forwarder.py`, on a
-    compression-in-progress marker publish `response.compaction.in_progress`
-    (POST to the session) so the spinner shows, and on completion publish
-    `response.compaction.completed` with the post-compression `total_tokens`
-    (pairs with the usage/context-ring work in the "Composer status line" item —
-    one usage path feeds the ring, cost, and the compaction token count). If the
-    stream has no compression event, scope this to "best-effort: emit completed
-    with the new token count when usage drops" and `log()` the limitation.
+- [x] **Compaction via `/compact` (web → TUI), with spinner + divider.**
+  Implemented, mirroring cursor-native PR #1259 — the web composer's `/compact`
+  now drives qwen's `/compress` in the TUI, with a "Compacting conversation…"
+  spinner that resolves to the "Conversation compacted" divider when qwen
+  actually finishes. Works for both explicit `/compact` and auto-compaction.
+  - **Server (existing, harness-agnostic):** `/compact` → forwards `{"type":
+    "compact"}` to the bound runner; a 200 means the control was handled in the
+    terminal (server skips its own AP-side compaction, which 400s on the
+    LLM-less native pseudo-agent).
+  - **Runner (`_handle_qwen_native_compact`):** publishes
+    `response.compaction.in_progress` (raises the spinner), submits `/compress`
+    via the **input file** (`submit_user_message`), returns 200; on failure
+    publishes `response.compaction.failed` (dismisses the spinner) + 503. Unlike
+    cursor's bracketed-paste, qwen's input-file `submit` routes through
+    `RemoteInputWatcher` → `submitQuery` (the keyboard's own path), which
+    processes the slash command directly — no autocomplete-dropdown trap, and no
+    `/compress` user bubble on the stream (verified live, `qwen` v0.18.2).
+  - **Completion signal — the chat recording, not the stream.** qwen emits **no**
+    compression event on the `--json-file` stream (`session_start`'s
+    `supported_events` omits it; the green "compressed from…" TUI line is an
+    internal `addItem`, never streamed). But it writes a `{"type":"system",
+    "subtype":"chat_compression","systemPayload":{"info":{originalTokenCount,
+    newTokenCount,compressionStatus}}}` record to its on-disk recording
+    (`~/.qwen/projects/<slug>/chats/<id>.jsonl`) the instant compression
+    finishes. `supervise_qwen_compaction_mirror` tails that recording (seeded at
+    EOF so a resumed session's prior records don't re-fire) and POSTs
+    `external_compaction_status` — `completed` on `compressionStatus == 1`,
+    `failed` on the `COMPRESSION_FAILED_*` codes (2/3) — which the server
+    republishes as `response.compaction.completed/failed`.
   - **Note on the ACP `qwen` harness:** the in-process executor compresses
     internally over ACP and is opaque to us (same boundary as the LLM-phase
     policy exclusion below), so this item is **native-qwen only**.
+  - **Follow-up:** the context ring won't shrink after compaction until usage is
+    forwarded as `external_session_usage` (see the "Composer status line" item) —
+    the recording's `newTokenCount` could feed that.
 
 - [ ] **Provider routing: settings.json precedence + token refresh.** The
   base injection now works (see What works today), but two gaps remain before

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -94,6 +94,26 @@ def _qwen_project_slug(workspace: Path | str) -> str:
     return re.sub(r"[^A-Za-z0-9]", "-", real)
 
 
+def qwen_session_recording_path(session_id: str, workspace: Path | str) -> Path:
+    """Return the path to qwen's on-disk chat recording for *session_id*.
+
+    ``~/.qwen/projects/<project-slug>/chats/<session-id>.jsonl`` — the JSONL
+    qwen appends interactive-session events to (``--chat-recording``, on by
+    default), scoped to *workspace*'s project slug. The file may not exist yet
+    (a fresh session creates it on first event). Used both to gate ``--resume``
+    (:func:`qwen_session_recording_exists`) and to tail for the
+    ``chat_compression`` marker (see :mod:`omnigent.qwen_native_forwarder`).
+    """
+    return (
+        Path.home()
+        / ".qwen"
+        / "projects"
+        / _qwen_project_slug(workspace)
+        / "chats"
+        / f"{session_id}.jsonl"
+    )
+
+
 def qwen_session_recording_exists(session_id: str, workspace: Path | str) -> bool:
     """Return whether qwen has an on-disk chat recording for *session_id* in *workspace*.
 
@@ -114,16 +134,8 @@ def qwen_session_recording_exists(session_id: str, workspace: Path | str) -> boo
     :returns: ``True`` if a recording for *session_id* exists under *workspace*'s
         qwen project dir.
     """
-    recording = (
-        Path.home()
-        / ".qwen"
-        / "projects"
-        / _qwen_project_slug(workspace)
-        / "chats"
-        / f"{session_id}.jsonl"
-    )
     try:
-        return recording.is_file()
+        return qwen_session_recording_path(session_id, workspace).is_file()
     except OSError:
         return False
 

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -29,6 +29,17 @@ Event shapes consumed (others are ignored defensively):
 Status (``running``/``idle``) is intentionally NOT posted here: the runner's
 PTY-activity watcher owns those edges for qwen-native (see
 :mod:`omnigent.runner.app`), exactly as for goose-/cursor-native.
+
+This module also hosts the **compaction mirror** (:func:`supervise_qwen_compaction_mirror`).
+qwen compaction (its *compression*) is invisible on the ``--json-file`` stream
+(``session_start``'s ``supported_events`` omits it — verified live, ``qwen``
+v0.18.2), but qwen writes a ``{"type":"system","subtype":"chat_compression",
+"systemPayload":{"info":{originalTokenCount,newTokenCount,compressionStatus}}}``
+record to its on-disk chat recording the instant compression finishes. The mirror
+tails that recording and POSTs ``external_compaction_status`` (``completed`` on
+success, ``failed`` otherwise) — the completion half of the web ``/compact`` →
+qwen ``/compress`` flow whose ``in_progress`` edge the runner raises on injection.
+It fires for both explicit ``/compress`` and auto-compaction.
 """
 
 from __future__ import annotations
@@ -383,3 +394,128 @@ async def supervise_qwen_forwarder(
             )
         await _supervisor_sleep(backoff_s)
         backoff_s = min(backoff_s * 2.0, _SUPERVISOR_MAX_BACKOFF_S)
+
+
+# --- Compaction mirror (chat-recording tail → external_compaction_status) ------
+
+#: qwen's CompressionStatus enum (verified, qwen v0.18.2): 1 = COMPRESSED (success),
+#: 2/3 = COMPRESSION_FAILED_*. 1 → completed; anything else → failed.
+_COMPRESSION_STATUS_OK = 1
+
+
+def _compaction_status_from_record(record: dict[str, object]) -> str | None:
+    """Map a chat-recording line to a compaction status, or ``None`` to skip it.
+
+    Returns ``"completed"`` for a successful ``chat_compression`` record,
+    ``"failed"`` for a failed one, and ``None`` for any other line.
+    """
+    if record.get("type") != "system" or record.get("subtype") != "chat_compression":
+        return None
+    payload = record.get("systemPayload")
+    info = payload.get("info") if isinstance(payload, dict) else None
+    status = info.get("compressionStatus") if isinstance(info, dict) else None
+    return "completed" if status == _COMPRESSION_STATUS_OK else "failed"
+
+
+def _read_new_compaction_statuses(recording: Path, offset: int) -> tuple[list[str], int]:
+    """Read NDJSON lines past *offset*, returning new compaction statuses + offset.
+
+    Same tail discipline as :func:`_read_new_events` (truncation rewind, only
+    newline-terminated lines consumed), but scoped to ``chat_compression`` records.
+    """
+    try:
+        size = recording.stat().st_size
+    except OSError:
+        return [], offset  # recording not created yet — retry next poll
+    if size < offset:
+        offset = 0  # truncated/recreated
+    if size == offset:
+        return [], offset
+    try:
+        with open(recording, "rb") as fh:
+            fh.seek(offset)
+            data = fh.read(size - offset)
+    except OSError:
+        return [], offset
+    last_nl = data.rfind(b"\n")
+    if last_nl == -1:
+        return [], offset
+    consumed = data[: last_nl + 1]
+    new_offset = offset + len(consumed)
+    statuses: list[str] = []
+    for raw in consumed.split(b"\n"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            record = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        status = _compaction_status_from_record(record)
+        if status is not None:
+            statuses.append(status)
+    return statuses, new_offset
+
+
+async def _post_external_compaction_status(
+    client: httpx.AsyncClient, *, session_id: str, status: str
+) -> None:
+    """POST one ``external_compaction_status`` event; the server republishes the SSE."""
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_compaction_status", "data": {"status": status}},
+    )
+    resp.raise_for_status()
+
+
+async def supervise_qwen_compaction_mirror(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    recording_path: Path,
+    auth: httpx.Auth | None = None,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+) -> None:
+    """Tail qwen's chat recording and mirror compaction completions to the session.
+
+    Seeds the read offset at the recording's current end of file so only
+    compactions that happen *after* launch are posted — a resumed session's
+    recording already holds prior ``chat_compression`` records, and re-posting them
+    would flash stale "Conversation compacted" dividers. Self-healing: any error is
+    logged and the loop continues (a transient blip never abandons the mirror);
+    cancellation propagates for clean teardown. Best-effort, like the approval
+    mirror — the offset is in-memory, so a forwarder restart may miss a compaction
+    that lands during the gap, which only drops one divider.
+
+    :param recording_path: qwen's chat recording for this session (see
+        :func:`omnigent.qwen_native_bridge.qwen_session_recording_path`).
+    """
+    try:
+        offset = recording_path.stat().st_size
+    except OSError:
+        offset = 0  # not created yet; first poll reads from the start
+    timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=headers, auth=auth, timeout=timeout
+    ) as client:
+        while True:
+            try:
+                statuses, offset = await asyncio.to_thread(
+                    _read_new_compaction_statuses, recording_path, offset
+                )
+                for status in statuses:
+                    await _post_external_compaction_status(
+                        client, session_id=session_id, status=status
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "qwen compaction mirror poll failed; session=%s recording=%s",
+                    session_id,
+                    recording_path,
+                )
+            await asyncio.sleep(poll_interval_s)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2572,8 +2572,14 @@ async def _auto_create_qwen_terminal(
     server_url = _required_runner_env("RUNNER_SERVER_URL")
     _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
 
-    from omnigent.qwen_native_forwarder import supervise_qwen_forwarder
+    from omnigent.qwen_native_bridge import qwen_session_recording_path
+    from omnigent.qwen_native_forwarder import (
+        supervise_qwen_compaction_mirror,
+        supervise_qwen_forwarder,
+    )
     from omnigent.qwen_native_permissions import supervise_qwen_approval_mirror
+
+    qwen_recording_path = qwen_session_recording_path(qwen_session_id, workspace)
 
     if server_client is not None and ensure_comment_relay is not None:
         await ensure_comment_relay(
@@ -2583,15 +2589,18 @@ async def _auto_create_qwen_terminal(
         )
 
     async def _supervise_qwen_native_bridges() -> None:
-        """Run the transcript forwarder and the approval mirror together.
+        """Run the transcript forwarder, approval mirror, and compaction mirror together.
 
-        Both are per-session, runner-owned, and self-healing (they catch and
+        All three are per-session, runner-owned, and self-healing (they catch and
         log their own failures rather than exiting); gathering them under one
         task keeps a single registration/cancellation handle
         (:func:`_register_auto_forwarder_task`) for session teardown. The
         forwarder mirrors qwen's replies onto the conversation; the approval
         mirror surfaces qwen's native ``can_use_tool`` prompts as web
-        elicitations (see :mod:`omnigent.qwen_native_permissions`).
+        elicitations (see :mod:`omnigent.qwen_native_permissions`); the compaction
+        mirror tails qwen's chat recording for the ``chat_compression`` marker and
+        posts the ``external_compaction_status: completed`` edge (see
+        :func:`omnigent.qwen_native_forwarder.supervise_qwen_compaction_mirror`).
         """
         await asyncio.gather(
             supervise_qwen_forwarder(
@@ -2607,6 +2616,13 @@ async def _auto_create_qwen_terminal(
                 headers={},
                 session_id=session_id,
                 bridge_dir=bridge_dir,
+                auth=_runner_auth,
+            ),
+            supervise_qwen_compaction_mirror(
+                base_url=server_url,
+                headers={},
+                session_id=session_id,
+                recording_path=qwen_recording_path,
                 auth=_runner_auth,
             ),
         )
@@ -11152,6 +11168,47 @@ def create_runner_app(
             )
         return Response(status_code=200)
 
+    async def _handle_qwen_native_compact(conv_id: str) -> Response:
+        """Submit ``/compress`` into the qwen TUI via the input file.
+
+        qwen-native sessions own their context window inside the qwen TUI, so
+        explicit compaction must run there (qwen's ``/compress`` slash command),
+        not as AP-side compaction — same rationale as
+        :func:`_handle_cursor_native_compact`. Injection is **file-based**, not
+        tmux send-keys: a ``{"type":"submit","text":"/compress"}`` line on the
+        input file routes through qwen's ``RemoteInputWatcher`` → ``submitQuery``
+        (the keyboard's own submit path), which processes the slash command —
+        sidestepping cursor's autocomplete-dropdown trap (verified, qwen v0.18.2:
+        it compresses and emits no ``/compress`` user bubble on the stream).
+
+        Publishes ``response.compaction.in_progress`` to raise the web "Compacting
+        conversation…" spinner; the matching ``completed`` edge is emitted later by
+        :func:`omnigent.qwen_native_forwarder.supervise_qwen_compaction_mirror` when
+        it observes the ``chat_compression`` record in qwen's recording, so the
+        permanent marker tracks qwen's real progress. On injection failure we
+        publish ``response.compaction.failed`` so the spinner is dismissed rather
+        than stranded. Returns 200 so the server skips its own AP-side compaction.
+
+        :param conv_id: Session/conversation identifier.
+        :returns: 200 once ``/compress`` has been submitted; 503 on injection error.
+        """
+        from omnigent.qwen_native_bridge import bridge_dir_for_session_id, submit_user_message
+
+        bridge_dir = bridge_dir_for_session_id(conv_id)
+        _publish_event(conv_id, {"type": "response.compaction.in_progress", "task_id": conv_id})
+        try:
+            await asyncio.to_thread(submit_user_message, bridge_dir, content="/compress")
+        except (RuntimeError, OSError) as exc:
+            _publish_event(conv_id, {"type": "response.compaction.failed", "task_id": conv_id})
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "qwen_native_compact_failed",
+                    "detail": _client_safe_error_detail(exc, context="qwen-native compact"),
+                },
+            )
+        return Response(status_code=200)
+
     async def _handle_claude_native_cost_popup(
         conv_id: str,
         elicitation_id: str,
@@ -14067,6 +14124,8 @@ def create_runner_app(
                 return await _handle_cursor_native_compact(conversation_id)
             if _session_harness_name(conversation_id) == "hermes-native":
                 return await _handle_hermes_native_compact(conversation_id)
+            if _session_harness_name(conversation_id) == "qwen-native":
+                return await _handle_qwen_native_compact(conversation_id)
             return Response(status_code=204)
 
         if body_type == "cost_approval_popup":

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -31,6 +31,7 @@ from omnigent import (
     codex_native_bridge,
     cursor_native_bridge,
     kiro_native_bridge,
+    qwen_native_bridge,
 )
 from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY,
@@ -11371,6 +11372,151 @@ async def test_events_compact_on_cursor_native_503_dismisses_spinner_on_inject_f
     ]
     # in_progress raised the spinner; failed must dismiss it. completed must
     # never fire — the history was not compacted.
+    assert compaction_types == [
+        "response.compaction.in_progress",
+        "response.compaction.failed",
+    ], f"Expected in_progress then failed (no completed); got {compaction_types!r}."
+
+
+@pytest.mark.asyncio
+async def test_events_compact_on_qwen_native_submits_compress_and_raises_spinner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    POST ``/events`` ``{"type":"compact"}`` on a qwen-native session submits
+    ``/compress`` via the input file, returns 200, and raises the spinner only.
+
+    qwen owns its context window inside the TUI, so compaction runs there
+    (``/compress``), not as AP-side compaction — same rationale as cursor-native.
+    Unlike cursor, injection is file-based: a ``submit`` line routes through
+    qwen's ``RemoteInputWatcher`` → ``submitQuery``, which processes the slash
+    command (no autocomplete-dropdown trap). The 200 is load-bearing (server
+    skips its own ``_run_compact_locked``). The handler publishes only
+    ``in_progress``; the ``completed`` edge is the compaction mirror's job once
+    the ``chat_compression`` record lands (covered in test_qwen_native_forwarder).
+    """
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.spec.types import ExecutorSpec
+
+    captured: list[tuple[Any, str]] = []
+
+    def _fake_submit(bridge_dir: Any, *, content: str) -> None:
+        """Record the input-file submit without touching disk."""
+        captured.append((bridge_dir, content))
+
+    monkeypatch.setattr(qwen_native_bridge, "submit_user_message", _fake_submit)
+
+    qwen_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "qwen-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return qwen_native_spec
+
+    conv_id = "conv_qwen_compact"
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "compact"},
+        )
+
+        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+    assert resp.status_code == 200, (
+        f"qwen-native compact must return 200 from /events; got {resp.status_code}: {resp.text}"
+    )
+    assert len(captured) == 1, (
+        f"Expected one submit_user_message call from qwen compact, got {len(captured)}."
+    )
+    bridge_dir, content = captured[0]
+    assert bridge_dir == qwen_native_bridge.bridge_dir_for_session_id(conv_id)
+    assert content == "/compress", f"Expected '/compress' submit content, got {content!r}."
+
+    compaction_types = [
+        e.get("type")
+        for e in queued_events
+        if str(e.get("type", "")).startswith("response.compaction")
+    ]
+    assert compaction_types == ["response.compaction.in_progress"], (
+        f"Handler must publish only in_progress (mirror completes it); got {compaction_types!r}."
+    )
+    in_progress = next(
+        e for e in queued_events if e.get("type") == "response.compaction.in_progress"
+    )
+    assert in_progress.get("task_id") == conv_id
+
+
+@pytest.mark.asyncio
+async def test_events_compact_on_qwen_native_503_dismisses_spinner_on_submit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A submit failure surfaces as 503 AND dismisses the spinner (in_progress→failed)."""
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.spec.types import ExecutorSpec
+
+    def _fake_submit(bridge_dir: Any, *, content: str) -> None:
+        del bridge_dir, content
+        raise RuntimeError("input file unwritable")
+
+    monkeypatch.setattr(qwen_native_bridge, "submit_user_message", _fake_submit)
+
+    qwen_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "qwen-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return qwen_native_spec
+
+    conv_id = "conv_qwen_compact_fail"
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "compact"},
+        )
+
+        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+
+    assert resp.status_code == 503, f"got {resp.status_code}: {resp.text}"
+    assert resp.json().get("error") == "qwen_native_compact_failed"
+    compaction_types = [
+        e.get("type")
+        for e in queued_events
+        if str(e.get("type", "")).startswith("response.compaction")
+    ]
     assert compaction_types == [
         "response.compaction.in_progress",
         "response.compaction.failed",

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -32,8 +32,10 @@ from omnigent.qwen_native_bridge import (
     write_tmux_target,
 )
 from omnigent.qwen_native_forwarder import (
+    _compaction_status_from_record,
     _event_to_item,
     _ForwardState,
+    _read_new_compaction_statuses,
     _read_new_events,
     _read_state,
     _write_state,
@@ -151,6 +153,61 @@ def test_malformed_line_tolerated(tmp_path: Path) -> None:
     assert [i.uuid for i in items] == ["u1"]
 
 
+# --- Compaction mirror (chat-recording tail) -------------------------------
+
+
+def _compression_record(status: int) -> dict:
+    """A qwen chat-recording ``chat_compression`` system event."""
+    return {
+        "type": "system",
+        "subtype": "chat_compression",
+        "systemPayload": {
+            "info": {
+                "originalTokenCount": 19398,
+                "newTokenCount": 17000,
+                "compressionStatus": status,
+            }
+        },
+    }
+
+
+def test_compaction_status_from_record() -> None:
+    assert _compaction_status_from_record(_compression_record(1)) == "completed"
+    # COMPRESSION_FAILED_* statuses → failed.
+    assert _compaction_status_from_record(_compression_record(2)) == "failed"
+    assert _compaction_status_from_record(_compression_record(3)) == "failed"
+    # Other recording lines are ignored.
+    assert _compaction_status_from_record({"type": "system", "subtype": "ui_telemetry"}) is None
+    assert _compaction_status_from_record(_user_ev("u1", "hi")) is None
+
+
+def test_read_new_compaction_statuses_incremental_and_ignores_other_lines(tmp_path: Path) -> None:
+    rec = tmp_path / "chat.jsonl"
+    # A transcript line + a successful compression record.
+    rec.write_bytes(_ev_bytes(_user_ev("u1", "hi")) + _ev_bytes(_compression_record(1)))
+    statuses, off = _read_new_compaction_statuses(rec, 0)
+    assert statuses == ["completed"]
+    assert off == rec.stat().st_size
+    # No new lines → nothing.
+    assert _read_new_compaction_statuses(rec, off) == ([], off)
+
+
+def test_read_new_compaction_statuses_detects_truncation(tmp_path: Path) -> None:
+    rec = tmp_path / "chat.jsonl"
+    rec.write_bytes(_ev_bytes(_user_ev("u1", "padding line, intentionally long " * 4)))
+    off = rec.stat().st_size
+    # A recreated (shorter) recording must rewind so a fresh compaction is seen.
+    rec.write_bytes(_ev_bytes(_compression_record(1)))
+    assert rec.stat().st_size < off
+    statuses, _ = _read_new_compaction_statuses(rec, off)
+    assert statuses == ["completed"]
+
+
+def test_read_new_compaction_statuses_missing_file(tmp_path: Path) -> None:
+    # Recording not created yet → no statuses, offset unchanged (retry next poll).
+    assert _read_new_compaction_statuses(tmp_path / "absent.jsonl", 0) == ([], 0)
+
+
 def test_wait_for_ready_times_out_without_boot_signal(tmp_path: Path) -> None:
     bridge = tmp_path / "bridge"
     prepare_bridge_files(bridge)
@@ -216,6 +273,19 @@ def test_qwen_session_recording_exists_is_workspace_scoped(
     assert qwen_session_recording_exists(sid, ws_b) is False
     # A different conversation's id under the same workspace is unaffected.
     assert qwen_session_recording_exists(qwen_session_id_for_conversation("conv_x"), ws_a) is False
+
+
+def test_qwen_session_recording_path_is_workspace_scoped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from omnigent.qwen_native_bridge import _qwen_project_slug, qwen_session_recording_path
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    sid = qwen_session_id_for_conversation("conv_rec")
+    expected = tmp_path / ".qwen" / "projects" / _qwen_project_slug(ws) / "chats" / f"{sid}.jsonl"
+    assert qwen_session_recording_path(sid, ws) == expected
 
 
 def test_bridge_submit_and_confirmation_append_jsonl(tmp_path: Path) -> None:
@@ -413,6 +483,45 @@ async def test_forward_loop_posts_new_events_and_persists(
     state = _read_state(bridge)
     assert state.offset > 0
     assert "u1" in (state.seen_uuids or [])
+
+
+async def test_compaction_mirror_seeds_at_eof_and_posts_new(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rec = tmp_path / "chat.jsonl"
+    # A pre-existing compression record (resume case): must NOT be re-posted.
+    rec.write_bytes(_ev_bytes(_compression_record(1)))
+
+    posted: list[str] = []
+
+    async def _fake_post(_client: object, *, session_id: str, status: str) -> None:
+        posted.append(status)
+
+    monkeypatch.setattr(fwd, "_post_external_compaction_status", _fake_post)
+
+    task = asyncio.create_task(
+        fwd.supervise_qwen_compaction_mirror(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            recording_path=rec,
+            poll_interval_s=0.01,
+        )
+    )
+    # Let it seed at EOF; the pre-existing record stays unposted.
+    await asyncio.sleep(0.05)
+    assert posted == []
+    # A new compression now lands and is mirrored.
+    with open(rec, "ab") as fh:
+        fh.write(_ev_bytes(_compression_record(1)))
+    for _ in range(200):
+        if posted:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+    assert posted == ["completed"]
 
 
 async def test_supervise_restarts_then_propagates_cancel(


### PR DESCRIPTION
## What

Wire the web UI's **compact** control to qwen-native sessions, with a "Compacting conversation…" → "Conversation compacted" indicator that tracks qwen's real progress. Mirrors cursor-native (#1259).

Previously the runner's `/events` compact dispatch had no qwen-native branch, so `/compact` returned a 204 no-op and the server fell through to its own AP-side compaction, which 400s on the LLM-less native pseudo-agent — explicit compaction must run inside the qwen TUI (it owns its own context window via `/compress`). Auto-compaction is surfaced too.

## How

```
 Web UI ──/compact──► Server ──forward──► Runner: _handle_qwen_native_compact
                                            ├─ publish in_progress  (spinner)
                                            ├─ submit "/compress" to --input-file
                                            └─ return 200 (server skips AP compaction)
                                                     │
                                          qwen TUI runs /compress, writes
                                          chat_compression to its recording
                                                     │
                              supervise_qwen_compaction_mirror tails recording
                                            └─ POST external_compaction_status
 Web UI ◄──completed SSE──────────────────────  (divider)
```

**Runner (`omnigent/runner/app.py`)** — add `_handle_qwen_native_compact`:
- Submits `/compress` into the TUI via the `--input-file` (`submit_user_message`). qwen's `RemoteInputWatcher` routes it through `submitQuery` (the keyboard's own path), which processes the slash command directly — **no** autocomplete-dropdown trap (cursor's send-keys bug) and no `/compress` user bubble on the stream (verified live, qwen v0.18.2).
- Publishes `response.compaction.in_progress` to raise the spinner; `response.compaction.failed` on injection error to dismiss it.
- Returns 200 so the server skips its own compaction.

**Forwarder (`omnigent/qwen_native_forwarder.py`)** — add `supervise_qwen_compaction_mirror`:
- Compaction is **invisible** on the `--json-file` stream (`session_start`'s `supported_events` omits it). But qwen writes a `{type:"system", subtype:"chat_compression", systemPayload:{info:{originalTokenCount,newTokenCount,compressionStatus}}}` record to its **built-in chat recording** (`~/.qwen/projects/<slug>/chats/<id>.jsonl`) the instant compression finishes.
- The mirror tails that recording (seeded at EOF so a resumed session's prior records don't re-fire) and POSTs `external_compaction_status` — `completed` on `compressionStatus == 1`, `failed` on the `COMPRESSION_FAILED_*` codes (2/3) — which the server republishes as the SSE the web UI already renders.
- Wired alongside the transcript forwarder + approval mirror under the one supervised bridges task.

**Bridge (`omnigent/qwen_native_bridge.py`)** — extract `qwen_session_recording_path` (reused by the mirror and the existing `--resume` guard).

## Testing

- `tests/runner/test_app_sessions_native.py`: compact → 200, submits `/compress`, raises the spinner but does **not** complete it; submit failure → 503 dismisses the spinner via `failed`.
- `tests/test_qwen_native_forwarder.py`: `chat_compression` status parsing (completed/failed/ignored), recording tail (incremental / truncation / missing-file), the mirror seeds at EOF and posts only new compactions, recording-path helper.

## Limitation / follow-up

The context ring won't shrink after compaction until usage is forwarded as `external_session_usage` (separate "Composer status line" follow-up in `docs/QWEN_FOLLOWUPS.md`); the recording's `newTokenCount` (or the stream's per-turn `message.usage`) can feed that.