### PR TITLE
fix(ap-web): skip workspace UI expansion for Databricks Apps hosts

### DIFF
--- a/ap-web/electron/src/url.js
+++ b/ap-web/electron/src/url.js
@@ -115,6 +115,15 @@
   const WORKSPACE_UI_PATH = "/ml/omnigents";
 
   /**
+   * Databricks Apps are served from ``*.databricksapps.com`` and answer with the
+   * same ``server: databricks`` header as a workspace, but they are NOT
+   * workspaces and have no ``/ml/omnigents`` mount. Skip expansion for these
+   * hosts so a user who points the shell at a Databricks App is left on the URL
+   * they entered.
+   */
+  const DATABRICKS_APPS_HOST_SUFFIX = "databricksapps.com";
+
+  /**
    * Probe timeout for Databricks workspace detection. Deliberately short: a
    * slow or unreachable host must not stall the connect flow — on timeout we
    * fall back to loading the URL exactly as entered.
@@ -150,6 +159,12 @@
     // already pointed at a specific mount, and Databricks workspaces are
     // https-only.
     if (url.protocol !== "https:" || (url.pathname !== "/" && url.pathname !== "")) {
+      return normalized;
+    }
+    // Databricks Apps share the workspace ``server: databricks`` header but have
+    // no ``/ml/omnigents`` mount, so never expand them.
+    const host = url.hostname.toLowerCase();
+    if (host === DATABRICKS_APPS_HOST_SUFFIX || host.endsWith(`.${DATABRICKS_APPS_HOST_SUFFIX}`)) {
       return normalized;
     }
     let probe;

--- a/ap-web/electron/test/url.test.js
+++ b/ap-web/electron/test/url.test.js
@@ -161,6 +161,25 @@ describe("expandDatabricksWorkspaceUrl", () => {
     assert.equal(probed, false);
   });
 
+  it("leaves a Databricks Apps host untouched, without probing", async () => {
+    let probed = false;
+    await withFetch(
+      async () => {
+        probed = true;
+        return fakeResponse("databricks");
+      },
+      async () => {
+        const url = "https://my-app-123.aws.databricksapps.com/";
+        assert.equal(await expandDatabricksWorkspaceUrl(url), url);
+        assert.equal(
+          await expandDatabricksWorkspaceUrl("https://databricksapps.com/"),
+          "https://databricksapps.com/",
+        );
+      },
+    );
+    assert.equal(probed, false);
+  });
+
   it("leaves a non-https URL untouched, without probing", async () => {
     let probed = false;
     await withFetch(

--- a/ap-web/ios/Omnigent/WorkspaceURLExpander.swift
+++ b/ap-web/ios/Omnigent/WorkspaceURLExpander.swift
@@ -3,8 +3,15 @@ import Foundation
 enum WorkspaceURLExpander {
   static let workspaceUIPath = "/ml/omnigents"
 
+  /// Databricks Apps are served from `*.databricksapps.com` and answer with the
+  /// same `server: databricks` header as a workspace, but they are NOT
+  /// workspaces and have no `/ml/omnigents` mount, so expansion is skipped for
+  /// these hosts.
+  static let databricksAppsHostSuffix = "databricksapps.com"
+
   static func expandIfNeeded(_ url: URL, session: URLSession = .shared) async -> URL {
-    guard url.scheme?.lowercased() == "https", isBareRoot(url), let origin = originURL(for: url)
+    guard url.scheme?.lowercased() == "https", isBareRoot(url), !isDatabricksAppsHost(url),
+      let origin = originURL(for: url)
     else {
       return url
     }
@@ -31,6 +38,11 @@ enum WorkspaceURLExpander {
 
   private static func isBareRoot(_ url: URL) -> Bool {
     url.path.isEmpty || url.path == "/"
+  }
+
+  private static func isDatabricksAppsHost(_ url: URL) -> Bool {
+    guard let host = url.host?.lowercased() else { return false }
+    return host == databricksAppsHostSuffix || host.hasSuffix(".\(databricksAppsHostSuffix)")
   }
 
   private static func originURL(for url: URL) -> URL? {

--- a/ap-web/ios/OmnigentTests/WorkspaceURLExpanderTests.swift
+++ b/ap-web/ios/OmnigentTests/WorkspaceURLExpanderTests.swift
@@ -53,6 +53,18 @@ final class WorkspaceURLExpanderTests: XCTestCase {
     XCTAssertNil(URLProtocolStub.handler)
   }
 
+  func testLeavesDatabricksAppsHostUnchangedWithoutProbe() async {
+    let app = URL(string: "https://my-app-123.aws.databricksapps.com")!
+    let expandedApp = await WorkspaceURLExpander.expandIfNeeded(app, session: stubbedSession())
+    XCTAssertEqual(expandedApp, app)
+
+    let apex = URL(string: "https://databricksapps.com")!
+    let expandedApex = await WorkspaceURLExpander.expandIfNeeded(apex, session: stubbedSession())
+    XCTAssertEqual(expandedApex, apex)
+
+    XCTAssertNil(URLProtocolStub.handler)
+  }
+
   private func stubbedSession() -> URLSession {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [URLProtocolStub.self]


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Databricks Apps are served from `*.databricksapps.com` and respond with the same `server: databricks` header as a real workspace, so the workspace-URL expander wrongly appended `/ml/omnigents` to them.
- Add a host exclusion in both the Electron (`src/url.js`) and iOS (`WorkspaceURLExpander.swift`) expanders: when the host is `databricksapps.com` or any subdomain of it, return the URL unchanged without probing.
- Match is case-insensitive and covers the apex and `*.databricksapps.com`.

## Test Plan

- Ran `node --test test/url.test.js` in `ap-web/electron` — all 21 tests pass, including the new "leaves a Databricks Apps host untouched, without probing" case.
- Added an equivalent iOS test (`testLeavesDatabricksAppsHostUnchangedWithoutProbe`); not executed here (requires Xcode/xcodebuild).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Electron unit tests run and pass. iOS unit test added but not executed in this environment (no Xcode); it mirrors the verified Electron logic.
