### PR TITLE
fix(web): align file size and download button in file lists

### DIFF
--- a/web/src/shell/FlatFileList.test.tsx
+++ b/web/src/shell/FlatFileList.test.tsx
@@ -60,3 +60,27 @@ describe("FlatFileList runner-offline state", () => {
     expect(screen.queryByText(/agent is asleep/i)).not.toBeInTheDocument();
   });
 });
+
+describe("FlatFileList file size / download alignment", () => {
+  it("overlays the download button on the file size so both share one slot", () => {
+    // The size label and the hover download button must occupy the same
+    // relative container: the size reserves the width and the button overlays
+    // it (absolute inset-0), so the button appears exactly where the size was.
+    renderList({
+      files: [
+        { path: "src/app.ts", name: "app.ts", status: "modified", bytes: 2048, modified_at: null },
+      ],
+    });
+
+    const size = screen.getByText("2.0 KB");
+    const slot = size.parentElement;
+    expect(slot).toHaveClass("relative");
+    // Size hides on hover but keeps its width to avoid a layout shift.
+    expect(size).toHaveClass("group-hover:invisible");
+
+    const download = screen.getByRole("button", { name: /download app\.ts/i });
+    const overlay = download.closest("span.absolute") as HTMLElement | null;
+    expect(overlay).not.toBeNull();
+    expect(slot).toContainElement(overlay);
+  });
+});

--- a/web/src/shell/FlatFileList.tsx
+++ b/web/src/shell/FlatFileList.tsx
@@ -114,14 +114,22 @@ function FileListItem({
           >
             <bdi>{file.path}</bdi>
           </span>
-          {file.bytes !== null && !isDeleted && (
-            <span className="shrink-0 text-muted-foreground text-[10px]">
+        </button>
+        {file.bytes !== null && !isDeleted ? (
+          <div className="relative shrink-0 flex items-center">
+            <span className="text-muted-foreground text-[10px] group-hover:invisible">
               {formatBytes(file.bytes)}
             </span>
-          )}
-        </button>
-        {!isDeleted && conversationId && (
-          <FileDownloadButton conversationId={conversationId} path={file.path} />
+            {conversationId && (
+              <span className="absolute inset-0 flex items-center justify-center">
+                <FileDownloadButton conversationId={conversationId} path={file.path} />
+              </span>
+            )}
+          </div>
+        ) : (
+          !isDeleted && conversationId && (
+            <FileDownloadButton conversationId={conversationId} path={file.path} />
+          )
         )}
       </div>
       {tooltip}

--- a/web/src/shell/FlatFileList.tsx
+++ b/web/src/shell/FlatFileList.tsx
@@ -127,9 +127,8 @@ function FileListItem({
             )}
           </div>
         ) : (
-          !isDeleted && conversationId && (
-            <FileDownloadButton conversationId={conversationId} path={file.path} />
-          )
+          !isDeleted &&
+          conversationId && <FileDownloadButton conversationId={conversationId} path={file.path} />
         )}
       </div>
       {tooltip}

--- a/web/src/shell/FolderTree.test.tsx
+++ b/web/src/shell/FolderTree.test.tsx
@@ -123,3 +123,39 @@ describe("FolderTree sorting", () => {
     expect(order).toEqual(["c.js", "a.md", "b.txt"]);
   });
 });
+
+describe("FolderTree file size / download alignment", () => {
+  it("overlays the download button on the file size so both share one slot", () => {
+    // The size label and the hover download button must occupy the same
+    // relative container: the size reserves the width and the button overlays
+    // it (absolute inset-0), so the button appears exactly where the size was.
+    renderTree({ files: [file("readme.md", 2048)] });
+
+    const size = screen.getByText("2.0 KB");
+    const slot = size.parentElement;
+    expect(slot).toHaveClass("relative");
+    // Size hides on hover but keeps its width to avoid a layout shift.
+    expect(size).toHaveClass("group-hover:invisible");
+
+    const download = screen.getByRole("button", { name: /download readme\.md/i });
+    // Button sits in an absolutely-positioned overlay inside the same slot.
+    const overlay = download.closest("span.absolute") as HTMLElement | null;
+    expect(overlay).not.toBeNull();
+    expect(slot).toContainElement(overlay);
+  });
+
+  it("renders the dirty-directory dot in a fixed-width slot matching the download column", () => {
+    // The directory status dot must align with the file rows' download button
+    // column, so it lives in a fixed-width (w-[22px]) centered container.
+    renderTree({
+      files: [dir("src")],
+      changedFiles: [
+        { path: "src/app.ts", name: "app.ts", status: "modified", bytes: 1, modified_at: null },
+      ],
+    });
+
+    const dot = screen.getByText("●");
+    const slot = dot.parentElement;
+    expect(slot).toHaveClass("w-[22px]");
+  });
+});

--- a/web/src/shell/FolderTree.tsx
+++ b/web/src/shell/FolderTree.tsx
@@ -504,9 +504,8 @@ function FileRowItem({
             )}
           </div>
         ) : (
-          !isDeleted && conversationId && (
-            <FileDownloadButton conversationId={conversationId} path={path} />
-          )
+          !isDeleted &&
+          conversationId && <FileDownloadButton conversationId={conversationId} path={path} />
         )}
       </div>
       {tooltip}

--- a/web/src/shell/FolderTree.tsx
+++ b/web/src/shell/FolderTree.tsx
@@ -491,12 +491,22 @@ function FileRowItem({
               {gitStatusLetter(fileStatus)}
             </span>
           )}
-          {bytes !== null && !isDeleted && (
-            <span className="shrink-0 text-muted-foreground text-[10px]">{formatBytes(bytes)}</span>
-          )}
         </button>
-        {!isDeleted && conversationId && (
-          <FileDownloadButton conversationId={conversationId} path={path} />
+        {bytes !== null && !isDeleted ? (
+          <div className="relative shrink-0 flex items-center">
+            <span className="text-muted-foreground text-[10px] group-hover:invisible">
+              {formatBytes(bytes)}
+            </span>
+            {conversationId && (
+              <span className="absolute inset-0 flex items-center justify-center">
+                <FileDownloadButton conversationId={conversationId} path={path} />
+              </span>
+            )}
+          </div>
+        ) : (
+          !isDeleted && conversationId && (
+            <FileDownloadButton conversationId={conversationId} path={path} />
+          )
         )}
       </div>
       {tooltip}
@@ -671,8 +681,8 @@ function TreeNodeRow({
           {node.name}/
         </span>
         {dirStatus && (
-          <span className={cn("shrink-0 text-[8px] leading-none", dirDotClass)} aria-hidden>
-            ●
+          <span className="flex w-[22px] shrink-0 items-center justify-center" aria-hidden>
+            <span className={cn("text-[8px] leading-none", dirDotClass)}>●</span>
           </span>
         )}
       </button>


### PR DESCRIPTION
## Summary
- File size labels in the workspace file lists now reserve a fixed slot, and the hover-reveal download button overlays that slot (`absolute inset-0`) instead of sitting beside it. The button appears exactly where the size was — no layout shift on hover.
- Dirty-directory status dots get a matching fixed-width column so they line up with the download-button column across rows.
- Applied to both the **All** tree (`FolderTree`) and the **Changed** list (`FlatFileList`).

## Testing
- Added rendering tests asserting the size label and download button share one relative slot, the size hides on hover (`group-hover:invisible`) while keeping its width, and the directory dot sits in the fixed-width column.
- `npm test` ✅
- `npm run build` ✅