### PR TITLE
Tokenize web color islands

### DIFF
--- a/ap-web/src/components/ai-elements/connection.tsx
+++ b/ap-web/src/components/ai-elements/connection.tsx
@@ -11,6 +11,13 @@ export const Connection: ConnectionLineComponent = ({ fromX, fromY, toX, toY }) 
       stroke="var(--color-ring)"
       strokeWidth={1}
     />
-    <circle cx={toX} cy={toY} fill="#fff" r={3} stroke="var(--color-ring)" strokeWidth={1} />
+    <circle
+      cx={toX}
+      cy={toY}
+      fill="var(--connection-end-fill)"
+      r={3}
+      stroke="var(--color-ring)"
+      strokeWidth={1}
+    />
   </g>
 );

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -215,7 +215,11 @@
   --search-highlight-current-foreground: var(--foreground);
   --selection-bg: color-mix(in srgb, var(--brand-accent) 20%, transparent);
   --selection-fg: var(--brand-accent);
-  --avatar-fg: var(--primary-foreground);
+  --markdown-selection-bg: color-mix(in srgb, #93c5fd 40%, transparent);
+  --markdown-selection-fg: var(--foreground);
+  --avatar-saturation: 60%;
+  --avatar-lightness: 50%;
+  --avatar-fg: white;
   --connection-end-fill: var(--background);
   --image-checkerboard-color: color-mix(in srgb, var(--muted-foreground) 25%, transparent);
   --shadow-color-soft: color-mix(in srgb, var(--foreground) 22%, transparent);
@@ -235,11 +239,11 @@
   --share-button-hover-mid: color-mix(in srgb, var(--brand-accent) 88%, black 12%);
   --share-button-hover-bottom: color-mix(in srgb, var(--brand-accent) 74%, black 26%);
   --share-button-foreground: var(--destructive-foreground);
-  --md-alert-note: var(--status-blue);
-  --md-alert-tip: var(--status-green);
-  --md-alert-important: var(--brand-accent);
-  --md-alert-warning: var(--status-yellow);
-  --md-alert-caution: var(--status-red);
+  --md-alert-note: #0969da;
+  --md-alert-tip: #1a7f37;
+  --md-alert-important: #8250df;
+  --md-alert-warning: #9a6700;
+  --md-alert-caution: #cf222e;
   --radius: 0.5rem;
   /* Sidebar + workspace cards are white (--card); they float on the
      * near-white .app-shell gradient canvas. --sidebar matches that
@@ -323,7 +327,11 @@
   --search-highlight-current-foreground: var(--foreground);
   --selection-bg: var(--brand-accent);
   --selection-fg: var(--primary-foreground);
-  --avatar-fg: var(--primary-foreground);
+  --markdown-selection-bg: color-mix(in srgb, #93c5fd 40%, transparent);
+  --markdown-selection-fg: var(--foreground);
+  --avatar-saturation: 60%;
+  --avatar-lightness: 50%;
+  --avatar-fg: white;
   --connection-end-fill: var(--background);
   --image-checkerboard-color: color-mix(in srgb, var(--muted-foreground) 22%, transparent);
   --shadow-color-soft: color-mix(in srgb, black 28%, transparent);
@@ -340,11 +348,11 @@
   --share-button-hover-mid: color-mix(in srgb, var(--brand-accent) 88%, black 12%);
   --share-button-hover-bottom: color-mix(in srgb, var(--brand-accent) 68%, black 32%);
   --share-button-foreground: var(--destructive-foreground);
-  --md-alert-note: var(--status-blue);
-  --md-alert-tip: var(--status-green);
-  --md-alert-important: var(--brand-accent);
-  --md-alert-warning: var(--status-yellow);
-  --md-alert-caution: var(--status-red);
+  --md-alert-note: #4493f8;
+  --md-alert-tip: #3fb950;
+  --md-alert-important: #ab7df8;
+  --md-alert-warning: #d29922;
+  --md-alert-caution: #f85149;
   /* bg-sidebar surfaces blend into the dark .app-shell gradient — a 45°
      * diagonal sweeping green (rgb 17,24,28) → purple (rgb 19,13,33);
      * --sidebar sits in the green-dominant region and stays translucent

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -64,6 +64,13 @@
   --color-status-yellow: var(--status-yellow);
   --color-status-red: var(--status-red);
   --color-status-gray: var(--status-gray);
+  --color-code-viewer: var(--code-viewer);
+  --color-comment-marker: var(--comment-marker);
+  --color-comment-highlight: var(--comment-highlight);
+  --color-comment-highlight-active: var(--comment-highlight-active);
+  --color-search-highlight: var(--search-highlight);
+  --color-search-highlight-current: var(--search-highlight-current);
+  --color-search-highlight-current-foreground: var(--search-highlight-current-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -199,6 +206,40 @@
   --chart-3: #2ea65c;
   --chart-4: #d4972a;
   --chart-5: #8e99a4;
+  --code-viewer: var(--background);
+  --comment-marker: var(--status-yellow);
+  --comment-highlight: color-mix(in srgb, var(--status-yellow) 18%, transparent);
+  --comment-highlight-active: color-mix(in srgb, var(--status-yellow) 28%, transparent);
+  --search-highlight: color-mix(in srgb, var(--status-yellow) 45%, transparent);
+  --search-highlight-current: var(--warning);
+  --search-highlight-current-foreground: var(--foreground);
+  --selection-bg: color-mix(in srgb, var(--brand-accent) 20%, transparent);
+  --selection-fg: var(--brand-accent);
+  --avatar-fg: var(--primary-foreground);
+  --connection-end-fill: var(--background);
+  --image-checkerboard-color: color-mix(in srgb, var(--muted-foreground) 25%, transparent);
+  --shadow-color-soft: color-mix(in srgb, var(--foreground) 22%, transparent);
+  --shadow-color-medium: color-mix(in srgb, var(--foreground) 35%, transparent);
+  --shadow-highlight: color-mix(in srgb, var(--background) 72%, transparent);
+  --glass-border: color-mix(in srgb, var(--foreground) 9%, transparent);
+  --glass-border-strong: color-mix(in srgb, var(--foreground) 14%, transparent);
+  --glass-sheen: color-mix(in srgb, var(--foreground) 4%, transparent);
+  --glass-sheen-transparent: color-mix(in srgb, var(--foreground) 0%, transparent);
+  --shadow-composer-card:
+    0 12px 20px -20px color-mix(in srgb, var(--foreground) 14%, transparent),
+    0 20px 28px -28px color-mix(in srgb, var(--foreground) 10%, transparent);
+  --share-button-top: color-mix(in srgb, var(--brand-accent) 88%, white 12%);
+  --share-button-mid: var(--brand-accent);
+  --share-button-bottom: color-mix(in srgb, var(--brand-accent) 82%, black 18%);
+  --share-button-hover-top: color-mix(in srgb, var(--brand-accent) 82%, white 8%);
+  --share-button-hover-mid: color-mix(in srgb, var(--brand-accent) 88%, black 12%);
+  --share-button-hover-bottom: color-mix(in srgb, var(--brand-accent) 74%, black 26%);
+  --share-button-foreground: var(--destructive-foreground);
+  --md-alert-note: var(--status-blue);
+  --md-alert-tip: var(--status-green);
+  --md-alert-important: var(--brand-accent);
+  --md-alert-warning: var(--status-yellow);
+  --md-alert-caution: var(--status-red);
   --radius: 0.5rem;
   /* Sidebar + workspace cards are white (--card); they float on the
      * near-white .app-shell gradient canvas. --sidebar matches that
@@ -273,6 +314,37 @@
   --chart-3: oklch(0.68 0.15 145);
   --chart-4: oklch(0.75 0.16 70);
   --chart-5: oklch(0.65 0.008 240);
+  --code-viewer: var(--background);
+  --comment-marker: var(--status-yellow);
+  --comment-highlight: color-mix(in srgb, var(--status-yellow) 20%, transparent);
+  --comment-highlight-active: color-mix(in srgb, var(--status-yellow) 28%, transparent);
+  --search-highlight: color-mix(in srgb, var(--status-yellow) 36%, transparent);
+  --search-highlight-current: var(--warning);
+  --search-highlight-current-foreground: var(--foreground);
+  --selection-bg: var(--brand-accent);
+  --selection-fg: var(--primary-foreground);
+  --avatar-fg: var(--primary-foreground);
+  --connection-end-fill: var(--background);
+  --image-checkerboard-color: color-mix(in srgb, var(--muted-foreground) 22%, transparent);
+  --shadow-color-soft: color-mix(in srgb, black 28%, transparent);
+  --shadow-color-medium: color-mix(in srgb, black 55%, transparent);
+  --shadow-highlight: color-mix(in srgb, var(--foreground) 12%, transparent);
+  --glass-border: color-mix(in srgb, var(--foreground) 9%, transparent);
+  --glass-border-strong: color-mix(in srgb, var(--foreground) 14%, transparent);
+  --glass-sheen: color-mix(in srgb, var(--foreground) 4%, transparent);
+  --glass-sheen-transparent: color-mix(in srgb, var(--foreground) 0%, transparent);
+  --share-button-top: color-mix(in srgb, var(--brand-accent) 88%, white 20%);
+  --share-button-mid: var(--brand-accent);
+  --share-button-bottom: color-mix(in srgb, var(--brand-accent) 76%, black 24%);
+  --share-button-hover-top: color-mix(in srgb, var(--brand-accent) 82%, white 12%);
+  --share-button-hover-mid: color-mix(in srgb, var(--brand-accent) 88%, black 12%);
+  --share-button-hover-bottom: color-mix(in srgb, var(--brand-accent) 68%, black 32%);
+  --share-button-foreground: var(--destructive-foreground);
+  --md-alert-note: var(--status-blue);
+  --md-alert-tip: var(--status-green);
+  --md-alert-important: var(--brand-accent);
+  --md-alert-warning: var(--status-yellow);
+  --md-alert-caution: var(--status-red);
   /* bg-sidebar surfaces blend into the dark .app-shell gradient — a 45°
      * diagonal sweeping green (rgb 17,24,28) → purple (rgb 19,13,33);
      * --sidebar sits in the green-dominant region and stays translucent
@@ -365,16 +437,16 @@
    * build) collapses the pair and keeps only the last declaration. */
   -webkit-backdrop-filter: blur(32px) saturate(180%) !important;
   backdrop-filter: blur(32px) saturate(180%) !important;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-top-color: rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--glass-border);
