### PR TITLE
Disable some user-select on UI elements

### DIFF
--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1986,7 +1986,7 @@ export function NewChatLandingScreen() {
           840 − 80 = 760px max on desktop. px-4 on phones (16px gutters)
           keeps the composer from feeling cramped against the viewport
           edges; widens to the full px-10 at the md breakpoint and up. */}
-      <div className="flex w-full max-w-[840px] flex-col items-center gap-8 px-4 pt-8 pb-16 md:px-10">
+      <div className="flex w-full max-w-[840px] flex-col items-center gap-8 px-4 pt-8 pb-16 md:select-none md:px-10">
         <div className="flex flex-col items-center gap-3.5 sm:flex-row">
           <OttoEyes className="h-18 w-auto shrink-0" />
           <h1 className="text-center text-3xl font-medium tracking-[-0.03em] text-foreground sm:text-left">
@@ -2110,7 +2110,7 @@ export function NewChatLandingScreen() {
               // inside them): min 60px = one 20px line + a spare line of
               // breathing room; max 200px = the spec's 180px of content.
               // useAutoGrowTextarea drives the height between the two.
-              className="max-h-[200px] min-h-[60px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-4 pb-1 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground"
+              className="max-h-[200px] min-h-[60px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-4 pb-1 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground md:select-text"
             />
             {/* Gated on an empty draft so it reads as the placeholder.
                 pointer-events-none lets clicks fall through to focus the

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -297,7 +297,7 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
         // conversations-sidebar only matters under the macOS Electron
         // shell, where it pushes the card below the traffic lights
         // (see the [data-electron-mac] rules in index.css).
-        "conversations-sidebar flex flex-col bg-card",
+        "conversations-sidebar flex flex-col bg-card md:select-none",
         // Mobile (default): fixed full-screen overlay, slide via
         // translate-x. Stays edge-to-edge — the floating-card
         // treatment below is desktop-only.
@@ -467,7 +467,7 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
                     onChange={(e) => setSearchQuery(e.target.value)}
                     aria-label="Search sessions"
                     placeholder="Search sessions"
-                    className="min-h-8 w-full rounded-full border border-input pr-3 pl-8 text-sm transition placeholder:text-muted-foreground focus-visible:outline-1"
+                    className="min-h-8 w-full rounded-full border border-input pr-3 pl-8 text-sm transition placeholder:text-muted-foreground focus-visible:outline-1 md:select-text"
                   />
                 </div>
                 <Tooltip>
@@ -2474,7 +2474,7 @@ function ConversationEditRow({ initialTitle, onCommit, onCancel }: ConversationE
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
         data-testid="rename-conversation-input"
-        className="min-w-0 flex-1 truncate rounded bg-transparent px-1 py-1 text-sm outline-none"
+        className="min-w-0 flex-1 truncate rounded bg-transparent px-1 py-1 text-sm outline-none md:select-text"
       />
       <Button
         type="button"

--- a/ap-web/src/shell/TitleBarServerPicker.tsx
+++ b/ap-web/src/shell/TitleBarServerPicker.tsx
@@ -79,7 +79,7 @@ export function TitleBarServerPicker({
   return (
     /* Sits over the drag strip; the button itself is no-drag via the blanket
        [data-electron-mac] rule in index.css, so it stays clickable. */
-    <div className="pointer-events-none absolute inset-x-0 top-0 z-40 flex h-9 justify-center">
+    <div className="pointer-events-none absolute inset-x-0 top-0 z-40 flex h-9 select-none justify-center">
       <DropdownMenu>
         <DropdownMenuTrigger
           className={cn(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Added desktop-only non-selection to the Electron titlebar server picker, sidebar chrome, and landing composer chrome so desktop app UI labels do not highlight during normal interaction.
- Restored text selection for editable fields inside those chrome surfaces, including the landing prompt textarea, sidebar search, and rename input.

## Test Plan

- `npx prettier --check src/shell/TitleBarServerPicker.tsx src/shell/Sidebar.tsx src/shell/NewChatDialog.tsx`
- `npx tsc --noEmit --pretty false`
- `NODE_OPTIONS=--localstorage-file=/private/tmp/ap-web-vitest-localstorage.json npx vitest run src/shell/NewChatDialog.test.tsx src/shell/Sidebar.test.tsx`

<img width="1186" height="800" alt="image" src="https://github.com/user-attachments/assets/4aa86b9a-98d4-4690-9ee9-f0b8c8226fae" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused React coverage passed for NewChatDialog and Sidebar behavior after the class changes. Manual verification was code/diff inspection of the desktop-only `select-none` additions and `select-text` overrides for editable controls, plus formatter and type-check runs.
