### PR TITLE
fix(runner): configurable harness idle window + quiet the expected force-close (part 1 of #1528)

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1442,8 +1442,9 @@ class ClaudeSDKExecutor(Executor):
         same_loop = state.loop is None or current_loop is state.loop
         same_task = state.task is None or current_task is state.task
         if not (same_loop and same_task):
-            logger.warning(
-                "Force-closing Claude SDK client for session %s from a different event loop/task",
+            logger.debug(
+                "Force-closing Claude SDK client for session %s (different event loop/task; "
+                "expected once the connecting turn has finished, e.g. idle reap / shutdown)",
                 session_key,
             )
             await self._force_close_client(state.client)
@@ -1453,8 +1454,9 @@ class ClaudeSDKExecutor(Executor):
         except RuntimeError as exc:
             if "different task" not in str(exc):
                 raise
-            logger.warning(
-                "Force-closing Claude SDK client for session %s from a different task",
+            logger.debug(
+                "Force-closing Claude SDK client for session %s (different task; "
+                "expected once the connecting turn has finished, e.g. idle reap / shutdown)",
                 session_key,
             )
             await self._force_close_client(state.client)

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1110,7 +1110,10 @@ class HarnessProcessManager:
         ``last_used_at`` is older than ``idle_timeout_s`` AND
         has no in-flight response on the harness. Sleeps for
         ``reaper_interval_s`` between passes. Terminates on
-        :class:`asyncio.CancelledError` from :meth:`shutdown`.
+        :class:`asyncio.CancelledError` from :meth:`shutdown`. A
+        non-positive ``idle_timeout_s`` (e.g.
+        ``OMNIGENT_HARNESS_IDLE_TIMEOUT_S=0``) disables reaping — each
+        pass is a no-op.
 
         Two safety guards beyond raw ``last_used_at`` checks:
 
@@ -1144,6 +1147,12 @@ class HarnessProcessManager:
                 await asyncio.sleep(self._reaper_interval_s)
             except asyncio.CancelledError:
                 return
+            # ``idle_timeout_s <= 0`` disables harness reaping entirely
+            # (``OMNIGENT_HARNESS_IDLE_TIMEOUT_S=0``). Without this guard a 0
+            # window makes ``cutoff == now``, so every entry (``last_used_at``
+            # always <= now) is reaped on each pass — the inverse of "disabled".
+            if self._idle_timeout_s <= 0:
+                continue
             now = time.monotonic()
             cutoff = now - self._idle_timeout_s
             stale: list[str] = []

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -99,6 +99,44 @@ _DEFAULT_IDLE_TIMEOUT_S = 30 * 60  # 30 minutes
 # without hammering ``time.monotonic()`` more than necessary.
 _DEFAULT_REAPER_INTERVAL_S = 60
 
+# Env override for the harness idle-reap window, so operators can tune it
+# without code changes (mirrors the runner-level ``runner.idle_timeout_s``).
+# ``0`` disables harness reaping entirely.
+_HARNESS_IDLE_TIMEOUT_ENV = "OMNIGENT_HARNESS_IDLE_TIMEOUT_S"
+
+
+def _resolve_harness_idle_timeout_s() -> float:
+    """Resolve the harness idle-reap window in seconds.
+
+    Honors :envvar:`OMNIGENT_HARNESS_IDLE_TIMEOUT_S` (``0`` disables reaping);
+    otherwise the 30-minute default. An unparseable or negative value logs a
+    warning and falls back to the default rather than failing the runner at
+    boot — an env typo shouldn't take the runner down.
+    """
+    raw = os.environ.get(_HARNESS_IDLE_TIMEOUT_ENV)
+    if not raw:
+        return float(_DEFAULT_IDLE_TIMEOUT_S)
+    try:
+        value = float(raw)
+    except ValueError:
+        _logger.warning(
+            "%s=%r is not a number; using default %ss",
+            _HARNESS_IDLE_TIMEOUT_ENV,
+            raw,
+            _DEFAULT_IDLE_TIMEOUT_S,
+        )
+        return float(_DEFAULT_IDLE_TIMEOUT_S)
+    if value < 0:
+        _logger.warning(
+            "%s=%r is negative; using default %ss",
+            _HARNESS_IDLE_TIMEOUT_ENV,
+            raw,
+            _DEFAULT_IDLE_TIMEOUT_S,
+        )
+        return float(_DEFAULT_IDLE_TIMEOUT_S)
+    return value
+
+
 # Grace period between SIGTERM and SIGKILL when releasing a
 # subprocess. Long enough for a well-behaved harness to flush
 # in-flight responses + close the FastAPI app cleanly; short
@@ -488,11 +526,15 @@ class HarnessProcessManager:
     def __init__(
         self,
         *,
-        idle_timeout_s: float = _DEFAULT_IDLE_TIMEOUT_S,
+        idle_timeout_s: float | None = None,
         reaper_interval_s: float = _DEFAULT_REAPER_INTERVAL_S,
         tmp_parent: Path | None = None,
     ) -> None:
-        self._idle_timeout_s = idle_timeout_s
+        # ``None`` (the default at both construction sites) resolves from the
+        # OMNIGENT_HARNESS_IDLE_TIMEOUT_S env var, else the 30-minute default.
+        self._idle_timeout_s = (
+            idle_timeout_s if idle_timeout_s is not None else _resolve_harness_idle_timeout_s()
+        )
         self._reaper_interval_s = reaper_interval_s
         self._tmp_parent = tmp_parent if tmp_parent is not None else _default_tmp_parent()
         # Pre-allocate the instance dir path so it stays stable

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -570,6 +570,37 @@ async def test_idle_reaper_skips_in_flight_turn(
         await fast.shutdown()
 
 
+async def test_idle_reaper_disabled_when_timeout_zero(
+    register_test_harness: None,
+    short_tmp_parent: Path,
+) -> None:
+    """A non-positive idle window disables reaping (``OMNIGENT_HARNESS_IDLE_TIMEOUT_S=0``).
+
+    Regression: ``0`` must mean "never reap", not "reap everything". Without the
+    ``idle_timeout_s <= 0`` guard the reaper computes ``cutoff = now - 0 == now``,
+    and since every ``last_used_at`` is <= now it reaps every entry on the first
+    pass. The spawned entry must survive many fast reaper passes.
+    """
+    fast = HarnessProcessManager(
+        idle_timeout_s=0.0,
+        reaper_interval_s=0.05,
+        tmp_parent=short_tmp_parent,
+    )
+    await fast.start()
+    try:
+        await fast.get_client("conv_a", _TEST_HARNESS_NAME)
+        socket_path = fast.instance_dir / "conv-conv_a.sock"
+        assert socket_path.exists()
+        # ~20 reaper passes at 0.05 s. With the bug the socket is gone almost
+        # immediately; with the guard it survives because reaping is disabled.
+        await asyncio.sleep(1.0)
+        assert socket_path.exists(), (
+            "idle_timeout_s=0 must DISABLE reaping, not reap every entry each pass"
+        )
+    finally:
+        await fast.shutdown()
+
+
 async def test_orphan_sweep_removes_dead_omnigent_dirs(
     short_tmp_parent: Path,
 ) -> None:

--- a/tests/runtime/harnesses/test_process_manager_idle_config.py
+++ b/tests/runtime/harnesses/test_process_manager_idle_config.py
@@ -1,0 +1,54 @@
+"""Tests for the configurable harness idle-reap window.
+
+The harness idle window (after which an idle harness subprocess is reaped) is
+now tunable via the ``OMNIGENT_HARNESS_IDLE_TIMEOUT_S`` env var, mirroring the
+runner-level ``runner.idle_timeout_s`` knob. ``0`` disables reaping; an
+unparseable / negative value falls back to the default rather than failing the
+runner at boot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.runtime.harnesses.process_manager import (
+    _DEFAULT_IDLE_TIMEOUT_S,
+    _HARNESS_IDLE_TIMEOUT_ENV,
+    HarnessProcessManager,
+    _resolve_harness_idle_timeout_s,
+)
+
+
+def test_resolve_default_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_HARNESS_IDLE_TIMEOUT_ENV, raising=False)
+    assert _resolve_harness_idle_timeout_s() == float(_DEFAULT_IDLE_TIMEOUT_S)
+
+
+def test_resolve_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_HARNESS_IDLE_TIMEOUT_ENV, "7200")
+    assert _resolve_harness_idle_timeout_s() == 7200.0
+
+
+def test_resolve_zero_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_HARNESS_IDLE_TIMEOUT_ENV, "0")
+    assert _resolve_harness_idle_timeout_s() == 0.0
+
+
+@pytest.mark.parametrize("bad", ["abc", "-5", ""])
+def test_resolve_invalid_falls_back_to_default(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    monkeypatch.setenv(_HARNESS_IDLE_TIMEOUT_ENV, bad)
+    assert _resolve_harness_idle_timeout_s() == float(_DEFAULT_IDLE_TIMEOUT_S)
+
+
+def test_manager_uses_env_when_no_explicit_value(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv(_HARNESS_IDLE_TIMEOUT_ENV, "1800")
+    mgr = HarnessProcessManager(tmp_parent=tmp_path)
+    assert mgr._idle_timeout_s == 1800.0
+
+
+def test_manager_explicit_value_overrides_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv(_HARNESS_IDLE_TIMEOUT_ENV, "1800")
+    mgr = HarnessProcessManager(idle_timeout_s=42.0, tmp_parent=tmp_path)
+    assert mgr._idle_timeout_s == 42.0


### PR DESCRIPTION
Part 1 of #1528.

## Context
When a session sits idle, the harness idle-reaper (~30 min) closes the Claude-SDK client and the runner eventually idle-times-out. No conversation state is lost (it's server-side; the harness lazily re-spawns), but the teardown was logged as a `WARNING` ("Force-closing Claude SDK client … from a different event loop/task") and read like a crash. Investigation (#1528) showed the **force-close is actually correct/necessary** — the turn's task that ran `connect()` has already finished by close time, and anyio binds `disconnect()` to that task, so a graceful disconnect is impossible.

## What this PR does (the safe, self-contained part)
- **Configurable harness idle window** — `OMNIGENT_HARNESS_IDLE_TIMEOUT_S` tunes the reap window (`0` disables harness reaping), mirroring the runner-level `runner.idle_timeout_s`. An unparseable/negative value logs a warning and falls back to the 30-min default rather than failing the runner at boot. `HarnessProcessManager` resolves it when no explicit value is passed, so both construction sites pick it up.
- **Quiet the expected force-close** — downgrade the two "Force-closing Claude SDK client …" logs from `warning` → `debug`, worded to note it's expected on idle reap / shutdown.

## Tests
`tests/runtime/harnesses/test_process_manager_idle_config.py`: the env resolver (unset → default; value; `0`; invalid/negative → default) and the constructor wiring (env used when no explicit value; explicit value overrides env).

## What's intentionally NOT here (follow-up PR, #1528)
The user-visible part: the **host suppressing the runner `--- log tail ---` on a benign idle exit**, a calm `runner_idle_paused` status + dim REPL note instead of red error boxes, and **auto-respawn of the runner on the next message**. That touches the runner-relay hot path and ships with an integration test, so it's kept separate.

This pull request and its description were written by Isaac.
