### PR TITLE
fix(native): re-mint expired hook token on Apps OAuth bounce instead of failing closed

### DIFF
--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -7,6 +7,7 @@ import json
 import secrets
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,7 @@ from omnigent.claude_native_bridge import (
 )
 from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.native_policy_hook import (
+    _is_login_redirect_or_unauthorized,
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
@@ -514,11 +516,58 @@ def _conversation_url_for_active_session(
     return fallback_url
 
 
+def _build_reauth(
+    ap_server_url: str, headers: dict[str, str]
+) -> Callable[[], dict[str, str] | None]:
+    """
+    Build a callable that re-mints the Omnigent bearer for ``ap_server_url``.
+
+    The native hooks authenticate with a one-shot ``ap_auth_headers`` snapshot
+    written into ``permission_hook.json`` at launch (``build_hook_settings``),
+    which dies with the ~1h Databricks OAuth token lifetime. When the Apps front
+    door later bounces a hook POST to its OAuth login flow (302→``/oidc/``) or
+    returns ``401``, this callable re-mints a fresh bearer through the SAME
+    factory the runner's refresh-capable ``_RunnerDatabricksAuth`` uses
+    (:func:`omnigent.runner._entry._make_auth_token_factory`), preserving the
+    other headers (e.g. the ``X-Databricks-Org-Id`` workspace-routing header)
+    so neither half is dropped. Best-effort: returns ``None`` when no refresh
+    mechanism is available (local unauthenticated servers, import failure, or a
+    transient mint failure), letting the caller fail closed.
+
+    :param ap_server_url: Omnigent server base URL the hook POSTs to — also the
+        key the token factory uses to resolve the stored OIDC token.
+    :param headers: The current (lapsed) outbound headers; the fresh bearer is
+        merged over a copy so routing headers survive.
+    :returns: A zero-arg callable returning fresh headers, or ``None``.
+    """
+
+    def _reauth() -> dict[str, str] | None:
+        # Lazy import: only paid on the rare re-auth path, keeping the
+        # per-tool-call hot path free of the runner/databricks-SDK import.
+        try:
+            from omnigent.runner._entry import _make_auth_token_factory
+        except Exception:  # noqa: BLE001 — re-auth is best-effort; fail closed if unavailable
+            return None
+        factory = _make_auth_token_factory(ap_server_url)
+        if factory is None:
+            return None
+        try:
+            token = factory()
+        except Exception:  # noqa: BLE001 — transient SDK/refresh failure; fail closed
+            return None
+        if not token:
+            return None
+        return {**headers, "Authorization": f"Bearer {token}"}
+
+    return _reauth
+
+
 def _post_hook_with_reattach(
     url: str,
     headers: dict[str, str],
     payload: dict[str, Any],
     hook_label: str,
+    reauth: Callable[[], dict[str, str] | None] | None = None,
 ) -> httpx.Response | None:
     """
     POST one permission-style hook payload, surviving severed long-polls.
@@ -538,6 +587,11 @@ def _post_hook_with_reattach(
         rides on a copy.
     :param hook_label: Diagnostic prefix for stderr lines, e.g.
         ``"permission"`` or ``"ask-user-question"``.
+    :param reauth: Optional callable that re-mints fresh auth headers when the
+        server bounces the POST to its OAuth login flow (Apps 302→``/oidc/``)
+        or returns ``401`` — i.e. the one-shot ``ap_auth_headers`` token lapsed.
+        Called at most once; new headers trigger an immediate retry with them.
+        ``None`` keeps the legacy behavior.
     :returns: The successful (2xx) response, or ``None`` when rejected
         or out of budget — callers fail-ask as before.
     """
@@ -548,10 +602,30 @@ def _post_hook_with_reattach(
     deadline = time.monotonic() + _PERMISSION_TIMEOUT_S
     backoff_s = _PERMISSION_RETRY_INITIAL_BACKOFF_S
     timeout = httpx.Timeout(_PERMISSION_TIMEOUT_S, connect=_PERMISSION_CONNECT_TIMEOUT_S)
+    reauthed = False
     while True:
         try:
             with httpx.Client(headers=headers, timeout=timeout) as client:
                 resp = client.post(url, json=body)
+                if (
+                    reauth is not None
+                    and not reauthed
+                    and _is_login_redirect_or_unauthorized(resp)
+                ):
+                    # One-shot ``ap_auth_headers`` token lapsed (~1h OAuth
+                    # lifetime): re-mint and retry once rather than fail-asking
+                    # into a terminal prompt no one watches. Mirrors the
+                    # evaluate-policy hook and ``_RunnerDatabricksAuth``.
+                    refreshed = reauth()
+                    if refreshed:
+                        headers = refreshed
+                        reauthed = True
+                        print(
+                            f"omnigent {hook_label} hook: Omnigent auth expired "
+                            "(login redirect/401); re-minted token and retrying",
+                            file=sys.stderr,
+                        )
+                        continue
                 resp.raise_for_status()
                 return resp
         except httpx.HTTPStatusError as exc:
@@ -620,7 +694,9 @@ def _main_permission_request(argv: list[str]) -> int:
         f"{ap_server_url.rstrip('/')}/v1/sessions/"
         f"{url_component(session_id)}/hooks/permission-request"
     )
-    resp = _post_hook_with_reattach(url, headers, payload, "claude permission")
+    resp = _post_hook_with_reattach(
+        url, headers, payload, "claude permission", reauth=_build_reauth(ap_server_url, headers)
+    )
     if resp is None:
         return 0
     if resp.content:
@@ -686,7 +762,9 @@ def _main_ask_user_question(argv: list[str]) -> int:
         f"{ap_server_url.rstrip('/')}/v1/sessions/"
         f"{url_component(session_id)}/hooks/permission-request"
     )
-    resp = _post_hook_with_reattach(url, headers, payload, "ask-user-question")
+    resp = _post_hook_with_reattach(
+        url, headers, payload, "ask-user-question", reauth=_build_reauth(ap_server_url, headers)
+    )
     if resp is None or not resp.content:
         return 0
     # The Omnigent server returns a PermissionRequest-shaped response:
@@ -832,7 +910,12 @@ def _main_evaluate_policy(argv: list[str]) -> int:
 
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{url_component(session_id)}/policies/evaluate"
     resp = post_evaluate_with_retry(
-        url, headers, eval_request, _EVALUATE_POLICY_TIMEOUT_S, "evaluate-policy hook"
+        url,
+        headers,
+        eval_request,
+        _EVALUATE_POLICY_TIMEOUT_S,
+        "evaluate-policy hook",
+        reauth=_build_reauth(ap_server_url, headers),
     )
     if resp is None:
         return _fail_closed()

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -24,6 +24,7 @@ import json
 import secrets
 import sys
 import time
+from collections.abc import Callable
 
 import httpx
 
@@ -55,8 +56,36 @@ _USER_PROMPT_SUBMIT = "UserPromptSubmit"
 # body). Mirrors the runner-side fail-closed default in
 # ``omnigent.runner.app._evaluate_policy_via_omnigent`` (PR #163).
 _EVAL_UNAVAILABLE_REASON = (
-    "Omnigent policy evaluation unavailable; failing closed for this tool call."
+    "Omnigent policy evaluation unavailable (could not reach or authenticate to the "
+    "Omnigent server); failing closed for this tool call."
 )
+
+
+def _is_login_redirect_or_unauthorized(response: httpx.Response) -> bool:
+    """
+    Return ``True`` when a response means "the bearer is no good — re-auth".
+
+    Mirrors :func:`omnigent.runner._entry._is_login_redirect_or_unauthorized`,
+    duplicated here so the dependency-light hook need not import the runner
+    package. The Databricks Apps front door bounces an *expired* bearer with a
+    ``302`` to the OAuth login flow (``/oidc/`` or ``/.auth/``) — **not** a
+    ``401`` — so a hook that only treats ``401`` as auth failure silently fails
+    closed once the one-shot ``ap_auth_headers`` token (snapshotted at launch by
+    ``build_hook_settings``) lapses with the ~1h Databricks OAuth lifetime.
+    Treat both the 401 and the OAuth-login redirect as a re-auth signal.
+
+    Unrelated 3xx (an application-level redirect to another resource) return
+    ``False`` so the caller does not waste a token round-trip on every redirect.
+
+    :param response: The hook's POST response to classify.
+    :returns: ``True`` when the caller should re-mint a token and retry.
+    """
+    if response.status_code == 401:
+        return True
+    if not response.is_redirect:
+        return False
+    location = response.headers.get("location", "")
+    return "/oidc/" in location or "/.auth/" in location
 
 
 def hook_payload_to_evaluation_request(
@@ -293,6 +322,7 @@ def post_evaluate_with_retry(
     eval_request: dict[str, object],
     read_timeout: float,
     hook_label: str,
+    reauth: Callable[[], dict[str, str] | None] | None = None,
 ) -> httpx.Response | None:
     """
     POST to the Omnigent policy evaluate endpoint, retrying on transient errors.
@@ -326,6 +356,15 @@ def post_evaluate_with_retry(
         large (e.g. one day) to accommodate long-polling ASK gates.
     :param hook_label: Diagnostic label used in stderr messages,
         e.g. ``"evaluate-policy hook"`` or ``"codex evaluate-policy hook"``.
+    :param reauth: Optional callable that re-mints fresh auth headers when
+        the server bounces the request to its OAuth login flow (the Apps
+        front door 302→``/oidc/``) or returns ``401`` — i.e. the one-shot
+        ``ap_auth_headers`` token lapsed. Called at most once; returning new
+        headers triggers an immediate retry with them, mirroring the runner's
+        refresh-capable :class:`~omnigent.runner._entry._RunnerDatabricksAuth`.
+        ``None`` (the default) keeps the legacy behavior for callers that have
+        no token source. Returning ``None`` from it falls through to the
+        normal failure handling (the caller fails closed).
     :returns: Successful :class:`httpx.Response`, or ``None`` when retries
         are exhausted or the error is non-retryable.
     """
@@ -338,10 +377,34 @@ def post_evaluate_with_retry(
     deadline = time.monotonic() + _EVALUATE_POLICY_RETRY_BUDGET_S
     backoff_s = _EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S
     timeout = httpx.Timeout(read_timeout, connect=_EVALUATE_POLICY_CONNECT_TIMEOUT_S)
+    reauthed = False
     while True:
         try:
             with httpx.Client(headers=headers, timeout=timeout) as client:
                 resp = client.post(url, json=request_body)
+                if (
+                    reauth is not None
+                    and not reauthed
+                    and _is_login_redirect_or_unauthorized(resp)
+                ):
+                    # The one-shot ``ap_auth_headers`` token lapsed (~1h
+                    # Databricks OAuth lifetime): the Apps front door bounces
+                    # an expired bearer with a 302→/oidc/ (or a 401). Re-mint
+                    # and retry once with the fresh token instead of failing
+                    # closed — exactly as ``_RunnerDatabricksAuth`` does for the
+                    # runner's own callbacks. Without this, every tool call on a
+                    # session older than the token lifetime fails CLOSED while
+                    # chat (refresh-capable) keeps working.
+                    refreshed = reauth()
+                    if refreshed:
+                        headers = refreshed
+                        reauthed = True
+                        print(
+                            f"omnigent {hook_label}: Omnigent auth expired "
+                            "(login redirect/401); re-minted token and retrying",
+                            file=sys.stderr,
+                        )
+                        continue
                 resp.raise_for_status()
                 return resp
         except httpx.HTTPStatusError as exc:

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1875,3 +1875,184 @@ def test_evaluate_policy_retries_5xx_and_succeeds(
     assert captured.out == ""
     # Two 503s then one 200 = 3 total attempts.
     assert call_count == 3
+
+
+def test_build_reauth_remints_and_preserves_routing_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_build_reauth`` re-mints the bearer and keeps the routing header.
+
+    The fresh token must be merged OVER the existing headers so the
+    ``X-Databricks-Org-Id`` workspace-routing header (which the Apps server
+    needs to avoid a 403 reroute to the account) is preserved, not dropped.
+    """
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda server_url=None: lambda: "fresh-token",
+    )
+    reauth = claude_native_hook._build_reauth(
+        "https://ap.example.com",
+        {"Authorization": "Bearer stale", "X-Databricks-Org-Id": "o9"},
+    )
+    assert reauth() == {"Authorization": "Bearer fresh-token", "X-Databricks-Org-Id": "o9"}
+
+
+def test_build_reauth_returns_none_without_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_build_reauth`` returns ``None`` when no refresh mechanism is available.
+
+    Local unauthenticated servers (no token factory) must not synthesize an
+    auth header; returning ``None`` lets the caller fall through to its normal
+    handling (which fails closed for a tool-call gate).
+    """
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda server_url=None: None,
+    )
+    reauth = claude_native_hook._build_reauth(
+        "https://ap.example.com", {"Authorization": "Bearer stale"}
+    )
+    assert reauth() is None
+
+
+def test_evaluate_policy_reauths_on_expired_token_instead_of_failing_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    An expired hook token self-heals: 302→/oidc re-mints and the tool is allowed.
+
+    End-to-end repro of the production bug — an "old" native session (token
+    past the ~1h Databricks OAuth lifetime) hits the Apps front-door
+    ``302 → /oidc`` on every tool call and used to fail CLOSED ("policy
+    evaluation unavailable"). The hook must now re-mint through the token
+    factory and retry, returning the real ALLOW verdict (no deny output).
+    """
+    attempts: list[dict[str, str]] = []
+
+    class _RedirectThenOkClient:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del timeout
+            self._headers = headers
+
+        def __enter__(self) -> _RedirectThenOkClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: object = None) -> httpx.Response:
+            del json
+            attempts.append(dict(self._headers))
+            req = httpx.Request("POST", url)
+            if len(attempts) == 1:
+                return httpx.Response(
+                    302,
+                    headers={"Location": "https://w.example.com/oidc/oauth2/v2.0/authorize"},
+                    request=req,
+                )
+            return httpx.Response(200, text='{"result":"POLICY_ACTION_ALLOW"}', request=req)
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _RedirectThenOkClient)
+    # The hook re-mints through the runner's token factory; stub a fresh token.
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda server_url=None: lambda: "fresh-token",
+    )
+    bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
+    write_active_session_id(bridge_dir, "conv_active")
+    build_hook_settings(
+        bridge_dir,
+        ap_server_url="https://omnigents.example.databricksapps.com",
+        ap_auth_headers={"Authorization": "Bearer stale-token", "X-Databricks-Org-Id": "o1"},
+    )
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    exit_code = claude_native_hook.main(["evaluate-policy", "--bridge-dir", str(bridge_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # Two attempts: first with the lapsed token, retry with the fresh one.
+    assert len(attempts) == 2
+    assert attempts[0]["Authorization"] == "Bearer stale-token"
+    assert attempts[1]["Authorization"] == "Bearer fresh-token"
+    # Routing header survives the re-mint.
+    assert attempts[1]["X-Databricks-Org-Id"] == "o1"
+    # ALLOW verdict → no hook output → the tool is NOT denied (no fail-closed).
+    assert captured.out == ""
+    assert "re-minted token and retrying" in captured.err
+
+
+def test_evaluate_policy_fails_closed_when_reauth_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    If the token can't be re-minted, the tool still fails CLOSED (safety net).
+
+    Re-auth is best-effort. When no refresh mechanism is available, the
+    authoritative PreToolUse gate must still DENY rather than let an
+    unevaluated tool through — preserving the fail-closed guarantee from #163.
+    """
+
+    class _RedirectClient:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _RedirectClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: object = None) -> httpx.Response:
+            del json
+            return httpx.Response(
+                302,
+                headers={"Location": "https://w.example.com/oidc/x"},
+                request=httpx.Request("POST", url),
+            )
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _RedirectClient)
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda server_url=None: None,
+    )
+    bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
+    write_active_session_id(bridge_dir, "conv_active")
+    build_hook_settings(
+        bridge_dir,
+        ap_server_url="https://omnigents.example.databricksapps.com",
+        ap_auth_headers={"Authorization": "Bearer stale-token"},
+    )
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    exit_code = claude_native_hook.main(["evaluate-policy", "--bridge-dir", str(bridge_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    result = json.loads(captured.out)
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert (
+        result["hookSpecificOutput"]["permissionDecisionReason"]
+        == native_policy_hook._EVAL_UNAVAILABLE_REASON
+    )

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
+from omnigent import native_policy_hook
 from omnigent.native_policy_hook import (
+    _is_login_redirect_or_unauthorized,
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    post_evaluate_with_retry,
 )
 
 
@@ -354,3 +358,173 @@ def test_fail_closed_unknown_event_fails_open() -> None:
     accidentally blocking — the conservative default for an unknown gate.
     """
     assert fail_closed_hook_output("SomeNewEvent") is None
+
+
+def _resp(status: int, location: str | None = None) -> httpx.Response:
+    """Build a fake response for re-auth classification tests."""
+    headers = {"Location": location} if location else {}
+    return httpx.Response(status, headers=headers, request=httpx.Request("POST", "https://ap/x"))
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (_resp(401), True),
+        (_resp(302, "https://w.example.com/oidc/oauth2/v2.0/authorize"), True),
+        (_resp(302, "https://omnigents.example.databricksapps.com/.auth/callback"), True),
+        # Unrelated redirect / success must NOT trigger a wasted token round-trip.
+        (_resp(302, "https://w.example.com/some/other/page"), False),
+        (_resp(302, None), False),
+        (_resp(200), False),
+        (_resp(503), False),
+    ],
+)
+def test_is_login_redirect_or_unauthorized_classifies_reauth_signals(
+    response: httpx.Response, expected: bool
+) -> None:
+    """
+    401 and an Apps OAuth-login 302 are re-auth signals; nothing else is.
+
+    The Databricks Apps front door bounces an *expired* bearer with a
+    ``302 → /oidc/`` (or ``/.auth/``), NOT a ``401`` — so a hook that only
+    checked ``401`` silently failed closed once the one-shot token lapsed.
+    This is the classifier that lets the hook re-mint instead.
+    """
+    assert _is_login_redirect_or_unauthorized(response) is expected
+
+
+def _make_redirect_then_ok_client(
+    seen_headers: list[dict[str, str]],
+    *,
+    redirect: httpx.Response,
+    ok: httpx.Response,
+) -> type:
+    """Build an httpx.Client stub: redirect on attempt 1, ``ok`` thereafter."""
+
+    class _Client:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del timeout
+            self._headers = headers
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del url, json
+            seen_headers.append(dict(self._headers))
+            return redirect if len(seen_headers) == 1 else ok
+
+    return _Client
+
+
+def test_post_evaluate_with_retry_reauths_on_login_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A 302→/oidc/ re-mints the bearer and retries, returning the real verdict.
+
+    Regression guard for the production bug where an "old" native session
+    (token past the ~1h Databricks OAuth lifetime) failed CLOSED on every tool
+    call. The first attempt carries the lapsed token (302), the retry carries
+    the fresh token and gets the ALLOW verdict — exactly as the runner's
+    refresh-capable ``_RunnerDatabricksAuth`` does for its own callbacks.
+    """
+    seen_headers: list[dict[str, str]] = []
+    redirect = httpx.Response(
+        302,
+        headers={"Location": "https://w.example.com/oidc/oauth2/v2.0/authorize"},
+        request=httpx.Request("POST", "https://ap/x"),
+    )
+    ok = httpx.Response(
+        200,
+        text='{"result":"POLICY_ACTION_ALLOW"}',
+        request=httpx.Request("POST", "https://ap/x"),
+    )
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _make_redirect_then_ok_client(seen_headers, redirect=redirect, ok=ok),
+    )
+    reauth_calls: list[int] = []
+
+    def _reauth() -> dict[str, str]:
+        reauth_calls.append(1)
+        return {"Authorization": "Bearer fresh", "X-Databricks-Org-Id": "o1"}
+
+    resp = post_evaluate_with_retry(
+        "https://ap/x",
+        {"Authorization": "Bearer stale"},
+        {"event": {}},
+        5.0,
+        "evaluate-policy hook",
+        reauth=_reauth,
+    )
+
+    assert resp is ok
+    assert reauth_calls == [1]  # re-minted exactly once
+    assert seen_headers[0]["Authorization"] == "Bearer stale"  # first attempt: lapsed token
+    assert seen_headers[1]["Authorization"] == "Bearer fresh"  # retry: fresh token
+
+
+def test_post_evaluate_with_retry_no_reauth_fails_on_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With no ``reauth`` callable, a login-redirect yields ``None`` (legacy).
+
+    Callers without a token source (e.g. codex/kimi today) see the same
+    behavior as before this change: ``raise_for_status`` rejects the 302 as a
+    non-retryable <500, the helper returns ``None``, and the caller fails
+    closed. Guards against the new branch altering that.
+    """
+    seen_headers: list[dict[str, str]] = []
+    redirect = httpx.Response(
+        302,
+        headers={"Location": "https://w.example.com/oidc/x"},
+        request=httpx.Request("POST", "https://ap/x"),
+    )
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _make_redirect_then_ok_client(seen_headers, redirect=redirect, ok=redirect),
+    )
+    resp = post_evaluate_with_retry("https://ap/x", {}, {"event": {}}, 5.0, "evaluate-policy hook")
+    assert resp is None
+    assert len(seen_headers) == 1  # one attempt; a 302 is not retried without reauth
+
+
+def test_post_evaluate_with_retry_reauth_unavailable_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    When re-mint yields no token, the helper returns ``None`` (caller fails closed).
+
+    Re-auth is best-effort: a ``reauth`` that returns ``None`` (no creds /
+    transient mint failure) must not loop — it falls through to
+    ``raise_for_status`` (302 → non-retryable) so the caller keeps the
+    fail-closed safety net.
+    """
+    seen_headers: list[dict[str, str]] = []
+    redirect = httpx.Response(
+        302,
+        headers={"Location": "https://w.example.com/oidc/x"},
+        request=httpx.Request("POST", "https://ap/x"),
+    )
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _make_redirect_then_ok_client(seen_headers, redirect=redirect, ok=redirect),
+    )
+    resp = post_evaluate_with_retry(
+        "https://ap/x",
+        {"Authorization": "Bearer stale"},
+        {"event": {}},
+        5.0,
+        "evaluate-policy hook",
+        reauth=lambda: None,
+    )
+    assert resp is None
+    assert len(seen_headers) == 1  # one attempt only; no retry loop


### PR DESCRIPTION
## Problem

On a hosted Databricks Apps deployment, **old** native Claude Code sessions can still **chat** but every **tool call** is denied with:

> Omnigent policy evaluation unavailable; failing closed for this tool call.

## Root cause

The native policy/permission hooks authenticate to the Omnigent server with a **one-shot bearer token** snapshotted into `permission_hook.json` at launch (`build_hook_settings` → `ap_auth_headers`). That token dies with the **~1h Databricks OAuth lifetime**. Once it lapses, the Apps front door bounces every hook POST with a **`302 → /oidc/...authorize`** (an expired bearer is a redirect, *not* a `401`, and never reaches the app — so these failures don't even show up in app logs). The hook can't obtain a verdict, and the authoritative `PreToolUse` gate fails **closed**.

Meanwhile **chat keeps working** because the relay / transcript forwarder use the refresh-capable `_RunnerDatabricksAuth(_make_auth_token_factory())`, whose entire purpose (per its own docstring) is to *"survive the 1-hour OAuth token lifetime"* and which already handles the Apps `302 → /oidc` re-auth. The hooks were left on the one-shot snapshot — a gap explicitly acknowledged at `runner/app.py:5128-5134`.

Verified live: an expired/invalid bearer at this app returns `302 → /oidc/oauth2/v2.0/authorize` with an HTML body.

## Fix

Give the hooks the same self-heal as `_RunnerDatabricksAuth`: on a `302 → /oidc | /.auth` redirect **or** a `401`, re-mint a fresh bearer via the **same** `_make_auth_token_factory` (preserving the `X-Databricks-Org-Id` routing header) and retry once — *before* falling back to fail-closed. Applies to the **evaluate-policy**, **permission-request**, and **ask-user-question** hooks.

- `native_policy_hook.py`: add `_is_login_redirect_or_unauthorized` (mirrors the runner helper) + an optional `reauth` callback to `post_evaluate_with_retry`.
- `claude_native_hook.py`: add `_build_reauth(ap_server_url, headers)` and wire it into the three hook entrypoints. The re-mint import is lazy (only paid on the rare re-auth path).
- Clarify the fail-closed reason to name the auth/connectivity cause.

**Fail-closed remains the last resort** when no token can be minted, preserving the #163 / #579 guarantee that a native tool never runs un-evaluated.

## Tests

- `_is_login_redirect_or_unauthorized` classification (401 / `/oidc` 302 / `/.auth` 302 vs unrelated 3xx / 200 / 503)
- `post_evaluate_with_retry`: re-mints on `302→/oidc` and retries with the fresh token; returns `None` (caller fails closed) with no `reauth` or when re-mint yields no token; legacy callers unchanged
- End-to-end `_main_evaluate_policy`: expired token self-heals to the real ALLOW verdict (no deny); still fails closed when no token can be minted
- `_build_reauth` preserves the routing header and returns `None` without a factory

## Scope / related

This is complementary to the merged fail-closed work (#163, #579, #913/#915, #1078) — none of which handle token expiry / the Apps `302` re-auth. The same one-shot-token pattern exists in the codex/kimi hooks (`post_evaluate_with_retry` already accepts the new `reauth` param, default off) and can follow up.

Related: #1026 (turn-context desync) is a separate orphaned-callback path; #357 / #1305 cover runner *tunnel* auth (not the hook token).

This pull request and its description were written by Isaac.
