### PR TITLE
test(server): cover cancel elicitation resolution

### DIFF
--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -1231,6 +1231,33 @@ async def test_resolve_url_decline_round_trip(client: httpx.AsyncClient) -> None
     assert resp.json()["hookSpecificOutput"]["decision"]["behavior"] == "deny"
 
 
+async def test_resolve_url_cancel_round_trip(client: httpx.AsyncClient) -> None:
+    """
+    A ``cancel`` verdict at the URL endpoint maps to Claude's
+    ``deny`` behavior and clears the pending elicitation.
+
+    ``cancel`` is a valid MCP ``ElicitationResult`` action alongside
+    ``accept`` and ``decline``. It represents dismissing the prompt
+    without an explicit choice, so the gated tool must not run.
+    """
+    from omnigent.runtime import pending_elicitations
+
+    agent = await create_test_agent(client, "test-resolve-url-cancel")
+    session_id = await _create_session(client, agent["id"])
+    hook_task, elicitation_id = await _park_permission_hook(client, session_id, tool_name="Bash")
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "cancel"},
+    )
+    assert verdict.status_code == 202, verdict.text
+
+    resp = await hook_task
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["hookSpecificOutput"]["decision"]["behavior"] == "deny"
+    assert pending_elicitations.count_for(session_id) == 0
+
+
 async def test_resolve_url_unknown_session_returns_404(
     client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
Adds missing integration test coverage for the `cancel` action on URL-based elicitation resolution.

Existing tests cover the allow/accept and decline paths. The `ElicitationResult` schema also accepts `cancel`; current route behavior maps non-accept valid actions to deny behavior and clears pending elicitation state.

This PR adds `test_resolve_url_cancel_round_trip` to cover that behavior.

Validation performed:

```bash
python3 -m pytest tests/server/integration/test_sessions_elicitation_resolve_url.py -k "test_resolve_url_cancel_round_trip"
```

The new test passes.
