### PR TITLE
fix(opencode-native): drop Codex approvalMode capability (crashed the TUI)

### DIFF
--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -58,7 +58,16 @@ export const NATIVE_CODING_AGENTS = [
     displayName: "OpenCode",
     iconKind: "opencode",
     sortRank: 25,
-    capabilities: ["approvalMode"],
+    // No capabilities → no permission picker. OpenCode has no claude-style
+    // permission-mode surface to mirror: its native modes are the `build`
+    // (allow-by-default) and `plan` primary agents, switched at runtime via Tab
+    // inside the TUI — and `opencode attach` (how the runner launches it) has
+    // no `--agent` flag to preset one anyway. The runner already forces
+    // `permission: "ask"` so tools route through the Omnigent policy engine, so
+    // a launch-time picker would mirror nothing. (Previously declared Codex's
+    // `approvalMode`, whose `--sandbox`/`--ask-for-approval` presets aren't
+    // understood by `opencode attach` and crashed the TUI on any non-default
+    // pick.)
   },
   {
     key: "cursor",

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -628,12 +628,12 @@ describe("NewChatLandingScreen create flow", () => {
     expect(screen.queryByTestId("new-chat-landing-approval-full-access")).toBeNull();
   });
 
-  it("resets the shared approval mode to default when switching codex-native → opencode-native", async () => {
-    // codex-native and opencode-native share a single approvalMode state. A
-    // codex pick must NOT linger after switching to OpenCode (which has no
-    // stored pick) — otherwise a more-permissive mode would silently flow
-    // into the OpenCode launch args. Regression test for the seeding effect's
-    // reset-on-no-stored-value branch.
+  it("posts no launch args for opencode-native, even after a codex full-access pick", async () => {
+    // OpenCode declares no mode capability (no permission picker) — `opencode
+    // attach` has no permission/sandbox CLI flag, and emitting Codex's
+    // `--sandbox`/`--ask-for-approval` presets is exactly what crashed the TUI.
+    // So a "Full access" pick on Codex must NOT bleed into OpenCode's launch:
+    // switching to OpenCode posts no terminal_launch_args at all.
     setAgents([
       agent({ id: "ag_codex", name: "codex-native-ui", display_name: "Codex" }),
       agent({ id: "ag_opencode", name: "opencode-native-ui", display_name: "OpenCode" }),
@@ -649,12 +649,10 @@ describe("NewChatLandingScreen create flow", () => {
     openAgentConfig("ag_codex");
     fireEvent.click(screen.getByTestId("new-chat-landing-approval-full-access"));
 
-    // Switch the picker to OpenCode by clicking its row (commits the pick).
+    // Switch to OpenCode by clicking its row (a plain row — no config submenu,
+    // since it has no mode knobs).
     selectAgent("ag_opencode");
 
-    // OpenCode has no stored pick → the shared approval knob must reset to
-    // Default, not keep Codex's "Full access". Proven by the launch args:
-    // a default preset posts no sandbox/approval flags.
     typeMessage("go");
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
     await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
## Problem

Opening OpenCode from the web UI with any non-default permission mode (e.g. "Read only") failed — the terminal view never came up and the TUI kept exiting.

**Root cause:** OpenCode was registered with Codex's `approvalMode` capability (`web/src/lib/nativeCodingAgents.ts`), whose mode presets are **Codex CLI flags** (`--sandbox`, `--ask-for-approval`). Picking a non-default mode passed those flags to `opencode attach`, which has no such flags, so it errored out and the terminal process exited. Only "Default" worked because it sends no args.

## Fix

Drop the capability so OpenCode gets **no permission picker**. After digging through opencode's source (`sst/opencode` @ 1.17.x), this is the correct model, not just the smallest diff:

- OpenCode has **no claude-style permission-mode surface to mirror**. Its native selectable modes are the `build` (allow-by-default) and `plan` primary agents, switched **at runtime via Tab in the TUI** — not at launch.
- `opencode attach` (how the runner launches the TUI) has **no `--agent` flag** to preset a mode anyway.
- The runner already writes `permission: "ask"` into opencode.json, so every tool routes through the Omnigent **policy engine**. A launch-time picker would mirror nothing.

Users who want plan mode just hit Tab in the embedded terminal — opencode's own native mechanism.

## Scope

One-line registry change (+ explanatory comment) and a renamed flow test asserting OpenCode posts no `terminal_launch_args`. The forced `permission: "ask"` default is unchanged.

This pull request and its description were written by Isaac.