### PR TITLE
feat(opencode): add env escape hatch for the version gate

### DIFF
--- a/omnigent/opencode_native_app_server.py
+++ b/omnigent/opencode_native_app_server.py
@@ -95,6 +95,10 @@ _ENV_OPENCODE_CONFIG_DENYLIST = frozenset(
 
 _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*)")
 
+# Escape hatch: set truthy to bypass the OpenCode CLI version gate (e.g. to
+# try an as-yet-unvalidated 1.18+/v2 release). Mirrors OMNIGENT_NO_UPDATE_CHECK.
+_SKIP_VERSION_CHECK_ENV = "OMNIGENT_OPENCODE_SKIP_VERSION_CHECK"
+
 
 class OpenCodeVersionError(RuntimeError):
     """Raised when the installed ``opencode`` CLI is an unsupported version."""
@@ -393,7 +397,16 @@ class OpenCodeNativeServer:
         """
         if self._verify_version:
             self.version = resolve_opencode_version(self.opencode_path)
-            check_opencode_version(self.version)
+            if os.environ.get(_SKIP_VERSION_CHECK_ENV):
+                _logger.warning(
+                    "%s set; skipping OpenCode version gate (got %s, supported >=%s,<%s)",
+                    _SKIP_VERSION_CHECK_ENV,
+                    self.version,
+                    OPENCODE_MIN_VERSION,
+                    OPENCODE_MAX_VERSION_EXCLUSIVE,
+                )
+            else:
+                check_opencode_version(self.version)
         if self.port is None:
             self.port = self._explicit_port or allocate_loopback_port()
         argv = self.build_argv()

--- a/tests/test_opencode_native_app_server.py
+++ b/tests/test_opencode_native_app_server.py
@@ -182,6 +182,63 @@ async def test_start_polls_until_ready(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert server.process.pid == 4242
 
 
+async def test_start_raises_on_unsupported_version_without_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(appsrv.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(appsrv, "resolve_opencode_version", lambda _path: "1.18.0")
+    monkeypatch.delenv("OMNIGENT_OPENCODE_SKIP_VERSION_CHECK", raising=False)
+    server = OpenCodeNativeServer(
+        bridge_dir=tmp_path,
+        workspace=tmp_path,
+        port=49231,
+        verify_version=True,
+    )
+
+    class _FakeProc:
+        pid = 4242
+
+        def poll(self) -> None:
+            return None
+
+    async def fake_wait(self: OpenCodeNativeServer) -> None:
+        return None
+
+    monkeypatch.setattr(appsrv.subprocess, "Popen", lambda argv, **kwargs: _FakeProc())
+    monkeypatch.setattr(OpenCodeNativeServer, "_wait_until_ready", fake_wait)
+    with pytest.raises(OpenCodeVersionError):
+        await server.start()
+
+
+async def test_start_skips_version_gate_when_env_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(appsrv.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(appsrv, "resolve_opencode_version", lambda _path: "1.18.0")
+    monkeypatch.setenv("OMNIGENT_OPENCODE_SKIP_VERSION_CHECK", "1")
+    server = OpenCodeNativeServer(
+        bridge_dir=tmp_path,
+        workspace=tmp_path,
+        port=49231,
+        verify_version=True,
+    )
+
+    class _FakeProc:
+        pid = 4242
+
+        def poll(self) -> None:
+            return None
+
+    async def fake_wait(self: OpenCodeNativeServer) -> None:
+        return None
+
+    monkeypatch.setattr(appsrv.subprocess, "Popen", lambda argv, **kwargs: _FakeProc())
+    monkeypatch.setattr(OpenCodeNativeServer, "_wait_until_ready", fake_wait)
+    await server.start()
+    assert server.version == "1.18.0"
+    assert server.process is not None
+
+
 def test_find_opencode_cli_absolute_executable(tmp_path: Path) -> None:
     exe = tmp_path / "opencode"
     exe.write_text("#!/bin/sh\n")


### PR DESCRIPTION
## Related issue

Closes #1550

## Summary

- The opencode-native harness pins the CLI to `[1.17.7, 1.18.0)` and raises `OpenCodeVersionError` on every start with no override; when 1.18 / v2 lands this hard-blocks the harness. Latest 1.17.11 is still in range, so this is future-proofing.
- Add `OMNIGENT_OPENCODE_SKIP_VERSION_CHECK`: when set, `start()` still records the detected version but logs a warning and skips the raise, mirroring the bare-presence semantics of `OMNIGENT_NO_UPDATE_CHECK`. The pure `check_opencode_version` predicate and `verify_version=False` path are unchanged.

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/test_opencode_native_app_server.py -q` (23 passed). Added: start() raises on out-of-range version without the env var; start() skips the gate (no raise, version recorded) with it set. Ruff clean.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
