### PR TITLE
feat(policies): per-subagent cost budget via sys_session_send

### DIFF
--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -842,7 +842,42 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
             "required": ["max_cost_usd"],
         },
     },
-    # NOTE: subagent_cost_budget is NOT registered here. It is for internal
-    # use only, attached by sys_session_send at spawn time. Users should not
-    # discover or manually attach it via the policy registry.
+    {
+        "handler": "omnigent.policies.builtins.cost.subagent_cost_budget",
+        "kind": "factory",
+        "name": "Subagent Cost Budget",
+        "description": "Gates a sub-agent on its own subtree LLM spend (USD): once a hard limit "
+        "is reached DENY (the whole turn at the request phase, or each tool call) while still on "
+        "an expensive model (prompting a /model downgrade), and ASK for approval at each soft "
+        "warning checkpoint (request + tool-call phases). Reads "
+        "event.context.subtree_usage.total_cost_usd and event.context.model. Intended to be "
+        "attached to a child session via sys_session_send's cost_budget argument.",
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "max_cost_usd": {
+                    "type": "number",
+                    "description": "Hard limit in USD for the subtree; once cumulative subtree "
+                    "cost reaches it, tool calls are blocked while on an expensive model.",
+                },
+                "ask_thresholds_usd": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "Optional soft warning checkpoints in USD; the subagent asks "
+                    "for approval the first time subtree spend crosses each (every value must "
+                    "be < max_cost_usd).",
+                },
+                "expensive_models": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional case-insensitive substring tokens for the model "
+                    "tiers blocked once over budget (default: Fable + Opus + GPT-5, excluding "
+                    "the cheap -mini/-nano variants). An empty list disables the hard limit, "
+                    "leaving only the soft thresholds.",
+                },
+            },
+            "required": ["max_cost_usd"],
+        },
+        "internal_only": True,
+    },
 ]

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -842,41 +842,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
             "required": ["max_cost_usd"],
         },
     },
-    {
-        "handler": "omnigent.policies.builtins.cost.subagent_cost_budget",
-        "kind": "factory",
-        "name": "Subagent Cost Budget",
-        "description": "Gates a sub-agent on its own subtree LLM spend (USD): once a hard limit "
-        "is reached DENY (the whole turn at the request phase, or each tool call) while still on "
-        "an expensive model (prompting a /model downgrade), and ASK for approval at each soft "
-        "warning checkpoint (request + tool-call phases). Reads "
-        "event.context.subtree_usage.total_cost_usd and event.context.model. Intended to be "
-        "attached to a child session via sys_session_send's cost_budget argument.",
-        "params_schema": {
-            "type": "object",
-            "properties": {
-                "max_cost_usd": {
-                    "type": "number",
-                    "description": "Hard limit in USD for the subtree; once cumulative subtree "
-                    "cost reaches it, tool calls are blocked while on an expensive model.",
-                },
-                "ask_thresholds_usd": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Optional soft warning checkpoints in USD; the subagent asks "
-                    "for approval the first time subtree spend crosses each (every value must "
-                    "be < max_cost_usd).",
-                },
-                "expensive_models": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Optional case-insensitive substring tokens for the model "
-                    "tiers blocked once over budget (default: Fable + Opus + GPT-5, excluding "
-                    "the cheap -mini/-nano variants). An empty list disables the hard limit, "
-                    "leaving only the soft thresholds.",
-                },
-            },
-            "required": ["max_cost_usd"],
-        },
-    },
+    # NOTE: subagent_cost_budget is NOT registered here. It is for internal
+    # use only, attached by sys_session_send at spawn time. Users should not
+    # discover or manually attach it via the policy registry.
 ]

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -670,7 +670,7 @@ def _subtree_cost_usd(event: PolicyEvent) -> float:
 
 
 def subagent_cost_budget(
-    max_cost_usd: float,
+    max_cost_usd: float | None = None,
     ask_thresholds_usd: list[float] | None = None,
     expensive_models: list[str] | None = None,
 ) -> PolicyCallable:
@@ -690,20 +690,24 @@ def subagent_cost_budget(
     stays local to the child's ``session_state`` — it is NOT routed to
     the root conversation, so approvals are scoped to the subagent.
 
-    :param max_cost_usd: Hard limit in USD for the subtree. Must be
-        ``> 0``.
+    :param max_cost_usd: Optional hard limit in USD for the subtree. Must be
+        ``> 0`` if provided. Either this or ask_thresholds_usd must be set.
     :param ask_thresholds_usd: Optional soft warning checkpoints in USD.
         Same semantics as :func:`cost_budget`.
     :param expensive_models: Optional case-insensitive substring tokens.
         Same semantics as :func:`cost_budget`.
     :returns: A policy callable implementing the subtree budget gate.
-    :raises ValueError: Same validation as :func:`cost_budget`.
+    :raises ValueError: If neither max_cost_usd nor ask_thresholds_usd is set,
+        or if validation fails.
     """
-    if max_cost_usd <= 0:
+    # At least one of max_cost_usd or ask_thresholds_usd must be present.
+    if max_cost_usd is None and not ask_thresholds_usd:
+        raise ValueError("subagent_cost_budget requires max_cost_usd and/or ask_thresholds_usd")
+    if max_cost_usd is not None and max_cost_usd <= 0:
         raise ValueError(f"max_cost_usd must be > 0, got {max_cost_usd!r}")
     thresholds = sorted({float(t) for t in (ask_thresholds_usd or [])})
     for t in thresholds:
-        if not (0 < t < max_cost_usd):
+        if max_cost_usd is not None and not (0 < t < max_cost_usd):
             raise ValueError(
                 f"each ask_thresholds_usd value must be in "
                 f"(0, max_cost_usd={max_cost_usd}), got {t!r}"
@@ -724,7 +728,8 @@ def subagent_cost_budget(
         if phase not in _GATED_PHASES:
             return _ALLOW
         cost = _subtree_cost_usd(event)
-        if cfg.hard_cap_enabled and cost >= max_cost_usd:
+        # Check hard limit if max_cost_usd is set.
+        if max_cost_usd is not None and cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
                 _current_model(event), cfg.expensive_tokens, cfg.exclude_tokens
             ):
@@ -741,17 +746,19 @@ def subagent_cost_budget(
                     ),
                 }
             return _ALLOW
+        # Check soft thresholds if ask_thresholds_usd is set.
         if thresholds:
             crossed = max((t for t in thresholds if cost >= t), default=None)
             if crossed is not None:
                 state = event.get("session_state") or {}
                 approved_up_to = float(state.get(_SUBAGENT_ASK_APPROVED_KEY, 0.0) or 0.0)
                 if crossed > approved_up_to:
+                    limit_str = f" (limit ${max_cost_usd:.2f})" if max_cost_usd else ""
                     return {
                         "result": "ASK",
                         "reason": (
                             f"Subagent subtree cost ${cost:.2f} passed the ${crossed:.2f} "
-                            f"warning threshold (limit ${max_cost_usd:.2f}). Continue?"
+                            f"warning threshold{limit_str}. Continue?"
                         ),
                         "state_updates": [
                             {
@@ -876,7 +883,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "leaving only the soft thresholds.",
                 },
             },
-            "required": ["max_cost_usd"],
+            "required": [],
         },
         "internal_only": True,
     },

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -645,6 +645,127 @@ def user_daily_cost_budget(
     return evaluate  # type: ignore[return-value]
 
 
+# session_state key recording the highest ``ask_thresholds_usd`` checkpoint
+# the user has already approved continuing past for a SUBAGENT cost budget.
+# Unlike ``_ASK_APPROVED_KEY`` (which routes to the ROOT conversation), this
+# stays local to the child's own session_state so approvals are scoped to the
+# subagent, not the whole spawn tree.
+_SUBAGENT_ASK_APPROVED_KEY = "subagent_cost_ask_approved_usd"
+
+
+def _subtree_cost_usd(event: PolicyEvent) -> float:
+    """Read cumulative subtree cost (USD) from a policy event.
+
+    :param event: Policy event dict.
+    :returns: ``event["context"]["subtree_usage"]["total_cost_usd"]`` as a
+        float, or ``0.0`` when the field is absent / not yet priced.
+    """
+    context = event.get("context") or {}
+    subtree_usage = context.get("subtree_usage") or {}
+    raw = subtree_usage.get("total_cost_usd", 0.0)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def subagent_cost_budget(
+    max_cost_usd: float,
+    ask_thresholds_usd: list[float] | None = None,
+    expensive_models: list[str] | None = None,
+) -> PolicyCallable:
+    """Factory: gate a sub-agent on its own subtree LLM spend (USD).
+
+    Identical gating logic to :func:`cost_budget`, but scoped to the
+    **child conversation's subtree** (itself + its descendants) rather
+    than the whole session tree. Reads
+    ``event["context"]["subtree_usage"]["total_cost_usd"]`` instead of
+    ``event["context"]["usage"]["total_cost_usd"]``.
+
+    Intended to be attached to a child session at spawn time via
+    ``sys_session_send``'s ``cost_budget`` argument. The parent sets the
+    budget; the child gates against its own subtree spend.
+
+    The soft-checkpoint approval key (``subagent_cost_ask_approved_usd``)
+    stays local to the child's ``session_state`` — it is NOT routed to
+    the root conversation, so approvals are scoped to the subagent.
+
+    :param max_cost_usd: Hard limit in USD for the subtree. Must be
+        ``> 0``.
+    :param ask_thresholds_usd: Optional soft warning checkpoints in USD.
+        Same semantics as :func:`cost_budget`.
+    :param expensive_models: Optional case-insensitive substring tokens.
+        Same semantics as :func:`cost_budget`.
+    :returns: A policy callable implementing the subtree budget gate.
+    :raises ValueError: Same validation as :func:`cost_budget`.
+    """
+    if max_cost_usd <= 0:
+        raise ValueError(f"max_cost_usd must be > 0, got {max_cost_usd!r}")
+    thresholds = sorted({float(t) for t in (ask_thresholds_usd or [])})
+    for t in thresholds:
+        if not (0 < t < max_cost_usd):
+            raise ValueError(
+                f"each ask_thresholds_usd value must be in "
+                f"(0, max_cost_usd={max_cost_usd}), got {t!r}"
+            )
+    cfg = _resolve_expensive_models(expensive_models)
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Evaluate the subagent subtree cost budget for a request or tool call.
+
+        Same gating logic as :func:`cost_budget`'s ``evaluate``, reading
+        the subtree cost and using a local approval key.
+
+        :param event: Policy event dict.
+        :returns: DENY when over budget on an expensive model; ASK when
+            a new soft checkpoint is newly crossed; ALLOW otherwise.
+        """
+        phase = event.get("type")
+        if phase not in _GATED_PHASES:
+            return _ALLOW
+        cost = _subtree_cost_usd(event)
+        if cfg.hard_cap_enabled and cost >= max_cost_usd:
+            if _model_blocked_over_budget(
+                _current_model(event), cfg.expensive_tokens, cfg.exclude_tokens
+            ):
+                return {
+                    "result": "DENY",
+                    "reason": _over_budget_deny_reason(
+                        cost,
+                        max_cost_usd,
+                        cfg.expensive_tokens,
+                        _current_harness(event),
+                        phase=phase,
+                        policy_label="subagent cost-budget",
+                        budget_label="subagent cost budget",
+                    ),
+                }
+            return _ALLOW
+        if thresholds:
+            crossed = max((t for t in thresholds if cost >= t), default=None)
+            if crossed is not None:
+                state = event.get("session_state") or {}
+                approved_up_to = float(state.get(_SUBAGENT_ASK_APPROVED_KEY, 0.0) or 0.0)
+                if crossed > approved_up_to:
+                    return {
+                        "result": "ASK",
+                        "reason": (
+                            f"Subagent subtree cost ${cost:.2f} passed the ${crossed:.2f} "
+                            f"warning threshold (limit ${max_cost_usd:.2f}). Continue?"
+                        ),
+                        "state_updates": [
+                            {
+                                "key": _SUBAGENT_ASK_APPROVED_KEY,
+                                "action": "set",
+                                "value": crossed,
+                            },
+                        ],
+                    }
+        return _ALLOW
+
+    return evaluate  # type: ignore[return-value]
+
+
 # ── Registry ─────────────────────────────────────────────────────────────────
 
 POLICY_REGISTRY: list[dict[str, Any]] = [
@@ -716,6 +837,43 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "tiers blocked once over the daily budget (default: Fable + Opus + GPT-5, "
                     "excluding the cheap -mini/-nano variants). An empty list disables the hard "
                     "limit, leaving only the soft thresholds.",
+                },
+            },
+            "required": ["max_cost_usd"],
+        },
+    },
+    {
+        "handler": "omnigent.policies.builtins.cost.subagent_cost_budget",
+        "kind": "factory",
+        "name": "Subagent Cost Budget",
+        "description": "Gates a sub-agent on its own subtree LLM spend (USD): once a hard limit "
+        "is reached DENY (the whole turn at the request phase, or each tool call) while still on "
+        "an expensive model (prompting a /model downgrade), and ASK for approval at each soft "
+        "warning checkpoint (request + tool-call phases). Reads "
+        "event.context.subtree_usage.total_cost_usd and event.context.model. Intended to be "
+        "attached to a child session via sys_session_send's cost_budget argument.",
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "max_cost_usd": {
+                    "type": "number",
+                    "description": "Hard limit in USD for the subtree; once cumulative subtree "
+                    "cost reaches it, tool calls are blocked while on an expensive model.",
+                },
+                "ask_thresholds_usd": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "Optional soft warning checkpoints in USD; the subagent asks "
+                    "for approval the first time subtree spend crosses each (every value must "
+                    "be < max_cost_usd).",
+                },
+                "expensive_models": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional case-insensitive substring tokens for the model "
+                    "tiers blocked once over budget (default: Fable + Opus + GPT-5, excluding "
+                    "the cheap -mini/-nano variants). An empty list disables the hard limit, "
+                    "leaving only the soft thresholds.",
                 },
             },
             "required": ["max_cost_usd"],

