### PR TITLE
fix(kiro-native): single status source; stop forwarder double-posting (#1137)

### DIFF
--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -270,24 +270,6 @@ async def _post_conversation_message(
     resp.raise_for_status()
 
 
-async def _post_session_status(
-    client: httpx.AsyncClient,
-    *,
-    session_id: str,
-    status: str,
-    response_id: str | None = None,
-) -> None:
-    """POST one Kiro turn-status edge as an external session status."""
-    data: dict[str, str] = {"status": status}
-    if response_id is not None:
-        data["response_id"] = response_id
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "external_session_status", "data": data},
-    )
-    resp.raise_for_status()
-
-
 async def _patch_external_session_id(
     client: httpx.AsyncClient,
     *,
@@ -371,25 +353,19 @@ async def forward_kiro_session_to_omnigent(
                         state.byte_offset,
                     )
                     for message in messages:
+                        # Mirror the transcript only. Running/idle status for
+                        # kiro-native is owned by the PTY watcher's ``emit_status``
+                        # (``runner/resource_registry.py``), matching the other
+                        # forwarder-backed native harnesses (goose/qwen/hermes),
+                        # whose forwarders mirror the transcript, not the
+                        # running/idle session status. Posting status here too
+                        # double-sourced it (#1137).
                         await _post_conversation_message(
                             client,
                             session_id=session_id,
                             agent_name=agent_name,
                             message=message,
                         )
-                        if message.role == "user":
-                            await _post_session_status(
-                                client,
-                                session_id=session_id,
-                                status="running",
-                            )
-                        elif message.role == "assistant":
-                            await _post_session_status(
-                                client,
-                                session_id=session_id,
-                                status="idle",
-                                response_id=f"kiro:{message.message_id}",
-                            )
                     if byte_offset != state.byte_offset:
                         state.byte_offset = byte_offset
                         _write_state(bridge_dir, state)

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -207,7 +207,6 @@ async def test_forward_kiro_session_posts_conversation_messages(
     )
     monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
     posted: list[tuple[str, str, forwarder._KiroConversationMessage]] = []
-    statuses: list[tuple[str, str, str | None]] = []
     external_ids: list[tuple[str, str]] = []
 
     async def _fake_post(
@@ -219,16 +218,6 @@ async def test_forward_kiro_session_posts_conversation_messages(
     ) -> None:
         del client
         posted.append((session_id, agent_name, message))
-
-    async def _fake_status(
-        client: httpx.AsyncClient,
-        *,
-        session_id: str,
-        status: str,
-        response_id: str | None = None,
-    ) -> None:
-        del client
-        statuses.append((session_id, status, response_id))
 
     async def _fake_patch_external_session_id(
         client: httpx.AsyncClient,
@@ -243,7 +232,6 @@ async def test_forward_kiro_session_posts_conversation_messages(
         raise asyncio.CancelledError
 
     monkeypatch.setattr(forwarder, "_post_conversation_message", _fake_post)
-    monkeypatch.setattr(forwarder, "_post_session_status", _fake_status)
     monkeypatch.setattr(
         forwarder,
         "_patch_external_session_id",
@@ -276,10 +264,9 @@ async def test_forward_kiro_session_posts_conversation_messages(
             ),
         ),
     ]
-    assert statuses == [
-        ("conv_kiro", "running", None),
-        ("conv_kiro", "idle", "kiro:assistant-1"),
-    ]
+    # The forwarder no longer posts session status; running/idle for
+    # kiro-native is owned by the PTY watcher's emit_status (#1137). See
+    # test_forward_kiro_session_does_not_post_session_status for the guard.
     assert external_ids == [("conv_kiro", "kiro-session")]
     state = json.loads((tmp_path / "bridge" / "kiro_session_forwarder.json").read_text())
     assert state["session_id"] == "kiro-session"
@@ -344,7 +331,6 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
     )
     monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
     posted: list[forwarder._KiroConversationMessage] = []
-    statuses: list[tuple[str, str | None]] = []
     external_ids: list[str] = []
 
     async def _fake_post(
@@ -356,16 +342,6 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
     ) -> None:
         del client, session_id, agent_name
         posted.append(message)
-
-    async def _fake_status(
-        client: httpx.AsyncClient,
-        *,
-        session_id: str,
-        status: str,
-        response_id: str | None = None,
-    ) -> None:
-        del client, session_id
-        statuses.append((status, response_id))
 
     async def _fake_patch_external_session_id(
         client: httpx.AsyncClient,
@@ -380,7 +356,6 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
         raise asyncio.CancelledError
 
     monkeypatch.setattr(forwarder, "_post_conversation_message", _fake_post)
-    monkeypatch.setattr(forwarder, "_post_session_status", _fake_status)
     monkeypatch.setattr(
         forwarder,
         "_patch_external_session_id",
@@ -406,7 +381,7 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
             message_id="resumed-assistant", role="assistant", text="resumed reply"
         ),
     ]
-    assert statuses == [("running", None), ("idle", "kiro:resumed-assistant")]
+    # No session status is posted by the forwarder anymore (#1137).
     assert external_ids == ["resumed-session"]
     state = json.loads((bridge_dir / "kiro_session_forwarder.json").read_text())
     assert state["session_id"] == "resumed-session"
@@ -487,3 +462,75 @@ async def test_forward_kiro_session_waits_for_expected_resume_session(
 
     assert posted == []
     assert external_ids == []
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_does_not_post_session_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #1137: the forwarder mirrors the transcript but must NOT
+    post ``external_session_status``. Running/idle for kiro-native is owned by
+    the PTY watcher's ``emit_status`` (runner/resource_registry.py); posting it
+    here too double-sourced the session status. Captures real HTTP via a mock
+    transport so it guards the behaviour however status might be sent."""
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            {
+                "version": "v1",
+                "kind": "Prompt",
+                "data": {"message_id": "user-1", "content": [{"kind": "text", "data": "hey"}]},
+            },
+            {
+                "version": "v1",
+                "kind": "AssistantMessage",
+                "data": {
+                    "message_id": "assistant-1",
+                    "content": [{"kind": "text", "data": "Hey!"}],
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+
+    posted_event_types: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            posted_event_types.append(json.loads(request.content)["type"])
+        return httpx.Response(200, json={})
+
+    real_async_client = forwarder.httpx.AsyncClient
+
+    def _client_factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.pop("transport", None)
+        return real_async_client(*args, transport=httpx.MockTransport(_handler), **kwargs)
+
+    monkeypatch.setattr(forwarder.httpx, "AsyncClient", _client_factory)
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+    # The transcript is still mirrored…
+    assert "external_conversation_item" in posted_event_types
+    # …but the forwarder posts no session status (the PTY watcher owns it).
+    assert "external_session_status" not in posted_event_types


### PR DESCRIPTION
## Problem

`kiro-native` was reporting working/idle status from **two** sources simultaneously:

1. **PTY watcher** — watches raw terminal output; ~1 s of quiet → idle (shared path with cursor/goose/qwen/hermes native harnesses, controlled by the `emit_status` set in `resource_registry.py`)
2. **Forwarder** — `kiro_native_session_forwarder.py` was also calling `_post_session_status()` on every user message (→ `running`) and every assistant message (→ `idle`)

This double-posts `external_session_status` events and diverges from every other native harness, where the forwarder mirrors transcript only and the PTY watcher owns status.

Flagged in the #1137 checklist as *'cheapest fix; consider doing first'*.

## Fix (option B)

Removed `_post_session_status` and its two call sites from `kiro_native_session_forwarder.py`. The PTY watcher is now the single status source for kiro-native, matching cursor-native, goose-native, qwen-native, and hermes-native.

The alternative (option A — keep the forwarder's status and remove `KIRO_NATIVE_TERMINAL_ROLE` from the `emit_status` set) was considered but rejected: it would make kiro-native the only native harness whose status comes from the forwarder, diverging from the documented design where PTY watcher = status for all native harnesses.

The forwarder's idle edge used `response_id=None`, which the server accepts (field is optional), so nothing is lost.

## What's verified

**Unit tests** (`tests/test_kiro_native_session_forwarder.py`):
- Added `test_forward_kiro_session_does_not_post_session_status`: uses `httpx.MockTransport` to capture real POSTs and asserts the forwarder emits `external_conversation_item` but **never** `external_session_status`. Confirmed fails-before / passes-after the fix.
- All 7 forwarder tests pass. 59 related kiro/native unit tests unaffected.
- `ruff check` + `ruff format --check` clean.

**Live Kiro validation** (kiro-cli 2.10.0, omnigent local stack, WSL2/Ubuntu 24.04):
- Started a kiro-native session and sent multiple prompts across several turns.
- Status badge showed **Working…** immediately on each turn → flipped to **idle within ~1 s** of Kiro's reply → **stayed idle with no flapping** across all turns.
- The ~1 s lag between response appearing in transcript and badge going idle is the PTY watcher's `_CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS = 1.0` doing its job correctly — it waits for Kiro's TUI to quiesce, not for the first transcript token.
- No double-posted status events observed.

Part of #1137