### PR TITLE
feat(ap-web): support shift-click range selection in multi-session mode

### DIFF
--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -692,6 +692,7 @@ function ProjectFolder({
   selectedIds,
   onToggleSelected,
   onProjectAssigned,
+  projectRenderedIdsRef,
 }: {
   name: string;
   expanded: boolean;
@@ -706,6 +707,7 @@ function ProjectFolder({
   selectedIds: Set<string>;
   onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
   onProjectAssigned?: (projectName: string) => void;
+  projectRenderedIdsRef?: RefObject<Map<string, string[]>>;
 }) {
   const query = useProjectSessions(name, expanded);
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
@@ -717,6 +719,15 @@ function ProjectFolder({
       activeOverride,
     );
   }, [query.data, pinnedSet, activeOverride]);
+
+  useEffect(() => {
+    if (!projectRenderedIdsRef) return;
+    const ids = expanded ? conversations.map((c) => c.id) : [];
+    projectRenderedIdsRef.current.set(name, ids);
+    return () => {
+      projectRenderedIdsRef.current.delete(name);
+    };
+  }, [projectRenderedIdsRef, name, expanded, conversations]);
 
   // While the first page loads, show a "Loading…" footer instead of the "No
   // chats" empty state (which would otherwise flash before rows arrive).
@@ -824,6 +835,10 @@ function ConversationList({
 
   // Project names for grouping sessions by their reserved project label.
   const { data: projectNames = [] } = useProjects();
+
+  // Each ProjectFolder registers its actually-rendered conversation IDs here
+  // so shift-select ranges use the real rendered order, not the global list.
+  const projectRenderedIdsRef = useRef<Map<string, string[]>>(new Map());
 
   // Backfill pinned sessions that aren't in the loaded set.
   const loadedIds = useMemo(() => new Set(allConversations.map((c) => c.id)), [allConversations]);
@@ -1115,7 +1130,21 @@ function ConversationList({
       ...visible("Shared with me", sections.shared),
     ].map((c) => c.id);
   }, [sections, effectiveCollapsedSections, expandedProjects]);
-  visibleIdsRef.current = orderedConversationIds;
+
+  // Build shift-select visible order from actual rendered data: project folders
+  // report their own IDs (from useProjectSessions), so the range is correct even
+  // when the per-project query diverges from the global paginated list.
+  const visible = (title: string, list: readonly Conversation[]) =>
+    effectiveCollapsedSections.includes(title) ? [] : list.map((c) => c.id);
+  const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
+  visibleIdsRef.current = [
+    ...visible("Pinned", sections.pinned),
+    ...(projectsCollapsed
+      ? []
+      : sections.projectGroups.flatMap((g) => projectRenderedIdsRef.current.get(g.name) ?? [])),
+    ...visible("Chats", sections.sessions),
+    ...visible("Shared with me", sections.shared),
+  ];
   useSessionSwitchHotkey(orderedConversationIds, activeId);
 
   // Cmd/Ctrl+1..9/0 jumps to the first ten pinned sessions (desktop only;
@@ -1277,6 +1306,7 @@ function ConversationList({
                     selectedIds={selectedIds}
                     onToggleSelected={onToggleSelected}
                     onProjectAssigned={expandProject}
+                    projectRenderedIdsRef={projectRenderedIdsRef}
                   />
                 ))}
               </SectionGroup>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -236,9 +236,8 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
         const anchorIdx = ids.indexOf(lastSelectedIdRef.current);
         const currentIdx = ids.indexOf(id);
         if (anchorIdx !== -1 && currentIdx !== -1) {
-          const [start, end] = anchorIdx < currentIdx
-            ? [anchorIdx, currentIdx]
-            : [currentIdx, anchorIdx];
+          const [start, end] =
+            anchorIdx < currentIdx ? [anchorIdx, currentIdx] : [currentIdx, anchorIdx];
           for (let i = start; i <= end; i++) {
             next.add(ids[i]);
           }

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -225,11 +225,29 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  const toggleSelected = useCallback((id: string) => {
+  const lastSelectedIdRef = useRef<string | null>(null);
+  const visibleIdsRef = useRef<string[]>([]);
+
+  const toggleSelected = useCallback((id: string, shiftKey?: boolean) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
+      if (shiftKey && lastSelectedIdRef.current != null) {
+        const ids = visibleIdsRef.current;
+        const anchorIdx = ids.indexOf(lastSelectedIdRef.current);
+        const currentIdx = ids.indexOf(id);
+        if (anchorIdx !== -1 && currentIdx !== -1) {
+          const [start, end] = anchorIdx < currentIdx
+            ? [anchorIdx, currentIdx]
+            : [currentIdx, anchorIdx];
+          for (let i = start; i <= end; i++) {
+            next.add(ids[i]);
+          }
+          return next;
+        }
+      }
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      lastSelectedIdRef.current = id;
       return next;
     });
   }, []);
@@ -245,6 +263,7 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   const exitSelectionMode = useCallback(() => {
     setSelectionMode(false);
     setSelectedIds(new Set());
+    lastSelectedIdRef.current = null;
   }, []);
 
   // Debounce search input so we don't fire a server request on every
@@ -544,6 +563,7 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
               selectionMode={selectionMode}
               selectedIds={selectedIds}
               onToggleSelected={toggleSelected}
+              visibleIdsRef={visibleIdsRef}
             />
           </nav>
 
@@ -685,7 +705,7 @@ function ProjectFolder({
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   selectedIds: Set<string>;
-  onToggleSelected: (conversationId: string) => void;
+  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
   onProjectAssigned?: (projectName: string) => void;
 }) {
   const query = useProjectSessions(name, expanded);
@@ -774,7 +794,8 @@ interface ConversationListProps {
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   selectedIds: Set<string>;
-  onToggleSelected: (conversationId: string) => void;
+  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
+  visibleIdsRef: RefObject<string[]>;
 }
 
 // permission_level null (no ACL row / legacy) or >= 4 both mean owner.
@@ -793,6 +814,7 @@ function ConversationList({
   selectionMode,
   selectedIds,
   onToggleSelected,
+  visibleIdsRef,
 }: ConversationListProps) {
   // All loaded conversations from the single paginated list (for pinned
   // backfill, normalization, and the flat session list).
@@ -1094,6 +1116,7 @@ function ConversationList({
       ...visible("Shared with me", sections.shared),
     ].map((c) => c.id);
   }, [sections, effectiveCollapsedSections, expandedProjects]);
+  visibleIdsRef.current = orderedConversationIds;
   useSessionSwitchHotkey(orderedConversationIds, activeId);
 
   // Cmd/Ctrl+1..9/0 jumps to the first ten pinned sessions (desktop only;
@@ -1606,7 +1629,7 @@ function ConversationSection({
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   selectedIds: Set<string>;
-  onToggleSelected: (conversationId: string) => void;
+  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
   /** Placeholder shown when expanded with no rows (e.g. an empty project). */
   emptyMessage?: string;
   /** Indent the rows one extra step (used to nest a project's chats). */
@@ -1993,7 +2016,7 @@ function ConversationRow({
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   isSelected: boolean;
-  onToggleSelected: (conversationId: string) => void;
+  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
   onProjectAssigned?: (projectName: string) => void;
 }) {
   // `useParams` reads from the active matched route. On `/`, the param is
@@ -2283,7 +2306,7 @@ function ConversationRow({
         if (selectionMode) {
           e.preventDefault();
           e.stopPropagation();
-          onToggleSelected(conversation.id);
+          onToggleSelected(conversation.id, e.shiftKey);
           return;
         }
         onClick(e);


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add shift-click support to multi-session selection mode in the sidebar. Holding Shift while clicking a session row selects the entire range between the last-clicked session and the current one, matching standard OS list-selection behavior.
- The anchor point (last non-shift click) is tracked via a ref and cleared when exiting selection mode. The visible session order is derived from the existing `orderedConversationIds` memo, which already respects collapsed sections and project folders.

## Test Plan

- Enter selection mode in the sidebar, click a session, then shift-click another session further down — all sessions in between should be selected.
- Shift-click above the anchor to select upward.
- Normal click after a shift-select to set a new anchor, then shift-click again to verify the new range.
- Exit and re-enter selection mode to verify the anchor resets.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified shift-click range selection in the sidebar across pinned, project, and flat chat sections. The range logic is a small inline calculation that would require a full component render to meaningfully unit test.