### PR TITLE
fix(runner): authenticate + route every native policy-hook channel; unify the header builder

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -648,9 +648,9 @@ def _remote_headers(
     # workspace or the request routes to the account. Merged onto the result
     # because these ad-hoc requests carry no httpx Auth.
     if server_url:
-        from omnigent.cli_auth import databricks_org_id_headers
+        from omnigent.cli_auth import databricks_request_headers
 
-        headers.update(databricks_org_id_headers(server_url))
+        headers.update(databricks_request_headers(server_url))
     return headers
 
 
@@ -771,9 +771,9 @@ class _DatabricksTokenAuth(httpx.Auth):
         # Workspace routing (empty when none recorded); independent of the
         # credential branch below.
         if self._server_url:
-            from omnigent.cli_auth import databricks_org_id_headers
+            from omnigent.cli_auth import databricks_request_headers
 
-            request.headers.update(databricks_org_id_headers(self._server_url))
+            request.headers.update(databricks_request_headers(self._server_url))
         if self._static_token:
             request.headers["Authorization"] = f"Bearer {self._static_token}"
             yield request

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -33,6 +33,7 @@ from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    policy_hook_reauth,
     post_evaluate_with_retry,
 )
 
@@ -516,52 +517,6 @@ def _conversation_url_for_active_session(
     return fallback_url
 
 
-def _build_reauth(
-    ap_server_url: str, headers: dict[str, str]
-) -> Callable[[], dict[str, str] | None]:
-    """
-    Build a callable that re-mints the Omnigent bearer for ``ap_server_url``.
-
-    The native hooks authenticate with a one-shot ``ap_auth_headers`` snapshot
-    written into ``permission_hook.json`` at launch (``build_hook_settings``),
-    which dies with the ~1h Databricks OAuth token lifetime. When the Apps front
-    door later bounces a hook POST to its OAuth login flow (302→``/oidc/``) or
-    returns ``401``, this callable re-mints a fresh bearer through the SAME
-    factory the runner's refresh-capable ``_RunnerDatabricksAuth`` uses
-    (:func:`omnigent.runner._entry._make_auth_token_factory`), preserving the
-    other headers (e.g. the ``X-Databricks-Org-Id`` workspace-routing header)
-    so neither half is dropped. Best-effort: returns ``None`` when no refresh
-    mechanism is available (local unauthenticated servers, import failure, or a
-    transient mint failure), letting the caller fail closed.
-
-    :param ap_server_url: Omnigent server base URL the hook POSTs to — also the
-        key the token factory uses to resolve the stored OIDC token.
-    :param headers: The current (lapsed) outbound headers; the fresh bearer is
-        merged over a copy so routing headers survive.
-    :returns: A zero-arg callable returning fresh headers, or ``None``.
-    """
-
-    def _reauth() -> dict[str, str] | None:
-        # Lazy import: only paid on the rare re-auth path, keeping the
-        # per-tool-call hot path free of the runner/databricks-SDK import.
-        try:
-            from omnigent.runner._entry import _make_auth_token_factory
-        except Exception:  # noqa: BLE001 — re-auth is best-effort; fail closed if unavailable
-            return None
-        factory = _make_auth_token_factory(ap_server_url)
-        if factory is None:
-            return None
-        try:
-            token = factory()
-        except Exception:  # noqa: BLE001 — transient SDK/refresh failure; fail closed
-            return None
-        if not token:
-            return None
-        return {**headers, "Authorization": f"Bearer {token}"}
-
-    return _reauth
-
-
 def _post_hook_with_reattach(
     url: str,
     headers: dict[str, str],
@@ -695,7 +650,11 @@ def _main_permission_request(argv: list[str]) -> int:
         f"{url_component(session_id)}/hooks/permission-request"
     )
     resp = _post_hook_with_reattach(
-        url, headers, payload, "claude permission", reauth=_build_reauth(ap_server_url, headers)
+        url,
+        headers,
+        payload,
+        "claude permission",
+        reauth=policy_hook_reauth(ap_server_url, headers),
     )
     if resp is None:
         return 0
@@ -763,7 +722,11 @@ def _main_ask_user_question(argv: list[str]) -> int:
         f"{url_component(session_id)}/hooks/permission-request"
     )
     resp = _post_hook_with_reattach(
-        url, headers, payload, "ask-user-question", reauth=_build_reauth(ap_server_url, headers)
+        url,
+        headers,
+        payload,
+        "ask-user-question",
+        reauth=policy_hook_reauth(ap_server_url, headers),
     )
     if resp is None or not resp.content:
         return 0
@@ -915,7 +878,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         eval_request,
         _EVALUATE_POLICY_TIMEOUT_S,
         "evaluate-policy hook",
-        reauth=_build_reauth(ap_server_url, headers),
+        reauth=policy_hook_reauth(ap_server_url, headers),
     )
     if resp is None:
         return _fail_closed()

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -226,46 +226,36 @@ def load_databricks_org_id(server_url: str) -> str | None:
 DATABRICKS_ORG_ID_HEADER = "X-Databricks-Org-Id"
 
 
-def databricks_org_id_headers(server_url: str) -> dict[str, str]:
-    """Return the workspace-routing header for *server_url*, or ``{}``.
+def databricks_request_headers(
+    server_url: str, *, bearer_token: str | None = None
+) -> dict[str, str]:
+    """Build the headers for a request to a Databricks-fronted server.
 
-    ``omnigent login https://<host>/?o=<id>`` records the ``?o=`` selector;
-    this surfaces it as the :data:`DATABRICKS_ORG_ID_HEADER` so requests
-    route to the workspace instead of the account. Empty when no selector
-    is recorded (single-workspace / non-Databricks hosts), so those callers
-    are unaffected.
+    The single source of truth for server-request headers. It always
+    includes the :data:`DATABRICKS_ORG_ID_HEADER` workspace-routing header
+    when ``omnigent login https://<host>/?o=<id>`` recorded a selector, and
+    adds ``Authorization`` when a bearer is supplied. Folding both into one
+    builder makes routing travel with auth: a caller that has a token gets
+    routing for free, and a caller whose credential is set elsewhere (an
+    httpx ``Auth`` that mints per request, or the managed-host token header)
+    omits the token and still gets routing.
 
