### PR TITLE
fix(pi): load user extensions in gateway harness sessions

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1874,40 +1874,42 @@ class PiExecutor(Executor):
             with open(models_path, "w") as f:
                 json.dump(models_json, f)
             env["PI_CODING_AGENT_DIR"] = tmp_dir
+            # Gateway mode relocates Pi's agent root — copy the user's global
+            # settings (extensions, packages, …) and symlink install trees so
+            # ``pi install`` packages still resolve. See #1423.
+            from omnigent.inner.pi_settings import prepare_managed_pi_agent_dir
+
+            prepare_managed_pi_agent_dir(
+                pathlib.Path(tmp_dir),
+                overlay=self._retry_policy.pi.settings(),
+            )
 
         # Pi natively supports retry config via ``.pi/settings.json``
-        # (see ``RetryPolicy.pi.settings()`` for schema). Write the
-        # retry block to ``<tmp_dir>/.pi/settings.json`` so Pi picks
-        # it up when spawned with ``cwd=tmp_dir`` (when the user
-        # didn't override cwd) or merge into ``<cwd>/.pi/settings.json``
-        # when they did. This sets max_retries, backoff base/cap from
-        # the spec policy.
-        retry_settings = self._retry_policy.pi.settings()
-        # Decide where to write. Project-level (cwd/.pi/settings.json)
-        # is Pi's documented project override; merge into existing
-        # file if present, else create.
-        settings_dir_root = self._cwd or tmp_dir
-        settings_path = os.path.join(settings_dir_root, ".pi", "settings.json")
-        try:
-            if os.path.exists(settings_path):
-                with open(settings_path) as f:
-                    existing_settings = json.load(f)
-                if not isinstance(existing_settings, dict):
+        # (see ``RetryPolicy.pi.settings()`` for schema). On the non-gateway
+        # path, merge the retry block into ``<cwd>/.pi/settings.json``.
+        # Gateway runs apply retry via :func:`prepare_managed_pi_agent_dir`
+        # into the managed agent dir instead.
+        if not self._gateway:
+            retry_settings = self._retry_policy.pi.settings()
+            settings_dir_root = self._cwd or tmp_dir
+            settings_path = os.path.join(settings_dir_root, ".pi", "settings.json")
+            try:
+                if os.path.exists(settings_path):
+                    with open(settings_path) as f:
+                        existing_settings = json.load(f)
+                    if not isinstance(existing_settings, dict):
+                        existing_settings = {}
+                else:
                     existing_settings = {}
-            else:
-                existing_settings = {}
-            existing_settings.update(retry_settings)
-            os.makedirs(os.path.dirname(settings_path), exist_ok=True)
-            with open(settings_path, "w") as f:
-                json.dump(existing_settings, f, indent=2)
-        except OSError:
-            # If we can't write to the user's cwd (read-only fs,
-            # permissions), fall back to tmp_dir; Pi will use its
-            # own defaults if neither location works.
-            fallback_path = os.path.join(tmp_dir, ".pi", "settings.json")
-            os.makedirs(os.path.dirname(fallback_path), exist_ok=True)
-            with open(fallback_path, "w") as f:
-                json.dump(retry_settings, f, indent=2)
+                existing_settings.update(retry_settings)
+                os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+                with open(settings_path, "w") as f:
+                    json.dump(existing_settings, f, indent=2)
+            except OSError:
+                fallback_path = os.path.join(tmp_dir, ".pi", "settings.json")
+                os.makedirs(os.path.dirname(fallback_path), exist_ok=True)
+                with open(fallback_path, "w") as f:
+                    json.dump(retry_settings, f, indent=2)
 
         # Generate the Omnigent tool bridge extension if tools are available.
         if tools and tool_server_port is not None:

