### PR TITLE
test(harnesses): de-flake test_runner_subprocess_exits_when_spawning_parent_exits

### DIFF
--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -682,6 +682,7 @@ async def test_runner_subprocess_exits_on_sigterm(
         await manager.shutdown()
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=0)
 async def test_runner_subprocess_exits_when_spawning_parent_exits(
     short_tmp_parent: Path,
     register_test_harness: None,
@@ -722,7 +723,7 @@ async def test_runner_subprocess_exits_when_spawning_parent_exits(
         check=True,
         text=True,
         capture_output=True,
-        timeout=10,
+        timeout=30,
         env={**os.environ, "PYTHONPATH": os.getcwd()},
     )
     runner_pid = int(proc.stdout.strip().splitlines()[-1])


### PR DESCRIPTION
## Summary

`test_runner_subprocess_exits_when_spawning_parent_exits` is flaky in CI (e.g. [this run](https://github.com/omnigent-ai/omnigent/actions/runs/28231954330/job/83637658473?pr=1380)).

The failure is `subprocess.TimeoutExpired` on the **helper subprocess**, raised during the test's *setup* phase — before the watchdog behavior the test actually asserts ever runs. The helper does a full cold start (interpreter launch + `import omnigent` + `mgr.start()` + a real uvicorn `_runner` boot + socket handshake) and had only a 10s ceiling. Under pytest-xdist contention on a saturated runner (the failing run was at `[gw7]`, 82%), that cold start can exceed 10s.

This is a tight-timeout flake, not a logic bug in the `--parent-pid` watchdog.

## Changes

- Bump the helper `subprocess.run` timeout `10s -> 30s` for headroom (~2–3× the worst realistic cold-start under load).
- Add the project's `@pytest.mark.flaky(reruns=2, reruns_delay=0)` marker (registered in `pyproject.toml` for timing/scheduling races, backed by the existing `pytest-rerunfailures` dependency) as defense-in-depth for the rare pathological case.