### PR TITLE
feat(web): add Geist as an opt-in interface font

### DIFF
--- a/ap-web/package-lock.json
+++ b/ap-web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@databricks/sdk-experimental": "^0.17.0",
         "@dnd-kit/core": "^6.3.1",
+        "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.7",
         "@lobehub/fluent-emoji": "^4.1.0",
         "@lobehub/icons": "^5.6.0",
@@ -1515,6 +1516,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/geist": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.9.tgz",
+      "integrity": "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@fontsource-variable/geist-mono": {
       "version": "5.2.8",
@@ -6747,7 +6757,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6757,7 +6766,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8096,6 +8104,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -16254,7 +16271,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -16545,7 +16561,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -17354,12 +17370,21 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/ap-web/package.json
+++ b/ap-web/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@databricks/sdk-experimental": "^0.17.0",
     "@dnd-kit/core": "^6.3.1",
+    "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@lobehub/fluent-emoji": "^4.1.0",
     "@lobehub/icons": "^5.6.0",

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -3,6 +3,11 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/geist-mono";
+/* Geist Sans — opt-in interface font, selectable in Settings → Appearance →
+ * Fonts. Not the default: the default sans stack stays native (see --font-sans
+ * below). Applied by setting data-chat-font="geist" on <html>; see
+ * src/lib/chatFont.ts. */
+@import "@fontsource-variable/geist";
 
 /* Streamdown ships utility classes pre-compiled in its dist; this @source
  * pragma tells Tailwind v4 to scan those files so the classes survive the
@@ -687,6 +692,17 @@
   }
   html {
     @apply font-sans;
+  }
+  /* Opt-in interface font override. The default (no attribute) keeps the
+   * native system sans stack from --font-sans. When the user picks Geist in
+   * Settings → Appearance → Fonts, src/lib/chatFont.ts sets this attribute on
+   * <html>; the rule re-fronts the same stack with "Geist Variable" so all UI
+   * + chat text uses Geist while keeping the original system fallbacks. The
+   * mono stack (code blocks, terminal) is intentionally left untouched. */
+  html[data-chat-font="geist"] {
+    font-family:
+      "Geist Variable", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   }
   /* Text selection — brand pink highlight. Light: gentle wash + dark pink
    * text. Dark: solid brand pink background + white text. */

--- a/ap-web/src/lib/chatFont.test.ts
+++ b/ap-web/src/lib/chatFont.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_CHAT_FONT, applyChatFont, readChatFont, writeChatFont } from "./chatFont";
+
+const STORAGE_KEY = "omnigent:chat-font";
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-chat-font");
+});
+
+describe("chatFont", () => {
+  it("returns the default when nothing is stored", () => {
+    // No write has happened — read must fall back to the system default,
+    // not throw or return an unknown value.
+    expect(readChatFont()).toBe(DEFAULT_CHAT_FONT);
+  });
+
+  it("round-trips a written font", () => {
+    writeChatFont("geist");
+    expect(readChatFont()).toBe("geist");
+  });
+
+  it("falls back to the default on an unrecognized stored value", () => {
+    // A stale or hand-edited value must not leak through to CSS; read coerces
+    // it back to the default so the attribute logic stays well-defined.
+    localStorage.setItem(STORAGE_KEY, "comic-sans");
+    expect(readChatFont()).toBe(DEFAULT_CHAT_FONT);
+  });
+
+  it("sets data-chat-font on the root for a non-default font", () => {
+    applyChatFont("geist");
+    expect(document.documentElement.getAttribute("data-chat-font")).toBe("geist");
+  });
+
+  it("clears the attribute for the default font", () => {
+    // Start dirty, then apply the default — the attribute must be removed so
+    // the base font-sans stack applies rather than an empty/garbage value.
+    document.documentElement.setAttribute("data-chat-font", "geist");
+    applyChatFont(DEFAULT_CHAT_FONT);
+    expect(document.documentElement.hasAttribute("data-chat-font")).toBe(false);
+  });
+
+  it("applies the font as a side effect of writing", () => {
+    writeChatFont("geist");
+    expect(document.documentElement.getAttribute("data-chat-font")).toBe("geist");
+    writeChatFont("system");
+    expect(document.documentElement.hasAttribute("data-chat-font")).toBe(false);
+  });
+});

