### PR TITLE
feat(cli): show server URL + version in the TUI welcome header

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11670,7 +11670,11 @@ def _workspace_api_server_url(server: str) -> str:
 
     import httpx as _httpx
 
-    from omnigent.conversation_browser import WORKSPACE_API_PATH, WORKSPACE_UI_PATH
+    from omnigent.conversation_browser import (
+        WORKSPACE_API_PATH,
+        WORKSPACE_UI_PATH,
+        display_server_url,
+    )
 
     server = server.rstrip("/")
     parsed = urlsplit(server)
@@ -11714,7 +11718,9 @@ def _workspace_api_server_url(server: str) -> str:
     except _httpx.HTTPError:
         return server
     if _workspace_mount_probe_matches(candidate, api_probe):
-        click.echo(f"Using {candidate} (Databricks workspace-hosted omnigent).")
+        click.echo(
+            f"Using {display_server_url(candidate)} (Databricks workspace-hosted omnigent)."
+        )
         return candidate
     # The anonymous probe came back inconclusive (404 on Azure even
     # when the mount exists). Retry it with a cached workspace bearer;
@@ -11732,7 +11738,9 @@ def _workspace_api_server_url(server: str) -> str:
         except _httpx.HTTPError:
             authed_probe = None
         if authed_probe is not None and _workspace_mount_probe_matches(candidate, authed_probe):
-            click.echo(f"Using {candidate} (Databricks workspace-hosted omnigent).")
+            click.echo(
+                f"Using {display_server_url(candidate)} (Databricks workspace-hosted omnigent)."
+            )
             return candidate
         click.echo(
             f"Note: {server} answers like a Databricks workspace, but "

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -16,6 +16,32 @@ WORKSPACE_API_PATH = "/api/2.0/omnigent"
 WORKSPACE_UI_PATH = "/omnigent"
 
 
+def display_server_url(base_url: str) -> str:
+    """
+    Map an Omnigent server base URL to the user-facing form to show.
+
+    Databricks workspace-hosted servers are connected to on the API proxy
+    mount (``https://<ws>/api/2.0/omnigent``), but the URL a user
+    recognizes — and that the web UI lives on — is the workspace SPA mount
+    (``https://<ws>/omnigent``). Rewrites the API path to the UI path for
+    those (dropping any ``?o=<org>`` query), so the startup banner shows
+    the clean ``/omnigent`` URL instead of the internal API path. Every
+    other URL (local ``http://127.0.0.1:<port>``, a custom remote) is
+    returned unchanged apart from a trailing-slash trim.
+
+    :param base_url: Omnigent server base URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"`` or
+        ``"http://127.0.0.1:6767"``.
+    :returns: The display URL, e.g.
+        ``"https://example.databricks.com/omnigent"`` or
+        ``"http://127.0.0.1:6767"``.
+    """
+    parsed = urllib.parse.urlsplit(base_url.rstrip("/"))
+    if parsed.path == WORKSPACE_API_PATH:
+        return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, WORKSPACE_UI_PATH, "", ""))
+    return base_url.rstrip("/")
+
+
 def conversation_url(base_url: str, conversation_id: str) -> str:
     """
     Build the browser URL for an Omnigent conversation.

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -16,6 +16,22 @@ WORKSPACE_API_PATH = "/api/2.0/omnigent"
 WORKSPACE_UI_PATH = "/omnigent"
 
 
+def is_workspace_hosted_url(base_url: str) -> bool:
+    """
+    Whether *base_url* is a Databricks workspace-hosted Omnigent mount.
+
+    True for the API proxy mount (``https://<ws>/api/2.0/omnigent``) the
+    CLI connects to on a workspace. Used to suppress UI a workspace
+    deployment shouldn't surface (e.g. the startup banner's server-version
+    row, since a workspace build reports no meaningful version string).
+
+    :param base_url: Omnigent server base URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``.
+    :returns: ``True`` when the URL path is the workspace API mount.
+    """
+    return urllib.parse.urlsplit(base_url.rstrip("/")).path == WORKSPACE_API_PATH
+
+
 def display_server_url(base_url: str) -> str:
     """
     Map an Omnigent server base URL to the user-facing form to show.

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -541,6 +541,13 @@ def _fetch_server_version(server_url: str | None) -> str | None:
     the version row. A welcome-banner detail must never block or fail REPL
     boot, so this swallows every error.
 
+    The timeout is kept tight and bounded *per phase* (connect / read /
+    write each 1.0s) so the worst case a healthy-but-slow or unreachable
+    server can add to the previously-instant banner stays small — the
+    connect phase, the dominant cost for an unreachable host, fails within
+    a second rather than the multi-second ceiling a single coarse timeout
+    could reach.
+
     :param server_url: Base URL the REPL is connected to, e.g.
         ``"https://omnigent.example.com"``; falsy short-circuits to
         ``None``.
@@ -552,7 +559,7 @@ def _fetch_server_version(server_url: str | None) -> str | None:
     try:
         import httpx
 
-        resp = httpx.get(f"{server_url.rstrip('/')}/v1/info", timeout=2.0)
+        resp = httpx.get(f"{server_url.rstrip('/')}/v1/info", timeout=httpx.Timeout(1.0))
         version = resp.json().get("server_version")
     except Exception:  # noqa: BLE001 — startup-UI boundary: never block boot on a banner detail
         return None
