### PR TITLE
feat(agents): first-class standalone agents — CRUD API + sidebar UI

### DIFF
--- a/ap-web/src/hooks/useAvailableAgents.ts
+++ b/ap-web/src/hooks/useAvailableAgents.ts
@@ -101,6 +101,26 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
 }
 
 /**
+ * Fetch the caller's standalone, owner-scoped agents (`GET /v1/agents/mine`)
+ * — the first-class agents managed from the sidebar "Agents" section. Same
+ * wire shape as the built-in list. Including these here is what makes a
+ * sidebar-created agent selectable in the new-chat picker.
+ */
+async function fetchMyStandaloneAgents(): Promise<AvailableAgent[]> {
+  const res = await authenticatedFetch("/v1/agents/mine");
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = (await res.json()) as { data: BuiltinAgentWire[] };
+  return body.data.map((a) => ({
+    id: a.id,
+    name: a.name,
+    display_name: displayNameForAgent(a.name, a.harness),
+    description: a.description ?? null,
+    harness: a.harness ?? null,
+    skills: a.skills ?? [],
+  }));
+}
+
+/**
  * A unique session-bound agent discovered by the sessions scan, paired
  * with one session it was seen on (used to fetch the full AgentObject
  * via `GET /v1/sessions/{id}/agent`, which is keyed by session id).
@@ -212,11 +232,17 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
  * availability must not be hostage to the discovery extension.
  */
 async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
-  const [builtins, scanned] = await Promise.all([
+  const [builtins, mine, scanned] = await Promise.all([
     fetchBuiltinAgents(),
+    // Degrades to [] so the picker still shows built-ins if /agents/mine
+    // fails (older server / transient error), same posture as the scan.
+    fetchMyStandaloneAgents().catch(() => [] as AvailableAgent[]),
     scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
   ]);
-  const builtinIds = new Set(builtins.map((a) => a.id));
+  // Standalone agents are already first-class rows; session-scan dedup is
+  // against built-ins AND standalone (by id) so a standalone agent that has
+  // been used in a session isn't listed twice.
+  const knownIds = new Set([...builtins, ...mine].map((a) => a.id));
   const builtinNames = new Set(builtins.map((a) => a.name));
   const hasKiroBuiltin = builtins.some(
     (a) => nativeCodingAgentForAvailableAgent(a)?.key === "kiro",
@@ -232,7 +258,7 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
     // leaves `"<builtin> (fork ag_a)"` — which is not a built-in name, so
     // the clone would slip past the shadow check and pollute the picker.
     const base = agentRootName(agent.agentName);
-    if (builtinIds.has(agent.agentId) || builtinNames.has(base)) continue;
+    if (knownIds.has(agent.agentId) || builtinNames.has(base)) continue;
     if (hasKiroBuiltin && kiroLegacyNames.has(base.toLocaleLowerCase())) continue;
     if (!customByName.has(base)) customByName.set(base, agent);
   }
@@ -242,10 +268,10 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
     const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
     return nativeKey !== "kiro" || !hasKiroBuiltin;
   });
