### PR TITLE
fix(ap-web): keep sidebar session highlighted when viewing a sub-agent

### DIFF
--- a/ap-web/src/hooks/useSession.ts
+++ b/ap-web/src/hooks/useSession.ts
@@ -108,3 +108,29 @@ export function useRootSessionId(
   if (parentSessionId === null) return conversationId;
   return data ?? null;
 }
+
+/**
+ * Resolve the top-level root of the *active* conversation in one call,
+ * fetching its snapshot for the parent link and walking up from there.
+ *
+ * The sidebar lists only top-level sessions — child (sub-agent) rows are
+ * omitted. When the user clicks a sub-agent in the Agents rail the URL
+ * becomes ``/c/<childId>``, which matches no sidebar row, so a row that
+ * compares its id against the raw active id loses its highlight. Comparing
+ * against this resolved root instead keeps the owning top-level session
+ * highlighted while viewing any of its descendants.
+ *
+ * Returns ``null`` while the snapshot or the parent walk is still loading
+ * (callers fall back to the raw active id for that one render), and the
+ * active id itself for a top-level session.
+ *
+ * @param activeConversationId - The conversation rendered in main, or
+ *   ``null`` when on a non-chat route (disables resolution).
+ */
+export function useActiveRootSessionId(
+  activeConversationId: string | null | undefined,
+): string | null {
+  const id = activeConversationId ?? null;
+  const { session } = useSession(id);
+  return useRootSessionId(id, session?.parentSessionId);
+}

--- a/ap-web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/ap-web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -1,0 +1,163 @@
+// Regression test for: clicking a sub-agent in the right rail dropped the
+// owning session's highlight in the left sidebar.
+//
+// The sidebar lists only top-level sessions — child (sub-agent) rows are
+// omitted. ConversationRow highlights the row whose id matches the active
+// route param. When the user clicks a sub-agent the URL becomes
+// `/c/<childId>`, which matches no sidebar row, so the parent row lost its
+// `bg-muted` highlight. The fix resolves the active conversation's
+// top-level root (via useActiveRootSessionId, walking parentSessionId) and
+// highlights against that, so the parent stays selected while viewing any
+// descendant.
+//
+// We mock the conversations list (top-level only, as in production) and the
+// per-session snapshot API so the REAL useSession / useRootSessionId chain
+// resolves the child up to its root.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Conversation } from "@/hooks/useConversations";
+import type { Session } from "@/lib/types";
+
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: vi.fn(),
+  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useConnectedConversations: () => [],
+  useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
+  usePinnedConversationBackfill: () => [],
+  useRenameConversation: () => ({ mutate: vi.fn() }),
+  useStopSession: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: [] }),
+  useProjectSessions: () => ({ data: undefined, isLoading: false, isError: false, error: null }),
+  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  fetchProjectSessionIds: () => Promise.resolve([]),
+  PROJECT_LABEL_KEY: "omni_project",
+}));
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+// The snapshot API feeds the real useSession / useRootSessionId walk: the
+// child reports its parent, the parent reports null (top-level).
+vi.mock("@/lib/sessionsApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/sessionsApi")>()),
+  getSessionSlim: vi.fn(),
+}));
+
+import { useConversations } from "@/hooks/useConversations";
+import { getSessionSlim } from "@/lib/sessionsApi";
+import { Sidebar } from "./Sidebar";
+
+const useConvMock = vi.mocked(useConversations);
+const getSessionSlimMock = vi.mocked(getSessionSlim);
+
+function topLevelConv(id: string): Conversation {
+  return {
+    id,
+    object: "conversation",
+    title: id,
+    created_at: 0,
+    updated_at: 0,
+    labels: {},
+    permission_level: null,
+    agent_name: "Claude Code",
+  };
+}
+
+function mockConversations(convs: Conversation[]) {
+  useConvMock.mockReturnValue({
+    data: {
+      pages: [{ data: convs, first_id: null, last_id: null, has_more: false }],
+      pageParams: [undefined],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  } as unknown as ReturnType<typeof useConversations>);
+}
+
+function snapshot(id: string, parentSessionId: string | null): Session {
+  return {
+    id,
+    agentId: "ag",
+    agentName: null,
+    runnerId: null,
+    status: "idle",
+    createdAt: 0,
+    title: null,
+    labels: {},
+    items: [],
+    pendingElicitations: [],
+    permissionLevel: 4,
+    parentSessionId,
+  } as unknown as Session;
+}
+
+function renderAt(initialEntry: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/" element={<Sidebar open onClose={vi.fn()} />} />
+            <Route path="/c/:conversationId" element={<Sidebar open onClose={vi.fn()} />} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  useConvMock.mockReset();
+  getSessionSlimMock.mockReset();
+  localStorage.clear();
+});
+
+afterEach(cleanup);
+
+function rowFor(id: string): HTMLElement {
+  // ConversationRow renders the title (== id here) inside its <a>; the <li>
+  // wrapper carries the highlight class via the link's className.
+  return screen.getByRole("link", { name: new RegExp(id) });
+}
+
+describe("sidebar highlight while viewing a sub-agent", () => {
+  it("highlights the top-level parent row when the active session is its child", async () => {
+    mockConversations([topLevelConv("conv_root"), topLevelConv("conv_other")]);
+    // conv_child is a sub-agent of conv_root and is NOT in the sidebar list.
+    getSessionSlimMock.mockImplementation((id: string) => {
+      if (id === "conv_child") return Promise.resolve(snapshot("conv_child", "conv_root"));
+      if (id === "conv_root") return Promise.resolve(snapshot("conv_root", null));
+      return Promise.resolve(snapshot(id, null));
+    });
+
+    // Active route is the CHILD — no matching sidebar row.
+    renderAt("/c/conv_child");
+
+    // Once the parent walk resolves, the root's row carries the highlight.
+    await waitFor(() => expect(rowFor("conv_root")).toHaveClass("bg-muted"));
+    expect(rowFor("conv_other")).not.toHaveClass("bg-muted");
+  });
+
+  it("still highlights a top-level session viewed directly", async () => {
+    mockConversations([topLevelConv("conv_root"), topLevelConv("conv_other")]);
+    getSessionSlimMock.mockImplementation((id: string) => Promise.resolve(snapshot(id, null)));
+
+    renderAt("/c/conv_root");
+
+    // A top-level session resolves to itself; highlight lands immediately and
+    // doesn't bleed onto siblings.
+    await waitFor(() => expect(rowFor("conv_root")).toHaveClass("bg-muted"));
+    expect(rowFor("conv_other")).not.toHaveClass("bg-muted");
+  });
+});

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -110,6 +110,7 @@ import { showToast } from "@/components/ui/toast";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { SessionStateBadge } from "@/components/SessionStateBadge";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useActiveRootSessionId } from "@/hooks/useSession";
 import { useCommentInbox } from "@/hooks/useCommentInbox";
 import { sumPendingApprovals } from "@/lib/inbox";
 import { isSessionStoppable } from "@/lib/sessionStop";