--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -238,6 +238,10 @@ def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
             "harness": ctx.harness,
             # Conversation labels (engine hot cache), empty when unpopulated.
             "labels": dict(ctx.labels) if ctx.labels is not None else {},
+            # Subtree-scoped cumulative cost (this conversation + its
+            # descendants only), injected by the engine only when a
+            # subagent_cost_budget policy is present; empty dict otherwise.
+            "subtree_usage": dict(ctx.subtree_usage) if ctx.subtree_usage else {},
         },
         # Mutable per-conversation state readable by the callable.
         # Empty dict when no policy has written state yet; the engine

--- a/omnigent/policies/registry.py
+++ b/omnigent/policies/registry.py
@@ -56,6 +56,7 @@ class PolicyRegistryEntry:
     name: str
     description: str
     params_schema: dict[str, Any] | None = None
+    internal_only: bool = False
 
 
 # Module-level singleton. Populated by load_registry().

--- a/omnigent/policies/registry.py
+++ b/omnigent/policies/registry.py
@@ -121,6 +121,7 @@ def load_registry(
                 name=name,
                 description=raw.get("description", ""),
                 params_schema=raw.get("params_schema"),
+                internal_only=raw.get("internal_only", False),
             )
             _registry.append(entry)
             _registry_by_handler[entry.handler] = entry

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -130,6 +130,13 @@ class EvaluationContext:
         callable. ``None`` means "engine not yet populated"
         (test contexts); empty dict means "no usage recorded
         yet."
+    :param subtree_usage: Subtree-scoped cumulative LLM cost for
+        this conversation and its descendants only (not the whole
+        session tree). Same shape as ``usage``. Injected by the
+        engine ONLY when a ``subagent_cost_budget`` policy is
+        configured — ``None`` otherwise, so sessions without that
+        policy pay no subtree-cost lookup. Surfaced as
+        ``event["context"]["subtree_usage"]`` to the callable.
     :param user_daily_cost: The session owner's per-UTC-day cost
         rollup, shape
         ``{"cost_usd": <float>, "ask_approved_usd": <float>}``,
@@ -179,6 +186,7 @@ class EvaluationContext:
     request_data: Any = None
     session_state: dict[str, Any] | None = None
     usage: dict[str, float] | None = None
+    subtree_usage: dict[str, float] | None = None
     user_daily_cost: dict[str, float | str] | None = None
     model: str | None = None
     harness: str | None = None

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -979,6 +979,28 @@ def _subagent_harness_override_from_args(args: dict[str, Any]) -> str | None:
     return raw_harness
 
 
+def _subagent_cost_budget_from_args(args: dict[str, Any]) -> float | None:
+    """
+    Extract and validate the per-dispatch cost budget from ``sys_session_send`` args.
+
+    The optional ``cost_budget`` field lives inside the object form of
+    ``args`` (``{"input": ..., "cost_budget": 2.0}``).
+
+    :param args: Parsed ``sys_session_send`` arguments.
+    :returns: The validated budget in USD, or ``None`` when absent.
+    :raises ValueError: If ``cost_budget`` is present but not positive.
+    """
+    raw_args = args.get("args")
+    if isinstance(raw_args, dict):
+        budget = raw_args.get("cost_budget")
+        if budget is not None:
+            budget = float(budget)
+            if budget <= 0:
+                raise ValueError("cost_budget must be > 0")
+            return budget
+    return None
+
+
 def _subagent_allowed_harnesses(sub_agent_name: str, agent_spec: Any | None) -> frozenset[str]:
     """
     Resolve the canonical harness allowlist a sub-agent opts into.
@@ -1138,6 +1160,11 @@ async def _execute_subagent_tool(
     except ValueError as exc:
         return f"Error: sys_session_send invalid 'harness': {exc}"
 
+    try:
+        cost_budget = _subagent_cost_budget_from_args(args)
+    except (ValueError, TypeError) as exc:
+        return f"Error: sys_session_send invalid 'cost_budget': {exc}"
+
     # By-session-id mode: post to an existing direct child instead of
     # spawning/continuing a named (agent, title) sub-agent.
     target_session_id = args.get("session_id")
@@ -1162,6 +1189,13 @@ async def _execute_subagent_tool(
                 "Error: sys_session_send 'harness' applies only when a "
                 "sub-agent session is first created; it cannot change an "
                 "existing session. Re-send without 'harness' to continue "
+                f"session {target_session_id!r}."
+            )
+        if cost_budget is not None:
+            return (
+                "Error: sys_session_send 'cost_budget' applies only when a "
+                "sub-agent session is first created; it cannot change an "
+                "existing session. Re-send without 'cost_budget' to continue "
                 f"session {target_session_id!r}."
             )
         return await _send_to_existing_session(
@@ -1227,6 +1261,15 @@ async def _execute_subagent_tool(
                 f"{child_session_id}. Re-send without 'model' to continue "
                 "it, or sys_session_close it first to spawn a fresh "
                 "session on the requested model."
+            )
+        if cost_budget is not None:
+            return (
+                f"Error: sys_session_send 'cost_budget' applies only when a "
+                f"sub-agent session is first created; {sub_agent_name!r} "
+                f"title {session_name!r} already exists as "
+                f"{child_session_id}. Re-send without 'cost_budget' to "
+                "continue it, or sys_session_close it first to spawn a "
+                "fresh session with the requested budget."
             )
         child_wrapper_label = _session_wrapper_label(existing)
         existing_work = _runner_app.get_subagent_work(child_session_id)
@@ -1355,6 +1398,36 @@ async def _execute_subagent_tool(
             return "Error: server did not return child session_id"
         child_wrapper_label = _session_wrapper_label(child_data)
         created_child = True
+
+        # Attach a subagent_cost_budget policy to the child when requested.
+        # Non-fatal: the child session is still usable without the budget.
+        if cost_budget is not None:
+            policy_body = {
+                "name": "__subagent_cost_budget",
+                "type": "python",
+                "handler": "omnigent.policies.builtins.cost.subagent_cost_budget",
+                "factory_params": {"max_cost_usd": cost_budget},
+                "enabled": True,
+            }
+            try:
+                pol_resp = await server_client.post(
+                    f"/v1/sessions/{child_session_id}/policies",
+                    json=policy_body,
+                    timeout=10.0,
+                )
+                if pol_resp.status_code >= 400:
+                    _logger.warning(
+                        "failed to set subagent_cost_budget policy on child %s: %s %s",
+                        child_session_id,
+                        pol_resp.status_code,
+                        pol_resp.text[:200],
+                    )
+            except httpx.HTTPError:
+                _logger.warning(
+                    "failed to set subagent_cost_budget policy on child %s",
+                    child_session_id,
+                    exc_info=True,
+                )
 
     # Publish session.created on the parent's SSE stream so the
     # REPL debug panel and any client subscribers discover the

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -979,25 +979,61 @@ def _subagent_harness_override_from_args(args: dict[str, Any]) -> str | None:
     return raw_harness
 
 
-def _subagent_cost_budget_from_args(args: dict[str, Any]) -> float | None:
+def _subagent_cost_budget_from_args(
+    args: dict[str, Any],
+) -> dict[str, Any] | None:
     """
     Extract and validate the per-dispatch cost budget from ``sys_session_send`` args.
 
