### PR TITLE
fix(onboarding): reflect configured Hermes model in setup overview

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11041,6 +11041,7 @@ def _run_configure_harnesses_interactive() -> None:
         # harness shows at once. Each row is (target, name, status, kind, hint),
         # where ``hint`` is the selection-only description (install command /
         # next step), empty for a ready harness.
+        from omnigent.onboarding.hermes_auth import hermes_config_summary
         from omnigent.onboarding.opencode_auth import opencode_auth_summary
 
         rows: list[tuple[str, str, str, str, str]] = []
@@ -11099,21 +11100,14 @@ def _run_configure_harnesses_interactive() -> None:
                 ),
             )
 
-        # Hermes — curl-installed, but provider/model config is opaque until
-        # `hermes model` has been run. Treat an installed binary as
-        # "not configured" rather than ready so setup does not overstate the
-        # state of a fresh install.
-        if harness_cli_installed(HERMES_KEY):
-            rows.append(
-                (
-                    _HERMES,
-                    "Hermes",
-                    "Not configured",
-                    "warn",
-                    "Open to configure with `hermes model`.",
-                ),
-            )
-        else:
+        # Hermes — curl-installed; its provider/model live in
+        # ``~/.hermes/config.yaml`` (written by `hermes model`). Read that so a
+        # configured Hermes shows the picked model as ready, instead of always
+        # reading "not configured" on an installed binary. A fresh install
+        # ships ``provider: auto`` (nothing picked), so it still reads
+        # "not configured" until `hermes model` selects a concrete provider.
+        hermes = hermes_config_summary()
+        if not hermes.installed:
             hermes_spec = harness_install_spec(HERMES_KEY)
             hermes_hint = (
                 hermes_spec.install_hint
@@ -11122,6 +11116,18 @@ def _run_configure_harnesses_interactive() -> None:
             )
             rows.append(
                 (_HERMES, "Hermes", "Not installed", "missing", _install_hint(hermes_hint)),
+            )
+        elif hermes.ready:
+            rows.append((_HERMES, "Hermes", hermes.describe(), "ready", ""))
+        else:
+            rows.append(
+                (
+                    _HERMES,
+                    "Hermes",
+                    "Not configured",
+                    "warn",
+                    "Open to configure with `hermes model`.",
+                ),
             )
 
         rows.append(_family_row(PI_SURFACE))

