### PR TITLE
fix(policies): reject url-type session policies loudly instead of skipping

### DIFF
--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -23,6 +23,7 @@ import cachetools
 
 from omnigent.entities import Conversation
 from omnigent.entities import Policy as StoredPolicy
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.llms.context_window import fetch_model_pricing
 from omnigent.policies.base import Policy
 from omnigent.policies.function import resolve_function_policy
@@ -853,9 +854,10 @@ def _load_session_policy_specs(
     Load enabled session policies from the store and convert
     them to :class:`FunctionPolicySpec` instances.
 
-    Only ``type="python"`` policies are instantiable today.
-    ``type="url"`` policies are skipped silently
-    (URL policy evaluation is a future extension).
+    Only ``type="python"`` policies are instantiable today. An
+    enabled policy of an unsupported type (e.g. ``type="url"``)
+    raises :class:`OmnigentError` rather than being skipped, so a
+    stored guardrail that never enforces fails loudly.
 
     :param conversation_id: The session whose policies to load,
         e.g. ``"conv_abc123"``.
@@ -863,6 +865,8 @@ def _load_session_policy_specs(
         ``None`` returns an empty list.
     :returns: List of :class:`FunctionPolicySpec` for enabled
         session policies, in ``created_at ASC`` order.
+    :raises OmnigentError: If an enabled policy has an unsupported
+        ``type`` (e.g. ``type="url"``).
     """
     if policy_store is None:
         return []
@@ -871,13 +875,11 @@ def _load_session_policy_specs(
     for policy in stored:
         if not policy.enabled:
             continue
-        converted = _stored_policy_to_spec(policy)
-        if converted is not None:
-            specs.append(converted)
+        specs.append(_stored_policy_to_spec(policy))
     return specs
 
 
-def _stored_policy_to_spec(policy: StoredPolicy) -> PolicySpec | None:
+def _stored_policy_to_spec(policy: StoredPolicy) -> PolicySpec:
     """
     Convert a stored :class:`Policy` entity to a
     :class:`FunctionPolicySpec`.
@@ -888,12 +890,15 @@ def _stored_policy_to_spec(policy: StoredPolicy) -> PolicySpec | None:
     all phases (``on=None``) — the callable itself decides
     whether to act by inspecting ``event["type"]``.
 
-    For ``type="url"``, returns ``None`` (URL policy evaluation
-    is a future extension).
+    For ``type="url"``, raises :class:`OmnigentError` (URL policy evaluation
+    is unimplemented). A stored policy that never enforces is a silent
+    safety hole, so converting an unsupported type fails loudly rather than
+    returning ``None``.
 
     :param policy: The stored session policy entity.
-    :returns: A :class:`FunctionPolicySpec`, or ``None`` if the
-        policy type is not yet supported at evaluation time.
+    :returns: A :class:`FunctionPolicySpec`.
+    :raises OmnigentError: If the policy ``type`` cannot be evaluated yet
+        (e.g. ``type="url"``).
     """
     if policy.type == "python":
         return FunctionPolicySpec(
@@ -906,8 +911,16 @@ def _stored_policy_to_spec(policy: StoredPolicy) -> PolicySpec | None:
                 arguments=policy.factory_params,
             ),
         )
-    # type="url" — future extension; skip silently.
-    return None
+    # Any non-"python" type (today only "url") cannot be evaluated yet.
+    # Reject loudly and fail closed: a stored policy that silently never
+    # enforces is worse than a visible failure the operator can act on.
+    raise OmnigentError(
+        f"Session policy {policy.name!r} (id {policy.id!r}) has unsupported "
+        f"type {policy.type!r}; only type='python' policies can be evaluated "
+        f"today. URL policy evaluation is a future extension. Remove or "
+        f"disable this policy, since storing it does not enforce anything.",
+        code=ErrorCode.INVALID_INPUT,
+    )
 
 
 __all__ = ["build_policy_engine"]

--- a/tests/runtime/policies/test_builder_session_policies.py
+++ b/tests/runtime/policies/test_builder_session_policies.py
@@ -8,7 +8,10 @@ engine evaluation alongside spec-declared policies.
 
 from __future__ import annotations
 
+import pytest
+
 from omnigent.entities import Policy as StoredPolicy
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.policies.function import FunctionPolicy
 from omnigent.runtime.policies.builder import (
     _load_session_policy_specs,
@@ -74,8 +77,13 @@ def test_stored_python_policy_without_factory_params() -> None:
     assert spec.function.arguments is None
 
 
-def test_stored_url_policy_returns_none() -> None:
-    """A stored ``type="url"`` policy returns ``None`` (not yet supported)."""
+def test_stored_url_policy_raises() -> None:
+    """A stored ``type="url"`` policy is rejected loudly, not skipped.
+
+    URL policy evaluation is unimplemented; converting one must raise
+    rather than silently return ``None`` (which would let an operator
+    store a guardrail that never enforces).
+    """
     stored = StoredPolicy(
         id="pol_url",
         name="external",
@@ -84,7 +92,11 @@ def test_stored_url_policy_returns_none() -> None:
         type="url",
         handler="https://example.com/eval",
     )
-    assert _stored_policy_to_spec(stored) is None
+    with pytest.raises(OmnigentError) as excinfo:
+        _stored_policy_to_spec(stored)
+    assert excinfo.value.code == ErrorCode.INVALID_INPUT
+    assert "url" in str(excinfo.value)
+    assert "external" in str(excinfo.value)
 
 
 # ── _load_session_policy_specs ──────────────────────────────────────────────
@@ -124,6 +136,28 @@ def test_load_session_policy_specs_filters_disabled(db_uri: str) -> None:
 
     assert len(specs) == 1
     assert specs[0].name == "enabled_policy"
+
+
+def test_load_session_policy_specs_rejects_enabled_url(db_uri: str) -> None:
+    """An enabled url-type session policy raises at load time (fail closed).
+
+    :param db_uri: Per-test SQLite URI from the root conftest.
+    """
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conv = conv_store.create_conversation()
+    store = SqlAlchemyPolicyStore(db_uri)
+    store.create(
+        policy_id="pol_url",
+        session_id=conv.id,
+        name="external",
+        type="url",
+        handler="https://example.com/eval",
+        enabled=True,
+    )
+
+    with pytest.raises(OmnigentError) as excinfo:
+        _load_session_policy_specs(conv.id, store)
+    assert excinfo.value.code == ErrorCode.INVALID_INPUT
 
 
 # ── build_policy_engine integration ─────────────────────────────────────────


### PR DESCRIPTION
## Related issue

Closes #1506

## Summary

- A session policy of `type="url"` was silently skipped at evaluation:
  `_stored_policy_to_spec` returned `None` for any non-`python` type and
  `_load_session_policy_specs` dropped it, so an operator could store a guardrail
  that never enforces, with no warning or error.
- Raise `OmnigentError(code=INVALID_INPUT)` for an unsupported policy type
  instead of returning `None`, so an enabled `url`-type policy fails loudly and
  fails closed (the session cannot proceed believing a non-existent guardrail is
  active). URL policy evaluation remains a future extension.
- Tightened the return type to `PolicySpec` (no longer Optional) and refreshed
  the two stale docstrings that described the silent-skip behavior.
- Create-time behavior is unchanged: the CRUD API still accepts/stores `url`
  policies (a deliberate placeholder); only evaluation now refuses to run with an
  unenforceable policy.

## Test Plan

- `python -m pytest -o addopts="" tests/runtime/policies/ tests/stores/test_session_policy_store.py -q`
  -> 363 passed.
- New/updated tests in `tests/runtime/policies/test_builder_session_policies.py`:
  inverted the old "returns None" test to assert a `url` policy now raises
  `OmnigentError` with `code=INVALID_INPUT`, and added a db-backed test that an
  enabled `url` policy raises at load time. Existing `python`/disabled-policy and
  CRUD/store tests are unchanged and still pass.
- `ruff check` + `ruff format --check` on the changed files: clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by unit tests. No model credentials or live services are involved;
the change is a pure evaluation-time guard in the policy builder.
