### PR TITLE
docs: add headless API-first local run guide

### DIFF
--- a/docs/headless_api_run_guide.md
+++ b/docs/headless_api_run_guide.md
@@ -1,0 +1,132 @@
+# Headless Local API Flow
+
+This guide shows a local API-first flow for running a registered agent without
+using the web UI.
+
+Use this when building scripts, test harnesses, bots, or other integrations that
+drive Omnigent over HTTP/SSE instead of a terminal UI.
+
+## 1. Start a local server with an agent
+
+Start the server in the foreground and pre-register an agent:
+
+```bash
+omnigent server \
+  --host 127.0.0.1 \
+  --port 6767 \
+  --no-open \
+  --agent ./path/to/agent
+```
+
+`--agent` registers an agent directory or YAML file at startup. `--no-open`
+avoids browser launch in headless, SSH, CI, and container-like environments.
+
+Wait for the server health endpoint before sending API traffic:
+
+```bash
+curl -fsS http://127.0.0.1:6767/health
+```
+
+## 2. Register the local host
+
+In a second terminal, connect the local host process to the server:
+
+```bash
+omnigent host --server http://127.0.0.1:6767
+```
+
+Keep this process running while creating and driving host-bound sessions. The
+host is what lets the server launch or bind agent work to this machine.
+
+## 3. Choose a client layer
+
+Prefer the Python client for new integrations. It keeps request bodies and stream
+events aligned with the server schema.
+
+For simple registered-agent calls, use the high-level client API with the
+registered agent name as `model`:
+
+```python
+import asyncio
+
+from omnigent_client import OmnigentClient
+
+
+async def main() -> None:
+    async with OmnigentClient(base_url="http://127.0.0.1:6767") as client:
+        result = await client.query(model="my-agent", input="Hello")
+        print(result.text)
+
+
+asyncio.run(main())
+```
+
+Use the lower-level sessions API when your integration needs direct control over
+session creation, event posting, stream subscription, or reconnect behavior.
+Create the session first, then keep the returned `conv_...` session id for later
+requests. When posting raw events, use the session id in the URL:
+
+```text
+POST /v1/sessions/{session_id}/events
+```
+
+## 4. Subscribe before posting a user event
+
+For integrations that need live output, open the session stream before posting
+the user message:
+
+```text
+GET /v1/sessions/{session_id}/stream
+```
+
+The server stream does not replay earlier events for late subscribers, so raw
+clients should subscribe first when they need to observe the full turn.
+
+Then post the user message. The Python `SessionsChat.send(...)` helper builds
+this event shape for you; raw HTTP clients should send the same wire payload:
+
+```text
+POST /v1/sessions/{session_id}/events
+Content-Type: application/json
+```
+
+```json
+{
+  "type": "message",
+  "data": {
+    "role": "user",
+    "content": [
+      {
+        "type": "input_text",
+        "text": "Hello"
+      }
+    ]
+  }
+}
+```
+
+The `type` field is the event discriminator. For message events, `data` must
+contain the message role and content blocks.
+
+## 5. Read results and reconcile
+
+Use stream events for live output. Use the session snapshot endpoint to
+reconcile after reconnects or to inspect final session state:
+
+```text
+GET /v1/sessions/{session_id}
+```
+
+If your integration only needs a terminal or REPL experience, use the higher
+level Python client helpers and block stream transforms instead of implementing
+the raw stream state machine directly.
+
+## Troubleshooting
+
+- Poll `/health` before treating the server as ready.
+- Keep `omnigent host --server ...` running while using host-bound sessions.
+- If `POST /events` returns a validation error for missing `role` or `content`,
+  check that those fields are inside the event `data` object.
+- If live output is missing, confirm the stream subscriber was opened before
+  the event was posted.
+- Stop foreground server and host processes with `Ctrl-C` when done.


### PR DESCRIPTION
Title: docs: add headless local API run guide

Author: Victor Pimshin (@vpimshin)

Problem:
Omnigent has good docs for the main CLI/UI flow and the Python headless client, but the local API-first flow is spread across several places. A user who wants to run a registered SDK agent without the web UI has to infer how to combine:

- `omnigent server --agent ...`
- `omnigent host --server ...`
- session creation
- `POST /v1/sessions/{id}/events`
- streaming or snapshot readback
- cleanup and readiness checks

Proposal:
Add a concise guide for running a local headless/API-first session against a registered SDK agent. The guide should be generic and provider-neutral, with a Python client example plus a small raw message-event example showing the server-validated payload shape.

Minimal example:

```bash
# Terminal 1
omnigent server --host 127.0.0.1 --port 6767 --no-open --agent ./examples/my-agent

# Terminal 2
omnigent host --server http://127.0.0.1:6767
```

```json
{
  "type": "message",
  "data": {
    "role": "user",
    "content": [
      {"type": "input_text", "text": "Hello"}
    ]
  }
}
```

Why this helps:

- Gives integrators a single copy/pasteable local flow for scripts, test harnesses, bots, and non-terminal frontends.
- Makes the host-bound session requirement explicit.
- Shows the high-level Python client path for simple registered-agent calls.
- Puts the message-event wire shape next to the API route that validates it.
- Collects readiness and cleanup notes that are otherwise implicit in source/tests.

Validation:

- `CONTRIBUTING.md` documents local `omnigent server` + `omnigent host --server` for UI development.
- `omnigent/cli.py` exposes `server --agent` and `host --server`.
- `sdks/README.md` documents the headless client and `LocalServer` helper.
- `sdks/python-client/omnigent_client/_client.py` documents `OmnigentClient.query(model=..., input=...)` for registered-agent calls.
- `sdks/python-client/omnigent_client/_sessions.py` documents `SessionEventInput` and `post_event` with the message payload shape.
- `tests/frontends/sdk/test_sessions_namespace.py` covers create, stream-before-post, and post_event behavior.

Notes:

- This is a docs-only change.
- It should not introduce a new public API.
- A read-only remote duplicate check found no matching issue or PR before this local branch was prepared.

Refs #1466.
