### PR TITLE
fix(comments): reject nonexistent sessions

### DIFF
--- a/omnigent/server/routes/comments.py
+++ b/omnigent/server/routes/comments.py
@@ -149,6 +149,23 @@ def create_comments_router(
         raise ValueError("conversation_store is required when permission_store is provided")
     router = APIRouter()
 
+    async def _require_session_access(user_id: str | None, session_id: str, level: int) -> None:
+        """Require access and a real session before comment store mutations.
+
+        :param user_id: The authenticated caller, or the single-user sentinel.
+        :param session_id: The session to check, e.g. ``"conv_abc123"``.
+        :param level: Required permission level for auth-enabled servers.
+        :raises OmnigentError: 404 when the session does not exist, or the
+            auth helper's 401/403/404 when permission enforcement is active.
+        """
+        if permission_store is not None:
+            assert conversation_store is not None
+            await require_access(user_id, session_id, level, permission_store, conversation_store)
+        if conversation_store is not None:
+            conversation = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+            if conversation is None:
+                raise OmnigentError("Session not found", code=ErrorCode.NOT_FOUND)
+
     async def _require_comment_author(
         user_id: str | None, comment_id: str, session_id: str
     ) -> None:
@@ -204,10 +221,7 @@ def create_comments_router(
         :raises OmnigentError: 401/403/404 if the user lacks edit permission.
         """
         user_id = get_user_id(request, auth_provider)
-        if permission_store is not None and conversation_store is not None:
-            await require_access(
-                user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
-            )
+        await _require_session_access(user_id, session_id, LEVEL_EDIT)
         comment = store.add(
             conversation_id=session_id,
             path=body.path,
@@ -242,10 +256,7 @@ def create_comments_router(
         :raises OmnigentError: 401/403/404 if the user lacks read permission.
         """
         user_id = get_user_id(request, auth_provider)
-        if permission_store is not None and conversation_store is not None:
-            await require_access(
-                user_id, session_id, LEVEL_READ, permission_store, conversation_store
-            )
+        await _require_session_access(user_id, session_id, LEVEL_READ)
         comments = store.list_for_conversation(session_id, path=path)
         return [asdict(c) for c in comments]
 
@@ -274,10 +285,8 @@ def create_comments_router(
             or 404 if the comment is not found.
         """
         user_id = get_user_id(request, auth_provider)
-        if permission_store is not None and conversation_store is not None:
-            await require_access(
-                user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
-            )
+        await _require_session_access(user_id, session_id, LEVEL_EDIT)
+        if permission_store is not None:
             # Rewriting comment text is author-only; a status-only change is a
             # shared review-workflow action that any editor (and the agent's
             # update_comment tool) may perform.
@@ -309,10 +318,8 @@ def create_comments_router(
             comment is not found or does not belong to this session.
         """
         user_id = get_user_id(request, auth_provider)
-        if permission_store is not None and conversation_store is not None:
-            await require_access(
-                user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
-            )
+        await _require_session_access(user_id, session_id, LEVEL_EDIT)
+        if permission_store is not None:
             await _require_comment_author(user_id, comment_id, session_id)
         deleted = store.delete(comment_id, session_id)
         if deleted is None:
@@ -344,10 +351,7 @@ def create_comments_router(
             this session.
         """
         user_id = get_user_id(request, auth_provider)
-        if permission_store is not None and conversation_store is not None:
-            await require_access(
-                user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
-            )
+        await _require_session_access(user_id, session_id, LEVEL_EDIT)
 
         # Fetch + mark-addressed for every requested comment runs N sync
         # DB gets + N sync updates. Do the whole batch in one worker-thread

--- a/tests/server/integration/test_comments_routes.py
+++ b/tests/server/integration/test_comments_routes.py
@@ -213,6 +213,31 @@ async def test_comments_created_by_reflects_request_user(
     )
 
 
+async def test_admin_cannot_add_comment_to_nonexistent_session(
+    auth_client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Admin bypass must not allow orphan comments on missing sessions."""
+    admin = "admin@example.com"
+    missing_session_id = "conv_does_not_exist"
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    perm_store.ensure_user(admin, is_admin=True)
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{missing_session_id}/comments",
+        json={
+            "path": "src/app.py",
+            "body": "Admin orphan probe",
+            "start_index": 0,
+            "end_index": 5,
+        },
+        headers={"X-Forwarded-Email": admin},
+    )
+
+    assert resp.status_code == 404
+    assert SqlAlchemyCommentStore(db_uri).list_for_conversation(missing_session_id) == []
+
+
 async def test_read_only_user_cannot_mutate_comments(
     auth_client: httpx.AsyncClient,
     db_uri: str,

--- a/tests/server/routes/test_comments_crud.py
+++ b/tests/server/routes/test_comments_crud.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 
 from omnigent.db.utils import generate_agent_id
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
@@ -67,6 +68,21 @@ async def test_add_comment_end_before_start(client: httpx.AsyncClient, session_i
         json=_comment_payload(start_index=10, end_index=5),
     )
     assert resp.status_code == 422
+
+
+async def test_add_comment_nonexistent_session_returns_404_without_persisting(
+    client: httpx.AsyncClient, db_uri: str
+) -> None:
+    """Adding a comment to a nonexistent single-user session returns 404."""
+    missing_session_id = "conv_does_not_exist"
+
+    resp = await client.post(
+        f"/v1/sessions/{missing_session_id}/comments",
+        json=_comment_payload(),
+    )
+
+    assert resp.status_code == 404
+    assert SqlAlchemyCommentStore(db_uri).list_for_conversation(missing_session_id) == []
 
 
 # ── GET /sessions/{id}/comments ──────────────────────────────────────


### PR DESCRIPTION
## Related issue

Closes #1401

## Summary

- Add a shared comments-route session guard that preserves the existing permission checks, then verifies the session row exists before comment reads/writes proceed.
- Apply the guard before listing, creating, updating, deleting, or sending comments so the comment store cannot create or expose orphan rows for missing conversations.
- Add regressions for both single-user mode and the auth/admin bypass path to ensure nonexistent sessions return 404 and no comment is persisted.

## Test Plan

- `uv run python -m pytest tests/server/routes/test_comments_crud.py::test_add_comment_nonexistent_session_returns_404_without_persisting tests/server/integration/test_comments_routes.py::test_admin_cannot_add_comment_to_nonexistent_session -q`  # single-user regression fails before the fix; both pass after
- `uv run python -m pytest tests/server/routes/test_comments_crud.py tests/server/integration/test_comments_rest_e2e.py tests/server/integration/test_comments_routes.py -q`
- `uv run ruff check omnigent/server/routes/comments.py tests/server/routes/test_comments_crud.py tests/server/integration/test_comments_routes.py`
- `uv run ruff format --check omnigent/server/routes/comments.py tests/server/routes/test_comments_crud.py tests/server/integration/test_comments_routes.py`
- `uv run mypy omnigent/server/routes/comments.py --hide-error-context --no-error-summary`
- `git diff --check HEAD~1..HEAD`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused backend route coverage only. No UI behavior changes.
