### PR TITLE
feat(web): show app-shell skeleton on cold start instead of a blank screen

### DIFF
--- a/ap-web/src/App.tsx
+++ b/ap-web/src/App.tsx
@@ -4,6 +4,7 @@ import { ChatPage } from "@/pages/ChatPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { AppShell } from "@/shell/AppShell";
+import { AppShellSkeleton } from "@/shell/AppShellSkeleton";
 
 // Lazy-load the three accounts pages so the bundle a header / OIDC
 // deploy ships (where accounts is off) doesn't include them in the
@@ -87,11 +88,14 @@ function App({ basename }: AppProps = {}) {
   // the original relative route table.
   const prefix = basename ?? "";
   const info = useServerInfo();
-  // While the probe is in flight, render nothing — first paint is
-  // ~30ms after boot anyway, and flashing the chrome we may
-  // immediately tear down once the probe returns is worse than a
-  // tiny blank moment.
-  if (info === "loading") return null;
+  // While the probe is in flight, paint the app-shell skeleton instead of a
+  // blank screen. main.tsx mounts the tree immediately (info starts
+  // "loading") and flips info to the resolved value when the probe settles —
+  // so on a slow/missing server the user sees the shell's silhouette (rail +
+  // header + central placeholder) rather than white for up to the 1.5s probe
+  // timeout. The skeleton approximates the real geometry, so the swap to the
+  // live tree doesn't shift layout.
+  if (info === "loading") return <AppShellSkeleton />;
 
   // First-run: accounts on but no admin claimed yet. Route EVERY path to
   // the Create-admin form so the first visitor lands on it no matter how

--- a/ap-web/src/lib/CapabilitiesContext.tsx
+++ b/ap-web/src/lib/CapabilitiesContext.tsx
@@ -24,7 +24,10 @@ export function CapabilitiesProvider({
   info,
   children,
 }: {
-  info: ServerInfo;
+  // Accepts the ``"loading"`` sentinel so main.tsx can mount the tree before
+  // the boot probe resolves (the app-shell skeleton renders during that
+  // window); flips to the resolved ``ServerInfo`` once the probe settles.
+  info: CapabilitiesValue;
   children: ReactNode;
 }) {
   return <CapabilitiesContext.Provider value={info}>{children}</CapabilitiesContext.Provider>;

--- a/ap-web/src/main.tsx
+++ b/ap-web/src/main.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { StrictMode } from "react";
+import { StrictMode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.tsx";
@@ -41,12 +41,14 @@ void resolveIdentity();
 // No-op off the iOS shell (the inset vars stay at their env()-only defaults).
 initNativeInsets();
 
-// Probe /v1/info BEFORE the first render so the route table knows
-// whether to mount accounts routes. The probe is unauthed and the
-// failure path resolves to "accounts off" — so even a stalled or
-// missing server doesn't deadlock first paint. We add a small
-// safety timeout (1.5s) so users on a flaky network still get
-// something on screen.
+// Probe /v1/info so the route table knows whether to mount accounts routes.
+// The probe is unauthed and the failure path resolves to "accounts off" — so
+// even a stalled or missing server doesn't deadlock the app. We add a small
+// safety timeout (1.5s) so the route table settles for users on a flaky
+// network. The React tree mounts IMMEDIATELY (see `Boot` below) with
+// `info: "loading"` — App renders the app-shell skeleton during this window
+// instead of a blank screen — and flips to the resolved value when this
+// settles.
 const _bootProbe: Promise<ServerInfo> = Promise.race([
   resolveServerInfo(),
   new Promise<ServerInfo>((resolve) =>
@@ -67,26 +69,48 @@ const _bootProbe: Promise<ServerInfo> = Promise.race([
   ),
 ]);
 
-void _bootProbe.then((info) => {
-  createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <CapabilitiesProvider info={info}>
-        <QueryClientProvider client={queryClient}>
-          <ThemeProvider>
-            <TooltipProvider>
-              <ImageLightboxProvider>
-                <BrowserRouter>
-                  <SessionUpdatesProvider>
-                    <RunnerHealthProvider>
-                      <App />
-                    </RunnerHealthProvider>
-                  </SessionUpdatesProvider>
-                </BrowserRouter>
-              </ImageLightboxProvider>
-            </TooltipProvider>
-          </ThemeProvider>
-        </QueryClientProvider>
-      </CapabilitiesProvider>
-    </StrictMode>,
+// Mounts the whole provider tree immediately with `info: "loading"` so the
+// app-shell skeleton paints on the very first frame, then subscribes to the
+// boot probe and flips `info` to the resolved value when it settles. Keeping
+// the providers mounted across the swap (rather than waiting for the probe to
+// even createRoot) is what turns the old up-to-1.5s blank screen into a
+// skeleton; App reads `info` from CapabilitiesContext and renders the skeleton
+// while it is "loading".
+function Boot() {
+  const [info, setInfo] = useState<ServerInfo | "loading">("loading");
+  useEffect(() => {
+    let active = true;
+    void _bootProbe.then((resolved) => {
+      if (active) setInfo(resolved);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <CapabilitiesProvider info={info}>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <TooltipProvider>
+            <ImageLightboxProvider>
+              <BrowserRouter>
+                <SessionUpdatesProvider>
+                  <RunnerHealthProvider>
+                    <App />
+                  </RunnerHealthProvider>
+                </SessionUpdatesProvider>
+              </BrowserRouter>
+            </ImageLightboxProvider>
+          </TooltipProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </CapabilitiesProvider>
   );
-});
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <Boot />
+  </StrictMode>,
+);

--- a/ap-web/src/shell/AppShellSkeleton.test.tsx
+++ b/ap-web/src/shell/AppShellSkeleton.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AppShellSkeleton } from "./AppShellSkeleton";
+
+afterEach(cleanup);
+
+describe("AppShellSkeleton", () => {
+  it("exposes a loading status for assistive tech", () => {
+    render(<AppShellSkeleton />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("paints the shell silhouette (rail + header + central placeholder)", () => {
+    const { container } = render(<AppShellSkeleton />);
+    // The outer node carries the app-shell canvas class so the gradient
+    // matches the real shell and the swap doesn't flash a different bg.
+    expect(container.querySelector(".app-shell")).not.toBeNull();
+    // Desktop conversations rail silhouette.
+    expect(container.querySelector("aside")).not.toBeNull();
+  });
+
+  it("only pulses when motion is allowed (prefers-reduced-motion safe)", () => {
+    const { container } = render(<AppShellSkeleton />);
+    const animated = container.querySelectorAll(".motion-safe\\:animate-pulse");
+    // Several placeholder blocks shimmer; none use a bare animate-pulse that
+    // would ignore prefers-reduced-motion.
+    expect(animated.length).toBeGreaterThan(0);
+    expect(container.querySelector(".animate-pulse:not(.motion-safe\\:animate-pulse)")).toBeNull();
+  });
+});

--- a/ap-web/src/shell/AppShellSkeleton.tsx
+++ b/ap-web/src/shell/AppShellSkeleton.tsx
@@ -1,0 +1,119 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Cold-start skeleton of the app shell.
+ *
+ * Rendered by ``App`` while the ``/v1/info`` boot probe is in flight
+ * (``info === "loading"``) in place of the old ``return null`` — so the
+ * very first paint shows the shell's silhouette (left conversations rail +
+ * top header + a central content placeholder) instead of a blank white
+ * screen. ``main.tsx`` now mounts the React tree immediately and flips
+ * ``info`` from ``"loading"`` to the resolved value when the probe settles,
+ * so this is what the user sees during that window.
+ *
+ * Geometry mirrors ``AppShell`` / ``Sidebar`` / ``ChatHeader`` — the 320px
+ * (``w-80``) desktop rail and the 56px (``h-14``) header — so swapping in the
+ * real tree on probe-resolve doesn't shift the layout (no CLS jump). On
+ * mobile the real sidebar is an off-screen overlay, so the rail is hidden
+ * here too and only the main column shows, matching the real first paint.
+ *
+ * Every surface is token-backed (``bg-card`` / ``border-border`` /
+ * ``bg-muted-foreground/20``) so the skeleton tracks both the light and dark
+ * themes with no hardcoded colors. The placeholder pulse is gated behind
+ * ``motion-safe:`` so users with ``prefers-reduced-motion`` get a static
+ * silhouette instead of an animation.
+ */
+
+/** One shimmering placeholder block. Decorative — hidden from assistive tech. */
+function Block({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn("rounded-md bg-muted-foreground/20 motion-safe:animate-pulse", className)}
+    />
+  );
+}
+
+// Stable ids (not array indices) keep the lists lint-clean and let each row
+// carry its own placeholder width so the rail reads like a real list.
+const RAIL_ROWS = [
+  { id: "rail-a", width: "w-4/5" },
+  { id: "rail-b", width: "w-3/5" },
+  { id: "rail-c", width: "w-11/12" },
+  { id: "rail-d", width: "w-2/3" },
+  { id: "rail-e", width: "w-3/4" },
+  { id: "rail-f", width: "w-1/2" },
+  { id: "rail-g", width: "w-5/6" },
+  { id: "rail-h", width: "w-3/5" },
+] as const;
+
+export function AppShellSkeleton() {
+  return (
+    <div
+      className="app-shell relative flex h-dvh bg-sidebar text-foreground"
+      role="status"
+      aria-busy="true"
+    >
+      <span className="sr-only">Loading…</span>
+
+      {/* Left conversations rail — desktop floating card (mirrors Sidebar's
+          md:m-2 md:w-[var(--sidebar-width)] floating treatment, default 320px).
+          Hidden on mobile, where the real sidebar starts as an off-screen
+          overlay. */}
+      <aside
+        aria-hidden
+        className="hidden md:m-2 md:flex md:w-80 md:flex-col md:gap-5 md:rounded-xl md:border md:border-border md:bg-card md:p-4 md:shadow-lg"
+      >
+        {/* Brand row + top controls (Omnigent label, inbox, collapse). */}
+        <div className="flex items-center justify-between">
+          <Block className="h-5 w-28" />
+          <div className="flex items-center gap-1.5">
+            <Block className="size-7 rounded-full" />
+            <Block className="size-7 rounded-full" />
+          </div>
+        </div>
+
+        {/* New-session button. */}
+        <Block className="h-9 w-full rounded-lg" />
+
+        {/* Conversation rows. */}
+        <div className="flex flex-col gap-3.5">
+          {RAIL_ROWS.map((row) => (
+            <div key={row.id} className="flex h-6 items-center">
+              <Block className={cn("h-3.5", row.width)} />
+            </div>
+          ))}
+        </div>
+      </aside>
+
+      {/* Content region (everything right of the rail). */}
+      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* Header band — same 56px height as ChatHeader so the body below
+            starts at the same offset the real chrome leaves it. */}
+        <div aria-hidden className="flex h-14 shrink-0 items-center justify-between px-3">
+          <div className="flex items-center gap-2">
+            {/* Sidebar-open affordance — mobile only, like ChatHeader's. */}
+            <Block className="size-8 rounded-md md:hidden" />
+            <Block className="size-5 rounded" />
+            <Block className="h-4 w-36" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Block className="h-8 w-24 rounded-full" />
+            <Block className="size-8 rounded-md" />
+          </div>
+        </div>
+
+        {/* Central placeholder — a centered greeting + composer, approximating
+            the landing/chat column so the real content lands in roughly the
+            same place. */}
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-8 px-4 pb-6">
+          <div className="flex w-full max-w-2xl flex-col items-center gap-3">
+            <Block className="h-6 w-48" />
+            <Block className="h-4 w-full max-w-md" />
+          </div>
+          <Block className="h-32 w-full max-w-2xl rounded-2xl" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What & why

On web cold start the boot sequence raced the `/v1/info` probe against a 1.5s
timeout and only called `createRoot` **after** it settled, so a slow or missing
server left the user staring at a blank white page for up to ~1.5s. `App.tsx`
compounded it with `if (info === "loading") return null`.

This replaces that blank screen with a **skeleton of the app shell**.

## How

- **`main.tsx`** — a new `Boot` wrapper mounts the full provider tree
  *immediately* with `info: "loading"` (first frame), then subscribes to the
  existing `_bootProbe` and flips `info` to the resolved value when it settles.
  The providers stay mounted across the swap, so there's no remount flash.
- **`App.tsx`** — `info === "loading"` now renders `<AppShellSkeleton />`
  instead of `null`.
- **`AppShellSkeleton.tsx`** (new) — paints the shell silhouette: desktop
  conversations rail + 56px header + a centered content/composer placeholder.
- **`CapabilitiesContext.tsx`** — the provider's `info` prop is widened to the
  already-defined `ServerInfo | "loading"` value (the context default was
  always `"loading"`); fully backward compatible.

## Acceptance contract

- ✅ During boot the user sees a **skeleton of the layout** (rail + header +
  central placeholders), not a blank screen.
- ✅ **Zero hardcoded colors** — every surface uses existing tokens
  (`bg-card`, `border-border`, `bg-muted-foreground/20`, `bg-sidebar`,
  `text-foreground`) and the `.app-shell` canvas class, so it's correct in
  light **and** dark.
- ✅ **No CLS** — geometry mirrors `AppShell`/`Sidebar`/`ChatHeader` (320px
  `w-80` rail, `h-14` header), so the swap to the live tree doesn't shift
  layout. On mobile the rail is hidden, matching the real off-screen overlay.
- ✅ **prefers-reduced-motion** — the placeholder pulse is gated behind
  `motion-safe:animate-pulse`; reduced-motion users get a static silhouette.
- ✅ New component lives in `ap-web/src/shell/AppShellSkeleton.tsx`; `App.tsx`
  renders it in place of `return null`.

Out of scope by request: did not touch `ap-web/src/shell/ChatHeader.tsx` or
`ap-web/src/index.css` (T2 token work) — `motion-safe:` avoided any CSS edit.

## Gates

| Gate | Command | Result |
| --- | --- | --- |
| Typecheck | `npm run type-check` (`tsc -b`) | ✅ pass (exit 0) |
| Build | `npm run build` (`tsc -b && vite build`) | ✅ pass (✓ built) |
| Lint (changed files) | `npx oxlint <changed files>` | ✅ clean |
| Tests | `npx vitest run AppShellSkeleton + AppShell` | ✅ 80 pass |

Note: full-repo `npm run lint` reports pre-existing `no-control-regex` errors in
`src/lib/agentBundle.test.ts` (present on the base branch, unrelated to this
change).
