### PR TITLE
fix(ap-web): bind newest agent version in new-session picker

### DIFF
--- a/ap-web/src/hooks/useAvailableAgents.test.tsx
+++ b/ap-web/src/hooks/useAvailableAgents.test.tsx
@@ -495,6 +495,137 @@ describe("useAvailableAgents", () => {
     ]);
   });
 
+  it("lets a newer upload supersede a same-named user-registered template (builtin: false)", async () => {
+    // The regression this guards: a user registers agent A as a template
+    // (e.g. `omnigent server --agent`, builtin: false), then `omnigent run`s
+    // a NEWER agent A whose session-scoped row has a distinct agent_id. The
+    // picker must bind the newest (the upload), not the stale template.
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [
+          // Seeded built-in — protected, always listed verbatim.
+          { id: "ag_debby", name: "debby", harness: "claude-sdk", builtin: true, created_at: 100 },
+          // User-registered template for "agent-a" (older).
+          {
+            id: "ag_template",
+            name: "agent-a",
+            harness: "claude-sdk",
+            builtin: false,
+            created_at: 200,
+          },
+        ],
+        has_more: false,
+      }),
+      [SCAN_URL]: mockResponse({
+        object: "list",
+        data: [
+          // A session that bound the template directly — dropped by id (the
+          // template already represents it as a candidate).
+          { id: "conv_a", agent_id: "ag_template", agent_name: "agent-a", created_at: 250 },
+          // The newer `omnigent run` upload: distinct agent_id, same name,
+          // created AFTER the template — must win.
+          { id: "conv_b", agent_id: "ag_upload_v2", agent_name: "agent-a", created_at: 300 },
+        ],
+        has_more: false,
+      }),
+      "/v1/sessions/conv_b/agent": mockResponse({
+        id: "ag_upload_v2",
+        object: "agent",
+        name: "agent-a",
+        description: "version 2",
+        harness: "claude-sdk",
+      }),
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Exactly one "agent-a", bound to the newer upload (ag_upload_v2). The
+    // seeded debby is untouched. ag_template winning would mean the stale
+    // template shadowed the upload (the original bug); two agent-a rows would
+    // mean the template and upload both leaked.
+    const ids = result.current.data?.map((a) => a.id);
+    expect(ids).toEqual(["ag_debby", "ag_upload_v2"]);
+    // The enrich ran against the upload's session, not the template-bound one.
+    const enrichCalls = fetchMock.mock.calls
+      .map((c) => c[0] as string)
+      .filter((u) => u.endsWith("/agent"));
+    expect(enrichCalls).toEqual(["/v1/sessions/conv_b/agent"]);
+  });
+
+  it("keeps a user-registered template when no newer upload exists", async () => {
+    // Mirror image of the supersede case: the template is the only agent-a,
+    // and a same-named session that simply bound it must not duplicate it.
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [
+          {
+            id: "ag_template",
+            name: "agent-a",
+            description: "the template",
+            harness: "claude-sdk",
+            builtin: false,
+            created_at: 200,
+          },
+        ],
+        has_more: false,
+      }),
+      [SCAN_URL]: mockResponse({
+        object: "list",
+        data: [{ id: "conv_a", agent_id: "ag_template", agent_name: "agent-a", created_at: 250 }],
+        has_more: false,
+      }),
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // One agent-a (the template), carried with its full catalog info. No
+    // enrich fetch — the only session bound the template directly.
+    expect(result.current.data?.map((a) => ({ id: a.id, description: a.description }))).toEqual([
+      { id: "ag_template", description: "the template" },
+    ]);
+    const enrichCalls = fetchMock.mock.calls
+      .map((c) => c[0] as string)
+      .filter((u) => u.endsWith("/agent"));
+    expect(enrichCalls).toEqual([]);
+  });
+
+  it("protects a seeded built-in from a same-named upload (builtin: true)", async () => {
+    // Option-1 half of the policy: a same-named upload must NOT shadow a
+    // SEEDED built-in (unlike a user-registered template). debby stays canonical.
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [
+          { id: "ag_debby", name: "debby", harness: "claude-sdk", builtin: true, created_at: 100 },
+        ],
+        has_more: false,
+      }),
+      [SCAN_URL]: mockResponse({
+        object: "list",
+        data: [
+          // A newer upload named "debby" — must be dropped, not surfaced.
+          { id: "conv_x", agent_id: "ag_fake_debby", agent_name: "debby", created_at: 999 },
+        ],
+        has_more: false,
+      }),
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Only the seeded debby; the same-named upload is shadowed (Option 1) and
+    // never enriched, even though it is newer than the built-in.
+    expect(result.current.data?.map((a) => a.id)).toEqual(["ag_debby"]);
+    const enrichCalls = fetchMock.mock.calls
+      .map((c) => c[0] as string)
+      .filter((u) => u.endsWith("/agent"));
+    expect(enrichCalls).toEqual([]);
+  });
+
   it("degrades to built-ins when the sessions scan fails", async () => {
     routeFetch({
       [BUILTINS_URL]: mockResponse({

--- a/ap-web/src/hooks/useAvailableAgents.test.tsx
+++ b/ap-web/src/hooks/useAvailableAgents.test.tsx
@@ -538,9 +538,7 @@ describe("useAvailableAgents", () => {
       }),
     });
 
-    const { result } = renderHook(() => useAvailableAgents({ supersedeTemplates: true }), {
-      wrapper,
-    });
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Exactly one "agent-a", bound to the newer upload (ag_upload_v2). The
@@ -581,9 +579,7 @@ describe("useAvailableAgents", () => {
       }),
     });
 
-    const { result } = renderHook(() => useAvailableAgents({ supersedeTemplates: true }), {
-      wrapper,
-    });
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // One agent-a (the template), carried with its full catalog info. No
@@ -618,57 +614,12 @@ describe("useAvailableAgents", () => {
       }),
     });
 
-    const { result } = renderHook(() => useAvailableAgents({ supersedeTemplates: true }), {
-      wrapper,
-    });
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Only the seeded debby; the same-named upload is shadowed (Option 1) and
     // never enriched, even though it is newer than the built-in.
     expect(result.current.data?.map((a) => a.id)).toEqual(["ag_debby"]);
