### PR TITLE
feat(copilot): forward reasoning effort from config.extra to the SDK session

### DIFF
--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -56,6 +56,7 @@ from pathlib import Path
 from typing import Any, TypeAlias
 
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
+from omnigent.reasoning_effort import COPILOT_EFFORTS, validate_effort
 
 from .datamodel import OSEnvSpec
 from .executor import (
@@ -114,6 +115,36 @@ def _resolve_model(model: str | None) -> str | None:
             )
         return None
     return model
+
+
+def _resolve_reasoning_effort(config: ExecutorConfig | None) -> str | None:
+    """Resolve the per-turn Copilot reasoning effort from ``config.extra``.
+
+    The runtime adapter threads a web ``/reasoning`` pick into
+    ``config.extra["reasoning_effort"]`` (see
+    :class:`~omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`).
+    The Copilot SDK exposes it only as ``create_session(reasoning_effort=...)``,
+    so like the model it is fixed at session creation (a change recreates the
+    session in :meth:`run_turn`). ``None`` lets the model use its default.
+
+    A value Copilot can't honor is dropped with a warning rather than raising:
+    an unsupported effort must not sink the whole turn (parity with the codex
+    native path). Per-model support is enforced by the Copilot backend.
+
+    Note: ``config.extra`` may also carry ``max_tokens`` (set by the adapter),
+    but the Copilot SDK has no per-turn output-token cap — the only
+    ``max_output_tokens`` lever is a model *capability* override folded into
+    context-window math, not a generation limit — so it is intentionally not
+    forwarded here.
+    """
+    if config is None:
+        return None
+    raw_effort = config.extra.get("reasoning_effort")
+    try:
+        return validate_effort(raw_effort, "copilot", COPILOT_EFFORTS)
+    except ValueError:
+        logger.warning("Ignoring unsupported copilot reasoning effort: %r", raw_effort)
+        return None
 
 
 def _tools_fingerprint(tools: list[ToolSpec]) -> str:
@@ -227,6 +258,7 @@ class _CopilotSessionState:
     session: Any = None  # copilot.CopilotSession
     system_prompt: str | None = None
     model: str | None = None
+    reasoning_effort: str | None = None
     tools_fingerprint: str | None = None
     has_sent_prompt: bool = False
     # call_id -> tool name, populated on TOOL_EXECUTION_START so the matching
@@ -382,6 +414,7 @@ class CopilotExecutor(Executor):
         model: str | None,
         tools: list[ToolSpec],
         system_prompt: str,