-    The optional ``cost_budget`` field lives inside the object form of
-    ``args`` (``{"input": ..., "cost_budget": 2.0}``).
+    The optional ``cost_budget`` field is an object with max_cost_usd
+    (hard limit) and/or ask_thresholds_usd (soft checkpoints). At least
+    one must be present.
 
     :param args: Parsed ``sys_session_send`` arguments.
-    :returns: The validated budget in USD, or ``None`` when absent.
-    :raises ValueError: If ``cost_budget`` is present but not positive.
+    :returns: A dict with max_cost_usd and/or ask_thresholds_usd, or
+        ``None`` when absent.
+    :raises ValueError: If cost_budget is malformed or values are invalid.
     """
     raw_args = args.get("args")
     if isinstance(raw_args, dict):
         budget = raw_args.get("cost_budget")
-        if budget is not None:
-            budget = float(budget)
-            if budget <= 0:
-                raise ValueError("cost_budget must be > 0")
-            return budget
+        if budget is None:
+            return None
+
+        if not isinstance(budget, dict):
+            raise ValueError("cost_budget must be an object")
+
+        result: dict[str, Any] = {}
+
+        # Extract and validate max_cost_usd if present.
+        if "max_cost_usd" in budget:
+            max_cost = budget["max_cost_usd"]
+            if max_cost is not None:
+                max_cost = float(max_cost)
+                if max_cost <= 0:
+                    raise ValueError("cost_budget.max_cost_usd must be > 0")
+                result["max_cost_usd"] = max_cost
+
+        # Extract and validate ask_thresholds_usd if present.
+        if "ask_thresholds_usd" in budget:
+            thresholds = budget["ask_thresholds_usd"]
+            if thresholds is not None:
+                if not isinstance(thresholds, list):
+                    raise ValueError("cost_budget.ask_thresholds_usd must be an array")
+                thresholds = [float(t) for t in thresholds]
+                if not all(t > 0 for t in thresholds):
+                    raise ValueError("cost_budget.ask_thresholds_usd values must be > 0")
+                # Check that thresholds are less than max if both are set.
+                if "max_cost_usd" in result and result["max_cost_usd"] is not None:
+                    if any(t >= result["max_cost_usd"] for t in thresholds):
+                        raise ValueError("ask_thresholds_usd values must be < max_cost_usd")
+                result["ask_thresholds_usd"] = thresholds
+
+        # At least one must be present.
+        if not result:
+            raise ValueError("cost_budget must include max_cost_usd and/or ask_thresholds_usd")
+        return result
+
     return None
 
 
@@ -1406,7 +1442,7 @@ async def _execute_subagent_tool(
                 "name": "__subagent_cost_budget",
                 "type": "python",
                 "handler": "omnigent.policies.builtins.cost.subagent_cost_budget",
-                "factory_params": {"max_cost_usd": cost_budget},
+                "factory_params": cost_budget,  # Dict with max_cost_usd and/or ask_thresholds_usd
                 "enabled": True,
             }
             try:

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -114,6 +114,25 @@ def _needs_subtree_usage(specs: list[PolicySpec]) -> bool:
     )
 
 
+def _normalize_usage_for_engine(usage: dict[str, float]) -> dict[str, float]:
+    """
+    Normalize a usage dict for injection into the policy engine.
+
+    Removes display-only fields (``by_model``) and converts the
+    enforcement-cost field (``policy_cost_usd``) to the engine's
+    canonical ``total_cost_usd`` key. Both operations are idempotent:
+    if a field is absent, the operation is a no-op.
+
+    :param usage: The usage dict to normalize (modified in-place).
+    :returns: The normalized dict (same object, for chaining).
+    """
+    usage.pop("by_model", None)
+    policy_cost = usage.pop("policy_cost_usd", None)
+    if policy_cost is not None:
+        usage["total_cost_usd"] = policy_cost
+    return usage
+
+
 def _subtree_usage_seed(
     conversation_id: str,
     conversation_store: ConversationStore,
@@ -133,13 +152,7 @@ def _subtree_usage_seed(
         ``total_cost_usd`` is the enforcement total.
     """
     usage = load_session_usage(conversation_id, conversation_store)
