### PR TITLE
feat(claude-native): pluggable launch command for the native Claude harness

### DIFF
--- a/omnigent/claude_launcher.py
+++ b/omnigent/claude_launcher.py
@@ -1,0 +1,131 @@
+"""Pluggable launch-command resolution for the native Claude harness.
+
+The native Claude terminal is normally spawned as ``claude <args>`` -- the
+``command`` defaults to ``"claude"`` in both launch paths:
+:func:`omnigent.claude_native._claude_terminal_request` (local CLI) and
+``_auto_create_claude_terminal`` in :mod:`omnigent.runner.app` (managed-host
+runner). Downstream integrations need to launch that *same* Claude Code process
+through a wrapper binary so the wrapper's process-level setup -- auth, telemetry,
+cost controls, enforcement hooks, plugin management -- is always applied. The
+motivating case is Databricks' ``isaac``, which wraps Claude/Codex with that
+tooling; running ``isaac claude`` instead of bare ``claude`` keeps it in force.
+
+Rather than hardcode the binary at each site, both paths route the
+``(command, args)`` pair through :func:`resolve_claude_launch`. By default this
+is the identity, so behaviour is unchanged. When ``OMNIGENT_CLAUDE_LAUNCHER``
+names a plugin, that plugin decides the final command and args. The argv handed
+to it is already fully augmented (MCP config, hook settings and skill flags
+injected by :func:`augment_claude_args`), so a plugin that merely wraps the
+command -- e.g. ``("isaac", ["claude", "--omni-internal", "--", *args])`` --
+preserves the Omnigent bridge unchanged.
+
+Plugin reference format is ``module.path:callable`` resolving to::
+
+    def launch(command: str, args: list[str]) -> tuple[str, list[str]]: ...
+
+Selection is per-process via the environment so the runner (which spawns the
+terminal on managed hosts) and the local CLI each opt in independently; the
+bootstrapping integration sets the env var before the launching process starts.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from collections.abc import Callable
+
+#: Environment variable naming the launcher plugin as ``module.path:callable``.
+CLAUDE_LAUNCHER_ENV_VAR = "OMNIGENT_CLAUDE_LAUNCHER"
+
+_logger = logging.getLogger(__name__)
+
+#: Signature a registered launcher plugin must implement.
+ClaudeLauncher = Callable[[str, list[str]], tuple[str, list[str]]]
+
+
+def resolve_claude_launch(command: str, args: list[str]) -> tuple[str, list[str]]:
+    """
+    Resolve the final launch command/args for the native Claude terminal.
+
+    Delegates to the plugin named by :data:`CLAUDE_LAUNCHER_ENV_VAR` when set;
+    otherwise returns the inputs unchanged. Any failure to load or run the
+    plugin -- bad reference, import error, raised exception, malformed return
+    value -- is logged and falls back to the default ``(command, args)`` so a
+    broken plugin can never block a Claude launch.
+
+    :param command: Default terminal command, e.g. ``"claude"``.
+    :param args: Fully-augmented Claude CLI args (MCP/hooks/skills already
+        injected by :func:`augment_claude_args`).
+    :returns: The ``(command, args)`` to spawn. ``args`` is always a fresh list.
+    """
+    default = (command, list(args))
+    spec = os.environ.get(CLAUDE_LAUNCHER_ENV_VAR, "").strip()
+    if not spec:
+        return default
+    launcher = _load_launcher(spec)
+    if launcher is None:
+        return default
+    try:
+        result = launcher(command, list(args))
+    except Exception:
+        _logger.exception("Claude launcher plugin %r raised; falling back to default launch", spec)
+        return default
+    return _validated_result(result, spec, default)
+
+
+def _load_launcher(spec: str) -> ClaudeLauncher | None:
+    """
+    Import the launcher callable from a ``module.path:callable`` reference.
+
+    :param spec: Plugin reference, e.g. ``"isaac_omni.launcher:launch_claude"``.
+    :returns: The resolved callable, or ``None`` when the reference is malformed
+        or cannot be imported.
+    """
+    module_path, sep, attr = spec.partition(":")
+    if not sep or not module_path or not attr:
+        _logger.error(
+            "Ignoring %s=%r: expected 'module.path:callable'",
+            CLAUDE_LAUNCHER_ENV_VAR,
+            spec,
+        )
+        return None
+    try:
+        module = importlib.import_module(module_path)
+        launcher = getattr(module, attr)
+    except (ImportError, AttributeError):
+        _logger.exception("Could not load Claude launcher plugin %r", spec)
+        return None
+    if not callable(launcher):
+        _logger.error("Claude launcher plugin %r is not callable", spec)
+        return None
+    return launcher
+
+
+def _validated_result(
+    result: object, spec: str, default: tuple[str, list[str]]
+) -> tuple[str, list[str]]:
+    """
+    Coerce and validate a plugin's return value to ``(str, list[str])``.
+
+    :param result: Raw plugin return value.
+    :param spec: Plugin reference, for diagnostics.
+    :param default: Fallback ``(command, args)`` when ``result`` is malformed.
+    :returns: A validated ``(command, args)`` tuple, or ``default``.
+    """
+    if (
+        isinstance(result, tuple)
+        and len(result) == 2
+        and isinstance(result[0], str)
+        and result[0]
+        and isinstance(result[1], list)
+        and all(isinstance(arg, str) for arg in result[1])
+    ):
+        return result[0], list(result[1])
+    _logger.error(
+        "Claude launcher plugin %r returned %r; expected (str, list[str]); "
+        "falling back to default launch",
+        spec,
+        result,
+    )
+    return default

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -61,6 +61,7 @@ from omnigent._wrapper_labels import (
 from omnigent._wrapper_labels import (
     WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY,
 )
+from omnigent.claude_launcher import resolve_claude_launch
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
     augment_claude_args,
@@ -3966,6 +3967,10 @@ def _claude_terminal_request(
         ap_auth_headers=ap_auth_headers,
         api_key_helper=claude_config.api_key_helper if claude_config is not None else None,
     )
+    # Let a registered launcher plugin (e.g. Databricks' isaac) rewrite the
+    # command/args to wrap the same fully-augmented Claude launch. Identity by
+    # default. See omnigent.claude_launcher.
+    command, args = resolve_claude_launch(command, args)
     spec: dict[str, Any] = {
         "command": command,
         "args": args,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -280,6 +280,14 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # ``OMNIGENT_RUNNER_ENV_PASSTHROUGH=OMNIGENT_CLAUDE_SDK_NO_SANDBOX``).
         # Safe to propagate: not a secret.
         "OMNIGENT_CLAUDE_SDK_NO_SANDBOX",
+        # Native-Claude launcher plugin selector (``module.path:callable``).
+        # Read by omnigent.claude_launcher.resolve_claude_launch in the
+        # managed-host runner (``_auto_create_claude_terminal``) to wrap the
+        # Claude launch through a downstream binary (e.g. Databricks' isaac).
+        # The daemon→runner env strip would otherwise drop it, leaving the
+        # runner on the default launch. Safe to propagate: not a secret, just a
+        # plugin reference string.
+        "OMNIGENT_CLAUDE_LAUNCHER",
         # Testing knob: override the context window size for compaction
         # trigger threshold. Not a secret — a plain integer.
         "AP_CONTEXT_WINDOW_OVERRIDE",

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5141,6 +5141,7 @@ async def _auto_create_claude_terminal(
     _runner_headers = databricks_auth_headers(server_url, _auth_token)
     _runner_auth = _RunnerDatabricksAuth(_auth_factory)
 
+    from omnigent.claude_launcher import resolve_claude_launch
     from omnigent.claude_native import (
         ClaudeNativeUcodeConfig,
         augment_claude_args,
@@ -5438,6 +5439,11 @@ async def _auto_create_claude_terminal(
         api_key_helper=claude_config.api_key_helper if claude_config is not None else None,
     )
 
+    # Let a registered launcher plugin (e.g. Databricks' isaac) rewrite the
+    # command/args to wrap the same fully-augmented Claude launch on this
+    # managed-host path. Identity by default. See omnigent.claude_launcher.
+    launch_command, launch_args = resolve_claude_launch("claude", list(claude_args))
+
     # Inherit the agent's os_env so its sandbox (e.g. ``type: none``),
     # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
     # and ``parent_os_env`` below, launch_terminal falls back to
@@ -5449,8 +5455,8 @@ async def _auto_create_claude_terminal(
             cwd=workspace,
             sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
         ),
-        command="claude",
-        args=list(claude_args),
+        command=launch_command,
+        args=launch_args,
         # Tool Search env plus ucode gateway env (ANTHROPIC_BASE_URL
         # etc.) when derived. Empty provider config still forces
         # ENABLE_TOOL_SEARCH=true so MCP schemas are loaded on demand.

--- a/tests/test_claude_launcher.py
+++ b/tests/test_claude_launcher.py
@@ -1,0 +1,100 @@
+"""Unit tests for :mod:`omnigent.claude_launcher`."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from omnigent.claude_launcher import CLAUDE_LAUNCHER_ENV_VAR, resolve_claude_launch
+
+
+def _register_plugin(monkeypatch, value, *, attr="launch", module="fake_launcher_mod"):
+    """Inject a fake plugin module and point the env var at it."""
+    mod = types.ModuleType(module)
+    setattr(mod, attr, value)
+    monkeypatch.setitem(sys.modules, module, mod)
+    monkeypatch.setenv(CLAUDE_LAUNCHER_ENV_VAR, f"{module}:{attr}")
+
+
+def test_identity_when_env_unset(monkeypatch):
+    monkeypatch.delenv(CLAUDE_LAUNCHER_ENV_VAR, raising=False)
+    assert resolve_claude_launch("claude", ["--foo", "bar"]) == ("claude", ["--foo", "bar"])
+
+
+def test_identity_returns_fresh_list(monkeypatch):
+    monkeypatch.delenv(CLAUDE_LAUNCHER_ENV_VAR, raising=False)
+    original = ["--foo"]
+    _, args = resolve_claude_launch("claude", original)
+    assert args == original
+    assert args is not original
+
+
+def test_plugin_wraps_command(monkeypatch):
+    def wrap(command, args):
+        return "isaac", ["claude", "--omni-internal", "--", *args]
+
+    _register_plugin(monkeypatch, wrap)
+    command, args = resolve_claude_launch("claude", ["--mcp-config", "{}"])
+    assert command == "isaac"
+    assert args == ["claude", "--omni-internal", "--", "--mcp-config", "{}"]
+
+
+def test_plugin_receives_default_command_and_args(monkeypatch):
+    seen = {}
+
+    def wrap(command, args):
+        seen["command"], seen["args"] = command, args
+        return command, args
+
+    _register_plugin(monkeypatch, wrap)
+    resolve_claude_launch("claude", ["--x"])
+    assert seen == {"command": "claude", "args": ["--x"]}
+
+
+@pytest.mark.parametrize("spec", ["nocolon", ":nomod", "mod:", "", "   "])
+def test_malformed_spec_falls_back(monkeypatch, spec):
+    monkeypatch.setenv(CLAUDE_LAUNCHER_ENV_VAR, spec)
+    assert resolve_claude_launch("claude", ["--x"]) == ("claude", ["--x"])
+
+
+def test_import_error_falls_back(monkeypatch):
+    monkeypatch.setenv(CLAUDE_LAUNCHER_ENV_VAR, "no_such_module_xyz:launch")
+    assert resolve_claude_launch("claude", ["--x"]) == ("claude", ["--x"])
+
+
+def test_missing_attr_falls_back(monkeypatch):
+    mod = types.ModuleType("fake_launcher_mod2")
+    monkeypatch.setitem(sys.modules, "fake_launcher_mod2", mod)
+    monkeypatch.setenv(CLAUDE_LAUNCHER_ENV_VAR, "fake_launcher_mod2:missing")
+    assert resolve_claude_launch("claude", ["--x"]) == ("claude", ["--x"])
+
+
+def test_not_callable_falls_back(monkeypatch):
+    _register_plugin(monkeypatch, "not-callable")
+    assert resolve_claude_launch("claude", ["--x"]) == ("claude", ["--x"])
+
+
+def test_plugin_raises_falls_back(monkeypatch):
+    def boom(command, args):
+        raise RuntimeError("boom")
+
+    _register_plugin(monkeypatch, boom)
+    assert resolve_claude_launch("claude", ["--x"]) == ("claude", ["--x"])
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "notatuple",
+        ("only-one",),
+        ("", ["x"]),
+        ("cmd", "notalist"),
+        ("cmd", [1, 2]),
+        (123, ["x"]),
+    ],
+)
+def test_malformed_return_falls_back(monkeypatch, bad):
+    _register_plugin(monkeypatch, lambda command, args: bad)
+    assert resolve_claude_launch("claude", ["--x"]) == ("claude", ["--x"])

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -7,6 +7,8 @@ import contextlib
 import io
 import json
 import os
