### PR TITLE
fix(hermes-native): confirm first-message delivery via state.db to stop drop + chat-order scramble

### DIFF
--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -59,12 +59,28 @@ _PASTE_COMMIT_TIMEOUT_S = 5.0
 # detected by the pane settling (no byte changes across consecutive captures).
 # This many stable polls in a row marks the input box ready.
 _SETTLE_STABLE_POLLS = 3
-# On a new session, Hermes initializes its MCP servers (omnigent, policy hook)
-# before the input prompt is active. The first paste can land during this
-# initialization window and be silently dropped. If the needle doesn't appear
-# after the first attempt, we re-settle (giving MCP time to finish loading) and
-# retry once. This budget caps the re-settle on the retry path.
+# On a NEW session, Hermes blocks its prompt_toolkit input loop while it cold-
+# starts the Omnigent MCP server (a heavyweight ``python -m`` subprocess). A
+# paste delivered during that window is silently dropped — the pane can look
+# "settled" (a static banner) even though no widget is capturing keys yet. A
+# dropped first message is doubly bad: it not only loses the turn, it permanently
+# off-by-ones the server's pending-input FIFO (see
+# :mod:`omnigent.runtime.pending_inputs` — the i-th persisted user row drains the
+# i-th queued web message), scrambling EVERY later message's reconciliation.
+#
+# The settle heuristic cannot tell "static banner" from "ready prompt", so we
+# confirm delivery against Hermes' OWN store instead: an accepted turn writes a
+# new ``messages`` row (Hermes flushes a row per agentic step), so a new row
+# appearing is the authoritative "message accepted" signal. If none appears we
+# re-deliver ONCE — safe against double-delivery precisely because the store
+# confirmed nothing landed — and otherwise raise so the turn fails cleanly (its
+# optimistic bubble rolls back) rather than silently desyncing the FIFO.
 _RETRY_SETTLE_S = 10.0
+# How long to wait for Hermes to persist a new ``messages`` row confirming it
+# accepted the injected turn. Generous: assistant rows stream within seconds of
+# acceptance, so a confirmation this slow means the keystrokes were dropped.
+_DELIVERY_CONFIRM_TIMEOUT_S = 12.0
+_DELIVERY_POLL_INTERVAL_S = 0.3
 
 
 def mint_hermes_session_id() -> str:
@@ -591,24 +607,88 @@ def _settle_pane(socket_path: str, tmux_target: str, *, timeout_s: float) -> Non
         previous = current
 
 