+  border-top-color: var(--glass-border-strong);
   background-image: linear-gradient(
     135deg,
-    rgba(255, 255, 255, 0.04) 0%,
-    rgba(255, 255, 255, 0) 60%
+    var(--glass-sheen) 0%,
+    var(--glass-sheen-transparent) 60%
   );
   box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.22),
-    0 1px 3px rgba(0, 0, 0, 0.16);
+    0 4px 16px var(--shadow-color-soft),
+    0 1px 3px var(--shadow-color-soft);
 }
 
 /* Side panels (FileViewer, TerminalsPanel, FilesPanelDrawer) manage their own
@@ -394,7 +466,7 @@
   /* -webkit- before unprefixed — see comment on the bg-card rule above. */
   -webkit-backdrop-filter: blur(24px) saturate(150%) !important;
   backdrop-filter: blur(24px) saturate(150%) !important;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--glass-border);
 }
 
 /* Electron desktop shell on macOS (AppShell sets data-electron-mac when the
@@ -485,11 +557,11 @@
      mid-drag — fully open the drawer covers the viewport, so its right edge (and
      the shadow) sit past the screen. iOS-only: the web overlay is unchanged. */
   [data-ios-native] .conversations-sidebar:not([data-collapsed]) {
-    box-shadow: 8px 0 28px -6px rgb(0 0 0 / 0.22);
+    box-shadow: 8px 0 28px -6px var(--shadow-color-soft);
   }
 
   .dark [data-ios-native] .conversations-sidebar:not([data-collapsed]) {
-    box-shadow: 8px 0 30px -4px rgb(0 0 0 / 0.55);
+    box-shadow: 8px 0 30px -4px var(--shadow-color-medium);
   }
 
   [data-ios-native] :is(input, textarea, select, [contenteditable="true"]) {
@@ -559,8 +631,8 @@
     -webkit-backdrop-filter: saturate(180%) blur(18px);
     backdrop-filter: saturate(180%) blur(18px);
     box-shadow:
-      0 12px 28px rgb(0 0 0 / 0.13),
-      0 1px 0 rgb(255 255 255 / 0.55) inset;
+      0 12px 28px var(--shadow-color-soft),
+      0 1px 0 var(--shadow-highlight) inset;
     font-size: 16px;
     line-height: 1;
   }
