### PR TITLE
fix(runtime): raise NoLiveHarnessError when get_client sentinel "any" has no live subprocess

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -73,7 +73,7 @@ from omnigent.runner.resource_registry import (
     TerminalExitEvent,
     TerminalLifecycle,
 )
-from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+from omnigent.runtime.harnesses.process_manager import HarnessProcessManager, NoLiveHarnessError
 from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
 from omnigent.terminals.ws_bridge import (
@@ -12295,6 +12295,8 @@ def create_runner_app(
                 # Bounded under the Omnigent server's 5s stop deadline.
                 timeout=3.0,
             )
+        except NoLiveHarnessError:
+            _logger.debug("Interrupt forward skipped for %s: no live harness", conv_id)
         except Exception:  # noqa: BLE001 — best-effort: harness may have exited
             _logger.warning(
                 "Interrupt forward to harness failed for %s",
@@ -14801,6 +14803,14 @@ def create_runner_app(
         # only spawning a fresh one does.
         try:
             harness_client = await process_manager.get_client(conversation_id, "any")
+        except NoLiveHarnessError:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": "no_live_harness",
+                    "detail": "no harness subprocess is running for this conversation",
+                },
+            )
         except RuntimeError as exc:
             return JSONResponse(
                 status_code=503,
@@ -17729,6 +17739,15 @@ def create_runner_app(
             )
         try:
             client = await process_manager.get_client(conv_id, "any")
+        except NoLiveHarnessError:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": "no_live_harness",
+                    "detail": "no harness subprocess is running for this conversation",
+                },
+            )
+        try:
             # Translate the MCP-shape ElicitationResult body
             # ({"action": ..., "content": ...}) onto the harness's
             # discriminated ``approval`` event per

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -140,6 +140,10 @@ _SPAWN_POLL_INTERVAL_S = 0.05
 _ORPHAN_SIGTERM_GRACE_S = 3.0
 
 
+class NoLiveHarnessError(RuntimeError):
+    """Raised when ``get_client`` is called with ``harness="any"`` and no subprocess is live."""
+
+
 def _default_tmp_parent() -> Path:
     """
     Resolve the deployment-level parent for harness Unix sockets.
@@ -684,6 +688,10 @@ class HarnessProcessManager:
                     await self._close_entry(entry)
                     entry = None
             if entry is None:
+                if harness == "any":
+                    raise NoLiveHarnessError(
+                        f"no live harness subprocess for conversation {conversation_id!r}"
+                    )
                 entry = await self._spawn_entry(conversation_id, harness, env)
                 self._entries[conversation_id] = entry
             # Use ``time.monotonic()`` directly rather than

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -40,6 +40,7 @@ from omnigent.runtime.harnesses.process_manager import (
     _AP_PID_FILE,
     _TMP_PARENT_ENV_VAR,
     HarnessProcessManager,
+    NoLiveHarnessError,
     _pid_alive,
     _pids_holding_socket,
 )
@@ -423,6 +424,24 @@ async def test_get_client_any_harness_sentinel_reuses_subprocess(
         # spuriously tripped the harness-change branch (the bug this guards).
         assert pid_any == pid_first
         assert _pid_alive(pid_first)
+    finally:
+        await manager.shutdown()
+
+
+async def test_get_client_any_harness_sentinel_no_subprocess_raises(
+    manager: HarnessProcessManager,
+) -> None:
+    """``get_client(conv, "any")`` raises ``NoLiveHarnessError`` when no
+    subprocess is live.
+
+    Before the fix, this fell through to ``_spawn_entry("any", ...)``
+    which called ``_resolve_module_path("any")`` and raised the misleading
+    ``RuntimeError: unknown harness 'any'; registered names: [...]``.
+    """
+    await manager.start()
+    try:
+        with pytest.raises(NoLiveHarnessError, match="no live harness subprocess"):
+            await manager.get_client("conv_never_spawned", "any")
     finally:
         await manager.shutdown()
 


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #1351 

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
-`get_client(conv, "any")` is a reuse-only sentinel. When no subprocess was live, it fell through to `_spawn_entry("any")` then `_resolve_module_path("any")` then raised `RuntimeError: unknown harness 'any'`. A misleading registry error for a benign "nothing running" condition.
- Added `NoLiveHarnessError(RuntimeError)` and a guard in `get_client` that raises it immediately when `harness == "any"` and `entry is None`, before reaching the spawn path.
- Updated 3 call sites in `app.py`: 503/502 replaced with 409 `no_live_harness`, WARNING log downgraded to DEBUG. Reduces 5xx retry noise from #1115.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->
- Ran `uv run pytest tests/runtime/harnesses/test_process_manager.py -v` — all tests pass including the new regression test.
- Ran `uv run ruff check . && uv run ruff format --check .` — all checks passed.
- Verified manually: calling `get_client(conv, "any")` with no live subprocess now raises `NoLiveHarnessError: no live harness subprocess for conversation 'conv_test'` instead of `RuntimeError: unknown harness 'any'; registered names: [...]`.


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes
`test_get_client_any_harness_sentinel_reuses_subprocess` covers the happy path (live subprocess reused). New test test_get_client_any_harness_sentinel_no_subprocess_raises confirms NoLiveHarnessError is raised instead of the old misleading RuntimeError.

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
