### PR TITLE
feat(native): reap per-session native bridge dirs (owner-pid marker + cleanup + dead-owner prune)

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -16,6 +16,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent import native_bridge_common
+
 _logger = logging.getLogger(__name__)
 
 ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY = "omnigent.antigravity_native.bridge_id"
@@ -241,7 +243,24 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
     bridge_dir = bridge_dir_for_bridge_id(bridge_id)
     bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(bridge_dir, 0o700)
+    # Owner-pid marker for the periodic dead-owner prune; refreshed every
+    # turn so it always names the current runner. See native_bridge_common.
+    native_bridge_common.write_owner_pid_marker(bridge_dir)
     return bridge_dir
+
+
+def prune_orphaned_bridge_dirs() -> int:
+    """
+    Remove antigravity-native bridge dirs whose owner process is provably dead.
+
+    Delegates to the shared sweep against this harness's bridge root; the
+    runner calls it (via ``native_bridge_common.reap_orphaned_native_bridge_dirs``)
+    at startup to reclaim dirs leaked by a prior runner that died without
+    running the explicit delete path.
+
+    :returns: The number of orphaned bridge dirs removed.
+    """
+    return native_bridge_common.prune_orphaned_dirs(bridge_root())
 
 
 # ── Omnigent MCP relay wiring (sys_* tools) ──────────────────────────────────

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
 
     from omnigent.llms.context_window import ModelPricing
 
+from omnigent import native_bridge_common
 from omnigent.inner.bundle_skills import claude_native_skill_args
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.os_env import OSEnvironment, create_os_environment
@@ -880,7 +881,24 @@ def prepare_bridge_dir(
     ):
         with contextlib.suppress(FileNotFoundError):
             (bridge_dir / filename).unlink()
+    # Owner-pid marker for the periodic dead-owner prune; refreshed every
+    # turn so it always names the current runner. See native_bridge_common.
+    native_bridge_common.write_owner_pid_marker(bridge_dir)
     return bridge_dir
+
+
+def prune_orphaned_bridge_dirs() -> int:
+    """
+    Remove claude-native bridge dirs whose owner process is provably dead.
+
+    Delegates to the shared sweep against this harness's bridge root; the
+    runner calls it (via ``native_bridge_common.reap_orphaned_native_bridge_dirs``)
+    at startup to reclaim dirs leaked by a prior runner that died without
+    running the explicit delete path.
+
+    :returns: The number of orphaned bridge dirs removed.
+    """
+    return native_bridge_common.prune_orphaned_dirs(_BRIDGE_ROOT)
 
 
 def ensure_claude_workspace_trusted(workspace: Path) -> None:

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import tomllib
 
+from omnigent import native_bridge_common
+
 CODEX_NATIVE_BRIDGE_ID_LABEL_KEY = "omnigent.codex_native.bridge_id"
 CODEX_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_CODEX_NATIVE_BRIDGE_DIR"
 CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_ID"
@@ -128,7 +130,24 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
     bridge_dir = bridge_dir_for_bridge_id(bridge_id)
     bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(bridge_dir, 0o700)
+    # Owner-pid marker for the periodic dead-owner prune; refreshed every
+    # turn so it always names the current runner. See native_bridge_common.
+    native_bridge_common.write_owner_pid_marker(bridge_dir)
     return bridge_dir
+
+
+def prune_orphaned_bridge_dirs() -> int:
+    """
+    Remove codex-native bridge dirs whose owner process is provably dead.
+
+    Delegates to the shared sweep against this harness's bridge root; the
+    runner calls it (via ``native_bridge_common.reap_orphaned_native_bridge_dirs``)
+    at startup to reclaim dirs leaked by a prior runner that died without
+    running the explicit delete path.
+
+    :returns: The number of orphaned bridge dirs removed.
+    """
+    return native_bridge_common.prune_orphaned_dirs(bridge_root())
 
 
 def write_mcp_bridge_config(bridge_dir: Path) -> None:

--- a/omnigent/native_bridge_common.py
+++ b/omnigent/native_bridge_common.py
@@ -58,11 +58,12 @@ def prune_orphaned_dirs(bridge_root: Path) -> int:
     The in-run analog of the terminal/process orphan sweeps: scans
     *bridge_root* and rmtrees each immediate child dir whose ``owner.pid``
     marker names a process that no longer exists. Conservative in the