@@ -1998,7 +1999,17 @@ function ConversationRow({
   // `useParams` reads from the active matched route. On `/`, the param is
   // undefined; on `/c/:conversationId`, it carries the active id.
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
-  const isActive = activeId === conversation.id;
+  // The sidebar lists only top-level sessions; child (sub-agent) rows are
+  // omitted. When the user clicks a sub-agent in the Agents rail the active
+  // id becomes the child's, which matches no row here — so highlighting on
+  // the raw id alone would leave the owning session unhighlighted. Resolve
+  // the active conversation's top-level root and highlight against that, so
+  // the parent row stays selected while viewing any of its descendants.
+  // While the resolution loads (`null`), fall back to the raw id for that
+  // render — a top-level session resolves to itself, so the common case is
+  // unaffected.
+  const activeRootId = useActiveRootSessionId(activeId ?? null);
+  const isActive = (activeRootId ?? activeId) === conversation.id;
   const navigate = useNavigate();
   // Track the *live* active conversation id. Delete is fire-and-forget,
   // so the user can navigate to another conversation before the mutation


### PR DESCRIPTION
## Problem

In the web UI, clicking a sub-agent in the right-rail Agents tree dropped the highlight on the owning session in the left sidebar.

## Root cause

The sidebar lists **only top-level sessions** — child (sub-agent) rows are intentionally omitted (`AppShell.tsx`). But `ConversationRow` highlighted the row whose id matched the raw `/c/:conversationId` route param:

```ts
const { conversationId: activeId } = useParams();
const isActive = activeId === conversation.id;   // bg-muted
```

Clicking a sub-agent navigates to `/c/<childId>`. Since no sidebar row has the child's id, the previously-highlighted parent row lost its `bg-muted`. (`AppShell` already solves the analogous problem for the rail itself by walking `parentSessionId` to the root via `useRootSessionId`; the sidebar just wasn't doing the same.)

## Fix

Highlight against the active session's **resolved top-level root** instead of the raw URL id.

- Added `useActiveRootSessionId` in `useSession.ts` — composes the existing `useSession` (for the parent link) + cache-backed `useRootSessionId` (parent-chain walk). Returns the id itself for top-level sessions, `null` while resolving.
- `ConversationRow` now uses `(activeRootId ?? activeId) === conversation.id`, falling back to the raw id while the walk is in flight (top-level case stays instant/unchanged).

The walk reuses the shared `["session", id]` query cache the rail already populates, so it's typically zero extra network.

## Tests

- New `Sidebar.subagentHighlight.test.tsx`: parent row keeps `bg-muted` while a child is active; direct top-level viewing still highlights without bleeding to siblings.
- Full suite green: 95 files / 1547 tests. `tsc -b`, `oxlint`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
