### PR TITLE
feat(file-viewer): comment on rendered HTML files

### DIFF
--- a/tests/e2e_ui/comments/test_html_preview_comments.py
+++ b/tests/e2e_ui/comments/test_html_preview_comments.py
@@ -1,0 +1,151 @@
+"""E2E: commenting on a *rendered* HTML file (the bridge path).
+
+HTML files open in the sandboxed preview iframe (opaque origin, no
+``allow-same-origin``), so the host app cannot read the frame's selection
+directly. ``HtmlCommentViewer`` injects a small bridge script into the frame
+that relays selections over a private MessageChannel; the parent then drives
+the same CommentsPanel + comment store used by Markdown and code. This test
+pins that round-trip end to end:
+
+  1. An ``.html`` file is seeded via the filesystem resources API (no agent
+     run), with a sentence that appears exactly once — verbatim in both the
+     rendered text and the raw source — so the stored offset is deterministic.
+  2. The FileViewer opens the file in the preview iframe (the HTML default).
+  3. The user selects that sentence *inside the sandboxed frame*; the bridge
+     relays it and the floating "Add comment" button (portalled to the parent
+     document) appears.
+  4. Clicking it opens the CommentsPanel with the selection as the pending
+     anchor; the user fills the body and saves.
+  5. Via the REST API, the stored comment carries the selected sentence as its
+     ``anchor_content`` at the offset matching the raw HTML source — so the
+     agent (which edits the source) can locate it.
+
+If this goes red, the regression is most likely in the bridge handshake or the
+selection relay: iframe load → MessageChannel init → ``omni:selection`` →
+parent offset resolution → ``onSetActiveSelection`` → add-comment POST.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# The hello_world agent spec uses ``os_env.cwd: .``, so the runner writes seeded
+# files into the server process's cwd — the repo root (this file is
+# ``<repo>/tests/e2e_ui/comments/...``, so the repo root is ``parents[3]``).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_HTML_PATH = "design_doc.html"
+
+# A distinctive sentence that appears exactly once and is identical in the
+# rendered text and the raw source (no inline markup inside it), so the rendered
+# selection maps to a single, deterministic offset in the source.
+_ANCHOR_SENTENCE = "uniqueanchortoken design review sentence"
+
+_HTML_CONTENT = f"""\
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Design doc</title>
+  </head>
+  <body>
+    <h1>Design Doc</h1>
+    <p id="anchor">{_ANCHOR_SENTENCE}</p>
+    <p>Some other unrelated prose for context.</p>
+  </body>
+</html>
+"""
+
+
+def _cleanup_session_workdir(session_id: str) -> None:
+    shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+@pytest.fixture
+def seeded_html(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str, str]]:
+    """Seed the HTML doc and yield ``(base_url, session_id, path)``."""
+    base_url, session_id = seeded_session
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_HTML_PATH}",
+        json={"content": _HTML_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    try:
+        yield (base_url, session_id, _HTML_PATH)
+    finally:
+        _cleanup_session_workdir(session_id)
+
+
+def test_html_preview_add_comment(
+    page: Page,
+    seeded_html: tuple[str, str, str],
+) -> None:
+    """Select rendered HTML text, add a comment, and verify it persists."""
+    base_url, session_id, file_path = seeded_html
+    # Wide viewport so the toolbar renders inline and the panel has room.
+    page.set_viewport_size({"width": 1600, "height": 900})
+    # HTML files default to preview, so the iframe mounts directly.
+    page.goto(f"{base_url}/c/{session_id}?file={_HTML_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    iframe_el = file_viewer.locator('iframe[title="HTML preview"]')
+    expect(iframe_el).to_be_visible(timeout=10_000)
+
+    # Reach into the sandboxed (opaque-origin) frame via CDP and select the
+    # anchor sentence. select_text drives a programmatic selection, which the
+    # bridge picks up via its debounced selectionchange listener.
+    preview = file_viewer.frame_locator('iframe[title="HTML preview"]')
+    expect(preview.locator("#anchor")).to_have_text(_ANCHOR_SENTENCE, timeout=10_000)
+    preview.locator("#anchor").select_text()
+
+    # The floating "Add comment" button is portalled to the PARENT document
+    # (not inside the frame), so find it on the page.
+    add_comment_btn = page.get_by_role("button", name="Add comment")
+    expect(add_comment_btn).to_be_visible(timeout=10_000)
+    add_comment_btn.click()
+
+    # CommentsPanel opens alongside the preview.
+    expect(file_viewer.locator("span.font-semibold", has_text="Comments")).to_be_visible()
+
+    comment_body = "This sentence needs a citation."
+    comment_textarea = file_viewer.locator("textarea[placeholder='Add a comment…']")
+    expect(comment_textarea).to_be_visible()
+    comment_textarea.fill(comment_body)
+    file_viewer.get_by_role("button", name="Add Comment").click()
+
+    # The comment card appears in the panel.
+    expect(file_viewer).to_contain_text(comment_body)
+
+    # Verify via the REST API that the comment persisted with the selected
+    # sentence as its anchor at an offset matching the raw HTML source.
+    comments_resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={file_path}",
+        timeout=10.0,
+    )
+    comments_resp.raise_for_status()
+    comments = comments_resp.json()
+    assert len(comments) == 1, f"Expected 1 comment, got {len(comments)}: {comments}"
+
+    comment = comments[0]
+    assert comment["body"] == comment_body
+    assert comment["anchor_content"] == _ANCHOR_SENTENCE, (
+        f"anchor_content {comment['anchor_content']!r} != selected sentence "
+        f"{_ANCHOR_SENTENCE!r}"
+    )
+    raw_idx = _HTML_CONTENT.find(_ANCHOR_SENTENCE)
+    assert raw_idx != -1, "fixture bug: anchor sentence missing from file content"
+    assert comment["start_index"] == raw_idx, (
+        f"stored start_index={comment['start_index']} does not match the raw "
+        f"source position {raw_idx} of the anchor sentence"
+    )
+    assert comment["end_index"] == raw_idx + len(_ANCHOR_SENTENCE)

--- a/tests/e2e_ui/comments/test_html_preview_comments.py
+++ b/tests/e2e_ui/comments/test_html_preview_comments.py
@@ -47,6 +47,31 @@ _HTML_PATH = "design_doc.html"
 # selection maps to a single, deterministic offset in the source.
 _ANCHOR_SENTENCE = "uniqueanchortoken design review sentence"
 
+# The rendered text of a paragraph whose SOURCE wraps the words across multiple
+# indented lines. The browser collapses that whitespace when rendering, so the
+# rendered selection ("... one single line") is NOT a verbatim substring of the
+# source — it exercises the whitespace-tolerant anchor matching on both sides.
+_WRAPPED_RENDERED = (
+    "uniquewrapped this rendered sentence spans several source lines yet reads as one single line"
+)
+_WRAPPED_SOURCE = (
+    "uniquewrapped this rendered sentence\n"
+    "      spans several source lines\n"
+    "      yet reads as one single line"
+)
+
+# A phrase that appears twice — once as a title, once in body prose — so a
+# comment on the title must highlight ONLY the title, not both copies.
+_REPEATED_PHRASE = "uniquerepeated Aurora Sync"
+
+# A sentence far down the document (after tall filler) so activating its comment
+# must scroll the iframe to bring it into view.
+_DEEP_SENTENCE = "uniquedeeptoken sentence near the bottom of the document"
+
+_FILLER = "\n".join(
+    f"    <p>Filler paragraph {i} providing vertical space.</p>" for i in range(60)
+)
+
 _HTML_CONTENT = f"""\
 <!DOCTYPE html>
 <html lang="en">
@@ -56,8 +81,12 @@ _HTML_CONTENT = f"""\
   </head>
   <body>
     <h1>Design Doc</h1>
+    <h2 id="repeated-title">{_REPEATED_PHRASE}</h2>
     <p id="anchor">{_ANCHOR_SENTENCE}</p>
-    <p>Some other unrelated prose for context.</p>
+    <p id="wrapped">{_WRAPPED_SOURCE}</p>
+    <p>Body prose mentioning <span id="repeated-body">{_REPEATED_PHRASE}</span> again.</p>
+{_FILLER}
+    <p id="deep">{_DEEP_SENTENCE}</p>
   </body>
 </html>
 """
