### PR TITLE
feat(copilot): emit CompactionComplete on SDK context compaction

### DIFF
--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -59,6 +59,7 @@ from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from
 
 from .datamodel import OSEnvSpec
 from .executor import (
+    CompactionComplete,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -580,6 +581,32 @@ class CopilotExecutor(Executor):
                 turn_error = str(
                     data.get("message") or data.get("errorMessage") or "copilot session error"
                 )
+            elif etype.endswith("SESSION_COMPACTION_COMPLETE"):
+                # The Copilot SDK auto-compacted the session's context window.
+                # Surface it as a CompactionComplete so the runner persists a
+                # compaction item and a resumed session gets the pre-compacted
+                # summary instead of replaying the full transcript (parity with
+                # claude-sdk / openai-agents). Only a *successful* compaction
+                # counts; ``success`` is False on a failed/aborted attempt.
+                if data.get("success"):
+                    post_tokens = data.get("postCompactionTokens")
+                    yield CompactionComplete(
+                        # Copilot uniquely reports the real summary text; fall
+                        # back to a synthetic placeholder like the peers do.
+                        summary=str(
+                            data.get("summaryContent")
+                            or "[GitHub Copilot compaction: context was automatically compacted]"
+                        ),
+                        # Post-compaction context size (same semantic as the
+                        # peers' ``context_tokens``).
+                        token_count=(
+                            int(post_tokens) if isinstance(post_tokens, (int, float)) else 0
+                        ),
+                        model=usage_model or model,
+                        # The event carries no message list; resume falls back to
+                        # the summary (allowed by the field's contract).
+                        compacted_messages=None,
+                    )
 
         try:
             while True:

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -31,6 +31,7 @@ from omnigent.inner.copilot_executor import (
     _resolve_model,
 )
 from omnigent.inner.executor import (
+    CompactionComplete,
     ExecutorConfig,
     ExecutorError,
     Message,
@@ -361,6 +362,89 @@ async def test_run_turn_streams_text_reasoning_and_usage(
     # github_token threaded to the client; unsubscribed after the turn.
     assert state["client_kwargs"][0]["github_token"] == "gho_x"
     assert state["unsub_calls"] >= 1
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_emits_compaction_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A successful SDK compaction surfaces as a CompactionComplete (before
+    # TurnComplete) so the runner persists a compaction item and a resumed
+    # session skips replaying the full transcript.
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("SESSION_COMPACTION_START", conversationTokens=120000),
+                _ev("ASSISTANT_USAGE", model="claude-haiku-4.5", inputTokens=5, outputTokens=1),
+                _ev(
+                    "SESSION_COMPACTION_COMPLETE",
+                    success=True,
+                    summaryContent="summary of the conversation so far",
+                    postCompactionTokens=4200,
+                    preCompactionTokens=120000,
+                    tokensRemoved=115800,
+                    messagesRemoved=42,
+                ),
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="done"),
+                _ev("ASSISTANT_MESSAGE", content="done"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    comps = [e for e in events if isinstance(e, CompactionComplete)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(comps) == 1
+    assert comps[0].summary == "summary of the conversation so far"
+    assert comps[0].token_count == 4200
+    assert comps[0].model == "claude-haiku-4.5"
+    assert comps[0].compacted_messages is None
+    # CompactionComplete must precede TurnComplete (runner persists it first).
+    assert events.index(comps[0]) < events.index(completes[0])
+    assert completes and completes[0].response == "done"
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_compaction_without_summary_uses_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No summaryContent -> synthetic placeholder; missing postCompactionTokens -> 0.
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("SESSION_COMPACTION_COMPLETE", success=True),
+                _ev("ASSISTANT_MESSAGE", content="ok"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    comps = [e for e in events if isinstance(e, CompactionComplete)]
+    assert len(comps) == 1
+    assert comps[0].summary.startswith("[GitHub Copilot compaction")
+    assert comps[0].token_count == 0
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_compaction_emits_no_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A failed/aborted compaction (success=False) must emit nothing.
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("SESSION_COMPACTION_COMPLETE", success=False, error="compaction failed"),
+                _ev("ASSISTANT_MESSAGE", content="ok"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    assert not [e for e in events if isinstance(e, CompactionComplete)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert completes and completes[0].response == "ok"
     await ex.close()
 
 


### PR DESCRIPTION
## Related issue

Closes #1504

## Summary

- The copilot executor's `_drain` mapped streamed Copilot `SessionEvent`s to
  ExecutorEvents but had no branch for `session.compaction_start` /
  `session.compaction_complete`, so a Copilot auto-compaction was silently
  dropped. The runner never persisted a compaction item, and a resumed session
  replayed the full transcript instead of the pre-compacted summary.
- Handle `SESSION_COMPACTION_COMPLETE`: on a successful compaction, emit a
  `CompactionComplete` (before `TurnComplete`) carrying the real `summaryContent`
  the Copilot SDK reports (synthetic placeholder fallback) and the
  `postCompactionTokens` count, matching the claude-sdk / openai-agents
  harnesses. A failed/aborted compaction (`success=False`) emits nothing.
  `compaction_start` carries only pre-compaction token counts and has no
  corresponding event, so it is left unhandled.

## Test Plan

- `python -m pytest -o addopts="" tests/inner/test_copilot_executor.py -q` -> 38
  passed (3 new tests: emits `CompactionComplete` before `TurnComplete` with the
  real summary + post-compaction tokens; placeholder + 0 fallback when those are
  absent; no event on `success=False`).
- `ruff check` + `ruff format --check` on the changed files: clean.
- The fake-SDK event shapes (`success`, `summaryContent`, `postCompactionTokens`)
  were verified against the installed `github-copilot-sdk`'s
  `SessionCompactionCompleteData.to_dict()`, and cross-checked against the latest
  `github/copilot-sdk` repo at the `1.0.66-1` commit
  (`SESSION_COMPACTION_START` / `SESSION_COMPACTION_COMPLETE`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Live verification was not practical for this path: organic compaction requires
genuinely overflowing the model's context window in one turn, and the harness
does not enable infinite-sessions. Coverage is via fake-SDK unit tests whose
event shapes were verified against the installed SDK's
`SessionCompactionCompleteData.to_dict()` (and the latest `github/copilot-sdk`
source), which is the same approach the claude-sdk / openai-agents harnesses use
for their compaction events.
