### PR TITLE
feat(opencode): use opencode user config

### DIFF
--- a/omnigent/opencode_native_bridge.py
+++ b/omnigent/opencode_native_bridge.py
@@ -410,6 +410,27 @@ def user_opencode_auth_path() -> Path:
     return base / "opencode" / "auth.json"
 
 
+def user_opencode_config_path() -> Path | None:
+    """
+    Return the user's real OpenCode config path (not the per-session one).
+
+    Honors ``XDG_CONFIG_HOME`` (the runner's own env, which is the user's real
+    config home — the per-session override is set only on the spawned server),
+    defaulting to ``~/.config/opencode/opencode.jsonc``.
+
+    OpenCode accepts both ``.jsonc`` (with comments) and ``.json`` extensions;
+    the ``.jsonc`` variant is checked first.
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    cfg_dir = base / "opencode"
+    for name in ("opencode.jsonc", "opencode.json"):
+        path = cfg_dir / name
+        if path.is_file():
+            return path
+    return None
+
+
 def seed_opencode_auth(bridge_dir: Path) -> Path | None:
     """
     Copy the user's OpenCode ``auth.json`` into the per-session ``XDG_DATA_HOME``.

--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -301,3 +301,185 @@ def _gateway_endpoint_for_model(model_id: str | None) -> str | None:
         return None
     candidate = model_id.split("/", 1)[1] if model_id.startswith("databricks/") else model_id
     return candidate if candidate.startswith("databricks-") else None