-  // Built-ins first; custom agents follow in scan order (newest session
-  // first). NewChatDialog's display-order sort is stable, so unranked
-  // custom names keep this relative order.
-  return [...builtins, ...enriched];
+  // Built-ins first, then the caller's standalone agents, then any remaining
+  // session-discovered custom agents (newest session first). NewChatDialog's
+  // display-order sort is stable, so unranked names keep this relative order.
+  return [...builtins, ...mine, ...enriched];
 }
 
 interface UseAvailableAgentsOptions {

--- a/ap-web/src/lib/agentsApi.ts
+++ b/ap-web/src/lib/agentsApi.ts
@@ -10,6 +10,14 @@
 import { type AgentBundleInput, buildAgentBundle } from "@/lib/agentBundle";
 import { authenticatedFetch } from "@/lib/identity";
 
+/**
+ * TanStack Query key for the caller's standalone agents (`/v1/agents/mine`).
+ * Shared by the sidebar manage view and the new-chat picker so a create/delete
+ * in either surface invalidates both. The picker query (`["available-agents"]`)
+ * is invalidated alongside it.
+ */
+export const MY_AGENTS_QUERY_KEY = ["my-agents"] as const;
+
 /** Summary of an MCP server attached to an agent (mirrors the API shape). */
 export interface AgentMcpServer {
   name: string;

--- a/ap-web/src/lib/agentsApi.ts
+++ b/ap-web/src/lib/agentsApi.ts
@@ -1,0 +1,89 @@
+// Client for the standalone (owner-scoped) agents CRUD API, `/v1/agents*`.
+//
+// These are first-class, session-independent agents managed from the
+// sidebar "Agents" section — distinct from the read-only built-ins
+// (`GET /v1/agents`) and from session-scoped agents. Create/update reuse
+// `buildAgentBundle` (the same `.tar.gz` the new-chat custom-agent flow
+// builds) and POST/PUT it as multipart; the server stores it owner-scoped
+// so the agent persists across sessions and survives session deletion.
+
+import { type AgentBundleInput, buildAgentBundle } from "@/lib/agentBundle";
+import { authenticatedFetch } from "@/lib/identity";
+
+/** Summary of an MCP server attached to an agent (mirrors the API shape). */
+export interface AgentMcpServer {
+  name: string;
+  transport: string;
+  description?: string | null;
+  url?: string | null;
+  command?: string | null;
+  args?: string[];
+}
+
+/** A standalone, user-owned agent as returned by the agents API. */
+export interface ManagedAgent {
+  id: string;
+  name: string;
+  description: string | null;
+  harness: string | null;
+  version: number;
+  created_at: number;
+  updated_at: number | null;
+  mcp_servers: AgentMcpServer[];
+}
+
+async function describeError(res: Response, action: string): Promise<string> {
+  let detail = "";
+  try {
+    const body = (await res.json()) as { error?: string; detail?: string };
+    detail = body.error || body.detail || "";
+  } catch {
+    // non-JSON body; fall back to the status line below
+  }
+  return detail || `Could not ${action} (HTTP ${res.status}).`;
+}
+
+/** List the current user's standalone agents (newest-first). */
+export async function listMyAgents(): Promise<ManagedAgent[]> {
+  const res = await authenticatedFetch("/v1/agents/mine");
+  if (!res.ok) throw new Error(await describeError(res, "load your agents"));
+  const body = (await res.json()) as { data: ManagedAgent[] };
+  return body.data;
+}
+
+/** Create a standalone agent from the given spec (built into a bundle). */
+export async function createAgent(input: AgentBundleInput): Promise<ManagedAgent> {
+  const bundle = await buildAgentBundle(input);
+  const form = new FormData();
+  form.append("bundle", bundle);
+  if (input.description) form.append("description", input.description);
+  const res = await authenticatedFetch("/v1/agents", { method: "POST", body: form });
+  if (!res.ok) throw new Error(await describeError(res, "create the agent"));
+  return (await res.json()) as ManagedAgent;
+}
+
+/** Replace a standalone agent's bundle with a new spec (owner only). */
+export async function updateAgent(
+  agentId: string,
+  input: AgentBundleInput,
+): Promise<ManagedAgent> {
+  const bundle = await buildAgentBundle(input);
+  const form = new FormData();
+  form.append("bundle", bundle);
+  const res = await authenticatedFetch(`/v1/agents/${encodeURIComponent(agentId)}`, {
+    method: "PUT",
+    body: form,
+  });
+  if (!res.ok) throw new Error(await describeError(res, "update the agent"));
+  return (await res.json()) as ManagedAgent;
+}
+
+/** Delete a standalone agent (owner only). */
+export async function deleteAgent(agentId: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/agents/${encodeURIComponent(agentId)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(await describeError(res, "delete the agent"));
+  }
+}

--- a/ap-web/src/shell/ManageAgentsDialog.tsx
+++ b/ap-web/src/shell/ManageAgentsDialog.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from "react";
+import { Bot, PlusIcon, TrashIcon } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { AgentBundleInput } from "@/lib/agentBundle";
+import { type ManagedAgent, createAgent, deleteAgent, listMyAgents } from "@/lib/agentsApi";
+import { CreateAgentDialog } from "./CreateAgentDialog";
+
+/**
+ * Manage standalone, owner-scoped agents — list / create / delete.
+ *
+ * Opened from the sidebar "Agents" button (below "New session"). Unlike the
+ * new-chat custom-agent flow (which stages an agent into a single session),
+ * agents created here are persisted via the agents CRUD API and reused across
+ * sessions, surviving session deletion. Create reuses {@link CreateAgentDialog}
+ * but writes straight to the backend instead of staging into a session.
+ */
+export function ManageAgentsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [agents, setAgents] = useState<ManagedAgent[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      setAgents(await listMyAgents());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) void refresh();
+  }, [open, refresh]);
+
+  async function handleCreate(input: AgentBundleInput) {
+    setError(null);
+    try {
+      await createAgent(input);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleDelete(agent: ManagedAgent) {
+    setBusyId(agent.id);
+    setError(null);
+    try {
+      await deleteAgent(agent.id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          data-testid="manage-agents-dialog"
+          className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
+        >
+          <DialogHeader>
+            <DialogTitle>Agents</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              Reusable agents you own — they persist across sessions and aren't tied to any chat.
+            </p>
+            <Button
+              size="sm"
+              className="shrink-0 gap-1.5"
+              data-testid="manage-agents-new"
+              onClick={() => setCreateOpen(true)}
+            >
+              <PlusIcon className="size-4" />
+              New agent
+            </Button>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+            {agents === null ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : agents.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No agents yet. Create one to reuse it across sessions.
+              </p>
+            ) : (
+              agents.map((agent) => (
+                <div
+                  key={agent.id}
+                  data-testid="manage-agents-row"
+                  className="flex items-center gap-3 rounded-md border border-border p-3"
+                >
+                  <Bot className="size-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium">{agent.name}</div>
+                    {agent.description && (
+                      <div className="truncate text-xs text-muted-foreground">
+                        {agent.description}
+                      </div>
+                    )}
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      {agent.harness ?? "agent"}
+                      {agent.mcp_servers.length > 0 &&
+                        ` · ${agent.mcp_servers.length} MCP server${
+                          agent.mcp_servers.length === 1 ? "" : "s"
+                        }`}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="shrink-0"
+                    aria-label={`Delete ${agent.name}`}
+                    disabled={busyId === agent.id}
+                    onClick={() => void handleDelete(agent)}
+                  >
+                    <TrashIcon className="size-4 text-destructive" />
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <CreateAgentDialog open={createOpen} onOpenChange={setCreateOpen} onCreate={handleCreate} />
+    </>
+  );
+}

--- a/ap-web/src/shell/ManageAgentsDialog.tsx
+++ b/ap-web/src/shell/ManageAgentsDialog.tsx
@@ -1,19 +1,27 @@
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Bot, PlusIcon, TrashIcon } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import type { AgentBundleInput } from "@/lib/agentBundle";
-import { type ManagedAgent, createAgent, deleteAgent, listMyAgents } from "@/lib/agentsApi";
+import {
+  MY_AGENTS_QUERY_KEY,
+  type ManagedAgent,
+  createAgent,
+  deleteAgent,
+  listMyAgents,
+} from "@/lib/agentsApi";
 import { CreateAgentDialog } from "./CreateAgentDialog";
 
 /**
  * Manage standalone, owner-scoped agents — list / create / delete.
  *
- * Opened from the sidebar "Agents" button (below "New session"). Unlike the
- * new-chat custom-agent flow (which stages an agent into a single session),
- * agents created here are persisted via the agents CRUD API and reused across
- * sessions, surviving session deletion. Create reuses {@link CreateAgentDialog}
- * but writes straight to the backend instead of staging into a session.
+ * Opened from the sidebar "Agents" button (below "New session"). Agents
+ * created here are persisted via the agents CRUD API and reused across
+ * sessions, surviving session deletion. The list is a shared TanStack query
+ * ({@link MY_AGENTS_QUERY_KEY}) so creates/deletes here — and from the
+ * new-chat picker — keep both surfaces in sync; mutations also invalidate the
+ * picker's `["available-agents"]` query so a new agent shows up there too.
  */
 export function ManageAgentsDialog({
   open,
@@ -22,42 +30,46 @@ export function ManageAgentsDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const [agents, setAgents] = useState<ManagedAgent[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const agentsQuery = useQuery({
+    queryKey: MY_AGENTS_QUERY_KEY,
+    queryFn: listMyAgents,
+    enabled: open,
+  });
+  const [actionError, setActionError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
 
-  const refresh = useCallback(async () => {
-    setError(null);
-    try {
-      setAgents(await listMyAgents());
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, []);
+  const agents = agentsQuery.isLoading ? null : (agentsQuery.data ?? []);
+  const error =
+    actionError ?? (agentsQuery.error instanceof Error ? agentsQuery.error.message : null);
 
-  useEffect(() => {
-    if (open) void refresh();
-  }, [open, refresh]);
+  async function invalidateAgents() {
+    // Refresh both this list and the new-chat picker catalog.
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: MY_AGENTS_QUERY_KEY }),
+      queryClient.invalidateQueries({ queryKey: ["available-agents"] }),
+    ]);
+  }
 
   async function handleCreate(input: AgentBundleInput) {
-    setError(null);
+    setActionError(null);
     try {
       await createAgent(input);
-      await refresh();
+      await invalidateAgents();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setActionError(e instanceof Error ? e.message : String(e));
     }
   }
 
   async function handleDelete(agent: ManagedAgent) {
     setBusyId(agent.id);
-    setError(null);
+    setActionError(null);
     try {
       await deleteAgent(agent.id);
-      await refresh();
+      await invalidateAgents();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setActionError(e instanceof Error ? e.message : String(e));
     } finally {
       setBusyId(null);
     }

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -76,6 +76,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
 import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
+import { MY_AGENTS_QUERY_KEY, createAgent } from "@/lib/agentsApi";
 import { createBundledSession, launchRunner } from "@/lib/sessionsApi";
 
 // Hidden from the new-session picker only. `nessie` is superseded by polly.
@@ -2707,10 +2708,28 @@ export function NewChatLandingScreen() {
       <CreateAgentDialog
         open={createAgentOpen}
         onOpenChange={setCreateAgentOpen}
-        onCreate={(input) => {
-          setPendingAgent(input);
-          setPickedAgentId(PENDING_AGENT_ID);
-          setPickedHarness(null);
+        onCreate={async (input) => {
+          // Persist as a first-class standalone agent so it shows up in the
+          // sidebar "Agents" list AND this picker, and is reusable across
+          // sessions. Invalidate both catalogs, then select the created
+          // agent by id (the normal agent-id session path takes over from
+          // here — no per-session bundle). Falls back to the legacy
+          // session-scoped staging if the create fails (e.g. older server
+          // without /v1/agents), so a chat can still be started.
+          try {
+            const created = await createAgent(input);
+            await Promise.all([
+              queryClient.invalidateQueries({ queryKey: ["available-agents"] }),
+              queryClient.invalidateQueries({ queryKey: MY_AGENTS_QUERY_KEY }),
+            ]);
+            setPendingAgent(null);
+            setPickedAgentId(created.id);
+            setPickedHarness(created.harness ?? null);
+          } catch {
+            setPendingAgent(input);
+            setPickedAgentId(PENDING_AGENT_ID);
+            setPickedHarness(null);
+          }
         }}
       />
     </div>

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -40,10 +40,12 @@ import {
   SquareCheckIcon,
   SquarePenIcon,
   Trash2Icon,
+  UsersIcon,
   XIcon,
 } from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
+import { ManageAgentsDialog } from "./ManageAgentsDialog";
 import {
   Dialog,
   DialogContent,
@@ -259,6 +261,10 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   // Which top-level nav button to highlight for the current route.
   const { isNewChatPage, isInboxPage } = useActiveNavItem();
 
+  // The "Agents" manage dialog (list/create/delete standalone agents),
+  // opened from the button below "New session".
+  const [manageAgentsOpen, setManageAgentsOpen] = useState(false);
+
   // On /settings the card keeps its chrome but swaps the conversation list
   // for the settings section nav (see settingsNav.tsx) — entering settings
   // shouldn't replace the whole sidebar.
@@ -444,6 +450,20 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
                 New session
               </Link>
             </Button>
+            {/* "Agents" opens the manage dialog for standalone, reusable
+            agents (list / create / delete) — independent of any session,
+            unlike the new-chat custom-agent flow. */}
+            <Button
+              type="button"
+              className="mt-1 w-full justify-start gap-2 text-sm"
+              variant="ghost"
+              data-testid="manage-agents-button"
+              onClick={() => setManageAgentsOpen(true)}
+            >
+              <UsersIcon className="size-4 text-foreground" />
+              Agents
+            </Button>
+            <ManageAgentsDialog open={manageAgentsOpen} onOpenChange={setManageAgentsOpen} />
             {selectionMode ? (
               <BulkActionBar
                 selectedIds={selectedIds}

--- a/omnigent/db/converters.py
+++ b/omnigent/db/converters.py
@@ -22,4 +22,5 @@ def sql_agent_to_entity(row: SqlAgent) -> Agent:
         description=row.description,
         updated_at=row.updated_at,
         session_id=row.session_id,
+        owner=row.owner,
     )

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -63,16 +63,34 @@ class SqlAgent(Base):
         ForeignKey("conversations.id", ondelete="CASCADE"),
         nullable=True,
     )
+    # User that owns a standalone agent (managed via the agents CRUD API).
+    # NULL for operator-seeded built-in/template agents (global, visible to
+    # everyone) and for session-scoped agents (which inherit access from the
+    # session). See entities/agent.py for the access model.
+    owner: Mapped[str | None] = mapped_column(String(256), nullable=True)
 
     __table_args__ = (
         Index("ix_agents_created_at", "created_at"),
+        # Operator built-ins (no owner, no session) keep globally-unique
+        # names — they back ``get_by_name`` and the built-in picker.
         Index(
-            "ix_agents_template_name",
+            "ix_agents_builtin_name",
             "name",
             unique=True,
-            sqlite_where=text("session_id IS NULL"),
-            postgresql_where=text("session_id IS NULL"),
+            sqlite_where=text("session_id IS NULL AND owner IS NULL"),
+            postgresql_where=text("session_id IS NULL AND owner IS NULL"),
         ),
+        # Standalone user agents are unique per (owner, name) so different
+        # users can each have an agent with the same name.
+        Index(
+            "ix_agents_owner_name",
+            "owner",
+            "name",
+            unique=True,
+            sqlite_where=text("session_id IS NULL AND owner IS NOT NULL"),
+            postgresql_where=text("session_id IS NULL AND owner IS NOT NULL"),
+        ),
+        Index("ix_agents_owner", "owner"),
         Index("ix_agents_session_id", "session_id", unique=True),
     )
 

--- a/omnigent/db/migrations/versions/o1a2b3c4d5e6_add_owner_to_agents.py
+++ b/omnigent/db/migrations/versions/o1a2b3c4d5e6_add_owner_to_agents.py
@@ -1,0 +1,88 @@
+"""add owner to agents
+
+Revision ID: o1a2b3c4d5e6
+Revises: n1a2b3c4d5e6
+Create Date: 2026-06-26 00:00:00.000000
+
+Adds ``agents.owner`` so agents can be standalone, user-owned resources
+managed through the agents CRUD API (``/v1/agents``), independent of any
+session. ``owner`` is nullable:
+
+- ``NULL`` for operator-seeded built-in/template agents (global) and for
+  session-scoped agents (``session_id`` set; access inherited from the
+  session).
+- a user id for standalone user agents (``session_id IS NULL``).
+
+Name-uniqueness is re-scoped accordingly: built-ins keep a global unique
+name (``session_id IS NULL AND owner IS NULL``), while standalone user
+agents are unique per ``(owner, name)`` so different users can each have an
+agent with the same name. The old ``ix_agents_template_name`` (unique name
+across ALL ``session_id IS NULL`` rows) is replaced by these two partial
+indexes.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "o1a2b3c4d5e6"
+down_revision: str | None = "n1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_logger = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    """Add nullable ``agents.owner`` and re-scope template-name uniqueness."""
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.add_column(sa.Column("owner", sa.String(length=256), nullable=True))
+        batch_op.drop_index("ix_agents_template_name")
+        batch_op.create_index(
+            "ix_agents_builtin_name",
+            ["name"],
+            unique=True,
+            sqlite_where=sa.text("session_id IS NULL AND owner IS NULL"),
+            postgresql_where=sa.text("session_id IS NULL AND owner IS NULL"),
+        )
+        batch_op.create_index(
+            "ix_agents_owner_name",
+            ["owner", "name"],
+            unique=True,
+            sqlite_where=sa.text("session_id IS NULL AND owner IS NOT NULL"),
+            postgresql_where=sa.text("session_id IS NULL AND owner IS NOT NULL"),
+        )
+        batch_op.create_index("ix_agents_owner", ["owner"])
+
+
+def downgrade() -> None:
+    """Drop standalone user agents, then restore the prior schema.
+
+    Owned agents (``session_id IS NULL AND owner IS NOT NULL``) have no
+    faithful pre-owner representation — and could collide under the
+    restored global template-name index — so they are deleted, mirroring
+    the session-agent downgrade policy.
+    """
+    bind = op.get_bind()
+    owned_count = bind.execute(
+        sa.text("SELECT COUNT(*) FROM agents WHERE session_id IS NULL AND owner IS NOT NULL"),
+    ).scalar_one()
+    if owned_count:
+        _logger.warning("Downgrade will delete %s standalone user agents", owned_count)
+    op.execute(sa.text("DELETE FROM agents WHERE session_id IS NULL AND owner IS NOT NULL"))
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.drop_index("ix_agents_owner")
+        batch_op.drop_index("ix_agents_owner_name")
+        batch_op.drop_index("ix_agents_builtin_name")
+        batch_op.create_index(
+            "ix_agents_template_name",
+            ["name"],
+            unique=True,
+            sqlite_where=sa.text("session_id IS NULL"),
+            postgresql_where=sa.text("session_id IS NULL"),
+        )
+        batch_op.drop_column("owner")

--- a/omnigent/entities/agent.py
+++ b/omnigent/entities/agent.py
@@ -28,6 +28,11 @@ class Agent:
         ``None`` if the agent has never been updated.
     :param session_id: Owning conversation/session id for
         session-scoped agents. ``None`` for template agents.
+    :param owner: User id that owns this agent, e.g.
+        ``"alice@example.com"``. Set for standalone user-created agents
+        (managed via the agents CRUD API); ``None`` for operator-seeded
+        built-in/template agents (visible to everyone) and for
+        session-scoped agents (which inherit access from their session).
     """
 
     id: str
@@ -38,6 +43,7 @@ class Agent:
     description: str | None = None
     updated_at: int | None = None
     session_id: str | None = None
+    owner: str | None = None
 
 
 @dataclass

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1795,6 +1795,7 @@ def create_app(
         create_builtin_agents_router(
             agent_store,
             agent_cache,
+            artifact_store=artifact_store,
             auth_provider=auth_provider,
         ),
         prefix="/v1",

--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -1,21 +1,21 @@
-"""Read-only route for discovering built-in agents (``GET /v1/agents``).
+"""Agents API (``/v1/agents``): built-in discovery + standalone CRUD.
 
-Built-in agents are the long-lived, shared agents the server provides
-out of the box — the seeded ``claude-native-ui`` agent plus anything
-registered at startup with ``omnigent server --agent``. They are the
-``session_id IS NULL`` rows in ``agent_store``; ``agent_store.list()``
-already filters to exactly these. Session-scoped agents (created via
-multipart ``POST /v1/sessions``) belong to one conversation and are read
-through ``GET /v1/sessions/{id}/agent`` — never here.
+Two kinds of agent are served here, both ``session_id IS NULL`` rows in
+``agent_store``:
 
-The Web UI's new-session picker calls this to discover bindable
-built-ins, then creates a session with
-``POST /v1/sessions {agent_id, host_id, workspace}``. See
-``designs/BUILTIN_AGENTS.md``.
+- **Built-in/template agents** (``owner IS NULL``): the long-lived, shared
+  agents the server seeds at startup (``claude-native-ui`` etc.). Read-only,
+  listed by ``GET /v1/agents``.
+- **Standalone user agents** (``owner`` set): first-class, user-owned agents
+  managed independently of any session via full CRUD — ``GET /v1/agents/mine``,
+  ``POST /v1/agents``, ``GET/PUT/DELETE /v1/agents/{id}``. They persist across
+  sessions and survive session deletion, unlike the session-scoped agents
+  created through multipart ``POST /v1/sessions`` (which belong to one
+  conversation and are read via ``GET /v1/sessions/{id}/agent``).
 
-This is the read-only successor to the removed ``GET /api/agents`` list:
-there is intentionally no create/update/delete — agent writes happen
-through session creation.
+The Web UI's new-session picker lists built-ins + the caller's standalone
+agents; the sidebar "Agents" section CRUDs the standalone ones. Owner scoping
+mirrors sessions: a user only sees/edits/deletes their own agents.
 """
 
 from __future__ import annotations
@@ -24,17 +24,50 @@ import logging
 
 from fastapi import APIRouter, Query, Request
 
+from omnigent.db.utils import generate_agent_id
 from omnigent.entities import Agent
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runtime.agent_cache import AgentCache
-from omnigent.server.auth import AuthProvider
+from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider, local_single_user_enabled
+from omnigent.server.bundles import bundle_location, validate_agent_bundle
 from omnigent.server.routes._auth_helpers import require_user as _require_user
 from omnigent.server.schemas import AgentObject, MCPServerSummary, PaginatedList, SkillSummary
 from omnigent.stores import AgentStore
+from omnigent.stores.artifact_store import ArtifactStore
 
 _logger = logging.getLogger(__name__)
 
 
-def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
+async def _read_bundle_and_description(request: Request) -> tuple[bytes, str | None]:
+    """Read the ``bundle`` file part (and optional ``description``) from a
+    multipart request.
+
+    Parses the form manually (rather than ``UploadFile``/``Form`` defaults)
+    to match the session-bundle upload path and keep handler signatures
+    free of call-in-default lint issues.
+
+    :param request: The incoming multipart request.
+    :returns: ``(bundle_bytes, description_or_None)``.
+    :raises OmnigentError: 400 when the ``bundle`` file part is missing.
+    """
+    form = await request.form()
+    part = form.get("bundle")
+    # A string here means the field was sent as a plain value, not a file.
+    if part is None or isinstance(part, str):
+        raise OmnigentError(
+            "a 'bundle' file part (the agent .tar.gz) is required",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    raw = await part.read()
+    bundle_bytes = raw if isinstance(raw, bytes) else raw.encode("utf-8")
+    desc = form.get("description")
+    description = desc.strip() if isinstance(desc, str) and desc.strip() else None
+    return bundle_bytes, description
+
+
+def _to_agent_object(
+    agent: Agent, agent_cache: AgentCache, *, mcp_servers_editable: bool = False
+) -> AgentObject:
     """
     Convert a runtime Agent entity to an API-layer AgentObject.
 
@@ -47,6 +80,8 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     :param agent: The runtime agent entity, e.g. the seeded
         ``claude-native-ui`` agent.
     :param agent_cache: Cache used to load the agent spec.
+    :param mcp_servers_editable: Whether the caller may edit this agent's
+        MCP servers (``True`` for the owner's standalone agents).
     :returns: An :class:`AgentObject` for the API response.
     """
     mcp_servers: list[MCPServerSummary] = []
@@ -60,11 +95,13 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     description: str | None = agent.description
     try:
         # Built-ins are operator-authored template agents
-        # (session_id is None), so ${VAR} expansion against the server
-        # env is allowed here; a tenant session-scoped agent would not
-        # expand.
+        # (session_id is None, owner is None), so ${VAR} expansion against
+        # the server env is allowed for them; a tenant-owned standalone
+        # agent (owner set) or a session-scoped agent would not expand.
         loaded = agent_cache.load(
-            agent.id, agent.bundle_location, expand_env=agent.session_id is None
+            agent.id,
+            agent.bundle_location,
+            expand_env=agent.session_id is None and agent.owner is None,
         )
         if description is None:
             description = loaded.spec.description
@@ -104,7 +141,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         updated_at=agent.updated_at,
         harness=harness,
         mcp_servers=mcp_servers,
-        mcp_servers_editable=False,
+        mcp_servers_editable=mcp_servers_editable,
         skills=skills,
         terminals=terminals,
     )
@@ -114,19 +151,20 @@ def create_builtin_agents_router(
     agent_store: AgentStore,
     agent_cache: AgentCache,
     *,
+    artifact_store: ArtifactStore | None = None,
     auth_provider: AuthProvider | None = None,
 ) -> APIRouter:
-    """Build the router for ``GET /v1/agents`` (built-in discovery).
+    """Build the ``/v1/agents`` router: built-in discovery + standalone CRUD.
 
-    Mounted with ``prefix="/v1"`` so the final path is ``/v1/agents``.
+    Mounted with ``prefix="/v1"`` so paths are ``/v1/agents*``.
 
-    :param agent_store: Store whose ``list()`` returns only built-in
-        (``session_id IS NULL``) agents.
-    :param agent_cache: Cache for loading specs (populates
-        ``mcp_servers`` on each agent).
+    :param agent_store: Store of agents (built-ins, standalone, session-scoped).
+    :param agent_cache: Cache for loading specs (populates ``mcp_servers``).
+    :param artifact_store: Store for agent bundle bytes; required for the
+        create/update routes (``None`` disables them — read-only deployment).
     :param auth_provider: Optional auth provider; when set, the caller
-        must be authenticated.
-    :returns: A FastAPI router exposing the read-only list.
+        must be authenticated and standalone agents are owner-scoped.
+    :returns: A FastAPI router exposing the agents API.
     """
     router = APIRouter()
 
@@ -140,8 +178,9 @@ def create_builtin_agents_router(
     ) -> PaginatedList:
         """List built-in agents with cursor-based pagination.
 
-        Returns only built-in agents — ``agent_store.list()`` filters
-        ``session_id IS NULL`` — so session-scoped agents never appear.
+        Returns only built-in agents (``session_id IS NULL AND owner IS
+        NULL``); session-scoped and standalone user agents never appear
+        here (the latter via ``GET /v1/agents/mine``).
 
         :param request: The incoming FastAPI request (for auth).
         :param limit: Maximum number of agents to return (1-1000).
@@ -158,5 +197,187 @@ def create_builtin_agents_router(
             last_id=page.last_id,
             has_more=page.has_more,
         )
+
+    # Registered BEFORE ``/agents/{agent_id}`` so the static path wins.
+    @router.get("/agents/mine")
+    async def list_my_agents(request: Request) -> PaginatedList:
+        """List the caller's standalone agents (newest-first).
+
+        These are the user-owned, session-independent agents managed by
+        the sidebar "Agents" section. Built-ins and session-scoped agents
+        are excluded.
+
+        :param request: The incoming FastAPI request (for auth).
+        :returns: A :class:`PaginatedList` of the owner's agents.
+        """
+        owner = _owner_for(request)
+        agents = agent_store.list_for_owner(owner)
+        data = [_to_agent_object(a, agent_cache, mcp_servers_editable=True) for a in agents]
+        return PaginatedList(
+            data=data,
+            first_id=data[0].id if data else None,
+            last_id=data[-1].id if data else None,
+            has_more=False,
+        )
+
+    @router.post("/agents")
+    async def create_agent(request: Request) -> AgentObject:
+        """Create a standalone, owner-scoped agent from an uploaded bundle.
+
+        Multipart form with a ``bundle`` file part (the agent ``.tar.gz``)
+        and an optional ``description`` field. The agent persists
+        independently of any session (``session_id IS NULL``, ``owner`` =
+        caller) — reusable across sessions and unaffected by session
+        deletion. The name comes from the bundle's spec; ``description``
+        overrides the spec description when given.
+
+        :param request: The incoming FastAPI request (multipart + auth).
+        :returns: The created :class:`AgentObject`.
+        :raises OmnigentError: 400 on a missing/invalid bundle, 409 on a
+            duplicate name for this owner, 500 if bundle storage is
+            unavailable.
+        """
+        if artifact_store is None:
+            raise OmnigentError(
+                "agent bundle storage is not configured on this server",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        owner = _owner_for(request)
+        bundle_bytes, description = await _read_bundle_and_description(request)
+        spec = validate_agent_bundle(
+            bundle_bytes,
+            enforce_handler_allowlist=not local_single_user_enabled(),
+        )
+        agent_id = generate_agent_id()
+        location = bundle_location(agent_id, bundle_bytes)
+        artifact_store.put(location, bundle_bytes)
+        try:
+            created = agent_store.create(
+                agent_id=agent_id,
+                name=spec.name or agent_id,
+                bundle_location=location,
+                description=description,
+                owner=owner,
+            )
+        except Exception as exc:
+            artifact_store.delete(location)
+            raise OmnigentError(
+                f"could not create agent {spec.name!r} (duplicate name?): {exc}",
+                code=ErrorCode.CONFLICT,
+            ) from exc
+        return _to_agent_object(created, agent_cache, mcp_servers_editable=True)
+
+    @router.get("/agents/{agent_id}")
+    async def get_agent(request: Request, agent_id: str) -> AgentObject:
+        """Return a built-in or caller-owned agent.
+
+        :param request: The incoming FastAPI request (for auth).
+        :param agent_id: Agent id, e.g. ``"ag_abc123"``.
+        :returns: The :class:`AgentObject`.
+        :raises OmnigentError: 404 if it does not exist or is not visible
+            to the caller (other users' agents and session-scoped agents).
+        """
+        owner = _owner_for(request)
+        agent = _visible_agent_or_404(agent_id, owner)
+        editable = agent.owner is not None and agent.owner == owner
+        return _to_agent_object(agent, agent_cache, mcp_servers_editable=editable)
+
+    @router.put("/agents/{agent_id}")
+    async def update_agent(request: Request, agent_id: str) -> AgentObject:
+        """Replace a standalone agent's bundle (owner only).
+
+        Multipart form with a ``bundle`` file part (the replacement
+        ``.tar.gz``). Validates + stores it, points the agent row at it,
+        and bumps its version (the spec cache re-reads on next load). The
+        previous bundle artifact is best-effort deleted. Built-in and
+        session-scoped agents are not editable here.
+
+        :param request: The incoming FastAPI request (multipart + auth).
+        :param agent_id: Agent id to update.
+        :returns: The updated :class:`AgentObject`.
+        :raises OmnigentError: 404 if not found/visible, 403 if not
+            owned by the caller, 400 on a missing/invalid bundle.
+        """
+        if artifact_store is None:
+            raise OmnigentError(
+                "agent bundle storage is not configured on this server",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        owner = _owner_for(request)
+        agent = _owned_agent_or_error(agent_id, owner)
+        bundle_bytes, _ = await _read_bundle_and_description(request)
+        validate_agent_bundle(
+            bundle_bytes,
+            enforce_handler_allowlist=not local_single_user_enabled(),
+        )
+        new_location = bundle_location(agent_id, bundle_bytes)
+        artifact_store.put(new_location, bundle_bytes)
+        old_location = agent.bundle_location
+        updated = agent_store.update(agent_id, new_location)
+        if updated is None:  # pragma: no cover — owner check already fetched it
+            artifact_store.delete(new_location)
+            raise OmnigentError("Agent not found", code=ErrorCode.NOT_FOUND)
+        if old_location != new_location:
+            try:
+                artifact_store.delete(old_location)
+            except Exception:  # noqa: BLE001 — orphaned old bundle is harmless
+                _logger.debug("Failed to delete old bundle %s", old_location, exc_info=True)
+        return _to_agent_object(updated, agent_cache, mcp_servers_editable=True)
+
+    @router.delete("/agents/{agent_id}", status_code=204)
+    async def delete_agent(request: Request, agent_id: str) -> None:
+        """Delete a standalone agent (owner only).
+
+        :param request: The incoming FastAPI request (for auth).
+        :param agent_id: Agent id to delete.
+        :raises OmnigentError: 404 if not found/visible, 403 if not
+            owned by the caller (built-ins/session agents can't be
+            deleted here).
+        """
+        owner = _owner_for(request)
+        agent = _owned_agent_or_error(agent_id, owner)
+        agent_store.delete(agent_id)
+        if artifact_store is not None:
+            try:
+                artifact_store.delete(agent.bundle_location)
+            except Exception:  # noqa: BLE001 — orphaned bundle is harmless
+                _logger.debug(
+                    "Failed to delete bundle %s", agent.bundle_location, exc_info=True
+                )
+
+    def _owner_for(request: Request) -> str:
+        """Resolve the caller's owner id (the authenticated user).
+
+        :param request: The incoming request.
+        :returns: The user id used as the agent ``owner``. Falls back to
+            :data:`RESERVED_USER_LOCAL` in single-user / no-auth mode
+            (where ``require_user`` returns ``None``), mirroring the
+            session-create path, so standalone agents always have a
+            stable non-NULL owner and never collapse into global built-ins.
+        :raises OmnigentError: 401 when auth is enabled and the caller is
+            unauthenticated (``require_user``'s contract).
+        """
+        return _require_user(request, auth_provider) or RESERVED_USER_LOCAL
+
+    def _visible_agent_or_404(agent_id: str, owner: str) -> Agent:
+        """Return an agent visible to *owner* (built-in or owned), else 404."""
+        agent = agent_store.get(agent_id)
+        # Hide: missing, session-scoped (read via the session route), or
+        # owned by a different user (404, not 403, to avoid enumeration).
+        if agent is None or agent.session_id is not None:
+            raise OmnigentError("Agent not found", code=ErrorCode.NOT_FOUND)
+        if agent.owner is not None and agent.owner != owner:
+            raise OmnigentError("Agent not found", code=ErrorCode.NOT_FOUND)
+        return agent
+
+    def _owned_agent_or_error(agent_id: str, owner: str) -> Agent:
+        """Return an agent the caller owns, else 404 (unseen) / 403 (built-in)."""
+        agent = _visible_agent_or_404(agent_id, owner)
+        if agent.owner is None:
+            raise OmnigentError(
+                "Built-in agents cannot be modified",
+                code=ErrorCode.FORBIDDEN,
+            )
+        return agent
 
     return router

--- a/omnigent/stores/agent_store/__init__.py
+++ b/omnigent/stores/agent_store/__init__.py
@@ -33,22 +33,38 @@ class AgentStore(ABC):
         name: str,
         bundle_location: str,
         description: str | None = None,
+        owner: str | None = None,
     ) -> Agent:
         """
-        Register a new template agent. Name must be unique among
-        template agents and raises if a template with that name
-        already exists.
+        Register a new agent. ``owner=None`` registers an operator
+        built-in/template agent (names unique among built-ins);
+        ``owner`` set registers a standalone user agent (names unique
+        per owner). Raises on a name collision within that scope.
 
         :param agent_id: Pre-generated unique agent identifier,
             e.g. ``"ag_0f1a2b3c..."``. Caller generates this so
             the bundle location can be computed before persisting.
-        :param name: Human-readable agent name. Must be unique
-            among template agents, e.g. ``"code-assistant"``.
+        :param name: Human-readable agent name. Unique among built-ins
+            when ``owner`` is ``None``, else unique per owner.
         :param bundle_location: Artifact store key for the bundle,
             e.g. ``"ag_abc123/a1b2c3d4e5f6..."``.
         :param description: Optional free-text description of the
             agent's purpose.
+        :param owner: Owning user id for a standalone agent, e.g.
+            ``"alice@example.com"``; ``None`` for an operator built-in.
         :returns: The newly created :class:`Agent`.
+        """
+        ...
+
+    @abstractmethod
+    def list_for_owner(self, owner: str) -> list[Agent]:
+        """
+        List standalone agents owned by ``owner`` (``session_id IS NULL``
+        and ``owner`` matching), newest-first. Excludes operator
+        built-ins and session-scoped agents.
+
+        :param owner: Owning user id, e.g. ``"alice@example.com"``.
+        :returns: The owner's standalone agents.
         """
         ...
 

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -43,17 +43,20 @@ class SqlAlchemyAgentStore(AgentStore):
         name: str,
         bundle_location: str,
         description: str | None = None,
+        owner: str | None = None,
     ) -> Agent:
         """
         Register a new agent in the database.
 
         :param agent_id: Pre-generated unique agent identifier,
             e.g. ``"ag_0f1a2b3c..."``.
-        :param name: Human-readable agent name. Must be unique,
-            e.g. ``"code-assistant"``.
+        :param name: Human-readable agent name. Unique among built-ins
+            when ``owner`` is ``None``, else unique per owner.
         :param bundle_location: Artifact store key for the bundle,
             e.g. ``"ag_abc123/a1b2c3d4e5f6..."``.
         :param description: Optional free-text description.
+        :param owner: Owning user id for a standalone agent, else
+            ``None`` for an operator built-in.
         :returns: The newly created :class:`Agent`.
         """
         row = SqlAgent(
@@ -63,10 +66,27 @@ class SqlAlchemyAgentStore(AgentStore):
             bundle_location=bundle_location,
             version=1,
             description=description,
+            owner=owner,
         )
         with self._session() as session:
             session.add(row)
             return sql_agent_to_entity(row)
+
+    def list_for_owner(self, owner: str) -> list[Agent]:
+        """
+        List standalone agents owned by ``owner``, newest-first.
+
+        :param owner: Owning user id, e.g. ``"alice@example.com"``.
+        :returns: The owner's standalone agents (``session_id IS NULL``
+            and ``owner`` matching).
+        """
+        with self._session() as session:
+            rows = session.execute(
+                select(SqlAgent)
+                .where(SqlAgent.session_id.is_(None), SqlAgent.owner == owner)
+                .order_by(desc(SqlAgent.created_at), desc(SqlAgent.id))
+            ).scalars().all()
+            return [sql_agent_to_entity(r) for r in rows]
 
     def get(self, agent_id: str) -> Agent | None:
         """
@@ -93,6 +113,7 @@ class SqlAlchemyAgentStore(AgentStore):
                 select(SqlAgent).where(
                     SqlAgent.name == name,
                     SqlAgent.session_id.is_(None),
+                    SqlAgent.owner.is_(None),
                 )
             ).scalar_one_or_none()
             return sql_agent_to_entity(row) if row else None
@@ -119,7 +140,10 @@ class SqlAlchemyAgentStore(AgentStore):
         with self._session() as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
-            template_agent = SqlAgent.session_id.is_(None)
+            # Built-in/template agents only: no session AND no owner, so the
+            # built-in picker never leaks one user's standalone agents to
+            # another (those are listed via ``list_for_owner``).
+            template_agent = and_(SqlAgent.session_id.is_(None), SqlAgent.owner.is_(None))
             stmt = select(SqlAgent).where(template_agent)
             if after:
                 sub = (

--- a/tests/db/test_migration_agents_session_id.py
+++ b/tests/db/test_migration_agents_session_id.py
@@ -57,11 +57,18 @@ def test_agents_session_id_column_is_nullable_and_indexed(db_engine: Engine) -> 
 
 
 def test_agents_name_unique_index_is_template_scoped(db_engine: Engine) -> None:
-    """Registered agent names stay unique while session copies may share them."""
+    """Registered agent names stay unique while session copies may share them.
+
+    The later ``add_owner_to_agents`` migration (o1a2b3c4d5e6) replaces the
+    original ``ix_agents_template_name`` with ``ix_agents_builtin_name``
+    (built-in name uniqueness, now scoped to ``owner IS NULL`` as well);
+    the end-state schema here reflects that successor index. Built-in name
+    uniqueness — what this test guards — is unchanged.
+    """
     indexes = sa.inspect(db_engine).get_indexes("agents")
-    template_indexes = [index for index in indexes if index["name"] == "ix_agents_template_name"]
+    template_indexes = [index for index in indexes if index["name"] == "ix_agents_builtin_name"]
     assert len(template_indexes) == 1, (
-        f"Expected ix_agents_template_name, got {[index['name'] for index in indexes]}"
+        f"Expected ix_agents_builtin_name, got {[index['name'] for index in indexes]}"
     )
     assert bool(template_indexes[0]["unique"]) is True
 

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -267,3 +267,75 @@ def test_delete_nonexistent_returns_false(agent_store: SqlAlchemyAgentStore) -> 
     """delete returns False for an ID that was never created."""
     result = agent_store.delete("ag_never_existed")
     assert result is False
+
+
+# ── Standalone, owner-scoped agents (agents-as-first-class-entity) ──────
+
+
+def test_owner_scoped_create_and_list_for_owner(
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """A standalone agent has an owner and is returned by list_for_owner."""
+    created = agent_store.create(
+        agent_id="ag_alice_research",
+        name="research",
+        bundle_location="ag_alice_research/h",
+        owner="alice@example.com",
+    )
+    assert created.owner == "alice@example.com"
+
+    mine = agent_store.list_for_owner("alice@example.com")
+    assert [a.id for a in mine] == ["ag_alice_research"]
+
+
+def test_owned_agents_are_not_builtins(agent_store: SqlAlchemyAgentStore) -> None:
+    """Owned standalone agents must not leak into built-in discovery APIs.
+
+    ``list()`` and ``get_by_name()`` back the built-in picker; an owned
+    agent appearing there would expose one user's agent to everyone.
+    """
+    agent_store.create(
+        agent_id="ag_owned_only",
+        name="private-helper",
+        bundle_location="ag_owned_only/h",
+        owner="alice@example.com",
+    )
+    assert "ag_owned_only" not in [a.id for a in agent_store.list().data]
+    assert agent_store.get_by_name("private-helper") is None
+
+
+def test_owner_isolation_and_per_owner_name_uniqueness(
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """Different owners are isolated and may reuse the same agent name."""
+    agent_store.create(
+        agent_id="ag_alice_dup",
+        name="shared-name",
+        bundle_location="ag_alice_dup/h",
+        owner="alice@example.com",
+    )
+    # Same name under a different owner is allowed (per-owner uniqueness).
+    agent_store.create(
+        agent_id="ag_bob_dup",
+        name="shared-name",
+        bundle_location="ag_bob_dup/h",
+        owner="bob@example.com",
+    )
+    assert [a.id for a in agent_store.list_for_owner("alice@example.com")] == ["ag_alice_dup"]
+    assert [a.id for a in agent_store.list_for_owner("bob@example.com")] == ["ag_bob_dup"]
+
+
+def test_builtin_and_owned_can_share_a_name(agent_store: SqlAlchemyAgentStore) -> None:
+    """A built-in and an owned agent may share a name without colliding."""
+    agent_store.create(agent_id="ag_builtin_dup", name="dup", bundle_location="ag_builtin_dup/h")
+    agent_store.create(
+        agent_id="ag_owned_dup",
+        name="dup",
+        bundle_location="ag_owned_dup/h",
+        owner="alice@example.com",
+    )
+    # Built-in lookup resolves to the built-in, ignoring the owned one.
+    found = agent_store.get_by_name("dup")
+    assert found is not None
+    assert found.id == "ag_builtin_dup"
+    assert [a.id for a in agent_store.list_for_owner("alice@example.com")] == ["ag_owned_dup"]


### PR DESCRIPTION
Fixes #1388.

Makes agents a **first-class, independently-managed resource** instead of only existing as session-scoped copies (created via multipart `POST /v1/sessions`, orphaned/lost when the session is deleted, with MCP/config re-entered per session).

## Backend (this commit)
- **`agents.owner` column** + migration `o1a2b3c4d5e6`. `NULL` for operator built-ins (global) and session-scoped agents; set for standalone user agents. Template-name uniqueness re-scoped: built-ins globally unique (`ix_agents_builtin_name`), standalone unique per `(owner, name)` so different users can reuse a name.
- **`AgentStore`**: `create(owner=…)`, `list_for_owner()`; `get_by_name()`/`list()` now scope to built-ins (`owner IS NULL`) so one user's agents never leak into the shared built-in picker.
- **CRUD on `/v1/agents`**: `GET /agents/mine`, `POST /agents` (multipart bundle), `GET/PUT/DELETE /agents/{id}`. Owner-scoped (404 hides others'; 403 protects built-ins). Standalone agents persist across sessions and **survive session deletion**, and expand `${ENV}`-free per the existing tenant-bundle security posture.

Tests: owner-isolation + per-owner name uniqueness in `test_agent_store.py`; migration applies/reverses (verified via the full chain); existing index-name assertion updated.

## Frontend (incoming on this branch)
- An **"Agents" button directly below "New session"** in the sidebar, opening a manage view that lists the caller's standalone agents with create / edit / delete (reusing `CreateAgentDialog`, writing straight to the CRUD API instead of staging into a session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)