### PR TITLE
fix(runner): recreate dead qwen terminals on attach

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -267,6 +267,9 @@ comments; this is the *what*, not the *how*.)
   still unsupported are binary documents (PDF, etc.) and audio input.
 - [ ] **Session resilience:** cancel a turn mid-flight, recover when the `qwen`
   subprocess crashes, and resume a session across separate runs.
+  - *Done in this pass:* dead qwen-native terminals now recreate on attach
+    instead of failing 4404, so the embedded pane recovers after a crash or
+    deferred-start failure.
 - [ ] **Vision/audio quality** depends on the model: text-only routes (e.g.
   `qwen3-coder:free`) can't see forwarded images. Worth surfacing model
   capability to users picking an agent.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -15894,6 +15894,67 @@ def create_runner_app(
                     return None
         return resolve_terminal_entry_by_resource_id(session_id, terminal_id, registry)
 
+    async def _recreate_qwen_terminal(
+        session_id: str, terminal_id: str
+    ) -> TerminalListEntry | None:
+        """Re-create a dead qwen-native terminal for attach.
+
+        The qwen terminal is the runner-owned TUI behind the web UI's
+        native chat view. Like the REPL pane, it can die underneath the
+        registry while the resource id still resolves to a stale entry.
+        Recreating the pane on attach keeps the qwen-native session
+        usable after a subprocess crash or a bad deferred start instead
+        of leaving the web view on a permanent 4404.
+
+        Serialized per session on ``_qwen_terminal_ensure_locks``
+        against the session-create bootstrap and concurrent attaches;
+        liveness is re-checked under the lock so a racer's fresh
+        terminal is reused rather than killed.
+
+        :param session_id: Session/conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param terminal_id: The qwen terminal's resource id
+            (``"terminal_qwen_main"``), passed through for the stale
+            close + final resolve.
+        :returns: The live ``TerminalListEntry``, or ``None`` when
+            recreation failed (the attach then closes 4404 as before).
+        """
+        if resource_registry is None or resource_registry.terminal_registry is None:
+            return None
+        registry = resource_registry.terminal_registry
+        lock = _qwen_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
+        async with lock:
+            existing = registry.get(session_id, "qwen", "main")
+            if existing is None or not existing.running or not await existing.is_alive():
+                # Low-level registry close, not ``close_terminal``: the
+                # resource-level scan skips entries whose ``running`` flag
+                # is already False (the liveness probe above flips it),
+                # which would leave the dead instance's activity watcher
+                # and scratch dir behind. ``TerminalRegistry.close``
+                # pops the entry unconditionally and tears the instance
+                # down.
+                await registry.close(session_id, "qwen", "main")
+                try:
+                    await _auto_create_qwen_terminal(
+                        session_id,
+                        resource_registry,
+                        _publish_event,
+                        server_client=server_client,
+                        ensure_comment_relay=_ensure_comment_relay_started,
+                    )
+                except Exception:
+                    # Broad catch, same rationale as the session-create
+                    # bootstrap: a failed relaunch (tmux spawn error,
+                    # label PATCH failure) must degrade to the
+                    # pre-existing 4404 close on this attach - never
+                    # crash the WS route.
+                    _logger.exception(
+                        "Failed to recreate omnigent qwen terminal for %s",
+                        session_id,
+                    )
+                    return None
+        return resolve_terminal_entry_by_resource_id(session_id, terminal_id, registry)
+
     @app.websocket("/v1/sessions/{session_id}/resources/terminals/{terminal_id}/attach")
     async def terminal_resource_attach_ws(
         websocket: WebSocket,
@@ -15909,12 +15970,14 @@ def create_runner_app(
         and bridges the tmux PTY.
 
         The embedded Omnigent REPL terminal (role
-        :data:`OMNIGENT_REPL_TERMINAL_ROLE`) gets recreate-on-attach
+        :data:`OMNIGENT_REPL_TERMINAL_ROLE`) and qwen-native terminal
+        (role :data:`QWEN_NATIVE_TERMINAL_ROLE`) get recreate-on-attach
         semantics: a dead pane is torn down and relaunched instead of
         rejected, so the web Terminal view always opens onto a live
-        REPL (see :func:`_recreate_repl_terminal`). Other terminals
-        keep the strict 4404 contract — a dead agent-created terminal
-        is meaningful state, not plumbing to resurrect.
+        shell (see :func:`_recreate_repl_terminal` and
+        :func:`_recreate_qwen_terminal`). Other terminals keep the
+        strict 4404 contract - a dead agent-created terminal is
+        meaningful state, not plumbing to resurrect.
 
         :param websocket: Accepted FastAPI WebSocket.
         :param session_id: Session/conversation identifier.
@@ -15928,13 +15991,16 @@ def create_runner_app(
             terminal_id,
             terminal_registry,
         )
+        terminal_role = (
+            resource_registry.terminal_resource_role(session_id, terminal_id)
+            if resource_registry is not None
+            else None
+        )
         if entry is None or not entry.instance.running or not await entry.instance.is_alive():
-            if (
-                resource_registry is not None
-                and resource_registry.terminal_resource_role(session_id, terminal_id)
-                == OMNIGENT_REPL_TERMINAL_ROLE
-            ):
+            if terminal_role == OMNIGENT_REPL_TERMINAL_ROLE:
                 entry = await _recreate_repl_terminal(session_id, terminal_id)
+            elif terminal_role == QWEN_NATIVE_TERMINAL_ROLE:
+                entry = await _recreate_qwen_terminal(session_id, terminal_id)
             else:
                 entry = None
             if entry is None:

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -23,6 +23,7 @@ from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner import create_runner_app
 from omnigent.runner.resource_registry import (
     OMNIGENT_REPL_TERMINAL_ROLE,
+    QWEN_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
 )
 from omnigent.terminals import TerminalRegistry
@@ -417,6 +418,125 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
 
     assert auto_create_sessions == ["conv_abc"]
     assert str(fresh_dir / "tui-main.sock") in attach_argvs[1]
+
+
+def test_runner_resource_attach_recreates_dead_qwen_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A dead qwen-native terminal is recreated on attach, not rejected.
+
+    Pins the same crash-recovery gap the REPL already covered:
+    qwen's TUI can die while the registry still holds a stale running
+    entry, and before the fix the attach route would close 4404 and
+    leave the embedded qwen pane blank for the rest of the session.
+    The route should tear down the dead terminal, rerun qwen auto-
+    create, and bridge the fresh pane on the same attach that noticed
+    the crash.
+
+    :param tmp_path: Pytest tmp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    registry = TerminalRegistry()
+    stale = _make_running_instance("qwen", "main", tmp_path)
+
+    async def dead_tmux() -> bool:
+        """
+        Simulate ``tmux has-session`` reporting the qwen pane gone.
+
+        :returns: ``False`` after flipping the optimistic running flag.
+        """
+        stale.running = False
+        return False
+
+    stale.is_alive = dead_tmux  # type: ignore[method-assign]
+    _seed_registry(registry, "conv_abc", stale)
+
+    resource_registry = SessionResourceRegistry(terminal_registry=registry)
+    resource_registry._terminal_roles[("conv_abc", "terminal_qwen_main")] = (
+        QWEN_NATIVE_TERMINAL_ROLE
+    )
+
+    app = create_runner_app(
+        terminal_registry=registry,
+        resource_registry=resource_registry,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    fresh_dir = tmp_path / "fresh"
+    fresh_dir.mkdir()
+    fresh = _make_running_instance("qwen", "main", fresh_dir)
+    auto_create_sessions: list[str] = []
+
+    async def fake_auto_create(
+        session_id: str,
+        rr: SessionResourceRegistry,
+        publish_event: object,
+        *,
+        server_client: object,
+        ensure_comment_relay: object = None,
+    ) -> SessionResourceView:
+        """
+        Stand-in for ``_auto_create_qwen_terminal`` that registers a
+        live pane without spawning real tmux.
+
+        :param session_id: Session being recreated, e.g. ``"conv_abc"``.
+        :param rr: The runner's resource registry (unused by the stub).
+        :param publish_event: Per-session SSE emitter (unused).
+        :param server_client: Omnigent server client (unused).
+        :param ensure_comment_relay: Comment relay hook threaded by the
+            recreate path (unused by the stub).
+        :returns: Terminal resource view for the fresh pane.
+        """
+        auto_create_sessions.append(session_id)
+        _seed_registry(registry, session_id, fresh)
+        return SessionResourceView(
+            id="terminal_qwen_main",
+            type="terminal",
+            session_id=session_id,
+            name="qwen",
+        )
+
+    monkeypatch.setattr("omnigent.runner.app._auto_create_qwen_terminal", fake_auto_create)
+
+    attach_argvs: list[list[str]] = []
+
+    def fake_fork() -> tuple[int, int]:
+        """Drive the child branch of ``pty.fork`` in-process."""
+        return 0, 0
+
+    def fake_execve(path: str, argv: list[str], env: dict[str, str]) -> None:
+        """Capture the tmux attach argv instead of exec'ing."""
+        attach_argvs.append(argv)
+        raise OSError("stop child path")
+
+    exit_exc = RuntimeError("child exited")
+    monkeypatch.setattr("omnigent.terminals.ws_bridge.pty.fork", fake_fork)
+    monkeypatch.setattr("omnigent.terminals.ws_bridge.os.execve", fake_execve)
+    monkeypatch.setattr(
+        "omnigent.terminals.ws_bridge.os._exit",
+        lambda code: (_ for _ in ()).throw(exit_exc),
+    )
+
+    with pytest.raises(RuntimeError, match="child exited"):
+        with TestClient(app).websocket_connect(
+            "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach"
+        ):
+            pass
+
+    assert auto_create_sessions == ["conv_abc"]
+    assert str(fresh_dir / "qwen-main.sock") in attach_argvs[0]
+    assert registry.get("conv_abc", "qwen", "main") is fresh
+
+    with pytest.raises(RuntimeError, match="child exited"):
+        with TestClient(app).websocket_connect(
+            "/v1/sessions/conv_abc/resources/terminals/terminal_qwen_main/attach"
+        ):
+            pass
+
+    assert auto_create_sessions == ["conv_abc"]
+    assert str(fresh_dir / "qwen-main.sock") in attach_argvs[1]
 
 
 def test_runner_resource_attach_dead_non_repl_terminal_keeps_4404(


### PR DESCRIPTION
## Summary
- Recreate dead qwen-native terminal panes on attach, matching the embedded REPL recovery path.
- Add regression coverage for stale qwen panes so attach relaunches instead of closing 4404.
- Update the Qwen follow-up doc to mark this attach-recovery slice as done.

## Test plan
- `UV_NO_CONFIG=1 OMNIGENT_SKIP_WEB_UI=true uv run python -m pytest tests/runner/test_terminal_resource_attach_ws.py -q`
- `UV_NO_CONFIG=1 OMNIGENT_SKIP_WEB_UI=true uv run python -m pytest tests/runner/test_app_sessions_native.py -k qwen -q`
- `UV_NO_CONFIG=1 OMNIGENT_SKIP_WEB_UI=true uv run pre-commit run --all-files --show-diff-on-failure`
- `npm --prefix ap-web ci --legacy-peer-deps --no-audit --no-fund`
- `npm --prefix ap-web run type-check`