### PR TITLE
fix(server): widen SessionResponse/SessionListItem status to include "waiting"

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2246,7 +2246,7 @@ def _pending_elicitation_snapshot_for_session(
 def _build_session_response(
     conv: Conversation,
     items: list[ConversationItem],
-    status: Literal["idle", "running", "failed"],
+    status: Literal["idle", "running", "waiting", "failed"],
     permission_level: int | None = None,
     llm_model: str | None = None,
     context_window: int | None = None,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1476,7 +1476,12 @@ class SessionResponse(BaseModel):
         be found (deleted or orphaned session).
     :param status: Session lifecycle status. One of
         ``"idle"`` (no loop running), ``"running"`` (loop
-        executing), or ``"failed"`` (terminal failure).
+        executing), ``"waiting"`` (loop parked on background
+        work / sub-agents), or ``"failed"`` (terminal failure).
+        Current read paths collapse ``"waiting"`` -> ``"running"``
+        before building this snapshot; the literal stays a superset
+        of what the runtime can produce so a server that forwards
+        the raw status never 500s on serialization.
     :param created_at: Unix epoch seconds of creation.
     :param title: Optional human-readable title, e.g.
         ``"debugging auth flow"``. ``None`` when unset.
@@ -1679,7 +1684,7 @@ class SessionResponse(BaseModel):
     id: str
     agent_id: str
     agent_name: str | None = None
-    status: Literal["idle", "running", "failed"]
+    status: Literal["idle", "running", "waiting", "failed"]
     created_at: int
     title: str | None = None
     labels: dict[str, str] = Field(default_factory=dict)
@@ -2048,7 +2053,7 @@ class SessionListItem(BaseModel):
     id: str
     agent_id: str
     agent_name: str | None = None
-    status: Literal["idle", "running", "failed"]
+    status: Literal["idle", "running", "waiting", "failed"]
     created_at: int
     updated_at: int
     title: str | None = None

--- a/openapi.json
+++ b/openapi.json
@@ -3769,6 +3769,7 @@
             "enum": [
               "idle",
               "running",
+              "waiting",
               "failed"
             ],
             "title": "Status",
@@ -4482,10 +4483,11 @@
             "type": "array"
           },
           "status": {
-            "description": "Session lifecycle status. One of `\"idle\"` (no loop running), `\"running\"` (loop executing), or `\"failed\"` (terminal failure).",
+            "description": "Session lifecycle status. One of `\"idle\"` (no loop running), `\"running\"` (loop executing), `\"waiting\"` (loop parked on background work / sub-agents), or `\"failed\"` (terminal failure). Current read paths collapse `\"waiting\"` -> `\"running\"` before building this snapshot; the literal stays a superset of what the runtime can produce so a server that forwards the raw status never 500s on serialization.",
             "enum": [
               "idle",
               "running",
+              "waiting",
               "failed"
             ],
             "title": "Status",

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -708,3 +708,42 @@ def test_session_create_external_rejects_repo_url_workspace() -> None:
             host_id="host_abc",
             workspace="https://github.com/org/repo",
         )
