### PR TITLE
feat(web): remember last-selected run mode per harness

### DIFF
--- a/ap-web/src/lib/modePreferences.test.ts
+++ b/ap-web/src/lib/modePreferences.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLastModeForHarness, writeLastModeForHarness } from "./modePreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("modePreferences", () => {
+  it("returns null when nothing is stored for a harness", () => {
+    // A first-time visitor has no pick on record — read must say so (null)
+    // so the composer seeds the harness default.
+    expect(readLastModeForHarness("claude-native")).toBeNull();
+  });
+
+  it("returns null for a null/empty harness", () => {
+    writeLastModeForHarness("claude-native", "auto");
+    expect(readLastModeForHarness(null)).toBeNull();
+    expect(readLastModeForHarness(undefined)).toBeNull();
+    expect(readLastModeForHarness("")).toBeNull();
+  });
+
+  it("round-trips a written mode", () => {
+    writeLastModeForHarness("claude-native", "plan");
+    expect(readLastModeForHarness("claude-native")).toBe("plan");
+  });
+
+  it("keeps each harness's pick independent", () => {
+    // The whole point: a Codex pick must not leak into Claude Code's slot.
+    writeLastModeForHarness("claude-native", "auto");
+    writeLastModeForHarness("codex-native", "full-access");
+    writeLastModeForHarness("cursor-native", "yolo");
+    expect(readLastModeForHarness("claude-native")).toBe("auto");
+    expect(readLastModeForHarness("codex-native")).toBe("full-access");
+    expect(readLastModeForHarness("cursor-native")).toBe("yolo");
+  });
+
+  it("overwrites the previous pick for the same harness", () => {
+    writeLastModeForHarness("claude-native", "auto");
+    writeLastModeForHarness("claude-native", "plan");
+    expect(readLastModeForHarness("claude-native")).toBe("plan");
+  });
+
+  it("ignores a null/empty harness on write", () => {
+    writeLastModeForHarness(null, "auto");
+    writeLastModeForHarness("", "auto");
+    expect(localStorage.getItem("omnigent:last-mode-by-harness")).toBeNull();
+  });
+
+  it("tolerates a corrupted blob", () => {
+    localStorage.setItem("omnigent:last-mode-by-harness", "not json{");
+    expect(readLastModeForHarness("claude-native")).toBeNull();
+    // A later write recovers — it doesn't propagate the corruption.
+    writeLastModeForHarness("claude-native", "plan");
+    expect(readLastModeForHarness("claude-native")).toBe("plan");
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeLastModeForHarness("claude-native", "auto")).not.toThrow();
+    expect(readLastModeForHarness("claude-native")).toBeNull();
+  });
+});

--- a/ap-web/src/lib/modePreferences.ts
+++ b/ap-web/src/lib/modePreferences.ts
@@ -1,0 +1,61 @@
+// Persisted, app-global preference for the last mode the user picked on the
+// new-session landing composer's Advanced menu, keyed by harness.
+//
+// The "mode" is harness-specific: Claude Code's permission mode, Codex's /
+// OpenCode's approval mode, and Cursor's execution mode are distinct knobs
+// living on distinct native harnesses. We store them under one JSON map
+// (harness id -> mode value) so each harness remembers its own last pick and
+// a new session seeds the Advanced menu from it instead of always starting on
+// the harness default.
+//
+// Like agentPreferences, the landing screen keeps live React state as the
+// source of truth; these helpers only snapshot a pick and seed it back on a
+// later visit. The consumer validates the stored value against the harness's
+// current mode list and falls back to the default when it no longer exists.
+
+const STORAGE_KEY = "omnigent:last-mode-by-harness";
+
+type ModeMap = Record<string, string>;
+
+function readMap(): ModeMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    // Keep only string->string entries; tolerate a corrupted/partial blob.
+    const out: ModeMap = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read the last mode the user picked for `harness` on the landing composer.
+ * Returns `null` when nothing is stored, on a server render (no `window`),
+ * or when storage is inaccessible/corrupted — never throws.
+ */
+export function readLastModeForHarness(harness: string | null | undefined): string | null {
+  if (!harness) return null;
+  return readMap()[harness] ?? null;
+}
+
+/**
+ * Persist `mode` as the user's last explicit pick for `harness`. Swallows
+ * quota/access errors so a failed write can't break session creation.
+ */
+export function writeLastModeForHarness(harness: string | null | undefined, mode: string): void {
+  if (typeof window === "undefined" || !harness) return;
+  try {
+    const map = readMap();
+    map[harness] = mode;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage quota or access errors shouldn't break the composer.
+  }
+}

