### PR TITLE
fix(onboarding): correct grok-4 caps and add grok-4.3, grok-build-0.1

### DIFF
--- a/omnigent/onboarding/providers/model_catalog/xai.json
+++ b/omnigent/onboarding/providers/model_catalog/xai.json
@@ -351,8 +351,8 @@
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
-        "reasoning": false,
+        "vision": true,
+        "reasoning": true,
         "prompt_caching": false,
         "response_schema": false
       }
@@ -377,8 +377,8 @@
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
-        "reasoning": false,
+        "vision": true,
+        "reasoning": true,
         "prompt_caching": false,
         "response_schema": false
       }
@@ -592,8 +592,8 @@
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
-        "reasoning": false,
+        "vision": true,
+        "reasoning": true,
         "prompt_caching": false,
         "response_schema": false
       }
@@ -658,6 +658,46 @@
         "response_schema": false
       }
     },
+    "grok-4.3": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000,
+        "max_tokens": 1000000
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.25,
+        "output_per_million_tokens": 2.5,
+        "cache_read_per_million_tokens": 0.2
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
+    "grok-4.3-latest": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 1000000,
+        "max_tokens": 1000000
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.25,
+        "output_per_million_tokens": 2.5,
+        "cache_read_per_million_tokens": 0.2
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
+      }
+    },
     "grok-beta": {
       "mode": "chat",
       "context_window": {
@@ -675,6 +715,26 @@
         "reasoning": false,
         "prompt_caching": false,
         "response_schema": false
+      }
+    },
+    "grok-build-0.1": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 256000,
+        "max_output": 256000,
+        "max_tokens": 256000
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.0,
+        "output_per_million_tokens": 2.0,
+        "cache_read_per_million_tokens": 0.2
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": true
       }
     },
     "grok-code-fast": {


### PR DESCRIPTION
## Related issue

N/A (data-correctness fix in the bundled xAI model catalog; no tracked issue).

## Summary

- The bundled xAI catalog marked `grok-4` (and its `grok-4-0709` / `grok-4-latest`
  aliases) as `vision: false` and `reasoning: false`. Grok 4 is a reasoning model
  with text and image input, so both flags are corrected to `true`.
- Adds the current xAI flagship models that were missing: `grok-4.3` and
  `grok-4.3-latest` (1M context) and `grok-build-0.1` (256K context). All three
  support reasoning, image input, and structured outputs.
- Data-only change. New entries follow the file's existing schema, 2-space indent,
  and alphabetical key order; pricing and capabilities were cross-checked against
  four independent sources (below).

### Sources

grok-4 family (vision + reasoning):
- xAI launch post: https://x.ai/news/grok-4
- xAI model page (grok-4 now aliases to grok-4.3): https://docs.x.ai/developers/models/grok-4-0709

grok-4.3 / grok-4.3-latest (1M ctx, reasoning, image, structured outputs, $1.25/$2.50):
- xAI docs: https://docs.x.ai/developers/models/grok-4.3
- OpenRouter: https://openrouter.ai/x-ai/grok-4.3
- models.dev (the OpenCode catalog): https://models.dev/

grok-build-0.1 (256K ctx, reasoning, image, structured outputs, $1.00/$2.00):
- xAI models pricing: https://docs.x.ai/docs/models
- OpenRouter: https://openrouter.ai/x-ai/grok-build-0.1

Cross-reference: LiteLLM price catalog
https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json

Changed file on this branch:
https://github.com/anxkhn/omnigent/blob/fix/xai-catalog-grok-models/omnigent/onboarding/providers/model_catalog/xai.json

## Test Plan

Data-only edit to a bundled provider catalog (no Python logic changed). Verified locally:

- JSON validity, model count (38), and alphabetical key ordering preserved.
- Loaded via the real provider loader; the three new ids resolve with correct
  context windows (`omnigent.onboarding.providers.get_chat_models("xai")`).
- Ran the catalog-consuming suites:
  `uv run --extra dev pytest tests/tools/builtins/test_list_models.py tests/cli/test_configure_models.py`
  -> 110 passed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Data-only refresh of `omnigent/onboarding/providers/model_catalog/xai.json` with no
behaviour-logic change, so no new test is warranted (same class as a catalog/data
refresh). The existing `tests/tools/builtins/test_list_models.py` and
`tests/cli/test_configure_models.py` suites exercise the loader that consumes this
file and pass (110 passed). Each value was manually cross-checked against the xAI
docs, the OpenRouter models API, models.dev, and LiteLLM (links above).