+
+
+@pytest.mark.parametrize("status", ["idle", "running", "waiting", "failed"])
+def test_session_response_status_accepts_canonical_set(status: str) -> None:
+    """
+    ``SessionResponse.status`` accepts the full canonical lifecycle set,
+    including ``"waiting"``.
+
+    The wire ``session.status`` event already models ``"waiting"`` (a turn
+    parked on background work / sub-agents). The REST snapshot collapses
+    ``"waiting"`` -> ``"running"`` on every current read path, so the value
+    does not normally reach this model — but a server >= 0.3.0 is documented
+    (``server/API.md``) to serialize the canonical set, and keeping the
+    Literal a strict subset means any future or alternate-backend path that
+    forwards the raw status would 500 on serialization. Widening keeps the
+    model a superset of what the runtime can produce.
+    """
+    from omnigent.server.schemas import SessionResponse
+
+    resp = SessionResponse(id="conv_x", agent_id="ag_x", status=status, created_at=0)
+    assert resp.status == status
+    assert resp.model_dump()["status"] == status
+
+
+@pytest.mark.parametrize("status", ["idle", "running", "waiting", "failed"])
+def test_session_list_item_status_accepts_canonical_set(status: str) -> None:
+    """``SessionListItem.status`` accepts the same canonical set as the snapshot."""
+    from omnigent.server.schemas import SessionListItem
+
+    item = SessionListItem(id="conv_x", agent_id="ag_x", status=status, created_at=0, updated_at=0)
+    assert item.status == status
+
+
+def test_session_response_status_rejects_unknown_value() -> None:
+    """A status outside the canonical set still fails loud (fail-closed wire shape)."""
+    from omnigent.server.schemas import SessionResponse
+
+    with pytest.raises(ValidationError):
+        SessionResponse(id="conv_x", agent_id="ag_x", status="launching", created_at=0)


### PR DESCRIPTION
## Summary

Widens `SessionResponse.status` and `SessionListItem.status` from `Literal["idle", "running", "failed"]` to the canonical lifecycle set `Literal["idle", "running", "waiting", "failed"]`, matching what `server/API.md` already documents and what the wire `session.status` event (`SessionStatusEvent`) already models.

Closes #1488.

## Investigation note (read before merging)

The issue reports a live HTTP 500 when loading any `waiting` session. I could **not** reproduce that on the current server, and I believe the "live 500" framing is stale:

- The server stores the fine-grained relay status (`waiting`/`running`/`failed`/`idle`) in `_session_status_cache`, then **collapses `"waiting"` → `"running"` on every read path** via `_session_status_from_cache` / `_session_status_with_child_rollup` before building any response model. So `GET /v1/sessions/{id}`, the list endpoint, and the WS updates stream never actually emit `"waiting"` today.
- The 500 was a **pre-0.3.0** problem, already mitigated runner-side in #1045 (the runner downgrades `"waiting"` → `"running"` for servers `< 0.3.0`). That PR's own commit note explicitly corrects the misconception: *"a current server does NOT serialize 'waiting'; it collapses cached 'waiting'->'running' on GET."*

**That said, widening the Literal is still worth doing as defensive hardening**, which is what this PR does:

- The narrow Literal is a latent serialization hazard — it is a *strict subset* of what the runtime can produce, so any path that forwards the raw status (a future code path, an alternate store backend, or a partially-collapsed path) would hit a Pydantic `ValidationError` → 500.
- It aligns the response models with the already-documented canonical set in `server/API.md` and with `SessionStatusEvent`.
- The change is purely additive and keeps the model a *superset* of the runtime's possible values.

## Changes

- `omnigent/server/schemas.py`: widen `SessionResponse.status` and `SessionListItem.status`; expand the `SessionResponse.status` docstring (notes the collapse behavior so future readers don't think `"waiting"` flows through untouched).
- `omnigent/server/routes/sessions.py`: widen the `_build_session_response` `status` parameter annotation to match. (The `_session_status_from_cache` / `_session_status_with_child_rollup` *return* annotations are intentionally left narrow — they genuinely only ever return the collapsed set.)
- `openapi.json`: regenerated (`scripts/dump_openapi.py`); `--check` passes.
- `tests/server/test_schemas.py`: parametrized tests that both models accept the full canonical set, and that an unknown value (e.g. `"launching"`) still fails loud.

`"launching"` is deliberately **not** added — per the existing comment in `routes/sessions.py`, it is runner-local sub-agent bookkeeping that rides in a child's `current_task_status`, never an external session status.

## Testing

- `uv run pytest tests/server/test_schemas.py tests/server/test_stream_events.py tests/runner/test_waiting_status_compat.py` → **98 passed**
- `uv run python scripts/dump_openapi.py --check` → up to date
- `uv run ruff check` / `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