-    const enrichCalls = fetchMock.mock.calls
-      .map((c) => c[0] as string)
-      .filter((u) => u.endsWith("/agent"));
-    expect(enrichCalls).toEqual([]);
-  });
-
-  it("default mode protects a user-registered template from a same-named upload", async () => {
-    // Without supersedeTemplates (the default), a user-registered template is
-    // protected just like a seeded built-in: a same-named session upload is
-    // shadowed, not surfaced. This is what Add-Subagent / Fork / Switch use so
-    // they bind the canonical registered agent (regression guard for
-    // test_add_subagent_from_dialog).
-    routeFetch({
-      [BUILTINS_URL]: mockResponse({
-        object: "list",
-        data: [
-          {
-            id: "ag_template",
-            name: "agent-a",
-            description: "the template",
-            harness: "claude-sdk",
-            builtin: false,
-            created_at: 200,
-          },
-        ],
-        has_more: false,
-      }),
-      [SCAN_URL]: mockResponse({
-        object: "list",
-        data: [
-          // A newer same-named upload — must be shadowed in the default mode.
-          { id: "conv_b", agent_id: "ag_upload_v2", agent_name: "agent-a", created_at: 300 },
-        ],
-        has_more: false,
-      }),
-    });
-
-    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    // Only the registered template; the newer upload is dropped (protected),
-    // and never enriched.
-    expect(result.current.data?.map((a) => a.id)).toEqual(["ag_template"]);
     const enrichCalls = fetchMock.mock.calls
       .map((c) => c[0] as string)
       .filter((u) => u.endsWith("/agent"));

--- a/ap-web/src/hooks/useAvailableAgents.test.tsx
+++ b/ap-web/src/hooks/useAvailableAgents.test.tsx
@@ -538,7 +538,9 @@ describe("useAvailableAgents", () => {
       }),
     });
 
-    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    const { result } = renderHook(() => useAvailableAgents({ supersedeTemplates: true }), {
+      wrapper,
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Exactly one "agent-a", bound to the newer upload (ag_upload_v2). The
@@ -579,7 +581,9 @@ describe("useAvailableAgents", () => {
       }),
     });
 
-    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    const { result } = renderHook(() => useAvailableAgents({ supersedeTemplates: true }), {
+      wrapper,
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // One agent-a (the template), carried with its full catalog info. No
@@ -614,12 +618,57 @@ describe("useAvailableAgents", () => {
       }),
     });
 
-    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    const { result } = renderHook(() => useAvailableAgents({ supersedeTemplates: true }), {
+      wrapper,
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Only the seeded debby; the same-named upload is shadowed (Option 1) and
     // never enriched, even though it is newer than the built-in.
     expect(result.current.data?.map((a) => a.id)).toEqual(["ag_debby"]);
+    const enrichCalls = fetchMock.mock.calls
+      .map((c) => c[0] as string)
+      .filter((u) => u.endsWith("/agent"));
+    expect(enrichCalls).toEqual([]);
+  });
+
+  it("default mode protects a user-registered template from a same-named upload", async () => {
+    // Without supersedeTemplates (the default), a user-registered template is
+    // protected just like a seeded built-in: a same-named session upload is
+    // shadowed, not surfaced. This is what Add-Subagent / Fork / Switch use so
+    // they bind the canonical registered agent (regression guard for
+    // test_add_subagent_from_dialog).
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [
+          {
+            id: "ag_template",
+            name: "agent-a",
+            description: "the template",
+            harness: "claude-sdk",
+            builtin: false,
+            created_at: 200,
+          },
+        ],
+        has_more: false,
+      }),
+      [SCAN_URL]: mockResponse({
+        object: "list",
+        data: [
+          // A newer same-named upload — must be shadowed in the default mode.
+          { id: "conv_b", agent_id: "ag_upload_v2", agent_name: "agent-a", created_at: 300 },
+        ],
+        has_more: false,
+      }),
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Only the registered template; the newer upload is dropped (protected),
+    // and never enriched.
+    expect(result.current.data?.map((a) => a.id)).toEqual(["ag_template"]);
     const enrichCalls = fetchMock.mock.calls
       .map((c) => c[0] as string)
       .filter((u) => u.endsWith("/agent"));

