### PR TITLE
feat: show host badge in chat UI

### DIFF
--- a/tests/e2e_ui/sessions/test_host_badge.py
+++ b/tests/e2e_ui/sessions/test_host_badge.py
@@ -1,0 +1,222 @@
+"""E2E: the chat header's host badge shows which host a session is bound to.
+
+The badge (``ap-web/src/components/HostBadge.tsx``) renders at the top of the
+chat window for a host-bound session: the friendly host name (or a
+sandbox-provider label) plus a green/red status dot driven by the live host
+``host_online`` signal. It renders nothing when the session isn't host-bound.
+
+The harness seeds a normal runner-bound ``hello_world`` session, so the browser
+view is patched into a host-bound shape via route interception (same approach as
+``test_host_asleep_composer.py``):
+
+- ``GET /v1/sessions/{id}`` (snapshot) → ``host_id`` set so the badge has a host
+  to resolve. ``host_resumable`` + an old ``created_at`` keep an offline host out
+  of the ``host_offline`` reconnect dead-end so the chat view stays normal.
+- ``GET /v1/hosts`` → returns the bound host so the badge resolves its name (or
+  the sandbox-provider label). ``HostBadge`` calls this via
+  ``useHosts({ includeSandbox: true })``.
+- ``GET /health`` → reports the session's live ``host_online`` so the dot reads
+  online/offline; the open-session poll overrides the WS stream.
+- ``GET /v1/sessions`` (sidebar list) → the session is dropped so the open row
+  resolves off-sidebar from the patched snapshot (host-bound).
+- ``WS /v1/sessions/updates`` → blocked so a stream push can't revert liveness to
+  the real (runner-online, host-unbound) values.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+_FAKE_HOST_ID = "host_test_badge"
+# Unix seconds well before now so an offline host is outside the startup grace
+# (STARTING_GRACE_S) and reads host_asleep, not `starting` — see
+# useSessionLiveness. Harmless for the online case.
+_OLD_CREATED_AT = 1_700_000_000
+
+
+def _patch_host_view(
+    page: Page,
+    session_id: str,
+    *,
+    host: dict,
+    host_online: bool,
+) -> None:
+    """Patch the browser's view of ``session_id`` into a host-bound shape.
+
+    Registered before navigation: four HTTP route patches plus one WS block.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    :param host: The host record ``GET /v1/hosts`` should return for the bound
+        host (``host_id`` is overwritten to match the patched snapshot).
+    :param host_online: Live ``host_online`` the session reports via ``/health``;
+        drives the badge's online (green) vs offline (red) dot.
+    """
+    host = {**host, "host_id": _FAKE_HOST_ID}
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        payload["host_id"] = _FAKE_HOST_ID
+        # Keep an offline host out of the host_offline reconnect dead-end so the
+        # chat view (and its header) renders normally; harmless when online.
+        payload["host_resumable"] = True
+        payload["created_at"] = _OLD_CREATED_AT
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_hosts(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/v1/hosts":
+            route.continue_()
+            return
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/json"},
+            body=json.dumps({"hosts": [host]}),
+        )
+
+    def _patch_list(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/v1/sessions":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(rows, list):
+            payload["data"] = [
+                r for r in rows if not (isinstance(r, dict) and r.get("id") == session_id)
+            ]
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_health(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/health":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        live = {"runner_online": False, "host_online": host_online}
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session_id] = live
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **live}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    # Snapshot route registered last so it wins for /v1/sessions/{id} (Playwright
+    # matches most-recently-registered first); the others fall through via
+    # continue_() for anything they don't own.
+    page.route(re.compile(r"/v1/hosts(\?|$)"), _patch_hosts)
+    page.route(re.compile(r"/v1/sessions(\?|$)"), _patch_list)
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+
+def test_host_badge_shows_host_name_when_online(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A host-bound, online session shows the host name with an online status.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to a host-bound, online shape.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_host_view(
+        page,
+        session_id,
+        host={"name": "e2e-host", "owner": "e2e", "status": "online", "sandbox_provider": None},
+        host_online=True,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    expect(badge).to_contain_text("e2e-host")
+    # The dot is decorative; status is conveyed by the title (mouse hover) and an
+    # sr-only word. Online == reachable host.
+    expect(badge).to_have_attribute("title", "Host e2e-host, online", timeout=15_000)
+
+
+def test_host_badge_shows_offline_when_host_unreachable(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A host-bound session whose host is offline shows an offline status.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to a host-bound, offline shape.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_host_view(
+        page,
+        session_id,
+        host={"name": "e2e-host", "owner": "e2e", "status": "offline", "sandbox_provider": None},
+        host_online=False,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    expect(badge).to_contain_text("e2e-host")
+    expect(badge).to_have_attribute("title", "Host e2e-host, offline", timeout=15_000)
+
+
+def test_host_badge_labels_sandbox_session_by_provider(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A sandbox-backed session is labeled by its provider, not its managed name.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to a sandbox-host-bound shape.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_host_view(
+        page,
+        session_id,
+        host={
+            "name": "managed-cd8f66d0",
+            "owner": "e2e",
+            "status": "online",
+            "sandbox_provider": "databricks-lakebox",
+        },
+        host_online=True,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    # The managed-<hex> host name is collapsed to the provider label.
+    expect(badge).to_contain_text("Databricks-lakebox Sandbox")
+    expect(badge).not_to_contain_text("managed-cd8f66d0")

--- a/web/src/components/HostBadge.test.tsx
+++ b/web/src/components/HostBadge.test.tsx
@@ -1,0 +1,234 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HostBadge, resolveHostBadge } from "./HostBadge";
+import type { Host } from "@/hooks/useHosts";
+
+function host(overrides: Partial<Host> = {}): Host {
+  return {
+    host_id: "host_a1b2",
+    name: "mac-laptop",
+    owner: "alice",
+    status: "online",
+    sandbox_provider: null,
+    ...overrides,
+  };
+}
+
+describe("resolveHostBadge", () => {
+  it("returns null when the session is not host-bound", () => {
+    expect(resolveHostBadge({ hostId: null, host: undefined, online: null })).toBeNull();
+    expect(resolveHostBadge({ hostId: undefined, host: undefined, online: undefined })).toBeNull();
+  });
+
+  it("uses the friendly host name and online status for a connected host", () => {
+    expect(resolveHostBadge({ hostId: "host_a1b2", host: host(), online: true })).toEqual({
+      label: "mac-laptop",
+      status: "online",
+    });
+  });
+
+  it("reports offline status for a connected host", () => {
+    expect(resolveHostBadge({ hostId: "host_a1b2", host: host(), online: false })).toEqual({
+      label: "mac-laptop",
+      status: "offline",
+    });
+  });
+
+  it("labels a sandbox host by provider, not its managed-* name", () => {
+    expect(
+      resolveHostBadge({
+        hostId: "host_sb",
+        host: host({ host_id: "host_sb", name: "managed-abc123", sandbox_provider: "lakebox" }),
+        online: true,
+      }),
+    ).toEqual({ label: "Databricks Sandbox", status: "online" });
+  });
+
+  it("falls back to the raw host_id when the host record is unresolved", () => {
+    // Shared session on another owner's host, or hosts not loaded yet:
+    // there's no name to show, but the session IS host-bound, so the
+    // badge must still answer "which host" with the id.
+    expect(resolveHostBadge({ hostId: "host_x9", host: undefined, online: true })).toEqual({
+      label: "host_x9",
+      status: "online",
+    });
+  });
+
+  it("reports unknown status while liveness is still settling", () => {
+    // null = not-host-bound signal from the health stream; undefined =
+    // not yet observed. Neither should flash a red 'offline' circle.
+    expect(
+      resolveHostBadge({ hostId: "host_a1b2", host: host(), online: undefined }),
+    ).toMatchObject({ status: "unknown" });
+    expect(resolveHostBadge({ hostId: "host_a1b2", host: host(), online: null })).toMatchObject({
+      status: "unknown",
+    });
+  });
+});
+
+// Stub the data hooks so the component test drives label/status purely
+// from inputs (resolveHostBadge is covered separately above).
+const useSessionMock = vi.fn();
+const useHostsMock = vi.fn();
+const useSessionHostOnlineMock = vi.fn();
+
+vi.mock("@/hooks/useSession", () => ({
+  useSession: (id: string | null | undefined) => useSessionMock(id),
+}));
+vi.mock("@/hooks/useHosts", () => ({
+  useHosts: (opts: unknown) => useHostsMock(opts),
+}));
+vi.mock("@/hooks/RunnerHealthProvider", () => ({
+  useSessionHostOnline: (id: string | undefined) => useSessionHostOnlineMock(id),
+}));
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  useHostsMock.mockReset();
+  useSessionHostOnlineMock.mockReset();
+  // Sensible defaults; each test overrides what it cares about.
+  useSessionMock.mockReturnValue({
+    session: { hostId: "host_a1b2" },
+    isLoading: false,
+    error: null,
+  });
+  useHostsMock.mockReturnValue({
+    data: [
+      {
+        host_id: "host_a1b2",
+        name: "mac-laptop",
+        owner: "alice",
+        status: "online",
+        sandbox_provider: null,
+      },
+    ],
+  });
+  useSessionHostOnlineMock.mockReturnValue(true);
+});
+
+afterEach(() => cleanup());
+
+describe("HostBadge", () => {
+  it("renders the host name with an online status when reachable", () => {
+    render(<HostBadge sessionId="conv_1" />);
+    const badge = screen.getByTestId("host-badge");
+    // Status is conveyed by the visible name + an sr-only status word
+    // (read together as "mac-laptop, online"), with `title` for hover.
+    expect(badge.textContent).toBe("mac-laptop, online");
+    expect(badge.getAttribute("title")).toBe("Host mac-laptop, online");
+  });
+
+  it("renders nothing when the session is not host-bound", () => {
+    useSessionMock.mockReturnValue({ session: { hostId: null }, isLoading: false, error: null });
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.queryByTestId("host-badge")).toBeNull();
+  });
+
+  it("labels a sandbox session by provider, requesting sandbox hosts", () => {
+    useSessionMock.mockReturnValue({
+      session: { hostId: "host_sb" },
+      isLoading: false,
+      error: null,
+    });
+    useHostsMock.mockReturnValue({
+      data: [
+        {
+          host_id: "host_sb",
+          name: "managed-abc123",
+          owner: "alice",
+          status: "online",
+          sandbox_provider: "lakebox",
+        },
+      ],
+    });
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toContain("Databricks Sandbox");
+    // The badge must opt into sandbox hosts — the default filtered call
+    // would drop this host and the label would regress to the raw id.
+    expect(useHostsMock).toHaveBeenCalledWith(expect.objectContaining({ includeSandbox: true }));
+  });
+
+  it("falls back to the raw host_id when the host isn't in the list", () => {
+    useSessionMock.mockReturnValue({
+      session: { hostId: "host_x9" },
+      isLoading: false,
+      error: null,
+    });
+    useHostsMock.mockReturnValue({ data: [] });
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toContain("host_x9");
+  });
+
+  it("falls back to the host record's status when liveness is unobserved", () => {
+    // liveOnline === undefined (stream hasn't reported yet) → trust the
+    // stored host.status so an offline record reads offline, not unknown.
+    useHostsMock.mockReturnValue({
+      data: [
+        {
+          host_id: "host_a1b2",
+          name: "mac-laptop",
+          owner: "alice",
+          status: "offline",
+          sandbox_provider: null,
+        },
+      ],
+    });
+    useSessionHostOnlineMock.mockReturnValue(undefined);
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("mac-laptop, offline");
+  });
+
+  it("lets a live offline signal override a stale 'online' host record", () => {
+    // host record says online, but the live stream says the host is down
+    // (false). The live signal wins — false must not be discarded.
+    useHostsMock.mockReturnValue({
+      data: [
+        {
+          host_id: "host_a1b2",
+          name: "mac-laptop",
+          owner: "alice",
+          status: "online",
+          sandbox_provider: null,
+        },
+      ],
+    });
+    useSessionHostOnlineMock.mockReturnValue(false);
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("mac-laptop, offline");
+  });
+
+  it("shows unknown (not a stale green) when the stream reports not-host-bound", () => {
+    // Shared-session race: the host record says online, but the live
+    // stream returns null ("not host-bound"). null must reach the badge
+    // as "unknown" rather than falling through to the record's online.
+    useHostsMock.mockReturnValue({
+      data: [
+        {
+          host_id: "host_a1b2",
+          name: "mac-laptop",
+          owner: "alice",
+          status: "online",
+          sandbox_provider: null,
+        },
+      ],
+    });
+    useSessionHostOnlineMock.mockReturnValue(null);
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("mac-laptop, status unknown");
+  });
+
+  it("shows unknown while the host list is still loading", () => {
+    // hosts === undefined and no live signal yet: nothing to derive
+    // status from → unknown, and the raw id stands in for the name.
+    useSessionMock.mockReturnValue({
+      session: { hostId: "host_x9" },
+      isLoading: false,
+      error: null,
+    });
+    useHostsMock.mockReturnValue({ data: undefined });
+    useSessionHostOnlineMock.mockReturnValue(undefined);
+    render(<HostBadge sessionId="conv_1" />);
+    expect(screen.getByTestId("host-badge").textContent).toBe("host_x9, status unknown");
+  });
+});

--- a/web/src/components/HostBadge.tsx
+++ b/web/src/components/HostBadge.tsx
@@ -1,0 +1,108 @@
+import { useHosts } from "@/hooks/useHosts";
+import type { Host } from "@/hooks/useHosts";
+import { useSession } from "@/hooks/useSession";
+import { useSessionHostOnline } from "@/hooks/RunnerHealthProvider";
+import { sandboxOptionLabel } from "@/lib/capabilities";
+import { cn } from "@/lib/utils";
+
+export type HostBadgeStatus = "online" | "offline" | "unknown";
+
+export interface HostBadgeInfo {
+  label: string;
+  status: HostBadgeStatus;
+}
+
+/**
+ * Compute the host badge's label + status from a session's host binding.
+ *
+ * - Not host-bound (`hostId` null/absent) → `null` (render nothing).
+ * - Sandbox-backed host → the provider label ("Databricks Sandbox").
+ * - Connected host → its friendly `name`.
+ * - Host-bound but record unresolved (shared session / not yet loaded)
+ *   → the raw `hostId`, so the badge always answers "which host".
+ *
+ * `online` is tri-stated: `true`/`false` map to online/offline; `null`
+ * (not-host-bound signal) and `undefined` (not yet observed) both map to
+ * "unknown" so the circle never flashes red before liveness settles.
+ */
+export function resolveHostBadge(args: {
+  hostId: string | null | undefined;
+  host: Host | undefined;
+  online: boolean | null | undefined;
+}): HostBadgeInfo | null {
+  const { hostId, host, online } = args;
+  if (!hostId) return null;
+  const label = host
+    ? host.sandbox_provider
+      ? sandboxOptionLabel(host.sandbox_provider)
+      : host.name
+    : hostId;
+  const status: HostBadgeStatus =
+    online === true ? "online" : online === false ? "offline" : "unknown";
+  return { label, status };
+}
+
+const STATUS_DOT_CLASS: Record<HostBadgeStatus, string> = {
+  online: "bg-success",
+  offline: "bg-destructive",
+  // Neutral while liveness is still settling — avoids a red flash.
+  unknown: "bg-muted-foreground/50",
+};
+
+const STATUS_WORD: Record<HostBadgeStatus, string> = {
+  online: "online",
+  offline: "offline",
+  unknown: "status unknown",
+};
+
+/**
+ * Host indicator for the open conversation, rendered at the top of the
+ * chat window (ChatHeader's left slot). Reads its own data and renders
+ * nothing when the session isn't host-bound — same self-contained shape
+ * as PresenceAvatars. Shows the friendly host name (or sandbox-provider
+ * label) plus a status circle: green online, red offline, neutral while
+ * liveness is still unknown.
+ */
+export function HostBadge({ sessionId }: { sessionId: string }) {
+  const { session } = useSession(sessionId);
+  const hostId = session?.hostId ?? null;
+  // Keep sandbox hosts so managed sessions resolve to a provider label.
+  // Skip the fetch (and its 10s refetch loop) when there's no host to
+  // resolve — the badge renders nothing in that case anyway.
+  const { data: hosts } = useHosts({ includeSandbox: true, enabled: Boolean(hostId) });
+  const liveOnline = useSessionHostOnline(sessionId);
+
+  const host = hostId ? hosts?.find((h) => h.host_id === hostId) : undefined;
+  // Prefer the live health signal. Both `false` (host down) and `null`
+  // (the stream's "not host-bound" signal) are meaningful answers, so we
+  // only fall back to the host record's stored status when liveness has
+  // not been observed yet (`undefined`). Falling back on `null` would let
+  // a stale record's "online" flash a green dot for a session the stream
+  // says is unbound — `null` must reach resolveHostBadge as "unknown".
+  const online =
+    liveOnline === undefined ? (host ? host.status === "online" : undefined) : liveOnline;
+
+  const badge = resolveHostBadge({ hostId, host, online });
+  if (!badge) return null;
+
+  return (
+    <div
+      data-testid="host-badge"
+      className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
+      title={`Host ${badge.label}, ${STATUS_WORD[badge.status]}`}
+    >
+      <span
+        aria-hidden
+        className={cn("size-2 shrink-0 rounded-full", STATUS_DOT_CLASS[badge.status])}
+      />
+      <span className="truncate">{badge.label}</span>
+      {/* The dot is decorative (aria-hidden), so the status would otherwise be
+          conveyed by color alone. Restate it in sr-only text — read together
+          with the visible label, a screen reader announces "<host>, <status>".
+          `title` carries the same text for mouse hover. No aria-label: on a
+          non-interactive div it's announced unreliably and would only
+          duplicate this text where it is honored. */}
+      <span className="sr-only">, {STATUS_WORD[badge.status]}</span>
+    </div>
+  );
+}

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -115,6 +115,81 @@ describe("useHosts", () => {
     expect(result.current.data?.map((h) => h.host_id)).toEqual(["host_laptop", "host_legacy"]);
   });
 
+  it("retains sandbox hosts when includeSandbox is set", async () => {
+    // The chat-header HostBadge needs sandbox-backed hosts so it can
+    // label them ("Databricks Sandbox"); the default filtered call must
+    // stay sandbox-free for the pickers.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        hosts: [
+          {
+            host_id: "host_sandbox",
+            name: "managed-abc123",
+            owner: "alice",
+            status: "online",
+            sandbox_provider: "lakebox",
+          },
+          {
+            host_id: "host_laptop",
+            name: "Laptop",
+            owner: "alice",
+            status: "online",
+            sandbox_provider: null,
+          },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useHosts({ includeSandbox: true }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.map((h) => h.host_id)).toEqual(["host_sandbox", "host_laptop"]);
+  });
+
+  it("keeps the filtered and unfiltered lists in separate cache entries", async () => {
+    // The filtered (picker) and unfiltered (badge) calls share an
+    // endpoint but use distinct query keys. If they ever collapsed back
+    // to a bare ["hosts"] key, the second queryFn's result would clobber
+    // the first in cache and both consumers would see the same list.
+    // Mounting both in ONE QueryClient and asserting they diverge guards
+    // that regression. mockResolvedValue (persistent) feeds both fetches.
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        hosts: [
+          {
+            host_id: "host_sandbox",
+            name: "managed-abc123",
+            owner: "alice",
+            status: "online",
+            sandbox_provider: "lakebox",
+          },
+          {
+            host_id: "host_laptop",
+            name: "Laptop",
+            owner: "alice",
+            status: "online",
+            sandbox_provider: null,
+          },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(
+      () => ({
+        filtered: useHosts(),
+        all: useHosts({ includeSandbox: true }),
+      }),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current.filtered.isSuccess).toBe(true);
+      expect(result.current.all.isSuccess).toBe(true);
+    });
+
+    expect(result.current.filtered.data?.map((h) => h.host_id)).toEqual(["host_laptop"]);
+    expect(result.current.all.data?.map((h) => h.host_id)).toEqual(["host_sandbox", "host_laptop"]);
+  });
+
   it("surfaces an error when the request fails", async () => {
     fetchMock.mockResolvedValueOnce(mockResponse({ detail: "nope" }, 503));
 

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -25,7 +25,7 @@ interface HostsResponse {
   hosts: Host[];
 }
 
-async function fetchHosts(): Promise<Host[]> {
+async function fetchHosts(includeSandbox: boolean): Promise<Host[]> {
   const res = await authenticatedFetch("/v1/hosts");
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = (await res.json()) as HostsResponse;
@@ -33,19 +33,26 @@ async function fetchHosts(): Promise<Host[]> {
   // are launch targets the server creates on demand (and relaunches
   // at will), not user-connectable machines, so offering them as
   // manual targets is misleading. Hosts from older servers lack the
-  // field and are kept.
+  // field and are kept. `includeSandbox` opts a caller (the chat-header
+  // HostBadge) back into seeing them so it can label sandbox sessions.
+  if (includeSandbox) return body.hosts;
   return body.hosts.filter((h) => !h.sandbox_provider);
 }
 
 interface UseHostsOptions {
   enabled?: boolean;
+  includeSandbox?: boolean;
 }
 
 export function useHosts(options: UseHostsOptions = {}) {
   const enabled = options.enabled ?? true;
+  const includeSandbox = options.includeSandbox ?? false;
   return useQuery({
-    queryKey: ["hosts"],
-    queryFn: fetchHosts,
+    // Distinct cache key per filtering mode so the picker's filtered
+    // list and the header's unfiltered list don't overwrite each other.
+    // A bare ["hosts"] invalidation still prefix-matches both.
+    queryKey: ["hosts", { includeSandbox }],
+    queryFn: () => fetchHosts(includeSandbox),
     enabled,
     staleTime: 10_000,
     refetchInterval: enabled ? 10_000 : false,

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AgentInfoButton } from "@/components/AgentInfo";
 import { PresenceAvatars } from "@/components/PresenceAvatars";
+import { HostBadge } from "@/components/HostBadge";
 import type { Agent } from "@/hooks/useAgents";
 import { cn } from "@/lib/utils";
 import { TAB_BADGE_BASE } from "./railTabs";
@@ -214,6 +215,7 @@ export function ChatHeader({
             <TooltipContent side="bottom">Open sidebar</TooltipContent>
           </Tooltip>
         )}
+        {!isChildSession && conversationId && <HostBadge sessionId={conversationId} />}
         {isChildSession && parentSessionId && (
           <>
             {/* Back affordance. Ghost (not a filled pill) so it sits on the


### PR DESCRIPTION
## Summary
- Adds a **host badge** to the chat header so you can tell which host an open conversation is bound to — the binding exists in the data (`Conversation.host_id`) but was previously surfaced nowhere until a host-bound session failed to reconnect.
- The badge shows the friendly host name (or sandbox-provider label, e.g. "Databricks-lakebox Sandbox") with a green / red / neutral status dot (online / offline / unknown), and renders nothing when the session isn't host-bound.
- Self-contained `<HostBadge>` mirroring the existing `PresenceAvatars` pattern; extends `useHosts` with an opt-in `includeSandbox` flag (distinct query cache key) so the badge can resolve sandbox hosts without changing picker behavior. Frontend-only — no server or wire-schema change.
**ELI5:** Old conversations never told you which machine they run on. This puts a small "⬤ mac-laptop" chip at the top of the chat, green if the host is reachable, red if it's offline.
```
ChatHeader (top of chat window)
┌─────────────────────────────────────────┐
│ [☰]  ⬤ mac-laptop          [Share] [▸]   │   ⬤ green=online · red=offline · gray=unknown
└──┬──────────────────────────────────────┘
   │ HostBadge sessionId={conversationId}
   ├─ useSession(id)            → host_id
   ├─ useHosts({includeSandbox}) → host name / sandbox provider
   └─ useSessionHostOnline(id)  → live status (falls back to host record)
        → resolveHostBadge() → { label, status } | null
```

## Test Plan
- `cd ap-web && npm run test -- HostBadge useHosts` → 20 passing (6 `resolveHostBadge` unit + 8 `HostBadge` component + 6 `useHosts` hook).
- `npm run type-check` (`tsc -b`) clean; `oxlint` clean; `prettier --check` clean on touched files.
- Manual: ran the local UI against a managed Databricks deployment and confirmed the badge renders the host name + green dot for a connected host, "Databricks-lakebox Sandbox" + red dot for an offline sandbox-backed session, and nothing for a non-host-bound session. Confirmed the new-session host pickers still list no sandbox hosts (default `useHosts()` filtering unchanged).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes
`resolveHostBadge` (the label/status logic) is fully unit-tested across every branch: not-host-bound → nothing, sandbox → provider label, connected → name, unresolved → raw `host_id`, and the tri-state online/offline/unknown mapping. `HostBadge` component tests cover the live-vs-static status fallback, including a live `false` overriding a stale "online" record and a `null` ("not host-bound") signal resolving to "unknown" rather than flashing green. `useHosts` tests pin the `includeSandbox` opt-in and the filtered/unfiltered cache-key separation. Manual verification covered the real-app rendering and host-picker non-regression that the component tests mock out.