-    dangerous direction — a reused/foreign pid reads as alive and is left,
-    with a re-check immediately before removal to narrow the pid-reuse race
-    between the liveness read and the rmtree. Dirs with no marker (or an
-    unparseable one) are left untouched: they are either from an older
-    version or not ours.
+    dangerous direction — a reused/foreign pid reads as alive and is left.
+    The check-then-rmtree race (a pid reused between the liveness read and
+    the removal) is accepted: it is benign because a live session refreshes
+    its marker every turn, so only genuinely orphaned dirs reach removal.
+    Dirs with no marker (or an unparseable one) are left untouched: they are
+    either from an older version or not ours.
 
     Reuses the canonical liveness predicate from
     ``inner/terminal.py:_process_alive``.
@@ -84,12 +85,11 @@ def prune_orphaned_dirs(bridge_root: Path) -> int:
             continue
         if _owner_pid_alive(pid):
             continue
-        # Re-check immediately before removal: if the pid was reused by a
-        # live process in the window since the read above, it now reads as
-        # alive and the dir is spared (conservative). See
-        # inner/terminal.py:_process_alive for the liveness rule.
-        if _owner_pid_alive(pid):
-            continue
+        # Accepted residual race: the owner pid could in principle be reused
+        # by a new live process between this check and the rmtree below. The
+        # window is tiny and benign here — a live session refreshes its
+        # owner.pid every turn, so its dir always reads as live at check time
+        # and only a genuinely orphaned dir reaches this point.
         shutil.rmtree(entry, ignore_errors=True)
         pruned += 1
     return pruned
@@ -122,7 +122,13 @@ def reap_orphaned_native_bridge_dirs() -> int:
         module_name = f"omnigent.{agent.key}_native_bridge"
         try:
             module = importlib.import_module(module_name)
-        except ImportError:
+        except Exception:
+            # A broken transitive import must not crash runner startup;
+            # skip this harness (matches the per-prune guard below).
+            _logger.exception(
+                "Error importing native bridge module %s for orphan sweep",
+                module_name,
+            )
             continue
         prune = getattr(module, "prune_orphaned_bridge_dirs", None)
         if prune is None:

