### PR TITLE
fix(ui): keep quick-pin button flex so the pin icon stays centered

### DIFF
--- a/ap-web/src/shell/Sidebar.rowActions.test.tsx
+++ b/ap-web/src/shell/Sidebar.rowActions.test.tsx
@@ -171,14 +171,34 @@ describe("quick pin/unpin hover button", () => {
     // affordance is visible at any breakpoint.
     renderSidebar();
 
-    // Desktop quick button: hidden on mobile, shown on desktop.
+    // Desktop quick button: hidden on mobile, revealed from `md` up. The reveal
+    // uses `md:inline-flex` (not `md:block`) so the button stays a flex
+    // container — see the centering regression test below.
     const quickButton = screen.getByTestId("quick-pin-conversation");
-    expect(quickButton).toHaveClass("hidden", "md:block");
+    expect(quickButton).toHaveClass("hidden", "md:inline-flex");
 
     // Kebab Pin item: present in the menu but hidden from `md` up, so it only
     // surfaces on mobile.
     fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
     expect(screen.getByTestId("pin-conversation")).toHaveClass("md:hidden");
+  });
+
+  it("reveals the quick-pin button without breaking icon centering (regression for #1226)", () => {
+    // The Button base centers its icon with `inline-flex` + `items-center
+    // justify-center`. The desktop reveal MUST keep a flex display: PR #1226
+    // revealed it with `md:block`, which overrode `inline-flex`, made the
+    // centering classes inert, and shoved the pin glyph to the button's
+    // top-left corner (~6px off-center). Guard the display so the reveal
+    // stays flex and the glyph stays centered.
+    renderSidebar();
+
+    const quickButton = screen.getByTestId("quick-pin-conversation");
+    // The centering classes are present...
+    expect(quickButton).toHaveClass("items-center", "justify-center");
+    // ...and the desktop reveal makes the button a flex container (so those
+    // classes actually take effect), rather than a block (which would not).
+    expect(quickButton).toHaveClass("md:inline-flex");
+    expect(quickButton).not.toHaveClass("md:block");
   });
 });
 

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1664,7 +1664,13 @@ function ConversationRow({
             // "Pinned" section header (and pinned-first ordering inside a
             // project) already conveys the pinned state. Revealed glyph:
             // unpin if pinned, pin otherwise.
-            "hidden md:block",
+            //
+            // `md:inline-flex` (not `md:block`): the Button base is
+            // `inline-flex` and relies on it for `items-center justify-center`
+            // to center the icon. `md:block` would override that display and
+            // collapse the centering, leaving the glyph pinned to the top-left
+            // of the button — so keep the flex display when revealing it.
+            "hidden md:inline-flex",
             "md:opacity-0 md:group-hover:opacity-100",
             "md:group-has-[:focus-visible]:opacity-100 md:group-has-[[aria-expanded=true]]:opacity-100",
           )}


### PR DESCRIPTION
## Problem

The desktop hover-revealed **quick-pin button** on sidebar conversation rows renders its pin glyph ~6px off-center (shoved to the top-left of the button), while the button background itself is correctly placed.

## Root cause — regression from #1226

PR #1226 (`fix(ui): fold the pin button into the kebab menu on mobile`) made the pin button desktop-only by revealing it with `"hidden md:block"`.

The intent was visibility control, but `md:block` also **overrides the Button base `inline-flex`**. The Button relies on `inline-flex` for its `items-center justify-center` to center the icon — with `display: block`, those classes become inert and the single pin svg sits at the top-left of the content box.

The adjacent kebab button is unaffected because it toggles visibility via `md:opacity-0` (not `display`), so it keeps its flex centering — which is why only the pin looked off.

## Fix

Reveal the button with `md:inline-flex` instead of `md:block`, preserving the flex display so `items-center justify-center` keep centering the icon.

Verified against a live dev server with a headless browser: the pin's center now matches the button's center exactly on both axes (`dx: 0, dy: 0`), where it was previously offset by ~6px horizontally.

## Test

- Updated the existing viewport-split assertion to the new visibility class.
- Added a regression test asserting the quick-pin button keeps a flex display (`md:inline-flex`, not `md:block`) on desktop so the centering classes take effect.

`npm test` passes (3184 passed).