### PR TITLE
docs(databricks): recommend the managed Omnigent on Databricks offering

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -119,7 +119,15 @@ deploy/
 | Share a server running on your **laptop**: demo it to teammates, or let remote runners & cloud sandboxes connect back to it (nothing to deploy) | Cloudflare quick tunnel | `cloudflared tunnel --url http://localhost:6767` |
 | Access your server privately from **your phone, tablet, or other personal devices** without exposing it to the internet | Tailscale | [`tailscale/README.md`](tailscale/README.md): `tailscale serve https / http://localhost:8000` |
 | Cloud Run / Kubernetes / other | Docker image | [`docker/README.md`](docker/README.md), then point your platform at the image |
-| Deploy on a Databricks workspace (Lakebase + UC Volumes) | Databricks Apps | [`databricks/README.md`](databricks/README.md): uses Asset Bundles |
+| Deploy on a Databricks workspace (Lakebase + UC Volumes), self-managed | Databricks Apps | [`databricks/README.md`](databricks/README.md): uses Asset Bundles |
+
+> **On Databricks?** The fully managed
+> [Omnigent on Databricks](https://docs.databricks.com/aws/en/omnigent/)
+> (Beta) is the recommended path: Databricks operates the server for
+> you, wired to workspace identity, Foundation Models, AI Gateway, and
+> MLflow Tracing. Enable the **Omnigent** preview in your workspace
+> settings. The self-managed Databricks Apps bundle above is for when
+> you need control the managed service does not expose yet.
 
 All non-Databricks deploy paths share the same image (`docker/Dockerfile`): a
 slim Python container running the FastAPI / WebSocket coordinator, with Postgres

--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -8,6 +8,16 @@ via [Databricks Asset Bundles](https://docs.databricks.com/aws/en/dev-tools/bund
 - **UC Volumes** — the artifact store for agent bundles and executor
   storage snapshots.
 
+> **Most Databricks users want the managed offering instead.**
+> [Omnigent on Databricks](https://docs.databricks.com/aws/en/omnigent/)
+> (Beta) runs the server for you, wired to workspace identity,
+> Foundation Models, AI Gateway, and MLflow Tracing out of the box.
+> Enable the **Omnigent** preview in your workspace settings and follow
+> the quickstart there. Use this directory only when you need to
+> self-manage the deployment: the managed service is not in your region
+> yet, or you need control it does not expose today (custom YAML
+> policies, bring-your-own provider API keys, custom egress controls).
+
 The orchestrator at `deploy.py` builds the wheels, generates an app
 `pyproject.toml` + `uv.lock`, and then runs
 `databricks bundle deploy` + `bundle run` against the bundle config

--- a/docs/databricks.md
+++ b/docs/databricks.md
@@ -12,6 +12,21 @@ omnigent's fine standalone with any OTLP backend and any LLM
 provider. This guide's for the production deployment story where
 governance, audit, cost tracking, and managed scale matter.
 
+> **Databricks customer? Start with the managed offering.**
+> [Omnigent on Databricks](https://docs.databricks.com/aws/en/omnigent/)
+> (Beta) is a fully managed service: Databricks operates the omnigent
+> server for you, already wired to workspace identity, Foundation
+> Models, AI Gateway, and MLflow Tracing. You enable the **Omnigent**
+> preview in your workspace settings and follow the quickstart there.
+> No deploy tooling, no Lakebase bootstrap, no bundle to maintain. That
+> is the recommended path for most Databricks users.
+>
+> This guide covers the **self-managed** path: deploying and operating
+> the omnigent server yourself on Databricks Apps. Reach for it when the
+> managed service is not available in your region, or when you need
+> something it does not expose today (custom YAML policies, bring-your-own
+> provider API keys, custom egress controls).
+
 ## Who this is for
 
 This guide assumes you're new to both omnigent and Databricks. Each


### PR DESCRIPTION
## What

Adds a recommendation callout to the three Databricks-facing docs, pointing readers to the managed [Omnigent on Databricks](https://docs.databricks.com/aws/en/omnigent/) (Beta) as the default path, and reframes the existing self-deploy tooling as the self-managed alternative.

- `docs/databricks.md` (the integration guide) - callout under the intro.
- `deploy/databricks/README.md` (the Apps bundle) - callout under the intro.
- `deploy/README.md` (the deploy menu) - note under the Databricks Apps row; the row label now reads "self-managed".

## Why

Databricks now offers a fully managed Omnigent service: Databricks operates the server, already wired to workspace identity, Foundation Models, AI Gateway, and MLflow Tracing. For most Databricks customers that is a better path than standing up and operating the server themselves. The docs should surface that first.

The self-managed Databricks Apps bundle stays exactly as-is and remains the right choice when the managed service is not available in a given region, or when a user needs control the managed product does not expose today (custom YAML policies, bring-your-own provider API keys, custom egress controls). The callouts say so explicitly so neither path looks deprecated.

## Notes

Docs-only change; no code touched. Callout wording is plain ASCII and links to the public Databricks docs page.
