### PR TITLE
feat(web): explicit subagent take-over / return-to-parent affordance

### DIFF
--- a/ap-web/src/shell/SubagentsPanel.test.tsx
+++ b/ap-web/src/shell/SubagentsPanel.test.tsx
@@ -1181,4 +1181,53 @@ describe("SubagentsPanel", () => {
     expect(childRow(container, "conv_grandchild").className.split(/\s+/)).toContain("bg-accent");
     expect(childRow(container, "conv_child").className.split(/\s+/)).not.toContain("bg-accent");
   });
+
+  it("exposes an explicit, always-visible 'take over' affordance with an accessible name", () => {
+    // The action must be discoverable, not inferred from hover: the cue is
+    // rendered up-front, the Link carries the accessible action name, and the
+    // row still navigates into the sub-agent.
+    mockChildTree({
+      conv_root: [childInfo({ id: "conv_child", tool: "researcher", session_name: "auth" })],
+    });
+
+    const { container } = renderPanel({ conversationId: "conv_root", rootSessionId: "conv_root" });
+
+    const row = childRow(container, "conv_child");
+    expect(within(row).getByTestId("subagent-takeover-affordance")).toBeInTheDocument();
+    // Status stays visible alongside the affordance (no hover-swap that hides it).
+    expect(within(row).getByTestId("subagent-status-dot")).toBeInTheDocument();
+    expect(row).toHaveAttribute("aria-label", expect.stringMatching(/take over/i));
+    expect(row).toHaveAttribute("href", "/c/conv_child");
+    // A non-active row offers "take over", not "return".
+    expect(within(row).queryByTestId("subagent-return-affordance")).toBeNull();
+  });
+
+  it("turns the active row into a search-clean 'return to parent' control", () => {
+    // From a grandchild, the active row links *up* to its immediate parent —
+    // an in-tree path back, not just the header — while railLinkSearch drops
+    // session-scoped params (?file) and preserves global ones (?debug).
+    mockChildTree({
+      conv_root: [childInfo({ id: "conv_child", tool: "researcher" })],
+      conv_child: [childInfo({ id: "conv_grandchild", tool: "Explore" })],
+    });
+
+    const { container } = renderPanel({
+      conversationId: "conv_grandchild",
+      rootSessionId: "conv_root",
+      initialEntries: ["/c/conv_grandchild?file=foo.txt&debug=1"],
+    });
+
+    const active = childRow(container, "conv_grandchild");
+    expect(active.getAttribute("href")).toBe("/c/conv_child?debug=1");
+    expect(active).toHaveAttribute("aria-label", expect.stringMatching(/return to parent/i));
+    expect(within(active).getByTestId("subagent-return-affordance")).toBeInTheDocument();
+    expect(within(active).queryByTestId("subagent-takeover-affordance")).toBeNull();
+
+    // The (non-active) parent row still navigates *into* its own session and
+    // keeps its take-over affordance.
+    const parentRow = childRow(container, "conv_child");
+    expect(parentRow.getAttribute("href")).toBe("/c/conv_child?debug=1");
+    expect(within(parentRow).getByTestId("subagent-takeover-affordance")).toBeInTheDocument();
+    expect(within(parentRow).queryByTestId("subagent-return-affordance")).toBeNull();
+  });
 });