--- a/ap-web/src/lib/chatFont.ts
+++ b/ap-web/src/lib/chatFont.ts
@@ -1,0 +1,86 @@
+// Persisted, app-global preference for the interface font.
+//
+// This is a *preference*, not per-session state: the chosen font applies to
+// the whole UI (chat, sidebar, settings) and should survive a page refresh.
+// It is stored under a single localStorage key, mirroring the global-toggle
+// semantics of fileViewPreferences.ts.
+//
+// The font is applied by toggling a `data-chat-font` attribute on the <html>
+// element, which CSS in index.css keys off of. We deliberately mirror the
+// next-themes approach (a single attribute on the document root) rather than
+// rewriting the `--font-sans` custom property: Tailwind v4 inlines the
+// `font-sans` utility's value at build time from the `@theme inline` block, so
+// reassigning the variable at runtime would not retroactively change utility
+// classes. A document-level font-family override does.
+
+export const chatFonts = ["system", "geist"] as const;
+
+export type ChatFont = (typeof chatFonts)[number];
+
+const STORAGE_KEY = "omnigent:chat-font";
+
+/** The native system stack — Omnigent's default; renders as native chrome. */
+export const DEFAULT_CHAT_FONT: ChatFont = "system";
+
+/** Human-readable labels for the settings UI. */
+export const CHAT_FONT_LABELS: Record<ChatFont, string> = {
+  system: "System",
+  geist: "Geist",
+};
+
+/** Whether a string is one of the selectable fonts. */
+export function isChatFont(value: string | null | undefined): value is ChatFont {
+  return value === "system" || value === "geist";
+}
+
+/**
+ * Read the persisted font preference. Returns the default when nothing is
+ * stored, on a server render (no `window`), or when the stored value is
+ * unrecognized — never throws, so a corrupt entry can't break the app.
+ */
+export function readChatFont(): ChatFont {
+  if (typeof window === "undefined") return DEFAULT_CHAT_FONT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return isChatFont(raw) ? raw : DEFAULT_CHAT_FONT;
+  } catch {
+    return DEFAULT_CHAT_FONT;
+  }
+}
+
+/**
+ * Persist the font preference and apply it. Swallows quota/access errors so a
+ * failed write can't break the app — the in-DOM effect still happens.
+ */
+export function writeChatFont(font: ChatFont): void {
+  applyChatFont(font);
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, font);
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+}
+
+/**
+ * Reflect the chosen font onto the document root. The default ("system")
+ * removes the attribute so the base `font-sans` stack applies; any non-default
+ * font sets `data-chat-font` for the index.css override to match.
+ */
+export function applyChatFont(font: ChatFont): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (font === DEFAULT_CHAT_FONT) {
+    root.removeAttribute("data-chat-font");
+  } else {
+    root.setAttribute("data-chat-font", font);
+  }
+}
+
+/**
+ * Apply the persisted font at boot. Called from main.tsx before first paint so
+ * a non-default choice doesn't flash the system font first.
+ */
+export function initChatFont(): void {
+  applyChatFont(readChatFont());
+}

--- a/ap-web/src/main.tsx
+++ b/ap-web/src/main.tsx
@@ -11,6 +11,7 @@ import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
 import { CapabilitiesProvider } from "./lib/CapabilitiesContext";
 import { resolveIdentity } from "./lib/identity";
+import { initChatFont } from "./lib/chatFont";
 import { initNativeInsets } from "./lib/nativeInsets";
 import { initChatStore } from "./store/chatStore";
 import "./index.css";
@@ -40,6 +41,11 @@ void resolveIdentity();
 // Mirror the iOS shell's native bar footprints into the inset CSS variables.
 // No-op off the iOS shell (the inset vars stay at their env()-only defaults).
 initNativeInsets();
+
+// Apply the persisted interface-font choice before first paint so a non-default
+// pick (Geist) doesn't flash the system font first. Mirrors next-themes' root
+// attribute approach.
+initChatFont();
 
 // Probe /v1/info BEFORE the first render so the route table knows
 // whether to mount accounts routes. The probe is unauthed and the

--- a/ap-web/src/pages/SettingsPage.tsx
+++ b/ap-web/src/pages/SettingsPage.tsx
@@ -56,6 +56,13 @@ import { conversationDisplayLabel } from "@/shell/sidebarNav";
 import { absoluteTime } from "@/lib/relativeTime";
 import { useSettingsRoute } from "@/shell/settingsNav";
 import { type ThemeMode, normalizeThemeMode } from "@/components/theme/themeMode";
+import {
+  type ChatFont,
+  CHAT_FONT_LABELS,
+  chatFonts,
+  readChatFont,
+  writeChatFont,
+} from "@/lib/chatFont";
 import { useIsEmbedded } from "@/lib/embedded";
 import { type CliStatus, getCliStatus, isElectronShell, resetCliPath } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
@@ -108,6 +115,26 @@ const themeCards: { mode: ThemeMode; label: string; icon: typeof SunIcon }[] = [
   { mode: "dark", label: "Dark", icon: MoonIcon },
 ];
 
