### PR TITLE
feat(regen): add /regen upgrade <pkgs> to bump transitive deps

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -3,6 +3,14 @@
 # ONTO that PR's branch. Use when the PR itself moved a dependency; complements
 # oss-regenerate-and-smoke.yml (standalone rolling PR on dispatch).
 #
+# Two forms:
+#   /regen                      re-resolve, preserving existing pins.
+#   /regen upgrade <pkg> [pkg]  additionally force uv to take the newest allowed
+#                               version of each named package (uv lock
+#                               --upgrade-package). Use for a transitive pip
+#                               security bump Dependabot can't land on this uv
+#                               workspace (plain `uv lock` keeps the old pin).
+#
 # Validation is left to the PR's own CI: the push uses a GitHub App token (NOT
 # GITHUB_TOKEN, which GitHub suppresses to avoid loops), so it re-fires the full
 # check suite on the new commit. Falls back to GITHUB_TOKEN if the App isn't
@@ -38,6 +46,8 @@ jobs:
       ok: ${{ steps.authz.outputs.ok }}
       head: ${{ steps.pr.outputs.head }}
       cross: ${{ steps.pr.outputs.cross }}
+      mode: ${{ steps.mode.outputs.mode }}
+      pkgs: ${{ steps.mode.outputs.pkgs }}
     steps:
       # Checkout main only for load-maintainers.sh; the PR branch is checked
       # out later (regen job), after authorization passes.
@@ -65,6 +75,36 @@ jobs:
           if [ "$ok" != "true" ]; then
             echo "::notice::@$ACTOR is not in .github/MAINTAINER; ignoring /regen."
           fi
+
+      # Parse an optional `upgrade <pkg...>` subcommand. Plain `/regen` keeps the
+      # default behaviour (re-resolve preserving pins). `/regen upgrade foo bar`
+      # asks uv to take the newest allowed version of foo + bar (a transitive
+      # security bump Dependabot can't land on this uv workspace). The comment
+      # body is read from env (never interpolated) and every package token is
+      # validated against a strict PEP 503-ish pattern, so nothing attacker-
+      # supplied can reach the shell in the regen job.
+      - name: Parse regen mode
+        id: mode
+        if: steps.authz.outputs.ok == 'true'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          python3 <<'PYEOF'
+          import os, re, pathlib
+          tokens = os.environ.get("COMMENT_BODY", "").split()
+          mode, pkgs = "regen", []
+          if len(tokens) >= 2 and tokens[0] == "/regen" and tokens[1] == "upgrade":
+              mode = "upgrade"
+              for t in tokens[2:]:
+                  # uv package names only; drop anything else (never shelled).
+                  if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", t):
+                      pkgs.append(t)
+          out = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a") as f:
+              f.write(f"mode={mode}\n")
+              f.write("pkgs=" + " ".join(pkgs) + "\n")
+          print(f"mode={mode} pkgs={pkgs}")
+          PYEOF
 
       - name: Resolve PR head ref
         id: pr
@@ -146,8 +186,23 @@ jobs:
       # with (React 18 runtime vs React 19 peers would otherwise ERESOLVE-fail,
       # and a flag mismatch rewrites dev/extraneous flags, failing the gate).
       - name: Regenerate lockfiles against public PyPI/npm
+        env:
+          REGEN_MODE: ${{ needs.authorize.outputs.mode }}
+          UPGRADE_PKGS: ${{ needs.authorize.outputs.pkgs }}
         run: |
-          uv lock
+          # Default `/regen`: re-resolve preserving existing pins.
+          # `/regen upgrade <pkgs...>`: force uv to take the newest allowed
+          # version for each named package (e.g. a transitive security fix).
+          # UPGRADE_PKGS holds only strictly-validated names (see the authorize
+          # job's Parse step), so word-splitting it here is safe.
+          if [ "$REGEN_MODE" = "upgrade" ] && [ -n "$UPGRADE_PKGS" ]; then
+            args=()
+            for p in $UPGRADE_PKGS; do args+=(--upgrade-package "$p"); done
+            echo "uv lock ${args[*]}"
+            uv lock "${args[@]}"
+          else
+            uv lock
+          fi
           ( cd ap-web && rm -f package-lock.json && npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund )
 
       # Mint the App token only AFTER `uv lock` so untrusted PR build backends
@@ -191,11 +246,17 @@ jobs:
           ISSUE: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           CHANGED: ${{ steps.push.outputs.changed }}
+          REGEN_MODE: ${{ needs.authorize.outputs.mode }}
+          UPGRADE_PKGS: ${{ needs.authorize.outputs.pkgs }}
           # App token used → push re-triggers CI; skipped (GITHUB_TOKEN fallback) → it won't.
           APP_USED: ${{ steps.app-token.conclusion == 'success' }} # App token → re-triggers CI; fallback → won't
         run: |
+          upgraded=""
+          if [ "$REGEN_MODE" = "upgrade" ] && [ -n "$UPGRADE_PKGS" ]; then
+            upgraded=" (upgraded: $UPGRADE_PKGS)"
+          fi
           if [ "$CHANGED" = "true" ]; then
-            base="✅ Regenerated \`uv.lock\` + \`ap-web/package-lock.json\` against public PyPI/npm and pushed to this PR."
+            base="✅ Regenerated \`uv.lock\`$upgraded + \`ap-web/package-lock.json\` against public PyPI/npm and pushed to this PR."
             if [ "$APP_USED" = "true" ]; then
               body="$base CI will re-run on the new commit."
             else


### PR DESCRIPTION
## What
Opt-in subcommand for the `/regen` workflow:
- `/regen` (unchanged): re-resolve lockfiles, preserving pins.
- `/regen upgrade <pkg> [pkg...]`: additionally run `uv lock --upgrade-package <pkg>` for each named package.

## Why
Plain `uv lock` preserves existing pins, so `/regen` can't bump a *transitive* pip dependency. That's the gap behind the cryptography / pydantic-settings security fixes (#1394, #1413): Dependabot doesn't regenerate `uv.lock` on this uv workspace, and a plain regen keeps the vulnerable pin. With this, a transitive pip advisory becomes a one-comment fix: `/regen upgrade <pkg>`.

## Safety
The comment body is read via env (never interpolated). Every package token is validated in the `authorize` job against `[A-Za-z0-9][A-Za-z0-9._-]*`; non-matching tokens (shell metacharacters, `$(...)`, backticks, leading-dash flags) are dropped before reaching the regen job, where the validated names are passed as quoted args to `uv lock --upgrade-package` (never to a shell). Only `.github/MAINTAINER` members can trigger `/regen`.

## Note
`/regen` runs on `issue_comment`, so this takes effect once merged to `main` (the handler always runs from the default branch). After merge I'll recreate the cryptography/pydantic-settings fix via `/regen upgrade` to exercise it.