### PR TITLE
fix(hermes-native): validate source DB before fork clone

### DIFF
--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -148,7 +148,17 @@ def clone_hermes_session(
         return
 
     target_db.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(source_db, target_db)
+    # Use SQLite's backup API instead of shutil.copy2 — Hermes uses WAL mode
+    # and may not have checkpointed, so the main .db file can be nearly empty
+    # with all data in the -wal sidecar. The backup API reads through WAL
+    # and produces a self-contained copy.
+    src_backup = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    tgt_backup = sqlite3.connect(str(target_db))
+    try:
+        src_backup.backup(tgt_backup)
+    finally:
+        tgt_backup.close()
+        src_backup.close()
 
     conn = sqlite3.connect(str(target_db))
     try:

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -107,7 +107,7 @@ def clone_hermes_session(
     target_session_id: str,
     *,
     workspace: str | None = None,
-) -> None:
+) -> int:
     """Clone a Hermes session from *source_db* into *target_db* under a new id.
 
     Copies the entire source database (preserving whatever schema Hermes uses)
@@ -138,14 +138,14 @@ def clone_hermes_session(
             "Source hermes state.db at %s is unreadable; skipping clone",
             source_db,
         )
-        return
+        return 0
     if row is None:
         _logger.warning(
             "Source hermes session %s not found in %s; skipping clone",
             source_session_id,
             source_db,
         )
-        return
+        return 0
 
     target_db.parent.mkdir(parents=True, exist_ok=True)
     # Use SQLite's backup API instead of shutil.copy2 — Hermes uses WAL mode
@@ -185,9 +185,19 @@ def clone_hermes_session(
         conn.execute("DELETE FROM sessions WHERE id != ?", (target_session_id,))
         conn.execute("DELETE FROM messages WHERE session_id != ?", (target_session_id,))
 
+        # Record the high-water message id so the forwarder skips cloned
+        # messages (Omnigent already has them from the fork item copy).
+        max_id_row = conn.execute(
+            "SELECT MAX(id) FROM messages WHERE session_id = ?",
+            (target_session_id,),
+        ).fetchone()
+        max_id = max_id_row[0] if max_id_row and max_id_row[0] is not None else 0
+
         conn.commit()
     finally:
         conn.close()
+
+    return max_id
 
 
 def bridge_dir_for_session_id(session_id: str) -> Path:

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -121,24 +121,37 @@ def clone_hermes_session(
     :param target_session_id: New session id for the cloned rows.
     :param workspace: If provided, overrides ``cwd`` on the cloned session row.
     """
+    # Validate the source DB before copying: it must have a sessions table
+    # and contain the requested session. If not, skip the clone silently so
+    # Hermes starts fresh rather than crashing on a broken state.db.
+    try:
+        src_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+        try:
+            row = src_conn.execute(
+                "SELECT id FROM sessions WHERE id = ?",
+                (source_session_id,),
+            ).fetchone()
+        finally:
+            src_conn.close()
+    except sqlite3.Error:
+        _logger.warning(
+            "Source hermes state.db at %s is unreadable; skipping clone",
+            source_db,
+        )
+        return
+    if row is None:
+        _logger.warning(
+            "Source hermes session %s not found in %s; skipping clone",
+            source_session_id,
+            source_db,
+        )
+        return
+
     target_db.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source_db, target_db)
 
     conn = sqlite3.connect(str(target_db))
     try:
-        # Verify the source session exists.
-        row = conn.execute(
-            "SELECT id FROM sessions WHERE id = ?",
-            (source_session_id,),
-        ).fetchone()
-        if row is None:
-            _logger.warning(
-                "Source hermes session %s not found in %s; skipping clone",
-                source_session_id,
-                source_db,
-            )
-            return
-
         # Remap session id and update started_at so the forwarder can
         # discover this cloned session (its floor is launch_epoch_s).
         conn.execute(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2440,7 +2440,7 @@ async def _auto_create_hermes_terminal(
             _target_db = _hermes_home_path / "state.db" if _hermes_home_path else None
             if _target_db is not None:
                 try:
-                    await asyncio.to_thread(
+                    _clone_max_id = await asyncio.to_thread(
                         clone_hermes_session,
                         _source_db,
                         _target_db,
@@ -2449,6 +2449,23 @@ async def _auto_create_hermes_terminal(
                         workspace=workspace,
                     )
                     hermes_args.extend(["--resume", _target_session_id])
+                    # Pre-seed the forwarder cursor past cloned messages so
+                    # the forwarder only mirrors NEW messages (Omnigent already
+                    # has the cloned ones from the fork item copy).
+                    if _clone_max_id > 0:
+                        from omnigent.hermes_native_forwarder import (
+                            _ForwardState,
+                            _write_state,
+                        )
+
+                        _write_state(
+                            bridge_dir,
+                            _ForwardState(
+                                hermes_session_id=_target_session_id,
+                                last_id=_clone_max_id,
+                                launch_epoch_s=launch_epoch_s,
+                            ),
+                        )
                     _logger.info(
                         "Cloned hermes session %s -> %s for fork; session=%s",
                         launch_config.fork_source_external_id,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2439,21 +2439,31 @@ async def _auto_create_hermes_terminal(
             _target_session_id = mint_hermes_session_id()
             _target_db = _hermes_home_path / "state.db" if _hermes_home_path else None
             if _target_db is not None:
-                await asyncio.to_thread(
-                    clone_hermes_session,
-                    _source_db,
-                    _target_db,
-                    launch_config.fork_source_external_id,
-                    _target_session_id,
-                    workspace=workspace,
-                )
-                hermes_args.extend(["--resume", _target_session_id])
-                _logger.info(
-                    "Cloned hermes session %s -> %s for fork; session=%s",
-                    launch_config.fork_source_external_id,
-                    _target_session_id,
-                    session_id,
-                )
+                try:
+                    await asyncio.to_thread(
+                        clone_hermes_session,
+                        _source_db,
+                        _target_db,
+                        launch_config.fork_source_external_id,
+                        _target_session_id,
+                        workspace=workspace,
+                    )
+                    hermes_args.extend(["--resume", _target_session_id])
+                    _logger.info(
+                        "Cloned hermes session %s -> %s for fork; session=%s",
+                        launch_config.fork_source_external_id,
+                        _target_session_id,
+                        session_id,
+                    )
+                except Exception:  # noqa: BLE001
+                    _logger.warning(
+                        "Failed to clone hermes session for fork; launching fresh; session=%s",
+                        session_id,
+                        exc_info=True,
+                    )
+                    # Remove broken state.db so Hermes starts fresh.
+                    if _target_db.exists():
+                        _target_db.unlink()
     # If a per-session HERMES_HOME was written (policy hook), pass it via env
     # so the TUI picks up the hook config alongside its own approval prompt.
     _hermes_terminal_env: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- Validate the source `state.db` has a `sessions` table and the requested session ID **before** `shutil.copy2`, preventing broken DBs from being copied
- If clone fails for any reason, remove the broken `state.db` and let Hermes start fresh instead of crashing with `native_terminal_start_failed`
- Fixes the crash caused by stale empty `state.db` files left by the prior hardcoded-DDL approach

## Test plan
- [ ] Fork a hermes-native session with a valid source → clone works
- [ ] Fork when source DB is broken/empty → Hermes starts fresh (no crash)
- [ ] All 27 bridge tests pass

This pull request and its description were written by Isaac.