--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -527,6 +527,76 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toEqual(["--permission-mode", "bypassPermissions"]);
   });
 
+  it("seeds the permission mode from the last pick for claude-native on a new session", async () => {
+    // A returning user's last pick for this harness is on record; the new
+    // session must auto-fill it (the "Mode:" pill reflects it) and post it
+    // WITHOUT the user re-opening the pill.
+    localStorage.setItem(
+      "omnigent:last-mode-by-harness",
+      JSON.stringify({ "claude-native": "plan" }),
+    );
+    setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_native" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    // Seeded without touching the pill — the label proves the state was
+    // pre-filled from storage.
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-permission-pill").textContent).toContain("Plan"),
+    );
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.terminal_launch_args).toEqual(["--permission-mode", "plan"]);
+  });
+
+  it("persists the picked permission mode for claude-native so the next session seeds it", async () => {
+    setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_native" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-permission-pill"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-permission-acceptEdits"));
+
+    // The pick is snapshotted under the harness key immediately, so the next
+    // visit can seed from it.
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem("omnigent:last-mode-by-harness") ?? "{}")).toEqual({
+        "claude-native": "acceptEdits",
+      }),
+    );
+  });
+
+  it("does not leak one harness's mode onto another harness's pill", async () => {
+    // Codex has a pick on record; selecting Claude Code (no pick) must stay on
+    // its default — modes are keyed per harness, not shared.
+    localStorage.setItem(
+      "omnigent:last-mode-by-harness",
+      JSON.stringify({ "codex-native": "full-access" }),
+    );
+    setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    // Claude Code has no stored pick → default; Codex's "Full access" must not
+    // bleed into the permission pill.
+    expect(screen.getByTestId("new-chat-landing-permission-pill").textContent).toContain("Default");
+    expect(screen.getByTestId("new-chat-landing-permission-pill").textContent).not.toContain(
+      "Full access",
+    );
+  });
+
   it("omits terminal_launch_args when permission mode is left at default for claude-native", async () => {
     setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({

--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -597,6 +597,52 @@ describe("NewChatLandingScreen create flow", () => {
     );
   });
 
+  it("resets the shared approval mode to default when switching codex-native → opencode-native", async () => {
+    // codex-native and opencode-native share a single approvalMode state. A
+    // codex pick must NOT linger after switching to OpenCode (which has no
+    // stored pick) — otherwise a more-permissive mode would silently flow
+    // into the OpenCode launch args. Regression test for the seeding effect's
+    // reset-on-no-stored-value branch.
+    setAgents([
+      agent({ id: "ag_codex", name: "codex-native-ui", display_name: "Codex" }),
+      agent({ id: "ag_opencode", name: "opencode-native-ui", display_name: "OpenCode" }),
+    ]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_opencode" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    // Pick "Full access" for Codex.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-approval-pill"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-approval-full-access"));
+    expect(screen.getByTestId("new-chat-landing-approval-pill").textContent).toContain(
+      "Full access",
+    );
+
+    // Switch the picker to OpenCode (Radix opens on pointerdown).
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-ag_opencode"));
+
+    // OpenCode has no stored pick → the shared approval knob must reset to
+    // Default, not keep Codex's "Full access".
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-approval-pill").textContent).toContain("Default"),
+    );
+    expect(screen.getByTestId("new-chat-landing-approval-pill").textContent).not.toContain(
+      "Full access",
+    );
+
+    // And that reset must reach the launch args: no sandbox/approval flags.
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.terminal_launch_args).toBeUndefined();
+  });
+
   it("omits terminal_launch_args when permission mode is left at default for claude-native", async () => {
     setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1268,19 +1268,28 @@ export function NewChatLandingScreen() {
   // Seed the harness's mode knob from the user's last pick when the selected
   // harness changes (including the first mount), so a returning user starts a
   // new session on the mode they used last for that harness instead of the
-  // default. A stale stored value not in the current list is ignored. Keyed
-  // on the harness so an in-session edit isn't clobbered on re-render — only a
-  // harness switch reseeds.
+  // default. Keyed on the harness so an in-session edit isn't clobbered on
+  // re-render — only a harness switch reseeds.
   useEffect(() => {
     if (!selectedNativeHarness) return;
     const stored = readLastModeForHarness(selectedNativeHarness);
-    if (stored == null) return;
+    // Resolve to the stored value when it's still valid for this harness,
+    // else the harness default. The else branch must RESET (not early-return)
+    // because codex-native and opencode-native share the single approvalMode
+    // state: returning early would leave the previously-selected harness's
+    // mode in place — e.g. codex's "full-access" carried onto OpenCode — and
+    // flow into the launch args unchanged. A stale value not in the current
+    // list resolves to the default for the same reason.
+    const resolve = (modes: readonly { value: string }[], dflt: string) =>
+      stored != null && modes.some((m) => m.value === stored) ? stored : dflt;
     if (supportsPermissionMode) {
-      if (CLAUDE_NATIVE_PERMISSION_MODES.some((m) => m.value === stored)) setPermissionMode(stored);
+      setPermissionMode(
+        resolve(CLAUDE_NATIVE_PERMISSION_MODES, CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE),
+      );
     } else if (supportsApprovalMode) {
-      if (CODEX_NATIVE_APPROVAL_MODES.some((m) => m.value === stored)) setApprovalMode(stored);
+      setApprovalMode(resolve(CODEX_NATIVE_APPROVAL_MODES, CODEX_NATIVE_DEFAULT_APPROVAL_MODE));
     } else if (supportsCursorMode) {
-      if (CURSOR_NATIVE_EXEC_MODES.some((m) => m.value === stored)) setCursorExecMode(stored);
+      setCursorExecMode(resolve(CURSOR_NATIVE_EXEC_MODES, CURSOR_NATIVE_DEFAULT_EXEC_MODE));
     }
     // Reseed only on harness change; capability flags are derived from the
     // same harness so they don't need to be deps.

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -44,12 +44,14 @@ import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import { getCliServerUrl } from "@/lib/host";
 import { getOmnigentHostConfig } from "@/lib/host";
 import { readLastAgentId, writeLastAgentId } from "@/lib/agentPreferences";
+import { readLastModeForHarness, writeLastModeForHarness } from "@/lib/modePreferences";
 import { BRAIN_HARNESS_LABELS } from "@/lib/agentLabels";
 import { BUILTIN_AGENTS, sortAgentsForDisplay } from "@/lib/agentGrouping";
 import { cn } from "@/lib/utils";
 import {
   isNativeCodingAgent,
   nativeAgentHasCapability,
+  nativeCodingAgentForAvailableAgent,
   nativeWrapperLabelsForAgent,
 } from "@/lib/nativeCodingAgents";
 import { useHosts, type Host } from "@/hooks/useHosts";
@@ -1259,6 +1261,32 @@ export function NewChatLandingScreen() {
   useEffect(() => {
     setBypassSandbox(false);
   }, [effectiveAgentId]);
+  // The selected native harness, used to persist/seed its mode pick (the
+  // mode knob is harness-specific). null for non-native agents, which have
+  // no mode knob to remember.
+  const selectedNativeHarness =
+    nativeCodingAgentForAvailableAgent(selectedAgent)?.harness ?? null;
+  // Seed the harness's mode knob from the user's last pick when the selected
+  // harness changes (including the first mount), so a returning user starts a
+  // new session on the mode they used last for that harness instead of the
+  // default. A stale stored value not in the current list is ignored. Keyed
+  // on the harness so an in-session edit isn't clobbered on re-render — only a
+  // harness switch reseeds.
+  useEffect(() => {
+    if (!selectedNativeHarness) return;
+    const stored = readLastModeForHarness(selectedNativeHarness);
+    if (stored == null) return;
+    if (supportsPermissionMode) {
+      if (CLAUDE_NATIVE_PERMISSION_MODES.some((m) => m.value === stored)) setPermissionMode(stored);
+    } else if (supportsApprovalMode) {
+      if (CODEX_NATIVE_APPROVAL_MODES.some((m) => m.value === stored)) setApprovalMode(stored);
+    } else if (supportsCursorMode) {
+      if (CURSOR_NATIVE_EXEC_MODES.some((m) => m.value === stored)) setCursorExecMode(stored);
+    }
+    // Reseed only on harness change; capability flags are derived from the
+    // same harness so they don't need to be deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedNativeHarness]);
   // Native-terminal agents interpret slash commands inside their own CLI
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
@@ -1884,13 +1912,22 @@ export function NewChatLandingScreen() {
                   <ModePill label={permissionModeLabel} testId="new-chat-landing-permission-pill">
                     <PermissionModeOptions
                       value={permissionMode}
-                      onValueChange={setPermissionMode}
+                      onValueChange={(mode) => {
+                        setPermissionMode(mode);
+                        writeLastModeForHarness(selectedNativeHarness, mode);
+                      }}
                     />
                   </ModePill>
                 )}
                 {supportsApprovalMode && (
                   <ModePill label={approvalModeLabel} testId="new-chat-landing-approval-pill">
-                    <ApprovalModeOptions value={approvalMode} onValueChange={setApprovalMode} />
+                    <ApprovalModeOptions
+                      value={approvalMode}
+                      onValueChange={(mode) => {
+                        setApprovalMode(mode);
+                        writeLastModeForHarness(selectedNativeHarness, mode);
+                      }}
+                    />
                     <DropdownMenuSeparator />
                     <BypassSandboxOption
                       enabled={bypassSandbox}
@@ -1900,7 +1937,13 @@ export function NewChatLandingScreen() {
                 )}
                 {supportsCursorMode && (
                   <ModePill label={cursorExecModeLabel} testId="new-chat-landing-cursor-mode-pill">
-                    <CursorModeOptions value={cursorExecMode} onValueChange={setCursorExecMode} />
+                    <CursorModeOptions
+                      value={cursorExecMode}
+                      onValueChange={(mode) => {
+                        setCursorExecMode(mode);
+                        writeLastModeForHarness(selectedNativeHarness, mode);
+                      }}
+                    />
                   </ModePill>
                 )}
               </div>

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1264,8 +1264,7 @@ export function NewChatLandingScreen() {
   // The selected native harness, used to persist/seed its mode pick (the
   // mode knob is harness-specific). null for non-native agents, which have
   // no mode knob to remember.
-  const selectedNativeHarness =
-    nativeCodingAgentForAvailableAgent(selectedAgent)?.harness ?? null;
+  const selectedNativeHarness = nativeCodingAgentForAvailableAgent(selectedAgent)?.harness ?? null;
   // Seed the harness's mode knob from the user's last pick when the selected
   // harness changes (including the first mount), so a returning user starts a
   // new session on the mode they used last for that harness instead of the


### PR DESCRIPTION
## What

On the new-session landing composer, the run mode you pick is now **remembered per harness** and auto-fills the **Mode:** pill the next time you start a session with that harness.

Before, the mode pill always reset to each harness's default on a new session. Now:

- **Claude Code** remembers its permission mode (e.g. *Auto*, *Plan*),
- **Codex / OpenCode** remember their approval mode (e.g. *Full access*),
- **Cursor** remembers its execution mode,

…each independently, keyed by harness — picking *Full access* for Codex never bleeds into Claude Code's pill.

## How

- New `ap-web/src/lib/modePreferences.ts` — mirrors the existing `agentPreferences.ts` pattern. Stores a `{ harness -> mode }` map in `localStorage` under `omnigent:last-mode-by-harness`, with `readLastModeForHarness` / `writeLastModeForHarness`. Tolerates a corrupted blob and swallows quota/access errors, so a broken preference can never break session creation.
- `NewChatDialog.tsx`:
  - derives the selected native harness and adds an effect, keyed on that harness, that **seeds** the relevant mode state when the harness changes (including first mount). Keying on the harness means an in-session edit isn't clobbered on re-render, and a stale stored value not in the current mode list is ignored.
  - the three `ModePill` dropdowns now **persist** the pick on change.

## Tests

- `modePreferences.test.ts` — round-trip, per-harness independence, corruption / inaccessible-storage resilience (8 tests).
- 3 new flow tests in `NewChatDialog.flow.test.tsx` proving: a seeded mode auto-fills the pill and posts the right launch args without opening the menu; a pick is snapshotted under the harness key immediately; and one harness's mode doesn't leak onto another.

`npm run type-check` clean; relevant vitest suites pass (44 passed, 1 pre-existing skip).