@@ -139,8 +168,7 @@ def test_html_preview_add_comment(
     comment = comments[0]
     assert comment["body"] == comment_body
     assert comment["anchor_content"] == _ANCHOR_SENTENCE, (
-        f"anchor_content {comment['anchor_content']!r} != selected sentence "
-        f"{_ANCHOR_SENTENCE!r}"
+        f"anchor_content {comment['anchor_content']!r} != selected sentence {_ANCHOR_SENTENCE!r}"
     )
     raw_idx = _HTML_CONTENT.find(_ANCHOR_SENTENCE)
     assert raw_idx != -1, "fixture bug: anchor sentence missing from file content"
@@ -149,3 +177,243 @@ def test_html_preview_add_comment(
         f"source position {raw_idx} of the anchor sentence"
     )
     assert comment["end_index"] == raw_idx + len(_ANCHOR_SENTENCE)
+
+
+def _open_preview(page: Page, base_url: str, session_id: str):
+    """Navigate to the HTML file and return the (file_viewer, preview) locators."""
+    page.set_viewport_size({"width": 1600, "height": 900})
+    page.goto(f"{base_url}/c/{session_id}?file={_HTML_PATH}")
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    expect(file_viewer.locator('iframe[title="HTML preview"]')).to_be_visible(timeout=10_000)
+    return file_viewer, file_viewer.frame_locator('iframe[title="HTML preview"]')
+
+
+def _add_comment_on(file_viewer, page: Page, locator_id: str, body: str) -> None:
+    """Select the element with ``locator_id`` in the frame and add ``body``."""
+    preview = file_viewer.frame_locator('iframe[title="HTML preview"]')
+    preview.locator(f"#{locator_id}").select_text()
+    add_btn = page.get_by_role("button", name="Add comment")
+    expect(add_btn).to_be_visible(timeout=10_000)
+    add_btn.click()
+    textarea = file_viewer.locator("textarea[placeholder='Add a comment…']")
+    expect(textarea).to_be_visible()
+    textarea.fill(body)
+    file_viewer.get_by_role("button", name="Add Comment").click()
+    expect(file_viewer).to_contain_text(body)
+
+
+def test_wrapped_anchor_matches_across_source_lines(
+    page: Page,
+    seeded_html: tuple[str, str, str],
+) -> None:
+    """A selection whose source wraps across lines still anchors + highlights.
+
+    The rendered text collapses the source's newlines/indentation, so the
+    selection is not a verbatim source substring. This pins the whitespace-
+    tolerant matching: the stored comment must anchor to the wrapped source span,
+    and the bridge must paint a Custom Highlight over the rendered range (the
+    matcher inside the frame would otherwise find nothing and leave it unpainted).
+    """
+    base_url, session_id, file_path = seeded_html
+    file_viewer, preview = _open_preview(page, base_url, session_id)
+
+    expect(preview.locator("#wrapped")).to_have_text(_WRAPPED_RENDERED, timeout=10_000)
+    _add_comment_on(file_viewer, page, "wrapped", "wrapped-anchor comment")
+
+    # The stored comment anchors to the wrapped span in the RAW source.
+    comments = _get_comments(base_url, session_id, file_path)
+    assert len(comments) == 1, comments
+    raw_idx = _HTML_CONTENT.find(_WRAPPED_SOURCE)
+    assert raw_idx != -1, "fixture bug: wrapped source span missing from file"
+    assert comments[0]["start_index"] == raw_idx
+    assert comments[0]["end_index"] == raw_idx + len(_WRAPPED_SOURCE)
+
+    # The bridge painted the highlight over the rendered range (Custom Highlight
+    # API is available in the Chromium harness).
+    assert _highlight_count(preview) >= 1, "expected the wrapped anchor to be highlighted"
+
+
+def test_repeated_anchor_highlights_only_commented_occurrence(
+    page: Page,
+    seeded_html: tuple[str, str, str],
+) -> None:
+    """A comment on repeated anchor text highlights only its own occurrence.
+
+    ``_REPEATED_PHRASE`` appears twice — as a title and again in body prose. The
+    bridge highlights by text match, so without the occurrence disambiguation it
+    would light up both copies. Commenting on the title must paint exactly one
+    highlight (the title's), matching the offset the parent stored.
+    """
+    base_url, session_id, file_path = seeded_html
+    file_viewer, preview = _open_preview(page, base_url, session_id)
+
+    expect(preview.locator("#repeated-title")).to_have_text(_REPEATED_PHRASE, timeout=10_000)
+    _add_comment_on(file_viewer, page, "repeated-title", "title comment")
+
+    # The comment anchored to the FIRST occurrence (the title) in the source.
+    comments = _get_comments(base_url, session_id, file_path)
+    assert len(comments) == 1, comments
+    title_idx = _HTML_CONTENT.find(_REPEATED_PHRASE)
+    assert comments[0]["start_index"] == title_idx
+
+    # Exactly one range is highlighted, even though the phrase appears twice.
+    assert _HTML_CONTENT.count(_REPEATED_PHRASE) == 2, "fixture bug: phrase should appear twice"
+    assert _highlight_count(preview) == 1, "only the commented occurrence should be highlighted"
+
+
+def test_repeated_anchor_second_occurrence_anchors_to_its_own_offset(
+    page: Page,
+    seeded_html: tuple[str, str, str],
+) -> None:
+    """Selecting the SECOND copy of repeated text anchors to the second offset.
+
+    The inbound path: the bridge reports which occurrence was selected, and the
+    parent resolves that occurrence's source offset. Without it, both copies
+    resolve to the first match — so commenting on the body copy would be stored
+    at the title's offset (and clicking it would open the title's comment).
+    """
+    base_url, session_id, file_path = seeded_html
+    file_viewer, preview = _open_preview(page, base_url, session_id)
+
+    expect(preview.locator("#repeated-body")).to_have_text(_REPEATED_PHRASE, timeout=10_000)
+    _add_comment_on(file_viewer, page, "repeated-body", "body comment")
+
+    # The stored comment must anchor to the SECOND occurrence in the source, not
+    # the title's first one.
+    comments = _get_comments(base_url, session_id, file_path)
+    assert len(comments) == 1, comments
+    title_idx = _HTML_CONTENT.find(_REPEATED_PHRASE)
+    body_idx = _HTML_CONTENT.find(_REPEATED_PHRASE, title_idx + 1)
+    assert body_idx != -1, "fixture bug: phrase should appear twice"
+    assert comments[0]["start_index"] == body_idx, (
+        f"comment anchored to {comments[0]['start_index']} (title is {title_idx}); "
+        f"expected the body occurrence at {body_idx}"
+    )
+
+
+def test_native_selection_cleared_after_comment_saved(
+    page: Page,
+    seeded_html: tuple[str, str, str],
+) -> None:
+    """After saving a comment, the native selection is dropped inside the frame.
+
+    The browser's ``::selection`` paints over the (lower-priority) Custom
+    Highlight, so a lingering selection would keep the just-commented range grey
+    instead of yellow until the user clicked elsewhere. The bridge clears it once
+    a saved comment covers the selection.
+    """
+    base_url, session_id, _ = seeded_html
+    file_viewer, preview = _open_preview(page, base_url, session_id)
+
+    expect(preview.locator("#anchor")).to_have_text(_ANCHOR_SENTENCE, timeout=10_000)
+    _add_comment_on(file_viewer, page, "anchor", "clears selection")
+
+    # The selection inside the frame must be collapsed after save.
+    selection_text = preview.locator("body").evaluate("() => window.getSelection().toString()")
+    assert selection_text == "", f"native selection should be cleared, got {selection_text!r}"
+    # And the highlight must be present (it was masked by grey before the clear).
+    assert _highlight_count(preview) >= 1
+
+
+def test_clicking_comment_scrolls_highlight_into_view(
+    page: Page,
+    seeded_html: tuple[str, str, str],
+) -> None:
+    """Activating a comment scrolls the sandboxed frame to its highlight."""
+    base_url, session_id, file_path = seeded_html
+
+    # Seed the deep comment via the REST API rather than the UI: the floating
+    # "Add comment" button tracks the selection rect, so commenting on a
+    # below-the-fold sentence would place the button off-screen. The scroll
+    # behavior under test is driven by clicking the card, not by how it was made.
+    raw_idx = _HTML_CONTENT.find(_DEEP_SENTENCE)
+    assert raw_idx != -1, "fixture bug: deep sentence missing from file content"
+    httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/comments",
+        json={
+            "path": file_path,
+            "body": "deep comment",
+            "start_index": raw_idx,
+            "end_index": raw_idx + len(_DEEP_SENTENCE),
+            "anchor_content": _DEEP_SENTENCE,
+        },
+        timeout=10.0,
+    ).raise_for_status()
+
+    file_viewer, preview = _open_preview(page, base_url, session_id)
+    # The frame starts at the top; the deep highlight is far below the fold.
+    assert preview.locator("body").evaluate("() => window.pageYOffset") == 0
+
+    # Open the comments panel via the toolbar (the seeded comment isn't shown
+    # until the panel is open).
+    file_viewer.get_by_role("button", name="Show comments").click()
+
+    # Clicking the comment card in the panel activates it → the bridge scrolls.
+    file_viewer.get_by_text("deep comment").click()
+    page.wait_for_timeout(800)  # smooth scroll settle
+    scrolled = preview.locator("body").evaluate("() => window.pageYOffset")
+    assert scrolled > 0, "activating the comment should scroll the frame to the highlight"
+
+
+def test_selecting_highlight_scrolls_comment_panel_to_its_card(
+    page: Page,
+    seeded_html: tuple[str, str, str],
+) -> None:
+    """Selecting a highlighted range in the file reveals its card in the panel.
+
+    The reverse direction of the scroll test: with many comments the panel list
+    scrolls, so clicking a highlight near the bottom of the doc must scroll the
+    panel to that comment's card (it would otherwise stay out of view).
+    """
+    base_url, session_id, file_path = seeded_html
+
+    # Seed a comment on each filler paragraph so the panel list is long, plus one
+    # on the deep sentence — the target we'll select in the file.
+    def _post(anchor: str, body: str) -> None:
+        idx = _HTML_CONTENT.find(anchor)
+        assert idx != -1, f"fixture bug: {anchor!r} missing"
+        httpx.post(
+            f"{base_url}/v1/sessions/{session_id}/comments",
+            json={
+                "path": file_path,
+                "body": body,
+                "start_index": idx,
+                "end_index": idx + len(anchor),
+                "anchor_content": anchor,
+            },
+            timeout=10.0,
+        ).raise_for_status()
+
+    for i in range(30):
+        _post(f"Filler paragraph {i} providing vertical space.", f"filler comment {i}")
+    _post(_DEEP_SENTENCE, "deep card")
+
+    file_viewer, preview = _open_preview(page, base_url, session_id)
+    file_viewer.get_by_role("button", name="Show comments").click()
+
+    # Select the deep sentence in the file (scroll it into the frame's view first
+    # so its rendered range is laid out, then select it).
+    preview.locator("#deep").scroll_into_view_if_needed()
+    preview.locator("#deep").select_text()
+
+    # The deep comment's card must scroll into the panel's visible viewport.
+    deep_card = file_viewer.get_by_text("deep card")
+    expect(deep_card).to_be_in_viewport(timeout=5_000)
+
+
+def _get_comments(base_url: str, session_id: str, file_path: str) -> list[dict]:
+    resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={file_path}",
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _highlight_count(preview) -> int:
+    """Number of ranges the bridge registered under the base comment highlight."""
+    return preview.locator("body").evaluate(
+        "() => { const h = (typeof CSS !== 'undefined' && CSS.highlights)"
+        " ? CSS.highlights.get('omni-comment') : null; return h ? h.size : 0; }"
+    )

--- a/web/src/hooks/useResizableCommentsPanel.test.tsx
+++ b/web/src/hooks/useResizableCommentsPanel.test.tsx
@@ -47,3 +47,41 @@ describe("useResizableCommentsPanel persistence", () => {
     restored.unmount();
   });
 });
+
+describe("useResizableCommentsPanel drag overlay", () => {
+  const overlaySelector = () =>
+    [...document.body.children].find(
+      (c): c is HTMLElement =>
+        c instanceof HTMLElement && c.style.position === "fixed" && c.style.zIndex === "2147483647",
+    ) ?? null;
+
+  it("mounts a full-window overlay during a drag so mouseup isn't lost to the preview iframe", () => {
+    // The divider sits between the HTML-preview iframe and this panel. Without
+    // an overlay, dragging over the frame routes mousemove/mouseup into it and
+    // the parent never sees the release, so the drag sticks to the cursor.
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    expect(overlaySelector()).toBeNull();
+
+    act(() =>
+      result.current.handleProps.onMouseDown({ preventDefault: () => {} } as React.MouseEvent),
+    );
+    const overlay = overlaySelector();
+    expect(overlay).not.toBeNull();
+    expect(overlay?.style.cursor).toBe("col-resize");
+
+    act(() => window.dispatchEvent(new MouseEvent("mouseup")));
+    expect(overlaySelector()).toBeNull();
+    unmount();
+  });
+
+  it("removes the overlay if unmounted mid-drag", () => {
+    const { result, unmount } = renderHook(() => useResizableCommentsPanel());
+    act(() =>
+      result.current.handleProps.onMouseDown({ preventDefault: () => {} } as React.MouseEvent),
+    );
+    expect(overlaySelector()).not.toBeNull();
+
+    unmount();
+    expect(overlaySelector()).toBeNull();
+  });
+});

--- a/web/src/hooks/useResizableCommentsPanel.ts
+++ b/web/src/hooks/useResizableCommentsPanel.ts
@@ -99,6 +99,25 @@ export function useResizableCommentsPanel() {
   const width = Math.max(MIN_WIDTH_PX, Math.min(raw ?? DEFAULT_WIDTH_PX, MAX_WIDTH_PX));
   const dragging = useRef(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+
+  // While dragging, a transparent full-window overlay sits above the panel so
+  // the pointer stream keeps reaching the parent document. Without it, dragging
+  // over a cross-origin/sandboxed iframe (e.g. the HTML preview) routes mousemove
+  // /mouseup into the frame, the parent never sees mouseup, and the drag sticks.
+  const addDragOverlay = useCallback(() => {
+    if (overlayRef.current || typeof document === "undefined") return;
+    const el = document.createElement("div");
+    el.style.cssText =
+      "position:fixed;inset:0;z-index:2147483647;cursor:col-resize;background:transparent;";
+    document.body.appendChild(el);
+    overlayRef.current = el;
+  }, []);
+
+  const removeDragOverlay = useCallback(() => {
+    overlayRef.current?.remove();
+    overlayRef.current = null;
+  }, []);
 
   const [isDesktop, setIsDesktop] = useState(
     () => typeof window !== "undefined" && window.innerWidth >= MD_BREAKPOINT,
@@ -120,12 +139,16 @@ export function useResizableCommentsPanel() {
     return Math.max(MIN_WIDTH_PX, Math.min(candidate, max));
   }, []);
 
-  const onMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    dragging.current = true;
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-  }, []);
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragging.current = true;
+      addDragOverlay();
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [addDragOverlay],
+  );
 
   // Keyboard resize: left/right arrows widen/narrow by 20px.
   const onKeyDown = useCallback(
@@ -153,6 +176,7 @@ export function useResizableCommentsPanel() {
     function onMouseUp() {
       if (!dragging.current) return;
       dragging.current = false;
+      removeDragOverlay();
       persistStoredWidth();
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
@@ -167,8 +191,9 @@ export function useResizableCommentsPanel() {
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }
+      removeDragOverlay();
     };
-  }, [clampWidth]);
+  }, [clampWidth, removeDragOverlay]);
 
   // Re-clamp the stored width when the viewport resizes so a width chosen on
   // a wider layout doesn't crowd out the viewer after the window shrinks.

--- a/web/src/hooks/useResizableInlinePanel.test.tsx
+++ b/web/src/hooks/useResizableInlinePanel.test.tsx
@@ -91,3 +91,43 @@ describe("useResizableInlinePanel persistence", () => {
     expect(result.current.panelWidth).toBe(620);
   });
 });
+
+describe("useResizableInlinePanel drag overlay", () => {
+  const overlaySelector = () =>
+    [...document.body.children].find(
+      (c): c is HTMLElement =>
+        c instanceof HTMLElement && c.style.position === "fixed" && c.style.zIndex === "2147483647",
+    ) ?? null;
+
+  it("mounts a full-window overlay during a drag so mouseup isn't lost to an iframe", () => {
+    // The panel sits beside the sandboxed HTML-preview iframe. Without an
+    // overlay, dragging over the frame routes mousemove/mouseup into it and the
+    // parent never sees the release, so the drag sticks to the cursor.
+    const { result, unmount } = renderHook(() => useResizableInlinePanel(SESSION));
+    expect(overlaySelector()).toBeNull();
+
+    act(() =>
+      result.current.handleProps.onMouseDown({ preventDefault: () => {} } as React.MouseEvent),
+    );
+    const overlay = overlaySelector();
+    expect(overlay).not.toBeNull();
+    expect(overlay?.style.cursor).toBe("col-resize");
+
+    act(() => window.dispatchEvent(new MouseEvent("mouseup")));
+    expect(overlaySelector()).toBeNull();
+    unmount();
+  });
+
+  it("removes the overlay if unmounted mid-drag", () => {
+    const { result, unmount } = renderHook(() => useResizableInlinePanel(SESSION));
+    act(() =>
+      result.current.handleProps.onMouseDown({ preventDefault: () => {} } as React.MouseEvent),
+    );
+    expect(overlaySelector()).not.toBeNull();
+
+    // Panel closes (e.g. tab switch) while still dragging — cleanup must not
+    // leave the transparent overlay swallowing every click on the page.
+    unmount();
+    expect(overlaySelector()).toBeNull();
+  });
+});