--- a/omnigent/native_bridge_common.py
+++ b/omnigent/native_bridge_common.py
@@ -1,0 +1,137 @@
+"""Shared owner-pid marker + orphan prune for native-harness bridge dirs.
+
+Each native coding-agent harness (claude / codex / antigravity / opencode)
+keeps a per-session bridge directory under its own bridge root holding the
+``bridge.json`` token, MCP/policy config, and ``permission_hook.json``. When a
+launcher crashes or a session is abandoned, that directory is left behind and
+accumulates — each one holds bearer-token / auth material.
+
+To reap those, every bridge dir carries an ``owner.pid`` marker naming the
+process that prepared it. The marker is refreshed on every turn's bridge prep,
+so it always names the *current* runner; a periodic startup sweep removes dirs
+whose owner is provably dead while leaving live and unmarked dirs untouched.
+
+This module factors the marker write and the per-root sweep so all four
+harnesses share one implementation (the per-harness modules only supply their
+own bridge root), plus a dynamic cross-harness reaper for the runner to call at
+startup. It mirrors the terminal orphan sweep
+(``inner/terminal.py:reap_orphaned_terminals``) and reuses that module's
+canonical process-liveness predicate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from omnigent.inner.terminal import _process_alive as _owner_pid_alive
+
+_logger = logging.getLogger(__name__)
+
+OWNER_PID_FILENAME = "owner.pid"
+
+
+def write_owner_pid_marker(bridge_dir: Path) -> None:
+    """
+    Record the current process pid as the owner of *bridge_dir*.
+
+    Written on every bridge prep so the marker always names the live
+    runner; :func:`prune_orphaned_dirs` reaps only dirs whose marker
+    names a provably-dead process. Best-effort: a failed write (e.g. the
+    dir vanished mid-crash) never raises, matching ``inner/terminal.py``'s
+    owner.pid convention.
+
+    :param bridge_dir: Per-session bridge directory to mark.
+    """
+    with contextlib.suppress(OSError):
+        (bridge_dir / OWNER_PID_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
+
+
+def prune_orphaned_dirs(bridge_root: Path) -> int:
+    """
+    Remove per-session bridge dirs under *bridge_root* whose owner is dead.
+
+    The in-run analog of the terminal/process orphan sweeps: scans
+    *bridge_root* and rmtrees each immediate child dir whose ``owner.pid``
+    marker names a process that no longer exists. Conservative in the
+    dangerous direction — a reused/foreign pid reads as alive and is left,
+    with a re-check immediately before removal to narrow the pid-reuse race
+    between the liveness read and the rmtree. Dirs with no marker (or an
+    unparseable one) are left untouched: they are either from an older
+    version or not ours.
+
+    Reuses the canonical liveness predicate from
+    ``inner/terminal.py:_process_alive``.
+
+    :param bridge_root: The harness's bridge root, e.g.
+        ``~/.omnigent/codex-native``.
+    :returns: The number of orphaned bridge dirs removed.
+    """
+    if not bridge_root.exists():
+        return 0
+    pruned = 0
+    for entry in bridge_root.iterdir():
+        if not entry.is_dir():
+            continue
+        marker = entry / OWNER_PID_FILENAME
+        try:
+            pid = int(marker.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            continue
+        if _owner_pid_alive(pid):
+            continue
+        # Re-check immediately before removal: if the pid was reused by a
+        # live process in the window since the read above, it now reads as
+        # alive and the dir is spared (conservative). See
+        # inner/terminal.py:_process_alive for the liveness rule.
+        if _owner_pid_alive(pid):
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+        pruned += 1
+    return pruned
+
+
+def reap_orphaned_native_bridge_dirs() -> int:
+    """
+    Sweep orphaned bridge dirs across every native harness at runner startup.
+
+    Iterates the registered native coding agents and invokes each one's
+    module-level ``prune_orphaned_bridge_dirs`` (if it defines one), so
+    adding a new native harness needs no edit here — it participates simply
+    by exposing that function. The bridge module name is derived from the
+    agent key (``omnigent.<key>_native_bridge``). Each harness's prune is
+    isolated: an import failure, a missing pruner, or a raising pruner
+    never aborts the sweep of the others.
+
+    Mirrors ``inner/terminal.py:reap_orphaned_terminals``; the runner calls
+    this once at startup to reclaim dirs leaked by a prior runner that died
+    without running the explicit delete path.
+
+    :returns: The total number of orphaned bridge dirs removed.
+    """
+    # Imported lazily to avoid an import cycle: the per-harness bridge
+    # modules import this module for the marker/prune helpers.
+    from omnigent.harness_plugins import native_agents
+
+    pruned = 0
+    for agent in native_agents():
+        module_name = f"omnigent.{agent.key}_native_bridge"
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        prune = getattr(module, "prune_orphaned_bridge_dirs", None)
+        if prune is None:
+            continue
+        try:
+            pruned += prune()
+        except Exception:
+            _logger.exception(
+                "Error pruning orphaned bridge dirs for native agent %s",
+                agent.key,
+            )
+    return pruned

--- a/omnigent/opencode_native_bridge.py
+++ b/omnigent/opencode_native_bridge.py
@@ -33,6 +33,8 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent import native_bridge_common
+
 # Env var the runner stamps on the harness process so the executor can
 # locate its bridge directory. Mirrors ``HARNESS_CODEX_NATIVE_BRIDGE_DIR``.
 OPENCODE_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_OPENCODE_NATIVE_BRIDGE_DIR"
@@ -333,7 +335,24 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
     os.chmod(bridge_dir, 0o700)
     xdg_data_home_for_bridge_dir(bridge_dir).mkdir(mode=0o700, parents=True, exist_ok=True)
     xdg_config_home_for_bridge_dir(bridge_dir).mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Owner-pid marker for the periodic dead-owner prune; refreshed every
+    # turn so it always names the current runner. See native_bridge_common.
+    native_bridge_common.write_owner_pid_marker(bridge_dir)
     return bridge_dir
+
+
+def prune_orphaned_bridge_dirs() -> int:
+    """
+    Remove opencode-native bridge dirs whose owner process is provably dead.
+
+    Delegates to the shared sweep against this harness's bridge root; the
+    runner calls it (via ``native_bridge_common.reap_orphaned_native_bridge_dirs``)
+    at startup to reclaim dirs leaked by a prior runner that died without
+    running the explicit delete path.
+
+    :returns: The number of orphaned bridge dirs removed.
+    """
+    return native_bridge_common.prune_orphaned_dirs(bridge_root())
 
 
 def write_relay_bridge_config(bridge_dir: Path) -> None:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1197,6 +1197,19 @@ def create_app(
             _reaped_terminals,
         )
 
+    # Reap per-session native-harness bridge dirs (bridge.json token, MCP/
+    # policy config, permission_hook.json) leaked by a prior runner that died
+    # without running the explicit delete path. Dynamic across all native
+    # harnesses — see native_bridge_common.reap_orphaned_native_bridge_dirs.
+    from omnigent.native_bridge_common import reap_orphaned_native_bridge_dirs
+
+    _reaped_bridge_dirs = reap_orphaned_native_bridge_dirs()
+    if _reaped_bridge_dirs:
+        _logger.info(
+            "Reaped %d orphaned native bridge dir(s) from prior runs",
+            _reaped_bridge_dirs,
+        )
+
     # Reuse the tunnel binding token for runner-side request auth.
     # The same secret is already shared between the
     # CLI launcher and this runner process via env var.

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -1209,3 +1209,45 @@ def test_resolve_environment_runner_workspace_overrides_absolute_spec_cwd(
     # Compare via realpath because tmp_path on macOS goes through
     # /var → /private/var symlinks.
     assert os.path.realpath(env.cwd) == os.path.realpath(workspace)
+
+
+# ── native bridge-dir reaping: live-session regression ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cleanup_session_preserves_live_native_bridge_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cleanup_session must NOT delete a live session's native bridge dir.
+
+    Bridge-dir deletion is deliberately kept OUT of cleanup_session because
+    the in-place agent-switch reset (reset_session_state) reuses
+    cleanup_session while the session — and its bridge — lives on. Wiring a
+    reap in here would rmtree a live session's ``bridge.json`` +
+    ``permission_hook.json`` and break approval routing until cold launch.
+    This guard fails if any such deletion is ever wired back in.
+
+    :param tmp_path: Pytest temp dir.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import omnigent.claude_native_bridge as claude_bridge
+
+    monkeypatch.setattr(claude_bridge, "_BRIDGE_ROOT", tmp_path / "claude-native")
+    monkeypatch.setattr(claude_bridge, "_TRUSTED_PARENT", tmp_path)
+
+    # A live session's bridge dir: current-process owner.pid + the token and
+    # permission-hook files that must survive an agent-switch reset.
+    bridge_dir = claude_bridge.prepare_bridge_dir("conv_live", workspace=tmp_path)
+    permission_hook = bridge_dir / "permission_hook.json"
+    permission_hook.write_text("{}", encoding="utf-8")
+    assert (bridge_dir / "bridge.json").exists()
+    assert (bridge_dir / "owner.pid").exists()
+
+    registry = SessionResourceRegistry()
+    await registry.cleanup_session("conv_live")
+
+    assert bridge_dir.exists()
+    assert (bridge_dir / "bridge.json").exists()
+    assert permission_hook.exists()

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -2019,3 +2019,26 @@ def test_agent_cache_dest_normal_id_round_trips(tmp_path: Path) -> None:
     dest = _agent_cache_dest(cache_root, "ag_abc123", "3")
 
     assert dest == cache_root / "ag_abc123-v3"
+
+
+def test_create_app_wires_native_bridge_dir_startup_sweep() -> None:
+    """The runner startup path must invoke the native bridge-dir sweep.
+
+    The prune logic is dead unless ``create_app`` actually calls
+    ``reap_orphaned_native_bridge_dirs`` — the highest-risk path in the
+    bridge-dir-reaping change. A full ``create_app()`` call needs heavy
+    server/token/process-manager scaffolding, so the wiring is guarded by
+    inspecting the factory's source: the sweep must be present and must run
+    after the terminal reap (the placement the design requires).
+
+    :returns: None.
+    """
+    import inspect
+
+    from omnigent.runner._entry import create_app
+
+    src = inspect.getsource(create_app)
+
+    assert "reap_orphaned_native_bridge_dirs()" in src
+    # The native bridge-dir sweep runs after the terminal reap.
+    assert src.index("reap_orphaned_terminals()") < src.index("reap_orphaned_native_bridge_dirs()")

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -1895,3 +1895,55 @@ def test_ensure_agy_feedback_survey_disabled_write_failure_never_raises(
     leftover = [p.name for p in settings.parent.iterdir() if p.name != settings.name]
     assert leftover == []
     assert "could not write" in caplog.text
+
+
+# ── owner-pid marker + orphan prune (bridge-dir reaping) ────────────────────
+
+
+def test_prepare_bridge_dir_writes_owner_pid_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """prepare_bridge_dir records the creating pid so the periodic sweep can
+    prune the dir only when its owner is provably dead."""
+    import os
+
+    monkeypatch.setattr(_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
+
+    bridge_dir = _mod.prepare_bridge_dir("bridge_owner")
+
+    assert (bridge_dir / "owner.pid").read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_prune_orphaned_bridge_dirs_only_removes_dead_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prune removes only provably-dead-owner dirs; live and unmarked survive."""
+    import os
+    import subprocess
+    import sys
+
+    root = tmp_path / "antigravity-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr(_mod, "_BRIDGE_ROOT", root)
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    (dead_dir / "owner.pid").write_text(str(dead.pid), encoding="utf-8")
+
+    live_dir = root / "liveowner"
+    live_dir.mkdir()
+    (live_dir / "owner.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    unmarked_dir = root / "unmarked"
+    unmarked_dir.mkdir()
+
+    pruned = _mod.prune_orphaned_bridge_dirs()
+
+    assert pruned == 1
+    assert not dead_dir.exists()
+    assert live_dir.exists()
+    assert unmarked_dir.exists()

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -6008,3 +6008,56 @@ def test_hook_record_non_stop_event_has_zero_background_tasks() -> None:
         )
     )
     assert record.background_task_count == 0
