### PR TITLE
fix(kiro-native): paste injected messages so multi-line submits as one (#1137)

### DIFF
--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -28,7 +29,7 @@ _KIRO_INPUT_READY_MARKERS = (
     "ask a question or describe a task",
     "Type to steer",
 )
-_SEND_KEYS_LITERAL_CHARS_PER_CALL = 1024
+_PASTE_BUFFER = "omnigent-kiro-paste"
 
 # Ambient provider/cloud/CI credentials that must not be inherited by Kiro.
 KIRO_NATIVE_ENV_UNSET = [
@@ -319,22 +320,54 @@ def _wait_for_kiro_input_ready(
     raise RuntimeError("kiro-native TUI input prompt was not ready before injection")
 
 
-def _type_literal_text(socket_path: str, tmux_target: str, text: str) -> None:
-    """Type text into Kiro using literal tmux keystrokes."""
-    for start in range(0, len(text), _SEND_KEYS_LITERAL_CHARS_PER_CALL):
-        chunk = text[start : start + _SEND_KEYS_LITERAL_CHARS_PER_CALL]
-        # ``--`` ends option parsing so a chunk starting with ``-`` (or a chunk
-        # boundary that lands on one) is sent as literal text, not parsed as a
-        # tmux flag — which would otherwise fail the send-keys call silently.
+def _paste_payload_bytes(text: str) -> bytes:
+    r"""Encode text for ``tmux load-buffer``: line breaks → CR, tabs kept, other
+    control bytes dropped (a stray ESC would close the bracketed-paste early)."""
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    body = bytearray()
+    for ch in normalized:
+        if ch == "\n":
+            body.append(0x0D)
+            continue
+        if ch == "\t":
+            body.append(0x09)
+            continue
+        if ord(ch) < 0x20:
+            continue
+        body.extend(ch.encode("utf-8"))
+    return bytes(body)
+
+
+def _paste_literal_text(socket_path: str, tmux_target: str, bridge_dir: Path, text: str) -> None:
+    """Deliver text into Kiro via a tmux bracketed paste (multi-line safe).
+
+    ``send-keys -l`` sends interior newlines as raw Enter keys, so a multi-line
+    web message submits line-by-line on the first break. ``load-buffer`` +
+    ``paste-buffer -p`` wraps the text in bracketed-paste markers so Kiro's
+    composer keeps the line breaks (encoded as CR by :func:`_paste_payload_bytes`)
+    as draft data, not submits. Mirrors cursor-native / goose-native; the trailing
+    newline absorbs any trailing backslash so it can't escape the follow-up Enter.
+    """
+    with tempfile.NamedTemporaryFile(
+        dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
+    ) as paste_file:
+        paste_file.write(_paste_payload_bytes(text + "\n"))
+        paste_path = paste_file.name
+    try:
+        _run_tmux(socket_path, "load-buffer", "-b", _PASTE_BUFFER, paste_path)
         _run_tmux(
             socket_path,
-            "send-keys",
-            "-l",
+            "paste-buffer",
+            "-p",  # bracketed-paste markers — the TUI keeps newlines as data
+            "-d",  # drop the buffer after pasting
+            "-b",
+            _PASTE_BUFFER,
             "-t",
             tmux_target,
-            "--",
-            chunk,
         )
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(paste_path)
 
 
 def inject_user_message(
@@ -363,7 +396,7 @@ def inject_user_message(
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
     baseline_region = _kiro_input_region(_capture_pane(socket_path, tmux_target))
-    _type_literal_text(socket_path, tmux_target, content)
+    _paste_literal_text(socket_path, tmux_target, bridge_dir, content)
     needle = _submit_needle(content)
     draft_seen = False
     if needle:

--- a/tests/test_kiro_native_bridge.py
+++ b/tests/test_kiro_native_bridge.py
@@ -65,8 +65,10 @@ def test_inject_user_message_does_not_wait_for_forwarder_on_fresh_kiro_session(
     inject_user_message(bridge_dir, content="hello", timeout_s=0.1)
 
     assert any(call[-1] == "Enter" for call in calls)
-    assert any(call[-1] == "hello" and "-l" in call for call in calls)
-    assert not any("load-buffer" in call or "paste-buffer" in call for call in calls)
+    # Message text is delivered via a bracketed paste, never ``send-keys -l``.
+    assert any("load-buffer" in call for call in calls)
+    assert any("paste-buffer" in call and "-p" in call for call in calls)
+    assert not any("-l" in call for call in calls)
 
 
 def test_inject_user_message_waits_for_forwarder_on_resumed_kiro_session(
@@ -114,9 +116,9 @@ def test_inject_user_message_waits_for_kiro_input_prompt(
     inject_user_message(bridge_dir, content="hello", timeout_s=0.1)
 
     capture_indexes = [index for index, call in enumerate(calls) if "capture-pane" in call]
-    type_index = next(index for index, call in enumerate(calls) if "-l" in call)
+    paste_index = next(index for index, call in enumerate(calls) if "paste-buffer" in call)
     assert len(capture_indexes) >= 2
-    assert max(capture_indexes[:2]) < type_index
+    assert max(capture_indexes[:2]) < paste_index
 
 
 def test_inject_user_message_fails_when_kiro_input_prompt_never_renders(
@@ -137,37 +139,32 @@ def test_inject_user_message_fails_when_kiro_input_prompt_never_renders(
         inject_user_message(bridge_dir, content="hello", timeout_s=0.01)
 
 
-def test_inject_user_message_chunks_literal_typing(
+def test_paste_payload_bytes_encodes_line_breaks_as_cr() -> None:
+    """Newlines (incl. CRLF/CR) become CR, tabs survive, other control bytes drop.
+
+    The TUI treats a bracketed-paste CR as an in-draft newline, so encoding all
+    line breaks to CR is what keeps a multi-line message a single draft. A stray
+    ESC (or other control byte) would close the bracketed paste early, so those
+    are dropped.
+    """
+    assert bridge._paste_payload_bytes("a\nb\r\nc\rd") == b"a\rb\rc\rd"
+    assert bridge._paste_payload_bytes("keep\ttab") == b"keep\ttab"
+    assert bridge._paste_payload_bytes("drop\x1bESC") == b"dropESC"
+
+
+def test_inject_user_message_multiline_routes_through_bracketed_paste(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Kiro text delivery avoids tmux's command-length cap."""
-    monkeypatch.setattr(bridge, "_TYPE_COMMIT_TIMEOUT_S", 0.0)
-    monkeypatch.setattr(bridge, "_SEND_KEYS_LITERAL_CHARS_PER_CALL", 4)
-    bridge_dir = tmp_path / "bridge"
-    calls = _install_fake_tmux(monkeypatch)
-    write_tmux_target(
-        bridge_dir,
-        socket_path=Path("/tmp/tmux.sock"),
-        tmux_target="main",
-    )
+    """A multi-line web message is pasted whole, not typed line-by-line.
 
-    inject_user_message(bridge_dir, content="helloworld", timeout_s=0.1)
-
-    typed = [call[-1] for call in calls if "-l" in call]
-    assert typed == ["hell", "owor", "ld"]
-
-
-def test_inject_user_message_dash_prefixed_text_is_sent_literally(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A message starting with '-' injects as literal text, not a tmux flag.
-
-    ``send-keys -l`` parses a leading ``-`` (e.g. ``-N``) as an option even in
-    literal mode, so the send must pass ``--`` before the content — otherwise a
-    dash-prefixed message (or a 1024-char chunk boundary landing on one) fails
-    to inject silently.
+    The bug: ``send-keys -l`` delivers the interior newlines as Enter keys, so
+    the first line submits on its own. The fix routes the message through a
+    single bracketed paste (``paste-buffer -p``) — the CR encoding the TUI needs
+    to keep the breaks as draft data is covered by
+    :func:`test_paste_payload_bytes_encodes_line_breaks_as_cr`. Here we just pin
+    that multi-line content never reaches ``send-keys -l`` and is committed by a
+    single Enter.
     """
     monkeypatch.setattr(bridge, "_TYPE_COMMIT_TIMEOUT_S", 0.0)
     bridge_dir = tmp_path / "bridge"
@@ -178,16 +175,12 @@ def test_inject_user_message_dash_prefixed_text_is_sent_literally(
         tmux_target="main",
     )
 
-    inject_user_message(bridge_dir, content="-N5 dangerous", timeout_s=0.1)
+    inject_user_message(bridge_dir, content="line one\nline two\nline three", timeout_s=0.1)
 
-    literal_calls = [call for call in calls if "-l" in call]
-    assert literal_calls, "expected a literal send-keys call"
-    for call in literal_calls:
-        # ``--`` must immediately precede the literal content so a leading '-'
-        # is sent as text, never parsed as a flag.
-        assert "--" in call
-        assert call.index("--") == len(call) - 2
-        assert call[-1] == "-N5 dangerous"
+    assert any("paste-buffer" in call and "-p" in call for call in calls)
+    assert not any("-l" in call for call in calls)
+    # Exactly one Enter commits the whole draft — not one per line.
+    assert sum(1 for call in calls if call[-1] == "Enter") == 1
 
 
 def test_inject_user_message_fails_when_resumed_forwarder_is_not_ready(


### PR DESCRIPTION
## Problem

`kiro-native` delivered web-UI messages into the Kiro TUI with `_type_literal_text`, which used `tmux send-keys -l` on the raw content. A multi-line web message therefore submitted **line-by-line on the first newline** — the interior breaks arrive as Enter keys, so only the first line was sent and the rest were stranded (or split into extra turns).

Flagged in the #1137 checklist ("Multi-line injection corruption").

## Fix

Replace the `send-keys -l` typing path with a tmux **bracketed paste** (`load-buffer` + `paste-buffer -p`), plus `_paste_payload_bytes` which encodes line breaks as CR and drops stray control bytes. Bracketed-paste markers tell the TUI to keep the line breaks as **draft data**, so the whole message stays one draft and a single Enter commits it. This mirrors `cursor-native` / `goose-native` exactly (`tempfile`, the `_PASTE_BUFFER` named buffer). The old `_SEND_KEYS_LITERAL_CHARS_PER_CALL` chunking constant is removed — it only existed to dodge tmux's argv-length cap for `send-keys -l`, and `paste-buffer` reads the payload from a file (no argv cap).

## What's verified

**Unit** (`tests/test_kiro_native_bridge.py`): `_paste_payload_bytes` encoding (newlines→CR, tabs kept, controls dropped); injection routes through `paste-buffer -p`, never `send-keys -l`, and commits with a single Enter — both for single-line and multi-line content. `ruff check` + `ruff format --check` clean.

**Live** (kiro-cli 2.10.0, local omnigent stack, web UI): a multi-line message — including the harder **blank-line-gap** case (`\n\n`) — lands as **one** user turn in both the web transcript and the Kiro terminal, and Kiro answers the whole message in a single turn. Pre-fix, only the first line would submit.

Part of #1137.