--- a/web/src/hooks/useResizableInlinePanel.ts
+++ b/web/src/hooks/useResizableInlinePanel.ts
@@ -133,8 +133,27 @@ export function useResizableInlinePanel(sessionId: string | null, minWidthPx = M
   }
   const resolvedWidth = clamp(effectiveRaw ?? defaultWidthPx(), minWidthPx);
   const dragging = useRef(false);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
   const minWidthRef = useRef(minWidthPx);
   minWidthRef.current = minWidthPx;
+
+  // While dragging, a transparent full-window overlay sits above the panel so
+  // the pointer stream keeps reaching the parent document. Without it, dragging
+  // over a cross-origin/sandboxed iframe (e.g. the HTML preview) routes mousemove
+  // /mouseup into the frame, the parent never sees mouseup, and the drag sticks.
+  const addDragOverlay = useCallback(() => {
+    if (overlayRef.current || typeof document === "undefined") return;
+    const el = document.createElement("div");
+    el.style.cssText =
+      "position:fixed;inset:0;z-index:2147483647;cursor:col-resize;background:transparent;";
+    document.body.appendChild(el);
+    overlayRef.current = el;
+  }, []);
+
+  const removeDragOverlay = useCallback(() => {
+    overlayRef.current?.remove();
+    overlayRef.current = null;
+  }, []);
 
   // Load the active session's saved width into the module store (and re-load
   // when it changes) so the live store and the drag handlers operate on the
