### PR TITLE
fix(ap-web): show the shells list in the mobile session menu, like desktop

### DIFF
--- a/ap-web/src/shell/AppShell.test.tsx
+++ b/ap-web/src/shell/AppShell.test.tsx
@@ -2533,6 +2533,45 @@ describe("Mobile session menu", () => {
     expect(screen.getByTestId("todo-panel")).toBeInTheDocument();
   });
 
+  it("opens the Shells drawer with the same InlineTerminalsSection list as the desktop tab", () => {
+    // Mobile parity with the desktop rail's Shells tab: the entry opens the
+    // shell *list* in a drawer (not a jump straight into a terminal), so the
+    // list's "+ New shell" row is the empty-state entry point.
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_abc", permission_level: null }]);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_main", name: "main", session: "main", running: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    renderShell("/c/conv_abc");
+
+    // Drawer starts closed and its list unmounted. The default desktop rail
+    // tab is Files, so no inline-terminals-section renders there yet.
+    const drawer = screen.getByTestId("shells-panel-drawer");
+    expect(drawer).toHaveAttribute("data-state", "closed");
+    expect(within(drawer).queryByTestId("inline-terminals-section")).toBeNull();
+
+    openSessionMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Shells/i }));
+
+    // Failure: openShellsList didn't set terminalsListOpen, or the entry still
+    // routed straight into a terminal instead of the list drawer.
+    const openDrawer = screen.getByTestId("shells-panel-drawer");
+    expect(openDrawer).toHaveAttribute("data-state", "open");
+    expect(within(openDrawer).getByTestId("inline-terminals-section")).toBeInTheDocument();
+
+    // Picking a row hands off to the terminal host and closes the drawer —
+    // the same onExpand path the desktop tab uses.
+    fireEvent.click(within(openDrawer).getByRole("button", { name: "rail: open terminal" }));
+    expect(screen.getByTestId("shells-panel-drawer")).toHaveAttribute("data-state", "closed");
+    expect(screen.getByTestId("terminals-panel")).toHaveAttribute("data-state", "open");
+  });
+
   it("keeps the FAB with only the Agents entry for a minimal agent", () => {
     // available:false → no files; no shells, no todos, no debug. The
     // Agents entry is unconditional (badge = 1, the main agent), so the

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -50,6 +50,7 @@ import { FileViewer } from "./FileViewer";
 import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
+import { InlineTerminalsSection } from "./InlineTerminalsSection";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
 import { isMobileViewport, Sidebar } from "./Sidebar";
 import { TitleBarServerPicker } from "./TitleBarServerPicker";
@@ -206,6 +207,10 @@ export function AppShell() {
   // on a phone they open as full-screen overlays from the session-menu FAB.
   const [subagentsPanelOpen, setSubagentsPanelOpen] = useState(false);
   const [todosPanelOpen, setTodosPanelOpen] = useState(false);
+  // The mobile Shells drawer hosts the same InlineTerminalsSection list as
+  // the desktop rail's Shells tab; clicking a row hands off to the terminal
+  // host (TerminalsPanel / inline MainTerminalView) via ``openTerminalsPanel``.
+  const [terminalsListOpen, setTerminalsListOpen] = useState(false);
   // The right "Workspace" rail (WorkspacePanel) is open by default and
   // remembers its open/closed state per session — a brand-new session starts
   // open; reopening a session restores how the user last left it. Toggled
@@ -515,6 +520,7 @@ export function AppShell() {
     setFilesPanelOpen(false);
     setSubagentsPanelOpen(false);
     setTodosPanelOpen(false);
+    setTerminalsListOpen(false);
     setFilesPanelShowHidden(false);
     if (!conversationId) {
       // No session → no rail; false (not the open default) so rail-gated
@@ -662,6 +668,7 @@ export function AppShell() {
       setFilesPanelOpen(false); // close files drawer so the viewer is unobscured
       setSubagentsPanelOpen(false); // close mobile agents drawer
       setTodosPanelOpen(false); // close mobile tasks drawer
+      setTerminalsListOpen(false); // close mobile shells drawer
       // Pull the rail to the Files tab when parked on a tab where the viewer
       // won't render (Terminals, Subagents, Todos). The Files tab surfaces the
       // FileViewer inline, so leave it undisturbed.
@@ -845,6 +852,7 @@ export function AppShell() {
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
+    setTerminalsListOpen(false); // close mobile shells drawer (row was picked)
     setPanelInitialKey(key);
   }
 
@@ -855,6 +863,7 @@ export function AppShell() {
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
+    setTerminalsListOpen(false); // close mobile shells drawer
     setExecutionLogsKey(key);
   }
 
@@ -868,6 +877,7 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setSubagentsPanelOpen(false); // close mobile agents drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
+    setTerminalsListOpen(false); // close mobile shells drawer
     setFilesPanelOpen(true);
   }
 
@@ -880,6 +890,7 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
     setTodosPanelOpen(false); // close mobile tasks drawer
+    setTerminalsListOpen(false); // close mobile shells drawer
     setSubagentsPanelOpen(true);
   }
 
@@ -892,16 +903,26 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
+    setTerminalsListOpen(false); // close mobile shells drawer
     setTodosPanelOpen(true);
   }
 
-  function openFirstTerminal() {
-    // Mobile FAB → "Terminals" routes to the first terminal so the
-    // single tap is equivalent to clicking the first row in the
-    // desktop rail's terminals card. Inventory view — the embedded
-    // REPL terminal is the pill's Terminal view, not a rail entry.
-    if (railTerminals.length === 0) return;
-    openTerminalsPanel(terminalTabKey(railTerminals[0]));
+  // Mobile FAB → "Shells" opens the same InlineTerminalsSection list as the
+  // desktop rail's Shells tab, as a full-screen drawer (not a jump straight
+  // into a terminal). Clicking a row — or the list's "+ New shell" — hands
+  // off to ``openTerminalsPanel``, which closes this drawer and opens the
+  // terminal host (the TerminalsPanel overlay, or the inline MainTerminalView
+  // in terminal-first sessions). The empty state is the list's own "+ New
+  // shell" row, exactly like the desktop tab.
+  function openShellsList() {
+    setSelectedFilePath(null); // close file viewer
+    clearFileViewerUrl();
+    setPanelInitialKey(null); // close terminals panel
+    setExecutionLogsKey(null); // close execution-logs panel
+    setFilesPanelOpen(false); // close files drawer
+    setSubagentsPanelOpen(false); // close mobile agents drawer
+    setTodosPanelOpen(false); // close mobile tasks drawer
+    setTerminalsListOpen(true);
   }
 
   function openMainExecutionLog() {
@@ -1088,7 +1109,8 @@ export function AppShell() {
                     filesPanelOpen,
                     subagentsPanelOpen,
                     todosPanelOpen,
-                    hideTerminalsTab,
+                    terminalsListOpen,
+                    showShellsTab: railTabsAvailable.terminals,
                     terminalsLength: railTerminals.length,
                     isClaudeNative,
                     todosCompleted,
@@ -1098,7 +1120,7 @@ export function AppShell() {
                     subagentsWorking,
                     agentCount,
                     onOpenFiles: openFilesPanel,
-                    onOpenFirstTerminal: openFirstTerminal,
+                    onOpenShells: openShellsList,
                     onOpenSubagents: openSubagentsPanel,
                     onOpenTodos: openTodosPanel,
                     onOpenMainExecutionLog: openMainExecutionLog,
@@ -1219,6 +1241,22 @@ export function AppShell() {
                   testId="todos-panel-drawer"
                 >
                   <TodoPanel frameless />
+                </MobilePanelDrawer>
+              )}
+              {conversationId && (
+                <MobilePanelDrawer
+                  open={terminalsListOpen}
+                  title="Shells"
+                  onClose={() => setTerminalsListOpen(false)}
+                  testId="shells-panel-drawer"
+                >
+                  {/* Same list as the desktop rail's Shells tab. ``onExpand``
+                      (a row click or "+ New shell") opens the terminal host
+                      and closes this drawer via ``openTerminalsPanel``. */}
+                  <InlineTerminalsSection
+                    conversationId={conversationId}
+                    onExpand={openTerminalsPanel}
+                  />
                 </MobilePanelDrawer>
               )}
               {/* Mobile-only push panel — on desktop the viewer lives inside the inline aside. */}

--- a/ap-web/src/shell/ChatHeader.test.tsx
+++ b/ap-web/src/shell/ChatHeader.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Agent } from "@/hooks/useAgents";
@@ -16,7 +16,8 @@ const mobileMenu = {
   filesPanelOpen: false,
   subagentsPanelOpen: false,
   todosPanelOpen: false,
-  hideTerminalsTab: false,
+  terminalsListOpen: false,
+  showShellsTab: false,
   terminalsLength: 0,
   isClaudeNative: false,
   todosCompleted: 0,
@@ -26,7 +27,7 @@ const mobileMenu = {
   subagentsWorking: 0,
   agentCount: 1,
   onOpenFiles: () => {},
-  onOpenFirstTerminal: () => {},
+  onOpenShells: () => {},
   onOpenSubagents: () => {},
   onOpenTodos: () => {},
   onOpenMainExecutionLog: () => {},
@@ -126,5 +127,73 @@ describe("ChatHeader — sub-agent affordance", () => {
       "/c/parent-123",
     );
     expect(screen.getByText("Sub-agent")).toBeInTheDocument();
+  });
+});
+
+describe("ChatHeader — mobile Shells entry", () => {
+  // Renders the header with an active session so the mobile FAB mounts,
+  // then opens its dropdown. `hasRailContent` is true so the FAB shows;
+  // every drawer/panel flag stays false so the menu isn't suppressed.
+  function openMobileMenu(menuOverrides: Partial<typeof mobileMenu> = {}) {
+    render(
+      <MemoryRouter initialEntries={["/c/conv_1"]}>
+        <TooltipProvider>
+          <ChatHeader
+            sidebarOpen
+            onOpenSidebar={() => {}}
+            isChildSession={false}
+            parentSessionId={undefined}
+            conversationId="conv_1"
+            boundAgent={undefined}
+            canShare={false}
+            onShare={() => {}}
+            hasAgentInfo={false}
+            onAgentInfo={() => {}}
+            hasHeaderMenu={false}
+            showFilesPanel={false}
+            hasRailContent
+            rightPanelOpen={false}
+            onToggleRightPanel={() => {}}
+            mobileMenu={{ ...mobileMenu, ...menuOverrides }}
+          />
+        </TooltipProvider>
+      </MemoryRouter>,
+    );
+    // Radix DropdownMenu opens on pointerdown, not click.
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Open session menu" }), { button: 0 });
+  }
+
+  it("shows the Shells entry with no badge when the agent supports shells but none exist", () => {
+    // Parity with the desktop rail's Shells tab: the entry is a default
+    // entry point (its tap opens the "+ New shell" empty state), so it
+    // renders even at zero shells — and like the desktop tab, omits the
+    // count badge there (a "0" would read as an error state).
+    openMobileMenu({ showShellsTab: true, terminalsLength: 0 });
+
+    const shells = screen.getByRole("menuitem", { name: /Shells/i });
+    expect(shells).toBeInTheDocument();
+    expect(shells).not.toHaveTextContent("0");
+  });
+
+  it("renders the count badge once shells exist", () => {
+    openMobileMenu({ showShellsTab: true, terminalsLength: 2 });
+
+    expect(screen.getByRole("menuitem", { name: /Shells/i })).toHaveTextContent("2");
+  });
+
+  it("hides the Shells entry when the tab is unavailable", () => {
+    // e.g. a claude-native sub-agent, or an agent with no shell access
+    // and no shells — the desktop tab is hidden the same way.
+    openMobileMenu({ showShellsTab: false, terminalsLength: 0 });
+
+    expect(screen.queryByRole("menuitem", { name: /Shells/i })).toBeNull();
+  });
+
+  it("routes a tap to onOpenShells (opens the InlineTerminalsSection drawer)", () => {
+    const onOpenShells = vi.fn();
+    openMobileMenu({ showShellsTab: true, terminalsLength: 0, onOpenShells });
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /Shells/i }));
+    expect(onOpenShells).toHaveBeenCalledTimes(1);
   });
 });

--- a/ap-web/src/shell/ChatHeader.tsx
+++ b/ap-web/src/shell/ChatHeader.tsx
@@ -48,9 +48,17 @@ interface MobileSessionMenuProps {
   subagentsPanelOpen: boolean;
   /** True while the mobile tasks drawer is open. */
   todosPanelOpen: boolean;
-  /** Hide the Shells entry (claude-native sub-agents only). */
-  hideTerminalsTab: boolean;
-  /** Number of open terminals (entry badge + visibility). */
+  /** True while the mobile shells drawer is open. */
+  terminalsListOpen: boolean;
+  /**
+   * Whether the Shells entry should render — mirrors the desktop rail's
+   * Shells tab gate (`railTabsAvailable.terminals`): shown when the
+   * agent declares shell access (its empty state is the "+ New shell"
+   * entry point) or once a shell exists, and hidden for claude-native
+   * sub-agents.
+   */
+  showShellsTab: boolean;
+  /** Number of open terminals (entry badge). */
   terminalsLength: number;
   /** Whether this is a claude-native session (gates the Tasks entry). */
   isClaudeNative: boolean;
@@ -71,8 +79,8 @@ interface MobileSessionMenuProps {
   agentCount: number;
   /** Open the mobile files drawer. */
   onOpenFiles: () => void;
-  /** Open the first terminal in the terminals push panel. */
-  onOpenFirstTerminal: () => void;
+  /** Open the mobile shells drawer (the InlineTerminalsSection list). */
+  onOpenShells: () => void;
   /** Open the mobile agents drawer. */
   onOpenSubagents: () => void;
   /** Open the mobile tasks drawer. */
@@ -358,6 +366,7 @@ export function ChatHeader({
           !mobileMenu.filesPanelOpen &&
           !mobileMenu.subagentsPanelOpen &&
           !mobileMenu.todosPanelOpen &&
+          !mobileMenu.terminalsListOpen &&
           (hasRailContent || mobileMenu.debugMode) && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -411,22 +420,32 @@ export function ChatHeader({
                       : mobileMenu.agentCount}
                   </span>
                 </DropdownMenuItem>
-                {/* Shells — hidden only for claude-native sub-agents,
-                    matching the desktop rail's Shells tab. The agent's
-                    own terminal (SDK REPL / native vendor pane) is
-                    excluded from the count (it's reached via the
-                    Chat/Terminal pill), so this entry appears only
-                    when real shells exist. */}
-                {!mobileMenu.hideTerminalsTab && mobileMenu.terminalsLength > 0 && (
+                {/* Shells — same gate as the desktop rail's Shells tab
+                    (``showShellsTab``): shown when the agent declares
+                    shell access or a shell exists, hidden for
+                    claude-native sub-agents. Opens the same
+                    InlineTerminalsSection list as the desktop tab in a
+                    drawer (where "+ New shell" is the empty-state entry
+                    point), rather than jumping straight into a terminal.
+                    The agent's own terminal (SDK REPL / native vendor
+                    pane) is excluded from the count, so the badge — like
+                    the desktop tab's — appears only once a real shell
+                    exists; a "0" next to a default-visible entry reads as
+                    an error state. */}
+                {mobileMenu.showShellsTab && (
                   <DropdownMenuItem
-                    onSelect={mobileMenu.onOpenFirstTerminal}
+                    onSelect={mobileMenu.onOpenShells}
                     className="gap-2.5 px-2.5 py-2 text-base"
                   >
                     <TerminalIcon className="size-4" />
                     Shells
-                    <span className={cn(TAB_BADGE_BASE, "ml-auto bg-muted text-muted-foreground")}>
-                      {mobileMenu.terminalsLength}
-                    </span>
+                    {mobileMenu.terminalsLength > 0 && (
+                      <span
+                        className={cn(TAB_BADGE_BASE, "ml-auto bg-muted text-muted-foreground")}
+                      >
+                        {mobileMenu.terminalsLength}
+                      </span>
+                    )}
                   </DropdownMenuItem>
                 )}
                 {mobileMenu.isClaudeNative && mobileMenu.todosTotal > 0 && (


### PR DESCRIPTION
## What

On mobile, the session-menu **Shells** entry now mirrors the desktop right-rail **Shells tab**:

- **Visibility:** the entry uses the same gate as the desktop tab (`railTabsAvailable.terminals`) — shown whenever the agent supports shells (or one already exists), instead of only once a shell existed.
- **Behavior:** tapping it opens the same `InlineTerminalsSection` **list** (open shells + a "+ New shell" row) in a full-screen `MobilePanelDrawer` — the same pattern Agents/Tasks already use — rather than jumping straight into the first terminal. Picking a row (or "+ New shell") hands off to the terminal host and closes the drawer.

## Why

The desktop Shells tab is always shown when the agent declares shell access; its empty state is the "+ New shell" entry point. The mobile menu only listed Shells once a shell existed, and even then jumped straight into the xterm — a different interaction that left no entry point for creating the first shell. (The old "jump to first terminal" was mirroring `SessionRail`'s legacy terminals card, which is no longer rendered — the live rail is `WorkspacePanel` → `InlineTerminalsSection`.)

Because the list's "+ New shell" row is the empty-state entry point, this also gives **terminal-first sessions** a real way to create a first shell on mobile, with no special-casing of the terminal host.

## Changes

- **`ChatHeader.tsx`** — gate the Shells entry on `showShellsTab`; entry opens the shells list drawer (`onOpenShells`); the FAB hides while that drawer is open; the count badge still appears only once a shell exists (a "0" reads as an error state, matching the desktop tab).
- **`AppShell.tsx`** — add the mobile Shells `MobilePanelDrawer` hosting `InlineTerminalsSection`; replace `openFirstTerminal` with `openShellsList`; row clicks / "+ New shell" route through `openTerminalsPanel`, which closes the drawer and opens the terminal host (the `TerminalsPanel` overlay, or the inline `MainTerminalView` for terminal-first sessions).

## Testing

- `npm run type-check` — clean.
- Affected suites pass (`ChatHeader`, `AppShell`, `TerminalsPanel`, `WorkspacePanel`, `InlineTerminalsSection`, `MainTerminalView`, `NewTerminalButton`).
- New coverage: ChatHeader Shells-entry visibility (shown at 0 shells with no badge, badge once shells exist, hidden when unavailable, routes to `onOpenShells`); AppShell opens the Shells drawer with the list and expanding a row opens the terminal host + closes the drawer.

This pull request and its description were written by Isaac.
