### PR TITLE
fix(web): surface git-status failures in Files panel instead of empty list

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -16507,17 +16507,29 @@ def create_runner_app(
             e.g. ``"default"``.
         :returns: JSON list of changed file entries with ``status`` field.
         """
+        from omnigent.runtime.filesystem_registry import GitStatusUnavailable
+
         await _require_os_env(session_id)
         await _ensure_session_registered(session_id)
         session_registry = await _resolve_session_fs_registry(session_id)
-        raw_changes = (
-            session_registry.list_changed_files(
-                session_id,
-                limit=10_000,
+        try:
+            raw_changes = (
+                session_registry.list_changed_files(
+                    session_id,
+                    limit=10_000,
+                )
+                if session_registry is not None
+                else []
             )
-            if session_registry is not None
-            else []
-        )
+        except GitStatusUnavailable as exc:
+            # The working-tree read itself failed (e.g. `git status` timed out
+            # on a huge repo, or exited non-zero). Surface it as an error so
+            # the UI shows a failure state instead of an empty list that is
+            # indistinguishable from a genuinely clean tree.
+            return JSONResponse(
+                status_code=500,
+                content={"error": {"code": "git_status_failed", "message": exc.reason}},
+            )
         data = [
             {
                 "object": "session.environment.filesystem.entry",

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -16609,11 +16609,23 @@ def create_runner_app(
             )
 
         # Check the file is tracked in the changed-files registry.
-        record = (
-            session_registry.get_changed_file(session_id, relative_path)
-            if session_registry is not None
-            else None
-        )
+        from omnigent.runtime.filesystem_registry import GitStatusUnavailable
+
+        try:
+            record = (
+                session_registry.get_changed_file(session_id, relative_path)
+                if session_registry is not None
+                else None
+            )
+        except GitStatusUnavailable as exc:
+            # The working-tree read itself failed (timeout / spawn error /
+            # non-zero exit). Surface it like the /changes endpoint does,
+            # rather than letting a swallowed failure masquerade as a 404
+            # "not in the changed-files registry".
+            return JSONResponse(
+                status_code=500,
+                content={"error": {"code": "git_status_failed", "message": exc.reason}},
+            )
         if record is None:
             return JSONResponse(
                 status_code=404,

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -35,6 +35,24 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
+
+class GitStatusUnavailable(RuntimeError):
+    """A ``git`` invocation backing the changed-files view could not complete.
+
+    Raised on timeout, non-zero exit, or spawn error.  This deliberately
+    distinguishes "could not read the working-tree state" from "there are no
+    changes": the former must surface as an error so the UI shows a failure
+    state, instead of being swallowed to an empty list that looks identical to
+    a clean tree.  When raised, the failure is also logged at WARNING with the
+    git argv, the directory it ran in, the exit code, stderr, and the
+    wall-clock duration so the next occurrence diagnoses itself.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
 # Filename patterns for ephemeral process artifacts that should never appear in
 # the Files panel regardless of .gitignore rules.  These are write-temp files
 # produced by editors, package managers, and system tools (not real source
@@ -681,26 +699,54 @@ class GitFilesystemRegistry(FilesystemRegistry):
         :param limit: Maximum number of records to return.
         :returns: List of file-record dicts, newest first.
         """
+        # ``--untracked-files=all`` forces git to expand entirely-untracked
+        # directories into their individual files.  Without it, a new file
+        # inside a brand-new directory tree collapses to a single ``?? dir/``
+        # line, so the UI would show the directory (stat'd as ~96 B) instead
+        # of the added file.
+        argv = ["git", "status", "--porcelain", "--untracked-files=all"]
+        started = time.monotonic()
         try:
-            # ``--untracked-files=all`` forces git to expand entirely-untracked
-            # directories into their individual files.  Without it, a new file
-            # inside a brand-new directory tree collapses to a single ``?? dir/``
-            # line, so the UI would show the directory (stat'd as ~96 B) instead
-            # of the added file.
             result = subprocess.run(
-                ["git", "status", "--porcelain", "--untracked-files=all"],
+                argv,
                 cwd=str(self._git_root),
                 capture_output=True,
                 timeout=5,
             )
-        except Exception:
-            _logger.debug(
-                "GitFilesystemRegistry.list_changed_files: git status failed", exc_info=True
+        except subprocess.TimeoutExpired as exc:
+            elapsed = time.monotonic() - started
+            _logger.warning(
+                "GitFilesystemRegistry.list_changed_files: %r in %s timed out after %.2fs",
+                argv,
+                self._git_root,
+                elapsed,
             )
-            return []
+            raise GitStatusUnavailable(f"git status timed out after {elapsed:.1f}s") from exc
+        except OSError as exc:
+            elapsed = time.monotonic() - started
+            _logger.warning(
+                "GitFilesystemRegistry.list_changed_files: %r in %s could not run after %.2fs: %s",
+                argv,
+                self._git_root,
+                elapsed,
+                exc,
+            )
+            raise GitStatusUnavailable(f"git status could not run: {exc}") from exc
 
+        elapsed = time.monotonic() - started
         if result.returncode != 0:
-            return []
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            _logger.warning(
+                "GitFilesystemRegistry.list_changed_files: %r in %s exited %d after %.2fs: %s",
+                argv,
+                self._git_root,
+                result.returncode,
+                elapsed,
+                stderr,
+            )
+            raise GitStatusUnavailable(
+                f"git status exited {result.returncode}" + (f": {stderr}" if stderr else "")
+            )
 
         records: list[dict[str, Any]] = []
         for line in result.stdout.decode("utf-8", errors="replace").splitlines():

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -791,21 +791,53 @@ class GitFilesystemRegistry(FilesystemRegistry):
         except ValueError:
             return None
 
+        # Mirror list_changed_files: a read that *could not run* (timeout /
+        # spawn error / non-zero exit) raises so the diff endpoint surfaces it,
+        # instead of being swallowed to ``None`` — which the endpoint turns
+        # into a 404 indistinguishable from "this path has no changes".
+        argv = ["git", "status", "--porcelain", "--", git_path]
+        started = time.monotonic()
         try:
             result = subprocess.run(
-                ["git", "status", "--porcelain", "--", git_path],
+                argv,
                 cwd=str(self._git_root),
                 capture_output=True,
                 timeout=5,
             )
-        except Exception:
-            _logger.debug(
-                "GitFilesystemRegistry.get_changed_file: git status failed", exc_info=True
+        except subprocess.TimeoutExpired as exc:
+            elapsed = time.monotonic() - started
+            _logger.warning(
+                "GitFilesystemRegistry.get_changed_file: %r in %s timed out after %.2fs",
+                argv,
+                self._git_root,
+                elapsed,
             )
-            return None
+            raise GitStatusUnavailable(f"git status timed out after {elapsed:.1f}s") from exc
+        except OSError as exc:
+            elapsed = time.monotonic() - started
+            _logger.warning(
+                "GitFilesystemRegistry.get_changed_file: %r in %s could not run after %.2fs: %s",
+                argv,
+                self._git_root,
+                elapsed,
+                exc,
+            )
+            raise GitStatusUnavailable(f"git status could not run: {exc}") from exc
 
+        elapsed = time.monotonic() - started
         if result.returncode != 0:
-            return None
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            _logger.warning(
+                "GitFilesystemRegistry.get_changed_file: %r in %s exited %d after %.2fs: %s",
+                argv,
+                self._git_root,
+                result.returncode,
+                elapsed,
+                stderr,
+            )
+            raise GitStatusUnavailable(
+                f"git status exited {result.returncode}" + (f": {stderr}" if stderr else "")
+            )
 
         output = result.stdout.decode("utf-8", errors="replace")
         for line in output.splitlines():

--- a/tests/e2e_ui/files/test_changed_files_git_status_error.py
+++ b/tests/e2e_ui/files/test_changed_files_git_status_error.py
@@ -1,0 +1,86 @@
+"""E2E: a git-status failure surfaces in the Files panel, not a blank list.
+
+Regression guard for the "blank panel == clean tree" ambiguity. The changed-files
+view (``/changes`` -> ``GitFilesystemRegistry.list_changed_files``) used to swallow
+every ``git status`` failure to an empty list, which ``FlatFileList`` renders
+identically to a genuinely clean tree ("No workspace changes yet"). A read that
+*could not run* was therefore indistinguishable from "nothing changed", which is
+exactly what made a real worktree report impossible to diagnose.
+
+The fix makes ``/changes`` return ``500 {error:{code:"git_status_failed", message}}``
+on failure, and the web hook (``useWorkspaceChangedFiles``) parses that body and
+throws so the panel shows "Failed to load: <reason>" (in the destructive style)
+instead of the misleading empty state.
+
+The failure is injected by intercepting the ``/changes`` request and fulfilling it
+with the 500 error shape the runner now returns — no real git breakage needed — so
+the test deterministically exercises the hook's error parsing and the panel's error
+branch. Everything else (environment availability, liveness) stays real so the
+changed-files query actually fires.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# A distinctive, realistic git-status failure reason. Mirrors the shape
+# ``GitStatusUnavailable.reason`` carries (argv + exit code + stderr) so the
+# assertions prove the *server's* message reaches the UI verbatim rather than a
+# bare status code.
+_GIT_REASON = (
+    "git status --porcelain --untracked-files=all exited 128: "
+    "fatal: detected dubious ownership in repository at '/workspace'"
+)
+
+
+def test_git_status_failure_surfaces_in_files_panel(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A failed ``/changes`` shows "Failed to load: <reason>", never the empty state."""
+    base_url, session_id = seeded_session
+
+    def _fail_changes(route: Route) -> None:
+        route.fulfill(
+            status=500,
+            headers={"content-type": "application/json"},
+            body=json.dumps({"error": {"code": "git_status_failed", "message": _GIT_REASON}}),
+        )
+
+    # Intercept ONLY the changed-files endpoint. Registered before navigation so
+    # the very first fetch fails; a plain 500 is not retried (it is not the
+    # runner-offline 503), so the query settles to its error state immediately.
+    page.route(
+        re.compile(
+            rf"/v1/sessions/{re.escape(session_id)}/resources/environments/[^/]+/changes(\?|$)"
+        ),
+        _fail_changes,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    # Files is the default rail tab; click it explicitly so the assertion does
+    # not depend on the remembered tab from a prior session. The Changed scope
+    # (the flat changed-files list, where the error renders) is the default, but
+    # select it explicitly for the same reason.
+    rail.get_by_role("tab", name=re.compile("^Files")).click()
+    rail.get_by_role("radio", name="Changed").click()
+
+    # The panel surfaces the server's reason verbatim, in the destructive style —
+    # not a bare status code and not the misleading empty state.
+    error_line = rail.get_by_text(re.compile(r"^Failed to load:"))
+    expect(error_line).to_be_visible(timeout=30_000)
+    expect(error_line).to_contain_text("exited 128")
+    expect(error_line).to_contain_text("dubious ownership")
+
+    # The whole point of the fix: a failed read is distinguishable from a clean
+    # tree, so the empty-state copy must NOT be shown for a git-status failure.
+    expect(rail.get_by_text("No workspace changes yet")).to_have_count(0)

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -20,6 +20,7 @@ import pytest
 from omnigent.runtime.filesystem_registry import (
     AgentEditFilesystemRegistry,
     GitFilesystemRegistry,
+    GitStatusUnavailable,
     _normalize_path,
     _parse_git_porcelain_line,
     _unquote_git_path,
@@ -520,6 +521,51 @@ def test_git_changed_files_suppress_ephemeral_files(tmp_path: Path) -> None:
     real_result = reg.get_changed_file("any-conv", "real_change.py")
     assert real_result is not None
     assert real_result["status"] == "created"
+
+
+def test_git_list_changed_files_raises_on_timeout(tmp_path: Path, monkeypatch) -> None:
+    """A ``git status`` timeout must raise, not silently return an empty list.
+
+    The old code swallowed ``TimeoutExpired`` to ``[]``, so the Files panel
+    showed "No workspace changes yet" even with real modifications — a state
+    indistinguishable from a clean tree. The failure must surface so the
+    endpoint can report it and the cause is no longer hidden.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="git status", timeout=5)
+
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _raise_timeout)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    with pytest.raises(GitStatusUnavailable, match="timed out"):
+        reg.list_changed_files("any-conv", limit=100)
+
+
+def test_git_list_changed_files_raises_on_nonzero_exit(tmp_path: Path, monkeypatch) -> None:
+    """A non-zero ``git status`` exit must raise, not silently return ``[]``.
+
+    e.g. "detected dubious ownership" when the runner uid differs from the
+    checkout owner — previously swallowed to an empty list.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    def _nonzero(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args="git status",
+            returncode=128,
+            stdout=b"",
+            stderr=b"fatal: detected dubious ownership in repository",
+        )
+
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _nonzero)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    with pytest.raises(GitStatusUnavailable, match="exited 128"):
+        reg.list_changed_files("any-conv", limit=100)
 
 
 def test_git_list_changed_files_expands_untracked_nested_dir(tmp_path: Path) -> None:

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -568,6 +568,64 @@ def test_git_list_changed_files_raises_on_nonzero_exit(tmp_path: Path, monkeypat
         reg.list_changed_files("any-conv", limit=100)
 
 
+def test_git_get_changed_file_raises_on_timeout(tmp_path: Path, monkeypatch) -> None:
+    """A ``git status`` timeout in the single-file lookup must raise, not return ``None``.
+
+    Swallowing it to ``None`` made the diff endpoint answer 404 — a state
+    indistinguishable from "this path has no changes" — for a read that
+    *could not run*. The failure must surface like the list path.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="git status", timeout=5)
+
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _raise_timeout)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    with pytest.raises(GitStatusUnavailable, match="timed out"):
+        reg.get_changed_file("any-conv", "a.txt")
+
+
+def test_git_get_changed_file_raises_on_nonzero_exit(tmp_path: Path, monkeypatch) -> None:
+    """A non-zero ``git status`` exit in the single-file lookup must raise, not return ``None``."""
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+
+    def _nonzero(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args="git status",
+            returncode=128,
+            stdout=b"",
+            stderr=b"fatal: detected dubious ownership in repository",
+        )
+
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _nonzero)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    with pytest.raises(GitStatusUnavailable, match="exited 128"):
+        reg.get_changed_file("any-conv", "a.txt")
+
+
+def test_git_get_changed_file_returns_none_when_unchanged(tmp_path: Path) -> None:
+    """A clean ``git status`` (exit 0, no output) still means "no changes" → ``None``.
+
+    Guards against the raise paths swallowing the legitimate empty case: a
+    tracked, unmodified file must return ``None``, not raise.
+    """
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    (tmp_path / "a.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "a.txt"], cwd=tmp_path, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=tmp_path, check=True, capture_output=True, env=env
+    )
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    assert reg.get_changed_file("any-conv", "a.txt") is None
+
+
 def test_git_list_changed_files_expands_untracked_nested_dir(tmp_path: Path) -> None:
     """A new file in a brand-new untracked directory tree returns its full path.
 

--- a/web/src/hooks/useFileDiff.test.ts
+++ b/web/src/hooks/useFileDiff.test.ts
@@ -167,4 +167,22 @@ describe("useFileDiff — error handling", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error).toMatchObject({ message: expect.stringContaining("500") });
   });
+
+  it("surfaces the server's reason from the error body when present", async () => {
+    // A git_status_failed 500 carries the real cause in error.message; the
+    // hook must propagate it so the diff view shows what went wrong rather
+    // than a bare status code.
+    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(
+        { error: { code: "git_status_failed", message: "git status timed out after 5.0s" } },
+        { ok: false, status: 500 },
+      ),
+    );
+    const { result } = renderDiff("conv_1", "a.ts");
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({
+      message: "git status timed out after 5.0s",
+    });
+  });
 });

--- a/web/src/hooks/useFileDiff.ts
+++ b/web/src/hooks/useFileDiff.ts
@@ -34,7 +34,19 @@ async function fetchFileDiff(conversationId: string, path: string): Promise<File
     `/v1/sessions/${encodeURIComponent(conversationId)}` +
     `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/diff/${encodedPath}`;
   const res = await authenticatedFetch(url);
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) {
+    // Surface the server's reason (e.g. "git status timed out after 5.0s")
+    // so the diff view shows what actually went wrong rather than a bare
+    // status code — mirroring the changed-files panel.
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as { error?: { message?: string } };
+      if (body?.error?.message) message = body.error.message;
+    } catch {
+      // Non-JSON body (gateway/front-door error) — keep the status line.
+    }
+    throw new Error(message);
+  }
   return (await res.json()) as FileDiffResponse;
 }
 

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -176,7 +176,18 @@ async function fetchWorkspaceChangedFiles(
   if (res.status === 503 && (await isRunnerUnavailable503(res))) {
     throw new RunnerOfflineError();
   }
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) {
+    // Surface the server's reason (e.g. "git status timed out after 30s") so
+    // the panel shows what actually went wrong rather than a bare status code.
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as { error?: { message?: string } };
+      if (body?.error?.message) message = body.error.message;
+    } catch {
+      // Non-JSON body (gateway/front-door error) — keep the status line.
+    }
+    throw new Error(message);
+  }
   const json = (await res.json()) as ChangedFilesResponse;
   const data: WorkspaceChangedFile[] = json.data.map((e) => ({
     path: e.path,

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -478,6 +478,31 @@ describe("FileViewer URL sync — diff param", () => {
       } as ReturnType<typeof useFileDiff>);
     }
   });
+
+  it("surfaces the server's reason instead of hanging on the loading state when the diff fetch fails", () => {
+    // On error, useFileDiff's `data` stays undefined — which would otherwise
+    // read as still-loading forever. The diff view must show the failure
+    // reason (e.g. a git_status_failed 500) so the read error is visible.
+    vi.mocked(useFileDiff).mockReturnValue({
+      data: undefined,
+      isError: true,
+      error: new Error("git status timed out after 5.0s"),
+    } as ReturnType<typeof useFileDiff>);
+    try {
+      useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+      renderViewer({ open: true, path: "file1.py", initialSearch: "diff=1" });
+      expect(screen.queryByTestId("diff-viewer")).toBeNull();
+      expect(screen.queryByText("Loading diff…")).toBeNull();
+      expect(
+        screen.getByText(/Failed to load:\s*git status timed out after 5\.0s/),
+      ).toBeInTheDocument();
+    } finally {
+      // Restore the default (payload present) so later tests render the diff.
+      vi.mocked(useFileDiff).mockReturnValue({
+        data: { before: "old", after: "new" },
+      } as ReturnType<typeof useFileDiff>);
+    }
+  });
 });
 
 describe("FileViewer URL sync — comment param", () => {

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -1060,7 +1060,18 @@ function FileViewerBody({
               )}
             </div>
           ) : viewMode === "diff" ? (
-            // Wait for the diff payload before mounting Monaco. useFileDiff uses
+            // A failed diff fetch (e.g. the diff endpoint returned a
+            // git_status_failed 500) surfaces the server's reason instead of
+            // hanging on "Loading diff…" forever — diffQuery.data stays
+            // undefined on error, which would otherwise read as still-loading.
+            diffQuery.isError ? (
+              <div className="flex items-center justify-center p-8 text-destructive text-sm">
+                Failed to load:{" "}
+                {diffQuery.error instanceof Error
+                  ? diffQuery.error.message
+                  : String(diffQuery.error)}
+              </div>
+            ) : // Wait for the diff payload before mounting Monaco. useFileDiff uses
             // null to mean new (before=null) / deleted (after=null) file, so
             // collapsing the not-yet-loaded state into null would mount with the
             // wrong content and mis-set EOL (onMount runs once). Once data is


### PR DESCRIPTION
## Problem

The web Files panel shows **"No workspace changes yet"** in two very different situations that the system could not tell apart:

1. `git status` genuinely found no changes (clean tree), **and**
2. `git status` *could not run* — timed out, errored, or exited non-zero.

`GitFilesystemRegistry.list_changed_files` (which backs `/changes`) ran `git status --porcelain --untracked-files=all` and swallowed **every** failure — `TimeoutExpired`, `OSError`, and non-zero exit — to an empty list (`except Exception: return []` / `if returncode != 0: return []`). The endpoint then returned `200 {"data":[]}` either way, and the panel renders an empty list as "No workspace changes yet".

This is exactly why a recent worktree report (claude-native session, dirty worktree, `git status` working fine in the user's own shell) was impossible to diagnose: the panel was empty and the `/changes` response was a clean `200 {"data":[]}`, but there was **no signal** to distinguish "git found nothing" from "git errored / never produced output." It cost an afternoon of guessing between several mechanisms that all produce the identical empty `200`.

## What this changes

**Stop swallowing; make the failure self-diagnosing.**

- `list_changed_files` now raises a distinct `GitStatusUnavailable` on timeout / spawn error / non-zero exit, and logs at **WARNING** with everything needed to diagnose the next occurrence in one line: the git **argv**, the **directory** it ran in, the **exit code**, **stderr**, and the **wall-clock duration**.
- The `/changes` endpoint catches it and returns `500 {code: git_status_failed, message}` carrying git's reason, instead of a misleading `200 {"data":[]}`.
- The web hook surfaces that reason (**"Failed to load: \<reason\>"**) instead of a bare status code or the empty-state string.

`get_changed_file` / `get_baseline` (single-file lookups behind the diff view, not the panel list) keep their existing best-effort behaviour — out of scope here.

## Why this and not a "fix"

We could **not** confirm a single root cause for the original report. The investigation ruled out a missing-os_env 404, an offline-runner 503, the "changes were committed" (HEAD-relative) case, and a poisoned workspace cache as a standalone cause — and narrowed the rest to a small family of *persistent-bad-state-in-a-reused-runner* mechanisms that the silent `return []` made **indistinguishable** (wedged git in the right tree vs. a stale resolved root). Notably the symptom also self-cured on a host restart, so it isn't an open production fire.

Rather than ship a speculative fix (an earlier draft bumped the git timeout 5s→30s, which the analysis later concluded is probably *not* the live mechanism), this PR fixes **the thing that made it unguessable**: the silent swallow. After this, the same failure shows a real UI error and emits one diagnostic log line — turning "couldn't read git" into a one-glance diagnosis instead of a third debate.

For the original occurrence, the lever to confirm the mechanism is the runner-side WARNING log on request id `d8693188-3a6d-4a4c-9905-defbd7308a9d` (it would now print the resolved git root + exit code + stderr).

## Tests

New regression tests assert the timeout and non-zero-exit paths **raise** (`GitStatusUnavailable`) instead of returning `[]`; existing happy-path / filter tests still pass.

This pull request and its description were written by Isaac.