-def _paste_and_check_needle(
+def _state_db_path(bridge_dir: Path) -> Path | None:
+    """Resolve the Hermes ``state.db`` this session writes to, for delivery checks.
+
+    Prefers the per-session ``HERMES_HOME`` under *bridge_dir* (created by
+    :func:`write_policy_hook_config` and passed to the TUI as ``HERMES_HOME``),
+    then ``$HERMES_HOME``, then the default ``~/.hermes``. Returns the EXPECTED
+    path even if the file does not exist yet — on a fresh session Hermes creates
+    ``state.db`` lazily, and the delivery check treats a missing DB as
+    ``MAX(id) == 0`` so the first persisted row still registers as new.
+
+    :returns: The state DB path, or ``None`` when no plausible home is known (no
+        per-session home, no ``$HERMES_HOME``, no ``~/.hermes`` dir) — the caller
+        then skips delivery confirmation and falls back to best-effort delivery.
+    """
+    home = bridge_dir / _HERMES_HOME_SUBDIR
+    if home.is_dir():
+        return home / "state.db"
+    env_home = os.environ.get("HERMES_HOME", "").strip()
+    if env_home:
+        return Path(env_home) / "state.db"
+    default_home = Path.home() / ".hermes"
+    if default_home.is_dir():
+        return default_home / "state.db"
+    return None
+
+
+def _max_message_id(db_path: Path) -> int:
+    """Return ``MAX(messages.id)`` in the Hermes ``state.db``, or ``0`` on error.
+
+    A missing file, a not-yet-created ``messages`` table, or a transient
+    mid-checkpoint read error all collapse to ``0`` — the delivery check only
+    needs a monotonically-increasing high-water mark, and a freshly-created
+    session legitimately starts at ``0``.
+    """
+    try:
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2.0)
+    except sqlite3.Error:
+        return 0
+    try:
+        row = con.execute("SELECT MAX(id) FROM messages").fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except sqlite3.Error:
+        return 0
+    finally:
+        con.close()
+
+
+def _await_new_message(db_path: Path, baseline_id: int, timeout_s: float) -> bool:
+    """Poll until ``MAX(messages.id) > baseline_id`` or *timeout_s* elapses.
+
+    A new ``messages`` row is Hermes' own record that it accepted the injected
+    turn (it flushes a row per agentic step), so this is the authoritative
+    "message landed" signal — far more reliable than scraping the pane. Always
+    checks at least once, even with a zero timeout.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        if _max_message_id(db_path) > baseline_id:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_DELIVERY_POLL_INTERVAL_S)
+
+
+def _deliver_once(
     socket_path: str,
     tmux_target: str,
     content: str,
     bridge_dir: Path,
     needle: str,
-) -> bool:
-    """Clear any draft, paste *content*, return True if *needle* appeared in pane.
+    *,
+    settle_timeout_s: float,
+) -> None:
+    """Settle, clear any draft, paste *content*, then submit with a single Enter.
 
-    Clears the input field (C-a + C-k), writes the content to a temp file,
-    and delivers it via ``load-buffer`` / ``paste-buffer -p`` (bracketed-paste
-    markers keep interior newlines as data). If *needle* is non-empty, polls
-    for up to :data:`_PASTE_COMMIT_TIMEOUT_S` seconds for the text to appear.
-
-    :returns: ``True`` when the needle is found, or when there is no needle
-        (blind-submit path — assume committed). ``False`` when a needle was
-        expected but never appeared, indicating the TUI was not ready.
+    Waits for the pane to settle, clears the input (C-a + C-k), delivers
+    *content* via ``load-buffer`` / ``paste-buffer -p`` (bracketed-paste markers
+    keep interior newlines as data), waits until *needle* is visibly committed
+    (so the trailing Enter isn't folded into the paste), then sends one Enter.
     """
