### PR TITLE
fix(workflow): resolve __web_researcher when a nested sub-agent owns web_fetch

### DIFF
--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -2566,13 +2566,25 @@ def _find_spec_by_name(
     when the parent is a coordinator). To keep that fallback safe, the
     researcher is reconstructed deterministically from the parent (the
     same pure builder ``WebFetchTool`` uses) instead of returning ``None``,
-    but only when the parent actually declares the ``web_fetch`` builtin.
-    That builtin is the sole reason the researcher ever exists, so a parent
-    without it has no such child and the name falls through to normal
-    resolution (``None``). Reconstructing unconditionally would let a
+    but only when some node in the tree actually declares the ``web_fetch``
+    builtin. That builtin is the sole reason the researcher ever exists, so a
+    tree without it anywhere has no such child and the name falls through to
+    normal resolution (``None``). Reconstructing unconditionally would let a
     caller-controlled ``sub_agent_name`` coerce any parent into a
     shell-capable researcher (``build_researcher_spec`` synthesizes an
     ``OSEnvSpec``), widening the parent's tool boundary.
+
+    The owning node need not be the root: a nested sub-agent may own
+    ``web_fetch`` while the handed-in root does not. The gate locates the
+    ``web_fetch`` owner via a root-first pre-order walk
+    (:func:`_find_web_fetch_owner`) and reconstructs from THAT owner, not the
+    root, so the researcher inherits the owner's LLM and sandbox/egress
+    boundary (``build_researcher_spec`` derives both from its argument). When
+    several nodes own ``web_fetch`` the first pre-order owner wins; this is a
+    deliberate limitation tied to the ``__web_researcher`` name not being
+    unique per owner (plumbing an "effective parent" through every call site
+    is out of scope). The root-owner case is unchanged: the owner is the
+    root, so the output is identical to before.
 
     :param spec: The root agent spec to search.
     :param name: The sub-agent name to find,
@@ -2584,18 +2596,43 @@ def _find_spec_by_name(
     found = _search_sub_agent_tree(spec, name)
     if found is not None:
         return found
-    # Built-in web_fetch researcher: derived from the parent, never
-    # persisted in the bundle, so reconstruct it on a resolve-miss rather
-    # than letting callers fall back to the parent spec. Gated on the parent
+    # Built-in web_fetch researcher: derived from its owner, never persisted
+    # in the bundle, so reconstruct it on a resolve-miss rather than letting
+    # callers fall back to the parent spec. Gated on some node in the tree
     # declaring the ``web_fetch`` builtin, the only reason the researcher
-    # exists (``WebFetchTool.__init__`` appends it). Imported lazily to keep
-    # the tools layer off this module's import path.
+    # exists (``WebFetchTool.__init__`` appends it). The owner may be nested,
+    # so reconstruct from the owner (root-first pre-order) — never the root —
+    # to inherit the owner's LLM and sandbox/egress boundary. Imported lazily
+    # to keep the tools layer off this module's import path.
     from omnigent.tools.builtins.web_fetch import RESEARCHER_NAME
 
-    if name == RESEARCHER_NAME and any(entry.name == "web_fetch" for entry in spec.tools.builtins):
-        from omnigent.tools.builtins.web_fetch import build_researcher_spec
+    if name == RESEARCHER_NAME:
+        owner = _find_web_fetch_owner(spec)
+        if owner is not None:
+            from omnigent.tools.builtins.web_fetch import build_researcher_spec
 
-        return build_researcher_spec(spec)
+            return build_researcher_spec(owner)
+    return None
+
+
+def _find_web_fetch_owner(spec: AgentSpec) -> AgentSpec | None:
+    """
+    Find the first node owning the ``web_fetch`` builtin, root-first.
+
+    Pre-order DFS (root, then children left-to-right), mirroring
+    :func:`_search_sub_agent_tree`. The ``web_fetch`` owner is the node whose
+    ``tools.builtins`` carries an entry named ``web_fetch``; that node's spec
+    is the correct parent for ``build_researcher_spec`` (its LLM + sandbox).
+
+    :param spec: The agent spec whose sub-tree to search.
+    :returns: The first node (root-first) owning ``web_fetch``, or ``None``.
+    """
+    if any(entry.name == "web_fetch" for entry in spec.tools.builtins):
+        return spec
+    for sa in spec.sub_agents:
+        owner = _find_web_fetch_owner(sa)
+        if owner is not None:
+            return owner
     return None
 
 

--- a/tests/runtime/test_workflow_subagent_resolution.py
+++ b/tests/runtime/test_workflow_subagent_resolution.py
@@ -59,6 +59,67 @@ def _coordinator_parent(*, web_fetch: bool = True) -> AgentSpec:
     )
 
 
