### PR TITLE
fix(openai-agents): tolerate empty SSE keepalive frames

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -343,10 +343,50 @@ class _ModelInputData(Protocol):
     input: list[ReplayItem]
 
 
+def _patch_openai_sse_keepalive_tolerance() -> None:
+    """Tolerate empty SSE keepalive frames from OpenAI-compatible proxies.
+
+    Some OpenAI-compatible proxies and relays (for example cli-proxy-api) keep
+    long streaming responses alive by periodically emitting an *empty* ``data:``
+    frame rather than an SSE comment. The stock openai client then calls
+    ``json.loads("")`` on that frame and raises ``Expecting value: line 1
+    column 1 (char 0)``, which aborts the whole turn with
+    ``Error streaming response: ...``.
+
+    SSE *comment* keepalives (``: ping``) are already ignored by the decoder;
+    this shim extends the same tolerance to empty-``data`` keepalives by
+    dropping any decoded event whose payload is blank, so a single keepalive no
+    longer kills a long-running streamed response. Best-effort and idempotent:
+    if the openai internals change shape it silently no-ops.
+    """
+    try:
+        from openai import _streaming as _oai_streaming
+    except Exception:  # noqa: BLE001 - openai internals are best-effort.
+        return
+
+    decoder = getattr(_oai_streaming, "SSEDecoder", None)
+    if decoder is None or getattr(decoder, "_omnigent_keepalive_patch", False):
+        return
+
+    _orig_decode = decoder.decode
+
+    def decode(self: Any, line: str) -> Any:  # type: ignore[explicit-any]
+        sse = _orig_decode(self, line)
+        if sse is not None and not (getattr(sse, "data", None) or "").strip():
+            # Empty-data keepalive frame: drop it so the client never calls
+            # json.loads("") on a blank payload mid-stream.
+            return None
+        return sse
+
+    decoder.decode = decode  # type: ignore[method-assign]
+    decoder._omnigent_keepalive_patch = True  # type: ignore[attr-defined]
+
+
 def _ensure_agents_sdk() -> ModuleType:
     try:
         import agents
 
+        _patch_openai_sse_keepalive_tolerance()
         return agents
     except ImportError as exc:
         raise ImportError(


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `N/A123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

Running the `openai-agents` harness against an OpenAI-compatible proxy/relay (for example cli-proxy-api) can abort a long streamed turn with:

```
OpenAIAgentsSDKExecutor: run failed: Error streaming response: Expecting value: line 1 column 1 (char 0)
```

Such relays keep long responses alive by periodically emitting an **empty `data:`** SSE keepalive frame. The stock `openai` client surfaces it as a `ServerSentEvent` with `data == ""`, and `ServerSentEvent.json()` then runs `json.loads("")`, which raises mid-stream and kills the whole turn. Short turns (< keepalive interval) never hit it; only longer ones do. SSE *comment* keepalives (`: ping`) are already ignored by the decoder — empty-`data` ones are not.

This adds a small, idempotent, best-effort shim `_patch_openai_sse_keepalive_tolerance()` (installed from `_ensure_agents_sdk()`) that wraps `openai._streaming.SSEDecoder.decode` so any decoded event with a blank `data` payload is dropped before it can reach `json.loads`. If the openai internals change shape it silently no-ops.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- Verified against the installed `openai` client that `SSEDecoder.decode(self, line) -> ServerSentEvent | None` and that `ServerSentEvent.json()` calls `json.loads(self.data)` — so returning `None` for empty-`data` frames means they never reach the failing parse.
- Repro: a long (> keepalive interval) `openai-agents` turn routed through a relay that emits periodic SSE keepalives — crashes on `main`, completes with the shim.
- `python -m py_compile` passes; the shim is guarded (`try/except` + `getattr`) and idempotent.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

Manually reproduced the failing → passing case by routing a long `openai-agents` turn through cli-proxy-api with streaming keepalives enabled. No automated test was added because doing so would couple the suite to openai's private `_streaming` internals; the shim is intentionally defensive/best-effort and no-ops if those internals change.
