### PR TITLE
feat(policies): show model checkboxes for expensive_models in policy dialogs

### DIFF
--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -907,7 +907,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                 },
                 "expensive_models": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"type": "string", "x-enum-source": "models"},
                     "description": "Optional case-insensitive substring tokens for the model "
                     "tiers blocked once over budget. Omit (or pass []) for a true hard stop "
                     "that blocks all models; pass a non-empty list for a downgrade gate that "
@@ -943,7 +943,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                 },
                 "expensive_models": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"type": "string", "x-enum-source": "models"},
                     "description": "Optional case-insensitive substring tokens for the model "
                     "tiers blocked once over the daily budget. Omit (or pass []) for a true "
                     "hard stop that blocks all models; pass a non-empty list for a downgrade "

--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -615,6 +615,99 @@ describe("SessionPoliciesSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("adds array (multi-select) values via the model combobox as a coerced list", () => {
+    // WHY: the expensive_models-style array param renders the single-input
+    // combobox; picking options and typing a free-form value must survive the
+    // comma-joined form state and coerce to a list[str] on submit — the
+    // behavior the checkbox→combobox refactor must not regress.
+    registryData.current = [
+      {
+        handler: "h.budget",
+        kind: "factory",
+        name: "Budget Guard",
+        description: "blocks expensive models",
+        params_schema: {
+          properties: {
+            expensive_models: {
+              type: "array",
+              items: { type: "string", enum: ["opus", "sonnet", "haiku"] },
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+    renderContent("conv_pol");
+
+    fireEvent.click(screen.getByTitle("Add policy"));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByText("Budget Guard"));
+
+    // Open the combobox and pick two options from the list.
+    const combo = within(dialog).getByPlaceholderText("Select or type a value…");
+    fireEvent.focus(combo);
+    fireEvent.mouseDown(within(dialog).getByRole("button", { name: "opus" }));
+    fireEvent.mouseDown(within(dialog).getByRole("button", { name: "haiku" }));
+    // Free-form typed value still works (Enter commits).
+    fireEvent.change(combo, { target: { value: "custom-tier" } });
+    fireEvent.keyDown(combo, { key: "Enter" });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add" }));
+
+    expect(addMutate).toHaveBeenCalledTimes(1);
+    const payload = addMutate.mock.calls[0][0];
+    expect(payload.handler).toBe("h.budget");
+    expect(payload.factory_params).toEqual({
+      expensive_models: ["opus", "haiku", "custom-tier"],
+    });
+  });
+
+  it("removes a picked array value via its chip", () => {
+    // WHY: selected values render as removable chips above the combobox;
+    // removing one must drop it from the submitted list.
+    registryData.current = [
+      {
+        handler: "h.budget",
+        kind: "factory",
+        name: "Budget Guard",
+        description: "blocks expensive models",
+        params_schema: {
+          properties: {
+            expensive_models: {
+              type: "array",
+              items: { type: "string", enum: ["opus", "sonnet", "haiku"] },
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+    renderContent("conv_pol");
+
+    fireEvent.click(screen.getByTitle("Add policy"));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByText("Budget Guard"));
+
+    const combo = within(dialog).getByPlaceholderText("Select or type a value…");
+    fireEvent.focus(combo);
+    fireEvent.mouseDown(within(dialog).getByRole("button", { name: "opus" }));
+    fireEvent.mouseDown(within(dialog).getByRole("button", { name: "sonnet" }));
+
+    // Remove opus via its chip's X button. The chip is a <span> holding the
+    // label text plus a remove <button>; the list option, by contrast, is a
+    // <button> — so pick the "opus" match that is itself a span with a button.
+    const opusChip = within(dialog)
+      .getAllByText("opus")
+      .map((el) => el.closest("span"))
+      .find((span) => span?.querySelector("button")) as HTMLElement;
+    fireEvent.click(within(opusChip).getByRole("button"));
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add" }));
+
+    const payload = addMutate.mock.calls[0][0];
+    expect(payload.factory_params).toEqual({ expensive_models: ["sonnet"] });
+  });
+
   it("shows the all-applied empty message when every registry policy is already added", () => {
     // WHY: when appliedHandlers covers the whole registry the filtered list is
     // empty AND available.length === 0, so the dialog says all are applied.

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -482,7 +482,7 @@ function AddPolicyDialog({
                         <span>
                           (
                           {prop.type === "array" && prop.items?.enum
-                            ? "select"
+                            ? "multi-select"
                             : prop.type === "array"
                               ? "comma-separated"
                               : prop.type}
@@ -535,35 +535,83 @@ function AddPolicyDialog({
                         ))}
                       </select>
                     ) : prop?.type === "array" && prop.items?.enum ? (
-                      <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-1">
-                        {prop.items.enum.map((v: string) => {
-                          const current = factoryParams[key]
-                            ? factoryParams[key].split(",").filter(Boolean)
-                            : Array.isArray(prop?.default)
-                              ? (prop.default as string[])
-                              : [];
-                          const checked = current.includes(v);
-                          return (
-                            <label key={v} className="flex items-center gap-1 text-sm">
-                              <input
-                                type="checkbox"
-                                checked={checked}
+                      (() => {
+                        const current = factoryParams[key]
+                          ? factoryParams[key].split(",").filter(Boolean)
+                          : Array.isArray(prop?.default)
+                            ? (prop.default as string[])
+                            : [];
+                        const available = prop.items.enum.filter(
+                          (v: string) => !current.includes(v),
+                        );
+                        return (
+                          <div className="mt-0.5 space-y-1.5">
+                            {current.length > 0 && (
+                              <div className="flex flex-wrap gap-1">
+                                {current.map((v: string) => (
+                                  <span
+                                    key={v}
+                                    className="inline-flex items-center gap-0.5 rounded-md bg-muted px-1.5 py-0.5 text-xs"
+                                  >
+                                    {v}
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        const next = current.filter((x) => x !== v);
+                                        setFactoryParams((prev) => ({
+                                          ...prev,
+                                          [key]: next.join(","),
+                                        }));
+                                      }}
+                                      className="ml-0.5 text-muted-foreground hover:text-foreground"
+                                    >
+                                      <XIcon className="size-3" />
+                                    </button>
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                            {available.length > 0 && (
+                              <select
+                                value=""
                                 onChange={(e) => {
-                                  const next = e.target.checked
-                                    ? [...current, v]
-                                    : current.filter((x) => x !== v);
+                                  if (!e.target.value) return;
+                                  const next = [...current, e.target.value];
                                   setFactoryParams((prev) => ({
                                     ...prev,
                                     [key]: next.join(","),
                                   }));
                                 }}
-                                className="rounded border-border"
-                              />
-                              <span>{v}</span>
-                            </label>
-                          );
-                        })}
-                      </div>
+                                className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+                              >
+                                <option value="">Add from list…</option>
+                                {available.map((v: string) => (
+                                  <option key={v} value={v}>
+                                    {v}
+                                  </option>
+                                ))}
+                              </select>
+                            )}
+                            <input
+                              type="text"
+                              placeholder="Add custom value…"
+                              onKeyDown={(e) => {
+                                if (e.key !== "Enter") return;
+                                e.preventDefault();
+                                const v = e.currentTarget.value.trim();
+                                if (!v || current.includes(v)) return;
+                                const next = [...current, v];
+                                setFactoryParams((prev) => ({
+                                  ...prev,
+                                  [key]: next.join(","),
+                                }));
+                                e.currentTarget.value = "";
+                              }}
+                              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+                            />
+                          </div>
+                        );
+                      })()
                     ) : (
                       <input
                         type={

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -48,6 +48,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { capitalizeAgentName } from "@/lib/agentLabels";
 import { coercePolicyParams } from "@/lib/policyParams";
+import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { agentRootName } from "@/lib/forkHarness";
 import { nativeCodingAgentForAgentName } from "@/lib/nativeCodingAgents";
 import { copyText } from "@/lib/clipboard";
@@ -275,9 +276,10 @@ function AddPolicyDialog({
   const [factoryParams, setFactoryParams] = useState<Record<string, string>>({});
   const [paramError, setParamError] = useState<string | null>(null);
   const addPolicy = useAddPolicy(sessionId);
+  const codexModelOptions = useChatStore((s) => s.codexModelOptions);
 
   const entry = registry.find((r) => r.handler === selected);
-  const schema = entry?.params_schema as
+  const rawSchema = entry?.params_schema as
     | {
         properties?: Record<
           string,
@@ -286,7 +288,7 @@ function AddPolicyDialog({
             description?: string;
             default?: unknown;
             enum?: string[];
-            items?: { type?: string; enum?: string[] };
+            items?: { type?: string; enum?: string[]; "x-enum-source"?: string };
             uniqueItems?: boolean;
           }
         >;
@@ -294,7 +296,26 @@ function AddPolicyDialog({
       }
     | null
     | undefined;
-  const properties = schema?.properties ?? {};
+  const modelIds = useMemo(() => {
+    const ids = CLAUDE_NATIVE_MODELS.map((m) => m.id);
+    for (const opt of codexModelOptions) {
+      if (opt.id && !ids.includes(opt.id)) ids.push(opt.id);
+    }
+    return ids;
+  }, [codexModelOptions]);
+  const properties = useMemo(() => {
+    const props = rawSchema?.properties ?? {};
+    if (!modelIds.length) return props;
+    const enriched: typeof props = {};
+    for (const [key, prop] of Object.entries(props)) {
+      if (prop.items?.["x-enum-source"] === "models" && !prop.items.enum) {
+        enriched[key] = { ...prop, items: { ...prop.items, enum: modelIds } };
+      } else {
+        enriched[key] = prop;
+      }
+    }
+    return enriched;
+  }, [rawSchema?.properties, modelIds]);
   const paramKeys = Object.keys(properties);
 
   function handleSelect(handler: string) {

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -45,6 +45,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ModelValueCombobox } from "@/components/ModelValueCombobox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { capitalizeAgentName } from "@/lib/agentLabels";
 import { coercePolicyParams } from "@/lib/policyParams";
@@ -541,9 +542,6 @@ function AddPolicyDialog({
                           : Array.isArray(prop?.default)
                             ? (prop.default as string[])
                             : [];
-                        const available = prop.items.enum.filter(
-                          (v: string) => !current.includes(v),
-                        );
                         return (
                           <div className="mt-0.5 space-y-1.5">
                             {current.length > 0 && (
@@ -571,43 +569,18 @@ function AddPolicyDialog({
                                 ))}
                               </div>
                             )}
-                            {available.length > 0 && (
-                              <select
-                                value=""
-                                onChange={(e) => {
-                                  if (!e.target.value) return;
-                                  const next = [...current, e.target.value];
-                                  setFactoryParams((prev) => ({
-                                    ...prev,
-                                    [key]: next.join(","),
-                                  }));
-                                }}
-                                className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
-                              >
-                                <option value="">Add from list…</option>
-                                {available.map((v: string) => (
-                                  <option key={v} value={v}>
-                                    {v}
-                                  </option>
-                                ))}
-                              </select>
-                            )}
-                            <input
-                              type="text"
-                              placeholder="Add custom value…"
-                              onKeyDown={(e) => {
-                                if (e.key !== "Enter") return;
-                                e.preventDefault();
-                                const v = e.currentTarget.value.trim();
-                                if (!v || current.includes(v)) return;
-                                const next = [...current, v];
+                            <ModelValueCombobox
+                              options={prop.items.enum}
+                              selected={current}
+                              onToggle={(v) => {
+                                const next = current.includes(v)
+                                  ? current.filter((x) => x !== v)
+                                  : [...current, v];
                                 setFactoryParams((prev) => ({
                                   ...prev,
                                   [key]: next.join(","),
                                 }));
-                                e.currentTarget.value = "";
                               }}
-                              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
                             />
                           </div>
                         );

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -297,7 +297,7 @@ function AddPolicyDialog({
     | null
     | undefined;
   const modelIds = useMemo(() => {
-    const ids = CLAUDE_NATIVE_MODELS.map((m) => m.id);
+    const ids: string[] = CLAUDE_NATIVE_MODELS.map((m) => m.id);
     for (const opt of codexModelOptions) {
       if (opt.id && !ids.includes(opt.id)) ids.push(opt.id);
     }

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -1,7 +1,7 @@
 // Agent info surface: the MCP-server and policy badges, and the
 // header info-icon popover that displays them.
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   CheckIcon,
   CopyIcon,
@@ -528,7 +528,7 @@ function AddPolicyDialog({
                         }
                         className="mt-0.5 w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
                       >
-                        {prop.enum.map((v) => (
+                        {prop.enum.map((v: string) => (
                           <option key={v} value={v}>
                             {v}
                           </option>
@@ -536,7 +536,7 @@ function AddPolicyDialog({
                       </select>
                     ) : prop?.type === "array" && prop.items?.enum ? (
                       <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-1">
-                        {prop.items.enum.map((v) => {
+                        {prop.items.enum.map((v: string) => {
                           const current = factoryParams[key]
                             ? factoryParams[key].split(",").filter(Boolean)
                             : Array.isArray(prop?.default)

--- a/web/src/components/ModelValueCombobox.test.tsx
+++ b/web/src/components/ModelValueCombobox.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { ModelValueCombobox } from "./ModelValueCombobox";
+
+afterEach(cleanup);
+
+const OPTIONS = ["opus", "sonnet", "haiku"];
+
+/**
+ * Stateful harness mirroring the call sites: ``onToggle`` adds/removes the
+ * value from a selection kept as a comma-joined string, exactly like the
+ * policy dialogs do.
+ */
+function Harness({ options = OPTIONS }: { options?: string[] }) {
+  const [csv, setCsv] = useState("");
+  const selected = csv ? csv.split(",").filter(Boolean) : [];
+  return (
+    <div>
+      <ModelValueCombobox
+        options={options}
+        selected={selected}
+        onToggle={(v) => {
+          const next = selected.includes(v) ? selected.filter((x) => x !== v) : [...selected, v];
+          setCsv(next.join(","));
+        }}
+      />
+      <output data-testid="csv">{csv}</output>
+    </div>
+  );
+}
+
+function openList() {
+  fireEvent.focus(screen.getByRole("textbox"));
+}
+
+describe("ModelValueCombobox", () => {
+  it("opens the option list on focus", () => {
+    render(<Harness />);
+    expect(screen.queryByRole("button", { name: "opus" })).not.toBeInTheDocument();
+    openList();
+    expect(screen.getByRole("button", { name: "opus" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "sonnet" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "haiku" })).toBeInTheDocument();
+  });
+
+  it("selects an option on click and reflects it in the comma-joined value", () => {
+    render(<Harness />);
+    openList();
+    fireEvent.mouseDown(screen.getByRole("button", { name: "opus" }));
+    expect(screen.getByTestId("csv")).toHaveTextContent("opus");
+  });
+
+  it("keeps every option listed after selecting (does not remove picked ones)", () => {
+    render(<Harness />);
+    openList();
+    fireEvent.mouseDown(screen.getByRole("button", { name: "opus" }));
+    // The list stays open and still shows all three options.
+    expect(screen.getByRole("button", { name: "opus" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "sonnet" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "haiku" })).toBeInTheDocument();
+  });
+
+  it("supports selecting multiple values in a row", () => {
+    render(<Harness />);
+    openList();
+    fireEvent.mouseDown(screen.getByRole("button", { name: "opus" }));
+    fireEvent.mouseDown(screen.getByRole("button", { name: "haiku" }));
+    expect(screen.getByTestId("csv")).toHaveTextContent("opus,haiku");
+  });
+
+  it("toggles a selected value off when clicked again", () => {
+    render(<Harness />);
+    openList();
+    fireEvent.mouseDown(screen.getByRole("button", { name: "opus" }));
+    expect(screen.getByTestId("csv")).toHaveTextContent("opus");
+    fireEvent.mouseDown(screen.getByRole("button", { name: "opus" }));
+    expect(screen.getByTestId("csv")).toHaveTextContent("");
+  });
+
+  it("adds a free-form typed value on Enter", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "gpt-4o" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(screen.getByTestId("csv")).toHaveTextContent("gpt-4o");
+    // Query clears after committing.
+    expect(input).toHaveValue("");
+  });
+
+  it("ignores Enter on blank / whitespace-only input", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(screen.getByTestId("csv")).toHaveTextContent("");
+  });
+
+  it("filters options by the typed query (case-insensitive)", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "OP" } });
+    expect(screen.getByRole("button", { name: "opus" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "sonnet" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "haiku" })).not.toBeInTheDocument();
+  });
+
+  it("hides the list when no option matches the query", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "zzz" } });
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("closes the list on Escape", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox");
+    openList();
+    expect(screen.getByRole("button", { name: "opus" })).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByRole("button", { name: "opus" })).not.toBeInTheDocument();
+  });
+
+  it("closes the list on outside pointer-down", () => {
+    render(<Harness />);
+    openList();
+    expect(screen.getByRole("button", { name: "opus" })).toBeInTheDocument();
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("button", { name: "opus" })).not.toBeInTheDocument();
+  });
+
+  it("marks selected options with a visible checkmark and unselected ones without", () => {
+    render(<Harness />);
+    openList();
+    fireEvent.mouseDown(screen.getByRole("button", { name: "opus" }));
+    // The checkmark is the first svg child of each option button; selected
+    // rows show it (no opacity-0), unselected rows keep it hidden.
+    const selectedCheck = screen.getByRole("button", { name: "opus" }).querySelector("svg");
+    const unselectedCheck = screen.getByRole("button", { name: "sonnet" }).querySelector("svg");
+    expect(selectedCheck?.getAttribute("class")).not.toContain("opacity-0");
+    expect(unselectedCheck?.getAttribute("class")).toContain("opacity-0");
+  });
+
+  it("uses a custom placeholder when provided", () => {
+    render(
+      <ModelValueCombobox
+        options={OPTIONS}
+        selected={[]}
+        onToggle={vi.fn()}
+        placeholder="Pick a model"
+      />,
+    );
+    expect(screen.getByPlaceholderText("Pick a model")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ModelValueCombobox.tsx
+++ b/web/src/components/ModelValueCombobox.tsx
@@ -1,0 +1,107 @@
+/**
+ * Single-input multi-select combobox for policy array params (e.g.
+ * ``expensive_models``).
+ *
+ * Users can type a free-form value or pick from a themed dropdown below the
+ * input. Every option stays listed with a checkmark on the ones already
+ * selected; clicking toggles it. Pressing Enter adds the typed value.
+ *
+ * The dropdown renders in normal flow (not absolutely positioned) so it grows
+ * the dialog and scrolls with it rather than floating over — and overlapping —
+ * the buttons beneath. The enclosing dialog is the scroll container.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { CheckIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function ModelValueCombobox({
+  options,
+  selected,
+  onToggle,
+  placeholder = "Select or type a value…",
+}: {
+  options: string[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  placeholder?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const lower = query.toLowerCase();
+  const filtered = lower ? options.filter((v) => v.toLowerCase().includes(lower)) : options;
+  const selectedSet = new Set(selected);
+  const showList = open && filtered.length > 0;
+
+  function pick(value: string) {
+    const v = value.trim();
+    if (!v) return;
+    onToggle(v);
+    setQuery("");
+    // Keep the dropdown open so more values can be picked in a row; the input
+    // is already focused, so relying on onFocus to reopen wouldn't fire.
+    setOpen(true);
+    inputRef.current?.focus();
+  }
+
+  // Close when clicking outside the combobox.
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: PointerEvent) {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  return (
+    <div ref={wrapperRef} className="space-y-1">
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        placeholder={placeholder}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            pick(query);
+          } else if (e.key === "Escape") {
+            setOpen(false);
+          }
+        }}
+        className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      {showList && (
+        <div className="max-h-40 overflow-y-auto rounded-lg border border-border bg-popover p-1 text-popover-foreground">
+          {filtered.map((v) => {
+            const isSelected = selectedSet.has(v);
+            return (
+              <button
+                key={v}
+                type="button"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                // mousedown fires before the input's blur, so the value toggles
+                // before the click-outside handler would close the dropdown.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  pick(v);
+                }}
+              >
+                <CheckIcon className={cn("size-3.5 shrink-0", !isSelected && "opacity-0")} />
+                <span className="flex-1 truncate">{v}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/PoliciesPage.test.tsx
+++ b/web/src/pages/PoliciesPage.test.tsx
@@ -185,6 +185,55 @@ describe("PoliciesPage actions", () => {
     expect(deleteMutate).toHaveBeenCalledWith("p1", expect.anything());
   });
 
+  it("adds array (multi-select) values via the model combobox as a coerced list", async () => {
+    // WHY: the expensive_models-style array param renders the single-input
+    // combobox; picking options and typing a free-form value must survive the
+    // comma-joined form state and coerce to a list[str] on submit — guarding
+    // the checkbox→combobox refactor against a regression.
+    vi.mocked(policies.usePolicyRegistry).mockReturnValue({
+      data: [
+        {
+          handler: "omnigent.policies.budget",
+          kind: "factory",
+          name: "Budget Guard",
+          description: "blocks expensive models",
+          params_schema: {
+            properties: {
+              expensive_models: {
+                type: "array",
+                items: { type: "string", enum: ["opus", "sonnet", "haiku"] },
+              },
+            },
+            required: [],
+          },
+        },
+      ],
+    } as never);
+    renderPage();
+    await screen.findByText(/No global policies configured/);
+
+    fireEvent.click(screen.getByRole("button", { name: /Add policy/ }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByText("Budget Guard"));
+
+    const combo = within(dialog).getByPlaceholderText("Select or type a value…");
+    fireEvent.focus(combo);
+    fireEvent.mouseDown(within(dialog).getByRole("button", { name: "opus" }));
+    fireEvent.mouseDown(within(dialog).getByRole("button", { name: "haiku" }));
+    // Free-form typed value still works (Enter commits).
+    fireEvent.change(combo, { target: { value: "custom-tier" } });
+    fireEvent.keyDown(combo, { key: "Enter" });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Add$/ }));
+
+    expect(addMutate).toHaveBeenCalledTimes(1);
+    const payload = addMutate.mock.calls[0][0];
+    expect(payload.handler).toBe("omnigent.policies.budget");
+    expect(payload.factory_params).toEqual({
+      expensive_models: ["opus", "haiku", "custom-tier"],
+    });
+  });
+
   it("adds a global policy from the registry via the Add dialog", async () => {
     vi.mocked(policies.usePolicyRegistry).mockReturnValue({
       data: [

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { PlusIcon, RefreshCwIcon, ShieldCheckIcon, TrashIcon } from "lucide-react";
+import { PlusIcon, RefreshCwIcon, ShieldCheckIcon, TrashIcon, XIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import {
@@ -250,7 +250,7 @@ function AddDefaultPolicyDialog({
                         <span>
                           (
                           {prop.type === "array" && prop.items?.enum
-                            ? "select"
+                            ? "multi-select"
                             : prop.type === "array"
                               ? "comma-separated"
                               : prop.type}
@@ -303,35 +303,83 @@ function AddDefaultPolicyDialog({
                         ))}
                       </select>
                     ) : prop?.type === "array" && prop.items?.enum ? (
-                      <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-1">
-                        {prop.items.enum.map((v) => {
-                          const current = factoryParams[key]
-                            ? factoryParams[key].split(",").filter(Boolean)
-                            : Array.isArray(prop?.default)
-                              ? (prop.default as string[])
-                              : [];
-                          const checked = current.includes(v);
-                          return (
-                            <label key={v} className="flex items-center gap-1 text-sm">
-                              <input
-                                type="checkbox"
-                                checked={checked}
+                      (() => {
+                        const current = factoryParams[key]
+                          ? factoryParams[key].split(",").filter(Boolean)
+                          : Array.isArray(prop?.default)
+                            ? (prop.default as string[])
+                            : [];
+                        const available = prop.items.enum.filter(
+                          (v: string) => !current.includes(v),
+                        );
+                        return (
+                          <div className="mt-0.5 space-y-1.5">
+                            {current.length > 0 && (
+                              <div className="flex flex-wrap gap-1">
+                                {current.map((v) => (
+                                  <span
+                                    key={v}
+                                    className="inline-flex items-center gap-0.5 rounded-md bg-muted px-1.5 py-0.5 text-xs"
+                                  >
+                                    {v}
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        const next = current.filter((x) => x !== v);
+                                        setFactoryParams((prev) => ({
+                                          ...prev,
+                                          [key]: next.join(","),
+                                        }));
+                                      }}
+                                      className="ml-0.5 text-muted-foreground hover:text-foreground"
+                                    >
+                                      <XIcon className="size-3" />
+                                    </button>
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                            {available.length > 0 && (
+                              <select
+                                value=""
                                 onChange={(e) => {
-                                  const next = e.target.checked
-                                    ? [...current, v]
-                                    : current.filter((x) => x !== v);
+                                  if (!e.target.value) return;
+                                  const next = [...current, e.target.value];
                                   setFactoryParams((prev) => ({
                                     ...prev,
                                     [key]: next.join(","),
                                   }));
                                 }}
-                                className="rounded border-border"
-                              />
-                              <span>{v}</span>
-                            </label>
-                          );
-                        })}
-                      </div>
+                                className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+                              >
+                                <option value="">Add from list…</option>
+                                {available.map((v: string) => (
+                                  <option key={v} value={v}>
+                                    {v}
+                                  </option>
+                                ))}
+                              </select>
+                            )}
+                            <input
+                              type="text"
+                              placeholder="Add custom value…"
+                              onKeyDown={(e) => {
+                                if (e.key !== "Enter") return;
+                                e.preventDefault();
+                                const v = e.currentTarget.value.trim();
+                                if (!v || current.includes(v)) return;
+                                const next = [...current, v];
+                                setFactoryParams((prev) => ({
+                                  ...prev,
+                                  [key]: next.join(","),
+                                }));
+                                e.currentTarget.value = "";
+                              }}
+                              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+                            />
+                          </div>
+                        );
+                      })()
                     ) : (
                       <input
                         type={

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -77,10 +77,7 @@ function AddDefaultPolicyDialog({
       }
     | null
     | undefined;
-  const modelIds = useMemo(
-    () => CLAUDE_NATIVE_MODELS.map((m) => m.id),
-    [],
-  );
+  const modelIds = useMemo(() => CLAUDE_NATIVE_MODELS.map((m) => m.id), []);
   const properties = useMemo(() => {
     const props = rawSchema?.properties ?? {};
     if (!modelIds.length) return props;

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { PlusIcon, RefreshCwIcon, ShieldCheckIcon, TrashIcon, XIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
+import { ModelValueCombobox } from "@/components/ModelValueCombobox";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -309,9 +310,6 @@ function AddDefaultPolicyDialog({
                           : Array.isArray(prop?.default)
                             ? (prop.default as string[])
                             : [];
-                        const available = prop.items.enum.filter(
-                          (v: string) => !current.includes(v),
-                        );
                         return (
                           <div className="mt-0.5 space-y-1.5">
                             {current.length > 0 && (
@@ -339,43 +337,18 @@ function AddDefaultPolicyDialog({
                                 ))}
                               </div>
                             )}
-                            {available.length > 0 && (
-                              <select
-                                value=""
-                                onChange={(e) => {
-                                  if (!e.target.value) return;
-                                  const next = [...current, e.target.value];
-                                  setFactoryParams((prev) => ({
-                                    ...prev,
-                                    [key]: next.join(","),
-                                  }));
-                                }}
-                                className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
-                              >
-                                <option value="">Add from list…</option>
-                                {available.map((v: string) => (
-                                  <option key={v} value={v}>
-                                    {v}
-                                  </option>
-                                ))}
-                              </select>
-                            )}
-                            <input
-                              type="text"
-                              placeholder="Add custom value…"
-                              onKeyDown={(e) => {
-                                if (e.key !== "Enter") return;
-                                e.preventDefault();
-                                const v = e.currentTarget.value.trim();
-                                if (!v || current.includes(v)) return;
-                                const next = [...current, v];
+                            <ModelValueCombobox
+                              options={prop.items.enum}
+                              selected={current}
+                              onToggle={(v) => {
+                                const next = current.includes(v)
+                                  ? current.filter((x) => x !== v)
+                                  : [...current, v];
                                 setFactoryParams((prev) => ({
                                   ...prev,
                                   [key]: next.join(","),
                                 }));
-                                e.currentTarget.value = "";
                               }}
-                              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
                             />
                           </div>
                         );

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -11,7 +11,7 @@
  * themselves — client-side gating is just UX.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { PlusIcon, RefreshCwIcon, ShieldCheckIcon, TrashIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
@@ -32,6 +32,7 @@ import {
   type DefaultPolicy,
 } from "@/hooks/useDefaultPolicies";
 import { usePolicyRegistry, type PolicyRegistryEntry } from "@/hooks/usePolicies";
+import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { coercePolicyParams } from "@/lib/policyParams";
@@ -59,7 +60,7 @@ function AddDefaultPolicyDialog({
   const addPolicy = useAddDefaultPolicy();
 
   const entry = registry.find((r) => r.handler === selected);
-  const schema = entry?.params_schema as
+  const rawSchema = entry?.params_schema as
     | {
         properties?: Record<
           string,
@@ -68,7 +69,7 @@ function AddDefaultPolicyDialog({
             description?: string;
             default?: unknown;
             enum?: string[];
-            items?: { type?: string; enum?: string[] };
+            items?: { type?: string; enum?: string[]; "x-enum-source"?: string };
             uniqueItems?: boolean;
           }
         >;
@@ -76,7 +77,23 @@ function AddDefaultPolicyDialog({
       }
     | null
     | undefined;
-  const properties = schema?.properties ?? {};
+  const modelIds = useMemo(
+    () => CLAUDE_NATIVE_MODELS.map((m) => m.id),
+    [],
+  );
+  const properties = useMemo(() => {
+    const props = rawSchema?.properties ?? {};
+    if (!modelIds.length) return props;
+    const enriched: typeof props = {};
+    for (const [key, prop] of Object.entries(props)) {
+      if (prop.items?.["x-enum-source"] === "models" && !prop.items.enum) {
+        enriched[key] = { ...prop, items: { ...prop.items, enum: modelIds } };
+      } else {
+        enriched[key] = prop;
+      }
+    }
+    return enriched;
+  }, [rawSchema?.properties, modelIds]);
   const paramKeys = Object.keys(properties);
 
   function handleSelect(handler: string) {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The `expensive_models` field in cost-budget policy dialogs (Session Cost Budget, Per-User Daily Cost Budget) was a free-text comma-separated input, requiring users to know and type model tokens manually.
- Added `x-enum-source: "models"` annotation to the schema and enriched it on the frontend with the existing model lists (`CLAUDE_NATIVE_MODELS` + session-scoped `codexModelOptions`), so the field renders as checkboxes instead.
- No new backend endpoint — reuses the same model data that powers the chat model picker.

## Test Plan

- All 455 existing policy tests pass (`pytest tests/policies/`).
- Manual verification: open the Add Policy dialog for Session Cost Budget or Per-User Daily Cost Budget and confirm `expensive_models` renders as checkboxes (Opus, Sonnet, Haiku) instead of a text input. In a Codex session, Codex model IDs also appear.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing policy tests verify the schema and cost-budget behavior are unchanged. The frontend change is UI-only (rendering checkboxes instead of text input based on the schema annotation) and was verified manually.