### PR TITLE
feat(host): auto-login un-authed remote hosts; add --non-interactive

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2349,7 +2349,7 @@ def _host_daemon_alive() -> bool:
 _LOCAL_SERVER_DISCOVER_TIMEOUT_S = 120.0
 
 
-def _ensure_databricks_server_auth(server: str) -> None:
+def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False) -> None:
     """Sign in (or fail with the login hint) for Databricks-fronted servers.
 
     Probes ``/v1/me`` with whatever credentials the auth chain can mint
@@ -2366,9 +2366,14 @@ def _ensure_databricks_server_auth(server: str) -> None:
 
     :param server: Remote server base URL without a trailing slash,
         e.g. ``"https://myapp-123.aws.databricksapps.com"``.
+    :param non_interactive: When ``True``, never run the browser login —
+        emit the same fail-loud hint a headless invocation gets, even on a
+        TTY. Lets callers (e.g. ``omnigent host --non-interactive``) keep
+        their scripted, no-prompt behavior.
     :raises click.ClickException: When the server is Databricks-fronted,
-        no credentials resolve, and stdin is not a TTY (or the login
-        flow itself fails).
+        no credentials resolve, and the login flow is suppressed (stdin is
+        not a TTY or ``non_interactive`` is set) — or the login flow itself
+        fails.
     """
     import httpx as _httpx
 
@@ -2390,7 +2395,7 @@ def _ensure_databricks_server_auth(server: str) -> None:
     if workspace_host is None:
         return
     login_cmd = f"omnigent login {server}"