+
+
+def _strip_jsonc_comments(text: str) -> str:
+    """
+    Strip ``//`` line comments and ``/* */`` block comments from JSONC text.
+
+    Uses a character-level state machine to track string boundaries, so
+    ``//`` inside string literals (e.g. URLs like ``"https://example.com"``)
+    are never mistaken for comments.
+    """
+    result: list[str] = []
+    i = 0
+    length = len(text)
+    in_string = False
+    string_char: str | None = None
+
+    while i < length:
+        ch = text[i]
+
+        if in_string:
+            if ch == "\\":
+                result.append(ch)
+                i += 1
+                if i < length:
+                    result.append(text[i])
+                    i += 1
+            elif ch == string_char:
+                in_string = False
+                result.append(ch)
+                i += 1
+            else:
+                result.append(ch)
+                i += 1
+        elif ch in ('"', "'"):
+            in_string = True
+            string_char = ch
+            result.append(ch)
+            i += 1
+        elif ch == "/" and i + 1 < length:
+            next_ch = text[i + 1]
+            if next_ch == "/":
+                i += 2
+                while i < length and text[i] != "\n":
+                    i += 1
+            elif next_ch == "*":
+                i += 2
+                while i + 1 < length:
+                    if text[i] == "*" and text[i + 1] == "/":
+                        i += 2
+                        break
+                    i += 1
+            else:
+                result.append(ch)
+                i += 1
+        else:
+            result.append(ch)
+            i += 1
+
+    return "".join(result)
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas before ``}`` or ``]`` (valid in JSONC, invalid in JSON).
+
+    Operates on text that has already had its JSONC comments stripped, so the
+    only commas present are real JSON commas.  Uses a character-level state
+    machine that tracks string boundaries so that ``, }`` or ``, ]`` inside
+    quoted values are never mistaken for trailing commas — preventing silent
+    corruption of provider options like ``"note": "a, }"``.
+    """
+    result: list[str] = []
+    i = 0
+    length = len(text)
+    in_string = False
+    string_char: str | None = None
+
+    while i < length:
+        ch = text[i]
+
+        if in_string:
+            if ch == "\\":
+                result.append(ch)
+                i += 1
+                if i < length:
+                    result.append(text[i])
+                    i += 1
+            elif ch == string_char:
+                in_string = False
+                result.append(ch)
+                i += 1
+            else:
+                result.append(ch)
+                i += 1
+        elif ch in ('"', "'"):
+            in_string = True
+            string_char = ch
+            result.append(ch)
+            i += 1
+        elif ch == ",":
+            j = i + 1
+            while j < length and text[j] in (" ", "\t", "\n", "\r"):
+                j += 1
+            if j < length and text[j] in ("}", "]"):
+                i = j
+            else:
+                result.append(ch)
+                i += 1
+        else:
+            result.append(ch)
+            i += 1
+
+    return "".join(result)
+
+
+def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, object]:
+    """
+    Merge the user's global OpenCode provider definitions into *config*.
+
+    OpenCode reads ``XDG_CONFIG_HOME/opencode/opencode.json(c)`` for custom
+    provider definitions (e.g. OpenAI-compatible endpoints with custom base
+    URLs). When running under Omnigent, the per-session ``XDG_CONFIG_HOME``
+    override hides this global config. This function reads the user's real
+    config and merges any ``provider`` block into *config* so the spawned
+    server sees both the user's providers (with their custom base URLs) and
+    any Omnigent-synthesized providers (e.g. Databricks gateway).
+
+    Only ``provider`` entries are merged — the synthesized config takes
+    precedence for all other keys (model, mcp, plugin, permission, etc.).
+
+    :param config: The synthesized config dict (may be empty).
+    :returns: *config* with user's ``provider`` entries merged in (if any).
+    """
+    from omnigent.opencode_native_bridge import user_opencode_config_path
+
+    user_path = user_opencode_config_path()
+    if user_path is None:
+        return config
+
+    try:
+        raw = user_path.read_text(encoding="utf-8")
+        # Try plain JSON first (handles .json files without comments).
+        # If that fails, strip JSONC comments and trailing commas, then
+        # retry (handles .jsonc).
+        try:
+            user_config = json.loads(raw)
+        except json.JSONDecodeError:
+            cleaned = _strip_jsonc_comments(raw)
+            cleaned = _strip_trailing_commas(cleaned)
+            user_config = json.loads(cleaned)
+    except (OSError, UnicodeDecodeError):
+        return config
+    except json.JSONDecodeError:
+        _logger.warning(
+            "Failed to parse user OpenCode config at %s — ignoring user providers",
+            user_path,
+        )
+        return config
+
+    if not isinstance(user_config, dict):
+        return config
+
+    user_providers = user_config.get("provider")
+    if not isinstance(user_providers, dict) or not user_providers:
+        return config
+
+    result = dict(config)
+    existing = result.get("provider")
+    if isinstance(existing, dict):
+        # Merge user's providers alongside existing ones; don't clobber
+        # synthesized providers (Omnigent's keys like "databricks-gateway"
+        # take priority).
+        merged = dict(existing)
+        for key, value in user_providers.items():
+            if key not in merged:
+                merged[key] = value
+        result["provider"] = merged
+    else:
+        result["provider"] = dict(user_providers)
+
+    result.setdefault("$schema", "https://opencode.ai/config.json")
+
+    return result

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1077,6 +1077,7 @@ async def _auto_create_opencode_terminal(
         build_opencode_model_default_config,
         build_opencode_omnigent_mcp_server,
         build_opencode_provider_config,
+        maybe_merge_user_provider_config,
         resolve_databricks_gateway,
         write_opencode_provider_config,
     )
@@ -1142,6 +1143,13 @@ async def _auto_create_opencode_terminal(
         _policy_token = _policy_factory() if _policy_factory is not None else None
         if _policy_token:
             policy_env["OMNIGENT_POLICY_AUTH"] = f"Bearer {_policy_token}"
+
+    # Merge the user's global provider definitions (e.g. OpenAI-compatible
+    # endpoints with custom base URLs) into the synthesized config so the
+    # spawned server sees both. The per-session XDG_CONFIG_HOME override
+    # hides the user's ~/.config/opencode/opencode.jsonc, so without this
+    # merge, custom providers with non-default base URLs are invisible.
+    config = maybe_merge_user_provider_config(config)
 
     if config:
         write_opencode_provider_config(xdg_config_home_for_bridge_dir(bridge_dir), config)

--- a/tests/test_opencode_native_bridge.py
+++ b/tests/test_opencode_native_bridge.py
@@ -21,6 +21,7 @@ from omnigent.opencode_native_bridge import (
     update_active_message_id,
     update_last_event_id,
     update_model_override,
+    user_opencode_config_path,
     write_bridge_state,
     write_cost_popup_config,
     write_opencode_policy_plugin,
@@ -240,3 +241,57 @@ def test_seed_opencode_auth_noop_without_source(
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "empty-share"))
     bridge_dir = bridge.prepare_bridge_dir("conv_noseed")
     assert bridge.seed_opencode_auth(bridge_dir) is None
+
+
+def test_user_opencode_config_path_default_location(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without XDG_CONFIG_HOME, looks at ~/.config/opencode/opencode.jsonc."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    fake_home = tmp_path / "fake_home"
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    # File does not exist → returns None.
+    assert user_opencode_config_path() is None
+    # Create the file and verify the path is as expected.
+    (fake_home / ".config" / "opencode").mkdir(parents=True)
+    (fake_home / ".config" / "opencode" / "opencode.jsonc").write_text("{}")
+    expected = fake_home / ".config" / "opencode" / "opencode.jsonc"
+    assert user_opencode_config_path() == expected
+
+
+def test_user_opencode_config_path_honors_xdg_config_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """XDG_CONFIG_HOME env var redirects the lookup."""
+    cfg_dir = tmp_path / "my-config" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "my-config"))
+    path = user_opencode_config_path()
+    assert path is not None and path.exists()
+    assert path.name == "opencode.jsonc"
+
+
+def test_user_opencode_config_path_falls_back_to_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When only opencode.json exists (no .jsonc), returns the .json path."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    path = user_opencode_config_path()
+    assert path is not None and path.name == "opencode.json"
+
+
+def test_user_opencode_config_path_prefers_jsonc(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When both .jsonc and .json exist, .jsonc is preferred."""
+    cfg_dir = tmp_path / "pref" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text("{}", encoding="utf-8")
+    (cfg_dir / "opencode.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "pref"))
+    path = user_opencode_config_path()
+    assert path is not None and path.name == "opencode.jsonc"

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -14,9 +14,12 @@ from omnigent.opencode_native_provider import (
     DEFAULT_DATABRICKS_GATEWAY_MODEL,
     OpenCodeGatewayResolution,
     _gateway_endpoint_for_model,
+    _strip_jsonc_comments,
+    _strip_trailing_commas,
     build_opencode_model_default_config,
     build_opencode_omnigent_mcp_server,
     build_opencode_provider_config,
+    maybe_merge_user_provider_config,
     resolve_databricks_gateway,
     write_opencode_provider_config,
 )
@@ -224,3 +227,205 @@ def test_build_mcp_block_http_databricks_injects_bearer(monkeypatch: pytest.Monk
     ]
     block = prov.build_opencode_mcp_block(servers)
     assert block["dbx"]["headers"] == {"Authorization": "Bearer tok123"}
+
+
+def test_strip_jsonc_comments_removes_line_and_block_comments() -> None:
+    raw = """{
+  // line comment
+  "key": "value", /* block comment */
+  "nested": /* another */ "val"
+}"""
+    cleaned = _strip_jsonc_comments(raw)
+    assert "//" not in cleaned
+    assert "/*" not in cleaned
+    assert "*/" not in cleaned
+    import json
+
+    parsed = json.loads(cleaned)
+    assert parsed == {"key": "value", "nested": "val"}
+
+
+def test_strip_jsonc_comments_preserves_valid_json() -> None:
+    raw = '{"key": "value", "nested": {"a": 1}}'
+    assert _strip_jsonc_comments(raw) == raw
+
+
+def test_strip_jsonc_comments_does_not_corrupt_urls() -> None:
+    """URLs containing // must not have the // stripped."""
+    raw = '{"baseURL": "https://my-gateway/v1"}'
+    cleaned = _strip_jsonc_comments(raw)
+    import json
+
+    parsed = json.loads(cleaned)
+    assert parsed["baseURL"] == "https://my-gateway/v1"
+
+
+def test_merge_user_provider_config_noop_without_user_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No user config file → config returned unchanged."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "nonexistent"))
+
+    config = {"model": "anthropic/claude-sonnet-4-5"}
+    result = maybe_merge_user_provider_config(config)
+    assert result == config
+
+
+def test_merge_user_provider_config_adds_user_providers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """User's provider definitions are merged into the synthesized config."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text(
+        '{"provider": {"my-openai": {"npm": "@ai-sdk/openai-compatible", '
+        '"options": {"baseURL": "https://my-gateway/v1", "apiKey": "sk-"}, '
+        '"models": {"gpt-4": {"name": "gpt-4"}}}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config: dict[str, object] = {}
+    result = maybe_merge_user_provider_config(config)
+
+    assert "provider" in result
+    providers = result["provider"]
+    assert isinstance(providers, dict)
+    assert "my-openai" in providers
+    assert providers["my-openai"]["options"]["baseURL"] == "https://my-gateway/v1"
+    # Synthesized $schema should have been added.
+    assert "$schema" in result
+
+
+def test_merge_user_provider_config_does_not_clobber_synthesized_providers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A user provider with the same key as a synthesized one is NOT overwritten."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text(
+        '{"provider": {"databricks-gateway": {"options": {"baseURL": "http://evil"}}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config = {
+        "provider": {
+            "databricks-gateway": {
+                "npm": "@ai-sdk/openai-compatible",
+                "options": {
+                    "baseURL": "https://real-databricks/serving-endpoints",
+                    "apiKey": "tok",
+                },
+            }
+        }
+    }
+    result = maybe_merge_user_provider_config(config)
+    assert (
+        result["provider"]["databricks-gateway"]["options"]["baseURL"]
+        == "https://real-databricks/serving-endpoints"
+    )
+
+
+def test_merge_user_provider_config_merges_alongside_synthesized_providers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """User providers appear alongside the synthesized ones when keys differ."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text(
+        '{"provider": {"my-openai": {"options": {"baseURL": "http://my-gw/v1"}}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config = {
+        "provider": {
+            "databricks-gateway": {
+                "options": {"baseURL": "https://dbx/serving-endpoints", "apiKey": "tok"},
+            }
+        }
+    }
+    result = maybe_merge_user_provider_config(config)
+    providers = result["provider"]
+    assert "databricks-gateway" in providers
+    assert "my-openai" in providers
+    assert providers["my-openai"]["options"]["baseURL"] == "http://my-gw/v1"
+
+
+def test_merge_user_provider_config_handles_jsonc_comments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The user's JSONC file with comments is parsed correctly."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text(
+        "{\n"
+        "  // my custom provider\n"
+        '  "provider": {\n'
+        '    "my-openai": {\n'
+        '      "options": {"baseURL": "https://my-gw/v1"}\n'
+        "    }\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    result = maybe_merge_user_provider_config({})
+    assert result["provider"]["my-openai"]["options"]["baseURL"] == "https://my-gw/v1"
+
+
+def test_strip_trailing_commas_object() -> None:
+    raw = '{"a": 1, "b": 2,}'
+    assert _strip_trailing_commas(raw) == '{"a": 1, "b": 2}'
+
+
+def test_strip_trailing_commas_array() -> None:
+    raw = "[1, 2, 3,]"
+    assert _strip_trailing_commas(raw) == "[1, 2, 3]"
+
+
+def test_strip_trailing_commas_nested() -> None:
+    raw = '{"a": [1, 2,], "b": {"c": 3,}}'
+    assert _strip_trailing_commas(raw) == '{"a": [1, 2], "b": {"c": 3}}'
+
+
+def test_strip_trailing_commas_noop_without_trailing_commas() -> None:
+    raw = '{"a": 1, "b": [1, 2]}'
+    assert _strip_trailing_commas(raw) == raw
+
+
+def test_strip_trailing_commas_preserves_commas_inside_strings() -> None:
+    """Commas followed by } or ] inside string literals must NOT be stripped."""
+    raw = '{"note": "a, }", "list": "b, ]"}'
+    assert _strip_trailing_commas(raw) == raw
+
+
+def test_strip_trailing_commas_nested_with_string_values() -> None:
+    """Trailing commas outside strings stripped; commas inside strings preserved."""
+    raw = '{"a": "x, }", "b": [1, 2,],}'
+    expected = '{"a": "x, }", "b": [1, 2]}'
+    assert _strip_trailing_commas(raw) == expected
+
+
+def test_merge_user_provider_config_handles_jsonc_trailing_commas(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Trailing commas in JSONC are handled (they're valid in JSONC but not JSON)."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text(
+        "{\n"
+        '  "provider": {\n'
+        '    "my-openai": {\n'
+        '      "options": {"baseURL": "https://my-gw/v1",},\n'  # trailing comma
+        "    },\n"  # trailing comma
+        "  },\n"  # trailing comma
+        "}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    result = maybe_merge_user_provider_config({})
+    assert result["provider"]["my-openai"]["options"]["baseURL"] == "https://my-gw/v1"


### PR DESCRIPTION
## Related issue

Closes #1515

## Summary

When running `omni opencode`, the spawned server's `XDG_CONFIG_HOME` is overridden to a per-session directory, hiding the user's global `~/.config/opencode/opencode.jsonc`. This means any providers with non-default base URLs (e.g. Cloudflare AI Gateway, custom OpenAI-compatible endpoints) are invisible to the spawned process.

- Added `user_opencode_config_path()` to locate the user's real config (honoring `XDG_CONFIG_HOME`, `.jsonc` > `.json` fallback).
- Added `maybe_merge_user_provider_config()` that reads the user's JSONC config (with comment/trailing-comma stripping) and merges only `provider` entries into the synthesized config without clobbering Omnigent's own providers (e.g. `databricks-gateway`).
- Called the merge in `_auto_create_opencode_terminal` before writing the per-session provider config so the spawned server sees both the user's custom providers and the synthesized ones.

## Test Plan

- `test_user_opencode_config_path_*` — 4 tests covering default location, `XDG_CONFIG_HOME` override, `.json` fallback, and `.jsonc` preference.
- `test_merge_user_provider_config_*` — 5 tests covering no-op without user config, adding user providers, not clobbering synthesized providers, merging alongside synthesized ones, and handling JSONC comments/trailing commas.
- `test_strip_jsonc_comments_*` — 3 tests covering line/block removal, no-op on valid JSON, and not corrupting URLs.
- `test_strip_trailing_commas_*` — 5 tests covering objects, arrays, nesting, no-op, string boundary safety.

All tests pass locally.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable
