### PR TITLE
fix(web): fork/switch agent picker — recursive clone names + history-carry split

### DIFF
--- a/web/src/lib/forkHarness.test.ts
+++ b/web/src/lib/forkHarness.test.ts
@@ -4,6 +4,7 @@ import {
   harnessFamily,
   isNativeHarness,
   forkTargetCarriesHistory,
+  switchTargetCarriesHistory,
 } from "./forkHarness";
 
 describe("harnessFamily", () => {
@@ -93,10 +94,16 @@ describe("forkTargetCarriesHistory", () => {
     ["native-claude"],
     ["codex-native"],
     ["native-codex"],
-    // Cursor is native but server-backed: a fork carries history as a text
-    // preamble (text-prefix replay), so it must be offered in the picker too.
+    // Hermes is a native-rebuild harness (in _FORK_HISTORY_NATIVE_HARNESSES).
+    ["hermes-native"],
+    ["native-hermes"],
+    // Cursor / OpenCode are native but server-backed: a FORK carries history
+    // as a text preamble (text-prefix replay), so both must be offered in the
+    // fork picker (switch differs — see switchTargetCarriesHistory).
     ["cursor-native"],
     ["native-cursor"],
+    ["opencode-native"],
+    ["native-opencode"],
     // Pi is native but multi-family (no single harnessFamily) — it must
     // still be offered, or the fork/switch-agent pickers silently drop it.
     ["pi-native"],
@@ -106,9 +113,20 @@ describe("forkTargetCarriesHistory", () => {
     // qwen-native rebuilds qwen's on-disk recording from the copied items.
     ["qwen-native"],
     ["native-qwen"],
-  ])("native target %s carries history", (target) => {
+  ])("native fork target %s carries history", (target) => {
     expect(forkTargetCarriesHistory(target)).toBe(true);
   });
+
+  // Native harnesses with NO carry path on the server (neither rebuild nor
+  // preamble) and no single provider family — forking into them would start
+  // fresh, so the fork picker must not offer them. (qwen-native DOES carry —
+  // it rebuilds from items — so it is intentionally absent here.)
+  it.each([["kiro-native"], ["kimi-native"], ["goose-native"]])(
+    "native target %s without a carry path does NOT carry on fork",
+    (target) => {
+      expect(forkTargetCarriesHistory(target)).toBe(false);
+    },
+  );
 
   it("does NOT offer a target whose harness is unknown (conservative; see TODO)", () => {
     // We can't classify an unrecognised harness (the catalog may report
@@ -117,6 +135,57 @@ describe("forkTargetCarriesHistory", () => {
     expect(forkTargetCarriesHistory("mystery")).toBe(false);
     expect(forkTargetCarriesHistory(null)).toBe(false);
     expect(forkTargetCarriesHistory(undefined)).toBe(false);
+  });
+});
+
+describe("switchTargetCarriesHistory", () => {
+  // Switch carries for native-rebuild targets (rebuilt from items) and SDK
+  // targets (replayed as context) — same as fork for these.
+  it.each([
+    ["claude-native"],
+    ["native-claude"],
+    ["codex-native"],
+    ["native-codex"],
+    ["pi-native"],
+    ["native-pi"],
+    ["hermes-native"],
+    ["native-hermes"],
+    // qwen-native rebuilds its on-disk recording, so it carries on switch too.
+    ["qwen-native"],
+    ["native-qwen"],
+    ["claude-sdk"],
+    ["openai-agents"],
+    ["antigravity"],
+    // antigravity-native currently carries via the family proxy (see the
+    // forkTargetCarriesHistory NOTE); kept offered until verified.
+    ["antigravity-native"],
+  ])("switch target %s carries history", (target) => {
+    expect(switchTargetCarriesHistory(target)).toBe(true);
+  });
+
+  // The preamble path (cursor/opencode) is FORK-ONLY: an in-place switch has
+  // no first-message injection point, so switching into one starts fresh and
+  // must NOT be offered — even though forkTargetCarriesHistory returns true.
+  it.each([["cursor-native"], ["native-cursor"], ["opencode-native"], ["native-opencode"]])(
+    "preamble target %s carries on fork but NOT on switch",
+    (target) => {
+      expect(forkTargetCarriesHistory(target)).toBe(true);
+      expect(switchTargetCarriesHistory(target)).toBe(false);
+    },
+  );
+
+  // Native harnesses with no carry path are offered by neither picker.
+  it.each([["kiro-native"], ["kimi-native"], ["goose-native"]])(
+    "native target %s without a carry path does NOT carry on switch",
+    (target) => {
+      expect(switchTargetCarriesHistory(target)).toBe(false);
+    },
+  );
+
+  it("does NOT offer an unknown/absent harness", () => {
+    expect(switchTargetCarriesHistory("mystery")).toBe(false);
+    expect(switchTargetCarriesHistory(null)).toBe(false);
+    expect(switchTargetCarriesHistory(undefined)).toBe(false);
   });
 });
 

--- a/web/src/lib/forkHarness.ts
+++ b/web/src/lib/forkHarness.ts
@@ -1,27 +1,25 @@
-// Pure helpers for the "fork with a different agent" flow: decide which
-// switch targets preserve the source's conversation history.
+// Pure helpers for the "fork / switch agent" flows: decide which target
+// harnesses preserve the source's conversation history (and so should appear
+// in each picker). Three carry mechanisms, all keyed off the TARGET harness —
+// a frontend mirror of the server (omnigent/server/routes/sessions.py):
 //
-// Two mechanisms carry a fork's history, both keyed off the TARGET harness:
 //   - SDK (non-native) harnesses replay the Omnigent transcript as LLM
-//     context, so they always carry history regardless of the source.
-//   - Native harnesses (Claude Code, Codex) do NOT replay the transcript;
-//     the runner rebuilds their on-disk transcript before launch — cloning
-//     the source's native transcript when the source is same-family native,
-//     else building one from the copied Omnigent items (a format-agnostic
-//     conversion, so the source harness doesn't matter).
-//   - Cursor is native but server-backed: a synthesized local store is NOT
-//     loaded by `cursor-agent --resume`, so the runner replays the prior turns
-//     as a text preamble on the fork's first message (text-prefix replay). The
-//     turns appear as one context block in the Cursor TUI rather than as
-//     reconstructed bubbles, but the agent gets the full prior context.
+//     context — carry on BOTH fork and switch, regardless of source/family.
+//   - Native-REBUILD harnesses (Claude Code, Codex, Pi, Hermes, Qwen Code)
+//     record a resumable on-disk session file the runner rebuilds from the
+//     copied Omnigent items (a same-family native source clones the source
+//     file instead; cross-family rebuilds, format-agnostic) — carry on BOTH
+//     fork and switch. Mirrors `_FORK_HISTORY_NATIVE_HARNESSES`.
+//   - PREAMBLE harnesses (Cursor, OpenCode) have no rebuildable local store,
+//     so prior turns replay as a text preamble on the fork's first message —
+//     FORK-ONLY. An in-place switch-agent has no first-message injection
+//     point, so switching into one starts fresh. Mirrors
+//     `_CURSOR_FORK_HISTORY_HARNESSES`.
 //
-// Native targets carry history from any source: the rollout synthesizer
-// writes the session_meta fields codex ≥ 0.133 requires (timestamp,
-// cli_version, model_provider) plus the event_msg mirrors codex rebuilds
-// visible turns from, so cross-family forks into codex-native rebuild the
-// rollout from the copied Omnigent items like claude-native always did
-// (see _codex_rollout_records_from_session_items in omnigent/codex_native.py
-// and tests/e2e/test_host_cross_family_fork_e2e.py).
+// Hence two predicates: forkTargetCarriesHistory (rebuild ∪ preamble ∪ SDK)
+// and switchTargetCarriesHistory (rebuild ∪ SDK — no preamble). Native
+// harnesses with no carry path (kiro/kimi/goose) are offered by neither; an
+// unclassifiable harness (catalog harness=null) is conservatively dropped.
 
 /** Provider family a harness consumes, or null when unknown. */
 export function harnessFamily(
@@ -84,33 +82,80 @@ export function isNativeHarness(harness: string | null | undefined): boolean {
 }
 
 /**
- * Whether forking/switching into `targetHarness` keeps the source's
- * conversation history (and so should be offered in the picker).
+ * Native harnesses whose runner REBUILDS a resumable on-disk transcript from
+ * the copied Omnigent items, so they carry history on BOTH fork and switch.
+ * Mirrors Python `_FORK_HISTORY_NATIVE_HARNESSES`
+ * (`omnigent/server/routes/sessions.py`); both canonical and reversed
+ * spellings are listed so a catalog `harness` in either form matches.
+ */
+const NATIVE_REBUILD_HARNESSES: ReadonlySet<string> = new Set([
+  "claude-native",
+  "native-claude",
+  "codex-native",
+  "native-codex",
+  "pi-native",
+  "native-pi",
+  "hermes-native",
+  "native-hermes",
+  "qwen-native",
+  "native-qwen",
+]);
+
+/**
+ * Native harnesses that carry FORK history only as a text preamble on the
+ * fork's first message (no rebuildable local store) — FORK-ONLY. An in-place
+ * switch-agent has no first-message injection point, so switching into one
+ * starts fresh. Mirrors Python `_CURSOR_FORK_HISTORY_HARNESSES`.
+ */
+const PREAMBLE_FORK_HARNESSES: ReadonlySet<string> = new Set([
+  "cursor-native",
+  "native-cursor",
+  "opencode-native",
+  "native-opencode",
+]);
+
+/**
+ * Whether forking into `targetHarness` keeps the source's conversation
+ * history (and so should be offered in the fork picker): a native-rebuild
+ * target, a preamble (cursor/opencode) target, or an SDK-family target (which
+ * replays the transcript as context). Conservatively false for an
+ * unclassifiable harness (the catalog can report harness=null when the bundle
+ * failed to load) and for native harnesses with no carry path
+ * (kiro/kimi/goose).
  *
- * True for every classifiable target — the source harness doesn't matter:
- *   - an SDK target replays the transcript as context;
- *   - a native target clones the source's native transcript when the
- *     source is same-family native, else the runner rebuilds the target's
- *     on-disk transcript from the copied Omnigent items (a format-agnostic
- *     conversion; see the module comment).
+ * NOTE: the SDK branch is `harnessFamily(h) !== null`, which also matches the
+ * one native harness that has a single family today — antigravity-native
+ * (gemini). That preserves Antigravity's prior presence in the pickers, but a
+ * native Antigravity fork is in NEITHER server carry-set, so whether it truly
+ * carries is unverified. TODO(fork-switch): confirm, then move it to a carry
+ * set or drop it rather than leaning on this proxy.
  *
- * Returns false — conservatively — only for a target whose harness we
- * can't classify.
- *
- * TODO(fork-switch): the false-for-unknown default exists because the
- * catalog can report `harness: null` when the server couldn't load the
- * agent's bundle (see `_to_agent_object` in
- * `server/routes/builtin_agents.py`). We don't offer a switch we can't
- * verify preserves history. Revisit once the catalog reliably reports a
- * harness for every built-in, or to add an explicit "may start fresh"
- * affordance for unclassified harnesses.
- *
- * @param targetHarness - The harness the fork would switch to.
+ * @param targetHarness - The harness the fork would bind.
  */
 export function forkTargetCarriesHistory(targetHarness: string | null | undefined): boolean {
-  // Gate on isNativeHarness too: Pi is native but multi-family, so its
-  // harnessFamily is null and it would otherwise be dropped from the pickers.
-  return isNativeHarness(targetHarness) || harnessFamily(targetHarness) !== null;
+  if (!targetHarness) return false;
+  return (
+    NATIVE_REBUILD_HARNESSES.has(targetHarness) ||
+    PREAMBLE_FORK_HARNESSES.has(targetHarness) ||
+    harnessFamily(targetHarness) !== null
+  );
+}
+
+/**
+ * Whether switching a session in place to `targetHarness` keeps history (and
+ * so should be offered in the switch-agent picker). Same as
+ * {@link forkTargetCarriesHistory} MINUS the preamble harnesses: the
+ * text-preamble path is fork-only (switch-agent has no first-message
+ * injection point), so a switch into cursor/opencode would silently start
+ * fresh and must not be offered. Mirrors the server, where switch-agent stamps
+ * carry-history only for `_FORK_HISTORY_NATIVE_HARNESSES`, never the cursor
+ * set.
+ *
+ * @param targetHarness - The harness the switch would bind.
+ */
+export function switchTargetCarriesHistory(targetHarness: string | null | undefined): boolean {
+  if (!targetHarness) return false;
+  return NATIVE_REBUILD_HARNESSES.has(targetHarness) || harnessFamily(targetHarness) !== null;
 }
 
 /**

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -398,6 +398,36 @@ describe("ForkSessionDialog", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("offers fork-only preamble (opencode) and rebuild (hermes) native targets", () => {
+    // OpenCode carries fork history as a text preamble; Hermes via native
+    // rebuild. Both must appear in the FORK picker — unlike the switch picker,
+    // where the fork-only preamble target (opencode) is hidden.
+    setAgents(
+      [
+        {
+          id: "ag_opencode",
+          name: "opencode-native-ui",
+          display_name: "OpenCode",
+          description: null,
+          harness: "opencode-native",
+        },
+        {
+          id: "ag_hermes",
+          name: "hermes-native-ui",
+          display_name: "Hermes",
+          description: null,
+          harness: "hermes-native",
+        },
+      ],
+      "claude-sdk",
+    );
+    renderDialog();
+    openAgentSelect();
+
+    expect(screen.getByTestId("fork-session-agent-option-ag_opencode")).toBeInTheDocument();
+    expect(screen.getByTestId("fork-session-agent-option-ag_hermes")).toBeInTheDocument();
+  });
+
   it("passes the chosen agent_id when switching agent", async () => {
     forkSessionMock.mockResolvedValue({
       id: "conv_fork",

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -349,6 +349,55 @@ describe("ForkSessionDialog", () => {
     expect(screen.getByTestId("fork-session-agent-option-ag_claude_native")).toBeInTheDocument();
   });
 
+  it("excludes the source's agent and resolves its label for a '(switch …)' clone", () => {
+    // The in-place Switch Agent flow names its clone "<builtin> (switch <id>)"
+    // (server: cloned_agent_name = f"{name} (switch …)"). The previous
+    // single-layer, fork-only strip left that suffix in place, so forking a
+    // switched session showed the raw slug as the "same as source" label and
+    // re-listed the current built-in as a switch target. agentRootName peels
+    // the "(switch …)" layer too.
+    setAgents(AVAILABLE_AGENTS, "claude-native");
+    useSessionAgentMock.mockReturnValue({
+      data: {
+        id: "ag_claude_switch",
+        name: "claude-native-ui (switch ag_c537b7b)",
+        harness: "claude-native",
+      },
+    } as unknown as ReturnType<typeof useSessionAgent>);
+    renderDialog();
+    openAgentSelect();
+
+    // Label resolves to the built-in's display name, not the raw suffixed slug.
+    expect(screen.getByTestId("fork-session-agent-option-same")).toHaveTextContent("Claude Code");
+    // The built-in the source was switched to is hidden (no duplicate).
+    expect(
+      screen.queryByTestId("fork-session-agent-option-ag_claude_native"),
+    ).not.toBeInTheDocument();
+    // Other same-family targets remain.
+    expect(screen.getByTestId("fork-session-agent-option-ag_claude_sdk")).toBeInTheDocument();
+  });
+
+  it("excludes the source's agent for a nested fork-of-a-fork clone", () => {
+    // Nested clones accumulate suffixes: "<builtin> (fork a) (fork b)". A
+    // single-layer strip would leave "<builtin> (fork a)", miss the match, and
+    // re-list the built-in. agentRootName recurses to the root.
+    setAgents(AVAILABLE_AGENTS, "claude-native");
+    useSessionAgentMock.mockReturnValue({
+      data: {
+        id: "ag_claude_nested",
+        name: "claude-native-ui (fork ag_b629fd6) (fork ag_a286ffe)",
+        harness: "claude-native",
+      },
+    } as unknown as ReturnType<typeof useSessionAgent>);
+    renderDialog();
+    openAgentSelect();
+
+    expect(screen.getByTestId("fork-session-agent-option-same")).toHaveTextContent("Claude Code");
+    expect(
+      screen.queryByTestId("fork-session-agent-option-ag_claude_native"),
+    ).not.toBeInTheDocument();
+  });
+
   it("passes the chosen agent_id when switching agent", async () => {
     forkSessionMock.mockResolvedValue({
       id: "conv_fork",

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -36,7 +36,7 @@ import { useHosts, type Host } from "@/hooks/useHosts";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
-import { forkTargetCarriesHistory } from "@/lib/forkHarness";
+import { agentRootName, forkTargetCarriesHistory } from "@/lib/forkHarness";
 import { getCliServerUrl } from "@/lib/host";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import { WorkspacePathField } from "./WorkspacePathField";
@@ -213,13 +213,17 @@ export function ForkSessionForm({
   const onDifferentHost =
     isCodingSource && selectedHostId !== null && selectedHostId !== sourceHostId;
 
-  // The source's bound agent, stripped of any " (fork <id>)" suffix the
-  // fork route appends when cloning an agent. A fork-of-a-fork's source
-  // agent is named e.g. "databricks_coding_agent (fork ag_5c78e6a)", which
-  // wouldn't match the built-in "databricks_coding_agent" by name — strip
-  // the suffix so the dedup below still hides it.
+  // The source's bound agent, reduced to its ROOT name by peeling every
+  // " (fork <id>)" / " (switch <id>)" clone suffix the fork/switch routes
+  // append. A fork-of-a-fork or a switched session is named e.g.
+  // "databricks_coding_agent (fork ag_a) (fork ag_b)" or
+  // "claude-native-ui (switch ag_c)", neither of which matches a built-in by
+  // name. agentRootName peels ALL layers — a single-layer / fork-only strip
+  // (the previous regex here) would miss nested clones and every "(switch …)"
+  // clone the in-place switch-agent flow creates — so the label resolves and
+  // the dedup below still hides the source's own agent.
   const sourceAgentName = sourceAgent?.name ?? null;
-  const sourceAgentBaseName = sourceAgentName?.replace(/ \(fork [^)]+\)$/, "") ?? null;
+  const sourceAgentBaseName = sourceAgentName ? agentRootName(sourceAgentName) : null;
 
   // Friendly label for the source's agent — the "same as source" option shows
   // this so the user sees the actual agent they're keeping. The source's YAML

--- a/web/src/shell/SwitchAgentDialog.test.tsx
+++ b/web/src/shell/SwitchAgentDialog.test.tsx
@@ -103,6 +103,46 @@ describe("SwitchAgentDialog", () => {
     expect(screen.getByTestId("switch-agent-option-ag_codex_native")).toBeInTheDocument();
   });
 
+  it("hides fork-only preamble targets (cursor/opencode) but offers hermes", () => {
+    // cursor/opencode carry history only as a FORK preamble; an in-place
+    // switch has no first-message injection point, so it would start fresh —
+    // they must be hidden here. hermes is a native-rebuild target, so offered.
+    useAvailableAgentsMock.mockReturnValue({
+      data: [
+        {
+          id: "ag_cursor",
+          name: "cursor-native-ui",
+          display_name: "Cursor",
+          description: null,
+          harness: "cursor-native",
+        },
+        {
+          id: "ag_opencode",
+          name: "opencode-native-ui",
+          display_name: "OpenCode",
+          description: null,
+          harness: "opencode-native",
+        },
+        {
+          id: "ag_hermes",
+          name: "hermes-native-ui",
+          display_name: "Hermes",
+          description: null,
+          harness: "hermes-native",
+        },
+      ],
+    } as unknown as ReturnType<typeof useAvailableAgents>);
+    useSessionAgentMock.mockReturnValue({
+      data: { id: "ag_source", name: "source", harness: "claude-sdk" },
+    } as unknown as ReturnType<typeof useSessionAgent>);
+    renderDialog();
+    openAgentSelect();
+
+    expect(screen.queryByTestId("switch-agent-option-ag_cursor")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("switch-agent-option-ag_opencode")).not.toBeInTheDocument();
+    expect(screen.getByTestId("switch-agent-option-ag_hermes")).toBeInTheDocument();
+  });
+
   it("excludes the session's own agent even when it's a '(switch …)' clone", () => {
     // The bound agent is a session-scoped clone named "<builtin> (switch
     // ag_…)". The dedup strips the suffix so the built-in it derives from is

--- a/web/src/shell/SwitchAgentDialog.tsx
+++ b/web/src/shell/SwitchAgentDialog.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button";
 import { switchSessionAgent } from "@/lib/sessionsApi";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { useSessionAgent } from "@/hooks/useAgents";
-import { agentRootName, forkTargetCarriesHistory, harnessFamily } from "@/lib/forkHarness";
+import { agentRootName, harnessFamily, switchTargetCarriesHistory } from "@/lib/forkHarness";
 
 // "" means no target chosen yet. It must be empty (not a sentinel like
 // "__none__"): Radix only renders the trigger placeholder when the controlled
@@ -38,7 +38,9 @@ const NONE_CHOSEN = "";
  * Unlike Clone (fork), this keeps the SAME session — transcript, comments,
  * files, and workspace are untouched; only the agent/harness changes, and
  * the next turn runs on it. The picker lists only history-preserving targets
- * (the same rule as the fork agent picker, via `forkTargetCarriesHistory`).
+ * via `switchTargetCarriesHistory` — like the fork picker but WITHOUT the
+ * fork-only preamble harnesses (cursor/opencode), which would start fresh on
+ * an in-place switch.
  * A cross-family switch resets model + reasoning effort to the target's
  * defaults, which the dialog warns about before submitting. On success it
  * refreshes the bound-agent and session-list queries; a failure (e.g. 409
@@ -86,15 +88,16 @@ export function SwitchAgentDialog({
     currentAgentName;
 
   // Targets, excluding the session's own agent (switching to it is a no-op)
-  // and any target that wouldn't preserve history — SDK and native targets
-  // both carry from any source (see forkTargetCarriesHistory); only
-  // unclassifiable harnesses are hidden.
+  // and any target that wouldn't preserve history on an in-place switch. SDK
+  // and native-rebuild targets carry from any source; the fork-only preamble
+  // harnesses (cursor/opencode) and unclassifiable harnesses are hidden — see
+  // switchTargetCarriesHistory.
   const switchableAgents = (agents ?? []).filter(
     (a) =>
       a.id !== currentAgent?.id &&
       a.name !== currentAgentName &&
       a.name !== currentAgentRootName &&
-      forkTargetCarriesHistory(a.harness),
+      switchTargetCarriesHistory(a.harness),
   );
 
   const chosen = switchableAgents.find((a) => a.id === agentChoice) ?? null;


### PR DESCRIPTION
Two related correctness fixes to the fork / switch **agent picker** (`ForkSessionDialog`, `SwitchAgentDialog`). Rebased onto latest main (post `ap-web/` → `web/` rename #1333, and folds in qwen's fork/switch carry from #1576).

## 1. Recursive clone-name handling (`agentRootName`)
`ForkSessionDialog` reduced the source agent's name with an inline, single-layer, **fork-only** regex (`/ \(fork [^)]+\)$/`). Fork itself no longer appends `(fork …)` (clones use the source name verbatim since the atomic-clone change), so the live, forward bug is the **`(switch …)`** suffix the in-place Switch Agent flow appends (`server/routes/sessions.py`) — which that regex never handled. Forking a switched session showed the raw suffixed slug as the **"same as original session"** label and failed to exclude the source's own agent from the switch-target list.

Fixed by using the canonical `agentRootName()` (already used by `SwitchAgentDialog` and `AgentInfo`), which peels every `(fork …)`/`(switch …)` layer to the root. Regression tests added for the `(switch …)` and nested cases.

## 2. Fork vs switch history-carry split
The two pickers shared one predicate (`forkTargetCarriesHistory`) and offered the same targets — but the server carries history differently per operation:
- **native-rebuild** (claude/codex/pi/hermes/qwen) — carry on **both** (`_FORK_HISTORY_NATIVE_HARNESSES`);
- **preamble** (cursor/opencode) — carry on **fork only** (text preamble on the fork's first message); an in-place switch starts fresh (`_CURSOR_FORK_HISTORY_HARNESSES`).

The shared predicate also leaned on an incomplete `isNativeHarness` list, which dropped Hermes/OpenCode from both pickers and wrongly offered Cursor in switch (where it starts fresh).

Now the two backend sets are mirrored explicitly and the predicate is split:
- `forkTargetCarriesHistory` = rebuild ∪ preamble ∪ SDK-family
- `switchTargetCarriesHistory` = rebuild ∪ SDK-family (no preamble)

Net effect:

| Harness | Fork | Switch | Before |
|---|---|---|---|
| Hermes | ✅ | ✅ | hidden in both |
| OpenCode | ✅ | ❌ | hidden in both |
| Cursor | ✅ | ❌ | shown in switch (started fresh) |
| Qwen | ✅ | ✅ | already correct (via #1576) — preserved |
| Kiro / Kimi / Goose | ❌ | ❌ | unchanged (no server carry path yet) |

`isNativeHarness` is kept (exported + tested) but no longer drives the carry predicates. Antigravity-native keeps its prior presence via the family proxy; whether a native Antigravity fork/switch truly carries is **unverified** (TODO in code), left for follow-up.

> Note: Kiro/Kimi/Goose still won't appear because the **server** has no fork-history path for them — surfacing them needs backend support first (separate work).

## Tests
`forkHarness`, `ForkSessionDialog`, `SwitchAgentDialog` suites green (124 tests); new regression coverage for both fixes. `oxlint` / `prettier --check` / `tsc -b` clean.

This pull request and its description were written by Isaac.