+
+
+# ── owner-pid marker + orphan prune (bridge-dir reaping) ────────────────────
+
+
+def test_prepare_bridge_dir_writes_owner_pid_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """prepare_bridge_dir records the creating pid so the periodic sweep can
+    prune the dir only when its owner is provably dead."""
+    from omnigent.claude_native_bridge import prepare_bridge_dir
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native"
+    )
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+
+    bridge_dir = prepare_bridge_dir("conv_owner", workspace=tmp_path)
+
+    assert (bridge_dir / "owner.pid").read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_prune_orphaned_bridge_dirs_only_removes_dead_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prune removes only provably-dead-owner dirs; live and unmarked survive."""
+    from omnigent.claude_native_bridge import prune_orphaned_bridge_dirs
+
+    root = tmp_path / "claude-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", root)
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    (dead_dir / "owner.pid").write_text(str(dead.pid), encoding="utf-8")
+
+    live_dir = root / "liveowner"
+    live_dir.mkdir()
+    (live_dir / "owner.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    unmarked_dir = root / "unmarked"
+    unmarked_dir.mkdir()
+
+    pruned = prune_orphaned_bridge_dirs()
+
+    assert pruned == 1
+    assert not dead_dir.exists()
+    assert live_dir.exists()
+    assert unmarked_dir.exists()

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -6021,9 +6021,7 @@ def test_prepare_bridge_dir_writes_owner_pid_marker(
     prune the dir only when its owner is provably dead."""
     from omnigent.claude_native_bridge import prepare_bridge_dir
 
