### PR TITLE
Standalone reusable MCP servers: CRUD + connection verify + select when creating agents

### DIFF
--- a/ap-web/src/lib/mcpApi.ts
+++ b/ap-web/src/lib/mcpApi.ts
@@ -1,0 +1,158 @@
+/**
+ * Client for standalone, owner-scoped MCP servers (`/v1/mcp-servers`).
+ *
+ * Standalone MCP servers are reusable connections the user registers once
+ * (and can verify — connect + list tools) and then selects when creating
+ * an agent, instead of re-typing url/headers into every create-agent form.
+ *
+ * Secret-bearing fields (`headers`, `env`) are sent on write but never
+ * returned by the server — list/get responses expose only the keys
+ * (`header_keys` / `env_keys`).
+ */
+
+import { authenticatedFetch } from "@/lib/identity";
+
+/** TanStack Query key for the caller's standalone MCP servers. */
+export const MY_MCP_SERVERS_QUERY_KEY = ["my-mcp-servers"] as const;
+
+/** Safe wire shape of a stored MCP server (no secret values). */
+export interface McpServerObject {
+  id: string;
+  name: string;
+  transport: "http" | "stdio";
+  description: string | null;
+  url: string | null;
+  command: string | null;
+  args: string[];
+  header_keys: string[];
+  env_keys: string[];
+  created_at: number;
+  updated_at: number | null;
+}
+
+/** Body for creating or updating a standalone MCP server. */
+export interface McpServerInput {
+  name: string;
+  transport: "http" | "stdio";
+  description?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/** One tool discovered on an MCP server. */
+export interface McpToolInfo {
+  name: string;
+  description: string | null;
+}
+
+/** Result of a connection verify. */
+export interface McpVerifyResult {
+  ok: boolean;
+  tools: McpToolInfo[];
+  error: string | null;
+}
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: { message?: string }; detail?: unknown };
+    if (body?.error?.message) return body.error.message;
+    if (typeof body?.detail === "string") return body.detail;
+  } catch {
+    // Non-JSON body — fall through to the generic message.
+  }
+  return fallback;
+}
+
+/** List the caller's standalone MCP servers. */
+export async function listMyMcpServers(): Promise<McpServerObject[]> {
+  const res = await authenticatedFetch("/v1/mcp-servers/mine");
+  if (!res.ok) throw new Error(await readError(res, `${res.status} ${res.statusText}`));
+  const body = (await res.json()) as { data: McpServerObject[] };
+  return body.data;
+}
+
+/** Register a new standalone MCP server. */
+export async function createMcpServer(input: McpServerInput): Promise<McpServerObject> {
+  const res = await authenticatedFetch("/v1/mcp-servers", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error(await readError(res, "Failed to create MCP server"));
+  return (await res.json()) as McpServerObject;
+}
+
+/** Replace a standalone MCP server. */
+export async function updateMcpServer(
+  id: string,
+  input: McpServerInput,
+): Promise<McpServerObject> {
+  const res = await authenticatedFetch(`/v1/mcp-servers/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error(await readError(res, "Failed to update MCP server"));
+  return (await res.json()) as McpServerObject;
+}
+
+/** Delete a standalone MCP server. */
+export async function deleteMcpServer(id: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/mcp-servers/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok && res.status !== 404) {
+    throw new Error(await readError(res, "Failed to delete MCP server"));
+  }
+}
+
+/** Full config of a stored server, including secret values (owner only). */
+export interface McpServerFullConfig {
+  id: string;
+  name: string;
+  transport: "http" | "stdio";
+  description: string | null;
+  url: string | null;
+  headers: Record<string, string>;
+  command: string | null;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/**
+ * Fetch a stored server's full config *with* secrets (owner only).
+ *
+ * Used by the create-agent flow to bake a selected preconfigured server
+ * into a new agent bundle — the bundle is built client-side, so the secret
+ * values must be retrievable here (same trust boundary as typing them into
+ * the create-agent form).
+ */
+export async function getMcpServerConfig(id: string): Promise<McpServerFullConfig> {
+  const res = await authenticatedFetch(`/v1/mcp-servers/${encodeURIComponent(id)}/config`);
+  if (!res.ok) throw new Error(await readError(res, "Failed to load MCP server config"));
+  return (await res.json()) as McpServerFullConfig;
+}
+
+/** Verify an ad-hoc MCP config (before saving): connect + list tools. */
+export async function verifyMcpServer(input: McpServerInput): Promise<McpVerifyResult> {
+  const res = await authenticatedFetch("/v1/mcp-servers/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error(await readError(res, "Failed to verify MCP server"));
+  return (await res.json()) as McpVerifyResult;
+}
+
+/** Verify a stored MCP server by id using its saved (secret) config. */
+export async function verifySavedMcpServer(id: string): Promise<McpVerifyResult> {
+  const res = await authenticatedFetch(
+    `/v1/mcp-servers/${encodeURIComponent(id)}/verify`,
+    { method: "POST" },
+  );
+  if (!res.ok) throw new Error(await readError(res, "Failed to verify MCP server"));
+  return (await res.json()) as McpVerifyResult;
+}

--- a/ap-web/src/shell/CreateAgentDialog.tsx
+++ b/ap-web/src/shell/CreateAgentDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { PlusIcon, TrashIcon } from "lucide-react";
 import {
   Dialog,
@@ -18,6 +19,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { BRAIN_HARNESS_LABELS } from "@/lib/agentLabels";
+import { showToast } from "@/components/ui/toast";
+import {
+  MY_MCP_SERVERS_QUERY_KEY,
+  getMcpServerConfig,
+  listMyMcpServers,
+  type McpServerFullConfig,
+} from "@/lib/mcpApi";
 import type { AgentBundleInput, MCPServerInput } from "@/lib/agentBundle";
 
 /**
@@ -104,6 +112,25 @@ function toMCPInputs(entries: MCPFormEntry[]): MCPServerInput[] | undefined {
   return result.length > 0 ? result : undefined;
 }
 
+/** Convert a stored MCP server's full config to the bundle input shape. */
+function fullConfigToMCPInput(config: McpServerFullConfig): MCPServerInput {
+  if (config.transport === "stdio") {
+    return {
+      name: config.name,
+      transport: "stdio",
+      command: config.command ?? "",
+      args: config.args,
+      env: Object.keys(config.env).length > 0 ? config.env : undefined,
+    };
+  }
+  return {
+    name: config.name,
+    transport: "http",
+    url: config.url ?? "",
+    headers: Object.keys(config.headers).length > 0 ? config.headers : undefined,
+  };
+}
+
 /**
  * Dialog for creating a custom agent from the new-session picker.
  *
@@ -128,6 +155,15 @@ export function CreateAgentDialog({
   const [model, setModel] = useState("");
   const [mcpEntries, setMcpEntries] = useState<MCPFormEntry[]>([]);
   const [nextKey, setNextKey] = useState(0);
+  const [selectedMcpIds, setSelectedMcpIds] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+
+  // The caller's preconfigured MCP servers, selectable instead of typed.
+  const mcpServersQuery = useQuery({
+    queryKey: MY_MCP_SERVERS_QUERY_KEY,
+    queryFn: listMyMcpServers,
+    enabled: open,
+  });
 
   function reset() {
     setName("");
@@ -137,6 +173,16 @@ export function CreateAgentDialog({
     setModel("");
     setMcpEntries([]);
     setNextKey(0);
+    setSelectedMcpIds(new Set());
+  }
+
+  function toggleSelectedMcp(id: string) {
+    setSelectedMcpIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   }
 
   function handleOpenChange(next: boolean) {
@@ -157,23 +203,46 @@ export function CreateAgentDialog({
     setMcpEntries((prev) => prev.map((e) => (e.key === key ? { ...e, ...patch } : e)));
   }
 
-  function handleSubmit() {
+  async function handleSubmit() {
     const trimmedName = name.trim();
     if (!trimmedName) return;
 
-    onCreate({
-      name: trimmedName,
-      description: description.trim() || undefined,
-      instructions: instructions.trim() || undefined,
-      harness,
-      model: model.trim(),
-      mcpServers: toMCPInputs(mcpEntries),
-    });
-    reset();
-    onOpenChange(false);
+    setSubmitting(true);
+    try {
+      // Resolve selected preconfigured servers (incl. secrets) and merge
+      // with the manually-entered rows. A manual entry with the same name
+      // wins, so the inline form can override a preconfigured server.
+      let preconfigured: MCPServerInput[] = [];
+      if (selectedMcpIds.size > 0) {
+        const configs = await Promise.all(
+          Array.from(selectedMcpIds).map(getMcpServerConfig),
+        );
+        preconfigured = configs.map(fullConfigToMCPInput);
+      }
+      const manual = toMCPInputs(mcpEntries) ?? [];
+      const manualNames = new Set(manual.map((m) => m.name));
+      const merged = [...preconfigured.filter((p) => !manualNames.has(p.name)), ...manual];
+
+      onCreate({
+        name: trimmedName,
+        description: description.trim() || undefined,
+        instructions: instructions.trim() || undefined,
+        harness,
+        model: model.trim(),
+        mcpServers: merged.length > 0 ? merged : undefined,
+      });
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      showToast(
+        `Could not load selected MCP servers: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
   }
 
-  const canSubmit = name.trim().length > 0 && model.trim().length > 0;
+  const canSubmit = name.trim().length > 0 && model.trim().length > 0 && !submitting;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -275,6 +344,36 @@ export function CreateAgentDialog({
             />
           </div>
 
+          {/* Preconfigured MCP servers — select from the user's registered
+          servers instead of re-typing url/headers. */}
+          {(mcpServersQuery.data?.length ?? 0) > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-muted-foreground">
+                Preconfigured MCP servers
+              </span>
+              <div className="flex flex-col gap-1 rounded-md border border-border p-2">
+                {mcpServersQuery.data?.map((server) => (
+                  <label
+                    key={server.id}
+                    className="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-sm hover:bg-muted"
+                    data-testid="create-agent-preconfigured-mcp"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedMcpIds.has(server.id)}
+                      onChange={() => toggleSelectedMcp(server.id)}
+                      className="size-3.5 accent-primary"
+                    />
+                    <span className="truncate">{server.name}</span>
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                      {server.transport}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* MCP Servers */}
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
@@ -306,7 +405,11 @@ export function CreateAgentDialog({
           <Button variant="ghost" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
-          <Button data-testid="create-agent-submit" onClick={handleSubmit} disabled={!canSubmit}>
+          <Button
+            data-testid="create-agent-submit"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+          >
             Create
           </Button>
         </DialogFooter>

--- a/ap-web/src/shell/ManageMcpServersDialog.tsx
+++ b/ap-web/src/shell/ManageMcpServersDialog.tsx
@@ -1,0 +1,408 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CheckCircle2Icon, Loader2Icon, PlugIcon, TrashIcon, XCircleIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { showToast } from "@/components/ui/toast";
+import {
+  MY_MCP_SERVERS_QUERY_KEY,
+  createMcpServer,
+  deleteMcpServer,
+  listMyMcpServers,
+  verifyMcpServer,
+  verifySavedMcpServer,
+  type McpServerInput,
+  type McpServerObject,
+  type McpVerifyResult,
+} from "@/lib/mcpApi";
+
+/** Parse "KEY=VAL" lines into a Record (undefined when empty). */
+function parseKVLines(text: string): Record<string, string> | undefined {
+  const result: Record<string, string> = {};
+  for (const line of text.split("\n").map((l) => l.trim()).filter(Boolean)) {
+    const eq = line.indexOf("=");
+    if (eq > 0) result[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+interface FormState {
+  name: string;
+  transport: "http" | "stdio";
+  url: string;
+  headers: string;
+  command: string;
+  args: string;
+  env: string;
+}
+
+const EMPTY_FORM: FormState = {
+  name: "",
+  transport: "http",
+  url: "",
+  headers: "",
+  command: "",
+  args: "",
+  env: "",
+};
+
+/** Build the API write body from the add-form state (null if incomplete). */
+function formToInput(form: FormState): McpServerInput | null {
+  const name = form.name.trim();
+  if (!name) return null;
+  if (form.transport === "http") {
+    const url = form.url.trim();
+    if (!url) return null;
+    return { name, transport: "http", url, headers: parseKVLines(form.headers) };
+  }
+  const command = form.command.trim();
+  if (!command) return null;
+  return {
+    name,
+    transport: "stdio",
+    command,
+    args: form.args.split(/\s+/).map((a) => a.trim()).filter(Boolean),
+    env: parseKVLines(form.env),
+  };
+}
+
+/**
+ * Sidebar dialog to manage standalone, reusable MCP servers: list, add a
+ * remote server, verify a connection (showing the tool list), and delete.
+ * Decoupled from any session — these are registered once and selected when
+ * creating agents.
+ */
+export function ManageMcpServersDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const serversQuery = useQuery({
+    queryKey: MY_MCP_SERVERS_QUERY_KEY,
+    queryFn: listMyMcpServers,
+    enabled: open,
+  });
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  // Verify state keyed by server id, or "new" for the add-form draft.
+  const [verifyResults, setVerifyResults] = useState<Record<string, McpVerifyResult>>({});
+  const [verifying, setVerifying] = useState<string | null>(null);
+
+  function patchForm(patch: Partial<FormState>) {
+    setForm((prev) => ({ ...prev, ...patch }));
+  }
+
+  const createMutation = useMutation({
+    mutationFn: createMcpServer,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: MY_MCP_SERVERS_QUERY_KEY });
+      setForm(EMPTY_FORM);
+      setVerifyResults((prev) => {
+        const next = { ...prev };
+        delete next.new;
+        return next;
+      });
+      showToast("MCP server added");
+    },
+    onError: (err: unknown) => {
+      showToast(`Could not add MCP server: ${err instanceof Error ? err.message : String(err)}`);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteMcpServer,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: MY_MCP_SERVERS_QUERY_KEY });
+    },
+    onError: (err: unknown) => {
+      showToast(
+        `Could not delete MCP server: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    },
+  });
+
+  async function runVerify(key: string, fn: () => Promise<McpVerifyResult>) {
+    setVerifying(key);
+    try {
+      const result = await fn();
+      setVerifyResults((prev) => ({ ...prev, [key]: result }));
+    } catch (err) {
+      setVerifyResults((prev) => ({
+        ...prev,
+        [key]: {
+          ok: false,
+          tools: [],
+          error: err instanceof Error ? err.message : String(err),
+        },
+      }));
+    } finally {
+      setVerifying(null);
+    }
+  }
+
+  const draftInput = formToInput(form);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setForm(EMPTY_FORM);
+      setVerifyResults({});
+    }
+    onOpenChange(next);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        data-testid="manage-mcp-dialog"
+        className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
+      >
+        <DialogHeader>
+          <DialogTitle>MCP servers</DialogTitle>
+          <DialogDescription>
+            Reusable connections to Model Context Protocol servers. Verify a connection to see
+            its tools, then select it when creating an agent.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+          {/* Existing servers */}
+          <div className="flex flex-col gap-2">
+            {serversQuery.isLoading ? (
+              <p className="text-xs text-muted-foreground">Loading…</p>
+            ) : (serversQuery.data?.length ?? 0) === 0 ? (
+              <p className="text-xs text-muted-foreground">No MCP servers yet.</p>
+            ) : (
+              serversQuery.data?.map((server) => (
+                <ServerRow
+                  key={server.id}
+                  server={server}
+                  verifyResult={verifyResults[server.id]}
+                  verifying={verifying === server.id}
+                  onVerify={() =>
+                    runVerify(server.id, () => verifySavedMcpServer(server.id))
+                  }
+                  onDelete={() => deleteMutation.mutate(server.id)}
+                  deleting={deleteMutation.isPending && deleteMutation.variables === server.id}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Add a server */}
+          <div className="flex flex-col gap-2 rounded-md border border-border p-3">
+            <span className="text-xs font-medium text-muted-foreground">Add a server</span>
+            <div className="flex items-center gap-2">
+              <Input
+                data-testid="mcp-add-name"
+                value={form.name}
+                onChange={(e) => patchForm({ name: e.target.value })}
+                placeholder="server-name"
+                className="flex-1"
+              />
+              <Select
+                value={form.transport}
+                onValueChange={(v: "http" | "stdio") => patchForm({ transport: v })}
+              >
+                <SelectTrigger data-testid="mcp-add-transport" className="w-24">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="http">http</SelectItem>
+                  <SelectItem value="stdio">stdio</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {form.transport === "http" ? (
+              <>
+                <Input
+                  data-testid="mcp-add-url"
+                  value={form.url}
+                  onChange={(e) => patchForm({ url: e.target.value })}
+                  placeholder="https://mcp.example.com/sse"
+                />
+                <Textarea
+                  data-testid="mcp-add-headers"
+                  value={form.headers}
+                  onChange={(e) => patchForm({ headers: e.target.value })}
+                  placeholder={"HTTP headers (KEY=VALUE per line)\ne.g. Authorization=Bearer tok_..."}
+                  className="min-h-[60px] font-mono text-xs"
+                />
+              </>
+            ) : (
+              <>
+                <Input
+                  data-testid="mcp-add-command"
+                  value={form.command}
+                  onChange={(e) => patchForm({ command: e.target.value })}
+                  placeholder="command (e.g. npx)"
+                />
+                <Input
+                  data-testid="mcp-add-args"
+                  value={form.args}
+                  onChange={(e) => patchForm({ args: e.target.value })}
+                  placeholder="args (e.g. -y @modelcontextprotocol/server-github)"
+                />
+                <Textarea
+                  data-testid="mcp-add-env"
+                  value={form.env}
+                  onChange={(e) => patchForm({ env: e.target.value })}
+                  placeholder={"Environment variables (KEY=VALUE per line)"}
+                  className="min-h-[60px] font-mono text-xs"
+                />
+              </>
+            )}
+
+            {verifyResults.new && <VerifyBadge result={verifyResults.new} />}
+
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                data-testid="mcp-add-verify"
+                disabled={!draftInput || verifying === "new"}
+                onClick={() => {
+                  if (draftInput) void runVerify("new", () => verifyMcpServer(draftInput));
+                }}
+              >
+                {verifying === "new" ? (
+                  <Loader2Icon className="size-3.5 animate-spin" />
+                ) : (
+                  <PlugIcon className="size-3.5" />
+                )}
+                Verify
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                data-testid="mcp-add-save"
+                disabled={!draftInput || createMutation.isPending}
+                onClick={() => {
+                  if (draftInput) createMutation.mutate(draftInput);
+                }}
+              >
+                Add server
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** A row for one existing MCP server with verify + delete controls. */
+function ServerRow({
+  server,
+  verifyResult,
+  verifying,
+  onVerify,
+  onDelete,
+  deleting,
+}: {
+  server: McpServerObject;
+  verifyResult: McpVerifyResult | undefined;
+  verifying: boolean;
+  onVerify: () => void;
+  onDelete: () => void;
+  deleting: boolean;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-md border border-border p-3"
+      data-testid="mcp-server-row"
+    >
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium">{server.name}</span>
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              {server.transport}
+            </span>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            {server.transport === "http"
+              ? server.url
+              : [server.command, ...server.args].filter(Boolean).join(" ")}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="mcp-server-verify"
+          disabled={verifying}
+          onClick={onVerify}
+        >
+          {verifying ? (
+            <Loader2Icon className="size-3.5 animate-spin" />
+          ) : (
+            <PlugIcon className="size-3.5" />
+          )}
+          Verify
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          data-testid="mcp-server-delete"
+          disabled={deleting}
+          onClick={onDelete}
+          className="size-7 text-muted-foreground hover:text-destructive"
+        >
+          <TrashIcon className="size-3.5" />
+        </Button>
+      </div>
+      {verifyResult && <VerifyBadge result={verifyResult} />}
+    </div>
+  );
+}
+
+/** Inline connection-status badge: error message or the discovered tools. */
+function VerifyBadge({ result }: { result: McpVerifyResult }) {
+  if (!result.ok) {
+    return (
+      <div className="flex items-start gap-1.5 rounded bg-destructive/10 p-2 text-xs text-destructive">
+        <XCircleIcon className="mt-0.5 size-3.5 shrink-0" />
+        <span className="break-words">{result.error ?? "Connection failed"}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-1 rounded bg-emerald-500/10 p-2 text-xs">
+      <div className="flex items-center gap-1.5 font-medium text-emerald-600 dark:text-emerald-400">
+        <CheckCircle2Icon className="size-3.5" />
+        Connected — {result.tools.length} tool{result.tools.length === 1 ? "" : "s"}
+      </div>
+      {result.tools.length > 0 && (
+        <ul className="flex flex-col gap-0.5 pl-5 text-muted-foreground">
+          {result.tools.map((tool) => (
+            <li key={tool.name} className="truncate">
+              <span className="font-mono text-foreground">{tool.name}</span>
+              {tool.description ? ` — ${tool.description}` : ""}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
   PencilIcon,
   PinIcon,
   PinOffIcon,
+  PlugIcon,
   PlusIcon,
   SearchIcon,
   SettingsIcon,
@@ -95,6 +96,7 @@ import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
 import { absoluteTime, relativeTime } from "@/lib/relativeTime";
+import { ManageMcpServersDialog } from "./ManageMcpServersDialog";
 import { SettingsSidebarBody, useSettingsRoute } from "./settingsNav";
 import {
   type ActiveChatOverride,
@@ -185,6 +187,7 @@ function showArchivedToast() {
 export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+  const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
   const [pinnedConversationIds, setPinnedConversationIds] = useState(readPinnedConversationIds);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -289,6 +292,7 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   const effectiveOpen = open || dragging;
 
   return (
+    <>
     <aside
       aria-label="Conversations"
       className={cn(
@@ -444,6 +448,17 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
                 New session
               </Link>
             </Button>
+            {/* Manage reusable MCP servers, decoupled from any session. */}
+            <Button
+              type="button"
+              variant="ghost"
+              className="mt-1 w-full justify-start gap-2 text-sm"
+              data-testid="manage-mcp-button"
+              onClick={() => setMcpDialogOpen(true)}
+            >
+              <PlugIcon className="size-4 text-muted-foreground" />
+              MCP servers
+            </Button>
             {selectionMode ? (
               <BulkActionBar
                 selectedIds={selectedIds}
@@ -552,6 +567,8 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
         </>
       )}
     </aside>
+    <ManageMcpServersDialog open={mcpDialogOpen} onOpenChange={setMcpDialogOpen} />
+    </>
   );
 }
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2999,6 +2999,7 @@ def server(
     # with "unable to open database file".
     _ensure_sqlite_parent_dir(db_uri)
 
+    from omnigent.stores.mcp_server_store.sqlalchemy_store import SqlAlchemyMcpServerStore
     from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
 
     agent_store = SqlAlchemyAgentStore(db_uri)
@@ -3007,6 +3008,7 @@ def server(
     comment_store = SqlAlchemyCommentStore(db_uri)
     policy_store = SqlAlchemyPolicyStore(db_uri)
     permission_store = SqlAlchemyPermissionStore(db_uri)
+    mcp_server_store = SqlAlchemyMcpServerStore(db_uri)
     artifact_store = _create_artifact_store(art_loc)
 
     # Initialize the runtime with store references so workflow code
@@ -3154,6 +3156,7 @@ def server(
         runner_tunnel_tokens=_runner_tunnel_tokens,
         permission_store=permission_store,
         auth_provider=auth_provider,
+        mcp_server_store=mcp_server_store,
         host_store=host_store,
         account_store=account_store,
         policy_modules=cfg.get("policy_modules"),

--- a/omnigent/db/converters.py
+++ b/omnigent/db/converters.py
@@ -2,8 +2,49 @@
 
 from __future__ import annotations
 
-from omnigent.db.db_models import SqlAgent
-from omnigent.entities import Agent
+import json
+
+from omnigent.db.db_models import SqlAgent, SqlMcpServer
+from omnigent.entities import Agent, McpServer
+
+
+def _loads_dict(raw: str | None) -> dict[str, str]:
+    """Decode a JSON object column to a ``dict[str, str]`` (``{}`` if null)."""
+    if not raw:
+        return {}
+    value = json.loads(raw)
+    return {str(k): str(v) for k, v in value.items()} if isinstance(value, dict) else {}
+
+
+def _loads_list(raw: str | None) -> list[str]:
+    """Decode a JSON array column to a ``list[str]`` (``[]`` if null)."""
+    if not raw:
+        return []
+    value = json.loads(raw)
+    return [str(v) for v in value] if isinstance(value, list) else []
+
+
+def sql_mcp_server_to_entity(row: SqlMcpServer) -> McpServer:
+    """
+    Convert a :class:`SqlMcpServer` ORM row to an :class:`McpServer`.
+
+    :param row: The SQLAlchemy ORM row to convert.
+    :returns: An :class:`McpServer` dataclass instance.
+    """
+    return McpServer(
+        id=row.id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        owner=row.owner,
+        name=row.name,
+        transport=row.transport,
+        url=row.url,
+        headers=_loads_dict(row.headers_json),
+        command=row.command,
+        args=_loads_list(row.args_json),
+        env=_loads_dict(row.env_json),
+        description=row.description,
+    )
 
 
 def sql_agent_to_entity(row: SqlAgent) -> Agent:

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -77,6 +77,56 @@ class SqlAgent(Base):
     )
 
 
+class SqlMcpServer(Base):
+    """
+    SQLAlchemy model for the ``mcp_servers`` table.
+
+    Each row is a reusable, owner-scoped MCP server connection. Unlike
+    the per-agent MCP declarations baked into agent bundles, these are
+    registered once and referenced when creating agents.
+
+    Secret-bearing ``headers`` and ``env`` are stored as JSON text
+    (``headers_json`` / ``env_json``); ``args`` likewise. They are never
+    returned verbatim by the API — only their keys.
+
+    :param id: Unique identifier, e.g. ``"mcp_0f1a2b3c..."``.
+    :param created_at: Unix epoch seconds when the row was created.
+    :param updated_at: Unix epoch seconds of the last update, or ``None``.
+    :param owner: Owning user id. ``None`` only for legacy/global rows.
+    :param name: Server name, unique per owner.
+    :param transport: ``"http"`` or ``"stdio"``.
+    :param url: HTTP endpoint for http transport, else ``None``.
+    :param headers_json: JSON-encoded dict of HTTP headers, or ``None``.
+    :param command: Executable for stdio transport, else ``None``.
+    :param args_json: JSON-encoded list of stdio args, or ``None``.
+    :param env_json: JSON-encoded dict of stdio env vars, or ``None``.
+    :param description: Optional free-text description.
+    """
+
+    __tablename__ = "mcp_servers"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    created_at: Mapped[int] = mapped_column(Integer)
+    updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    owner: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    name: Mapped[str] = mapped_column(String(256))
+    transport: Mapped[str] = mapped_column(String(16))
+    url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    headers_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    command: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    args_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    env_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("ix_mcp_servers_created_at", "created_at"),
+        Index("ix_mcp_servers_owner", "owner"),
+        # One server name per owner. Owner-scoped uniqueness so two
+        # different users may each register a server named "litellm".
+        Index("ix_mcp_servers_owner_name", "owner", "name", unique=True),
+    )
+
+
 class SqlFile(Base):
     """
     SQLAlchemy model for the ``files`` table.

--- a/omnigent/db/migrations/versions/p1a2b3c4d5e6_add_mcp_servers_table.py
+++ b/omnigent/db/migrations/versions/p1a2b3c4d5e6_add_mcp_servers_table.py
@@ -1,0 +1,66 @@
+"""add mcp_servers table
+
+Revision ID: p1a2b3c4d5e6
+Revises: n1a2b3c4d5e6
+Create Date: 2026-06-26 00:00:00.000000
+
+Creates the ``mcp_servers`` table backing standalone, owner-scoped MCP
+server configs. These are reusable connections a user registers once
+and references when creating agents (and can verify — connect + list
+tools — before saving).
+
+Secret-bearing ``headers`` and ``env`` are stored JSON-encoded
+alongside ``args``; the API never returns their values, only their keys.
+Uniqueness is per-owner (``ix_mcp_servers_owner_name``) so two users may
+each register a server under the same name.
+
+NOTE: this revision chains off ``n1a2b3c4d5e6``. If the standalone-agents
+migration (``o1a2b3c4d5e6``) is also present in a deployment, re-point one
+of the two ``down_revision``s so the chain stays linear (single head).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "p1a2b3c4d5e6"
+down_revision: str | None = "n1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_servers",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.Integer(), nullable=True),
+        sa.Column("owner", sa.String(length=256), nullable=True),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("transport", sa.String(length=16), nullable=False),
+        sa.Column("url", sa.String(length=2048), nullable=True),
+        sa.Column("headers_json", sa.Text(), nullable=True),
+        sa.Column("command", sa.String(length=1024), nullable=True),
+        sa.Column("args_json", sa.Text(), nullable=True),
+        sa.Column("env_json", sa.Text(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_mcp_servers_created_at", "mcp_servers", ["created_at"])
+    op.create_index("ix_mcp_servers_owner", "mcp_servers", ["owner"])
+    op.create_index(
+        "ix_mcp_servers_owner_name",
+        "mcp_servers",
+        ["owner", "name"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mcp_servers_owner_name", table_name="mcp_servers")
+    op.drop_index("ix_mcp_servers_owner", table_name="mcp_servers")
+    op.drop_index("ix_mcp_servers_created_at", table_name="mcp_servers")
+    op.drop_table("mcp_servers")

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -24,6 +24,7 @@ from omnigent.entities.conversation import (
     synthesize_conversation_title,
 )
 from omnigent.entities.file import StoredFile
+from omnigent.entities.mcp_server import McpServer
 from omnigent.entities.pagination import PagedList
 from omnigent.entities.permission import ResolvedAccess, SessionPermission
 from omnigent.entities.policy import Policy
@@ -51,6 +52,7 @@ __all__ = [
     "FunctionCallOutputData",
     "ItemData",
     "LoadedAgent",
+    "McpServer",
     "MessageData",
     "NativeToolData",
     "NewConversationItem",

--- a/omnigent/entities/mcp_server.py
+++ b/omnigent/entities/mcp_server.py
@@ -1,0 +1,48 @@
+"""MCP server entity — a reusable, owner-scoped MCP server config.
+
+A standalone MCP server is registered once by a user and reused across
+agents: instead of re-typing url/headers into every create-agent form,
+the user picks from their preconfigured servers. Each row is owned by a
+single user (``owner``) and carries the full connection config — including
+secret-bearing ``headers``/``env`` — so it can both be verified
+(connect + list tools) and baked into an agent bundle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class McpServer:
+    """A reusable MCP server connection owned by one user.
+
+    :param id: Unique identifier, e.g. ``"mcp_0f1a2b3c..."``.
+    :param created_at: Unix epoch seconds when the server was created.
+    :param name: User-facing server name, unique per owner,
+        e.g. ``"litellm"``.
+    :param transport: Transport type — ``"http"`` or ``"stdio"``.
+    :param owner: Owning user id, e.g. ``"alice@example.com"``. The
+        reserved ``"local"`` sentinel in single-user mode.
+    :param url: HTTP(S) endpoint for ``transport="http"`` servers.
+    :param headers: HTTP headers (e.g. ``Authorization``) for http
+        servers. Secret-bearing — never returned verbatim by the API.
+    :param command: Executable for ``transport="stdio"`` servers.
+    :param args: Command-line arguments for stdio servers.
+    :param env: Environment variables for stdio servers. Secret-bearing.
+    :param description: Optional free-text description.
+    :param updated_at: Unix epoch seconds of the last update, or ``None``.
+    """
+
+    id: str
+    created_at: int
+    name: str
+    transport: str
+    owner: str | None = None
+    url: str | None = None
+    headers: dict[str, str] = field(default_factory=dict, repr=False)
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict, repr=False)
+    description: str | None = None
+    updated_at: int | None = None

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -53,6 +53,7 @@ from omnigent.server.performance_metrics import (
 from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
+from omnigent.server.routes.mcp_servers import create_mcp_servers_router
 from omnigent.server.routes.policy_registry import create_policy_registry_router
 from omnigent.server.routes.runner_tunnel import create_runner_tunnel_router
 from omnigent.server.routes.session_mcp_servers import create_session_mcp_servers_router
@@ -69,6 +70,7 @@ from omnigent.stores import (
     ArtifactStore,
     ConversationStore,
     FileStore,
+    McpServerStore,
 )
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.conversation_store import SessionConnectivity
@@ -975,6 +977,7 @@ def create_app(
     policy_store: PolicyStore | None = None,
     permission_store: PermissionStore | None = None,
     auth_provider: AuthProvider | None = None,
+    mcp_server_store: McpServerStore | None = None,
     host_store: HostStore | None = None,
     account_store: Any | None = None,  # SqlAlchemyAccountStore — accounts mode only
     extra_routers: list[tuple[Any, str, list[str]]] | None = None,
@@ -1800,6 +1803,17 @@ def create_app(
         prefix="/v1",
         tags=["agents"],
     )
+    # Standalone, owner-scoped MCP servers: reusable connections a user
+    # registers once (and can verify) then selects when creating agents.
+    if mcp_server_store is not None:
+        app.include_router(
+            create_mcp_servers_router(
+                mcp_server_store,
+                auth_provider=auth_provider,
+            ),
+            prefix="/v1",
+            tags=["mcp-servers"],
+        )
     app.include_router(
         create_terminal_attach_router(
             auth_provider=auth_provider,

--- a/omnigent/server/routes/mcp_servers.py
+++ b/omnigent/server/routes/mcp_servers.py
@@ -1,0 +1,377 @@
+"""Routes for standalone, owner-scoped MCP servers (``/v1/mcp-servers``).
+
+Standalone MCP servers are reusable connections a user registers once and
+references when creating agents — instead of re-typing url/headers into
+every create-agent form. This router exposes owner-scoped CRUD plus a
+**verify** endpoint that actually connects to the server and returns its
+tool list, so the user can confirm a connection (and see what it offers)
+before saving or selecting it.
+
+Mounted with ``prefix="/v1"`` → final paths are ``/v1/mcp-servers*``.
+
+Security notes:
+- ``headers``/``env`` are secret-bearing. They are accepted on write and
+  used for verify/agent-baking, but never returned verbatim — responses
+  expose only the *keys* (``header_keys`` / ``env_keys``).
+- Verify connects from the server to an operator-supplied URL (same
+  posture as the existing server-side MCP pool). In a hardened
+  multi-tenant deployment this warrants an egress allowlist / SSRF guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from typing import Any, Literal
+
+from fastapi import APIRouter, Request, Response, status
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from omnigent.entities import McpServer
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
+from omnigent.server.routes._auth_helpers import get_user_id, require_user
+from omnigent.spec.types import MCPServerConfig
+from omnigent.stores.mcp_server_store import McpServerStore
+
+_logger = logging.getLogger(__name__)
+
+# Same name shape as session MCP servers (schemas._MCP_SERVER_NAME_RE):
+# safe as a YAML filename and tool-namespace prefix.
+_MCP_SERVER_NAME_RE = r"^[A-Za-z0-9_-][A-Za-z0-9_.-]{0,127}$"
+
+# Hard cap on the verify connect so a hung/slow server can't pin a worker.
+_VERIFY_TIMEOUT_S = 25.0
+
+
+class _MCPFields(BaseModel):
+    """Shared transport-shape validation for MCP write/verify bodies."""
+
+    transport: Literal["http", "stdio"]
+    url: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+    command: str | None = None
+    args: list[str] = Field(default_factory=list, max_length=64)
+    env: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_transport_fields(self) -> _MCPFields:
+        """Enforce the same transport shape as the agent spec parser."""
+        if self.transport == "http":
+            if not self.url:
+                raise ValueError("url is required when transport is 'http'")
+            if not (self.url.startswith("http://") or self.url.startswith("https://")):
+                raise ValueError("url must start with http:// or https://")
+            if self.command:
+                raise ValueError("command is not allowed when transport is 'http'")
+            if self.args:
+                raise ValueError("args are not allowed when transport is 'http'")
+        if self.transport == "stdio":
+            if not self.command:
+                raise ValueError("command is required when transport is 'stdio'")
+            if self.url:
+                raise ValueError("url is not allowed when transport is 'stdio'")
+        return self
+
+
+class MCPServerWriteRequest(_MCPFields):
+    """Body for creating or updating a standalone MCP server."""
+
+    name: str = Field(min_length=1, max_length=128, pattern=_MCP_SERVER_NAME_RE)
+    description: str | None = Field(default=None, max_length=512)
+
+    @field_validator("name")
+    @classmethod
+    def _reject_dot_names(cls, value: str) -> str:
+        """Reject names that would make unsafe YAML filenames."""
+        if value in {".", ".."}:
+            raise ValueError("name cannot be '.' or '..'")
+        return value
+
+
+class MCPVerifyRequest(_MCPFields):
+    """Body for an ad-hoc connection verify (name optional)."""
+
+    name: str | None = Field(default=None, max_length=128)
+    timeout: int | None = Field(default=None, ge=1, le=120)
+
+
+class MCPToolInfo(BaseModel):
+    """One tool discovered on an MCP server."""
+
+    name: str
+    description: str | None = None
+
+
+class MCPVerifyResponse(BaseModel):
+    """Result of a connection verify: ``ok`` + the discovered tools."""
+
+    ok: bool
+    tools: list[MCPToolInfo] = Field(default_factory=list)
+    error: str | None = None
+
+
+class MCPServerObject(BaseModel):
+    """Safe wire shape of a stored MCP server (no secret values)."""
+
+    id: str
+    name: str
+    transport: str
+    description: str | None = None
+    url: str | None = None
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    header_keys: list[str] = Field(default_factory=list)
+    env_keys: list[str] = Field(default_factory=list)
+    created_at: int
+    updated_at: int | None = None
+
+
+def _to_object(server: McpServer) -> MCPServerObject:
+    """Project an :class:`McpServer` to its secret-free API shape."""
+    return MCPServerObject(
+        id=server.id,
+        name=server.name,
+        transport=server.transport,
+        description=server.description,
+        url=server.url,
+        command=server.command,
+        args=list(server.args),
+        header_keys=sorted(server.headers),
+        env_keys=sorted(server.env),
+        created_at=server.created_at,
+        updated_at=server.updated_at,
+    )
+
+
+class MCPServerFullConfig(BaseModel):
+    """Full config of a stored server, *including* secret values.
+
+    Returned only to the owner, only via the explicit ``/config`` route.
+    The create-agent flow uses it to bake a selected preconfigured server
+    into a new agent bundle (which the browser builds client-side and
+    uploads) — the same trust boundary as typing the secrets into the
+    create-agent form directly.
+    """
+
+    id: str
+    name: str
+    transport: str
+    description: str | None = None
+    url: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+
+
+def _to_full_config(server: McpServer) -> MCPServerFullConfig:
+    """Project an :class:`McpServer` to its full (secret-bearing) shape."""
+    return MCPServerFullConfig(
+        id=server.id,
+        name=server.name,
+        transport=server.transport,
+        description=server.description,
+        url=server.url,
+        headers=dict(server.headers),
+        command=server.command,
+        args=list(server.args),
+        env=dict(server.env),
+    )
+
+
+async def _verify_config(config: MCPServerConfig) -> MCPVerifyResponse:
+    """Connect to an MCP server and return its tools (or the error)."""
+    # Imported lazily: pulls the MCP client stack, which the route module
+    # otherwise wouldn't need at import time.
+    from omnigent.tools.mcp import McpServerConnection
+
+    conn = McpServerConnection(config=config)
+    try:
+        tools = await asyncio.wait_for(conn.connect(), timeout=_VERIFY_TIMEOUT_S)
+        return MCPVerifyResponse(
+            ok=True,
+            tools=[
+                MCPToolInfo(name=t.name, description=getattr(t, "description", None))
+                for t in tools
+            ],
+        )
+    except TimeoutError:
+        return MCPVerifyResponse(
+            ok=False, error=f"Connection timed out after {int(_VERIFY_TIMEOUT_S)}s"
+        )
+    except Exception as exc:  # noqa: BLE001 — surface any connect failure to the user
+        return MCPVerifyResponse(ok=False, error=f"{type(exc).__name__}: {exc}")
+    finally:
+        try:
+            await conn.close()
+        except Exception:  # noqa: BLE001 — best-effort teardown
+            _logger.debug("MCP verify connection close failed", exc_info=True)
+
+
+def _config_from_fields(fields: _MCPFields, name: str, timeout: int | None) -> MCPServerConfig:
+    """Build an :class:`MCPServerConfig` from a validated request body."""
+    if fields.transport == "http":
+        return MCPServerConfig(
+            name=name,
+            transport="http",
+            url=fields.url,
+            headers=dict(fields.headers),
+            timeout=timeout,
+        )
+    return MCPServerConfig(
+        name=name,
+        transport="stdio",
+        command=fields.command,
+        args=list(fields.args),
+        env=dict(fields.env),
+        timeout=timeout,
+    )
+
+
+def create_mcp_servers_router(
+    mcp_server_store: McpServerStore,
+    *,
+    auth_provider: AuthProvider | None = None,
+) -> APIRouter:
+    """Build the standalone MCP servers router (owner-scoped CRUD + verify).
+
+    :param mcp_server_store: Persistence for standalone MCP servers.
+    :param auth_provider: Optional auth provider; when set the caller
+        must be authenticated and rows are scoped to their identity.
+    :returns: A FastAPI router mounted under ``/v1``.
+    """
+    router = APIRouter()
+
+    def _owner(request: Request) -> str:
+        """Resolve the caller's owner key (``"local"`` in single-user)."""
+        return get_user_id(request, auth_provider) or RESERVED_USER_LOCAL
+
+    async def _owned(request: Request, server_id: str) -> McpServer:
+        """Fetch a server the caller owns, else 404 (hides others' rows)."""
+        owner = _owner(request)
+        server = await asyncio.to_thread(mcp_server_store.get, server_id)
+        if server is None or server.owner != owner:
+            raise OmnigentError("MCP server not found", code=ErrorCode.NOT_FOUND)
+        return server
+
+    # ── Static paths before /{server_id} so they aren't captured by it ──
+
+    @router.get("/mcp-servers/mine")
+    async def list_my_mcp_servers(request: Request) -> dict[str, Any]:
+        """List the caller's standalone MCP servers (no secret values)."""
+        require_user(request, auth_provider)
+        owner = _owner(request)
+        servers = await asyncio.to_thread(mcp_server_store.list_for_owner, owner)
+        return {"object": "list", "data": [_to_object(s).model_dump() for s in servers]}
+
+    @router.post("/mcp-servers/verify")
+    async def verify_mcp_server(request: Request, body: MCPVerifyRequest) -> MCPVerifyResponse:
+        """Connect to an ad-hoc MCP config and return its tool list."""
+        require_user(request, auth_provider)
+        config = _config_from_fields(body, body.name or "verify", body.timeout)
+        return await _verify_config(config)
+
+    @router.post("/mcp-servers", status_code=status.HTTP_201_CREATED)
+    async def create_mcp_server(
+        request: Request, body: MCPServerWriteRequest
+    ) -> MCPServerObject:
+        """Register a new standalone MCP server for the caller."""
+        require_user(request, auth_provider)
+        owner = _owner(request)
+        existing = await asyncio.to_thread(mcp_server_store.get_by_name, owner, body.name)
+        if existing is not None:
+            raise OmnigentError(
+                f"MCP server {body.name!r} already exists",
+                code=ErrorCode.CONFLICT,
+            )
+        server_id = f"mcp_{secrets.token_hex(12)}"
+        created = await asyncio.to_thread(
+            mcp_server_store.create,
+            server_id,
+            owner,
+            body.name,
+            body.transport,
+            url=body.url,
+            headers=body.headers,
+            command=body.command,
+            args=body.args,
+            env=body.env,
+            description=body.description,
+        )
+        return _to_object(created)
+
+    @router.get("/mcp-servers/{server_id}")
+    async def get_mcp_server(request: Request, server_id: str) -> MCPServerObject:
+        """Fetch one of the caller's MCP servers (no secret values)."""
+        require_user(request, auth_provider)
+        return _to_object(await _owned(request, server_id))
+
+    @router.get("/mcp-servers/{server_id}/config")
+    async def get_mcp_server_config(request: Request, server_id: str) -> MCPServerFullConfig:
+        """Fetch a server's full config *with* secrets (owner only).
+
+        Used by the create-agent flow to bake a selected preconfigured
+        server into a new agent bundle. 404 hides servers the caller
+        doesn't own.
+        """
+        require_user(request, auth_provider)
+        return _to_full_config(await _owned(request, server_id))
+
+    @router.put("/mcp-servers/{server_id}")
+    async def update_mcp_server(
+        request: Request, server_id: str, body: MCPServerWriteRequest
+    ) -> MCPServerObject:
+        """Replace one of the caller's MCP servers."""
+        require_user(request, auth_provider)
+        owner = _owner(request)
+        server = await _owned(request, server_id)
+        if body.name != server.name:
+            clash = await asyncio.to_thread(mcp_server_store.get_by_name, owner, body.name)
+            if clash is not None:
+                raise OmnigentError(
+                    f"MCP server {body.name!r} already exists",
+                    code=ErrorCode.CONFLICT,
+                )
+        updated = await asyncio.to_thread(
+            mcp_server_store.update,
+            server_id,
+            name=body.name,
+            transport=body.transport,
+            url=body.url,
+            headers=body.headers,
+            command=body.command,
+            args=body.args,
+            env=body.env,
+            description=body.description,
+        )
+        if updated is None:
+            raise OmnigentError("MCP server not found", code=ErrorCode.NOT_FOUND)
+        return _to_object(updated)
+
+    @router.delete("/mcp-servers/{server_id}", status_code=status.HTTP_204_NO_CONTENT)
+    async def delete_mcp_server(request: Request, server_id: str) -> Response:
+        """Delete one of the caller's MCP servers."""
+        require_user(request, auth_provider)
+        await _owned(request, server_id)
+        await asyncio.to_thread(mcp_server_store.delete, server_id)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @router.post("/mcp-servers/{server_id}/verify")
+    async def verify_saved_mcp_server(request: Request, server_id: str) -> MCPVerifyResponse:
+        """Verify a stored server using its saved (secret) config."""
+        require_user(request, auth_provider)
+        server = await _owned(request, server_id)
+        config = MCPServerConfig(
+            name=server.name,
+            transport=server.transport,  # type: ignore[arg-type]
+            url=server.url,
+            headers=dict(server.headers),
+            command=server.command,
+            args=list(server.args),
+            env=dict(server.env),
+        )
+        return await _verify_config(config)
+
+    return router

--- a/omnigent/stores/__init__.py
+++ b/omnigent/stores/__init__.py
@@ -4,6 +4,7 @@ from omnigent.stores.agent_store import AgentStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import ConversationStore
 from omnigent.stores.file_store import FileStore
+from omnigent.stores.mcp_server_store import McpServerStore
 from omnigent.stores.permission_store import PermissionStore
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "ArtifactStore",
     "ConversationStore",
     "FileStore",
+    "McpServerStore",
     "PermissionStore",
 ]

--- a/omnigent/stores/mcp_server_store/__init__.py
+++ b/omnigent/stores/mcp_server_store/__init__.py
@@ -1,0 +1,121 @@
+"""MCP server store — manages reusable, owner-scoped MCP servers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from omnigent.entities import McpServer
+
+
+class McpServerStore(ABC):
+    """
+    Abstract base for standalone MCP server persistence.
+
+    Manages the lifecycle of reusable MCP server connections: creation
+    with per-owner name uniqueness, lookup by id or name, owner-scoped
+    listing, update, and deletion.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Initialize the MCP server store.
+
+        :param storage_location: Backend-specific storage URI,
+            e.g. ``"sqlite:///omnigent.db"``.
+        """
+        self.storage_location = storage_location
+
+    @abstractmethod
+    def create(
+        self,
+        server_id: str,
+        owner: str | None,
+        name: str,
+        transport: str,
+        *,
+        url: str | None = None,
+        headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        description: str | None = None,
+    ) -> McpServer:
+        """
+        Register a new MCP server. Name must be unique for the owner.
+
+        :param server_id: Pre-generated unique id, e.g. ``"mcp_ab12..."``.
+        :param owner: Owning user id, or ``None`` for a global row.
+        :param name: Server name; unique among the owner's servers.
+        :param transport: ``"http"`` or ``"stdio"``.
+        :param url: HTTP endpoint (http transport).
+        :param headers: HTTP headers (http transport).
+        :param command: Executable (stdio transport).
+        :param args: Command-line args (stdio transport).
+        :param env: Environment variables (stdio transport).
+        :param description: Optional free-text description.
+        :returns: The newly created :class:`McpServer`.
+        """
+        ...
+
+    @abstractmethod
+    def get(self, server_id: str) -> McpServer | None:
+        """
+        Return the server, or ``None`` if it does not exist.
+
+        :param server_id: Unique server id, e.g. ``"mcp_ab12..."``.
+        :returns: The :class:`McpServer` if found, otherwise ``None``.
+        """
+        ...
+
+    @abstractmethod
+    def get_by_name(self, owner: str | None, name: str) -> McpServer | None:
+        """
+        Look up one of the owner's servers by name.
+
+        :param owner: Owning user id.
+        :param name: Server name.
+        :returns: The :class:`McpServer` if found, otherwise ``None``.
+        """
+        ...
+
+    @abstractmethod
+    def list_for_owner(self, owner: str | None) -> list[McpServer]:
+        """
+        List all of the owner's servers, newest first.
+
+        :param owner: Owning user id.
+        :returns: The owner's :class:`McpServer` rows.
+        """
+        ...
+
+    @abstractmethod
+    def update(
+        self,
+        server_id: str,
+        *,
+        name: str,
+        transport: str,
+        url: str | None,
+        headers: dict[str, str],
+        command: str | None,
+        args: list[str],
+        env: dict[str, str],
+        description: str | None,
+    ) -> McpServer | None:
+        """
+        Replace a server's config and bump ``updated_at``.
+
+        :param server_id: Unique server id.
+        :returns: The updated :class:`McpServer`, or ``None`` if absent.
+        """
+        ...
+
+    @abstractmethod
+    def delete(self, server_id: str) -> bool:
+        """
+        Delete a server. Returns ``True`` if it existed.
+
+        :param server_id: Unique server id.
+        :returns: ``True`` if deleted, ``False`` if it did not exist.
+        """
+        ...

--- a/omnigent/stores/mcp_server_store/sqlalchemy_store.py
+++ b/omnigent/stores/mcp_server_store/sqlalchemy_store.py
@@ -1,0 +1,143 @@
+"""SQLAlchemy-backed MCP server store."""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import desc, select
+
+from omnigent.db.converters import sql_mcp_server_to_entity
+from omnigent.db.db_models import SqlMcpServer
+from omnigent.db.utils import (
+    get_or_create_engine,
+    make_managed_session_maker,
+    now_epoch,
+)
+from omnigent.entities import McpServer
+from omnigent.stores.mcp_server_store import McpServerStore
+
+
+def _dump_dict(value: dict[str, str] | None) -> str | None:
+    """Encode a dict to JSON text, or ``None`` when empty."""
+    return json.dumps(dict(value)) if value else None
+
+
+def _dump_list(value: list[str] | None) -> str | None:
+    """Encode a list to JSON text, or ``None`` when empty."""
+    return json.dumps(list(value)) if value else None
+
+
+class SqlAlchemyMcpServerStore(McpServerStore):
+    """SQLAlchemy-backed implementation of :class:`McpServerStore`."""
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Initialize the SQLAlchemy MCP server store.
+
+        :param storage_location: SQLAlchemy database URI.
+        """
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        self._session = make_managed_session_maker(self._engine)
+
+    def create(
+        self,
+        server_id: str,
+        owner: str | None,
+        name: str,
+        transport: str,
+        *,
+        url: str | None = None,
+        headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        description: str | None = None,
+    ) -> McpServer:
+        """Register a new MCP server in the database."""
+        row = SqlMcpServer(
+            id=server_id,
+            created_at=now_epoch(),
+            owner=owner,
+            name=name,
+            transport=transport,
+            url=url,
+            headers_json=_dump_dict(headers),
+            command=command,
+            args_json=_dump_list(args),
+            env_json=_dump_dict(env),
+            description=description,
+        )
+        with self._session() as session:
+            session.add(row)
+            session.flush()
+            return sql_mcp_server_to_entity(row)
+
+    def get(self, server_id: str) -> McpServer | None:
+        """Fetch a server by id."""
+        with self._session() as session:
+            row = session.get(SqlMcpServer, server_id)
+            return sql_mcp_server_to_entity(row) if row else None
+
+    def get_by_name(self, owner: str | None, name: str) -> McpServer | None:
+        """Fetch one of the owner's servers by name."""
+        with self._session() as session:
+            stmt = select(SqlMcpServer).where(
+                SqlMcpServer.name == name,
+                SqlMcpServer.owner == owner if owner is not None else SqlMcpServer.owner.is_(None),
+            )
+            row = session.execute(stmt).scalar_one_or_none()
+            return sql_mcp_server_to_entity(row) if row else None
+
+    def list_for_owner(self, owner: str | None) -> list[McpServer]:
+        """List the owner's servers, newest first."""
+        with self._session() as session:
+            owner_clause = (
+                SqlMcpServer.owner == owner if owner is not None else SqlMcpServer.owner.is_(None)
+            )
+            stmt = (
+                select(SqlMcpServer)
+                .where(owner_clause)
+                .order_by(desc(SqlMcpServer.created_at), desc(SqlMcpServer.id))
+            )
+            rows = session.execute(stmt).scalars().all()
+            return [sql_mcp_server_to_entity(r) for r in rows]
+
+    def update(
+        self,
+        server_id: str,
+        *,
+        name: str,
+        transport: str,
+        url: str | None,
+        headers: dict[str, str],
+        command: str | None,
+        args: list[str],
+        env: dict[str, str],
+        description: str | None,
+    ) -> McpServer | None:
+        """Replace a server's config and bump ``updated_at``."""
+        with self._session() as session:
+            row = session.get(SqlMcpServer, server_id)
+            if not row:
+                return None
+            row.name = name
+            row.transport = transport
+            row.url = url
+            row.headers_json = _dump_dict(headers)
+            row.command = command
+            row.args_json = _dump_list(args)
+            row.env_json = _dump_dict(env)
+            row.description = description
+            row.updated_at = now_epoch()
+            session.flush()
+            return sql_mcp_server_to_entity(row)
+
+    def delete(self, server_id: str) -> bool:
+        """Delete a server by id."""
+        with self._session() as session:
+            row = session.get(SqlMcpServer, server_id)
+            if not row:
+                return False
+            session.delete(row)
+            return True

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -45,6 +45,7 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.mcp_server_store.sqlalchemy_store import SqlAlchemyMcpServerStore
 
 # ── Controllable mock LLM ─────────────────────────────
 
@@ -594,6 +595,7 @@ def app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
             cache_dir=tmp_path / "cache",
         ),
         comment_store=SqlAlchemyCommentStore(db_uri),
+        mcp_server_store=SqlAlchemyMcpServerStore(db_uri),
     )
 
 

--- a/tests/server/test_mcp_servers.py
+++ b/tests/server/test_mcp_servers.py
@@ -1,0 +1,129 @@
+"""Route tests for standalone MCP servers (``/v1/mcp-servers``)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_list_get_delete_round_trip(client: httpx.AsyncClient) -> None:
+    # Create.
+    resp = await client.post(
+        "/v1/mcp-servers",
+        json={
+            "name": "litellm",
+            "transport": "http",
+            "url": "https://gateway.example.com/mcp",
+            "headers": {"Authorization": "Bearer secret"},
+            "description": "LiteLLM gateway",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    created = resp.json()
+    assert created["name"] == "litellm"
+    assert created["id"].startswith("mcp_")
+    # Secret values never leave the server; only the keys do.
+    assert created["header_keys"] == ["Authorization"]
+    assert "headers" not in created
+
+    server_id = created["id"]
+
+    # List/mine.
+    resp = await client.get("/v1/mcp-servers/mine")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert [s["id"] for s in data] == [server_id]
+
+    # Get one.
+    resp = await client.get(f"/v1/mcp-servers/{server_id}")
+    assert resp.status_code == 200
+    assert resp.json()["url"] == "https://gateway.example.com/mcp"
+
+    # Delete.
+    resp = await client.delete(f"/v1/mcp-servers/{server_id}")
+    assert resp.status_code == 204
+    resp = await client.get(f"/v1/mcp-servers/{server_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_duplicate_name_conflicts(client: httpx.AsyncClient) -> None:
+    body = {"name": "dup", "transport": "http", "url": "https://a.example.com"}
+    assert (await client.post("/v1/mcp-servers", json=body)).status_code == 201
+    resp = await client.post("/v1/mcp-servers", json=body)
+    assert resp.status_code == 409, resp.text
+
+
+@pytest.mark.asyncio
+async def test_http_requires_url(client: httpx.AsyncClient) -> None:
+    resp = await client.post(
+        "/v1/mcp-servers",
+        json={"name": "nourl", "transport": "http"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_stdio_requires_command(client: httpx.AsyncClient) -> None:
+    resp = await client.post(
+        "/v1/mcp-servers",
+        json={"name": "nocmd", "transport": "stdio"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_replaces_config(client: httpx.AsyncClient) -> None:
+    created = (
+        await client.post(
+            "/v1/mcp-servers",
+            json={"name": "old", "transport": "http", "url": "https://old.example.com"},
+        )
+    ).json()
+    resp = await client.put(
+        f"/v1/mcp-servers/{created['id']}",
+        json={"name": "new", "transport": "http", "url": "https://new.example.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "new"
+    assert resp.json()["url"] == "https://new.example.com"
+
+
+@pytest.mark.asyncio
+async def test_config_endpoint_returns_secrets_to_owner(client: httpx.AsyncClient) -> None:
+    created = (
+        await client.post(
+            "/v1/mcp-servers",
+            json={
+                "name": "secretful",
+                "transport": "http",
+                "url": "https://gw.example.com",
+                "headers": {"Authorization": "Bearer tok"},
+            },
+        )
+    ).json()
+    # The plain GET hides secret values...
+    plain = (await client.get(f"/v1/mcp-servers/{created['id']}")).json()
+    assert "headers" not in plain
+    assert plain["header_keys"] == ["Authorization"]
+    # ...but the explicit /config route returns them for agent baking.
+    resp = await client.get(f"/v1/mcp-servers/{created['id']}/config")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["headers"] == {"Authorization": "Bearer tok"}
+
+
+@pytest.mark.asyncio
+async def test_config_missing_is_404(client: httpx.AsyncClient) -> None:
+    resp = await client.get("/v1/mcp-servers/mcp_nope/config")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_verify_validates_body(client: httpx.AsyncClient) -> None:
+    # Bad transport shape is rejected before any connection attempt.
+    resp = await client.post(
+        "/v1/mcp-servers/verify",
+        json={"transport": "stdio"},  # missing command
+    )
+    assert resp.status_code == 422

--- a/tests/stores/conftest.py
+++ b/tests/stores/conftest.py
@@ -11,6 +11,7 @@ from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
+from omnigent.stores.mcp_server_store.sqlalchemy_store import SqlAlchemyMcpServerStore
 from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
 
 
@@ -20,6 +21,14 @@ def agent_store(db_uri: str) -> SqlAlchemyAgentStore:
     :returns: A SqlAlchemyAgentStore backed by the test database.
     """
     return SqlAlchemyAgentStore(db_uri)
+
+
+@pytest.fixture()
+def mcp_server_store(db_uri: str) -> SqlAlchemyMcpServerStore:
+    """
+    :returns: A SqlAlchemyMcpServerStore backed by the test database.
+    """
+    return SqlAlchemyMcpServerStore(db_uri)
 
 
 @pytest.fixture()

--- a/tests/stores/test_mcp_server_store.py
+++ b/tests/stores/test_mcp_server_store.py
@@ -1,0 +1,137 @@
+"""Tests for SqlAlchemyMcpServerStore."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.stores.mcp_server_store.sqlalchemy_store import SqlAlchemyMcpServerStore
+
+
+def test_create_and_get(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    server = mcp_server_store.create(
+        "mcp_one",
+        "alice",
+        "litellm",
+        "http",
+        url="https://gateway.example.com/mcp",
+        headers={"Authorization": "Bearer secret"},
+        description="LiteLLM gateway",
+    )
+    assert server.id == "mcp_one"
+    assert server.owner == "alice"
+    assert server.transport == "http"
+    assert server.headers == {"Authorization": "Bearer secret"}
+
+    fetched = mcp_server_store.get("mcp_one")
+    assert fetched is not None
+    assert fetched.url == "https://gateway.example.com/mcp"
+    # Secrets round-trip through the JSON column.
+    assert fetched.headers == {"Authorization": "Bearer secret"}
+    assert fetched.description == "LiteLLM gateway"
+
+
+def test_get_nonexistent(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    assert mcp_server_store.get("mcp_missing") is None
+
+
+def test_stdio_args_and_env_round_trip(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    server = mcp_server_store.create(
+        "mcp_stdio",
+        "alice",
+        "local-fs",
+        "stdio",
+        command="uvx",
+        args=["mcp-server-filesystem", "/data"],
+        env={"TOKEN": "xyz"},
+    )
+    fetched = mcp_server_store.get(server.id)
+    assert fetched is not None
+    assert fetched.command == "uvx"
+    assert fetched.args == ["mcp-server-filesystem", "/data"]
+    assert fetched.env == {"TOKEN": "xyz"}
+    assert fetched.url is None
+
+
+def test_list_is_owner_scoped_and_newest_first(
+    mcp_server_store: SqlAlchemyMcpServerStore,
+) -> None:
+    mcp_server_store.create("mcp_a", "alice", "a", "http", url="https://a.example.com")
+    mcp_server_store.create("mcp_b", "alice", "b", "http", url="https://b.example.com")
+    mcp_server_store.create("mcp_c", "bob", "c", "http", url="https://c.example.com")
+
+    alice = mcp_server_store.list_for_owner("alice")
+    assert {s.id for s in alice} == {"mcp_a", "mcp_b"}
+    # Bob never sees alice's servers.
+    bob = mcp_server_store.list_for_owner("bob")
+    assert {s.id for s in bob} == {"mcp_c"}
+
+
+def test_get_by_name_is_owner_scoped(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    mcp_server_store.create("mcp_a", "alice", "shared", "http", url="https://a.example.com")
+    mcp_server_store.create("mcp_b", "bob", "shared", "http", url="https://b.example.com")
+
+    # Same name is allowed across owners; lookup stays scoped.
+    assert mcp_server_store.get_by_name("alice", "shared").id == "mcp_a"  # type: ignore[union-attr]
+    assert mcp_server_store.get_by_name("bob", "shared").id == "mcp_b"  # type: ignore[union-attr]
+    assert mcp_server_store.get_by_name("alice", "nope") is None
+
+
+def test_duplicate_name_for_owner_rejected(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    mcp_server_store.create("mcp_a", "alice", "dup", "http", url="https://a.example.com")
+    with pytest.raises(Exception):  # noqa: B017 — unique-index violation
+        mcp_server_store.create("mcp_b", "alice", "dup", "http", url="https://b.example.com")
+
+
+def test_update_replaces_config(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    mcp_server_store.create(
+        "mcp_u",
+        "alice",
+        "old",
+        "http",
+        url="https://old.example.com",
+        headers={"A": "1"},
+    )
+    updated = mcp_server_store.update(
+        "mcp_u",
+        name="new",
+        transport="http",
+        url="https://new.example.com",
+        headers={"B": "2"},
+        command=None,
+        args=[],
+        env={},
+        description="renamed",
+    )
+    assert updated is not None
+    assert updated.name == "new"
+    assert updated.url == "https://new.example.com"
+    assert updated.headers == {"B": "2"}
+    assert updated.updated_at is not None
+
+    fetched = mcp_server_store.get("mcp_u")
+    assert fetched is not None
+    assert fetched.name == "new"
+    assert fetched.headers == {"B": "2"}
+
+
+def test_update_missing_returns_none(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    result = mcp_server_store.update(
+        "mcp_missing",
+        name="x",
+        transport="http",
+        url="https://x.example.com",
+        headers={},
+        command=None,
+        args=[],
+        env={},
+        description=None,
+    )
+    assert result is None
+
+
+def test_delete(mcp_server_store: SqlAlchemyMcpServerStore) -> None:
+    mcp_server_store.create("mcp_d", "alice", "d", "http", url="https://d.example.com")
+    assert mcp_server_store.delete("mcp_d") is True
+    assert mcp_server_store.get("mcp_d") is None
+    # Second delete is a no-op.
+    assert mcp_server_store.delete("mcp_d") is False


### PR DESCRIPTION
Closes #1411.

Standalone MCP servers are reusable connections a user registers once and references when creating agents — instead of re-typing url/headers into every create-agent form. They can be **verified** (connect + list tools) before saving or selecting.

## Backend (`0c912fa2`)
- `mcp_servers` table + migration `p1a2b3c4d5e6` (chained off `n1a2b3c4d5e6`).
- `McpServer` entity + `SqlMcpServer` model; secret-bearing `headers`/`env`/`args` stored JSON-encoded.
- `McpServerStore` (owner-scoped) + SQLAlchemy impl; per-owner name uniqueness (`ix_mcp_servers_owner_name`, so two users may each register `litellm`).
- `/v1/mcp-servers` router (mounted when a store is wired):
  - owner-scoped CRUD: `GET /mine`, `POST`, `GET/PUT/DELETE /{id}`
  - **`POST /verify`** (ad-hoc) and **`POST /{id}/verify`** (saved) → connect via `McpServerConnection` and return `{ok, tools[], error}`
  - `GET /{id}/config` → full config **incl. secrets**, owner-only, used to bake a selected server into a client-built agent bundle
- Responses never leak secret *values* — only `header_keys` / `env_keys` — except the explicit owner-only `/config` route.
- Wired through `create_app(mcp_server_store=…)` and the CLI server.

## Frontend (`b5a32856`)
- `mcpApi.ts`: typed client + shared TanStack query key.
- **Sidebar → "MCP servers"** dialog: list / add a remote server / **verify (renders the discovered tool list)** / delete.
- **CreateAgentDialog**: a "Preconfigured MCP servers" multi-select; chosen servers' full configs are fetched and merged into the bundle (inline rows override by name).

## Security
- `headers`/`env` are accepted on write and used for verify/agent-baking, never returned verbatim except via the owner-only `/config` route (same trust boundary as typing secrets into the create-agent form, which already builds them into the bundle client-side).
- Verify connects from the server to an operator-supplied URL (same posture as the existing server-side MCP pool). A hardened multi-tenant deployment should add an egress allowlist / SSRF guard — noted in the route docstring.

## Tests
- 9 store tests (CRUD, owner isolation, per-owner dup-name rejection, args/env round-trip).
- 8 route tests (CRUD round-trip, dup-name 409, transport validation, verify body validation, owner-only `/config` secret reveal + 404).
- Frontend: `tsc -b`, `oxlint`, `vite build` all pass.

## Migration note
`p1a2b3c4d5e6` chains off `n1a2b3c4d5e6` (current `main` head). If landed alongside the standalone-agents migration (`o1a2b3c4d5e6`, #1402), re-point one `down_revision` so the chain stays linear (single head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)