### PR TITLE
fix(images): pin agy to verified 1.0.10 via hash-checked GitHub release

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -258,36 +258,46 @@ RUN curl -fsSL https://cli.kiro.dev/install | bash \
 # on the host, launching it in a tmux pane (see omnigent/antigravity_native*.py),
 # so a managed host image must carry it. It is NOT an npm package
 # (harness_install.py lists agy as a non-npm, installer-script harness), so it
-# can't join the `npm install -g` set above: the official bootstrapper fetches
-# the platform-native binary. The bootstrapper's ``--dir`` flag is a no-op in
-# agy 1.0.10 (it always installs to ``$HOME/.local/bin`` regardless — verified),
-# and that dir is NOT on the venv PATH and is per-user (root's, not the uid-1000
-# runtime user's). So install to the default, then move the single self-contained
-# binary onto a system PATH dir every user shares. ``test -x`` fails the build
-# loudly if the layout ever changes again.
+# can't join the `npm install -g` set above. The tarball holds a single
+# self-contained ``antigravity`` binary; install it as ``agy`` on a system PATH
+# dir every user shares (its bootstrapper default ~/.local/bin is per-user and
+# off the venv PATH). ``test -x`` fails the build loudly if the layout changes.
 #
-# Version pin: the native harness is behaviorally coupled to a specific agy build
-# (its out-of-order transcript writes, connect-RPC quirks, and TUI injection are
-# all verified against 1.0.10 — grep ``agy 1.0.10`` under omnigent/antigravity_native*).
-# The official bootstrapper has NO version flag — it always fetches the LATEST
-# build from its auto-updater manifest (verified: only ``-d/--dir`` and ``-h`` are
-# accepted; it does SHA512-verify the payload, but only against that latest-pointing
-# manifest). So the DOWNLOAD itself cannot be pinned here. Instead we pin the
-# ACCEPTED version and FAIL THE BUILD if the installer served a different one —
-# turning a future silent harness break (a newer agy whose behavior diverged) into
-# a visible, conscious bump. To adopt a new agy: re-verify the coupled behavior,
-# then bump AGY_EXPECTED_VERSION (override at build with --build-arg if needed).
-ARG AGY_EXPECTED_VERSION=1.0.10
-RUN curl -fsSL https://antigravity.google/cli/install.sh | bash \
- && install -m 0755 "${HOME:-/root}/.local/bin/agy" /usr/local/bin/agy \
- && test -x /usr/local/bin/agy \
- && installed_agy_version="$(/usr/local/bin/agy --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)" \
- && if [ "$installed_agy_version" != "$AGY_EXPECTED_VERSION" ]; then \
-      echo "ERROR: agy installer served version '${installed_agy_version:-<unparseable>}', but the native harness is pinned to '$AGY_EXPECTED_VERSION'." >&2; \
-      echo "       The bootstrapper has no version flag (always latest). Re-verify the harness against the new agy, then bump AGY_EXPECTED_VERSION." >&2; \
+# Version + integrity pin: the native harness is behaviorally coupled to a
+# specific agy build (out-of-order transcript writes, connect-RPC quirks, and TUI
+# injection are all verified against 1.0.10 — grep ``agy 1.0.10`` under
+# omnigent/antigravity_native*). The official ``install.sh`` bootstrapper has NO
+# version flag — it always fetches the LATEST build from an auto-updater manifest
+# and old builds are not retained at any stable, reconstructable URL — so it
+# cannot pin anything. Instead we fetch the exact, immutable per-arch release
+# asset from GitHub and verify its SHA256: this both holds the verified version
+# AND fails the build if the bytes ever change underneath us, which is the actual
+# supply-chain control (a version-string check alone is not). To adopt a new agy:
+# re-verify the coupled behavior, then bump AGY_VERSION and both SHA256s (from
+# https://github.com/google-antigravity/antigravity-cli/releases).
+ARG AGY_VERSION=1.0.10
+ARG AGY_SHA256_AMD64=6547cf9a37227f26004fa4b805418b1df96f54c57b9723ca7d10864d2610bb0f
+ARG AGY_SHA256_ARM64=4674fabc3681221e54c90d15077c9a97a25ea71222001dabe44bf1576e888593
+RUN set -eu; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) asset="agy_cli_linux_x64.tar.gz"; sha="$AGY_SHA256_AMD64" ;; \
+      arm64) asset="agy_cli_linux_arm64.tar.gz"; sha="$AGY_SHA256_ARM64" ;; \
+      *) echo "ERROR: unsupported arch '$arch' for agy" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_VERSION}/${asset}"; \
+    curl -fsSL -o /tmp/agy.tar.gz "$url"; \
+    echo "${sha}  /tmp/agy.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/agy.tar.gz -C /tmp antigravity; \
+    install -m 0755 /tmp/antigravity /usr/local/bin/agy; \
+    rm -f /tmp/agy.tar.gz /tmp/antigravity; \
+    test -x /usr/local/bin/agy; \
+    installed="$(/usr/local/bin/agy --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"; \
+    if [ "$installed" != "$AGY_VERSION" ]; then \
+      echo "ERROR: agy reports '${installed:-<unparseable>}', expected '$AGY_VERSION'." >&2; \
       exit 1; \