-    # ``by_model`` is a display-only breakdown; drop it so the engine's
-    # subtree usage context carries only the flat numeric counters.
-    usage.pop("by_model", None)
-    policy_cost = usage.pop("policy_cost_usd", None)
-    if policy_cost is not None:
-        usage["total_cost_usd"] = policy_cost
-    return usage
+    return _normalize_usage_for_engine(usage)
 
 
 def _resolve_session_owner_cached(
@@ -824,13 +837,7 @@ def _policy_usage_seed(
     if conv is None:
         return {}
     usage = load_session_usage(conv.root_conversation_id, conversation_store)
-    # ``by_model`` is a display-only breakdown; drop it so the engine's usage
-    # context carries only the flat numeric counters the gate reads.
-    usage.pop("by_model", None)
-    policy_cost = usage.pop("policy_cost_usd", None)
-    if policy_cost is not None:
-        usage["total_cost_usd"] = policy_cost
-    return usage
+    return _normalize_usage_for_engine(usage)
 
 
 def _load_tree_conversations(

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -49,6 +49,11 @@ from omnigent.stores.policy_store import PolicyStore
 # nothing extra per evaluation.
 _USER_DAILY_COST_POLICY_PATH = "omnigent.policies.builtins.cost.user_daily_cost_budget"
 
+# Dotted path of the per-subagent cost-budget factory. The engine is
+# seeded with the subtree-scoped usage ONLY when a policy set includes
+# this handler — otherwise the subtree usage lookup is skipped.
+_SUBAGENT_COST_POLICY_PATH = "omnigent.policies.builtins.cost.subagent_cost_budget"
+
 # Hardcoded policy that always ASKs before sys_add_policy executes.
 # Injected unconditionally into every engine so agents cannot add
 # policies without user approval.
@@ -88,6 +93,53 @@ def _needs_user_daily_cost(specs: list[PolicySpec]) -> bool:
         and s.function.path == _USER_DAILY_COST_POLICY_PATH
         for s in specs
     )
+
+
+def _needs_subtree_usage(specs: list[PolicySpec]) -> bool:
+    """
+    Return whether any policy in *specs* is the per-subagent cost-budget.
+
+    Drives the conditional injection: only when this returns ``True``
+    does :func:`build_policy_engine` compute the subtree usage seed.
+
+    :param specs: The merged policy specs for the engine.
+    :returns: ``True`` when a :class:`FunctionPolicySpec` references the
+        ``subagent_cost_budget`` factory.
+    """
+    return any(
+        isinstance(s, FunctionPolicySpec)
+        and s.function is not None
+        and s.function.path == _SUBAGENT_COST_POLICY_PATH
+        for s in specs
+    )
+
+
+def _subtree_usage_seed(
+    conversation_id: str,
+    conversation_store: ConversationStore,
+) -> dict[str, float]:
+    """
+    SUBTREE-scoped usage seed for the per-subagent cost budget.
+
+    Unlike :func:`_policy_usage_seed` (which seeds from the whole session
+    tree via ``root_conversation_id``), this seeds from ``conversation_id``
+    itself — so the budget gates on this conversation's own subtree cost
+    (itself + its descendants), not the whole session.
+
+    :param conversation_id: Conversation to seed the subtree usage for,
+        e.g. ``"conv_child"``.
+    :param conversation_store: Store to read the subtree usage from.
+    :returns: Subtree usage seed dict; when an enforcement cost exists its
+        ``total_cost_usd`` is the enforcement total.
+    """
+    usage = load_session_usage(conversation_id, conversation_store)
+    # ``by_model`` is a display-only breakdown; drop it so the engine's
+    # subtree usage context carries only the flat numeric counters.
+    usage.pop("by_model", None)
+    policy_cost = usage.pop("policy_cost_usd", None)
+    if policy_cost is not None:
+        usage["total_cost_usd"] = policy_cost
+    return usage
 
 
 def _resolve_session_owner_cached(
@@ -271,6 +323,13 @@ def build_policy_engine(
     # not just its own subtree. The cost read is the enforcement total
     # (in-flight sub-agent spend); see _policy_usage_seed.
     initial_usage = _policy_usage_seed(conversation_id, conversation_store)
+    # Conditional injection (#1a): only compute subtree usage when a
+    # subagent_cost_budget policy is present.
+    initial_subtree_usage = (
+        _subtree_usage_seed(conversation_id, conversation_store)
+        if _needs_subtree_usage(all_policy_specs)
+        else None
+    )
     # Conditional injection (#1): only pay the owner + daily-cost lookups
     # when a per-user daily cost-budget policy is actually present.
     initial_user_daily_cost = (
@@ -307,6 +366,7 @@ def build_policy_engine(
         initial_labels=initial_labels,
         initial_session_state=initial_session_state,
         initial_usage=initial_usage,
+        initial_subtree_usage=initial_subtree_usage,
         initial_user_daily_cost=initial_user_daily_cost,
         token_pricing=token_pricing,
         initial_model=initial_model,

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -112,6 +112,7 @@ class PolicyEngine:
         initial_labels: dict[str, str],
         initial_session_state: dict[str, Any] | None = None,
         initial_usage: dict[str, float] | None = None,
+        initial_subtree_usage: dict[str, float] | None = None,
         initial_user_daily_cost: dict[str, float | str] | None = None,
         token_pricing: ModelPricing | None = None,
         initial_model: str | None = None,
@@ -145,6 +146,13 @@ class PolicyEngine:
         # persisted usage that predates cache-token tracking.
         self._usage.setdefault("cache_read_input_tokens", 0)
         self._usage.setdefault("cache_creation_input_tokens", 0)
+        # Subtree-scoped usage seed (this conversation + its descendants
+        # only, not the whole session tree). Seeded at build time ONLY when
+        # a ``subagent_cost_budget`` policy is configured — ``None``
+        # otherwise, so sessions without that policy pay no subtree lookup.
+        self._subtree_usage: dict[str, float] | None = (
+            dict(initial_subtree_usage) if initial_subtree_usage is not None else None
+        )
         # The session owner's per-UTC-day cost rollup
         # ({"cost_usd", "ask_approved_usd"}), seeded at build time ONLY
         # when a policy needs it (per-user daily cost-budget configured).
@@ -287,6 +295,7 @@ class PolicyEngine:
         ctx = self._populate_trajectory(ctx)
         ctx = self._inject_session_state(ctx)
         ctx = self._inject_usage(ctx)
+        ctx = self._inject_subtree_usage(ctx)
         ctx = self._inject_user_daily_cost(ctx)
         ctx = self._inject_model(ctx)
         ctx = self._inject_labels(ctx)
@@ -615,7 +624,17 @@ class PolicyEngine:
                 "cache_read_input_tokens": cache_read_input_tokens,
                 "cache_creation_input_tokens": cache_creation_input_tokens,
             }
-            self._usage["total_cost_usd"] += compute_llm_cost(delta_usage, self._token_pricing)
+            delta_cost = compute_llm_cost(delta_usage, self._token_pricing)
+            self._usage["total_cost_usd"] += delta_cost
+        else:
+            delta_cost = 0.0
+        if self._subtree_usage is not None:
+            self._subtree_usage["input_tokens"] += input_tokens
+            self._subtree_usage["output_tokens"] += output_tokens
+            self._subtree_usage["total_tokens"] += total_tokens
+            self._subtree_usage["cache_read_input_tokens"] += cache_read_input_tokens
+            self._subtree_usage["cache_creation_input_tokens"] += cache_creation_input_tokens
+            self._subtree_usage["total_cost_usd"] += delta_cost
         self._store.set_session_usage(self._conversation_id, dict(self._usage))
 
     def _inject_usage(self, ctx: EvaluationContext) -> EvaluationContext:
@@ -633,6 +652,25 @@ class PolicyEngine:
             set to a defensive copy of the cumulative counters.
         """
         return replace(ctx, usage=dict(self._usage))
+
+    def _inject_subtree_usage(self, ctx: EvaluationContext) -> EvaluationContext:
+        """
+        Return a copy of *ctx* with ``subtree_usage`` populated, when seeded.
+
+        Injects the engine's subtree-scoped cumulative cost so the
+        ``subagent_cost_budget`` policy can gate on the child's own
+        subtree spend rather than the whole session total. When the
+        engine was built without it (``None`` — no policy needs it),
+        *ctx* is returned unchanged.
+
+        :param ctx: Original :class:`EvaluationContext` from the
+            caller.
+        :returns: *ctx* unchanged when no subtree usage was seeded,
+            else a copy with ``subtree_usage`` set to a defensive copy.
+        """
+        if self._subtree_usage is None:
+            return ctx
+        return replace(ctx, subtree_usage=dict(self._subtree_usage))
 
     def _inject_user_daily_cost(self, ctx: EvaluationContext) -> EvaluationContext:
         """

--- a/omnigent/server/routes/policy_registry.py
+++ b/omnigent/server/routes/policy_registry.py
@@ -50,9 +50,12 @@ def create_policy_registry_router(
         # check needed since the registry is not session-scoped.
         require_user(request, auth_provider)
         entries = get_registry()
+        # Filter out internal-only policies (e.g., subagent_cost_budget)
+        # that are for internal use only and should not appear in the UI
+        public_entries = [e for e in entries if not e.internal_only]
         return {
             "object": "list",
-            "data": [asdict(e) for e in entries],
+            "data": [asdict(e) for e in public_entries],
         }
 
     return router

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -373,7 +373,6 @@ def _build_sys_session_send_schema(
                                                 ),
                                             },
                                         },
-                                        "additionalProperties": False,
                                         "description": (
                                             "Optional per-subagent cost budget configuration "
                                             "with max_cost_usd (hard limit) and/or "

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -280,17 +280,19 @@ def _build_sys_session_send_schema(
             "The user-input message to send to the sub-agent. The sub-agent "
             "treats this as the first user turn in its conversation. Pass a "
             "plain string for the normal contract, or pass "
-            "{input, purpose, model, harness} when a spec-level policy "
-            "requires explicit dispatch metadata, a per-dispatch model "
-            "override, or an allowlisted harness override."
+            "{input, purpose, model, harness, cost_budget} when a spec-level "
+            "policy requires explicit dispatch metadata, a per-dispatch model "
+            "override, an allowlisted harness override, or a per-subagent "
+            "cost budget."
         )
         if harness_opt_in
         else (
             "The user-input message to send to the sub-agent. The sub-agent "
             "treats this as the first user turn in its conversation. Pass a "
             "plain string for the normal contract, or pass "
-            "{input, purpose, model} when a spec-level policy requires "
-            "explicit dispatch metadata or a per-dispatch model override."
+            "{input, purpose, model, cost_budget} when a spec-level policy "
+            "requires explicit dispatch metadata, a per-dispatch model "
+            "override, or a per-subagent cost budget."
         )
     )
     return {
@@ -348,6 +350,16 @@ def _build_sys_session_send_schema(
                                         ),
                                     },
                                     **harness_property,
+                                    "cost_budget": {
+                                        "type": "number",
+                                        "description": (
+                                            "Optional per-subagent cost budget in USD. "
+                                            "When set, the spawned sub-agent session will have a "
+                                            "subagent_cost_budget policy enforced at this limit. "
+                                            "Applies only when this send creates the session; "
+                                            "ignored on continuation sends."
+                                        ),
+                                    },
                                 },
                                 "required": ["input"],
                                 "additionalProperties": False,

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -351,13 +351,35 @@ def _build_sys_session_send_schema(
                                     },
                                     **harness_property,
                                     "cost_budget": {
-                                        "type": "number",
+                                        "type": "object",
+                                        "properties": {
+                                            "max_cost_usd": {
+                                                "type": "number",
+                                                "description": (
+                                                    "Optional hard limit in USD. "
+                                                    "Blocks tool calls once exceeded "
+                                                    "on expensive models."
+                                                ),
+                                            },
+                                            "ask_thresholds_usd": {
+                                                "type": "array",
+                                                "items": {"type": "number"},
+                                                "description": (
+                                                    "Optional soft warning checkpoints "
+                                                    "in USD. The subagent asks for "
+                                                    "approval the first time spend "
+                                                    "crosses each threshold (each must "
+                                                    "be < max_cost_usd if both are set)."
+                                                ),
+                                            },
+                                        },
+                                        "additionalProperties": False,
                                         "description": (
-                                            "Optional per-subagent cost budget in USD. "
-                                            "When set, the spawned sub-agent session will have a "
-                                            "subagent_cost_budget policy enforced at this limit. "
-                                            "Applies only when this send creates the session; "
-                                            "ignored on continuation sends."
+                                            "Optional per-subagent cost budget configuration "
+                                            "with max_cost_usd (hard limit) and/or "
+                                            "ask_thresholds_usd (soft checkpoints). At least "
+                                            "one must be set. Applies only when this send "
+                                            "creates the session; ignored on continuation sends."
                                         ),
                                     },
                                 },

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -319,7 +319,7 @@ def test_sanitize_real_sys_session_send_args_collapses_to_object() -> None:
     # Structured fields the purpose guard and the per-dispatch model
     # override read must survive the collapse.
     assert sanitized_args["type"] == "object"
-    assert set(sanitized_args["properties"]) == {"input", "purpose", "model"}
+    assert set(sanitized_args["properties"]) == {"input", "purpose", "model", "cost_budget"}
     assert sanitized_args["required"] == ["input"]
     # Exact dict: the chosen object branch minus its stripped
     # additionalProperties — anything else means extra keys leaked or

--- a/tests/runtime/policies/test_builder.py
+++ b/tests/runtime/policies/test_builder.py
@@ -816,3 +816,178 @@ def test_load_session_usage_merges_by_model_across_subtree(
         conversation_store=conversation_store,
     )
     assert "by_model" not in engine.usage
+
+
+# ── Subtree-scoped cost budgeting (per-subagent cost gates) ──
+
+
+def test_build_subagent_with_cost_budget_gets_session_wide_usage(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A subagent with ``cost_budget`` policy sees session-wide usage.
+
+    The per-session cost gate (``cost_budget``) gates the whole spawn tree.
+    A subagent's engine must be seeded with the full-tree total, not just
+    its own subtree, so it doesn't re-allow budgets already exhausted by
+    parent + siblings.
+
+    This test verifies the existing cost_budget behavior (baseline for
+    the new subagent_cost_budget feature).
+    """
+    parent = conversation_store.create_conversation()
+    child = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id
+    )
+    sibling = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id
+    )
+
+    conversation_store.set_session_usage(parent.id, {"total_cost_usd": 0.10})
+    conversation_store.set_session_usage(child.id, {"total_cost_usd": 0.05})
+    conversation_store.set_session_usage(sibling.id, {"total_cost_usd": 0.03})
+
+    # Child's engine sees full-tree total (0.18), not just child+sibling subtree.
+    engine = build_policy_engine(
+        spec=AgentSpec(spec_version=1, name="child"),
+        conversation_id=child.id,
+        conversation_store=conversation_store,
+    )
+    assert engine.usage["total_cost_usd"] == pytest.approx(0.18)  # 0.10+0.05+0.03
+
+
+def test_build_injects_subtree_usage_only_when_policy_present(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    The engine's ``subtree_usage`` is injected only when
+    subagent_cost_budget policy is present; otherwise None.
+
+    This guards against unnecessary DB traversals (the conditional
+    injection pattern) — if the policy isn't used, we skip the lookup.
+    """
+    from omnigent.spec.types import GuardrailsSpec
+
+    parent = conversation_store.create_conversation()
+    child = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id
+    )
+    conversation_store.set_session_usage(parent.id, {"total_cost_usd": 0.10})
+    conversation_store.set_session_usage(child.id, {"total_cost_usd": 0.05})
+
+    # Engine without subagent_cost_budget policy: subtree_usage is None.
+    engine_no_policy = build_policy_engine(
+        spec=AgentSpec(
+            spec_version=1,
+            name="child",
+            guardrails=GuardrailsSpec(policies={}),
+        ),
+        conversation_id=child.id,
+        conversation_store=conversation_store,
+    )
+    assert engine_no_policy._subtree_usage is None
+
+    # Engine with subagent_cost_budget policy: subtree_usage is populated.
+    # (We can't easily construct the policy spec without going through
+    # the registry, so we just verify it would be computed by checking
+    # that the engine has the infrastructure to store it.)
+    engine_with_policy = build_policy_engine(
+        spec=AgentSpec(spec_version=1, name="child"),
+        conversation_id=child.id,
+        conversation_store=conversation_store,
+    )
+    # The engine was built successfully; when the policy is present,
+    # _subtree_usage would be populated. This is a structural test that
+    # the builder plumbs the value through.
+    assert hasattr(engine_with_policy, "_subtree_usage")
+
+
+def test_build_subagent_subtree_usage_excludes_parent_and_siblings(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """
+    A subagent's subtree_usage includes only its own subtree, not parent/siblings.
+
+    The per-subagent cost gate (``subagent_cost_budget``) gates each
+    subagent independently on its own spend. A child's subtree_usage must
+    therefore reflect only the child + its descendants, not the parent or
+    siblings.
+
+    This is the key semantic difference from cost_budget (which sees
+    session-wide) vs. subagent_cost_budget (which sees only its own subtree).
+    """
+    from omnigent.runtime.policies.builder import load_session_usage
+
+    parent = conversation_store.create_conversation()
+    child = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id
+    )
+    sibling = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id
+    )
+    grandchild = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=child.id
+    )
+
+    conversation_store.set_session_usage(parent.id, {"total_cost_usd": 0.10})
+    conversation_store.set_session_usage(child.id, {"total_cost_usd": 0.05})
+    conversation_store.set_session_usage(sibling.id, {"total_cost_usd": 0.03})
+    conversation_store.set_session_usage(grandchild.id, {"total_cost_usd": 0.02})
+
+    # load_session_usage with the child's ID gives us only its subtree.
+    child_subtree = load_session_usage(child.id, conversation_store)
+    # 0.07 = child (0.05) + grandchild (0.02), NOT parent or sibling.
+    assert child_subtree["total_cost_usd"] == pytest.approx(0.07)
+
+    # Parent sees full tree (0.20); child's subtree_usage would be 0.07.
+    parent_fullsession = load_session_usage(parent.id, conversation_store)
+    assert parent_fullsession["total_cost_usd"] == pytest.approx(0.20)
+
+    # Verify the difference: child subtree < session total.
+    assert child_subtree["total_cost_usd"] < parent_fullsession["total_cost_usd"]
+
+
+def test_normalize_usage_for_engine_drops_display_fields() -> None:
+    """
+    _normalize_usage_for_engine removes by_model and promotes policy_cost_usd.
+
+    Both _policy_usage_seed and _subtree_usage_seed use this helper to
+    prepare usage for the engine: strip the display-only ``by_model``
+    breakdown, and swap ``policy_cost_usd`` to ``total_cost_usd`` for
+    enforcement cost (falling back to ``total_cost_usd`` when no enforcement
+    cost exists).
+    """
+    from omnigent.runtime.policies.builder import _normalize_usage_for_engine
+
+    # Case 1: Has both policy_cost (enforcement) and by_model (display).
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "total_tokens": 120,
+        "total_cost_usd": 0.10,
+        "policy_cost_usd": 0.15,  # In-flight estimate, higher than display.
+        "by_model": {"claude-opus": {"input_tokens": 100, "total_cost_usd": 0.10}},
+    }
+    normalized = _normalize_usage_for_engine(usage)
+    assert normalized["total_cost_usd"] == 0.15  # Swapped from policy_cost_usd.
+    assert "policy_cost_usd" not in normalized  # Removed.
+    assert "by_model" not in normalized  # Removed.
+    assert normalized["input_tokens"] == 100  # Untouched.
+
+    # Case 2: No policy_cost (codex/relay style) — falls back to total_cost_usd.
+    usage2 = {
+        "input_tokens": 50,
+        "total_cost_usd": 0.05,
+        "by_model": {"claude-sonnet": {"input_tokens": 50, "total_cost_usd": 0.05}},
+    }
+    normalized2 = _normalize_usage_for_engine(usage2)
+    assert normalized2["total_cost_usd"] == 0.05  # Unchanged; no policy_cost to promote.
+    assert "by_model" not in normalized2
+    assert normalized2["input_tokens"] == 50
+
+    # Case 3: Empty usage (no cost fields at all) — idempotent.
+    usage3: dict[str, float] = {"input_tokens": 0, "output_tokens": 0}
+    normalized3 = _normalize_usage_for_engine(usage3)
+    assert "by_model" not in normalized3
+    assert "policy_cost_usd" not in normalized3
+    assert normalized3["input_tokens"] == 0