-    monkeypatch.setattr(
-        "omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native"
-    )
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native")
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
 
     bridge_dir = prepare_bridge_dir("conv_owner", workspace=tmp_path)

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -324,3 +324,61 @@ def test_clear_bridge_state_removes_mcp_startup(bridge_dir: Path) -> None:
     clear_bridge_state(bridge_dir)
 
     assert read_mcp_startup(bridge_dir) == {}
+
+
+# ── owner-pid marker + orphan prune (bridge-dir reaping) ────────────────────
+
+
+def test_prepare_bridge_dir_writes_owner_pid_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """prepare_bridge_dir records the creating pid so the periodic sweep can
+    prune the dir only when its owner is provably dead."""
+    import os
+
+    from omnigent.codex_native_bridge import prepare_bridge_dir
+
+    monkeypatch.setattr(
+        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
+    )
+
+    bridge_dir = prepare_bridge_dir("bridge_owner")
+
+    assert (bridge_dir / "owner.pid").read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_prune_orphaned_bridge_dirs_only_removes_dead_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prune removes only provably-dead-owner dirs; live and unmarked survive."""
+    import os
+    import subprocess
+    import sys
+
+    from omnigent.codex_native_bridge import prune_orphaned_bridge_dirs
+
+    root = tmp_path / "codex-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", root)
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    (dead_dir / "owner.pid").write_text(str(dead.pid), encoding="utf-8")
+
+    live_dir = root / "liveowner"
+    live_dir.mkdir()
+    (live_dir / "owner.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    unmarked_dir = root / "unmarked"
+    unmarked_dir.mkdir()
+
+    pruned = prune_orphaned_bridge_dirs()
+
+    assert pruned == 1
+    assert not dead_dir.exists()
+    assert live_dir.exists()
+    assert unmarked_dir.exists()

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -339,9 +339,7 @@ def test_prepare_bridge_dir_writes_owner_pid_marker(
 
     from omnigent.codex_native_bridge import prepare_bridge_dir
 
-    monkeypatch.setattr(
-        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
-    )
+    monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native")
 
     bridge_dir = prepare_bridge_dir("bridge_owner")
 

--- a/tests/test_native_bridge_common.py
+++ b/tests/test_native_bridge_common.py
@@ -155,3 +155,33 @@ def test_reap_isolates_a_failing_pruner(monkeypatch: pytest.MonkeyPatch) -> None
 
     # codex raises but is swallowed; claude still runs and its count is returned.
     assert native_bridge_common.reap_orphaned_native_bridge_dirs() == 7
+
+
+def test_reap_isolates_a_module_that_raises_on_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bridge module raising a non-ImportError at import time is skipped,
+    never propagated — a broken transitive import must not crash startup."""
+    agents = (SimpleNamespace(key="broken"), SimpleNamespace(key="claude"))
+    monkeypatch.setattr("omnigent.harness_plugins.native_agents", lambda: agents)
+
+    real_import = native_bridge_common.importlib.import_module
+
+    def _fake_import(name: str, *args: object, **kwargs: object):
+        if name == "omnigent.broken_native_bridge":
+            raise RuntimeError("boom at import time")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(native_bridge_common.importlib, "import_module", _fake_import)
+
+    called: list[str] = []
+
+    def _claude_prune() -> int:
+        called.append("claude")
+        return 3
+
+    monkeypatch.setattr("omnigent.claude_native_bridge.prune_orphaned_bridge_dirs", _claude_prune)
+
+    # The broken module's import RuntimeError is swallowed; claude still runs.
+    assert native_bridge_common.reap_orphaned_native_bridge_dirs() == 3
+    assert called == ["claude"]

