### PR TITLE
fix(server): source version handling

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -114,9 +114,19 @@ def _version_supports_waiting_status(server_version: str) -> bool:
     :returns: ``True`` iff the server's PEP 440 release tuple is ``>= 0.3.0``
         (the release that added "waiting" to the session-status model).
     """
-    from packaging.version import Version
+    from packaging.version import InvalidVersion, Version
 
-    return Version(server_version).release >= Version(_WAITING_STATUS_MIN_SERVER_VERSION).release
+    try:
+        return (
+            Version(server_version).release
+            >= Version(_WAITING_STATUS_MIN_SERVER_VERSION).release
+        )
+    except InvalidVersion:
+        _logger.warning(
+            "server version %r is not PEP 440; treating waiting status support as unknown",
+            server_version,
+        )
+        return False
 
 
 async def _get_server_version(server_client: httpx.AsyncClient) -> str | None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -118,8 +118,7 @@ def _version_supports_waiting_status(server_version: str) -> bool:
 
     try:
         return (
-            Version(server_version).release
-            >= Version(_WAITING_STATUS_MIN_SERVER_VERSION).release
+            Version(server_version).release >= Version(_WAITING_STATUS_MIN_SERVER_VERSION).release
         )
     except InvalidVersion:
         _logger.warning(

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -79,6 +79,85 @@ from omnigent.stores.policy_store import PolicyStore
 _logger = logging.getLogger(__name__)
 
 
+def _is_pep440_version(version: str) -> bool:
+    """Return whether *version* can be parsed as a PEP 440 version."""
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        Version(version)
+    except InvalidVersion:
+        return False
+    return True
+
+
+def _metadata_omnigent_version() -> str:
+    """Return the omnigent version recorded in installed package metadata."""
+    from importlib.metadata import version as _pkg_version
+
+    return _pkg_version("omnigent")
+
+
+def _source_pyproject_version(start: Path | None = None) -> str | None:
+    """Return ``[project].version`` from a source checkout's ``pyproject.toml``."""
+    import tomllib
+
+    current = start or Path(__file__).resolve()
+    for parent in (current, *current.parents):
+        pyproject = parent / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        try:
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+            _logger.warning(
+                "could not read %s for server version fallback (%s)",
+                pyproject,
+                exc,
+            )
+            return None
+        project = data.get("project")
+        if not isinstance(project, dict) or project.get("name") != "omnigent":
+            continue
+        version = project.get("version")
+        if not isinstance(version, str) or not version:
+            return None
+        if not _is_pep440_version(version):
+            _logger.warning(
+                "pyproject version %r from %s is not PEP 440",
+                version,
+                pyproject,
+            )
+            return None
+        return version
+    return None
+
+
+def _server_version() -> str:
+    """Return the server version exposed to clients.
+
+    Source/editable installs can have placeholder package metadata such as
+    ``source``. Prefer the installed metadata when it is parseable, but fall
+    back to the source checkout's ``pyproject.toml`` version so local developer
+    servers still report a PEP 440 version.
+    """
+    version = _metadata_omnigent_version()
+    if _is_pep440_version(version):
+        return version
+    fallback = _source_pyproject_version()
+    if fallback is not None:
+        _logger.info(
+            "installed omnigent version %r is not PEP 440; using pyproject version %s",
+            version,
+            fallback,
+        )
+        return fallback
+    _logger.warning(
+        "installed omnigent version %r is not PEP 440 and no pyproject fallback was found",
+        version,
+    )
+    return version
+
+
 def _register_web_mimetypes() -> None:
     """Pin Content-Type for web UI assets regardless of the OS MIME registry.
 
@@ -1633,9 +1712,7 @@ def create_app(
         :returns: ``{"version": "<semver string>"}``,
             e.g. ``{"version": "0.1.0"}``.
         """
-        from importlib.metadata import version as _pkg_version
-
-        return {"version": _pkg_version("omnigent")}
+        return {"version": _server_version()}
 
     @app.get("/v1/info")
     async def info() -> dict[str, bool | str | None]:
@@ -1705,8 +1782,6 @@ def create_app(
         # server_version is the installed omnigent package version (same
         # source as /api/version), surfaced so the web UI can show it in the
         # session info popover alongside the per-session host version.
-        from importlib.metadata import version as _pkg_version
-
         # smart_routing_enabled: true when the server can route — either
         # a RoutingClient is explicitly configured (OMNIGENT_SMART_ROUTING=1
         # + llm: config) or the managed deployment registered a
@@ -1727,7 +1802,7 @@ def create_app(
             "databricks_features": databricks_features,
             "managed_sandboxes_enabled": managed_sandboxes_enabled,
             "sandbox_provider": sandbox_provider,
-            "server_version": _pkg_version("omnigent"),
+            "server_version": _server_version(),
             "smart_routing_enabled": smart_routing_enabled,
         }
 

--- a/tests/runner/test_waiting_status_compat.py
+++ b/tests/runner/test_waiting_status_compat.py
@@ -26,6 +26,8 @@ from omnigent.runner.app import _version_supports_waiting_status
         ("0.3.1", True),
         ("0.4.0", True),  # later minor: still supports "waiting"
         ("1.0.0", True),
+        ("source", False),  # source installs can report non-PEP-440 metadata
+        ("not-a-version", False),  # malformed probes fail closed
     ],
 )
 def test_version_supports_waiting_status(server_version: str, expected: bool) -> None:

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -61,6 +61,40 @@ async def test_version_returns_installed_package_version(
     )
 
 
+def test_server_version_uses_metadata_when_pep440(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid installed package version is the server version source of truth."""
+    monkeypatch.setattr(server_app, "_metadata_omnigent_version", lambda: "0.3.1")
+    monkeypatch.setattr(server_app, "_source_pyproject_version", lambda: "0.3.0.dev0")
+
+    assert server_app._server_version() == "0.3.1"
+
+
+def test_server_version_falls_back_to_pyproject_for_source_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Source/editable installs can report ``source``; use pyproject's version."""
+    monkeypatch.setattr(server_app, "_metadata_omnigent_version", lambda: "source")
+    monkeypatch.setattr(server_app, "_source_pyproject_version", lambda: "0.3.0.dev0")
+
+    assert server_app._server_version() == "0.3.0.dev0"
+
+
+def test_source_pyproject_version_reads_project_version(tmp_path: Path) -> None:
+    """The pyproject fallback reads the source checkout's ``[project].version``."""
+    repo = tmp_path / "repo"
+    package_file = repo / "omnigent" / "server" / "app.py"
+    package_file.parent.mkdir(parents=True)
+    package_file.write_text("", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "omnigent"\nversion = "0.3.0.dev0"\n',
+        encoding="utf-8",
+    )
+
+    assert server_app._source_pyproject_version(package_file) == "0.3.0.dev0"
+
+
 class _StubWebSocket:
     """
     Minimal real ``WebSocketLike`` for registering a runner tunnel.


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #1455 

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
- Treat non-PEP-440 server versions as unknown in the runner's waiting-status compatibility check instead of failing turn setup.
- Resolve server version metadata through a helper that falls back from invalid installed metadata such as `source` to `[project].version` in `pyproject.toml` for local source checkouts.
- Reuse the resolved server version for both `/api/version` and `/v1/info` so UI/reporting paths stay consistent.

local developer servers can say their version is `source`. The runner tried to compare that like a normal version number and crashed. Now source checkouts report the dev version from `pyproject.toml`, and the runner still backs off safely if it ever sees an invalid version.

```mermaid
flowchart LR
    Runner -->|GET /api/version| Server
    Server -->|metadata is PEP 440| Metadata[installed package version]
    Server -->|metadata is source/invalid| Pyproject[pyproject.toml project.version]
    Runner -->|invalid version anyway| Running[downgrade waiting to running]
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- `uv run pytest tests/runner/test_waiting_status_compat.py tests/server/test_app.py -q`
- `uv run ruff check omnigent/runner/app.py omnigent/server/app.py tests/runner/test_waiting_status_compat.py tests/server/test_app.py`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