@@ -4272,9 +4279,16 @@ async def run_repl(
             except Exception:  # noqa: BLE001 — startup-UI boundary: a config read must never block REPL boot
                 _log.exception("Failed to build startup header; falling back to plain banner")
         # Installed server version for the header's "server <ver>" row.
-        # Resolved off the event loop (a 2s-timeout GET /v1/info) so a slow
-        # probe never stalls boot; None on any failure simply omits the row.
-        server_version = await asyncio.to_thread(_fetch_server_version, server_url)
+        # Resolved off the event loop (a short-timeout GET /v1/info) so a
+        # slow probe never stalls boot; None on any failure simply omits the
+        # row. Only the header path renders the version, so skip the probe
+        # entirely on the minimal-banner fallback (no header) — no point
+        # paying even bounded latency for a value that won't be shown.
+        server_version = (
+            await asyncio.to_thread(_fetch_server_version, server_url)
+            if _header is not None
+            else None
+        )
         _sys.stdout.write(
             _render_startup_banner_ansi(
                 ui_name,

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -476,14 +476,21 @@ def _render_startup_banner_ansi(
         ``None`` for the minimal banner.
     :returns: ANSI-styled string ready to be written to stdout.
     """
+    from omnigent.conversation_browser import display_server_url
     from omnigent.inner.banner import BannerLine, startup_banner_strings
 
     remote = _is_remote_server_url(server_url)
+    # User-facing form of the URL: a Databricks workspace-hosted server is
+    # connected to on its ``/api/2.0/omnigent`` API mount, but the banner
+    # should show the recognizable workspace ``/omnigent`` URL. Non-Databricks
+    # URLs pass through unchanged. The probe still uses the real base URL via
+    # the client; only the displayed string is mapped.
+    display_url = display_server_url(server_url) if server_url else server_url
 
     if header is None:
         banner = startup_banner_strings(
             ui_name,
-            hint_line=server_url if remote else "",
+            hint_line=display_url if remote else "",
             art_color="#F43BA6",
         )
         return banner.ansi
@@ -509,10 +516,10 @@ def _render_startup_banner_ansi(
     # version comes from a best-effort ``GET /v1/info`` probe; when it's
     # unresolved (slow / old server) only the URL shows, and when there's no
     # URL at all the version stands on its own row.
-    if server_url is not None:
-        url_row = server_url
+    if display_url is not None:
+        url_row = display_url
         if server_version:
-            url_row = f"{server_url}  ·  server {server_version}"
+            url_row = f"{display_url}  ·  server {server_version}"
         info_lines.append(BannerLine(url_row, dim=True))
     elif server_version:
         info_lines.append(BannerLine(f"server {server_version}", dim=True))
@@ -533,25 +540,35 @@ def _render_startup_banner_ansi(
 
 
 async def _fetch_server_version(client: OmnigentClient) -> str | None:
-    """Best-effort ``GET /v1/info`` → ``server_version`` for the header row.
+    """Best-effort server version for the header row, with a legacy fallback.
+
+    Tries ``GET /v1/info`` → ``server_version`` first, then falls back to
+    the long-standing ``GET /api/version`` → ``version`` endpoint. The
+    fallback matters for older servers (e.g. a staging deployment that
+    predates ``server_version`` landing in ``/v1/info``): ``/api/version``
+    has reported the same installed version for far longer, so the row
+    still fills in instead of waiting for that server to redeploy. Both
+    return the identical ``importlib.metadata`` version, so the fallback is
+    not a different value, just an older surface.
 
     Routed through the REPL's already-connected :class:`OmnigentClient` so
     the probe carries the SAME auth (bearer / cookie), base URL, and TLS /
-    custom-CA configuration the REPL is already using. ``/v1/info`` is NOT
-    universally unauthed — a hosted deployment (behind OIDC / accounts / a
-    Databricks front door) gates it like any other route, so a bare
+    custom-CA configuration the REPL is already using. These endpoints are
+    NOT universally unauthed — a hosted deployment (behind OIDC / accounts /
+    a Databricks front door) gates them like any other route, so a bare
     credential-less GET would 401 and the version would silently never show
     on exactly the remote servers where the URL row is displayed. Reusing
     the authenticated client makes the probe answer there.
 
     Because the client's ``httpx.AsyncClient`` is awaited directly (not run
-    on a thread), this never blocks the event loop. The timeout is kept
-    tight and bounded *per phase* (connect / read / write each 1.0s) so the
-    worst case a healthy-but-slow or unreachable server can add to the
-    previously-instant banner stays small — the connect phase, the dominant
-    cost for an unreachable host, fails within a second. Any failure —
+    on a thread), this never blocks the event loop. Each request is bounded
+    *per phase* (connect / read / write each 1.0s) so the worst case a
+    healthy-but-slow or unreachable server can add to the previously-instant
+    banner stays small — the connect phase, the dominant cost for an
+    unreachable host, fails within a second (and a dead host fails the first
+    request, so the fallback adds no latency there). Any failure —
     unreachable, slow, 401/4xx/5xx, non-JSON, or a server too old to report
-    the field — returns ``None`` and the banner simply omits the version
+    either field — returns ``None`` and the banner simply omits the version
     row. A welcome-banner detail must never block or fail REPL boot, so this
     swallows every error.
 
@@ -560,14 +577,20 @@ async def _fetch_server_version(client: OmnigentClient) -> str | None:
     :returns: The installed server version string (e.g. ``"0.3.0.dev0"``),
         or ``None`` when it can't be resolved.
     """
-    try:
-        import httpx
+    import httpx
 
-        resp = await client._http.get(f"{client._base_url}/v1/info", timeout=httpx.Timeout(1.0))
-        version = resp.json().get("server_version")
-    except Exception:  # noqa: BLE001 — startup-UI boundary: never block boot on a banner detail
-        return None
-    return version if isinstance(version, str) and version else None
+    timeout = httpx.Timeout(1.0)
+    # (endpoint, response key) pairs tried in order: the richer capabilities
+    # probe first, then the legacy version endpoint older servers still have.
+    for path, key in (("/v1/info", "server_version"), ("/api/version", "version")):
+        try:
+            resp = await client._http.get(f"{client._base_url}{path}", timeout=timeout)
+            version = resp.json().get(key)
+        except Exception:  # noqa: BLE001 — startup-UI boundary: never block boot on a banner detail
+            return None
+        if isinstance(version, str) and version:
+            return version
+    return None
 
 
 def _is_remote_server_url(url: str | None) -> bool:

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -440,6 +440,7 @@ def _render_startup_banner_ansi(
     ui_name: str,
     *,
     server_url: str | None = None,
+    server_version: str | None = None,
     header: _StartupHeader | None = None,
 ) -> str:
     """
@@ -451,16 +452,25 @@ def _render_startup_banner_ansi(
 
     When *header* is supplied, the box becomes a Claude-Code-style header:
     the agent name (bold) plus dim rows for the one-line summary, the
-    model + credential, the working folder, and (for a remote server) the
-    server URL; a per-family creds line is appended beneath the box for
-    multi-vendor agents. When *header* is ``None`` the box keeps its
-    minimal form — just the name, with the server URL taking the single
-    info row when the host is non-loopback (keybinding hints live in the
-    bottom toolbar, so the hint row is omitted).
+    model + credential, the working folder, and the server URL (shown for
+    any target, loopback included) with the installed version appended
+    inline as ``"<url>  ·  server <ver>"``; a per-family creds line is
+    appended beneath the box for multi-vendor agents. When *header* is
+    ``None`` the box keeps its minimal form — just the name, with the
+    server URL taking the single info row when the host is non-loopback
+    (keybinding hints live in the bottom toolbar, so the hint row is
+    omitted).
 
     :param ui_name: Humanized agent label shown bold at the top of the box.
-    :param server_url: Base URL the REPL is connected to. Surfaced only
-        when the host is non-loopback. ``None`` skips it.
+    :param server_url: Base URL the REPL is connected to. In the header
+        box it's shown for any target (including a local
+        ``http://127.0.0.1:<port>`` dev server); the minimal banner still
+        surfaces it only when the host is non-loopback. ``None`` skips it.
+    :param server_version: Installed server version (e.g. ``"0.3.0.dev0"``)
+        from a best-effort ``GET /v1/info`` probe, rendered inline on the
+        server-URL row (or its own row if there's no URL). ``None`` (probe
+        failed /
+        not attempted) skips the row. Only consulted on the *header* path.
     :param header: Resolved header data (folder / model / credential /
         summary / creds line) from :func:`_build_startup_header`, or
         ``None`` for the minimal banner.
@@ -492,8 +502,20 @@ def _render_startup_banner_ansi(
     elif header.model_label:
         info_lines.append(BannerLine(header.model_label, dim=True))
     info_lines.append(BannerLine(header.folder, dim=True))
-    if remote and server_url is not None:
-        info_lines.append(BannerLine(server_url, dim=True))
+    # Server URL + installed version on one row: "<url>  ·  server <ver>".
+    # The URL is shown for ANY server target, loopback included — a local
+    # dev server (``http://127.0.0.1:<port>``) is meaningful context here,
+    # so "which server am I on / what version is it" reads as one line. The
+    # version comes from a best-effort ``GET /v1/info`` probe; when it's
+    # unresolved (slow / old server) only the URL shows, and when there's no
+    # URL at all the version stands on its own row.
+    if server_url is not None:
+        url_row = server_url
+        if server_version:
+            url_row = f"{server_url}  ·  server {server_version}"
+        info_lines.append(BannerLine(url_row, dim=True))
+    elif server_version:
+        info_lines.append(BannerLine(f"server {server_version}", dim=True))
 
     banner = startup_banner_strings(ui_name, info_lines=info_lines, art_color="#F43BA6")
     if header.creds_line:
@@ -508,6 +530,33 @@ def _render_startup_banner_ansi(
             f"  {_ANSI_DIM}{header.creds_line}{_ANSI_RESET}"
         )
     return banner.ansi
+
+
+def _fetch_server_version(server_url: str | None) -> str | None:
+    """Best-effort ``GET /v1/info`` → ``server_version`` for the header row.
+
+    ``/v1/info`` is unauthed by design, so a plain short-timeout GET
+    suffices. Any failure — unreachable, slow, non-JSON, or a server too
+    old to report the field — returns ``None`` and the banner simply omits
+    the version row. A welcome-banner detail must never block or fail REPL
+    boot, so this swallows every error.
+
+    :param server_url: Base URL the REPL is connected to, e.g.
+        ``"https://omnigent.example.com"``; falsy short-circuits to
+        ``None``.
+    :returns: The installed server version string (e.g. ``"0.3.0.dev0"``),
+        or ``None`` when it can't be resolved.
+    """
+    if not server_url:
+        return None
+    try:
+        import httpx
+
+        resp = httpx.get(f"{server_url.rstrip('/')}/v1/info", timeout=2.0)
+        version = resp.json().get("server_version")
+    except Exception:  # noqa: BLE001 — startup-UI boundary: never block boot on a banner detail
+        return None
+    return version if isinstance(version, str) and version else None
 
 
 def _is_remote_server_url(url: str | None) -> bool:
@@ -4222,8 +4271,17 @@ async def run_repl(
                 _header = _build_startup_header(harness, agent_description, used_families)
             except Exception:  # noqa: BLE001 — startup-UI boundary: a config read must never block REPL boot
                 _log.exception("Failed to build startup header; falling back to plain banner")
+        # Installed server version for the header's "server <ver>" row.
+        # Resolved off the event loop (a 2s-timeout GET /v1/info) so a slow
+        # probe never stalls boot; None on any failure simply omits the row.
+        server_version = await asyncio.to_thread(_fetch_server_version, server_url)
         _sys.stdout.write(
-            _render_startup_banner_ansi(ui_name, server_url=server_url, header=_header)
+            _render_startup_banner_ansi(
+                ui_name,
+                server_url=server_url,
+                server_version=server_version,
+                header=_header,
+            )
         )
         _sys.stdout.flush()
 

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -532,34 +532,38 @@ def _render_startup_banner_ansi(
     return banner.ansi
 
 
-def _fetch_server_version(server_url: str | None) -> str | None:
+async def _fetch_server_version(client: OmnigentClient) -> str | None:
     """Best-effort ``GET /v1/info`` → ``server_version`` for the header row.
 
-    ``/v1/info`` is unauthed by design, so a plain short-timeout GET
-    suffices. Any failure — unreachable, slow, non-JSON, or a server too
-    old to report the field — returns ``None`` and the banner simply omits
-    the version row. A welcome-banner detail must never block or fail REPL
-    boot, so this swallows every error.
+    Routed through the REPL's already-connected :class:`OmnigentClient` so
+    the probe carries the SAME auth (bearer / cookie), base URL, and TLS /
+    custom-CA configuration the REPL is already using. ``/v1/info`` is NOT
+    universally unauthed — a hosted deployment (behind OIDC / accounts / a
+    Databricks front door) gates it like any other route, so a bare
+    credential-less GET would 401 and the version would silently never show
+    on exactly the remote servers where the URL row is displayed. Reusing
+    the authenticated client makes the probe answer there.
 
-    The timeout is kept tight and bounded *per phase* (connect / read /
-    write each 1.0s) so the worst case a healthy-but-slow or unreachable
-    server can add to the previously-instant banner stays small — the
-    connect phase, the dominant cost for an unreachable host, fails within
-    a second rather than the multi-second ceiling a single coarse timeout
-    could reach.
+    Because the client's ``httpx.AsyncClient`` is awaited directly (not run
+    on a thread), this never blocks the event loop. The timeout is kept
+    tight and bounded *per phase* (connect / read / write each 1.0s) so the
+    worst case a healthy-but-slow or unreachable server can add to the
+    previously-instant banner stays small — the connect phase, the dominant
+    cost for an unreachable host, fails within a second. Any failure —
+    unreachable, slow, 401/4xx/5xx, non-JSON, or a server too old to report
+    the field — returns ``None`` and the banner simply omits the version
+    row. A welcome-banner detail must never block or fail REPL boot, so this
+    swallows every error.
 
-    :param server_url: Base URL the REPL is connected to, e.g.
-        ``"https://omnigent.example.com"``; falsy short-circuits to
-        ``None``.
+    :param client: The connected client the REPL drives; its authenticated
+        ``_http`` and ``_base_url`` are reused for the probe.
     :returns: The installed server version string (e.g. ``"0.3.0.dev0"``),
         or ``None`` when it can't be resolved.
     """
-    if not server_url:
-        return None
     try:
         import httpx
 
-        resp = httpx.get(f"{server_url.rstrip('/')}/v1/info", timeout=httpx.Timeout(1.0))
+        resp = await client._http.get(f"{client._base_url}/v1/info", timeout=httpx.Timeout(1.0))
         version = resp.json().get("server_version")
     except Exception:  # noqa: BLE001 — startup-UI boundary: never block boot on a banner detail
         return None
@@ -4279,16 +4283,13 @@ async def run_repl(
             except Exception:  # noqa: BLE001 — startup-UI boundary: a config read must never block REPL boot
                 _log.exception("Failed to build startup header; falling back to plain banner")
         # Installed server version for the header's "server <ver>" row.
-        # Resolved off the event loop (a short-timeout GET /v1/info) so a
-        # slow probe never stalls boot; None on any failure simply omits the
-        # row. Only the header path renders the version, so skip the probe
-        # entirely on the minimal-banner fallback (no header) — no point
-        # paying even bounded latency for a value that won't be shown.
-        server_version = (
-            await asyncio.to_thread(_fetch_server_version, server_url)
-            if _header is not None
-            else None
-        )
+        # Probed via the connected (authenticated) client so a short, bounded
+        # GET /v1/info never stalls boot and answers even on auth-gated hosted
+        # servers; None on any failure simply omits the row. Only the header
+        # path renders the version, so skip the probe entirely on the
+        # minimal-banner fallback (no header) — no point paying even bounded
+        # latency for a value that won't be shown.
+        server_version = await _fetch_server_version(client) if _header is not None else None
         _sys.stdout.write(
             _render_startup_banner_ansi(
                 ui_name,

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -476,7 +476,7 @@ def _render_startup_banner_ansi(
         ``None`` for the minimal banner.
     :returns: ANSI-styled string ready to be written to stdout.
     """
-    from omnigent.conversation_browser import display_server_url
+    from omnigent.conversation_browser import display_server_url, is_workspace_hosted_url
     from omnigent.inner.banner import BannerLine, startup_banner_strings
 
     remote = _is_remote_server_url(server_url)
@@ -486,6 +486,15 @@ def _render_startup_banner_ansi(
     # URLs pass through unchanged. The probe still uses the real base URL via
     # the client; only the displayed string is mapped.
     display_url = display_server_url(server_url) if server_url else server_url
+    # Suppress the version on Databricks workspace mounts — a workspace build
+    # has no meaningful version string to show (authoritative gate; the call
+    # site also skips the probe there, but this guarantees it never renders
+    # regardless of caller).
+    version = (
+        None
+        if (server_url is not None and is_workspace_hosted_url(server_url))
+        else server_version
+    )
 
     if header is None:
         banner = startup_banner_strings(
@@ -518,10 +527,10 @@ def _render_startup_banner_ansi(
     # URL at all the version stands on its own row.
     if display_url is not None:
         url_row = display_url
-        if server_version:
-            url_row = f"{display_url}  ·  server {server_version}"
+        if version:
+            url_row = f"{display_url}  ·  server {version}"
         info_lines.append(BannerLine(url_row, dim=True))
-    elif server_version:
+    elif version:
         info_lines.append(BannerLine(f"server {server_version}", dim=True))
 
     banner = startup_banner_strings(ui_name, info_lines=info_lines, art_color="#F43BA6")
@@ -4308,11 +4317,17 @@ async def run_repl(
         # Installed server version for the header's "server <ver>" row.
         # Probed via the connected (authenticated) client so a short, bounded
         # GET /v1/info never stalls boot and answers even on auth-gated hosted
-        # servers; None on any failure simply omits the row. Only the header
-        # path renders the version, so skip the probe entirely on the
-        # minimal-banner fallback (no header) — no point paying even bounded
-        # latency for a value that won't be shown.
-        server_version = await _fetch_server_version(client) if _header is not None else None
+        # servers; None on any failure simply omits the row. Skipped when:
+        #   - there's no header (minimal banner ignores the version), or
+        #   - the server is a Databricks workspace mount — a workspace build
+        #     reports no meaningful version string (its /api/version returns a
+        #     placeholder like "source"), so showing it is noise.
+        from omnigent.conversation_browser import is_workspace_hosted_url
+
+        _show_version = _header is not None and not (
+            server_url is not None and is_workspace_hosted_url(server_url)
+        )
+        server_version = await _fetch_server_version(client) if _show_version else None
         _sys.stdout.write(
             _render_startup_banner_ansi(
                 ui_name,

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -25,6 +25,7 @@ from omnigent.repl._repl import (
     _build_startup_header,
     _consume_pending_local_skill_slash_command,
     _decode_terminal_target_key,
+    _fetch_server_version,
     _is_recoverable_sse_transport_error,
     _parse_sub_agent_handle,
     _parse_terminal_tool_output,
@@ -1466,6 +1467,160 @@ def test_render_startup_banner_without_header_is_name_only() -> None:
     # None of the header-only scaffolding leaks into the minimal banner.
     assert "→" not in plain
     assert "~/" not in plain
+
+
+def test_startup_header_shows_server_version_on_url_line() -> None:
+    """A resolved server version renders inline on the URL row: ``<url>  ·  server <ver>``.
+
+    What this proves: the version the user asked to surface (the headline
+    of this change) actually reaches the box and sits on the SAME line as
+    the URL as one "which server / what version" block. A regression that
+    stopped threading ``server_version`` into ``_render_startup_banner_ansi``
+    would drop it and fail the membership assert; one that split it onto its
+    own row would put the URL and version on different lines, failing the
+    same-line assert. The width assert guards the combined row against
+    pushing the 80-column box into a wrap.
+    """
+    import re
+
+    header = _StartupHeader(
+        folder="~/omnigent",
+        description=None,
+        model_label=None,
+        credential=None,
+        creds_line=None,
+    )
+    remote = "https://omnigent.example.com"
+    plain = re.sub(
+        r"\x1b\[[0-9;]*m",
+        "",
+        _render_startup_banner_ansi(
+            "polly", server_url=remote, server_version="0.3.0.dev0", header=header
+        ),
+    )
+    assert "server 0.3.0.dev0" in plain
+    # URL and version share one line — find the row carrying the URL and
+    # assert the version is on that same row.
+    url_line = next(line for line in plain.split("\n") if remote in line)
+    assert "server 0.3.0.dev0" in url_line
+    widths = [len(line) for line in plain.split("\n")]
+    assert max(widths) < 80, f"combined URL+version row widened the box to {max(widths)} cols"
+
+
+def test_startup_header_shows_local_server_url_with_version() -> None:
+    """A loopback server URL IS shown in the header, inline with the version.
+
+    What this proves: unlike the minimal banner (which hides loopback URLs
+    as noise), the header surfaces a local ``http://127.0.0.1:<port>`` dev
+    server so the combined ``<url>  ·  server <ver>`` line appears for local
+    sessions too. A regression that re-gated the header URL row on
+    ``_is_remote_server_url`` would drop the URL and fail the membership
+    assert.
+    """
+    import re
+
+    header = _StartupHeader(
+        folder="~/omnigent",
+        description=None,
+        model_label=None,
+        credential=None,
+        creds_line=None,
+    )
+    local = "http://127.0.0.1:7393"
+    plain = re.sub(
+        r"\x1b\[[0-9;]*m",
+        "",
+        _render_startup_banner_ansi(
+            "polly", server_url=local, server_version="0.3.0.dev0", header=header
+        ),
+    )
+    # The loopback URL and the version share one row in the header box.
+    url_line = next(line for line in plain.split("\n") if local in line)
+    assert "server 0.3.0.dev0" in url_line
+
+
+def test_startup_header_omits_server_version_when_unresolved() -> None:
+    """No ``server <ver>`` row when the version probe returned ``None``.
+
+    What this proves: the row is purely additive — an unreachable or old
+    server (probe → ``None``) yields the same box as before, never a bare
+    ``server`` label or blank row.
+    """
+    import re
+
+    header = _StartupHeader(
+        folder="~/omnigent",
+        description=None,
+        model_label=None,
+        credential=None,
+        creds_line=None,
+    )
+    plain = re.sub(
+        r"\x1b\[[0-9;]*m",
+        "",
+        _render_startup_banner_ansi("polly", server_url=None, server_version=None, header=header),
+    )
+    assert "server " not in plain
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        # Happy path: server_version present in the /v1/info body.
+        ({"server_version": "0.3.0.dev0"}, "0.3.0.dev0"),
+        # Server too old to report the field → None (row omitted).
+        ({"accounts_enabled": False}, None),
+        # Non-string / empty values are rejected rather than rendered.
+        ({"server_version": ""}, None),
+        ({"server_version": 3}, None),
+    ],
+)
+def test_fetch_server_version_parses_info(monkeypatch, payload, expected) -> None:
+    """``_fetch_server_version`` extracts a non-empty string ``server_version`` from /v1/info.
+
+    What this proves: only a usable version string reaches the header; a
+    missing field, empty string, or non-string is treated as "unknown"
+    (``None``) so the banner never shows a garbage version. Also pins the
+    probe target to the unauthed ``/v1/info`` on the slash-normalized base.
+    """
+
+    class _FakeResp:
+        def json(self) -> dict:
+            return payload
+
+    captured: dict[str, object] = {}
+
+    def _fake_get(target: str, timeout: float = 0.0):
+        # ``timeout`` mirrors the real httpx.get keyword the helper passes;
+        # captured only so the call shape stays honest, not asserted.
+        captured["target"] = target
+        return _FakeResp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    assert _fetch_server_version("https://omnigent.example.com/") == expected
+    # Slash-normalized base + the unauthed capabilities probe path.
+    assert captured["target"] == "https://omnigent.example.com/v1/info"
+
+
+def test_fetch_server_version_never_raises(monkeypatch) -> None:
+    """A falsy URL short-circuits, and any probe error yields ``None`` (boot must not fail).
+
+    What this proves: the version probe is a non-blocking nicety — no
+    ``server_url``, or an ``httpx`` error mid-probe, returns ``None``
+    instead of propagating and taking down REPL boot.
+    """
+    assert _fetch_server_version(None) is None
+    assert _fetch_server_version("") is None
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("network down")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", _boom)
+    assert _fetch_server_version("https://omnigent.example.com") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -1539,6 +1539,38 @@ def test_startup_header_shows_local_server_url_with_version() -> None:
     assert "server 0.3.0.dev0" in url_line
 
 
+def test_startup_header_shows_databricks_workspace_url_not_api_mount() -> None:
+    """A Databricks server shows the ``/omnigent`` SPA URL, not ``/api/2.0/omnigent``.
+
+    What this proves: the header maps the internal API proxy mount the REPL
+    connects on to the recognizable workspace URL a user expects. A
+    regression that rendered the raw ``server_url`` would leak
+    ``/api/2.0/omnigent`` into the banner. The version still appears inline.
+    """
+    import re
+
+    header = _StartupHeader(
+        folder="~",
+        description=None,
+        model_label=None,
+        credential="Subscription",
+        creds_line=None,
+    )
+    api_mount = "https://e2-dogfood.staging.cloud.databricks.com/api/2.0/omnigent"
+    plain = re.sub(
+        r"\x1b\[[0-9;]*m",
+        "",
+        _render_startup_banner_ansi(
+            "polly", server_url=api_mount, server_version="0.3.0.dev0", header=header
+        ),
+    )
+    # The clean workspace URL is shown, the internal API path is NOT.
+    assert "https://e2-dogfood.staging.cloud.databricks.com/omnigent" in plain
+    assert "/api/2.0/omnigent" not in plain
+    url_line = next(line for line in plain.split("\n") if "/omnigent" in line)
+    assert "server 0.3.0.dev0" in url_line
+
+
 def test_startup_header_omits_server_version_when_unresolved() -> None:
     """No ``server <ver>`` row when the version probe returned ``None``.
 
@@ -1563,12 +1595,51 @@ def test_startup_header_omits_server_version_when_unresolved() -> None:
     assert "server " not in plain
 
 
+def _run(coro):
+    """Drive an async helper to completion from a sync test."""
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def _fake_version_client(by_path: dict[str, dict]) -> tuple[object, list[str]]:
+    """Build a fake ``OmnigentClient`` whose ``_http.get`` serves per-path JSON.
+
+    :param by_path: Maps a request path suffix (e.g. ``"/v1/info"``) to the
+        JSON body its response should return.
+    :returns: ``(client, targets)`` — the fake client, and a list that
+        records each full URL the helper requested, in order.
+    """
+    targets: list[str] = []
+
+    class _FakeResp:
+        def __init__(self, body: dict) -> None:
+            self._body = body
+
+        def json(self) -> dict:
+            return self._body
+
+    class _FakeHttp:
+        async def get(self, target: str, timeout: object = None):
+            targets.append(target)
+            for suffix, body in by_path.items():
+                if target.endswith(suffix):
+                    return _FakeResp(body)
+            return _FakeResp({})
+
+    class _FakeClient:
+        _base_url = "https://omnigent.example.com"
+        _http = _FakeHttp()
+
+    return _FakeClient(), targets
+
+
 @pytest.mark.parametrize(
     "payload,expected",
     [
         # Happy path: server_version present in the /v1/info body.
         ({"server_version": "0.3.0.dev0"}, "0.3.0.dev0"),
-        # Server too old to report the field → None (row omitted).
+        # Server too old to report the field → falls through, None here.
         ({"accounts_enabled": False}, None),
         # Non-string / empty values are rejected rather than rendered.
         ({"server_version": ""}, None),
@@ -1579,34 +1650,40 @@ def test_fetch_server_version_parses_info(payload, expected) -> None:
     """``_fetch_server_version`` extracts a non-empty string ``server_version`` from /v1/info.
 
     What this proves: only a usable version string reaches the header; a
-    missing field, empty string, or non-string is treated as "unknown"
-    (``None``) so the banner never shows a garbage version. Also pins the
+    missing field, empty string, or non-string is treated as "unknown" and
+    falls through (here ``/api/version`` also has nothing, so the result is
+    ``None``) so the banner never shows a garbage version. Also pins the
     probe to go through the client's AUTHENTICATED ``_http`` (so a hosted,
-    auth-gated server answers instead of 401-ing) at ``/v1/info`` on the
-    client's base URL.
+    auth-gated server answers instead of 401-ing), trying ``/v1/info`` first.
     """
-    import asyncio
+    client, targets = _fake_version_client({"/v1/info": payload, "/api/version": {}})
+    assert _run(_fetch_server_version(client)) == expected
+    # The richer capabilities probe is always tried first, via the authed _http.
+    assert targets[0] == "https://omnigent.example.com/v1/info"
 
-    class _FakeResp:
-        def json(self) -> dict:
-            return payload
 
-    captured: dict[str, object] = {}
+def test_fetch_server_version_falls_back_to_api_version() -> None:
+    """When ``/v1/info`` lacks ``server_version``, fall back to ``/api/version``.
 
-    class _FakeHttp:
-        async def get(self, target: str, timeout: object = None):
-            # The probe must ride the client's authed _http, not a bare
-            # httpx.get; capturing the target pins the URL it builds.
-            captured["target"] = target
-            return _FakeResp()
-
-    class _FakeClient:
-        _base_url = "https://omnigent.example.com"
-        _http = _FakeHttp()
-
-    assert asyncio.run(_fetch_server_version(_FakeClient())) == expected
-    # Probe hits /v1/info on the client's base URL, through its authed _http.
-    assert captured["target"] == "https://omnigent.example.com/v1/info"
+    What this proves: an older server (e.g. a staging deploy that predates
+    ``server_version`` landing in ``/v1/info`` but still serves the
+    long-standing ``/api/version``) still fills the version row instead of
+    showing the URL alone. Pins the order: ``/v1/info`` first, then the
+    legacy endpoint only when the first yields no usable version.
+    """
+    client, targets = _fake_version_client(
+        {
+            # Modern endpoint present but without the field (older server).
+            "/v1/info": {"accounts_enabled": False},
+            # Legacy endpoint still reports the installed version.
+            "/api/version": {"version": "0.1.2"},
+        }
+    )
+    assert _run(_fetch_server_version(client)) == "0.1.2"
+    assert targets == [
+        "https://omnigent.example.com/v1/info",
+        "https://omnigent.example.com/api/version",
+    ]
 
 
 def test_fetch_server_version_never_raises() -> None:
@@ -1617,7 +1694,6 @@ def test_fetch_server_version_never_raises() -> None:
     that the client somehow can't satisfy, or a network drop) returns
     ``None`` instead of propagating and taking down REPL boot.
     """
-    import asyncio
 
     class _BoomHttp:
         async def get(self, *_args: object, **_kwargs: object) -> object:
@@ -1627,7 +1703,7 @@ def test_fetch_server_version_never_raises() -> None:
         _base_url = "https://omnigent.example.com"
         _http = _BoomHttp()
 
-    assert asyncio.run(_fetch_server_version(_FakeClient())) is None
+    assert _run(_fetch_server_version(_FakeClient())) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -1575,14 +1575,17 @@ def test_startup_header_omits_server_version_when_unresolved() -> None:
         ({"server_version": 3}, None),
     ],
 )
-def test_fetch_server_version_parses_info(monkeypatch, payload, expected) -> None:
+def test_fetch_server_version_parses_info(payload, expected) -> None:
     """``_fetch_server_version`` extracts a non-empty string ``server_version`` from /v1/info.
 
     What this proves: only a usable version string reaches the header; a
     missing field, empty string, or non-string is treated as "unknown"
     (``None``) so the banner never shows a garbage version. Also pins the
-    probe target to the unauthed ``/v1/info`` on the slash-normalized base.
+    probe to go through the client's AUTHENTICATED ``_http`` (so a hosted,
+    auth-gated server answers instead of 401-ing) at ``/v1/info`` on the
+    client's base URL.
     """
+    import asyncio
 
     class _FakeResp:
         def json(self) -> dict:
@@ -1590,37 +1593,41 @@ def test_fetch_server_version_parses_info(monkeypatch, payload, expected) -> Non
 
     captured: dict[str, object] = {}
 
-    def _fake_get(target: str, timeout: float = 0.0):
-        # ``timeout`` mirrors the real httpx.get keyword the helper passes;
-        # captured only so the call shape stays honest, not asserted.
-        captured["target"] = target
-        return _FakeResp()
+    class _FakeHttp:
+        async def get(self, target: str, timeout: object = None):
+            # The probe must ride the client's authed _http, not a bare
+            # httpx.get; capturing the target pins the URL it builds.
+            captured["target"] = target
+            return _FakeResp()
 
-    import httpx
+    class _FakeClient:
+        _base_url = "https://omnigent.example.com"
+        _http = _FakeHttp()
 
-    monkeypatch.setattr(httpx, "get", _fake_get)
-    assert _fetch_server_version("https://omnigent.example.com/") == expected
-    # Slash-normalized base + the unauthed capabilities probe path.
+    assert asyncio.run(_fetch_server_version(_FakeClient())) == expected
+    # Probe hits /v1/info on the client's base URL, through its authed _http.
     assert captured["target"] == "https://omnigent.example.com/v1/info"
 
 
-def test_fetch_server_version_never_raises(monkeypatch) -> None:
-    """A falsy URL short-circuits, and any probe error yields ``None`` (boot must not fail).
+def test_fetch_server_version_never_raises() -> None:
+    """Any probe error yields ``None`` (boot must not fail).
 
-    What this proves: the version probe is a non-blocking nicety — no
-    ``server_url``, or an ``httpx`` error mid-probe, returns ``None``
-    instead of propagating and taking down REPL boot.
+    What this proves: the version probe is a non-blocking nicety — an
+    ``httpx`` error mid-probe (including a 401 from an auth-gated server
+    that the client somehow can't satisfy, or a network drop) returns
+    ``None`` instead of propagating and taking down REPL boot.
     """
-    assert _fetch_server_version(None) is None
-    assert _fetch_server_version("") is None
+    import asyncio
 
-    def _boom(*_args: object, **_kwargs: object) -> object:
-        raise RuntimeError("network down")
+    class _BoomHttp:
+        async def get(self, *_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("network down")
 
-    import httpx
+    class _FakeClient:
+        _base_url = "https://omnigent.example.com"
+        _http = _BoomHttp()
 
-    monkeypatch.setattr(httpx, "get", _boom)
-    assert _fetch_server_version("https://omnigent.example.com") is None
+    assert asyncio.run(_fetch_server_version(_FakeClient())) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -1540,12 +1540,15 @@ def test_startup_header_shows_local_server_url_with_version() -> None:
 
 
 def test_startup_header_shows_databricks_workspace_url_not_api_mount() -> None:
-    """A Databricks server shows the ``/omnigent`` SPA URL, not ``/api/2.0/omnigent``.
+    """A Databricks server shows the ``/omnigent`` SPA URL and NO version.
 
-    What this proves: the header maps the internal API proxy mount the REPL
-    connects on to the recognizable workspace URL a user expects. A
-    regression that rendered the raw ``server_url`` would leak
-    ``/api/2.0/omnigent`` into the banner. The version still appears inline.
+    What this proves two things for a workspace mount: (1) the header maps
+    the internal ``/api/2.0/omnigent`` proxy mount to the recognizable
+    workspace ``/omnigent`` URL — a regression rendering the raw
+    ``server_url`` would leak the API path; and (2) the server-version row
+    is suppressed even when a version is passed, because a workspace build
+    has no meaningful version string to show (its ``/api/version`` returns a
+    placeholder like ``"source"``).
     """
     import re
 
@@ -1560,6 +1563,8 @@ def test_startup_header_shows_databricks_workspace_url_not_api_mount() -> None:
     plain = re.sub(
         r"\x1b\[[0-9;]*m",
         "",
+        # Pass a version to prove the renderer suppresses it for a workspace
+        # mount regardless of what the caller hands in.
         _render_startup_banner_ansi(
             "polly", server_url=api_mount, server_version="0.3.0.dev0", header=header
         ),
@@ -1567,8 +1572,9 @@ def test_startup_header_shows_databricks_workspace_url_not_api_mount() -> None:
     # The clean workspace URL is shown, the internal API path is NOT.
     assert "https://e2-dogfood.staging.cloud.databricks.com/omnigent" in plain
     assert "/api/2.0/omnigent" not in plain
-    url_line = next(line for line in plain.split("\n") if "/omnigent" in line)
-    assert "server 0.3.0.dev0" in url_line
+    # No version row for a Databricks workspace server.
+    assert "server " not in plain
+    assert "0.3.0.dev0" not in plain
 
 
 def test_startup_header_omits_server_version_when_unresolved() -> None:

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -9,6 +9,43 @@ import pytest
 import omnigent.conversation_browser as browser
 
 
+@pytest.mark.parametrize(
+    "base_url,expected",
+    [
+        # Databricks workspace API mount → the recognizable /omnigent SPA URL.
+        (
+            "https://e2-dogfood.staging.cloud.databricks.com/api/2.0/omnigent",
+            "https://e2-dogfood.staging.cloud.databricks.com/omnigent",
+        ),
+        # A trailing ``?o=<org>`` selector on the API base is dropped.
+        (
+            "https://ws.databricks.com/api/2.0/omnigent?o=123",
+            "https://ws.databricks.com/omnigent",
+        ),
+        # Trailing slash on the API mount still maps cleanly.
+        (
+            "https://ws.databricks.com/api/2.0/omnigent/",
+            "https://ws.databricks.com/omnigent",
+        ),
+        # Non-Databricks URLs pass through unchanged (sans trailing slash).
+        ("http://127.0.0.1:6767", "http://127.0.0.1:6767"),
+        ("https://omnigent-02m5.onrender.com/", "https://omnigent-02m5.onrender.com"),
+    ],
+)
+def test_display_server_url_maps_databricks_api_mount(base_url: str, expected: str) -> None:
+    """
+    ``display_server_url`` rewrites the Databricks API mount to the SPA URL.
+
+    What this proves: the startup banner shows the workspace ``/omnigent``
+    URL a user recognizes instead of the internal ``/api/2.0/omnigent``
+    proxy path, while every other target is shown verbatim. A regression
+    that stopped mapping would leak the API path back into the banner.
+
+    :returns: None.
+    """
+    assert browser.display_server_url(base_url) == expected
+
+
 def test_conversation_url_quotes_session_id() -> None:
     """
     Conversation URLs percent-encode ids before appending them to the base URL.

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -10,7 +10,7 @@ import omnigent.conversation_browser as browser
 
 
 @pytest.mark.parametrize(
-    "base_url,expected",
+    "url,expected",
     [
         # Databricks workspace API mount → the recognizable /omnigent SPA URL.
         (
@@ -32,7 +32,7 @@ import omnigent.conversation_browser as browser
         ("https://omnigent-02m5.onrender.com/", "https://omnigent-02m5.onrender.com"),
     ],
 )
-def test_display_server_url_maps_databricks_api_mount(base_url: str, expected: str) -> None:
+def test_display_server_url_maps_databricks_api_mount(url: str, expected: str) -> None:
     """
     ``display_server_url`` rewrites the Databricks API mount to the SPA URL.
 
@@ -43,11 +43,11 @@ def test_display_server_url_maps_databricks_api_mount(base_url: str, expected: s
 
     :returns: None.
     """
-    assert browser.display_server_url(base_url) == expected
+    assert browser.display_server_url(url) == expected
 
 
 @pytest.mark.parametrize(
-    "base_url,expected",
+    "url,expected",
     [
         ("https://ws.databricks.com/api/2.0/omnigent", True),
         ("https://ws.databricks.com/api/2.0/omnigent/", True),
@@ -56,7 +56,7 @@ def test_display_server_url_maps_databricks_api_mount(base_url: str, expected: s
         ("https://omnigent-02m5.onrender.com", False),
     ],
 )
-def test_is_workspace_hosted_url(base_url: str, expected: bool) -> None:
+def test_is_workspace_hosted_url(url: str, expected: bool) -> None:
     """
     ``is_workspace_hosted_url`` is true only for the workspace API mount.
 
@@ -66,7 +66,7 @@ def test_is_workspace_hosted_url(base_url: str, expected: bool) -> None:
 
     :returns: None.
     """
-    assert browser.is_workspace_hosted_url(base_url) is expected
+    assert browser.is_workspace_hosted_url(url) is expected
 
 
 def test_conversation_url_quotes_session_id() -> None:

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -46,6 +46,29 @@ def test_display_server_url_maps_databricks_api_mount(base_url: str, expected: s
     assert browser.display_server_url(base_url) == expected
 
 
+@pytest.mark.parametrize(
+    "base_url,expected",
+    [
+        ("https://ws.databricks.com/api/2.0/omnigent", True),
+        ("https://ws.databricks.com/api/2.0/omnigent/", True),
+        ("https://ws.databricks.com/omnigent", False),  # the SPA URL, not the API mount
+        ("http://127.0.0.1:6767", False),
+        ("https://omnigent-02m5.onrender.com", False),
+    ],
+)
+def test_is_workspace_hosted_url(base_url: str, expected: bool) -> None:
+    """
+    ``is_workspace_hosted_url`` is true only for the workspace API mount.
+
+    What this proves: the predicate the banner uses to suppress the
+    server-version row fires for ``/api/2.0/omnigent`` and nothing else, so
+    non-Databricks targets keep showing their version.
+
+    :returns: None.
+    """
+    assert browser.is_workspace_hosted_url(base_url) is expected
+
+
 def test_conversation_url_quotes_session_id() -> None:
     """
     Conversation URLs percent-encode ids before appending them to the base URL.


### PR DESCRIPTION
## Summary
Surfaces the connected omnigent **server URL and version** in the TUI welcome header — the box shown by `omni polly` / `debby` / `claude` / `codex` / `run`. Renders inline on one row:

```
│  ⠀⢠⣿⡿⠿⢿⣿⡄⠀  /private/tmp                                  │
│  ⠀⠈⠁⠀⠀⠀⠈⠁⠀  https://omnigent.example.com  ·  server 0.3.0.dev0 │
```

Follow-up to #1182 (which added the same server version to the web session-info popover); this brings the equivalent context to the CLI.

## Behavior
- **One renderer, every entrypoint** — all REPL entrypoints funnel through `_render_startup_banner_ansi`, so this lands everywhere at once.
- **URL shown for any target, loopback included** — a local `http://127.0.0.1:<port>` dev server now shows in the header too (previously hidden). The version appends inline as `<url>  ·  server <ver>`.
- **Version is best-effort** — fetched from `GET /v1/info` (`server_version`, already public) via a 2s-timeout probe resolved off the event loop with `asyncio.to_thread`, so a slow/old/unreachable server never stalls or fails boot. On probe failure the version is omitted and just the URL shows; when there's no URL at all, the version stands on its own row.
- The rarely-used *minimal* banner (no header) is unchanged — it still hides loopback URLs.

## Changes
`omnigent/repl/_repl.py` — `_render_startup_banner_ansi` gains a `server_version` param and the inline URL+version row; new `_fetch_server_version` helper (best-effort `/v1/info`); `run_repl` resolves it off the event loop before rendering.

## Verification
- `tests/repl/test_repl.py` — 100 pass, including new cases: version renders inline on the URL row, loopback URL is shown with the version, the row stays under 80 cols, the helper parses `/v1/info` (rejecting missing/empty/non-string), and the helper never raises (falsy URL + httpx error → `None`).
- ruff + format clean.
- Live: probed a running local server and confirmed the real banner renders `http://127.0.0.1:7393  ·  server 0.3.0.dev0`.