+import sys
+import types
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
@@ -106,6 +108,50 @@ def test_claude_terminal_request_pins_launch_cwd(tmp_path, monkeypatch) -> None:
         "TaskCreated",
         "UserPromptSubmit",
     ]
+
+
+def test_claude_terminal_request_default_launch_is_unwrapped(tmp_path, monkeypatch) -> None:
+    """Without ``OMNIGENT_CLAUDE_LAUNCHER`` the command/args are unchanged."""
+    monkeypatch.delenv("OMNIGENT_CLAUDE_LAUNCHER", raising=False)
+    monkeypatch.chdir(tmp_path)
+    body = claude_native._claude_terminal_request(
+        ("--resume", "s"),
+        command="claude",
+        bridge_dir=Path("/tmp/omnigent-test-bridge"),
+    )
+    spec = body["spec"]
+    assert spec["command"] == "claude"
+    assert spec["args"][:2] == ["--resume", "s"]
+
+
+def test_claude_terminal_request_launcher_plugin_wraps(tmp_path, monkeypatch) -> None:
+    """
+    A registered launcher plugin rewrites the spawn command, keeping the bridge.
+
+    Exercises the local-CLI wiring of :func:`resolve_claude_launch`: with a
+    launcher plugin selected, the terminal spec runs the wrapped command
+    (here ``isaac -- <augmented args>``) while the Omnigent bridge
+    (``--mcp-config`` / ``--settings``) survives intact in the passed-through
+    argv.
+    """
+    launcher_mod = types.ModuleType("fake_isaac_launcher")
+    launcher_mod.launch = lambda command, args: ("isaac", ["--", *args])
+    monkeypatch.setitem(sys.modules, "fake_isaac_launcher", launcher_mod)
+    monkeypatch.setenv("OMNIGENT_CLAUDE_LAUNCHER", "fake_isaac_launcher:launch")
+    monkeypatch.chdir(tmp_path)
+    body = claude_native._claude_terminal_request(
+        ("--resume", "s"),
+        command="claude",
+        bridge_dir=Path("/tmp/omnigent-test-bridge"),
+    )
+    spec = body["spec"]
+    assert spec["command"] == "isaac"
+    # Claude's argv is now passed through isaac after the ``--`` separator.
+    assert spec["args"][0] == "--"
+    assert spec["args"][1:3] == ["--resume", "s"]
+    # The bridge MCP + hook injection still rides along.
+    assert "--mcp-config" in spec["args"]
+    assert "--settings" in spec["args"]
 
 
 def test_claude_terminal_request_injects_claude_config() -> None:


### PR DESCRIPTION
## Summary

Add an `OMNIGENT_CLAUDE_LAUNCHER` plugin point so the native Claude harness can be launched through a wrapper binary (e.g. Databricks' `isaac`) that applies its own process-level tooling, without forking the framework.

## Changes

- **`omnigent/claude_launcher.py`**: `resolve_claude_launch(command, args)` reads `OMNIGENT_CLAUDE_LAUNCHER` (`module:callable`). Identity by default; any load/run/validation failure falls back to the default launch so a broken plugin can never block a Claude launch.
- Route both launch paths through it: the local CLI (`claude_native._claude_terminal_request`) and the managed-host runner (`runner.app._auto_create_claude_terminal`, previously hardcoded `"claude"`). The plugin receives the fully-augmented argv (bridge MCP/hooks), so a wrapper that prepends its command preserves the Omnigent bridge.
- Forward `OMNIGENT_CLAUDE_LAUNCHER` through `_RUNNER_ENV_ALLOWLIST` so the selector reaches the daemon-spawned runner.
- Tests for the resolver and both call-site wirings.

## Testing

Isaac Review: clean (0 findings across logical + deadcode reviewers).