--- a/omnigent/onboarding/hermes_auth.py
+++ b/omnigent/onboarding/hermes_auth.py
@@ -1,0 +1,121 @@
+"""Hermes readiness + config reporting for ``omnigent setup``.
+
+Like :mod:`omnigent.onboarding.goose_auth`, Omnigent manages **no** Hermes
+credentials: Hermes owns its own auth via ``hermes model`` (an interactive
+provider/model picker) which writes the chosen provider + model into
+``~/.hermes/config.yaml``. This module is a thin, read-only reporter — it
+confirms the ``hermes`` binary is installed and surfaces the configured
+provider/model so ``omnigent setup`` can show Hermes as ready (and which model
+it will drive) instead of always reading "Not configured" on an installed
+binary.
+
+Detection reads ``~/.hermes/config.yaml`` directly — the same user config the
+native bridge copies forward in
+:func:`omnigent.hermes_native_bridge._load_user_hermes_config`. A fresh install
+ships ``model.provider: auto`` (auto-detect from credentials — nothing picked
+yet); a finished ``hermes model`` run replaces that with a concrete provider id
+(e.g. ``openrouter``). So "configured" is a concrete, non-``auto`` provider,
+which cleanly distinguishes a completed ``hermes model`` run from an untouched
+scaffold. As with Goose, a bad/absent credential surfaces at run time via
+Hermes' own error — the daemon's launch gate (:mod:`harness_readiness`)
+deliberately fails open — so this reporter gates only on the picked provider,
+never on credential resolution it cannot reliably enumerate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from omnigent.onboarding.harness_install import HERMES_KEY, harness_cli_installed
+
+#: Provider value Hermes ships in a fresh ``config.yaml``. ``"auto"`` means
+#: "auto-detect from credentials", i.e. the user has not picked a provider via
+#: ``hermes model`` yet — treated as not-configured for the setup overview.
+_AUTO_PROVIDER = "auto"
+
+
+def hermes_cli_installed() -> bool:
+    """Return whether the ``hermes`` binary is on ``PATH``."""
+    return harness_cli_installed(HERMES_KEY)
+
+
+def hermes_config_path() -> Path:
+    """Return the user's Hermes config path (``~/.hermes/config.yaml``)."""
+    return Path.home() / ".hermes" / "config.yaml"
+
+
+@dataclass(frozen=True)
+class HermesConfigSummary:
+    """What setup needs to know about the local Hermes configuration.
+
+    :param installed: ``hermes`` binary present on ``PATH``.
+    :param provider: Configured ``model.provider`` (a concrete provider id),
+        or ``None`` when unset, empty, or still the ``auto`` scaffold default.
+    :param model: Configured ``model.default`` model id, or ``None``.
+    """
+
+    installed: bool
+    provider: str | None
+    model: str | None
+
+    @property
+    def ready(self) -> bool:
+        """Configured once a concrete provider has been picked via ``hermes model``.
+
+        A fresh install ships ``provider: auto`` (nothing chosen); a finished
+        ``hermes model`` run writes a concrete provider id. Gate on the binary
+        too so an absent CLI never reads as ready.
+        """
+        return self.installed and self.provider is not None
+
+    def describe(self) -> str:
+        """Return a one-line status for the setup overview.
+
+        e.g. ``"openrouter / z-ai/glm-5.2"`` when both are known, else whichever
+        of provider/model is set, falling back to ``"Configured"``.
+        """
+        if self.provider and self.model:
+            return f"{self.provider} / {self.model}"
+        return self.provider or self.model or "Configured"
+
+
+def _model_section() -> dict:
+    """Return the ``model`` mapping from ``~/.hermes/config.yaml`` (best-effort).
+
+    Returns ``{}`` on a missing file, parse failure, or a non-mapping top-level
+    document / ``model`` value — this is read-only reporting and must never
+    raise.
+    """
+    path = hermes_config_path()
+    try:
+        import yaml
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    model = data.get("model")
+    return model if isinstance(model, dict) else {}
+
+
+def hermes_config_summary() -> HermesConfigSummary:
+    """Summarize the local Hermes configuration for the setup overview.
+
+    Reads ``model.provider`` (reported as ``None`` when unset, empty, or the
+    ``auto`` scaffold default) and the selected model id (``model.default``,
+    accepting the ``model.model`` alternate spelling Hermes also honors).
+    """
+    section = _model_section()
+    raw_provider = section.get("provider")
+    provider = raw_provider.strip() if isinstance(raw_provider, str) else ""
+    if provider.lower() == _AUTO_PROVIDER:
+        provider = ""
+    raw_model = section.get("default") or section.get("model")
+    model = raw_model.strip() if isinstance(raw_model, str) else ""
+    return HermesConfigSummary(
+        installed=hermes_cli_installed(),
+        provider=provider or None,
+        model=model or None,
+    )

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1714,6 +1714,51 @@ def test_overview_lists_kiro_row(isolated_config, monkeypatch) -> None:
     assert "kiro-cli login" in Text.from_markup(descriptions[kiro]).plain
 
 