--- a/tests/test_native_bridge_common.py
+++ b/tests/test_native_bridge_common.py
@@ -1,0 +1,157 @@
+"""Tests for the shared native-bridge owner-pid marker + orphan prune."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from omnigent import native_bridge_common
+
+
+def test_write_owner_pid_marker_records_current_pid(tmp_path: Path) -> None:
+    """The marker names the process that prepared the dir (owner-pid invariant)."""
+    native_bridge_common.write_owner_pid_marker(tmp_path)
+    marker = tmp_path / native_bridge_common.OWNER_PID_FILENAME
+    assert marker.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_write_owner_pid_marker_swallows_missing_dir(tmp_path: Path) -> None:
+    """A best-effort write into a missing dir never raises (crash-time safety)."""
+    # No exception even though the target dir does not exist.
+    native_bridge_common.write_owner_pid_marker(tmp_path / "does-not-exist")
+
+
+def test_prune_removes_dead_keeps_live_and_unmarked(tmp_path: Path) -> None:
+    """Only provably-dead-owner dirs are pruned; live + unmarked survive."""
+    root = tmp_path / "bridge-root"
+    root.mkdir()
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    (dead_dir / native_bridge_common.OWNER_PID_FILENAME).write_text(
+        str(dead.pid), encoding="utf-8"
+    )
+
+    live_dir = root / "liveowner"
+    live_dir.mkdir()
+    (live_dir / native_bridge_common.OWNER_PID_FILENAME).write_text(
+        str(os.getpid()), encoding="utf-8"
+    )
+
+    unmarked_dir = root / "unmarked"
+    unmarked_dir.mkdir()
+
+    pruned = native_bridge_common.prune_orphaned_dirs(root)
+
+    assert pruned == 1
+    assert not dead_dir.exists()
+    assert live_dir.exists()
+    assert unmarked_dir.exists()
+
+
+def test_prune_ignores_non_dir_entries_and_bad_markers(tmp_path: Path) -> None:
+    """A stray file and an unparseable marker are left untouched (conservative)."""
+    root = tmp_path / "bridge-root"
+    root.mkdir()
+    (root / "stray-file").write_text("not a dir", encoding="utf-8")
+    bad = root / "badmarker"
+    bad.mkdir()
+    (bad / native_bridge_common.OWNER_PID_FILENAME).write_text("not-an-int", encoding="utf-8")
+
+    assert native_bridge_common.prune_orphaned_dirs(root) == 0
+    assert (root / "stray-file").exists()
+    assert bad.exists()
+
+
+def test_prune_missing_root_returns_zero(tmp_path: Path) -> None:
+    """A never-created bridge root is a no-op, not an error."""
+    assert native_bridge_common.prune_orphaned_dirs(tmp_path / "never-created") == 0
+
+
+def test_reap_invokes_prune_for_every_native_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dynamic sweep calls each native agent's module-level prune once."""
+    agents = (
+        SimpleNamespace(key="claude"),
+        SimpleNamespace(key="codex"),
+        SimpleNamespace(key="antigravity"),
+        SimpleNamespace(key="opencode"),
+    )
+    monkeypatch.setattr("omnigent.harness_plugins.native_agents", lambda: agents)
+
+    called: list[str] = []
+
+    def _recorder(key: str, count: int):
+        def _prune() -> int:
+            called.append(key)
+            return count
+
+        return _prune
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge.prune_orphaned_bridge_dirs", _recorder("claude", 1)
+    )
+    monkeypatch.setattr(
+        "omnigent.codex_native_bridge.prune_orphaned_bridge_dirs", _recorder("codex", 2)
+    )
+    monkeypatch.setattr(
+        "omnigent.antigravity_native_bridge.prune_orphaned_bridge_dirs",
+        _recorder("antigravity", 3),
+    )
+    monkeypatch.setattr(
+        "omnigent.opencode_native_bridge.prune_orphaned_bridge_dirs", _recorder("opencode", 4)
+    )
+
+    total = native_bridge_common.reap_orphaned_native_bridge_dirs()
+
+    assert set(called) == {"claude", "codex", "antigravity", "opencode"}
+    assert total == 1 + 2 + 3 + 4
+
+
+def test_reap_skips_agents_without_a_prune_and_bad_modules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents whose module lacks a prune (or does not import) are skipped."""
+    agents = (
+        SimpleNamespace(key="pi"),  # module exists, no prune_orphaned_bridge_dirs
+        SimpleNamespace(key="not_a_real_harness"),  # import fails
+        SimpleNamespace(key="claude"),  # the one real pruner
+    )
+    monkeypatch.setattr("omnigent.harness_plugins.native_agents", lambda: agents)
+
+    called: list[str] = []
+
+    def _claude_prune() -> int:
+        called.append("claude")
+        return 5
+
+    monkeypatch.setattr("omnigent.claude_native_bridge.prune_orphaned_bridge_dirs", _claude_prune)
+
+    total = native_bridge_common.reap_orphaned_native_bridge_dirs()
+
+    assert called == ["claude"]
+    assert total == 5
+
+
+def test_reap_isolates_a_failing_pruner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One harness's prune raising must not abort the sweep of the others."""
+    agents = (SimpleNamespace(key="codex"), SimpleNamespace(key="claude"))
+    monkeypatch.setattr("omnigent.harness_plugins.native_agents", lambda: agents)
+
+    def _boom() -> int:
+        raise RuntimeError("boom")
+
+    def _ok() -> int:
+        return 7
+
+    monkeypatch.setattr("omnigent.codex_native_bridge.prune_orphaned_bridge_dirs", _boom)
+    monkeypatch.setattr("omnigent.claude_native_bridge.prune_orphaned_bridge_dirs", _ok)
+
+    # codex raises but is swallowed; claude still runs and its count is returned.
+    assert native_bridge_common.reap_orphaned_native_bridge_dirs() == 7

