### PR TITLE
feat(cli): "!" shell passthrough — run a command, fold output into the next turn

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import re
 import sys
+import tempfile
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, TextIO
@@ -61,6 +62,7 @@ from omnigent_ui_sdk.terminal._theme import LIGHT_THEME, get_theme
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion, merge_completers
 from prompt_toolkit.document import Document
 from rich.console import RenderableType
+from rich.markup import escape
 from rich.text import Text
 
 from omnigent.spec.types import SkillSpec
@@ -3819,6 +3821,14 @@ async def run_repl(
 
     host.on_help = show_help
 
+    # Output of "!" shell commands, buffered and folded into the next turn's
+    # llm_text so the agent can reason about what the user ran.
+    _pending_bang_blocks: list[str] = []
+    # Lightweight cwd persistence for "!" commands: a standalone "!cd <dir>"
+    # updates this; other "!" commands run in it. One-element list so the
+    # nested closure can rebind the value.
+    _bang_cwd: list[str] = [os.getcwd()]
+
     async def on_input(text: str, attachments: list[PendingAttachment] | None = None) -> None:
         nonlocal conversation_id, is_streaming
 
@@ -3862,6 +3872,45 @@ async def run_repl(
             approval_state.resolve_verdict(verdict)
             return
 
+        # A line starting with "!" runs a shell command (Claude Code parity);
+        # its output is buffered and folded into the next agent turn. "!!"
+        # escapes — it sends a literal leading "!" as an ordinary prompt.
+        if text.startswith("!") and not text.startswith("!!"):
+            cmd = text[1:].strip()
+            if not cmd:
+                host.output(
+                    Text.from_markup(
+                        f"   [{fmt.muted}]! <command> runs a shell command · "
+                        f"!! sends a literal ![/{fmt.muted}]",
+                    ),
+                )
+                return
+            # Lightweight cwd persistence: a standalone "!cd <dir>" changes the
+            # directory subsequent "!" commands run in (see _resolve_cd).
+            cd_target = _resolve_cd(cmd, _bang_cwd[0])
+            if cd_target is not None:
+                if os.path.isdir(cd_target):
+                    _bang_cwd[0] = cd_target
+                    host.output(
+                        Text.from_markup(f"  [{fmt.accent}]![/{fmt.accent}] {escape(cmd)}")
+                    )
+                    host.output(
+                        Text.from_markup(
+                            f"   [{fmt.muted}]now in {escape(cd_target)}[/{fmt.muted}]"
+                        ),
+                    )
+                    _pending_bang_blocks.append(
+                        f"$ {cmd}\n(changed shell directory to: {cd_target})"
+                    )
+                else:
+                    msg = f"cd: not a directory: {escape(cd_target)}"
+                    host.output(Text.from_markup(f"   [{fmt.warning}]{msg}[/{fmt.warning}]"))
+                return
+            _pending_bang_blocks.append(await _run_bang_command(cmd, host, fmt, cwd=_bang_cwd[0]))
+            return
+        if text.startswith("!!"):
+            text = text[1:]  # drop one "!"; fall through as a normal prompt
+
         # Slash commands are short tokens like "/help", "/clear".
         # File paths like "/Users/foo/bar.jpg" start with "/" but
         # contain more path separators — don't treat those as commands.
@@ -3899,6 +3948,10 @@ async def run_repl(
         if filenames:
             suffix = " ".join(filenames)
             llm_text = f"{text} {suffix}".strip() if text else suffix
+        # Fold any buffered "!" shell output into this turn so the agent sees it.
+        if _pending_bang_blocks:
+            llm_text = "\n\n".join([*_pending_bang_blocks, llm_text]).strip()
+            _pending_bang_blocks.clear()
 
         if is_streaming:
             # Show the message immediately in dimmed style so the
@@ -8250,6 +8303,190 @@ class _SlashCommandCompleter(Completer):
                 display=name,
                 display_meta=desc,
             )
+
+
+# ── "!" shell passthrough ──────────────────────────────────────────────
+# A line beginning with "!" runs the rest in the user's shell; its output is
+# shown and folded into the next agent turn so the agent can reason about it.
+# Env-overridable knobs (Claude Code-parity defaults).
+_BANG_TIMEOUT_S: float = float(os.environ.get("OMNIGENT_BANG_TIMEOUT_S") or 120.0)
+_BANG_DISPLAY_MAX: int = int(os.environ.get("OMNIGENT_BANG_DISPLAY_MAX") or 30_000)
+_BANG_CONTEXT_MAX: int = int(os.environ.get("OMNIGENT_BANG_CONTEXT_MAX") or 16_000)
+
+
+def _bang_shell_argv(cmd: str) -> list[str]:
+    """Argv to run ``cmd`` via the platform shell.
+
+    POSIX: ``$SHELL -c <cmd>`` (falling back to ``/bin/sh``). Windows:
+    ``%COMSPEC% /c <cmd>`` (falling back to ``cmd.exe``). ``-c`` (not a login
+    shell) keeps it predictable and avoids ``!``-history expansion, at the cost
+    of not loading interactive-rc aliases.
+    """
+    if os.name == "nt":
+        return [os.environ.get("COMSPEC") or "cmd.exe", "/c", cmd]
+    return [os.environ.get("SHELL") or "/bin/sh", "-c", cmd]
+
+
+def _resolve_cd(cmd: str, cwd: str) -> str | None:
+    """If ``cmd`` is a standalone ``cd`` (no shell operators), return the
+    resolved absolute target directory, else ``None``.
+
+    ``cd`` with no argument resolves to home. Only a lone ``cd`` is handled —
+    a ``cd`` inside a compound command (``cd x && …``) runs in its own subshell
+    and does not persist (lightweight cwd model; full shell-state persistence
+    would need a long-lived shell).
+    """
+    s = cmd.strip()
+    if s != "cd" and not s.startswith("cd "):
+        return None
+    if any(op in s for op in ("&&", "||", ";", "|", ">", "<", "`", "$(", "\n")):
+        return None
+    arg = s[2:].strip().strip("\"'")
+    if not arg or arg == "~":
+        return os.path.expanduser("~")
+    target = os.path.expanduser(arg)
+    if not os.path.isabs(target):
+        target = os.path.join(cwd, target)
+    return os.path.normpath(target)
+
+
+def _clip_text(text: str, limit: int) -> str:
+    """Clip ``text`` to ``limit`` chars, keeping head + tail with a marker."""
+    if len(text) <= limit:
+        return text
+    head = limit * 3 // 4
+    tail = limit - head
+    omitted = len(text) - limit
+    return f"{text[:head]}\n… [{omitted} chars truncated] …\n{text[-tail:]}"
+
+
+def _write_bang_overflow(cmd: str, stdout: str, stderr: str) -> str | None:
+    """When combined output exceeds the model cap, spill the FULL (ANSI-stripped)
+    capture to a temp file and return its path; else ``None``. Lets the agent
+    read everything instead of losing the truncated remainder."""
+    from rich.text import Text as _RText
+
+    if len(stdout) + len(stderr) <= _BANG_CONTEXT_MAX:
+        return None
+    fd, path = tempfile.mkstemp(prefix="omnigent-bang-", suffix=".log")
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(f"$ {cmd}\n\n")
+        if stdout:
+            fh.write(_RText.from_ansi(stdout).plain)
+        if stderr:
+            fh.write("\n--- stderr ---\n")
+            fh.write(_RText.from_ansi(stderr).plain)
+    return path
+
+
+def _build_bang_context(
+    cmd: str,
+    stdout: str,
+    stderr: str,
+    status: str,
+    overflow_path: str | None = None,
+) -> str:
+    """Build the model-facing block for a "!" command: ANSI stripped, capped,
+    with separate stdout/stderr fences. ``status`` is e.g. ``"exit: 0"``. When
+    ``overflow_path`` is given, the full output was spilled there and is noted
+    so the agent can read it in full."""
+    from rich.text import Text as _RText
+
+    parts = [
+        "I ran a shell command in the terminal. Here is the command and its output.",
+        "",
+        f"$ {cmd}",
+        status,
+    ]
+    out = _clip_text(_RText.from_ansi(stdout).plain.rstrip(), _BANG_CONTEXT_MAX)
+    err = _clip_text(_RText.from_ansi(stderr).plain.rstrip(), _BANG_CONTEXT_MAX)
+    if out:
+        parts += ["", "```stdout", out, "```"]
+    if err:
+        parts += ["", "```stderr", err, "```"]
+    if not out and not err:
+        parts += ["", "(no output)"]
+    if overflow_path:
+        parts += ["", f"(output truncated above — full output saved to: {overflow_path})"]
+    return "\n".join(parts)
+
+
+async def _run_bang_command(
+    cmd: str, host: TerminalHost, fmt: RichBlockFormatter, *, cwd: str | None = None
+) -> str:
+    """Run ``cmd`` in the user's shell, render its output, and return a
+    model-facing block to fold into the next turn.
+
+    Best-effort and non-interactive: stdin is ``/dev/null`` (interactive
+    commands fail fast instead of hanging) and the run is bounded by a timeout.
+    Cross-platform (POSIX ``$SHELL -c`` / Windows ``cmd.exe /c``). stdout/stderr
+    are captured separately; ANSI is preserved on screen and stripped for the
+    model; output is capped, with the full capture spilled to a temp file when
+    it overflows.
+    """
+    from rich.text import Text as _RText
+
+    host.output(_RText.from_markup(""))
+    host.output(_RText.from_markup(f"  [{fmt.accent}]![/{fmt.accent}] {escape(cmd)}"))
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *_bang_shell_argv(cmd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+            cwd=cwd or os.getcwd(),
+        )
+    except OSError as exc:
+        host.output(
+            _RText.from_markup(
+                f"   [{fmt.warning}]! could not run: {escape(str(exc))}[/{fmt.warning}]"
+            ),
+        )
+        return f"$ {cmd}\n(command could not be started: {exc})"
+
+    timed_out = False
+    try:
+        out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=_BANG_TIMEOUT_S)
+    except asyncio.TimeoutError:
+        timed_out = True
+        proc.kill()
+        out_b, err_b = await proc.communicate()
+
+    elapsed = loop.time() - start
+    stdout = out_b.decode(errors="replace")
+    stderr = err_b.decode(errors="replace")
+    code = proc.returncode
+
+    if stdout:
+        host.output(_RText.from_ansi(_clip_text(stdout, _BANG_DISPLAY_MAX)))
+    if stderr:
+        host.output(_RText.from_markup(f"  [{fmt.muted}][stderr][/{fmt.muted}]"))
+        host.output(_RText.from_ansi(_clip_text(stderr, _BANG_DISPLAY_MAX)))
+
+    overflow_path = _write_bang_overflow(cmd, stdout, stderr)
+    if overflow_path:
+        host.output(
+            _RText.from_markup(
+                f"   [{fmt.muted}]full output: {escape(overflow_path)}[/{fmt.muted}]"
+            )
+        )
+
+    if timed_out:
+        secs = int(_BANG_TIMEOUT_S)
+        host.output(
+            _RText.from_markup(
+                f"   [{fmt.warning}]⏱ killed after {secs}s (timeout)[/{fmt.warning}]"
+            )
+        )
+        status = f"timed out and was killed after {secs}s"
+    else:
+        style = fmt.muted if code == 0 else fmt.warning
+        host.output(_RText.from_markup(f"   [{style}]exit {code} · {elapsed:.1f}s[/{style}]"))
+        status = f"exit: {code}"
+    return _build_bang_context(cmd, stdout, stderr, status, overflow_path)
 
 
 async def handle_slash_command(

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -61,6 +61,8 @@ from omnigent_ui_sdk.terminal._formatter import FormattedItem
 from omnigent_ui_sdk.terminal._theme import LIGHT_THEME, get_theme
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion, merge_completers
 from prompt_toolkit.document import Document
+from prompt_toolkit.formatted_text import StyleAndTextTuples
+from prompt_toolkit.lexers import Lexer
 from rich.console import RenderableType
 from rich.markup import escape
 from rich.text import Text
@@ -3829,6 +3831,14 @@ async def run_repl(
     # nested closure can rebind the value.
     _bang_cwd: list[str] = [os.getcwd()]
 
+    # Paint the composer in the omnigent-logo green while the line is a "!"
+    # shell command, so bang mode is visible before Enter is pressed.
+    # ``PromptSession`` reads ``.lexer`` through a ``DynamicLexer``, so setting
+    # it here takes effect live.
+    _prompt_session = getattr(host, "_prompt", None)
+    if _prompt_session is not None:
+        _prompt_session.lexer = _BangInputLexer()
+
     async def on_input(text: str, attachments: list[PendingAttachment] | None = None) -> None:
         nonlocal conversation_id, is_streaming
 
@@ -3891,9 +3901,7 @@ async def run_repl(
             if cd_target is not None:
                 if os.path.isdir(cd_target):
                     _bang_cwd[0] = cd_target
-                    host.output(
-                        Text.from_markup(f"  [{fmt.accent}]![/{fmt.accent}] {escape(cmd)}")
-                    )
+                    host.output(Text.from_markup(f"  [{_BANG_ECHO_MARKUP}]! {escape(cmd)}[/]"))
                     host.output(
                         Text.from_markup(
                             f"   [{fmt.muted}]now in {escape(cd_target)}[/{fmt.muted}]"
@@ -8313,6 +8321,34 @@ _BANG_TIMEOUT_S: float = float(os.environ.get("OMNIGENT_BANG_TIMEOUT_S") or 120.
 _BANG_DISPLAY_MAX: int = int(os.environ.get("OMNIGENT_BANG_DISPLAY_MAX") or 30_000)
 _BANG_CONTEXT_MAX: int = int(os.environ.get("OMNIGENT_BANG_CONTEXT_MAX") or 16_000)
 
+# The omnigent-logo green. Marks a "!" shell command consistently: the composer
+# while it's being typed, and the echoed command line once it runs.
+_BANG_GREEN = "#26a079"
+_BANG_INPUT_STYLE = f"fg:{_BANG_GREEN} bold"  # prompt-toolkit composer style
+# Rich-markup style for the echoed "! <cmd>" line (see _run_bang_command).
+_BANG_ECHO_MARKUP = f"bold {_BANG_GREEN}"
+
+
+class _BangInputLexer(Lexer):
+    """
+    Color the composer green while the current line is a "!" shell command.
+
+    A line that begins with ``!`` (but not the ``!!`` literal-escape) runs in
+    the shell via the passthrough; painting it in the omnigent-logo green is
+    live feedback that bang mode is active. Any other input renders unstyled.
+    """
+
+    def lex_document(self, document: Document) -> Callable[[int], StyleAndTextTuples]:
+        text = document.text
+        is_bang = text.startswith("!") and not text.startswith("!!")
+        style = _BANG_INPUT_STYLE if is_bang else ""
+        lines = document.lines
+
+        def get_line(lineno: int) -> StyleAndTextTuples:
+            return [(style, lines[lineno])]
+
+        return get_line
+
 
 def _bang_shell_argv(cmd: str) -> list[str]:
     """Argv to run ``cmd`` via the platform shell.
@@ -8427,7 +8463,7 @@ async def _run_bang_command(
     from rich.text import Text as _RText
 
     host.output(_RText.from_markup(""))
-    host.output(_RText.from_markup(f"  [{fmt.accent}]![/{fmt.accent}] {escape(cmd)}"))
+    host.output(_RText.from_markup(f"  [{_BANG_ECHO_MARKUP}]! {escape(cmd)}[/]"))
 
     loop = asyncio.get_running_loop()
     start = loop.time()

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -3924,6 +3924,11 @@ async def run_repl(
         # contain more path separators — don't treat those as commands.
         first_token = text.split()[0] if text.split() else ""
         if first_token.startswith("/") and "/" not in first_token[1:]:
+            # Starting a new conversation orphans any buffered "!" output — it
+            # belonged to the prior conversation. Drop it so it can't leak into
+            # the fresh conversation's first turn.
+            if first_token in ("/clear", "/new"):
+                _pending_bang_blocks.clear()
             await handle_slash_command(text, session, client, host, fmt)
             return
 
@@ -8397,21 +8402,30 @@ def _clip_text(text: str, limit: int) -> str:
 
 
 def _write_bang_overflow(cmd: str, stdout: str, stderr: str) -> str | None:
-    """When combined output exceeds the model cap, spill the FULL (ANSI-stripped)
+    """
+    When combined output exceeds the model cap, spill the FULL (ANSI-stripped)
     capture to a temp file and return its path; else ``None``. Lets the agent
-    read everything instead of losing the truncated remainder."""
+    read everything instead of losing the truncated remainder.
+
+    The overflow is measured on the ANSI-stripped text — the same form the
+    context builder caps — so heavily-styled output doesn't trip the spill when
+    the text the model sees would fit. The file is intentionally left in place
+    for the agent to read on a later turn; the OS temp dir reclaims it.
+    """
     from rich.text import Text as _RText
 
-    if len(stdout) + len(stderr) <= _BANG_CONTEXT_MAX:
+    plain_out = _RText.from_ansi(stdout).plain if stdout else ""
+    plain_err = _RText.from_ansi(stderr).plain if stderr else ""
+    if len(plain_out) + len(plain_err) <= _BANG_CONTEXT_MAX:
         return None
     fd, path = tempfile.mkstemp(prefix="omnigent-bang-", suffix=".log")
     with os.fdopen(fd, "w", encoding="utf-8") as fh:
         fh.write(f"$ {cmd}\n\n")
-        if stdout:
-            fh.write(_RText.from_ansi(stdout).plain)
-        if stderr:
+        if plain_out:
+            fh.write(plain_out)
+        if plain_err:
             fh.write("\n--- stderr ---\n")
-            fh.write(_RText.from_ansi(stderr).plain)
+            fh.write(plain_err)
     return path
 
 

--- a/tests/e2e/omnigent/test_repl_bang_e2e.py
+++ b/tests/e2e/omnigent/test_repl_bang_e2e.py
@@ -185,3 +185,64 @@ def test_repl_bang_bare_shows_hint_and_double_bang_escapes(
     assert "exit 0" not in turn.stripped, (
         "'!!' prompt rendered a shell exit footer — it was executed, not escaped"
     )
+
+
+def test_repl_bang_buffer_dropped_on_new_conversation(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """
+    Buffered ``!`` output is discarded when a new conversation starts (``/clear``)
+    — it belonged to the prior conversation and must not leak into the fresh
+    conversation's first turn.
+    """
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": "Ok."}])
+    yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
+
+    child = spawn_omnigent_run(
+        omnigent_python=omnigent_python,
+        yaml_path=yaml_path,
+        model=_MODEL,
+        harness=_HARNESS,
+        env=mock_credentials_env,
+        cwd=omnigent_repo_root,
+        timeout=_SPAWN_TIMEOUT,
+    )
+    try:
+        child.expect(_COMPLETION_MARKER, timeout=_BOOT_TIMEOUT)
+
+        submit_prompt(child, "!echo LEAK_SENTINEL_QQQ")
+        child.expect(r"exit 0", timeout=_BANG_TIMEOUT)
+
+        # /clear starts a new conversation — it must drop the buffered output.
+        # Re-sync on the freshly re-rendered prompt before sending the next
+        # line, otherwise it races the /clear redraw and never submits.
+        submit_prompt(child, "/clear")
+        child.expect(_COMPLETION_MARKER, timeout=_BOOT_TIMEOUT)
+        drain_for(child, 1.5)
+
+        submit_prompt(child, "hello fresh conversation")
+        await_turn_complete(
+            child,
+            running_timeout=_RUNNING_TIMEOUT,
+            completion_timeout=_COMPLETION_TIMEOUT,
+            running_marker=_RUNNING_MARKER,
+            completion_pattern=_COMPLETION_MARKER,
+        )
+        clean_exit(child, timeout=_EXIT_TIMEOUT)
+    finally:
+        if not child.closed:
+            child.close(force=True)
+
+    requests = _captured_requests(mock_llm_server_url)
+    assert requests, "the post-/clear prompt never reached the model"
+    blob = json.dumps(requests)
+    assert "LEAK_SENTINEL_QQQ" not in blob, (
+        "buffered bang output leaked into the new conversation after /clear:\n" + blob[-2000:]
+    )
+    assert "hello fresh conversation" in blob, (
+        "the post-/clear prompt is missing from the model request"
+    )

--- a/tests/e2e/omnigent/test_repl_bang_e2e.py
+++ b/tests/e2e/omnigent/test_repl_bang_e2e.py
@@ -1,0 +1,187 @@
+"""End-to-end coverage for the REPL "!" shell passthrough.
+
+The unit suite (``tests/repl/test_bang_command.py``) covers the extracted
+helpers — the clip/context builders and the ``_run_bang_command`` runner. What
+it cannot reach is the wiring inside ``run_repl.on_input``: the ``!`` / ``!!`` /
+bare-``!`` dispatch and the buffer that folds a command's output into the *next*
+agent turn. Those only exist as a closure over the live REPL, so they are
+exercised here by driving the real ``omnigent run`` REPL under a PTY and
+inspecting what the model actually received via the mock LLM server.
+
+**What breaks if these fail:**
+- ``!<cmd>`` stops running in the shell / stops rendering its output + footer.
+- A bare ``!<cmd>`` wrongly costs a model turn (or silently drops its output
+  instead of folding it into the next turn's ``llm_text``).
+- The bare ``!`` usage hint or the ``!!`` literal-escape routing regresses.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+
+from tests.e2e.omnigent._pexpect_harness import (
+    await_turn_complete,
+    clean_exit,
+    spawn_omnigent_run,
+    strip_ansi,
+    submit_prompt,
+)
+from tests.e2e.omnigent._repl_test_helpers import drain_for
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm
+
+_MODEL = "mock-model"
+_HARNESS = "openai-agents"
+
+# Visible turn-synchronization markers — same ones the green smoke / model /
+# effort e2e tests use. ``working`` is the streaming activity line; ``❯ `` is
+# the input prompt the REPL re-renders when a turn settles.
+_RUNNING_MARKER = r"working"
+_COMPLETION_MARKER = r"❯ "
+
+_SPAWN_TIMEOUT = 60.0
+_BOOT_TIMEOUT = 30.0
+_RUNNING_TIMEOUT = 20.0
+_COMPLETION_TIMEOUT = 60.0
+_BANG_TIMEOUT = 20.0
+_EXIT_TIMEOUT = 15.0
+
+
+def _captured_requests(mock_llm_server_url: str) -> list[dict]:
+    resp = httpx.get(f"{mock_llm_server_url}/mock/requests", timeout=5.0)
+    resp.raise_for_status()
+    return resp.json()["requests"]
+
+
+def test_repl_bang_runs_and_folds_into_next_turn(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """
+    ``!echo`` runs locally, renders its output, costs no model turn, and its
+    output is folded into the following prompt's request to the model.
+    """
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": "Understood."}])
+    yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
+
+    child = spawn_omnigent_run(
+        omnigent_python=omnigent_python,
+        yaml_path=yaml_path,
+        model=_MODEL,
+        harness=_HARNESS,
+        env=mock_credentials_env,
+        cwd=omnigent_repo_root,
+        timeout=_SPAWN_TIMEOUT,
+    )
+    try:
+        child.expect(_COMPLETION_MARKER, timeout=_BOOT_TIMEOUT)
+
+        # A "!" command runs in the shell and prints its own exit footer; it
+        # does NOT enter a model turn, so synchronize on the footer, not on
+        # "working".
+        submit_prompt(child, "!echo BANG_SENTINEL_XYZ")
+        child.expect(r"exit 0", timeout=_BANG_TIMEOUT)
+        bang_render = strip_ansi(child.before or "") + strip_ansi(drain_for(child, 2.0))
+        assert "BANG_SENTINEL_XYZ" in bang_render, (
+            "bang command stdout not rendered on screen:\n" + bang_render[-1500:]
+        )
+
+        # The bang alone must not have hit the model.
+        assert _captured_requests(mock_llm_server_url) == [], (
+            "a bare '!' command wrongly triggered a model request"
+        )
+
+        # Now a normal prompt: the buffered bang output must be folded into it.
+        submit_prompt(child, "what did that print?")
+        await_turn_complete(
+            child,
+            running_timeout=_RUNNING_TIMEOUT,
+            completion_timeout=_COMPLETION_TIMEOUT,
+            running_marker=_RUNNING_MARKER,
+            completion_pattern=_COMPLETION_MARKER,
+        )
+        clean_exit(child, timeout=_EXIT_TIMEOUT)
+    finally:
+        if not child.closed:
+            child.close(force=True)
+
+    requests = _captured_requests(mock_llm_server_url)
+    assert requests, "the follow-up prompt never reached the model"
+    blob = json.dumps(requests)
+    assert "BANG_SENTINEL_XYZ" in blob, (
+        "bang stdout was not folded into the next turn's model request:\n" + blob[-2000:]
+    )
+    assert "I ran a shell command" in blob, (
+        "the model-facing bang context header is missing from the request"
+    )
+    assert "what did that print?" in blob, (
+        "the user's follow-up prompt is missing from the model request"
+    )
+
+
+def test_repl_bang_bare_shows_hint_and_double_bang_escapes(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """
+    A bare ``!`` prints a usage hint and costs no model turn; ``!!text`` drops
+    one ``!`` and is sent to the model as the literal prompt ``!text`` (it is
+    NOT executed as a shell command).
+    """
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": "Ok."}])
+    yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
+
+    child = spawn_omnigent_run(
+        omnigent_python=omnigent_python,
+        yaml_path=yaml_path,
+        model=_MODEL,
+        harness=_HARNESS,
+        env=mock_credentials_env,
+        cwd=omnigent_repo_root,
+        timeout=_SPAWN_TIMEOUT,
+    )
+    try:
+        child.expect(_COMPLETION_MARKER, timeout=_BOOT_TIMEOUT)
+
+        submit_prompt(child, "!")
+        child.expect(r"runs a shell command", timeout=_BANG_TIMEOUT)
+        assert _captured_requests(mock_llm_server_url) == [], (
+            "a bare '!' usage hint wrongly triggered a model request"
+        )
+
+        # "!!" escapes: one "!" is stripped and the rest is an ordinary prompt.
+        submit_prompt(child, "!!literal-bang-prompt")
+        turn = await_turn_complete(
+            child,
+            running_timeout=_RUNNING_TIMEOUT,
+            completion_timeout=_COMPLETION_TIMEOUT,
+            running_marker=_RUNNING_MARKER,
+            completion_pattern=_COMPLETION_MARKER,
+        )
+        clean_exit(child, timeout=_EXIT_TIMEOUT)
+    finally:
+        if not child.closed:
+            child.close(force=True)
+
+    requests = _captured_requests(mock_llm_server_url)
+    assert requests, "the '!!'-escaped prompt never reached the model"
+    blob = json.dumps(requests)
+    # Exactly one leading "!" survives the escape.
+    assert "!literal-bang-prompt" in blob, (
+        "'!!' did not send a literal single-'!' prompt to the model:\n" + blob[-2000:]
+    )
+    # The escaped prompt must NOT have been run as a shell command.
+    assert "I ran a shell command" not in blob, (
+        "'!!' prompt was wrongly executed as a shell command"
+    )
+    assert "exit 0" not in turn.stripped, (
+        "'!!' prompt rendered a shell exit footer — it was executed, not escaped"
+    )

--- a/tests/repl/test_bang_command.py
+++ b/tests/repl/test_bang_command.py
@@ -1,0 +1,185 @@
+"""Tests for the REPL "!" shell-passthrough handler.
+
+`!<cmd>` runs `<cmd>` in the user's shell, shows the output, and returns a
+model-facing block that is folded into the next agent turn. Covers the pure
+helpers (clip + context builder) and the async runner against real (POSIX)
+commands, including non-zero exit, stderr, no-output, ANSI stripping, output
+capping, and timeout.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from omnigent.repl import _repl
+from omnigent.repl._repl import (
+    _bang_shell_argv,
+    _build_bang_context,
+    _clip_text,
+    _resolve_cd,
+    _run_bang_command,
+    _write_bang_overflow,
+)
+
+
+class _FakeHost:
+    """Collects whatever the runner writes to the terminal."""
+
+    def __init__(self) -> None:
+        self.items: list = []
+
+    def output(self, item: object) -> None:
+        self.items.append(item)
+
+
+class _FakeFmt:
+    accent = "cyan"
+    muted = "dim"
+    warning = "yellow"
+
+
+# ── _clip_text ──────────────────────────────────────────
+
+
+def test_clip_text_under_limit_is_unchanged() -> None:
+    assert _clip_text("short", 100) == "short"
+
+
+def test_clip_text_over_limit_keeps_head_tail_with_marker() -> None:
+    out = _clip_text("A" * 50 + "B" * 50, 40)
+    assert "chars truncated" in out
+    assert out.startswith("A")  # head preserved
+    assert out.endswith("B")  # tail preserved
+    assert len(out) < 100
+
+
+# ── _build_bang_context (model-facing block) ────────────
+
+
+def test_build_context_has_command_exit_and_stdout_fence() -> None:
+    block = _build_bang_context("ls", "a\nb\n", "", "exit: 0")
+    assert "$ ls" in block
+    assert "exit: 0" in block
+    assert "```stdout" in block and "a\nb" in block
+    assert "```stderr" not in block  # no stderr → no stderr fence
+
+
+def test_build_context_includes_stderr_fence_when_present() -> None:
+    block = _build_bang_context("x", "", "boom\n", "exit: 1")
+    assert "```stderr" in block and "boom" in block
+
+
+def test_build_context_no_output_marker() -> None:
+    block = _build_bang_context("true", "", "", "exit: 0")
+    assert "(no output)" in block
+    assert "```" not in block
+
+
+def test_build_context_strips_ansi_for_the_model() -> None:
+    block = _build_bang_context("c", "\x1b[31mred\x1b[0m text", "", "exit: 0")
+    assert "red text" in block
+    assert "\x1b[" not in block  # escapes removed
+
+
+def test_build_context_caps_huge_output() -> None:
+    block = _build_bang_context("big", "X" * (_repl._BANG_CONTEXT_MAX + 5000), "", "exit: 0")
+    assert "chars truncated" in block
+
+
+# ── _run_bang_command (async, real subprocess; POSIX shell semantics) ───
+
+
+@pytest.mark.posix_only
+async def test_run_echo_captures_stdout_and_exit_zero() -> None:
+    block = await _run_bang_command("echo hello", _FakeHost(), _FakeFmt())
+    assert "hello" in block
+    assert "exit: 0" in block
+
+
+@pytest.mark.posix_only
+async def test_run_renders_to_the_host() -> None:
+    host = _FakeHost()
+    await _run_bang_command("echo hi", host, _FakeFmt())
+    assert host.items  # echo line + output + footer were written
+
+
+@pytest.mark.posix_only
+async def test_run_nonzero_exit_is_reported_not_fatal() -> None:
+    block = await _run_bang_command("exit 3", _FakeHost(), _FakeFmt())
+    assert "exit: 3" in block
+
+
+@pytest.mark.posix_only
+async def test_run_captures_stderr() -> None:
+    block = await _run_bang_command("echo oops 1>&2", _FakeHost(), _FakeFmt())
+    assert "```stderr" in block and "oops" in block
+
+
+@pytest.mark.posix_only
+async def test_run_timeout_kills_and_reports(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_repl, "_BANG_TIMEOUT_S", 0.2)
+    block = await _run_bang_command("sleep 5", _FakeHost(), _FakeFmt())
+    assert "timed out" in block
+
+
+@pytest.mark.posix_only
+async def test_run_respects_cwd(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "marker.txt").write_text("x")
+    block = await _run_bang_command("ls", _FakeHost(), _FakeFmt(), cwd=str(tmp_path))
+    assert "marker.txt" in block
+
+
+# ── cross-platform shell selection ──────────────────────
+
+
+@pytest.mark.posix_only
+def test_shell_argv_posix() -> None:
+    assert _bang_shell_argv("echo hi")[-2:] == ["-c", "echo hi"]
+
+
+def test_shell_argv_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("os.name", "nt")
+    monkeypatch.setenv("COMSPEC", r"C:\Windows\System32\cmd.exe")
+    assert _bang_shell_argv("dir") == [r"C:\Windows\System32\cmd.exe", "/c", "dir"]
+
+
+# ── _resolve_cd (lightweight cwd persistence) ───────────
+
+
+@pytest.mark.posix_only
+def test_resolve_cd_absolute_relative_and_home() -> None:
+    assert _resolve_cd("cd /tmp", "/work") == "/tmp"
+    assert _resolve_cd("cd sub", "/work") == "/work/sub"
+    assert _resolve_cd("cd", "/work") == os.path.expanduser("~")
+    assert _resolve_cd("cd ~", "/work") == os.path.expanduser("~")
+
+
+def test_resolve_cd_none_for_non_cd_or_compound() -> None:
+    assert _resolve_cd("ls", "/work") is None
+    assert _resolve_cd("cd a && ls", "/work") is None  # compound → not handled
+    assert _resolve_cd("cdfoo", "/work") is None
+
+
+# ── _write_bang_overflow (huge-output temp file) ────────
+
+
+def test_write_overflow_none_when_small() -> None:
+    assert _write_bang_overflow("c", "small", "") is None
+
+
+def test_write_overflow_writes_full_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_repl, "_BANG_CONTEXT_MAX", 10)
+    big = "Z" * 50
+    path = _write_bang_overflow("mycmd", big, "")
+    assert path is not None
+    content = pathlib.Path(path).read_text()
+    assert "mycmd" in content and big in content
+    pathlib.Path(path).unlink()
+
+
+def test_build_context_notes_overflow_path() -> None:
+    block = _build_bang_context("c", "x", "", "exit: 0", overflow_path="/tmp/x.log")
+    assert "/tmp/x.log" in block and "full output" in block

--- a/tests/repl/test_bang_command.py
+++ b/tests/repl/test_bang_command.py
@@ -13,10 +13,13 @@ import os
 import pathlib
 
 import pytest
+from prompt_toolkit.document import Document
 
 from omnigent.repl import _repl
 from omnigent.repl._repl import (
+    _BANG_INPUT_STYLE,
     _bang_shell_argv,
+    _BangInputLexer,
     _build_bang_context,
     _clip_text,
     _resolve_cd,
@@ -132,6 +135,16 @@ async def test_run_respects_cwd(tmp_path: pathlib.Path) -> None:
     assert "marker.txt" in block
 
 
+@pytest.mark.posix_only
+async def test_run_echoes_command_in_logo_green() -> None:
+    # The echoed "! <cmd>" line is rendered in the omnigent-logo green so it
+    # matches the green composer input.
+    host = _FakeHost()
+    await _run_bang_command("echo hi", host, _FakeFmt())
+    styles = [str(span.style) for item in host.items for span in getattr(item, "spans", [])]
+    assert any("#26a079" in s for s in styles), styles
+
+
 # ── cross-platform shell selection ──────────────────────
 
 
@@ -183,3 +196,29 @@ def test_write_overflow_writes_full_capture(monkeypatch: pytest.MonkeyPatch) -> 
 def test_build_context_notes_overflow_path() -> None:
     block = _build_bang_context("c", "x", "", "exit: 0", overflow_path="/tmp/x.log")
     assert "/tmp/x.log" in block and "full output" in block
+
+
+# ── _BangInputLexer (composer coloring) ─────────────────
+
+
+def test_bang_input_style_is_the_logo_green() -> None:
+    # The omnigent-logo green (#26a079) must be the exact hex used.
+    assert "#26a079" in _BANG_INPUT_STYLE
+
+
+@pytest.mark.parametrize(
+    ("text", "colored"),
+    [
+        ("!echo hi", True),  # a "!" shell command → green
+        ("!", True),  # bare "!" (bang mode active) → green
+        ("!cd /tmp", True),  # "!cd" is still a bang command → green
+        ("!!literal", False),  # "!!" escape → ordinary prompt, not green
+        ("ls -la", False),  # normal prompt → unstyled
+        ("", False),  # empty composer → unstyled
+    ],
+)
+def test_bang_input_lexer_colors_only_bang_lines(text: str, colored: bool) -> None:
+    get_line = _BangInputLexer().lex_document(Document(text))
+    style, rendered = get_line(0)[0]
+    assert rendered == text
+    assert (style == _BANG_INPUT_STYLE) is colored


### PR DESCRIPTION
## What
Adds a Claude Code-style **`!` shell passthrough** to the REPL prompt: a line beginning with `!` runs the rest in the user's shell, and the command + output are folded into the next agent turn so the assistant can reason about what ran.

```
> !git status
  ! git status
  <output…>
  exit 0 · 0.1s
> what changed?      ← the git output is folded into this turn's context
```

## Behavior
- `!<cmd>` → runs `<cmd>` **cross-platform** (`$SHELL -c` on POSIX, `%COMSPEC% /c` on Windows), non-interactive (`stdin=/dev/null`), timeout-bounded. Output shown inline — **ANSI preserved on screen**, separate `[stderr]`, an `exit N · Ns` footer (warning-styled on non-zero).
- **Buffer model:** the command + output are buffered and prepended to the next turn's `llm_text` (ANSI **stripped** for the model, capped) — so a bare `!ls` costs **no** model turn; the agent sees it when you next ask something.
- **`!cd <dir>`** (standalone) persists the working directory for later `!` commands (lightweight: a compound `cd x && …` does not persist; full shell-state persistence would need a long-lived shell, deferred).
- **Huge output** spills to a temp file (path referenced in the block) instead of being dropped, so the agent can read it in full.
- `!!<rest>` → escapes: sends a literal leading `!` as an ordinary prompt. Bare `!` → usage hint.
- Knobs: `OMNIGENT_BANG_TIMEOUT_S` (120), `OMNIGENT_BANG_DISPLAY_MAX` (30k), `OMNIGENT_BANG_CONTEXT_MAX` (16k).

## Scope / deferred
v1 is buffer-into-next-turn (not a per-command model turn). **Deferred fast-follows:** `Ctrl+B` backgrounding, Tab `!`-completion, persistent-shell state (env/aliases/compound-`cd`), and `Ctrl+T` tool-output-toggle integration. Uses `-c` (not login `-lc`) to stay predictable and avoid `!`-history expansion, so interactive-rc aliases don't resolve.

## Tests
`tests/repl/test_bang_command.py` (20): clip head/tail; the model-facing context builder (exit code, stdout/stderr fences, no-output, ANSI strip, capping, overflow note); cross-platform shell selection (POSIX + Windows); `cd` resolution; the temp-file overflow; and the async runner against real commands (echo, non-zero exit, stderr, cwd, timeout-kills). POSIX-shell tests are marked `posix_only` (auto-skipped on Windows).

This pull request and its description were written by Isaac.