+def _nested_web_fetch_parent() -> AgentSpec:
+    """A root whose ``web_fetch`` owner is a NESTED sub-agent, not the root.
+
+    The root declares no ``web_fetch`` builtin; a nested child does. This is
+    the topology #817 missed: the resolver gate inspected only the root's
+    builtins, so a nested owner failed the gate and the resolve fell back to a
+    parent clone. The root and the nested owner use DIFFERENT LLM models so a
+    test can prove reconstruction walks to the owner rather than lazily
+    building from the root.
+
+    :returns: A root :class:`AgentSpec` without ``web_fetch``, whose nested
+        ``researcher_host`` child owns it.
+    """
+    host = AgentSpec(
+        spec_version=1,
+        name="researcher_host",
+        llm=LLMConfig(model="anthropic/claude-nested-7"),
+        executor=ExecutorSpec(max_iterations=40),
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_fetch")]),
+    )
+    return AgentSpec(
+        spec_version=1,
+        name="concordia",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(max_iterations=40),
+        tools=ToolsConfig(builtins=[]),
+        sub_agents=[host],
+    )
+
+
+def test_web_researcher_resolves_when_nested_subagent_owns_web_fetch() -> None:
+    """A nested ``web_fetch`` owner must still synthesize the lean researcher.
+
+    Fails before the fix: the gate inspected only the root's builtins, so a
+    nested owner failed the gate and the resolver returned ``None``. The
+    researcher must be rebuilt from the OWNER node, inheriting the owner's LLM
+    (not the root's).
+    """
+    root = _nested_web_fetch_parent()
+    # Precondition: the root itself neither declares web_fetch nor carries the
+    # researcher; only the nested child owns web_fetch.
+    assert "web_fetch" not in [b.name for b in root.tools.builtins]
+    assert RESEARCHER_NAME not in [s.name for s in root.sub_agents]
+
+    resolved = _find_spec_by_name(root, RESEARCHER_NAME)
+
+    assert resolved is not None, (
+        "nested web_fetch owner failed the gate; resolver returned None and "
+        "every swap site falls back to a parent clone."
+    )
+    assert resolved.name == RESEARCHER_NAME
+    assert resolved.executor.max_iterations == 5
+    assert resolved.interaction.conversational is False
+    # Built from the nested OWNER, not the root → inherits the owner's LLM.
+    assert resolved.llm is not None
+    assert resolved.llm.model == "anthropic/claude-nested-7", (
+        "researcher inherited the root's LLM, not the nested owner's; the gate "
+        "rebuilt from root instead of walking to the web_fetch owner."
+    )
+
+
 def test_web_researcher_resolves_to_lean_researcher_on_bundle_reparse() -> None:
     """A resolve-miss for ``__web_researcher`` must rebuild the lean researcher.
 


### PR DESCRIPTION
## Related issue

Closes #1014

## Summary

- The `_find_spec_by_name` `__web_researcher` resolver gate in `omnigent/runtime/workflow.py` checked only the ROOT spec's `tools.builtins` for `web_fetch`. A **nested** sub-agent that owns `web_fetch` failed the gate, so resolution returned `None` and every swap site fell back to a coordinator clone (runaway recursion / fan-out via `sys_session_send`).
- Predecessor PR #817 handled the root-owner case; this is the nested-owner follow-up.
- Added `_find_web_fetch_owner(spec)` (root-first pre-order DFS, mirroring `_search_sub_agent_tree`) and rewrote the gate to reconstruct the researcher from the **owner** node, not the handed-in root, so it inherits the owner's LLM and sandbox/egress boundary (`build_researcher_spec` derives both from its argument). Building from root when a nested node owns `web_fetch` would give the wrong LLM and could widen the egress boundary.

Behavior preservation: root-owner case → owner is root → identical output; no `web_fetch` anywhere → owner `None` → returns `None` (security boundary intact). The `_search_sub_agent_tree` short-circuit still runs first, so a genuinely declared/in-tree researcher is returned verbatim. With multiple `web_fetch` owners the first pre-order owner wins — a deliberate limitation tied to the `__web_researcher` name not being unique per owner.

## Test Plan

Added a nested-topology regression test in `tests/runtime/test_workflow_subagent_resolution.py`:
`test_web_researcher_resolves_when_nested_subagent_owns_web_fetch` — root declares no `web_fetch`; a nested child (`researcher_host`) owns it. Root and owner use **different** LLM models so the final assertion (`resolved.llm.model == "anthropic/claude-nested-7"`) proves reconstruction walks to the owner rather than lazily building from root.

Fail-before / pass-after:
- Fail-before (`git stash push -- omnigent/runtime/workflow.py`): `AssertionError: nested web_fetch owner failed the gate; resolver returned None ... assert None is not None`.
- Pass-after: `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest tests/runtime/test_workflow_subagent_resolution.py -q` → `6 passed`.
- Lint: `OMNIGENT_SKIP_WEB_UI=true uv run ruff check .` → All checks passed; `ruff format --check .` → all formatted.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified via the fail-before/pass-after loop above. Fail-before: stashed the `workflow.py` change and ran the new test, confirming it failed (`assert None is not None`); restored and confirmed all 6 tests pass. The 5 pre-existing tests in the file remain green, covering the root-owner, no-`web_fetch` security boundary, declared-sub-agent, unknown-name, and verbatim-declared-researcher cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
