### PR TITLE
fix: codex/claude compaction persistence, transcript reconstruction, and web UI

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3471,6 +3471,28 @@ def _claude_transcript_records_from_session_items(
                 records.clear()
                 parent_uuid = None
                 tool_parent_by_call_id.clear()
+                # Emit a compact_boundary system record so Claude
+                # Code recognizes the compaction on resume.
+                boundary_uuid = _synthetic_claude_transcript_uuid(
+                    session_id=session_id,
+                    external_session_id=external_session_id,
+                    item=item,
+                    index=index,
+                )
+                records.append(
+                    {
+                        "parentUuid": None,
+                        "isSidechain": False,
+                        "type": "system",
+                        "subtype": "compact_boundary",
+                        "content": "Conversation compacted",
+                        "isMeta": False,
+                        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                        "uuid": boundary_uuid,
+                        "level": "info",
+                    }
+                )
+                parent_uuid = boundary_uuid
                 for ci, cm in enumerate(compacted_msgs):
                     cm_uuid = _synthetic_claude_transcript_uuid(
                         session_id=session_id,

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3462,6 +3462,33 @@ def _claude_transcript_records_from_session_items(
     parent_uuid: str | None = None
     tool_parent_by_call_id: dict[str, str] = {}
     for index, item in enumerate(items):
+        # Compaction items carry the post-compaction context. Replace
+        # all prior records with the compacted messages so the
+        # reconstructed transcript reflects the compacted state.
+        if item.get("type") == "compaction":
+            compacted_msgs = item.get("compacted_messages")
+            if compacted_msgs:
+                records.clear()
+                parent_uuid = None
+                tool_parent_by_call_id.clear()
+                for ci, cm in enumerate(compacted_msgs):
+                    cm_uuid = _synthetic_claude_transcript_uuid(
+                        session_id=session_id,
+                        external_session_id=external_session_id,
+                        item=cm,
+                        index=ci,
+                    )
+                    cm_record = _claude_transcript_record_from_session_item(
+                        cm,
+                        session_id=external_session_id,
+                        record_uuid=cm_uuid,
+                        parent_uuid=parent_uuid,
+                        cwd=cwd,
+                    )
+                    if cm_record is not None:
+                        records.append(cm_record)
+                        parent_uuid = cm_uuid
+            continue
         record_uuid = _synthetic_claude_transcript_uuid(
             session_id=session_id,
             external_session_id=external_session_id,

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -1910,6 +1910,30 @@ def _codex_rollout_records_from_session_items(
     for index, item in enumerate(items):
         if _session_item_response_id(item) in interrupted_response_ids:
             continue
+        # Compaction items carry the post-compaction context. Emit a
+        # Compacted rollout record and discard all prior records — the
+        # replacement_history replaces them.
+        if item.get("type") == "compaction":
+            compacted_msgs = item.get("compacted_messages")
+            if compacted_msgs:
+                compacted_record: dict[str, Any] = {
+                    "timestamp": timestamp,
+                    "type": "compacted",
+                    "payload": {
+                        "message": item.get("summary", ""),
+                        "replacement_history": compacted_msgs,
+                    },
+                }
+                w_id = item.get("window_id")
+                if w_id is not None:
+                    compacted_record["payload"]["window_id"] = w_id
+                # Replace all prior response_item records — the
+                # replacement_history is the new context baseline.
+                # Keep only session_meta and turn_context records.
+                records = [r for r in records if r.get("type") in ("session_meta",)]
+                records.append(compacted_record)
+                seen_turn_ids.clear()
+            continue
         payload = _codex_response_item_from_session_item(item)
         if payload is None:
             continue

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -5127,12 +5127,18 @@ def _read_compacted_history(rollout_path: Path) -> list[dict[str, object]] | Non
     history = payload.get("replacement_history")
     if not isinstance(history, list) or not history:
         return None
-    # Store the replacement_history as-is. It contains the full
-    # post-compaction context including opaque compaction tokens
-    # ({type: "compaction", encrypted_content: "..."}), user
-    # messages, and any other ResponseItem types. Filtering would
-    # lose the compaction tokens which ARE the compacted context.
-    return [item for item in history if isinstance(item, dict)] or None
+    # Only keep items that don't already exist in our conversation
+    # store — the opaque compaction tokens ({type: "compaction",
+    # encrypted_content: "..."}). User/assistant messages are already
+    # persisted as individual msg_* items; storing them again in
+    # compacted_messages would be redundant.
+    tokens = [
+        item
+        for item in history
+        if isinstance(item, dict)
+        and item.get("type") not in ("message", "function_call", "function_call_output")
+    ]
+    return tokens or None
 
 
 async def _handle_reasoning_delta(

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -5072,7 +5072,7 @@ async def _persist_codex_compaction_item(
                 codex_home = Path(state.codex_home)
                 thread_id = state.thread_id
                 rollout_files = sorted(
-                    codex_home.glob(f"sessions/*/*rollout-*{thread_id}.jsonl"),
+                    codex_home.glob(f"sessions/**/*rollout-*{thread_id}.jsonl"),
                     key=lambda p: p.stat().st_mtime,
                     reverse=True,
                 )

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -5064,7 +5064,7 @@ async def _persist_codex_compaction_item(
     items = resp.json().get("data", [])
     last_item_id = items[0]["id"] if items else f"compact_boundary_{session_id}"
 
-    compacted_messages = None
+    compacted = None
     if bridge_dir is not None:
         try:
             state = read_bridge_state(bridge_dir)
@@ -5077,7 +5077,7 @@ async def _persist_codex_compaction_item(
                     reverse=True,
                 )
                 if rollout_files:
-                    compacted_messages = _read_compacted_history(rollout_files[0])
+                    compacted = _read_compacted_history(rollout_files[0])
         except Exception:  # noqa: BLE001
             _logger.debug(
                 "Failed to read codex rollout for compaction persist",
@@ -5090,8 +5090,11 @@ async def _persist_codex_compaction_item(
         "model": "unknown",
         "token_count": 0,
     }
-    if compacted_messages:
-        data["compacted_messages"] = compacted_messages
+    if compacted is not None:
+        if compacted.get("replacement_history"):
+            data["compacted_messages"] = compacted["replacement_history"]
+        if compacted.get("window_id") is not None:
+            data["window_id"] = compacted["window_id"]
 
     resp = await client.post(
         f"/v1/sessions/{session_id}/events",
@@ -5100,15 +5103,15 @@ async def _persist_codex_compaction_item(
     resp.raise_for_status()
 
 
-def _read_compacted_history(rollout_path: Path) -> list[dict[str, object]] | None:
-    """Read ``replacement_history`` from the last ``Compacted`` entry in a rollout.
+def _read_compacted_history(rollout_path: Path) -> dict[str, object] | None:
+    """Read the last ``Compacted`` entry from a rollout JSONL.
 
-    Codex appends a ``{type: "compacted", payload: {replacement_history: [...]}}``
-    entry to the JSONL after compaction. The ``replacement_history`` contains the
-    post-compaction ``ResponseItem`` list — the actual context the model sees.
+    Codex appends a ``{type: "compacted", payload: {replacement_history: [...],
+    window_id: N}}`` entry after compaction. Returns a dict with
+    ``replacement_history`` and ``window_id`` for persistence, or ``None``.
 
     :param rollout_path: Path to the rollout JSONL.
-    :returns: List of message dicts from ``replacement_history``, or ``None``.
+    :returns: Dict with ``replacement_history`` and ``window_id``, or ``None``.
     """
     last_compacted = None
     with rollout_path.open() as f:
@@ -5131,10 +5134,11 @@ def _read_compacted_history(rollout_path: Path) -> list[dict[str, object]] | Non
     # tokens. Although the messages duplicate pre-compaction items
     # in the conversation store, they are needed for rollout
     # reconstruction (e.g. sandbox recovery where the rollout file
-    # is lost). The encrypted compaction token alone is not enough;
-    # the rollout's Compacted entry needs the complete
-    # replacement_history to reconstruct the context.
-    return [item for item in history if isinstance(item, dict)] or None
+    # is lost).
+    return {
+        "replacement_history": [item for item in history if isinstance(item, dict)],
+        "window_id": payload.get("window_id"),
+    }
 
 
 async def _handle_reasoning_delta(

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -5127,18 +5127,14 @@ def _read_compacted_history(rollout_path: Path) -> list[dict[str, object]] | Non
     history = payload.get("replacement_history")
     if not isinstance(history, list) or not history:
         return None
-    # Only keep items that don't already exist in our conversation
-    # store — the opaque compaction tokens ({type: "compaction",
-    # encrypted_content: "..."}). User/assistant messages are already
-    # persisted as individual msg_* items; storing them again in
-    # compacted_messages would be redundant.
-    tokens = [
-        item
-        for item in history
-        if isinstance(item, dict)
-        and item.get("type") not in ("message", "function_call", "function_call_output")
-    ]
-    return tokens or None
+    # Store the full replacement_history — messages + compaction
+    # tokens. Although the messages duplicate pre-compaction items
+    # in the conversation store, they are needed for rollout
+    # reconstruction (e.g. sandbox recovery where the rollout file
+    # is lost). The encrypted compaction token alone is not enough;
+    # the rollout's Compacted entry needs the complete
+    # replacement_history to reconstruct the context.
+    return [item for item in history if isinstance(item, dict)] or None
 
 
 async def _handle_reasoning_delta(

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -5127,42 +5127,12 @@ def _read_compacted_history(rollout_path: Path) -> list[dict[str, object]] | Non
     history = payload.get("replacement_history")
     if not isinstance(history, list) or not history:
         return None
-    # Convert ResponseItems to the harness input format.
-    msgs: list[dict[str, object]] = []
-    for item in history:
-        if not isinstance(item, dict):
-            continue
-        # ResponseItem shapes: {type: "message", role, content},
-        # {type: "function_call", ...}, {type: "function_call_output", ...}
-        item_type = item.get("type")
-        if item_type == "message":
-            role = item.get("role")
-            if role in ("user", "assistant"):
-                msgs.append(
-                    {
-                        "type": "message",
-                        "role": role,
-                        "content": item.get("content", []),
-                    }
-                )
-        elif item_type == "function_call":
-            msgs.append(
-                {
-                    "type": "function_call",
-                    "call_id": item.get("call_id"),
-                    "name": item.get("name"),
-                    "arguments": item.get("arguments"),
-                }
-            )
-        elif item_type == "function_call_output":
-            msgs.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": item.get("call_id"),
-                    "output": item.get("output"),
-                }
-            )
-    return msgs if msgs else None
+    # Store the replacement_history as-is. It contains the full
+    # post-compaction context including opaque compaction tokens
+    # ({type: "compaction", encrypted_content: "..."}), user
+    # messages, and any other ResponseItem types. Filtering would
+    # lose the compaction tokens which ARE the compacted context.
+    return [item for item in history if isinstance(item, dict)] or None
 
 
 async def _handle_reasoning_delta(

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -407,6 +407,7 @@ class CompactionData(BaseModel):
     model: str | None = None
     token_count: int
     compacted_messages: list[dict[str, Any]] | None = None
+    window_id: int | None = None
 
 
 class NativeToolData(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -737,6 +737,17 @@
             "description": "Approximate token count of the summary text, for budget tracking, e.g. `342`.",
             "title": "Token Count",
             "type": "integer"
+          },
+          "window_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Window Id"
           }
         },
         "required": [

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -6091,3 +6091,71 @@ class _capture_warnings:
         self._logger.removeHandler(self._handler)
         self._logger.setLevel(self._prev_level)
         return False
+
+
+def test_claude_transcript_records_handles_compaction_item() -> None:
+    """Compaction items replace prior records with compacted_messages."""
+    items: list[dict[str, Any]] = [
+        {
+            "id": "msg_1",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+            "response_id": "resp_1",
+        },
+        {
+            "id": "msg_2",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hi there"}],
+            "response_id": "resp_1",
+        },
+        {
+            "id": "cmp_1",
+            "type": "compaction",
+            "summary": "compaction summary",
+            "compacted_messages": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "compacted reply"}],
+                },
+            ],
+            "response_id": "compact_1",
+        },
+        {
+            "id": "msg_3",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "after compaction"}],
+            "response_id": "resp_2",
+        },
+    ]
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+    )
+    types = [r.get("type") for r in records]
+    # Should have compacted user + assistant + post-compaction user
+    assert "user" in types
+    assert "assistant" in types
+    # Pre-compaction "hi there" should be gone, replaced by "compacted reply"
+    all_text = " ".join(
+        str(r.get("message", {}).get("content", ""))
+        for r in records
+        if r.get("type") == "assistant"
+    )
+    assert "compacted reply" in all_text
+    assert "hi there" not in all_text
+    # Post-compaction message should be present
+    user_texts = [
+        str(r.get("message", {}).get("content", "")) for r in records if r.get("type") == "user"
+    ]
+    assert any("after compaction" in t for t in user_texts)

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -9173,3 +9173,106 @@ def test_forwarder_mirrors_codex_context_compaction(tmp_path: Path) -> None:
         {"type": "external_compaction_status", "data": {"status": "in_progress"}},
         {"type": "external_compaction_status", "data": {"status": "completed"}},
     ]
+
+
+def test_rollout_records_includes_compacted_entry_from_compaction_item() -> None:
+    """Compaction items emit a Compacted rollout record and discard prior items."""
+    items: list[dict[str, Any]] = [
+        {
+            "id": "msg_1",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+            "response_id": "resp_1",
+        },
+        {
+            "id": "msg_2",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hi there"}],
+            "response_id": "resp_1",
+        },
+        {
+            "id": "cmp_1",
+            "type": "compaction",
+            "summary": "compaction summary",
+            "compacted_messages": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+                {
+                    "type": "compaction",
+                    "encrypted_content": "gAAAA_encrypted",
+                },
+            ],
+            "window_id": 2,
+            "response_id": "compact_1",
+        },
+        {
+            "id": "msg_3",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "after compaction"}],
+            "response_id": "resp_2",
+        },
+    ]
+    records = codex_native._codex_rollout_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="019f-thread",
+        cwd=Path("/tmp/test"),
+        model_provider="openai",
+        cli_version="0.140.0",
+    )
+    # Should have: session_meta, compacted, turn_context, response_item (msg_3), event_msg
+    types = [r["type"] for r in records]
+    assert "session_meta" in types
+    assert "compacted" in types
+    # Pre-compaction response_items should be gone
+    pre_compaction_items = [
+        r
+        for r in records
+        if r["type"] == "response_item"
+        and r["payload"].get("content") == [{"type": "input_text", "text": "hello"}]
+    ]
+    assert len(pre_compaction_items) == 0, "Pre-compaction items should be discarded"
+    # The compacted record should have replacement_history and window_id
+    compacted_records = [r for r in records if r["type"] == "compacted"]
+    assert len(compacted_records) == 1
+    cp = compacted_records[0]["payload"]
+    assert cp["window_id"] == 2
+    assert len(cp["replacement_history"]) == 2
+    assert cp["replacement_history"][1]["encrypted_content"] == "gAAAA_encrypted"
+    # Post-compaction message should still be present
+    post_items = [
+        r
+        for r in records
+        if r["type"] == "response_item"
+        and r["payload"].get("content") == [{"type": "input_text", "text": "after compaction"}]
+    ]
+    assert len(post_items) == 1
+
+
+def test_rollout_records_without_compaction_item_has_no_compacted_entry() -> None:
+    """Sessions without compaction produce no Compacted rollout record."""
+    items: list[dict[str, Any]] = [
+        {
+            "id": "msg_1",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+            "response_id": "resp_1",
+        },
+    ]
+    records = codex_native._codex_rollout_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="019f-thread",
+        cwd=Path("/tmp/test"),
+        model_provider="openai",
+        cli_version="0.140.0",
+    )
+    types = [r["type"] for r in records]
+    assert "compacted" not in types

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1355,3 +1355,59 @@ async def test_persist_codex_compaction_item_empty_items_fallback() -> None:
     body = kwargs["json"]
     assert body["data"]["last_item_id"].startswith("compact_boundary_")
     assert "compacted_messages" not in body["data"]
+
+
+def test_read_compacted_history_extracts_replacement_history_and_window_id(
+    tmp_path: Path,
+) -> None:
+    """_read_compacted_history returns replacement_history and window_id."""
+    import json as _json
+
+    rollout = tmp_path / "rollout.jsonl"
+    lines = [
+        _json.dumps({"type": "session_meta", "payload": {"id": "abc"}}),
+        _json.dumps({"type": "response_item", "payload": {"type": "message", "role": "user"}}),
+        _json.dumps(
+            {
+                "type": "compacted",
+                "payload": {
+                    "message": "summary",
+                    "replacement_history": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "hi"}],
+                        },
+                        {
+                            "type": "compaction",
+                            "encrypted_content": "gAAAA_test_token",
+                        },
+                    ],
+                    "window_id": 2,
+                },
+            }
+        ),
+    ]
+    rollout.write_text("\n".join(lines) + "\n")
+
+    result = fwd._read_compacted_history(rollout)
+
+    assert result is not None
+    assert result["window_id"] == 2
+    assert len(result["replacement_history"]) == 2
+    assert result["replacement_history"][0]["type"] == "message"
+    assert result["replacement_history"][0]["role"] == "user"
+    assert result["replacement_history"][1]["type"] == "compaction"
+    assert result["replacement_history"][1]["encrypted_content"] == "gAAAA_test_token"
+
+
+def test_read_compacted_history_returns_none_for_no_compacted_entry(
+    tmp_path: Path,
+) -> None:
+    """_read_compacted_history returns None when no Compacted entry exists."""
+    import json as _json
+
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(_json.dumps({"type": "session_meta", "payload": {"id": "abc"}}) + "\n")
+
+    assert fwd._read_compacted_history(rollout) is None

--- a/web/src/lib/itemsToBlocks.test.ts
+++ b/web/src/lib/itemsToBlocks.test.ts
@@ -510,9 +510,7 @@ describe("itemsToBlocks — edge cases", () => {
     const userBlocks = blocks.filter((b) => b.type === "user_message") as UserMessageBlock[];
     // The compaction summary should be hidden; only "hello" and "what next?" remain
     expect(userBlocks).toHaveLength(2);
-    const texts = userBlocks.map((b) =>
-      b.content.map((c) => ("text" in c ? c.text : "")).join(""),
-    );
+    const texts = userBlocks.map((b) => b.content.map((c) => ("text" in c ? c.text : "")).join(""));
     expect(texts).toContain("hello");
     expect(texts).toContain("what next?");
     expect(texts.some((t) => t.includes("continued from a previous conversation"))).toBe(false);

--- a/web/src/lib/itemsToBlocks.test.ts
+++ b/web/src/lib/itemsToBlocks.test.ts
@@ -492,4 +492,29 @@ describe("itemsToBlocks — edge cases", () => {
     // The unknown item is dropped; only user_message + text_done survive.
     expect(blocks.map((b) => b.type)).toEqual(["user_message", "text_done"]);
   });
+
+  it("hides the compaction summary message injected after /compact", () => {
+    const items: ConversationItem[] = [
+      userMessage("r1", "hello", "msg_1"),
+      assistantMessage("r1", "hi there", "msg_2"),
+      // Compaction summary message — should be hidden
+      userMessage(
+        "r2",
+        "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\nSummary:\n1. User asked hello.",
+        "msg_compact_summary",
+      ),
+      // Normal message after compaction — should be visible
+      userMessage("r3", "what next?", "msg_3"),
+    ];
+    const blocks = itemsToBlocks(items);
+    const userBlocks = blocks.filter((b) => b.type === "user_message") as UserMessageBlock[];
+    // The compaction summary should be hidden; only "hello" and "what next?" remain
+    expect(userBlocks).toHaveLength(2);
+    const texts = userBlocks.map((b) =>
+      b.content.map((c) => ("text" in c ? c.text : "")).join(""),
+    );
+    expect(texts).toContain("hello");
+    expect(texts).toContain("what next?");
+    expect(texts.some((t) => t.includes("continued from a previous conversation"))).toBe(false);
+  });
 });

--- a/web/src/lib/itemsToBlocks.ts
+++ b/web/src/lib/itemsToBlocks.ts
@@ -79,6 +79,13 @@ function itemToBlock(item: ConversationItem): AnyBlock | null {
     return null;
   }
   if (isMessageItem(item) && item.role === "user") {
+    // Hide the compaction summary message injected by Claude Code
+    // after /compact. It starts with a distinctive prefix and is
+    // part of the model's context (needed for resume) but should
+    // not be shown as a chat bubble in the web UI.
+    if (isCompactionSummaryMessage(item)) {
+      return null;
+    }
     return userMessageToBlock(item);
   }
   if (isMessageItem(item) && item.role === "assistant") {
@@ -110,6 +117,23 @@ function itemToBlock(item: ConversationItem): AnyBlock | null {
   }
   // Unknown future item types — skip silently so the page still renders.
   return null;
+}
+
+/**
+ * Detect the compaction summary message injected by Claude Code after
+ * `/compact`. The message carries the conversation summary for the
+ * model's context but should not render as a user chat bubble.
+ */
+function isCompactionSummaryMessage(item: MessageItem): boolean {
+  const prefix = "This session is being continued from a previous conversation";
+  for (const block of item.content) {
+    if (block.type === "input_text" && typeof block.text === "string") {
+      if (block.text.startsWith(prefix)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 function userMessageToBlock(item: MessageItem): UserMessageBlock {


### PR DESCRIPTION
## Summary

Fixes compaction persistence for codex-native and claude-native harnesses, enables transcript reconstruction from DB for sandbox recovery, and hides the compaction summary message in the web UI.

### Codex-native
- **Fix glob pattern**: rollout path is `sessions/2026/06/29/...` (3 levels), glob was `sessions/*/*` (2 levels) → `sessions/**/*`
- **Store full `replacement_history`**: includes user messages + encrypted compaction tokens + `window_id` from the rollout's `Compacted` entry — all needed for rollout reconstruction
- **Reconstruct `Compacted` rollout record**: `_codex_rollout_records_from_session_items` now emits a `{type: "compacted"}` record from DB compaction items, enabling sandbox recovery via `codex resume`
- **Thread `bridge_dir`** through `_handle_completed_item` so both compaction call sites can read the rollout

### Claude-native
- **Reconstruct `compact_boundary`**: `_claude_transcript_records_from_session_items` now emits `{type: "system", subtype: "compact_boundary"}` and replays `compacted_messages` — enabling Claude transcript recovery in sandboxes
- **Add `window_id` to `CompactionData`**: new optional field for codex's context window ID

### Web UI
- **Hide compaction summary**: user messages starting with "This session is being continued from a previous conversation" are filtered out of chat bubbles (needed for model context but not user-visible)

## Test plan

- [x] Codex: verified `compacted_messages` with encrypted token stored in DB (`conv_b978f2fe...`)
- [x] Codex: deleted rollout, resumed session, verified reconstructed rollout has `Compacted` entry
- [x] Claude: verified `compacted_messages` stored in DB (`conv_dc88f8c8...`)
- [x] Unit tests: `_read_compacted_history` (2 tests), rollout reconstruction (2 tests), claude transcript reconstruction (1 test), web UI hiding (1 test)
- [x] Web UI: `npm run format:check` passes, vitest 21/21 pass