### PR TITLE
fix(kiro-native): bind session forwarder only when exactly one candidate (#1137)

### DIFF
--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -106,6 +106,33 @@ def _same_workspace(left: object, right: str) -> bool:
         return left == right
 
 
+# Competing-candidate sets already warned about, so the ambiguous branch logs
+# once per distinct collision instead of every poll tick for the session's life.
+# ponytail: grows by one entry per distinct concurrent collision — too rare to
+# bound; add a cap only if a pathological churn ever shows up.
+_ambiguous_discovery_warned: set[frozenset[str]] = set()
+
+
+def _warn_ambiguous_discovery(workspace: str, session_ids: list[str]) -> None:
+    """Warn once per distinct set of competing same-workspace Kiro sessions.
+
+    Discovery returns ``None`` for both "no candidate yet" (transient) and ">=2
+    candidates" (won't ever bind until one goes away). This makes the latter
+    diagnosable without flooding logs on every ~0.7s poll.
+    """
+    key = frozenset(session_ids)
+    if key in _ambiguous_discovery_warned:
+        return
+    _ambiguous_discovery_warned.add(key)
+    _logger.warning(
+        "kiro session discovery ambiguous; %d same-workspace sessions above the "
+        "launch floor, binding none to avoid cross-talk; workspace=%s sessions=%s",
+        len(session_ids),
+        workspace,
+        sorted(session_ids),
+    )
+
+
 def _discover_kiro_session_jsonl(
     *,
     workspace: str,
@@ -114,9 +141,10 @@ def _discover_kiro_session_jsonl(
 ) -> tuple[str, Path] | None:
     """Find this Omnigent session's Kiro JSONL file — only when it's unambiguous.
 
-    Candidates are Kiro sessions in the same workspace (``cwd``) created at/after
-    the launch floor (``launch_epoch_ms`` minus a small skew, which already drops
-    pre-existing sessions). We bind **only when exactly one** session qualifies.
+    Candidates are Kiro sessions in the same workspace (``cwd``) with a parseable
+    ``created_at`` at/after the launch floor (``launch_epoch_ms`` minus a small
+    skew, which already drops pre-existing sessions). We bind **only when exactly
+    one** session qualifies.
 
     Each Kiro session is its own JSONL keyed by Kiro's minted id, so two fresh
     sessions launched in the same workspace within the skew window both qualify.
@@ -124,9 +152,11 @@ def _discover_kiro_session_jsonl(
     whichever session most recently emitted a turn — i.e. it can bind the *other*
     session's transcript and silently cross-talk it into this conversation. With
     two or more candidates we can't tell which JSONL is ours, so we return
-    ``None`` and retry rather than guess. A brief delay is safe; mirroring the
-    wrong conversation is not. Mirrors cursor-native's "bind only when exactly one
-    chat qualifies" (:func:`omnigent.cursor_native_forwarder._discover_store`).
+    ``None`` and retry rather than guess (logged once via
+    :func:`_warn_ambiguous_discovery` so the ambiguous case is distinct from "not
+    written yet"). A brief delay is safe; mirroring the wrong conversation is not.
+    Mirrors cursor-native's "bind only when exactly one chat qualifies"
+    (:func:`omnigent.cursor_native_forwarder._discover_store`).
 
     The resume/fork path doesn't reach here: when the Kiro id is already known the
     caller binds it directly via :func:`_kiro_session_jsonl_for_id`.
@@ -148,12 +178,17 @@ def _discover_kiro_session_jsonl(
         if not isinstance(metadata, dict) or not _same_workspace(metadata.get("cwd"), workspace):
             continue
         created_ms = _parse_iso_epoch_ms(metadata.get("created_at"))
-        if created_ms and created_ms < floor_ms:
+        # Require a parseable created_at at/after the floor. A fresh session always
+        # stamps created_at, so a missing/garbled one can't be confirmed in-window;
+        # dropping it stops an undateable straggler from poisoning the "exactly one"
+        # count and silently blocking discovery forever.
+        if not created_ms or created_ms < floor_ms:
             continue
         candidates.append((session_id, jsonl_path))
-    if len(candidates) != 1:
+    if len(candidates) > 1:
+        _warn_ambiguous_discovery(workspace, [session_id for session_id, _ in candidates])
         return None
-    return candidates[0]
+    return candidates[0] if candidates else None
 
 
 def _kiro_session_jsonl_for_id(

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -112,12 +112,30 @@ def _discover_kiro_session_jsonl(
     launch_epoch_ms: int,
     sessions_dir: Path | None = None,
 ) -> tuple[str, Path] | None:
-    """Find this Omnigent session's Kiro JSONL file."""
+    """Find this Omnigent session's Kiro JSONL file — only when it's unambiguous.
+
+    Candidates are Kiro sessions in the same workspace (``cwd``) created at/after
+    the launch floor (``launch_epoch_ms`` minus a small skew, which already drops
+    pre-existing sessions). We bind **only when exactly one** session qualifies.
+
+    Each Kiro session is its own JSONL keyed by Kiro's minted id, so two fresh
+    sessions launched in the same workspace within the skew window both qualify.
+    Picking newest-by-``updated_at`` (the old behaviour) would latch onto
+    whichever session most recently emitted a turn — i.e. it can bind the *other*
+    session's transcript and silently cross-talk it into this conversation. With
+    two or more candidates we can't tell which JSONL is ours, so we return
+    ``None`` and retry rather than guess. A brief delay is safe; mirroring the
+    wrong conversation is not. Mirrors cursor-native's "bind only when exactly one
+    chat qualifies" (:func:`omnigent.cursor_native_forwarder._discover_store`).
+
+    The resume/fork path doesn't reach here: when the Kiro id is already known the
+    caller binds it directly via :func:`_kiro_session_jsonl_for_id`.
+    """
     root = sessions_dir or _kiro_cli_sessions_dir()
     if not root.is_dir():
         return None
     floor_ms = max(0, launch_epoch_ms - _DISCOVERY_SKEW_MS)
-    best: tuple[int, str, Path] | None = None
+    candidates: list[tuple[str, Path]] = []
     for metadata_path in root.glob("*.json"):
         session_id = metadata_path.stem
         jsonl_path = root / f"{session_id}.jsonl"
@@ -130,15 +148,12 @@ def _discover_kiro_session_jsonl(
         if not isinstance(metadata, dict) or not _same_workspace(metadata.get("cwd"), workspace):
             continue
         created_ms = _parse_iso_epoch_ms(metadata.get("created_at"))
-        updated_ms = _parse_iso_epoch_ms(metadata.get("updated_at"))
         if created_ms and created_ms < floor_ms:
             continue
-        sort_ms = updated_ms or created_ms
-        if best is None or sort_ms > best[0]:
-            best = (sort_ms, session_id, jsonl_path)
-    if best is None:
+        candidates.append((session_id, jsonl_path))
+    if len(candidates) != 1:
         return None
-    return best[1], best[2]
+    return candidates[0]
 
 
 def _kiro_session_jsonl_for_id(

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -127,6 +127,42 @@ def test_discover_kiro_session_jsonl_returns_none_when_multiple_candidates(
     assert discovered is None
 
 
+def test_discover_kiro_session_jsonl_skips_session_with_unparseable_created_at(
+    tmp_path: Path,
+) -> None:
+    """An undateable same-workspace session can't poison the unique-bind count.
+
+    A session whose ``created_at`` won't parse can't be confirmed in-window, so it
+    is dropped rather than counted as a second candidate — otherwise a single
+    garbage straggler would make discovery permanently ambiguous and bind nothing.
+    """
+    sessions_dir = tmp_path / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="undateable",
+        cwd=workspace,
+        created_at="garbage",
+        updated_at="2026-06-21T01:41:00Z",
+    )
+    expected = _write_kiro_session(
+        sessions_dir,
+        session_id="current",
+        cwd=workspace,
+        created_at="2026-06-21T01:39:35Z",
+        updated_at="2026-06-21T01:40:10Z",
+    )
+
+    discovered = forwarder._discover_kiro_session_jsonl(
+        workspace=str(workspace),
+        launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        sessions_dir=sessions_dir,
+    )
+
+    assert discovered == ("current", expected)
+
+
 def test_read_new_kiro_messages_returns_user_and_assistant_text(tmp_path: Path) -> None:
     """The JSONL reader mirrors Kiro prompt and assistant message text."""
     jsonl_path = tmp_path / "session.jsonl"

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -47,7 +47,11 @@ def _write_kiro_session(
 def test_discover_kiro_session_jsonl_filters_by_workspace_and_launch_time(
     tmp_path: Path,
 ) -> None:
-    """Discovery chooses the newest Kiro session for the runner workspace."""
+    """Discovery binds the unique qualifying Kiro session for the workspace.
+
+    The wrong-workspace and below-floor sessions are filtered out, leaving
+    exactly one candidate, which is bound.
+    """
     sessions_dir = tmp_path / "sessions" / "cli"
     workspace = tmp_path / "repo"
     other = tmp_path / "other"
@@ -82,6 +86,45 @@ def test_discover_kiro_session_jsonl_filters_by_workspace_and_launch_time(
     )
 
     assert discovered == ("current", expected)
+
+
+def test_discover_kiro_session_jsonl_returns_none_when_multiple_candidates(
+    tmp_path: Path,
+) -> None:
+    """Two concurrent same-workspace sessions are ambiguous → bind nothing.
+
+    Each Kiro session is its own JSONL, so two fresh sessions launched in the
+    same workspace within the discovery window both qualify. Picking newest-by-
+    ``updated_at`` could latch onto the other session's transcript (cross-talk),
+    so discovery must return ``None`` and retry rather than guess. Regression for
+    the #1137 'forwarder can bind the wrong session' item.
+    """
+    sessions_dir = tmp_path / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    # Both created after the launch floor, same workspace — indistinguishable.
+    _write_kiro_session(
+        sessions_dir,
+        session_id="session-a",
+        cwd=workspace,
+        created_at="2026-06-21T01:39:35Z",
+        updated_at="2026-06-21T01:40:10Z",
+    )
+    _write_kiro_session(
+        sessions_dir,
+        session_id="session-b",
+        cwd=workspace,
+        created_at="2026-06-21T01:39:36Z",
+        updated_at="2026-06-21T01:41:00Z",  # newest updated_at — the old tie-break
+    )
+
+    discovered = forwarder._discover_kiro_session_jsonl(
+        workspace=str(workspace),
+        launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        sessions_dir=sessions_dir,
+    )
+
+    assert discovered is None
 
 
 def test_read_new_kiro_messages_returns_user_and_assistant_text(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`_discover_kiro_session_jsonl` located "this session's" Kiro JSONL by taking the **newest-by-`updated_at`** among sessions whose metadata `cwd` matches the workspace and whose `created_at` is at/after the launch floor — with **no uniqueness guard**.

Each Kiro session is its own JSONL keyed by Kiro's minted id, so two fresh sessions launched in the **same workspace** within the discovery window both qualify. `updated_at` flips to whichever session most recently emitted a turn, so a forwarder can latch onto the **other** session's JSONL and silently cross-talk its transcript into this conversation.

Flagged in the #1137 checklist ("Forwarder can bind the wrong session").

## Fix

Bind **only when exactly one** session qualifies. With two or more candidates we can't tell which JSONL is ours, so return `None` and retry rather than guess — a brief mirror delay is safe; mirroring the wrong conversation is not. Mirrors cursor-native's "bind only when exactly one chat qualifies" (`cursor_native_forwarder._discover_store`).

Scope notes:
- The **resume/fork path is unaffected** — when the Kiro id is already known (`expected_session_id`), the caller binds it directly via `_kiro_session_jsonl_for_id`; discovery isn't reached.
- The launch-floor filter already drops pre-existing sessions, so the only ambiguous case is two **fresh** same-workspace sessions launched within the skew window.
- A fuller claim/heartbeat scheme (so concurrent same-workspace sessions each bind their own, as cursor does for its *shared* store) is a possible follow-up — but kiro arbitrates **assignment** (N JSONLs), not shared **ownership** (1 store), so it warrants its own design rather than a direct copy. This PR closes the cross-talk hole the issue names.

## What's verified

**Unit** (`tests/test_kiro_native_session_forwarder.py`): added `test_discover_kiro_session_jsonl_returns_none_when_multiple_candidates` — two same-workspace candidates above the floor → `None` (fails before this change, which returned the newest); existing workspace/floor filter test still binds the unique candidate. `ruff` + scoped `pre-commit run` clean.

Part of #1137.
