### PR TITLE
Option A: stop surfacing runner disconnect/exit as 'Failed'

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1861,23 +1861,16 @@ def create_app(
 
     # ── Tunnel lifecycle callbacks (Step 8.5 crash recovery) ───
     async def _on_runner_disconnect(runner_id: str) -> None:
-        """Mark sessions pinned to *this* runner as offline.
+        """Let liveness report sessions pinned to *this* runner offline.
 
         Filters by ``runner_id`` against ``conversation_store`` so a
-        disconnect on one runner does not flip every cached session
-        (e.g. sessions owned by other runners on the same server, or
-        sessions left in the module-level cache by earlier tests on
-        the same xdist worker) to ``"failed"``. The cache is updated
-        in lockstep with the publish so the list endpoint stays
-        coherent.
+        disconnect on one runner does not affect sessions owned by other
+        runners on the same server. A runner disconnect is liveness, not a
+        task failure, so this callback intentionally leaves the session
+        status cache untouched.
 
         :param runner_id: The disconnected runner's id.
         """
-        from omnigent.server.routes.sessions import (
-            _publish_status,
-            _session_status_cache,
-        )
-
         # Direct by-runner lookup: read-after-write consistent (the
         # listing path may be served from an eventually-consistent
         # search index in alternate store backends) and
@@ -1892,35 +1885,25 @@ def create_app(
             )
         ]
         _logger.warning(
-            "Runner %s disconnected; marking %d session(s) offline",
+            "Runner %s disconnected; %d session(s) now offline via liveness",
             runner_id,
             len(affected),
         )
-        for session_id in affected:
-            _session_status_cache[session_id] = "failed"
-            _publish_status(session_id, "failed")
 
     async def _on_runner_exited(runner_id: str, error: str) -> None:
-        """Mark a crashed runner's session(s) failed and push the cause.
+        """Record a crashed runner without marking sessions failed.
 
         Fired by the host tunnel when a daemon reports
-        ``host.runner_exited`` — the only failure signal for a runner
-        that died before connecting its tunnel (so ``_on_runner_disconnect``
-        never fires for it). Mirrors that callback's by-runner lookup,
-        but carries the daemon-composed error onto the ``session.status:
-        failed`` event so the open view surfaces the cause immediately
-        instead of spinning on "starting" until a timeout.
+        ``host.runner_exited`` — the only signal for a runner that died
+        before connecting its tunnel (so ``_on_runner_disconnect`` never
+        fires for it). Runner reachability is surfaced separately via
+        runner_online/liveness; publishing ``session.status: failed`` here
+        makes a runner lifecycle event indistinguishable from a task error.
 
         :param runner_id: The crashed runner's id.
         :param error: Human-readable cause from the daemon (exit code +
             log tail), e.g. ``"runner process exited with code 1 ..."``.
         """
-        from omnigent.server.routes.sessions import (
-            _publish_status,
-            _session_status_cache,
-        )
-        from omnigent.server.schemas import ErrorDetail
-
         affected = [
             c.id
             for c in await asyncio.to_thread(
@@ -1928,15 +1911,11 @@ def create_app(
             )
         ]
         _logger.warning(
-            "Runner %s reported crashed; marking %d session(s) failed: %s",
+            "Runner %s reported exited; %d session(s) now offline via liveness: %s",
             runner_id,
             len(affected),
             error,
         )
-        detail = ErrorDetail(code="runner_failed_to_start", message=error)
-        for session_id in affected:
-            _session_status_cache[session_id] = "failed"
-            _publish_status(session_id, "failed", error=detail)
 
     async def _on_runner_connect(runner_id: str) -> None:
         """Re-assign sessions and restart SSE relays on reconnect.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9611,16 +9611,11 @@ async def _relay_runner_stream(
             session_id,
             exc_info=True,
         )
-        # Publish a failed status so the client's SSE stream sees a
-        # clean error event instead of silent truncation (#1114).
-        _publish_status(
-            session_id,
-            "failed",
-            ErrorDetail(
-                code="runner_disconnected",
-                message="Runner disconnected unexpectedly.",
-            ),
-        )
+        # End the relay cleanly without turning runner liveness into a
+        # task failure. The UI learns the runner is offline through the
+        # existing runner_online/liveness path; poisoning the session
+        # status cache with ``failed`` makes a benign disconnect look like
+        # a failed task in the Subagents panel.
     except asyncio.CancelledError:
         raise
     finally:
@@ -13761,7 +13756,6 @@ def create_sessions_router(
             conversation=access.conversation,
             liveness_lookup=liveness_lookup if include_liveness else None,
             include_items=include_items,
-            runner_exit_reports=runner_exit_reports,
             refresh_state=refresh_state,
             host_store=getattr(request.app.state, "host_store", None),
             sandbox_config=getattr(request.app.state, "sandbox_config", None),
@@ -14729,7 +14723,6 @@ def create_sessions_router(
             agent_store,
             agent_cache,
             liveness_lookup=liveness_lookup,
-            runner_exit_reports=runner_exit_reports,
         )
 
     # ── POST /sessions/{source_id}/fork ─────────────────────────
@@ -19888,7 +19881,6 @@ async def _get_session_snapshot(
     conversation: Conversation | None = None,
     liveness_lookup: Callable[[list[str]], dict[str, SessionLiveness]] | None = None,
     include_items: bool = True,
-    runner_exit_reports: RunnerExitReports | None = None,
     refresh_state: bool = False,
     host_store: HostStore | None = None,
     sandbox_config: ManagedSandboxConfig | None = None,
@@ -20015,20 +20007,9 @@ async def _get_session_snapshot(
     if isinstance(raw_label, str) and raw_label.isdigit():
         last_total_tokens = int(raw_label)
     last_task_error = _last_task_error_from_labels(conv.labels)
-    # Runner-crash durability: if the session's bound runner reported an
-    # unexpected exit (host.runner_exited → RunnerExitReports), surface the
-    # cause as last_task_error so a reload/late-open still renders the error
-    # banner — the live session.status:failed push is gone by then. status
-    # already reads "failed" from the cache (set by _on_runner_exited). The
-    # report is keyed by the CURRENT runner_id, so a successful relaunch
-    # (new token-bound runner_id) naturally stops matching. Access is gated
-    # by the session-snapshot's own authorization, so the unscoped get is
-    # correct here (the report is this session's own runner).
-    if runner_exit_reports is not None and conv.runner_id is not None:
-        exit_error = runner_exit_reports.get(conv.runner_id)
-        if exit_error is not None:
-            last_task_error = {"code": "runner_failed_to_start", "message": exit_error}
-            status = "failed"
+    # Runner exit/disconnect is represented by runner_online/liveness, not
+    # by session ``status='failed'``. Genuine task failures still arrive via
+    # explicit failed status events and persisted last-task-error labels.
     llm_model: str | None = None
     context_window: int | None = None
     agent_name: str | None = None

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -12,6 +12,7 @@ from omnigent.entities import Conversation, ConversationItem, MessageData, Paged
 from omnigent.server.routes import sessions as _sessions_mod
 from omnigent.server.routes.sessions import (
     SessionLiveness,
+    _child_session_summary_from_conversation,
     _get_session_snapshot,
     _publish_subtree_cost_to_ancestors,
 )
@@ -209,17 +210,10 @@ async def test_session_snapshot_populates_runner_online_from_session_lookup() ->
 
 
 @pytest.mark.asyncio
-async def test_session_snapshot_surfaces_runner_exit_report_as_failed() -> None:
-    """A crashed runner's exit report surfaces as failed + last_task_error.
-
-    This is the reload-durability leg: the live ``session.status:failed``
-    push is gone by the time a page reloads, so the snapshot must read the
-    cause from ``RunnerExitReports`` (keyed by the session's runner_id) and
-    project it as ``status="failed"`` + ``last_task_error`` — exactly what
-    the web's synthetic-error path renders. Without this, a reload after a
-    runner crash shows no error.
-    """
+async def test_session_snapshot_runner_exit_report_does_not_force_failed() -> None:
+    """Runner exit reports are liveness, not session task failures."""
     from omnigent.server.host_registry import RunnerExitReports
+    from omnigent.server.routes import sessions as sessions_module
 
     conv = Conversation(
         id="conv_crashed",
@@ -237,19 +231,17 @@ async def test_session_snapshot_surfaces_runner_exit_report_as_failed() -> None:
     daemon_error = "runner process exited with code 1\n--- runner log tail ---\nboom"
     reports.record("runner_dead", daemon_error, owner=None)
 
-    snapshot = await _get_session_snapshot(
-        conv_store,  # type: ignore[arg-type]
-        "conv_crashed",
-        runner_exit_reports=reports,
-    )
+    sessions_module._session_status_cache.pop("conv_crashed", None)
+    try:
+        snapshot = await _get_session_snapshot(
+            conv_store,  # type: ignore[arg-type]
+            "conv_crashed",
+        )
+    finally:
+        sessions_module._session_status_cache.pop("conv_crashed", None)
 
-    # Forced to failed by the exit report even though no task ran and the
-    # status cache is empty (a fresh crash before any turn).
-    assert snapshot.status == "failed"
-    assert snapshot.last_task_error is not None
-    assert snapshot.last_task_error["code"] == "runner_failed_to_start"
-    # The daemon's full cause (incl. log tail) rides through verbatim.
-    assert snapshot.last_task_error["message"] == daemon_error
+    assert snapshot.status == "idle"
+    assert snapshot.last_task_error is None
 
 
 @pytest.mark.asyncio
@@ -278,26 +270,70 @@ async def test_session_snapshot_surfaces_status_error_labels_as_last_task_error(
         conversations={"conv_failed_terminal": conv},
     )
 
-    snapshot = await _get_session_snapshot(  # type: ignore[arg-type]
-        conv_store,
-        "conv_failed_terminal",
-    )
+    _sessions_mod._session_status_cache["conv_failed_terminal"] = "failed"
+    try:
+        snapshot = await _get_session_snapshot(  # type: ignore[arg-type]
+            conv_store,
+            "conv_failed_terminal",
+        )
+    finally:
+        _sessions_mod._session_status_cache.pop("conv_failed_terminal", None)
 
     assert snapshot.last_task_error == {
         "code": "required_terminal_exited",
         "message": "Required terminal exited unexpectedly",
     }
+    assert snapshot.status == "failed"
+
+
+def test_child_summary_uses_cache_for_failure_but_disconnect_leaves_prior_status() -> None:
+    """Child summary reports real failed cache values, not runner disconnects."""
+    from omnigent.server.routes import sessions as sessions_module
+
+    conv = Conversation(
+        id="conv_child_summary",
+        created_at=1,
+        updated_at=1,
+        root_conversation_id="conv_parent_summary",
+        parent_conversation_id="conv_parent_summary",
+        kind="sub_agent",
+        title="codex:impl",
+    )
+    cache = sessions_module._session_status_cache
+    cache.pop(conv.id, None)
+    try:
+        summary = _child_session_summary_from_conversation(
+            conv,
+            "conv_parent_summary",
+            last_message_preview=None,
+        )
+        assert summary.current_task_status is None
+        assert summary.busy is False
+
+        cache[conv.id] = "running"
+        summary = _child_session_summary_from_conversation(
+            conv,
+            "conv_parent_summary",
+            last_message_preview=None,
+        )
+        assert summary.current_task_status is None
+        assert summary.busy is True
+
+        cache[conv.id] = "failed"
+        summary = _child_session_summary_from_conversation(
+            conv,
+            "conv_parent_summary",
+            last_message_preview=None,
+        )
+        assert summary.current_task_status == "failed"
+        assert summary.busy is False
+    finally:
+        cache.pop(conv.id, None)
 
 
 @pytest.mark.asyncio
-async def test_session_snapshot_no_exit_report_stays_unfailed() -> None:
-    """A session whose runner has no exit report is not marked failed.
-
-    Guards the override from firing for healthy/idle sessions — only a
-    recorded crash for THIS session's runner should flip it.
-    """
-    from omnigent.server.host_registry import RunnerExitReports
-
+async def test_session_snapshot_runner_bound_session_stays_unfailed() -> None:
+    """A runner-bound session is not marked failed without task failure state."""
     conv = Conversation(
         id="conv_ok",
         created_at=1,
@@ -310,15 +346,12 @@ async def test_session_snapshot_no_exit_report_stays_unfailed() -> None:
         [_message_item("item_1", "hi")],
         conversations={"conv_ok": conv},
     )
-    reports = RunnerExitReports()  # empty — no crash recorded
 
     snapshot = await _get_session_snapshot(
         conv_store,  # type: ignore[arg-type]
         "conv_ok",
-        runner_exit_reports=reports,
     )
 
-    # No report for runner_live → no forced failure, no synthetic error.
     assert snapshot.status != "failed"
     assert snapshot.last_task_error is None
 

--- a/tests/server/test_stream_events.py
+++ b/tests/server/test_stream_events.py
@@ -20,6 +20,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
@@ -442,6 +443,43 @@ def test_publish_session_status_rejects_unknown_status() -> None:
 
     with pytest.raises(ValidationError):
         _publish_session_status("conv_abc", "bogus")
+
+
+@pytest.mark.asyncio
+async def test_relay_runner_disconnect_does_not_publish_failed_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner transport loss ends the relay without poisoning status cache."""
+    from omnigent.server.routes import sessions as sessions_module
+
+    published: list[dict[str, Any]] = []
+    session_id = "conv_runner_disconnect"
+    sessions_module._session_status_cache[session_id] = "running"
+
+    class _BrokenRunnerClient(httpx.AsyncClient):
+        def stream(self, *args: Any, **kwargs: Any) -> object:  # type: ignore[override]
+            del args, kwargs
+            raise httpx.ConnectError("runner tunnel closed")
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda _session_id, event: published.append(event),
+    )
+    try:
+        await sessions_module._relay_runner_stream(  # type: ignore[arg-type]
+            session_id,
+            _BrokenRunnerClient(),
+            object(),  # type: ignore[arg-type]
+        )
+    finally:
+        cache_after = sessions_module._session_status_cache.get(session_id)
+        sessions_module._session_status_cache.pop(session_id, None)
+
+    assert cache_after == "running"
+    assert not any(
+        event.get("type") == "session.status" and event.get("status") == "failed"
+        for event in published
+    )
 
 
 def test_session_created_event_payload_shape() -> None:


### PR DESCRIPTION
## Summary
- Stop treating runner disconnect/exit lifecycle events as session task failures.
- Leave existing runner_online/liveness reporting responsible for disconnected banners.
- Add backend regressions for relay disconnects, child-summary cache projection, snapshot runner-exit behavior, and genuine failed status preservation.

## Gates
- uv run ruff check omnigent/server/app.py omnigent/server/routes/sessions.py tests/server/routes/test_sessions_snapshot.py tests/server/test_stream_events.py
- uv run --extra dev pytest tests/server/test_stream_events.py tests/server/routes/test_sessions_snapshot.py
- uv run mypy omnigent/server/app.py omnigent/server/routes/sessions.py tests/server/routes/test_sessions_snapshot.py tests/server/test_stream_events.py (currently exposes existing unallowlisted module/test errors unrelated to this change)