### PR TITLE
fix(web): show active Claude model and effort in picker

### DIFF
--- a/ap-web/src/pages/ChatPage.composer.test.tsx
+++ b/ap-web/src/pages/ChatPage.composer.test.tsx
@@ -521,13 +521,97 @@ describe("AgentPicker trigger label", () => {
     expect(within(trigger).getByText("High")).toHaveClass("text-muted-foreground");
   });
 
+  it("shows the inherited Claude default effort on the trigger", () => {
+    // Issue #1463: a fresh claude-native session has no explicit effort
+    // override, but the effective default is still Medium and must be visible
+    // up front instead of leaving the trigger as model-only.
+    useChatStore.setState({
+      selectedModel: null,
+      selectedEffort: null,
+      llmModel: "claude-sonnet-4-6",
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "claude" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "claude",
+          showModels: true,
+        })}
+      />,
+    );
+
+    const trigger = screen.getByTestId("agent-picker-trigger");
+    expect(trigger).toHaveTextContent("Sonnet");
+    expect(trigger).toHaveTextContent("Medium");
+    expect(trigger).not.toHaveTextContent("Claude");
+  });
+
+  it("falls back to Claude's default model and effort before the snapshot model resolves", () => {
+    // The issue calls out the pre-hydration/default path too: no explicit
+    // override and no llmModel yet should still read as the effective Claude
+    // defaults, not as "Claude", "Model", or effort-only.
+    useChatStore.setState({ selectedModel: null, selectedEffort: null, llmModel: null });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "claude" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "claude",
+          showModels: true,
+        })}
+      />,
+    );
+
+    const trigger = screen.getByTestId("agent-picker-trigger");
+    expect(trigger).toHaveTextContent("Sonnet");
+    expect(trigger).toHaveTextContent("Medium");
+    expect(trigger).not.toHaveTextContent("Claude");
+  });
+
+  it("marks the active model and inherited default effort in the dropdown", () => {
+    // A background tint alone is easy to miss and was indistinguishable from
+    // hover. The current model/effort rows need an explicit readable marker,
+    // including the inherited default effort before any override is set.
+    useChatStore.setState({
+      selectedModel: null,
+      selectedEffort: null,
+      llmModel: null,
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "claude" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "claude",
+          showModels: true,
+        })}
+      />,
+    );
+
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "/model " } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    const sonnet = screen
+      .getAllByTestId("model-picker-item")
+      .find((item) => item.getAttribute("data-model-id") === "sonnet");
+    expect(sonnet).toHaveAttribute("data-active", "true");
+    expect(within(sonnet!).getByText("Current")).toBeInTheDocument();
+
+    const medium = screen
+      .getAllByTestId("effort-picker-item")
+      .find((item) => item.getAttribute("data-effort-level") === "medium");
+    expect(medium).toHaveAttribute("data-active", "true");
+    expect(within(medium!).getByText("Current")).toBeInTheDocument();
+  });
+
   it("still renders an enabled trigger when the model/effort label is unresolved", () => {
     // Regression guard: a claude-native session before the snapshot fills
-    // llmModel/selectedEffort has no model label, no effort label, and no
-    // agent switcher — but CLAUDE_NATIVE_MODELS still gives the dropdown
-    // model rows to switch (hasPickerActions). The trigger must NOT vanish
-    // (which would also take the model dropdown and the bare-`/model` path
-    // with it); it falls back to a stable identity label and stays enabled.
+    // llmModel/selectedEffort still has static Claude model rows to switch.
+    // The trigger must NOT vanish (which would also take the model dropdown
+    // and the bare-`/model` path with it); it now surfaces Claude's effective
+    // default model when the live snapshot has not resolved yet.
     useChatStore.setState({ selectedModel: null, selectedEffort: null, llmModel: null });
     renderWithTooltips(
       <Composer
@@ -545,8 +629,9 @@ describe("AgentPicker trigger label", () => {
     // Enabled because there are still model rows to switch — so the dropdown
     // (and the bare-`/model` open path) stays reachable.
     expect(trigger).toBeEnabled();
-    // Falls back to the bound agent's display label rather than rendering empty.
-    expect(trigger).toHaveTextContent("Claude");
+    // Uses Claude's default model instead of falling back to the harness name.
+    expect(trigger).toHaveTextContent("Sonnet");
+    expect(trigger).not.toHaveTextContent("Claude");
   });
 
   it("surfaces a cursor-native session's model from the override, not the cross-session sticky", () => {

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3098,13 +3098,18 @@ function ContextRing({ contextWindow, tokensUsed }: { contextWindow: number; tok
 export function formatStatusModelLabel(
   model: string | null,
   codexModelOptions: readonly CodexModelOption[] = [],
+  collapseClaudeNativeAliases = false,
 ): string | null {
   const raw = model?.trim();
   if (!raw) return null;
   const lower = raw.toLowerCase();
   const codexOption = findCodexModelOption(codexModelOptions, raw);
   if (codexOption) return codexOption.displayName ?? codexOption.id;
-  const known = CLAUDE_NATIVE_MODELS.find((m) => m.id === lower);
+  const known = CLAUDE_NATIVE_MODELS.find((m) =>
+    collapseClaudeNativeAliases
+      ? m.id === lower || lower.endsWith(`/${m.id}`) || lower.includes(m.id)
+      : m.id === lower,
+  );
   if (known) return known.label;
   return raw;
 }
@@ -3113,6 +3118,35 @@ function formatStatusEffortLabel(effort: string | null, raw = false): string | n
   if (!effort) return null;
   if (raw) return effort;
   return effort.toLowerCase() === "xhigh" ? "xHigh" : formatEffortLabel(effort);
+}
+
+function defaultModelForPicker(
+  modelPickerKind: NativeModelPickerKind | null,
+  modelOptions: ReadonlyArray<{ id: string }>,
+): string | null {
+  if (modelPickerKind === "claude") {
+    return modelOptions.some((m) => m.id === CLAUDE_NATIVE_DEFAULT_MODEL)
+      ? CLAUDE_NATIVE_DEFAULT_MODEL
+      : null;
+  }
+  return null;
+}
+
+function defaultEffortForPicker(
+  modelPickerKind: NativeModelPickerKind | null,
+  effectiveModel: string | null,
+  codexModelOptions: readonly CodexModelOption[],
+  effortLevels: readonly string[],
+): string | null {
+  if (modelPickerKind === "claude") {
+    return effortLevels.includes("medium") ? "medium" : (effortLevels[0] ?? null);
+  }
+  if (modelPickerKind === "codex" && effectiveModel) {
+    const option = findCodexModelOption(codexModelOptions, effectiveModel);
+    const defaultEffort = option?.defaultReasoningEffort ?? null;
+    return defaultEffort && effortLevels.includes(defaultEffort) ? defaultEffort : null;
+  }
+  return null;
 }
 
 /**
@@ -4455,6 +4489,9 @@ export function isUnboundCodingFork(params: {
 
 const EFFORT_LEVELS = ["low", "medium", "high"] as const;
 
+/** Claude Code's effective default model for fresh claude-native sessions. */
+const CLAUDE_NATIVE_DEFAULT_MODEL = "sonnet";
+
 /** Anthropic-side efforts for claude-native sessions (matches ANTHROPIC_EFFORTS in reasoning_effort.py). */
 const CLAUDE_NATIVE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
@@ -4696,10 +4733,25 @@ function AgentPicker({
           (sessionModelOverride ?? llmModel)
         : null
     : nonNativeModel;
-  const modelLabel = formatStatusModelLabel(effectiveModel, codexModelOptions);
+  const effectiveModelForPicker =
+    effectiveModel ?? defaultModelForPicker(modelPickerKind, modelOptions);
+  const modelLabel = formatStatusModelLabel(
+    effectiveModelForPicker,
+    codexModelOptions,
+    modelPickerKind === "claude",
+  );
+  const effectiveEffort = showEffort
+    ? (selectedEffort ??
+      defaultEffortForPicker(
+        modelPickerKind,
+        effectiveModelForPicker,
+        codexModelOptions,
+        effortLevels,
+      ))
+    : null;
   const effortTriggerLabel =
-    showEffort && selectedEffort
-      ? formatStatusEffortLabel(selectedEffort, modelPickerKind === "codex")
+    effectiveEffort != null
+      ? formatStatusEffortLabel(effectiveEffort, modelPickerKind === "codex")
       : null;
   const hasPickerActions = showAgents || modelOptions.length > 0 || showEffort;
 
@@ -4789,8 +4841,8 @@ function AgentPicker({
               const isImplicit =
                 pickerSelectedModel === null &&
                 (usesServerModelOptions
-                  ? findCodexModelOption(codexModelOptions, llmModel)?.id === m.id
-                  : isModelImplicitlySelected(m.id, llmModel));
+                  ? findCodexModelOption(codexModelOptions, effectiveModelForPicker)?.id === m.id
+                  : isModelImplicitlySelected(m.id, effectiveModelForPicker));
               const isActive = isExplicit || isImplicit;
               return (
                 <DropdownMenuItem
@@ -4812,6 +4864,7 @@ function AgentPicker({
                   <span className="flex-1 truncate">
                     {usesServerModelOptions ? (m.displayName ?? m.id) : m.label}
                   </span>
+                  {isActive && <PickerCurrentMarker />}
                 </DropdownMenuItem>
               );
             })}
@@ -4828,7 +4881,7 @@ function AgentPicker({
                 key={level}
                 data-testid="effort-picker-item"
                 data-effort-level={level}
-                data-active={selectedEffort === level ? "true" : undefined}
+                data-active={effectiveEffort === level ? "true" : undefined}
                 onSelect={() =>
                   void useChatStore
                     .getState()
@@ -4842,6 +4895,7 @@ function AgentPicker({
                 )}
               >
                 <span className="flex-1 truncate">{level}</span>
+                {effectiveEffort === level && <PickerCurrentMarker />}
               </DropdownMenuItem>
             ))}
           </>
@@ -4860,5 +4914,14 @@ function PickerSectionHeader({ children }: { children: React.ReactNode }) {
     <div className="px-2 pt-2 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
       {children}
     </div>
+  );
+}
+
+function PickerCurrentMarker() {
+  return (
+    <span className="ml-2 inline-flex shrink-0 items-center gap-1 text-[10px] font-medium text-muted-foreground">
+      <CheckIcon className="size-3" aria-hidden="true" />
+      Current
+    </span>
   );
 }

--- a/tests/e2e_ui/chat/test_composer_model_effort_picker.py
+++ b/tests/e2e_ui/chat/test_composer_model_effort_picker.py
@@ -1,0 +1,122 @@
+"""Browser e2e: claude-native composer picker shows effective model + effort.
+
+Issue #1463 is user-facing UI behavior: a fresh Claude Code session with no
+explicit model/effort override should still tell the user what is active. The
+unit tests cover the pure picker logic; this e2e stubs the session bind APIs and
+proves the routed chat surface renders the same defaults on the real composer
+trigger and marks them inside the dropdown.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from playwright.sync_api import Page, Route, expect
+
+_SESSION_ID = "conv_picker_e2e"
+_AGENT_ID = "ag_claude_picker_e2e"
+_AGENT_NAME = "claude-native-ui"
+_HOST_ID = "host_picker_e2e"
+
+_SESSIONS_LIST_RE = re.compile(r"/v1/sessions(\?.*)?$")
+_FILESYSTEM_RE = re.compile(r"/v1/hosts/[^/]+/filesystem")
+_SESSION_DETAIL_RE = re.compile(rf"/v1/sessions/{_SESSION_ID}(\?.*)?$")
+_ITEMS_RE = re.compile(rf"/v1/sessions/{_SESSION_ID}/items")
+_STREAM_RE = re.compile(rf"/v1/sessions/{_SESSION_ID}/stream")
+_AGENT_RE = re.compile(rf"/v1/sessions/{_SESSION_ID}/agent")
+_SUBRESOURCE_RE = re.compile(rf"/v1/sessions/{_SESSION_ID}/(child_sessions|resources)")
+_HEALTH_RE = re.compile(r"/health(\?.*)?$")
+
+_EMPTY_LIST_BODY = {"object": "list", "data": [], "has_more": False}
+_DONE_SSE = "data: [DONE]\n\n"
+
+_AGENTS_BODY = {
+    "data": [
+        {
+            "id": _AGENT_ID,
+            "name": _AGENT_NAME,
+            "display_name": "Claude Code",
+            "description": "Anthropic's coding agent",
+            "harness": None,
+            "skills": [],
+        }
+    ]
+}
+_HOSTS_BODY = {
+    "hosts": [{"host_id": _HOST_ID, "name": "e2e-host", "owner": "e2e", "status": "online"}]
+}
+_ITEMS_BODY = {"object": "list", "data": [], "first_id": None, "last_id": None, "has_more": False}
+_SESSION_BODY = {
+    "id": _SESSION_ID,
+    "agent_id": _AGENT_ID,
+    "agent_name": _AGENT_NAME,
+    "status": "idle",
+    "created_at": 1704067200,
+    "updated_at": 1704067200,
+    "title": None,
+    "labels": {"omnigent.wrapper": "claude-code-native-ui", "omnigent.ui": "terminal"},
+    # Fresh native session: no explicit overrides and no resolved snapshot model yet.
+    "reasoning_effort": None,
+    "llm_model": None,
+    "model_override": None,
+    "items": [],
+    "permission_level": 4,
+}
+_AGENT_BODY = {
+    "id": _AGENT_ID,
+    "object": "agent",
+    "name": _AGENT_NAME,
+    "description": "Anthropic's coding agent",
+    "harness": None,
+    "mcp_servers": [],
+    "policies": [],
+    "terminals": [],
+}
+_HEALTH_BODY = {"sessions": {_SESSION_ID: {"runner_online": True, "host_online": True}}}
+
+
+def _fulfill_json(route: Route, payload: object) -> None:
+    route.fulfill(status=200, content_type="application/json", body=json.dumps(payload))
+
+
+def _register_stubbed_chat_routes(page: Page) -> None:
+    page.route("**/v1/agents", lambda r: _fulfill_json(r, _AGENTS_BODY))
+    page.route("**/v1/hosts", lambda r: _fulfill_json(r, _HOSTS_BODY))
+    page.route(_FILESYSTEM_RE, lambda r: _fulfill_json(r, _EMPTY_LIST_BODY))
+    page.route(_SESSIONS_LIST_RE, lambda r: _fulfill_json(r, _EMPTY_LIST_BODY))
+    page.route(_ITEMS_RE, lambda r: _fulfill_json(r, _ITEMS_BODY))
+    page.route(_AGENT_RE, lambda r: _fulfill_json(r, _AGENT_BODY))
+    page.route(_SUBRESOURCE_RE, lambda r: _fulfill_json(r, _EMPTY_LIST_BODY))
+    page.route(_SESSION_DETAIL_RE, lambda r: _fulfill_json(r, _SESSION_BODY))
+    page.route(_HEALTH_RE, lambda r: _fulfill_json(r, _HEALTH_BODY))
+    page.route(
+        _STREAM_RE,
+        lambda r: r.fulfill(status=200, content_type="text/event-stream", body=_DONE_SSE),
+    )
+
+
+def test_claude_native_picker_shows_default_model_and_effort(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Fresh claude-native session shows Sonnet/Medium on trigger and dropdown."""
+    _register_stubbed_chat_routes(page)
+
+    page.goto(f"{live_server}/c/{_SESSION_ID}")
+
+    trigger = page.get_by_test_id("agent-picker-trigger")
+    expect(trigger).to_be_visible(timeout=30_000)
+    expect(trigger).to_contain_text("Sonnet")
+    expect(trigger).to_contain_text("Medium")
+    expect(trigger).not_to_contain_text("Claude")
+
+    trigger.click()
+
+    sonnet = page.locator('[data-testid="model-picker-item"][data-model-id="sonnet"]')
+    expect(sonnet).to_have_attribute("data-active", "true")
+    expect(sonnet.get_by_text("Current", exact=True)).to_be_visible()
+
+    medium = page.locator('[data-testid="effort-picker-item"][data-effort-level="medium"]')
+    expect(medium).to_have_attribute("data-active", "true")
+    expect(medium.get_by_text("Current", exact=True)).to_be_visible()


### PR DESCRIPTION
## Related issue

Closes #1463

## Summary

- Show the effective Claude native model and inherited/default effort on the composer picker trigger, even before the session snapshot has resolved `llm_model`.
- Mark the active model and effort rows in the picker dropdown with an explicit `Current` marker instead of relying only on background tint.
- Cover the fresh-session default path with unit tests and a browser e2e UI test.

## Test Plan

- `cd ap-web && npm run test -- src/pages/ChatPage.composer.test.tsx`
- `cd ap-web && npm run type-check`
- `cd ap-web && npm run build`
- `cd ap-web && npx prettier --check src/pages/ChatPage.tsx src/pages/ChatPage.composer.test.tsx`
- `uv run ruff format --check tests/e2e_ui/chat/test_composer_model_effort_picker.py`
- `uv run ruff check tests/e2e_ui/chat/test_composer_model_effort_picker.py`
- `uv run pytest tests/e2e_ui/chat/test_composer_model_effort_picker.py -q`
- `git diff --check`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new Playwright e2e stubs a fresh `claude-code-native-ui` session with no explicit model or reasoning-effort override and no resolved `llm_model`, then verifies the routed chat composer shows `Sonnet Medium` on the trigger and marks `Sonnet` / `medium` as `Current` in the dropdown.
