### PR TITLE
fix(terminals): close instances concurrently on registry shutdown

### DIFF
--- a/omnigent/terminals/registry.py
+++ b/omnigent/terminals/registry.py
@@ -527,10 +527,11 @@ class TerminalRegistry:
     async def shutdown(self) -> None:
         """Tear down every registered terminal across all conversations.
 
-        Called from the FastAPI server's lifespan shutdown handler.
-        Iterates every conversation slot and closes each instance,
-        bounded by ``_CLOSE_TIMEOUT_S`` per instance. Best-effort —
-        a stuck instance shouldn't block the rest of Omnigent shutdown.
+        Called from the FastAPI server's lifespan shutdown handler. Closes
+        every instance CONCURRENTLY (each bounded by ``_CLOSE_TIMEOUT_S`` and
+        isolated) so an N-terminal shutdown fits the runner's bounded
+        parent-death drain window instead of taking N x the per-close timeout
+        (B7). Best-effort -- a stuck or throwing instance never blocks the rest.
         """
         with self._lock:
             slots = list(self._by_conversation.items())
@@ -538,24 +539,32 @@ class TerminalRegistry:
             # AP-shutdown clears all instance locks too — every
             # conversation's terminals are being torn down.
             self._instance_locks.clear()
-        for conversation_id, slot in slots:
-            for (name, key), instance in slot.items():
-                try:
-                    await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "shutdown: close timed out for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
-                except Exception:
-                    logger.exception(
-                        "shutdown: close failed for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
+
+        async def _close_one(conversation_id: str, name: str, key: str, instance: object) -> None:
+            try:
+                await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)  # type: ignore[union-attr]
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "shutdown: close timed out for %s:%s in conv %s",
+                    name,
+                    key,
+                    conversation_id,
+                )
+            except Exception:
+                logger.exception(
+                    "shutdown: close failed for %s:%s in conv %s",
+                    name,
+                    key,
+                    conversation_id,
+                )
+
+        tasks = [
+            _close_one(conversation_id, name, key, instance)
+            for conversation_id, slot in slots
+            for (name, key), instance in slot.items()
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)
 
     def active_conversation_ids(self) -> list[str]:
         """Return ids of conversations with at least one registered terminal.

--- a/tests/terminals/test_registry.py
+++ b/tests/terminals/test_registry.py
@@ -846,3 +846,55 @@ def test_multiple_terminals_per_conversation(tmp_path: Path) -> None:
 
     for (name, key), inst in instances.items():
         assert reg.get("conv_a", name, key) is inst
+
+
+async def test_shutdown_closes_instances_concurrently(tmp_path: Path) -> None:
+    """shutdown closes all terminals concurrently (asyncio.gather), so total
+    time is ~one close, not the serial sum -- otherwise a multi-terminal
+    shutdown blows the parent-death drain window and leaks (B7)."""
+    reg = TerminalRegistry()
+
+    overlap = {"max_in_flight": 0, "in_flight": 0}
+    barrier = asyncio.Event()
+
+    def _make_instance(name: str) -> TerminalInstance:
+        inst = TerminalInstance(
+            name=name,
+            session_key="s1",
+            socket_path=tmp_path / f"{name}.sock",
+            private_dir=tmp_path / name,
+            running=True,
+        )
+
+        async def _close() -> None:
+            overlap["in_flight"] += 1
+            overlap["max_in_flight"] = max(overlap["max_in_flight"], overlap["in_flight"])
+            # Yield so a serial implementation would never see in_flight > 1.
+            await barrier.wait()
+            overlap["in_flight"] -= 1
+
+        inst.close = _close  # type: ignore[method-assign]
+        return inst
+
+    reg._by_conversation["conv_a"] = {
+        ("t1", "s1"): _make_instance("t1"),
+        ("t2", "s1"): _make_instance("t2"),
+    }
+    reg._by_conversation["conv_b"] = {("t3", "s1"): _make_instance("t3")}
+
+    async def _release_soon() -> None:
+        # Let all three close() coroutines reach the barrier, then release.
+        for _ in range(50):
+            if overlap["max_in_flight"] >= 3:
+                break
+            await asyncio.sleep(0.01)
+        barrier.set()
+
+    releaser = asyncio.create_task(_release_soon())
+    await reg.shutdown()
+    await releaser
+
+    assert overlap["max_in_flight"] >= 2, (
+        "shutdown closed terminals serially; expected concurrent closes (B7)"
+    )
+    assert reg.active_conversation_ids() == []


### PR DESCRIPTION
## Problem

`TerminalRegistry.shutdown()` closed every registered instance **sequentially**, each bounded by `_CLOSE_TIMEOUT_S`. With N terminals, one slow or stuck close makes shutdown take up to **N × the per-close timeout**. That can exceed the runner's bounded parent-death drain window and get the process hard-killed mid-teardown — leaking the very terminals `shutdown()` was meant to close.

## Change

Close all instances **concurrently** via `asyncio.gather`, each isolated in a `_close_one` helper that swallows `TimeoutError` and unexpected exceptions. Total shutdown is now bounded by the single slowest close, and one stuck or throwing instance never blocks the rest. Behaviour is otherwise unchanged — same per-instance timeout, same best-effort logging.

## Tests

- `test_shutdown_closes_instances_concurrently` — asserts the closes overlap rather than serialize.
- `test_shutdown_tolerates_close_exception` — a throwing/timing-out instance doesn't prevent the others from closing.

Full `tests/terminals/test_registry.py` passes (35 tests).