-    :param server_url: The server URL, e.g.
-        ``"https://example.databricks.com/api/2.0/omnigent"``.
-    :returns: ``{"X-Databricks-Org-Id": "<id>"}`` when a selector is
-        recorded for *server_url*, otherwise ``{}``.
-    """
-    org_id = load_databricks_org_id(server_url)
-    return {DATABRICKS_ORG_ID_HEADER: org_id} if org_id else {}
-
-
-def databricks_auth_headers(server_url: str, bearer_token: str | None) -> dict[str, str]:
-    """Mint the bearer and the workspace-routing header together.
-
-    Pairs ``Authorization`` with :data:`DATABRICKS_ORG_ID_HEADER` in one
-    call so a hand-built header dict can't carry the bearer without the
-    routing header. Use it where a static dict is constructed (the
-    WebSocket handshakes, the hook-config replay) instead of writing the
-    ``Authorization`` entry inline; the long-lived httpx clients set both
-    in their ``auth_flow``. Either value is omitted when absent, so
-    single-workspace and unauthenticated callers are unaffected.
+    Both values are omitted when absent, so single-workspace and
+    local-unauthenticated callers get ``{}`` and are unaffected.
 
     :param server_url: The server URL, e.g.
         ``"https://example.databricks.com/api/2.0/omnigent"``.
-    :param bearer_token: The workspace bearer token, or ``None`` to omit
-        the ``Authorization`` header (local unauthenticated runs).
+    :param bearer_token: The workspace bearer token, or ``None`` when the
+        credential is supplied by a separate mechanism (or there is none).
     :returns: A header dict carrying ``Authorization`` and/or
         ``X-Databricks-Org-Id`` as available, possibly empty.
     """
     headers: dict[str, str] = {}
     if bearer_token:
         headers["Authorization"] = f"Bearer {bearer_token}"
-    headers.update(databricks_org_id_headers(server_url))
+    org_id = load_databricks_org_id(server_url)
+    if org_id:
+        headers[DATABRICKS_ORG_ID_HEADER] = org_id
     return headers
 
 

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -26,6 +26,7 @@ from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    policy_hook_reauth,
     post_evaluate_with_retry,
 )
 
@@ -160,7 +161,13 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     session_component = urllib.parse.quote(session_id, safe="")
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{session_component}/policies/evaluate"
     resp = post_evaluate_with_retry(
-        url, headers, eval_request, _EVALUATE_POLICY_TIMEOUT_S, "codex evaluate-policy hook"
+        url,
+        headers,
+        eval_request,
+        _EVALUATE_POLICY_TIMEOUT_S,
+        "codex evaluate-policy hook",
+        # Re-mint the baked one-shot token if it lapses mid-session.
+        reauth=policy_hook_reauth(ap_server_url, headers),
     )
     if resp is None:
         return _fail_closed()

--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -323,15 +323,14 @@ def write_policy_hook_config(
 
     hook_script_path = str(Path(__file__).resolve().parent / "inner" / "hermes_policy_hook.py")
 
-    # Wrapper shell script: sets env vars and execs the Python hook.
+    # Wrapper shell script: sets env vars and execs the Python hook. It bakes a
+    # one-shot auth token + workspace-routing header, so it is owner-only
+    # (0o700) — the secret is never world-readable.
+    from omnigent.native_policy_hook import policy_hook_wrapper_script
+
     wrapper = hermes_home / "omnigent-policy-hook.sh"
-    wrapper.write_text(
-        f"#!/bin/sh\n"
-        f"export _OMNIGENT_SERVER_URL='{server_url}'\n"
-        f"export _OMNIGENT_SESSION_ID='{session_id}'\n"
-        f"exec '{sys.executable}' '{hook_script_path}'\n"
-    )
-    wrapper.chmod(0o755)
+    wrapper.write_text(policy_hook_wrapper_script(server_url, session_id, hook_script_path))
+    wrapper.chmod(0o700)
 
     # Write bridge.json with an auth token for serve-mcp (idempotent).
     _write_mcp_bridge_config(bridge_dir)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1425,9 +1425,9 @@ class HostProcess:
         # Workspace routing: the tunnel handshake must name the workspace or
         # it routes to the account. Empty for single-workspace and managed
         # hosts (no recorded selector), so neither is affected.
-        from omnigent.cli_auth import databricks_org_id_headers
+        from omnigent.cli_auth import databricks_request_headers
 
-        headers.update(databricks_org_id_headers(self._server_url))
+        headers.update(databricks_request_headers(self._server_url))
 
         managed_token = os.environ.get(HOST_TOKEN_ENV_VAR)
         if managed_token:

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -406,15 +406,14 @@ def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, sessio
     hooks_dir.mkdir(parents=True, exist_ok=True)
     hooks_file = hooks_dir / "hooks.json"
 
-    # Write a wrapper script that sets env vars and execs the hook.
+    # Write a wrapper script that sets env vars and execs the hook. It bakes a
+    # one-shot auth token + workspace-routing header, so it is owner-only
+    # (0o700) — the secret is never world-readable.
+    from omnigent.native_policy_hook import policy_hook_wrapper_script
+
     wrapper = hooks_dir / "omnigent-hook.sh"
-    wrapper.write_text(
-        f"#!/bin/sh\n"
-        f"export _OMNIGENT_SERVER_URL='{server_url}'\n"
-        f"export _OMNIGENT_SESSION_ID='{session_id}'\n"
-        f"exec '{sys.executable}' '{hook_script_path}'\n"
-    )
-    wrapper.chmod(0o755)
+    wrapper.write_text(policy_hook_wrapper_script(server_url, session_id, hook_script_path))
+    wrapper.chmod(0o700)
     command = str(wrapper)
     config = {
         "version": 1,

--- a/omnigent/inner/cursor_policy_hook.py
+++ b/omnigent/inner/cursor_policy_hook.py
@@ -57,11 +57,14 @@ def main() -> None:
     url = f"{server_url.rstrip('/')}/v1/sessions/{session_id}/policies/evaluate"
 
     try:
-        from omnigent.native_policy_hook import post_evaluate_with_retry
+        from omnigent.native_policy_hook import (
+            policy_hook_request_headers,
+            post_evaluate_with_retry,
+        )
 
         resp = post_evaluate_with_retry(
             url=url,
-            headers={"Content-Type": "application/json"},
+            headers=policy_hook_request_headers(),
             eval_request=eval_body,
             # One day — must match the hooks.json ``timeout`` and the
             # server's ``ask_timeout`` so the hook stays alive while the

--- a/omnigent/inner/cursor_policy_hook.py
+++ b/omnigent/inner/cursor_policy_hook.py
@@ -58,19 +58,23 @@ def main() -> None:
 
     try:
         from omnigent.native_policy_hook import (
+            policy_hook_reauth,
             policy_hook_request_headers,
             post_evaluate_with_retry,
         )
 
+        headers = policy_hook_request_headers()
         resp = post_evaluate_with_retry(
             url=url,
-            headers=policy_hook_request_headers(),
+            headers=headers,
             eval_request=eval_body,
             # One day — must match the hooks.json ``timeout`` and the
             # server's ``ask_timeout`` so the hook stays alive while the
             # human responds to the web-UI approval card.
             read_timeout=86400.0,
             hook_label="cursor preToolUse",
+            # Re-mint the baked one-shot token if it lapses mid-session.
+            reauth=policy_hook_reauth(server_url, headers),
         )
     except Exception:  # noqa: BLE001 -- fail open on import / unexpected error
         json.dump({"permission": "allow"}, sys.stdout)

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -232,15 +232,14 @@ def _populate_hermes_home(
     """
     hermes_home.mkdir(parents=True, exist_ok=True)
 
