### PR TITLE
fix(harnesses): keep idle reaper from killing active turns (#1414)

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -12267,6 +12267,13 @@ def create_runner_app(
         _active_turns.pop(conv_id, None)
         # Turn ended: clear the live marker so a concurrent forward is skipped.
         _live_response_id.pop(conv_id, None)
+        # Mirror the clear onto the process manager's in-flight map so the
+        # idle reaper can reap the (now genuinely idle) entry once its idle
+        # window elapses. Reached on every terminal path, so a dropped or
+        # late terminal SSE event can't strand a permanently-marked entry
+        # (which would never be reaped — the inverse of #1414, cf. #1349).
+        if process_manager is not None:
+            process_manager.clear_in_flight(conv_id)
         # Skip the idle transient when a buffered message will start a
         # continuation turn immediately — `_check_and_start_next_turn`
         # publishes "running" microseconds later, and the in-between idle
@@ -13924,6 +13931,13 @@ def create_runner_app(
                                         _resp_to_conv[_response_id] = conv_id
                                         # Mark the turn live for the forward gate.
                                         _live_response_id[conv_id] = _response_id
+                                        # Register the live turn with the process
+                                        # manager so its idle reaper skips this
+                                        # conversation while it is streaming (and
+                                        # forward_cancel can resolve the harness
+                                        # response id). Cleared in
+                                        # _on_proxy_stream_end. See issue #1414.
+                                        process_manager.mark_in_flight(conv_id, _response_id)
 
                                 # Defer publish for action_required
                                 # events that the runner dispatches
@@ -14105,6 +14119,39 @@ def create_runner_app(
                                         ) = await _resolve_turn_spec_lazy()
                                         if _lazy_err is not None:
                                             _err_type, _err_msg = _lazy_err
+                                            # Finalize the turn like the two
+                                            # sibling spec-error early-returns
+                                            # above (eager-error, non-200): a
+                                            # bare return here exits the
+                                            # generator cleanly, so without this
+                                            # no _on_proxy_stream_end runs and
+                                            # the turn's terminal bookkeeping
+                                            # (status publish + clearing the
+                                            # live/in-flight markers) is skipped,
+                                            # stranding the idle-reaper guard
+                                            # (#1414/#1349). Reachable on a
+                                            # transient resolver failure: the
+                                            # setup-phase resolution fails (so
+                                            # _session_spec_cache stays empty)
+                                            # but the harness resolution
+                                            # succeeds (so the turn streams),
+                                            # then this lazy dispatch resolution
+                                            # fails again.
+                                            _fail = {
+                                                "type": "response.failed",
+                                                "error": {
+                                                    "message": _err_msg,
+                                                    "type": _err_type,
+                                                },
+                                            }
+                                            _publish_event(conv_id, _fail)
+                                            _on_proxy_stream_end(
+                                                conv_id,
+                                                error={
+                                                    "message": _err_msg,
+                                                    "type": _err_type,
+                                                },
+                                            )
                                             yield _response_failed_event(
                                                 {"message": _err_msg, "type": _err_type}
                                             )

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -499,14 +499,17 @@ class HarnessProcessManager:
         # across re-entrant ``start()`` calls (idempotent boot).
         self._instance_dir = self._tmp_parent / f"ap-{uuid.uuid4().hex}"
         self._entries: dict[str, _SubprocessEntry] = {}
-        # Per-conversation in-flight harness response_id, populated
-        # by callers when the harness emits ``response.created``
-        # and cleared on ``response.completed``/``response.failed``
-        # /``response.cancelled``. :meth:`forward_cancel` reads it to translate
-        # an AP-side cancel into the harness's own response_id —
-        # AP's ``task_id`` and the harness's ``resp_<uuid>`` are
-        # different identifiers; the harness scaffold's ``/cancel``
-        # route keys ``_in_flight`` by the harness id only.
+        # Per-conversation in-flight harness response_id. The runner's
+        # ``proxy_stream`` populates it via :meth:`mark_in_flight` when
+        # the harness emits ``response.created`` and clears it via
+        # :meth:`clear_in_flight` at stream end (``_on_proxy_stream_end``,
+        # reached on every terminal path). Two readers depend on it:
+        # :meth:`forward_cancel` translates an AP-side cancel into the
+        # harness's own response_id (AP's ``task_id`` and the harness's
+        # ``resp_<uuid>`` are different identifiers; the harness scaffold's
+        # ``/cancel`` route keys ``_in_flight`` by the harness id only),
+        # and the idle reaper skips any conversation present here so an
+        # actively-streaming turn is never reaped mid-flight.
         self._in_flight_response_ids: dict[str, str] = {}
         # Per-conversation spawn lock — see §Process management:
         # Spawn lock. The lock guards the lazy-init window in
@@ -731,10 +734,11 @@ class HarnessProcessManager:
         REPL.
 
         The harness-side ``response_id`` is looked up from
-        ``_in_flight_response_ids``, which callers populate on
-        ``response.created`` (currently no writers wired up — the
-        mapping is always empty in production, so this method is a
-        no-op until in-flight tracking is restored).
+        ``_in_flight_response_ids``, which the runner's ``proxy_stream``
+        populates on ``response.created`` (via :meth:`mark_in_flight`)
+        and clears at stream end (via :meth:`clear_in_flight`). If no
+        turn is currently live the mapping has no entry and this method
+        is a silent no-op.
 
         Best-effort: a missing harness (no entry registered for
         this conversation) OR a missing in-flight mapping (no turn
@@ -810,6 +814,40 @@ class HarnessProcessManager:
             registered.
         """
         return conversation_id in self._in_flight_response_ids
+
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        """
+        Record that *conversation_id* has a live harness turn.
+
+        Called by the runner's ``proxy_stream`` on ``response.created``.
+        Registering the response id keeps the idle reaper from killing
+        an actively-streaming turn (the reaper skips any conversation
+        present in ``_in_flight_response_ids``) and lets
+        :meth:`forward_cancel` translate an AP-side cancel into the
+        harness's own response id. Always paired with a later
+        :meth:`clear_in_flight`.
+
+        :param conversation_id: AP-allocated conversation id,
+            e.g. ``"conv_abc123"``.
+        :param response_id: The harness-side ``resp_<uuid>`` from the
+            ``response.created`` event.
+        """
+        self._in_flight_response_ids[conversation_id] = response_id
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        """
+        Clear the live-turn marker for *conversation_id*.
+
+        Called by the runner from ``_on_proxy_stream_end``, which is
+        reached on every terminal path (success, error, status-fail,
+        interrupt) — so a dropped or late terminal SSE event cannot
+        leave an entry permanently marked in-flight and therefore never
+        reaped. No-op if no marker is set.
+
+        :param conversation_id: AP-allocated conversation id,
+            e.g. ``"conv_abc123"``.
+        """
+        self._in_flight_response_ids.pop(conversation_id, None)
 
     async def release(self, conversation_id: str) -> None:
         """

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -225,6 +225,11 @@ class _FakeProcessManager:
         self.released: list[str] = []
         self.cancelled: list[str] = []
         self.get_client_calls: list[tuple[str, str, dict[str, str] | None]] = []
+        # In-flight tracking the runner wires up on response.created /
+        # stream end (issue #1414). Recorded so tests can assert the
+        # idle reaper's guard is actually populated for a live turn.
+        self.marked_in_flight: list[tuple[str, str]] = []
+        self.cleared_in_flight: list[str] = []
 
     async def get_client(
         self, conversation_id: str, harness: str, env: Any = None
@@ -245,6 +250,16 @@ class _FakeProcessManager:
     def mark_turn_active(self, conversation_id: str) -> None:
         """Mark a conversation as having an active turn (test helper)."""
         self._active_turns.add(conversation_id)
+
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        """Record a live turn, mirroring the real manager's reaper guard."""
+        self.marked_in_flight.append((conversation_id, response_id))
+        self._active_turns.add(conversation_id)
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        """Clear the live-turn marker at stream end."""
+        self.cleared_in_flight.append(conversation_id)
+        self._active_turns.discard(conversation_id)
 
     async def forward_cancel(self, conversation_id: str) -> bool:
         """Record a cancel and return ``True``."""
@@ -819,6 +834,343 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
         "dispatch must use the resolved bundle workdir, not runner_workspace "
         f"({workspace!r}); got {captured_workspaces[0]!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_sessions_native_marks_and_clears_in_flight_turn() -> None:
+    """proxy_stream registers the live turn with the process manager.
+
+    Regression test for #1414. The idle reaper skips conversations present in
+    the manager's ``_in_flight_response_ids``, but that map had no writers, so
+    a turn running past the idle window was reaped mid-stream. The runner must
+    call ``mark_in_flight`` on ``response.created`` (so the reaper spares the
+    live turn) and ``clear_in_flight`` at stream end (so the now-idle entry can
+    later be reclaimed — not leaked, cf. #1349). Before the fix the runner
+    never called either, so both recorded lists stay empty.
+    """
+    sse_frames = [
+        _sse({"type": "response.created", "response": {"id": "resp_live"}}),
+        _sse({"type": "response.completed", "response": {"id": "resp_live"}}),
+    ]
+    harness_client = _ScriptedHarnessClient(sse_frames)
+    pm = _FakeProcessManager(harness_client)
+    spec = AgentSpec(spec_version=1, name="plain-agent")
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions/conv_live/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_live",
+                "model": "plain-agent",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert resp.status_code == 202
+        # Wait for the background turn to finish (clear runs at stream end).
+        for _ in range(100):
+            if pm.cleared_in_flight:
+                break
+            await asyncio.sleep(0.05)
+
+    # Live turn was registered with the reaper's in-flight guard on
+    # response.created, then cleared once the stream ended.
+    assert pm.marked_in_flight == [("conv_live", "resp_live")], pm.marked_in_flight
+    assert pm.cleared_in_flight == ["conv_live"], pm.cleared_in_flight
+
+
+class _StreamErrorHarnessClient(_ScriptedHarnessClient):
+    """Harness whose stream yields its frames then drops mid-stream.
+
+    Mirrors the production reaper-kill failure: after ``response.created``
+    the per-conversation client is force-closed and ``aiter_text`` raises
+    ``httpx.ReadError``, which proxy_stream surfaces as the
+    "Harness stream connection error." terminal failure.
+    """
+
+    def stream(self, method: str, url: str, *, json: dict[str, Any], timeout: Any) -> Any:
+        """Return a context manager whose stream errors after the frames."""
+        del method, url, timeout
+        self.posted_bodies.append(json)
+        frames = self._sse_frames
+
+        class _ErrCtx:
+            status_code = 200
+
+            async def __aenter__(self) -> _StreamErrorHarnessClient._ErrHandle:
+                return _StreamErrorHarnessClient._ErrHandle(frames)
+
+            async def __aexit__(self, *_: Any) -> None:
+                return None
+
+        return _ErrCtx()
+
+    class _ErrHandle:
+        """Stream handle that raises ``ReadError`` after yielding its frames."""
+
+        status_code = 200
+
+        def __init__(self, frames: list[str]) -> None:
+            """Store the frames to yield before erroring."""
+            self._frames = frames
+
+        async def aiter_text(self) -> AsyncIterator[str]:
+            """Yield each scripted frame, then drop the stream mid-flight."""
+            for frame in self._frames:
+                yield frame
+            raise httpx.ReadError("harness subprocess closed mid-stream")
+
+
+@pytest.mark.asyncio
+async def test_sessions_native_clears_in_flight_when_stream_errors() -> None:
+    """clear_in_flight fires even when a turn ends abnormally.
+
+    The fix clears the reaper's in-flight marker in ``_on_proxy_stream_end``,
+    which is reached on every terminal path — not only on ``response.completed``.
+    A turn that streams ``response.created`` and then drops mid-stream (exactly
+    the reaper-kill failure: ``httpx.ReadError`` → "Harness stream connection
+    error.") must still clear the marker; a missed clear would leave the entry
+    permanently in-flight and therefore never reaped — the inverse of #1414
+    (cf. #1349).
+    """
+    sse_frames = [
+        _sse({"type": "response.created", "response": {"id": "resp_drop"}}),
+    ]
+    harness_client = _StreamErrorHarnessClient(sse_frames)
+    pm = _FakeProcessManager(harness_client)
+    spec = AgentSpec(spec_version=1, name="plain-agent")
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions/conv_drop/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_drop",
+                "model": "plain-agent",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert resp.status_code == 202
+        # Wait for the background turn to error out (clear runs at stream end).
+        for _ in range(100):
+            if pm.cleared_in_flight:
+                break
+            await asyncio.sleep(0.05)
+
+    # Marked live on response.created, then cleared despite the mid-stream drop.
+    assert pm.marked_in_flight == [("conv_drop", "resp_drop")], pm.marked_in_flight
+    assert pm.cleared_in_flight == ["conv_drop"], pm.cleared_in_flight
+
+
+@pytest.mark.asyncio
+async def test_stop_session_clears_in_flight_marker() -> None:
+    """A mid-stream cancel clears the reaper's in-flight marker.
+
+    Guards the in-flight-tracking contract against a #1349-class inverse leak:
+    because ``mark_in_flight`` (set on ``response.created``) *persists*, a
+    cancel must still clear it, or ``has_active_turn`` stays true and the idle
+    reaper skips the subprocess forever. The clear happens because cancelling
+    the turn task raises ``CancelledError`` into ``_run_turn_bg``'s handler,
+    which runs ``_on_proxy_stream_end`` (→ ``clear_in_flight``). This test locks
+    that path so a future change to the cancel teardown can't silently strand
+    the marker.
+    """
+    import asyncio as _aio
+
+    gate = _aio.Event()  # never set → harness blocks after response.created
+    app, pm, hc = _build_interrupt_app(gate)
+    conv_id = "conv_stop_clear"
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_stop",
+                "model": "test-agent",
+                "content": [{"type": "input_text", "text": "blocked"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert resp.status_code == 202
+        # Wait until response.created is processed (marker set), then stop.
+        await _aio.wait_for(hc.post_seen.wait(), timeout=5.0)
+        for _ in range(100):
+            if pm.marked_in_flight:
+                break
+            await _aio.sleep(0.05)
+        assert pm.marked_in_flight == [(conv_id, "resp_int")], pm.marked_in_flight
+
+        stop_resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "stop_session"},
+        )
+        assert stop_resp.status_code == 204, stop_resp.text
+        gate.set()  # release the blocked stream so teardown completes cleanly
+        for _ in range(100):
+            if pm.cleared_in_flight:
+                break
+            await _aio.sleep(0.05)
+
+    # The cancel teardown must have cleared the marker (else the reaper would
+    # skip this subprocess forever and has_active_turn would stay true). Clear
+    # is idempotent, so it may fire on more than one teardown path — what
+    # matters is the end state: marked, then cleared, no longer active.
+    assert conv_id in pm.cleared_in_flight, pm.cleared_in_flight
+    assert not pm.has_active_turn(conv_id)
+
+
+class _SignalOnCreatedHarnessClient(_ScriptedHarnessClient):
+    """Streams its frames, firing an event the moment ``response.created`` is sent.
+
+    Lets a test distinguish the lazy turn-spec resolution (which runs only after
+    the harness has started streaming) from the eager setup-phase resolutions
+    that precede it.
+    """
+
+    def __init__(self, sse_frames: list[str], created: asyncio.Event) -> None:
+        """Store the frames and the event to fire on ``response.created``."""
+        super().__init__(sse_frames)
+        self._created = created
+
+    def stream(self, method: str, url: str, *, json: dict[str, Any], timeout: Any) -> Any:
+        """Return a context manager that signals once ``response.created`` is sent."""
+        del method, url, timeout
+        self.posted_bodies.append(json)
+        frames = self._sse_frames
+        created = self._created
+
+        class _Ctx:
+            status_code = 200
+
+            async def __aenter__(self) -> _SignalOnCreatedHarnessClient._Handle:
+                return _SignalOnCreatedHarnessClient._Handle(frames, created)
+
+            async def __aexit__(self, *_: Any) -> None:
+                return None
+
+        return _Ctx()
+
+    class _Handle:
+        """Stream handle that fires *created* right after the ``response.created`` frame."""
+
+        status_code = 200
+
+        def __init__(self, frames: list[str], created: asyncio.Event) -> None:
+            """Store the frames and the response.created signal."""
+            self._frames = frames
+            self._created = created
+
+        async def aiter_text(self) -> AsyncIterator[str]:
+            """Yield each frame, signalling once ``response.created`` has been sent."""
+            for frame in self._frames:
+                yield frame
+                if '"response.created"' in frame:
+                    self._created.set()
+
+
+@pytest.mark.asyncio
+async def test_sessions_native_clears_in_flight_on_lazy_spec_error() -> None:
+    """A lazy turn-spec resolution failure mid-dispatch still clears the marker.
+
+    Regression for a #1349-class inverse leak. For a non-MCP agent the turn
+    spec is resolved lazily at tool-dispatch time — after ``response.created``
+    has already set the in-flight marker. A transient resolver failure there
+    drives ``proxy_stream``'s lazy-spec-error early ``return``, which (unlike a
+    stream error or a cancel) exits the generator *cleanly* — so neither the
+    drain nor ``_run_turn_bg``'s ``CancelledError`` handler runs
+    ``_on_proxy_stream_end``. Routing that early return through
+    ``_on_proxy_stream_end`` is what clears the marker; without it the reaper
+    skips the subprocess forever and ``has_active_turn`` stays true.
+
+    The resolver is gated on ``response.created`` so it succeeds for the two
+    setup-phase resolutions (spec cache + harness pick) — letting the turn
+    stream — and fails only on the lazy dispatch call.
+    """
+    import asyncio as _aio
+
+    created = _aio.Event()
+    sse_frames = [
+        _sse({"type": "response.created", "response": {"id": "resp_lazy"}}),
+        _sse(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "status": "action_required",
+                    "name": "sys_list_models",
+                    "call_id": "call_lazy",
+                    "arguments": "{}",
+                },
+            }
+        ),
+        _sse({"type": "response.completed", "response": {"id": "resp_lazy"}}),
+    ]
+    harness_client = _SignalOnCreatedHarnessClient(sse_frames, created)
+    pm = _FakeProcessManager(harness_client)
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> Any:
+        # Before the harness streams response.created the two setup-phase
+        # resolutions run: return None (uncached spec → default harness) so the
+        # turn streams without populating _session_spec_cache. Once streaming
+        # has started the only caller is the lazy dispatch resolution — fail it.
+        del agent_id, session_id
+        if created.is_set():
+            raise RuntimeError("transient lazy spec resolution failure")
+        return None
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    conv_id = "conv_lazy"
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_lazy",
+                "model": "plain-agent",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert resp.status_code == 202
+        # Wait for the background turn to finish; the marker should be cleared.
+        for _ in range(100):
+            if pm.cleared_in_flight:
+                break
+            await _aio.sleep(0.05)
+
+    # Marked live on response.created; the lazy-spec-error early return must
+    # still finalize the turn and clear the marker.
+    assert pm.marked_in_flight == [(conv_id, "resp_lazy")], pm.marked_in_flight
+    assert conv_id in pm.cleared_in_flight, pm.cleared_in_flight
+    assert not pm.has_active_turn(conv_id)
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_enforce_sandbox_gate.py
+++ b/tests/runner/test_enforce_sandbox_gate.py
@@ -100,6 +100,14 @@ class _FakeProcessManager:
         """
         self._sessions.discard(conversation_id)
 
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        """Reaper in-flight marker — no-op for this stub (issue #1414)."""
+        del conversation_id, response_id
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        """Reaper in-flight clear — no-op for this stub (issue #1414)."""
+        del conversation_id
+
 
 @contextlib.asynccontextmanager
 async def _runner_client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -327,6 +327,14 @@ class _FakeProcessManager:
             raise AssertionError("get_client should not be called")
         return self._harness_client
 
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        """Reaper in-flight marker — no-op for this stub (issue #1414)."""
+        del conversation_id, response_id
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        """Reaper in-flight clear — no-op for this stub (issue #1414)."""
+        del conversation_id
+
 
 @pytest.fixture
 async def started_manager() -> AsyncIterator[HarnessProcessManager]:
@@ -481,6 +489,14 @@ class _RecordingProcessManager:
         self._reached.set()
         return _FakeHarnessClient([])
 
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        """Reaper in-flight marker — no-op for this stub (issue #1414)."""
+        del conversation_id, response_id
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        """Reaper in-flight clear — no-op for this stub (issue #1414)."""
+        del conversation_id
+
 
 @pytest.mark.asyncio
 async def test_runner_resolves_agent_from_server_snapshot_when_msg_lacks_agent_id() -> None:
@@ -621,6 +637,14 @@ class _ContentCapturingProcessManager:
         """
         del conversation_id, harness_name, env
         return _ContentCapturingHarnessClient(self._captured, self._reached)
+
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        """Reaper in-flight marker — no-op for this stub (issue #1414)."""
+        del conversation_id, response_id
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        """Reaper in-flight clear — no-op for this stub (issue #1414)."""
+        del conversation_id
 
 
 class _ContentCapturingHarnessClient:

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -519,6 +519,57 @@ async def test_idle_reaper_releases_stale_entries(
         await fast.shutdown()
 
 
+async def test_idle_reaper_skips_in_flight_turn(
+    register_test_harness: None,
+    short_tmp_parent: Path,
+) -> None:
+    """A conversation with a live harness turn is never reaped mid-flight.
+
+    Regression test for #1414. ``last_used_at`` is stamped once per turn at
+    ``get_client``, so a turn that runs longer than ``idle_timeout_s`` looks
+    "idle" to the reaper. The only guard against killing it —
+    ``conv_id in _in_flight_response_ids`` — had no writers and was always
+    empty, so long turns were ``SIGTERM``'d mid-stream. ``mark_in_flight`` /
+    ``clear_in_flight`` populate that guard (the runner calls them from
+    ``proxy_stream`` on ``response.created`` and from ``_on_proxy_stream_end``).
+
+    Marks a turn in-flight, holds it well past the 2 s idle window across many
+    reaper passes, and asserts the subprocess survives; then clears the marker
+    and asserts the now-genuinely-idle entry is reaped (so the fix doesn't
+    leak entries that never get reclaimed — the inverse failure, cf. #1349).
+    """
+    fast = HarnessProcessManager(
+        idle_timeout_s=2.0,
+        reaper_interval_s=0.1,
+        tmp_parent=short_tmp_parent,
+    )
+    await fast.start()
+    try:
+        await fast.get_client("conv_a", _TEST_HARNESS_NAME)
+        socket_path = fast.instance_dir / "conv-conv_a.sock"
+        assert socket_path.exists()
+        # Mark the turn live, as the runner does on ``response.created``.
+        fast.mark_in_flight("conv_a", "resp_x")
+        assert fast.has_active_turn("conv_a")
+        # Hold past the 2 s idle window across ~40 reaper passes (~4 s). An
+        # unguarded reaper would have reaped this stale-looking entry; the
+        # in-flight guard must keep the subprocess alive the whole time.
+        for _ in range(40):
+            await asyncio.sleep(0.1)
+            assert socket_path.exists(), "in-flight turn was reaped mid-flight"
+        # Turn ends: clear the marker (as ``_on_proxy_stream_end`` does). The
+        # entry is now genuinely idle and must become reapable.
+        fast.clear_in_flight("conv_a")
+        assert not fast.has_active_turn("conv_a")
+        for _ in range(60):
+            if not socket_path.exists():
+                break
+            await asyncio.sleep(0.1)
+        assert not socket_path.exists()
+    finally:
+        await fast.shutdown()
+
+
 async def test_orphan_sweep_removes_dead_omnigent_dirs(
     short_tmp_parent: Path,
 ) -> None:

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -144,6 +144,14 @@ class FakeProcessManager:
     def has_active_turn(self, conversation_id: str) -> bool:
         return conversation_id in self._in_flight
 
+    def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
+        # Mirror the real manager: the runner registers the live turn on
+        # response.created so the idle reaper spares it (issue #1414).
+        self._in_flight[conversation_id] = response_id
+
+    def clear_in_flight(self, conversation_id: str) -> None:
+        self._in_flight.pop(conversation_id, None)
+
     async def release(self, conversation_id: str) -> None:
         client = self._clients.pop(conversation_id, None)
         if client is not None:


### PR DESCRIPTION
## Related issue

Closes #1414

## Summary

- The harness process manager's idle reaper SIGTERMs any subprocess whose `last_used_at` is older than the 30-min idle window. `last_used_at` is stamped **once per turn at turn start** (`get_client`), and the reaper's only guard against killing an *active* turn — `conv_id in _in_flight_response_ids` — read a map that **had no writers and was always empty in production**. So any single turn outliving the window was reaped mid-stream and surfaced to the parent as the opaque `"Harness stream connection error."`
- Fix: wire up the existing (intended) guard. The runner's `proxy_stream` already captures the harness `response_id` on `response.created` and clears its live marker in `_on_proxy_stream_end` (hit on every terminal path). This mirrors those two points onto the manager via new `mark_in_flight` / `clear_in_flight`, so the reaper spares a conversation for the whole duration of its live turn — even one that emits no events (e.g. a long `sleep`) — and reclaims it only once genuinely idle.
- Clearing in `_on_proxy_stream_end` (not on the terminal SSE event) means a dropped/late terminal event can't strand a permanently-marked entry that never gets reaped — the inverse failure, cf. #1349. As a bonus this also restores `forward_cancel` and `has_active_turn`, which were dead for the same missing-writers reason.
- **Review follow-up:** routed `proxy_stream`'s lazy-spec-error early `return` through `_on_proxy_stream_end` like its two sibling spec-error early-returns. The bare `return` exited the generator cleanly, so on a *transient* `spec_resolver` failure mid-dispatch (setup resolution fails → cache stays empty, harness resolution succeeds → turn streams, then the lazy dispatch resolution fails again) the marker was stranded — same inverse leak (#1349).

## Test Plan

- `uv run pytest tests/runtime/harnesses/test_process_manager.py tests/runner/test_app_sessions_native.py` — passes. Tests:
  - `test_idle_reaper_skips_in_flight_turn` — a marked-in-flight turn survives well past the idle window across many reaper passes, then is reaped after `clear_in_flight`.
  - `test_sessions_native_marks_and_clears_in_flight_turn` — `proxy_stream` calls `mark_in_flight` on `response.created` and `clear_in_flight` at stream end.
  - `test_sessions_native_clears_in_flight_when_stream_errors` — clear still fires when the stream drops mid-flight (`httpx.ReadError` → "Harness stream connection error."), pinning the inverse-leak guard (cf. #1349).
  - `test_sessions_native_clears_in_flight_on_lazy_spec_error` — clear still fires when a transient lazy `spec_resolver` failure drives the lazy-spec-error early return (the review follow-up above).
  - `test_stop_session_clears_in_flight_marker` — a guard pinning that a `stop_session`/interrupt cancel clears the marker (via `_run_turn_bg`'s `CancelledError` handler).
  - The four fails-before/passes-after tests were each confirmed to fail before their fix (production change reverted).
- Affected suites green after rebasing onto latest `main`: both `test_process_manager` files, `test_app_sessions_native`, plus `test_runner_dispatch` / `test_enforce_sandbox_gate` / `test_sessions_tunnel_three_layer` (PM test-doubles extended with the new methods). `ruff check` + `ruff format --check` clean.

### Review feedback (Polly)

The automated review flagged two paths that could strand the now-persistent marker. **B1: Lazy-spec-error early return** was real — fixed and covered above. **B2: Cancel/interrupt teardown** turned out to be a false positive: the cancelled task is `_run_turn_bg`, whose `except asyncio.CancelledError` handler runs `_on_proxy_stream_end` (→ `clear_in_flight`), so the marker is cleared on every cancel path. Verified by `test_stop_session_clears_in_flight_marker`, which passes even without any change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

**Automated:** the fix is covered by the three new tests above; the two runner tests are true fails-before/passes-after regression tests (confirmed by reverting each production call).

**Manual end-to-end:** ran an agent (one turn calling a blocking `sleep`, reaper window shimmed to 5s) through the real runner/harness/reaper as a controlled before/after on the same build:
- with the fix — the turn ran the full sleep and completed (`rc=0`, model reported the sleep finished);
- with the fix reverted — the identical turn was killed mid-sleep with `httpx.ReadError` (the root cause behind "Harness stream connection error.") and `rc=1`.

(A reaper-kill log line appears in *both* runs — with the fix it's the *correct* post-turn idle reap, not a mid-stream kill — so turn survival / exit code is the discriminator, not the reap-line count.)