@@ -160,12 +179,16 @@ export function useResizableInlinePanel(sessionId: string | null, minWidthPx = M
   // The resolvedWidth formula already enforces the visual minimum. No effect
   // needed — this lets the panel shrink back when minWidthPx drops.
 
-  const onMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    dragging.current = true;
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-  }, []);
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragging.current = true;
+      addDragOverlay();
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [addDragOverlay],
+  );
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -192,6 +215,7 @@ export function useResizableInlinePanel(sessionId: string | null, minWidthPx = M
     function onMouseUp() {
       if (!dragging.current) return;
       dragging.current = false;
+      removeDragOverlay();
       persistStoredWidth();
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
@@ -207,8 +231,9 @@ export function useResizableInlinePanel(sessionId: string | null, minWidthPx = M
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }
+      removeDragOverlay();
     };
-  }, []);
+  }, [removeDragOverlay]);
 
   return {
     panelWidth: resolvedWidth,

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -47,16 +47,15 @@ import { MarkdownRichTextViewer } from "./MarkdownRichTextViewer";
 import {
   type ActiveSelection,
   type SaveStatus,
-  HTML_PREVIEW_SANDBOX,
   detectLang,
   getSelectionOffsets,
   indexToLine,
   isBinaryPath,
   isImageFile,
   lineOverlapsSelection,
-  prepareHtmlPreviewDoc,
 } from "./codeViewerHelpers";
 import { renderLineTokens } from "./codeViewerRendering";
+import { HtmlCommentViewer } from "./HtmlCommentViewer";
 import { TruncatedBanner } from "./TruncatedBanner";
 import { useLightbox } from "@/components/ImageLightbox";
 import { getEmbedRoot } from "@/lib/host";
@@ -501,19 +500,24 @@ export function CodeViewer({
     );
   }
 
-  if (viewMode === "preview" && (lang === "markdown" || lang === "html")) {
-    const preview =
-      lang === "markdown" ? (
-        <MarkdownPreview content={content} />
-      ) : (
-        <iframe
-          srcDoc={prepareHtmlPreviewDoc(content)}
-          // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
-          sandbox={HTML_PREVIEW_SANDBOX}
-          title="HTML preview"
-          className="w-full h-full border-0"
-        />
-      );
+  // HTML preview gets its own comment-enabled viewer (selection capture +
+  // highlights relayed over a bridge into the still-sandboxed iframe), so it
+  // owns the truncated banner internally.
+  if (viewMode === "preview" && lang === "html") {
+    return (
+      <HtmlCommentViewer
+        conversationId={conversationId}
+        content={content}
+        truncated={truncated}
+        comments={comments}
+        activeSelection={activeSelection}
+        onSetActiveSelection={onSetActiveSelection}
+      />
+    );
+  }
+
+  if (viewMode === "preview" && lang === "markdown") {
+    const preview = <MarkdownPreview content={content} />;
     // A truncated preview renders incomplete content; warn the user (the editor
     // and source surfaces already do). No layout change when not truncated.
     if (!truncated) return preview;

--- a/web/src/shell/CommentsPanel.test.tsx
+++ b/web/src/shell/CommentsPanel.test.tsx
@@ -25,13 +25,17 @@ const mockGetCurrentAuthorId = vi.mocked(getCurrentAuthorId);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeComment(id: string, status: Comment["status"] = "draft"): Comment {
+function makeComment(
+  id: string,
+  status: Comment["status"] = "draft",
+  range: { start_index: number; end_index: number } = { start_index: 0, end_index: 5 },
+): Comment {
   return {
     id,
     conversation_id: "conv_1",
     path: "file.py",
-    start_index: 0,
-    end_index: 5,
+    start_index: range.start_index,
+    end_index: range.end_index,
     body: `Comment ${id}`,
     status,
     created_at: 0,
@@ -428,5 +432,80 @@ describe("CommentsPanel resize affordance", () => {
     } finally {
       Object.defineProperty(window, "innerWidth", { configurable: true, value: orig });
     }
+  });
+});
+
+// ── Active-comment reveal (selecting a highlight in the file) ──────────────
+//
+// Selecting a highlighted range in the file sets activeSelection to that
+// comment's range. The panel must reveal the matching card: switch to the tab
+// that holds it (if needed) and scroll it into view. scrollIntoView isn't
+// implemented in jsdom, so it's stubbed to record the call.
+
+function renderWithSelection(
+  comments: Comment[],
+  addressedComments: Comment[],
+  activeSelection: ActiveSelection | null,
+) {
+  return render(
+    <CommentsPanel
+      comments={comments}
+      addressedComments={addressedComments}
+      activeSelection={activeSelection}
+      onAddComment={vi.fn()}
+      onAddressAll={vi.fn()}
+      onEditComment={vi.fn()}
+      onDeleteComment={vi.fn()}
+      onClickComment={vi.fn()}
+      canAddress={false}
+      addressPending={false}
+    />,
+  );
+}
+
+/** Run pending requestAnimationFrame callbacks (the scroll effect defers via rAF). */
+function flushRaf(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+describe("CommentsPanel active-comment reveal", () => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  it("scrolls the active comment's card into view", async () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+
+    const target = makeComment("c2", "draft", { start_index: 40, end_index: 60 });
+    renderWithSelection([makeComment("c1"), target], [], {
+      start_index: 40,
+      end_index: 60,
+      anchor_content: "hello",
+    });
+    await flushRaf();
+
+    // Only the matching card scrolls, and it scrolls without yanking layout
+    // when already visible (block: nearest).
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
+  });
+
+  it("switches to the Addressed tab when the active comment lives there", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const addressed = makeComment("c2", "addressed", { start_index: 40, end_index: 60 });
+    renderWithSelection([makeComment("c1")], [addressed], {
+      start_index: 40,
+      end_index: 60,
+      anchor_content: "hello",
+    });
+    await flushRaf();
+
+    // The Addressed tab must become active so the card is rendered; its body
+    // ("Comment c2") is then in the document.
+    expect(screen.getByText("Comment c2")).toBeInTheDocument();
   });
 });

--- a/web/src/shell/CommentsPanel.tsx
+++ b/web/src/shell/CommentsPanel.tsx
@@ -87,6 +87,7 @@ export function CommentsPanel({
   const [body, setBody] = useState("");
   const [tab, setTab] = useState<Tab>("open");
   const addCommentTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const selectedCardRef = useRef<HTMLDivElement>(null);
   const { width, containerRef, isDesktop, handleProps } = useResizableCommentsPanel();
 
   // Editing or deleting a comment is author-only (the backend enforces this
@@ -117,6 +118,32 @@ export function CommentsPanel({
       return () => cancelAnimationFrame(id);
     }
   }, [activeSelection?.start_index, activeSelection?.end_index, comments]);
+
+  // Selecting a highlighted range in the file activates its comment; if that
+  // comment lives on the other tab, switch to the tab that holds it so its card
+  // is rendered (and can then be scrolled into view below).
+  useEffect(() => {
+    if (!activeSelection) return;
+    const matches = (c: Comment) =>
+      c.start_index === activeSelection.start_index && c.end_index === activeSelection.end_index;
+    if (tab === "open" && !comments.some(matches) && addressedComments.some(matches)) {
+      setTab("addressed");
+    } else if (tab === "addressed" && !addressedComments.some(matches) && comments.some(matches)) {
+      setTab("open");
+    }
+  }, [activeSelection, comments, addressedComments, tab]);
+
+  // Scroll the active comment's card into view within the panel, so selecting a
+  // highlight in the file reveals its card even when the list is long. rAF lets
+  // a tab switch render the card first. `block: nearest` avoids scrolling when
+  // it's already visible.
+  useEffect(() => {
+    if (!activeSelection) return;
+    const id = requestAnimationFrame(() =>
+      selectedCardRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" }),
+    );
+    return () => cancelAnimationFrame(id);
+  }, [activeSelection, tab]);
 
   return (
     <div
@@ -242,20 +269,23 @@ export function CommentsPanel({
             </div>
           ) : (
             <div className="space-y-2 p-3">
-              {comments.map((c) => (
-                <CommentCard
-                  key={c.id}
-                  comment={c}
-                  isSelected={
-                    activeSelection?.start_index === c.start_index &&
-                    activeSelection?.end_index === c.end_index
-                  }
-                  onClick={() => onClickComment(c)}
-                  onDelete={canModify(c) ? () => onDeleteComment(c.id) : undefined}
-                  onEdit={canModify(c) ? (newBody) => onEditComment(c.id, newBody) : undefined}
-                  onCopyLink={onCopyCommentLink ? () => onCopyCommentLink(c.id) : undefined}
-                />
-              ))}
+              {comments.map((c) => {
+                const isSelected =
+                  activeSelection?.start_index === c.start_index &&
+                  activeSelection?.end_index === c.end_index;
+                return (
+                  <CommentCard
+                    key={c.id}
+                    comment={c}
+                    isSelected={isSelected}
+                    cardRef={isSelected ? selectedCardRef : undefined}
+                    onClick={() => onClickComment(c)}
+                    onDelete={canModify(c) ? () => onDeleteComment(c.id) : undefined}
+                    onEdit={canModify(c) ? (newBody) => onEditComment(c.id, newBody) : undefined}
+                    onCopyLink={onCopyCommentLink ? () => onCopyCommentLink(c.id) : undefined}
+                  />
+                );
+              })}
             </div>
           )
         ) : addressedComments.length === 0 ? (
@@ -264,14 +294,21 @@ export function CommentsPanel({
           </div>
         ) : (
           <div className="space-y-2 p-3">
-            {addressedComments.map((c) => (
-              <CommentCard
-                key={c.id}
-                comment={c}
-                onDelete={canModify(c) ? () => onDeleteComment(c.id) : undefined}
-                onCopyLink={onCopyCommentLink ? () => onCopyCommentLink(c.id) : undefined}
-              />
-            ))}
+            {addressedComments.map((c) => {
+              const isSelected =
+                activeSelection?.start_index === c.start_index &&
+                activeSelection?.end_index === c.end_index;
+              return (
+                <CommentCard
+                  key={c.id}
+                  comment={c}
+                  isSelected={isSelected}
+                  cardRef={isSelected ? selectedCardRef : undefined}
+                  onDelete={canModify(c) ? () => onDeleteComment(c.id) : undefined}
+                  onCopyLink={onCopyCommentLink ? () => onCopyCommentLink(c.id) : undefined}
+                />
+              );
+            })}
           </div>
         )}
       </div>
@@ -286,6 +323,8 @@ export function CommentsPanel({
 interface CommentCardProps {
   comment: Comment;
   isSelected?: boolean;
+  /** Set on the currently-selected card so the panel can scroll it into view. */
+  cardRef?: RefObject<HTMLDivElement | null>;
   onClick?: () => void;
   onEdit?: (body: string) => void;
   onDelete?: () => void;
@@ -295,6 +334,7 @@ interface CommentCardProps {
 function CommentCard({
   comment: c,
   isSelected,
+  cardRef,
   onClick,
   onEdit,
   onDelete,
@@ -355,6 +395,7 @@ function CommentCard({
 
   return (
     <div
+      ref={cardRef}
       className={cn(
         "rounded-lg border p-3 space-y-2 transition-colors",
         isSelected

--- a/web/src/shell/HtmlCommentViewer.test.tsx
+++ b/web/src/shell/HtmlCommentViewer.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HtmlCommentViewer } from "./HtmlCommentViewer";
+
+// Permissions gate the floating "Add comment" button; default to editable.
+vi.mock("@/hooks/usePermissions", () => ({ useCanEdit: vi.fn(() => true) }));
+
+afterEach(cleanup);
+
+function renderViewer(content: string, truncated = false) {
+  return render(
+    <HtmlCommentViewer
+      conversationId="conv_1"
+      content={content}
+      truncated={truncated}
+      comments={[]}
+      activeSelection={null}
+      onSetActiveSelection={() => {}}
+    />,
+  );
+}
+
+describe("HtmlCommentViewer", () => {
+  it("renders the preview in a sandboxed iframe that still withholds allow-same-origin", () => {
+    const { container } = renderViewer("<html><body><p>doc</p></body></html>");
+    const iframe = container.querySelector('iframe[title="HTML preview"]') as HTMLIFrameElement;
+    expect(iframe).not.toBeNull();
+    const sandbox = iframe.getAttribute("sandbox") ?? "";
+    expect(sandbox).toContain("allow-scripts");
+    // The security-critical invariant: the opaque origin must be preserved so
+    // untrusted artifact HTML can never reach the host app.
+    expect(sandbox).not.toContain("allow-same-origin");
+  });
+
+  it("injects the comment bridge (and base-target) into the iframe srcDoc", () => {
+    const { container } = renderViewer("<html><head></head><body><p>doc</p></body></html>");
+    const iframe = container.querySelector('iframe[title="HTML preview"]') as HTMLIFrameElement;
+    const srcDoc = iframe.getAttribute("srcdoc") ?? "";
+    expect(srcDoc).toContain("<script>");
+    expect(srcDoc).toContain("omni-html-comment");
+    expect(srcDoc).toContain('<base target="_blank">');
+  });
+
+  it("shows the truncated banner only when truncated", () => {
+    const { queryByText, rerender } = renderViewer("<body>x</body>", false);
+    expect(queryByText(/truncated/i)).toBeNull();
+    rerender(
+      <HtmlCommentViewer
+        conversationId="conv_1"
+        content="<body>x</body>"
+        truncated={true}
+        comments={[]}
+        activeSelection={null}
+        onSetActiveSelection={() => {}}
+      />,
+    );
+    expect(queryByText(/truncated/i)).not.toBeNull();
+  });
+
+  it("does not show the floating Add-comment button before any selection", () => {
+    renderViewer("<body><p>doc</p></body>");
+    expect(document.querySelector("[data-add-comment-btn]")).toBeNull();
+  });
+});

--- a/web/src/shell/HtmlCommentViewer.tsx
+++ b/web/src/shell/HtmlCommentViewer.tsx
@@ -1,0 +1,238 @@
+// Comment-enabled HTML preview: renders agent-generated HTML in the same
+// sandboxed iframe as the read-only preview, but injects a bridge script so
+// users can select rendered text and attach review comments — parity with the
+// Markdown (TipTap) and code (Monaco/Shiki) comment surfaces.
+//
+// The iframe stays sandboxed WITHOUT `allow-same-origin` (see HTML_PREVIEW_SANDBOX),
+// so the parent can't touch its DOM directly. All selection capture and
+// highlight painting happens inside the iframe via the injected bridge, relayed
+// over a private MessageChannel. See htmlCommentBridge.ts for the protocol and
+// trust model.
+
+import { createPortal } from "react-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { MessageSquarePlusIcon } from "lucide-react";
+import { type Comment } from "@/hooks/useComments";
+import { useCanEdit } from "@/hooks/usePermissions";
+import { getEmbedRoot } from "@/lib/host";
+import { type ActiveSelection, HTML_PREVIEW_SANDBOX } from "./codeViewerHelpers";
+import {
+  BRIDGE_MSG,
+  BRIDGE_SOURCE,
+  findAnchorInSource,
+  injectCommentBridge,
+  parseBridgeMessage,
+} from "./htmlCommentBridge";
+import { TruncatedBanner } from "./TruncatedBanner";
+
+interface HtmlCommentViewerProps {
+  conversationId: string;
+  /** Raw HTML source — rendered in the iframe and searched for comment anchors. */
+  content: string;
+  truncated: boolean;
+  comments: Comment[];
+  activeSelection: ActiveSelection | null;
+  onSetActiveSelection: (sel: ActiveSelection | null) => void;
+}
+
+/** Floating "Add comment" button position + the resolved selection it commits. */
+interface FloatingAnchor {
+  x: number;
+  y: number;
+  start_index: number;
+  end_index: number;
+  anchor_content: string;
+}
+
+function genNonce(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  // Deterministic-enough fallback for environments without crypto.randomUUID.
+  return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+}
+
+export function HtmlCommentViewer({
+  conversationId,
+  content,
+  truncated,
+  comments,
+  activeSelection,
+  onSetActiveSelection,
+}: HtmlCommentViewerProps) {
+  const canEdit = useCanEdit(conversationId);
+
+  // A fresh nonce + srcDoc per content load. Changing srcDoc reloads the iframe
+  // document, which re-runs the bridge and (via the new nonce) re-establishes
+  // the channel — clearing any stale highlights from the previous content.
+  const { nonce, srcDoc } = useMemo(() => {
+    const n = genNonce();
+    return { nonce: n, srcDoc: injectCommentBridge(content, n) };
+  }, [content]);
+
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const portRef = useRef<MessagePort | null>(null);
+  const [floating, setFloating] = useState<FloatingAnchor | null>(null);
+
+  // Latest values for the port message handler without re-establishing the channel.
+  const commentsRef = useRef(comments);
+  commentsRef.current = comments;
+  const contentRef = useRef(content);
+  contentRef.current = content;
+  const onSetActiveSelectionRef = useRef(onSetActiveSelection);
+  onSetActiveSelectionRef.current = onSetActiveSelection;
+  const activeSelectionRef = useRef(activeSelection);
+  activeSelectionRef.current = activeSelection;
+
+  // Establish the MessageChannel once the iframe document has loaded. Parent-
+  // initiated handshake (post init on load) avoids a ready/listen race.
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    let channel: MessageChannel | null = null;
+
+    const handleInbound = (raw: unknown) => {
+      const msg = parseBridgeMessage(raw, nonce);
+      if (!msg) return;
+      if (msg.type === BRIDGE_MSG.ready) {
+        // Flush current state now that the frame is connected.
+        postState();
+      } else if (msg.type === BRIDGE_MSG.selection) {
+        const rect = iframe.getBoundingClientRect();
+        const offsets = findAnchorInSource(contentRef.current, msg.text);
+        setFloating({
+          x: rect.left + msg.rect.left,
+          y: rect.top + msg.rect.top - 6,
+          start_index: offsets?.start_index ?? 0,
+          end_index: offsets?.end_index ?? 0,
+          anchor_content: msg.text,
+        });
+      } else if (msg.type === BRIDGE_MSG.commentClick) {
+        const c = commentsRef.current.find((x) => x.id === msg.id);
+        if (c) {
+          onSetActiveSelectionRef.current({
+            start_index: c.start_index,
+            end_index: c.end_index,
+            anchor_content: c.anchor_content ?? "",
+          });
+        }
+        setFloating(null);
+      } else if (msg.type === BRIDGE_MSG.selectionCleared) {
+        onSetActiveSelectionRef.current(null);
+        setFloating(null);
+      }
+    };
+
+    const postState = () => {
+      const port = portRef.current;
+      if (!port) return;
+      port.postMessage({
+        source: BRIDGE_SOURCE,
+        nonce,
+        type: BRIDGE_MSG.setComments,
+        comments: commentsRef.current.map((c) => ({
+          id: c.id,
+          anchor_content: c.anchor_content ?? "",
+        })),
+      });
+      port.postMessage({
+        source: BRIDGE_SOURCE,
+        nonce,
+        type: BRIDGE_MSG.setActive,
+        active: activeSelectionRef.current
+          ? { anchor_content: activeSelectionRef.current.anchor_content }
+          : null,
+      });
+    };
+
+    const onLoad = () => {
+      const win = iframe.contentWindow;
+      if (!win) return;
+      channel?.port1.close();
+      channel = new MessageChannel();
+      channel.port1.onmessage = (ev) => handleInbound(ev.data);
+      portRef.current = channel.port1;
+      // targetOrigin "*" is required: the sandboxed frame has an opaque ("null")
+      // origin, so we cannot name a concrete origin. The transferred port + the
+      // nonce are the trust mechanism, not the origin.
+      win.postMessage({ source: BRIDGE_SOURCE, nonce, type: BRIDGE_MSG.init }, "*", [
+        channel.port2,
+      ]);
+    };
+
+    iframe.addEventListener("load", onLoad);
+    return () => {
+      iframe.removeEventListener("load", onLoad);
+      channel?.port1.close();
+      portRef.current = null;
+    };
+  }, [nonce]);
+
+  // Push comment-list changes into the frame.
+  useEffect(() => {
+    portRef.current?.postMessage({
+      source: BRIDGE_SOURCE,
+      nonce,
+      type: BRIDGE_MSG.setComments,
+      comments: comments.map((c) => ({ id: c.id, anchor_content: c.anchor_content ?? "" })),
+    });
+  }, [comments, nonce]);
+
+  // Push active-selection changes into the frame (drives the active highlight).
+  useEffect(() => {
+    portRef.current?.postMessage({
+      source: BRIDGE_SOURCE,
+      nonce,
+      type: BRIDGE_MSG.setActive,
+      active: activeSelection ? { anchor_content: activeSelection.anchor_content } : null,
+    });
+  }, [activeSelection, nonce]);
+
+  // Dismiss the floating button on any mousedown in the parent outside of it.
+  // (Clicks inside the iframe are relayed as selection/clear messages instead.)
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (!(e.target as HTMLElement).closest("[data-add-comment-btn]")) setFloating(null);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, []);
+
+  const preview = (
+    <iframe
+      ref={iframeRef}
+      srcDoc={srcDoc}
+      // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
+      sandbox={HTML_PREVIEW_SANDBOX}
+      title="HTML preview"
+      className="w-full h-full border-0"
+    />
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      {truncated && <TruncatedBanner />}
+      <div className="min-h-0 flex-1">{preview}</div>
+      {floating &&
+        canEdit &&
+        createPortal(
+          <button
+            data-add-comment-btn
+            type="button"
+            className="fixed z-50 flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+            style={{ left: floating.x, top: floating.y, transform: "translateY(-100%)" }}
+            onClick={() => {
+              onSetActiveSelection({
+                start_index: floating.start_index,
+                end_index: floating.end_index,
+                anchor_content: floating.anchor_content,
+              });
+              setFloating(null);
+            }}
+          >
+            <MessageSquarePlusIcon className="size-3.5" />
+            Add comment
+          </button>,
+          getEmbedRoot() ?? document.body,
+        )}
+    </div>
+  );
+}

--- a/web/src/shell/HtmlCommentViewer.tsx
+++ b/web/src/shell/HtmlCommentViewer.tsx
@@ -17,6 +17,7 @@ import { useCanEdit } from "@/hooks/usePermissions";
 import { getEmbedRoot } from "@/lib/host";
 import { type ActiveSelection, HTML_PREVIEW_SANDBOX } from "./codeViewerHelpers";
 import {
+  anchorOccurrence,
   BRIDGE_MSG,
   BRIDGE_SOURCE,
   findAnchorInSource,
@@ -48,6 +49,27 @@ function genNonce(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
   // Deterministic-enough fallback for environments without crypto.randomUUID.
   return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+}
+
+/** Bridge payload for one comment: its id, anchor text, and which occurrence of
+ * that text (by source offset) it belongs to — so repeated anchor text such as
+ * a title reused in the body highlights only the commented instance. */
+function commentPayload(content: string, c: Comment) {
+  const anchor = c.anchor_content ?? "";
+  return {
+    id: c.id,
+    anchor_content: anchor,
+    occ: anchorOccurrence(content, anchor, c.start_index),
+  };
+}
+
+/** Bridge payload for the active selection, or null. */
+function activePayload(content: string, sel: ActiveSelection | null) {
+  if (!sel) return null;
+  return {
+    anchor_content: sel.anchor_content,
+    occ: anchorOccurrence(content, sel.anchor_content, sel.start_index),
+  };
 }
 
 export function HtmlCommentViewer({
@@ -96,8 +118,24 @@ export function HtmlCommentViewer({
         // Flush current state now that the frame is connected.
         postState();
       } else if (msg.type === BRIDGE_MSG.selection) {
+        const offsets = findAnchorInSource(contentRef.current, msg.text, msg.occ);
+        // Selecting a range that already has a comment activates it (which
+        // scrolls the panel to its card) rather than offering to add a new one.
+        const existing =
+          offsets &&
+          commentsRef.current.find(
+            (c) => c.start_index === offsets.start_index && c.end_index === offsets.end_index,
+          );
+        if (existing) {
+          onSetActiveSelectionRef.current({
+            start_index: existing.start_index,
+            end_index: existing.end_index,
+            anchor_content: existing.anchor_content ?? "",
+          });
+          setFloating(null);
+          return;
+        }
         const rect = iframe.getBoundingClientRect();
-        const offsets = findAnchorInSource(contentRef.current, msg.text);
         setFloating({
           x: rect.left + msg.rect.left,
           y: rect.top + msg.rect.top - 6,
@@ -128,18 +166,13 @@ export function HtmlCommentViewer({
         source: BRIDGE_SOURCE,
         nonce,
         type: BRIDGE_MSG.setComments,
-        comments: commentsRef.current.map((c) => ({
-          id: c.id,
-          anchor_content: c.anchor_content ?? "",
-        })),
+        comments: commentsRef.current.map((c) => commentPayload(contentRef.current, c)),
       });
       port.postMessage({
         source: BRIDGE_SOURCE,
         nonce,
         type: BRIDGE_MSG.setActive,
-        active: activeSelectionRef.current
-          ? { anchor_content: activeSelectionRef.current.anchor_content }
-          : null,
+        active: activePayload(contentRef.current, activeSelectionRef.current),
       });
     };
 
@@ -172,9 +205,9 @@ export function HtmlCommentViewer({
       source: BRIDGE_SOURCE,
       nonce,
       type: BRIDGE_MSG.setComments,
-      comments: comments.map((c) => ({ id: c.id, anchor_content: c.anchor_content ?? "" })),
+      comments: comments.map((c) => commentPayload(content, c)),
     });
-  }, [comments, nonce]);
+  }, [comments, content, nonce]);
 
   // Push active-selection changes into the frame (drives the active highlight).
   useEffect(() => {
@@ -182,9 +215,9 @@ export function HtmlCommentViewer({
       source: BRIDGE_SOURCE,
       nonce,
       type: BRIDGE_MSG.setActive,
-      active: activeSelection ? { anchor_content: activeSelection.anchor_content } : null,
+      active: activePayload(content, activeSelection),
     });
-  }, [activeSelection, nonce]);
+  }, [activeSelection, content, nonce]);
 
   // Dismiss the floating button on any mousedown in the parent outside of it.
   // (Clicks inside the iframe are relayed as selection/clear messages instead.)

--- a/web/src/shell/htmlCommentBridge.test.ts
+++ b/web/src/shell/htmlCommentBridge.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  BRIDGE_MSG,
+  BRIDGE_SOURCE,
+  buildBridgeScript,
+  findAnchorInSource,
+  injectCommentBridge,
+  parseBridgeMessage,
+} from "./htmlCommentBridge";
+
+// ---------------------------------------------------------------------------
+// injectCommentBridge — script/style placement (mirrors prepareHtmlPreviewDoc)
+// ---------------------------------------------------------------------------
+
+describe("injectCommentBridge", () => {
+  const NONCE = "test-nonce-123";
+
+  it("injects the bridge script before </body> when present", () => {
+    const html = "<html><head></head><body><p>hi</p></body></html>";
+    const out = injectCommentBridge(html, NONCE);
+    const scriptAt = out.indexOf("<script>");
+    const bodyCloseAt = out.indexOf("</body>");
+    expect(scriptAt).toBeGreaterThan(-1);
+    expect(scriptAt).toBeLessThan(bodyCloseAt);
+    expect(out).toContain(NONCE);
+  });
+
+  it("falls back to before </html> when there is no body", () => {
+    const html = "<html><head></head><p>hi</p></html>";
+    const out = injectCommentBridge(html, NONCE);
+    expect(out.indexOf("<script>")).toBeLessThan(out.indexOf("</html>"));
+  });
+
+  it("appends to a bare fragment with no body/html", () => {
+    const out = injectCommentBridge("<p>just a fragment</p>", NONCE);
+    // prepareHtmlPreviewDoc prepends <base> for a bare fragment; the bridge is
+    // then appended at the end since there's no </body>/</html> to inject before.
+    expect(out).toContain("<p>just a fragment</p>");
+    const fragAt = out.indexOf("<p>just a fragment</p>");
+    expect(out.indexOf("<script>")).toBeGreaterThan(fragAt);
+  });
+
+  it("preserves the prepared <base target=_blank> link behavior", () => {
+    const out = injectCommentBridge("<html><head></head><body></body></html>", NONCE);
+    expect(out).toContain('<base target="_blank">');
+  });
+
+  it("includes the highlight style for the Custom Highlight ranges", () => {
+    const out = injectCommentBridge("<body></body>", NONCE);
+    expect(out).toContain("::highlight(omni-comment)");
+    expect(out).toContain("::highlight(omni-comment-active)");
+  });
+
+  it("substitutes the nonce, source tag, and message types into the script", () => {
+    const script = buildBridgeScript(NONCE);
+    expect(script).toContain(NONCE);
+    expect(script).toContain(BRIDGE_SOURCE);
+    expect(script).toContain(BRIDGE_MSG.selection);
+    // Placeholders must be fully replaced.
+    expect(script).not.toContain("__OMNI_NONCE__");
+    expect(script).not.toContain("__OMNI_TYPES__");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBridgeMessage — inbound validation (guards against spoofed postMessage)
+// ---------------------------------------------------------------------------
+
+describe("parseBridgeMessage", () => {
+  const NONCE = "n1";
+  const base = { source: BRIDGE_SOURCE, nonce: NONCE };
+
+  it("accepts a well-formed selection message", () => {
+    const msg = parseBridgeMessage(
+      { ...base, type: BRIDGE_MSG.selection, text: "Design Goals", rect: { left: 1, top: 2, right: 3, bottom: 4 } },
+      NONCE,
+    );
+    expect(msg).toEqual({
+      type: BRIDGE_MSG.selection,
+      text: "Design Goals",
+      rect: { left: 1, top: 2, right: 3, bottom: 4 },
+    });
+  });
+
+  it("round-trips anchor text containing quotes and newlines", () => {
+    const text = 'He said "hi"\nthen left';
+    const msg = parseBridgeMessage(
+      { ...base, type: BRIDGE_MSG.selection, text, rect: { left: 0, top: 0, right: 0, bottom: 0 } },
+      NONCE,
+    );
+    expect(msg && "text" in msg && msg.text).toBe(text);
+  });
+
+  it("accepts commentClick, selectionCleared, and ready", () => {
+    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.commentClick, id: "c1" }, NONCE)).toEqual({
+      type: BRIDGE_MSG.commentClick,
+      id: "c1",
+    });
+    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.selectionCleared }, NONCE)).toEqual({
+      type: BRIDGE_MSG.selectionCleared,
+    });
+    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.ready }, NONCE)).toEqual({
+      type: BRIDGE_MSG.ready,
+    });
+  });
+
+  it("rejects a wrong nonce (spoof from artifact JS)", () => {
+    expect(
+      parseBridgeMessage({ ...base, nonce: "other", type: BRIDGE_MSG.selectionCleared }, NONCE),
+    ).toBeNull();
+  });
+
+  it("rejects a wrong source tag", () => {
+    expect(
+      parseBridgeMessage({ source: "evil", nonce: NONCE, type: BRIDGE_MSG.selectionCleared }, NONCE),
+    ).toBeNull();
+  });
+
+  it("rejects an unknown type, a malformed selection, and non-objects", () => {
+    expect(parseBridgeMessage({ ...base, type: "omni:bogus" }, NONCE)).toBeNull();
+    // Empty text / missing rect must not produce a selection.
+    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.selection, text: "   " }, NONCE)).toBeNull();
+    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.selection, text: "x" }, NONCE)).toBeNull();
+    expect(parseBridgeMessage("not-an-object", NONCE)).toBeNull();
+    expect(parseBridgeMessage(null, NONCE)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAnchorInSource — rendered selection text -> raw HTML source offsets
+// ---------------------------------------------------------------------------
+
+describe("findAnchorInSource", () => {
+  it("returns exact offsets when the anchor is a verbatim substring", () => {
+    const src = "<h1>Title</h1><p>The quick brown fox.</p>";
+    const res = findAnchorInSource(src, "quick brown fox");
+    expect(res).not.toBeNull();
+    expect(src.slice(res!.start_index, res!.end_index)).toBe("quick brown fox");
+  });
+
+  it("trims the anchor before matching", () => {
+    const src = "<p>hello world</p>";
+    const res = findAnchorInSource(src, "  hello world  ");
+    expect(src.slice(res!.start_index, res!.end_index)).toBe("hello world");
+  });
+
+  it("tolerates collapsed whitespace via a normalized fallback", () => {
+    // Rendered selection collapses the newline+indent the source spells out.
+    const src = "<p>Design\n      goals matter</p>";
+    const res = findAnchorInSource(src, "Design goals matter");
+    expect(res).not.toBeNull();
+    expect(src.slice(res!.start_index, res!.end_index)).toBe("Design\n      goals matter");
+  });
+
+  it("returns null when the anchor is empty or absent", () => {
+    expect(findAnchorInSource("<p>hi</p>", "   ")).toBeNull();
+    expect(findAnchorInSource("<p>hi</p>", "not present anywhere")).toBeNull();
+  });
+
+  it("picks the first occurrence for repeated text", () => {
+    const src = "alpha beta alpha";
+    const res = findAnchorInSource(src, "alpha");
+    expect(res).toEqual({ start_index: 0, end_index: 5 });
+  });
+});

--- a/web/src/shell/htmlCommentBridge.test.ts
+++ b/web/src/shell/htmlCommentBridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  anchorOccurrence,
   BRIDGE_MSG,
   BRIDGE_SOURCE,
   buildBridgeScript,
@@ -60,6 +61,12 @@ describe("injectCommentBridge", () => {
     expect(script).not.toContain("__OMNI_NONCE__");
     expect(script).not.toContain("__OMNI_TYPES__");
   });
+
+  it("produces a syntactically valid script (guards template-literal escaping)", () => {
+    // The script body is a template literal; regex/backslash content in it can
+    // silently break parsing. new Function throws on a syntax error.
+    expect(() => new Function(buildBridgeScript(NONCE))).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -70,16 +77,36 @@ describe("parseBridgeMessage", () => {
   const NONCE = "n1";
   const base = { source: BRIDGE_SOURCE, nonce: NONCE };
 
-  it("accepts a well-formed selection message", () => {
+  it("accepts a well-formed selection message with its occurrence index", () => {
     const msg = parseBridgeMessage(
-      { ...base, type: BRIDGE_MSG.selection, text: "Design Goals", rect: { left: 1, top: 2, right: 3, bottom: 4 } },
+      {
+        ...base,
+        type: BRIDGE_MSG.selection,
+        text: "Design Goals",
+        occ: 2,
+        rect: { left: 1, top: 2, right: 3, bottom: 4 },
+      },
       NONCE,
     );
     expect(msg).toEqual({
       type: BRIDGE_MSG.selection,
       text: "Design Goals",
+      occ: 2,
       rect: { left: 1, top: 2, right: 3, bottom: 4 },
     });
+  });
+
+  it("defaults occ to 0 when a selection message omits it (older frame)", () => {
+    const msg = parseBridgeMessage(
+      {
+        ...base,
+        type: BRIDGE_MSG.selection,
+        text: "x",
+        rect: { left: 0, top: 0, right: 0, bottom: 0 },
+      },
+      NONCE,
+    );
+    expect(msg).toMatchObject({ type: BRIDGE_MSG.selection, occ: 0 });
   });
 
   it("round-trips anchor text containing quotes and newlines", () => {
@@ -92,10 +119,12 @@ describe("parseBridgeMessage", () => {
   });
 
   it("accepts commentClick, selectionCleared, and ready", () => {
-    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.commentClick, id: "c1" }, NONCE)).toEqual({
-      type: BRIDGE_MSG.commentClick,
-      id: "c1",
-    });
+    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.commentClick, id: "c1" }, NONCE)).toEqual(
+      {
+        type: BRIDGE_MSG.commentClick,
+        id: "c1",
+      },
+    );
     expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.selectionCleared }, NONCE)).toEqual({
       type: BRIDGE_MSG.selectionCleared,
     });
@@ -112,15 +141,22 @@ describe("parseBridgeMessage", () => {
 
   it("rejects a wrong source tag", () => {
     expect(
-      parseBridgeMessage({ source: "evil", nonce: NONCE, type: BRIDGE_MSG.selectionCleared }, NONCE),
+      parseBridgeMessage(
+        { source: "evil", nonce: NONCE, type: BRIDGE_MSG.selectionCleared },
+        NONCE,
+      ),
     ).toBeNull();
   });
 
   it("rejects an unknown type, a malformed selection, and non-objects", () => {
     expect(parseBridgeMessage({ ...base, type: "omni:bogus" }, NONCE)).toBeNull();
     // Empty text / missing rect must not produce a selection.
-    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.selection, text: "   " }, NONCE)).toBeNull();
-    expect(parseBridgeMessage({ ...base, type: BRIDGE_MSG.selection, text: "x" }, NONCE)).toBeNull();
+    expect(
+      parseBridgeMessage({ ...base, type: BRIDGE_MSG.selection, text: "   " }, NONCE),
+    ).toBeNull();
+    expect(
+      parseBridgeMessage({ ...base, type: BRIDGE_MSG.selection, text: "x" }, NONCE),
+    ).toBeNull();
     expect(parseBridgeMessage("not-an-object", NONCE)).toBeNull();
     expect(parseBridgeMessage(null, NONCE)).toBeNull();
   });
@@ -157,9 +193,68 @@ describe("findAnchorInSource", () => {
     expect(findAnchorInSource("<p>hi</p>", "not present anywhere")).toBeNull();
   });
 
-  it("picks the first occurrence for repeated text", () => {
+  it("picks the first occurrence for repeated text by default", () => {
     const src = "alpha beta alpha";
     const res = findAnchorInSource(src, "alpha");
     expect(res).toEqual({ start_index: 0, end_index: 5 });
+  });
+
+  it("resolves the requested occurrence for repeated text", () => {
+    // "Aurora Sync" as a title, then again in body prose — selecting the body
+    // copy (occurrence 1) must anchor to the SECOND match, not the first.
+    const src = "<h1>Aurora Sync</h1><p>Aurora Sync keeps state.</p>";
+    const first = src.indexOf("Aurora Sync");
+    const second = src.indexOf("Aurora Sync", first + 1);
+    expect(findAnchorInSource(src, "Aurora Sync", 0)).toEqual({
+      start_index: first,
+      end_index: first + "Aurora Sync".length,
+    });
+    expect(findAnchorInSource(src, "Aurora Sync", 1)).toEqual({
+      start_index: second,
+      end_index: second + "Aurora Sync".length,
+    });
+  });
+
+  it("resolves a later occurrence even when an earlier one is whitespace-wrapped", () => {
+    const src = "<p>then\n   latency</p><p>then latency again</p>";
+    const second = src.indexOf("then latency again");
+    expect(findAnchorInSource(src, "then latency", 1)).toEqual({
+      start_index: second,
+      end_index: second + "then latency".length,
+    });
+  });
+
+  it("returns null when the requested occurrence doesn't exist", () => {
+    expect(findAnchorInSource("only once here", "once", 3)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// anchorOccurrence — which copy of repeated anchor text a comment refers to
+// ---------------------------------------------------------------------------
+
+describe("anchorOccurrence", () => {
+  // A title reused verbatim in the body — the exact case that highlighted both.
+  const src = "<h1>Aurora Sync</h1><p>Aurora Sync keeps state.</p>";
+  const first = src.indexOf("Aurora Sync");
+  const second = src.indexOf("Aurora Sync", first + 1);
+
+  it("returns 0 for the first occurrence (the title)", () => {
+    expect(anchorOccurrence(src, "Aurora Sync", first)).toBe(0);
+  });
+
+  it("returns 1 for the second occurrence (the body)", () => {
+    expect(anchorOccurrence(src, "Aurora Sync", second)).toBe(1);
+  });
+
+  it("counts whitespace-tolerantly so wrapped source occurrences still count", () => {
+    // First occurrence wraps across lines; the second is the target.
+    const wrapped = "<p>then\n   latency</p><p>then latency again</p>";
+    const target = wrapped.indexOf("then latency again");
+    expect(anchorOccurrence(wrapped, "then latency", target)).toBe(1);
+  });
+
+  it("returns 0 for empty anchor text", () => {
+    expect(anchorOccurrence(src, "   ", 0)).toBe(0);
   });
 });

--- a/web/src/shell/htmlCommentBridge.ts
+++ b/web/src/shell/htmlCommentBridge.ts
@@ -170,8 +170,10 @@ export function findAnchorInSource(
   // whitespace that the source spells out (newlines, indentation between tags).
   const pattern = trimmed.split(/\s+/).map(escapeRegExp).join("\\s+");
   try {
-    const match = new RegExp(pattern).exec(source);
-    if (match) return { start_index: match.index, end_index: match.index + match[0].length };
+    const match = source.match(new RegExp(pattern));
+    if (match?.index !== undefined) {
+      return { start_index: match.index, end_index: match.index + match[0].length };
+    }
   } catch {
     // Pathological anchor produced an invalid pattern — fall through to null.
   }

--- a/web/src/shell/htmlCommentBridge.ts
+++ b/web/src/shell/htmlCommentBridge.ts
@@ -1,0 +1,427 @@
+// Bridge between the host app and the sandboxed HTML-preview iframe so users
+// can comment on *rendered* HTML the same way they comment on Markdown/code.
+//
+// Why a bridge at all:
+//   The HTML preview iframe is deliberately sandboxed WITHOUT `allow-same-origin`
+//   (see HTML_PREVIEW_SANDBOX in codeViewerHelpers.ts) so untrusted, agent-
+//   generated HTML runs in an opaque origin and cannot reach the host app. That
+//   same isolation means the parent CANNOT read the iframe's selection or DOM.
+//   So we inject a small, app-authored script into the iframe that reads the
+//   selection *inside* the frame and relays it over a private MessageChannel,
+//   and paints highlights *inside* the frame on command. The sandbox flags are
+//   unchanged — postMessage works fine across the opaque-origin boundary.
+//
+// Trust model:
+//   Post-handshake messages travel over a MessagePort that only the parent and
+//   the injected script hold, so ordinary page content can't read them. The
+//   initial init message (which transfers the port) is delivered to *every*
+//   `message` listener in the frame, so in principle artifact JS could grab the
+//   port and post spoofed selections. That is a bounded, low-severity nuisance
+//   confined to the review UI: it can never reach host-app data (the opaque
+//   origin still applies), which is exactly the property the sandbox guarantees.
+//   We still gate on a per-mount nonce + a source tag to reject stray messages.
+//
+// These helpers are pure (no React) so they unit-test in isolation.
+
+import { prepareHtmlPreviewDoc } from "./codeViewerHelpers";
+
+/** Protocol version — bump on any breaking change to the message shapes. */
+export const BRIDGE_VERSION = 1;
+
+/** Tag stamped on every message so we ignore unrelated postMessage traffic. */
+export const BRIDGE_SOURCE = "omni-html-comment";
+
+/** Message type strings shared by parent and the injected script. */
+export const BRIDGE_MSG = {
+  /** parent → iframe: hands over the MessagePort (transferred). */
+  init: "omni:init",
+  /** iframe → parent: port adopted, ready to receive state. */
+  ready: "omni:ready",
+  /** parent → iframe: full set of comments to highlight. */
+  setComments: "omni:setComments",
+  /** parent → iframe: the currently-active comment/selection (or null). */
+  setActive: "omni:setActive",
+  /** iframe → parent: the user made a non-empty text selection. */
+  selection: "omni:selection",
+  /** iframe → parent: the user clicked inside an existing comment range. */
+  commentClick: "omni:commentClick",
+  /** iframe → parent: the selection collapsed without hitting a comment. */
+  selectionCleared: "omni:selectionCleared",
+} as const;
+
+/** Rect of a selection in the iframe's own viewport coordinates. */
+export interface BridgeRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/** A selection event relayed from inside the iframe. */
+export interface BridgeSelection {
+  type: typeof BRIDGE_MSG.selection;
+  /** The selected rendered text, used as the comment anchor_content. */
+  text: string;
+  rect: BridgeRect;
+}
+
+export interface BridgeCommentClick {
+  type: typeof BRIDGE_MSG.commentClick;
+  id: string;
+}
+
+export interface BridgeSelectionCleared {
+  type: typeof BRIDGE_MSG.selectionCleared;
+}
+
+export interface BridgeReady {
+  type: typeof BRIDGE_MSG.ready;
+}
+
+/** Any message the iframe can send to the parent (post-handshake). */
+export type InboundBridgeMessage =
+  | BridgeReady
+  | BridgeSelection
+  | BridgeCommentClick
+  | BridgeSelectionCleared;
+
+// ---------------------------------------------------------------------------
+// Inbound message validation
+// ---------------------------------------------------------------------------
+
+function isRect(r: unknown): r is BridgeRect {
+  if (typeof r !== "object" || r === null) return false;
+  const o = r as Record<string, unknown>;
+  return (
+    typeof o.left === "number" &&
+    typeof o.top === "number" &&
+    typeof o.right === "number" &&
+    typeof o.bottom === "number"
+  );
+}
+
+/**
+ * Validate and narrow a raw message received from the iframe. Returns the typed
+ * message on success, or `null` for anything that isn't a well-formed bridge
+ * message carrying the expected `nonce` — guarding against arbitrary
+ * postMessage traffic (including spoofs from artifact JS).
+ *
+ * @param data  The raw `MessageEvent.data`.
+ * @param nonce The per-mount nonce the iframe was initialised with.
+ */
+export function parseBridgeMessage(data: unknown, nonce: string): InboundBridgeMessage | null {
+  if (typeof data !== "object" || data === null) return null;
+  const d = data as Record<string, unknown>;
+  if (d.source !== BRIDGE_SOURCE || d.nonce !== nonce) return null;
+  switch (d.type) {
+    case BRIDGE_MSG.ready:
+      return { type: BRIDGE_MSG.ready };
+    case BRIDGE_MSG.selection:
+      if (typeof d.text === "string" && d.text.trim() !== "" && isRect(d.rect)) {
+        return { type: BRIDGE_MSG.selection, text: d.text, rect: d.rect };
+      }
+      return null;
+    case BRIDGE_MSG.commentClick:
+      if (typeof d.id === "string" && d.id !== "") {
+        return { type: BRIDGE_MSG.commentClick, id: d.id };
+      }
+      return null;
+    case BRIDGE_MSG.selectionCleared:
+      return { type: BRIDGE_MSG.selectionCleared };
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source-offset resolution (parent side)
+// ---------------------------------------------------------------------------
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Locate `anchor` (text selected in the *rendered* HTML) within the raw HTML
+ * `source`, returning absolute character offsets so the comment anchors to the
+ * source the agent actually edits — consistent with how Markdown/code comments
+ * store offsets.
+ *
+ * Rendered prose is almost always a verbatim substring of the source, so an
+ * exact match succeeds in the common case. When the browser has collapsed or
+ * altered whitespace (e.g. text wrapping across source lines), we fall back to a
+ * whitespace-tolerant match that maps back to raw source indices.
+ *
+ * Returns `null` when the anchor can't be located at all; callers should still
+ * keep `anchor_content`, which is the agent's primary locator (offsets are a
+ * hint), and let `classifyAndRemapComments` re-anchor on a later load.
+ */
+export function findAnchorInSource(
+  source: string,
+  anchor: string,
+): { start_index: number; end_index: number } | null {
+  const trimmed = anchor.trim();
+  if (!trimmed) return null;
+
+  const exact = source.indexOf(trimmed);
+  if (exact !== -1) return { start_index: exact, end_index: exact + trimmed.length };
+
+  // Whitespace-tolerant fallback: rendered selection text may collapse runs of
+  // whitespace that the source spells out (newlines, indentation between tags).
+  const pattern = trimmed.split(/\s+/).map(escapeRegExp).join("\\s+");
+  try {
+    const match = new RegExp(pattern).exec(source);
+    if (match) return { start_index: match.index, end_index: match.index + match[0].length };
+  } catch {
+    // Pathological anchor produced an invalid pattern — fall through to null.
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Injected bridge script
+// ---------------------------------------------------------------------------
+
+// The script that runs INSIDE the sandboxed iframe. Authored as a plain string
+// (no template interpolation / backticks) so it can be injected verbatim; the
+// per-mount nonce is substituted via `.replace` in buildBridgeScript(). Must be
+// dependency-free vanilla JS — it runs in the artifact's opaque-origin document.
+const BRIDGE_SCRIPT_BODY = `(function () {
+  var NONCE = "__OMNI_NONCE__";
+  var SRC = "__OMNI_SRC__";
+  var T = __OMNI_TYPES__;
+  var port = null;
+  var comments = [];        // [{ id, anchor_content }]
+  var activeAnchor = null;  // string | null
+  var ranges = [];          // [{ id, range }] for click hit-testing
+
+  function send(msg) {
+    if (!port) return;
+    msg.source = SRC;
+    msg.nonce = NONCE;
+    try { port.postMessage(msg); } catch (e) {}
+  }
+
+  // Flat index of visible text nodes -> concatenated string, so an anchor that
+  // spans multiple nodes still resolves to a single Range.
+  function buildIndex() {
+    var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (n) {
+        var p = n.parentElement;
+        if (!p) return NodeFilter.FILTER_REJECT;
+        var tag = p.tagName;
+        if (tag === "SCRIPT" || tag === "STYLE" || tag === "NOSCRIPT") {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+    var nodes = [];
+    var text = "";
+    var n;
+    while ((n = walker.nextNode())) {
+      nodes.push({ node: n, start: text.length });
+      text += n.nodeValue;
+    }
+    return { nodes: nodes, text: text };
+  }
+
+  function locate(nodes, pos) {
+    for (var i = 0; i < nodes.length; i++) {
+      var len = nodes[i].node.nodeValue.length;
+      if (pos <= nodes[i].start + len) {
+        return { node: nodes[i].node, offset: pos - nodes[i].start };
+      }
+    }
+    var last = nodes[nodes.length - 1];
+    return last ? { node: last.node, offset: last.node.nodeValue.length } : null;
+  }
+
+  // All ranges whose text equals the (whitespace-tolerant) anchor.
+  function anchorRanges(index, anchor) {
+    var out = [];
+    var needle = (anchor || "").trim();
+    if (!needle) return out;
+    var hay = index.text;
+    var from = 0;
+    var guard = 0;
+    while (guard++ < 1000) {
+      var at = hay.indexOf(needle, from);
+      if (at === -1) break;
+      var s = locate(index.nodes, at);
+      var e = locate(index.nodes, at + needle.length);
+      if (s && e) {
+        var r = document.createRange();
+        try {
+          r.setStart(s.node, s.offset);
+          r.setEnd(e.node, e.offset);
+          out.push(r);
+        } catch (err) {}
+      }
+      from = at + Math.max(1, needle.length);
+    }
+    return out;
+  }
+
+  function repaint() {
+    var supported = typeof CSS !== "undefined" && CSS.highlights && typeof Highlight !== "undefined";
+    if (!supported) return; // highlights degrade gracefully; commenting still works
+    var index = buildIndex();
+    ranges = [];
+    var base = [];
+    var active = [];
+    for (var i = 0; i < comments.length; i++) {
+      var rs = anchorRanges(index, comments[i].anchor_content);
+      for (var j = 0; j < rs.length; j++) {
+        ranges.push({ id: comments[i].id, range: rs[j] });
+        if (activeAnchor && comments[i].anchor_content === activeAnchor) {
+          active.push(rs[j]);
+        } else {
+          base.push(rs[j]);
+        }
+      }
+    }
+    try {
+      CSS.highlights.set("omni-comment", new Highlight(...base.filter(Boolean)));
+      CSS.highlights.set("omni-comment-active", new Highlight(...active.filter(Boolean)));
+    } catch (e) {}
+  }
+
+  function rectOf(range) {
+    var list = range.getClientRects();
+    var r = (list && list.length) ? list[0] : range.getBoundingClientRect();
+    return { left: r.left, top: r.top, right: r.right, bottom: r.bottom };
+  }
+
+  function caretRange(x, y) {
+    if (document.caretRangeFromPoint) return document.caretRangeFromPoint(x, y);
+    if (document.caretPositionFromPoint) {
+      var p = document.caretPositionFromPoint(x, y);
+      if (!p) return null;
+      var r = document.createRange();
+      r.setStart(p.offsetNode, p.offset);
+      r.collapse(true);
+      return r;
+    }
+    return null;
+  }
+
+  // The current non-empty selection, or null if collapsed/empty.
+  function currentSelection() {
+    var sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return null;
+    var text = sel.toString();
+    if (sel.isCollapsed || !text.trim()) return null;
+    return { range: sel.getRangeAt(0), text: text };
+  }
+
+  function emitSelection() {
+    var s = currentSelection();
+    if (s) send({ type: T.selection, text: s.text, rect: rectOf(s.range) });
+  }
+
+  function onMouseUp(e) {
+    var s = currentSelection();
+    if (s) {
+      send({ type: T.selection, text: s.text, rect: rectOf(s.range) });
+      return;
+    }
+    // A plain click (collapsed selection) — did it land inside a comment range?
+    var cr = caretRange(e.clientX, e.clientY);
+    if (cr) {
+      for (var i = 0; i < ranges.length; i++) {
+        if (ranges[i].range.isPointInRange(cr.startContainer, cr.startOffset)) {
+          send({ type: T.commentClick, id: ranges[i].id });
+          return;
+        }
+      }
+    }
+    send({ type: T.selectionCleared });
+  }
+
+  // Also react to programmatic / keyboard selection (mouseup alone misses
+  // these, and Playwright's select_text drives selection without a mouse).
+  // Debounced; only emits for a non-empty selection so a collapse here never
+  // clears the active comment (mouseup owns the clear path).
+  var selTimer = null;
+  document.addEventListener("selectionchange", function () {
+    if (selTimer) clearTimeout(selTimer);
+    selTimer = setTimeout(emitSelection, 150);
+  });
+
+  window.addEventListener("message", function (e) {
+    var d = e.data;
+    if (!d || d.source !== SRC || d.nonce !== NONCE) return;
+    if (d.type === T.init && e.ports && e.ports[0]) {
+      port = e.ports[0];
+      port.onmessage = function (ev) {
+        var m = ev.data;
+        if (!m) return;
+        if (m.type === T.setComments) {
+          comments = Array.isArray(m.comments) ? m.comments : [];
+          repaint();
+        } else if (m.type === T.setActive) {
+          activeAnchor = m.active && m.active.anchor_content ? m.active.anchor_content : null;
+          repaint();
+        }
+      };
+      send({ type: T.ready });
+    }
+  });
+
+  document.addEventListener("mouseup", onMouseUp, true);
+})();`;
+
+/** A `<style>` block that colors the Custom Highlight ranges painted by the bridge. */
+const BRIDGE_HIGHLIGHT_STYLE =
+  "<style>" +
+  "::highlight(omni-comment){background-color:rgba(250,204,21,0.25);}" +
+  "::highlight(omni-comment-active){background-color:rgba(250,204,21,0.5);}" +
+  "</style>";
+
+/**
+ * Build the injected bridge script with the given nonce substituted in.
+ * Exported for unit testing.
+ */
+export function buildBridgeScript(nonce: string): string {
+  const types = JSON.stringify({
+    init: BRIDGE_MSG.init,
+    ready: BRIDGE_MSG.ready,
+    setComments: BRIDGE_MSG.setComments,
+    setActive: BRIDGE_MSG.setActive,
+    selection: BRIDGE_MSG.selection,
+    commentClick: BRIDGE_MSG.commentClick,
+    selectionCleared: BRIDGE_MSG.selectionCleared,
+  });
+  return BRIDGE_SCRIPT_BODY.replace("__OMNI_NONCE__", nonce)
+    .replace("__OMNI_SRC__", BRIDGE_SOURCE)
+    .replace("__OMNI_TYPES__", types);
+}
+
+/**
+ * Prepare HTML artifact content for the comment-enabled preview iframe: first
+ * run {@link prepareHtmlPreviewDoc} (so links still open in a new tab), then
+ * append the highlight `<style>` and the bridge `<script>` so the script runs
+ * after the document body has been parsed.
+ *
+ * Placement mirrors prepareHtmlPreviewDoc's deliberately-simple regex approach
+ * (NOT a full HTML parse, which could subtly change how the artifact renders):
+ * inject before `</body>` when present, else before `</html>`, else append.
+ *
+ * @param html  Raw artifact HTML.
+ * @param nonce Per-mount nonce shared with the parent for message validation.
+ */
+export function injectCommentBridge(html: string, nonce: string): string {
+  const prepared = prepareHtmlPreviewDoc(html);
+  const inject = BRIDGE_HIGHLIGHT_STYLE + "<script>" + buildBridgeScript(nonce) + "</script>";
+
+  const bodyClose = prepared.search(/<\/body\s*>/i);
+  if (bodyClose !== -1) {
+    return prepared.slice(0, bodyClose) + inject + prepared.slice(bodyClose);
+  }
+  const htmlClose = prepared.search(/<\/html\s*>/i);
+  if (htmlClose !== -1) {
+    return prepared.slice(0, htmlClose) + inject + prepared.slice(htmlClose);
+  }
+  return prepared + inject;
+}

--- a/web/src/shell/htmlCommentBridge.ts
+++ b/web/src/shell/htmlCommentBridge.ts
@@ -62,6 +62,9 @@ export interface BridgeSelection {
   type: typeof BRIDGE_MSG.selection;
   /** The selected rendered text, used as the comment anchor_content. */
   text: string;
+  /** Which occurrence (0-based, document order) of `text` was selected, so the
+   * parent anchors to the copy the user picked rather than the first match. */
+  occ: number;
   rect: BridgeRect;
 }
 
@@ -118,7 +121,10 @@ export function parseBridgeMessage(data: unknown, nonce: string): InboundBridgeM
       return { type: BRIDGE_MSG.ready };
     case BRIDGE_MSG.selection:
       if (typeof d.text === "string" && d.text.trim() !== "" && isRect(d.rect)) {
-        return { type: BRIDGE_MSG.selection, text: d.text, rect: d.rect };
+        // occ is optional for resilience against older frames — default to the
+        // first occurrence, which is the pre-occurrence behavior.
+        const occ = typeof d.occ === "number" && d.occ >= 0 ? d.occ : 0;
+        return { type: BRIDGE_MSG.selection, text: d.text, occ, rect: d.rect };
       }
       return null;
     case BRIDGE_MSG.commentClick:
@@ -159,25 +165,66 @@ function escapeRegExp(s: string): string {
 export function findAnchorInSource(
   source: string,
   anchor: string,
+  occurrence = 0,
 ): { start_index: number; end_index: number } | null {
   const trimmed = anchor.trim();
   if (!trimmed) return null;
 
-  const exact = source.indexOf(trimmed);
-  if (exact !== -1) return { start_index: exact, end_index: exact + trimmed.length };
+  // Fast path: for the first occurrence, an exact substring match is the common
+  // case (rendered prose is usually verbatim in the source).
+  if (occurrence === 0) {
+    const exact = source.indexOf(trimmed);
+    if (exact !== -1) return { start_index: exact, end_index: exact + trimmed.length };
+  }
 
-  // Whitespace-tolerant fallback: rendered selection text may collapse runs of
-  // whitespace that the source spells out (newlines, indentation between tags).
+  // Whitespace-tolerant match, walking to the requested occurrence. Rendered
+  // selection text may collapse runs of whitespace that the source spells out
+  // (newlines, indentation between tags), and the same text can repeat, so the
+  // caller passes which copy (document order) was selected.
   const pattern = trimmed.split(/\s+/).map(escapeRegExp).join("\\s+");
   try {
-    const match = source.match(new RegExp(pattern));
-    if (match?.index !== undefined) {
-      return { start_index: match.index, end_index: match.index + match[0].length };
+    const re = new RegExp(pattern, "g");
+    let i = 0;
+    for (const m of source.matchAll(re)) {
+      if (m.index === undefined) break;
+      if (i === occurrence) {
+        return { start_index: m.index, end_index: m.index + m[0].length };
+      }
+      i += 1;
     }
   } catch {
     // Pathological anchor produced an invalid pattern — fall through to null.
   }
   return null;
+}
+
+/**
+ * Which occurrence of `anchor` (0-based, document order) the comment at
+ * `startIndex` refers to. Anchor text can repeat — e.g. a title and a body
+ * paragraph both containing "Aurora Sync" — and the bridge highlights by text
+ * match, so without this it would light up every copy. Counting the matches
+ * before `startIndex` disambiguates to the one the user actually selected.
+ *
+ * Uses the same whitespace-tolerant match as `findAnchorInSource` so a wrapped
+ * source occurrence still counts. Returns 0 when the anchor is empty or the
+ * pattern is pathological (the bridge then falls back to matching all copies).
+ */
+export function anchorOccurrence(source: string, anchor: string, startIndex: number): number {
+  const trimmed = anchor.trim();
+  if (!trimmed) return 0;
+  const pattern = trimmed.split(/\s+/).map(escapeRegExp).join("\\s+");
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern, "g");
+  } catch {
+    return 0;
+  }
+  let count = 0;
+  for (const m of source.matchAll(re)) {
+    if (m.index === undefined || m.index >= startIndex) break;
+    count += 1;
+  }
+  return count;
 }
 
 // ---------------------------------------------------------------------------
@@ -193,8 +240,9 @@ const BRIDGE_SCRIPT_BODY = `(function () {
   var SRC = "__OMNI_SRC__";
   var T = __OMNI_TYPES__;
   var port = null;
-  var comments = [];        // [{ id, anchor_content }]
-  var activeAnchor = null;  // string | null
+  var comments = [];        // [{ id, anchor_content, occ }]
+  var active = null;        // { anchor_content, occ } | null
+  var activeRanges = [];    // ranges matching the active comment (for scroll-into-view)
   var ranges = [];          // [{ id, range }] for click hit-testing
 
   function send(msg) {
@@ -239,19 +287,51 @@ const BRIDGE_SCRIPT_BODY = `(function () {
     return last ? { node: last.node, offset: last.node.nodeValue.length } : null;
   }
 
-  // All ranges whose text equals the (whitespace-tolerant) anchor.
+  // Whitespace-normalized view of a string: runs of whitespace collapse to a
+  // single space, with a map from each normalized index back to its raw offset
+  // (plus a trailing sentinel = raw length). charAt(i) <= " " treats every code
+  // <= U+0020 (space, tab, CR/LF, FF) as whitespace without needing regex — which
+  // matters here because the script is injected as a template-literal string.
+  function normWs(text) {
+    var norm = "";
+    var map = [];
+    var prevSpace = false;
+    for (var i = 0; i < text.length; i++) {
+      var ch = text.charAt(i);
+      if (ch <= " ") {
+        if (prevSpace) continue;
+        norm += " ";
+        map.push(i);
+        prevSpace = true;
+      } else {
+        norm += ch;
+        map.push(i);
+        prevSpace = false;
+      }
+    }
+    map.push(text.length);
+    return { norm: norm, map: map };
+  }
+
+  // All ranges matching the anchor. anchor_content is rendered-selection text
+  // (whitespace collapsed) but the haystack is raw text-node data that preserves
+  // the source's newlines/indentation, so match on the normalized view and map
+  // normalized offsets back to raw node positions — mirroring the parent's
+  // whitespace-tolerant findAnchorInSource.
   function anchorRanges(index, anchor) {
     var out = [];
-    var needle = (anchor || "").trim();
+    var raw = (anchor || "").trim();
+    if (!raw) return out;
+    var H = normWs(index.text);
+    var needle = normWs(raw).norm.trim();
     if (!needle) return out;
-    var hay = index.text;
     var from = 0;
     var guard = 0;
     while (guard++ < 1000) {
-      var at = hay.indexOf(needle, from);
+      var at = H.norm.indexOf(needle, from);
       if (at === -1) break;
-      var s = locate(index.nodes, at);
-      var e = locate(index.nodes, at + needle.length);
+      var s = locate(index.nodes, H.map[at]);
+      var e = locate(index.nodes, H.map[at + needle.length]);
       if (s && e) {
         var r = document.createRange();
         try {
@@ -265,28 +345,100 @@ const BRIDGE_SCRIPT_BODY = `(function () {
     return out;
   }
 
+  // Flat raw-text offset of a selection boundary (node, offset) within the
+  // index's concatenated text. When the boundary is a text node we map directly;
+  // when it's an element (e.g. selecting a whole <span>, the boundary is the
+  // parent with a child index) we return the flat start of the first indexed
+  // text node at or after that boundary, using a collapsed range to compare
+  // document order. Returns -1 if nothing matches.
+  function flatOffset(index, node, offset) {
+    if (node.nodeType === 3) {
+      for (var i = 0; i < index.nodes.length; i++) {
+        if (index.nodes[i].node === node) return index.nodes[i].start + offset;
+      }
+      return -1;
+    }
+    var boundary = document.createRange();
+    try {
+      boundary.setStart(node, offset);
+    } catch (e) {
+      return -1;
+    }
+    for (var k = 0; k < index.nodes.length; k++) {
+      var tn = index.nodes[k].node;
+      // First text node that starts at or after the boundary.
+      if (boundary.comparePoint(tn, 0) >= 0) return index.nodes[k].start;
+    }
+    return -1;
+  }
+
+  // Which occurrence (0-based, document order) of the selected text the current
+  // selection is, so the parent can anchor to the copy actually selected rather
+  // than the first text match. Counts normalized matches starting before the
+  // selection's start — mirrors anchorRanges/anchorOccurrence so a wrapped
+  // occurrence still counts. Returns 0 if the position can't be resolved.
+  function selectionOccurrence(range, text) {
+    var index = buildIndex();
+    var start = flatOffset(index, range.startContainer, range.startOffset);
+    if (start === -1) return 0;
+    var H = normWs(index.text);
+    var needle = normWs((text || "").trim()).norm.trim();
+    if (!needle) return 0;
+    var count = 0;
+    var from = 0;
+    var guard = 0;
+    while (guard++ < 1000) {
+      var at = H.norm.indexOf(needle, from);
+      if (at === -1) break;
+      if (H.map[at] >= start) break;
+      count++;
+      from = at + Math.max(1, needle.length);
+    }
+    return count;
+  }
+
   function repaint() {
     var supported = typeof CSS !== "undefined" && CSS.highlights && typeof Highlight !== "undefined";
     if (!supported) return; // highlights degrade gracefully; commenting still works
     var index = buildIndex();
     ranges = [];
     var base = [];
-    var active = [];
+    var activeHi = [];
     for (var i = 0; i < comments.length; i++) {
-      var rs = anchorRanges(index, comments[i].anchor_content);
-      for (var j = 0; j < rs.length; j++) {
-        ranges.push({ id: comments[i].id, range: rs[j] });
-        if (activeAnchor && comments[i].anchor_content === activeAnchor) {
-          active.push(rs[j]);
-        } else {
-          base.push(rs[j]);
-        }
+      var c = comments[i];
+      var rs = anchorRanges(index, c.anchor_content);
+      // Anchor text can repeat (e.g. a title and a body paragraph). The parent
+      // sends the occurrence index (document order) the comment belongs to, so
+      // highlight only that one. When occ is missing or out of range (stale
+      // offset), fall back to all matches so the comment is at least visible.
+      var picked = (typeof c.occ === "number" && c.occ >= 0 && c.occ < rs.length) ? [rs[c.occ]] : rs;
+      var isActive = active && c.anchor_content === active.anchor_content &&
+        (active.occ == null || active.occ === c.occ);
+      for (var j = 0; j < picked.length; j++) {
+        ranges.push({ id: c.id, range: picked[j] });
+        if (isActive) activeHi.push(picked[j]);
+        else base.push(picked[j]);
       }
     }
+    activeRanges = activeHi;
     try {
       CSS.highlights.set("omni-comment", new Highlight(...base.filter(Boolean)));
-      CSS.highlights.set("omni-comment-active", new Highlight(...active.filter(Boolean)));
+      CSS.highlights.set("omni-comment-active", new Highlight(...activeHi.filter(Boolean)));
     } catch (e) {}
+  }
+
+  // Scroll the first active-comment range into view. Uses the range's client
+  // rect (Ranges have no scrollIntoView) to center it in the viewport, but only
+  // when off-screen so an already-visible highlight doesn't jump.
+  function scrollActiveIntoView() {
+    var r = activeRanges && activeRanges[0];
+    if (!r) return;
+    var rect = r.getBoundingClientRect();
+    if (!rect || (rect.width === 0 && rect.height === 0)) return;
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    if (rect.top >= 0 && rect.bottom <= vh) return; // already fully visible
+    var target = window.pageYOffset + rect.top - vh / 2 + rect.height / 2;
+    window.scrollTo({ top: target < 0 ? 0 : target, behavior: "smooth" });
   }
 
   function rectOf(range) {
@@ -319,13 +471,43 @@ const BRIDGE_SCRIPT_BODY = `(function () {
 
   function emitSelection() {
     var s = currentSelection();
-    if (s) send({ type: T.selection, text: s.text, rect: rectOf(s.range) });
+    if (s) {
+      send({
+        type: T.selection,
+        text: s.text,
+        occ: selectionOccurrence(s.range, s.text),
+        rect: rectOf(s.range),
+      });
+    }
+  }
+
+  // Drop the native selection once it's covered by a saved comment, so the
+  // browser's ::selection stops masking the (lower-priority) Custom Highlight.
+  // Matches on normalized text so collapsed rendered whitespace still compares
+  // equal to the comment's stored anchor_content.
+  function clearSelectionIfCommented() {
+    var s = currentSelection();
+    if (!s) return;
+    var selText = normWs(s.text).norm.trim();
+    if (!selText) return;
+    for (var i = 0; i < comments.length; i++) {
+      if (normWs(comments[i].anchor_content || "").norm.trim() === selText) {
+        var sel = window.getSelection();
+        if (sel) sel.removeAllRanges();
+        return;
+      }
+    }
   }
 
   function onMouseUp(e) {
     var s = currentSelection();
     if (s) {
-      send({ type: T.selection, text: s.text, rect: rectOf(s.range) });
+      send({
+        type: T.selection,
+        text: s.text,
+        occ: selectionOccurrence(s.range, s.text),
+        rect: rectOf(s.range),
+      });
       return;
     }
     // A plain click (collapsed selection) — did it land inside a comment range?
@@ -361,10 +543,24 @@ const BRIDGE_SCRIPT_BODY = `(function () {
         if (!m) return;
         if (m.type === T.setComments) {
           comments = Array.isArray(m.comments) ? m.comments : [];
+          // If a newly-arrived comment covers the still-active native selection
+          // (i.e. the user just saved a comment on it), drop that selection.
+          // The browser's ::selection paints over Custom Highlights, so the range
+          // would stay grey — masking the yellow highlight — until the user
+          // clicked elsewhere to collapse it. Keeping the selection during
+          // compose is intentional; we only clear once the comment exists.
+          clearSelectionIfCommented();
           repaint();
         } else if (m.type === T.setActive) {
-          activeAnchor = m.active && m.active.anchor_content ? m.active.anchor_content : null;
+          var next = m.active && m.active.anchor_content ? m.active : null;
+          var prevKey = active ? active.anchor_content + "#" + active.occ : null;
+          var nextKey = next ? next.anchor_content + "#" + next.occ : null;
+          active = next;
           repaint();
+          // Only scroll when a comment becomes newly active (e.g. clicked in the
+          // panel), so list refreshes that keep the same active comment don't
+          // yank the reader's scroll position.
+          if (nextKey && nextKey !== prevKey) scrollActiveIntoView();
         }
       };
       send({ type: T.ready });


### PR DESCRIPTION
## What

Reviewers can now highlight text in the **rendered HTML preview** and attach review comments — full parity with the Markdown (TipTap) and code (Monaco/Shiki) comment surfaces. Previously HTML opened in a sandboxed preview iframe with a visible "Comments" tab but no way to actually add a comment.

Motivated by a request to review HTML design docs (which render far better than `.md`) directly in Omnigent.

## How

The HTML preview iframe is deliberately sandboxed **without `allow-same-origin`**, so the host app can't read its selection or DOM. Rather than weaken that, this adds a small, nonce-guarded **bridge script** injected into the iframe that:

- relays the user's text selection to the parent over a private `MessageChannel`, and
- paints comment highlights *inside* the frame via the CSS Custom Highlight API.

Comments store **raw-HTML-source offsets + `anchor_content`** (resolved on the parent side by locating the selected text in the source), so the existing `classifyAndRemapComments` re-anchoring and the agent's source-editing semantics keep working unchanged.

**No backend changes** — the comment store/API are already file-type agnostic.

### Files
- `ap-web/src/shell/htmlCommentBridge.ts` *(new)* — injected bridge script, message protocol + validation, rendered-selection → source-offset resolution
- `ap-web/src/shell/HtmlCommentViewer.tsx` *(new)* — iframe owner, channel handshake, floating "Add comment" button, comment↔iframe sync
- `ap-web/src/shell/CodeViewer.tsx` — route the HTML-preview branch to `HtmlCommentViewer`
- `ap-web/src/shell/htmlCommentBridge.test.ts`, `HtmlCommentViewer.test.tsx` *(new)* — unit + component tests
- `tests/e2e_ui/comments/test_html_preview_comments.py` *(new)* — Playwright e2e (select rendered text → comment → assert source-anchored offsets via REST)

## Testing

- `tsc -b`: clean; `oxlint`: clean
- New unit/component tests pass; full `ap-web` shell suite (1038 tests) passes with no regressions
- Production SPA build succeeds with the new code
- e2e written to the established pattern (not run in CI here — needs the Playwright harness)
- 
<img width="1360" height="695" alt="image" src="https://github.com/user-attachments/assets/81dc4d01-865a-4cdd-8ea5-23c4b7756fd8" />


## Notes / limitations

- The sandbox flags are unchanged — the iframe keeps its opaque origin; the bridge only adds a `postMessage`/`MessageChannel` path. Inbound messages are nonce + source-tag validated.
- Highlight painting uses the **CSS Custom Highlight API** (Chromium/modern browsers). Where unavailable, commenting still works but persistent highlights silently no-op.

This pull request and its description were written by Isaac.