### PR TITLE
fix(mcp): route /sse URLs straight to the SSE transport (Streamable HTTP hangs on SSE-only servers)

### DIFF
--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -902,6 +902,14 @@ class McpServerConnection:
             # Streamable HTTP client in teardown, which would block the
             # except-clause SSE fallback below from ever running. Route
             # straight to SSE.
+            #
+            # Note: this routing is one-way and purely path-based, not
+            # capability-based. A server that speaks Streamable HTTP but
+            # happens to live at a /sse path is sent only to the SSE
+            # client, with no reverse fallback to Streamable HTTP. That
+            # is the intended trade-off: it matches the /sse convention
+            # and avoiding the teardown hang takes priority over covering
+            # a misnamed-endpoint case that is not known to occur.
             return await self._open_sse_transport(stack, timeout, headers)
         try:
             return await self._open_streamable_http_transport(stack, timeout, headers)

--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 from anyio.streams.memory import (
     MemoryObjectReceiveStream,
@@ -339,6 +340,23 @@ _discovery_cache: TTLCache[str, list[McpToolDef]] = TTLCache(
     maxsize=_DEFAULT_CACHE_MAX_SIZE,
     ttl=_DEFAULT_CACHE_TTL_SECONDS,
 )
+
+
+def _is_sse_endpoint(url: str) -> bool:
+    """
+    Whether an HTTP MCP URL points at a legacy SSE endpoint.
+
+    True when the URL path's last segment is ``sse`` (e.g.
+    ``http://host/mcp/sse`` or a bare ``/sse``). Such servers speak
+    only the legacy SSE transport; the Streamable HTTP client hangs in
+    teardown when pointed at them, so :meth:`_open_http_transport`
+    routes these straight to the SSE client instead of trying — and
+    hanging on — Streamable HTTP first.
+
+    :param url: The configured MCP server URL.
+    :returns: ``True`` for an ``…/sse`` path, ``False`` otherwise.
+    """
+    return urlparse(url).path.rstrip("/").endswith("/sse")
 
 
 def _cache_key(config: MCPServerConfig, cwd: Path | None = None) -> str:
@@ -876,6 +894,12 @@ class McpServerConnection:
             )
         timeout = self.config.timeout
         headers = self._resolve_http_headers()
+        if _is_sse_endpoint(self.config.url):
+            # Legacy-SSE servers (e.g. crawl4ai's /mcp/sse) hang the
+            # Streamable HTTP client in teardown, which would block the
+            # except-clause SSE fallback below from ever running. Route
+            # straight to SSE.
+            return await self._open_sse_transport(stack, timeout, headers)
         try:
             return await self._open_streamable_http_transport(stack, timeout, headers)
         except Exception as exc:

--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -873,10 +873,13 @@ class McpServerConnection:
         """
         Open an HTTP MCP transport — Streamable HTTP or legacy SSE.
 
-        Tries the Streamable HTTP transport first (the current MCP
-        spec default, used by Databricks MCP gateways and newer
-        servers). Falls back to legacy SSE if the Streamable HTTP
-        handshake fails, so older servers still work.
+        URLs whose path ends in ``/sse`` are routed straight to the
+        legacy SSE client (see :func:`_is_sse_endpoint`), since the
+        Streamable HTTP client hangs in teardown against SSE-only
+        servers. Otherwise tries the Streamable HTTP transport first
+        (the current MCP spec default, used by Databricks MCP gateways
+        and newer servers) and falls back to legacy SSE if the
+        Streamable HTTP handshake fails, so older servers still work.
 
         :param stack: The lifecycle task's exit stack.
         :returns: A ``(read_stream, write_stream)`` tuple of

--- a/tests/tools/test_mcp.py
+++ b/tests/tools/test_mcp.py
@@ -1334,14 +1334,14 @@ async def test_http_connect_passes_url_to_transport() -> None:
     """
     config = MCPServerConfig(
         name="test-http",
-        url="https://mcp.example.com/sse",
+        url="https://mcp.example.com/mcp",
     )
 
     with _mock_http_transport() as captured:
         conn = McpServerConnection(config=config)
         await conn.connect()
 
-    assert captured.transport_kwargs["url"] == "https://mcp.example.com/sse"
+    assert captured.transport_kwargs["url"] == "https://mcp.example.com/mcp"
 
     await conn.close()
 
@@ -2335,3 +2335,83 @@ async def test_call_tool_with_elicitation_raises_on_second_mrtr() -> None:
     )
 
     await conn.close()