+    _settle_pane(socket_path, tmux_target, timeout_s=settle_timeout_s)
+    # Clear any leftover draft: Home (C-a) + kill-to-end (C-k).
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
     with tempfile.NamedTemporaryFile(
@@ -632,14 +712,17 @@ def _paste_and_check_needle(
     finally:
         with contextlib.suppress(OSError):
             os.unlink(paste_path)
-    if not needle:
-        return True  # no usable needle — assume committed (blind-submit path)
-    deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
-    while time.monotonic() < deadline:
-        if needle in _capture_pane(socket_path, tmux_target):
-            return True
-        time.sleep(_POLL_INTERVAL_S)
-    return False
+    # Wait until the paste is visibly committed before Enter. Submitting mid-paste
+    # folds the Enter in as a newline (rapid stdin bursts coalesce), leaving the
+    # message unsent. Poll for the text, then submit; blind-submit if no needle.
+    if needle:
+        deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if needle in _capture_pane(socket_path, tmux_target):
+                break
+            time.sleep(_POLL_INTERVAL_S)
+    time.sleep(_PASTE_SETTLE_S)
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
 
 
 def inject_user_message(
@@ -652,20 +735,21 @@ def inject_user_message(
 
     Clears any leftover draft, pastes *content* (multi-line safe via
     ``load-buffer``/``paste-buffer -p`` so interior newlines stay data, not
-    submits), settles, then submits with a *single* Enter. Hermes' prompt_toolkit
-    input submits on Enter, so exactly one Enter is sent — a second would submit
-    an empty turn.
+    submits), settles, then submits with a *single* Enter.
 
-    On new sessions, Hermes initializes its MCP servers before the input prompt
-    is active. If the first paste doesn't commit (needle not visible), we re-settle
-    to give the TUI time to finish loading and retry once — this prevents the first
-    web-UI message from being silently dropped during startup.
+    On a NEW session Hermes blocks input while cold-starting its MCP server, so
+    the first paste can be silently dropped — and a dropped first message
+    permanently off-by-ones the server's pending-input FIFO, scrambling every
+    later turn. To prevent that, when Hermes' ``state.db`` is readable we confirm
+    the turn landed (a new ``messages`` row appears); if it didn't we re-deliver
+    ONCE (safe — the store proved nothing landed, so this can't double-submit) and
+    otherwise raise so the turn fails cleanly instead of desyncing the FIFO.
 
     :param bridge_dir: The hermes-native bridge dir holding ``tmux.json``.
     :param content: User text (non-empty).
     :param timeout_s: Per-readiness-gate timeout.
-    :raises RuntimeError: If the tmux target is never advertised or a tmux
-        command fails.
+    :raises RuntimeError: If the tmux target is never advertised, a tmux command
+        fails, or Hermes never confirms acceptance of the message.
     """
     if not content:
         raise RuntimeError("hermes-native injection requires non-empty content")
@@ -678,21 +762,34 @@ def inject_user_message(
         raise RuntimeError(
             "hermes terminal is no longer running (the TUI exited); restart the session"
         )
-    _settle_pane(socket_path, tmux_target, timeout_s=timeout_s)
     needle = _submit_needle(content)
-    # Wait until the paste is visibly committed before Enter. Submitting mid-paste
-    # folds the Enter in as a newline (rapid stdin bursts coalesce), leaving the
-    # message unsent. Poll for the text, then submit; blind-submit if no needle.
-    committed = _paste_and_check_needle(socket_path, tmux_target, content, bridge_dir, needle)
-    if not committed:
-        # The paste did not commit — the TUI was likely still initializing when
-        # we first attempted (e.g., MCP server startup on a fresh session). Re-
-        # settle to let the TUI finish loading, then retry once so the first
-        # web-UI message is not silently dropped on new sessions.
-        _settle_pane(socket_path, tmux_target, timeout_s=_RETRY_SETTLE_S)
-        _paste_and_check_needle(socket_path, tmux_target, content, bridge_dir, needle)
-    time.sleep(_PASTE_SETTLE_S)
-    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+    # Snapshot the store high-water mark BEFORE delivery so a new row afterwards
+    # is unambiguous proof Hermes accepted this turn.
+    db_path = _state_db_path(bridge_dir)
+    baseline_id = _max_message_id(db_path) if db_path is not None else None
+
+    _deliver_once(
+        socket_path, tmux_target, content, bridge_dir, needle, settle_timeout_s=timeout_s
+    )
+
+    if db_path is None:
+        # No readable store to confirm against — best-effort single delivery,
+        # preserving prior behavior for setups without a per-session HERMES_HOME.
+        return
+    if _await_new_message(db_path, baseline_id or 0, _DELIVERY_CONFIRM_TIMEOUT_S):
+        return
+    # The first delivery did not land (the TUI was still initializing). Re-deliver
+    # once — the store confirmed no row was written, so there is no double-submit
+    # risk — giving the pane a longer settle to let MCP startup finish.
+    _deliver_once(
+        socket_path, tmux_target, content, bridge_dir, needle, settle_timeout_s=_RETRY_SETTLE_S
+    )
+    if _await_new_message(db_path, baseline_id or 0, _DELIVERY_CONFIRM_TIMEOUT_S):
+        return
+    raise RuntimeError(
+        "hermes did not accept the message (the TUI may still be initializing); "
+        "no new transcript row appeared after two delivery attempts"
+    )
 
 
 def inject_interrupt(bridge_dir: Path, *, timeout_s: float = _TMUX_READY_TIMEOUT_S) -> None:

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -59,6 +59,12 @@ _PASTE_COMMIT_TIMEOUT_S = 5.0
 # detected by the pane settling (no byte changes across consecutive captures).
 # This many stable polls in a row marks the input box ready.
 _SETTLE_STABLE_POLLS = 3
+# On a new session, Hermes initializes its MCP servers (omnigent, policy hook)
+# before the input prompt is active. The first paste can land during this
+# initialization window and be silently dropped. If the needle doesn't appear
+# after the first attempt, we re-settle (giving MCP time to finish loading) and
+# retry once. This budget caps the re-settle on the retry path.
+_RETRY_SETTLE_S = 10.0
 
 
 def mint_hermes_session_id() -> str:
@@ -585,39 +591,24 @@ def _settle_pane(socket_path: str, tmux_target: str, *, timeout_s: float) -> Non
         previous = current
 
 
-def inject_user_message(
-    bridge_dir: Path,
-    *,
+def _paste_and_check_needle(
+    socket_path: str,
+    tmux_target: str,
     content: str,
-    timeout_s: float = _TMUX_READY_TIMEOUT_S,
-) -> None:
-    """Deliver a web-UI user message into the Hermes TUI via a tmux bracketed paste.
+    bridge_dir: Path,
+    needle: str,
+) -> bool:
+    """Clear any draft, paste *content*, return True if *needle* appeared in pane.
 
-    Clears any leftover draft, pastes *content* (multi-line safe via
-    ``load-buffer``/``paste-buffer -p`` so interior newlines stay data, not
-    submits), settles, then submits with a *single* Enter. Hermes' prompt_toolkit
-    input submits on Enter, so exactly one Enter is sent — a second would submit
-    an empty turn.
+    Clears the input field (C-a + C-k), writes the content to a temp file,
+    and delivers it via ``load-buffer`` / ``paste-buffer -p`` (bracketed-paste
+    markers keep interior newlines as data). If *needle* is non-empty, polls
+    for up to :data:`_PASTE_COMMIT_TIMEOUT_S` seconds for the text to appear.
 
-    :param bridge_dir: The hermes-native bridge dir holding ``tmux.json``.
-    :param content: User text (non-empty).
-    :param timeout_s: Per-readiness-gate timeout.
-    :raises RuntimeError: If the tmux target is never advertised or a tmux
-        command fails.
+    :returns: ``True`` when the needle is found, or when there is no needle
+        (blind-submit path — assume committed). ``False`` when a needle was
+        expected but never appeared, indicating the TUI was not ready.
     """
-    if not content:
-        raise RuntimeError("hermes-native injection requires non-empty content")
-    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    socket_path = info["socket_path"]
-    tmux_target = info["tmux_target"]
-    # Fast-fail if the TUI already exited: otherwise _settle_pane polls a dead
-    # pane for the full timeout and the web message is silently lost.
-    if not _session_alive(socket_path, tmux_target):
-        raise RuntimeError(
-            "hermes terminal is no longer running (the TUI exited); restart the session"
-        )
-    _settle_pane(socket_path, tmux_target, timeout_s=timeout_s)
-    # Clear any leftover draft: Home (C-a) + kill-to-end (C-k).
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
     with tempfile.NamedTemporaryFile(
@@ -641,16 +632,65 @@ def inject_user_message(
     finally:
         with contextlib.suppress(OSError):
             os.unlink(paste_path)
+    if not needle:
+        return True  # no usable needle — assume committed (blind-submit path)
+    deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if needle in _capture_pane(socket_path, tmux_target):
+            return True
+        time.sleep(_POLL_INTERVAL_S)
+    return False
+
+
+def inject_user_message(
+    bridge_dir: Path,
+    *,
+    content: str,
+    timeout_s: float = _TMUX_READY_TIMEOUT_S,
+) -> None:
+    """Deliver a web-UI user message into the Hermes TUI via a tmux bracketed paste.
+
+    Clears any leftover draft, pastes *content* (multi-line safe via
+    ``load-buffer``/``paste-buffer -p`` so interior newlines stay data, not
+    submits), settles, then submits with a *single* Enter. Hermes' prompt_toolkit
+    input submits on Enter, so exactly one Enter is sent — a second would submit
+    an empty turn.
+
+    On new sessions, Hermes initializes its MCP servers before the input prompt
+    is active. If the first paste doesn't commit (needle not visible), we re-settle
+    to give the TUI time to finish loading and retry once — this prevents the first
+    web-UI message from being silently dropped during startup.
+
+    :param bridge_dir: The hermes-native bridge dir holding ``tmux.json``.
+    :param content: User text (non-empty).
+    :param timeout_s: Per-readiness-gate timeout.
+    :raises RuntimeError: If the tmux target is never advertised or a tmux
+        command fails.
+    """
+    if not content:
+        raise RuntimeError("hermes-native injection requires non-empty content")
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    socket_path = info["socket_path"]
+    tmux_target = info["tmux_target"]
+    # Fast-fail if the TUI already exited: otherwise _settle_pane polls a dead
+    # pane for the full timeout and the web message is silently lost.
+    if not _session_alive(socket_path, tmux_target):
+        raise RuntimeError(
+            "hermes terminal is no longer running (the TUI exited); restart the session"
+        )
+    _settle_pane(socket_path, tmux_target, timeout_s=timeout_s)
+    needle = _submit_needle(content)
     # Wait until the paste is visibly committed before Enter. Submitting mid-paste
     # folds the Enter in as a newline (rapid stdin bursts coalesce), leaving the
     # message unsent. Poll for the text, then submit; blind-submit if no needle.
-    needle = _submit_needle(content)
-    if needle:
-        deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
-        while time.monotonic() < deadline:
-            if needle in _capture_pane(socket_path, tmux_target):
-                break
-            time.sleep(_POLL_INTERVAL_S)
+    committed = _paste_and_check_needle(socket_path, tmux_target, content, bridge_dir, needle)
+    if not committed:
+        # The paste did not commit — the TUI was likely still initializing when
+        # we first attempted (e.g., MCP server startup on a fresh session). Re-
+        # settle to let the TUI finish loading, then retry once so the first
+        # web-UI message is not silently dropped on new sessions.
+        _settle_pane(socket_path, tmux_target, timeout_s=_RETRY_SETTLE_S)
+        _paste_and_check_needle(socket_path, tmux_target, content, bridge_dir, needle)
     time.sleep(_PASTE_SETTLE_S)
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
 

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -56,8 +56,8 @@ def test_submit_needle_prefers_last_qualifying_line() -> None:
     assert b._submit_needle("ok") == ""
 
 
-def test_inject_user_message_clears_pastes_and_submits(tmp_path, monkeypatch) -> None:
-    calls: list[tuple[str, ...]] = []
+def _patch_inject_tmux(monkeypatch, calls: list[tuple[str, ...]]) -> None:
+    """Common monkeypatches: live pane, instant settle, capture shows needle."""
     monkeypatch.setattr(
         b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
     )
@@ -67,6 +67,13 @@ def test_inject_user_message_clears_pastes_and_submits(tmp_path, monkeypatch) ->
     monkeypatch.setattr(b, "_capture_pane", lambda *_a, **_k: "do something now")
     monkeypatch.setattr(b.time, "sleep", lambda *_a, **_k: None)
     monkeypatch.setattr(b, "_run_tmux", lambda _sock, *args: calls.append(args))
+
+
+def test_inject_user_message_clears_pastes_and_submits(tmp_path, monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    _patch_inject_tmux(monkeypatch, calls)
+    # No readable store → best-effort single delivery (no confirmation loop).
+    monkeypatch.setattr(b, "_state_db_path", lambda _bd: None)
 
     b.inject_user_message(tmp_path, content="do something now")
 
@@ -78,42 +85,102 @@ def test_inject_user_message_clears_pastes_and_submits(tmp_path, monkeypatch) ->
     assert calls[-1] == ("send-keys", "-t", "t", "Enter")
     # The temp paste file is cleaned up.
     assert not list(tmp_path.glob("paste_*.bin"))
+    # Exactly one delivery: one load-buffer, one Enter.
+    assert sum(1 for a in calls if a[0] == "load-buffer") == 1
+    assert sum(1 for a in calls if a[-1] == "Enter") == 1
 
 
-def test_inject_user_message_retries_when_paste_not_committed(tmp_path, monkeypatch) -> None:
-    """First paste fails (TUI still loading) → re-settle + retry → single Enter."""
+def test_inject_user_message_single_delivery_when_store_confirms(tmp_path, monkeypatch) -> None:
+    """Store row appears after the first delivery → no retry."""
     calls: list[tuple[str, ...]] = []
-    settle_calls: list[tuple] = []
-    # Zero out the commit timeout so the first attempt times out immediately,
-    # exercising the retry path without a real 5-second wait.
-    monkeypatch.setattr(b, "_PASTE_COMMIT_TIMEOUT_S", 0.0)
-    monkeypatch.setattr(
-        b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
-    )
-    monkeypatch.setattr(b, "_session_alive", lambda *_a, **_k: True)
-    monkeypatch.setattr(b, "_settle_pane", lambda *a, **k: settle_calls.append((a, k)))
-    # Pane never shows the needle — needle-check always fails → retry triggered.
-    monkeypatch.setattr(b, "_capture_pane", lambda *_a, **_k: "")
-    monkeypatch.setattr(b.time, "sleep", lambda *_a, **_k: None)
-    monkeypatch.setattr(b, "_run_tmux", lambda _sock, *args: calls.append(args))
+    _patch_inject_tmux(monkeypatch, calls)
+    monkeypatch.setattr(b, "_state_db_path", lambda _bd: tmp_path / "state.db")
+    # Baseline 0, then a new row (id=1) confirms delivery on the first check.
+    ids = iter([0, 1])
+    monkeypatch.setattr(b, "_max_message_id", lambda _p: next(ids))
 
     b.inject_user_message(tmp_path, content="do something now")
 
-    # _settle_pane called twice: initial settle + retry settle.
+    assert sum(1 for a in calls if a[0] == "load-buffer") == 1, "no retry when confirmed"
+    assert sum(1 for a in calls if a[-1] == "Enter") == 1
+
+
+def test_inject_user_message_retries_once_when_first_not_confirmed(tmp_path, monkeypatch) -> None:
+    """No new store row after delivery #1 → re-deliver once, then confirm."""
+    calls: list[tuple[str, ...]] = []
+    settle_calls: list[tuple] = []
+    _patch_inject_tmux(monkeypatch, calls)
+    monkeypatch.setattr(b, "_settle_pane", lambda *a, **k: settle_calls.append((a, k)))
+    monkeypatch.setattr(b, "_DELIVERY_CONFIRM_TIMEOUT_S", 0.0)  # first confirm fails fast
+    monkeypatch.setattr(b, "_state_db_path", lambda _bd: tmp_path / "state.db")
+    # baseline=0 → confirm#1 sees 0 (fail) → confirm#2 sees 1 (success after retry).
+    seq = iter([0, 0, 1])
+    monkeypatch.setattr(b, "_max_message_id", lambda _p: next(seq))
+
+    b.inject_user_message(tmp_path, content="do something now")
+
+    # Two deliveries: two settles, two pastes, two Enters (one per attempt).
     assert len(settle_calls) == 2
-    # load-buffer called twice: initial paste + retry paste.
-    load_cmds = [a for a in calls if a[0] == "load-buffer"]
-    assert len(load_cmds) == 2, "paste should be retried once"
-    # Exactly one Enter at the end (submit happens once, after both attempts).
-    send_key_cmds = [a for a in calls if a[0] == "send-keys"]
-    assert send_key_cmds[-1] == ("send-keys", "-t", "t", "Enter")
-    enter_count = sum(1 for a in send_key_cmds if a[-1] == "Enter")
-    assert enter_count == 1, "exactly one Enter must be sent"
+    assert sum(1 for a in calls if a[0] == "load-buffer") == 2
+    assert sum(1 for a in calls if a[-1] == "Enter") == 2
+
+
+def test_inject_user_message_raises_when_never_confirmed(tmp_path, monkeypatch) -> None:
+    """Store row never appears after two deliveries → raise (FIFO-safe failure)."""
+    calls: list[tuple[str, ...]] = []
+    _patch_inject_tmux(monkeypatch, calls)
+    monkeypatch.setattr(b, "_DELIVERY_CONFIRM_TIMEOUT_S", 0.0)
+    monkeypatch.setattr(b, "_state_db_path", lambda _bd: tmp_path / "state.db")
+    monkeypatch.setattr(b, "_max_message_id", lambda _p: 0)  # never advances
+
+    with pytest.raises(RuntimeError, match="did not accept"):
+        b.inject_user_message(tmp_path, content="do something now")
+
+    # Both attempts ran (two pastes) before giving up.
+    assert sum(1 for a in calls if a[0] == "load-buffer") == 2
 
 
 def test_inject_user_message_requires_content(tmp_path) -> None:
     with pytest.raises(RuntimeError):
         b.inject_user_message(tmp_path, content="")
+
+
+def test_state_db_path_prefers_per_session_home(tmp_path, monkeypatch) -> None:
+    # No per-session home, no $HERMES_HOME, no ~/.hermes → None.
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(b.Path, "home", staticmethod(lambda: tmp_path / "nohome"))
+    assert b._state_db_path(tmp_path) is None
+    # Per-session HERMES_HOME under the bridge dir wins, even before state.db exists.
+    home = tmp_path / b._HERMES_HOME_SUBDIR
+    home.mkdir()
+    assert b._state_db_path(tmp_path) == home / "state.db"
+
+
+def test_max_message_id_reads_high_water_mark(tmp_path) -> None:
+    db = tmp_path / "state.db"
+    # Missing file → 0.
+    assert b._max_message_id(db) == 0
+    con = sqlite3.connect(str(db))
+    con.executescript(b._MESSAGES_DDL)
+    # Empty table → 0.
+    assert b._max_message_id(db) == 0
+    con.execute(
+        "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?,?,?,?,?)",
+        (7, "s1", "user", "hi", 0.0),
+    )
+    con.commit()
+    con.close()
+    assert b._max_message_id(db) == 7
+
+
+def test_await_new_message_checks_at_least_once(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(b.time, "sleep", lambda *_a, **_k: None)
+    # Even with a zero timeout, one check runs: baseline 5, current 6 → True.
+    monkeypatch.setattr(b, "_max_message_id", lambda _p: 6)
+    assert b._await_new_message(tmp_path / "state.db", 5, 0.0) is True
+    # No advance → False.
+    monkeypatch.setattr(b, "_max_message_id", lambda _p: 5)
+    assert b._await_new_message(tmp_path / "state.db", 5, 0.0) is False
 
 
 def test_inject_user_message_dead_pane_raises(tmp_path, monkeypatch) -> None:

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -80,6 +80,37 @@ def test_inject_user_message_clears_pastes_and_submits(tmp_path, monkeypatch) ->
     assert not list(tmp_path.glob("paste_*.bin"))
 
 
+def test_inject_user_message_retries_when_paste_not_committed(tmp_path, monkeypatch) -> None:
+    """First paste fails (TUI still loading) → re-settle + retry → single Enter."""
+    calls: list[tuple[str, ...]] = []
+    settle_calls: list[tuple] = []
+    # Zero out the commit timeout so the first attempt times out immediately,
+    # exercising the retry path without a real 5-second wait.
+    monkeypatch.setattr(b, "_PASTE_COMMIT_TIMEOUT_S", 0.0)
+    monkeypatch.setattr(
+        b, "_wait_for_tmux_info", lambda *_a, **_k: {"socket_path": "/s", "tmux_target": "t"}
+    )
+    monkeypatch.setattr(b, "_session_alive", lambda *_a, **_k: True)
+    monkeypatch.setattr(b, "_settle_pane", lambda *a, **k: settle_calls.append((a, k)))
+    # Pane never shows the needle — needle-check always fails → retry triggered.
+    monkeypatch.setattr(b, "_capture_pane", lambda *_a, **_k: "")
+    monkeypatch.setattr(b.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(b, "_run_tmux", lambda _sock, *args: calls.append(args))
+
+    b.inject_user_message(tmp_path, content="do something now")
+
+    # _settle_pane called twice: initial settle + retry settle.
+    assert len(settle_calls) == 2
+    # load-buffer called twice: initial paste + retry paste.
+    load_cmds = [a for a in calls if a[0] == "load-buffer"]
+    assert len(load_cmds) == 2, "paste should be retried once"
+    # Exactly one Enter at the end (submit happens once, after both attempts).
+    send_key_cmds = [a for a in calls if a[0] == "send-keys"]
+    assert send_key_cmds[-1] == ("send-keys", "-t", "t", "Enter")
+    enter_count = sum(1 for a in send_key_cmds if a[-1] == "Enter")
+    assert enter_count == 1, "exactly one Enter must be sent"
+
+
 def test_inject_user_message_requires_content(tmp_path) -> None:
     with pytest.raises(RuntimeError):
         b.inject_user_message(tmp_path, content="")


### PR DESCRIPTION
## Related issue

N/A

## Summary

On a fresh `omnigent hermes` (native) session, the **first** web-UI message was dropped, and the chat then rendered messages **out of order**. Both are one root cause.

When a web message is posted to a native-terminal session, the server records an optimistic **pending-input** entry (a FIFO per session) and injects the text into the Hermes tmux pane. Hermes echoes the accepted turn to its `state.db`; the forwarder mirrors that row back, and `_persist_external_conversation_item` drains the **oldest** pending entry to reconcile the optimistic bubble with the durable item (`omnigent/runtime/pending_inputs.py` — "the i-th persisted user row corresponds to the i-th queued web message").

On a brand-new session Hermes blocks its `prompt_toolkit` input loop while it cold-starts the `omnigent` MCP server (a heavyweight `python -m` subprocess). The first paste lands in that window and is silently dropped — the pane can look "settled" (a static banner) even though no widget is capturing keys. Because that first turn never reaches `state.db`, its pending entry is never drained, which **permanently off-by-ones the FIFO**: every later Hermes echo then drains the *wrong* pending entry, scrambling the chat order. Subsequent sessions/messages "work" only because the TUI is warm by then.

The first attempt on this branch gated on scraping the pane for the pasted text (a needle) and retried if it didn't appear. That was the wrong signal — it can't distinguish a static startup banner from a live prompt, so the message was still dropped, and the double-paste retry risked over-delivering (over-draining the FIFO the other way).

This change confirms delivery against Hermes' **own store** — the authoritative signal the forwarder already trusts:

- Snapshot `MAX(messages.id)` before injecting; an accepted turn writes a new `messages` row (Hermes flushes a row per agentic step).
- If no new row appears within the confirm window, re-deliver **once** — safe from double-submit precisely because the store proved nothing landed.
- If still unconfirmed after two attempts, raise so the turn fails cleanly (its optimistic bubble rolls back via the existing `pending_inputs.resolve` path) instead of silently desyncing the FIFO.
- When no per-session `HERMES_HOME` store is readable, fall back to best-effort single delivery (prior behavior) — no regression for non-policy setups.

**Why this is FIFO-safe:** the retry only fires when the store confirms the prior attempt produced no row, so it cannot double-deliver; and for a fresh-session first message the TUI is idle, so a new row appears *only* if our message actually landed.

**How to review:** start at `inject_user_message` in `omnigent/hermes_native_bridge.py` and the new `_state_db_path` / `_max_message_id` / `_await_new_message` / `_deliver_once` helpers.

## Test Plan

- [x] `uv run python -m pytest tests/test_hermes_native_bridge.py` — added: store-confirmed single delivery, retry-once-when-unconfirmed, raise-when-never-confirmed, no-store best-effort fallback, plus unit tests for `_state_db_path`, `_max_message_id`, `_await_new_message`.
- [x] `uv run python -m pytest tests/test_hermes_native*.py tests/inner/test_hermes_native_executor.py` — 92 passed.
- [ ] Live verification on the user's environment (first message of a fresh native session lands; chat order stays correct across several messages). Could not run headlessly — `hermes` isn't installed on the dev box.

## Verification Commands

\`\`\`bash
uv run python -m pytest tests/test_hermes_native_bridge.py tests/test_hermes_native_forwarder.py tests/test_hermes_native_permissions.py tests/inner/test_hermes_native_executor.py -q
\`\`\`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the delivery-confirmation state machine (confirm / retry-once / raise / no-store fallback) and the store helpers. Live verification is still pending because the `hermes` binary is not available on the development box; the fix relies only on Hermes' documented `state.db` write behavior that the forwarder already depends on.