### PR TITLE
fix(ap-web): paginate and dedupe agent picker catalog

### DIFF
--- a/ap-web/src/hooks/useAvailableAgents.test.tsx
+++ b/ap-web/src/hooks/useAvailableAgents.test.tsx
@@ -94,7 +94,9 @@ describe("useAvailableAgents", () => {
     routeFetch({
       [BUILTINS_URL]: mockResponse({
         object: "list",
-        data: [{ id: "ag_codex_fork", name: "codex-native-ui (fork ag_old)", harness: "codex-native" }],
+        data: [
+          { id: "ag_codex_fork", name: "codex-native-ui (fork ag_old)", harness: "codex-native" },
+        ],
         has_more: true,
         last_id: "ag_codex_fork",
       }),
@@ -421,7 +423,11 @@ describe("useAvailableAgents", () => {
           // resolve by harness but must not compete with the seeded rows.
           { id: "ag_stale_codex", name: "codex-native-ui (fork ag_old)", harness: "codex-native" },
           { id: "ag_codex", name: "codex-native-ui", harness: "codex-native" },
-          { id: "ag_stale_claude", name: "claude-native-ui (fork ag_old)", harness: "claude-native" },
+          {
+            id: "ag_stale_claude",
+            name: "claude-native-ui (fork ag_old)",
+            harness: "claude-native",
+          },
           { id: "ag_claude", name: "claude-native-ui", harness: "claude-native" },
           { id: "ag_stale_kiro", name: "kiro-naitive", harness: "kiro-native" },
           { id: "ag_kiro", name: "kiro-native-ui", harness: "kiro-native" },

--- a/ap-web/src/hooks/useAvailableAgents.test.tsx
+++ b/ap-web/src/hooks/useAvailableAgents.test.tsx
@@ -121,8 +121,9 @@ describe("useAvailableAgents", () => {
         skills: [],
       },
     ]);
-    expect(fetchMock).toHaveBeenCalledWith("/v1/agents");
-    expect(fetchMock).toHaveBeenCalledWith("/v1/agents?after=ag_codex_fork");
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(urls).toContain("/v1/agents");
+    expect(urls).toContain("/v1/agents?after=ag_codex_fork");
   });
 
   it("maps rows into AvailableAgent and applies native, nessie, and debby display names", async () => {

--- a/ap-web/src/hooks/useAvailableAgents.test.tsx
+++ b/ap-web/src/hooks/useAvailableAgents.test.tsx
@@ -90,6 +90,39 @@ describe("useAvailableAgents", () => {
     expect(urls).toContain(SCAN_URL);
   });
 
+  it("paginates built-ins so defaults pushed past fork rows are still listed", async () => {
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [{ id: "ag_codex_fork", name: "codex-native-ui (fork ag_old)", harness: "codex-native" }],
+        has_more: true,
+        last_id: "ag_codex_fork",
+      }),
+      "/v1/agents?after=ag_codex_fork": mockResponse({
+        object: "list",
+        data: [{ id: "ag_codex", name: "codex-native-ui", harness: "codex-native" }],
+        has_more: false,
+      }),
+      [SCAN_URL]: EMPTY_SCAN,
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([
+      {
+        id: "ag_codex",
+        name: "codex-native-ui",
+        display_name: "Codex",
+        description: null,
+        harness: "codex-native",
+        skills: [],
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith("/v1/agents");
+    expect(fetchMock).toHaveBeenCalledWith("/v1/agents?after=ag_codex_fork");
+  });
+
   it("maps rows into AvailableAgent and applies native, nessie, and debby display names", async () => {
     routeFetch({
       [BUILTINS_URL]: mockResponse({
@@ -384,8 +417,12 @@ describe("useAvailableAgents", () => {
       [BUILTINS_URL]: mockResponse({
         object: "list",
         data: [
-          // Stale/non-canonical native row from older local state; it
-          // resolves by harness but must not compete with the seeded row.
+          // Stale/non-canonical native rows from older local state; they
+          // resolve by harness but must not compete with the seeded rows.
+          { id: "ag_stale_codex", name: "codex-native-ui (fork ag_old)", harness: "codex-native" },
+          { id: "ag_codex", name: "codex-native-ui", harness: "codex-native" },
+          { id: "ag_stale_claude", name: "claude-native-ui (fork ag_old)", harness: "claude-native" },
+          { id: "ag_claude", name: "claude-native-ui", harness: "claude-native" },
           { id: "ag_stale_kiro", name: "kiro-naitive", harness: "kiro-native" },
           { id: "ag_kiro", name: "kiro-native-ui", harness: "kiro-native" },
         ],
@@ -415,6 +452,22 @@ describe("useAvailableAgents", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toEqual([
+      {
+        id: "ag_codex",
+        name: "codex-native-ui",
+        display_name: "Codex",
+        description: null,
+        harness: "codex-native",
+        skills: [],
+      },
+      {
+        id: "ag_claude",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
       {
         id: "ag_kiro",
         name: "kiro-native-ui",

--- a/ap-web/src/hooks/useAvailableAgents.ts
+++ b/ap-web/src/hooks/useAvailableAgents.ts
@@ -62,7 +62,7 @@ function dedupeNativeAgents(agents: AvailableAgent[]): AvailableAgent[] {
   const nativeIndex = new Map<string, number>();
   for (const agent of agents) {
     const nativeAgent = nativeCodingAgentForAvailableAgent(agent);
-    if (nativeAgent?.key !== "kiro") {
+    if (nativeAgent === undefined) {
       result.push(agent);
       continue;
     }
@@ -93,6 +93,12 @@ interface BuiltinAgentWire {
   created_at?: number | null;
 }
 
+interface BuiltinAgentsListWire {
+  data: BuiltinAgentWire[];
+  has_more?: boolean;
+  last_id?: string | null;
+}
+
 /** Wire row of the sessions scan, GET /v1/sessions?kind=any. */
 interface SessionListItemWire {
   id: string;
@@ -108,11 +114,19 @@ interface SessionListItemWire {
  * (see designs/BUILTIN_AGENTS.md).
  */
 async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
-  const res = await authenticatedFetch("/v1/agents");
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  const body = (await res.json()) as { data: BuiltinAgentWire[] };
+  const rows: BuiltinAgentWire[] = [];
+  let after: string | null = null;
+  do {
+    const url = after == null ? "/v1/agents" : `/v1/agents?after=${encodeURIComponent(after)}`;
+    const res = await authenticatedFetch(url);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const body = (await res.json()) as BuiltinAgentsListWire;
+    rows.push(...body.data);
+    after = body.has_more === true && body.last_id ? body.last_id : null;
+  } while (after != null);
+
   return dedupeNativeAgents(
-    body.data.map((a) => ({
+    rows.map((a) => ({
       id: a.id,
       name: a.name,
       display_name: displayNameForAgent(a.name, a.harness),

--- a/ap-web/src/hooks/useAvailableAgents.ts
+++ b/ap-web/src/hooks/useAvailableAgents.ts
@@ -125,21 +125,19 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
     after = body.has_more === true && body.last_id ? body.last_id : null;
   } while (after != null);
 
-  return dedupeNativeAgents(
-    rows.map((a) => ({
-      id: a.id,
-      name: a.name,
-      display_name: displayNameForAgent(a.name, a.harness),
-      description: a.description ?? null,
-      harness: a.harness ?? null,
-      skills: a.skills ?? [],
-      // Raw passthrough (not coerced): an absent value stays undefined so
-      // older servers degrade to "protected" and existing strict-equality
-      // tests (which ignore undefined props) are unaffected.
-      builtin: a.builtin,
-      created_at: a.created_at,
-    })),
-  );
+  return rows.map((a) => ({
+    id: a.id,
+    name: a.name,
+    display_name: displayNameForAgent(a.name, a.harness),
+    description: a.description ?? null,
+    harness: a.harness ?? null,
+    skills: a.skills ?? [],
+    // Raw passthrough (not coerced): an absent value stays undefined so
+    // older servers degrade to "protected" and existing strict-equality
+    // tests (which ignore undefined props) are unaffected.
+    builtin: a.builtin,
+    created_at: a.created_at,
+  }));
 }
 
 /**
@@ -278,10 +276,10 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
   // `builtin !== false` keeps both true (seeded) and undefined (older server,
   // no flag) protected — only an explicit false marks a supersedable
   // user-registered template.
-  const seeded = catalog.filter((a) => a.builtin !== false);
+  const seeded = dedupeNativeAgents(catalog.filter((a) => a.builtin !== false));
   const userTemplates = catalog.filter((a) => a.builtin === false);
   const catalogIds = new Set(catalog.map((a) => a.id));
-  const seededNames = new Set(seeded.map((a) => a.name));
+  const seededNames = new Set(seeded.map((a) => agentRootName(a.name)));
   const hasKiroBuiltin = seeded.some((a) => nativeCodingAgentForAvailableAgent(a)?.key === "kiro");
   const kiroLegacyNames = new Set(["kiro"]);
 
@@ -298,7 +296,8 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
 
   // Seed with user-registered templates. A template name is globally unique
   // among catalog rows, so it cannot collide with a seeded built-in; guard
-  // defensively anyway.
+  // defensively anyway. Rooting seeded names also drops stale fork rows from
+  // older catalogs once their canonical built-in is present.
   for (const t of userTemplates) {
     const base = agentRootName(t.name);
     if (seededNames.has(base)) continue;

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -159,6 +159,58 @@ def _codex_native_agents_body() -> str:
     )
 
 
+def _forked_codex_first_page_body() -> str:
+    """First ``GET /v1/agents`` page with stale Codex forks only.
+
+    Mirrors an older deployment where fork clones leaked into the built-in
+    catalog before the server-side forward fix. The canonical Codex row is on
+    page 2, so the picker must paginate before deduping native rows.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_codex_fork_1",
+                    "name": "codex-native-ui (fork ag_old1)",
+                    "display_name": "Codex",
+                    "description": "Stale Codex fork",
+                    "harness": "codex-native",
+                    "skills": [],
+                },
+                {
+                    "id": "ag_codex_fork_2",
+                    "name": "codex-native-ui (fork ag_old2)",
+                    "display_name": "Codex",
+                    "description": "Another stale Codex fork",
+                    "harness": "codex-native",
+                    "skills": [],
+                },
+            ],
+            "has_more": True,
+            "last_id": "ag_codex_fork_2",
+        }
+    )
+
+
+def _canonical_codex_second_page_body() -> str:
+    """Second ``GET /v1/agents`` page containing canonical Codex."""
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_codex_e2e",
+                    "name": "codex-native-ui",
+                    "display_name": "Codex",
+                    "description": "OpenAI's coding agent",
+                    "harness": "codex-native",
+                    "skills": [],
+                }
+            ],
+            "has_more": False,
+        }
+    )
+
+
 def _bundle_agents_body() -> str:
     """Stub body for ``GET /v1/agents``: the two harness-overridable bundle agents.
 
@@ -548,6 +600,85 @@ def test_start_session_select_approval_mode(seeded_session: tuple[str, str]) -> 
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_approval_mode(base_url, session_id))
+
+
+def test_start_session_agent_picker_paginates_and_dedupes_native_forks(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The new-session picker recovers canonical Codex from page 2.
+
+    Older servers leaked fork clones into ``GET /v1/agents``. New servers stop
+    creating those rows, but existing databases can still have enough stale
+    forked native agents to push canonical built-ins off page 1. The picker must
+    follow pagination and then collapse all ``codex-native`` rows to the
+    canonical ``codex-native-ui`` row, so users see one top-level Codex choice.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_agent_picker_pagination_dedupe(base_url, session_id))
+
+
+async def _drive_agent_picker_pagination_dedupe(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page,
+                created_session_id=session_id,
+                create_bodies=create_bodies,
+                agents_body=_forked_codex_first_page_body(),
+            )
+
+            async def handle_agents_page_2(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=_canonical_codex_second_page_body(),
+                )
+
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route("**/v1/agents?after=ag_codex_fork_2", handle_agents_page_2)
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            picker = page.get_by_test_id("new-chat-landing-agent-select")
+            await expect(picker).to_contain_text("Codex")
+            await picker.click()
+
+            await expect(page.get_by_test_id("new-chat-landing-agent-ag_codex_e2e")).to_be_visible()
+            await expect(page.get_by_test_id("new-chat-landing-agent-ag_codex_fork_1")).to_have_count(
+                0
+            )
+            await expect(page.get_by_test_id("new-chat-landing-agent-ag_codex_fork_2")).to_have_count(
+                0
+            )
+
+            await page.keyboard.press("Escape")
+            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_codex_e2e", body
+        finally:
+            await browser.close()
 
 
 async def _drive_approval_mode(base_url: str, session_id: str) -> None:

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -662,13 +662,15 @@ async def _drive_agent_picker_pagination_dedupe(base_url: str, session_id: str) 
             await expect(picker).to_contain_text("Codex")
             await picker.click()
 
-            await expect(page.get_by_test_id("new-chat-landing-agent-ag_codex_e2e")).to_be_visible()
-            await expect(page.get_by_test_id("new-chat-landing-agent-ag_codex_fork_1")).to_have_count(
-                0
-            )
-            await expect(page.get_by_test_id("new-chat-landing-agent-ag_codex_fork_2")).to_have_count(
-                0
-            )
+            await expect(
+                page.get_by_test_id("new-chat-landing-agent-ag_codex_e2e")
+            ).to_be_visible()
+            await expect(
+                page.get_by_test_id("new-chat-landing-agent-ag_codex_fork_1")
+            ).to_have_count(0)
+            await expect(
+                page.get_by_test_id("new-chat-landing-agent-ag_codex_fork_2")
+            ).to_have_count(0)
 
             await page.keyboard.press("Escape")
             await page.get_by_test_id("new-chat-landing-input").fill("set up the project")


### PR DESCRIPTION
## Related issue

N/A — drive-by bug fix from hosted app agent picker regression.

Closes #

## Summary

The new-session agent picker only fetched the first `/v1/agents` page. On deployments with stale forked native-agent rows from before the server-side forward fix, canonical built-ins like `codex-native-ui` could be pushed onto page 2. The picker then showed repeated fork rows as duplicate `Codex` custom entries and missed the default Codex row.

This is complementary to #1444, which teaches the picker how to choose the newest same-named user-registered template/upload using the new server `builtin` flag. This PR keeps that behavior intact: pagination stays in the catalog fetch, while native fork dedupe runs after the seeded-built-in vs user-template split.

- Paginate `GET /v1/agents` until the server reports no more pages.
- Dedupe native seeded/catalog rows by native harness/key, preferring canonical names like `codex-native-ui` over stale `codex-native-ui (fork ...)` rows.
- Keep non-native agents distinct; e.g. plain `claude` is not collapsed into `claude-native-ui`.
- Add unit coverage for pagination and native fork dedupe, plus e2e UI coverage for the new-session picker recovering canonical Codex from page 2.

## Test Plan

- `cd ap-web && npm test -- useAvailableAgents.test.tsx` — 15 passed.
- `uv run python -m py_compile tests/e2e_ui/start_session/test_start_session.py` — pass.
- CI: full `ap-web Tests`, `Lint`, and `E2E UI Tests` run on this PR.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This covers the backward-compatibility cleanup needed after the recent server-side forward fix (`fix(server): create fork agent clone atomically to stop /v1/agents leak`). New fork leaks should be stopped at creation time, while this PR makes the UI robust to older rows already present in existing agent catalogs.

## Screenshots

<img width="471" height="566" alt="Screenshot 2026-06-26 at 4 33 58 PM" src="https://github.com/user-attachments/assets/17972bed-e5c1-4c39-a5ce-3d02e42abee3" />
<img width="432" height="809" alt="Screenshot 2026-06-26 at 4 34 09 PM" src="https://github.com/user-attachments/assets/4fd7a99d-6f3f-4d6a-a8bc-884c12c72e13" />
