### PR TITLE
fix(codex): CodexExecutor honors os_env.sandbox.env_passthrough

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -16,7 +16,7 @@ import re
 import shutil
 import tempfile
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -348,7 +348,7 @@ async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> asyncio.subproce
     return await asyncio.create_subprocess_exec(*args, **kwargs)
 
 
-def _clean_codex_env() -> dict[str, str]:
+def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
     """
     Build a filtered copy of ``os.environ`` for the codex subprocess.
 
@@ -376,23 +376,31 @@ def _clean_codex_env() -> dict[str, str]:
         "LC_",
     )
     allow_exact = {
-        "HOME",
-        "PATH",
-        "TERM",
-        "TMPDIR",
-        "TMP",
-        "TEMP",
-        "PYTHONUTF8",
-        "DATABRICKS_BEARER",  # explicit CI/integration bearer used by auth.command
-        "DATABRICKS_CODEX_TOKEN",  # env_key referenced by ~/.codex/config.toml's DB provider
-        OMNIGENT_SESSION_ENV_VAR,  # "inside Omnigent" marker (CLAUDE_CODE/CODEX analog)
-    }
+        "HOME", "PATH", "TERM", "TMPDIR", "TMP", "TEMP", "PYTHONUTF8",
+        "DATABRICKS_BEARER", "DATABRICKS_CODEX_TOKEN", OMNIGENT_SESSION_ENV_VAR,
+    } | set(extra_allow)
     for key, value in os.environ.items():
         if key in _CODEX_ENV_DENY_EXACT:
             continue
         if key in allow_exact or key.startswith(allow_prefixes):
             env[key] = value
     return env
+
+
+def _declared_passthrough(os_env: OSEnvSpec | None) -> tuple[str, ...]:
+    """Env-var names an agent declared for tool passthrough.
+
+    Lives on ``os_env.sandbox.env_passthrough`` (an
+    :class:`OSEnvSandboxSpec` field), not on ``OSEnvSpec`` directly.
+    Returns an empty tuple when any link in that chain is absent.
+    """
+    if (
+        os_env is not None
+        and os_env.sandbox is not None
+        and os_env.sandbox.env_passthrough
+    ):
+        return tuple(os_env.sandbox.env_passthrough)
+    return ()
 
 
 def codex_skill_sources(bundle_dir: Path | None, home: Path) -> list[Path]:
@@ -2116,7 +2124,7 @@ class CodexExecutor(Executor):
         if not resolved_codex:
             raise ImportError("CodexExecutor requires the 'codex' CLI on PATH.")
         self._codex_path = resolved_codex
-        self._env = _clean_codex_env()
+        self._env = _clean_codex_env(_declared_passthrough(self._os_env_spec))
         # Retry policy → OpenAI SDK env vars (Codex uses the OpenAI
         # SDK internally). Speculative — empirical audit pending.
         self._retry_policy = retry_policy if retry_policy is not None else RetryPolicy()

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -376,8 +376,16 @@ def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
         "LC_",
     )
     allow_exact = {
-        "HOME", "PATH", "TERM", "TMPDIR", "TMP", "TEMP", "PYTHONUTF8",
-        "DATABRICKS_BEARER", "DATABRICKS_CODEX_TOKEN", OMNIGENT_SESSION_ENV_VAR,
+        "HOME",
+        "PATH",
+        "TERM",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "PYTHONUTF8",
+        "DATABRICKS_BEARER",  # explicit CI/integration bearer used by auth.command
+        "DATABRICKS_CODEX_TOKEN",  # env_key referenced by ~/.codex/config.toml's DB provider
+        OMNIGENT_SESSION_ENV_VAR,  # "inside Omnigent" marker (CLAUDE_CODE/CODEX analog)
     } | set(extra_allow)
     for key, value in os.environ.items():
         if key in _CODEX_ENV_DENY_EXACT:
@@ -394,11 +402,7 @@ def _declared_passthrough(os_env: OSEnvSpec | None) -> tuple[str, ...]:
     :class:`OSEnvSandboxSpec` field), not on ``OSEnvSpec`` directly.
     Returns an empty tuple when any link in that chain is absent.
     """
-    if (
-        os_env is not None
-        and os_env.sandbox is not None
-        and os_env.sandbox.env_passthrough
-    ):
+    if os_env is not None and os_env.sandbox is not None and os_env.sandbox.env_passthrough:
         return tuple(os_env.sandbox.env_passthrough)
     return ()
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2781,3 +2781,39 @@ def test_codex_skill_sources_omits_absent_dirs(tmp_path: Path) -> None:
     (home / ".codex" / "skills").mkdir(parents=True)
     assert codex_skill_sources(None, home) == [home / ".codex" / "skills"]
     assert codex_skill_sources(tmp_path / "no-bundle", home) == [home / ".codex" / "skills"]