+def test_overview_hermes_row_reflects_configured_model(isolated_config, monkeypatch) -> None:
+    """Hermes reads ready (with its picked model) once ``hermes model`` has run.
+
+    Regression for the overview hardcoding an installed Hermes to
+    ``✗ Not configured`` regardless of ``~/.hermes/config.yaml``. With the
+    ``hermes`` binary present:
+
+    * a fresh scaffold (``model.provider: auto`` — nothing picked yet) still
+      reads a yellow ``✗ Not configured`` and points at ``hermes model``;
+    * a finished ``hermes model`` run (a concrete ``provider`` + ``default``
+      model) reads a green ✓ with ``"<provider> / <model>"``.
+
+    HOME is the isolated tmp dir (``isolated_config``), so the probe reads the
+    config written here, not the developer's real ``~/.hermes``. The probe
+    binds ``harness_cli_installed`` at import, so patch the ``hermes_auth``
+    symbol it actually calls rather than relying on the install fixture.
+    """
+    from rich.text import Text
+
+    monkeypatch.setattr("omnigent.onboarding.hermes_auth.hermes_cli_installed", lambda: True)
+    hermes_dir = os.path.join(isolated_config, ".hermes")
+    os.makedirs(hermes_dir, exist_ok=True)
+    hermes_config = os.path.join(hermes_dir, "config.yaml")
+
+    # Fresh scaffold: provider "auto" (auto-detect), nothing picked → unconfigured.
+    with open(hermes_config, "w") as f:
+        yaml.safe_dump({"model": {"default": "anthropic/claude-opus-4.6", "provider": "auto"}}, f)
+    options, selectable, descriptions, _, _max_visible = _capture_setup_overview(monkeypatch)
+    names = _overview_row_names(options, selectable)
+    hermes = names.index("Hermes")
+    assert "[yellow]✗ Not configured[/]" in options[hermes]
+    assert "hermes model" in Text.from_markup(descriptions[hermes]).plain
+
+    # Configured: a concrete provider + model picked → green ✓ with the model.
+    with open(hermes_config, "w") as f:
+        yaml.safe_dump({"model": {"default": "z-ai/glm-5.2", "provider": "openrouter"}}, f)
+    options, selectable, _descriptions, _, _max_visible = _capture_setup_overview(monkeypatch)
+    names = _overview_row_names(options, selectable)
+    hermes = names.index("Hermes")
+    assert "[green]✓" in options[hermes]
+    plain = Text.from_markup(options[hermes]).plain
+    assert "openrouter" in plain
+    assert "z-ai/glm-5.2" in plain
+
+
 def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, monkeypatch) -> None:
     """Verbose ready statuses are capped from the terminal width before rendering.
 
@@ -1828,17 +1873,19 @@ def test_overview_status_color_distinguishes_missing_from_unconfigured(
     assert "[red]✗ Not installed[/]" in codex
 
 
-@pytest.mark.parametrize("name", ["Hermes", "Kiro", "Kimi Code"])
+@pytest.mark.parametrize("name", ["Kiro", "Kimi Code"])
 def test_installed_native_cli_auth_unknown_rows_are_not_configured(
     isolated_config, monkeypatch, name: str
 ) -> None:
     """Installed native CLIs with opaque auth/config state must not render ready.
 