+        reasoning_effort: str | None = None,
     ) -> None:
         """Start the SDK client and create the session if not already live.
 
@@ -430,6 +463,7 @@ class CopilotExecutor(Executor):
                 tools=self._make_tools(tools) or None,
                 on_permission_request=PermissionHandler.approve_all,
                 working_directory=cwd,
+                reasoning_effort=reasoning_effort or None,
             )
         except BaseException:
             await _safe_stop(client)
@@ -446,15 +480,18 @@ class CopilotExecutor(Executor):
     ) -> AsyncIterator[ExecutorEvent]:
         session_key = self._session_key(messages)
         model = _resolve_model((config.model if config else None) or self._model_override)
+        reasoning_effort = _resolve_reasoning_effort(config)
         tools_fp = _tools_fingerprint(tools)
         state = self._session_states.setdefault(session_key, _CopilotSessionState())
 
-        # System prompt, model, and tool set are all fixed at session creation,
-        # so a change to any of them means a fresh session (otherwise a changed
-        # tool set would leave the initial ``tools`` stale for the conversation).
+        # System prompt, model, reasoning effort, and tool set are all fixed at
+        # session creation, so a change to any of them means a fresh session
+        # (otherwise a changed tool set would leave the initial ``tools`` stale
+        # for the conversation, and a new ``/reasoning`` pick would never apply).
         if state.session is not None and (
             state.system_prompt != system_prompt
             or state.model != model
+            or state.reasoning_effort != reasoning_effort
             or state.tools_fingerprint != tools_fp
         ):
             await self._close_state(state)
@@ -463,10 +500,11 @@ class CopilotExecutor(Executor):
         is_first_turn = not state.has_sent_prompt
         state.system_prompt = system_prompt
         state.model = model
+        state.reasoning_effort = reasoning_effort
         state.tools_fingerprint = tools_fp
 
         try:
-            await self._ensure_session(state, model, tools, system_prompt)
+            await self._ensure_session(state, model, tools, system_prompt, reasoning_effort)
         except Exception as exc:  # noqa: BLE001 — surfaced as ExecutorError (CancelledError propagates)
             await self.close_session(session_key)
             yield ExecutorError(message=f"Failed to start copilot-sdk session: {exc}")

--- a/omnigent/reasoning_effort.py
+++ b/omnigent/reasoning_effort.py
@@ -16,6 +16,10 @@ CODEX_EFFORTS = OPENAI_EFFORTS
 OPENAI_AGENTS_EFFORTS = OPENAI_EFFORTS
 GEMINI_EFFORTS = frozenset({"low", "medium", "high"})
 ANTIGRAVITY_EFFORTS = GEMINI_EFFORTS
+# The GitHub Copilot SDK's ``create_session(reasoning_effort=...)`` accepts
+# exactly these levels (``copilot.session.ReasoningEffort`` literal); per-model
+# support is gated by the Copilot backend (``list_models()``).
+COPILOT_EFFORTS = frozenset({"low", "medium", "high", "xhigh"})
 
 
 def format_supported(values: Iterable[str]) -> str:

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -29,6 +29,7 @@ from omnigent.inner.copilot_executor import (
     _event_data,
     _finalize_usage,
     _resolve_model,
+    _resolve_reasoning_effort,
 )
 from omnigent.inner.executor import (
     ExecutorConfig,
@@ -213,6 +214,20 @@ def test_resolve_model_passthrough_and_databricks_drop() -> None:
     assert _resolve_model(None) is None
     assert _resolve_model("claude-haiku-4.5") == "claude-haiku-4.5"
     assert _resolve_model("databricks-claude-opus-4-8") is None
+
+
+def test_resolve_reasoning_effort() -> None:
+    # No config / no effort -> None (model default).
+    assert _resolve_reasoning_effort(None) is None
+    assert _resolve_reasoning_effort(ExecutorConfig()) is None
+    # Supported Copilot levels pass through.
+    for level in ("low", "medium", "high", "xhigh"):
+        assert (
+            _resolve_reasoning_effort(ExecutorConfig(extra={"reasoning_effort": level})) == level
+        )
+    # Values Copilot can't honor (OpenAI-style) are dropped, not raised.
+    assert _resolve_reasoning_effort(ExecutorConfig(extra={"reasoning_effort": "minimal"})) is None
+    assert _resolve_reasoning_effort(ExecutorConfig(extra={"reasoning_effort": "none"})) is None
 
 
 def test_build_prompt_first_turn_history_and_latest() -> None:
@@ -483,6 +498,64 @@ async def test_system_message_and_model_threaded(monkeypatch: pytest.MonkeyPatch
     # system prompt delivered as an append-mode system_message.
     assert kwargs["system_message"] == {"mode": "append", "content": "SYS"}
     assert kwargs["on_permission_request"] == _PermissionHandler.approve_all
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_threaded_to_create_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_copilot(monkeypatch, [[_ev("ASSISTANT_MESSAGE", content="ok")]])
+    ex = CopilotExecutor(github_token="gho_x")
+    _ = [
+        e
+        async for e in ex.run_turn(
+            [_user("hi")], [], "SYS", ExecutorConfig(extra={"reasoning_effort": "high"})
+        )
+    ]
+    # The /reasoning pick reaches the SDK's create_session.
+    assert state["create_kwargs"][0]["reasoning_effort"] == "high"
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_omitted_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(monkeypatch, [[_ev("ASSISTANT_MESSAGE", content="ok")]])
+    ex = CopilotExecutor(github_token="gho_x")
+    _ = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    # No effort pinned -> None, so the model uses its default.
+    assert state["create_kwargs"][0]["reasoning_effort"] is None
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_session_restart_on_reasoning_effort_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [
+            [_ev("ASSISTANT_MESSAGE", content="one")],
+            [_ev("ASSISTANT_MESSAGE", content="two")],
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    _ = [
+        e
+        async for e in ex.run_turn(
+            [_user("first")], [], "SYS", ExecutorConfig(extra={"reasoning_effort": "low"})
+        )
+    ]
+    _ = [
+        e
+        async for e in ex.run_turn(
+            [_user("second")], [], "SYS", ExecutorConfig(extra={"reasoning_effort": "high"})
+        )
+    ]
+    # Reasoning effort is fixed at session creation, so a change recreates it.
+    assert len(state["create_kwargs"]) == 2
+    assert [k["reasoning_effort"] for k in state["create_kwargs"]] == ["low", "high"]
+    assert state["client_closed"] >= 1
     await ex.close()
 
 


### PR DESCRIPTION
## Related issue

Closes #1502

## Summary

- The runtime adapter threads a web `/reasoning` pick into
  `config.extra["reasoning_effort"]`, but the copilot executor's `run_turn`
  read only `config.model`, so the effort never reached the Copilot SDK. A
  `/reasoning` change was a silent no-op for copilot agents (parity gap vs
  codex-native / antigravity-native / claude-sdk, which already honor it).
- Resolve the per-turn effort from `config.extra`, validate it against the
  Copilot SDK's accepted levels (`low`, `medium`, `high`, `xhigh`, matching
  `copilot.session.ReasoningEffort`), and pass it to
  `create_session(reasoning_effort=...)`. Like the model, effort is fixed at
  session creation, so a change recreates the session (history is re-seeded via
  the first-turn replay). An unsupported value is dropped with a warning rather
  than failing the turn, matching the codex-native path.
- `max_tokens` (also present in `config.extra`) is intentionally not forwarded:
  the Copilot SDK exposes no per-turn output-token cap. Verified against
  `github/copilot-sdk` at the `1.0.66-1` commit that neither `create_session`
  nor `send`/`send_and_wait` accept one; the only `max_output_tokens` lever is a
  model capability override folded into context-window math, not a generation
  limit. This is documented in the resolver docstring.

## Test Plan

- `python -m pytest -o addopts="" tests/inner/test_copilot_executor.py -q` -> 39
  passed (4 new tests: pure resolver pass-through + drop, effort forwarded to
  `create_session`, omitted when unset, session restart on effort change).
- `ruff check` + `ruff format --check` on the changed files: clean.
- Live verification against the real Copilot backend (`gpt-5-mini`), spying on
  the real `CopilotClient.create_session`:
  - forward path: `config.extra={"reasoning_effort":"high"}` ->
    `create_session` received `reasoning_effort='high'`, turn completed, answer
    correct.
  - drop path: `config.extra={"reasoning_effort":"minimal"}` (not a Copilot
    level) -> warning logged, `create_session` received `reasoning_effort=None`,
    turn still completed.
- Cross-checked the effort levels three ways: installed `github-copilot-sdk`
  source + runtime introspection, the bundled `1.0.1` metadata, and the latest
  `github/copilot-sdk` repo at `1.0.66-1`
  (`ReasoningEffort = Literal["low","medium","high","xhigh"]`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was a live run against the real Copilot backend
(`gpt-5-mini`) that spied on the SDK's `create_session`: a `high` effort was
forwarded and the turn completed, while an unsupported `minimal` effort was
dropped (warned) to `None` and the turn still completed. The reasoning-effort
levels were additionally confirmed against the latest `github/copilot-sdk`
source at the `1.0.66-1` commit.
