### PR TITLE
OMNI-859: right-click on session row opens the same context menu as the kebab

### DIFF
--- a/ap-web/src/components/ui/context-menu.tsx
+++ b/ap-web/src/components/ui/context-menu.tsx
@@ -1,0 +1,265 @@
+import * as React from "react";
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
+
+import { getEmbedRoot } from "@/lib/host";
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
+
+function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return (
+    <ContextMenuPrimitive.Portal
+      data-slot="context-menu-portal"
+      container={getEmbedRoot() ?? undefined}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  // Context menus position at the pointer (no trigger anchor), so there's no
+  // `align`/`sideOffset` and no trigger-width var — the menu sizes to content.
+  return (
+    <ContextMenuPrimitive.Portal container={getEmbedRoot() ?? undefined}>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />;
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/context-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="context-menu-checkbox-item-indicator"
+      >
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />;
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="context-menu-radio-item-indicator"
+      >
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+function ContextMenuSubContent({
+  className,
+  sideOffset = 6,
+  collisionPadding = 8,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  // Portal the sub-flyout (Radix doesn't by default) for the same reason as
+  // ContextMenuContent. Without it, the sub-content's position:fixed popper
+  // wrapper renders inside the parent menu's [role="menu"] box. The dark-mode
+  // glass rule applies `backdrop-filter` to that box, which makes it the
+  // containing block for fixed descendants — so the flyout re-anchors to the
+  // parent and gets clipped by its `overflow-x: hidden` (invisible in dark
+  // mode only). Portaling lifts the wrapper out of that subtree; Radix still
+  // positions it against the sub-trigger ref, not DOM ancestry.
+  return (
+    <ContextMenuPrimitive.Portal container={getEmbedRoot() ?? undefined}>
+      <ContextMenuPrimitive.SubContent
+        data-slot="context-menu-sub-content"
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
+        className={cn(
+          "z-50 min-w-[96px] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuPortal,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuLabel,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+};

--- a/ap-web/src/shell/Sidebar.rowActions.test.tsx
+++ b/ap-web/src/shell/Sidebar.rowActions.test.tsx
@@ -235,3 +235,28 @@ describe("double-click to rename", () => {
     expect(mocks.rename.mutate).not.toHaveBeenCalled();
   });
 });
+
+describe("right-click context menu", () => {
+  it("opens the same action items as the kebab and drives the same handlers", () => {
+    renderSidebar();
+
+    // Nothing in the DOM until the row is right-clicked (the kebab menu is
+    // closed, so its items aren't rendered either).
+    expect(screen.queryByTestId("rename-conversation")).toBeNull();
+
+    fireEvent.contextMenu(screen.getByRole("link", { name: /My Session/ }));
+
+    // The context menu carries the full set of kebab actions — same testids,
+    // so it renders from the shared ConversationMenuItems body.
+    expect(screen.getByTestId("share-conversation")).toBeInTheDocument();
+    expect(screen.getByTestId("rename-conversation")).toBeInTheDocument();
+    expect(screen.getByTestId("move-to-project")).toBeInTheDocument();
+    expect(screen.getByTestId("archive-conversation")).toBeInTheDocument();
+    expect(screen.getByTestId("delete-conversation")).toBeInTheDocument();
+
+    // Selecting Rename runs the same path as the kebab / double-click: the
+    // inline rename input appears.
+    fireEvent.click(screen.getByTestId("rename-conversation"));
+    expect(screen.getByTestId("rename-conversation-input")).toBeInTheDocument();
+  });
+});

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  type ComponentType,
   type CSSProperties,
   type KeyboardEvent,
   type MouseEvent,
@@ -52,6 +53,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -1372,6 +1383,305 @@ function ConversationSection({
   );
 }
 
+// The minimal item-prop shape shared by the dropdown- and context-menu
+// primitive families (both wrappers accept a superset). Typing the bundle
+// against this — rather than `ComponentProps<typeof DropdownMenuItem>` — lets
+// either family satisfy `MenuComponents` so `ConversationMenuItems` can author
+// the menu body once and render it under either menu kind.
+type MenuItemProps = {
+  children?: ReactNode;
+  className?: string;
+  disabled?: boolean;
+  variant?: "default" | "destructive";
+  // Radix's menu `onSelect` receives a native Event in both families.
+  onSelect?: (event: Event) => void;
+  "data-testid"?: string;
+};
+
+type MenuComponents = {
+  Item: ComponentType<MenuItemProps>;
+  Separator: ComponentType<{ className?: string }>;
+  Sub: ComponentType<{ children?: ReactNode }>;
+  SubTrigger: ComponentType<{
+    children?: ReactNode;
+    className?: string;
+    "data-testid"?: string;
+  }>;
+  SubContent: ComponentType<{ children?: ReactNode; className?: string }>;
+};
+
+// Two stable bundles, one per Radix menu family. Annotated so a future prop
+// divergence surfaces here rather than at the call site.
+const dropdownBundle: MenuComponents = {
+  Item: DropdownMenuItem,
+  Separator: DropdownMenuSeparator,
+  Sub: DropdownMenuSub,
+  SubTrigger: DropdownMenuSubTrigger,
+  SubContent: DropdownMenuSubContent,
+};
+
+const contextBundle: MenuComponents = {
+  Item: ContextMenuItem,
+  Separator: ContextMenuSeparator,
+  Sub: ContextMenuSub,
+  SubTrigger: ContextMenuSubTrigger,
+  SubContent: ContextMenuSubContent,
+};
+
+/**
+ * The conversation row's action menu body — authored once and rendered under
+ * both the kebab {@link DropdownMenu} and the row's right-click {@link ContextMenu}
+ * via the {@link MenuComponents} bundle, so the two menus stay identical.
+ *
+ * Radix requires a menu's Content and its Item/Sub* descendants to come from the
+ * same primitive family (roving focus / keyboard nav), so the items can't simply
+ * be shared as elements — they're rendered through the injected `components` set.
+ */
+function ConversationMenuItems({
+  components: C,
+  conversation,
+  isPinned,
+  isArchived,
+  isOwner,
+  canEdit,
+  canManage,
+  canStop,
+  currentProject,
+  onTogglePinned,
+  onProjectAssigned,
+  moveToProject,
+  stopSession,
+  setShareOpen,
+  setIsEditing,
+  setStopOpen,
+  setDeleteOpen,
+  setRemoveProjectOpen,
+  setMenuOpen,
+  runArchive,
+}: {
+  components: MenuComponents;
+  conversation: Conversation;
+  isPinned: boolean;
+  isArchived: boolean;
+  isOwner: boolean;
+  canEdit: boolean;
+  canManage: boolean;
+  canStop: boolean;
+  currentProject: string | null;
+  onTogglePinned: (conversationId: string) => void;
+  onProjectAssigned?: (projectName: string) => void;
+  moveToProject: ReturnType<typeof useMoveToProject>;
+  stopSession: ReturnType<typeof useStopSession>;
+  setShareOpen: (open: boolean) => void;
+  setIsEditing: (editing: boolean) => void;
+  setStopOpen: (open: boolean) => void;
+  setDeleteOpen: (open: boolean) => void;
+  setRemoveProjectOpen: (open: boolean) => void;
+  // Closes the controlled kebab after a project pick; a no-op for the
+  // (uncontrolled) context menu, which Radix closes on select automatically.
+  setMenuOpen: (open: boolean) => void;
+  runArchive: () => void;
+}) {
+  return (
+    <>
+      {/* Pin/Unpin — mobile-only (md:hidden); desktop uses the
+          hover-revealed quick-pin button. Archived rows omit it (archive
+          outranks pin). */}
+      {!isArchived && (
+        <C.Item
+          data-testid="pin-conversation"
+          className="md:hidden"
+          onSelect={() => onTogglePinned(conversation.id)}
+        >
+          {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
+          {isPinned ? "Unpin" : "Pin"}
+        </C.Item>
+      )}
+      {canManage ? (
+        <C.Item data-testid="share-conversation" onSelect={() => setShareOpen(true)}>
+          <ShareIcon className="size-3.5" />
+          Share
+        </C.Item>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <C.Item data-testid="share-conversation" disabled>
+                <ShareIcon className="size-3.5" />
+                Share
+              </C.Item>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            You need manage permissions to share this session
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {canEdit ? (
+        <C.Item data-testid="rename-conversation" onSelect={() => setIsEditing(true)}>
+          <PencilIcon className="size-3.5" />
+          Rename
+        </C.Item>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <C.Item data-testid="rename-conversation" disabled>
+                <PencilIcon className="size-3.5" />
+                Rename
+              </C.Item>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            You need edit permissions to rename this session
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {canEdit && (
+        <C.Sub>
+          <C.SubTrigger data-testid="move-to-project" className="whitespace-nowrap">
+            <FolderInputIcon className="size-3.5" />
+            {/* "Add to project" until the session is filed, then "Move
+                session" to switch or remove it. */}
+            {currentProject ? "Move session" : "Add to project"}
+          </C.SubTrigger>
+          <C.SubContent className="w-56 p-1 [&_[role=menuitem]]:text-xs">
+            {/* A native submenu flyout — no separate popover layer, so no
+                open/dismiss race with the parent menu. */}
+            <ProjectPickerMenu
+              components={C}
+              currentProject={currentProject}
+              onSelect={(project) => {
+                setMenuOpen(false);
+                // Moving to another project is harmless — apply it now,
+                // and expand that (possibly new) project so the session
+                // is visible in it rather than hidden in a collapsed folder.
+                if (project !== "") {
+                  moveToProject.mutate({ id: conversation.id, project });
+                  onProjectAssigned?.(project);
+                  return;
+                }
+                // Removing: only confirm when this is the project's LAST
+                // session (removing it would delete the implicit project).
+                // Otherwise remove silently. The check is server-side so
+                // it's accurate regardless of the loaded window / pins.
+                void (async () => {
+                  let isLastSession = true;
+                  if (currentProject) {
+                    try {
+                      const ids = await fetchProjectSessionIds(currentProject);
+                      isLastSession = ids.every((id) => id === conversation.id);
+                    } catch {
+                      // If the check fails, fall back to confirming.
+                      isLastSession = true;
+                    }
+                  }
+                  if (isLastSession) {
+                    setRemoveProjectOpen(true);
+                  } else {
+                    moveToProject.mutate({ id: conversation.id, project: "" });
+                  }
+                })();
+              }}
+            />
+          </C.SubContent>
+        </C.Sub>
+      )}
+      {/* Stop / Archive / Delete are grouped at the bottom, below a
+          divider: lifecycle-ending actions separated from the everyday
+          ones above. */}
+      <C.Separator />
+      {/* Stop session — only on stoppable sessions whose runner isn't
+        already known-offline (canStop). Owner-gated like Delete:
+        non-owners see it disabled with an explanatory tooltip. */}
+      {canStop &&
+        (isOwner ? (
+          <C.Item
+            data-testid="stop-conversation"
+            variant="destructive"
+            onSelect={() => {
+              // Clear any prior failure so a stale "couldn't stop"
+              // message doesn't greet the next attempt. Must happen
+              // here: Radix only fires the Dialog's onOpenChange for
+              // Radix-initiated changes, not this programmatic open.
+              stopSession.reset();
+              setStopOpen(true);
+            }}
+          >
+            <CircleStopIcon className="size-3.5" />
+            Stop session
+          </C.Item>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <C.Item data-testid="stop-conversation" disabled>
+                  <CircleStopIcon className="size-3.5" />
+                  Stop session
+                </C.Item>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              Only the session owner can stop this session
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      {isOwner ? (
+        <C.Item data-testid="archive-conversation" onSelect={runArchive}>
+          {isArchived ? (
+            <ArchiveRestoreIcon className="size-3.5" />
+          ) : (
+            <ArchiveIcon className="size-3.5" />
+          )}
+          {isArchived ? "Unarchive" : "Archive"}
+        </C.Item>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <C.Item data-testid="archive-conversation" disabled>
+                {isArchived ? (
+                  <ArchiveRestoreIcon className="size-3.5" />
+                ) : (
+                  <ArchiveIcon className="size-3.5" />
+                )}
+                {isArchived ? "Unarchive" : "Archive"}
+              </C.Item>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            Only the session owner can {isArchived ? "unarchive" : "archive"} this session
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {isOwner ? (
+        <C.Item
+          data-testid="delete-conversation"
+          variant="destructive"
+          onSelect={() => setDeleteOpen(true)}
+        >
+          <Trash2Icon className="size-3.5" />
+          Delete
+        </C.Item>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <C.Item data-testid="delete-conversation" disabled>
+                <Trash2Icon className="size-3.5" />
+                Delete
+              </C.Item>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            Only the session owner can delete this session
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  );
+}
+
 function ConversationRow({
   conversation,
   isPinned,
@@ -1582,57 +1892,105 @@ function ConversationRow({
     });
   }
 
+  // Shared by the kebab dropdown and the right-click context menu so the two
+  // menus render identical items. `setMenuOpen` is supplied per-call (the
+  // controlled kebab passes the real setter; the uncontrolled context menu a
+  // no-op — Radix closes it on select).
+  const menuItemProps = {
+    conversation,
+    isPinned,
+    isArchived,
+    isOwner,
+    canEdit,
+    canManage,
+    canStop,
+    currentProject,
+    onTogglePinned,
+    onProjectAssigned,
+    moveToProject,
+    stopSession,
+    setShareOpen,
+    setIsEditing,
+    setStopOpen,
+    setDeleteOpen,
+    setRemoveProjectOpen,
+    runArchive,
+  };
+
+  // The clickable row surface. Extracted so it can be rendered bare (selection
+  // mode) or wrapped in the right-click ContextMenuTrigger below.
+  const rowLink = (
+    <Link
+      to={selectionMode ? "#" : `/c/${conversation.id}`}
+      className={cn(
+        "relative flex w-full flex-col gap-0.5 rounded-md px-4 py-2 text-left text-sm hover:bg-muted",
+        !selectionMode && (sessionState?.kind === "awaiting" ? "pr-48 md:pr-29" : "pr-28 md:pr-16"),
+        selectionMode && "pr-10",
+        isActive && "bg-muted",
+        selectionMode && isSelected && "bg-primary/5",
+      )}
+      onClick={(e) => {
+        if (selectionMode) {
+          e.preventDefault();
+          e.stopPropagation();
+          onToggleSelected(conversation.id);
+          return;
+        }
+        onClick(e);
+      }}
+      onDoubleClick={(e) => {
+        if (selectionMode) return;
+        if (!canEdit) return;
+        e.preventDefault();
+        setIsEditing(true);
+      }}
+      title={conversation.title ?? conversation.id}
+    >
+      {/* Row 1: the session name. Status markers (working, needs-approval,
+          unseen) render in the trailing time-marker slot below, replacing
+          the timestamp — not inline here. Leading icons (agent type, pin,
+          shared) were removed to keep rows text-clean; pinned rows still
+          group under "Pinned". */}
+      <div className="flex w-full items-center gap-1.5">
+        <span className="relative min-w-0 truncate">
+          {label}
+          {hasUnseenMessages && <span className="sr-only"> (unread)</span>}
+        </span>
+      </div>
+      {/* Row 2: git branch subtitle, spanning the full row below. */}
+      {gitBranch !== null && (
+        <span
+          className="flex items-center gap-1 font-normal text-xs text-muted-foreground"
+          title={gitBranch}
+        >
+          <GitBranchIcon className="size-3 shrink-0" />
+          <span className="truncate">{gitBranch}</span>
+        </span>
+      )}
+    </Link>
+  );
+
   return (
     <li ref={rowRef} className="group relative">
-      <Link
-        to={selectionMode ? "#" : `/c/${conversation.id}`}
-        className={cn(
-          "relative flex w-full flex-col gap-0.5 rounded-md px-4 py-2 text-left text-sm hover:bg-muted",
-          !selectionMode &&
-            (sessionState?.kind === "awaiting" ? "pr-48 md:pr-29" : "pr-28 md:pr-16"),
-          selectionMode && "pr-10",
-          isActive && "bg-muted",
-          selectionMode && isSelected && "bg-primary/5",
-        )}
-        onClick={(e) => {
-          if (selectionMode) {
-            e.preventDefault();
-            e.stopPropagation();
-            onToggleSelected(conversation.id);
-            return;
-          }
-          onClick(e);
-        }}
-        onDoubleClick={(e) => {
-          if (selectionMode) return;
-          if (!canEdit) return;
-          e.preventDefault();
-          setIsEditing(true);
-        }}
-        title={conversation.title ?? conversation.id}
-      >
-        {/* Row 1: the session name. Status markers (working, needs-approval,
-            unseen) render in the trailing time-marker slot below, replacing
-            the timestamp — not inline here. Leading icons (agent type, pin,
-            shared) were removed to keep rows text-clean; pinned rows still
-            group under "Pinned". */}
-        <div className="flex w-full items-center gap-1.5">
-          <span className="relative min-w-0 truncate">
-            {label}
-            {hasUnseenMessages && <span className="sr-only"> (unread)</span>}
-          </span>
-        </div>
-        {/* Row 2: git branch subtitle, spanning the full row below. */}
-        {gitBranch !== null && (
-          <span
-            className="flex items-center gap-1 font-normal text-xs text-muted-foreground"
-            title={gitBranch}
-          >
-            <GitBranchIcon className="size-3 shrink-0" />
-            <span className="truncate">{gitBranch}</span>
-          </span>
-        )}
-      </Link>
+      {/* Right-click anywhere on the row opens the same actions as the kebab.
+          Suppressed in selection mode (bulk-select owns the row), where the
+          bare link is rendered instead. ContextMenuTrigger preventDefaults the
+          native contextmenu event, so right-click never navigates; asChild
+          merges its handler onto the Link, preserving left-click / double-click. */}
+      {selectionMode ? (
+        rowLink
+      ) : (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
+          <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-xs">
+            <ConversationMenuItems
+              components={contextBundle}
+              setMenuOpen={() => {}}
+              {...menuItemProps}
+            />
+          </ContextMenuContent>
+        </ContextMenu>
+      )}
       {selectionMode ? (
         <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-2.5 flex items-center">
           {isSelected ? (
@@ -1724,205 +2082,11 @@ function ConversationRow({
               denser kebab that reads closer to the row text. Scoped here so the
               shared dropdown-menu component is untouched. */}
           <DropdownMenuContent align="end" className="min-w-44 [&_[role=menuitem]]:text-xs">
-            {/* Pin/Unpin — mobile-only (md:hidden); desktop uses the
-                hover-revealed quick-pin button. Archived rows omit it (archive
-                outranks pin). */}
-            {!isArchived && (
-              <DropdownMenuItem
-                data-testid="pin-conversation"
-                className="md:hidden"
-                onSelect={() => onTogglePinned(conversation.id)}
-              >
-                {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
-                {isPinned ? "Unpin" : "Pin"}
-              </DropdownMenuItem>
-            )}
-            {canManage ? (
-              <DropdownMenuItem
-                data-testid="share-conversation"
-                onSelect={() => setShareOpen(true)}
-              >
-                <ShareIcon className="size-3.5" />
-                Share
-              </DropdownMenuItem>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div>
-                    <DropdownMenuItem data-testid="share-conversation" disabled>
-                      <ShareIcon className="size-3.5" />
-                      Share
-                    </DropdownMenuItem>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="left">
-                  You need manage permissions to share this session
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {canEdit ? (
-              <DropdownMenuItem
-                data-testid="rename-conversation"
-                onSelect={() => setIsEditing(true)}
-              >
-                <PencilIcon className="size-3.5" />
-                Rename
-              </DropdownMenuItem>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div>
-                    <DropdownMenuItem data-testid="rename-conversation" disabled>
-                      <PencilIcon className="size-3.5" />
-                      Rename
-                    </DropdownMenuItem>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="left">
-                  You need edit permissions to rename this session
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {canEdit && (
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger data-testid="move-to-project" className="whitespace-nowrap">
-                  <FolderInputIcon className="size-3.5" />
-                  {/* "Add to project" until the session is filed, then "Move
-                      session" to switch or remove it. */}
-                  {currentProject ? "Move session" : "Add to project"}
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent className="w-56 p-1 [&_[role=menuitem]]:text-xs">
-                  {/* A native submenu flyout — no separate popover layer, so no
-                      open/dismiss race with the parent menu. */}
-                  <ProjectPickerMenu
-                    currentProject={currentProject}
-                    onSelect={(project) => {
-                      setMenuOpen(false);
-                      // Moving to another project is harmless — apply it now,
-                      // and expand that (possibly new) project so the session
-                      // is visible in it rather than hidden in a collapsed folder.
-                      if (project !== "") {
-                        moveToProject.mutate({ id: conversation.id, project });
-                        onProjectAssigned?.(project);
-                        return;
-                      }
-                      // Removing: only confirm when this is the project's LAST
-                      // session (removing it would delete the implicit project).
-                      // Otherwise remove silently. The check is server-side so
-                      // it's accurate regardless of the loaded window / pins.
-                      void (async () => {
-                        let isLastSession = true;
-                        if (currentProject) {
-                          try {
-                            const ids = await fetchProjectSessionIds(currentProject);
-                            isLastSession = ids.every((id) => id === conversation.id);
-                          } catch {
-                            // If the check fails, fall back to confirming.
-                            isLastSession = true;
-                          }
-                        }
-                        if (isLastSession) {
-                          setRemoveProjectOpen(true);
-                        } else {
-                          moveToProject.mutate({ id: conversation.id, project: "" });
-                        }
-                      })();
-                    }}
-                  />
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
-            )}
-            {/* Stop / Archive / Delete are grouped at the bottom, below a
-                divider: lifecycle-ending actions separated from the everyday
-                ones above. */}
-            <DropdownMenuSeparator />
-            {/* Stop session — only on stoppable sessions whose runner isn't
-              already known-offline (canStop). Owner-gated like Delete:
-              non-owners see it disabled with an explanatory tooltip. */}
-            {canStop &&
-              (isOwner ? (
-                <DropdownMenuItem
-                  data-testid="stop-conversation"
-                  variant="destructive"
-                  onSelect={() => {
-                    // Clear any prior failure so a stale "couldn't stop"
-                    // message doesn't greet the next attempt. Must happen
-                    // here: Radix only fires the Dialog's onOpenChange for
-                    // Radix-initiated changes, not this programmatic open.
-                    stopSession.reset();
-                    setStopOpen(true);
-                  }}
-                >
-                  <CircleStopIcon className="size-3.5" />
-                  Stop session
-                </DropdownMenuItem>
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div>
-                      <DropdownMenuItem data-testid="stop-conversation" disabled>
-                        <CircleStopIcon className="size-3.5" />
-                        Stop session
-                      </DropdownMenuItem>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="left">
-                    Only the session owner can stop this session
-                  </TooltipContent>
-                </Tooltip>
-              ))}
-            {isOwner ? (
-              <DropdownMenuItem data-testid="archive-conversation" onSelect={runArchive}>
-                {isArchived ? (
-                  <ArchiveRestoreIcon className="size-3.5" />
-                ) : (
-                  <ArchiveIcon className="size-3.5" />
-                )}
-                {isArchived ? "Unarchive" : "Archive"}
-              </DropdownMenuItem>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div>
-                    <DropdownMenuItem data-testid="archive-conversation" disabled>
-                      {isArchived ? (
-                        <ArchiveRestoreIcon className="size-3.5" />
-                      ) : (
-                        <ArchiveIcon className="size-3.5" />
-                      )}
-                      {isArchived ? "Unarchive" : "Archive"}
-                    </DropdownMenuItem>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="left">
-                  Only the session owner can {isArchived ? "unarchive" : "archive"} this session
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {isOwner ? (
-              <DropdownMenuItem
-                data-testid="delete-conversation"
-                variant="destructive"
-                onSelect={() => setDeleteOpen(true)}
-              >
-                <Trash2Icon className="size-3.5" />
-                Delete
-              </DropdownMenuItem>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div>
-                    <DropdownMenuItem data-testid="delete-conversation" disabled>
-                      <Trash2Icon className="size-3.5" />
-                      Delete
-                    </DropdownMenuItem>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="left">
-                  Only the session owner can delete this session
-                </TooltipContent>
-              </Tooltip>
-            )}
+            <ConversationMenuItems
+              components={dropdownBundle}
+              setMenuOpen={setMenuOpen}
+              {...menuItemProps}
+            />
           </DropdownMenuContent>
         </DropdownMenu>
       )}
@@ -2307,9 +2471,11 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
  * the menu's built-in typeahead and arrow-key navigation don't hijack typing.
  */
 function ProjectPickerMenu({
+  components: C,
   currentProject,
   onSelect,
 }: {
+  components: MenuComponents;
   currentProject: string | null;
   onSelect: (project: string) => void;
 }) {
@@ -2356,12 +2522,12 @@ function ProjectPickerMenu({
       </div>
       <div className="max-h-48 overflow-y-auto">
         {filtered.map((name) => (
-          <DropdownMenuItem key={name} onSelect={() => onSelect(name)}>
+          <C.Item key={name} onSelect={() => onSelect(name)}>
             <span className="flex-1 truncate text-left">{name}</span>
             {currentProject === name && (
               <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />
             )}
-          </DropdownMenuItem>
+          </C.Item>
         ))}
         {filtered.length === 0 && !creatingNew && (
           <p className="px-2 py-1.5 text-xs text-muted-foreground">No projects yet.</p>
@@ -2390,7 +2556,7 @@ function ProjectPickerMenu({
             />
           </div>
         ) : (
-          <DropdownMenuItem
+          <C.Item
             // Keep the menu open so the inline input can take over in place.
             onSelect={(e) => {
               e.preventDefault();
@@ -2399,15 +2565,15 @@ function ProjectPickerMenu({
           >
             <PlusIcon className="size-3.5 shrink-0" />
             Create new project
-          </DropdownMenuItem>
+          </C.Item>
         )}
         {currentProject && (
-          <DropdownMenuItem onSelect={() => onSelect("")}>
+          <C.Item onSelect={() => onSelect("")}>
             Remove from{" "}
             <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
               {currentProject}
             </span>
-          </DropdownMenuItem>
+          </C.Item>
         )}
       </div>
     </>

--- a/tests/e2e_ui/sessions/test_sidebar_context_menu.py
+++ b/tests/e2e_ui/sessions/test_sidebar_context_menu.py
@@ -1,0 +1,63 @@
+"""Browser e2e for the sidebar row right-click context menu.
+
+Right-clicking a session row opens the same actions as the row kebab
+(three-dots) — Share / Rename / Add-to-project / Stop / Archive / Delete —
+positioned at the cursor. Both menus render from a single shared item body
+(``ConversationMenuItems`` in ``Sidebar.tsx``), one under a Radix
+``DropdownMenu`` (the kebab) and one under a Radix ``ContextMenu`` (this
+right-click path).
+
+This guards the wiring the mocked unit test can't exercise end-to-end:
+
+- The native browser context menu is suppressed (``ContextMenuTrigger``
+  preventDefaults the ``contextmenu`` event) and the app menu opens instead.
+- Right-clicking does NOT navigate, and the same item handlers run — picking
+  Rename here swaps the row for the inline edit field, exactly as the kebab's
+  Rename does.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Locator, Page, expect
+
+
+def _row_link(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row's clickable link for *session_id* by its href."""
+    return page.locator(f'a[href="/c/{session_id}"]')
+
+
+def test_right_click_opens_session_actions_menu(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Right-clicking a row opens the kebab actions and drives the same handlers.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    link = _row_link(page, session_id)
+    expect(link).to_be_visible()
+
+    # Right-click the row surface. Radix's ContextMenuTrigger preventDefaults
+    # the native contextmenu event and opens the app menu at the cursor.
+    link.click(button="right")
+
+    # The context menu carries the full set of kebab actions — same testids,
+    # proving it renders from the shared ConversationMenuItems body. (The kebab
+    # DropdownMenu is closed, so these are the context menu's own items.)
+    expect(page.get_by_test_id("share-conversation")).to_be_visible()
+    expect(page.get_by_test_id("rename-conversation")).to_be_visible()
+    expect(page.get_by_test_id("move-to-project")).to_be_visible()
+    expect(page.get_by_test_id("archive-conversation")).to_be_visible()
+    expect(page.get_by_test_id("delete-conversation")).to_be_visible()
+
+    # Selecting Rename runs the same path as the kebab / double-click: the row
+    # swaps for the inline edit field. Right-click did not navigate away.
+    page.get_by_test_id("rename-conversation").click()
+    expect(page.get_by_test_id("rename-conversation-input")).to_be_visible()
+    expect(page).to_have_url(f"{base_url}/c/{session_id}")


### PR DESCRIPTION
## Related issue

Closes [OMNI-859](https://linear.app/omnigent/issue/OMNI-859/right-click-on-chat-in-session-list-should-show-the-same-menu-as-three)

## Summary

* Right-clicking a chat session row in the sidebar now opens a true context menu at the cursor with the same actions as the three-dots kebab (Share, Rename, Add/Move to project, Stop session, Archive, Delete).
* Added `ap-web/src/components/ui/context-menu.tsx`, a Radix `ContextMenu` wrapper mirroring `dropdown-menu.tsx` (same styling, portal-to-`getEmbedRoot()`, dark-mode sub-content fix) using the `--radix-context-menu-*` vars and pointer positioning.
* Extracted the kebab menu body into a single shared `ConversationMenuItems` component parameterized over a typed `MenuComponents` bundle, so the identical item JSX renders under either the dropdown or the context menu (Radix requires Content and its Item/Sub\* descendants to come from the same primitive family). `ProjectPickerMenu` is parameterized the same way.
* Wrapped each row's `<Link>` in a `<ContextMenu>` gated on `!selectionMode`; the kebab now renders the shared items too, so the two menus can't drift.

## Test Plan

* `npm run type-check` (tsc -b) — clean.
* `npm run lint` (oxlint) — no issues in changed files.
* `npx prettier --check` on changed files — clean.
* `npx vitest run src/shell/` — all 60 shell test files / 1063 tests pass.
* Added a test in `Sidebar.rowActions.test.tsx`: right-clicking a row opens the menu with the same item testids (share/rename/move/archive/delete) and selecting Rename enters the inline rename input (same handler path as the kebab and double-click).

https://github.com/user-attachments/assets/b7e03924-37dc-42ab-95f6-1cc2a46b23ec

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [X] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified via the component test suite (the new context-menu test plus the existing kebab/delete/archive/stop row-action tests, which exercise the now-shared menu body). The cursor-positioned rendering, left-click navigation preservation, and dark-mode/embedded-host portal behavior are inherently DOM/layout concerns covered by reusing the already-tested `dropdown-menu` styling and Radix `ContextMenuTrigger` semantics; a manual right-click pass in the running app is recommended before release for the visual placement.