### PR TITLE
fix(pi-harness): propagate keychain errors instead of silently skipping family

### DIFF
--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -796,22 +796,31 @@ def _optional_provider_family(entry: ProviderEntry, family_name: str) -> FamilyC
     """Return a provider family, or ``None`` if absent *or* its key env var is unset.
 
     For the ``pi`` harness, which carries a single credential but probes
-    both families: a family whose ``$VAR`` is unresolved is treated as
-    unavailable rather than fatal, so e.g. a user who only exported
-    ``ANTHROPIC_API_KEY`` can still run pi on the anthropic family.
+    both families: a family whose inline ``$VAR`` / ``env:<VAR>`` credential is
+    unresolved is treated as unavailable rather than fatal, so e.g. a user
+    who only exported ``ANTHROPIC_API_KEY`` can still run pi on the anthropic
+    family.
 
-    The only :class:`OmnigentError` raised at family-access time comes from
-    the deferred ``$VAR`` expansion (structural validation already happened
-    at parse time), so catching it here narrowly means "this family's
-    credential is not configured". A ``keychain:`` ref raises ``ValueError``
-    (deferred — see :func:`resolve_secret`); that propagates so the user
-    sees the clear "not yet supported" message rather than a silent skip.
+    A family configured with a ``keychain:<name>`` ref is an explicit,
+    deliberate choice — if the named secret is missing or inaccessible, the
+    :class:`OmnigentError` propagates so the user gets a clear message
+    (e.g. "no stored secret named 'openrouter'") instead of the confusing
+    "no family resolves" fallthrough.  Only env-var misses are soft-skipped.
 
     :param entry: The resolved provider entry.
     :param family_name: Family key, e.g. ``"openai"`` or ``"anthropic"``.
     :returns: The :class:`FamilyConfig`, or ``None`` when the family is
         absent or its credential env var is unset.
+    :raises OmnigentError: When the family is configured with a
+        ``keychain:`` ref but the named secret is not stored.
     """
+    raw = entry.families.get(family_name)
+    if raw is None:
+        return None
+    # Keychain refs are explicit: a missing secret is a user error, not a
+    # "family not configured" signal.  Let OmnigentError propagate.
+    if raw.api_key_ref is not None and raw.api_key_ref.startswith("keychain:"):
+        return entry.family(family_name)
     try:
         return entry.family(family_name)
     except OmnigentError:

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -450,6 +450,101 @@ def test_pi_uses_anthropic_global_default(config_home: Path) -> None:
     assert env["HARNESS_PI_MODEL"] == "claude-default-model"
 
 
+# ── Keychain-backed credentials for the pi harness ────────────────────────
+
+
+def test_pi_keychain_ref_resolves_when_secret_present(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A ``keychain:`` api_key_ref with the secret present boots pi successfully.
+
+    The openrouter provider stores its key in the omnigent secret store
+    (``api_key_ref: keychain:openrouter``).  When the secret IS present,
+    ``_optional_provider_family`` must resolve it and inject it as the pi
+    gateway auth command — not silently skip the family.
+
+    Failure means the pi harness cannot use providers configured with
+    keychain-backed credentials even when the key is actually stored.
+    """
+    import json as _json
+
+    # Force the file backend so the test does not need the OS keychain.
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    # Write the secret into the isolated config home's secrets.json.
+    (config_home / "secrets.json").write_text(_json.dumps({"openrouter": "sk-or-testkey"}))
+
+    config: dict[str, object] = {
+        "providers": {
+            "openrouter": {
+                "kind": "gateway",
+                "default": True,
+                "openai": {
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key_ref": "keychain:openrouter",
+                    "models": {"default": "openai/gpt-4o"},
+                },
+            }
+        }
+    }
+    _write_config(config_home, config)
+    spec = _make_spec(harness="pi")
+
+    env = _build_pi_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_PI_GATEWAY"] == "true"
+    # pi maps the openai family to its "openai" family name.
+    assert env["HARNESS_PI_GATEWAY_BASE_URLS"] == (
+        '{"openai": "https://openrouter.ai/api/v1"}'
+    )
+    assert env["HARNESS_PI_GATEWAY_HOST"] == "https://openrouter.ai"
+    # The keychain secret must be resolved to its plaintext value and injected
+    # via printf so the pi subprocess receives the real key.
+    assert env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] == "printf %s sk-or-testkey"
+    assert env["HARNESS_PI_MODEL"] == "openai/gpt-4o"
+
+
+def test_pi_keychain_ref_missing_secret_raises_clear_error(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A ``keychain:`` api_key_ref with the secret absent raises a clear error.
+
+    When a family uses ``api_key_ref: keychain:<name>`` but the named secret
+    is not in the store, the error must propagate with a user-readable message
+    (e.g. "no stored secret named 'openrouter'") rather than being silently
+    swallowed by ``_optional_provider_family`` and turning into the confusing
+    "provider configures no family whose credentials resolve" message.
+
+    Failure (wrong error text or no error at all) means a user who mis-typed
+    the keychain name or forgot to run ``omnigent setup`` gets a confusing
+    error that does not point them at the real problem.
+    """
+    from omnigent.errors import OmnigentError
+
+    # Force the file backend; no secrets.json written — the key is absent.
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+
+    config: dict[str, object] = {
+        "providers": {
+            "openrouter": {
+                "kind": "gateway",
+                "default": True,
+                "openai": {
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key_ref": "keychain:openrouter",
+                    "models": {"default": "openai/gpt-4o"},
+                },
+            }
+        }
+    }
+    _write_config(config_home, config)
+    spec = _make_spec(harness="pi")
+
+    with pytest.raises(OmnigentError, match="openrouter"):
+        _build_pi_spawn_env(spec, workdir=None)
+
+
 # ── Named ProviderAuth selection ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`_optional_provider_family` was catching all `OmnigentError` and returning `None`, treating a missing keychain secret as "family not configured". This caused providers with `api_key_ref: keychain:<name>` to silently fail through to the confusing "provider configures no family whose credentials resolve" message even when the family was explicitly configured.

## Changes

- A family whose `api_key_ref` starts with `keychain:` is now treated as an explicit credential configuration: a missing secret propagates with a clear error (e.g. `no stored secret named 'openrouter'`) so the user knows exactly what to fix.
- Only env-var misses (`api_key: $UNSET_VAR`, `api_key_ref: env:UNSET`) continue to be soft-skipped, preserving existing behaviour.
- Tests added in `tests/runtime/test_provider_spawn_env.py` covering both cases.