### PR TITLE
fix(antigravity-native): run agy under the real HOME on macOS (#1477)

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -446,24 +446,47 @@ def write_mcp_config(
 
 
 def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
-    """Seed the per-session isolated agy HOME and return the launch env override.
+    """Resolve the agy launch HOME and return the env override (platform-specific).
 
-    Copies the user's real agy OAuth token + onboarding/migration state (NEVER
-    moving or modifying the real files) into ``<bridge_dir>/agy-home/.gemini`` so
-    a launch under this isolated HOME does not re-demand OAuth or re-run the
-    onboarding wizard. The relay's ``mcp_config.json`` is written separately by
-    :func:`write_mcp_config` so it lands in this same isolated tree rather than
-    the user's real ``~/.gemini`` (the footgun this whole design avoids).
+    **Linux** — return ``{"HOME": <iso_home>}`` for a per-session ISOLATED HOME:
+    copy the user's real agy OAuth token + onboarding/migration state (NEVER moving
+    or modifying the real files) into ``<bridge_dir>/agy-home/.gemini`` so the
+    launch does not re-demand OAuth or re-run the wizard, and the relay's
+    ``mcp_config.json`` (:func:`write_mcp_config`) lands in this isolated tree
+    rather than clobbering the user's real ``~/.gemini``. Verified live (agy
+    1.0.12): the ``/mcp`` panel shows ``✓ omnigent`` with the ``sys_*`` tools.
 