@@ -590,8 +662,8 @@
   [data-ios-native] .terminal-first-switcher-option[aria-pressed="true"] {
     background: color-mix(in srgb, var(--background) 82%, white 18%);
     box-shadow:
-      0 3px 10px rgb(0 0 0 / 0.1),
-      0 1px 0 rgb(255 255 255 / 0.72) inset;
+      0 3px 10px var(--shadow-color-soft),
+      0 1px 0 var(--shadow-highlight) inset;
   }
 
   [data-ios-native] .terminal-first-switcher-option svg {
@@ -603,15 +675,15 @@
     border-color: color-mix(in srgb, var(--border) 82%, transparent);
     background: color-mix(in srgb, var(--card) 78%, transparent);
     box-shadow:
-      0 14px 30px rgb(0 0 0 / 0.35),
-      0 1px 0 rgb(255 255 255 / 0.1) inset;
+      0 14px 30px var(--shadow-color-medium),
+      0 1px 0 var(--shadow-highlight) inset;
   }
 
   .dark [data-ios-native] .terminal-first-switcher-option[aria-pressed="true"] {
     background: color-mix(in srgb, var(--muted) 82%, white 6%);
     box-shadow:
-      0 3px 12px rgb(0 0 0 / 0.28),
-      0 1px 0 rgb(255 255 255 / 0.12) inset;
+      0 3px 12px var(--shadow-color-soft),
+      0 1px 0 var(--shadow-highlight) inset;
   }
 
   [data-ios-native]
