### PR TITLE
feat(web): auto-scroll the active session row into view in the sidebar

### DIFF
--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -897,6 +897,56 @@ describe("Sidebar mobile overlay background", () => {
   });
 });
 
+// When the active conversation changes (e.g. a freshly created session the
+// app navigates to via /c/:id), its sidebar row scrolls into view so it isn't
+// stranded below the fold. We center it with a smooth animation. jsdom doesn't
+// implement scrollIntoView, so it's spied on.
+describe("Sidebar active-row auto-scroll", () => {
+  function renderAtRoute(initialEntry: string) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={[initialEntry]}>
+            <Routes>
+              <Route path="/" element={<Sidebar open onClose={vi.fn()} />} />
+              <Route path="/c/:conversationId" element={<Sidebar open onClose={vi.fn()} />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+  }
+
+  it("scrolls the active session's row to center with a smooth animation", () => {
+    const scrollIntoView = vi.fn();
+    vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+
+    mockConversations([conv("conv_top", "Claude Code"), conv("conv_active", "Claude Code")]);
+    renderAtRoute("/c/conv_active");
+
+    // The active row owns the only scrollIntoView call, centered + smooth.
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+
+    vi.restoreAllMocks();
+  });
+
+  it("does not scroll any row when no conversation is active", () => {
+    const scrollIntoView = vi.fn();
+    vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+
+    mockConversations([conv("conv_a", "Claude Code"), conv("conv_b", "Claude Code")]);
+    // Landing route "/" has no :conversationId — nothing is active, so no row
+    // should yank the list around on mount.
+    renderAtRoute("/");
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+});
+
 describe("Sidebar collapsed marker", () => {
   // The dark-mode glass rule in index.css keys its border/blur on
   // :not([data-collapsed]) — NOT on aria-hidden, which Radix also toggles

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1404,6 +1404,14 @@ function ConversationRow({
   useEffect(() => {
     activeIdRef.current = activeId;
   }, [activeId]);
+  // When this row becomes the active conversation (e.g. a freshly created
+  // session navigated to via `/c/:id`), scroll it toward the center of the
+  // sidebar so it's comfortably in view rather than pinned to an edge.
+  const rowRef = useRef<HTMLLIElement>(null);
+  useEffect(() => {
+    if (!isActive) return;
+    rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [isActive]);
   const rename = useRenameConversation();
   const del = useStopAndDeleteConversation();
   const archive = useArchiveConversation();
@@ -1575,7 +1583,7 @@ function ConversationRow({
   }
 
   return (
-    <li className="group relative">
+    <li ref={rowRef} className="group relative">
       <Link
         to={selectionMode ? "#" : `/c/${conversation.id}`}
         className={cn(


### PR DESCRIPTION
## What

When the active conversation changes — e.g. a freshly created session the app navigates to via `/c/:id` — its row in the left sidebar now scrolls into view if it's off-screen, so a new session below the fold isn't stranded out of sight.

The row is brought to the **center** of the sidebar with a **smooth** animation:

```ts
rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
```

The effect lives in `ConversationRow` and fires whenever the row becomes active (`isActive` keyed off the `/c/:conversationId` route param), so it covers both newly created sessions and navigating to any existing one.

## Tests

Added two cases to `Sidebar.test.tsx` (jsdom doesn't implement `scrollIntoView`, so it's spied on):
- the active session's row scrolls to center with a smooth animation
- no row scrolls when there is no active conversation (landing route `/`)

All 36 tests in the file pass.