-    # Write the wrapper shell script that sets env vars and execs the hook.
+    # Write the wrapper shell script that sets env vars and execs the hook. It
+    # bakes a one-shot auth token + workspace-routing header, so it is
+    # owner-only (0o700) — the secret is never world-readable.
+    from omnigent.native_policy_hook import policy_hook_wrapper_script
+
     wrapper = hermes_home / "omnigent-policy-hook.sh"
-    wrapper.write_text(
-        f"#!/bin/sh\n"
-        f"export _OMNIGENT_SERVER_URL='{server_url}'\n"
-        f"export _OMNIGENT_SESSION_ID='{session_id}'\n"
-        f"exec '{sys.executable}' '{hook_script_path}'\n"
-    )
-    wrapper.chmod(0o755)
+    wrapper.write_text(policy_hook_wrapper_script(server_url, session_id, hook_script_path))
+    wrapper.chmod(0o700)
 
     # Start from the user's config so model/provider/auth settings carry over.
     # Hermes scopes everything to HERMES_HOME, so without this merge it won't

--- a/omnigent/inner/hermes_policy_hook.py
+++ b/omnigent/inner/hermes_policy_hook.py
@@ -71,11 +71,14 @@ def main() -> None:
     url = f"{server_url.rstrip('/')}/v1/sessions/{session_id}/policies/evaluate"
 
     try:
-        from omnigent.native_policy_hook import post_evaluate_with_retry
+        from omnigent.native_policy_hook import (
+            policy_hook_request_headers,
+            post_evaluate_with_retry,
+        )
 
         resp = post_evaluate_with_retry(
             url=url,
-            headers={"Content-Type": "application/json"},
+            headers=policy_hook_request_headers(),
             eval_request=eval_body,
             # One day — must match the server's ``ask_timeout`` so the hook
             # stays alive while the human responds to the web-UI approval card.

--- a/omnigent/inner/hermes_policy_hook.py
+++ b/omnigent/inner/hermes_policy_hook.py
@@ -72,18 +72,22 @@ def main() -> None:
 
     try:
         from omnigent.native_policy_hook import (
+            policy_hook_reauth,
             policy_hook_request_headers,
             post_evaluate_with_retry,
         )
 
+        headers = policy_hook_request_headers()
         resp = post_evaluate_with_retry(
             url=url,
-            headers=policy_hook_request_headers(),
+            headers=headers,
             eval_request=eval_body,
             # One day — must match the server's ``ask_timeout`` so the hook
             # stays alive while the human responds to the web-UI approval card.
             read_timeout=86400.0,
             hook_label="hermes pre_tool_call",
+            # Re-mint the baked one-shot token if it lapses mid-session.
+            reauth=policy_hook_reauth(server_url, headers),
         )
     except Exception:  # noqa: BLE001 -- fail open on import / unexpected error
         json.dump({}, sys.stdout)

--- a/omnigent/kimi_native_hook.py
+++ b/omnigent/kimi_native_hook.py
@@ -55,6 +55,7 @@ from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    policy_hook_reauth,
     post_evaluate_with_retry,
 )
 
@@ -148,7 +149,13 @@ def _main_evaluate_policy(argv: list[str]) -> int:
 
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{_url_component(session_id)}/policies/evaluate"
     resp = post_evaluate_with_retry(
-        url, headers, eval_request, _EVALUATE_POLICY_TIMEOUT_S, "kimi evaluate-policy hook"
+        url,
+        headers,
+        eval_request,
+        _EVALUATE_POLICY_TIMEOUT_S,
+        "kimi evaluate-policy hook",
+        # Re-mint the baked one-shot token if it lapses mid-session.
+        reauth=policy_hook_reauth(ap_server_url, headers),
     )
     if resp is None or not resp.content:
         return _fail_closed()

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -21,7 +21,9 @@ model sees it).
 from __future__ import annotations
 
 import json
