### PR TITLE
fix(server): truncate session error labels

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -504,6 +504,12 @@ class SqlConversationItem(Base):
     )
 
 
+# Width of the ``conversation_labels.value`` column. Exported so the store
+# (and the session-status error-label path) can clamp values to fit instead
+# of letting an over-length write raise ``DataError`` on PostgreSQL.
+LABEL_VALUE_MAX_LEN = 256
+
+
 class SqlConversationLabel(Base):
     """
     SQLAlchemy model for the ``conversation_labels`` table.
@@ -542,7 +548,7 @@ class SqlConversationLabel(Base):
         primary_key=True,
     )
     key: Mapped[str] = mapped_column(String(128), primary_key=True)
-    value: Mapped[str] = mapped_column(String(256))
+    value: Mapped[str] = mapped_column(String(LABEL_VALUE_MAX_LEN))
     updated_at: Mapped[int] = mapped_column(Integer)
 
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -62,6 +62,7 @@ from omnigent.cost_plan import (
     COST_CONTROL_LABEL_NAMESPACE,
     reserved_cost_control_keys,
 )
+from omnigent.db.db_models import LABEL_VALUE_MAX_LEN
 from omnigent.db.utils import generate_agent_id, generate_task_id
 from omnigent.entities import (
     Agent,
@@ -499,8 +500,9 @@ _LAST_CONTEXT_WINDOW_LABEL_KEY: str = "omnigent.last_context_window"
 # by. Empty string clears a stale value because labels are upsert-only.
 _LAST_TASK_ERROR_CODE_LABEL_KEY: str = "omnigent.last_task_error_code"
 _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: str = "omnigent.last_task_error_message"
-# Hard limit matching the ``String(256)`` column in ``db_models.py``.
-_LABEL_VALUE_MAX_LEN: int = 256
+# Hard limit matching the ``conversation_labels.value`` column width. Sourced
+# from the schema so the truncation and the column can never drift apart.
+_LABEL_VALUE_MAX_LEN: int = LABEL_VALUE_MAX_LEN
 
 # Todo-list update from the claude-native forwarder. Carries the raw
 # todo items captured from PostToolUse/TodoWrite hook events. Payload
@@ -5235,15 +5237,22 @@ def _publish_status(
 
 
 def _truncate_label(value: str) -> str:
-    """Truncate a label value to fit the ``String(256)`` DB column.
+    """Truncate a label value to fit the ``conversation_labels.value`` column.
 
     Long failure messages (tracebacks, 5xx bodies) overflow the column and
-    cause a ``DataError`` that silently drops the error reason.
+    cause a ``DataError`` that silently drops the error reason. Error messages
+    front-load their signal, so keeping the head and appending an ellipsis
+    preserves the useful part while flagging that more was dropped. The store
+    clamps again as a final guard, but truncating here keeps the marker and
+    makes the call site directly testable.
 
     :param value: The raw string to truncate.
-    :returns: ``value`` unchanged if short enough, else the first 256 chars.
+    :returns: ``value`` unchanged if it already fits, else the head trimmed to
+        the column width with a trailing ``…`` to signal truncation.
     """
