### PR TITLE
fix(server): reject server-side callable tools in uploaded agent bundles

### DIFF
--- a/omnigent/server/bundles.py
+++ b/omnigent/server/bundles.py
@@ -7,7 +7,51 @@ import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.spec import AgentSpec, ExtractionError, load
+from omnigent.spec import AgentSpec, ExtractionError, ToolRuntime, load
+
+
+def _is_dotted_callable_path(path: str) -> bool:
+    """Whether a local-tool ``path`` is a dotted Python *import* path.
+
+    A server-side ``callable:`` tool carries a dotted import path such as
+    ``"subprocess.check_output"`` that the runner resolves with
+    ``importlib.import_module`` and then invokes (see
+    ``omnigent.runner.tool_dispatch._resolve_spec_callable``) — the
+    GHSA-756x runner-RCE sink. Bundled tool *files* instead carry a
+    bundle-relative filesystem path (``"tools/python/arxiv_search.py"``),
+    distinguished by a ``/`` separator or a source-file suffix; those run
+    the bundle's own shipped code rather than importing an arbitrary
+    server-installed module, so they are out of scope here.
+    """
+    return "/" not in path and not path.endswith((".py", ".ts")) and "." in path
+
+
+def _reject_uploaded_callable_tools(spec: AgentSpec) -> None:
+    """Reject server-side Python ``callable:`` tools in an untrusted upload.
+
+    Recurses into sub-agents — each is a full :class:`AgentSpec` with its
+    own ``local_tools`` — mirroring the handler-allowlist guard's sub-agent
+    coverage so a malicious callable can't hide in a child agent.
+
+    :param spec: The parsed (sub-)agent spec to scan.
+    :raises OmnigentError: If any (sub-)agent declares a server-runtime tool
+        whose ``path`` is a dotted import path.
+    """
+    for tool in spec.local_tools:
+        if (
+            tool.runtime == ToolRuntime.SERVER
+            and tool.path is not None
+            and _is_dotted_callable_path(tool.path)
+        ):
+            raise OmnigentError(
+                "uploaded agent bundle may not declare a server-side Python "
+                f"callable tool (tool {tool.name!r} -> {tool.path!r}); a "
+                "'callable:' tool imports and runs operator-trusted code on "
+                "the runner, so it is rejected from untrusted uploads",
+                code=ErrorCode.INVALID_INPUT,
+            )
+    for sub in spec.sub_agents:
+        _reject_uploaded_callable_tools(sub)
 
 
 def _cwd_escapes_workspace(spec_cwd: str) -> bool:
