### PR TITLE
fix(server): heal stale sub-agent runner binding so terminal status survives runner relaunch

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -4993,6 +4993,90 @@ def _require_external_status_forward(
         )
 
 
+# How long the terminal sub-agent-status forward waits for the parent's
+# runner tunnel to (re)connect before giving up. A relaunch/redeploy
+# reconnect gap is normally sub-second; a few seconds bridges it without
+# holding the POST open long. The runner re-posts on a 503 regardless, so
+# this is a best-effort fast path, not the only delivery chance.
+_SUBAGENT_FORWARD_RECONNECT_WAIT_S = 5.0
+
+
+async def _recover_subagent_status_forward_via_parent(
+    child_conv: Conversation,
+    runner_router: RunnerRouter | None,
+    tunnel_registry: TunnelRegistry | None,
+    conversation_store: ConversationStore,
+    forward_body: dict[str, Any],
+) -> _RunnerForwardResult | None:
+    """
+    Re-deliver a sub-agent terminal status through the parent's live runner.
+
+    A native sub-agent child copies its parent's ``runner_id`` once, at
+    creation (``create_conversation(..., runner_id=parent_conv.runner_id)`` —
+    see :func:`_persist_external_subagent_start`). It is never repointed when
+    the runner is later relaunched under a freshly minted ``runner_id`` (a host
+    relaunch after a tunnel drop / server redeploy / crash mints a new binding
+    token; only the *parent* conversation is rebound, via the PATCH path on its
+    next message). The child then points at a permanently offline ``runner_id``,
+    so its terminal ``idle``/``failed`` forward resolves no runner client and
+    503s forever (``_forward_session_change_to_runner`` → ``None`` →
+    :func:`_require_external_status_forward`). The parent never receives the
+    child's inbox result and hangs with no timeout.
+
+    A child always runs on its parent's runner, so the live binding is the
+    parent's. This re-resolves the forward through the parent/root
+    conversation's *current* ``runner_id``: it waits briefly for that runner's
+    tunnel to (re)connect (covering the reconnect gap right after a relaunch),
+    heals the child's stale ``runner_id`` so future forwards and
+    ``_on_runner_connect`` resolve it correctly, and retries the forward.
+
+    :param child_conv: The sub-agent child conversation whose terminal-status
+        forward could not reach its pinned runner.
+    :param runner_router: Router used to resolve the bound runner client, or
+        ``None`` in in-process setups.
+    :param tunnel_registry: Runner-tunnel registry used to await the parent
+        runner's (re)connect, or ``None`` in setups without runner tunnels.
+    :param conversation_store: Store used to look up the parent and persist the
+        child's healed ``runner_id``.
+    :param forward_body: The ``external_session_status`` event body to re-POST.
+    :returns: The retry's :class:`_RunnerForwardResult` when a live parent
+        runner was resolved, or ``None`` when none could be (the caller then
+        fails the forward as before).
+    """
+    parent_id = child_conv.parent_conversation_id or child_conv.root_conversation_id
+    if not parent_id or parent_id == child_conv.id:
+        return None
+    parent = await asyncio.to_thread(conversation_store.get_conversation, parent_id)
+    if parent is None or parent.runner_id is None:
+        return None
+    parent_runner_id = parent.runner_id
+    # Wait for the parent's runner tunnel to be live before re-resolving. When
+    # no registry is wired (in-process / tests) skip the wait and retry
+    # best-effort against whatever the router resolves.
+    if tunnel_registry is not None:
+        client = await _wait_for_runner_client(
+            parent_id,
+            runner_router,
+            tunnel_registry,
+            runner_id=parent_runner_id,
+            timeout_s=_SUBAGENT_FORWARD_RECONNECT_WAIT_S,
+        )
+        if client is None:
+            return None
+    if parent_runner_id != child_conv.runner_id:
+        # Heal the divergence so this child's id matches the live runner: the
+        # next forward resolves directly and a future ``_on_runner_connect``
+        # (which rebinds by matching runner_id) can recover it.
+        await asyncio.to_thread(
+            conversation_store.replace_runner_id, child_conv.id, parent_runner_id
+        )
+    return await _forward_session_change_to_runner(
+        child_conv.id,
+        runner_router,
+        forward_body,
+    )
+
+
 def _require_collaboration_mode_forward(
     session_id: str,
     enabled: bool,
@@ -18181,6 +18265,23 @@ def create_sessions_router(
                 # Codex-internal children are tracked inside the same
                 # app-server thread tree; they have no runner inbox entry
                 # to forward terminal status to.
+                if runner_result is None:
+                    # The child's pinned runner_id is stale — its runner was
+                    # relaunched under a new id and only the parent was
+                    # rebound, so the child points at a dead runner forever and
+                    # this terminal status would 503 indefinitely while the
+                    # parent hangs waiting for the child's inbox result. Heal
+                    # the binding and re-deliver through the parent's live
+                    # runner before failing.
+                    recovered = await _recover_subagent_status_forward_via_parent(
+                        conv,
+                        runner_router,
+                        getattr(request.app.state, "tunnel_registry", None),
+                        conversation_store,
+                        forward_body,
+                    )
+                    if recovered is not None:
+                        runner_result = recovered
                 _require_external_status_forward(
                     session_id,
                     status,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -5067,9 +5067,17 @@ async def _recover_subagent_status_forward_via_parent(
         # Heal the divergence so this child's id matches the live runner: the
         # next forward resolves directly and a future ``_on_runner_connect``
         # (which rebinds by matching runner_id) can recover it.
-        await asyncio.to_thread(
-            conversation_store.replace_runner_id, child_conv.id, parent_runner_id
-        )
+        try:
+            await asyncio.to_thread(
+                conversation_store.replace_runner_id, child_conv.id, parent_runner_id
+            )
+        except ConversationNotFoundError:
+            # The child was deleted between ``post_event`` reading it and this
+            # heal (e.g. the session was removed mid-teardown). Recovery is
+            # strictly best-effort — degrade to ``None`` so the caller falls
+            # through to the existing 503/no-op rather than surfacing this
+            # benign race as an unhandled 500.
+            return None
     return await _forward_session_change_to_runner(
         child_conv.id,
         runner_router,

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1589,3 +1589,107 @@ async def test_multipart_create_with_unknown_parent_404s(
         files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
     )
     assert resp.status_code == 404, resp.text
+
+
+async def _create_native_child(client: httpx.AsyncClient, name: str) -> dict[str, Any]:
+    """
+    Create a claude-native sub-agent child under a fresh parent.
+
+    :param client: The test HTTP client.
+    :param name: Unique parent agent name for this test.
+    :returns: The created child session JSON.
+    """
+    parent = await _create_parent_with_subagents(
+        client,
+        name=name,
+        sub_agents=[{"name": "impl", "harness": "claude-native"}],
+    )
+    child_resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": parent["agent_id"],
+            "parent_session_id": parent["session_id"],
+            "title": "impl:task-1",
+            "sub_agent_name": "impl",
+        },
+    )
+    assert child_resp.status_code == 201, child_resp.text
+    return child_resp.json()
+
+
+async def test_subagent_idle_forward_recovers_via_parent_when_child_runner_stale(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A sub-agent ``idle`` whose direct forward 503s is re-delivered via recovery.
+
+    Reproduces the production hang's server edge: the child's pinned runner is
+    gone (direct ``_forward_session_change_to_runner`` returns ``None``), so the
+    terminal-status branch must invoke
+    ``_recover_subagent_status_forward_via_parent`` and, when it lands, accept
+    the event (``202`` — the parent gets the child result) instead of the old
+    hard ``503`` that left the parent hanging.
+    """
+    child = await _create_native_child(client, name="orch-recover-ok")
+
+    async def _forward_none(*_args: Any, **_kwargs: Any) -> None:
+        """Child's pinned runner is unreachable — the direct forward fails."""
+        return
+
+    recovered_for: list[str] = []
+
+    async def _recover_spy(child_conv: Any, *_args: Any, **_kwargs: Any) -> Any:
+        """Stand in for recovery: record the child and report a delivered 202."""
+        recovered_for.append(child_conv.id)
+        return sessions_module._RunnerForwardResult(status_code=202, body="")
+
+    monkeypatch.setattr(sessions_module, "_forward_session_change_to_runner", _forward_none)
+    monkeypatch.setattr(
+        sessions_module, "_recover_subagent_status_forward_via_parent", _recover_spy
+    )
+
+    resp = await client.post(
+        f"/v1/sessions/{child['id']}/events",
+        json={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    # 202 Accepted is the endpoint's success code; the body confirms the event
+    # was handled (not the old 503 that stranded the parent).
+    assert resp.status_code == 202, resp.text
+    assert resp.json() == {"queued": False}
+    # Recovery was invoked for THIS child (the stale-binding heal path).
+    assert recovered_for == [child["id"]]
+
+
+async def test_subagent_idle_forward_503s_when_recovery_also_fails(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    When recovery cannot reach a live parent runner either, the 503 is preserved.
+
+    The runner re-posts on a 503, so failing here (rather than acking a
+    delivery that never happened) keeps the at-least-once contract intact.
+    """
+    child = await _create_native_child(client, name="orch-recover-fail")
+
+    async def _forward_none(*_args: Any, **_kwargs: Any) -> None:
+        """Both the direct forward and (below) recovery cannot reach a runner."""
+        return
+
+    async def _recover_none(*_args: Any, **_kwargs: Any) -> None:
+        """Recovery also fails to resolve a live parent runner."""
+        return
+
+    monkeypatch.setattr(sessions_module, "_forward_session_change_to_runner", _forward_none)
+    monkeypatch.setattr(
+        sessions_module, "_recover_subagent_status_forward_via_parent", _recover_none
+    )
+
+    resp = await client.post(
+        f"/v1/sessions/{child['id']}/events",
+        json={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    assert resp.status_code == 503, resp.text

--- a/tests/server/routes/test_subagent_status_forward_recovery.py
+++ b/tests/server/routes/test_subagent_status_forward_recovery.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import types
 from typing import Any
 
+import httpx
 import pytest
 
 from omnigent.server.routes import sessions as sessions_mod
@@ -248,3 +249,78 @@ async def test_recover_falls_back_to_root_when_no_direct_parent(
     assert result is not None and result.status_code == 202
     assert store.rebinds == [("conv_child", "runner_new")]
     assert _patch_forward_and_wait["waited_for"] == ["conv_root"]
+
+
+async def test_recover_real_body_retry_resolves_healed_runner() -> None:
+    """
+    End-to-end recovery body: the healed ``runner_id`` is what the retry resolves.
+
+    Drives the REAL recovery path with NO stub of
+    ``_forward_session_change_to_runner``. A fake router mirrors
+    ``RunnerRouter``'s contract — it re-reads the conversation's current
+    ``runner_id`` fresh on every resolve and only hands back a client for the
+    live runner. This asserts the load-bearing invariant flagged in review:
+    after ``replace_runner_id`` heals the child onto the parent's live runner,
+    the retry's resolver picks the NEW runner and the forward lands (202) — i.e.
+    healing the persisted binding genuinely repoints the retry, rather than
+    resolving a stale in-memory id.
+    """
+    convs: dict[str, Any] = {
+        "conv_parent": _conv("conv_parent", runner_id="R_live"),
+        "conv_child": _conv("conv_child", runner_id="R_old", parent_id="conv_parent"),
+    }
+    rebinds: list[tuple[str, str]] = []
+
+    class _Store:
+        def get_conversation(self, conversation_id: str) -> Any | None:
+            return convs.get(conversation_id)
+
+        def replace_runner_id(self, conversation_id: str, runner_id: str) -> Any:
+            rebinds.append((conversation_id, runner_id))
+            prev = convs[conversation_id]
+            convs[conversation_id] = _conv(
+                conversation_id,
+                runner_id=runner_id,
+                parent_id=prev.parent_conversation_id,
+                root_id=prev.root_conversation_id,
+            )
+            return convs[conversation_id]
+
+    posted: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        posted.append(request.url.path)
+        return httpx.Response(202)
+
+    live_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler), base_url="http://runner"
+    )
+
+    class _Router:
+        """Re-reads the conv's CURRENT runner_id; resolves only the live one."""
+
+        def client_for_session_resources(self, conversation_id: str) -> Any:
+            runner_id = convs[conversation_id].runner_id
+            if runner_id != "R_live":
+                raise LookupError(f"runner {runner_id} offline")
+            return types.SimpleNamespace(client=live_client)
+
+    try:
+        # tunnel_registry=None → skip the liveness wait and exercise the real
+        # rebind + forward + resolver path.
+        result = await _recover_subagent_status_forward_via_parent(
+            convs["conv_child"],
+            runner_router=_Router(),  # type: ignore[arg-type]
+            tunnel_registry=None,
+            conversation_store=_Store(),  # type: ignore[arg-type]
+            forward_body={"type": "external_session_status", "data": {"status": "idle"}},
+        )
+    finally:
+        await live_client.aclose()
+
+    assert result is not None and result.status_code == 202
+    # Child healed to the parent's live runner...
+    assert rebinds == [("conv_child", "R_live")]
+    # ...and the retry forwarded via the CHILD id, which the resolver — reading
+    # the freshly healed runner_id — routed to the live runner.
+    assert posted == ["/v1/sessions/conv_child/events"]

--- a/tests/server/routes/test_subagent_status_forward_recovery.py
+++ b/tests/server/routes/test_subagent_status_forward_recovery.py
@@ -1,0 +1,215 @@
+"""Unit tests for sub-agent terminal-status forward recovery.
+
+Covers :func:`_recover_subagent_status_forward_via_parent`, the server-side
+heal for the production hang where a native sub-agent child's ``runner_id``
+goes stale after its runner is relaunched under a new id (only the parent is
+rebound), so the child's terminal ``idle``/``failed`` forward 503s forever and
+the parent never receives the child result.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+from omnigent.server.routes import sessions as sessions_mod
+from omnigent.server.routes.sessions import (
+    _recover_subagent_status_forward_via_parent,
+    _RunnerForwardResult,
+)
+
+
+def _conv(
+    conv_id: str,
+    *,
+    runner_id: str | None,
+    parent_id: str | None = None,
+    root_id: str | None = None,
+) -> Any:
+    """Build a minimal conversation stand-in with the fields the helper reads."""
+    return types.SimpleNamespace(
+        id=conv_id,
+        runner_id=runner_id,
+        parent_conversation_id=parent_id,
+        root_conversation_id=root_id or conv_id,
+    )
+
+
+class _FakeStore:
+    """Records ``replace_runner_id`` calls and serves a fixed parent."""
+
+    def __init__(self, parent: Any | None) -> None:
+        self._parent = parent
+        self.rebinds: list[tuple[str, str]] = []
+
+    def get_conversation(self, conversation_id: str) -> Any | None:
+        if self._parent is not None and conversation_id == self._parent.id:
+            return self._parent
+        return None
+
+    def replace_runner_id(self, conversation_id: str, runner_id: str) -> Any:
+        self.rebinds.append((conversation_id, runner_id))
+        return _conv(conversation_id, runner_id=runner_id)
+
+
+@pytest.fixture
+def _patch_forward_and_wait(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """
+    Stub ``_forward_session_change_to_runner`` and ``_wait_for_runner_client``.
+
+    Returns a mutable dict the test tunes (``wait_returns`` / ``forward_result``)
+    and reads back (``forwarded_with`` — the session id the retry forwarded to).
+    """
+    state: dict[str, Any] = {
+        "wait_returns": object(),  # truthy "client" by default
+        "forward_result": _RunnerForwardResult(status_code=202, body=""),
+        "forwarded_with": [],
+        "waited_for": [],
+    }
+
+    async def _fake_wait(session_id: str, *_a: Any, **_k: Any) -> Any:
+        state["waited_for"].append(session_id)
+        return state["wait_returns"]
+
+    async def _fake_forward(session_id: str, *_a: Any, **_k: Any) -> Any:
+        state["forwarded_with"].append(session_id)
+        return state["forward_result"]
+
+    monkeypatch.setattr(sessions_mod, "_wait_for_runner_client", _fake_wait)
+    monkeypatch.setattr(sessions_mod, "_forward_session_change_to_runner", _fake_forward)
+    return state
+
+
+async def test_recover_rebinds_to_parent_runner_and_redelivers(
+    _patch_forward_and_wait: dict[str, Any],
+) -> None:
+    """
+    Stale child id heals to the parent's live runner and the forward re-lands.
+
+    This is the core production fix: the child was pinned to ``runner_old``
+    (now dead), the parent has since rebound to ``runner_new``. Recovery must
+    rebind the child to ``runner_new`` and re-POST the terminal status THROUGH
+    the child id (which now resolves to the live runner), returning the 202.
+    """
+    child = _conv("conv_child", runner_id="runner_old", parent_id="conv_parent")
+    parent = _conv("conv_parent", runner_id="runner_new")
+    store = _FakeStore(parent)
+
+    result = await _recover_subagent_status_forward_via_parent(
+        child,
+        runner_router=None,
+        tunnel_registry=object(),  # non-None → the wait path runs
+        conversation_store=store,  # type: ignore[arg-type]
+        forward_body={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    assert result is not None and result.status_code == 202
+    # Child healed to the parent's current runner...
+    assert store.rebinds == [("conv_child", "runner_new")]
+    # ...and the retry forwarded through the (now-rebound) CHILD id.
+    assert _patch_forward_and_wait["forwarded_with"] == ["conv_child"]
+    assert _patch_forward_and_wait["waited_for"] == ["conv_parent"]
+
+
+async def test_recover_gives_up_when_parent_runner_never_connects(
+    _patch_forward_and_wait: dict[str, Any],
+) -> None:
+    """
+    If the parent's runner tunnel never (re)connects, recovery returns None.
+
+    The caller then fails the forward as before (a 503 the runner retries) —
+    we must NOT rebind or forward against a runner we couldn't confirm live.
+    """
+    _patch_forward_and_wait["wait_returns"] = None  # tunnel never comes up
+    child = _conv("conv_child", runner_id="runner_old", parent_id="conv_parent")
+    store = _FakeStore(_conv("conv_parent", runner_id="runner_new"))
+
+    result = await _recover_subagent_status_forward_via_parent(
+        child,
+        runner_router=None,
+        tunnel_registry=object(),
+        conversation_store=store,  # type: ignore[arg-type]
+        forward_body={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    assert result is None
+    assert store.rebinds == []
+    assert _patch_forward_and_wait["forwarded_with"] == []
+
+
+async def test_recover_no_parent_returns_none(
+    _patch_forward_and_wait: dict[str, Any],
+) -> None:
+    """
+    A child with no resolvable parent (root == self) cannot be recovered.
+
+    Guards against a top-level session that was mislabeled, or a child whose
+    root points at itself — neither has a distinct parent runner to heal to.
+    """
+    child = _conv("conv_orphan", runner_id="runner_old", parent_id=None, root_id="conv_orphan")
+    store = _FakeStore(None)
+
+    result = await _recover_subagent_status_forward_via_parent(
+        child,
+        runner_router=None,
+        tunnel_registry=object(),
+        conversation_store=store,  # type: ignore[arg-type]
+        forward_body={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    assert result is None
+    assert store.rebinds == []
+    assert _patch_forward_and_wait["forwarded_with"] == []
+
+
+async def test_recover_same_runner_skips_rebind_but_retries(
+    _patch_forward_and_wait: dict[str, Any],
+) -> None:
+    """
+    A transient gap (child and parent share the SAME live id) retries, no rebind.
+
+    Here the runner reconnected under its stable id, so the child's binding is
+    already correct — recovery should NOT issue a needless ``replace_runner_id``
+    but should still re-forward after waiting out the reconnect gap.
+    """
+    child = _conv("conv_child", runner_id="runner_same", parent_id="conv_parent")
+    store = _FakeStore(_conv("conv_parent", runner_id="runner_same"))
+
+    result = await _recover_subagent_status_forward_via_parent(
+        child,
+        runner_router=None,
+        tunnel_registry=object(),
+        conversation_store=store,  # type: ignore[arg-type]
+        forward_body={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    assert result is not None and result.status_code == 202
+    assert store.rebinds == []  # same id → no rebind
+    assert _patch_forward_and_wait["forwarded_with"] == ["conv_child"]
+
+
+async def test_recover_falls_back_to_root_when_no_direct_parent(
+    _patch_forward_and_wait: dict[str, Any],
+) -> None:
+    """
+    When ``parent_conversation_id`` is unset, recovery resolves via ``root``.
+
+    A child persisted without a direct parent pointer (older rows / codex
+    nesting) still belongs to a root conversation whose runner is the live one.
+    """
+    child = _conv("conv_child", runner_id="runner_old", parent_id=None, root_id="conv_root")
+    store = _FakeStore(_conv("conv_root", runner_id="runner_new"))
+
+    result = await _recover_subagent_status_forward_via_parent(
+        child,
+        runner_router=None,
+        tunnel_registry=object(),
+        conversation_store=store,  # type: ignore[arg-type]
+        forward_body={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    assert result is not None and result.status_code == 202
+    assert store.rebinds == [("conv_child", "runner_new")]
+    assert _patch_forward_and_wait["waited_for"] == ["conv_root"]

--- a/tests/server/routes/test_subagent_status_forward_recovery.py
+++ b/tests/server/routes/test_subagent_status_forward_recovery.py
@@ -19,6 +19,7 @@ from omnigent.server.routes.sessions import (
     _recover_subagent_status_forward_via_parent,
     _RunnerForwardResult,
 )
+from omnigent.stores.conversation_store import ConversationNotFoundError
 
 
 def _conv(
@@ -40,8 +41,9 @@ def _conv(
 class _FakeStore:
     """Records ``replace_runner_id`` calls and serves a fixed parent."""
 
-    def __init__(self, parent: Any | None) -> None:
+    def __init__(self, parent: Any | None, *, raise_on_rebind: bool = False) -> None:
         self._parent = parent
+        self._raise_on_rebind = raise_on_rebind
         self.rebinds: list[tuple[str, str]] = []
 
     def get_conversation(self, conversation_id: str) -> Any | None:
@@ -50,6 +52,10 @@ class _FakeStore:
         return None
 
     def replace_runner_id(self, conversation_id: str, runner_id: str) -> Any:
+        if self._raise_on_rebind:
+            # Simulate the child row being deleted between post_event reading
+            # it and this heal (a mid-teardown race).
+            raise ConversationNotFoundError(conversation_id)
         self.rebinds.append((conversation_id, runner_id))
         return _conv(conversation_id, runner_id=runner_id)
 
@@ -188,6 +194,35 @@ async def test_recover_same_runner_skips_rebind_but_retries(
     assert result is not None and result.status_code == 202
     assert store.rebinds == []  # same id → no rebind
     assert _patch_forward_and_wait["forwarded_with"] == ["conv_child"]
+
+
+async def test_recover_deleted_child_race_degrades_to_none(
+    _patch_forward_and_wait: dict[str, Any],
+) -> None:
+    """
+    A child deleted mid-heal degrades to ``None`` (→ 503), never a 500.
+
+    If the child row is removed between ``post_event`` reading it and the
+    rebind, ``replace_runner_id`` raises ``ConversationNotFoundError``. Recovery
+    is best-effort: it must swallow that benign race and return ``None`` so the
+    caller falls through to the existing 503/no-op, not surface an unhandled
+    500. (Polly review note on PR #1446.)
+    """
+    child = _conv("conv_child", runner_id="runner_old", parent_id="conv_parent")
+    store = _FakeStore(_conv("conv_parent", runner_id="runner_new"), raise_on_rebind=True)
+
+    result = await _recover_subagent_status_forward_via_parent(
+        child,
+        runner_router=None,
+        tunnel_registry=object(),
+        conversation_store=store,  # type: ignore[arg-type]
+        forward_body={"type": "external_session_status", "data": {"status": "idle"}},
+    )
+
+    assert result is None
+    assert store.rebinds == []
+    # The deleted-child race short-circuits before any retry forward.
+    assert _patch_forward_and_wait["forwarded_with"] == []
 
 
 async def test_recover_falls_back_to_root_when_no_direct_parent(


### PR DESCRIPTION
## Problem

On a hosted deployment, native **sub-agent** sessions hang forever after a runner relaunch, and the server logs fill with a tight loop of:

```
ERROR Internal error: Could not reach runner to deliver external_session_status 'idle'
for sub-agent session 'conv_…'   (RUNNER_UNAVAILABLE)  →  503
```

Live evidence (one 90s window on the `omnigents` app): one child got **267 identical 503s, steady ~3/sec, zero successes** — the terminal status never lands, so the parent never gets the child result and never resumes.

## Root cause — `runner_id` divergence for children

A native sub-agent child copies its parent's `runner_id` **once, at creation** (`create_conversation(..., runner_id=parent_conv.runner_id)` in `_persist_external_subagent_start`, `sessions.py:4440`/`:4602`). It is never repointed when the runner is later **relaunched under a freshly-minted `runner_id`** — a host relaunch after a tunnel drop (#1116), a server redeploy, or a crash mints a new binding token, and only the **parent** conversation is rebound (via the PATCH path on its next message — *which is why chat keeps working*). `_on_runner_connect` (`app.py:1941`) only re-binds sessions whose stored id already equals the reconnecting runner, so the child — still pinned to the dead id — is never recovered.

When the child finishes, its terminal `external_session_status` forward resolves no runner client (`_forward_session_change_to_runner` → `None`) and `_require_external_status_forward` raises `RUNNER_UNAVAILABLE` → 503. The parent's only resume path is a wake gated on that status landing in the runner's in-memory parent inbox, and there is **no timeout or escalation** — so it hangs.

## Fix

A child always runs on its parent's runner, so the live binding is the parent's. When the direct forward of a sub-agent terminal status returns no runner, `_recover_subagent_status_forward_via_parent` re-resolves through the parent/root conversation's **current** `runner_id`:

1. **Wait briefly** for that runner's tunnel to (re)connect (`_wait_for_runner_client`, ~5s) — bridges the relaunch/redeploy reconnect gap.
2. **Heal the child's stale `runner_id`** (`replace_runner_id`) so future forwards and `_on_runner_connect` resolve it.
3. **Retry the forward** through the (now-rebound) child id.

Falls through to the existing 503 (which the runner retries) when no live parent runner resolves — the at-least-once contract is preserved. Self-healing regardless of *when* a redeploy/relaunch happens, which was the explicit goal.

Touches only the sub-agent `idle`/`failed` branch of `post_event`; top-level and codex-internal children are unaffected.

## Tests

- **Unit** (`test_subagent_status_forward_recovery.py`): rebind-to-parent + redeliver; give-up when the parent runner never connects (no rebind, no forward); no-parent → None; same-id transient gap retries without a needless rebind; `parent_conversation_id` unset → resolves via `root`.
- **End-to-end wiring** (`test_sessions_child_sessions.py`): a stale child's `idle` whose direct forward 503s → recovery invoked → `202`; recovery also fails → `503` preserved.

All pass locally; `ruff` clean; zero new `mypy` errors in the touched code.

## Scope / related

This is the **net-new** server-side durability fix; complementary to the open work, not overlapping:
- **#1116** (P0) — the ws-tunnel keepalive `1011` drops are the *trigger* (the `websockets`-library default `ping_timeout` isn't tuned on the tunnel clients). This PR makes a drop *non-fatal* for children but does not change keepalive tuning — that belongs in #1116.
- **#1120 / #1077 / #853** — runner-side forwarder backoff and parent-inbox recovery. Two follow-ups I deliberately left out of this PR to keep it focused: (a) runner-side backoff so the `idle` re-post doesn't hot-loop at ~3/sec, and (b) server log-hygiene so the now-rare residual `RUNNER_UNAVAILABLE` 503 isn't logged as an `ERROR` + traceback (`app.py:1341`).

## Verification note

The recovery logic and the `post_event` wiring are covered by the tests above. The full live repro (a hosted redeploy with in-flight sub-agents) can't be reproduced from a local checkout; the unit + integration tests reproduce the exact server edge (child runner unreachable → recover-or-503).

This pull request and its description were written by Isaac.