-    Verified live (agy 1.0.12): under this isolated HOME agy logs in as the real
-    user from the seeded token and its ``/mcp`` panel shows ``✓ omnigent`` with the
-    ``sys_*`` tools discovered.
+    **macOS (darwin)** — return ``{"HOME": <real_home>}`` with NO isolation: agy
+    binds its OAuth credential to the real login HOME via the Keychain item
+    "Antigravity Safe Storage" (resolved against the real home PATH, not the
+    contents of ``$HOME/.gemini``), so any isolated HOME makes every agy turn hang
+    at the interactive OAuth prompt (#1477; verified — ``agy -p`` authenticates
+    under the real HOME but stalls under any isolated HOME, even one whose
+    ``.gemini`` is symlinked with ``oauth_creds.json`` present). Two deliberate
+    consequences on macOS: (1) the relay ``mcp_config.json`` :func:`write_mcp_config`
+    writes into the (unread) isolated tree is NOT seen by agy, so the ``sys_*`` /
+    relay tools are unavailable there (#1194 — logged at WARNING, not silent); (2)
+    concurrent agy-native sessions and the user's own interactive ``agy`` share the
+    real ``~/.gemini`` global state (Linux isolates this) — acceptable for a
+    single-session dev machine. Assumes ``Path.home()`` is the Keychain-bound login
+    user; a service account whose ``$HOME`` differs would not authenticate.
 
     :param bridge_dir: Native Antigravity bridge directory.
-    :returns: An env-override mapping (``{"HOME": <iso_home>}``) to layer onto the
-        agy launch environment.
+    :returns: An env-override mapping to layer onto the agy launch environment —
+        ``{"HOME": <iso_home>}`` on Linux, ``{"HOME": <real_home>}`` on macOS.
     """
     real_home = Path.home()
+    if sys.platform == "darwin":
+        # Real HOME for Keychain auth (#1477; see the docstring). The relay config
+        # write lands in the unread isolated tree, so sys_* / relay tools are absent
+        # on macOS (#1194) — surface it at WARNING (the server swallows DEBUG/INFO)
+        # rather than letting the tools silently disappear.
+        _logger.warning(
+            "agy-native on macOS runs under the real HOME for Keychain auth (#1477); "
+            "the Omnigent MCP relay / sys_* tools are unavailable and per-session HOME "
+            "isolation is disabled there (#1194)"
+        )
+        return {"HOME": str(real_home)}
     iso_home = agy_home_dir(bridge_dir)
     iso_gemini = iso_home / ".gemini"
     (iso_gemini / "antigravity-cli" / "cache").mkdir(mode=0o700, parents=True, exist_ok=True)

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -3440,6 +3440,9 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
 
     session_id = "conv_agy_mcp"
     monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
+    # This asserts the Linux isolated-HOME relay wiring; on macOS agy runs under the
+    # real HOME (Keychain auth, #1477) so the relay isn't wired into the bridge tree.
+    monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
     (tmp_path / "workspace").mkdir(parents=True, exist_ok=True)

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1080,6 +1081,7 @@ def test_seed_isolated_agy_home_returns_home_override_and_seeds_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """seed_isolated_agy_home copies the OAuth token + markers and returns HOME."""
+    monkeypatch.setattr(sys, "platform", "linux")  # exercise the isolated-HOME path
     fake_home = tmp_path / "real-home"
     (fake_home / ".gemini" / "antigravity-cli").mkdir(parents=True)
     (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").write_text(
@@ -1113,6 +1115,7 @@ def test_seed_isolated_agy_home_tolerates_missing_credential(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A missing OAuth token only means agy re-auths — never a hard failure."""
+    monkeypatch.setattr(sys, "platform", "linux")  # exercise the isolated-HOME path
     fake_home = tmp_path / "real-home"
     fake_home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
@@ -1126,6 +1129,36 @@ def test_seed_isolated_agy_home_tolerates_missing_credential(
     # No token copied (none existed), but the isolated HOME + markers still exist.
     assert not (iso / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").exists()
     assert (iso / ".gemini" / "antigravity-cli" / "cache" / "onboarding.json").is_file()
+
+
+def test_seed_isolated_agy_home_darwin_returns_real_home_unisolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On macOS agy must run under the REAL HOME (Keychain auth, #1477) — no isolation.
+
+    The isolated HOME breaks agy's Keychain-bound OAuth, so the darwin branch
+    returns the real home and seeds nothing into the bridge tree.
+    """
+    fake_home = tmp_path / "real-home"
+    (fake_home / ".gemini" / "antigravity-cli").mkdir(parents=True)
+    (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").write_text(
+        "real-token", encoding="utf-8"
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    env = seed_isolated_agy_home(bridge_dir)
+
+    # Returns the REAL home, not the per-session isolated bridge tree.
+    assert env == {"HOME": str(fake_home)}
+    # The isolated tree is NOT created or seeded on macOS.
+    assert not (agy_home_dir(bridge_dir) / ".gemini").exists()
+    # The real token is left untouched (never moved/modified).
+    assert (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").read_text(
+        encoding="utf-8"
+    ) == "real-token"
 
 
 def test_agy_home_dir_is_under_bridge_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #1477. On macOS, agy binds its OAuth credential to the **real `$HOME`** via the login Keychain item *"Antigravity Safe Storage"* — which resolves against the real home path, **not** the contents of an isolated `$HOME/.gemini`. The per-session isolated HOME the bridge uses on Linux therefore makes **every agy turn hang at the interactive OAuth login prompt** on macOS — even with `.gemini`/`.antigravity` symlinked into the bridge tree and `oauth_creds.json` seeded.

## Fix

`seed_isolated_agy_home` returns `{"HOME": <real home>}` on `darwin` — no per-session HOME isolation, because the Keychain binding makes it impossible. Linux keeps the seedable file-token (`antigravity-cli/antigravity-oauth-token`) isolation unchanged.

## Trade-off (macOS only)

Per-session agy state shares the user's real `~/.gemini`, and the relay MCP config lands in the bridge tree agy won't read (separate concern, #1194). Given agy's Keychain binding this is the only way it authenticates on macOS, and macOS hosts are single-user dev machines, so a shared `~/.gemini` is acceptable.

## Validation

**Live-validated 2026-06-27.** With this change, agy **1.0.13** authenticated headlessly on macOS (Google AI Pro account, model Gemini 3.5 Flash) and ran a full 3-gate approval turn end-to-end through a homelab omnigent server — the same run that validated #1472. Without it, agy stalls at the OAuth prompt under the isolated HOME and the turn never starts.

## Scope

One self-contained change to `seed_isolated_agy_home` (darwin early-return). ruff clean; introduces no new mypy errors over `main`. Independent of #1473 (the #1472 fix) — branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