-    if not sys.stdin.isatty():
+    if non_interactive or not sys.stdin.isatty():
         raise click.ClickException(
             f"Not signed in to {server} (Databricks-fronted; /v1/me answered "
             f"HTTP {probe.status_code}). Run `{login_cmd}` and retry."
@@ -6634,8 +6639,19 @@ def _prompt_stop_local_server() -> None:
 
 @cli.group("host", cls=_HostGroup, invoke_without_command=True)
 @click.option("--server", default=None, help="Remote omnigent server URL.")
+@click.option(
+    "--non-interactive",
+    "non_interactive",
+    is_flag=True,
+    default=False,
+    help=(
+        "Never prompt for sign-in. When the server requires auth and you "
+        "are not logged in, fail with the `omnigent login` hint instead of "
+        "launching the browser login flow. Use this in scripts and CI."
+    ),
+)
 @click.pass_context
-def host(ctx: click.Context, server: str | None) -> None:
+def host(ctx: click.Context, server: str | None, non_interactive: bool) -> None:
     """
     Register this machine as a host with a server.
 
@@ -6649,11 +6665,20 @@ def host(ctx: click.Context, server: str | None) -> None:
     <url>``) or via ``--server <url>``. A leading ``status``, ``stop``,
     or ``stop-session`` token still runs that management subcommand.
 
+    When the target server is Databricks-fronted and you are not signed
+    in, ``host`` runs the same flow ``omnigent login`` would before
+    connecting (an interactive browser flow). Pass ``--non-interactive``
+    to keep the old scripted behavior: fail with the login command to run
+    instead of prompting.
+
     :param ctx: Click invocation context. ``ctx.invoked_subcommand`` is
         set when a management subcommand such as ``"status"`` is running.
     :param server: Remote Omnigent server URL, e.g.
         ``"https://example.databricksapps.com"``. ``None`` falls back
         to config; empty string selects local mode.
+    :param non_interactive: When ``True``, never launch the browser login
+        for an un-authed remote server — fail with the ``omnigent login``
+        hint instead.
     """
     ctx.ensure_object(dict)
     ctx.obj["server"] = server
@@ -6664,6 +6689,10 @@ def host(ctx: click.Context, server: str | None) -> None:
         server = cfg.get("server")
     if server:
         server = _resolve_server_url(server)
+    # Remote mode is decided here, before the local-mode branch reassigns
+    # ``server`` to the spawned loopback URL — only a remote target needs
+    # the sign-in pre-flight.
+    remote_mode = bool(server)
 
     from omnigent.host.connect import run_host_process
 
@@ -6692,6 +6721,14 @@ def host(ctx: click.Context, server: str | None) -> None:
     # prompt over an error.
     stopped_cleanly = False
     try:
+        # Sign in first when the remote server is Databricks-fronted and we
+        # hold no usable credentials — otherwise the tunnel upgrade is
+        # redirected to a login page and the host dies with an opaque
+        # "redirected to a login page" error after several retries. On a TTY
+        # this runs the browser login and continues; ``--non-interactive``
+        # (or a headless invocation) fails loud with the command to run.
+        if remote_mode:
+            _ensure_databricks_server_auth(server, non_interactive=non_interactive)
         run_host_process(server_url=server)
         stopped_cleanly = True
     except KeyboardInterrupt:

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -667,6 +667,7 @@ def test_foreground_connect_registers_status_record(
     monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
     monkeypatch.setattr(cli, "_load_effective_config", dict)
     monkeypatch.setattr(cli, "_load_or_create_host_id", lambda: "host_abc")
+    monkeypatch.setattr(cli, "_ensure_databricks_server_auth", lambda server, **kw: None)
     observed: list[cli._HostDaemonRecord] = []
 
     def _fake_run_host_process(server_url: str) -> None:
@@ -924,6 +925,7 @@ def test_foreground_connect_remote_omits_local_server_prompt(
     monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
     monkeypatch.setattr(cli, "_load_effective_config", dict)
     monkeypatch.setattr(cli, "_load_or_create_host_id", lambda: "host_abc")
+    monkeypatch.setattr(cli, "_ensure_databricks_server_auth", lambda server, **kw: None)
     monkeypatch.setattr(
         cli,
         "local_server_url_if_healthy",
@@ -1467,6 +1469,168 @@ def test_ensure_backend_databricks_preflight_skips_when_authenticated(
     assert result == "https://myapp-1234.aws.databricksapps.com"
 
 
+# ── Foreground ``host`` auth pre-flight ─────────────────────────────
+#
+# ``host`` runs the same Databricks sign-in pre-flight ``run`` does before
+# connecting to a remote server, but exposes ``--non-interactive`` so a
+# scripted invocation keeps the old fail-loud behavior instead of launching
+# the browser login. ``CliRunner`` swaps ``sys.stdin`` for a non-TTY stream,
+# so the auto-login-on-TTY branch is covered by the direct pre-flight test
+# below; the ``host`` wiring is asserted with a capturing pre-flight stub.
+
+_HOST_DATABRICKS_SERVER = "https://myapp-1234.aws.databricksapps.com"
+
+
+def test_databricks_preflight_non_interactive_overrides_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``non_interactive=True`` fails with the login hint even on a TTY.
+
+    Without the override an un-authed Databricks server would launch the
+    browser login on a TTY (covered by
+    ``test_ensure_backend_databricks_preflight_runs_login_on_tty``); the
+    flag is what lets ``host`` stay scripted.
+    """
+    login_calls = _patch_auth_preflight(monkeypatch, probe_status=302, tty=True)
+
+    with pytest.raises(click.ClickException) as exc:
+        cli._ensure_databricks_server_auth(_HOST_DATABRICKS_SERVER, non_interactive=True)
+
+    assert f"omnigent login {_HOST_DATABRICKS_SERVER}" in str(exc.value)
+    # The browser login never ran despite the TTY.
+    assert login_calls == []
+
+
+def _patch_foreground_host(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> list[str]:
+    """Stub the foreground-host plumbing and capture connect targets.
+
+    Covers both local and remote ``host`` invocations: the local server
+    bring-up is stubbed so ``host ""`` reaches ``run_host_process`` too.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temp dir for the host pidfile.
+    :returns: Capture list of ``run_host_process`` server URLs.
+    """
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    monkeypatch.setattr(cli, "_load_effective_config", dict)
+    monkeypatch.setattr(cli, "_load_or_create_host_id", lambda: "host_abc")
+    monkeypatch.setattr(
+        cli,
+        "ensure_local_omnigent_server",
+        lambda: LocalServerStartup(url="http://127.0.0.1:8000", spawned=True),
+    )
+    # No healthy local server after exit → the Ctrl-C stop prompt stays quiet.
+    monkeypatch.setattr(cli, "local_server_url_if_healthy", lambda: None)
+    connected: list[str] = []
+    monkeypatch.setattr(
+        "omnigent.host.connect.run_host_process",
+        lambda server_url: connected.append(server_url),
+    )
+    return connected
+
+
+def _capture_preflight(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, bool]]:
+    """Replace the auth pre-flight with a capturing no-op.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: Capture list of ``(server, non_interactive)`` pre-flight calls.
+    """
+    calls: list[tuple[str, bool]] = []
+
+    def _capture(server: str, *, non_interactive: bool = False) -> None:
+        calls.append((server, non_interactive))
+
+    monkeypatch.setattr(cli, "_ensure_databricks_server_auth", _capture)
+    return calls
+
+
+def test_host_remote_runs_auth_preflight_before_connect(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Remote ``host`` runs the sign-in pre-flight, then connects."""
+    preflight = _capture_preflight(monkeypatch)
+    connected = _patch_foreground_host(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(cli_group, ["host", "--server", _HOST_DATABRICKS_SERVER])
+
+    assert result.exit_code == 0, result.output
+    assert preflight == [(_HOST_DATABRICKS_SERVER, False)]
+    assert connected == [_HOST_DATABRICKS_SERVER]
+
+
+def test_host_non_interactive_flag_forwarded_to_preflight(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--non-interactive`` reaches the pre-flight as ``non_interactive=True``."""
+    preflight = _capture_preflight(monkeypatch)
+    _patch_foreground_host(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(
+        cli_group, ["host", "--server", _HOST_DATABRICKS_SERVER, "--non-interactive"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert preflight == [(_HOST_DATABRICKS_SERVER, True)]
+
+
+def test_host_non_interactive_flag_positional_shorthand(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``omnigent host <url> --non-interactive`` parses the flag with the shorthand."""
+    preflight = _capture_preflight(monkeypatch)
+    _patch_foreground_host(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(cli_group, ["host", _HOST_DATABRICKS_SERVER, "--non-interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert preflight == [(_HOST_DATABRICKS_SERVER, True)]
+
+
+def test_host_local_skips_auth_preflight(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Local-mode ``host ""`` never runs the remote sign-in pre-flight."""
+    preflight = _capture_preflight(monkeypatch)
+    connected = _patch_foreground_host(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(cli_group, ["host", ""])
+
+    assert result.exit_code == 0, result.output
+    assert preflight == []
+    assert connected == ["http://127.0.0.1:8000"]
+
+
+def test_host_remote_preflight_hints_headless(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Un-authed Databricks ``host`` (no TTY) fails with the login hint, never connecting."""
+    login_calls = _patch_auth_preflight(monkeypatch, probe_status=302, tty=False)
+    connected = _patch_foreground_host(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(cli_group, ["host", "--server", _HOST_DATABRICKS_SERVER])
+
+    assert result.exit_code != 0
+    assert f"omnigent login {_HOST_DATABRICKS_SERVER}" in result.output
+    # Pre-flight bailed: no browser login and no connect.
+    assert login_calls == []
+    assert connected == []
+
+
+def test_host_remote_preflight_skips_when_authenticated(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A 200 probe (valid creds / header mode) connects without a login flow."""
+    login_calls = _patch_auth_preflight(monkeypatch, probe_status=200, tty=False)
+    connected = _patch_foreground_host(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(cli_group, ["host", "--server", _HOST_DATABRICKS_SERVER])
+
+    assert result.exit_code == 0, result.output
+    assert login_calls == []
+    assert connected == [_HOST_DATABRICKS_SERVER]
+
+
 # ── Workspace-URL expansion for attach / resume / host ──────────────
 #
 # ``run`` / ``claude`` / ``codex`` expand a bare Databricks workspace URL to
@@ -1631,6 +1795,7 @@ def test_host_command_defaults_scheme_and_accepts_omnigent_web_url(
     monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
     monkeypatch.setattr(cli, "_load_effective_config", dict)
     monkeypatch.setattr(cli, "_load_or_create_host_id", lambda: "host_abc")
+    monkeypatch.setattr(cli, "_ensure_databricks_server_auth", lambda server, **kw: None)
     seen: list[str] = []
     monkeypatch.setattr(cli, "_workspace_api_server_url", _recording_expander(seen))
     observed: list[str] = []


### PR DESCRIPTION
## What

`omnigent host --server <url>` now runs the same Databricks sign-in pre-flight that `omnigent run` already uses before connecting to a remote server. When the target is Databricks-fronted and you hold no usable credentials, `host` signs you in (or tells you exactly how to) instead of dying much later with the opaque "the server redirected the host tunnel to a login page" error after several retries.

A new `--non-interactive` flag preserves the old, scripted behavior so this stays safe in CI / automation.

## Behavior (`omnigent host --server <databricks-app>`, un-authed)

| Context | Result |
|---|---|
| TTY, default | runs the browser login (`omnigent login <url>`), then connects |
| `--non-interactive` (any context) | fails with `Run \`omnigent login <url>\` and retry` — no prompt, no browser, no connect |
| headless / no TTY, default | same fail-loud hint (pre-existing safety, now actually reached) |
| already authenticated (200) | connects directly, no login |

Local mode (`omnigent host ""`) is untouched — the pre-flight only runs for a remote target.

## How

- `_ensure_databricks_server_auth(server, *, non_interactive=False)` — added the `non_interactive` kwarg, which forces the fail-loud `omnigent login` hint even on a TTY. Default `False` keeps `run`'s behavior byte-for-byte identical.
- `host` command — added the `--non-interactive` group flag and a `remote_mode` guard; runs the pre-flight inside the connect path before `run_host_process`. A failed pre-flight cleanly restores the daemon record (no stale claim).

## Scope

Matches `run`: this covers Databricks-fronted servers (the dominant remote case — `*.databricksapps.com` and workspace-hosted `/api/2.0/omnigent`). Generic OIDC/accounts servers are deliberately left alone, exactly as `run` does today.

## Tests

`tests/cli/test_backend.py` — stubbed the pre-flight in the existing remote-host tests (they'd otherwise hit the network) and added coverage for: the `non_interactive` override on a TTY, flag forwarding (including the `host <url> --non-interactive` positional shorthand), local-mode skip, the headless hint, and the authenticated skip.



This pull request and its description were written by Isaac.
