### PR TITLE
fix(server): reject comments on nonexistent sessions

### DIFF
--- a/omnigent/server/routes/comments.py
+++ b/omnigent/server/routes/comments.py
@@ -208,6 +208,17 @@ def create_comments_router(
             await require_access(
                 user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
             )
+        elif conversation_store is not None:
+            # Single-user mode skips require_access, which is the only path
+            # that would otherwise reject a nonexistent session. Verify the
+            # session exists here so we don't persist an orphan comment for an
+            # id that ``GET /v1/sessions`` never lists (#1401).
+            conversation = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+            if conversation is None:
+                raise OmnigentError(
+                    f"Session not found: {session_id!r}",
+                    code=ErrorCode.NOT_FOUND,
+                )
         comment = store.add(
             conversation_id=session_id,
             path=body.path,

--- a/tests/server/routes/test_comments_crud.py
+++ b/tests/server/routes/test_comments_crud.py
@@ -69,6 +69,24 @@ async def test_add_comment_end_before_start(client: httpx.AsyncClient, session_i
     assert resp.status_code == 422
 
 
+async def test_add_comment_nonexistent_session(client: httpx.AsyncClient) -> None:
+    """Posting to a session that does not exist returns 404 and persists nothing.
+
+    Regression test for #1401: in single-user mode (no permission store) the
+    handler skipped its only existence guard and stored an orphan comment for a
+    session that ``GET /v1/sessions`` never lists.
+    """
+    resp = await client.post(
+        "/v1/sessions/nonexistent_session/comments",
+        json=_comment_payload(),
+    )
+    assert resp.status_code == 404
+
+    # No orphan row may be persisted for the nonexistent session.
+    list_resp = await client.get("/v1/sessions/nonexistent_session/comments")
+    assert list_resp.json() == []
+
+
 # ── GET /sessions/{id}/comments ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Fixes #1401

## Summary

- In single-user mode (no `permission_store`), `POST /v1/sessions/{id}/comments` skipped `require_access` — its only existence guard — and persisted an **orphan comment** for a session that `GET /v1/sessions` never lists.
- Added an explicit existence check on the single-user path: when a `conversation_store` is available but no `permission_store`, look up the session and raise **404 NOT_FOUND** if it does not exist, so nothing is stored. Multi-user mode is unchanged (`require_access` already 404s on no-access/nonexistent sessions).

## Test Plan

Added `tests/server/routes/test_comments_crud.py::test_add_comment_nonexistent_session`: POST a comment to a nonexistent session id → assert `404`, then assert `GET .../comments` is empty (no row persisted).

- **Fails before** the fix (`assert 200 == 404`), **passes after**.
- `uv run pytest tests/server/routes/ tests/server/integration/test_comments_rest_e2e.py` → 498 passed.
- `uv run pre-commit run --files omnigent/server/routes/comments.py tests/server/routes/test_comments_crud.py` → all hooks pass.

Sibling mutating endpoints (PATCH/DELETE/`/comments/send`) already key off an existing `(comment_id, session_id)` and return 404 for unknown comments, so they are not affected.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — a focused unit test in the matching `tests/server/routes/` suite reproduces the bug (404 + no persisted row) and is the appropriate level for this server-side fix.
