### PR TITLE
fix(server): reject absolute/escaping os_env.cwd in uploaded agent bundles

### DIFF
--- a/omnigent/server/bundles.py
+++ b/omnigent/server/bundles.py
@@ -4,10 +4,29 @@ from __future__ import annotations
 
 import hashlib
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.spec import AgentSpec, ExtractionError, load
+
+
+def _cwd_escapes_workspace(spec_cwd: str) -> bool:
+    """Whether an agent-spec ``os_env.cwd`` would escape the session workspace.
+
+    ``True`` for an absolute path or one containing a ``..`` segment, in
+    either POSIX or Windows form (the runner is POSIX, but checking both
+    avoids a separator-style bypass). Such a cwd must be rejected for
+    untrusted uploads (GHSA-p8rw-8qj3-hf33): on a runner without
+    ``OMNIGENT_RUNNER_WORKSPACE`` it becomes the agent environment root and
+    ``copytree`` source, exposing the host filesystem.
+    """
+    posix, win = PurePosixPath(spec_cwd), PureWindowsPath(spec_cwd)
+    return (
+        posix.is_absolute()
+        or win.is_absolute()
+        or ".." in posix.parts
+        or ".." in win.parts
+    )
 
 
 def validate_agent_bundle(
@@ -43,7 +62,8 @@ def validate_agent_bundle(
     :returns: The validated :class:`AgentSpec`.
     :raises OmnigentError: If the bundle is invalid, the spec is
         missing a name, or (when *enforce_handler_allowlist*) a policy
-        names an unregistered handler.
+        names an unregistered handler or ``os_env.cwd`` is an absolute
+        or escaping path.
     """
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -70,6 +90,25 @@ def validate_agent_bundle(
             "agent spec must include a name",
             code=ErrorCode.INVALID_INPUT,
         )
+
+    # Untrusted uploads may not pin an absolute or escaping os_env.cwd
+    # (GHSA-p8rw-8qj3-hf33). This is gated on the same trust signal as the
+    # handler allowlist: a trusted single-user/local server
+    # (enforce_handler_allowlist=False) uploads the operator's OWN bundle, and
+    # the operator legitimately controls cwd — matching the documented
+    # absolute-cwd behavior for direct/local runs in
+    # designs/SESSION_WORKSPACE_SELECTION.md.
+    if enforce_handler_allowlist:
+        os_env = getattr(spec, "os_env", None)
+        spec_cwd = getattr(os_env, "cwd", None) if os_env is not None else None
+        if spec_cwd is not None and spec_cwd not in (".", "./") and _cwd_escapes_workspace(
+            spec_cwd
+        ):
+            raise OmnigentError(
+                "agent os_env.cwd must be a relative path within the workspace "
+                f"(no absolute paths or '..'); got {spec_cwd!r}",
+                code=ErrorCode.INVALID_INPUT,
+            )
 
     return spec
 

--- a/omnigent/server/bundles.py
+++ b/omnigent/server/bundles.py
@@ -21,12 +21,7 @@ def _cwd_escapes_workspace(spec_cwd: str) -> bool:
     ``copytree`` source, exposing the host filesystem.
     """
     posix, win = PurePosixPath(spec_cwd), PureWindowsPath(spec_cwd)
-    return (
-        posix.is_absolute()
-        or win.is_absolute()
-        or ".." in posix.parts
-        or ".." in win.parts
-    )
+    return posix.is_absolute() or win.is_absolute() or ".." in posix.parts or ".." in win.parts
 
 
 def validate_agent_bundle(
@@ -101,8 +96,10 @@ def validate_agent_bundle(
     if enforce_handler_allowlist:
         os_env = getattr(spec, "os_env", None)
         spec_cwd = getattr(os_env, "cwd", None) if os_env is not None else None
-        if spec_cwd is not None and spec_cwd not in (".", "./") and _cwd_escapes_workspace(
-            spec_cwd
+        if (
+            spec_cwd is not None
+            and spec_cwd not in (".", "./")
+            and _cwd_escapes_workspace(spec_cwd)
         ):
             raise OmnigentError(
                 "agent os_env.cwd must be a relative path within the workspace "

--- a/tests/server/test_bundles.py
+++ b/tests/server/test_bundles.py
@@ -286,3 +286,65 @@ def test_validate_bundle_accepts_registered_handler_in_sub_agent() -> None:
     )
     spec = validate_agent_bundle(bundle)
     assert spec.name == "root_agent"
+
+
+# ── os_env.cwd containment on the upload path (GHSA-p8rw-8qj3-hf33) ──
+
+
+def _bundle_with_cwd(cwd: str) -> bytes:
+    """Pack a minimal valid bundle whose ``os_env.cwd`` is *cwd*."""
+    return _make_bundle_bytes(
+        {
+            "config.yaml": yaml.dump(
+                {
+                    "spec_version": 1,
+                    "name": "uploaded-agent",
+                    "executor": {
+                        "type": "omnigent",
+                        "config": {"harness": "claude-sdk"},
+                    },
+                    "prompt": "hi",
+                    "os_env": {
+                        "type": "caller_process",
+                        "cwd": cwd,
+                        "sandbox": {"type": "none"},
+                    },
+                }
+            )
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_cwd", ["/", "/etc", "/etc/passwd", "../../etc", "a/../../b"]
+)
+def test_validate_agent_bundle_rejects_escaping_os_env_cwd(bad_cwd: str) -> None:
+    """An uploaded bundle may not pin an absolute or ``..``-escaping cwd.
+
+    On a runner without ``OMNIGENT_RUNNER_WORKSPACE`` such a cwd becomes the
+    agent environment root / ``copytree`` source, exposing the host
+    filesystem (GHSA-p8rw-8qj3-hf33). The untrusted upload path must reject it.
+    """
+    with pytest.raises(OmnigentError, match=r"os_env\.cwd must be a relative path"):
+        validate_agent_bundle(_bundle_with_cwd(bad_cwd))
+
+
+@pytest.mark.parametrize("ok_cwd", ["sub", "sub/dir", "a/b/c", ".", "./"])
+def test_validate_agent_bundle_allows_contained_relative_cwd(ok_cwd: str) -> None:
+    """A relative, non-escaping ``os_env.cwd`` is accepted on the upload path."""
+    spec = validate_agent_bundle(_bundle_with_cwd(ok_cwd))
+    assert spec.name == "uploaded-agent"
+
+
+def test_validate_agent_bundle_allows_absolute_cwd_for_trusted_local_server() -> None:
+    """The trusted single-user/local path keeps the documented absolute-cwd
+    behavior.
+
+    With ``enforce_handler_allowlist=False`` the operator uploads their OWN
+    bundle and legitimately controls cwd, so containment is not enforced —
+    matching ``designs/SESSION_WORKSPACE_SELECTION.md`` for direct/local runs.
+    """
+    spec = validate_agent_bundle(
+        _bundle_with_cwd("/abs/operator/path"), enforce_handler_allowlist=False
+    )
+    assert spec.name == "uploaded-agent"

--- a/tests/server/test_bundles.py
+++ b/tests/server/test_bundles.py
@@ -315,9 +315,7 @@ def _bundle_with_cwd(cwd: str) -> bytes:
     )
 
 
-@pytest.mark.parametrize(
-    "bad_cwd", ["/", "/etc", "/etc/passwd", "../../etc", "a/../../b"]
-)
+@pytest.mark.parametrize("bad_cwd", ["/", "/etc", "/etc/passwd", "../../etc", "a/../../b"])
 def test_validate_agent_bundle_rejects_escaping_os_env_cwd(bad_cwd: str) -> None:
     """An uploaded bundle may not pin an absolute or ``..``-escaping cwd.
 


### PR DESCRIPTION
## Related issue

N/A — private advisory GHSA-p8rw-8qj3-hf33 (High, CWE-22). Fixing in the open per maintainer guidance.

## Summary

- An authenticated user could upload an agent bundle whose `os_env.cwd` is absolute (`/`) or `..`-escaping. On a runner without `OMNIGENT_RUNNER_WORKSPACE` that cwd becomes the agent environment root and `copytree` source — arbitrary host-FS read/write + runner secret exposure.
- Fix: `validate_agent_bundle` rejects an absolute/escaping `os_env.cwd`, gated on the existing `enforce_handler_allowlist` trust signal so trusted local runs keep their documented absolute-cwd behavior.

## Test Plan

`uv run --extra all --extra dev pytest tests/server/test_bundles.py` — rejects `/`, `/etc`, `/etc/passwd`, `../../etc`, `a/../../b`; accepts `sub`, `sub/dir`, `.`, `./`; confirms trusted-local (`enforce_handler_allowlist=False`) still allows an absolute cwd. 19/19 pass.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A