-    fi \
- && echo "agy ${AGY_EXPECTED_VERSION} pinned and verified"
+    fi; \
+    echo "agy ${AGY_VERSION} pinned (sha256 verified)"
 
 # Preserve /build/ — the venv's editable install .pth files reference
 # /build/omnigent and /build/sdks/* by absolute path. Copying these to


### PR DESCRIPTION
## Problem

The `Publish images (public)` workflow fails at **Build and push host image** ([run 28273356134](https://github.com/omnigent-ai/omnigent/actions/runs/28273356134)):

```
ERROR: agy installer served version '1.0.12', but the native harness is pinned to '1.0.10'.
```

The agy `install.sh` bootstrapper has no version flag and always installs the latest build (now 1.0.13). The Dockerfile pinned an accepted version and version-string-checked it, so it could only ever track latest and tripped the build on every upstream release.

## Change

Stop using the `curl | bash` bootstrapper. Instead download the exact, immutable per-arch release asset from GitHub (`google-antigravity/antigravity-cli` retains old releases: 1.0.4 through 1.0.12 today) and verify its SHA256. Arch is selected via `dpkg --print-architecture` for the multi-arch (amd64 + arm64) build.

Pinned to **1.0.10**, the version the native harness is verified against:

```
amd64  6547cf9a37227f26004fa4b805418b1df96f54c57b9723ca7d10864d2610bb0f
arm64  4674fabc3681221e54c90d15077c9a97a25ea71222001dabe44bf1576e888593
```

## Why this is better than bumping the pin

- **Stays on the verified version.** The harness behavior (out-of-order transcript writes, connect-RPC quirks, TUI injection) is verified against 1.0.10. No more forced unverified bumps each time Google ships a build.
- **Pins the bytes, not a label.** SHA256 verification fails the build if the artifact is ever swapped or tampered. A version-string match alone is not a supply-chain control: the old flow downloaded and executed latest before checking anything, and a malicious build carrying the right version string would have passed.
- **No unpinned bootstrapper.** Removes `curl | bash` of an always-latest install script running with build privileges.
- **No more drift races.** The build no longer breaks whenever upstream releases a new version.

## Verification

Validated the shell logic against the real release assets: the SHA256 `-c` check passes for both arches, a tampered/wrong hash fails the build (non-zero exit under `set -eu`), and each tarball extracts a single glibc-linked linux ELF `antigravity` binary (matches the debian-slim base), installed as `/usr/local/bin/agy`.

## Bumping agy later

Re-verify the harness against the new version, then update `AGY_VERSION` and both SHA256s from https://github.com/google-antigravity/antigravity-cli/releases.