@@ -640,28 +712,52 @@
  * the full emboss + dark depth shadow reads too heavy on the light
  * canvas. Dark mode: stronger emboss plus the grounding shadow. */
 .share-button-glassy {
-  background: linear-gradient(to bottom, #fa3d99 0%, #f22286 40%, #d51d74 100%);
+  background: linear-gradient(
+    to bottom,
+    var(--share-button-top) 0%,
+    var(--share-button-mid) 40%,
+    var(--share-button-bottom) 100%
+  );
   border: none;
   box-shadow: none;
-  color: #ffffff;
+  color: var(--share-button-foreground);
 }
 
 .share-button-glassy:hover {
   /* Darken the gradient slightly on hover */
-  background: linear-gradient(to bottom, #ec3790 0%, #e51b7d 40%, #c41a6b 100%);
+  background: linear-gradient(
+    to bottom,
+    var(--share-button-hover-top) 0%,
+    var(--share-button-hover-mid) 40%,
+    var(--share-button-hover-bottom) 100%
+  );
 }
 
 .dark .share-button-glassy {
-  background: linear-gradient(150deg, #ff4da6 0%, #f22286 40%, #b8185f 100%);
+  background: linear-gradient(
+    150deg,
+    var(--share-button-top) 0%,
+    var(--share-button-mid) 40%,
+    var(--share-button-bottom) 100%
+  );
   border: none;
   box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.5),
-    0 1px 3px rgba(0, 0, 0, 0.4);
-  color: #ffffff;
+    0 4px 16px var(--shadow-color-medium),
+    0 1px 3px var(--shadow-color-soft);
+  color: var(--share-button-foreground);
 }
 
 .dark .share-button-glassy:hover {
-  background: linear-gradient(150deg, #f0408f 0%, #e51b7d 40%, #a51455 100%);
+  background: linear-gradient(
+    150deg,
+    var(--share-button-hover-top) 0%,
+    var(--share-button-hover-mid) 40%,
+    var(--share-button-hover-bottom) 100%
+  );
+}
+
+.composer-card-shadow {
+  box-shadow: var(--shadow-composer-card);
 }
 
 @layer base {
@@ -691,12 +787,12 @@
   /* Text selection — brand pink highlight. Light: gentle wash + dark pink
    * text. Dark: solid brand pink background + white text. */
   ::selection {
-    background: color-mix(in srgb, #f22286 20%, transparent);
-    color: #f22286;
+    background: var(--selection-bg);
+    color: var(--selection-fg);
   }
   .dark ::selection {
-    background: #f22286;
-    color: #ffffff;
+    background: var(--selection-bg);
+    color: var(--selection-fg);
   }
 }
 
@@ -1183,40 +1279,24 @@
   -webkit-mask: var(--md-alert-icon) no-repeat center / contain;
 }
 .tiptap-md-content .ProseMirror blockquote[data-alert-type="note"] {
-  --md-alert-color: #0969da;
+  --md-alert-color: var(--md-alert-note);
   --md-alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
 }
 .tiptap-md-content .ProseMirror blockquote[data-alert-type="tip"] {
-  --md-alert-color: #1a7f37;
+  --md-alert-color: var(--md-alert-tip);
   --md-alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5Zm.75 3.75a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 0 1.5h-1.5a.75.75 0 0 1-.75-.75Z'/%3E%3C/svg%3E");
 }
 .tiptap-md-content .ProseMirror blockquote[data-alert-type="important"] {
-  --md-alert-color: #8250df;
+  --md-alert-color: var(--md-alert-important);
   --md-alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
 }
 .tiptap-md-content .ProseMirror blockquote[data-alert-type="warning"] {
-  --md-alert-color: #9a6700;
+  --md-alert-color: var(--md-alert-warning);
   --md-alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
 }
 .tiptap-md-content .ProseMirror blockquote[data-alert-type="caution"] {
-  --md-alert-color: #cf222e;
+  --md-alert-color: var(--md-alert-caution);
   --md-alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25a.749.749 0 0 1-.53.22H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
-}
-/* GitHub's dark-palette hues for the same five types. */
-.dark .tiptap-md-content .ProseMirror blockquote[data-alert-type="note"] {
-  --md-alert-color: #4493f8;
-}
-.dark .tiptap-md-content .ProseMirror blockquote[data-alert-type="tip"] {
-  --md-alert-color: #3fb950;
-}
-.dark .tiptap-md-content .ProseMirror blockquote[data-alert-type="important"] {
-  --md-alert-color: #ab7df8;
-}
-.dark .tiptap-md-content .ProseMirror blockquote[data-alert-type="warning"] {
-  --md-alert-color: #d29922;
-}
-.dark .tiptap-md-content .ProseMirror blockquote[data-alert-type="caution"] {
-  --md-alert-color: #f85149;
 }
 .tiptap-md-content .ProseMirror code {
   font-family: var(--font-mono);

--- a/ap-web/src/shell/CodeViewer.tsx
+++ b/ap-web/src/shell/CodeViewer.tsx
@@ -87,10 +87,10 @@ function MarkdownPreview({ content }: { content: string }) {
 // against either light or dark backgrounds.
 const CHECKERBOARD_STYLE: React.CSSProperties = {
   backgroundImage:
-    "linear-gradient(45deg, rgba(128,128,128,0.15) 25%, transparent 25%)," +
-    "linear-gradient(-45deg, rgba(128,128,128,0.15) 25%, transparent 25%)," +
-    "linear-gradient(45deg, transparent 75%, rgba(128,128,128,0.15) 75%)," +
-    "linear-gradient(-45deg, transparent 75%, rgba(128,128,128,0.15) 75%)",
+    "linear-gradient(45deg, var(--image-checkerboard-color) 25%, transparent 25%)," +
+    "linear-gradient(-45deg, var(--image-checkerboard-color) 25%, transparent 25%)," +
+    "linear-gradient(45deg, transparent 75%, var(--image-checkerboard-color) 75%)," +
+    "linear-gradient(-45deg, transparent 75%, var(--image-checkerboard-color) 75%)",
   backgroundSize: "16px 16px",
   backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0",
 };
@@ -606,8 +606,8 @@ export function CodeViewer({
         </div>
       )}
 
-      {/* GitHub Light/Dark backgrounds match the shiki themes used by highlightCode */}
-      <div ref={codeContainerRef} className="font-mono text-xs bg-white dark:bg-[#0d1117]">
+      {/* Code surface is tokenized; Shiki token colors still come from the loaded theme. */}
+      <div ref={codeContainerRef} className="font-mono text-xs bg-code-viewer">
         {rawLines.map((rawLine, idx) => {
           const lineNum = idx + 1;
           const isMatchLine =
@@ -665,9 +665,9 @@ export function CodeViewer({
                     "relative w-12 shrink-0 select-none border-r border-border text-xs",
                     "flex items-center justify-end px-2 py-0.5 leading-5",
                     commentOnLine
-                      ? "cursor-pointer text-yellow-500 dark:text-yellow-400 hover:bg-muted/60"
+                      ? "cursor-pointer text-comment-marker hover:bg-muted/60"
                       : "text-muted-foreground/50",
-                    hasAnyHighlight && "bg-yellow-500/10 dark:bg-yellow-400/15",
+                    hasAnyHighlight && "bg-comment-highlight",
                   )}
                   onClick={() => {
                     if (commentOnLine) {
@@ -699,9 +699,7 @@ export function CodeViewer({
                       aria-hidden
                       className={cn(
                         "absolute inset-y-0 pointer-events-none",
-                        o.isSelected
-                          ? "bg-yellow-400/25 dark:bg-yellow-400/25"
-                          : "bg-yellow-200/40 dark:bg-yellow-400/20",
+                        o.isSelected ? "bg-comment-highlight-active" : "bg-comment-highlight",
                       )}
                       style={{
                         left: `calc(0.75rem + ${o.startCol}ch)`,
@@ -719,7 +717,7 @@ export function CodeViewer({
                     ) && (
                       <span
                         aria-hidden
-                        className="absolute inset-y-0 bg-yellow-400/25 dark:bg-yellow-400/25 pointer-events-none"
+                        className="absolute inset-y-0 bg-comment-highlight-active pointer-events-none"
                         style={{
                           left: `calc(0.75rem + ${selStartCol}ch)`,
                           width: `${selEndCol - selStartCol}ch`,

--- a/ap-web/src/shell/CommentsPanel.tsx
+++ b/ap-web/src/shell/CommentsPanel.tsx
@@ -11,7 +11,10 @@ import type { ActiveSelection } from "./codeViewerHelpers";
 function avatarStyle(name: string): { backgroundColor: string; color: string } {
   let hash = 0;
   for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
-  return { backgroundColor: `hsl(${hash % 360} 60% 50%)`, color: "white" };
+  return {
+    backgroundColor: `color-mix(in hsl longer hue, var(--brand-accent) ${hash % 100}%, var(--status-blue))`,
+    color: "var(--avatar-fg)",
+  };
 }
 
 function formatCommentTime(createdAt: number): string {
@@ -101,7 +104,7 @@ export function CommentsPanel({
   useEffect(() => {
     setBody("");
     if (pendingBodyRef) pendingBodyRef.current = "";
-  }, [activeSelection?.start_index, activeSelection?.end_index]);
+  }, [activeSelection?.start_index, activeSelection?.end_index, pendingBodyRef]);
 
   // Auto-focus the textarea when a new pending selection appears (no existing
   // comment at that range) so the user can start typing immediately.
@@ -116,7 +119,7 @@ export function CommentsPanel({
       const id = requestAnimationFrame(() => addCommentTextareaRef.current?.focus());
       return () => cancelAnimationFrame(id);
     }
-  }, [activeSelection?.start_index, activeSelection?.end_index, comments]);
+  }, [activeSelection, comments]);
 
   return (
     <div

--- a/ap-web/src/shell/CommentsPanel.tsx
+++ b/ap-web/src/shell/CommentsPanel.tsx
@@ -12,7 +12,7 @@ function avatarStyle(name: string): { backgroundColor: string; color: string } {
   let hash = 0;
   for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
   return {
-    backgroundColor: `color-mix(in hsl longer hue, var(--brand-accent) ${hash % 100}%, var(--status-blue))`,
+    backgroundColor: `hsl(${hash % 360} var(--avatar-saturation) var(--avatar-lightness))`,
     color: "var(--avatar-fg)",
   };
 }

--- a/ap-web/src/shell/MarkdownRichTextViewer.tsx
+++ b/ap-web/src/shell/MarkdownRichTextViewer.tsx
@@ -425,7 +425,7 @@ function MarkdownRichTextViewerInner({
         )}
         <EditorContent
           editor={editor}
-          className="outline-none max-w-none text-sm text-foreground [&_*::selection]:bg-blue-300/40 [&_*::selection]:text-foreground [&::selection]:bg-blue-300/40 [&::selection]:text-foreground tiptap-md-content"
+          className="outline-none max-w-none text-sm text-foreground [&_*::selection]:bg-[var(--selection-bg)] [&_*::selection]:text-[var(--selection-fg)] [&::selection]:bg-[var(--selection-bg)] [&::selection]:text-[var(--selection-fg)] tiptap-md-content"
         />
       </div>
       {canEdit && editor && (

--- a/ap-web/src/shell/MarkdownRichTextViewer.tsx
+++ b/ap-web/src/shell/MarkdownRichTextViewer.tsx
@@ -425,7 +425,7 @@ function MarkdownRichTextViewerInner({
         )}
         <EditorContent
           editor={editor}
-          className="outline-none max-w-none text-sm text-foreground [&_*::selection]:bg-[var(--selection-bg)] [&_*::selection]:text-[var(--selection-fg)] [&::selection]:bg-[var(--selection-bg)] [&::selection]:text-[var(--selection-fg)] tiptap-md-content"
+          className="outline-none max-w-none text-sm text-foreground [&_*::selection]:bg-[var(--markdown-selection-bg)] [&_*::selection]:text-[var(--markdown-selection-fg)] [&::selection]:bg-[var(--markdown-selection-bg)] [&::selection]:text-[var(--markdown-selection-fg)] tiptap-md-content"
         />
       </div>
       {canEdit && editor && (

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1485,17 +1485,20 @@ export function NewChatLandingScreen() {
       ? PENDING_AGENT_ID
       : ((agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ??
         null);
-  const selectedAgent =
-    effectiveAgentId === PENDING_AGENT_ID && pendingAgent
-      ? ({
-          id: PENDING_AGENT_ID,
-          name: pendingAgent.name,
-          display_name: pendingAgent.name,
-          description: pendingAgent.description ?? null,
-          harness: pendingAgent.harness ?? null,
-          skills: [],
-        } satisfies AvailableAgent)
-      : agentList.find((a) => a.id === effectiveAgentId);
+  const selectedAgent = useMemo(
+    () =>
+      effectiveAgentId === PENDING_AGENT_ID && pendingAgent
+        ? ({
+            id: PENDING_AGENT_ID,
+            name: pendingAgent.name,
+            display_name: pendingAgent.name,
+            description: pendingAgent.description ?? null,
+            harness: pendingAgent.harness ?? null,
+            skills: [],
+          } satisfies AvailableAgent)
+        : agentList.find((a) => a.id === effectiveAgentId),
+    [agentList, effectiveAgentId, pendingAgent],
+  );
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
@@ -2012,7 +2015,7 @@ export function NewChatLandingScreen() {
             // translucent card. Mirrors the chat composer card. Drag-over
             // lifts an inset ring (overlay below).
             className={cn(
-              "relative z-10 flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid shadow-[0_12px_20px_-20px_rgba(0,0,0,0.14),0_20px_28px_-28px_rgba(0,0,0,0.1)] transition-[border-color,box-shadow] duration-150 has-[textarea:focus]:border-foreground",
+              "relative z-10 flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid composer-card-shadow transition-[border-color,box-shadow] duration-150 has-[textarea:focus]:border-foreground",
               isDragActive && "ring-2 ring-ring ring-inset",
             )}
             data-testid="new-chat-landing-composer"

--- a/ap-web/src/shell/codeViewerRendering.tsx
+++ b/ap-web/src/shell/codeViewerRendering.tsx
@@ -77,8 +77,8 @@ export function renderLineTokens(
               key={si}
               className={
                 isCurrentMatch
-                  ? "rounded-sm bg-orange-400 text-black"
-                  : "rounded-sm bg-yellow-300/80"
+                  ? "rounded-sm bg-search-highlight-current text-search-highlight-current-foreground"
+                  : "rounded-sm bg-search-highlight"
               }
             >
               {seg.text}

--- a/ap-web/src/shell/monacoCodeEditor.css
+++ b/ap-web/src/shell/monacoCodeEditor.css
@@ -5,16 +5,16 @@
 
 /* Saved comment range — dim highlight. */
 .oa-comment {
-  background-color: rgba(250, 204, 21, 0.2);
+  background-color: var(--comment-highlight);
 }
 /* The active comment, or a not-yet-saved selection — stronger highlight. */
 .oa-comment-active {
-  background-color: rgba(250, 204, 21, 0.38);
+  background-color: var(--comment-highlight-active);
 }
 /* The dim highlight reads the same in dark mode, so only the active color
    needs a dark override (softer so it doesn't overpower the dark canvas). */
 .dark .oa-comment-active {
-  background-color: rgba(250, 204, 21, 0.3);
+  background-color: var(--comment-highlight-active);
 }
 
 /* In dark mode, paint the editor surface with the app's --card tone instead of


### PR DESCRIPTION
## Summary
- Tokenized hardcoded web color islands for share button gradients, markdown alert colors, selection/comment/search highlights, code/image surfaces, glass borders, shadows, and React Flow connection endpoint fill.
- Added light/dark CSS variables in ap-web/src/index.css and consumed them through Tailwind token utilities or CSS var references.
- Left intentional brand SVG colors and terminal xterm theme colors untouched per scope.

## Gates
- `npm ci`: failed before tests because package-lock.json is not in sync with package.json (`yaml@1.10.3` vs `yaml@2.9.0`).
- `npm install`: succeeded to install local deps without committing lockfile churn.
- `npm run lint`: fails on existing baseline errors outside this task/scope, including terminal files and unrelated hooks/fetch/control-regex findings.
- `npx oxlint src/components/ai-elements/connection.tsx src/shell/CodeViewer.tsx src/shell/CommentsPanel.tsx src/shell/MarkdownRichTextViewer.tsx src/shell/NewChatDialog.tsx src/shell/codeViewerRendering.tsx`: passes with warnings only.
- `npm run type-check`: pass.
- `npm run build`: pass (Vite chunk-size warnings only).