+
+
+def test_clean_codex_env_honors_extra_allow(monkeypatch):
+    from omnigent.inner.codex_executor import _clean_codex_env
+    monkeypatch.setenv("CRAWL4AI_API_TOKEN", "secret-tok")
+    monkeypatch.setenv("COMPANIES_HOUSE_API_KEY", "ch-key")
+    # undeclared → stripped by the hardcoded allowlist
+    assert "CRAWL4AI_API_TOKEN" not in _clean_codex_env()
+    # declared via env_passthrough → admitted
+    env = _clean_codex_env(["CRAWL4AI_API_TOKEN", "COMPANIES_HOUSE_API_KEY"])
+    assert env["CRAWL4AI_API_TOKEN"] == "secret-tok"
+    assert env["COMPANIES_HOUSE_API_KEY"] == "ch-key"
+
+
+def test_clean_codex_env_deny_wins_over_extra_allow(monkeypatch):
+    from omnigent.inner.codex_executor import _clean_codex_env
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-stripped")
+    # the deny rule (subscription auth) wins even if a caller declares it
+    assert "OPENAI_API_KEY" not in _clean_codex_env(["OPENAI_API_KEY"])
+
+
+def test_declared_passthrough_reads_sandbox_env_passthrough():
+    from omnigent.inner.codex_executor import _declared_passthrough
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+    # env_passthrough lives on os_env.sandbox, not os_env directly
+    spec = OSEnvSpec(
+        sandbox=OSEnvSandboxSpec(
+            type="none", env_passthrough=["CRAWL4AI_API_TOKEN", "COMPANIES_HOUSE_API_KEY"]
+        )
+    )
+    assert _declared_passthrough(spec) == ("CRAWL4AI_API_TOKEN", "COMPANIES_HOUSE_API_KEY")
+    # guards: None os_env / None sandbox / unset list all yield ()
+    assert _declared_passthrough(None) == ()
+    assert _declared_passthrough(OSEnvSpec(sandbox=None)) == ()
+    assert _declared_passthrough(OSEnvSpec(sandbox=OSEnvSandboxSpec(type="none"))) == ()

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2785,6 +2785,7 @@ def test_codex_skill_sources_omits_absent_dirs(tmp_path: Path) -> None:
 
 def test_clean_codex_env_honors_extra_allow(monkeypatch):
     from omnigent.inner.codex_executor import _clean_codex_env
+
     monkeypatch.setenv("CRAWL4AI_API_TOKEN", "secret-tok")
     monkeypatch.setenv("COMPANIES_HOUSE_API_KEY", "ch-key")
     # undeclared → stripped by the hardcoded allowlist
@@ -2797,6 +2798,7 @@ def test_clean_codex_env_honors_extra_allow(monkeypatch):
 
 def test_clean_codex_env_deny_wins_over_extra_allow(monkeypatch):
     from omnigent.inner.codex_executor import _clean_codex_env
+
     monkeypatch.setenv("OPENAI_API_KEY", "sk-stripped")
     # the deny rule (subscription auth) wins even if a caller declares it
     assert "OPENAI_API_KEY" not in _clean_codex_env(["OPENAI_API_KEY"])


### PR DESCRIPTION
## Problem

`CodexExecutor` builds the codex subprocess environment from the hardcoded `_clean_codex_env()` allowlist (`omnigent/inner/codex_executor.py`) and never consulted the agent's declared **`os_env.sandbox.env_passthrough`**. So a codex-harness agent's shell tools (`sys_os_shell`) cannot see secrets the spec explicitly allows — e.g. an external API token an in-tree helper script needs — even though the `claude-sdk` os_env path honors the very same `env_passthrough` field. The agent silently runs with a degraded tool environment.

This is the **codex-executor counterpart of #1022** (a deliberately strict env allowlist dropping vars a component genuinely needs).

## Fix

- `_clean_codex_env(extra_allow: Iterable[str] = ())` unions the declared names into its exact-allowlist.
- A guarded `_declared_passthrough(os_env)` helper reads `os_env.sandbox.env_passthrough` (returning `()` when any link in that chain is absent), passed at the call site.
- **`_CODEX_ENV_DENY_EXACT` still wins** — `OPENAI_API_KEY` (subscription-auth) is stripped even if a caller declares it. Opt-in + targeted: only declared names pass through, never the full host env.

## Tests

Three unit tests in `tests/inner/test_codex_executor.py`: undeclared var stripped; declared var admitted; `OPENAI_API_KEY` denied even when declared; plus `_declared_passthrough`'s None-guards (None os_env / None sandbox / unset list → `()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)