### PR TITLE
test(antigravity-native): --gemini_dir residual coverage (core already landed via #1598)

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -13896,9 +13896,10 @@ def create_runner_app(
             antigravity_bdir = antigravity_bridge_dir_for_id(antigravity_bid or conv)
             write_mcp_bridge_config(antigravity_bdir)
             # Fallback for sessions not started via _auto_create_antigravity_terminal
-            # (which already started the relay + wrote agy's isolated-HOME mcp_config).
-            # await_notify=False: agy starts its MCP client lazily, so awaiting would
-            # stall the turn (see the _ensure_comment_relay_started docstring).
+            # (which already started the relay + wrote agy's mcp_config into the
+            # per-session isolated --gemini_dir). await_notify=False: agy starts its
+            # MCP client lazily, so awaiting would stall the turn (see the
+            # _ensure_comment_relay_started docstring).
             await _ensure_comment_relay_started(
                 conv, explicit_bridge_dir=antigravity_bdir, await_notify=False
             )

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -3907,6 +3907,121 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     assert settings_data.get("showFeedbackSurvey") is False
 
 
+@pytest.mark.asyncio
+async def test_auto_create_antigravity_prepends_gemini_dir_to_generated_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--gemini_dir`` is inserted right after the binary, ahead of every other flag.
+
+    The sibling relay-wiring test mocks ``build_agy_launch`` to emit no flags, so it
+    cannot prove the insertion does not corrupt the order of the REAL generated
+    flags (``--conversation``, ``--model``, ``--dangerously-skip-permissions``, and
+    pass-through ``extra_args``). agy global flags must precede any positional /
+    subcommand token, so ``--gemini_dir`` is prepended at index 0 and the rest of
+    argv is preserved verbatim. This guards that invariant against a future change
+    to the argv-composition line in ``_auto_create_antigravity_terminal``.
+    """
+    import omnigent.antigravity_native_bridge as bridge_mod
+    import omnigent.antigravity_native_launch as launch_mod
+    import omnigent.antigravity_native_reader as reader_mod
+    import omnigent.antigravity_native_rpc as rpc_mod
+    import omnigent.runner.app as runner_app_mod
+
+    session_id = "conv_agy_argv"
+    monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    (tmp_path / "workspace").mkdir(parents=True, exist_ok=True)
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+    monkeypatch.setattr(bridge_mod, "ensure_agy_onboarding_complete", lambda: None)
+    monkeypatch.setattr(runner_app_mod, "_terminal_tmux_pane", lambda *_a, **_k: (None, None))
+    monkeypatch.setattr(rpc_mod, "_candidate_agy_rpc_ports", list)
+
+    # A realistic build_agy_launch output: binary + a full set of generated flags.
+    # The argv-composition line must preserve these verbatim after the prepend.
+    generated_tail = [
+        "--conversation",
+        "abc-123",
+        "--model",
+        "gemini-2.5-pro",
+        "--dangerously-skip-permissions",
+        "--print-timeout",
+        "30",
+    ]
+    monkeypatch.setattr(
+        launch_mod,
+        "build_agy_launch",
+        lambda **_kwargs: (("agy", *generated_tail), {}),
+    )
+
+    def _noop_reader(*_args: Any, **_kwargs: Any) -> Any:
+        async def _runner() -> None:
+            await asyncio.Event().wait()
+
+        return _runner()
+
+    monkeypatch.setattr(reader_mod, "supervise_reader", _noop_reader)
+
+    async def _recording_relay(_session_id_arg: str, **_kwargs: Any) -> None:
+        return None
+
+    captured_spec: dict[str, Any] = {}
+    snapshot = {"workspace": str(tmp_path / "workspace")}
+
+    class _SnapshotServerClient:
+        async def get(self, url: str, **_kwargs: Any) -> httpx.Response:
+            assert url == f"/v1/sessions/{session_id}"
+            return httpx.Response(200, json=snapshot, request=httpx.Request("GET", url))
+
+        async def patch(self, url: str, *, json: dict[str, Any], **_kwargs: Any) -> httpx.Response:
+            del json
+            return httpx.Response(200, json={}, request=httpx.Request("PATCH", url))
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            *,
+            resource_role: str | None = None,
+            **_kwargs: Any,
+        ) -> SessionResourceView:
+            captured_spec["command"] = spec.command
+            captured_spec["args"] = list(spec.args)
+            return SessionResourceView(
+                id="terminal_antigravity_main",
+                type="terminal",
+                session_id=session_id,
+                name="Antigravity",
+            )
+
+    try:
+        await _auto_create_antigravity_terminal(
+            session_id,
+            cast(SessionResourceRegistry, _FakeResourceRegistry()),
+            lambda _sid, _event: None,
+            server_client=cast(httpx.AsyncClient, _SnapshotServerClient()),
+            ensure_comment_relay=_recording_relay,
+        )
+        await asyncio.sleep(0)
+    finally:
+        await runner_app_mod._cancel_auto_forwarder_task(session_id)
+
+    bridge_dir = bridge_mod.bridge_dir_for_bridge_id(session_id)
+    iso_gemini = bridge_mod.agy_gemini_dir(bridge_dir)
+
+    # The terminal command stays the agy binary; --gemini_dir leads the arg list and
+    # every generated flag follows in its original order (none dropped or reordered).
+    assert captured_spec["command"] == "agy"
+    assert captured_spec["args"] == [f"--gemini_dir={iso_gemini}", *generated_tail]
+
+
 @pytest.mark.parametrize("parent_host_id", ["host_parent", None])
 @pytest.mark.asyncio
 async def test_codex_subagent_always_needs_runner_terminal(

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -1367,6 +1367,58 @@ def test_agy_gemini_dir_is_under_agy_home_dir(tmp_path: Path) -> None:
     assert agy_gemini_dir(bridge_dir) == agy_home_dir(bridge_dir) / ".gemini"
 
 
+def test_seeding_and_mcp_config_never_mutate_real_gemini_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Linux non-regression: the user's real ``~/.gemini`` is read-only to setup.
+
+    This is the central promise of the ``--gemini_dir`` design: keeping the real
+    ``HOME`` must NOT reintroduce the clobber/concurrency footgun the prior
+    isolated-HOME design avoided. Both setup steps that touch the real
+    ``~/.gemini`` — ``seed_isolated_agy_home`` (COPIES the OAuth markers out) and
+    ``write_mcp_config`` (writes the relay config) — must leave a fully populated
+    real ``~/.gemini`` (interactive-agy user with their own MCP config) byte-for-byte
+    untouched, writing only under the per-session isolated Gemini dir.
+    """
+    fake_home = tmp_path / "real-home"
+    real_gemini = fake_home / ".gemini"
+    (real_gemini / "antigravity-cli").mkdir(parents=True)
+    (real_gemini / "config").mkdir(parents=True)
+    # Populate the real tree as a logged-in interactive-agy user would have it,
+    # including their OWN mcp_config.json the design must never clobber.
+    seeded_files = {
+        real_gemini / "oauth_creds.json": '{"access_token":"mac-token"}',
+        real_gemini / "installation_id": "root-install-id",
+        real_gemini / "antigravity-cli" / "antigravity-oauth-token": "linux-token",
+        real_gemini / "antigravity-cli" / "installation_id": "cli-install-id",
+        real_gemini / "config" / "mcp_config.json": '{"mcpServers":{"user_own":{}}}',
+    }
+    for path, body in seeded_files.items():
+        path.write_text(body, encoding="utf-8")
+    before = {path: path.read_text(encoding="utf-8") for path in seeded_files}
+    real_listing_before = sorted(
+        p.relative_to(real_gemini).as_posix() for p in real_gemini.rglob("*")
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    seed_isolated_agy_home(bridge_dir)
+    write_mcp_config(bridge_dir, python_executable="python-test")
+
+    # Every real file is byte-for-byte unchanged: nothing copied OUT was mutated,
+    # and the user's own mcp_config.json was NOT overwritten by the relay config.
+    for path, original in before.items():
+        assert path.read_text(encoding="utf-8") == original
+    # No new files leaked into the real tree (e.g. a relay config under real config/).
+    real_listing_after = sorted(
+        p.relative_to(real_gemini).as_posix() for p in real_gemini.rglob("*")
+    )
+    assert real_listing_after == real_listing_before
+    # The relay config DID land in the isolated tree (positive control).
+    assert (agy_gemini_dir(bridge_dir) / "config" / "mcp_config.json").is_file()
+
+
 # ---------------------------------------------------------------------------
 # Interaction-prompt TUI delivery (send_interaction_keys_via_tui) — #1200
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

N/A — the isolation fix this branch originally carried (agy `--gemini_dir`,
keeping the real HOME for macOS keyring auth) already merged to `main` via
#1598, which explicitly cherry-picked this branch's commits.

## Summary

The core change is already on `main` (via #1598). Rebased onto `main`, this PR
now contains only the coverage + doc bits #1598 did **not** absorb:

- **`test_seeding_and_mcp_config_never_mutate_real_gemini_dir`** — Linux
  non-regression proving `seed_isolated_agy_home` + `write_mcp_config` leave the
  user's real `~/.gemini` (including their own `mcp_config.json`) byte-for-byte
  untouched, writing only under the per-session isolated dir.
- **`test_auto_create_antigravity_prepends_gemini_dir_to_generated_flags`** —
  guards that `--gemini_dir` is prepended ahead of every generated `agy` flag
  (`--conversation`/`--model`/…) so the arg order is never corrupted.
- A stale-comment fix in the runner's fallback relay path (it still read
  "isolated-HOME mcp_config" though `main` now uses the isolated `--gemini_dir`).

This resolves the prior merge conflict (the branch had fallen behind `main` and
its substance was redundant with #1598) and leaves a small, mergeable coverage PR.

## Test Plan

- `ruff check` + `ruff format --check` on the 3 changed files — clean.
- `pytest tests/test_antigravity_native_bridge.py` (full file incl. the new test)
  and `tests/runner/test_app_sessions_native.py -k antigravity` — all pass.
- Antigravity SDK unit suites (executor / harness / spawn-env / auth) — 159 passed.
- Live SDK smoke (`omni run --harness antigravity`) attempted; blocked by the
  host's glibc 2.31 (the bundled `localharness` needs ≥ 2.36) — an environment
  limit, unrelated to these native-bridge, test-only changes.

## Demo

N/A — test + comment-only changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two added tests are the coverage; existing antigravity-native tests cover the
surrounding behavior. Live SDK e2e was not runnable on this host (glibc 2.31 <
2.36 for the bundled native binary); these are native-bridge, test-only changes
with no runtime behavior change.