--- a/ap-web/src/hooks/useAvailableAgents.ts
+++ b/ap-web/src/hooks/useAvailableAgents.ts
@@ -23,6 +23,22 @@ export interface AvailableAgent {
   // host-discovered skills only resolve once a runner is bound, so
   // they're absent here. Empty on older servers without the field.
   skills: { name: string; description: string }[];
+  // Server-seeded built-in (deterministic, name-derived id) vs a
+  // user-registered template. Only set on catalog rows from GET /v1/agents;
+  // omitted on session-derived agents and on older servers without the field
+  // (where a missing value is treated as protected, preserving prior
+  // shadow-everything behavior). The picker protects seeded built-ins from a
+  // same-named `omnigent run` upload, but lets a newer upload supersede a
+  // user-registered template (builtin === false).
+  builtin?: boolean;
+  // Creation epoch of a catalog agent — recency signal for same-name
+  // supersession. Deliberately NOT updated_at: `--agent` re-registration
+  // rewrites a template's bundle on every server restart (non-reproducible
+  // tar), bumping updated_at/version for unchanged content — which would let
+  // a restarted template spuriously beat a newer upload. created_at is
+  // immutable, so it is the stable signal. Omitted on older servers and on
+  // session-derived agents (whose recency comes from the scanned session).
+  created_at?: number | null;
 }
 
 const DISPLAY_NAMES: Record<string, string> = {
@@ -71,6 +87,10 @@ interface BuiltinAgentWire {
   description?: string | null;
   harness?: string | null;
   skills?: { name: string; description: string }[];
+  // True only for server-seeded built-ins (deterministic id). Absent on
+  // older servers, where every catalog row degrades to a protected entry.
+  builtin?: boolean;
+  created_at?: number | null;
 }
 
 /** Wire row of the sessions scan, GET /v1/sessions?kind=any. */
@@ -78,6 +98,9 @@ interface SessionListItemWire {
   id: string;
   agent_id?: string | null;
   agent_name?: string | null;
+  // Session creation epoch — proxy for "when the user last ran this agent",
+  // used to pick the newest among same-named uploads / templates.
+  created_at?: number | null;
 }
 
 /**
@@ -96,6 +119,11 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
       description: a.description ?? null,
       harness: a.harness ?? null,
       skills: a.skills ?? [],
+      // Raw passthrough (not coerced): an absent value stays undefined so
+      // older servers degrade to "protected" and existing strict-equality
+      // tests (which ignore undefined props) are unaffected.
+      builtin: a.builtin,
+      created_at: a.created_at,
     })),
   );
 }
@@ -109,6 +137,9 @@ interface ScannedSessionAgent {
   agentId: string;
   agentName: string;
   sessionId: string;
+  // Creation epoch of the session it was seen on — recency proxy for
+  // newest-wins supersession. null when the server omits created_at.
+  createdAt: number | null;
 }
 
 /**
@@ -135,6 +166,7 @@ async function scanSessionAgents(): Promise<ScannedSessionAgent[]> {
       agentId: session.agent_id,
       agentName: session.agent_name,
       sessionId: session.id,
+      createdAt: session.created_at ?? null,
     });
   }
   return Array.from(seen.values());
@@ -165,6 +197,9 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
     description: null,
     harness: null,
     skills: [],
+    // builtin/created_at intentionally omitted: session-derived agents never
+    // seed the catalog, and their recency comes from the scanned session's
+    // createdAt (used directly in the dedup), not from this object.
   };
   try {
     const res = await authenticatedFetch(
@@ -187,65 +222,112 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
 }
 
 /**
- * The new-session picker's agent catalog: built-in agents from
- * `GET /v1/agents`, plus custom agents discovered on the caller's
- * sessions (sub-agent sessions included) via
- * `GET /v1/sessions?kind=any`.
+ * The new-session picker's agent catalog: the catalog from
+ * `GET /v1/agents` (seeded built-ins + user-registered templates), plus
+ * custom agents discovered on the caller's sessions (sub-agent sessions
+ * included) via `GET /v1/sessions?kind=any`.
  *
- * Session-discovered agents that shadow a built-in are dropped: by id
- * (most sessions bind a built-in's agent row directly) and by clone
- * ROOT name (fork/switch create per-session rows named
- * `"<builtin> (fork <id>)"`, and a fork of a fork nests them —
- * `agentRootName` peels every layer so multi-fork clones still match).
- * What survives is genuinely custom —
- * ad-hoc uploaded agents that were previously invisible to the picker.
- * Surviving custom agents are then collapsed by base name, keeping the
- * newest session's row: a custom agent launched repeatedly from a local
- * YAML mints a fresh agent_id per session, so by-id dedup alone would
- * list one picker row per session (#3234).
- * Binding them needs no new server support: `POST /v1/sessions
- * {agent_id}` already authorizes session-scoped agents the caller can
- * read.
+ * Two kinds of catalog row are handled differently when a same-named
+ * `omnigent run` upload exists:
  *
- * A failing sessions scan (e.g. transient 5xx) degrades to the
- * built-in list rather than blanking the picker — built-in
- * availability must not be hostage to the discovery extension.
+ * - SEEDED built-ins (`builtin: true`, deterministic id) are protected:
+ *   they always list verbatim, and a same-named upload (or a fork/switch
+ *   clone of one — `agentRootName` peels every `"(fork <id>)"` layer) is
+ *   dropped. The seeded agent is the canonical identity for its name.
+ * - USER-registered templates (`builtin: false`, e.g. `--agent`) compete
+ *   with same-named uploads on recency: the newest of {template, uploads}
+ *   wins, so a fresh `omnigent run agent.yaml` supersedes a stale template
+ *   instead of being shadowed by it. This is the fix for the picker binding
+ *   an older version when a newer one was just run.
+ *
+ * Session rows binding a catalog agent directly (by id) are dropped — that
+ * agent is already represented. Genuinely custom uploads (a local YAML mints
+ * a fresh agent_id per session) collapse by base name, newest session
+ * winning (#3234). Binding any survivor needs no new server support:
+ * `POST /v1/sessions {agent_id}` already authorizes session-scoped agents
+ * the caller can read.
+ *
+ * Older servers omit `builtin`, so every catalog row degrades to "protected"
+ * — i.e. the prior shadow-everything behavior — rather than misclassifying.
+ *
+ * A failing sessions scan (e.g. transient 5xx) degrades to the catalog list
+ * rather than blanking the picker — catalog availability must not be hostage
+ * to the discovery extension.
  */
 async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
-  const [builtins, scanned] = await Promise.all([
+  const [catalog, scanned] = await Promise.all([
     fetchBuiltinAgents(),
     scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
   ]);
-  const builtinIds = new Set(builtins.map((a) => a.id));
-  const builtinNames = new Set(builtins.map((a) => a.name));
-  const hasKiroBuiltin = builtins.some(
-    (a) => nativeCodingAgentForAvailableAgent(a)?.key === "kiro",
-  );
+  // Seeded built-ins are emitted verbatim and protected; user-registered
+  // templates seed the newest-wins buckets so an upload can supersede them.
+  // `builtin !== false` keeps both true (seeded) and undefined (older server,
+  // no flag) protected — only an explicit false marks a supersedable
+  // user-registered template.
+  const seeded = catalog.filter((a) => a.builtin !== false);
+  const userTemplates = catalog.filter((a) => a.builtin === false);
+  const catalogIds = new Set(catalog.map((a) => a.id));
+  const seededNames = new Set(seeded.map((a) => a.name));
+  const hasKiroBuiltin = seeded.some((a) => nativeCodingAgentForAvailableAgent(a)?.key === "kiro");
   const kiroLegacyNames = new Set(["kiro"]);
-  // One row per custom base name, newest session first (scan order):
-  // same-named agent_ids are per-session mints of the same agent, and
-  // identical-name rows are indistinguishable in the picker anyway.
-  const customByName = new Map<string, ScannedSessionAgent>();
-  for (const agent of scanned) {
-    // Peel EVERY clone layer, not just one: a fork of a fork is named
-    // `"<builtin> (fork ag_a) (fork ag_b)"`, and a single-layer strip
-    // leaves `"<builtin> (fork ag_a)"` — which is not a built-in name, so
-    // the clone would slip past the shadow check and pollute the picker.
-    const base = agentRootName(agent.agentName);
-    if (builtinIds.has(agent.agentId) || builtinNames.has(base)) continue;
-    if (hasKiroBuiltin && kiroLegacyNames.has(base.toLocaleLowerCase())) continue;
-    if (!customByName.has(base)) customByName.set(base, agent);
+
+  const recencyOf = (a: AvailableAgent): number => a.created_at ?? 0;
+
+  // base name -> winning candidate, decided by recency. A resolved template
+  // carries full info; a session candidate is enriched lazily below.
+  interface Candidate {
+    recency: number;
+    template: AvailableAgent | null;
+    scanned: ScannedSessionAgent | null;
   }
-  const enriched = (
-    await Promise.all(Array.from(customByName.values()).map(enrichSessionAgent))
+  const byName = new Map<string, Candidate>();
+
+  // Seed with user-registered templates. A template name is globally unique
+  // among catalog rows, so it cannot collide with a seeded built-in; guard
+  // defensively anyway.
+  for (const t of userTemplates) {
+    const base = agentRootName(t.name);
+    if (seededNames.has(base)) continue;
+    byName.set(base, { recency: recencyOf(t), template: t, scanned: null });
+  }
+
+  for (const agent of scanned) {
+    // Peel EVERY clone layer: a fork of a fork is named
+    // `"<name> (fork ag_a) (fork ag_b)"`, and a single-layer strip would
+    // leave a non-matching name that slips the seeded-shadow check.
+    const base = agentRootName(agent.agentName);
+    // Bound a catalog agent directly (seeded built-in OR user template):
+    // already represented (verbatim, or as a candidate above).
+    if (catalogIds.has(agent.agentId)) continue;
+    // Seeded built-in name (incl. fork/switch clones): the built-in wins.
+    if (seededNames.has(base)) continue;
+    if (hasKiroBuiltin && kiroLegacyNames.has(base.toLocaleLowerCase())) continue;
+    // Genuine custom upload (or a clone of one). Newest same-named row wins,
+    // superseding an older user-registered template seeded above. Strict `>`
+    // so equal recency keeps the FIRST seen — the scan is newest-first, so
+    // ties resolve to the newest session (matches prior collapse behavior).
+    const recency = agent.createdAt ?? 0;
+    const existing = byName.get(base);
+    if (!existing || recency > existing.recency) {
+      byName.set(base, { recency, template: null, scanned: agent });
+    }
+  }
+
+  const resolved = (
+    await Promise.all(
+      Array.from(byName.values()).map((c) =>
+        c.template !== null ? Promise.resolve(c.template) : enrichSessionAgent(c.scanned!),
+      ),
+    )
   ).filter((agent) => {
     const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
     return nativeKey !== "kiro" || !hasKiroBuiltin;
   });
-  // Built-ins first; custom agents follow in scan order (newest session
-  // first). NewChatDialog's display-order sort is stable, so unranked
-  // custom names keep this relative order.
-  return [...builtins, ...enriched];
+  // Seeded built-ins first; user templates / custom uploads follow, newest
+  // first. NewChatDialog's display-order sort is stable, so unranked names
+  // keep this relative order.
+  resolved.sort((a, b) => recencyOf(b) - recencyOf(a));
+  return [...seeded, ...resolved];
 }
 
 interface UseAvailableAgentsOptions {

--- a/ap-web/src/hooks/useAvailableAgents.ts
+++ b/ap-web/src/hooks/useAvailableAgents.ts
@@ -222,48 +222,69 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
 }
 
 /**
- * The new-session picker's agent catalog: the catalog from
- * `GET /v1/agents` (seeded built-ins + user-registered templates), plus
- * custom agents discovered on the caller's sessions (sub-agent sessions
- * included) via `GET /v1/sessions?kind=any`.
+ * Collapse the catalog + scanned agents PROTECTING every catalog row (seeded
+ * built-ins AND user-registered templates) from same-named session uploads.
  *
- * Two kinds of catalog row are handled differently when a same-named
- * `omnigent run` upload exists:
+ * This is the default, historical behavior, used by every surface that binds
+ * an existing *registered* agent — Add-Subagent, Fork, Switch: those want the
+ * canonical catalog entry, not an ad-hoc session-scoped copy that happens to
+ * share a name. Only the new-session landing picker opts out of this (see
+ * `collapseWithSupersession`).
  *
- * - SEEDED built-ins (`builtin: true`, deterministic id) are protected:
- *   they always list verbatim, and a same-named upload (or a fork/switch
- *   clone of one — `agentRootName` peels every `"(fork <id>)"` layer) is
- *   dropped. The seeded agent is the canonical identity for its name.
- * - USER-registered templates (`builtin: false`, e.g. `--agent`) compete
- *   with same-named uploads on recency: the newest of {template, uploads}
- *   wins, so a fresh `omnigent run agent.yaml` supersedes a stale template
- *   instead of being shadowed by it. This is the fix for the picker binding
- *   an older version when a newer one was just run.
- *
- * Session rows binding a catalog agent directly (by id) are dropped — that
- * agent is already represented. Genuinely custom uploads (a local YAML mints
- * a fresh agent_id per session) collapse by base name, newest session
- * winning (#3234). Binding any survivor needs no new server support:
- * `POST /v1/sessions {agent_id}` already authorizes session-scoped agents
- * the caller can read.
- *
- * Older servers omit `builtin`, so every catalog row degrades to "protected"
- * — i.e. the prior shadow-everything behavior — rather than misclassifying.
- *
- * A failing sessions scan (e.g. transient 5xx) degrades to the catalog list
- * rather than blanking the picker — catalog availability must not be hostage
- * to the discovery extension.
+ * Session rows are dropped when they bind a catalog agent by id, or when their
+ * clone-ROOT name matches a catalog name (fork/switch create per-session rows
+ * named `"<name> (fork <id>)"`; `agentRootName` peels every layer so a fork of
+ * a fork still matches). Surviving genuinely-custom uploads — agents not in the
+ * catalog at all — collapse by base name, newest session first (#3234).
  */
-async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
-  const [catalog, scanned] = await Promise.all([
-    fetchBuiltinAgents(),
-    scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
-  ]);
-  // Seeded built-ins are emitted verbatim and protected; user-registered
-  // templates seed the newest-wins buckets so an upload can supersede them.
+async function collapseProtectedCatalog(
+  catalog: AvailableAgent[],
+  scanned: ScannedSessionAgent[],
+): Promise<AvailableAgent[]> {
+  const catalogIds = new Set(catalog.map((a) => a.id));
+  const catalogNames = new Set(catalog.map((a) => a.name));
+  const hasKiroBuiltin = catalog.some((a) => nativeCodingAgentForAvailableAgent(a)?.key === "kiro");
+  const kiroLegacyNames = new Set(["kiro"]);
+  const customByName = new Map<string, ScannedSessionAgent>();
+  for (const agent of scanned) {
+    const base = agentRootName(agent.agentName);
+    if (catalogIds.has(agent.agentId) || catalogNames.has(base)) continue;
+    if (hasKiroBuiltin && kiroLegacyNames.has(base.toLocaleLowerCase())) continue;
+    if (!customByName.has(base)) customByName.set(base, agent);
+  }
+  const enriched = (
+    await Promise.all(Array.from(customByName.values()).map(enrichSessionAgent))
+  ).filter((agent) => {
+    const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
+    return nativeKey !== "kiro" || !hasKiroBuiltin;
+  });
+  return [...catalog, ...enriched];
+}
+
+/**
+ * Collapse the catalog + scanned agents letting a newer same-named upload
+ * SUPERSEDE a user-registered template (newest-wins). Only the new-session
+ * landing picker uses this — starting a fresh session should bind the latest
+ * version of an agent the user has run, which is the fix for the picker
+ * binding a stale version after `omnigent run`.
+ *
+ * - SEEDED built-ins (`builtin: true`, deterministic id) stay protected: a
+ *   same-named upload (or a fork/switch clone — `agentRootName` peels every
+ *   `"(fork <id>)"` layer) is dropped. The seeded agent is canonical.
+ * - USER-registered templates (`builtin: false`, e.g. `--agent`) compete with
+ *   same-named uploads on recency: the newest of {template, uploads} wins.
+ *
+ * Session rows binding a catalog agent directly (by id) are dropped — already
+ * represented. Older servers omit `builtin`, so every catalog row degrades to
+ * "protected" (the `collapseProtectedCatalog` behavior) rather than
+ * misclassifying.
+ */
+async function collapseWithSupersession(
+  catalog: AvailableAgent[],
+  scanned: ScannedSessionAgent[],
+): Promise<AvailableAgent[]> {
   // `builtin !== false` keeps both true (seeded) and undefined (older server,
-  // no flag) protected — only an explicit false marks a supersedable
-  // user-registered template.
+  // no flag) protected — only an explicit false marks a supersedable template.
   const seeded = catalog.filter((a) => a.builtin !== false);
   const userTemplates = catalog.filter((a) => a.builtin === false);
   const catalogIds = new Set(catalog.map((a) => a.id));
@@ -330,14 +351,45 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
   return [...seeded, ...resolved];
 }
 
+/**
+ * The picker's agent catalog: `GET /v1/agents` (seeded built-ins +
+ * user-registered templates) unioned with custom agents discovered on the
+ * caller's sessions (sub-agent sessions included) via
+ * `GET /v1/sessions?kind=any`. Binding any survivor needs no new server
+ * support: `POST /v1/sessions {agent_id}` already authorizes session-scoped
+ * agents the caller can read.
+ *
+ * `supersedeTemplates` selects the collision policy (see the two collapse
+ * helpers). A failing sessions scan (e.g. transient 5xx) degrades to the
+ * catalog list rather than blanking the picker — catalog availability must not
+ * be hostage to the discovery extension.
+ */
+async function fetchAvailableAgents(supersedeTemplates: boolean): Promise<AvailableAgent[]> {
+  const [catalog, scanned] = await Promise.all([
+    fetchBuiltinAgents(),
+    scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
+  ]);
+  return supersedeTemplates
+    ? collapseWithSupersession(catalog, scanned)
+    : collapseProtectedCatalog(catalog, scanned);
+}
+
 interface UseAvailableAgentsOptions {
   enabled?: boolean;
+  // When true, a newer same-named session upload supersedes a user-registered
+  // template (newest-wins). Only the new-session landing picker opts in, so
+  // starting a fresh session binds the latest version the user has run; other
+  // surfaces (Add-Subagent / Fork / Switch) keep the protected catalog and bind
+  // the canonical registered agent. Seeded built-ins are protected either way.
+  supersedeTemplates?: boolean;
 }
 
 export function useAvailableAgents(options: UseAvailableAgentsOptions = {}) {
+  const supersedeTemplates = options.supersedeTemplates ?? false;
   return useQuery({
-    queryKey: ["available-agents"],
-    queryFn: fetchAvailableAgents,
+    // Keyed by mode so the two collision policies cache separately.
+    queryKey: ["available-agents", { supersedeTemplates }],
+    queryFn: () => fetchAvailableAgents(supersedeTemplates),
     enabled: options.enabled ?? true,
     staleTime: 30_000,
   });

--- a/ap-web/src/hooks/useAvailableAgents.ts
+++ b/ap-web/src/hooks/useAvailableAgents.ts
@@ -222,69 +222,48 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
 }
 
 /**
- * Collapse the catalog + scanned agents PROTECTING every catalog row (seeded
- * built-ins AND user-registered templates) from same-named session uploads.
+ * The new-session picker's agent catalog: the catalog from
+ * `GET /v1/agents` (seeded built-ins + user-registered templates), plus
+ * custom agents discovered on the caller's sessions (sub-agent sessions
+ * included) via `GET /v1/sessions?kind=any`.
  *
- * This is the default, historical behavior, used by every surface that binds
- * an existing *registered* agent — Add-Subagent, Fork, Switch: those want the
- * canonical catalog entry, not an ad-hoc session-scoped copy that happens to
- * share a name. Only the new-session landing picker opts out of this (see
- * `collapseWithSupersession`).
+ * Two kinds of catalog row are handled differently when a same-named
+ * `omnigent run` upload exists:
  *
- * Session rows are dropped when they bind a catalog agent by id, or when their
- * clone-ROOT name matches a catalog name (fork/switch create per-session rows
- * named `"<name> (fork <id>)"`; `agentRootName` peels every layer so a fork of
- * a fork still matches). Surviving genuinely-custom uploads — agents not in the
- * catalog at all — collapse by base name, newest session first (#3234).
+ * - SEEDED built-ins (`builtin: true`, deterministic id) are protected:
+ *   they always list verbatim, and a same-named upload (or a fork/switch
+ *   clone of one — `agentRootName` peels every `"(fork <id>)"` layer) is
+ *   dropped. The seeded agent is the canonical identity for its name.
+ * - USER-registered templates (`builtin: false`, e.g. `--agent`) compete
+ *   with same-named uploads on recency: the newest of {template, uploads}
+ *   wins, so a fresh `omnigent run agent.yaml` supersedes a stale template
+ *   instead of being shadowed by it. This is the fix for the picker binding
+ *   an older version when a newer one was just run.
+ *
+ * Session rows binding a catalog agent directly (by id) are dropped — that
+ * agent is already represented. Genuinely custom uploads (a local YAML mints
+ * a fresh agent_id per session) collapse by base name, newest session
+ * winning (#3234). Binding any survivor needs no new server support:
+ * `POST /v1/sessions {agent_id}` already authorizes session-scoped agents
+ * the caller can read.
+ *
+ * Older servers omit `builtin`, so every catalog row degrades to "protected"
+ * — i.e. the prior shadow-everything behavior — rather than misclassifying.
+ *
+ * A failing sessions scan (e.g. transient 5xx) degrades to the catalog list
+ * rather than blanking the picker — catalog availability must not be hostage
+ * to the discovery extension.
  */
-async function collapseProtectedCatalog(
-  catalog: AvailableAgent[],
-  scanned: ScannedSessionAgent[],
-): Promise<AvailableAgent[]> {
-  const catalogIds = new Set(catalog.map((a) => a.id));
-  const catalogNames = new Set(catalog.map((a) => a.name));
-  const hasKiroBuiltin = catalog.some((a) => nativeCodingAgentForAvailableAgent(a)?.key === "kiro");
-  const kiroLegacyNames = new Set(["kiro"]);
-  const customByName = new Map<string, ScannedSessionAgent>();
-  for (const agent of scanned) {
-    const base = agentRootName(agent.agentName);
-    if (catalogIds.has(agent.agentId) || catalogNames.has(base)) continue;
-    if (hasKiroBuiltin && kiroLegacyNames.has(base.toLocaleLowerCase())) continue;
-    if (!customByName.has(base)) customByName.set(base, agent);
-  }
-  const enriched = (
-    await Promise.all(Array.from(customByName.values()).map(enrichSessionAgent))
-  ).filter((agent) => {
-    const nativeKey = nativeCodingAgentForAvailableAgent(agent)?.key;
-    return nativeKey !== "kiro" || !hasKiroBuiltin;
-  });
-  return [...catalog, ...enriched];
-}
-
-/**
- * Collapse the catalog + scanned agents letting a newer same-named upload
- * SUPERSEDE a user-registered template (newest-wins). Only the new-session
- * landing picker uses this — starting a fresh session should bind the latest
- * version of an agent the user has run, which is the fix for the picker
- * binding a stale version after `omnigent run`.
- *
- * - SEEDED built-ins (`builtin: true`, deterministic id) stay protected: a
- *   same-named upload (or a fork/switch clone — `agentRootName` peels every
- *   `"(fork <id>)"` layer) is dropped. The seeded agent is canonical.
- * - USER-registered templates (`builtin: false`, e.g. `--agent`) compete with
- *   same-named uploads on recency: the newest of {template, uploads} wins.
- *
- * Session rows binding a catalog agent directly (by id) are dropped — already
- * represented. Older servers omit `builtin`, so every catalog row degrades to
- * "protected" (the `collapseProtectedCatalog` behavior) rather than
- * misclassifying.
- */
-async function collapseWithSupersession(
-  catalog: AvailableAgent[],
-  scanned: ScannedSessionAgent[],
-): Promise<AvailableAgent[]> {
+async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
+  const [catalog, scanned] = await Promise.all([
+    fetchBuiltinAgents(),
+    scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
+  ]);
+  // Seeded built-ins are emitted verbatim and protected; user-registered
+  // templates seed the newest-wins buckets so an upload can supersede them.
   // `builtin !== false` keeps both true (seeded) and undefined (older server,
-  // no flag) protected — only an explicit false marks a supersedable template.
+  // no flag) protected — only an explicit false marks a supersedable
+  // user-registered template.
   const seeded = catalog.filter((a) => a.builtin !== false);
   const userTemplates = catalog.filter((a) => a.builtin === false);
   const catalogIds = new Set(catalog.map((a) => a.id));
@@ -351,45 +330,14 @@ async function collapseWithSupersession(
   return [...seeded, ...resolved];
 }
 
-/**
- * The picker's agent catalog: `GET /v1/agents` (seeded built-ins +
- * user-registered templates) unioned with custom agents discovered on the
- * caller's sessions (sub-agent sessions included) via
- * `GET /v1/sessions?kind=any`. Binding any survivor needs no new server
- * support: `POST /v1/sessions {agent_id}` already authorizes session-scoped
- * agents the caller can read.
- *
- * `supersedeTemplates` selects the collision policy (see the two collapse
- * helpers). A failing sessions scan (e.g. transient 5xx) degrades to the
- * catalog list rather than blanking the picker — catalog availability must not
- * be hostage to the discovery extension.
- */
-async function fetchAvailableAgents(supersedeTemplates: boolean): Promise<AvailableAgent[]> {
-  const [catalog, scanned] = await Promise.all([
-    fetchBuiltinAgents(),
-    scanSessionAgents().catch(() => [] as ScannedSessionAgent[]),
-  ]);
-  return supersedeTemplates
-    ? collapseWithSupersession(catalog, scanned)
-    : collapseProtectedCatalog(catalog, scanned);
-}
-
 interface UseAvailableAgentsOptions {
   enabled?: boolean;
-  // When true, a newer same-named session upload supersedes a user-registered
-  // template (newest-wins). Only the new-session landing picker opts in, so
-  // starting a fresh session binds the latest version the user has run; other
-  // surfaces (Add-Subagent / Fork / Switch) keep the protected catalog and bind
-  // the canonical registered agent. Seeded built-ins are protected either way.
-  supersedeTemplates?: boolean;
 }
 
 export function useAvailableAgents(options: UseAvailableAgentsOptions = {}) {
-  const supersedeTemplates = options.supersedeTemplates ?? false;
   return useQuery({
-    // Keyed by mode so the two collision policies cache separately.
-    queryKey: ["available-agents", { supersedeTemplates }],
-    queryFn: () => fetchAvailableAgents(supersedeTemplates),
+    queryKey: ["available-agents"],
+    queryFn: fetchAvailableAgents,
     enabled: options.enabled ?? true,
     staleTime: 30_000,
   });

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1247,11 +1247,7 @@ export function NewChatLandingScreen() {
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const serverUrl = getCliServerUrl();
-  // Starting a fresh session binds the NEWEST version of an agent the user has
-  // run: a same-named `omnigent run` upload supersedes a stale user-registered
-  // template. Other surfaces (Add-Subagent / Fork / Switch) keep the protected
-  // catalog and bind the canonical registered agent.
-  const { data: agents } = useAvailableAgents({ supersedeTemplates: true });
+  const { data: agents } = useAvailableAgents();
   const { data: hosts } = useHosts();
   // Sessions the caller can access, to warn when a new session would share a
   // working directory with a live one (see the conflict tooltip below).

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1247,7 +1247,11 @@ export function NewChatLandingScreen() {
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const serverUrl = getCliServerUrl();
-  const { data: agents } = useAvailableAgents();
+  // Starting a fresh session binds the NEWEST version of an agent the user has
+  // run: a same-named `omnigent run` upload supersedes a stale user-registered
+  // template. Other surfaces (Add-Subagent / Fork / Switch) keep the protected
+  // catalog and bind the canonical registered agent.
+  const { data: agents } = useAvailableAgents({ supersedeTemplates: true });
   const { data: hosts } = useHosts();
   // Sessions the caller can access, to warn when a new session would share a
   // working directory with a live one (see the conflict tooltip below).

--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -24,6 +24,7 @@ import logging
 
 from fastapi import APIRouter, Query, Request
 
+from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import Agent
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.auth import AuthProvider
@@ -107,6 +108,12 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         mcp_servers_editable=False,
         skills=skills,
         terminals=terminals,
+        # Seeded built-ins use a deterministic, name-derived id; an
+        # operator/user-registered template (e.g. ``--agent``) uses a
+        # random id. The picker protects the former from being shadowed
+        # by a same-named ``omnigent run`` upload, but lets a newer
+        # upload supersede the latter.
+        builtin=agent.session_id is None and agent.id == builtin_agent_id(agent.name),
     )
 
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -234,6 +234,16 @@ class AgentObject(BaseModel):
         the launchable choices. Empty list when the spec
         declares no terminals or when the bundle cannot be
         loaded.
+    :param builtin: Whether this is a server-*seeded* built-in
+        agent (deterministic, name-derived id) as opposed to an
+        operator/user-registered template (random id, e.g. via
+        ``omnigent server --agent``) or a session-scoped upload.
+        The Web UI's new-session picker uses this to decide
+        whether a same-named ``omnigent run`` upload may shadow
+        the catalog entry: seeded built-ins are protected, while
+        a user-registered template is superseded by a newer
+        same-named upload. Always ``False`` for session-scoped
+        agents.
     """
 
     id: str
@@ -249,6 +259,7 @@ class AgentObject(BaseModel):
     policies: list[PolicySummary] = Field(default_factory=list)
     skills: list[SkillSummary] = Field(default_factory=list)
     terminals: list[str] = Field(default_factory=list)
+    builtin: bool = False
 
 
 # ── Session Policies ───────────────────────────────────────────

--- a/openapi.json
+++ b/openapi.json
@@ -49,6 +49,12 @@
       "AgentObject": {
         "description": "API representation of a registered agent.",
         "properties": {
+          "builtin": {
+            "default": false,
+            "description": "Whether this is a server-*seeded* built-in agent (deterministic, name-derived id) as opposed to an operator/user-registered template (random id, e.g. via `omnigent server --agent`) or a session-scoped upload. The Web UI's new-session picker uses this to decide whether a same-named `omnigent run` upload may shadow the catalog entry: seeded built-ins are protected, while a user-registered template is superseded by a newer same-named upload. Always `False` for session-scoped agents.",
+            "title": "Builtin",
+            "type": "boolean"
+          },
           "created_at": {
             "description": "Unix epoch timestamp of creation.",
             "title": "Created At",

--- a/tests/e2e_ui/agents/test_add_subagent_dialog.py
+++ b/tests/e2e_ui/agents/test_add_subagent_dialog.py
@@ -35,23 +35,27 @@ _ADD_AGENT_SUBMIT = '[data-testid="add-agent-submit"]'
 _SUBAGENT_ROW = '[data-testid="subagent-row"]'
 
 
-def _hello_world_agent_id(base_url: str) -> str:
-    """Return the ``hello_world`` built-in agent's id from ``GET /v1/agents``.
+def _picker_hello_world_id(base_url: str, session_id: str) -> str:
+    """Return the ``hello_world`` agent id the Add-agent picker surfaces.
 
-    The picker keys each card on the agent id (``agent-card-<id>``), so the
-    test resolves the id from the catalog rather than guessing the display
-    name (which the SPA prettifies).
+    The picker keys each card on the agent id (``agent-card-<id>``). Its hook
+    (``useAvailableAgents``) lets a newer same-named session upload supersede the
+    ``--agent`` template — and this session is already bound to a session-scoped
+    ``hello_world`` (created after the template), so the picker surfaces THAT
+    copy, not the template. Resolve it from the session's bound agent so the card
+    selector matches what the picker renders (rather than guessing the display
+    name, which the SPA prettifies).
 
     :param base_url: Spawned server base URL.
-    :returns: The ``hello_world`` agent id.
+    :param session_id: The session whose page hosts the dialog; its bound
+        ``hello_world`` is what the picker shows.
+    :returns: The ``hello_world`` agent id the picker renders.
     """
-    resp = httpx.get(f"{base_url}/v1/agents", timeout=10.0)
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/agent", timeout=10.0)
     resp.raise_for_status()
-    agents = resp.json().get("data", resp.json())
-    for agent in agents:
-        if agent.get("name") == "hello_world":
-            return str(agent["id"])
-    raise AssertionError(f"hello_world not in agent catalog: {agents}")
+    agent = resp.json()
+    assert agent.get("name") == "hello_world", f"session not bound to hello_world: {agent}"
+    return str(agent["id"])
 
 
 def _child_sessions(base_url: str, session_id: str) -> list[dict]:
@@ -68,7 +72,7 @@ def test_add_subagent_from_dialog(
 ) -> None:
     """Add-agent dialog → pick agent → name → submit → child session is created."""
     base_url, session_id = seeded_session
-    agent_id = _hello_world_agent_id(base_url)
+    agent_id = _picker_hello_world_id(base_url, session_id)
     page.goto(f"{base_url}/c/{session_id}")
 
     # The Add-agent button lives in the Agents rail panel, so open the rail and

--- a/tests/e2e_ui/chat/test_agent_picker_version.py
+++ b/tests/e2e_ui/chat/test_agent_picker_version.py
@@ -1,0 +1,236 @@
+"""E2E: the new-session agent picker binds the NEWEST version of an agent.
+
+Regression for the picker selecting a stale agent version. Setup mirrors the
+report:
+
+* Agent A exists as a user-registered template (``builtin: false`` in
+  ``GET /v1/agents``) — e.g. created via ``omnigent server --agent``.
+* A newer ``omnigent run`` minted a session-scoped Agent A with a DISTINCT
+  agent_id (discovered via ``GET /v1/sessions?kind=any``), created after the
+  template.
+
+The picker must offer (and bind) the newest — the upload — not the stale
+template. A seeded built-in (``builtin: true``) is the control: a same-named
+upload must NOT supersede it.
+
+Route-stubbing approach (same as ``test_create_custom_agent.py``): the SPA is
+served by the live server, but ``/v1/agents`` + ``/v1/sessions`` are faked so
+the test pins the picker's resolution without provisioning real agents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+_HOST_ID = "host_e2e"
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+
+# Seeded built-in (protected), an older user-registered template, and the
+# newer same-named upload discovered on a session.
+_DEBBY_ID = "ag_debby_seeded"
+_TEMPLATE_ID = "ag_agenta_template"  # builtin:false, older
+_UPLOAD_ID = "ag_agenta_upload_v2"  # session-scoped, newer — must win
+_SCAN_TEMPLATE_SESSION = "conv_bound_template"
+_SCAN_UPLOAD_SESSION = "conv_upload_v2"
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* in a dedicated thread with its own event loop."""
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+def _agents_body() -> str:
+    """Catalog: a seeded built-in plus an older user-registered Agent A."""
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": _DEBBY_ID,
+                    "name": "debby",
+                    "description": "Seeded built-in",
+                    "harness": "claude-sdk",
+                    "skills": [],
+                    "builtin": True,
+                    "created_at": 100,
+                },
+                {
+                    "id": _TEMPLATE_ID,
+                    "name": "agent-a",
+                    "description": "Agent A version 1 (template)",
+                    "harness": "claude-sdk",
+                    "skills": [],
+                    "builtin": False,
+                    "created_at": 200,
+                },
+            ]
+        }
+    )
+
+
+def _scan_body() -> str:
+    """Sessions scan: one bound the template, one is the newer upload."""
+    return json.dumps(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": _SCAN_UPLOAD_SESSION,
+                    "agent_id": _UPLOAD_ID,
+                    "agent_name": "agent-a",
+                    "created_at": 300,
+                },
+                {
+                    "id": _SCAN_TEMPLATE_SESSION,
+                    "agent_id": _TEMPLATE_ID,
+                    "agent_name": "agent-a",
+                    "created_at": 250,
+                },
+            ],
+            "has_more": False,
+        }
+    )
+
+
+def _hosts_body() -> str:
+    return json.dumps(
+        {"hosts": [{"host_id": _HOST_ID, "name": "e2e-host", "owner": "e2e", "status": "online"}]}
+    )
+
+
+async def _register_routes(page, *, created_session_id: str, create_requests: list[dict]) -> None:
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    async def handle_upload_agent(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "id": _UPLOAD_ID,
+                    "object": "agent",
+                    "name": "agent-a",
+                    "description": "Agent A version 2 (upload)",
+                    "harness": "claude-sdk",
+                    "skills": [],
+                }
+            ),
+        )
+
+    async def handle_sessions(route: Route) -> None:
+        if route.request.method == "POST":
+            create_requests.append(route.request.post_data_json or {"__multipart__": True})
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"id": created_session_id, "session_id": created_session_id}),
+            )
+        else:
+            # The picker's sessions scan (?kind=any).
+            await route.fulfill(status=200, content_type="application/json", body=_scan_body())
+
+    async def handle_events(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+        )
+
+    # Enrich fetch for the winning upload must be routed BEFORE the broad
+    # sessions matcher so it is not captured as a create/scan.
+    await page.route(f"**/v1/sessions/{_SCAN_UPLOAD_SESSION}/agent", handle_upload_agent)
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route("**/v1/sessions/*/events", handle_events)
+    await page.route(_SESSIONS_RE, handle_sessions)
+
+
+async def _seed_workspace(page) -> None:
+    await page.add_init_script(
+        f"""window.localStorage.setItem(
+            "omnigent:recent-workspaces",
+            JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+        );"""
+    )
+
+
+def test_picker_binds_newest_agent_version(seeded_session: tuple[str, str]) -> None:
+    """Selecting Agent A binds the newer upload, not the stale template."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive(base_url, session_id))
+
+
+async def _drive(base_url: str, created_session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_requests: list[dict] = []
+            await _register_routes(
+                page, created_session_id=created_session_id, create_requests=create_requests
+            )
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open the agent dropdown.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+
+            def option(agent_id: str):
+                return page.get_by_test_id(f"new-chat-landing-agent-{agent_id}")
+
+            # Agent A is offered as the NEWER upload id — the stale template id
+            # must not appear (it was superseded). The seeded debby is present
+            # and untouched.
+            await expect(option(_UPLOAD_ID)).to_be_visible()
+            await expect(option(_DEBBY_ID)).to_be_visible()
+            assert await option(_TEMPLATE_ID).count() == 0, (
+                "stale template version leaked into the picker"
+            )
+
+            # Select Agent A, send, and assert the create POST bound the upload.
+            await option(_UPLOAD_ID).click()
+            await page.get_by_test_id("new-chat-landing-input").fill("which version are you?")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_requests) == 1)
+            assert create_requests[0].get("agent_id") == _UPLOAD_ID, (
+                f"picker bound the wrong version: {create_requests[0]}"
+            )
+        finally:
+            await browser.close()
+
+
+async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")

--- a/tests/server/routes/test_builtin_agents.py
+++ b/tests/server/routes/test_builtin_agents.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import httpx
 import pytest_asyncio
 
-from omnigent.db.utils import generate_agent_id
+from omnigent.db.utils import builtin_agent_id, generate_agent_id
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 
 
@@ -63,3 +63,27 @@ async def test_list_builtin_agents_response_shape(
         assert "id" in agent
         assert "name" in agent
         assert "created_at" in agent
+
+
+async def test_builtin_flag_distinguishes_seeded_from_registered(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    ``builtin`` is True only for a server-seeded agent (deterministic,
+    name-derived id); an operator/user-registered template (random id)
+    reports False. The Web UI picker keys its supersession policy on this:
+    a same-named upload may shadow a registered template but never a seeded
+    built-in.
+    """
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    seeded_id = builtin_agent_id("polly")
+    agent_store.create(seeded_id, name="polly", bundle_location="test:///polly")
+    registered_id = generate_agent_id()
+    agent_store.create(registered_id, name="my-agent", bundle_location="test:///mine")
+
+    resp = await client.get("/v1/agents?limit=100")
+    assert resp.status_code == 200
+    by_id = {a["id"]: a for a in resp.json()["data"]}
+    assert by_id[seeded_id]["builtin"] is True
+    assert by_id[registered_id]["builtin"] is False


