### PR TITLE
fix(subagents): show "Disconnected" pill for runner disconnect, not red "Failed"

### DIFF
--- a/ap-web/src/shell/SubagentsPanel.test.tsx
+++ b/ap-web/src/shell/SubagentsPanel.test.tsx
@@ -776,6 +776,144 @@ describe("SubagentsPanel", () => {
     );
   });
 
+  it.each([
+    ["runner_disconnected", "Runner disconnected unexpectedly."],
+    ["runner_failed_to_start", "runner exited before the first turn"],
+  ])(
+    "renders 'Disconnected' (amber, not red 'Failed') for the runner-disconnect code %s",
+    (code, message) => {
+      // Option B: a runner that merely disconnected/exited is NOT a task
+      // failure. The child summary still collapses to current_task_status
+      // "failed", but last_task_error.code carries the disconnect cause, so
+      // the row must branch to the amber "Disconnected" pill before the red
+      // "Failed" one.
+      mockChildTree({
+        conv_parent: [
+          childInfo({
+            id: "conv_child",
+            title: "researcher:auth",
+            tool: "researcher",
+            session_name: "auth",
+            current_task_status: "failed",
+            last_task_error: { code, message },
+          }),
+        ],
+      });
+
+      const { container } = renderPanel();
+
+      const row = childRow(container, "conv_child");
+      const indicator = within(row).getByTestId("subagent-status-dot");
+      expect(row).toHaveTextContent(/Disconnected/);
+      expect(row).not.toHaveTextContent(/Failed/);
+      // Non-destructive amber tone — distinct from the red failure pill.
+      expect(indicator).toHaveClass("text-warning");
+      expect(indicator).not.toHaveClass("text-destructive");
+      expect(indicator.querySelector(".bg-warning")).not.toBeNull();
+      expect(indicator.querySelector(".bg-destructive")).toBeNull();
+      // The cause is still surfaced in the accessible label / tooltip.
+      expect(indicator).toHaveAttribute("aria-label", `Disconnected: ${message}`);
+    },
+  );
+
+  it("keeps rendering red 'Failed' for a genuine task failure (non-disconnect code)", () => {
+    // Guard the hard constraint: only runner-disconnect/exit codes become
+    // "Disconnected"; any other error code is a real failure and stays red.
+    mockChildTree({
+      conv_parent: [
+        childInfo({
+          id: "conv_child",
+          title: "researcher:auth",
+          tool: "researcher",
+          session_name: "auth",
+          current_task_status: "failed",
+          last_task_error: { code: "tool_error", message: "Tool raised ValueError" },
+        }),
+      ],
+    });
+
+    const { container } = renderPanel();
+
+    const row = childRow(container, "conv_child");
+    const indicator = within(row).getByTestId("subagent-status-dot");
+    expect(row).toHaveTextContent(/Failed/);
+    expect(row).not.toHaveTextContent(/Disconnected/);
+    expect(indicator).toHaveClass("text-destructive");
+    expect(indicator.querySelector(".bg-destructive")).not.toBeNull();
+  });
+
+  it("renders 'Disconnected' on the main row when the parent failed with a runner-disconnect code", () => {
+    // The session snapshot collapses a runner exit to status "failed" but
+    // preserves the cause in lastTaskError.code (runner_failed_to_start /
+    // runner_disconnected). The main row must branch on it to render the
+    // amber "Disconnected" pill rather than the red "Failed" one.
+    useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_root",
+        agentId: "ag_root",
+        agentName: null,
+        runnerId: null,
+        status: "failed",
+        lastTaskError: {
+          code: "runner_failed_to_start",
+          message: "runner exited before the first turn",
+        },
+        createdAt: 0,
+        title: null,
+        labels: {},
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: 4,
+        parentSessionId: null,
+        subAgentName: null,
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useSession>);
+
+    renderPanel({ rootSessionId: "conv_root" });
+
+    const mainRow = screen.getByTestId("subagent-main-row");
+    const indicator = within(mainRow).getByTestId("subagent-status-dot");
+    expect(mainRow).toHaveTextContent(/Disconnected/);
+    expect(mainRow).not.toHaveTextContent(/Failed/);
+    expect(indicator).toHaveClass("text-warning");
+    expect(indicator).not.toHaveClass("text-destructive");
+  });
+
+  it("renders red 'Failed' on the main row for a genuine parent failure (non-disconnect code)", () => {
+    useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_root",
+        agentId: "ag_root",
+        agentName: null,
+        runnerId: null,
+        status: "failed",
+        lastTaskError: { code: "turn_error", message: "turn setup failed" },
+        createdAt: 0,
+        title: null,
+        labels: {},
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: 4,
+        parentSessionId: null,
+        subAgentName: null,
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useSession>);
+
+    renderPanel({ rootSessionId: "conv_root" });
+
+    const mainRow = screen.getByTestId("subagent-main-row");
+    const indicator = within(mainRow).getByTestId("subagent-status-dot");
+    expect(mainRow).toHaveTextContent(/Failed/);
+    expect(mainRow).not.toHaveTextContent(/Disconnected/);
+    expect(indicator).toHaveClass("text-destructive");
+  });
+
   it("shows the pulsing working dot (no redundant 'Working' word) on the main row when the parent session is running", () => {
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
     useSessionMock.mockReturnValue({

--- a/ap-web/src/shell/SubagentsPanel.tsx
+++ b/ap-web/src/shell/SubagentsPanel.tsx
@@ -149,7 +149,31 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
 // ``busy`` + ``current_task_status``). Drives the dot tone, whether the
 // label word shows, and whether the row is de-emphasized. ``awaiting`` =
 // parked on an approval / input prompt and needs the user's attention.
-type AgentActivity = "launching" | "working" | "awaiting" | "done" | "failed" | "idle" | "other";
+// ``disconnected`` = the runner dropped its tunnel or exited; the task did
+// NOT genuinely fail, so it renders a non-destructive (amber) pill rather
+// than the red "Failed" one.
+type AgentActivity =
+  | "launching"
+  | "working"
+  | "awaiting"
+  | "done"
+  | "failed"
+  | "disconnected"
+  | "idle"
+  | "other";
+
+// Error codes that mean "the runner went away", not "the task failed".
+// ``runner_disconnected`` is published when the SSE relay's tunnel drops
+// mid-stream; ``runner_failed_to_start`` when a bound runner reports an
+// unexpected exit. Both are surfaced via ``last_task_error.code`` (child
+// rows) / the session snapshot's ``lastTaskError.code`` (main row). A
+// genuine task failure carries any other code (or none), so it still
+// renders the red "Failed" pill.
+const RUNNER_DISCONNECT_CODES = new Set(["runner_disconnected", "runner_failed_to_start"]);
+
+function isRunnerDisconnectCode(code: string | null | undefined): boolean {
+  return code != null && RUNNER_DISCONNECT_CODES.has(code);
+}
 
 interface AgentStatus {
   activity: AgentActivity;
@@ -189,6 +213,18 @@ function childStatus(child: ChildSessionInfo): AgentStatus {
     return { activity: "launching", label: "Launching" };
   }
   if (child.busy) return { activity: "working", label: "Working" };
+  // A runner disconnect/exit is NOT a task failure — branch on the error
+  // code before the generic failed paths so it renders the amber
+  // "Disconnected" pill instead of the red "Failed" one.
+  if (isRunnerDisconnectCode(child.last_task_error?.code)) {
+    return {
+      activity: "disconnected",
+      label: "Disconnected",
+      details: child.last_task_error
+        ? firstErrorLine(child.last_task_error.message)
+        : undefined,
+    };
+  }
   if (child.last_task_error) {
     return {
       activity: "failed",
@@ -209,12 +245,31 @@ function childStatus(child: ChildSessionInfo): AgentStatus {
  *
  * @param status - ``session.status`` from the snapshot, e.g. ``"running"``,
  *   or ``undefined`` while the snapshot is still loading.
+ * @param lastTaskError - The snapshot's ``lastTaskError`` (code + message),
+ *   used to tell a benign runner disconnect/exit apart from a real failure
+ *   when ``status === "failed"``.
  * @returns The collapsed activity + its label.
  */
-function sessionStatus(status: string | undefined): AgentStatus {
+function sessionStatus(
+  status: string | undefined,
+  lastTaskError?: { code: string; message: string } | null,
+): AgentStatus {
   if (status === "launching") return { activity: "launching", label: "Launching" };
   if (status === "running") return { activity: "working", label: "Working" };
-  if (status === "failed") return { activity: "failed", label: "Failed" };
+  if (status === "failed") {
+    // A runner disconnect/exit collapses the snapshot to ``failed`` but
+    // preserves the cause in ``lastTaskError.code`` — branch on it before
+    // the generic failed path so it reads as "Disconnected", not a real
+    // failure.
+    if (isRunnerDisconnectCode(lastTaskError?.code)) {
+      return {
+        activity: "disconnected",
+        label: "Disconnected",
+        details: lastTaskError ? firstErrorLine(lastTaskError.message) : undefined,
+      };
+    }
+    return { activity: "failed", label: "Failed" };
+  }
   return { activity: "idle", label: "Idle" };
 }
 
@@ -225,6 +280,9 @@ function sessionStatus(status: string | undefined): AgentStatus {
 const DOT_TONE: Record<Exclude<AgentActivity, "working" | "awaiting">, string> = {
   done: "bg-muted-foreground/55",
   failed: "bg-destructive",
+  // Amber, not destructive — a disconnect is a transient liveness loss,
+  // not a task failure, so it must read distinctly from the red "Failed".
+  disconnected: "bg-warning",
   idle: "bg-muted-foreground/55",
   launching: "bg-muted-foreground/70",
   other: "bg-muted-foreground/55",
@@ -239,6 +297,9 @@ const QUIET_STATE: Record<AgentActivity, boolean> = {
   working: true,
   awaiting: false,
   failed: false,
+  // Show the "Disconnected" word — the user needs to know the runner
+  // went away, the same way "Failed" keeps its word.
+  disconnected: false,
   other: false,
   done: true,
   idle: true,
@@ -252,6 +313,9 @@ const SETTLED_STATE: Record<AgentActivity, boolean> = {
   working: false,
   awaiting: false,
   failed: false,
+  // Not dimmed — a disconnected runner is something the user may want to
+  // notice and act on (retry/reconnect), so it stays full-strength.
+  disconnected: false,
   other: false,
   done: true,
   idle: true,
@@ -362,6 +426,21 @@ function StatusIndicator({ activity, label, details }: AgentStatus) {
       >
         <span>{label}</span>
         <span className={cn("inline-block size-2 shrink-0 rounded-full", DOT_TONE.failed)} />
+      </span>
+    );
+  }
+  if (activity === "disconnected") {
+    // Amber, non-destructive — a runner disconnect/exit is a liveness loss,
+    // not a task failure, so it must read distinctly from the red "Failed".
+    return (
+      <span
+        aria-label={title}
+        title={title}
+        data-testid="subagent-status-dot"
+        className="inline-flex shrink-0 items-center gap-1 text-warning text-xs"
+      >
+        <span>{label}</span>
+        <span className={cn("inline-block size-2 shrink-0 rounded-full", DOT_TONE.disconnected)} />
       </span>
     );
   }
@@ -526,7 +605,7 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
           <Icon className="size-3.5 shrink-0 text-muted-foreground" />
           <span className="shrink-0 truncate text-xs font-medium">{label}</span>
           <span className="flex-1" />
-          <StatusIndicator {...sessionStatus(session?.status)} />
+          <StatusIndicator {...sessionStatus(session?.status, session?.lastTaskError)} />
         </div>
         {preview && (
           // Indented to align with the title text above: 14px icon + 4px gap.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9613,13 +9613,23 @@ async def _relay_runner_stream(
         )
         # Publish a failed status so the client's SSE stream sees a
         # clean error event instead of silent truncation (#1114).
-        _publish_status(
+        disconnect_error = ErrorDetail(
+            code="runner_disconnected",
+            message="Runner disconnected unexpectedly.",
+        )
+        _publish_status(session_id, "failed", disconnect_error)
+        # Persist the disconnect cause as durable labels so the
+        # distinction survives into snapshots and child-session
+        # summaries. Without this the relay-fed cache only carries a
+        # generic ``failed`` and ``last_task_error`` is dropped, leaving
+        # the UI unable to tell a benign runner disconnect from a real
+        # task failure (Option B: render a "Disconnected" pill, not the
+        # red "Failed" pill). Cleared on the next ``running`` edge by the
+        # session.status handler, exactly like other failure labels.
+        await _persist_session_status_error_labels(
             session_id,
-            "failed",
-            ErrorDetail(
-                code="runner_disconnected",
-                message="Runner disconnected unexpectedly.",
-            ),
+            disconnect_error,
+            conversation_store,
         )
     except asyncio.CancelledError:
         raise

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -469,3 +469,80 @@ async def test_relay_publishes_failed_status_on_tunnel_close() -> None:
                 await asyncio.wait_for(handle.task, timeout=1.0)
         sessions_module._runner_relay_tasks.clear()
         session_stream.close(session_id)
+
+
+class _RecordingLabelStore:
+    """Minimal conversation store that records ``set_labels`` calls.
+
+    The disconnect path persists the failure cause as durable labels so
+    snapshots and child summaries can tell a benign runner disconnect
+    from a real task failure (Option B). Only ``set_labels`` is exercised
+    by the tunnel-close path, so that is all this fake implements.
+    """
+
+    def __init__(self) -> None:
+        self.labels: dict[str, dict[str, str]] = {}
+
+    def set_labels(self, conversation_id: str, updates: dict[str, str]) -> None:
+        self.labels.setdefault(conversation_id, {}).update(updates)
+
+
+@pytest.mark.asyncio
+async def test_relay_persists_disconnect_error_labels_on_tunnel_close() -> None:
+    """
+    A tunnel close persists the ``runner_disconnected`` cause as labels.
+
+    Option B: a runner that merely disconnected must be distinguishable
+    from a genuine task failure. The relay-fed status cache only carries a
+    generic ``failed``, so the disconnect cause is preserved as durable
+    ``last_task_error`` labels — these survive into snapshots and child
+    summaries, letting the UI render a "Disconnected" pill (not red
+    "Failed"). The code must be ``runner_disconnected`` so the UI can
+    branch on it before the generic failed path.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _TunnelCloseRunnerClient(gate)
+    store = _RecordingLabelStore()
+    session_id = "conv_tunnel_close_labels"
+
+    try:
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_tunnel_close_labels",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+        gate.set()
+
+        # The relay task should finish quickly after the ConnectionError.
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        persisted = store.labels.get(session_id)
+        assert persisted is not None, "disconnect did not persist failure labels"
+        assert persisted[sessions_module._LAST_TASK_ERROR_CODE_LABEL_KEY] == "runner_disconnected"
+        # The message is non-empty so the projection surfaces a typed
+        # ``last_task_error`` (both code and message are required there).
+        assert persisted[sessions_module._LAST_TASK_ERROR_MESSAGE_LABEL_KEY]
+
+        # The persisted labels project back to a code-preserving
+        # ``last_task_error`` — proving the disconnect cause is NOT
+        # collapsed into an indistinguishable generic failure.
+        projected = sessions_module._last_task_error_from_labels(persisted)
+        assert projected == {
+            "code": "runner_disconnected",
+            "message": "Runner disconnected unexpectedly.",
+        }
+    finally:
+        gate.set()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        session_stream.close(session_id)


### PR DESCRIPTION
## Problem

In the Omnigent web UI **Subagents panel**, a session/sub-agent whose runner merely **disconnected** (tunnel drop) — or whose runner **exited** — was shown with a red **"Failed"** badge, indistinguishable from a genuine task failure.

Root cause: the SSE relay's tunnel-drop handler published a sticky `failed` status but the disconnect *cause* (`runner_disconnected`) was dropped from child-session summaries, so the UI only ever saw a generic `failed` and rendered the red pill.

## Fix (Option B — explicit "Disconnected" state)

Introduce a distinct **Disconnected** state, visually and semantically separate from **Failed**.

### Backend — `omnigent/server/routes/sessions.py`
- On relay tunnel drop, **persist the `runner_disconnected` cause as durable `last_task_error` labels**, alongside the existing clean SSE `session.status: failed` terminal event (preserves the #1114 fix — no silent truncation). This carries the cause end-to-end into child-session summaries and the snapshot.
- Runner exits already surface `runner_failed_to_start` via the snapshot builder.
- Genuine failures keep their own distinct error codes; the disconnect label is cleared on the next `running` edge, exactly like other failure labels.

### Frontend — `ap-web` `SubagentsPanel`
- Add a `disconnected` variant to the `AgentActivity` union, an **amber (non-destructive)** `DOT_TONE` entry, and a dedicated status pill.
- In `childStatus()` and `sessionStatus()`, branch to `disconnected` when the error code is `runner_disconnected` / `runner_failed_to_start` **before** the generic failed branch. Any other cause still renders the red **"Failed"** pill.

## Tests
- **Backend**: `test_relay_persists_disconnect_error_labels_on_tunnel_close` — asserts the relay persists code-preserving `runner_disconnected` labels on tunnel close.
- **Frontend**: child + main rows render **"Disconnected"** (amber, not red) for both disconnect codes, and still **"Failed"** for a genuine (non-disconnect) failure.

## Gates run
- Python: `uv run ruff format --check` ✅, `uv run ruff check` ✅, `uv run pytest tests/server/routes/test_sessions_runner_relay.py tests/server/integration/test_sessions_child_sessions.py` → **42 passed** ✅. `uv run mypy` shows 59 pre-existing baseline errors, **0 new** (identical count on base).
- ap-web: `npm run type-check` ✅, `npx vitest run src/shell/SubagentsPanel.test.tsx` → **59 passed** ✅, full suite adds exactly the 5 new passing tests with no new failures (pre-existing locale/env failures are identical on base). `npm run lint` on touched files clean (repo-wide pre-existing lint errors are unrelated and identical on base).

This pull request and its description were written by Isaac.
