### PR TITLE
feat(terminal): predictive local echo to mask remote-PTY typing latency

### DIFF
--- a/ap-web/.gitignore
+++ b/ap-web/.gitignore
@@ -14,6 +14,13 @@ dist-ssr
 coverage
 *.local
 
+# Playwright (browser test runner)
+test-results
+playwright-report
+.playwright
+# Harness screenshot captured during a local browser-test run (transient)
+src/components/blocks/typeahead/__harness__/.prediction.png
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/ap-web/package-lock.json
+++ b/ap-web/package-lock.json
@@ -71,6 +71,7 @@
         "zustand": "^5.0.12"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/vite": "^4.2.4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -2573,6 +2574,22 @@
       "license": "MIT",
       "engines": {
         "vscode": "^1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@primer/octicons": {
@@ -6747,7 +6764,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6757,7 +6773,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8096,6 +8111,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -13701,6 +13725,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -16254,7 +16325,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -16545,7 +16615,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -17354,12 +17424,21 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/ap-web/package.json
+++ b/ap-web/package.json
@@ -15,7 +15,8 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:browser": "playwright test"
   },
   "dependencies": {
     "@databricks/sdk-experimental": "^0.17.0",
@@ -120,6 +121,7 @@
     "react-dom": "$react-dom"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/ap-web/playwright.config.ts
+++ b/ap-web/playwright.config.ts
@@ -1,0 +1,34 @@
+// Playwright config for the predictive-local-echo browser verification.
+// Only picks up *.browser.spec.ts (vitest owns the rest). Starts Vite to serve
+// the harness page; OMNIGENT_URL points at a dummy local origin so the dev
+// proxy's auth path stays inert (the harness needs no backend).
+
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 5234;
+
+export default defineConfig({
+  testDir: "./src",
+  testMatch: "**/*.browser.spec.ts",
+  fullyParallel: false,
+  // Vite's first compile of the harness on a cold start can race navigation;
+  // a single retry absorbs that without masking a real feature regression
+  // (the assertions themselves are deterministic once the page loads).
+  retries: 2,
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "off",
+    // Generous nav timeout: the first goto triggers Vite's on-demand compile
+    // of the harness module graph (xterm + addon), which is slow cold.
+    navigationTimeout: 30_000,
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: `npx vite --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}/`,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    env: { OMNIGENT_URL: "http://localhost:6767" },
+  },
+});

--- a/ap-web/src/components/blocks/TerminalSession.ts
+++ b/ap-web/src/components/blocks/TerminalSession.ts
@@ -14,6 +14,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import { TypeAheadAddon } from "./typeahead/terminalTypeAheadAddon";
 
 // Card background colors derived from the app's CSS palette.
 // Light: --card: oklch(1.000 0 0) = pure white.
@@ -172,6 +173,27 @@ export const SYNC_ECHO_WINDOW_MS = 750;
 export const SYNC_ECHO_MAX_BYTES = 2048;
 
 /**
+ * Predictive local echo (type-ahead) mode. A remote PTY has no local echo, so
+ * every keystroke costs a network round-trip before it paints. The
+ * {@link TypeAheadAddon} (ported from VS Code) predicts the on-screen effect of
+ * keystrokes and renders them immediately (dimmed), reconciling against the
+ * authoritative PTY echo — masking RTT.
+ *
+ * - ``"auto"``: the addon self-gates on measured latency, only showing
+ *   predictions once median RTT exceeds {@link LOCAL_ECHO_LATENCY_THRESHOLD_MS}.
+ *   Fast/local links stay dormant (no overhead, no flicker).
+ * - ``"on"``: always predict (subject to the addon's accuracy gate).
+ * - ``"off"``: addon is never constructed — identical to the legacy behavior.
+ */
+export type LocalEchoMode = "auto" | "on" | "off";
+
+/**
+ * Network delay (ms) above which ``"auto"`` mode starts showing predictions.
+ * Matches VS Code's ``terminal.integrated.localEchoLatencyThreshold`` default.
+ */
+export const LOCAL_ECHO_LATENCY_THRESHOLD_MS = 30;
+
+/**
  * Decide whether an inbound PTY chunk should be painted synchronously
  * rather than queued through xterm's async ``write``.
  *
@@ -294,6 +316,20 @@ export class TerminalSession {
   private readonly listenerCtl: AbortController;
   private readonly resizeObserver: ResizeObserver;
   private readonly dataDispose: { dispose: () => void };
+  /**
+   * Predictive local-echo addon (ported from VS Code), or ``null`` when local
+   * echo is ``"off"``. When present, inbound PTY bytes are routed through its
+   * {@link TypeAheadAddon.beforeServerInput} before painting so prediction
+   * rollbacks/rollforwards are interleaved with the real echo.
+   */
+  private readonly typeAhead: TypeAheadAddon | null;
+  /**
+   * Streaming decoder for the local-echo path: the addon works on strings, so
+   * inbound bytes are decoded with ``{ stream: true }`` to hold back any
+   * multi-byte sequence split across WebSocket frames (never hand a half
+   * character to the prediction matcher). Only allocated when type-ahead is on.
+   */
+  private readonly outputDecoder: TextDecoder | null;
   /** ``performance.now()`` of the last keystroke; gates the echo fast path. */
   private lastUserInputAt = 0;
   /** Guards {@link dispose} so calling it twice is a safe no-op. */
@@ -312,6 +348,8 @@ export class TerminalSession {
    *     server. This is a best-effort UI activity signal, not a shell
    *     job-state oracle.
    * :param onInput: Called when user input is sent to the terminal.
+   * :param localEcho: Predictive local-echo mode. Defaults to ``"auto"``
+   *     (self-gating on measured latency). See {@link LocalEchoMode}.
    */
   constructor(
     container: HTMLElement,
@@ -320,6 +358,7 @@ export class TerminalSession {
     isDark = false,
     onActivity?: TerminalActivityListener,
     onInput?: TerminalInputListener,
+    localEcho: LocalEchoMode = "auto",
   ) {
     this.term = new Terminal({
       // Match the system mono stack at the configured base size. The
@@ -360,6 +399,20 @@ export class TerminalSession {
     // Load the GPU renderer after open() (it needs the mounted canvas).
     // Falls back to the DOM renderer when WebGL is unavailable.
     this.webgl = loadWebglRenderer(this.term);
+    // Predictive local echo. Loaded after open() so the addon's `activate`
+    // sees a mounted terminal. `"off"` skips construction entirely (no
+    // overhead). `"auto"` uses VS Code's latency threshold so prediction only
+    // engages on slow links; `"on"` forces it (threshold 0).
+    if (localEcho === "off") {
+      this.typeAhead = null;
+    } else {
+      this.typeAhead = new TypeAheadAddon({
+        latencyThreshold: localEcho === "on" ? 0 : LOCAL_ECHO_LATENCY_THRESHOLD_MS,
+        style: "dim",
+      });
+      this.term.loadAddon(this.typeAhead);
+    }
+    this.outputDecoder = this.typeAhead ? new TextDecoder() : null;
     try {
       this.fit.fit();
     } catch (err) {
@@ -506,6 +559,10 @@ export class TerminalSession {
     } catch {
       /* noop */
     }
+    // Dispose the type-ahead addon (its timers/listeners) before the terminal.
+    // `term.dispose()` would also dispose loaded addons, but doing it explicitly
+    // keeps teardown order obvious and cancels the pending rollback timeout.
+    this.typeAhead?.dispose();
     // Dispose the WebGL renderer before the terminal so its canvas and
     // GL context are released while the terminal still owns them.
     this.webgl?.dispose();
@@ -522,8 +579,24 @@ export class TerminalSession {
    * future xterm that drops it — falls back to the async public ``write``.
    * Correctness never depends on the private API; it only shaves a frame
    * off the echo when present.
+   *
+   * When predictive local echo is active, bytes are first decoded (streaming,
+   * to keep multi-byte sequences intact across frames) and routed through the
+   * type-ahead timeline, which interleaves prediction rollbacks/rollforwards
+   * with the real echo. That rewritten string is then written normally — the
+   * sync-echo fast path is bypassed because prediction already masks the RTT
+   * the fast path was shaving frames off of, and the rewritten stream is no
+   * longer the raw byte chunk the fast path assumes.
    */
   private writeOutput(bytes: Uint8Array): void {
+    if (this.typeAhead && this.outputDecoder) {
+      const decoded = this.outputDecoder.decode(bytes, { stream: true });
+      if (decoded.length === 0) {
+        return; // an incomplete multi-byte sequence; wait for the rest
+      }
+      this.term.write(this.typeAhead.beforeServerInput(decoded));
+      return;
+    }
     if (shouldEchoSynchronously(bytes.length, performance.now() - this.lastUserInputAt)) {
       // eslint-disable-next-line no-underscore-dangle
       const core = (this.term as unknown as TerminalCore)._core;

--- a/ap-web/src/components/blocks/TerminalView.tsx
+++ b/ap-web/src/components/blocks/TerminalView.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { resolveWebSocketUrl } from "@/lib/host";
 import {
   type ConnectionState,
+  type LocalEchoMode,
   type TerminalActivityListener,
   type TerminalInputListener,
   isUnexpectedTerminalClose,
@@ -65,6 +66,12 @@ interface TerminalViewProps {
   onResume?: () => void | Promise<void>;
   /** Whether the optional resume action is currently in flight. */
   resumePending?: boolean;
+  /**
+   * Predictive local-echo (type-ahead) mode. ``"auto"`` (default) engages only
+   * on high-latency links; ``"off"`` disables it entirely. Changing this
+   * re-dials the session (it's an addressing input). See {@link LocalEchoMode}.
+   */
+  localEcho?: LocalEchoMode;
 }
 
 export function TerminalView({
@@ -76,6 +83,7 @@ export function TerminalView({
   onInput,
   onResume,
   resumePending = false,
+  localEcho = "auto",
 }: TerminalViewProps) {
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
   const [connectAttempt, setConnectAttempt] = useState(0);
@@ -172,6 +180,7 @@ export function TerminalView({
           isDarkRef.current,
           notifyActivity,
           notifyInput,
+          localEcho,
         );
         sessionRef.current = terminalSession;
       });
@@ -182,7 +191,7 @@ export function TerminalView({
         onStateChangeRef.current?.(null);
       };
     },
-    [sessionId, terminalId, readOnly, notifyState, notifyActivity, notifyInput],
+    [sessionId, terminalId, readOnly, notifyState, notifyActivity, notifyInput, localEcho],
   );
 
   // Push theme changes into the live session without remounting.

--- a/ap-web/src/components/blocks/typeahead/__harness__/harness.html
+++ b/ap-web/src/components/blocks/typeahead/__harness__/harness.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>TypeAhead harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: #131517;
+      }
+      #term {
+        width: 800px;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="term"></div>
+    <script type="module" src="./harness.ts"></script>
+  </body>
+</html>

--- a/ap-web/src/components/blocks/typeahead/__harness__/harness.ts
+++ b/ap-web/src/components/blocks/typeahead/__harness__/harness.ts
@@ -1,0 +1,86 @@
+// Browser harness for manually/automatically verifying the predictive local
+// echo addon in a REAL browser (Playwright drives it). It reproduces the
+// TerminalSession wiring without a WebSocket: a fake PTY echoes typed bytes
+// back after an artificial round-trip delay, and that echo is routed through
+// `typeAhead.beforeServerInput(...)` before painting — exactly as
+// TerminalSession.writeOutput does on the real path.
+//
+// The test controls everything via `window.__ta`.
+/* eslint-disable no-underscore-dangle -- `window.__ta` is the test control API
+   and `_timeline` is the addon's (intentionally) private field read for state. */
+
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { TypeAheadAddon } from "../terminalTypeAheadAddon";
+
+const RTT_MS = 250; // simulated network round-trip — well above the 30ms gate
+
+const term = new Terminal({
+  cols: 80,
+  rows: 24,
+  fontFamily: "monospace",
+  fontSize: 14,
+  theme: { background: "#131517", foreground: "#e4e4e7" },
+});
+
+// latencyThreshold 0 => "on" (show predictions immediately, no warm-up needed
+// for a deterministic test). The real app uses "auto" (30ms gate).
+const addon = new TypeAheadAddon({ latencyThreshold: 0, style: "dim" });
+term.loadAddon(addon);
+term.open(document.getElementById("term")!);
+
+// Fake PTY: echo each byte back after RTT, through the addon's reconciler.
+// A real shell prints a prompt first; emit one so the cursor isn't at column 0
+// (where the addon guards the prompt edge).
+function serverWrite(data: string) {
+  term.write(addon.beforeServerInput(data));
+}
+
+term.onData((d) => {
+  // Echo back after the simulated round-trip, like a remote PTY would.
+  setTimeout(() => serverWrite(d), RTT_MS);
+});
+
+// Initial prompt (written straight, not via the reconciler — it's not an echo).
+term.write("$ ");
+
+/** Read the rendered text of a buffer row (trimmed). */
+function rowText(y: number): string {
+  return term.buffer.active.getLine(y)?.translateToString(true) ?? "";
+}
+
+/**
+ * Read the SGR "dim" state of the cell at (x, yFromTop). xterm exposes
+ * `isDim()` on the cell — predicted (unconfirmed) glyphs are painted dim.
+ */
+function cellIsDim(x: number, y: number): boolean {
+  const cell = term.buffer.active.getLine(y)?.getCell(x);
+  return cell ? cell.isDim() !== 0 : false;
+}
+
+declare global {
+  interface Window {
+    __ta: {
+      rttMs: number;
+      type: (s: string) => void;
+      rowText: (y: number) => string;
+      cellIsDim: (x: number, y: number) => boolean;
+      cursorX: () => number;
+      isShowing: () => boolean;
+      ready: boolean;
+    };
+  }
+}
+
+window.__ta = {
+  rttMs: RTT_MS,
+  // `term.input` fires onData exactly as a real keystroke does.
+  type: (s: string) => term.input(s),
+  rowText,
+  cellIsDim,
+  cursorX: () => term.buffer.active.cursorX,
+  isShowing: () =>
+    (addon as unknown as { _timeline?: { isShowingPredictions: boolean } })._timeline
+      ?.isShowingPredictions ?? false,
+  ready: true,
+};

--- a/ap-web/src/components/blocks/typeahead/__harness__/typeahead.browser.spec.ts
+++ b/ap-web/src/components/blocks/typeahead/__harness__/typeahead.browser.spec.ts
@@ -1,0 +1,66 @@
+// Browser (Playwright) verification of predictive local echo in a REAL browser.
+// Loads the harness (xterm + TypeAheadAddon + a fake PTY that echoes after a
+// simulated RTT) and asserts the user-visible behavior that unit tests in jsdom
+// cannot: a typed character is painted DIMMED immediately (before the echo
+// returns) and then becomes solid (non-dim) once the server echo reconciles.
+//
+// Run: npx playwright test (see playwright.config.ts — it starts `vite`).
+
+/* eslint-disable no-underscore-dangle -- the harness exposes a `window.__ta`
+   control API and the test reads the addon's `_timeline`; both are test-only. */
+import { expect, test } from "@playwright/test";
+
+const HARNESS = "/src/components/blocks/typeahead/__harness__/harness.html";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(HARNESS);
+  await page.waitForFunction(() => window.__ta?.ready === true);
+});
+
+test("predicts a typed character immediately (dimmed), then confirms it (solid)", async ({
+  page,
+}) => {
+  const rtt = await page.evaluate(() => window.__ta.rttMs);
+
+  // The prompt "$ " occupies cols 0-1, so typed input lands at col 2 on row 0.
+  // First char on a line is held tentative (epoch model), so prime the line:
+  // type "a", let it round-trip and confirm, so the line is proven to echo.
+  await page.evaluate(() => window.__ta.type("a"));
+  await page.waitForTimeout(rtt + 100);
+
+  // Now type "b": it must be PREDICTED (painted dim) BEFORE the echo returns.
+  await page.evaluate(() => window.__ta.type("b"));
+
+  // Immediately (well within the RTT window) the glyph is on screen AND dim.
+  const predicted = await page.evaluate(() => ({
+    text: window.__ta.rowText(0),
+    bDim: window.__ta.cellIsDim(3, 0), // col 3 = third typed-area cell ($ a b)
+  }));
+  expect(predicted.text).toContain("ab");
+  expect(predicted.bDim).toBe(true); // unconfirmed → dim
+
+  // After the round-trip echo reconciles, the same cell is no longer dim.
+  await page.waitForFunction(() => window.__ta.cellIsDim(3, 0) === false, undefined, {
+    timeout: rtt + 1000,
+  });
+  const confirmed = await page.evaluate(() => window.__ta.rowText(0));
+  expect(confirmed).toContain("ab");
+});
+
+test("captures a screenshot of an in-flight (dimmed) prediction", async ({ page }) => {
+  const rtt = await page.evaluate(() => window.__ta.rttMs);
+  // Prime + confirm the first char.
+  await page.evaluate(() => window.__ta.type("l"));
+  await page.waitForTimeout(rtt + 100);
+  // Type a burst; with RTT=250ms these are all unconfirmed (dim) at capture time.
+  await page.evaluate(() => window.__ta.type("s -la"));
+  // Capture while predictions are still in flight (before the echo returns).
+  await page.screenshot({
+    path: "src/components/blocks/typeahead/__harness__/.prediction.png",
+  });
+  // Sanity: at least one of the burst cells is dim right now.
+  const anyDim = await page.evaluate(
+    () => window.__ta.cellIsDim(3, 0) || window.__ta.cellIsDim(4, 0) || window.__ta.cellIsDim(5, 0),
+  );
+  expect(anyDim).toBe(true);
+});

--- a/ap-web/src/components/blocks/typeahead/shims.ts
+++ b/ap-web/src/components/blocks/typeahead/shims.ts
@@ -1,0 +1,188 @@
+/* eslint-disable no-underscore-dangle -- these mirror VS Code's `vs/base/common/*`
+   utilities, which use `_`-prefixed private members; kept identical so the addon
+   that consumes them reads the same as upstream. */
+// Minimal standalone replacements for the VS Code platform utilities that
+// `terminalTypeAheadAddon.ts` (vendored from microsoft/vscode, MIT) depends on.
+// Upstream imports these from `vs/base/common/*`; outside the VS Code repo we
+// provide just the slices the addon uses. Kept deliberately small and free of
+// any VS Code coupling.
+
+/** Something that can be torn down. Mirrors `vs/base/common/lifecycle` IDisposable. */
+export interface IDisposable {
+  dispose(): void;
+}
+
+/** Wrap a teardown callback as an IDisposable. */
+export function toDisposable(fn: () => void): IDisposable {
+  return { dispose: fn };
+}
+
+/**
+ * Base class holding child disposables, registered via {@link Disposable._register}
+ * and torn down together on {@link Disposable.dispose}. A trimmed copy of
+ * `vs/base/common/lifecycle` Disposable — no leak tracking, same semantics.
+ */
+export class Disposable implements IDisposable {
+  // Upstream exposes a `DisposableStore` as `this._store`; the addon passes it
+  // to `disposableTimeout` as the owning store. We model it as the same object
+  // that `_register` adds to, exposing an `add` method.
+  protected readonly _store: DisposableStore = new DisposableStore();
+
+  protected _register<T extends IDisposable>(o: T): T {
+    this._store.add(o);
+    return o;
+  }
+
+  dispose(): void {
+    this._store.dispose();
+  }
+}
+
+/** Holds a set of disposables and disposes them all at once. */
+export class DisposableStore implements IDisposable {
+  private readonly _items = new Set<IDisposable>();
+  private _isDisposed = false;
+
+  add<T extends IDisposable>(o: T): T {
+    if (this._isDisposed) {
+      o.dispose();
+      return o;
+    }
+    this._items.add(o);
+    return o;
+  }
+
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    for (const item of this._items) {
+      item.dispose();
+    }
+    this._items.clear();
+  }
+}
+
+/** Listener callback. */
+export type Event<T> = (listener: (e: T) => void) => IDisposable;
+
+/**
+ * Tiny event emitter mirroring `vs/base/common/event` Emitter: `.event` is a
+ * subscribe function returning an unsubscribe disposable, `.fire(value)`
+ * notifies current listeners.
+ */
+export class Emitter<T> implements IDisposable {
+  private _listeners?: Set<(e: T) => void>;
+
+  readonly event: Event<T> = (listener: (e: T) => void): IDisposable => {
+    (this._listeners ??= new Set()).add(listener);
+    return toDisposable(() => this._listeners?.delete(listener));
+  };
+
+  fire(event: T): void {
+    if (!this._listeners) {
+      return;
+    }
+    // Snapshot so a listener that (un)subscribes during dispatch is safe.
+    for (const listener of [...this._listeners]) {
+      listener(event);
+    }
+  }
+
+  dispose(): void {
+    this._listeners?.clear();
+    this._listeners = undefined;
+  }
+}
+
+/**
+ * Run `fn` after `delayMs`, returning a disposable that cancels the pending
+ * timer. If `store` is provided the timeout is registered to it so it's
+ * cancelled on store disposal. Mirrors `vs/base/common/async` disposableTimeout.
+ */
+export function disposableTimeout(
+  fn: () => void,
+  delayMs: number,
+  store?: DisposableStore,
+): IDisposable {
+  const timer = setTimeout(fn, delayMs);
+  const disposable = toDisposable(() => clearTimeout(timer));
+  store?.add(disposable);
+  return disposable;
+}
+
+/**
+ * Returns a debounced wrapper of `fn`: rapid calls within `delayMs` collapse to
+ * a single trailing invocation. Replaces upstream's `@debounce(ms)` *method
+ * decorator* (unavailable here: ap-web's tsconfig has no `experimentalDecorators`
+ * and uses `erasableSyntaxOnly`). Call sites wrap the method explicitly instead.
+ */
+export function debounce<A extends unknown[]>(
+  fn: (...args: A) => void,
+  delayMs: number,
+): (...args: A) => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return (...args: A) => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      fn(...args);
+    }, delayMs);
+  };
+}
+
+/** Escape a string for literal use inside a RegExp. From `vs/base/common/strings`. */
+export function escapeRegExpCharacters(value: string): string {
+  return value.replace(/[\\{}*+?|^$.[\]()]/g, "\\$&");
+}
+
+/** Type guard for finite/any numbers. From `vs/base/common/types`. */
+export function isNumber(obj: unknown): obj is number {
+  return typeof obj === "number" && !isNaN(obj);
+}
+
+/** A value that may be a single item or an array of them. From `vs/base/common/types`. */
+export type SingleOrMany<T> = T | T[];
+
+/**
+ * RGBA color, 0-255 channels and 0-1 alpha. Trimmed from `vs/base/common/color`
+ * — the addon only constructs one and reads `.r/.g/.b`.
+ */
+export class RGBA {
+  readonly r: number;
+  readonly g: number;
+  readonly b: number;
+  readonly a: number;
+
+  constructor(r: number, g: number, b: number, a = 1) {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+    this.a = a;
+  }
+}
+
+/**
+ * Minimal Color supporting just what the addon uses: `Color.fromHex('#rrggbb')`
+ * (throws on bad input, matching upstream's try/catch contract) and `.rgba`.
+ */
+export class Color {
+  readonly rgba: RGBA;
+
+  constructor(rgba: RGBA) {
+    this.rgba = rgba;
+  }
+
+  static fromHex(hex: string): Color {
+    const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex.trim());
+    if (!match) {
+      throw new Error(`Invalid hex color: ${hex}`);
+    }
+    return new Color(
+      new RGBA(parseInt(match[1]!, 16), parseInt(match[2]!, 16), parseInt(match[3]!, 16), 1),
+    );
+  }
+}

--- a/ap-web/src/components/blocks/typeahead/terminalTypeAheadAddon.test.ts
+++ b/ap-web/src/components/blocks/typeahead/terminalTypeAheadAddon.test.ts
@@ -1,0 +1,274 @@
+/* eslint-disable no-underscore-dangle -- tests reach into the addon's `_timeline`
+   and xterm's `_core` to assert internal state; that introspection is the point. */
+// Tests for the vendored VS Code type-ahead (predictive local echo) addon and
+// its standalone shims. We exercise the addon against a real xterm Terminal in
+// jsdom (the upstream code has no public unit surface, so we drive it through
+// `term.onData` + the public `beforeServerInput` entry point and observe what
+// it writes back to the terminal).
+//
+// Style note: predicted glyphs are wrapped in the "dim" SGR (`CSI 2 m` … `CSI
+// 22 m`); we assert on those sequences to tell "a prediction was painted" from
+// "nothing happened".
+
+import { Terminal } from "@xterm/xterm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  Color,
+  DisposableStore,
+  Emitter,
+  RGBA,
+  debounce,
+  disposableTimeout,
+  escapeRegExpCharacters,
+  isNumber,
+} from "./shims";
+import { TypeAheadAddon, type ITypeAheadOptions } from "./terminalTypeAheadAddon";
+
+// ---------------------------------------------------------------------------
+// Shims
+// ---------------------------------------------------------------------------
+
+describe("shims", () => {
+  it("Emitter delivers events and unsubscribes via the returned disposable", () => {
+    const emitter = new Emitter<number>();
+    const seen: number[] = [];
+    const sub = emitter.event((n) => seen.push(n));
+    emitter.fire(1);
+    emitter.fire(2);
+    sub.dispose();
+    emitter.fire(3);
+    expect(seen).toEqual([1, 2]);
+  });
+
+  it("DisposableStore disposes children once and short-circuits after disposal", () => {
+    const store = new DisposableStore();
+    const a = vi.fn();
+    store.add({ dispose: a });
+    store.dispose();
+    store.dispose(); // idempotent
+    expect(a).toHaveBeenCalledOnce();
+    // adding after disposal disposes immediately
+    const b = vi.fn();
+    store.add({ dispose: b });
+    expect(b).toHaveBeenCalledOnce();
+  });
+
+  it("disposableTimeout fires after the delay and can be cancelled", () => {
+    vi.useFakeTimers();
+    try {
+      const fn = vi.fn();
+      disposableTimeout(fn, 100);
+      vi.advanceTimersByTime(99);
+      expect(fn).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(fn).toHaveBeenCalledOnce();
+
+      const fn2 = vi.fn();
+      disposableTimeout(fn2, 100).dispose();
+      vi.advanceTimersByTime(200);
+      expect(fn2).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("debounce collapses rapid calls to a single trailing invocation", () => {
+    vi.useFakeTimers();
+    try {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 50);
+      debounced();
+      debounced();
+      debounced();
+      vi.advanceTimersByTime(49);
+      expect(fn).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(fn).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("escapeRegExpCharacters escapes regex metacharacters", () => {
+    expect(escapeRegExpCharacters("a.b*c")).toBe("a\\.b\\*c");
+    // used by the exclude-program list — a literal program name must match literally
+    expect(new RegExp(escapeRegExpCharacters("g++")).test("g++")).toBe(true);
+  });
+
+  it("isNumber narrows only finite numeric values", () => {
+    expect(isNumber(3)).toBe(true);
+    expect(isNumber(NaN)).toBe(false);
+    expect(isNumber("3")).toBe(false);
+  });
+
+  it("Color.fromHex parses #rrggbb and throws on garbage", () => {
+    expect(new Color(new RGBA(1, 2, 3)).rgba.r).toBe(1);
+    expect(Color.fromHex("#ff8800").rgba).toMatchObject({ r: 255, g: 136, b: 0 });
+    expect(() => Color.fromHex("not-a-color")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Addon
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a real Terminal + activated addon. We don't call `term.open` (jsdom has
+ * no canvas); the buffer/cursor APIs the addon reads work on an unopened
+ * terminal. `writes` captures everything the addon paints back.
+ */
+function makeAddon(options?: Partial<ITypeAheadOptions>) {
+  const term = new Terminal({ allowProposedApi: true, cols: 80, rows: 24 });
+  const writes: string[] = [];
+  const realWrite = term.write.bind(term);
+  vi.spyOn(term, "write").mockImplementation((data: string | Uint8Array, cb?: () => void) => {
+    writes.push(typeof data === "string" ? data : new TextDecoder().decode(data));
+    return realWrite(data as string, cb);
+  });
+
+  const addon = new TypeAheadAddon({
+    latencyThreshold: 0, // "on": show predictions immediately
+    style: "dim",
+    ...options,
+  });
+  addon.activate(term);
+  return { term, addon, writes };
+}
+
+/** Flush xterm's async write queue so buffer state reflects what we wrote. */
+function flush(term: Terminal): Promise<void> {
+  return new Promise((resolve) => term.write("", () => resolve()));
+}
+
+const DIM = "\x1b[2m"; // CSI 2 m — the "apply" sequence for style: 'dim'
+
+describe("TypeAheadAddon", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("holds the first char on a line tentative, then paints once the line is confirmed", async () => {
+    const { term, addon, writes } = makeAddon();
+    await flush(term);
+    writes.length = 0;
+
+    // First char on a fresh line is wrapped in a TentativeBoundary (epoch
+    // model): it's queued for matching but NOT painted, so a no-echo context
+    // (password prompt) never flickers.
+    term.input("a");
+    expect(writes.join("")).not.toContain(DIM);
+
+    // Server confirms the first char → the line is proven to echo.
+    addon.beforeServerInput("a");
+    writes.length = 0;
+
+    // Now subsequent chars paint immediately as dimmed (unconfirmed) glyphs.
+    term.input("b");
+    const painted = writes.join("");
+    expect(painted).toContain(DIM);
+    expect(painted).toContain("b");
+  });
+
+  it("does not predict in the alternate screen buffer (TUI like vim)", async () => {
+    const { term, writes } = makeAddon();
+    // Enter the alternate screen.
+    await new Promise<void>((r) => term.write("\x1b[?1049h", () => r()));
+    writes.length = 0;
+
+    term.input("a");
+
+    // No dim-styled prediction should be emitted on the alt screen.
+    expect(writes.join("")).not.toContain(DIM);
+  });
+
+  it("beforeServerInput returns input unchanged when there are no predictions", () => {
+    const { addon } = makeAddon();
+    expect(addon.beforeServerInput("hello")).toBe("hello");
+  });
+
+  it("reconciles a correct echo (prediction confirmed, stats record success)", async () => {
+    const { term, addon } = makeAddon();
+    await flush(term);
+
+    term.input("a");
+    // The server echoes the same character back.
+    addon.beforeServerInput("a");
+
+    // A confirmed prediction is recorded as accurate.
+    expect(addon.stats!.sampleSize).toBeGreaterThan(0);
+    expect(addon.stats!.accuracy).toBe(1);
+  });
+
+  it("rolls back on a contradicting echo (prediction failed)", async () => {
+    const { term, addon } = makeAddon();
+    await flush(term);
+
+    term.input("a");
+    // Server echoes a DIFFERENT character — the prediction was wrong.
+    addon.beforeServerInput("X");
+
+    expect(addon.stats!.sampleSize).toBeGreaterThan(0);
+    expect(addon.stats!.accuracy).toBe(0);
+  });
+
+  it("clears outstanding predictions after the timeout when no echo arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      const { term, addon } = makeAddon();
+      term.write("");
+      // Type two chars and confirm the first so the second is a live (painted)
+      // prediction left outstanding.
+      term.input("a");
+      addon.beforeServerInput("a");
+      term.input("b");
+      const timeline = (addon as unknown as { _timeline: { length: number } })._timeline;
+      expect(timeline.length).toBeGreaterThan(0);
+
+      // No echo for "b". The deferred-clear timer (>=500ms) undoes predictions.
+      vi.advanceTimersByTime(1000);
+      expect(timeline.length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("suppresses prediction when the terminal title matches an excluded program", async () => {
+    const { term, writes } = makeAddon({
+      excludePrograms: ["vim"],
+      latencyThreshold: 0,
+    });
+    await flush(term);
+    // Set the title to a vim session via OSC 0.
+    await new Promise<void>((r) => term.write("\x1b]0;vim README.md\x07", () => r()));
+    // Title change triggers a debounced re-evaluate; let it run.
+    await new Promise((r) => setTimeout(r, 150));
+    writes.length = 0;
+
+    term.input("a");
+
+    expect(writes.join("")).not.toContain(DIM);
+  });
+
+  it("disposes cleanly without leaking the rollback timer", () => {
+    vi.useFakeTimers();
+    try {
+      const { term, addon } = makeAddon();
+      term.write("");
+      term.input("a"); // arms the deferred-clear timeout
+      addon.dispose();
+      // After dispose, the pending timer must not fire into a torn-down timeline.
+      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("regression guard: xterm still exposes the private _curAttrData the addon depends on", () => {
+    const term = new Terminal({ allowProposedApi: true });
+    // The addon reads `_core._inputHandler._curAttrData` for style rollback.
+    const core = (term as unknown as { _core?: { _inputHandler?: { _curAttrData?: unknown } } })
+      ._core;
+    expect(core?._inputHandler?._curAttrData).toBeDefined();
+    term.dispose();
+  });
+});

--- a/ap-web/src/components/blocks/typeahead/terminalTypeAheadAddon.ts
+++ b/ap-web/src/components/blocks/typeahead/terminalTypeAheadAddon.ts
@@ -1,0 +1,1704 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable no-underscore-dangle -- vendored VS Code code uses `_`-prefixed
+   private members throughout; renaming them all would diverge hard from upstream
+   and make future re-syncs painful. (TerminalSession.ts suppresses the same rule
+   inline for its own private-core access.) */
+/* eslint-disable no-control-regex -- terminal code matches ESC/CSI control
+   sequences (\x1b) in regexes by necessity; that's the whole point here. */
+//
+// Vendored from microsoft/vscode (MIT):
+//   src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts
+//
+// This is VS Code's "local echo" / type-ahead engine: it predicts the on-screen
+// effect of keystrokes and renders them immediately (dimmed/unconfirmed), then
+// reconciles against the authoritative PTY echo — masking network RTT on remote
+// terminals (the Mosh approach). See plan: predictive local echo.
+//
+// Changes from upstream, required to run standalone under ap-web's tsconfig
+// (no `experimentalDecorators`, `erasableSyntaxOnly`, `verbatimModuleSyntax`):
+//   - `const enum` → `const` objects with `as const` (enums are non-erasable).
+//   - Constructor parameter properties → explicit field declarations.
+//   - `@debounce(ms)` method decorators → explicit `debounce(...)` wrappers.
+//   - `@IConfigurationService` / `@ITelemetryService` DI → a plain options object
+//     ({@link ITypeAheadOptions}); config reactivity dropped (re-create to change).
+//   - Telemetry (`_sendLatencyStats`) dropped entirely.
+//   - The VS Code `ITerminalProcessManager.onBeforeProcessData` middleware is
+//     replaced by a public {@link TypeAheadAddon.beforeServerInput} method the
+//     embedder calls with inbound PTY bytes BEFORE writing them to xterm.
+//   - VS Code base utilities (`Emitter`, `Disposable`, `disposableTimeout`,
+//     `Color`, helpers) come from ./shims; `IXtermCore`/`XtermAttributes` are
+//     declared locally (private xterm core, same approach as TerminalSession).
+
+import type { IBuffer, IBufferCell, IDisposable, ITerminalAddon, Terminal } from "@xterm/xterm";
+import {
+  Color,
+  Disposable,
+  Emitter,
+  RGBA,
+  type SingleOrMany,
+  debounce,
+  disposableTimeout,
+  escapeRegExpCharacters,
+  isNumber,
+  toDisposable,
+} from "./shims";
+
+// ---------------------------------------------------------------------------
+// Configuration (inlined from VS Code's terminalTypeAheadConfiguration.ts so we
+// don't pull in its nls/configuration-registry dependencies).
+// ---------------------------------------------------------------------------
+
+/** Programs that disable prediction when their name appears in the terminal title. */
+export const DEFAULT_LOCAL_ECHO_EXCLUDE: ReadonlyArray<string> = ["vim", "vi", "nano", "tmux"];
+
+/** Visual style applied to locally-echoed (unconfirmed) text. */
+export type LocalEchoStyle = "bold" | "dim" | "italic" | "underlined" | "inverted" | (string & {});
+
+/** Options for {@link TypeAheadAddon}, replacing VS Code's injected config service. */
+export interface ITypeAheadOptions {
+  /**
+   * Network delay (ms) above which local echo activates. `0` = always on,
+   * `-1` = disabled. Below the threshold the engine still measures latency but
+   * never displays predictions.
+   */
+  latencyThreshold: number;
+  /** Program names that suppress prediction when found in the terminal title. */
+  excludePrograms?: ReadonlyArray<string>;
+  /** Style for unconfirmed glyphs. */
+  style: LocalEchoStyle;
+}
+
+// ---------------------------------------------------------------------------
+// Private xterm core access (not in public typings — same family as the
+// `_core.writeSync` access in TerminalSession.ts). Only the slices used here.
+// ---------------------------------------------------------------------------
+
+/**
+ * The cell-attribute surface used by {@link attributesToArgs}. `IBufferCell`
+ * structurally satisfies this, as does xterm's internal `_curAttrData`.
+ */
+interface XtermAttributes {
+  isAttributeDefault(): boolean;
+  isBold(): number;
+  isDim(): number;
+  isItalic(): number;
+  isUnderline(): number;
+  isBlink(): number;
+  isInverse(): number;
+  isInvisible(): number;
+  isFgRGB(): boolean;
+  isBgRGB(): boolean;
+  isFgPalette(): boolean;
+  isBgPalette(): boolean;
+  isFgDefault(): boolean;
+  isBgDefault(): boolean;
+  getFgColor(): number;
+  getBgColor(): number;
+}
+
+interface IXtermCore {
+  _inputHandler: {
+    _curAttrData: XtermAttributes;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants (upstream `const enum`s rewritten as erasable const objects).
+// ---------------------------------------------------------------------------
+
+const VT = {
+  Esc: "\x1b",
+  Csi: "\x1b[",
+  ShowCursor: "\x1b[?25h",
+  HideCursor: "\x1b[?25l",
+  DeleteChar: "\x1b[X",
+  DeleteRestOfLine: "\x1b[K",
+} as const;
+
+const CSI_STYLE_RE = /^\x1b\[[0-9;]*m/;
+const CSI_MOVE_RE = /^\x1b\[?([0-9]*)(;[35])?O?([DC])/;
+const NOT_WORD_RE = /[^a-z0-9]/i;
+
+const StatsConstants = {
+  StatsBufferSize: 24,
+  StatsMinSamplesToTurnOn: 5,
+  StatsMinAccuracyToTurnOn: 0.3,
+  /** if latency is less than `threshold * this`, turn off */
+  StatsToggleOffThreshold: 0.5,
+} as const;
+
+/**
+ * Codes that should be omitted from sending to the prediction engine and instead omitted directly:
+ * - Hide/Show cursor (DECTCEM): we wrap the local echo sequence in hide and show.
+ * - Device Status Report (DSR): these fire report events from xterm which could cause
+ *   double reporting and potentially a stack overflow (vscode#119472).
+ */
+const PREDICTION_OMIT_RE = /^(\x1b\[(\??25[hl]|\??[0-9;]+n))+/;
+
+const core = (terminal: Terminal): IXtermCore => {
+  interface XtermWithCore extends Terminal {
+    _core: IXtermCore;
+  }
+  return (terminal as unknown as XtermWithCore)._core;
+};
+
+const flushOutput = (_terminal: Terminal) => {
+  // TODO: Flushing output is not possible anymore without async (matches upstream).
+};
+
+const CursorMoveDirection = {
+  Back: "D",
+  Forwards: "C",
+} as const;
+type CursorMoveDirection = (typeof CursorMoveDirection)[keyof typeof CursorMoveDirection];
+
+interface ICoordinate {
+  x: number;
+  y: number;
+  baseY: number;
+}
+
+class Cursor implements ICoordinate {
+  private _x = 0;
+  private _y = 1;
+  private _baseY = 1;
+
+  readonly rows: number;
+  readonly cols: number;
+  private readonly _buffer: IBuffer;
+
+  get x() {
+    return this._x;
+  }
+
+  get y() {
+    return this._y;
+  }
+
+  get baseY() {
+    return this._baseY;
+  }
+
+  get coordinate(): ICoordinate {
+    return { x: this._x, y: this._y, baseY: this._baseY };
+  }
+
+  constructor(rows: number, cols: number, buffer: IBuffer) {
+    this.rows = rows;
+    this.cols = cols;
+    this._buffer = buffer;
+    this._x = buffer.cursorX;
+    this._y = buffer.cursorY;
+    this._baseY = buffer.baseY;
+  }
+
+  getLine() {
+    return this._buffer.getLine(this._y + this._baseY);
+  }
+
+  getCell(loadInto?: IBufferCell) {
+    return this.getLine()?.getCell(this._x, loadInto);
+  }
+
+  moveTo(coordinate: ICoordinate) {
+    this._x = coordinate.x;
+    this._y = coordinate.y + coordinate.baseY - this._baseY;
+    return this.moveInstruction();
+  }
+
+  clone() {
+    const c = new Cursor(this.rows, this.cols, this._buffer);
+    c.moveTo(this);
+    return c;
+  }
+
+  move(x: number, y: number) {
+    this._x = x;
+    this._y = y;
+    return this.moveInstruction();
+  }
+
+  shift(x = 0, y = 0) {
+    this._x += x;
+    this._y += y;
+    return this.moveInstruction();
+  }
+
+  moveInstruction() {
+    if (this._y >= this.rows) {
+      this._baseY += this._y - (this.rows - 1);
+      this._y = this.rows - 1;
+    } else if (this._y < 0) {
+      this._baseY -= this._y;
+      this._y = 0;
+    }
+
+    return `${VT.Csi}${this._y + 1};${this._x + 1}H`;
+  }
+}
+
+const moveToWordBoundary = (_b: IBuffer, cursor: Cursor, direction: -1 | 1) => {
+  let ateLeadingWhitespace = false;
+  if (direction < 0) {
+    cursor.shift(-1);
+  }
+
+  let cell: IBufferCell | undefined;
+  while (cursor.x >= 0) {
+    cell = cursor.getCell(cell);
+    if (!cell?.getCode()) {
+      return;
+    }
+
+    const chars = cell.getChars();
+    if (NOT_WORD_RE.test(chars)) {
+      if (ateLeadingWhitespace) {
+        break;
+      }
+    } else {
+      ateLeadingWhitespace = true;
+    }
+
+    cursor.shift(direction);
+  }
+
+  if (direction < 0) {
+    cursor.shift(1); // place the cursor after the whitespace starting the word
+  }
+};
+
+const MatchResult = {
+  /** matched successfully */
+  Success: 0,
+  /** failed to match */
+  Failure: 1,
+  /** buffer data, it might match in the future once more data comes in */
+  Buffer: 2,
+} as const;
+type MatchResult = (typeof MatchResult)[keyof typeof MatchResult];
+
+export interface IPrediction {
+  /**
+   * Whether applying this prediction can modify the style attributes of the
+   * terminal. If so we need to reset the cursor style if it's rolled back.
+   */
+  readonly affectsStyle?: boolean;
+
+  /**
+   * If set to false, the prediction will not be cleared if no input is
+   * received from the server.
+   */
+  readonly clearAfterTimeout?: boolean;
+
+  /**
+   * Returns a sequence to apply the prediction. Should advance the cursor.
+   */
+  apply(buffer: IBuffer, cursor: Cursor): string;
+
+  /**
+   * Returns a sequence to roll back a previous `apply()` call.
+   */
+  rollback(cursor: Cursor): string;
+
+  /**
+   * If available, this will be called when the prediction is correct.
+   */
+  rollForwards(cursor: Cursor, withInput: string): string;
+
+  /**
+   * Returns whether the given input is one expected by this prediction.
+   */
+  matches(input: StringReader, lookBehind?: IPrediction): MatchResult;
+}
+
+class StringReader {
+  index = 0;
+
+  private readonly _input: string;
+
+  get remaining() {
+    return this._input.length - this.index;
+  }
+
+  get eof() {
+    return this.index === this._input.length;
+  }
+
+  get rest() {
+    return this._input.slice(this.index);
+  }
+
+  constructor(input: string) {
+    this._input = input;
+  }
+
+  /** Advances the reader and returns the character if it matches. */
+  eatChar(char: string) {
+    if (this._input[this.index] !== char) {
+      return;
+    }
+
+    this.index++;
+    return char;
+  }
+
+  /** Advances the reader and returns the string if it matches. */
+  eatStr(substr: string) {
+    if (this._input.slice(this.index, substr.length) !== substr) {
+      return;
+    }
+
+    this.index += substr.length;
+    return substr;
+  }
+
+  /**
+   * Matches and eats the substring character-by-character. If EOF is reached
+   * before the substring is consumed, it will buffer. Index is not moved if
+   * it's not a match.
+   */
+  eatGradually(substr: string): MatchResult {
+    const prevIndex = this.index;
+    for (let i = 0; i < substr.length; i++) {
+      if (i > 0 && this.eof) {
+        return MatchResult.Buffer;
+      }
+
+      if (!this.eatChar(substr[i]!)) {
+        this.index = prevIndex;
+        return MatchResult.Failure;
+      }
+    }
+
+    return MatchResult.Success;
+  }
+
+  /** Advances the reader and returns the regex match if it matches. */
+  eatRe(re: RegExp) {
+    const match = re.exec(this._input.slice(this.index));
+    if (!match) {
+      return;
+    }
+
+    this.index += match[0].length;
+    return match;
+  }
+
+  /** Advances the reader and returns the char code if it matches the range. */
+  eatCharCode(min = 0, max = min + 1) {
+    const code = this._input.charCodeAt(this.index);
+    if (code < min || code >= max) {
+      return undefined;
+    }
+
+    this.index++;
+    return code;
+  }
+}
+
+/**
+ * Prediction which never tests true. Will always discard predictions made
+ * after it.
+ */
+class HardBoundary implements IPrediction {
+  readonly clearAfterTimeout = false;
+
+  apply() {
+    return "";
+  }
+
+  rollback() {
+    return "";
+  }
+
+  rollForwards() {
+    return "";
+  }
+
+  matches() {
+    return MatchResult.Failure;
+  }
+}
+
+/**
+ * Wraps another prediction. Does not apply the prediction, but will pass
+ * through its `matches` request.
+ */
+class TentativeBoundary implements IPrediction {
+  private _appliedCursor?: Cursor;
+
+  readonly inner: IPrediction;
+
+  constructor(inner: IPrediction) {
+    this.inner = inner;
+  }
+
+  apply(buffer: IBuffer, cursor: Cursor) {
+    this._appliedCursor = cursor.clone();
+    this.inner.apply(buffer, this._appliedCursor);
+    return "";
+  }
+
+  rollback(cursor: Cursor) {
+    this.inner.rollback(cursor.clone());
+    return "";
+  }
+
+  rollForwards(cursor: Cursor, withInput: string) {
+    if (this._appliedCursor) {
+      cursor.moveTo(this._appliedCursor);
+    }
+
+    return withInput;
+  }
+
+  matches(input: StringReader) {
+    return this.inner.matches(input);
+  }
+}
+
+const isTenativeCharacterPrediction = (
+  p: unknown,
+): p is TentativeBoundary & { inner: CharacterPrediction } =>
+  p instanceof TentativeBoundary && p.inner instanceof CharacterPrediction;
+
+/** Prediction for a single alphanumeric character. */
+class CharacterPrediction implements IPrediction {
+  readonly affectsStyle = true;
+
+  appliedAt?: {
+    pos: ICoordinate;
+    oldAttributes: string;
+    oldChar: string;
+  };
+
+  private readonly _style: TypeAheadStyle;
+  private readonly _char: string;
+
+  constructor(style: TypeAheadStyle, char: string) {
+    this._style = style;
+    this._char = char;
+  }
+
+  apply(_: IBuffer, cursor: Cursor) {
+    const cell = cursor.getCell();
+    this.appliedAt = cell
+      ? { pos: cursor.coordinate, oldAttributes: attributesToSeq(cell), oldChar: cell.getChars() }
+      : { pos: cursor.coordinate, oldAttributes: "", oldChar: "" };
+
+    cursor.shift(1);
+
+    return this._style.apply + this._char + this._style.undo;
+  }
+
+  rollback(cursor: Cursor) {
+    if (!this.appliedAt) {
+      return ""; // not applied
+    }
+
+    const { oldAttributes, oldChar, pos } = this.appliedAt;
+    const r =
+      cursor.moveTo(pos) +
+      (oldChar ? `${oldAttributes}${oldChar}${cursor.moveTo(pos)}` : VT.DeleteChar);
+    return r;
+  }
+
+  rollForwards(cursor: Cursor, input: string) {
+    if (!this.appliedAt) {
+      return ""; // not applied
+    }
+
+    return cursor.clone().moveTo(this.appliedAt.pos) + input;
+  }
+
+  matches(input: StringReader, lookBehind?: IPrediction) {
+    const startIndex = input.index;
+
+    // remove any styling CSI before checking the char
+    while (input.eatRe(CSI_STYLE_RE)) {
+      /* consume */
+    }
+
+    if (input.eof) {
+      return MatchResult.Buffer;
+    }
+
+    if (input.eatChar(this._char)) {
+      return MatchResult.Success;
+    }
+
+    if (lookBehind instanceof CharacterPrediction) {
+      // see vscode#112842
+      const sillyZshOutcome = input.eatGradually(`\b${lookBehind._char}${this._char}`);
+      if (sillyZshOutcome !== MatchResult.Failure) {
+        return sillyZshOutcome;
+      }
+    }
+
+    input.index = startIndex;
+    return MatchResult.Failure;
+  }
+}
+
+class BackspacePrediction implements IPrediction {
+  protected _appliedAt?: {
+    pos: ICoordinate;
+    oldAttributes: string;
+    oldChar: string;
+    isLastChar: boolean;
+  };
+
+  private readonly _terminal: Terminal;
+
+  constructor(terminal: Terminal) {
+    this._terminal = terminal;
+  }
+
+  apply(_: IBuffer, cursor: Cursor) {
+    // at eol if everything to the right is whitespace (zsh emits a "clear line" code here)
+    const isLastChar = !cursor.getLine()?.translateToString(undefined, cursor.x).trim();
+    const pos = cursor.coordinate;
+    const move = cursor.shift(-1);
+    const cell = cursor.getCell();
+    this._appliedAt = cell
+      ? { isLastChar, pos, oldAttributes: attributesToSeq(cell), oldChar: cell.getChars() }
+      : { isLastChar, pos, oldAttributes: "", oldChar: "" };
+
+    return move + VT.DeleteChar;
+  }
+
+  rollback(cursor: Cursor) {
+    if (!this._appliedAt) {
+      return ""; // not applied
+    }
+
+    const { oldAttributes, oldChar, pos } = this._appliedAt;
+    if (!oldChar) {
+      return cursor.moveTo(pos) + VT.DeleteChar;
+    }
+
+    return (
+      oldAttributes +
+      oldChar +
+      cursor.moveTo(pos) +
+      attributesToSeq(core(this._terminal)._inputHandler._curAttrData)
+    );
+  }
+
+  rollForwards() {
+    return "";
+  }
+
+  matches(input: StringReader) {
+    if (this._appliedAt?.isLastChar) {
+      const r1 = input.eatGradually(`\b${VT.Csi}K`);
+      if (r1 !== MatchResult.Failure) {
+        return r1;
+      }
+
+      const r2 = input.eatGradually(`\b \b`);
+      if (r2 !== MatchResult.Failure) {
+        return r2;
+      }
+    }
+
+    return MatchResult.Failure;
+  }
+}
+
+class NewlinePrediction implements IPrediction {
+  protected _prevPosition?: ICoordinate;
+
+  apply(_: IBuffer, cursor: Cursor) {
+    this._prevPosition = cursor.coordinate;
+    cursor.move(0, cursor.y + 1);
+    return "\r\n";
+  }
+
+  rollback(cursor: Cursor) {
+    return this._prevPosition ? cursor.moveTo(this._prevPosition) : "";
+  }
+
+  rollForwards() {
+    return ""; // does not need to rewrite
+  }
+
+  matches(input: StringReader) {
+    return input.eatGradually("\r\n");
+  }
+}
+
+/**
+ * Prediction when the cursor reaches the end of the line. Similar to newline
+ * prediction, but shells handle it slightly differently.
+ */
+class LinewrapPrediction extends NewlinePrediction implements IPrediction {
+  override apply(_: IBuffer, cursor: Cursor) {
+    this._prevPosition = cursor.coordinate;
+    cursor.move(0, cursor.y + 1);
+    return " \r";
+  }
+
+  override matches(input: StringReader) {
+    // bash and zsh add a space which wraps in the terminal, then a CR
+    const r = input.eatGradually(" \r");
+    if (r !== MatchResult.Failure) {
+      // zsh additionally adds a clear line after wrapping to be safe -- eat it
+      const r2 = input.eatGradually(VT.DeleteRestOfLine);
+      return r2 === MatchResult.Buffer ? MatchResult.Buffer : r;
+    }
+
+    return input.eatGradually("\r\n");
+  }
+}
+
+class CursorMovePrediction implements IPrediction {
+  private _applied?: {
+    rollForward: string;
+    prevPosition: number;
+    prevAttrs: string;
+    amount: number;
+  };
+
+  private readonly _direction: CursorMoveDirection;
+  private readonly _moveByWords: boolean;
+  private readonly _amount: number;
+
+  constructor(direction: CursorMoveDirection, moveByWords: boolean, amount: number) {
+    this._direction = direction;
+    this._moveByWords = moveByWords;
+    this._amount = amount;
+  }
+
+  apply(buffer: IBuffer, cursor: Cursor) {
+    const prevPosition = cursor.x;
+    const currentCell = cursor.getCell();
+    const prevAttrs = currentCell ? attributesToSeq(currentCell) : "";
+
+    const amount = this._amount;
+    const direction = this._direction;
+    const moveByWords = this._moveByWords;
+    const delta = direction === CursorMoveDirection.Back ? -1 : 1;
+
+    const target = cursor.clone();
+    if (moveByWords) {
+      for (let i = 0; i < amount; i++) {
+        moveToWordBoundary(buffer, target, delta);
+      }
+    } else {
+      target.shift(delta * amount);
+    }
+
+    this._applied = {
+      amount: Math.abs(cursor.x - target.x),
+      prevPosition,
+      prevAttrs,
+      rollForward: cursor.moveTo(target),
+    };
+
+    return this._applied.rollForward;
+  }
+
+  rollback(cursor: Cursor) {
+    if (!this._applied) {
+      return "";
+    }
+
+    return cursor.move(this._applied.prevPosition, cursor.y) + this._applied.prevAttrs;
+  }
+
+  rollForwards() {
+    return ""; // does not need to rewrite
+  }
+
+  matches(input: StringReader) {
+    if (!this._applied) {
+      return MatchResult.Failure;
+    }
+
+    const direction = this._direction;
+    const { amount, rollForward } = this._applied;
+
+    // arg can be omitted to move one character. We don't eatGradually() here
+    // or moves that don't go as far as the cursor would be buffered indefinitely.
+    if (input.eatStr(`${VT.Csi}${direction}`.repeat(amount))) {
+      return MatchResult.Success;
+    }
+
+    // \b is the equivalent to moving one character back
+    if (direction === CursorMoveDirection.Back) {
+      if (input.eatStr(`\b`.repeat(amount))) {
+        return MatchResult.Success;
+      }
+    }
+
+    // check if the cursor position is set absolutely
+    if (rollForward) {
+      const r = input.eatGradually(rollForward);
+      if (r !== MatchResult.Failure) {
+        return r;
+      }
+    }
+
+    // check for a relative move in the direction
+    return input.eatGradually(`${VT.Csi}${amount}${direction}`);
+  }
+}
+
+export class PredictionStats extends Disposable {
+  private readonly _stats: [latency: number, correct: boolean][] = [];
+  private _index = 0;
+  private readonly _addedAtTime = new WeakMap<IPrediction, number>();
+  private readonly _changeEmitter = this._register(new Emitter<void>());
+  readonly onChange = this._changeEmitter.event;
+
+  /** Gets the percent (0-1) of predictions that were accurate. */
+  get accuracy() {
+    let correctCount = 0;
+    for (const [, correct] of this._stats) {
+      if (correct) {
+        correctCount++;
+      }
+    }
+
+    return correctCount / (this._stats.length || 1);
+  }
+
+  /** Gets the number of recorded stats. */
+  get sampleSize() {
+    return this._stats.length;
+  }
+
+  /** Gets latency stats of successful predictions. */
+  get latency() {
+    const latencies = this._stats
+      .filter(([, correct]) => correct)
+      .map(([s]) => s)
+      .sort();
+
+    return {
+      count: latencies.length,
+      min: latencies[0],
+      median: latencies[Math.floor(latencies.length / 2)],
+      max: latencies[latencies.length - 1],
+    };
+  }
+
+  /** Gets the maximum observed latency. */
+  get maxLatency() {
+    let max = -Infinity;
+    for (const [latency, correct] of this._stats) {
+      if (correct) {
+        max = Math.max(latency, max);
+      }
+    }
+
+    return max;
+  }
+
+  constructor(timeline: PredictionTimeline) {
+    super();
+    this._register(timeline.onPredictionAdded((p) => this._addedAtTime.set(p, Date.now())));
+    this._register(timeline.onPredictionSucceeded(this._pushStat.bind(this, true)));
+    this._register(timeline.onPredictionFailed(this._pushStat.bind(this, false)));
+  }
+
+  private _pushStat(correct: boolean, prediction: IPrediction) {
+    const started = this._addedAtTime.get(prediction)!;
+    this._stats[this._index] = [Date.now() - started, correct];
+    this._index = (this._index + 1) % StatsConstants.StatsBufferSize;
+    this._changeEmitter.fire();
+  }
+}
+
+export class PredictionTimeline extends Disposable {
+  readonly terminal: Terminal;
+  private readonly _style: TypeAheadStyle;
+
+  /**
+   * Expected queue of events. Only predictions for the lowest are written into
+   * the terminal.
+   */
+  private _expected: { gen: number; p: IPrediction }[] = [];
+
+  /** Current prediction generation. */
+  private _currentGen = 0;
+
+  /**
+   * Current cursor position -- kept outside the buffer since it can be ahead if
+   * typing swiftly.
+   */
+  private _physicalCursor: Cursor | undefined;
+
+  /**
+   * Cursor position taking into account all (possibly not-yet-applied)
+   * predictions.
+   */
+  private _tenativeCursor: Cursor | undefined;
+
+  /** Previously sent data that was buffered and should be prepended to the next input. */
+  private _inputBuffer?: string;
+
+  /**
+   * Whether predictions are echoed to the terminal. If false, predictions will
+   * still be computed internally for latency metrics, but input is never adjusted.
+   */
+  private _showPredictions = false;
+
+  /** The last successfully-made prediction. */
+  private _lookBehind?: IPrediction;
+
+  private readonly _addedEmitter = this._register(new Emitter<IPrediction>());
+  readonly onPredictionAdded = this._addedEmitter.event;
+  private readonly _failedEmitter = this._register(new Emitter<IPrediction>());
+  readonly onPredictionFailed = this._failedEmitter.event;
+  private readonly _succeededEmitter = this._register(new Emitter<IPrediction>());
+  readonly onPredictionSucceeded = this._succeededEmitter.event;
+
+  private get _currentGenerationPredictions() {
+    return this._expected.filter(({ gen }) => gen === this._expected[0]!.gen).map(({ p }) => p);
+  }
+
+  get isShowingPredictions() {
+    return this._showPredictions;
+  }
+
+  get length() {
+    return this._expected.length;
+  }
+
+  constructor(terminal: Terminal, style: TypeAheadStyle) {
+    super();
+    this.terminal = terminal;
+    this._style = style;
+  }
+
+  setShowPredictions(show: boolean) {
+    if (show === this._showPredictions) {
+      return;
+    }
+
+    this._showPredictions = show;
+
+    const buffer = this._getActiveBuffer();
+    if (!buffer) {
+      return;
+    }
+
+    const toApply = this._currentGenerationPredictions;
+    if (show) {
+      this.clearCursor();
+      this._style.expectIncomingStyle(
+        toApply.reduce((count, p) => (p.affectsStyle ? count + 1 : count), 0),
+      );
+      this.terminal.write(
+        toApply.map((p) => p.apply(buffer, this.physicalCursor(buffer))).join(""),
+      );
+    } else {
+      this.terminal.write(
+        toApply
+          .reverse()
+          .map((p) => p.rollback(this.physicalCursor(buffer)))
+          .join(""),
+      );
+    }
+  }
+
+  /** Undoes any predictions written and resets expectations. */
+  undoAllPredictions() {
+    const buffer = this._getActiveBuffer();
+    if (this._showPredictions && buffer) {
+      this.terminal.write(
+        this._currentGenerationPredictions
+          .reverse()
+          .map((p) => p.rollback(this.physicalCursor(buffer)))
+          .join(""),
+      );
+    }
+
+    this._expected = [];
+  }
+
+  /** Should be called when input is incoming to the terminal. */
+  beforeServerInput(input: string): string {
+    const originalInput = input;
+    if (this._inputBuffer) {
+      input = this._inputBuffer + input;
+      this._inputBuffer = undefined;
+    }
+
+    if (!this._expected.length) {
+      this._clearPredictionState();
+      return input;
+    }
+
+    const buffer = this._getActiveBuffer();
+    if (!buffer) {
+      this._clearPredictionState();
+      return input;
+    }
+
+    let output = "";
+
+    const reader = new StringReader(input);
+    const startingGen = this._expected[0]!.gen;
+    const emitPredictionOmitted = () => {
+      const omit = reader.eatRe(PREDICTION_OMIT_RE);
+      if (omit) {
+        output += omit[0];
+      }
+    };
+
+    ReadLoop: while (this._expected.length && reader.remaining > 0) {
+      emitPredictionOmitted();
+
+      const { p: prediction, gen } = this._expected[0]!;
+      const cursor = this.physicalCursor(buffer);
+      const beforeTestReaderIndex = reader.index;
+      switch (prediction.matches(reader, this._lookBehind)) {
+        case MatchResult.Success: {
+          // if the input character matches what the next prediction expected, undo
+          // the prediction and write the real character out.
+          const eaten = input.slice(beforeTestReaderIndex, reader.index);
+          if (gen === startingGen) {
+            output += prediction.rollForwards?.(cursor, eaten);
+          } else {
+            prediction.apply(buffer, this.physicalCursor(buffer)); // move cursor for additional apply
+            output += eaten;
+          }
+
+          this._succeededEmitter.fire(prediction);
+          this._lookBehind = prediction;
+          this._expected.shift();
+          break;
+        }
+        case MatchResult.Buffer:
+          // on a buffer, store the remaining data and completely read data to be
+          // output as normal.
+          this._inputBuffer = input.slice(beforeTestReaderIndex);
+          reader.index = input.length;
+          break ReadLoop;
+        case MatchResult.Failure: {
+          // on a failure, roll back all remaining items in this generation and
+          // clear predictions, since they are no longer valid
+          const rollback = this._expected.filter((p) => p.gen === startingGen).reverse();
+          output += rollback.map(({ p }) => p.rollback(this.physicalCursor(buffer))).join("");
+          if (rollback.some((r) => r.p.affectsStyle)) {
+            // reading the current style should generally be safe, since predictions
+            // always restore the style if they modify it.
+            output += attributesToSeq(core(this.terminal)._inputHandler._curAttrData);
+          }
+          this._clearPredictionState();
+          this._failedEmitter.fire(prediction);
+          break ReadLoop;
+        }
+      }
+    }
+
+    emitPredictionOmitted();
+
+    // Extra data (like the result of running a command) should cause us to
+    // reset the cursor
+    if (!reader.eof) {
+      output += reader.rest;
+      this._clearPredictionState();
+    }
+
+    // If we passed a generation boundary, apply the current generation's predictions
+    if (this._expected.length && startingGen !== this._expected[0]!.gen) {
+      for (const { p, gen } of this._expected) {
+        if (gen !== this._expected[0]!.gen) {
+          break;
+        }
+        if (p.affectsStyle) {
+          this._style.expectIncomingStyle();
+        }
+
+        output += p.apply(buffer, this.physicalCursor(buffer));
+      }
+    }
+
+    if (!this._showPredictions) {
+      return originalInput;
+    }
+
+    if (output.length === 0 || output === input) {
+      return output;
+    }
+
+    if (this._physicalCursor) {
+      output += this._physicalCursor.moveInstruction();
+    }
+
+    // prevent cursor flickering while typing
+    output = VT.HideCursor + output + VT.ShowCursor;
+
+    return output;
+  }
+
+  /**
+   * Clears any expected predictions and stored state. Should be called when the
+   * pty gives us something we don't recognize.
+   */
+  private _clearPredictionState() {
+    this._expected = [];
+    this.clearCursor();
+    this._lookBehind = undefined;
+  }
+
+  /** Appends a typeahead prediction. */
+  addPrediction(buffer: IBuffer, prediction: IPrediction) {
+    this._expected.push({ gen: this._currentGen, p: prediction });
+    this._addedEmitter.fire(prediction);
+
+    if (this._currentGen !== this._expected[0]!.gen) {
+      prediction.apply(buffer, this.tentativeCursor(buffer));
+      return false;
+    }
+
+    const text = prediction.apply(buffer, this.physicalCursor(buffer));
+    this._tenativeCursor = undefined; // next read will get or clone the physical cursor
+
+    if (this._showPredictions && text) {
+      if (prediction.affectsStyle) {
+        this._style.expectIncomingStyle();
+      }
+      this.terminal.write(text);
+    }
+
+    return true;
+  }
+
+  /**
+   * Appends a prediction followed by a boundary. The predictions applied after
+   * this one will only be displayed after the given prediction matches pty output.
+   */
+  addBoundary(): void;
+  addBoundary(buffer: IBuffer, prediction: IPrediction): boolean;
+  addBoundary(buffer?: IBuffer, prediction?: IPrediction) {
+    let applied = false;
+    if (buffer && prediction) {
+      // We apply the prediction so that it's matched against, but wrapped in a
+      // tentativeBoundary so that it doesn't affect the physical cursor. Then we
+      // apply it specifically to the tentative cursor.
+      applied = this.addPrediction(buffer, new TentativeBoundary(prediction));
+      prediction.apply(buffer, this.tentativeCursor(buffer));
+    }
+    this._currentGen++;
+    return applied;
+  }
+
+  /** Peeks the last prediction written. */
+  peekEnd(): IPrediction | undefined {
+    return this._expected[this._expected.length - 1]?.p;
+  }
+
+  /** Peeks the first pending prediction. */
+  peekStart(): IPrediction | undefined {
+    return this._expected[0]?.p;
+  }
+
+  /** Current position of the cursor in the terminal. */
+  physicalCursor(buffer: IBuffer) {
+    if (!this._physicalCursor) {
+      if (this._showPredictions) {
+        flushOutput(this.terminal);
+      }
+      this._physicalCursor = new Cursor(this.terminal.rows, this.terminal.cols, buffer);
+    }
+
+    return this._physicalCursor;
+  }
+
+  /**
+   * Cursor position if all predictions and boundaries that have been inserted so
+   * far turn out to be successfully predicted.
+   */
+  tentativeCursor(buffer: IBuffer) {
+    if (!this._tenativeCursor) {
+      this._tenativeCursor = this.physicalCursor(buffer).clone();
+    }
+
+    return this._tenativeCursor;
+  }
+
+  clearCursor() {
+    this._physicalCursor = undefined;
+    this._tenativeCursor = undefined;
+  }
+
+  private _getActiveBuffer() {
+    const buffer = this.terminal.buffer.active;
+    return buffer.type === "normal" ? buffer : undefined;
+  }
+}
+
+/** Gets the escape sequence args to restore state/appearance in the cell. */
+const attributesToArgs = (cell: XtermAttributes) => {
+  if (cell.isAttributeDefault()) {
+    return [0];
+  }
+
+  const args = [];
+  if (cell.isBold()) {
+    args.push(1);
+  }
+  if (cell.isDim()) {
+    args.push(2);
+  }
+  if (cell.isItalic()) {
+    args.push(3);
+  }
+  if (cell.isUnderline()) {
+    args.push(4);
+  }
+  if (cell.isBlink()) {
+    args.push(5);
+  }
+  if (cell.isInverse()) {
+    args.push(7);
+  }
+  if (cell.isInvisible()) {
+    args.push(8);
+  }
+
+  if (cell.isFgRGB()) {
+    args.push(
+      38,
+      2,
+      cell.getFgColor() >>> 24,
+      (cell.getFgColor() >>> 16) & 0xff,
+      cell.getFgColor() & 0xff,
+    );
+  }
+  if (cell.isFgPalette()) {
+    args.push(38, 5, cell.getFgColor());
+  }
+  if (cell.isFgDefault()) {
+    args.push(39);
+  }
+
+  if (cell.isBgRGB()) {
+    args.push(
+      48,
+      2,
+      cell.getBgColor() >>> 24,
+      (cell.getBgColor() >>> 16) & 0xff,
+      cell.getBgColor() & 0xff,
+    );
+  }
+  if (cell.isBgPalette()) {
+    args.push(48, 5, cell.getBgColor());
+  }
+  if (cell.isBgDefault()) {
+    args.push(49);
+  }
+
+  return args;
+};
+
+/** Gets the escape sequence to restore state/appearance in the cell. */
+const attributesToSeq = (cell: XtermAttributes) => `${VT.Csi}${attributesToArgs(cell).join(";")}m`;
+
+const arrayHasPrefixAt = <T>(a: ReadonlyArray<T>, ai: number, b: ReadonlyArray<T>) => {
+  if (a.length - ai > b.length) {
+    return false;
+  }
+
+  for (let bi = 0; bi < b.length; bi++, ai++) {
+    if (b[ai] !== a[ai]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * @see https://github.com/xtermjs/xterm.js/blob/065eb13a9d3145bea687239680ec9696d9112b8e/src/common/InputHandler.ts#L2127
+ */
+const getColorWidth = (params: SingleOrMany<number>[], pos: number) => {
+  const accu = [0, 0, -1, 0, 0, 0];
+  let cSpace = 0;
+  let advance = 0;
+
+  do {
+    const v = params[pos + advance]!;
+    accu[advance + cSpace] = isNumber(v) ? v : v[0]!;
+    if (!isNumber(v)) {
+      let i = 0;
+      do {
+        if (accu[1] === 5) {
+          cSpace = 1;
+        }
+        accu[advance + i + 1 + cSpace] = v[i]!;
+      } while (++i < v.length && i + advance + 1 + cSpace < accu.length);
+      break;
+    }
+    // exit early if can decide color mode with semicolons
+    if ((accu[1] === 5 && advance + cSpace >= 2) || (accu[1] === 2 && advance + cSpace >= 5)) {
+      break;
+    }
+    // offset colorSpace slot for semicolon mode
+    if (accu[1]) {
+      cSpace = 1;
+    }
+  } while (++advance + pos < params.length && advance + cSpace < accu.length);
+
+  return advance;
+};
+
+class TypeAheadStyle implements IDisposable {
+  private static _compileArgs(args: ReadonlyArray<number>) {
+    return `${VT.Csi}${args.join(";")}m`;
+  }
+
+  /**
+   * Number of typeahead style arguments we expect to read. If this is 0 and we
+   * see a style coming in, we know that the PTY actually wanted to update.
+   */
+  private _expectedIncomingStyles = 0;
+  private _applyArgs!: ReadonlyArray<number>;
+  private _originalUndoArgs!: ReadonlyArray<number>;
+  private _undoArgs!: ReadonlyArray<number>;
+
+  apply!: string;
+  undo!: string;
+  private _csiHandler?: IDisposable;
+
+  private readonly _terminal: Terminal;
+
+  /**
+   * Debounced stop-tracking (replaces upstream's `@debounce(2000)`). Toggles CSI
+   * tracking off after a typing pause.
+   */
+  readonly debounceStopTracking: () => void;
+
+  constructor(value: LocalEchoStyle, terminal: Terminal) {
+    this._terminal = terminal;
+    this.debounceStopTracking = debounce(() => this._stopTracking(), 2000);
+    this.onUpdate(value);
+  }
+
+  /** Signals that a style was written and we should watch for it coming in. */
+  expectIncomingStyle(n = 1) {
+    this._expectedIncomingStyles += n * 2;
+  }
+
+  /** Starts tracking for CSI changes in the terminal. */
+  startTracking() {
+    this._expectedIncomingStyles = 0;
+    this._onDidWriteSGR(attributesToArgs(core(this._terminal)._inputHandler._curAttrData));
+    this._csiHandler = this._terminal.parser.registerCsiHandler({ final: "m" }, (args) => {
+      this._onDidWriteSGR(args);
+      return false;
+    });
+  }
+
+  dispose() {
+    this._stopTracking();
+  }
+
+  private _stopTracking() {
+    this._csiHandler?.dispose();
+    this._csiHandler = undefined;
+  }
+
+  private _onDidWriteSGR(args: SingleOrMany<number>[]) {
+    const originalUndo = this._undoArgs;
+    for (let i = 0; i < args.length; ) {
+      const px = args[i]!;
+      const p = isNumber(px) ? px : px[0]!;
+
+      if (this._expectedIncomingStyles) {
+        if (arrayHasPrefixAt(args, i, this._undoArgs)) {
+          this._expectedIncomingStyles--;
+          i += this._undoArgs.length;
+          continue;
+        }
+        if (arrayHasPrefixAt(args, i, this._applyArgs)) {
+          this._expectedIncomingStyles--;
+          i += this._applyArgs.length;
+          continue;
+        }
+      }
+
+      const width = p === 38 || p === 48 || p === 58 ? getColorWidth(args, i) : 1;
+      switch (this._applyArgs[0]) {
+        case 1:
+          if (p === 2) {
+            this._undoArgs = [22, 2];
+          } else if (p === 22 || p === 0) {
+            this._undoArgs = [22];
+          }
+          break;
+        case 2:
+          if (p === 1) {
+            this._undoArgs = [22, 1];
+          } else if (p === 22 || p === 0) {
+            this._undoArgs = [22];
+          }
+          break;
+        case 38:
+          if (p === 0 || p === 39 || p === 100) {
+            this._undoArgs = [39];
+          } else if ((p >= 30 && p <= 38) || (p >= 90 && p <= 97)) {
+            this._undoArgs = args.slice(i, i + width) as number[];
+          }
+          break;
+        default:
+          if (p === this._applyArgs[0]) {
+            this._undoArgs = this._applyArgs;
+          } else if (p === 0) {
+            this._undoArgs = this._originalUndoArgs;
+          }
+        // no-op
+      }
+
+      i += width;
+    }
+
+    if (originalUndo !== this._undoArgs) {
+      this.undo = TypeAheadStyle._compileArgs(this._undoArgs);
+    }
+  }
+
+  /** Updates the current typeahead style. */
+  onUpdate(style: LocalEchoStyle) {
+    const { applyArgs, undoArgs } = this._getArgs(style);
+    this._applyArgs = applyArgs;
+    this._undoArgs = this._originalUndoArgs = undoArgs;
+    this.apply = TypeAheadStyle._compileArgs(this._applyArgs);
+    this.undo = TypeAheadStyle._compileArgs(this._undoArgs);
+  }
+
+  private _getArgs(style: LocalEchoStyle) {
+    switch (style) {
+      case "bold":
+        return { applyArgs: [1], undoArgs: [22] };
+      case "dim":
+        return { applyArgs: [2], undoArgs: [22] };
+      case "italic":
+        return { applyArgs: [3], undoArgs: [23] };
+      case "underlined":
+        return { applyArgs: [4], undoArgs: [24] };
+      case "inverted":
+        return { applyArgs: [7], undoArgs: [27] };
+      default: {
+        let color: Color;
+        try {
+          color = Color.fromHex(style);
+        } catch {
+          color = new Color(new RGBA(255, 0, 0, 1));
+        }
+
+        const { r, g, b } = color.rgba;
+        return { applyArgs: [38, 2, r, g, b], undoArgs: [39] };
+      }
+    }
+  }
+}
+
+const compileExcludeRegexp = (programs: ReadonlyArray<string> = DEFAULT_LOCAL_ECHO_EXCLUDE) =>
+  new RegExp(`\\b(${programs.map(escapeRegExpCharacters).join("|")})\\b`, "i");
+
+export const CharPredictState = {
+  /** No characters typed on this line yet */
+  Unknown: 0,
+  /** Has a pending character prediction */
+  HasPendingChar: 1,
+  /** Character validated on this line */
+  Validated: 2,
+} as const;
+export type CharPredictState = (typeof CharPredictState)[keyof typeof CharPredictState];
+
+export class TypeAheadAddon extends Disposable implements ITerminalAddon {
+  private _typeaheadStyle?: TypeAheadStyle;
+  private _typeaheadThreshold: number;
+  private _excludeProgramRe: RegExp;
+  private readonly _style: LocalEchoStyle;
+  protected _lastRow?: {
+    y: number;
+    startingX: number;
+    endingX: number;
+    charState: CharPredictState;
+  };
+  protected _timeline?: PredictionTimeline;
+  private _terminalTitle = "";
+  stats?: PredictionStats;
+
+  /** Debounce that clears predictions after a timeout if the PTY doesn't apply them. */
+  private _clearPredictionDebounce?: IDisposable;
+
+  /**
+   * Debounced predictor-state re-evaluation (replaces upstream's `@debounce(100)`).
+   * We only toggle state during a typing pause; otherwise we could turn this on
+   * when the PTY sent data but the terminal cursor isn't updated, causing issues.
+   */
+  protected readonly _reevaluatePredictorState: (
+    stats: PredictionStats,
+    timeline: PredictionTimeline,
+  ) => void;
+
+  constructor(options: ITypeAheadOptions) {
+    super();
+    this._typeaheadThreshold = options.latencyThreshold;
+    this._style = options.style;
+    this._excludeProgramRe = compileExcludeRegexp(options.excludePrograms);
+    this._reevaluatePredictorState = debounce(
+      (stats: PredictionStats, timeline: PredictionTimeline) =>
+        this._reevaluatePredictorStateNow(stats, timeline),
+      100,
+    );
+    this._register(toDisposable(() => this._clearPredictionDebounce?.dispose()));
+  }
+
+  activate(terminal: Terminal): void {
+    const style = (this._typeaheadStyle = this._register(
+      new TypeAheadStyle(this._style, terminal),
+    ));
+    const timeline = (this._timeline = this._register(
+      new PredictionTimeline(terminal, this._typeaheadStyle),
+    ));
+    const stats = (this.stats = this._register(new PredictionStats(this._timeline)));
+
+    timeline.setShowPredictions(this._typeaheadThreshold === 0);
+    this._register(terminal.onData((e) => this._onUserData(e)));
+    this._register(
+      terminal.onTitleChange((title) => {
+        this._terminalTitle = title;
+        this._reevaluatePredictorState(stats, timeline);
+      }),
+    );
+    this._register(
+      terminal.onResize(() => {
+        timeline.setShowPredictions(false);
+        timeline.clearCursor();
+        this._reevaluatePredictorState(stats, timeline);
+      }),
+    );
+    this._register(
+      this._timeline.onPredictionSucceeded((p) => {
+        if (
+          this._lastRow?.charState === CharPredictState.HasPendingChar &&
+          isTenativeCharacterPrediction(p) &&
+          p.inner.appliedAt
+        ) {
+          if (p.inner.appliedAt.pos.y + p.inner.appliedAt.pos.baseY === this._lastRow.y) {
+            this._lastRow.charState = CharPredictState.Validated;
+          }
+        }
+      }),
+    );
+
+    this._register(
+      stats.onChange(() => {
+        if (timeline.length === 0) {
+          style.debounceStopTracking();
+        }
+
+        this._reevaluatePredictorState(stats, timeline);
+      }),
+    );
+  }
+
+  /**
+   * Feed inbound PTY bytes through the prediction timeline BEFORE writing them
+   * to xterm, returning the (possibly rewritten) stream to actually write.
+   * Replaces VS Code's `onBeforeProcessData` middleware. No-op until activated.
+   */
+  beforeServerInput(data: string): string {
+    if (!this._timeline) {
+      return data;
+    }
+
+    const out = this._timeline.beforeServerInput(data);
+    this._deferClearingPredictions();
+    return out;
+  }
+
+  reset() {
+    this._lastRow = undefined;
+  }
+
+  private _deferClearingPredictions() {
+    if (!this.stats || !this._timeline) {
+      return;
+    }
+
+    this._clearPredictionDebounce?.dispose();
+    if (this._timeline.length === 0 || this._timeline.peekStart()?.clearAfterTimeout === false) {
+      this._clearPredictionDebounce = undefined;
+      return;
+    }
+
+    this._clearPredictionDebounce = disposableTimeout(
+      () => {
+        this._timeline?.undoAllPredictions();
+        if (this._lastRow?.charState === CharPredictState.HasPendingChar) {
+          this._lastRow.charState = CharPredictState.Unknown;
+        }
+      },
+      Math.max(500, (this.stats.maxLatency * 3) / 2),
+      this._store,
+    );
+  }
+
+  protected _reevaluatePredictorStateNow(stats: PredictionStats, timeline: PredictionTimeline) {
+    if (this._excludeProgramRe.test(this._terminalTitle)) {
+      timeline.setShowPredictions(false);
+    } else if (this._typeaheadThreshold < 0) {
+      timeline.setShowPredictions(false);
+    } else if (this._typeaheadThreshold === 0) {
+      timeline.setShowPredictions(true);
+    } else if (
+      stats.sampleSize > StatsConstants.StatsMinSamplesToTurnOn &&
+      stats.accuracy > StatsConstants.StatsMinAccuracyToTurnOn
+    ) {
+      const latency = stats.latency.median;
+      if (latency !== undefined && latency >= this._typeaheadThreshold) {
+        timeline.setShowPredictions(true);
+      } else if (
+        latency !== undefined &&
+        latency < this._typeaheadThreshold / StatsConstants.StatsToggleOffThreshold
+      ) {
+        timeline.setShowPredictions(false);
+      }
+    }
+  }
+
+  private _onUserData(data: string): void {
+    if (this._timeline?.terminal.buffer.active.type !== "normal") {
+      return;
+    }
+
+    const terminal = this._timeline.terminal;
+    const buffer = terminal.buffer.active;
+
+    // Detect programs like git log/less that use the normal buffer but don't
+    // take input by default (fixes vscode#109541)
+    if (buffer.cursorX === 1 && buffer.cursorY === terminal.rows - 1) {
+      if (
+        buffer
+          .getLine(buffer.cursorY + buffer.baseY)
+          ?.getCell(0)
+          ?.getChars() === ":"
+      ) {
+        return;
+      }
+    }
+
+    // the following code guards the terminal prompt to avoid being able to arrow
+    // or backspace-into the prompt. Record the lowest X value at which the user
+    // gave input, and mark all additions before that as tentative.
+    const actualY = buffer.baseY + buffer.cursorY;
+    if (actualY !== this._lastRow?.y) {
+      this._lastRow = {
+        y: actualY,
+        startingX: buffer.cursorX,
+        endingX: buffer.cursorX,
+        charState: CharPredictState.Unknown,
+      };
+    } else {
+      this._lastRow.startingX = Math.min(this._lastRow.startingX, buffer.cursorX);
+      this._lastRow.endingX = Math.max(
+        this._lastRow.endingX,
+        this._timeline.physicalCursor(buffer).x,
+      );
+    }
+
+    const addLeftNavigating = (p: IPrediction) =>
+      this._timeline!.tentativeCursor(buffer).x <= this._lastRow!.startingX
+        ? this._timeline!.addBoundary(buffer, p)
+        : this._timeline!.addPrediction(buffer, p);
+
+    const addRightNavigating = (p: IPrediction) =>
+      this._timeline!.tentativeCursor(buffer).x >= this._lastRow!.endingX - 1
+        ? this._timeline!.addBoundary(buffer, p)
+        : this._timeline!.addPrediction(buffer, p);
+
+    /** @see https://github.com/xtermjs/xterm.js/blob/1913e9512c048e3cf56bb5f5df51bfff6899c184/src/common/input/Keyboard.ts */
+    const reader = new StringReader(data);
+    while (reader.remaining > 0) {
+      if (reader.eatCharCode(127)) {
+        // backspace
+        const previous = this._timeline.peekEnd();
+        if (previous && previous instanceof CharacterPrediction) {
+          this._timeline.addBoundary();
+        }
+
+        // backspace must be able to read the previously-written character in the
+        // event that it needs to undo it
+        if (this._timeline.isShowingPredictions) {
+          flushOutput(this._timeline.terminal);
+        }
+
+        if (this._timeline.tentativeCursor(buffer).x <= this._lastRow.startingX) {
+          this._timeline.addBoundary(buffer, new BackspacePrediction(this._timeline.terminal));
+        } else {
+          // Backspace decrements our ability to go right.
+          this._lastRow.endingX--;
+          this._timeline.addPrediction(buffer, new BackspacePrediction(this._timeline.terminal));
+        }
+
+        continue;
+      }
+
+      if (reader.eatCharCode(32, 126)) {
+        // alphanum
+        const char = data[reader.index - 1]!;
+        const prediction = new CharacterPrediction(this._typeaheadStyle!, char);
+        if (this._lastRow.charState === CharPredictState.Unknown) {
+          this._timeline.addBoundary(buffer, prediction);
+          this._lastRow.charState = CharPredictState.HasPendingChar;
+        } else {
+          this._timeline.addPrediction(buffer, prediction);
+        }
+
+        if (this._timeline.tentativeCursor(buffer).x >= terminal.cols) {
+          this._timeline.addBoundary(buffer, new LinewrapPrediction());
+        }
+        continue;
+      }
+
+      const cursorMv = reader.eatRe(CSI_MOVE_RE);
+      if (cursorMv) {
+        const direction = cursorMv[3] as CursorMoveDirection;
+        const p = new CursorMovePrediction(direction, !!cursorMv[2], Number(cursorMv[1]) || 1);
+        if (direction === CursorMoveDirection.Back) {
+          addLeftNavigating(p);
+        } else {
+          addRightNavigating(p);
+        }
+        continue;
+      }
+
+      if (reader.eatStr(`${VT.Esc}f`)) {
+        addRightNavigating(new CursorMovePrediction(CursorMoveDirection.Forwards, true, 1));
+        continue;
+      }
+
+      if (reader.eatStr(`${VT.Esc}b`)) {
+        addLeftNavigating(new CursorMovePrediction(CursorMoveDirection.Back, true, 1));
+        continue;
+      }
+
+      if (reader.eatChar("\r") && buffer.cursorY < terminal.rows - 1) {
+        this._timeline.addPrediction(buffer, new NewlinePrediction());
+        continue;
+      }
+
+      // something else
+      this._timeline.addBoundary(buffer, new HardBoundary());
+      break;
+    }
+
+    if (this._timeline.length === 1) {
+      this._deferClearingPredictions();
+      this._typeaheadStyle!.startTracking();
+    }
+  }
+}

--- a/ap-web/vite.config.ts
+++ b/ap-web/vite.config.ts
@@ -138,6 +138,10 @@ export default defineConfig({
     // vitest's default glob descends into the nested electron package and
     // tries to run its node:test files (which aren't vitest suites).
     include: ["src/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+    // Playwright browser specs (*.browser.spec.ts) run under @playwright/test,
+    // not vitest/jsdom — exclude them so vitest doesn't try to import the
+    // playwright runner and fail.
+    exclude: ["**/node_modules/**", "**/*.browser.spec.ts"],
     coverage: {
       provider: "v8",
       // With `include` set, vitest counts every matching source file (untested

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3229,6 +3229,12 @@ def server(
             port=port,
             log_config=_server_uvicorn_log_config(),
             ws_max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+            # Disable WebSocket per-message-deflate (uvicorn defaults it on).
+            # Our hottest WS frames are tiny, latency-sensitive terminal
+            # keystrokes/echoes; compressing them adds CPU and a setup cost for
+            # no size win, hurting interactive feel. Matches the codex-native WS
+            # client, which already connects with compression disabled.
+            ws_per_message_deflate=False,
             timeout_graceful_shutdown=_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
         )
     finally:


### PR DESCRIPTION
## Why

The embedded web terminal (xterm.js) feels laggy **when typing on remote sessions**. We traced this through all three layers and confirmed it's **inherent, not a bug**:

- The server bridge (`ws_bridge.py`) is well-tuned — non-blocking PTY drain, no artificial batching.
- The client already paints the server's echo synchronously (`_core.writeSync`).
- **But a remote PTY has no local echo.** Every keystroke round-trips (browser → server → tmux → shell echo → back → paint) before appearing. At 50–150ms RTT, every character visibly lags. The sync-paint fast path only shaves a frame off the *paint* — it can't beat the round-trip.

Research (Mosh USENIX ATC '12; VS Code's local echo, shipped v1.51) confirms: **nobody beats the RTT — fast terminals hide it with predictive local echo.** Draw the typed char immediately as "unconfirmed", then reconcile against the authoritative echo.

## What

**Predictive local echo, ported from VS Code's MIT `TypeAheadAddon`** — the most battle-tested xterm.js implementation (prediction types, epoch/confidence gating, RTT-adaptive timeout, alt-screen/excluded-program suppression). Rather than reinvent Mosh's heuristics, we vendor and shim it.

- `typeahead/terminalTypeAheadAddon.ts` — vendored engine, refactored for ap-web's strict tsconfig (`erasableSyntaxOnly` forbids `const enum` + constructor parameter properties; no `experimentalDecorators`, so `@debounce`/DI decorators became plain code).
- `typeahead/shims.ts` — standalone replacements for the VS Code base utils (`Emitter`/`Disposable`/`disposableTimeout`/`debounce`/`Color`).
- `TerminalSession` wires it in behind a `localEcho: "auto" | "on" | "off"` arg (`TerminalView` prop, default **`"auto"`**). `writeOutput` routes inbound bytes through `beforeServerInput` before painting; a streaming `TextDecoder` holds back multibyte sequences split across WS frames. **`"auto"` self-gates on measured latency (30ms threshold)** — local/fast links stay dormant (zero overhead, no flicker), remote links get instant typing.

**Plus a server-side quick win:** disable WebSocket per-message-deflate (`cli.py`). uvicorn defaults it on, but compressing tiny latency-sensitive keystroke/echo frames is pure overhead. (TCP_NODELAY is already handled by uvloop; the default Caddy proxy streams WebSockets — both checked, no change needed.)

## Verification

- **16 jsdom unit tests** for the addon + shims: predict→confirm, predict→rollback, timeout rollback, alt-screen suppression, excluded-program, dispose cleanup, plus a **regression guard** that xterm still exposes the private `_curAttrData` the addon depends on.
- **Playwright browser test** (`npm run test:browser`): drives a real Chromium against a fake-RTT harness and asserts a typed char paints **dimmed before the echo**, then snaps **solid after reconciliation**. Screenshot + timing confirmed `isDim: true` (before echo) -> `isDim: false` (after).
- **Server flag verified live**: booted the server and inspected the WS handshake — negotiated extensions went from `PerMessageDeflate(...)` -> `None`.
- Full ap-web unit suite green (**3240 passed**); typecheck + lint clean.

## Reviewer notes

- **Two Playwright stacks.** The repo already has a Python `pytest-playwright` e2e_ui suite. This adds a small JS `@playwright/test` harness because that suite structurally **can't** read xterm's WebGL buffer to assert dim-state (the existing terminal e2e test documents giving up on rendered-content assertions for exactly this reason). The JS harness is the deterministic visual regression test for this feature. Deliberate tradeoff — flagging so it isn't a surprise.
- **Lockfile drift.** `npm ci` currently fails on `ap-web` (lockfile out of sync, missing `yaml@1.10.3`), so deps were installed with `npm install`. The `package-lock.json` diff therefore includes a few incidental `dev`-flag/`yaml` reconciliations beyond the `@playwright/test` addition. That drift is **pre-existing** and worth a separate fix.
- **Private xterm internals.** The addon reads `_core._inputHandler._curAttrData` (same fragility class as the existing `_core.writeSync` use) — feature-detect + try/catch, with a CI guard test. If a future xterm drops it, prediction degrades to off; it never corrupts the buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