+import os
 import secrets
+import shlex
 import sys
 import time
 from collections.abc import Callable
@@ -59,6 +61,71 @@ _EVAL_UNAVAILABLE_REASON = (
     "Omnigent policy evaluation unavailable (could not reach or authenticate to the "
     "Omnigent server); failing closed for this tool call."
 )
+
+
+# Env var carrying the one-shot auth + workspace-routing headers from the
+# executor (which writes the hook wrapper) to the hook subprocess. The hook
+# is import-free of the runner, so the headers are passed in rather than
+# resolved in-process — the same reason ``ap_auth_headers`` is baked for the
+# claude/codex/kimi hooks.
+_AUTH_HEADERS_ENV = "_OMNIGENT_AUTH_HEADERS"
+
+
+def policy_hook_request_headers() -> dict[str, str]:
+    """Build the headers for a policy-hook subprocess's POST to the server.
+
+    Always carries ``Content-Type``, and merges the one-shot auth +
+    workspace-routing headers the executor baked into :data:`_AUTH_HEADERS_ENV`
+    at launch (see :func:`policy_hook_wrapper_script`). Without them the POST
+    is unauthenticated and unrouted — it 401s on an authenticated server and
+    misroutes to the account on a unified-account workspace. Missing or
+    malformed env → just ``Content-Type`` (a local unauthenticated server
+    needs no auth).
+
+    :returns: Request headers for ``post_evaluate_with_retry``.
+    """
+    headers = {"Content-Type": "application/json"}
+    raw = os.environ.get(_AUTH_HEADERS_ENV, "")
+    if raw:
+        try:
+            extra = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            extra = None
+        if isinstance(extra, dict):
+            headers.update({str(k): str(v) for k, v in extra.items()})
+    return headers
+
+
+def policy_hook_wrapper_script(
+    server_url: str, session_id: str, hook_script_path: str
+) -> str:
+    """Build the ``/bin/sh`` wrapper a native policy hook is launched as.
+
+    Resolves a one-shot Omnigent-server token and bakes the auth +
+    workspace-routing headers (via
+    :func:`omnigent.cli_auth.databricks_request_headers`) into
+    :data:`_AUTH_HEADERS_ENV`, so the hook's POST authenticates and routes to
+    the workspace. The token is a secret, so callers MUST write the returned
+    wrapper ``0o700`` (owner-only) — it is never world-readable.
+
+    :param server_url: Omnigent server base URL the hook posts to.
+    :param session_id: Session / conversation id for policy evaluation.
+    :param hook_script_path: Absolute path to the hook's Python entrypoint.
+    :returns: Shell-script text for the wrapper (write it ``0o700``).
+    """
+    from omnigent.cli_auth import databricks_request_headers
+    from omnigent.runner._entry import _make_auth_token_factory
+
+    factory = _make_auth_token_factory(server_url=server_url)
+    token = factory() if factory is not None else None
+    auth_headers = databricks_request_headers(server_url, bearer_token=token)
+    return (
+        "#!/bin/sh\n"
+        f"export _OMNIGENT_SERVER_URL={shlex.quote(server_url)}\n"
+        f"export _OMNIGENT_SESSION_ID={shlex.quote(session_id)}\n"
+        f"export {_AUTH_HEADERS_ENV}={shlex.quote(json.dumps(auth_headers))}\n"
+        f"exec {shlex.quote(sys.executable)} {shlex.quote(hook_script_path)}\n"
+    )
 
 
 def _is_login_redirect_or_unauthorized(response: httpx.Response) -> bool:

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -96,9 +96,7 @@ def policy_hook_request_headers() -> dict[str, str]:
     return headers
 
 
-def policy_hook_wrapper_script(
-    server_url: str, session_id: str, hook_script_path: str
-) -> str:
+def policy_hook_wrapper_script(server_url: str, session_id: str, hook_script_path: str) -> str:
     """Build the ``/bin/sh`` wrapper a native policy hook is launched as.
 
     Resolves a one-shot Omnigent-server token and bakes the auth +
@@ -126,6 +124,44 @@ def policy_hook_wrapper_script(
         f"export {_AUTH_HEADERS_ENV}={shlex.quote(json.dumps(auth_headers))}\n"
         f"exec {shlex.quote(sys.executable)} {shlex.quote(hook_script_path)}\n"
     )
+
+
+def policy_hook_reauth(
+    server_url: str, headers: dict[str, str]
+) -> Callable[[], dict[str, str] | None]:
+    """Build a callable that re-mints the Omnigent bearer for *server_url*.
+
+    The baked one-shot token dies with the ~1h Databricks OAuth lifetime; on a
+    lapsed-token signal (401 or Apps ``302→/oidc/``) ``post_evaluate_with_retry``
+    calls this once to mint a fresh bearer through the same factory the
+    refresh-capable runtime auth uses, keeping the other headers (e.g.
+    ``X-Databricks-Org-Id``) so routing survives. Returns ``None`` when no
+    refresh mechanism is available, so the caller fails closed.
+
+    :param server_url: Omnigent server base URL the hook POSTs to.
+    :param headers: Current (lapsed) headers; the fresh bearer is merged over
+        a copy so routing headers survive.
+    :returns: A zero-arg callable returning fresh headers, or ``None``.
+    """
+
+    def _reauth() -> dict[str, str] | None:
+        # Lazy import: paid only on the rare re-auth path, off the hot path.
+        try:
+            from omnigent.runner._entry import _make_auth_token_factory
+        except Exception:  # noqa: BLE001 — best-effort; fail closed if unavailable
+            return None
+        factory = _make_auth_token_factory(server_url)
+        if factory is None:
+            return None
+        try:
+            token = factory()
+        except Exception:  # noqa: BLE001 — transient mint failure; fail closed
+            return None
+        if not token:
+            return None
+        return {**headers, "Authorization": f"Bearer {token}"}
+
+    return _reauth
 
 
 def _is_login_redirect_or_unauthorized(response: httpx.Response) -> bool:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -220,9 +220,9 @@ class _RunnerDatabricksAuth(httpx.Auth):
         # account (the forwarder's POST /events otherwise 403s). Empty when
         # none recorded. Set once here; it persists across the retry yield.
         if self._server_url:
-            from omnigent.cli_auth import databricks_org_id_headers
+            from omnigent.cli_auth import databricks_request_headers
 
-            request.headers.update(databricks_org_id_headers(self._server_url))
+            request.headers.update(databricks_request_headers(self._server_url))
         if self._factory is not None:
             token = self._factory()
             if not token:
@@ -670,7 +670,7 @@ def create_app(
         a second time during runner boot.
     :returns: A runner FastAPI app exposing the harness-contract subset.
     """
