### PR TITLE
fix(repl): distinguish waiting from idle/failed terminal states

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2841,6 +2841,51 @@ def _render_failed_status_error(
     return err_items
 
 
+def _render_waiting_status_notice(
+    fmt: RichBlockFormatter,
+    host: TerminalHost,
+) -> list[FormattedItem]:
+    """
+    Render the "alive, waiting on background work" line for a terminal
+    ``session.status: waiting`` event.
+
+    The runtime emits ``waiting`` when a parent turn ends while
+    dispatched background work is still in flight: the parent loop parks
+    on the async-work drain (``_drain_async_completions(
+    block_for_one=True)`` in ``omnigent/runtime/workflow.py``) until a
+    sub-agent or background tool completes, then a follow-up ``running``
+    resumes the turn. The REPL tears the turn down on the same path as
+    ``idle`` (flush trailing text, stop the spinner, signal turn-done),
+    so without this line the spinner just vanishes and a live, waiting
+    session is indistinguishable from a finished ``idle`` one — it looks
+    dead even though it will resume on its own.
+
+    This writes a themed notice that both states the session is still
+    alive and names what it is waiting on. The wire event carries no
+    finer-grained reason (only ``status`` / ``response_id`` / ``error``,
+    and ``error`` is ``None`` for ``waiting``), so the message describes
+    the documented cause — background work — rather than guessing; a more
+    specific reason should be surfaced here if the schema ever carries
+    one.
+
+    :param fmt: The active block formatter; supplies the theme styles
+        (``fmt.warning`` for the label, ``fmt.muted`` for the detail) so
+        the notice honors the active light/dark theme.
+    :param host: The terminal host the notice is written to.
+    :returns: The single-item list written to the host (for debug-tape
+        recording by the caller); never empty, so a ``waiting`` turn is
+        never silent.
+    """
+    notice = Text.from_markup(
+        f"  [{fmt.warning}]⏳ waiting[/{fmt.warning}] "
+        f"[{fmt.muted}]— a sub-agent or background task is still running; "
+        f"the session is alive and resumes automatically when it "
+        f"finishes.[/{fmt.muted}]"
+    )
+    host.output(notice)
+    return [notice]
+
+
 async def run_repl(
     client: OmnigentClient,
     agent_name: str,
@@ -3226,18 +3271,37 @@ async def run_repl(
             elif event.status in ("idle", "waiting", "failed"):
                 from omnigent_client import TextDone
 
-                # A SETUP-phase failure (spec resolution, spawn-env
-                # build) ends the turn before the LLM stream starts, so
-                # no response.failed / ErrorEvent ever arrives — the only
-                # signal is this terminal ``failed`` status. Render its
-                # error message as an error line; without this the turn
-                # ends silently and the user sees the spinner vanish with
-                # no output. The helper falls back to a generic message
-                # when the event carries no error detail.
+                # idle / waiting / failed all reach the same turn-teardown
+                # tail below (flush trailing text, stop the spinner, signal
+                # turn-done, refresh the context ring), but they must NOT
+                # read the same to the user, so each gets its own leading
+                # line first:
+                #
+                # * ``failed`` -> a red error line. A SETUP-phase failure
+                #   (spec resolution, spawn-env build) ends the turn before
+                #   the LLM stream starts, so no response.failed / ErrorEvent
+                #   ever arrives — this terminal status is the only signal;
+                #   without the line the spinner vanishes silently. The helper
+                #   falls back to a generic message when no error is carried.
+                # * ``waiting`` -> a muted "still alive, working in the
+                #   background" notice. The parent turn parked on the
+                #   async-work drain (a sub-agent or background tool is still
+                #   running) and resumes on its own; without a line it is
+                #   indistinguishable from a dead ``idle`` session.
+                # * ``idle`` -> nothing extra: the turn is done and the input
+                #   prompt returns, which is the conventional "ready" signal;
+                #   a per-turn idle banner would be noise on every response.
+                #
+                # Only the representation differs here — the underlying status
+                # semantics and the teardown tail are unchanged.
                 if event.status == "failed":
                     err_items = _render_failed_status_error(fmt, host, event)
                     if tape_entry is not None and err_items:
                         _event_tape.mark_rendered(tape_entry, len(err_items))  # type: ignore[union-attr]
+                elif event.status == "waiting":
+                    wait_items = _render_waiting_status_notice(fmt, host)
+                    if tape_entry is not None and wait_items:
+                        _event_tape.mark_rendered(tape_entry, len(wait_items))  # type: ignore[union-attr]
 
                 items_out = list(
                     fmt.format_text_done(TextDone(full_text="", has_code_blocks=False))

--- a/tests/repl/test_sessions_chat_adapter.py
+++ b/tests/repl/test_sessions_chat_adapter.py
@@ -1000,3 +1000,58 @@ def test_failed_status_event_without_error_falls_back() -> None:
 
     assert "turn failed" in host.text
     assert items
+
+
+def test_waiting_status_notice_renders_alive_line() -> None:
+    """A terminal ``session.status: waiting`` renders an alive notice.
+
+    Regression: idle / waiting / failed shared one branch and only
+    ``failed`` rendered anything, so a ``waiting`` turn tore down exactly
+    like ``idle`` — the spinner vanished with no output and a live
+    session that had merely parked on background work (a sub-agent or
+    async tool still running) looked dead. ``_render_waiting_status_notice``
+    must surface a line that BOTH says the session is still alive and
+    names what it is waiting on, so it can never be confused with a
+    finished ``idle`` turn.
+    """
+    from omnigent_ui_sdk import RichBlockFormatter
+
+    from omnigent.repl._repl import _render_waiting_status_notice
+    from tests.repl.helpers import CapturingHost
+
+    host = CapturingHost()
+
+    items = _render_waiting_status_notice(RichBlockFormatter(), host)  # type: ignore[arg-type]
+
+    # Collapse wrap-induced newlines so the substring checks are
+    # width-independent.
+    text = " ".join(host.text.lower().split())
+    # Reads as the live "waiting" state, not a dead/finished session.
+    assert "waiting" in text
+    assert "alive" in text
+    # Names WHAT it is waiting on (background work).
+    assert "background" in text
+    # Non-empty render -> a ``waiting`` turn is never silent (the point).
+    assert items
+
+
+def test_waiting_status_notice_is_not_an_error() -> None:
+    """The waiting notice reads as alive-and-working, not as a failure.
+
+    ``waiting`` is a healthy, transient state — the parent turn parked on
+    the async-work drain and resumes on its own — so its line must not
+    reuse the ``failed`` error wording, or a normal background wait would
+    read to the user as a turn failure.
+    """
+    from omnigent_ui_sdk import RichBlockFormatter
+
+    from omnigent.repl._repl import _render_waiting_status_notice
+    from tests.repl.helpers import CapturingHost
+
+    host = CapturingHost()
+
+    _render_waiting_status_notice(RichBlockFormatter(), host)  # type: ignore[arg-type]
+
+    text = " ".join(host.text.lower().split())
+    assert "failed" not in text
+    assert "error" not in text


### PR DESCRIPTION
## What & why

In the REPL session-status renderer (`omnigent/repl/_repl.py`), the
three terminal-edge statuses **idle / waiting / failed** shared one
branch and only `failed` rendered anything. So a `waiting` turn tore
down exactly like `idle`: the working spinner just vanished with no
output.

`waiting` is emitted when a parent turn ends while dispatched background
work is still in flight — the parent loop parks on the async-work drain
(`_drain_async_completions(block_for_one=True)`) until a sub-agent or
background tool completes, then a follow-up `running` resumes the turn.
Because nothing was rendered, that **live, waiting** session was
indistinguishable from a **dead, finished** `idle` one. The user had no
way to tell the session was still alive and waiting on something.

## Change

Give each terminal status its own representation, while leaving the
underlying status semantics and the shared turn-teardown tail (flush
trailing text, stop spinner, signal turn-done, refresh context ring)
**unchanged** — only the representation differs:

- **waiting** → a new themed helper `_render_waiting_status_notice`
  prints an "alive, waiting on background work" line that (a) says the
  session is still alive and (b) names what it is waiting on. The wire
  event carries no finer-grained reason (only `status` / `response_id` /
  `error`, with `error=None` for waiting), so the message describes the
  documented cause — background work (a sub-agent or async tool) — rather
  than guessing; a more specific reason can be surfaced there if the
  schema ever carries one.
- **failed** → unchanged (red error line via
  `_render_failed_status_error`).
- **idle** → unchanged: silent finalize + the returning input prompt is
  the conventional "ready" signal; a per-turn idle banner would be noise
  on every response.

The notice uses the existing theme tokens (`fmt.warning` for the label,
`fmt.muted` for the detail), so it honors the active light/dark theme.

## Before / after

```
idle    (before & after):  (no line — prompt returns -> ready)

waiting (before):          (spinner vanishes, no output -> looks dead)
waiting (after):           ⏳ waiting — a sub-agent or background task is
                           still running; the session is alive and resumes
                           automatically when it finishes.

failed  (before & after):  ╭─────────────────────────────────────────╮
                           │ [runner] turn setup failed: ...           │
                           ╰─────────────────────────────────────────╯
```

## Files touched

- `omnigent/repl/_repl.py` — new `_render_waiting_status_notice` helper +
  status-branch dispatch.
- `tests/repl/test_sessions_chat_adapter.py` — two tests mirroring the
  existing failed-status tests.

## Gates

- `ruff format --check` → 2 files already formatted ✅
- `ruff check` → All checks passed! ✅
- `pyrefly check omnigent/repl/_repl.py` → 31 errors with **and** without
  this change (all pre-existing, none in the edited regions) — zero new
  errors ✅ (mypy likewise unchanged at 56 pre-existing errors)
- `pytest tests/repl/` → **404 passed** (incl. 2 new waiting tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