@@ -57,8 +101,8 @@ def validate_agent_bundle(
     :returns: The validated :class:`AgentSpec`.
     :raises OmnigentError: If the bundle is invalid, the spec is
         missing a name, or (when *enforce_handler_allowlist*) a policy
-        names an unregistered handler or ``os_env.cwd`` is an absolute
-        or escaping path.
+        names an unregistered handler, ``os_env.cwd`` is an absolute or
+        escaping path, or a tool declares a server-side Python ``callable:``.
     """
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -86,14 +130,17 @@ def validate_agent_bundle(
             code=ErrorCode.INVALID_INPUT,
         )
 
-    # Untrusted uploads may not pin an absolute or escaping os_env.cwd
-    # (GHSA-p8rw-8qj3-hf33). This is gated on the same trust signal as the
-    # handler allowlist: a trusted single-user/local server
+    # Both guards below apply only to untrusted uploads, gated on the same
+    # trust signal as the handler allowlist: a trusted single-user/local server
     # (enforce_handler_allowlist=False) uploads the operator's OWN bundle, and
-    # the operator legitimately controls cwd — matching the documented
-    # absolute-cwd behavior for direct/local runs in
-    # designs/SESSION_WORKSPACE_SELECTION.md.
+    # the operator legitimately controls cwd and Python callable tools (they
+    # already have code execution), so neither restriction applies there.
     if enforce_handler_allowlist:
+        # Untrusted uploads may not pin an absolute or escaping os_env.cwd
+        # (GHSA-p8rw-8qj3-hf33): on a runner without OMNIGENT_RUNNER_WORKSPACE
+        # it becomes the agent environment root and copytree source, exposing
+        # the host filesystem. (Trusted local runs keep the documented
+        # absolute-cwd behavior — designs/SESSION_WORKSPACE_SELECTION.md.)
         os_env = getattr(spec, "os_env", None)
         spec_cwd = getattr(os_env, "cwd", None) if os_env is not None else None
         if (
@@ -106,6 +153,14 @@ def validate_agent_bundle(
                 f"(no absolute paths or '..'); got {spec_cwd!r}",
                 code=ErrorCode.INVALID_INPUT,
             )
+
+        # Untrusted uploads may not declare server-side Python ``callable:``
+        # tools (GHSA-756x-9hf6-q4h4): the runner imports the dotted path and
+        # invokes it, so a bundle pointing one at e.g. ``subprocess.check_output``
+        # is authenticated RCE on shared runner infrastructure. Bundled tool
+        # *files* (``tools/python/*.py``) are unaffected: they ship the agent's
+        # own code, not an arbitrary server-installed module.
+        _reject_uploaded_callable_tools(spec)
 
     return spec
 

--- a/tests/server/test_bundles.py
+++ b/tests/server/test_bundles.py
@@ -346,3 +346,99 @@ def test_validate_agent_bundle_allows_absolute_cwd_for_trusted_local_server() ->
         _bundle_with_cwd("/abs/operator/path"), enforce_handler_allowlist=False
     )
     assert spec.name == "uploaded-agent"
+
+
+# ── no server-side `callable:` tools on the upload path (GHSA-756x) ──
+
+
+# A omnigent function tool whose ``callable:`` is a dotted import path the
+# runner resolves with ``importlib`` and invokes — the RCE gadget.
+_CALLABLE_TOOL_YAML = (
+    "name: {name}\n"
+    "prompt: hi\n"
+    "executor:\n"
+    "  harness: claude-sdk\n"
+    "tools:\n"
+    "  run_cmd:\n"
+    "    type: function\n"
+    "    description: run a shell command\n"
+    "    callable: subprocess.check_output\n"
+    "    parameters:\n"
+    "      type: object\n"
+    "      properties:\n"
+    "        cmd:\n"
+    "          type: string\n"
+    "      required: [cmd]\n"
+)
+
+
+def test_validate_bundle_rejects_server_callable_tool() -> None:
+    """An uploaded bundle may not declare a server-side Python ``callable:`` tool.
+
+    The runner imports the dotted path and invokes it (GHSA-756x), so a
+    tenant-uploaded ``callable: subprocess.check_output`` is authenticated
+    RCE on the shared runner. The upload boundary must refuse it.
+    """
+    bundle = _single_file_yaml_bundle(_CALLABLE_TOOL_YAML.format(name="rce_tool_agent"))
+    with pytest.raises(OmnigentError, match=r"may not declare a server-side Python callable tool"):
+        validate_agent_bundle(bundle)
+
+
+def test_validate_bundle_allows_server_callable_tool_when_not_enforced() -> None:
+    """``enforce_handler_allowlist=False`` accepts a server ``callable:`` tool.
+
+    The trusted single-user / local-server path uploads the operator's own
+    bundle through this same function; Python callable tools are the intended
+    operator feature there (the operator already has code execution), so the
+    guard must not block them — mirroring the handler-allowlist exemption.
+    """
+    spec = validate_agent_bundle(
+        _single_file_yaml_bundle(_CALLABLE_TOOL_YAML.format(name="local_tool_agent")),
+        enforce_handler_allowlist=False,
+    )
+    assert spec.name == "local_tool_agent"
+
+
+def test_validate_bundle_allows_bundled_python_tool_file() -> None:
+    """A bundled ``tools/python/*.py`` tool file is not a ``callable:`` and is allowed.
+
+    File tools ship the agent's own code (path ``tools/python/echo.py``), not a
+    dotted import of an arbitrary server-installed module, so the GHSA-756x
+    guard must not over-block them.
+    """
+    bundle = _make_bundle_bytes(
+        {
+            "config.yaml": _MIN_CONFIG.format(name="filetool_agent"),
+            "tools/python/echo.py": "def echo(text: str) -> str:\n    return text\n",
+        }
+    )
+    spec = validate_agent_bundle(bundle)
+    assert spec.name == "filetool_agent"
+    assert any(t.name == "echo" for t in spec.local_tools)
+
+
+def test_reject_uploaded_callable_tools_recurses_into_sub_agents() -> None:
+    """The callable-tool guard catches a malicious callable hidden in a sub-agent.
+
+    Exercised directly: the directory ``config.yaml`` sub-agent shape does not
+    surface YAML ``tools:`` callables through the parser, so this guards the
+    recursion itself — the defense-in-depth that any future surfacing path
+    relies on, matching the handler-allowlist guard's sub-agent coverage.
+    """
+    from omnigent.server.bundles import _reject_uploaded_callable_tools
+    from omnigent.spec import AgentSpec
+    from omnigent.spec.types import LocalToolInfo, ToolRuntime
+
+    sub = AgentSpec(name="evil_sub", spec_version=1)
+    sub.local_tools = [
+        LocalToolInfo(
+            name="run_cmd",
+            path="subprocess.check_output",
+            language="omnigent-python-callable",
+            runtime=ToolRuntime.SERVER,
+        )
+    ]
+    root = AgentSpec(name="root", spec_version=1)
+    root.sub_agents = [sub]
+    with pytest.raises(OmnigentError, match=r"may not declare a server-side Python callable tool"):
+        _reject_uploaded_callable_tools(root)


### PR DESCRIPTION
## Related issue

N/A — private advisory GHSA-756x-9hf6-q4h4 (High, CWE-94). Fixing in the open per maintainer guidance.

Reported by @xttraa. Thanks for the report.

## Summary

- An authenticated user could upload an agent bundle whose function tool declares a server-side Python `callable:` (a dotted import path). The runner resolves that path via `importlib.import_module` and invokes it (`runner/tool_dispatch.py::_resolve_spec_callable`), so a tenant-uploaded `callable: subprocess.check_output` is authenticated RCE on shared runner infrastructure.
- Fix: `validate_agent_bundle` rejects server-runtime tools whose `path` is a dotted import path, gated on the existing `enforce_handler_allowlist` trust signal — exactly like the policy-handler allowlist and the `os_env.cwd` guard (#1417). Trusted single-user/local runs (`omnigent run` uploads the operator's own bundle) keep the documented Python-callable feature.
- Bundled tool **files** (`tools/python/*.py`) ship the agent's own code, not an arbitrary server-installed module import, so they are unaffected (path carries a `/` and a source suffix). The scan recurses into sub-agents, mirroring the handler-allowlist guard.

## Test Plan

`uv run --extra all --extra dev pytest tests/server/test_bundles.py` — 12/12 pass. New cases: rejects a `callable: subprocess.check_output` upload; accepts the same when `enforce_handler_allowlist=False` (trusted local); accepts a bundled `tools/python/*.py` file tool (no over-block); and a direct test that the guard recurses into sub-agents.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Directory-shape sub-agent configs do not surface YAML `tools:` callables through the parser today, so the sub-agent recursion is covered by a direct unit test of the guard rather than an end-to-end bundle.

This pull request and its description were written by Isaac.