+/** A labeled subsection within a Section: a small heading above its control. */
+function SettingGroup({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-sm font-medium">{label}</h2>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Per-font preview string, rendered in the font it selects so the choice is
+ * visible before committing. "System" reverts to the document default by
+ * clearing the inline family; "Geist" names the imported variable face.
+ */
+const fontPreviewFamily: Record<ChatFont, string | undefined> = {
+  system: undefined,
+  geist: '"Geist Variable", ui-sans-serif, system-ui, sans-serif',
+};
+
 function AppearanceSection() {
   // Embedded: the host owns the theme (embed.tsx forces light), so the
   // selector would be a no-op — match ThemeModeMenu and hide it.
@@ -115,36 +142,86 @@ function AppearanceSection() {
   const { theme, setTheme } = useTheme();
   const mode = normalizeThemeMode(theme);
 
-  return (
-    <Section title="Appearance" description="Choose how Omnigent looks on this device.">
-      {isEmbedded ? (
+  // Font lives in localStorage (see lib/chatFont), not next-themes. Mirror it
+  // into local state so the radio selection updates on click; the DOM/storage
+  // write happens in writeChatFont.
+  const [font, setFont] = useState<ChatFont>(readChatFont);
+  const onPickFont = useCallback((next: ChatFont) => {
+    setFont(next);
+    writeChatFont(next);
+  }, []);
+
+  if (isEmbedded) {
+    return (
+      <Section title="Appearance" description="Choose how Omnigent looks on this device.">
         <p className="text-sm text-muted-foreground">
           Appearance is controlled by the host application.
         </p>
-      ) : (
-        <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-label="Theme">
-          {themeCards.map(({ mode: cardMode, label, icon: Icon }) => {
-            const selected = mode === cardMode;
-            return (
-              <button
-                key={cardMode}
-                type="button"
-                role="radio"
-                aria-checked={selected}
-                data-testid={`theme-${cardMode}`}
-                onClick={() => setTheme(cardMode)}
-                className={cn(
-                  "flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
-                  selected ? "border-primary bg-primary/5" : "border-border",
-                )}
-              >
-                <Icon className="size-6 text-muted-foreground" />
-                <span className="text-sm font-medium">{label}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+      </Section>
+    );
+  }
+
+  return (
+    <Section title="Appearance" description="Choose how Omnigent looks on this device.">
+      <div className="flex flex-col gap-8">
+        <SettingGroup label="Theme">
+          <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-label="Theme">
+            {themeCards.map(({ mode: cardMode, label, icon: Icon }) => {
+              const selected = mode === cardMode;
+              return (
+                <button
+                  key={cardMode}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  data-testid={`theme-${cardMode}`}
+                  onClick={() => setTheme(cardMode)}
+                  className={cn(
+                    "flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
+                    selected ? "border-primary bg-primary/5" : "border-border",
+                  )}
+                >
+                  <Icon className="size-6 text-muted-foreground" />
+                  <span className="text-sm font-medium">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </SettingGroup>
+
+        <SettingGroup label="Font">
+          <div className="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Font">
+            {chatFonts.map((value) => {
+              const selected = font === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  data-testid={`font-${value}`}
+                  onClick={() => onPickFont(value)}
+                  className={cn(
+                    "flex flex-col items-start gap-1 rounded-lg border-2 p-4 transition-colors hover:bg-muted",
+                    selected ? "border-primary bg-primary/5" : "border-border",
+                  )}
+                >
+                  <span className="text-sm font-medium">{CHAT_FONT_LABELS[value]}</span>
+                  <span
+                    className="text-lg text-muted-foreground"
+                    style={{ fontFamily: fontPreviewFamily[value] }}
+                  >
+                    Ag
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Applies to all interface text. Code and terminal output always use a monospace font.
+          </p>
+        </SettingGroup>
+      </div>
     </Section>
   );
 }


### PR DESCRIPTION
Adds a "Font" picker to Settings → Appearance letting users switch the interface font between the native system stack (default) and Geist.

Geist Sans pairs with the Geist Mono we already ship for code, and skews toward dev-tooling brands (Vercel, Redis, Neon, GitBook) — a coherent fit for Omnigent without changing the default.

- Add @fontsource-variable/geist; import it in index.css.
- Apply via a `data-chat-font="geist"` attribute on <html>, re-fronting the sans stack with "Geist Variable" while keeping system fallbacks. The mono stack (code/terminal) is untouched.
- Persist the choice in localStorage (src/lib/chatFont.ts), mirroring the fileViewPreferences pattern; apply at boot before first paint to avoid a font flash, mirroring next-themes' root-attribute approach.
- Add a radio-card Font group with live "Ag" previews to AppearanceSection.

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
