### PR TITLE
fix(server): block shared-agent overwrite via bundle upload

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -19391,7 +19391,7 @@ def create_sessions_router(
                 code=ErrorCode.NOT_FOUND,
             )
 
-        # Shared/template agents are read-only here (GHSA-jrrm-9hc7-2v3h);
+        # Shared/template agents are read-only here;
         # mirrors the guard in session_mcp_servers._editable_agent.
         if agent.session_id is None:
             raise OmnigentError(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -19391,6 +19391,14 @@ def create_sessions_router(
                 code=ErrorCode.NOT_FOUND,
             )
 
+        # Shared/template agents are read-only here (GHSA-jrrm-9hc7-2v3h);
+        # mirrors the guard in session_mcp_servers._editable_agent.
+        if agent.session_id is None:
+            raise OmnigentError(
+                "Built-in agents are read-only through this endpoint.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+
         bundle_bytes = await bundle.read()
         # Run bundle validation (tar extraction + spec parse, both
         # blocking) off the event loop -- mirrors the POST


### PR DESCRIPTION
## Related issue

N/A — private advisory GHSA-jrrm-9hc7-2v3h (Critical, CWE-94). Fixing in the open per maintainer guidance.

Reported by @xttraa. Thanks for the report.

## Summary

- `PUT /sessions/{session_id}/agent` checked `LEVEL_EDIT` but not whether the bound agent is a shared/template agent (`agent.session_id is None`). A user could overwrite a shared agent's bundle, inject a `stdio` MCP server (launched as a runner subprocess), and gain RCE on future sessions using it.
- Fix: add the same `agent.session_id is None` guard the per-server MCP-edit endpoint already enforces (`session_mcp_servers._editable_agent`).

## Test Plan

Compiles clean; the guard is a 1:1 mirror of the already-shipped MCP-edit guard. A route-level regression test (built-in-agent-bound session -> `PUT /agent` -> 4xx) needs a sessions-app + built-in-agent-session fixture and is tracked as a follow-up.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No new automated test in this PR — the route test needs a heavier sessions-app harness (tracked as follow-up). The guard mirrors the tested `session_mcp_servers._editable_agent` check.