### PR TITLE
feat(copilot): surface authoritative AI-credit cost as cost_usd

### DIFF
--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -788,7 +788,9 @@ def _accumulate_usage(acc: dict[str, int], data: dict[str, Any]) -> None:  # typ
     """Sum the token counts from one ASSISTANT_USAGE event into *acc*.
 
     Copilot emits one usage event per underlying model call, so a turn with
-    tool round-trips reports usage several times; we accumulate.
+    tool round-trips reports usage several times; we accumulate. The
+    authoritative AI-credit cost (``copilotUsage.totalNanoAiu``, in nano-AIU) is
+    summed too and converted to ``cost_usd`` in :func:`_finalize_usage`.
     """
     mapping = {
         "inputTokens": "input_tokens",
@@ -799,6 +801,11 @@ def _accumulate_usage(acc: dict[str, int], data: dict[str, Any]) -> None:  # typ
         value = data.get(wire_key)
         if isinstance(value, (int, float)):
             acc[usage_key] = acc.get(usage_key, 0) + int(value)
+    copilot_usage = data.get("copilotUsage")
+    if isinstance(copilot_usage, dict):
+        nano_aiu = copilot_usage.get("totalNanoAiu")
+        if isinstance(nano_aiu, (int, float)):
+            acc["_cost_nano_aiu"] = acc.get("_cost_nano_aiu", 0) + int(nano_aiu)
 
 
 def _finalize_usage(acc: dict[str, int]) -> dict[str, Any] | None:  # type: ignore[explicit-any]
@@ -806,7 +813,11 @@ def _finalize_usage(acc: dict[str, int]) -> dict[str, Any] | None:  # type: igno
     if not acc:
         return None
     usage: dict[str, Any] = dict(acc)  # type: ignore[explicit-any]
+    nano_aiu = usage.pop("_cost_nano_aiu", 0)
     usage["total_tokens"] = usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
+    if nano_aiu:
+        # 1 AIC = 1e9 nano-AIU = $0.01, so nano-AIU / 1e11 = USD.
+        usage["cost_usd"] = nano_aiu / 1e11
     return usage
 
 

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -1608,6 +1608,9 @@ class HarnessApp:
                 cache_creation_input_tokens=u.get("cache_creation_input_tokens") or 0,
                 # Harness-reported model for cost pricing (ResponseObject.model is the agent name).
                 model=u.get("model"),
+                # Authoritative per-turn cost reported by the harness (e.g. Copilot
+                # AI credits); preferred over the catalog estimate. None if absent.
+                cost_usd=u.get("cost_usd"),
             )
         response = ResponseObject(
             id=ctx.response_id,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2884,10 +2884,14 @@ def _accumulate_session_usage(
 
     Cost is computed when the model's per-token pricing is
     available from the MLflow catalog (looked up once per call
-    from the response's ``model`` field). The ``total_cost_usd`` key is
-    written **only when pricing is available** — an unpriced session
-    leaves it absent (its presence is what distinguishes a priced
-    ``$0.00`` from "unpriced"; see :func:`_priced_cost_for_display`).
+    from the response's ``model`` field). When the harness instead
+    reports an authoritative per-turn ``cost_usd`` (e.g. Copilot's
+    AI-credit total), that value is used directly in preference to
+    the catalog estimate. The ``total_cost_usd`` key is written
+    **only when the turn is priced** (catalog pricing available or a
+    harness-reported cost) — an unpriced session leaves it absent
+    (its presence is what distinguishes a priced ``$0.00`` from
+    "unpriced"; see :func:`_priced_cost_for_display`).
 
     :param resp_obj: The ``response`` dict from the
         ``response.completed`` SSE event.
@@ -2940,6 +2944,9 @@ def _accumulate_session_usage(
     # created only on this priced branch, so an unpriced session never
     # gains a (misleading $0.00) cost key.
     cost_delta = 0.0
+    # Prefer an authoritative harness-reported cost over the catalog estimate.
+    provider_cost = usage_obj.get("cost_usd")
+    has_provider_cost = isinstance(provider_cost, (int, float))
     usage_model = usage_obj.get("model")
     llm_model = (
         usage_model
@@ -2947,15 +2954,20 @@ def _accumulate_session_usage(
         else (conv.model_override if conv and conv.model_override else _resolve_llm_model(conv))
     )
     if llm_model:
-        from omnigent.llms.context_window import compute_llm_cost, fetch_model_pricing
+        if has_provider_cost:
+            cost_delta = float(provider_cost)
+            priced = True
+        else:
+            from omnigent.llms.context_window import compute_llm_cost, fetch_model_pricing
 
-        pricing = fetch_model_pricing(llm_model)
-        priced = pricing is not None
-        if pricing is not None:
-            # Cache-aware: usage_obj carries cache_read/cache_creation
-            # token counts when the harness reports them; compute_llm_cost
-            # prices them at their own (cheaper read / pricier write) rates.
-            cost_delta = compute_llm_cost(usage_obj, pricing)
+            pricing = fetch_model_pricing(llm_model)
+            priced = pricing is not None
+            if pricing is not None:
+                # Cache-aware: usage_obj carries cache_read/cache_creation
+                # token counts when the harness reports them; compute_llm_cost
+                # prices them at their own (cheaper read / pricier write) rates.
+                cost_delta = compute_llm_cost(usage_obj, pricing)
+        if priced:
             current["total_cost_usd"] = current.get("total_cost_usd", 0.0) + cost_delta
         # Per-model attribution (ADD). Tokens are attributed whenever the
         # model is known — including unpriced turns — so the per-model token

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -780,6 +780,12 @@ class Usage(BaseModel):
         (e.g. supervisors that delegate / use the harness default).
         ``None`` when the executor doesn't report it; the cost path
         then falls back to the session override / spec model.
+    :param cost_usd: Authoritative per-turn cost in USD reported
+        directly by the harness/provider (e.g. GitHub Copilot's
+        AI-credit total). When present, the server-side cost path uses
+        it in preference to the catalog token-price estimate; ``None``
+        when the harness doesn't report a cost (the common case, where
+        cost is computed from token counts x catalog pricing).
     """
 
     input_tokens: int = 0
@@ -790,6 +796,7 @@ class Usage(BaseModel):
     cache_read_input_tokens: int = 0
     cache_creation_input_tokens: int = 0
     model: str | None = None
+    cost_usd: float | None = None
 
 
 class ErrorDetail(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -5725,6 +5725,19 @@
             "description": "Context-fill estimate for the next turn \u2014 set only by executors that make multiple LLM sub-calls per turn (e.g. `openai-agents`). For single-call executors this is absent and `total_tokens` serves the same purpose. The toolbar context ring and `/context` command use this field when present, falling back to `total_tokens`.",
             "title": "Context Tokens"
           },
+          "cost_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Authoritative per-turn cost in USD reported directly by the harness/provider (e.g. GitHub Copilot's AI-credit total). When present, the server-side cost path uses it in preference to the catalog token-price estimate; `None` when the harness doesn't report a cost (the common case, where cost is computed from token counts x catalog pricing).",
+            "title": "Cost Usd"
+          },
           "input_tokens": {
             "default": 0,
             "description": "Number of input (prompt) tokens consumed.",

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -253,6 +253,38 @@ def test_usage_accumulation_and_finalize() -> None:
     assert _finalize_usage({}) is None
 
 
+def test_usage_accumulates_copilot_aic_cost() -> None:
+    # ``copilotUsage.totalNanoAiu`` (the authoritative AI-credit cost) is summed
+    # across the turn's usage events and converted to ``cost_usd`` in finalize:
+    # 1 AIC = 1e9 nano-AIU = $0.01, so nano-AIU / 1e11 = USD.
+    acc: dict[str, int] = {}
+    _accumulate_usage(
+        acc,
+        {"inputTokens": 10, "outputTokens": 2, "copilotUsage": {"totalNanoAiu": 1_832_000_000}},
+    )
+    _accumulate_usage(
+        acc,
+        {"inputTokens": 3, "outputTokens": 1, "copilotUsage": {"totalNanoAiu": 68_000_000}},
+    )
+    usage = _finalize_usage(acc)
+    assert usage is not None
+    assert usage["input_tokens"] == 13
+    # (1_832_000_000 + 68_000_000) / 1e11 = 0.019 USD (1.9 AIC).
+    assert usage["cost_usd"] == pytest.approx(0.019)
+    # The private accumulator key must not leak into the usage dict.
+    assert "_cost_nano_aiu" not in usage
+
+
+def test_usage_without_copilot_cost_omits_cost_usd() -> None:
+    # A usage event with no ``copilotUsage`` block yields no ``cost_usd`` key,
+    # so the catalog cost path stays in charge for those turns.
+    acc: dict[str, int] = {}
+    _accumulate_usage(acc, {"inputTokens": 5, "outputTokens": 1})
+    usage = _finalize_usage(acc)
+    assert usage is not None
+    assert "cost_usd" not in usage
+
+
 def test_ambient_github_token_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
         monkeypatch.delenv(var, raising=False)

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4217,6 +4217,81 @@ async def test_accumulate_session_usage_prices_from_usage_model(
     assert usage.get("total_cost_usd") == pytest.approx(0.002)
 
 
+async def test_accumulate_session_usage_prefers_provider_cost(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A harness-reported ``cost_usd`` is used verbatim, overriding the catalog estimate.
+
+    Copilot reports the authoritative AI-credit cost it billed; the relay must
+    prefer that over recomputing from token counts x catalog pricing (which can
+    diverge, e.g. when the catalog lacks a cache-write rate).
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    # The catalog WOULD price this turn at 2.0 USD; the provider cost must win.
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: ModelPricing(input_per_token=1e-3, output_per_token=2e-3),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    sessions_routes._accumulate_session_usage(
+        {
+            "usage": {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "model": "harness-model",
+                "cost_usd": 0.01827875,
+            }
+        },
+        session["id"],
+        SqlAlchemyConversationStore(db_uri),
+    )
+    usage = _read_session_usage(db_uri, session["id"])
+    # Catalog would charge 1000*1e-3 + 500*2e-3 = 2.0; the provider cost wins.
+    assert usage.get("total_cost_usd") == pytest.approx(0.01827875)
+    assert usage["by_model"]["harness-model"]["total_cost_usd"] == pytest.approx(0.01827875)
+
+
+async def test_accumulate_session_usage_provider_cost_prices_uncatalogued_model(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A harness ``cost_usd`` makes a turn priced even when the catalog can't price it.
+
+    Without a catalog entry the token-price path leaves the turn unpriced; an
+    authoritative provider cost should still record ``total_cost_usd``.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: None,  # catalog can't price anything
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    sessions_routes._accumulate_session_usage(
+        {
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "model": "grok-4.3",
+                "cost_usd": 0.0042,
+            }
+        },
+        session["id"],
+        SqlAlchemyConversationStore(db_uri),
+    )
+    usage = _read_session_usage(db_uri, session["id"])
+    assert usage.get("total_cost_usd") == pytest.approx(0.0042)
+    assert usage["by_model"]["grok-4.3"]["total_cost_usd"] == pytest.approx(0.0042)
+
+
 async def test_accumulate_session_usage_unpriced_without_usage_model(
     client: httpx.AsyncClient,
     db_uri: str,


### PR DESCRIPTION
## Related issue

N/A (improvement found while auditing the Copilot harness usage accounting;
independent follow-up to the cache-write token fix).

## Summary

Copilot's `assistant.usage` event carries the cost it actually billed,
computed server-side at the real per-token rates, as
`copilotUsage.totalNanoAiu` (AI Credits: 1 AIC = 1e9 nano-AIU = $0.01).
Omnigent ignored it and instead *estimated* cost from token counts x a static
pricing catalog. That estimate can diverge from the real bill (e.g. the catalog
has no cache-write rate for grok and falls back to a 1.25x input ratio).

This forwards the provider's authoritative cost end to end and prefers it over
the estimate:

- **copilot_executor**: read `copilotUsage.totalNanoAiu`, accumulate across the
  turn's usage events, emit `usage["cost_usd"]` (nano-AIU / 1e11).
- **Usage schema**: add an optional `cost_usd` field (generic; any harness may
  report an authoritative per-turn cost).
- **scaffold**: carry `cost_usd` onto the `response.completed` usage.
- **_accumulate_session_usage**: when `cost_usd` is present, use it as the turn's
  cost (and mark the turn priced) in preference to the catalog estimate;
  otherwise keep the existing token-price computation unchanged.

Backward-compatible and additive: turns from harnesses that don't report a cost
are priced exactly as before.

### Why total_nano_aiu and not the event's `cost` field

The event also has a `cost` field, but in testing it was `0.33` and equal to
`result.usage.premiumRequests` - it's the legacy premium-request count, not USD.
`totalNanoAiu` is the authoritative AI-credit total, so we use that.

### Sources

- AI-credit accounting, `copilot_usage.total_nano_aiu`, and the conversion:
  https://www.kenmuse.com/blog/decoding-copilot-token-costs-using-vs-code/
- Copilot SDK usage schema (`copilotUsage.totalNanoAiu`, `cost`):
  `github-copilot-sdk==1.0.1`, `copilot/generated/session_events.py`

## Test Plan

`uv run --extra dev --extra copilot python -m pytest tests/inner/test_copilot_executor.py
tests/server/integration/test_sessions_endpoints.py -k "test_copilot or accumulate_session_usage"` -> all pass.

New tests:
- `test_usage_accumulates_copilot_aic_cost` / `test_usage_without_copilot_cost_omits_cost_usd`
  (executor conversion + the no-cost case).
- `test_accumulate_session_usage_prefers_provider_cost` (provider cost overrides
  the catalog estimate) and
  `test_accumulate_session_usage_provider_cost_prices_uncatalogued_model`
  (provider cost prices a turn the catalog can't).

Live verification against a real Copilot turn (headless `copilot -p --output-format
json --log-level debug`, model `claude-haiku-4.5`):
- Debug log reported `copilot_usage.total_nano_aiu = 2139025000` for one turn, and
  the `token_details` (input/cache_read/cache_write/output x server rates) summed
  to exactly that, matching the kenmuse walkthrough.
- Driving the real SDK through the harness path produced
  `cost_usd = 0.01827875` for a turn whose `totalNanoAiu = 1827875000`
  (== totalNanoAiu / 1e11). Match exact.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both new hops: the executor's nano-AIU -> `cost_usd` conversion
and the relay's preference for a harness-reported cost over the catalog estimate
(including overriding a priced model and pricing an otherwise-unpriced one). The
scaffold serialization hop (`Usage(cost_usd=...)` -> `response.completed`) was
verified to carry the field. Plus the live cross-check above.