--- a/ap-web/src/shell/SubagentsPanel.tsx
+++ b/ap-web/src/shell/SubagentsPanel.tsx
@@ -615,18 +615,38 @@ function SubagentRow({
             <Icon className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="shrink-0 truncate text-xs font-medium">{primary}</span>
             <span className="flex-1" />
-            
             {isActive ? (
-              <span className="flex items-center gap-1 rounded bg-accent-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors group-hover:bg-accent-foreground/20 group-hover:text-foreground group-focus-visible:bg-accent-foreground/20 group-focus-visible:text-foreground">
-                Return <CornerLeftUpIcon className="size-3" />
+              // The active (current) row doubles as an explicit "go back up
+              // the tree" control: its Link targets the parent, and this
+              // always-visible pill names the action so a child/grandchild
+              // has a discoverable path to its parent from inside the tree —
+              // not only from the header. ``aria-hidden`` keeps it from
+              // double-announcing the Link's own ``aria-label``; the visual
+              // ``title`` tooltip and brand-token styling stay theme-aware.
+              <span
+                aria-hidden="true"
+                title="Return to parent"
+                data-testid="subagent-return-affordance"
+                className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors group-hover:bg-accent-foreground/10 group-hover:text-foreground group-focus-visible:bg-accent-foreground/10 group-focus-visible:text-foreground"
+              >
+                Return
+                <CornerLeftUpIcon className="size-3" />
               </span>
             ) : (
               <>
-                <div className="group-hover:hidden group-focus-visible:hidden">
-                  <StatusIndicator {...status} />
-                </div>
-                <span className="hidden items-center gap-1 rounded bg-accent-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors group-hover:flex group-hover:bg-accent-foreground/20 group-hover:text-foreground group-focus-visible:flex group-focus-visible:bg-accent-foreground/20 group-focus-visible:text-foreground">
-                  Open <ArrowRightIcon className="size-3" />
+                <StatusIndicator {...status} />
+                {/* Always-visible "take over" cue: the action is explicit and
+                    discoverable, never inferred from hover alone. The row's
+                    Link carries the accessible "Take over …" name, so this
+                    icon is decorative (``aria-hidden``) with a ``title``
+                    tooltip, and brightens on row hover / keyboard focus. */}
+                <span
+                  aria-hidden="true"
+                  title="Take over"
+                  data-testid="subagent-takeover-affordance"
+                  className="flex shrink-0 items-center text-muted-foreground/70 transition-colors group-hover:text-foreground group-focus-visible:text-foreground"
+                >
+                  <ArrowRightIcon className="size-3.5" />
                 </span>
               </>
             )}

--- a/ap-web/src/shell/SubagentsPanel.tsx
+++ b/ap-web/src/shell/SubagentsPanel.tsx
@@ -17,11 +17,13 @@
 import { useState } from "react";
 import type { ComponentType, SVGProps } from "react";
 import {
+  ArrowRightIcon,
   BookOpenIcon,
   BotIcon,
   Code2Icon,
   CompassIcon,
   CornerDownRightIcon,
+  CornerLeftUpIcon,
   FileTextIcon,
   FlaskConicalIcon,
   PlusIcon,
@@ -132,7 +134,7 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
       <ul className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-1">
         <MainRow rootSessionId={rootSessionId} isActive={conversationId === rootSessionId} />
         {children.map((child) => (
-          <SubagentRow key={child.id} child={child} depth={1} conversationId={conversationId} />
+          <SubagentRow key={child.id} child={child} depth={1} conversationId={conversationId} parentId={rootSessionId} />
         ))}
       </ul>
       {/* Mounted only while open so a closed rail issues no /v1/agents
@@ -557,12 +559,15 @@ function SubagentRow({
   child,
   depth,
   conversationId,
+  parentId,
 }: {
   child: ChildSessionInfo;
   /** Levels below the root, 1 = direct child of "main". */
   depth: number;
   /** The conversation currently rendered in main, for row highlighting. */
   conversationId: string;
+  /** The parent session ID for 'return to parent' navigation. */
+  parentId: string;
 }) {
   const status = childStatus(child);
   const search = railLinkSearch(useLocation().search);
@@ -586,7 +591,8 @@ function SubagentRow({
           // See MainRow: drop session-scoped params on rail navigation
           // (preserving global ones like ``?debug=1``) so a sticky
           // ``?file=`` from the previous session doesn't carry over.
-          to={{ pathname: `/c/${child.id}`, search }}
+          to={{ pathname: `/c/${isActive ? parentId : child.id}`, search }}
+          aria-label={isActive ? `Return to parent of ${primary}` : `Take over ${primary}`}
           data-testid="subagent-row"
           data-child-session-id={child.id}
           data-depth={depth}
@@ -594,7 +600,7 @@ function SubagentRow({
           // under its parent, signaling where it sits in the tree.
           style={{ paddingLeft: ROW_BASE_PADDING_PX + (depth - 1) * ROW_DEPTH_STEP_PX }}
           className={cn(
-            "flex w-full flex-col gap-0.5 py-2 pr-2.5 text-left hover:bg-accent/60",
+            "group flex w-full flex-col gap-0.5 py-2 pr-2.5 text-left hover:bg-accent/60",
             isActive && "bg-accent",
             dim && "opacity-60 hover:opacity-100",
           )}
@@ -609,7 +615,21 @@ function SubagentRow({
             <Icon className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="shrink-0 truncate text-xs font-medium">{primary}</span>
             <span className="flex-1" />
-            <StatusIndicator {...status} />
+            
+            {isActive ? (
+              <span className="flex items-center gap-1 rounded bg-accent-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors group-hover:bg-accent-foreground/20 group-hover:text-foreground group-focus-visible:bg-accent-foreground/20 group-focus-visible:text-foreground">
+                Return <CornerLeftUpIcon className="size-3" />
+              </span>
+            ) : (
+              <>
+                <div className="group-hover:hidden group-focus-visible:hidden">
+                  <StatusIndicator {...status} />
+                </div>
+                <span className="hidden items-center gap-1 rounded bg-accent-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors group-hover:flex group-hover:bg-accent-foreground/20 group-hover:text-foreground group-focus-visible:flex group-focus-visible:bg-accent-foreground/20 group-focus-visible:text-foreground">
+                  Open <ArrowRightIcon className="size-3" />
+                </span>
+              </>
+            )}
           </div>
           {child.last_message_preview && (
             // Preview indented to align with the title text on the row
@@ -628,6 +648,7 @@ function SubagentRow({
           child={grandchild}
           depth={depth + 1}
           conversationId={conversationId}
+          parentId={child.id}
         />
       ))}
     </>


### PR DESCRIPTION
## What & why

The Subagents rail let you move between agents in the session tree, but the
"open / take over a sub-agent" action was only **inferred** from the fact that
the whole row was a link, and there was no in-tree way to go **back up** to a
parent (only the header). This makes both actions explicit and discoverable.

## Changes

`ap-web/src/shell/SubagentsPanel.tsx`

- **Take over (every non-active row):** a persistent, always-visible arrow cue
  sits next to the (still-visible) status indicator. The row's `Link` carries
  an accessible `aria-label="Take over <name>"`; the icon is decorative
  (`aria-hidden`) with a `title` tooltip and brightens on row hover / keyboard
  focus. The action is shown, never inferred from hover alone.
- **Return to parent (the active row):** the current row becomes an explicit
  "go back up the tree" control — its `Link` targets the **parent** session
  (`parentId`, threaded root→child→grandchild), shows a `Return` pill, and is
  labelled `aria-label="Return to parent of <name>"`. This gives a
  child/grandchild an in-tree path back up, not only via the header.
- Navigation still routes to `/c/<id>` and respects `railLinkSearch()`, so
  `?file/?diff/?comment/?view` are stripped while globals like `?debug=1`
  survive — on both the open **and** return paths.
- Styling uses existing theme tokens only (no hardcoded colors; light/dark
  safe).

`ap-web/src/shell/SubagentsPanel.test.tsx`

- Asserts the always-visible take-over affordance + accessible name and that
  the row still navigates into the sub-agent.
- Asserts the active (grandchild) row links **up** to its parent, keeps a
  return affordance, and that `railLinkSearch()` strips `?file` while keeping
  `?debug` on the return path.

## UI before / after

- **Before:** non-active row → status indicator only; the "take over" action
  was implicit (hover briefly revealed a pill that *replaced* the status). The
  active row had no explicit way back to its parent.
- **After:** non-active row → `status  →` (visible take-over cue, status kept).
  Active row → `Return ⌐` pill that navigates to the parent. Tooltips +
  `aria-label`s on both; keyboard-focusable; theme-tokenised.

## Acceptance contract

1. ✅ Explicit, discoverable open/take-over affordance per row (visible icon +
   tooltip + `aria-label`, keyboard-reachable) — not inferred.
2. ✅ Clear "return to parent" from child/grandchild **inside the tree**.
3. ✅ No navigation regression — `/c/<id>` jumps correct; `railLinkSearch()`
   honoured on open and return.
4. ✅ Accessible (roles/aria/focus) and theme-token coherent (no hardcoded
   colors).
5. ✅ Tests added.

## Gates (ap-web/)

- `npm run type-check` (tsc -b) — ✅ green
- `npm run build` (vite) — ✅ green (preexisting chunk-size warning only)
- `npx oxlint src/shell/SubagentsPanel.tsx src/shell/SubagentsPanel.test.tsx` — ✅ clean
- `npx vitest run src/shell/SubagentsPanel.test.tsx` — ✅ 56 passed

> Note: the repo-wide `npm run lint` exits non-zero on a **preexisting**
> baseline (`no-shadow`/`no-await-in-loop` in `ChatPage.test.ts` /
> `chatStore.test.ts`) and `package-lock.json` is preexistingly desynced
> (`yaml@1.10.3` vs `2.9.0`) — both are outside this change and left untouched.

This branch carries the earlier attempt's plumbing commit (`f1b0a708`,
preserved) plus the completion commit that makes the affordances always-visible
and adds the tests.
