### PR TITLE
feat(opencode): surface the blocking question tool as a web card

### DIFF
--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -18,6 +18,7 @@ session never double-post.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from collections import OrderedDict
@@ -31,7 +32,7 @@ import httpx
 
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.opencode_native_bridge import update_active_message_id
-from omnigent.opencode_native_client import OpenCodeClient, OpenCodeEvent
+from omnigent.opencode_native_client import OpenCodeClient, OpenCodeClientError, OpenCodeEvent
 from omnigent.opencode_native_permissions import (
     OpenCodePermissionRequest,
     PolicyDecision,
@@ -58,6 +59,7 @@ _EXTERNAL_SESSION_USAGE = "external_session_usage"
 # Mirrors a model switch typed in the opencode TUI (``/model`` or the picker)
 # back to Omnigent so the web model pill stays in sync (claude-native contract).
 _EXTERNAL_MODEL_CHANGE = "external_model_change"
+_EXTERNAL_ELICITATION_RESOLVED = "external_elicitation_resolved"
 # Transient chain-of-thought delta — the reasoning analogue of the text delta
 # (same contract codex-native uses). The web paints a reasoning block; it is not
 # persisted, so on reload it is gone (acceptable, mirrors codex).
@@ -211,6 +213,7 @@ class OpenCodeNativeForwarder:
         # turn; both reset in :meth:`_end_turn`.
         self._active_message_id: str | None = None
         self._running_response_id: str | None = None
+        self._question_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def seed_dedupe_from_history(self) -> None:
         """
@@ -332,27 +335,41 @@ class OpenCodeNativeForwarder:
         """
         attempt = 0
         backoff = 0.5
-        while True:
-            if attempt == 0:
-                await self.seed_dedupe_from_history()
-            else:
-                await self.catch_up_from_history()
-            try:
-                await self._consume_once()
-                # Clean stream end (server closed): reconnect.
-            except asyncio.CancelledError:
-                raise
-            except Exception:  # noqa: BLE001 - reconnect on any transient SSE failure.
-                _logger.warning(
-                    "OpenCode forwarder SSE error for session=%s; reconnecting",
-                    self._session_id,
-                    exc_info=True,
-                )
-            attempt += 1
-            if max_reconnects is not None and attempt > max_reconnects:
-                return
-            await asyncio.sleep(min(backoff, 5.0))
-            backoff = min(backoff * 2, 5.0)
+        try:
+            while True:
+                if attempt == 0:
+                    await self.seed_dedupe_from_history()
+                else:
+                    await self.catch_up_from_history()
+                try:
+                    await self._consume_once()
+                    # Clean stream end (server closed): reconnect.
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001 - reconnect on any transient SSE failure.
+                    _logger.warning(
+                        "OpenCode forwarder SSE error for session=%s; reconnecting",
+                        self._session_id,
+                        exc_info=True,
+                    )
+                attempt += 1
+                if max_reconnects is not None and attempt > max_reconnects:
+                    return
+                await asyncio.sleep(min(backoff, 5.0))
+                backoff = min(backoff * 2, 5.0)
+        finally:
+            # Never leave a parked ``question`` task orphaned when the consume
+            # loop exits (cap reached, return, or cancellation): cancel them all.
+            await self._cancel_question_tasks()
+
+    async def _cancel_question_tasks(self) -> None:
+        """Cancel and await every in-flight question park task."""
+        tasks = list(self._question_tasks.values())
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._question_tasks.clear()
 
     async def _consume_once(self) -> None:
         """Consume the SSE stream once, dispatching each event."""
@@ -1018,6 +1035,216 @@ class OpenCodeNativeForwarder:
         return map_verdict_to_decision(verdict)
 
 
+    async def _on_question_asked(self, event: OpenCodeEvent) -> None:
+        """Handle ``question.asked`` — surface opencode's blocking ``question``.
+
+        opencode's ``question`` tool blocks the turn until answered. Parking the
+        web elicitation card and waiting for the verdict CANNOT run inline here:
+        the SSE consume loop awaits each handler sequentially, so an inline park
+        would stall every other event for this session until the human answers.
+        So spawn a background task (deduped by request id) and return immediately.
+        ``question.asked`` carries the request id under ``id`` (``question.replied``
+        / ``.rejected`` use ``requestID``).
+        """
+        request_id = event.properties.get("id")
+        questions = event.properties.get("questions")
+        if not isinstance(request_id, str) or not request_id:
+            return
+        if not isinstance(questions, list):
+            return
+        if request_id in self._question_tasks:
+            return
+        task = asyncio.create_task(
+            self._handle_question(request_id, questions, event.properties.get("tool"))
+        )
+        self._question_tasks[request_id] = task
+        # Self-evict from the registry once done so it can't grow unbounded; a
+        # later withdrawal (``question.replied``) that already popped it is a
+        # no-op (``pop(..., None)``).
+        task.add_done_callback(lambda _t, rid=request_id: self._question_tasks.pop(rid, None))
+
+    async def _handle_question(self, request_id: str, questions: list[Any], tool: Any) -> None:
+        """Park one opencode ``question`` as a web card and apply the verdict.
+
+        Translates the opencode question shape into the web ``ask_user_question``
+        form (preserving each question's ORIGINAL index as its ``id`` so answers
+        realign), POSTs it to the native permission hook, then maps the web
+        verdict back onto ``reply_question`` (one selected-label list per original
+        question, in order) or ``reject_question``. A ``None`` verdict (the TUI
+        answered, or the wait timed out) rejects to unblock opencode.
+
+        ``asyncio.CancelledError`` PROPAGATES (it is raised by
+        :meth:`_on_question_replied` / ``_on_question_rejected`` when the TUI
+        resolves the question, or by ``run()`` teardown) — the card withdrawal is
+        handled there, so this must NOT reject on cancel.
+        """
+        del tool  # Currently unused; accepted for forward-compat / logging parity.
+        web_questions: list[dict[str, Any]] = []
+        for index, question in enumerate(questions):
+            if not isinstance(question, dict):
+                continue
+            prompt = question.get("question")
+            raw_options = question.get("options")
+            if not isinstance(prompt, str) or not prompt or not isinstance(raw_options, list):
+                continue
+            options = [
+                {"label": opt["label"]}
+                for opt in raw_options
+                if isinstance(opt, dict) and isinstance(opt.get("label"), str) and opt["label"]
+            ]
+            if not options:
+                continue
+            web_questions.append(
+                {
+                    "question": prompt,
+                    "options": options,
+                    "multiSelect": question.get("multiple") is True,
+                    # ORIGINAL index — the answer for question ``i`` is read back
+                    # under ``str(i)`` so skipped/malformed questions don't shift
+                    # the alignment.
+                    "id": str(index),
+                }
+            )
+        if not web_questions:
+            # Nothing renderable → unblock opencode rather than parking a card
+            # the web UI can't show.
+            await self._reject_question_quietly(request_id)
+            return
+        first = questions[0] if isinstance(questions[0], dict) else {}
+        header = first.get("header")
+        message = header if isinstance(header, str) and header else "OpenCode is asking a question"
+        preview_text = first.get("question")
+        preview = preview_text[:1024] if isinstance(preview_text, str) and preview_text else None
+        try:
+            verdict = await self._park_question(
+                request_id, message=message, payload={"questions": web_questions}, preview=preview
+            )
+            if verdict is None:
+                # Empty 200 → answered in the TUI or timed out: unblock opencode.
+                await self._reject_question_quietly(request_id)
+                return
+            if verdict.get("action") == "accept":
+                content = verdict.get("content")
+                if not isinstance(content, dict):
+                    content = {}
+                answers: list[list[str]] = []
+                for i in range(len(questions)):
+                    val = content.get(str(i))
+                    if isinstance(val, str):
+                        answers.append([val])
+                    elif isinstance(val, list):
+                        answers.append([x for x in val if isinstance(x, str)])
+                    else:
+                        answers.append([])
+                await self._opencode.reply_question(request_id, answers)
+            else:
+                # ``decline`` / ``cancel`` / anything else → reject.
+                await self._reject_question_quietly(request_id)
+        except asyncio.CancelledError:
+            raise
+        except (httpx.HTTPError, OpenCodeClientError) as exc:
+            _logger.warning(
+                "OpenCode question handling failed for request=%s: %s", request_id, exc
+            )
+            # Best effort: still try to unblock opencode so the turn isn't wedged.
+            with contextlib.suppress(OpenCodeClientError):
+                await self._opencode.reject_question(request_id)
+
+    async def _reject_question_quietly(self, request_id: str) -> None:
+        """Best-effort reject a question, swallowing OpenCode client errors.
+
+        A TUI resolution commonly makes this request return not found. Other
+        client failures are also non-fatal because rejection is only cleanup
+        after the web path can no longer provide an answer.
+        """
+        try:
+            await self._opencode.reject_question(request_id)
+        except OpenCodeClientError:
+            _logger.debug(
+                "OpenCode question reject for request=%s failed during best-effort cleanup",
+                request_id,
+                exc_info=True,
+            )
+
+    async def _park_question(
+        self,
+        request_id: str,
+        *,
+        message: str,
+        payload: dict[str, Any],
+        preview: str | None,
+    ) -> dict[str, Any] | None:
+        """POST the native permission hook for a question; return the web verdict.
+
+        Returns ``None`` for every "no answer" outcome (transport error, status
+        >= 400, empty body, or non-dict JSON) so the caller only handles a real
+        verdict dict — mirrors
+        :func:`omnigent.cursor_native_permissions._park_cursor_elicitation`. The
+        structured ``ask_user_question`` is the authoritative payload the web UI
+        renders; ``content_preview`` is only the legacy fallback.
+        """
+        body: dict[str, Any] = {
+            "elicitation_id": request_id,
+            "operation_type": "question",
+            "agent": "OpenCode",
+            "policy_name": "opencode_native_question",
+            "message": message,
+            "ask_user_question": payload,
+        }
+        if preview is not None:
+            body["content_preview"] = preview
+        url = f"/v1/sessions/{quote(self._session_id, safe='')}/hooks/native-permission-request"
+        try:
+            response = await self._server.post(url, json=body)
+        except httpx.HTTPError:
+            _logger.warning(
+                "OpenCode question hook POST failed for session=%s request=%s",
+                self._session_id,
+                request_id,
+                exc_info=True,
+            )
+            return None
+        if response.status_code >= 400:
+            _logger.warning(
+                "OpenCode question hook rejected: status=%s body=%s",
+                response.status_code,
+                response.text[:512],
+            )
+            return None
+        if not response.content:
+            return None
+        try:
+            result = response.json()
+        except ValueError:
+            _logger.warning("OpenCode question hook returned non-JSON: %s", response.text[:512])
+            return None
+        return result if isinstance(result, dict) else None
+
+    async def _on_question_replied(self, event: OpenCodeEvent) -> None:
+        """Handle ``question.replied`` — the TUI answered, so withdraw the card."""
+        await self._withdraw_question(event.properties.get("requestID"))
+
+    async def _on_question_rejected(self, event: OpenCodeEvent) -> None:
+        """Handle ``question.rejected`` — the TUI declined, so withdraw the card."""
+        await self._withdraw_question(event.properties.get("requestID"))
+
+    async def _withdraw_question(self, request_id: Any) -> None:
+        """Cancel a pending question park (if any) and clear its web card.
+
+        Fired when opencode reports the question was resolved in the TUI
+        (``question.replied`` / ``.rejected`` use ``requestID``, not ``id``):
+        cancel the still-parked POST so it neither double-replies nor lingers,
+        then post ``external_elicitation_resolved`` so the web card disappears.
+        """
+        if not isinstance(request_id, str) or not request_id:
+            return
+        task = self._question_tasks.pop(request_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        await self._post_event(_EXTERNAL_ELICITATION_RESOLVED, {"elicitation_id": request_id})
+
+
 def opencode_tool_output_text(state: _JsonMapping) -> str:
     """
     Extract shared durable output from a completed OpenCode tool state.
@@ -1070,4 +1297,7 @@ _HANDLERS: dict[str, Callable[[OpenCodeNativeForwarder, OpenCodeEvent], Awaitabl
     # too so a point-release rename still routes through the policy gate.
     "permission.asked": OpenCodeNativeForwarder._on_permission_asked,
     "permission.v2.asked": OpenCodeNativeForwarder._on_permission_asked,
+    "question.asked": OpenCodeNativeForwarder._on_question_asked,
+    "question.replied": OpenCodeNativeForwarder._on_question_replied,
+    "question.rejected": OpenCodeNativeForwarder._on_question_rejected,
 }

--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -1082,18 +1082,21 @@ class OpenCodeNativeForwarder:
         web_questions: list[dict[str, Any]] = []
         for index, question in enumerate(questions):
             if not isinstance(question, dict):
-                continue
+                await self._reject_question_quietly(request_id)
+                return
             prompt = question.get("question")
             raw_options = question.get("options")
             if not isinstance(prompt, str) or not prompt or not isinstance(raw_options, list):
-                continue
+                await self._reject_question_quietly(request_id)
+                return
             options = [
                 {"label": opt["label"]}
                 for opt in raw_options
                 if isinstance(opt, dict) and isinstance(opt.get("label"), str) and opt["label"]
             ]
-            if not options:
-                continue
+            if not options or len(options) != len(raw_options):
+                await self._reject_question_quietly(request_id)
+                return
             web_questions.append(
                 {
                     "question": prompt,
@@ -1106,8 +1109,6 @@ class OpenCodeNativeForwarder:
                 }
             )
         if not web_questions:
-            # Nothing renderable → unblock opencode rather than parking a card
-            # the web UI can't show.
             await self._reject_question_quietly(request_id)
             return
         first = questions[0] if isinstance(questions[0], dict) else {}

--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -1034,7 +1034,6 @@ class OpenCodeNativeForwarder:
             return self._default_decision
         return map_verdict_to_decision(verdict)
 
-
     async def _on_question_asked(self, event: OpenCodeEvent) -> None:
         """Handle ``question.asked`` — surface opencode's blocking ``question``.
 

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -1317,6 +1317,12 @@ def register_hooks_routes(
         policy_name = payload.get("policy_name")
         if not isinstance(policy_name, str) or not policy_name:
             policy_name = "native_permission"
+        extras: dict[str, Any] = {}
+        ask_user_question = payload.get("ask_user_question")
+        if isinstance(ask_user_question, dict) and isinstance(
+            ask_user_question.get("questions"), list
+        ):
+            extras["ask_user_question"] = ask_user_question
         params = ElicitationRequestParams(
             mode="form",
             message=message,
@@ -1325,6 +1331,7 @@ def register_hooks_routes(
             phase="pre_tool_use",
             policy_name=policy_name,
             content_preview=content_preview,
+            **extras,
         )
         from omnigent.server.routes import sessions as _sf
 

--- a/tests/e2e_ui/approvals/test_opencode_question.py
+++ b/tests/e2e_ui/approvals/test_opencode_question.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import threading
 
 import httpx
@@ -82,15 +83,28 @@ def test_opencode_question_round_trips_through_web(
 
     thread = threading.Thread(target=_run_forwarder, daemon=True)
     thread.start()
-    page.goto(f"{base_url}/c/{session_id}")
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
 
-    form = page.locator(_FORM)
-    expect(form).to_be_visible(timeout=15_000)
-    form.get_by_role("checkbox", name="Tests").check()
-    form.get_by_role("checkbox", name="Lint").check()
-    form.locator(_SUBMIT).click()
+        form = page.locator(_FORM)
+        expect(form).to_be_visible(timeout=15_000)
+        form.get_by_role("checkbox", name="Tests").check()
+        form.get_by_role("checkbox", name="Lint").check()
+        form.locator(_SUBMIT).click()
+    finally:
+        thread.join(timeout=5)
+        if thread.is_alive():
+            with contextlib.suppress(httpx.HTTPError):
+                httpx.post(
+                    f"{base_url}/v1/sessions/{session_id}/events",
+                    json={
+                        "type": "approval",
+                        "data": {"elicitation_id": "que_e2e", "action": "decline"},
+                    },
+                    timeout=10.0,
+                ).raise_for_status()
+            thread.join(timeout=30)
 
-    thread.join(timeout=30)
     assert not thread.is_alive(), "OpenCode question hook did not receive the web verdict"
     if "error" in result:
         raise AssertionError(f"forwarder failed: {result['error']}") from result["error"]

--- a/tests/e2e_ui/approvals/test_opencode_question.py
+++ b/tests/e2e_ui/approvals/test_opencode_question.py
@@ -1,0 +1,97 @@
+"""E2E: an OpenCode question event round-trips through the web form."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from omnigent.opencode_native_client import OpenCodeEvent
+from omnigent.opencode_native_forwarder import OpenCodeNativeForwarder
+
+_FORM = '[data-testid="ask-user-question-form"]'
+_SUBMIT = '[data-testid="ask-user-question-submit"]'
+
+
+class _RecordingOpenCodeClient:
+    """Record the answer returned by the live web elicitation flow."""
+
+    def __init__(self) -> None:
+        self.replies: list[tuple[str, list[list[str]]]] = []
+
+    async def reply_question(self, request_id: str, answers: list[list[str]]) -> bool:
+        self.replies.append((request_id, answers))
+        return True
+
+    async def reject_question(self, request_id: str) -> bool:
+        return True
+
+
+@pytest.mark.timeout(90)
+def test_opencode_question_round_trips_through_web(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """question.asked -> web checkboxes -> reply_question selected labels."""
+    base_url, session_id = seeded_session
+    opencode = _RecordingOpenCodeClient()
+    result: dict[str, object] = {}
+
+    async def _forward_question() -> None:
+        async with httpx.AsyncClient(base_url=base_url, timeout=60.0) as server:
+            forwarder = OpenCodeNativeForwarder(
+                session_id=session_id,
+                opencode_session_id="ses_e2e",
+                opencode_client=opencode,  # type: ignore[arg-type]
+                server_client=server,
+            )
+            await forwarder.handle_event(
+                OpenCodeEvent(
+                    id=None,
+                    type="question.asked",
+                    properties={
+                        "sessionID": "ses_e2e",
+                        "id": "que_e2e",
+                        "questions": [
+                            {
+                                "header": "Choose tools",
+                                "question": "Which tools should run?",
+                                "multiple": True,
+                                "options": [
+                                    {"label": "Tests"},
+                                    {"label": "Lint"},
+                                    {"label": "Build"},
+                                ],
+                            }
+                        ],
+                    },
+                    raw={},
+                )
+            )
+            task = forwarder._question_tasks["que_e2e"]
+            await task
+
+    def _run_forwarder() -> None:
+        try:
+            asyncio.run(_forward_question())
+        except Exception as exc:
+            result["error"] = exc
+
+    thread = threading.Thread(target=_run_forwarder, daemon=True)
+    thread.start()
+    page.goto(f"{base_url}/c/{session_id}")
+
+    form = page.locator(_FORM)
+    expect(form).to_be_visible(timeout=15_000)
+    form.get_by_role("checkbox", name="Tests").check()
+    form.get_by_role("checkbox", name="Lint").check()
+    form.locator(_SUBMIT).click()
+
+    thread.join(timeout=30)
+    assert not thread.is_alive(), "OpenCode question hook did not receive the web verdict"
+    if "error" in result:
+        raise AssertionError(f"forwarder failed: {result['error']}") from result["error"]
+    assert opencode.replies == [("que_e2e", [["Tests", "Lint"]])]

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -314,6 +314,7 @@ async def test_qwen_permission_request_hook_allow_round_trip(
         "operation_type": "run_shell_command",
         "message": "qwen wants to run run_shell_command",
         "content_preview": "echo hi > out.txt",
+        "ask_user_question": {"questions": [{"id": "0", "question": "Continue?", "options": []}]},
     }
 
     drain_task = asyncio.create_task(_drain_until_elicitation(session_id))
@@ -332,6 +333,7 @@ async def test_qwen_permission_request_hook_allow_round_trip(
     assert params["phase"] == "pre_tool_use"
     assert params["policy_name"] == "qwen_native_permission"
     assert params["content_preview"] == "echo hi > out.txt"
+    assert params["ask_user_question"] == payload["ask_user_question"]
 
     verdict = await _post_approval(client, session_id, elicitation_id, "accept")
     assert verdict.status_code == 202, verdict.text

--- a/tests/test_opencode_native_forwarder.py
+++ b/tests/test_opencode_native_forwarder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from typing import Any
 
 import httpx
@@ -17,24 +19,38 @@ class _RecordingServerClient:
 
     def __init__(self) -> None:
         self.posts: list[tuple[str, dict[str, Any]]] = []
+        self.hook_response: dict[str, Any] | None = None
 
     async def post(self, url: str, *, json: dict[str, Any]) -> httpx.Response:
         self.posts.append((url, json))
-        return httpx.Response(200, request=httpx.Request("POST", url))
+        request = httpx.Request("POST", url)
+        if url.endswith("/hooks/native-permission-request") and self.hook_response is not None:
+            return httpx.Response(200, json=self.hook_response, request=request)
+        return httpx.Response(200, request=request)
 
 
 class _FakeOpenCodeClient:
-    """Fake OpenCode client recording permission replies + history."""
+    """Fake OpenCode client recording permission and question replies + history."""
 
     def __init__(self) -> None:
         self.replies: list[tuple[str, dict[str, Any]]] = []
         self.messages: list[dict[str, Any]] = []
+        self.question_replies: list[tuple[str, list[Any]]] = []
+        self.question_rejects: list[str] = []
 
     async def list_messages(self, session_id: str) -> list[dict[str, Any]]:
         return self.messages
 
     async def reply_permission(self, request_id: str, reply: dict[str, Any]) -> bool:
         self.replies.append((request_id, reply))
+        return True
+
+    async def reply_question(self, request_id: str, answers: list[Any]) -> bool:
+        self.question_replies.append((request_id, answers))
+        return True
+
+    async def reject_question(self, request_id: str) -> bool:
+        self.question_rejects.append(request_id)
         return True
 
 

--- a/tests/test_opencode_native_forwarder.py
+++ b/tests/test_opencode_native_forwarder.py
@@ -878,3 +878,240 @@ async def test_file_part_dedupes_across_snapshots() -> None:
     await fwd.handle_event(_event("message.part.updated", part=dict(part)))
     items = [b for _u, b in server.posts if b["type"] == "external_conversation_item"]
     assert len(items) == 1
+<<<<<<< HEAD
+=======
+
+
+# --- question tool (blocking ``question`` → web elicitation) --------------
+
+
+def _hook_post(server: _RecordingServerClient) -> dict[str, Any] | None:
+    """Return the body of the native-permission-request hook POST, if any."""
+    for url, body in server.posts:
+        if url.endswith("/hooks/native-permission-request"):
+            return body
+    return None
+
+
+async def test_question_asked_accept_single_select_replies() -> None:
+    """A single-select web verdict → reply_question with the chosen label list.
+
+    The asked event carries the request id under ``id``; the question is parked
+    on the native-permission-request hook (NOT inline — a background task), and
+    the accept verdict's per-question content is keyed by the ORIGINAL index.
+    """
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    server.hook_response = {"action": "accept", "content": {"0": "Tabs"}}
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(
+        _event(
+            "question.asked",
+            id="que_1",
+            tool="question",
+            questions=[
+                {
+                    "question": "Indent style?",
+                    "header": "Formatting",
+                    "options": [{"label": "Tabs"}, {"label": "Spaces"}],
+                }
+            ],
+        )
+    )
+    # The handler spawns a task and returns immediately (never blocks the loop);
+    # capture it before awaiting (the done-callback evicts it on completion).
+    task = fwd._question_tasks["que_1"]
+    await task
+    assert opencode.question_replies == [("que_1", [["Tabs"]])]
+    assert opencode.question_rejects == []
+    hook = _hook_post(server)
+    assert hook is not None
+    assert hook["operation_type"] == "question"
+    assert hook["agent"] == "OpenCode"
+    assert hook["policy_name"] == "opencode_native_question"
+    # Header drives the card message; the structured payload is authoritative.
+    assert hook["message"] == "Formatting"
+    assert hook["content_preview"] == "Indent style?"
+    web_questions = hook["ask_user_question"]["questions"]
+    assert web_questions[0]["id"] == "0"
+    assert web_questions[0]["multiSelect"] is False
+    assert web_questions[0]["options"] == [{"label": "Tabs"}, {"label": "Spaces"}]
+
+
+async def test_question_asked_accept_multi_question_multi_select_replies() -> None:
+    """Two questions (one multi-select) → one answer list per question, in order."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    server.hook_response = {"action": "accept", "content": {"0": ["A", "B"], "1": "X"}}
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(
+        _event(
+            "question.asked",
+            id="que_1",
+            questions=[
+                {
+                    "question": "Pick letters",
+                    "multiple": True,
+                    "options": [{"label": "A"}, {"label": "B"}, {"label": "C"}],
+                },
+                {"question": "Pick one", "options": [{"label": "X"}, {"label": "Y"}]},
+            ],
+        )
+    )
+    task = fwd._question_tasks["que_1"]
+    await task
+    assert opencode.question_replies == [("que_1", [["A", "B"], ["X"]])]
+    assert opencode.question_rejects == []
+    web_questions = _hook_post(server)["ask_user_question"]["questions"]
+    assert web_questions[0]["multiSelect"] is True
+    assert [q["id"] for q in web_questions] == ["0", "1"]
+
+
+async def test_question_asked_decline_rejects_without_reply() -> None:
+    """A ``decline`` web verdict → reject_question, never reply_question."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    server.hook_response = {"action": "decline"}
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(
+        _event(
+            "question.asked",
+            id="que_1",
+            questions=[{"question": "Q?", "options": [{"label": "A"}]}],
+        )
+    )
+    task = fwd._question_tasks["que_1"]
+    await task
+    assert opencode.question_rejects == ["que_1"]
+    assert opencode.question_replies == []
+
+
+async def test_question_asked_empty_verdict_rejects() -> None:
+    """An empty 200 (TUI answered / timeout, no scripted verdict) → reject_question."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    # hook_response stays None → the hook returns an empty 200 body.
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(
+        _event(
+            "question.asked",
+            id="que_1",
+            questions=[{"question": "Q?", "options": [{"label": "A"}]}],
+        )
+    )
+    task = fwd._question_tasks["que_1"]
+    await task
+    assert opencode.question_rejects == ["que_1"]
+    assert opencode.question_replies == []
+    # The card WAS parked (the hook was POSTed); it just resolved with no verdict.
+    assert _hook_post(server) is not None
+
+
+async def test_question_replied_cancels_pending_task_and_clears_card() -> None:
+    """``question.replied`` (TUI answered) cancels the park and withdraws the card.
+
+    ``replied`` keys the id as ``requestID`` (not ``id``). It must cancel the
+    still-parked POST (so the forwarder doesn't also reply) and post
+    ``external_elicitation_resolved`` so the web card disappears.
+    """
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    fwd = _forwarder(server, opencode)
+
+    async def _never() -> None:
+        await asyncio.sleep(3600)
+
+    pending: asyncio.Task[None] = asyncio.create_task(_never())
+    fwd._question_tasks["que_1"] = pending
+    await fwd.handle_event(_event("question.replied", requestID="que_1", answers=[["A"]]))
+    # The parked task was cancelled and removed from the registry.
+    assert "que_1" not in fwd._question_tasks
+    with contextlib.suppress(asyncio.CancelledError):
+        await pending
+    assert pending.cancelled()
+    resolved = next(
+        b["data"] for _u, b in server.posts if b["type"] == "external_elicitation_resolved"
+    )
+    assert resolved == {"elicitation_id": "que_1"}
+    # No reply/reject was sent for a TUI-resolved question.
+    assert opencode.question_replies == []
+    assert opencode.question_rejects == []
+
+
+async def test_question_rejected_clears_card() -> None:
+    """``question.rejected`` (TUI declined) withdraws the web card."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(_event("question.rejected", requestID="que_9"))
+    resolved = next(
+        b["data"] for _u, b in server.posts if b["type"] == "external_elicitation_resolved"
+    )
+    assert resolved == {"elicitation_id": "que_9"}
+
+
+async def test_run_awaits_cancelled_question_tasks() -> None:
+    """Forwarder shutdown waits for question-task cancellation cleanup."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    fwd = _forwarder(server, opencode)
+    cleanup_finished = asyncio.Event()
+
+    async def _pending_question() -> None:
+        try:
+            await asyncio.Future()
+        finally:
+            await asyncio.sleep(0)
+            cleanup_finished.set()
+
+    pending = asyncio.create_task(_pending_question())
+    fwd._question_tasks["que_1"] = pending
+    await asyncio.sleep(0)
+    await fwd.run(max_reconnects=0)
+
+    assert cleanup_finished.is_set()
+    assert pending.cancelled()
+    assert fwd._question_tasks == {}
+
+
+async def test_question_asked_no_valid_options_rejects_without_hook() -> None:
+    """A question with no renderable options → reject_question, no card parked."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(
+        _event(
+            "question.asked",
+            id="que_1",
+            # Options present but none carry a usable string label.
+            questions=[{"question": "Q?", "options": [{}, {"label": ""}]}],
+        )
+    )
+    task = fwd._question_tasks["que_1"]
+    await task
+    assert opencode.question_rejects == ["que_1"]
+    assert opencode.question_replies == []
+    assert _hook_post(server) is None
+
+
+async def test_question_asked_empty_questions_rejects_without_hook() -> None:
+    """An empty questions list → reject_question, no card parked."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(_event("question.asked", id="que_1", questions=[]))
+    task = fwd._question_tasks["que_1"]
+    await task
+    assert opencode.question_rejects == ["que_1"]
+    assert _hook_post(server) is None
+
+
+async def test_question_asked_dedupes_concurrent_same_request() -> None:
+    """A duplicate ``question.asked`` for the same id spawns only one park task."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    server.hook_response = {"action": "accept", "content": {"0": "A"}}
+    fwd = _forwarder(server, opencode)
+    ev = _event(
+        "question.asked",
+        id="que_1",
+        questions=[{"question": "Q?", "options": [{"label": "A"}]}],
+    )
+    await fwd.handle_event(ev)
+    task = fwd._question_tasks["que_1"]
+    # A second asked event before the first resolves must NOT spawn a 2nd task.
+    await fwd.handle_event(ev)
+    assert fwd._question_tasks["que_1"] is task
+    await task
+    assert opencode.question_replies == [("que_1", [["A"]])]
+>>>>>>> 287206b0 (test(opencode): cover question web round trip)

--- a/tests/test_opencode_native_forwarder.py
+++ b/tests/test_opencode_native_forwarder.py
@@ -878,8 +878,6 @@ async def test_file_part_dedupes_across_snapshots() -> None:
     await fwd.handle_event(_event("message.part.updated", part=dict(part)))
     items = [b for _u, b in server.posts if b["type"] == "external_conversation_item"]
     assert len(items) == 1
-<<<<<<< HEAD
-=======
 
 
 # --- question tool (blocking ``question`` → web elicitation) --------------
@@ -1135,4 +1133,3 @@ async def test_question_asked_dedupes_concurrent_same_request() -> None:
     assert fwd._question_tasks["que_1"] is task
     await task
     assert opencode.question_replies == [("que_1", [["A"]])]
->>>>>>> 287206b0 (test(opencode): cover question web round trip)

--- a/tests/test_opencode_native_forwarder.py
+++ b/tests/test_opencode_native_forwarder.py
@@ -1097,6 +1097,27 @@ async def test_question_asked_empty_questions_rejects_without_hook() -> None:
     assert _hook_post(server) is None
 
 
+async def test_question_asked_mixed_valid_and_malformed_rejects_whole_request() -> None:
+    """One malformed question rejects the request instead of sending empty answers."""
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    fwd = _forwarder(server, opencode)
+    await fwd.handle_event(
+        _event(
+            "question.asked",
+            id="que_1",
+            questions=[
+                {"question": "Valid?", "options": [{"label": "Yes"}]},
+                {"question": "Malformed", "options": [{"label": ""}]},
+            ],
+        )
+    )
+    task = fwd._question_tasks["que_1"]
+    await task
+    assert opencode.question_rejects == ["que_1"]
+    assert opencode.question_replies == []
+    assert _hook_post(server) is None
+
+
 async def test_question_asked_dedupes_concurrent_same_request() -> None:
     """A duplicate ``question.asked`` for the same id spawns only one park task."""
     server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()


### PR DESCRIPTION
## Related issue

Closes #1551

## Summary

- OpenCode's blocking `question` tool emits `question.asked` (separate from permissions) but the forwarder had no handler, so prompts were only answerable in the TUI; `reply_question`/`reject_question` existed but nothing called them.
- `question.asked` spawns a background task (the SSE loop awaits handlers sequentially, so the blocking park must not run inline) that maps the question to the web `ask_user_question` form, parks it on the native-permission hook, and maps the verdict back: accept replies one selected-label list per question (in original order), decline/timeout/empty rejects. `question.replied`/`.rejected` (TUI answered) cancel the task and post `external_elicitation_resolved`; `run()` teardown cancels in-flight parks. The generic native-permission hook now forwards `ask_user_question` (mirroring the cursor hook).

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/test_opencode_native_forwarder.py` (40 passed) and `tests/server/integration/test_sessions_permission_request_hook.py` (native + ask_user_question pass). Covers accept (single + multi-select), decline, empty/timeout, replied withdrawal, malformed, dedupe, and the server-side `ask_user_question` passthrough. Ruff clean.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
