### PR TITLE
fix(opencode): seed usage from history so cost survives resume

### DIFF
--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -192,6 +192,8 @@ class OpenCodeNativeForwarder:
             role = info.get("role") if isinstance(info, Mapping) else None
             if isinstance(message_id, str) and isinstance(role, str):
                 self._msg_role[message_id] = role
+                if role == "assistant" and isinstance(info, Mapping):
+                    self._record_assistant_usage(message_id, info)
             parts = message.get("parts") if isinstance(message, Mapping) else None
             if isinstance(parts, list):
                 for part in parts:
@@ -214,6 +216,12 @@ class OpenCodeNativeForwarder:
                             self.state.mark(self._key("tool-out", call_id))
             if isinstance(message_id, str):
                 self.state.mark(self._key("message", message_id))
+        try:
+            await self._post_session_usage()
+        except Exception:  # noqa: BLE001 - usage re-post is best effort.
+            _logger.debug(
+                "OpenCode forwarder could not re-post usage after seeding", exc_info=True
+            )
 
     async def run(self, *, max_reconnects: int | None = None) -> None:
         """

--- a/tests/test_opencode_native_forwarder.py
+++ b/tests/test_opencode_native_forwarder.py
@@ -431,6 +431,45 @@ async def test_seed_dedupe_from_history_swallows_errors() -> None:
     assert fwd._msg_role == {}
 
 
+async def test_seed_dedupe_from_history_seeds_usage() -> None:
+    """Resume seeding rebuilds cumulative usage and re-posts it immediately."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    opencode.messages = [
+        {
+            "info": {
+                "id": "msg_1",
+                "role": "assistant",
+                "modelID": "claude-sonnet-4-5",
+                "providerID": "anthropic",
+                "cost": 0.01,
+                "tokens": {"input": 1000, "output": 50, "cache": {"read": 200, "write": 0}},
+            },
+            "parts": [],
+        },
+        {
+            "info": {
+                "id": "msg_2",
+                "role": "assistant",
+                "modelID": "claude-sonnet-4-5",
+                "providerID": "anthropic",
+                "cost": 0.02,
+                "tokens": {"input": 2000, "output": 100, "cache": {"read": 300, "write": 0}},
+            },
+            "parts": [],
+        },
+        {"info": {"id": "msg_u", "role": "user"}, "parts": []},
+    ]
+    fwd = _forwarder(server, opencode)
+    await fwd.seed_dedupe_from_history()
+    # Usage is rebuilt per assistant message id (user messages contribute none).
+    assert set(fwd._usage_by_message) == {"msg_1", "msg_2"}
+    usage = next(b for _u, b in server.posts if b["type"] == "external_session_usage")["data"]
+    assert usage["cumulative_cost_usd"] == 0.03  # 0.01 + 0.02
+    assert usage["cumulative_input_tokens"] == 3000  # 1000 + 2000
+    assert usage["cumulative_output_tokens"] == 150  # 50 + 100
+    assert usage["cumulative_cache_read_input_tokens"] == 500  # 200 + 300
+
+
 async def test_compaction_started_posts_in_progress() -> None:
     """`session.next.compaction.started` → external_compaction_status in_progress."""
     server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()


### PR DESCRIPTION
## Related issue

Closes #1547

## Summary

- OpenCode-native cumulative usage (`external_session_usage`: cost badge + context ring) is summed only from `_usage_by_message`, which is populated by the live `_record_assistant_usage` handler. On resume, `seed_dedupe_from_history` reseeded roles + dedupe marks but not usage, so cost/context reset to zero.
- Seed usage from assistant-message history during dedupe seeding, then re-post the cumulative once. OpenCode history carries durable per-message `cost`/`tokens`, so it is recoverable. Both steps are best effort and no-op with no history.

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/test_opencode_native_forwarder.py -q` (32 passed). Added `test_seed_dedupe_from_history_seeds_usage` asserting `_usage_by_message` is rebuilt and a summed `external_session_usage` is posted. Ruff check + format clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