-    Hermes, Kiro, and Kimi expose installation separately from their own
-    provider/login configuration. Since setup has no reliable local auth probe
-    for them yet, an installed binary should be yellow ``Not configured`` with a
-    next-step hint — not a green ``Installed`` row that implies the harness is
-    ready to use.
+    Kiro and Kimi expose installation separately from their own provider/login
+    configuration. Since setup has no reliable local auth probe for them yet, an
+    installed binary should be yellow ``Not configured`` with a next-step hint —
+    not a green ``Installed`` row that implies the harness is ready to use.
+    (Hermes, like Goose, *does* have a config probe now — its ``model`` is read
+    from ``~/.hermes/config.yaml`` — so its ready/unconfigured split is covered
+    by ``test_overview_hermes_row_reflects_configured_model`` instead.)
     """
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_installed", lambda family: True
@@ -1864,6 +1911,7 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
     from rich.text import Text
 
     from omnigent.onboarding.goose_auth import GooseConfigSummary
+    from omnigent.onboarding.hermes_auth import HermesConfigSummary
     from omnigent.onboarding.opencode_auth import OpenCodeAuthSummary
 
     monkeypatch.setattr("omnigent.onboarding.cursor_auth.cursor_sdk_installed", lambda: True)
@@ -1878,6 +1926,11 @@ def test_overview_descriptions_map_to_their_rows(isolated_config, monkeypatch) -
     monkeypatch.setattr(
         "omnigent.onboarding.goose_auth.goose_config_summary",
         lambda: GooseConfigSummary(installed=True, provider=None, model=None),
+    )
+    # Installed but no provider picked → the "Open to configure" warn hint.
+    monkeypatch.setattr(
+        "omnigent.onboarding.hermes_auth.hermes_config_summary",
+        lambda: HermesConfigSummary(installed=True, provider=None, model=None),
     )
 
     options, selectable, descriptions, _compact, _max_visible = _capture_setup_overview(

--- a/tests/onboarding/test_hermes_auth.py
+++ b/tests/onboarding/test_hermes_auth.py
@@ -1,0 +1,124 @@
+"""Unit tests for the Hermes onboarding readiness/config reporter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.onboarding import hermes_auth
+from omnigent.onboarding.hermes_auth import HermesConfigSummary, hermes_config_summary
+
+
+def _write_config(home: Path, model_section: object) -> None:
+    """Write ``~/.hermes/config.yaml`` under *home* with the given ``model`` block."""
+    hermes_dir = home / ".hermes"
+    hermes_dir.mkdir(parents=True, exist_ok=True)
+    (hermes_dir / "config.yaml").write_text(yaml.safe_dump({"model": model_section}))
+
+
+def test_config_path_honors_home(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert hermes_auth.hermes_config_path() == tmp_path / ".hermes" / "config.yaml"
+
+
+def test_summary_reports_concrete_provider_and_model(tmp_path: Path, monkeypatch) -> None:
+    """A finished ``hermes model`` run (concrete provider + model) reads ready."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: True)
+    _write_config(tmp_path, {"default": "z-ai/glm-5.2", "provider": "openrouter"})
+
+    summary = hermes_config_summary()
+    assert summary == HermesConfigSummary(
+        installed=True, provider="openrouter", model="z-ai/glm-5.2"
+    )
+    assert summary.ready is True
+    assert summary.describe() == "openrouter / z-ai/glm-5.2"
+
+
+def test_summary_auto_provider_is_not_configured(tmp_path: Path, monkeypatch) -> None:
+    """The fresh-scaffold ``provider: auto`` sentinel reports as not-yet-configured.
+
+    A fresh ``hermes`` install ships ``model.provider: auto`` (auto-detect) with a
+    placeholder model. That must not read as ready, or the overview would call an
+    untouched install "configured" — the exact bug this reporter fixes.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: True)
+    _write_config(tmp_path, {"default": "anthropic/claude-opus-4.6", "provider": "auto"})
+
+    summary = hermes_config_summary()
+    assert summary.provider is None
+    assert summary.ready is False
+
+
+@pytest.mark.parametrize("provider", ["", "  ", "AUTO", "Auto"])
+def test_summary_blank_or_auto_provider_variants_not_ready(
+    tmp_path: Path, monkeypatch, provider: str
+) -> None:
+    """Empty/whitespace and any-case ``auto`` all collapse to unconfigured."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: True)
+    _write_config(tmp_path, {"default": "some/model", "provider": provider})
+    assert hermes_config_summary().ready is False
+
+
+def test_summary_accepts_model_alternate_key(tmp_path: Path, monkeypatch) -> None:
+    """Hermes allows ``model.model`` as well as ``model.default`` for the model id."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: True)
+    _write_config(tmp_path, {"model": "moonshot/kimi-k2", "provider": "openrouter"})
+
+    summary = hermes_config_summary()
+    assert summary.model == "moonshot/kimi-k2"
+    assert summary.describe() == "openrouter / moonshot/kimi-k2"
+
+
+def test_summary_missing_config_is_not_configured(tmp_path: Path, monkeypatch) -> None:
+    """No ``~/.hermes/config.yaml`` at all → installed but not configured."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: True)
+
+    summary = hermes_config_summary()
+    assert summary == HermesConfigSummary(installed=True, provider=None, model=None)
+    assert summary.ready is False
+
+
+@pytest.mark.parametrize("body", ["", "not-a-mapping", "model: [a, b]", ": : :"])
+def test_summary_malformed_config_never_raises(tmp_path: Path, monkeypatch, body: str) -> None:
+    """A missing/garbage/non-mapping config degrades to not-configured, never raises."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: True)
+    hermes_dir = tmp_path / ".hermes"
+    hermes_dir.mkdir(parents=True, exist_ok=True)
+    (hermes_dir / "config.yaml").write_text(body)
+
+    summary = hermes_config_summary()
+    assert summary.provider is None
+    assert summary.ready is False
+
+
+def test_ready_gates_on_installed_binary(tmp_path: Path, monkeypatch) -> None:
+    """A configured provider with no ``hermes`` binary is not ready (nothing to launch)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: False)
+    _write_config(tmp_path, {"default": "z-ai/glm-5.2", "provider": "openrouter"})
+
+    summary = hermes_config_summary()
+    assert summary.provider == "openrouter"  # config is still read…
+    assert summary.installed is False
+    assert summary.ready is False  # …but an absent binary can't be launched.
+
+
+@pytest.mark.parametrize(
+    "summary,expected",
+    [
+        (HermesConfigSummary(True, "openrouter", "z-ai/glm-5.2"), "openrouter / z-ai/glm-5.2"),
+        (HermesConfigSummary(True, "openrouter", None), "openrouter"),
+        (HermesConfigSummary(True, None, "z-ai/glm-5.2"), "z-ai/glm-5.2"),
+        (HermesConfigSummary(True, None, None), "Configured"),
+    ],
+)
+def test_describe_variants(summary: HermesConfigSummary, expected: str) -> None:
+    assert summary.describe() == expected


### PR DESCRIPTION
## Related issue

N/A — drive-by bug fix (no tracking issue).

Closes #

## Summary

`omnigent setup`'s harness overview hardcoded an installed Hermes to `✗ Not configured` whenever the `hermes` binary was present — it never looked at Hermes' own config. So a Hermes set up via `hermes model` (provider + model written to `~/.hermes/config.yaml`) still showed as unconfigured.

- Add `omnigent/onboarding/hermes_auth.py`, a read-only reporter mirroring `goose_auth`, that reads `model.provider` / `model.default` from `~/.hermes/config.yaml`.
- The overview now renders a configured Hermes as ready (`✓ <provider> / <model>`). A fresh install ships `provider: auto` (nothing picked) and still reads `✗ Not configured`.
- The daemon launch gate (`harness_readiness.harness_is_configured`) is intentionally left fail-open and unchanged.

## Test Plan

- `tests/onboarding/test_hermes_auth.py` (new): provider/model parsing, the `auto` scaffold sentinel, the `model.model` alias, missing/malformed config (never raises), and `ready` gating on the binary.
- `tests/cli/test_configure_models.py`: added `test_overview_hermes_row_reflects_configured_model` (fresh `auto` → Not configured; concrete provider+model → ready). Hermes now has a real probe, so it is dropped from `test_installed_native_cli_auth_unknown_rows_are_not_configured` (Kiro/Kimi remain) and given a summary stub in `test_overview_descriptions_map_to_their_rows` — mirroring how Goose is already handled.
- Ran the new + affected overview tests locally (pass) plus `ruff check` / `ruff format`. Full suite on CI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified against a real configured `~/.hermes/config.yaml` (`provider: openrouter`, `model.default: z-ai/glm-5.2`) — exactly the case the overview previously mislabeled as unconfigured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
