### PR TITLE
feat: support native session permission mode changes from Web UI

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -5890,6 +5890,40 @@ def _read_json_file(path: Path) -> _JsonObject:
     return payload if isinstance(payload, dict) else {}
 
 
+def update_permission_mode(bridge_dir: Path, permission_mode: str) -> bool:
+    """Update the invocation-local Claude permission mode.
+
+    :param bridge_dir: Claude-native bridge directory for the live session.
+    :param permission_mode: Claude permission mode, or ``"default"`` to clear
+        the override.
+    :returns: ``True`` when the invocation settings existed and were updated;
+        ``False`` when the bridge has not created them yet.
+    """
+    valid_modes = {"default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"}
+    if permission_mode not in valid_modes:
+        raise ValueError(f"Unsupported Claude permission mode: {permission_mode!r}")
+
+    settings_path = bridge_dir / _INVOCATION_SETTINGS_FILE
+    if not settings_path.is_file():
+        return False
+    settings = _read_json_file(settings_path)
+    permissions = settings.get("permissions")
+    if not isinstance(permissions, dict):
+        permissions = {}
+    else:
+        permissions = dict(permissions)
+    if permission_mode == "default":
+        permissions.pop("defaultMode", None)
+    else:
+        permissions["defaultMode"] = permission_mode
+    if permissions:
+        settings["permissions"] = permissions
+    else:
+        settings.pop("permissions", None)
+    _write_json_file(settings_path, settings)
+    return True
+
+
 def _write_json_file(path: Path, payload: _JsonObject) -> None:
     """
     Atomically write a JSON object file with owner-only permissions.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6334,6 +6334,40 @@ def create_runner_app(
                 )
             return Response(status_code=204)
 
+        if body_type == "permission_mode_change":
+            harness = _session_harness_name(conversation_id)
+            if harness == "claude-native":
+                permission_mode = body.get("permission_mode") if isinstance(body, dict) else None
+                if not isinstance(permission_mode, str) or not permission_mode:
+                    return JSONResponse(
+                        status_code=400,
+                        content={
+                            "error": "invalid_input",
+                            "detail": "Body 'permission_mode' must be a non-empty string",
+                        },
+                    )
+                from omnigent.claude_native_bridge import (
+                    bridge_dir_for_bridge_id,
+                    update_permission_mode,
+                )
+
+                bridge_id = await _claude_native_bridge_id_for_session(
+                    server_client=server_client,
+                    session_id=conversation_id,
+                )
+                try:
+                    await asyncio.to_thread(
+                        update_permission_mode,
+                        bridge_dir_for_bridge_id(bridge_id),
+                        permission_mode,
+                    )
+                except ValueError as exc:
+                    return JSONResponse(
+                        status_code=400,
+                        content={"error": "invalid_input", "detail": str(exc)},
+                    )
+            return Response(status_code=204)
+
         if body_type == "plan_mode_change":
             harness = _session_harness_name(conversation_id)
             if harness == "codex-native":

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -473,6 +473,12 @@ Fields:
     `PATCH /v1/sessions/{id}` (also the path the REPL's `/model`
     command uses) so the web picker and the TUI stay in sync.
 
+  permission_mode (string)
+    Effective Claude-native permission mode: `default`, `auto`,
+    `acceptEdits`, `plan`, `dontAsk`, or `bypassPermissions`. Derived from
+    `terminal_launch_args`; `default` means no launch override is active.
+    Set via `PATCH /v1/sessions/{id}`.
+
   cost_control_mode_override (string or null)
     Per-session cost-control switch: `"on"` activates the spec's
     configured cost-control mode, `"off"` disables cost control for
@@ -765,6 +771,7 @@ Content-Type: application/json
   "labels": {"env": "test"},
   "reasoning_effort": "high",
   "model_override": "claude-opus-4-7",
+  "permission_mode": "acceptEdits",
   "collaboration_mode": "plan",
   "external_session_id": "a1b2c3d4-1234-5678-9abc-def012345678"
 }
@@ -806,6 +813,13 @@ Request body:
     persisted; if no live runner or loaded Codex bridge can apply the
     change, the request fails and the stored mode is left unchanged.
 
+  permission_mode (string, optional)
+    Claude-native permission mode: `default`, `auto`, `acceptEdits`, `plan`,
+    `dontAsk`, or `bypassPermissions`. Replaces any existing
+    `--permission-mode` launch argument while preserving other arguments and
+    forwards the change to a live Claude runner. `default` clears the launch
+    override. Any other value fails with 400 `invalid_input`.
+
   cost_control_mode_override (string or null, optional)
     Per-session cost-control switch: `"on"` activates the spec's
     configured cost-control mode, `"off"` disables cost control for
@@ -826,8 +840,8 @@ Request body:
 `runner_id` set to the newly bound value when `runner_id` was present.
 
 400 Bad Request - runner is not currently registered; `collaboration_mode`
-is used on a non-Codex-native session; or `external_session_id` would
-overwrite a different existing value
+is used on a non-Codex-native session; `permission_mode` is invalid; or
+`external_session_id` would overwrite a different existing value
 404 Not Found - no session with that id
 
 This is the mutable affinity primitive for Alpha. The same endpoint

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1044,6 +1044,13 @@ def _build_session_response(
     labels = labels_with_closed_status(_labels_for_viewer(conv.labels, viewer_id), conv.title)
     if agent_name in (_CLAUDE_NATIVE_MODEL, _CODEX_NATIVE_MODEL):
         labels = {**labels, _CLAUDE_NATIVE_UI_LABEL_KEY: _CLAUDE_NATIVE_UI_LABEL_VALUE}
+    permission_mode = "default"
+    launch_args = conv.terminal_launch_args or []
+    for index, arg in enumerate(launch_args):
+        if arg.startswith("--permission-mode="):
+            permission_mode = arg.split("=", 1)[1] or "default"
+        elif arg == "--permission-mode" and index + 1 < len(launch_args):
+            permission_mode = launch_args[index + 1]
     return SessionResponse(
         id=conv.id,
         agent_id=conv.agent_id,
@@ -1089,6 +1096,7 @@ def _build_session_response(
         last_task_error=last_task_error,
         external_session_id=conv.external_session_id,
         terminal_launch_args=conv.terminal_launch_args,
+        permission_mode=permission_mode,
         # Replay outstanding approval prompts into the snapshot.
         # The live SSE stream has no buffer, so a prompt emitted
         # before the user opened this chat would otherwise never

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -189,6 +189,10 @@ from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
 
+_CLAUDE_PERMISSION_MODES = frozenset(
+    {"default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"}
+)
+
 
 def register_core_routes(
     router: APIRouter,
@@ -1669,6 +1673,40 @@ def register_core_routes(
                 code=ErrorCode.INVALID_INPUT,
             ) from exc
 
+        permission_mode = body.permission_mode
+        if permission_mode is not None:
+            if permission_mode not in _CLAUDE_PERMISSION_MODES:
+                raise OmnigentError(
+                    f"invalid permission_mode: must be one of {sorted(_CLAUDE_PERMISSION_MODES)}",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            if terminal_launch_args is None:
+                conv_for_permission_mode = conv_for_collaboration_mode
+                if conv_for_permission_mode is None:
+                    conv_for_permission_mode = await asyncio.to_thread(
+                        conversation_store.get_conversation,
+                        session_id,
+                    )
+                if conv_for_permission_mode is None:
+                    raise _session_not_found()
+                terminal_launch_args = list(conv_for_permission_mode.terminal_launch_args or [])
+
+            resolved_launch_args: list[str] = []
+            index = 0
+            while index < len(terminal_launch_args):
+                arg = terminal_launch_args[index]
+                if arg == "--permission-mode":
+                    index += 2
+                    continue
+                if arg.startswith("--permission-mode="):
+                    index += 1
+                    continue
+                resolved_launch_args.append(arg)
+                index += 1
+            if permission_mode != "default":
+                resolved_launch_args.extend(("--permission-mode", permission_mode))
+            terminal_launch_args = resolved_launch_args
+
         if body.runner_id is not None:
             # Empty string is the clear sentinel (None = leave unchanged);
             # used by /clear and /switch to move the runner between sessions.
@@ -1843,6 +1881,15 @@ def register_core_routes(
                     updated.model_override,
                     conversation_store,
                 )
+        if live_forward and permission_mode is not None:
+            await _forward_session_change_to_runner(
+                session_id,
+                runner_router,
+                {
+                    "type": "permission_mode_change",
+                    "permission_mode": permission_mode,
+                },
+            )
         if requested_codex_collaboration_mode is not None and live_forward:
             _codex_plan_enabled = _codex_plan_mode_enabled(requested_codex_collaboration_mode)
             _runner_result = await _forward_session_change_to_runner(

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1769,6 +1769,8 @@ class SessionResponse(BaseModel):
         ``["--dangerously-skip-permissions"]``. ``None`` for
         non-native sessions or a native session launched with none.
         Lets the launcher reproduce the command on resume.
+    :param permission_mode: Effective Claude-native permission mode derived
+        from ``terminal_launch_args``. ``"default"`` when no override is set.
     :param pending_elicitations: Outstanding approval prompts on
         this session at the moment the snapshot was built — the
         original ``response.elicitation_request`` event dicts.
@@ -1888,6 +1890,7 @@ class SessionResponse(BaseModel):
     last_task_error: dict[str, str] | None = None
     external_session_id: str | None = None
     terminal_launch_args: list[str] | None = None
+    permission_mode: str | None = None
     pending_elicitations: list[dict[str, Any]] = Field(default_factory=list)
     # Un-consumed web-composer user messages on native-terminal
     # sessions at snapshot time, each ``{"pending_id", "content"}``.
@@ -1979,10 +1982,14 @@ class UpdateSessionRequest(BaseModel):
         A list (including ``[]``) replaces the stored value wholesale
         — resume is last-write-wins, never an append. Bounds (count /
         length) are validated server-side. ``None`` leaves unchanged.
+    :param permission_mode: Claude-native permission mode. A supported value
+        replaces any existing ``--permission-mode`` launch argument and is
+        forwarded to a live runner. ``"default"`` clears the launch override;
+        ``None`` leaves it unchanged.
     :param silent: When ``True``, persist metadata changes but skip
         the runner-side side effects — specifically the
-        native ``/effort`` / ``/model`` / Codex collaboration-mode
-        forwards into the live runtime. Used by automatic bind-time
+        native ``/effort`` / ``/model`` / permission-mode / Codex
+        collaboration-mode forwards into the live runtime. Used by automatic bind-time
         handoffs (web's sticky-pref apply on session switch, the
         REPL's pre-create ``/model`` snapshot) where injecting a
         visible slash command into a freshly-spawned pane would
@@ -2014,6 +2021,7 @@ class UpdateSessionRequest(BaseModel):
     subagent_routing_override: str | None = None
     external_session_id: str | None = None
     terminal_launch_args: list[str] | None = None
+    permission_mode: str | None = None
     archived: bool | None = None
     project_id: str | None = None
     silent: bool = False

--- a/openapi.json
+++ b/openapi.json
@@ -5160,6 +5160,18 @@
             "description": "The requesting user's numeric permission level on this session: `1` = read, `2` = edit, `3` = manage. `None` when permissions are disabled (single-user mode without a permission store).",
             "title": "Permission Level"
           },
+          "permission_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Effective Claude-native permission mode derived from `terminal_launch_args`. `\"default\"` when no override is set.",
+            "title": "Permission Mode"
+          },
           "project_id": {
             "anyOf": [
               {
@@ -6605,6 +6617,18 @@
             "description": "Per-session LLM model override, e.g. `\"claude-opus-4-7\"`. The value is forwarded as-is to the executor at turn start; the server does not enumerate valid models. Clear aliases such as `\"default\"`, `\"off\"`, or `\"reset\"` remove the override (matching the REPL's `/model` semantics). `None` leaves unchanged.",
             "title": "Model Override"
           },
+          "permission_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Claude-native permission mode. A supported value replaces any existing `--permission-mode` launch argument and is forwarded to a live runner. `\"default\"` clears the launch override; `None` leaves it unchanged.",
+            "title": "Permission Mode"
+          },
           "project_id": {
             "anyOf": [
               {
@@ -6643,7 +6667,7 @@
           },
           "silent": {
             "default": false,
-            "description": "When `True`, persist metadata changes but skip the runner-side side effects \u2014 specifically the native `/effort` / `/model` / Codex collaboration-mode forwards into the live runtime. Used by automatic bind-time handoffs (web's sticky-pref apply on session switch, the REPL's pre-create `/model` snapshot) where injecting a visible slash command into a freshly-spawned pane would render as an unexpected \"Command model X\" item before the user has sent anything. Default `False` preserves the user-driven picker / `/model` behaviour where the live forward IS the desired feedback.",
+            "description": "When `True`, persist metadata changes but skip the runner-side side effects \u2014 specifically the native `/effort` / `/model` / permission-mode / Codex collaboration-mode forwards into the live runtime. Used by automatic bind-time handoffs (web's sticky-pref apply on session switch, the REPL's pre-create `/model` snapshot) where injecting a visible slash command into a freshly-spawned pane would render as an unexpected \"Command model X\" item before the user has sent anything. Default `False` preserves the user-driven picker / `/model` behaviour where the live forward IS the desired feedback.",
             "title": "Silent",
             "type": "boolean"
           },

--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -47,6 +47,7 @@ def _patch_session_as_claude_native(
     catalog_state: dict[str, bool] | None = None,
     model_options: list[dict] | None = None,
     llm_model: str = "system.ai.claude-sonnet-5",
+    permission_mode: str = "default",
     host_asleep: bool = False,
 ) -> list[dict]:
     """Patch the browser's session snapshot into a claude-native response.