-    return value[:_LABEL_VALUE_MAX_LEN]
+    if len(value) <= _LABEL_VALUE_MAX_LEN:
+        return value
+    return value[: _LABEL_VALUE_MAX_LEN - 1] + "…"
 
 
 async def _persist_session_status_error_labels(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -499,6 +499,8 @@ _LAST_CONTEXT_WINDOW_LABEL_KEY: str = "omnigent.last_context_window"
 # by. Empty string clears a stale value because labels are upsert-only.
 _LAST_TASK_ERROR_CODE_LABEL_KEY: str = "omnigent.last_task_error_code"
 _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: str = "omnigent.last_task_error_message"
+# Hard limit matching the ``String(256)`` column in ``db_models.py``.
+_LABEL_VALUE_MAX_LEN: int = 256
 
 # Todo-list update from the claude-native forwarder. Carries the raw
 # todo items captured from PostToolUse/TodoWrite hook events. Payload
@@ -5232,6 +5234,18 @@ def _publish_status(
     session_stream.publish(session_id, payload)
 
 
+def _truncate_label(value: str) -> str:
+    """Truncate a label value to fit the ``String(256)`` DB column.
+
+    Long failure messages (tracebacks, 5xx bodies) overflow the column and
+    cause a ``DataError`` that silently drops the error reason.
+
+    :param value: The raw string to truncate.
+    :returns: ``value`` unchanged if short enough, else the first 256 chars.
+    """
+    return value[:_LABEL_VALUE_MAX_LEN]
+
+
 async def _persist_session_status_error_labels(
     session_id: str,
     error: ErrorDetail | None,
@@ -5253,8 +5267,8 @@ async def _persist_session_status_error_labels(
     """
     updates = (
         {
-            _LAST_TASK_ERROR_CODE_LABEL_KEY: error.code,
-            _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: error.message,
+            _LAST_TASK_ERROR_CODE_LABEL_KEY: _truncate_label(error.code),
+            _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: _truncate_label(error.message),
         }
         if error is not None
         else {

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -25,6 +25,7 @@ from sqlalchemy.sql.selectable import Subquery
 from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
 from omnigent.db.converters import sql_agent_to_entity
 from omnigent.db.db_models import (
+    LABEL_VALUE_MAX_LEN,
     SqlAgent,
     SqlConversation,
     SqlConversationItem,
@@ -263,11 +264,17 @@ def _upsert_labels(
         touched by this call.
     """
     dialect = session.bind.dialect.name if session.bind is not None else ""
+    # Defense-in-depth: clamp every value to the column width so no label
+    # writer can overflow ``String(256)`` and raise ``DataError`` on
+    # PostgreSQL. Callers (session error labels, client-supplied ``body.labels``
+    # on session create/patch, policy-author writes) all funnel through here,
+    # so this is the single point that guarantees the column constraint. The
+    # slice is character-based, matching Postgres ``VARCHAR(n)`` semantics.
     rows = [
         {
             "conversation_id": conversation_id,
             "key": key,
-            "value": value,
+            "value": value[:LABEL_VALUE_MAX_LEN],
             "updated_at": updated_at,
         }
         for key, value in updates.items()

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -2424,6 +2424,43 @@ async def test_relay_persists_failed_status_error_labels_from_runner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_relay_truncates_long_error_message_before_persisting() -> None:
+    """A >256-char error message is truncated before the label write.
+
+    Long messages (tracebacks, 5xx bodies) overflow the String(256)
+    ``conversation_labels.value`` column and previously caused a
+    ``DataError`` that silently dropped the failure reason — the session
+    rendered as bare ``"failed"`` with no explanation on reload.
+    Truncation must happen inside the relay (the real call site) so no
+    long message ever reaches the store.
+    """
+    from omnigent.server.routes.sessions import _LABEL_VALUE_MAX_LEN, _relay_runner_stream
+
+    store = _ConversationStore()
+    long_message = "Runner MCP execute failed: " + "x" * 300  # 327 chars, well over 256
+    client = _FakeStreamingRunnerClient(
+        [
+            _sse_frame(
+                {
+                    "type": "session.status",
+                    "status": "failed",
+                    "error": {
+                        "code": "mcp_error",
+                        "message": long_message,
+                    },
+                }
+            ),
+            "data: [DONE]\n\n",
+        ]
+    )
+
+    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+
+    stored = store._conversations["conv_proxy"].labels["omnigent.last_task_error_message"]
+    assert len(stored) <= _LABEL_VALUE_MAX_LEN
+
+
+@pytest.mark.asyncio
 async def test_relay_persists_routing_decision_before_assistant_output() -> None:
     """The relay persists a turn-start ``routing_decision`` item BEFORE the
     turn's assistant output.

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -11,9 +11,12 @@ import pytest
 from omnigent.entities import Conversation, ConversationItem, MessageData, PagedList
 from omnigent.server.routes import sessions as _sessions_mod
 from omnigent.server.routes.sessions import (
+    _LABEL_VALUE_MAX_LEN,
     SessionLiveness,
     _get_session_snapshot,
+    _persist_session_status_error_labels,
     _publish_subtree_cost_to_ancestors,
+    _truncate_label,
 )
 
 
@@ -1517,3 +1520,68 @@ def test_publish_subtree_cost_to_ancestors_publishes_each_ancestor_subtree(
     assert by_conv["conv_g"]["usage_by_model"]["model-a"]["input_tokens"] == 70
     # The payload is a session.usage broadcast the web client renders as the badge.
     assert by_conv["conv_p"]["type"] == "session.usage"
+
+
+# ── _truncate_label ──────────────────────────────────────────────────────────
+
+
+def test_truncate_label_short_value_unchanged() -> None:
+    """Values at or below the column limit pass through unmodified."""
+    value = "x" * _LABEL_VALUE_MAX_LEN
+    assert _truncate_label(value) == value
+
+
+def test_truncate_label_long_value_fits_column() -> None:
+    """Truncated output never exceeds the column limit."""
+    long_value = "a" * (_LABEL_VALUE_MAX_LEN + 100)
+    result = _truncate_label(long_value)
+    assert len(result) <= _LABEL_VALUE_MAX_LEN
+
+
+
+def test_truncate_label_empty_string() -> None:
+    """Empty string is returned unchanged (no off-by-one crash)."""
+    assert _truncate_label("") == ""
+
+
+# ── _persist_session_status_error_labels ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_persist_error_labels_truncates_long_message() -> None:
+    """A failure message longer than 256 chars is truncated before the store
+    write, preventing the ``DataError`` that silently dropped the reason."""
+    from omnigent.server.schemas import ErrorDetail
+
+    captured: dict[str, dict[str, str]] = {}
+
+    class _MockStore:
+        def set_labels(self, session_id: str, updates: dict[str, str]) -> None:
+            captured[session_id] = updates
+
+    long_message = "Runner MCP execute failed: " + "x" * 300
+    error = ErrorDetail(code="mcp_error", message=long_message)
+
+    await _persist_session_status_error_labels("conv_123", error, _MockStore())  # type: ignore[arg-type]
+
+    stored = captured["conv_123"]
+    assert len(stored["omnigent.last_task_error_message"]) <= _LABEL_VALUE_MAX_LEN
+
+
+@pytest.mark.asyncio
+async def test_persist_error_labels_short_message_stored_verbatim() -> None:
+    """A short failure message is stored without modification."""
+    from omnigent.server.schemas import ErrorDetail
+
+    captured: dict[str, dict[str, str]] = {}
+
+    class _MockStore:
+        def set_labels(self, session_id: str, updates: dict[str, str]) -> None:
+            captured[session_id] = updates
+
+    error = ErrorDetail(code="runner_error", message="Process exited with code 1")
+
+    await _persist_session_status_error_labels("conv_456", error, _MockStore())  # type: ignore[arg-type]
+
+    assert captured["conv_456"]["omnigent.last_task_error_message"] == "Process exited with code 1"
+    assert captured["conv_456"]["omnigent.last_task_error_code"] == "runner_error"

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -1532,10 +1532,21 @@ def test_truncate_label_short_value_unchanged() -> None:
 
 
 def test_truncate_label_long_value_fits_column() -> None:
-    """Truncated output never exceeds the column limit."""
+    """Truncated output fits the column, keeps the head, and flags the cut."""
     long_value = "a" * (_LABEL_VALUE_MAX_LEN + 100)
     result = _truncate_label(long_value)
-    assert len(result) <= _LABEL_VALUE_MAX_LEN
+    assert len(result) == _LABEL_VALUE_MAX_LEN
+    # The informative head is preserved and a marker signals the truncation.
+    assert result.endswith("…")
+    assert result[:-1] == long_value[: _LABEL_VALUE_MAX_LEN - 1]
+
+
+def test_truncate_label_at_limit_no_marker() -> None:
+    """A value exactly at the limit is kept verbatim — no spurious ellipsis."""
+    value = "b" * _LABEL_VALUE_MAX_LEN
+    result = _truncate_label(value)
+    assert result == value
+    assert not result.endswith("…")
 
 
 def test_truncate_label_empty_string() -> None:
@@ -1563,8 +1574,10 @@ async def test_persist_error_labels_truncates_long_message() -> None:
 
     await _persist_session_status_error_labels("conv_123", error, _MockStore())  # type: ignore[arg-type]
 
-    stored = captured["conv_123"]
-    assert len(stored["omnigent.last_task_error_message"]) <= _LABEL_VALUE_MAX_LEN
+    stored = captured["conv_123"]["omnigent.last_task_error_message"]
+    assert len(stored) <= _LABEL_VALUE_MAX_LEN
+    # The diagnostic prefix survives so the reload-visible reason is still useful.
+    assert stored.startswith("Runner MCP execute failed: ")
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -1538,7 +1538,6 @@ def test_truncate_label_long_value_fits_column() -> None:
     assert len(result) <= _LABEL_VALUE_MAX_LEN
 
 
-
 def test_truncate_label_empty_string() -> None:
     """Empty string is returned unchanged (no off-by-one crash)."""
     assert _truncate_label("") == ""

--- a/tests/stores/test_conversation_labels.py
+++ b/tests/stores/test_conversation_labels.py
@@ -104,6 +104,32 @@ def test_set_labels_empty_dict_is_noop(
     assert got.labels == {"x": "1"}
 
 
+def test_set_labels_clamps_overlong_value_to_column_width(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Values longer than the column width are clamped at the store
+    chokepoint so no writer can raise ``DataError`` on PostgreSQL.
+
+    SQLite (used here) doesn't enforce ``VARCHAR`` length, so this proves
+    the Python-side clamp in ``_upsert_labels`` — not the DB — does the
+    trimming, which is exactly what protects the Postgres production path.
+    """
+    from omnigent.db.db_models import LABEL_VALUE_MAX_LEN
+
+    conv = conversation_store.create_conversation()
+    overlong = "z" * (LABEL_VALUE_MAX_LEN + 50)
+    conversation_store.set_labels(conv.id, {"omnigent.last_task_error_message": overlong})
+    got = conversation_store.get_conversation(conv.id)
+    assert got is not None
+    stored = got.labels["omnigent.last_task_error_message"]
+    assert len(stored) == LABEL_VALUE_MAX_LEN
+    # Head preserved (the clamp keeps the front, not a tail or empty string).
+    assert stored == overlong[:LABEL_VALUE_MAX_LEN]
+    # Every label writer (client ``body.labels`` on create, policy writes,
+    # session error labels) funnels through ``_upsert_labels``, so clamping
+    # here is the single guarantee that the column can never overflow.
+
+
 def test_set_labels_many_keys_atomic(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #1467

## Summary

Truncates long session failure error label values before persisting them to conversation labels.
Prevents long error messages from causing label persistence failures when they exceed the `conversation_labels.value` column limit.
Adds regression coverage for long session failure messages.

## Test Plan
uv run ruff check . # all passed

uv run python -m pytest \
  tests/server/routes/test_sessions_snapshot.py \
  tests/server/routes/test_session_resources.py \
  -k "truncate_label or persist_error_labels or relay_truncates" -v

Result: 8 passed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added regression coverage for:
label truncation helper behavior for short, long, and empty values
_persist_session_status_error_labels storing long messages within the 256-character label value limit
_relay_runner_stream persisting a truncated long runner error message through the real call site

Integration tests were not added because SQLite does not enforce VARCHAR(256) length constraints, so a SQLite-backed test would not catch the original failure mode. The truncation happens in Python before the DB write and is covered at the unit/call-site level.