--- a/tests/server/routes/test_policy_registry.py
+++ b/tests/server/routes/test_policy_registry.py
@@ -24,3 +24,45 @@ async def test_policy_registry_entry_shape(client: httpx.AsyncClient) -> None:
             assert "handler" in entry
             assert "description" in entry
             assert "params_schema" in entry
+
+
+async def test_internal_only_policies_excluded_from_registry(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Internal-only policies (internal_only=True) are excluded from the registry.
+
+    When the policy registry is populated with policies that have
+    internal_only=True, they should be filtered out in the GET /v1/policy-registry
+    response. This ensures internal-only policies remain in the validation
+    allowlist (for sys_session_send to attach them) but don't appear in the
+    UI's policy selector.
+    """
+    from omnigent.policies.registry import get_registry, load_registry
+
+    # Ensure the registry is loaded with all built-in policies.
+    load_registry()
+    all_entries = get_registry()
+
+    # Get the response from the API.
+    resp = await client.get("/v1/policy-registry")
+    assert resp.status_code == 200
+    public_entries = resp.json()["data"]
+
+    # Extract public handler paths from the API response.
+    public_handlers = {entry["handler"] for entry in public_entries}
+
+    # Any internal_only policies should be in the full registry but NOT
+    # in the public API response.
+    internal_only_handlers = {e.handler for e in all_entries if e.internal_only}
+
+    # Verify internal_only policies are excluded from the public API.
+    assert internal_only_handlers.isdisjoint(public_handlers), (
+        f"Internal-only policies {internal_only_handlers & public_handlers} "
+        "should not appear in the public registry"
+    )
+
+    # Verify at least one internal_only policy exists (to make the test meaningful).
+    assert len(internal_only_handlers) > 0, (
+        "Registry should contain at least one internal_only policy"
+    )

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -188,7 +188,7 @@ def test_send_schema_advertises_plain_string_and_purpose_object_args() -> None:
     # required, or plain-string sends would break.
     assert object_schema["required"] == ["input"]
     assert object_schema["additionalProperties"] is False
-    assert set(object_schema["properties"]) == {"input", "purpose", "model"}
+    assert set(object_schema["properties"]) == {"input", "purpose", "model", "cost_budget"}
     assert "dispatch metadata" in object_schema["properties"]["purpose"]["description"]
     # The model property must say it is create-time-only and optional,
     # so the LLM doesn't attach it to continuation sends.
@@ -223,7 +223,7 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
     plain = SysSessionSendTool(
         {"claude": AgentSpec(spec_version=1, name="claude", description="Review helper.")}
     )
-    assert _object_branch_props(plain) == {"input", "purpose", "model"}
+    assert _object_branch_props(plain) == {"input", "purpose", "model", "cost_budget"}
 
     # Opted in: a sub-agent whose executor.config.allowed_harnesses declares a
     # non-empty allowlist (the polly/debby `codex`/`opencode` worker shape) →
@@ -241,7 +241,13 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         ),
     )
     opted_in = SysSessionSendTool({"codex": opted_in_spec})
-    assert _object_branch_props(opted_in) == {"input", "purpose", "model", "harness"}
+    assert _object_branch_props(opted_in) == {
+        "input",
+        "purpose",
+        "model",
+        "harness",
+        "cost_budget",
+    }
     object_schema = next(
         b
         for b in opted_in.get_schema()["function"]["parameters"]["properties"]["args"]["anyOf"]
@@ -260,7 +266,7 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
             "codex": opted_in_spec,
         }
     )
-    assert _object_branch_props(mixed) == {"input", "purpose", "model", "harness"}
+    assert _object_branch_props(mixed) == {"input", "purpose", "model", "harness", "cost_budget"}
 
 
 def test_peek_schema_required_fields_and_no_extra_props() -> None:


### PR DESCRIPTION
## Summary
- Allow main agents to set a `cost_budget` when spawning subagents via `sys_session_send`, creating a `subagent_cost_budget` policy on the child session
- The budget gates on the child's own **subtree cost** (itself + descendants), not the whole session tree — so parent/sibling spend doesn't count against the child's budget
- Adds `subtree_usage` to `EvaluationContext` and `PolicyEngine` as a parallel cost tracker (same turn deltas, different initial seed)
- The new `subagent_cost_budget` factory reuses all shared helpers (`_resolve_expensive_models`, `_over_budget_deny_reason`, `_model_blocked_over_budget`) but reads from `subtree_usage` and uses a local ASK approval key (not routed to root)
- `cost_budget` is rejected on continuation and by-session-id sends (create-time only, same pattern as `model` and `harness`)

## Test plan
- [x] All existing cost policy tests pass (50 tests)
- [x] All policy engine/builder tests pass (323 tests)
- [x] All sys_session schema tests pass (24 tests, updated to include `cost_budget` in property sets)
- [x] Integration test: spawn a subagent with `cost_budget`, verify policy is created on the child session
- [x] Verify subtree cost isolation: child budget doesn't trip from parent spend

<img width="870" height="922" alt="image" src="https://github.com/user-attachments/assets/05dc889b-3e6f-49d9-b4e4-bd99ca2e590e" />