@@ -63,16 +64,18 @@ def _patch_session_as_claude_native(
     :param catalog_state: Optional mutable readiness gate for delayed options.
     :param model_options: Catalog rows to expose; defaults to the live-alias set.
     :param llm_model: Bound model id shown for the session.
+    :param permission_mode: Effective Claude permission mode exposed in the snapshot.
     :param host_asleep: Shape the snapshot like a dormant resumable managed
         host (host-bound, resumable, aged past the startup grace); pair with
         :func:`_force_asleep_liveness` to drive the ``host_asleep`` state.
     :returns: Captured PATCH request bodies.
     """
     latest_payload: dict | None = None
+    current_permission_mode = permission_mode
     patch_bodies: list[dict] = []
 
     def _handle(route: Route) -> None:
-        nonlocal latest_payload
+        nonlocal current_permission_mode, latest_payload
         request = route.request
         parsed = urlparse(request.url)
         if parsed.path != f"/v1/sessions/{session_id}":
@@ -90,6 +93,8 @@ def _patch_session_as_claude_native(
             payload = dict(latest_payload or {})
             if "model_override" in request_body:
                 payload["model_override"] = request_body["model_override"]
+            if "permission_mode" in request_body:
+                current_permission_mode = request_body["permission_mode"]
         else:
             route.continue_()
             return
@@ -100,6 +105,7 @@ def _patch_session_as_claude_native(
         }
         payload["harness"] = "claude"
         payload["llm_model"] = llm_model
+        payload["permission_mode"] = current_permission_mode
         catalog = _MODEL_OPTIONS if model_options is None else model_options
         payload["model_options"] = (
             catalog if catalog_state is None or catalog_state["ready"] else []
@@ -263,6 +269,38 @@ def test_claude_native_alias_selection_persists(
     assert patch_bodies[-1] == {"model_override": "opus"}
     # The read-only composer label reflects the new pick.
     expect(page.get_by_test_id("composer-model-effort-label")).to_contain_text("Opus 4.10")
+
+
+def test_claude_native_permission_mode_persists(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Changing permissions in the session config PATCHes the selected mode."""
+    base_url, session_id = seeded_session
+    patch_bodies = _patch_session_as_claude_native(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    gear = page.get_by_test_id("composer-config-gear")
+    expect(gear).to_be_visible(timeout=15_000)
+    gear.click()
+    page.get_by_test_id("composer-config-permission").click()
+    page.get_by_role("option", name="Accept edits").click()
+
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH"
+            and urlparse(response.url).path == f"/v1/sessions/{session_id}"
+            and response.status == 200
+        )
+    ):
+        page.get_by_test_id("composer-config-save").click()
+
+    assert patch_bodies[-1] == {"permission_mode": "acceptEdits"}
+    gear.hover()
+    expect(page.get_by_test_id("composer-config-gear-tooltip")).to_contain_text(
+        "Permissions: Accept edits"
+    )
 
 
 def _force_asleep_liveness(page: Page, session_id: str) -> None:

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -1937,6 +1937,50 @@ async def test_events_model_change_on_native_session_types_slash_command(
 
 
 @pytest.mark.asyncio
+async def test_events_permission_mode_change_updates_claude_invocation_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claude-native permission events update the live invocation sidecar."""
+    captured: list[tuple[Path, str]] = []
+
+    def _fake_update(bridge_dir: Path, permission_mode: str) -> bool:
+        captured.append((bridge_dir, permission_mode))
+        return True
+
+    monkeypatch.setattr(claude_native_bridge, "update_permission_mode", _fake_update)
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return native_spec
+
+    conv_id = "57c7c1acc5eeec3978c5e62043da51b0"
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        resp = await client.post(
+            f"/v1/sessions/{conv_id}/events",
+            json={"type": "permission_mode_change", "permission_mode": "acceptEdits"},
+        )
+
+    assert resp.status_code == 204, resp.text
+    assert captured == [(bridge_dir_for_conversation_id(conv_id), "acceptEdits")]
+
+
+@pytest.mark.asyncio
 async def test_events_model_change_rejects_a_model_the_picker_cannot_spell(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -397,6 +397,54 @@ async def test_patch_session_empty_project_removes_label(
     assert "omni_project" not in conv.labels
 
 
+async def test_patch_session_permission_mode(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """Permission changes replace the launch flag and preserve unrelated args."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conv_store.update_conversation(
+        session_id,
+        terminal_launch_args=["--verbose", "--permission-mode=plan"],
+    )
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"permission_mode": "acceptEdits"},
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["permission_mode"] == "acceptEdits"
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.terminal_launch_args == ["--verbose", "--permission-mode", "acceptEdits"]
+
+    clear_resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"permission_mode": "default"},
+        headers={"Content-Type": "application/json"},
+    )
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["permission_mode"] == "default"
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.terminal_launch_args == ["--verbose"]
+
+
+async def test_patch_session_rejects_unknown_permission_mode(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> None:
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"permission_mode": "unrestricted"},
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+    assert "invalid permission_mode" in resp.json()["error"]["message"]
+
+
 # ── Pinned session label (omnigent.pinned) ───────────────────────────
 
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2617,6 +2617,25 @@ def test_augment_claude_args_mirrors_launch_overrides_into_settings(
     assert settings["effortLevel"] == "xhigh"
 
 
+def test_update_permission_mode_preserves_and_clears_invocation_settings(tmp_path: Path) -> None:
+    """A live permission change edits only the invocation-local permission key."""
+    args = augment_claude_args(
+        ("--model", "claude-fable-5", "--permission-mode", "plan"),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+
+    assert claude_native_bridge.update_permission_mode(tmp_path, "acceptEdits") is True
+    settings = _load_invocation_settings(args)
+    assert settings["model"] == "claude-fable-5"
+    assert settings["permissions"] == {"defaultMode": "acceptEdits"}
+
+    assert claude_native_bridge.update_permission_mode(tmp_path, "default") is True
+    settings = _load_invocation_settings(args)
+    assert settings["model"] == "claude-fable-5"
+    assert "permissions" not in settings
+
+
 def test_augment_claude_args_mirrors_joined_model_arg_into_settings(
     tmp_path: Path,
 ) -> None:

--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -119,6 +119,34 @@ export const CLAUDE_NATIVE_EFFORTS: { value: string; label: string }[] = [
   { value: "max", label: "Max" },
 ];
 
+// Claude Code's `--permission-mode` choices. "default" sends no launch flag;
+// the remaining values are stored as `--permission-mode <value>`.
+export const CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE = "default";
+export const CLAUDE_NATIVE_PERMISSION_MODES: {
+  value: string;
+  label: string;
+  description: string;
+}[] = [
+  { value: "default", label: "Default", description: "Prompts before edits and commands" },
+  { value: "auto", label: "Auto", description: "Auto-runs; a classifier blocks risky actions" },
+  {
+    value: "acceptEdits",
+    label: "Accept edits",
+    description: "Auto-applies file edits; commands still prompt",
+  },
+  { value: "plan", label: "Plan", description: "Plans only; makes no edits" },
+  {
+    value: "dontAsk",
+    label: "Don't ask",
+    description: "Auto-denies anything not pre-approved",
+  },
+  {
+    value: "bypassPermissions",
+    label: "Bypass permissions",
+    description: "Runs everything; no prompts or safety checks",
+  },
+];
+
 /**
  * A labeled configuration row: bold label + muted sub-description on the left,
  * the control on the right. Mirrors the "Configure …" modal layout.

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -425,6 +425,25 @@ describe("runner binding", () => {
     expect(session.modelOverride).toBe("claude-opus-4-7");
   });
 
+  it("PATCHes permission_mode and parses the canonical response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_abc",
+        agent_id: "agent_xyz",
+        status: "idle",
+        created_at: 1704067200,
+        items: [],
+        permission_mode: "acceptEdits",
+      }),
+    );
+
+    const session = await updateSession("conv_abc", { permissionMode: "acceptEdits" });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ permission_mode: "acceptEdits" });
+    expect(session.permissionMode).toBe("acceptEdits");
+  });
+
   it("PATCHes model_override='default' when modelOverride is null (matches REPL /model semantics)", async () => {
     fetchMock.mockResolvedValueOnce(
       mockJsonResponse({

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -145,6 +145,7 @@ interface SessionResponseWire {
   /** Effective brain harness (override-aware), e.g. ``"claude-sdk"``. */
   harness?: string | null;
   model_override?: string | null;
+  permission_mode?: string | null;
   /** Per-session cost-control switch; `null`/absent = spec default. */
   cost_control_mode_override?: "on" | "off" | null;
   /** Sub-agent routing switch; `null`/absent reads the same as `"off"` (Default). */
@@ -298,6 +299,7 @@ function sessionFromWire(wire: SessionResponseWire): Session {
     llmModel: wire.llm_model,
     harness: wire.harness ?? null,
     modelOverride: wire.model_override,
+    permissionMode: wire.permission_mode,
     costControlModeOverride: wire.cost_control_mode_override,
     subagentRoutingOverride: wire.subagent_routing_override,
     contextWindow: wire.context_window,
@@ -633,7 +635,7 @@ export async function launchRunner(
 /**
  * PATCH mutable session properties.
  *
- * `null` on `reasoningEffort` / `modelOverride` sends the server's
+ * `null` on `reasoningEffort` / `modelOverride` / `permissionMode` sends the server's
  * ``"default"`` clear alias (matches the REPL's ``/effort | /model
  * default``). `null` on `costControlModeOverride` /
  * `subagentRoutingOverride` is sent as a JSON ``null`` — for those fields
@@ -652,6 +654,7 @@ export async function updateSession(
   updates: {
     reasoningEffort?: string | null;
     modelOverride?: string | null;
+    permissionMode?: string | null;
     codexPlanMode?: boolean;
     costControlModeOverride?: "on" | "off" | null;
     subagentRoutingOverride?: "on" | "off" | null;
@@ -666,6 +669,9 @@ export async function updateSession(
   }
   if ("modelOverride" in updates) {
     body.model_override = updates.modelOverride ?? "default";
+  }
+  if ("permissionMode" in updates) {
+    body.permission_mode = updates.permissionMode ?? "default";
   }
   if (updates.codexPlanMode !== undefined) {
     body.collaboration_mode = updates.codexPlanMode ? "plan" : "default";

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -308,6 +308,7 @@ export interface Session {
    * so the surfaces stay in sync.
    */
   modelOverride?: string | null;
+  permissionMode?: string | null;
   /**
    * Per-session cost-control switch: `"on"` activates the spec's
    * configured cost-control mode, `"off"` disables cost control for

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1608,6 +1608,8 @@ describe("Composer — queued-message flush gating", () => {
 });
 
 describe("Composer config gear", () => {
+  const realSetPermissionMode = useChatStore.getState().setPermissionMode;
+
   beforeEach(() => {
     useChatStore.setState({
       conversationId: "conv_test",
@@ -1617,6 +1619,7 @@ describe("Composer config gear", () => {
       llmModel: null,
       nativeVendorOwnsModel: false,
       selectedEffort: null,
+      permissionMode: "default",
       costControlModeOverride: null,
       // Opening the gear re-reads the routing switches; stub the fetch away.
       refreshSessionOverrides: vi.fn().mockResolvedValue(undefined),
@@ -1624,6 +1627,7 @@ describe("Composer config gear", () => {
   });
 
   afterEach(() => {
+    useChatStore.setState({ setPermissionMode: realSetPermissionMode });
     cleanup();
     vi.restoreAllMocks();
   });
@@ -1692,8 +1696,12 @@ describe("Composer config gear", () => {
     expect(tip.textContent).toContain("Model:");
   });
 
-  it("shows a hover summary with Harness/Model/Effort rows and no Permissions row", async () => {
-    useChatStore.setState({ selectedEffort: "high", sessionHarness: "claude-sdk" });
+  it("shows Claude's live permission mode in the hover summary", async () => {
+    useChatStore.setState({
+      selectedEffort: "high",
+      permissionMode: "acceptEdits",
+      sessionHarness: "claude-sdk",
+    });
     renderWithTooltips(
       <Composer
         {...composerProps({
@@ -1711,8 +1719,7 @@ describe("Composer config gear", () => {
     expect(tip.textContent).toContain("Harness:");
     expect(tip.textContent).toContain("Model:");
     expect(tip.textContent).toContain("Effort:");
-    // Effort is switchable in-session; permission mode is not, so it must be absent.
-    expect(tip.textContent).not.toContain("Permissions");
+    expect(tip.textContent).toContain("Permissions: Accept edits");
   });
 
   it("reflects Smart Routing in the Model row of the summary when routing is on", async () => {
@@ -1758,9 +1765,29 @@ describe("Composer config gear", () => {
     );
     fireEvent.click(gear()!);
     expect(await screen.findByTestId("composer-config-modal")).toBeTruthy();
-    // Claude native → Model + Effort selects present.
+    // Claude native → Model + Effort + Permissions selects present.
     expect(screen.getByTestId("composer-config-model")).toBeTruthy();
     expect(screen.getByTestId("composer-config-effort")).toBeTruthy();
+    expect(screen.getByTestId("composer-config-permission")).toBeTruthy();
+  });
+
+  it("applies a drafted Claude permission mode only on Save", async () => {
+    const setPermissionMode = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ setPermissionMode, permissionMode: "default" });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({ showEffort: false, showModels: true, modelPickerKind: "claude" })}
+      />,
+    );
+
+    fireEvent.click(gear()!);
+    await screen.findByTestId("composer-config-modal");
+    fireEvent.click(screen.getByTestId("composer-config-permission"));
+    fireEvent.click(screen.getByRole("option", { name: "Accept edits" }));
+    expect(setPermissionMode).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("composer-config-save"));
+    await waitFor(() => expect(setPermissionMode).toHaveBeenCalledWith("acceptEdits"));
   });
 
   it("uses the Default sentinel when Kiro marks no catalog row as default", async () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -180,7 +180,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
+  CLAUDE_NATIVE_PERMISSION_MODES,
   ConfigRow,
+  DescribedSelect,
   EFFORT_SELECT_NONE,
   EFFORT_UNAVAILABLE_PLACEHOLDER,
   MODEL_SELECT_DEFAULT,
@@ -5875,15 +5878,15 @@ const SUBAGENT_ROUTING_DESCRIPTION = "Model routing for subagents this session s
  * In-session run-config modal opened from the composer's gear icon. The
  * live-committing analogue of the new-session ``HarnessConfigModal``: only the
  * knobs switchable mid-session appear — Model (which folds Smart Routing in as
- * an option where a dropdown exists), Effort, and Subagent routing. A session's
- * own Smart Routing is otherwise a create-time choice, and
- * permission/approval/cursor modes are launch-time only (no in-session state to
- * read or write), so they are intentionally absent.
+ * an option where a dropdown exists), Effort, Claude permissions, and Subagent
+ * routing. A session's own Smart Routing is otherwise a create-time choice;
+ * approval/cursor modes remain launch-time only.
  *
  * Like the new-session modal, changes are drafted locally and only applied on
  * Save (through the store setters ``setModel`` / ``setEffort`` /
- * ``setCostControlMode`` / ``setSubagentRouting``); Cancel / dismiss discards
- * them. The setters enforce the model↔routing mutual exclusion server-side.
+ * ``setPermissionMode`` / ``setCostControlMode`` / ``setSubagentRouting``);
+ * Cancel / dismiss discards them. The setters enforce the model↔routing mutual
+ * exclusion server-side.
  */
 function SessionConfigModal({
   open,
@@ -5909,6 +5912,7 @@ function SessionConfigModal({
   subagentRoutingEligible: boolean;
 }) {
   const selectedEffort = useChatStore((s) => s.selectedEffort);
+  const permissionMode = useChatStore((s) => s.permissionMode);
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
   const subagentRoutingOverride = useChatStore((s) => s.subagentRoutingOverride);
   const conversationId = useChatStore((s) => s.conversationId);
@@ -5938,6 +5942,9 @@ function SessionConfigModal({
   // `draftRoutingOn` folds Smart Routing in as a mutually-exclusive choice.
   const [draftModelId, setDraftModelId] = useState<string | null>(resolvedModelId);
   const [draftEffort, setDraftEffort] = useState<string | null>(selectedEffort);
+  const [draftPermissionMode, setDraftPermissionMode] = useState(
+    permissionMode ?? CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
+  );
   const [draftRoutingOn, setDraftRoutingOn] = useState(liveRoutingOn);
   // The sub-agent row is stored as a PICK, not a pre-seeded draft:
   // `undefined` means "untouched", so the row mirrors the live stored value for
@@ -5952,6 +5959,7 @@ function SessionConfigModal({
     if (!open) return;
     setDraftModelId(resolvedModelId);
     setDraftEffort(selectedEffort);
+    setDraftPermissionMode(permissionMode ?? CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE);
     setDraftRoutingOn(liveRoutingOn);
     setPickedSubagentRouting(undefined);
     // Nothing pushes a routing-switch change to the client (no SSE event, and
@@ -6024,6 +6032,11 @@ function SessionConfigModal({
         // stray ``/effort`` injection would just be noise.
         if (showEffort && !draftRoutingOn && draftEffort !== selectedEffort)
           await store.setEffort(draftEffort);
+        if (
+          modelPickerKind === "claude" &&
+          draftPermissionMode !== (permissionMode ?? CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE)
+        )
+          await store.setPermissionMode(draftPermissionMode);
         // Sub-agent routing is independent of this session's own model — a
         // plain PATCH with no slash-command injection, so ordering is free.
         // Only an explicit pick is written, and only when it still differs from
@@ -6068,7 +6081,8 @@ function SessionConfigModal({
         <DialogHeader>
           <DialogTitle>Configure {harnessLabel ?? "session"}</DialogTitle>
           <DialogDescription className="sr-only">
-            Change how this session runs. Model, effort, and smart routing apply to the next turn.
+            Change how this session runs. Model, effort, permissions, and smart routing apply to the
+            next turn.
           </DialogDescription>
         </DialogHeader>
 
@@ -6122,6 +6136,17 @@ function SessionConfigModal({
                   ))}
                 </SelectContent>
               </Select>
+            </ConfigRow>
+          )}
+          {modelPickerKind === "claude" && (
+            <ConfigRow label="Permissions" description="What the agent can do without asking">
+              <DescribedSelect
+                value={draftPermissionMode}
+                onValueChange={setDraftPermissionMode}
+                options={CLAUDE_NATIVE_PERMISSION_MODES}
+                testId="composer-config-permission"
+                ariaLabel="Permissions"
+              />
             </ConfigRow>
           )}
           {/* Sub-agent routing — the only in-session routing control, for a
@@ -6179,8 +6204,8 @@ function SessionConfigModal({
 /**
  * Composer gear affordance: a ghost `SettingsIcon` that shows the session's
  * live run-config on hover and opens `SessionConfigModal` on click. Rendered
- * only when the session has at least one switchable knob (model, effort, or
- * smart routing) — otherwise there's nothing to configure.
+ * only when the session has at least one switchable knob (model, effort,
+ * permissions, or smart routing) — otherwise there's nothing to configure.
  *
  * @param openNonce External "open the modal" signal, nonce-keyed so repeat
  *   requests re-open (bare ``/model`` submits route here now that the composer
@@ -6229,7 +6254,14 @@ function ComposerConfigGear({
     costRoutingEligible,
   });
 
-  if (!showModels && !showEffort && !costRoutingEligible && !subagentRoutingEligible) return null;
+  if (
+    !showModels &&
+    !showEffort &&
+    !costRoutingEligible &&
+    !subagentRoutingEligible &&
+    modelPickerKind !== "claude"
+  )
+    return null;
 
   return (
     <>
@@ -6296,9 +6328,8 @@ function ComposerConfigGear({
 }
 
 /**
- * Label/value rows summarizing the session's live run-config, for the gear
- * icon's hover tooltip. Mirrors the new-session summary but with in-session
- * values and no Permissions row (permission mode is launch-time only).
+ * Label/value rows summarizing the session's live run-config for the gear
+ * icon's hover tooltip.
  */
 function useSessionConfigSummary({
   harnessLabel,
@@ -6316,6 +6347,7 @@ function useSessionConfigSummary({
   costRoutingEligible: boolean;
 }): { label: string; value: string }[] {
   const selectedEffort = useChatStore((s) => s.selectedEffort);
+  const permissionMode = useChatStore((s) => s.permissionMode);
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
   const { modelLabel } = useResolvedComposerModel(modelPickerKind, codexModelOptions);
   const routingOn = costRoutingEligible && costControlModeOverride === "on";
@@ -6333,6 +6365,12 @@ function useSessionConfigSummary({
   if (showEffort && !routingOn) {
     const effortValue = formatStatusEffortLabel(selectedEffort, modelPickerKind === "codex");
     rows.push({ label: "Effort", value: effortValue ?? "Default" });
+  }
+  if (modelPickerKind === "claude") {
+    const permissionLabel = CLAUDE_NATIVE_PERMISSION_MODES.find(
+      (mode) => mode.value === (permissionMode ?? CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE),
+    )?.label;
+    rows.push({ label: "Permissions", value: permissionLabel ?? "Default" });
   }
   return rows;
 }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -47,7 +47,9 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
   CLAUDE_NATIVE_EFFORTS,
+  CLAUDE_NATIVE_PERMISSION_MODES,
   ConfigRow,
   DescribedSelect,
   EFFORT_SELECT_NONE,
@@ -213,32 +215,6 @@ const AGENT_PICKER_DESCRIPTIONS: Record<string, string> = {
 // landing composer. Deliberately an allowlist while the pattern proves
 // out — other agents keep the "/" menu as the only skill surface.
 const SKILL_PILL_AGENTS = new Set(["polly", "debby"]);
-
-// Claude Code's `claude --permission-mode` choices (v2.1). Claude-native
-// sessions only. "default" is Claude's own default and sends no flag; any
-// other value is passed through as `--permission-mode <value>` via the
-// session's terminal_launch_args. Keep in sync with `claude --help`.
-const CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE = "default";
-const CLAUDE_NATIVE_PERMISSION_MODES: { value: string; label: string; description: string }[] = [
-  { value: "default", label: "Default", description: "Prompts before edits and commands" },
-  {
-    value: "auto",
-    label: "Auto",
-    description: "Auto-runs; a classifier blocks risky actions",
-  },
-  {
-    value: "acceptEdits",
-    label: "Accept edits",
-    description: "Auto-applies file edits; commands still prompt",
-  },
-  { value: "plan", label: "Plan", description: "Plans only; makes no edits" },
-  { value: "dontAsk", label: "Don't ask", description: "Auto-denies anything not pre-approved" },
-  {
-    value: "bypassPermissions",
-    label: "Bypass permissions",
-    description: "Runs everything; no prompts or safety checks",
-  },
-];
 
 // The Auto Harness's Permissions vocabulary: Default only. No cross-harness
 // permission mapping exists, so the row stays locked and the create call sends

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -404,6 +404,11 @@ export interface ChatState {
    */
   codexPlanMode: boolean;
   /**
+   * Per-session permission mode for the active session (e.g. "default", "acceptEdits").
+   * Hydrated from the session snapshot on bind and written through `setPermissionMode`.
+   */
+  permissionMode: string | null;
+  /**
    * True when older items exist before the loaded history window. Binds
    * hydrate only the most recent page (see `fetchSessionItemsPage`);
    * scroll-up `loadMoreHistory` pages older until this goes false.
@@ -671,6 +676,12 @@ export interface ChatState {
    * active conversation.
    */
   setCodexPlanMode: (enabled: boolean) => Promise<void>;
+  /**
+   * Set the active session's permission mode — optimistic local flip,
+   * then PATCH; the server's canonical value (or a rollback on failure)
+   * settles the state.
+   */
+  setPermissionMode: (mode: string) => Promise<void>;
   /**
    * Fetch the next page of older messages and prepend them to `blocks`.
    *
@@ -1059,6 +1070,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   costControlModeOverride: null,
   subagentRoutingOverride: null,
   codexPlanMode: false,
+  permissionMode: null,
   hasMoreHistory: false,
   loadingMoreHistory: false,
   oldestItemId: null,
@@ -1776,6 +1788,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         costControlModeOverride: null,
         subagentRoutingOverride: null,
         codexPlanMode: false,
+        permissionMode: null,
         contextWindow: null,
         tokensUsed: null,
         sessionCostUsd: null,
@@ -2018,6 +2031,23 @@ export const useChatStore = create<ChatState>((set, get) => ({
     } catch (err) {
       if (get().conversationId === conversationId) {
         set({ codexPlanMode: previous });
+      }
+      throw err;
+    }
+  },
+
+  setPermissionMode: async (mode) => {
+    const { conversationId } = get();
+    if (!conversationId) return;
+    const previous = get().permissionMode;
+    set({ permissionMode: mode });
+    try {
+      const session = await updateSession(conversationId, { permissionMode: mode });
+      if (get().conversationId !== conversationId) return;
+      set({ permissionMode: session.permissionMode ?? null });
+    } catch (err) {
+      if (get().conversationId === conversationId) {
+        set({ permissionMode: previous });
       }
       throw err;
     }
@@ -2320,6 +2350,7 @@ function sessionBindingPatch(
   | "boundAgentName"
   | "llmModel"
   | "sessionModelOverride"
+  | "permissionMode"
   | "sessionHarness"
   | "subAgentName"
   | "costControlModeOverride"
@@ -2345,6 +2376,7 @@ function sessionBindingPatch(
     boundAgentName: session.agentName,
     llmModel: session.llmModel ?? null,
     sessionModelOverride: session.modelOverride ?? null,
+    permissionMode: session.permissionMode ?? null,
     sessionHarness: session.harness ?? null,
     subAgentName: session.subAgentName ?? null,
     costControlModeOverride: session.costControlModeOverride ?? null,


### PR DESCRIPTION
## Related issue

Closes #1454

## Summary

- Adds a permission-mode control to the session configuration modal for Claude native sessions, allowing the mode to change without restarting the session.
- Persists the selected mode in `terminal_launch_args` and forwards live changes to the runner, which updates the invocation-local `claude-settings.json`. Selecting `default` clears the override.
- Updates the API schema, generated OpenAPI document, web store/API bindings, documentation, and backend/web/browser tests for the current repository architecture.

ELI5: choosing a permission mode saves it for the next launch and also tells the currently running Claude process about the change, so both stay in sync.

```text
Session config modal -> PATCH /v1/sessions/{id} -> persisted launch arguments
                                             \-> runner event -> invocation settings
```

## Test Plan

- `uv run pytest tests/server/routes/test_sessions_crud.py tests/test_claude_native_bridge.py -q` — 239 passed.
- `uv run pytest tests/runner/test_app_sessions_native_events_options.py::test_permission_mode_change_updates_claude_native_settings -q` — passed.
- `uv run pytest tests/e2e_ui/chat/test_claude_model_picker.py::test_claude_native_permission_mode_persists -vv` — passed in Chromium.
- `pnpm run format:check && pnpm run lint && pnpm run type-check && pnpm exec vitest run src/lib/sessionsApi.test.ts src/pages/ChatPage.composer.test.tsx` — formatting, lint, and type checks passed; 192 tests passed.
- `uv run --no-sync pyrefly check` — passed with 0 errors.
- `uv run python scripts/dump_openapi.py --check` — passed.
- `pnpm --dir web run build` — passed.
- `uv run --no-sync pre-commit run --all-files` — all hooks passed.

## Demo

The new flow is exercised by the Playwright E2E test above. No media attachment was produced in the headless development environment.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes permission-mode argument replacement and clearing, invalid-value rejection, invocation settings updates, runner event dispatch, API serialization, optimistic web-store behavior, modal interaction, persistence, and the browser flow.

## Changelog

Claude Code sessions can now change permission mode from the session configuration menu without restarting.