+
+
+# ── _is_sse_endpoint / legacy-SSE routing ────────────────
+
+
+def test_is_sse_endpoint_detects_sse_paths() -> None:
+    """
+    URLs whose path ends in a ``/sse`` segment are legacy-SSE
+    endpoints (e.g. crawl4ai's ``/mcp/sse``). The Streamable HTTP
+    client hangs in teardown against such a server, so the transport
+    router must detect these and use the SSE client directly.
+    """
+    from omnigent.tools.mcp import _is_sse_endpoint
+
+    assert _is_sse_endpoint("http://h:1/mcp/sse")
+    assert _is_sse_endpoint("http://h:1/mcp/sse/")  # trailing slash
+    assert _is_sse_endpoint("http://h:1/sse")
+    assert not _is_sse_endpoint("http://h:1/mcp")
+    assert not _is_sse_endpoint("http://h:1/")
+    assert not _is_sse_endpoint("http://h:1")
+    assert not _is_sse_endpoint("http://h:1/mcp/sse-events")  # not a /sse segment
+
+
+@pytest.mark.asyncio()
+async def test_open_http_transport_routes_sse_url_straight_to_sse() -> None:
+    """
+    An ``…/sse`` URL goes directly to the SSE transport.
+
+    The Streamable HTTP client hangs in teardown against an SSE-only
+    server (crawl4ai), so it must be SKIPPED — not merely
+    tried-then-fallen-back-from, because the hang prevents the
+    fallback from ever running.
+    """
+    from contextlib import AsyncExitStack
+
+    conn = McpServerConnection(config=MCPServerConfig(name="c", url="http://h:1/mcp/sse"))
+    calls: list[str] = []
+
+    async def fake_sse(stack, timeout, headers):
+        calls.append("sse")
+        return ("r", "w")
+
+    async def fake_streamable(stack, timeout, headers):
+        calls.append("streamable")
+        return ("r", "w")
+
+    conn._open_sse_transport = fake_sse  # type: ignore[method-assign]
+    conn._open_streamable_http_transport = fake_streamable  # type: ignore[method-assign]
+    async with AsyncExitStack() as stack:
+        await conn._open_http_transport(stack)
+
+    assert calls == ["sse"], "…/sse URL must skip Streamable HTTP entirely"
+
+
+@pytest.mark.asyncio()
+async def test_open_http_transport_uses_streamable_for_non_sse_url() -> None:
+    """
+    A plain HTTP MCP URL still tries Streamable HTTP first (with the
+    existing SSE fallback on failure) — the routing change must not
+    regress modern Streamable-HTTP servers.
+    """
+    from contextlib import AsyncExitStack
+
+    conn = McpServerConnection(config=MCPServerConfig(name="c", url="http://h:1/mcp"))
+    calls: list[str] = []
+
+    async def fake_sse(stack, timeout, headers):
+        calls.append("sse")
+        return ("r", "w")
+
+    async def fake_streamable(stack, timeout, headers):
+        calls.append("streamable")
+        return ("r", "w")
+
+    conn._open_sse_transport = fake_sse  # type: ignore[method-assign]
+    conn._open_streamable_http_transport = fake_streamable  # type: ignore[method-assign]
+    async with AsyncExitStack() as stack:
+        await conn._open_http_transport(stack)
+
+    assert calls == ["streamable"], "plain URL must try Streamable HTTP first"

--- a/tests/tools/test_mcp.py
+++ b/tests/tools/test_mcp.py
@@ -1406,10 +1406,15 @@ async def test_http_falls_back_to_sse_when_streamable_fails() -> None:
     would fail to connect. If ``streamablehttp_client`` is not
     tried first, Streamable HTTP servers (e.g. Databricks MCP
     gateways) would get the wrong transport.
+
+    A non-``/sse`` URL is used on purpose: an ``…/sse`` URL is routed
+    straight to the SSE client by ``_is_sse_endpoint`` and would bypass
+    Streamable HTTP entirely, so it would not exercise the fallback this
+    test guards.
     """
     config = MCPServerConfig(
         name="test-sse-fallback",
-        url="http://legacy-mcp.example.com/sse",
+        url="http://legacy-mcp.example.com/mcp",
         headers={"Authorization": "Bearer tok"},
     )
 
@@ -1442,7 +1447,7 @@ async def test_http_falls_back_to_sse_when_streamable_fails() -> None:
     with patch(
         "omnigent.tools.mcp.streamablehttp_client",
         side_effect=RuntimeError("server returned text/html, not application/json"),
-    ):
+    ) as mock_streamable:
         with patch(
             "omnigent.tools.mcp.sse_client",
             side_effect=_capturing_sse,
@@ -1454,8 +1459,13 @@ async def test_http_falls_back_to_sse_when_streamable_fails() -> None:
                 conn = McpServerConnection(config=config)
                 tools = await conn.connect()
 
+    # Streamable HTTP was tried first and failed, so the fallback ran.
+    assert mock_streamable.called, (
+        "Streamable HTTP must be tried first for a non-/sse URL; if it was "
+        "skipped, the SSE fallback this test guards was never exercised"
+    )
     # Fallback reached sse_client with the correct URL and headers.
-    assert captured_sse_kwargs["url"] == "http://legacy-mcp.example.com/sse", (
+    assert captured_sse_kwargs["url"] == "http://legacy-mcp.example.com/mcp", (
         "SSE fallback must receive the same URL as the original config"
     )
     assert captured_sse_kwargs["headers"] == {"Authorization": "Bearer tok"}, (


### PR DESCRIPTION
## Problem

`McpServerConnection._open_http_transport` always tries `streamablehttp_client` first and falls back to `sse_client` only inside an `except`. Against a **legacy SSE-only** MCP server (one whose endpoint is `…/sse`, e.g. crawl4ai's `/mcp/sse`), the Streamable HTTP client does not fail fast — it **hangs in teardown** inside the `TaskGroup`. Because the failing attempt never returns, the `except`-clause SSE fallback never runs, and every connection ends as:

```
ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
```

so the server's tools never load.

## Fix

Detect an SSE endpoint by URL path (`_is_sse_endpoint` → path ends in a `/sse` segment) and route those URLs **straight to** `_open_sse_transport`, skipping the hang-prone Streamable HTTP attempt. Plain HTTP MCP URLs are unchanged (Streamable HTTP first, SSE fallback on failure).

## Tests

- `_is_sse_endpoint` truth table (`/mcp/sse`, `/mcp/sse/`, `/sse` → True; `/mcp`, `/`, `/mcp/sse-events` → False)
- `…/sse` URL routes to the SSE transport (Streamable HTTP skipped entirely)
- plain URL still tries Streamable HTTP first

All `tests/tools/test_mcp.py` pass; `ruff` clean. Verified end-to-end against a live SSE-only MCP server (crawl4ai): with this change the connection succeeds and all tools register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