-    from omnigent.cli_auth import databricks_org_id_headers
+    from omnigent.cli_auth import databricks_request_headers
     from omnigent.runner.app import create_runner_app
     from omnigent.runner.identity import (
         OMNIGENT_INTERNAL_WS_ORIGIN,
@@ -727,7 +727,7 @@ def create_app(
         #
         # The workspace-routing header (empty unless a ?o= selector was
         # recorded for this server) routes these callbacks to the workspace.
-        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN, **databricks_org_id_headers(server_url)},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN, **databricks_request_headers(server_url)},
         timeout=httpx.Timeout(5.0, read=None),
         # NOTE: ``follow_redirects`` deliberately stays False.
         # ``_RunnerDatabricksAuth.auth_flow`` needs to *see* the

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3273,9 +3273,9 @@ async def _auto_create_kimi_terminal(
     # The hook subprocess replays these static headers from its config (no
     # refresh-capable httpx.Auth of its own); the helper pairs the bearer with
     # the workspace-routing header so neither is dropped.
-    from omnigent.cli_auth import databricks_auth_headers
+    from omnigent.cli_auth import databricks_request_headers
 
-    _runner_headers = databricks_auth_headers(server_url, _auth_token)
+    _runner_headers = databricks_request_headers(server_url, bearer_token=_auth_token)
     write_hook_config(
         bridge_dir,
         server_url=server_url,
@@ -3636,9 +3636,11 @@ async def _auto_create_codex_terminal(
     # The codex policy hook subprocess replays these static headers from its
     # config (no refresh-capable auth of its own); the helper pairs the bearer
     # with the workspace-routing header so neither is dropped.
-    from omnigent.cli_auth import databricks_auth_headers
+    from omnigent.cli_auth import databricks_request_headers
 
-    policy_headers = databricks_auth_headers(launch_config.policy_server_url, _policy_auth_token)
+    policy_headers = databricks_request_headers(
+        launch_config.policy_server_url, bearer_token=_policy_auth_token
+    )
 
     app_server = build_codex_native_server(
         socket_path=socket_path,
@@ -5360,9 +5362,9 @@ async def _auto_create_claude_terminal(
     # The hook subprocess replays these static headers from its config (no
     # refresh-capable auth of its own); the helper pairs the bearer with the
     # workspace-routing header so neither is dropped.
-    from omnigent.cli_auth import databricks_auth_headers
+    from omnigent.cli_auth import databricks_request_headers
 
-    _runner_headers = databricks_auth_headers(server_url, _auth_token)
+    _runner_headers = databricks_request_headers(server_url, bearer_token=_auth_token)
     _runner_auth = _RunnerDatabricksAuth(_auth_factory)
 
     from omnigent.claude_launcher import resolve_claude_launch
@@ -12316,7 +12318,7 @@ def create_runner_app(
             # the routing header already). The popup subprocess replays these
             # static headers, so pair the bearer with the workspace-routing
             # header — bearer alone misroutes the popup's POST to the account.
-            from omnigent.cli_auth import databricks_auth_headers
+            from omnigent.cli_auth import databricks_request_headers
             from omnigent.opencode_native_bridge import (
                 bridge_dir_for_bridge_id as _oc_bridge_dir,
             )
@@ -12332,7 +12334,7 @@ def create_runner_app(
                 write_cost_popup_config,
                 _oc_bridge_dir(conv_id),
                 ap_server_url=_server_url,
-                ap_auth_headers=databricks_auth_headers(_server_url, _token),
+                ap_auth_headers=databricks_request_headers(_server_url, bearer_token=_token),
             )
         from omnigent import codex_native_bridge as _cxb
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -12311,6 +12311,12 @@ def create_runner_app(
             )
             return _cnb.bridge_dir_for_bridge_id(bridge_id) / _cnb._PERMISSION_HOOK_FILE
         if harness == "opencode-native":
+            # opencode is the one harness whose popup config is minted fresh here
+            # (claude/codex reuse their permission/policy hook files, which carry
+            # the routing header already). The popup subprocess replays these
+            # static headers, so pair the bearer with the workspace-routing
+            # header — bearer alone misroutes the popup's POST to the account.
+            from omnigent.cli_auth import databricks_auth_headers
             from omnigent.opencode_native_bridge import (
                 bridge_dir_for_bridge_id as _oc_bridge_dir,
             )
@@ -12319,13 +12325,14 @@ def create_runner_app(
             )
             from omnigent.runner._entry import _make_auth_token_factory
 
+            _server_url = _required_runner_env("RUNNER_SERVER_URL")
             _factory = _make_auth_token_factory()
             _token = _factory() if _factory is not None else None
             return await asyncio.to_thread(
                 write_cost_popup_config,
                 _oc_bridge_dir(conv_id),
-                ap_server_url=_required_runner_env("RUNNER_SERVER_URL"),
-                ap_auth_headers={"Authorization": f"Bearer {_token}"} if _token else {},
+                ap_server_url=_server_url,
+                ap_auth_headers=databricks_auth_headers(_server_url, _token),
             )
         from omnigent import codex_native_bridge as _cxb
 

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -534,10 +534,10 @@ async def _serve_tunnel_once(
     # Pair the bearer with the workspace-routing header: the handshake must
     # name the workspace or it routes to the account. Both empty for
     # single-workspace hosts / local unauthenticated runs.
-    from omnigent.cli_auth import databricks_auth_headers
+    from omnigent.cli_auth import databricks_request_headers
 
     headers: dict[str, str] = {"Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
-    headers.update(databricks_auth_headers(server_url, auth_token))
+    headers.update(databricks_request_headers(server_url, bearer_token=auth_token))
     if tunnel_token:
         headers[RUNNER_TUNNEL_TOKEN_HEADER] = tunnel_token
     async with websockets.connect(

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2874,7 +2874,7 @@ def test_databricks_token_auth_sets_org_header(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.delenv(chat_module._REMOTE_AUTH_TOKEN_ENV, raising=False)
     monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
     monkeypatch.setattr(
-        "omnigent.cli_auth.databricks_org_id_headers",
+        "omnigent.cli_auth.databricks_request_headers",
         lambda _url: {"X-Databricks-Org-Id": "2850744067564480"},
     )
     # Isolate from real Databricks SDK resolution: the bearer is irrelevant

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -228,21 +228,21 @@ def test_store_and_load_databricks_record(token_dir) -> None:
     )
 
 
-def test_databricks_org_id_headers_from_record(token_dir) -> None:
+def test_databricks_request_headers_org_only(token_dir) -> None:
     """A recorded ?o= selector surfaces as the workspace-routing header.
 
     When the bare host is the account, the request routes by this header
     (equivalently to ``?o=``). A record with no org id (single-workspace
     host) yields no header, so those callers are unaffected.
     """
-    from omnigent.cli_auth import databricks_org_id_headers, store_databricks_auth
+    from omnigent.cli_auth import databricks_request_headers, store_databricks_auth
 
     store_databricks_auth(
         server_url="https://acme.databricks.com/api/2.0/omnigent",
         workspace_host="https://acme.databricks.com",
         org_id="2850744067564480",
     )
-    assert databricks_org_id_headers("https://acme.databricks.com/api/2.0/omnigent") == {
+    assert databricks_request_headers("https://acme.databricks.com/api/2.0/omnigent") == {
         "X-Databricks-Org-Id": "2850744067564480"
     }
 
@@ -250,10 +250,10 @@ def test_databricks_org_id_headers_from_record(token_dir) -> None:
         server_url="https://single.databricks.com/api/2.0/omnigent",
         workspace_host="https://single.databricks.com",
     )
-    assert databricks_org_id_headers("https://single.databricks.com/api/2.0/omnigent") == {}
+    assert databricks_request_headers("https://single.databricks.com/api/2.0/omnigent") == {}
 
 
-def test_databricks_auth_headers_pairs_bearer_and_org(token_dir) -> None:
+def test_databricks_request_headers_pairs_bearer_and_org(token_dir) -> None:
     """The paired minter always emits the bearer and the ?o= header together.
 
     The static-dict seams (WS handshakes, hook-config replay) call this so a
@@ -261,7 +261,7 @@ def test_databricks_auth_headers_pairs_bearer_and_org(token_dir) -> None:
     header. A missing token or selector is omitted, so single-workspace and
     local-unauthenticated callers are unaffected.
     """
-    from omnigent.cli_auth import databricks_auth_headers, store_databricks_auth
+    from omnigent.cli_auth import databricks_request_headers, store_databricks_auth
 
     store_databricks_auth(
         server_url="https://acme.databricks.com/api/2.0/omnigent",
@@ -270,14 +270,14 @@ def test_databricks_auth_headers_pairs_bearer_and_org(token_dir) -> None:
     )
     recorded = "https://acme.databricks.com/api/2.0/omnigent"
     # Bearer + org travel together.
-    assert databricks_auth_headers(recorded, "tok") == {
+    assert databricks_request_headers(recorded, bearer_token="tok") == {
         "Authorization": "Bearer tok",
         "X-Databricks-Org-Id": "2850744067564480",
     }
     # Recorded selector but no token (local/unauth): org still rides, no bearer.
-    assert databricks_auth_headers(recorded, None) == {"X-Databricks-Org-Id": "2850744067564480"}
+    assert databricks_request_headers(recorded) == {"X-Databricks-Org-Id": "2850744067564480"}
     # No record (unknown server): bearer only, no routing header.
-    assert databricks_auth_headers("https://other.example.com", "tok") == {
+    assert databricks_request_headers("https://other.example.com", bearer_token="tok") == {
         "Authorization": "Bearer tok"
     }
 

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1511,9 +1511,14 @@ async def test_ensure_session_writes_hooks_json(
     wrapper = tmp_path / ".cursor" / "omnigent-hook.sh"
     assert wrapper.exists()
     wrapper_text = wrapper.read_text()
-    assert "_OMNIGENT_SERVER_URL='http://127.0.0.1:6767'" in wrapper_text
-    assert "_OMNIGENT_SESSION_ID='conv_test123'" in wrapper_text
+    # Values are shlex-quoted (shell-safe URLs/ids need no quotes).
+    assert "_OMNIGENT_SERVER_URL=http://127.0.0.1:6767" in wrapper_text
+    assert "_OMNIGENT_SESSION_ID=conv_test123" in wrapper_text
     assert "cursor_policy_hook.py" in wrapper_text
+    # The wrapper bakes a one-shot auth + workspace-routing header...
+    assert "_OMNIGENT_AUTH_HEADERS=" in wrapper_text
+    # ...so it must be owner-only (the baked token is never world-readable).
+    assert wrapper.stat().st_mode & 0o777 == 0o700
 
     # auto_review=True must be passed so cursor's own TUI approval prompts
     # are bypassed in favour of the executor's native elicitation card.

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1879,47 +1879,6 @@ def test_evaluate_policy_retries_5xx_and_succeeds(
     assert call_count == 3
 
 
-def test_build_reauth_remints_and_preserves_routing_header(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """
-    ``_build_reauth`` re-mints the bearer and keeps the routing header.
-
-    The fresh token must be merged OVER the existing headers so the
-    ``X-Databricks-Org-Id`` workspace-routing header (which the Apps server
-    needs to avoid a 403 reroute to the account) is preserved, not dropped.
-    """
-    monkeypatch.setattr(
-        "omnigent.runner._entry._make_auth_token_factory",
-        lambda server_url=None: lambda: "fresh-token",
-    )
-    reauth = claude_native_hook._build_reauth(
-        "https://ap.example.com",
-        {"Authorization": "Bearer stale", "X-Databricks-Org-Id": "o9"},
-    )
-    assert reauth() == {"Authorization": "Bearer fresh-token", "X-Databricks-Org-Id": "o9"}
-
-
-def test_build_reauth_returns_none_without_factory(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """
-    ``_build_reauth`` returns ``None`` when no refresh mechanism is available.
-
-    Local unauthenticated servers (no token factory) must not synthesize an
-    auth header; returning ``None`` lets the caller fall through to its normal
-    handling (which fails closed for a tool-call gate).
-    """
-    monkeypatch.setattr(
-        "omnigent.runner._entry._make_auth_token_factory",
-        lambda server_url=None: None,
-    )
-    reauth = claude_native_hook._build_reauth(
-        "https://ap.example.com", {"Authorization": "Bearer stale"}
-    )
-    assert reauth() is None
-
-
 def test_evaluate_policy_reauths_on_expired_token_instead_of_failing_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -284,13 +284,16 @@ def test_write_policy_hook_config_creates_expected_files(tmp_path) -> None:
     assert hermes_home == bridge_dir / "hermes_home"
     assert hermes_home.is_dir()
 
-    # Wrapper shell script exists and is executable.
+    # Wrapper shell script exists and is owner-only (it bakes a one-shot auth
+    # token, so the secret is never world-readable).
     wrapper = hermes_home / "omnigent-policy-hook.sh"
     assert wrapper.is_file()
-    assert wrapper.stat().st_mode & 0o111
+    assert wrapper.stat().st_mode & 0o777 == 0o700
     wrapper_text = wrapper.read_text()
-    assert "_OMNIGENT_SERVER_URL='http://localhost:6767'" in wrapper_text
-    assert "_OMNIGENT_SESSION_ID='session-123'" in wrapper_text
+    # Values are shlex-quoted (shell-safe URLs/ids need no quotes).
+    assert "_OMNIGENT_SERVER_URL=http://localhost:6767" in wrapper_text
+    assert "_OMNIGENT_SESSION_ID=session-123" in wrapper_text
+    assert "_OMNIGENT_AUTH_HEADERS=" in wrapper_text
     assert sys.executable in wrapper_text
     assert "hermes_policy_hook.py" in wrapper_text
 

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -528,3 +528,99 @@ def test_post_evaluate_with_retry_reauth_unavailable_fails_closed(
     )
     assert resp is None
     assert len(seen_headers) == 1  # one attempt only; no retry loop
+
+
+# ── shared policy-hook header plumbing (writer + reader) ─────────────
+
+
+def test_policy_hook_request_headers_merges_baked_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reader merges the executor-baked auth + routing headers.
+
+    The import-free hook subprocess can't resolve credentials in-process, so
+    the executor bakes them into ``_OMNIGENT_AUTH_HEADERS``; the reader must
+    fold them onto ``Content-Type`` for the policy POST.
+    """
+    monkeypatch.setenv(
+        "_OMNIGENT_AUTH_HEADERS",
+        '{"Authorization": "Bearer tok", "X-Databricks-Org-Id": "org123"}',
+    )
+    assert native_policy_hook.policy_hook_request_headers() == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer tok",
+        "X-Databricks-Org-Id": "org123",
+    }
+
+
+@pytest.mark.parametrize("raw", ["", "not json", "[1,2]"])
+def test_policy_hook_request_headers_tolerates_missing_or_bad_env(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """Absent / malformed env → just ``Content-Type`` (local-unauth path).
+
+    A bad value must not crash the hook nor inject garbage headers — the
+    server simply decides without auth (a local unauthenticated server needs
+    none).
+    """
+    if raw:
+        monkeypatch.setenv("_OMNIGENT_AUTH_HEADERS", raw)
+    else:
+        monkeypatch.delenv("_OMNIGENT_AUTH_HEADERS", raising=False)
+    assert native_policy_hook.policy_hook_request_headers() == {"Content-Type": "application/json"}
+
+
+def test_policy_hook_wrapper_script_bakes_auth_and_routing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The writer bakes bearer + routing into the wrapper via the one builder.
+
+    A new harness wiring up its hook through this helper gets auth AND
+    workspace routing for free — the gap that left the cursor/hermes hooks
+    posting unauthenticated and unrouted.
+    """
+    import omnigent.cli_auth as cli_auth
+    import omnigent.runner._entry as entry
+
+    monkeypatch.setattr(
+        entry, "_make_auth_token_factory", lambda *, server_url=None: lambda: "tok"
+    )
+    monkeypatch.setattr(cli_auth, "load_databricks_org_id", lambda _url: "org123")
+
+    script = native_policy_hook.policy_hook_wrapper_script(
+        "https://acme.databricks.com/api/2.0/omnigent", "conv_x", "/path/hook.py"
+    )
+
+    assert script.startswith("#!/bin/sh\n")
+    assert "_OMNIGENT_SERVER_URL=https://acme.databricks.com/api/2.0/omnigent" in script
+    assert "_OMNIGENT_SESSION_ID=conv_x" in script
+    # The baked headers carry BOTH the bearer and the routing header.
+    line = next(
+        ln for ln in script.splitlines() if ln.startswith("export _OMNIGENT_AUTH_HEADERS=")
+    )
+    assert "Bearer tok" in line
+    assert "X-Databricks-Org-Id" in line and "org123" in line
+
+
+def test_policy_hook_wrapper_script_omits_auth_when_unauthenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No token + no recorded selector → empty auth dict (local-unauth runs).
+
+    The wrapper still exports the (empty) header dict, so the reader yields
+    just ``Content-Type`` — non-workspace callers are unaffected.
+    """
+    import omnigent.cli_auth as cli_auth
+    import omnigent.runner._entry as entry
+
+    monkeypatch.setattr(entry, "_make_auth_token_factory", lambda *, server_url=None: None)
+    monkeypatch.setattr(cli_auth, "load_databricks_org_id", lambda _url: None)
+
+    script = native_policy_hook.policy_hook_wrapper_script(
+        "http://127.0.0.1:6767", "conv_local", "/path/hook.py"
+    )
+    line = next(
+        ln for ln in script.splitlines() if ln.startswith("export _OMNIGENT_AUTH_HEADERS=")
+    )
+    assert "Bearer" not in line
+    assert "X-Databricks-Org-Id" not in line

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -624,3 +624,38 @@ def test_policy_hook_wrapper_script_omits_auth_when_unauthenticated(
     )
     assert "Bearer" not in line
     assert "X-Databricks-Org-Id" not in line
+
+
+def test_policy_hook_reauth_remints_and_preserves_routing_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared reauth re-mints the bearer and keeps the routing header.
+
+    When a baked one-shot token lapses, the four hooks (codex/kimi/cursor/
+    hermes) that wire this builder must mint a fresh bearer through the same
+    factory the refresh-capable runtime auth uses — without dropping the
+    workspace-routing header that travels alongside it.
+    """
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda _server_url: lambda: "fresh-token",
+    )
+    reauth = native_policy_hook.policy_hook_reauth(
+        "https://acme.databricks.com/api/2.0/omnigent",
+        {"Authorization": "Bearer stale", "X-Databricks-Org-Id": "o9"},
+    )
+    assert reauth() == {"Authorization": "Bearer fresh-token", "X-Databricks-Org-Id": "o9"}
+
+
+def test_policy_hook_reauth_returns_none_without_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No refresh mechanism (local/unauth) → ``None`` so the caller fails closed."""
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda _server_url: None,
+    )
+    reauth = native_policy_hook.policy_hook_reauth(
+        "http://127.0.0.1:6767", {"Content-Type": "application/json"}
+    )
+    assert reauth() is None


### PR DESCRIPTION
Follow-up to #1324. An audit of the native policy-hook channels found that
some hooks POST to the server from outside the runner's httpx client (as
import-free subprocesses), so #1324's auth/routing never reached them. This
PR closes those gaps and converges all header construction onto one builder.

Four commits, each reviewable on its own:

### 1. `fix(runner)`: route the opencode cost popup with `?o=`
The opencode-native cost popup is the only writer that mints a *fresh*
`ap_auth_headers` dict (claude/codex reuse their org-aware hook files). It
carried `Authorization` only, so its `POST /policies/evaluate` misrouted to
the account on a unified-account workspace. Now sourced from the unified
builder.

### 2. `refactor(cli)`: unify server-request headers into one builder
#1324 left two public helpers — `databricks_org_id_headers(url)` and
`databricks_auth_headers(url, token)`. They were already DRY (the latter
built on the former), but two entry points invite the "which do I call?"
mistake. Collapse to one:

    databricks_request_headers(server_url, *, bearer_token=None)

Always includes the `X-Databricks-Org-Id` routing header when recorded; adds
`Authorization` when given a bearer. Routing now travels with auth from one
place. Behavior-preserving; all callers repointed.

### 3. `fix(runner)`: authenticate + route the cursor/hermes policy hooks
The cursor (sdk) and hermes (sdk + native) PreToolUse hooks ran as
import-free subprocesses POSTing with `Content-Type` only — no auth, no
routing. On an authenticated server they 401 (cursor fails open, hermes
fails closed); on a unified-account workspace they misroute. `native_policy_hook`
gains a writer/reader pair (`policy_hook_wrapper_script` /
`policy_hook_request_headers`) sourced from `databricks_request_headers`. The
wrapper bakes a token, so it is now written **0o700 (owner-only)** instead of
world-readable **0o755**, with `shlex.quote`d values.

### 4. `fix(runner)`: self-heal the policy hooks past the ~1h token lapse
The baked one-shot token dies with the ~1h Databricks OAuth lifetime. The
claude hook already re-mints on a lapsed-token signal; codex/kimi/cursor/hermes
did not. Promote the re-mint to one shared `policy_hook_reauth(server_url,
headers)` and wire all four, so a policy check firing past ~1h into a long
session re-mints through the same factory the refresh-capable runtime auth
uses (and keeps the routing header) instead of 401-ing. The long-lived runtime
clients already refresh transparently (per-request SDK `authenticate()`); this
only closes the per-tool-call hook channel.

### Verified
`ruff` clean; the touched cli / chat / host / runner / hook / executor suites
pass, plus the cost-popup, native-policy-hook, and claude/codex/kimi hook
suites. New tests cover the unified builder, the writer (bakes bearer +
routing), the reader (merges / tolerates missing), the wrapper's owner-only
perms, and the shared reauth (re-mints + preserves routing / fails closed
without a factory).

This pull request and its description were written by Isaac.