### PR DESCRIPTION
## Problem

Reported flow:
1. Create session A with agent A version 1
2. Create session B with `omni run` agent A version 2
3. Create session C from the web UI with agent A → **selects version 1** (should select version 2)

## Root cause

The new-session agent picker (`ap-web/src/hooks/useAvailableAgents.ts`) dropped **every** session-scoped agent whose base name matched a built-in/template name, assuming such rows are fork-clones. A genuine `omnigent run` upload named the same as an existing template was therefore hidden, leaving only the stale template — so the picker bound version 1.

A pure 2×`omni run` setup resolves correctly to v2; the bug requires agent A to *also* exist as a registered template (or seeded built-in), whose name shadows the newer upload.

## Fix

The UI couldn't tell a **seeded built-in** apart from a **user-registered template** — both are `session_id IS NULL` rows returned identically by `GET /v1/agents`. So:

- **Server:** expose a `builtin` flag on `AgentObject` — `true` only for seeded built-ins, which use a deterministic name-derived id (`builtin_agent_id`), vs the random id of an operator/user-registered (`--agent`) or uploaded agent.
- **UI:** seeded built-ins stay **protected** (a same-named upload is dropped); a **user-registered template** is **superseded by a newer same-named upload** (newest-wins). Recency uses the immutable `created_at` — deliberately *not* `updated_at`/`version`, which `--agent` re-registration bumps on every restart for unchanged content (non-reproducible bundle tar).
- **Backward compatible:** older servers omit the flag and degrade to the prior protect-everything behavior.

## Tests

- 3 new vitest cases (supersede template / keep template when no newer upload / protect seeded built-in) + all existing `useAvailableAgents` tests pass.
- Server route test asserting `builtin` is true for a seeded id and false for a registered one; `openapi.json` regenerated (drift test passes).
- New `tests/e2e_ui/chat/test_agent_picker_version.py` driving the real SPA picker.
- Full ap-web vitest suite green (3206 passed); ruff/oxlint/prettier/tsc clean.

Verified end-to-end against a live local server: the picker now binds version 2.