--- a/omnigent/inner/pi_settings.py
+++ b/omnigent/inner/pi_settings.py
@@ -1,0 +1,113 @@
+"""Helpers for seeding a managed Pi agent dir (``PI_CODING_AGENT_DIR``).
+
+When the pi harness runs in gateway mode it relocates Pi's agent root to a
+per-session temp directory (for ``models.json``). That hides the user's global
+``~/.pi/agent/settings.json`` and installed package trees. This module copies
+the global settings metadata into the managed dir and symlinks install
+directories so Pi's native loader still sees extensions and ``pi install``
+packages — without mutating the user's home directory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+# Default global Pi agent root (``PI_CODING_AGENT_DIR`` when unset).
+DEFAULT_PI_AGENT_DIR = Path.home() / ".pi" / "agent"
+
+# Install / checkout trees Pi places under the agent dir. Symlinked into the
+# managed dir so ``packages`` entries in settings keep resolving.
+_PI_AGENT_RESOURCE_DIRS: tuple[str, ...] = ("npm", "git")
+
+
+def _read_settings_file(path: Path) -> dict[str, Any]:
+    """Load a Pi ``settings.json`` file, returning ``{}`` when absent/invalid."""
+    if not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _logger.warning("Ignoring unreadable Pi settings at %s: %s", path, exc)
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _deep_merge_settings(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge *overlay* onto *base* using Pi's nested-object merge semantics."""
+    merged = dict(base)
+    for key, value in overlay.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_settings(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _symlink_agent_resource_dirs(
+    managed_dir: Path,
+    global_agent_dir: Path,
+) -> None:
+    """Symlink package install trees from *global_agent_dir* into *managed_dir*."""
+    for name in _PI_AGENT_RESOURCE_DIRS:
+        source = global_agent_dir / name
+        if not source.is_dir():
+            continue
+        target = managed_dir / name
+        if target.exists():
+            continue
+        try:
+            target.symlink_to(source, target_is_directory=True)
+        except OSError as exc:
+            _logger.warning(
+                "Could not symlink Pi agent resource %s -> %s: %s",
+                target,
+                source,
+                exc,
+            )
+
+
+def prepare_managed_pi_agent_dir(
+    managed_dir: Path,
+    *,
+    overlay: dict[str, Any] | None = None,
+    global_agent_dir: Path | None = None,
+) -> None:
+    """
+    Seed a managed ``PI_CODING_AGENT_DIR`` with the user's global Pi settings.
+
+    Copies (merges) ``settings.json`` from the user's global agent dir into
+    *managed_dir*, applies *overlay* (e.g. Omnigent retry policy), and
+    symlinks install trees (``npm/``, ``git/``) so ``packages`` entries keep
+    working. The user's ``~/.pi/agent`` is never modified.
+
+    Project-scoped ``.pi/settings.json`` at the session cwd is still read by
+    Pi at runtime and overrides these global settings per Pi's normal rules.
+
+    :param managed_dir: Per-session agent root (already contains ``models.json``).
+    :param overlay: Settings merged on top of the copied global file.
+    :param global_agent_dir: Override for tests; defaults to
+        :data:`DEFAULT_PI_AGENT_DIR`.
+    """
+    agent_root = global_agent_dir if global_agent_dir is not None else DEFAULT_PI_AGENT_DIR
+    settings = _read_settings_file(agent_root / "settings.json")
+    if overlay:
+        settings = _deep_merge_settings(settings, overlay)
+
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = managed_dir / "settings.json"
+    try:
+        settings_path.write_text(
+            json.dumps(settings, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        _logger.warning("Could not write managed Pi settings at %s: %s", settings_path, exc)
+        return
+
+    _symlink_agent_resource_dirs(managed_dir, agent_root)

--- a/tests/e2e/omnigent/test_pi_managed_extensions_e2e.py
+++ b/tests/e2e/omnigent/test_pi_managed_extensions_e2e.py
@@ -1,0 +1,155 @@
+"""E2E: pi gateway harness loads user extensions from the managed agent dir.
+
+Gateway mode sets ``PI_CODING_AGENT_DIR`` to a per-session temp directory for
+``models.json``. Without seeding that dir from ``~/.pi/agent``, extensions
+installed via ``pi install`` (or listed in global settings) never load (#1423).
+
+This test drives a real ``omnigent run --harness pi`` subprocess with:
+
+- an isolated ``HOME`` carrying ``~/.pi/agent/settings.json`` + a marker
+  extension;
+- a mock OpenAI provider in ``OMNIGENT_CONFIG_HOME`` so pi enters gateway mode
+  while still routing LLM calls to the session mock server;
+- a marker file the extension writes on ``session_start``.
+
+**Serial execution:** uses the session-scoped mock LLM server like the other
+``tests/e2e/omnigent/`` pi rows — do not run under xdist against a shared mock.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.e2e._harness_probes import cli_unavailable_reason
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm
+
+_EXTENSION_PATH = (
+    Path(__file__).resolve().parents[2] / "resources" / "pi_extensions" / "e2e_marker_extension.js"
+)
+_MARKER_NAME = "omnigent-pi-ext-marker"
+_PROMPT = "say hi in 5 words"
+_RUN_TIMEOUT_SEC = 180
+
+_pytest_pi_unavailable = cli_unavailable_reason("pi")
+pytestmark = pytest.mark.skipif(
+    _pytest_pi_unavailable is not None,
+    reason=(
+        "pi managed-extensions e2e requires a runnable 'pi' CLI; "
+        f"{_pytest_pi_unavailable}. Install/fix Pi to run this test."
+    ),
+)
+
+
+def _write_pi_gateway_config(config_home: Path, *, mock_url: str, model: str) -> None:
+    """Write a provider config that puts pi in gateway mode against the mock LLM."""
+    config = {
+        "auth": {"type": "api_key"},
+        "providers": {
+            "mock-oai": {
+                "kind": "key",
+                "default": True,
+                "openai": {
+                    "base_url": f"{mock_url}/v1",
+                    "api_key": "mock-key",
+                    "models": {"default": model},
+                },
+            },
+        },
+    }
+    config_home.mkdir(parents=True, exist_ok=True)
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _seed_pi_extension_home(home: Path) -> Path:
+    """
+    Install a global Pi settings file pointing at the marker extension.
+
+    :returns: Path where the extension should write its marker file.
+    """
+    agent_dir = home / ".pi" / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "settings.json").write_text(
+        json.dumps({"extensions": [str(_EXTENSION_PATH.resolve())]}),
+        encoding="utf-8",
+    )
+    return home / _MARKER_NAME
+
+
+def test_pi_gateway_run_loads_global_extensions(
+    omnigent_repo_root: Path,
+    omnigent_python: Path,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
+    tmp_path: Path,
+) -> None:
+    """
+    ``omnigent run --harness pi`` in gateway mode loads extensions from the
+    user's global Pi agent settings.
+
+    The marker extension writes ``~/omnigent-pi-ext-marker`` on
+    ``session_start``. Presence of that file after a successful run proves the
+    managed ``PI_CODING_AGENT_DIR`` was seeded from ``~/.pi/agent``.
+    """
+    model = f"mock-pi-ext-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello from the mock model."}],
+        key=model,
+    )
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    marker_path = _seed_pi_extension_home(fake_home)
+    assert not marker_path.exists()
+
+    config_home = tmp_path / "omnigent-config"
+    _write_pi_gateway_config(config_home, mock_url=mock_llm_server_url, model=model)
+
+    env = dict(mock_credentials_env)
+    env["HOME"] = str(fake_home)
+    env["OMNIGENT_CONFIG_HOME"] = str(config_home)
+
+    yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
+    result = subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(yaml_path),
+            "--model",
+            model,
+            "--harness",
+            "pi",
+            "-p",
+            _PROMPT,
+            "--no-log",
+            "--no-session",
+        ],
+        env=env,
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+
+    assert result.returncode == 0, (
+        "pi gateway run failed; stdout:\n"
+        f"{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    assert marker_path.is_file(), (
+        "Pi extension marker missing — gateway managed agent dir was not seeded "
+        f"from {fake_home / '.pi' / 'agent' / 'settings.json'!s}.\n"
+        f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    assert marker_path.read_text(encoding="utf-8") == "loaded"

--- a/tests/e2e/omnigent/test_pi_managed_extensions_e2e.py
+++ b/tests/e2e/omnigent/test_pi_managed_extensions_e2e.py
@@ -144,8 +144,7 @@ def test_pi_gateway_run_loads_global_extensions(
     )
 
     assert result.returncode == 0, (
-        "pi gateway run failed; stdout:\n"
-        f"{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+        f"pi gateway run failed; stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
     )
     assert marker_path.is_file(), (
         "Pi extension marker missing — gateway managed agent dir was not seeded "

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -1513,11 +1513,17 @@ class TestBuildEnvAndDir(unittest.TestCase):
         config = executor._build_env_and_dir([], None, None, None)
         try:
             self.assertIn("PI_CODING_AGENT_DIR", config.env)
-            models_path = os.path.join(config.env["PI_CODING_AGENT_DIR"], "models.json")
-            self.assertTrue(os.path.exists(models_path))
+            managed_dir = Path(config.env["PI_CODING_AGENT_DIR"])
+            models_path = managed_dir / "models.json"
+            self.assertTrue(models_path.is_file())
             with open(models_path) as f:
                 data = json.load(f)
             self.assertIn("providers", data)
+            settings_path = managed_dir / "settings.json"
+            self.assertTrue(settings_path.is_file())
+            with open(settings_path) as f:
+                settings = json.load(f)
+            self.assertIn("retry", settings)
         finally:
             import shutil
 
@@ -1550,6 +1556,42 @@ class TestBuildEnvAndDir(unittest.TestCase):
             import shutil
 
             shutil.rmtree(config.tmp_dir, ignore_errors=True)
+
+
+def test_gateway_seeds_managed_settings_from_global_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gateway mode copies global Pi settings into the managed agent dir."""
+    global_agent = tmp_path / "pi-agent"
+    global_agent.mkdir()
+    (global_agent / "settings.json").write_text(
+        json.dumps({"extensions": ["/ext/demo.ts"], "packages": ["npm:@x/y"]}),
+        encoding="utf-8",
+    )
+    (global_agent / "npm").mkdir()
+    monkeypatch.setattr(
+        "omnigent.inner.pi_settings.DEFAULT_PI_AGENT_DIR",
+        global_agent,
+    )
+    with (
+        patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+        patch(
+            "omnigent.inner.pi_executor._read_databrickscfg",
+            return_value=DatabricksCredentials(host="https://h.example.com", token="tok"),
+        ),
+    ):
+        executor = PiExecutor(gateway=True)
+
+    config = executor._build_env_and_dir([], None, None, None)
+    try:
+        managed_dir = Path(config.env["PI_CODING_AGENT_DIR"])
+        settings = json.loads((managed_dir / "settings.json").read_text(encoding="utf-8"))
+        assert settings["extensions"] == ["/ext/demo.ts"]
+        assert settings["packages"] == ["npm:@x/y"]
+        assert (managed_dir / "npm").is_symlink()
+    finally:
+        shutil.rmtree(config.tmp_dir, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_pi_settings.py
+++ b/tests/inner/test_pi_settings.py
@@ -1,0 +1,87 @@
+"""Tests for managed Pi agent dir seeding (extensions / packages)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from omnigent.inner.pi_settings import prepare_managed_pi_agent_dir
+
+
+def test_prepare_managed_pi_agent_dir_copies_settings_and_symlinks_npm(
+    tmp_path: Path,
+) -> None:
+    """Gateway managed dir gets global settings metadata and npm install tree."""
+    global_agent = tmp_path / "global-agent"
+    global_agent.mkdir()
+    (global_agent / "settings.json").write_text(
+        json.dumps(
+            {
+                "extensions": ["/tmp/my-ext.ts"],
+                "packages": ["npm:@foo/bar"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    npm_dir = global_agent / "npm" / "foo"
+    npm_dir.mkdir(parents=True)
+
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "models.json").write_text("{}", encoding="utf-8")
+
+    prepare_managed_pi_agent_dir(
+        managed,
+        overlay={"retry": {"maxRetries": 5}},
+        global_agent_dir=global_agent,
+    )
+
+    written = json.loads((managed / "settings.json").read_text(encoding="utf-8"))
+    assert written["extensions"] == ["/tmp/my-ext.ts"]
+    assert written["packages"] == ["npm:@foo/bar"]
+    assert written["retry"] == {"maxRetries": 5}
+    assert (managed / "npm").is_symlink()
+    assert (managed / "npm").resolve() == (global_agent / "npm").resolve()
+
+
+def test_prepare_managed_pi_agent_dir_empty_global_writes_overlay_only(
+    tmp_path: Path,
+) -> None:
+    """Missing global settings still writes the Omnigent overlay."""
+    global_agent = tmp_path / "empty-global"
+    global_agent.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+
+    prepare_managed_pi_agent_dir(
+        managed,
+        overlay={"retry": {"enabled": True}},
+        global_agent_dir=global_agent,
+    )
+
+    written = json.loads((managed / "settings.json").read_text(encoding="utf-8"))
+    assert written == {"retry": {"enabled": True}}
+
+
+def test_prepare_managed_pi_agent_dir_deep_merges_nested_overlay(tmp_path: Path) -> None:
+    """Nested settings (e.g. compaction) merge like Pi project overrides."""
+    global_agent = tmp_path / "global-agent"
+    global_agent.mkdir()
+    (global_agent / "settings.json").write_text(
+        json.dumps({"compaction": {"enabled": True, "reserveTokens": 16384}}),
+        encoding="utf-8",
+    )
+    managed = tmp_path / "managed"
+    managed.mkdir()
+
+    prepare_managed_pi_agent_dir(
+        managed,
+        overlay={"compaction": {"reserveTokens": 8192}},
+        global_agent_dir=global_agent,
+    )
+
+    written = json.loads((managed / "settings.json").read_text(encoding="utf-8"))
+    assert written["compaction"] == {
+        "enabled": True,
+        "reserveTokens": 8192,
+    }

--- a/tests/resources/pi_extensions/e2e_marker_extension.js
+++ b/tests/resources/pi_extensions/e2e_marker_extension.js
@@ -1,0 +1,12 @@
+// E2E marker extension: writes a file under $HOME when Pi loads extensions.
+// Used by tests/e2e/omnigent/test_pi_managed_extensions_e2e.py.
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+module.exports = function (pi) {
+  pi.on("session_start", () => {
+    const marker = path.join(os.homedir(), "omnigent-pi-ext-marker");
+    fs.writeFileSync(marker, "loaded", "utf8");
+  });
+};


### PR DESCRIPTION
## Summary
- Fixes #1423: pi harness gateway mode already relocates Pi's agent root via `PI_CODING_AGENT_DIR` for `models.json`, but that hid `~/.pi/agent` settings and `pi install` package trees.
- Seed the managed agent dir by copying global `settings.json` (extensions, packages, etc.) and symlinking `npm/` / `git/` install dirs; user's home is never modified.
- Gateway retry policy is merged into the managed settings file; non-gateway behavior is unchanged.

## Test plan
- [x] `uv run pytest tests/inner/test_pi_settings.py tests/inner/test_pi_executor.py::TestBuildEnvAndDir::test_databricks_creates_models_json tests/inner/test_pi_executor.py::test_gateway_seeds_managed_settings_from_global_agent`
- [ ] Manual: `pi install` an extension, run an agent with `harness: pi` via gateway, confirm extension loads