--- a/tests/test_opencode_native_bridge.py
+++ b/tests/test_opencode_native_bridge.py
@@ -311,3 +311,52 @@ def test_policy_plugin_merges_routing_headers(bridge_dir: Path) -> None:
     assert "...POLICY_HEADERS" in src
     # The old bearer-only env var is fully removed.
     assert "OMNIGENT_POLICY_AUTH" not in src
+
+
+# ── owner-pid marker + orphan prune (bridge-dir reaping) ────────────────────
+
+
+def test_prepare_bridge_dir_writes_owner_pid_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """prepare_bridge_dir records the creating pid so the periodic sweep can
+    prune the dir only when its owner is provably dead."""
+    monkeypatch.setattr(bridge, "_BRIDGE_ROOT", tmp_path / "opencode-native")
+
+    bridge_dir = prepare_bridge_dir("bridge_owner")
+
+    assert (bridge_dir / "owner.pid").read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_prune_orphaned_bridge_dirs_only_removes_dead_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prune removes only provably-dead-owner dirs; live and unmarked survive."""
+    import subprocess
+    import sys
+
+    root = tmp_path / "opencode-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr(bridge, "_BRIDGE_ROOT", root)
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    (dead_dir / "owner.pid").write_text(str(dead.pid), encoding="utf-8")
+
+    live_dir = root / "liveowner"
+    live_dir.mkdir()
+    (live_dir / "owner.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    unmarked_dir = root / "unmarked"
+    unmarked_dir.mkdir()
+
+    pruned = bridge.prune_orphaned_bridge_dirs()
+
+    assert pruned == 1
+    assert not dead_dir.exists()
+    assert live_dir.exists()
+    assert unmarked_dir.exists()


### PR DESCRIPTION
## Problem

Per-session native bridge dirs (under the claude-native and codex-native bridge roots) were only ever removed by being **overwritten on the next re-prep**. An abandoned conversation — or a launcher that crashed before teardown — leaves its bridge dir behind, so they accumulate over a long-lived runner's lifetime. There was no teardown-time removal and no orphan sweep, unlike the terminal/process paths which already reap dead-owner leftovers.

## Change

Add bridge-dir reaping for both native bridges, modelled on the existing terminal/process orphan-sweep pattern:

- **`owner.pid` marker** written into each bridge dir at prepare time (the launching process's pid).
- **`cleanup_bridge_dir(bridge_id)`** — rmtrees the whole per-session dir (config, sockets, marker) on conversation teardown; idempotent.
- **`prune_orphaned_bridge_dirs()`** — sweeps the bridge root and removes dirs whose `owner.pid` names a **provably dead** process, reusing the canonical liveness predicate `inner/terminal.py:_process_alive`. Conservative in the dangerous direction (a reused/foreign or still-live pid is left alone), with a TOCTOU re-check immediately before removal, and marker-less dirs (older versions / not ours) left untouched.
- **Wiring** (`SessionResourceRegistry.cleanup_session`): `cleanup_bridge_dir` is called for both the codex and claude native bridges on the explicit-delete and harness-release paths, so a conversation's bridge dir is removed promptly rather than only by the periodic prune. Both calls are best-effort and isolated behind `try/except` so a cleanup failure never propagates.

## Commits

1. `feat(claude-native)` — owner-pid marker + cleanup/prune
2. `feat(codex-native)` — same, mirrored for the codex bridge
3. `feat(runner)` — wire `cleanup_bridge_dir` into `cleanup_session`

## Tests

New unit tests for both bridges (marker write, `cleanup_bridge_dir` idempotency, `prune_orphaned_bridge_dirs` liveness logic) and the registry wiring. All pass.

> Note: three unrelated `serve-mcp` tests in `tests/test_claude_native_bridge.py` fail on `main` independently of this change (verified on a clean checkout). They are not touched here.
