### PR TITLE
feat(qwen-native): expose Omnigent MCP tools to the qwen TUI

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -246,12 +246,16 @@ comments; this is the *what*, not the *how*.)
     `databricks-*` model), then `omni run`; confirm the runner log's
     `qwen gateway routing:` line shows the Databricks base URL + profile.
 - [x] **Omnigent tools.** Qwen-native now registers the shared Omnigent MCP
-  relay (`omnigent.claude_native_bridge serve-mcp`) in
-  `<workspace>/.qwen/settings.json` (`mcpServers.omnigent`, `trust: true`) before
-  launch, so qwen connects to it on boot, `/mcp` lists it, and the model can call
-  Omnigent's builtin tools (`sys_*`, `load_skill`, `web_fetch`, …). The token is
-  written via `qwen_native_bridge.write_mcp_config`; the server connection is
-  added to `bridge.json` by `ensure_comment_relay`. Mirrors cursor-/claude-native.
+  relay (`omnigent.claude_native_bridge serve-mcp`) in `<workspace>/.mcp.json`
+  (qwen's dedicated project-MCP file — `mcpServers.omnigent`, `trust: true`)
+  before launch, so qwen connects to it on boot, `/mcp` lists it, and the model
+  can call Omnigent's builtin tools (`sys_*`, `load_skill`, `web_fetch`, …). A
+  dedicated file (not the shared `.qwen/settings.json`) avoids touching the
+  user's auth/theme config; the merge is JSONC-aware and fail-safe (an
+  unparseable existing `.mcp.json` is left untouched and MCP wiring is skipped).
+  The token is written via `qwen_native_bridge.write_mcp_config`; the live tool
+  surface is advertised by the `tool_relay.json` that `ensure_comment_relay`
+  writes. Mirrors cursor-/claude-native.
   A project-scoped MCP server is gated behind qwen's "Untrusted MCP server"
   startup prompt, so the runner pre-approves it non-interactively via
   `qwen mcp approve omnigent` (`qwen_native_bridge.approve_mcp_server`, qwen's own

--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -255,14 +255,10 @@ comments; this is the *what*, not the *how*.)
   collide, and CLI-provided servers are ungated (no "Untrusted MCP server"
   prompt → no pre-approval step). The token + config are written by
   `qwen_native_bridge.write_mcp_config`; the live tool surface is advertised by
-  the `tool_relay.json` that `ensure_comment_relay` writes.
-  A project-scoped MCP server is gated behind qwen's "Untrusted MCP server"
-  startup prompt, so the runner pre-approves it non-interactively via
-  `qwen mcp approve omnigent` (`qwen_native_bridge.approve_mcp_server`, qwen's own
-  hash-exact command — the analog of cursor's `cursor mcp enable`), writing to a
-  per-session approvals store isolated via `QWEN_CODE_MCP_APPROVALS_PATH` (avoids
-  polluting `~/.qwen` and a same-workspace concurrency race). Permission gating on
-  qwen's *own* tool calls already works.
+  the `tool_relay.json` that `ensure_comment_relay` writes. The `bridge.json`
+  bearer token is written through `_ensure_secure_bridge_dir` (the same
+  owner-only ancestor validation the shared relay applies to token-bearing
+  trees). Permission gating on qwen's *own* tool calls already works.
 - [ ] **File I/O recording / content policy.** Omnigent now *executes* delegated
   file reads/writes through the `OSEnvironment` (see "File I/O delegation" in
   What works today), so the bytes flow through Omnigent and the sandbox roots are

--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -245,17 +245,17 @@ comments; this is the *what*, not the *how*.)
   - *Full route:* spec with `executor.profile: <db-profile>` (or a
     `databricks-*` model), then `omni run`; confirm the runner log's
     `qwen gateway routing:` line shows the Databricks base URL + profile.
-- [x] **Omnigent tools.** Qwen-native now registers the shared Omnigent MCP
-  relay (`omnigent.claude_native_bridge serve-mcp`) in `<workspace>/.mcp.json`
-  (qwen's dedicated project-MCP file — `mcpServers.omnigent`, `trust: true`)
-  before launch, so qwen connects to it on boot, `/mcp` lists it, and the model
-  can call Omnigent's builtin tools (`sys_*`, `load_skill`, `web_fetch`, …). A
-  dedicated file (not the shared `.qwen/settings.json`) avoids touching the
-  user's auth/theme config; the merge is JSONC-aware and fail-safe (an
-  unparseable existing `.mcp.json` is left untouched and MCP wiring is skipped).
-  The token is written via `qwen_native_bridge.write_mcp_config`; the live tool
-  surface is advertised by the `tool_relay.json` that `ensure_comment_relay`
-  writes. Mirrors cursor-/claude-native.
+- [x] **Omnigent tools.** Qwen-native now exposes the shared Omnigent MCP relay
+  (`omnigent.claude_native_bridge serve-mcp`, `mcpServers.omnigent`,
+  `trust: true`) to qwen via the `--mcp-config <path>` launch flag (the
+  claude-native model). qwen connects to it on boot, `/mcp` lists it, and the
+  model can call Omnigent's builtin tools (`sys_*`, `load_skill`, `web_fetch`, …).
+  The config lives in the per-session bridge dir, **not** the workspace, so we
+  drop no file in the user's repo, concurrent same-workspace sessions can't
+  collide, and CLI-provided servers are ungated (no "Untrusted MCP server"
+  prompt → no pre-approval step). The token + config are written by
+  `qwen_native_bridge.write_mcp_config`; the live tool surface is advertised by
+  the `tool_relay.json` that `ensure_comment_relay` writes.
   A project-scoped MCP server is gated behind qwen's "Untrusted MCP server"
   startup prompt, so the runner pre-approves it non-interactively via
   `qwen mcp approve omnigent` (`qwen_native_bridge.approve_mcp_server`, qwen's own

--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -245,9 +245,20 @@ comments; this is the *what*, not the *how*.)
   - *Full route:* spec with `executor.profile: <db-profile>` (or a
     `databricks-*` model), then `omni run`; confirm the runner log's
     `qwen gateway routing:` line shows the Databricks base URL + profile.
-- [ ] **Omnigent tools.** Qwen can only call its own built-in tools; tools
-  defined by Omnigent aren't exposed to it (so they can't be invoked or
-  recorded). Permission gating on qwen's *own* tool calls already works.
+- [x] **Omnigent tools.** Qwen-native now registers the shared Omnigent MCP
+  relay (`omnigent.claude_native_bridge serve-mcp`) in
+  `<workspace>/.qwen/settings.json` (`mcpServers.omnigent`, `trust: true`) before
+  launch, so qwen connects to it on boot, `/mcp` lists it, and the model can call
+  Omnigent's builtin tools (`sys_*`, `load_skill`, `web_fetch`, …). The token is
+  written via `qwen_native_bridge.write_mcp_config`; the server connection is
+  added to `bridge.json` by `ensure_comment_relay`. Mirrors cursor-/claude-native.
+  A project-scoped MCP server is gated behind qwen's "Untrusted MCP server"
+  startup prompt, so the runner pre-approves it non-interactively via
+  `qwen mcp approve omnigent` (`qwen_native_bridge.approve_mcp_server`, qwen's own
+  hash-exact command — the analog of cursor's `cursor mcp enable`), writing to a
+  per-session approvals store isolated via `QWEN_CODE_MCP_APPROVALS_PATH` (avoids
+  polluting `~/.qwen` and a same-workspace concurrency race). Permission gating on
+  qwen's *own* tool calls already works.
 - [ ] **File I/O recording / content policy.** Omnigent now *executes* delegated
   file reads/writes through the `OSEnvironment` (see "File I/O delegation" in
   What works today), so the bytes flow through Omnigent and the sandbox roots are

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -62,10 +62,12 @@ _POLL_INTERVAL_S = 0.2
 _BRIDGE_CONFIG_FILE = "bridge.json"
 #: Name qwen lists the Omnigent MCP server under (shows in ``/mcp``).
 _MCP_SERVER_NAME = "omnigent"
-#: qwen reads MCP servers from ``<workspace>/.qwen/settings.json`` (project
-#: scope) — the per-workspace analog of cursor's ``.cursor/mcp.json``.
-_QWEN_SETTINGS_DIR = ".qwen"
-_QWEN_SETTINGS_FILE = "settings.json"
+#: qwen reads project-scoped MCP servers from ``<workspace>/.mcp.json`` (its
+#: ``loadProjectMcpServers`` path) — a dedicated MCP file we own wholesale, the
+#: true analog of cursor's ``.cursor/mcp.json``. Deliberately NOT the shared
+#: ``.qwen/settings.json`` (which also holds auth/theme/gateway config), so we
+#: never risk clobbering unrelated user settings.
+_PROJECT_MCP_FILE = ".mcp.json"
 #: Env var qwen reads to locate its MCP-approvals store, overriding the default
 #: ``~/.qwen/mcpApprovals.json``. We point it at a per-session file in the bridge
 #: dir so approvals don't pollute the user's home and concurrent same-workspace
@@ -217,9 +219,11 @@ def write_mcp_bridge_config(bridge_dir: Path) -> None:
 
     The ``serve-mcp`` relay (spawned by qwen) reads ``bridge.json`` for a bearer
     token and exits if it's missing, so this must exist *before* qwen launches.
-    The server connection (URL, session, workspace) is added to this same file
-    by the runner's comment relay (``ensure_comment_relay``) when it starts.
-    Mirrors :func:`omnigent.cursor_native_bridge.write_mcp_bridge_config`.
+    ``bridge.json`` only ever holds ``{token}``; the live tool surface is
+    advertised separately via the ``tool_relay.json`` that the runner's comment
+    relay (``ensure_comment_relay`` → ``_ensure_comment_relay_started``) writes
+    into this same bridge dir when it starts. Mirrors
+    :func:`omnigent.cursor_native_bridge.write_mcp_bridge_config`.
     """
     _ensure_dir(bridge_dir)
     config_path = bridge_dir / _BRIDGE_CONFIG_FILE
@@ -263,40 +267,113 @@ def build_mcp_server_entry(
     }
 
 
+def _strip_json_comments(text: str) -> str:
+    """Replace ``//`` and ``/* */`` comments with spaces, preserving strings.
+
+    qwen's ``settings.json`` is JSONC — qwen parses it with
+    ``JSON.parse(stripJsonComments(content))`` — so a user's file legitimately
+    contains comments that plain :func:`json.loads` rejects. This mirrors the
+    ``strip-json-comments`` behaviour qwen uses (blank out comment characters in
+    place, leaving lengths/positions intact) while never touching characters
+    inside string literals. Trailing commas are *not* handled — qwen doesn't
+    accept them either (its final ``JSON.parse`` would reject them).
+    """
+    out: list[str] = []
+    in_string = False
+    escaped = False
+    in_line_comment = False
+    in_block_comment = False
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+                out.append(ch)
+            else:
+                out.append(" ")
+            i += 1
+        elif in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                out.append("  ")
+                i += 2
+            else:
+                out.append("\n" if ch == "\n" else " ")
+                i += 1
+        elif in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+        elif ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+        elif ch == "/" and nxt == "/":
+            in_line_comment = True
+            out.append("  ")
+            i += 2
+        elif ch == "/" and nxt == "*":
+            in_block_comment = True
+            out.append("  ")
+            i += 2
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
 def write_mcp_config(
     workspace: Path,
     bridge_dir: Path,
     *,
     python_executable: str | None = None,
-) -> Path:
-    """Register the Omnigent MCP server in ``<workspace>/.qwen/settings.json``.
+) -> Path | None:
+    """Register the Omnigent MCP server in ``<workspace>/.mcp.json``.
 
-    Merges (does not overwrite) into any existing project settings so unrelated
-    keys — and other ``mcpServers`` — are preserved; only the ``omnigent`` entry
-    is (re)written. Project scope (not ``~/.qwen/settings.json``) keeps the
-    user's home config — including auth/gateway settings whose precedence the
-    qwen-native design deliberately avoids touching — untouched. Also writes the
-    relay token (:func:`write_mcp_bridge_config`). Mirrors
+    Writes qwen's dedicated project-MCP file (its ``loadProjectMcpServers`` path)
+    rather than the shared ``.qwen/settings.json``, so we never touch the user's
+    auth/theme/gateway config. Merges (does not overwrite) into an existing
+    ``.mcp.json`` so a user's own ``mcpServers`` are preserved; only the
+    ``omnigent`` entry is (re)written. Also writes the relay token
+    (:func:`write_mcp_bridge_config`). The analog of
     :func:`omnigent.cursor_native_bridge.write_mcp_config`.
 
-    :returns: Path to the written ``settings.json``.
+    qwen parses ``.mcp.json`` as JSONC, so an existing file is read through
+    :func:`_strip_json_comments` before parsing. **Fail-safe:** if a non-empty
+    existing file cannot be parsed even as JSONC (or doesn't decode to a JSON
+    object, or can't be read), the merge is aborted and the file is left
+    untouched — overwriting it would silently destroy real user config we simply
+    failed to understand. The caller skips MCP wiring in that case.
+
+    :returns: Path to the written ``.mcp.json``, or ``None`` if the merge was
+        aborted to avoid clobbering an unparseable existing file.
     """
-    write_mcp_bridge_config(bridge_dir)
-    settings_dir = workspace / _QWEN_SETTINGS_DIR
-    settings_dir.mkdir(parents=True, exist_ok=True)
-    path = settings_dir / _QWEN_SETTINGS_FILE
+    path = workspace / _PROJECT_MCP_FILE
 
     data: dict[str, Any] = {}
     if path.is_file():
         try:
-            existing = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(existing, dict):
-                data = existing
-        except (OSError, ValueError):
-            # Malformed/unreadable settings: fall back to a fresh file rather
-            # than crash the launch (worst case the user loses stray edits we
-            # couldn't parse — the omnigent server is what matters here).
-            data = {}
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        if raw.strip():
+            try:
+                parsed = json.loads(_strip_json_comments(raw))
+            except ValueError:
+                # Non-empty file we can't parse even as JSONC — may be valid qwen
+                # config we don't understand. Refuse to overwrite it.
+                return None
+            if not isinstance(parsed, dict):
+                return None
+            data = parsed
 
     servers = data.get("mcpServers")
     if not isinstance(servers, dict):
@@ -306,7 +383,11 @@ def write_mcp_config(
     )
     data["mcpServers"] = servers
 
-    tmp = path.with_suffix(path.suffix + ".tmp")
+    write_mcp_bridge_config(bridge_dir)
+    workspace.mkdir(parents=True, exist_ok=True)
+    # Unique temp name so concurrent writers (same-workspace co-tenant sessions)
+    # don't race on a shared ``.mcp.json.tmp`` before the atomic replace.
+    tmp = path.with_name(f"{_PROJECT_MCP_FILE}.{secrets.token_hex(8)}.tmp")
     tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     os.replace(tmp, path)
     return path

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -31,7 +31,9 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import subprocess
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -54,6 +56,22 @@ _EVENTS_FILE = "qwen_out.ndjson"
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 10.0
 _POLL_INTERVAL_S = 0.2
+
+#: Token config the shared Omnigent MCP relay (``serve-mcp``) reads from the
+#: bridge dir. Mirrors cursor-/claude-native (``cursor_native_bridge.py``).
+_BRIDGE_CONFIG_FILE = "bridge.json"
+#: Name qwen lists the Omnigent MCP server under (shows in ``/mcp``).
+_MCP_SERVER_NAME = "omnigent"
+#: qwen reads MCP servers from ``<workspace>/.qwen/settings.json`` (project
+#: scope) — the per-workspace analog of cursor's ``.cursor/mcp.json``.
+_QWEN_SETTINGS_DIR = ".qwen"
+_QWEN_SETTINGS_FILE = "settings.json"
+#: Env var qwen reads to locate its MCP-approvals store, overriding the default
+#: ``~/.qwen/mcpApprovals.json``. We point it at a per-session file in the bridge
+#: dir so approvals don't pollute the user's home and concurrent same-workspace
+#: sessions don't fight over a single (workspace, server) approval entry.
+MCP_APPROVALS_ENV_VAR = "QWEN_CODE_MCP_APPROVALS_PATH"
+_MCP_APPROVALS_FILE = "mcpApprovals.json"
 
 
 def bridge_dir_for_session_id(session_id: str) -> Path:
@@ -183,6 +201,164 @@ def build_qwen_native_spawn_env(session_id: str) -> dict[str, str]:
     bridge_dir = bridge_dir_for_session_id(session_id)
     _ensure_dir(bridge_dir)
     return {BRIDGE_DIR_ENV_VAR: str(bridge_dir)}
+
+
+# ---------------------------------------------------------------------------
+# Omnigent MCP server config — expose Omnigent's builtin tools (sys_*,
+# load_skill, web_fetch, …) to the qwen TUI so it can call them and ``/mcp``
+# lists them. Reuses the shared stdio relay implemented in
+# ``omnigent.claude_native_bridge serve-mcp`` (same server cursor-/claude-/
+# opencode-native point at); only the *registration* surface differs per CLI.
+# ---------------------------------------------------------------------------
+
+
+def write_mcp_bridge_config(bridge_dir: Path) -> None:
+    """Write the token config the shared Omnigent MCP relay reads at startup.
+
+    The ``serve-mcp`` relay (spawned by qwen) reads ``bridge.json`` for a bearer
+    token and exits if it's missing, so this must exist *before* qwen launches.
+    The server connection (URL, session, workspace) is added to this same file
+    by the runner's comment relay (``ensure_comment_relay``) when it starts.
+    Mirrors :func:`omnigent.cursor_native_bridge.write_mcp_bridge_config`.
+    """
+    _ensure_dir(bridge_dir)
+    config_path = bridge_dir / _BRIDGE_CONFIG_FILE
+    if config_path.exists():
+        return
+    payload = {"token": secrets.token_urlsafe(32)}
+    tmp = bridge_dir / (_BRIDGE_CONFIG_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, config_path)
+
+
+def build_mcp_server_entry(
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> dict[str, Any]:
+    """Build qwen's ``mcpServers.omnigent`` entry for the Omnigent relay.
+
+    ``trust: true`` auto-approves the qwen-side MCP tool gate so the TUI doesn't
+    add a second in-terminal prompt: Omnigent already gates these calls through
+    its own policy/elicitation engine (surfaced as web cards by the approval
+    mirror), so qwen's prompt would only be a hidden duplicate. Same rationale
+    as cursor's ``autoApprove`` (see ``cursor_native_bridge.build_mcp_config``).
+    """
+    python = python_executable or sys.executable
+    return {
+        "command": python,
+        "args": [
+            "-I",
+            "-m",
+            "omnigent.claude_native_bridge",
+            "serve-mcp",
+            "--bridge-dir",
+            str(bridge_dir),
+        ],
+        "env": {
+            "PYTHONUNBUFFERED": "1",
+            "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+        },
+        "trust": True,
+    }
+
+
+def write_mcp_config(
+    workspace: Path,
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> Path:
+    """Register the Omnigent MCP server in ``<workspace>/.qwen/settings.json``.
+
+    Merges (does not overwrite) into any existing project settings so unrelated
+    keys — and other ``mcpServers`` — are preserved; only the ``omnigent`` entry
+    is (re)written. Project scope (not ``~/.qwen/settings.json``) keeps the
+    user's home config — including auth/gateway settings whose precedence the
+    qwen-native design deliberately avoids touching — untouched. Also writes the
+    relay token (:func:`write_mcp_bridge_config`). Mirrors
+    :func:`omnigent.cursor_native_bridge.write_mcp_config`.
+
+    :returns: Path to the written ``settings.json``.
+    """
+    write_mcp_bridge_config(bridge_dir)
+    settings_dir = workspace / _QWEN_SETTINGS_DIR
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    path = settings_dir / _QWEN_SETTINGS_FILE
+
+    data: dict[str, Any] = {}
+    if path.is_file():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(existing, dict):
+                data = existing
+        except (OSError, ValueError):
+            # Malformed/unreadable settings: fall back to a fresh file rather
+            # than crash the launch (worst case the user loses stray edits we
+            # couldn't parse — the omnigent server is what matters here).
+            data = {}
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+    servers[_MCP_SERVER_NAME] = build_mcp_server_entry(
+        bridge_dir, python_executable=python_executable
+    )
+    data["mcpServers"] = servers
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+    return path
+
+
+def mcp_approvals_path(bridge_dir: Path) -> Path:
+    """Return the per-session MCP-approvals store path (see :data:`MCP_APPROVALS_ENV_VAR`)."""
+    return bridge_dir / _MCP_APPROVALS_FILE
+
+
+def mcp_launch_env(bridge_dir: Path) -> dict[str, str]:
+    """Env the qwen TUI launch needs so it reads the per-session approvals store."""
+    return {MCP_APPROVALS_ENV_VAR: str(mcp_approvals_path(bridge_dir))}
+
+
+def approve_mcp_server(
+    workspace: Path,
+    bridge_dir: Path,
+    *,
+    qwen_command: str,
+) -> bool:
+    """Pre-approve the Omnigent MCP server so qwen skips its startup trust prompt.
+
+    A project ``.qwen/settings.json`` MCP server is *gated*: on launch qwen shows
+    an "Untrusted MCP server" prompt and won't start the server until approved,
+    blocking the relay (and ``/mcp`` listing) behind a manual in-terminal step.
+    ``qwen mcp approve`` is qwen's own non-interactive approval command — it
+    computes the config hash exactly (version-proof, unlike replicating the hash
+    ourselves) and records ``{status: approved}`` keyed by ``(workspace, name)``
+    in the approvals store. Run with the SAME cwd and :data:`MCP_APPROVALS_ENV_VAR`
+    the TUI will launch with, so the approval the TUI reads matches. The analog of
+    cursor's ``cursor mcp enable`` (``cursor_native_bridge``).
+
+    Best-effort: on failure we log and return ``False``; the launch proceeds and
+    qwen falls back to its in-terminal trust prompt (no worse than before).
+
+    :returns: ``True`` if the approve command succeeded.
+    """
+    env = {**os.environ, **mcp_launch_env(bridge_dir)}
+    try:
+        proc = subprocess.run(
+            [qwen_command, "mcp", "approve", _MCP_SERVER_NAME],
+            cwd=str(workspace),
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_READY_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
 
 
 def _append_command(bridge_dir: Path, command: dict[str, Any]) -> None:

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -62,18 +62,13 @@ _POLL_INTERVAL_S = 0.2
 _BRIDGE_CONFIG_FILE = "bridge.json"
 #: Name qwen lists the Omnigent MCP server under (shows in ``/mcp``).
 _MCP_SERVER_NAME = "omnigent"
-#: qwen reads project-scoped MCP servers from ``<workspace>/.mcp.json`` (its
-#: ``loadProjectMcpServers`` path) — a dedicated MCP file we own wholesale, the
-#: true analog of cursor's ``.cursor/mcp.json``. Deliberately NOT the shared
-#: ``.qwen/settings.json`` (which also holds auth/theme/gateway config), so we
-#: never risk clobbering unrelated user settings.
-_PROJECT_MCP_FILE = ".mcp.json"
-#: Env var qwen reads to locate its MCP-approvals store, overriding the default
-#: ``~/.qwen/mcpApprovals.json``. We point it at a per-session file in the bridge
-#: dir so approvals don't pollute the user's home and concurrent same-workspace
-#: sessions don't fight over a single (workspace, server) approval entry.
-MCP_APPROVALS_ENV_VAR = "QWEN_CODE_MCP_APPROVALS_PATH"
-_MCP_APPROVALS_FILE = "mcpApprovals.json"
+#: Per-session MCP config passed to qwen via ``--mcp-config <path>``. Lives in
+#: the bridge dir (NOT the workspace), so we never drop a file in the user's repo
+#: and concurrent same-workspace sessions can't collide. CLI-provided MCP servers
+#: are also ungated (no "Untrusted MCP server" prompt), unlike a project
+#: ``.mcp.json`` / ``.qwen/settings.json``. The claude-native ``--mcp-config``
+#: model (it writes no workspace file either).
+_MCP_CONFIG_FILE = "mcp_config.json"
 
 
 def bridge_dir_for_session_id(session_id: str) -> Path:
@@ -267,179 +262,48 @@ def build_mcp_server_entry(
     }
 
 
-def _strip_json_comments(text: str) -> str:
-    """Replace ``//`` and ``/* */`` comments with spaces, preserving strings.
-
-    qwen's ``settings.json`` is JSONC — qwen parses it with
-    ``JSON.parse(stripJsonComments(content))`` — so a user's file legitimately
-    contains comments that plain :func:`json.loads` rejects. This mirrors the
-    ``strip-json-comments`` behaviour qwen uses (blank out comment characters in
-    place, leaving lengths/positions intact) while never touching characters
-    inside string literals. Trailing commas are *not* handled — qwen doesn't
-    accept them either (its final ``JSON.parse`` would reject them).
-    """
-    out: list[str] = []
-    in_string = False
-    escaped = False
-    in_line_comment = False
-    in_block_comment = False
-    i = 0
-    n = len(text)
-    while i < n:
-        ch = text[i]
-        nxt = text[i + 1] if i + 1 < n else ""
-        if in_line_comment:
-            if ch == "\n":
-                in_line_comment = False
-                out.append(ch)
-            else:
-                out.append(" ")
-            i += 1
-        elif in_block_comment:
-            if ch == "*" and nxt == "/":
-                in_block_comment = False
-                out.append("  ")
-                i += 2
-            else:
-                out.append("\n" if ch == "\n" else " ")
-                i += 1
-        elif in_string:
-            out.append(ch)
-            if escaped:
-                escaped = False
-            elif ch == "\\":
-                escaped = True
-            elif ch == '"':
-                in_string = False
-            i += 1
-        elif ch == '"':
-            in_string = True
-            out.append(ch)
-            i += 1
-        elif ch == "/" and nxt == "/":
-            in_line_comment = True
-            out.append("  ")
-            i += 2
-        elif ch == "/" and nxt == "*":
-            in_block_comment = True
-            out.append("  ")
-            i += 2
-        else:
-            out.append(ch)
-            i += 1
-    return "".join(out)
+def mcp_config_path(bridge_dir: Path) -> Path:
+    """Return the per-session ``--mcp-config`` file path inside the bridge dir."""
+    return bridge_dir / _MCP_CONFIG_FILE
 
 
 def write_mcp_config(
-    workspace: Path,
     bridge_dir: Path,
     *,
     python_executable: str | None = None,
-) -> Path | None:
-    """Register the Omnigent MCP server in ``<workspace>/.mcp.json``.
+) -> Path:
+    """Write the per-session Omnigent MCP config for qwen's ``--mcp-config`` flag.
 
-    Writes qwen's dedicated project-MCP file (its ``loadProjectMcpServers`` path)
-    rather than the shared ``.qwen/settings.json``, so we never touch the user's
-    auth/theme/gateway config. Merges (does not overwrite) into an existing
-    ``.mcp.json`` so a user's own ``mcpServers`` are preserved; only the
-    ``omnigent`` entry is (re)written. Also writes the relay token
-    (:func:`write_mcp_bridge_config`). The analog of
-    :func:`omnigent.cursor_native_bridge.write_mcp_config`.
+    Writes ``{"mcpServers": {"omnigent": ...}}`` to a file *inside the bridge dir*
+    (never the workspace) and the relay token (:func:`write_mcp_bridge_config`).
+    The runner passes the returned path to qwen via ``--mcp-config <path>``. Unlike
+    a project ``.mcp.json`` / ``.qwen/settings.json``, a CLI-provided MCP server:
 
-    qwen parses ``.mcp.json`` as JSONC, so an existing file is read through
-    :func:`_strip_json_comments` before parsing. **Fail-safe:** if a non-empty
-    existing file cannot be parsed even as JSONC (or doesn't decode to a JSON
-    object, or can't be read), the merge is aborted and the file is left
-    untouched — overwriting it would silently destroy real user config we simply
-    failed to understand. The caller skips MCP wiring in that case.
+    - drops no file in the user's (often git) workspace — nothing to accidentally
+      commit, nothing left behind pointing at a dead bridge dir;
+    - is per-session by construction (the file and its ``--bridge-dir`` live in
+      this session's bridge dir), so concurrent same-workspace sessions can't
+      collide on a shared file;
+    - is **not** gated behind qwen's "Untrusted MCP server" prompt (CLI servers
+      carry no project/workspace scope), so no pre-approval step is needed.
 
-    :returns: Path to the written ``.mcp.json``, or ``None`` if the merge was
-        aborted to avoid clobbering an unparseable existing file.
+    The claude-native ``--mcp-config`` model (it writes no workspace file either).
+
+    :returns: Path to the written ``--mcp-config`` file.
     """
-    path = workspace / _PROJECT_MCP_FILE
-
-    data: dict[str, Any] = {}
-    if path.is_file():
-        try:
-            raw = path.read_text(encoding="utf-8")
-        except OSError:
-            return None
-        if raw.strip():
-            try:
-                parsed = json.loads(_strip_json_comments(raw))
-            except ValueError:
-                # Non-empty file we can't parse even as JSONC — may be valid qwen
-                # config we don't understand. Refuse to overwrite it.
-                return None
-            if not isinstance(parsed, dict):
-                return None
-            data = parsed
-
-    servers = data.get("mcpServers")
-    if not isinstance(servers, dict):
-        servers = {}
-    servers[_MCP_SERVER_NAME] = build_mcp_server_entry(
-        bridge_dir, python_executable=python_executable
-    )
-    data["mcpServers"] = servers
-
     write_mcp_bridge_config(bridge_dir)
-    workspace.mkdir(parents=True, exist_ok=True)
-    # Unique temp name so concurrent writers (same-workspace co-tenant sessions)
-    # don't race on a shared ``.mcp.json.tmp`` before the atomic replace.
-    tmp = path.with_name(f"{_PROJECT_MCP_FILE}.{secrets.token_hex(8)}.tmp")
-    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path = mcp_config_path(bridge_dir)
+    payload = {
+        "mcpServers": {
+            _MCP_SERVER_NAME: build_mcp_server_entry(
+                bridge_dir, python_executable=python_executable
+            )
+        }
+    }
+    tmp = path.with_name(f"{_MCP_CONFIG_FILE}.{secrets.token_hex(8)}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     os.replace(tmp, path)
     return path
-
-
-def mcp_approvals_path(bridge_dir: Path) -> Path:
-    """Return the per-session MCP-approvals store path (see :data:`MCP_APPROVALS_ENV_VAR`)."""
-    return bridge_dir / _MCP_APPROVALS_FILE
-
-
-def mcp_launch_env(bridge_dir: Path) -> dict[str, str]:
-    """Env the qwen TUI launch needs so it reads the per-session approvals store."""
-    return {MCP_APPROVALS_ENV_VAR: str(mcp_approvals_path(bridge_dir))}
-
-
-def approve_mcp_server(
-    workspace: Path,
-    bridge_dir: Path,
-    *,
-    qwen_command: str,
-) -> bool:
-    """Pre-approve the Omnigent MCP server so qwen skips its startup trust prompt.
-
-    A project ``.qwen/settings.json`` MCP server is *gated*: on launch qwen shows
-    an "Untrusted MCP server" prompt and won't start the server until approved,
-    blocking the relay (and ``/mcp`` listing) behind a manual in-terminal step.
-    ``qwen mcp approve`` is qwen's own non-interactive approval command — it
-    computes the config hash exactly (version-proof, unlike replicating the hash
-    ourselves) and records ``{status: approved}`` keyed by ``(workspace, name)``
-    in the approvals store. Run with the SAME cwd and :data:`MCP_APPROVALS_ENV_VAR`
-    the TUI will launch with, so the approval the TUI reads matches. The analog of
-    cursor's ``cursor mcp enable`` (``cursor_native_bridge``).
-
-    Best-effort: on failure we log and return ``False``; the launch proceeds and
-    qwen falls back to its in-terminal trust prompt (no worse than before).
-
-    :returns: ``True`` if the approve command succeeded.
-    """
-    env = {**os.environ, **mcp_launch_env(bridge_dir)}
-    try:
-        proc = subprocess.run(
-            [qwen_command, "mcp", "approve", _MCP_SERVER_NAME],
-            cwd=str(workspace),
-            env=env,
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=_TMUX_READY_TIMEOUT_S,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return proc.returncode == 0
 
 
 def _append_command(bridge_dir: Path, command: dict[str, Any]) -> None:

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -172,6 +172,28 @@ def _ensure_dir(path: Path) -> None:
         os.chmod(path, 0o700)
 
 
+def _ensure_secure_bridge_dir(bridge_dir: Path) -> None:
+    """Create/validate *bridge_dir* as an owner-only chain before writing secrets.
+
+    ``_ensure_dir`` only ``mkdir(parents=True, exist_ok=True)`` + a suppressed
+    ``chmod`` on the leaf: it trusts pre-existing ancestors, so on a shared host
+    an attacker could pre-create ``$TMPDIR/omnigent-<uid>`` (or a deeper ancestor)
+    as a symlink / world-writable dir and redirect the bridge tree. That tree now
+    holds ``bridge.json`` — a bearer token for the relay's localhost control
+    endpoint — so its directory must be hardened. Delegate to the same
+    ``_ensure_secure_dir`` the shared relay (``start_tool_relay``) already applies
+    to token-bearing trees; it rejects symlinked / non-owned / group-or-other
+    accessible ancestors (the qwen-native root is in its allowlist). Lazy import
+    avoids a cycle (``claude_native_bridge`` resolves qwen's ``bridge_root`` lazily
+    in turn).
+
+    :raises RuntimeError: If any ancestor fails owner-only validation.
+    """
+    from omnigent.claude_native_bridge import _ensure_secure_dir
+
+    _ensure_secure_dir(bridge_dir)
+
+
 def prepare_bridge_files(bridge_dir: Path) -> None:
     """Create the bridge dir and a fresh, empty input file before launch.
 
@@ -219,8 +241,11 @@ def write_mcp_bridge_config(bridge_dir: Path) -> None:
     relay (``ensure_comment_relay`` → ``_ensure_comment_relay_started``) writes
     into this same bridge dir when it starts. Mirrors
     :func:`omnigent.cursor_native_bridge.write_mcp_bridge_config`.
+
+    :raises RuntimeError: If the bridge dir fails owner-only validation
+        (:func:`_ensure_secure_bridge_dir`) — the token is not written.
     """
-    _ensure_dir(bridge_dir)
+    _ensure_secure_bridge_dir(bridge_dir)
     config_path = bridge_dir / _BRIDGE_CONFIG_FILE
     if config_path.exists():
         return

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2796,12 +2796,15 @@ async def _auto_create_qwen_terminal(
     # drop the prior terminal's stale forward cursor + queued input.
     await _cancel_auto_forwarder_task(session_id)
     from omnigent.qwen_native_bridge import (
+        approve_mcp_server,
         bridge_dir_for_session_id,
         events_file_path,
         input_file_path,
+        mcp_launch_env,
         prepare_bridge_files,
         qwen_session_id_for_conversation,
         qwen_session_recording_exists,
+        write_mcp_config,
         write_tmux_target,
     )
     from omnigent.qwen_native_forwarder import clear_qwen_bridge_state
@@ -2853,6 +2856,29 @@ async def _auto_create_qwen_terminal(
         # First launch (or a prior persist that didn't land): record the id so the
         # next resume reads it from the snapshot and forks can carry history.
         await _persist_qwen_external_session_id(server_client, session_id, qwen_session_id)
+    # Expose Omnigent's builtin tools (sys_*, load_skill, web_fetch, …) to qwen
+    # by registering the shared MCP relay in ``<workspace>/.qwen/settings.json``
+    # so qwen connects to it on boot and ``/mcp`` lists it. Written before launch
+    # so the relay's ``bridge.json`` token exists when qwen spawns ``serve-mcp``;
+    # the server connection is added to that file by ``ensure_comment_relay``
+    # below. Only when the relay will actually start (``ensure_comment_relay``
+    # present), else the registered tools would be dead (serve-mcp with nothing
+    # to route calls back to) — mirrors the opencode-native gating.
+    mcp_enabled = server_client is not None and ensure_comment_relay is not None
+    if mcp_enabled:
+        write_mcp_config(Path(workspace), bridge_dir)
+        # A project-scoped MCP server is gated behind qwen's "Untrusted MCP
+        # server" startup prompt; pre-approve it non-interactively (qwen's own
+        # ``mcp approve``, hash-exact) so the relay starts and ``/mcp`` lists it
+        # without a manual in-terminal step. Run with the SAME cwd + approvals
+        # env the TUI launches with (see ``mcp_launch_env`` in the spec below).
+        if not approve_mcp_server(Path(workspace), bridge_dir, qwen_command=qwen_command):
+            _logger.warning(
+                "qwen-native: could not pre-approve the omnigent MCP server for "
+                "session %s; qwen will show its in-terminal trust prompt.",
+                session_id,
+            )
+
     # The dual-output + input-file flags wire qwen to the bridge; any user
     # ``terminal_launch_args`` (e.g. ``-m <model>``) precede them. Approval stays
     # the default in-terminal prompt (the embedded pane shows it) — Omnigent-side
@@ -2874,6 +2900,9 @@ async def _auto_create_qwen_terminal(
             os_env=OSEnvSpec(type="caller_process", cwd=workspace),
             command=qwen_command,
             args=qwen_args,
+            # Point qwen at the per-session MCP-approvals store the pre-approval
+            # above wrote, so the TUI reads our approval (not ~/.qwen's).
+            env=mcp_launch_env(bridge_dir) if mcp_enabled else {},
             scrollback=100_000,
             tmux_allow_passthrough=True,
             tmux_start_on_attach=False,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2869,8 +2869,22 @@ async def _auto_create_qwen_terminal(
     mcp_enabled = server_client is not None and ensure_comment_relay is not None
     mcp_args: list[str] = []
     if mcp_enabled:
-        mcp_config = write_mcp_config(bridge_dir)
-        mcp_args = ["--mcp-config", str(mcp_config)]
+        try:
+            mcp_config = write_mcp_config(bridge_dir)
+        except RuntimeError:
+            # The bridge dir failed owner-only validation (e.g. a redirected
+            # ancestor on a shared host) — don't write the relay token there.
+            # Degrade to no MCP rather than crash the session; the relay's own
+            # secure-dir check would reject it later too.
+            mcp_enabled = False
+            _logger.warning(
+                "qwen-native: bridge dir failed secure validation; skipping "
+                "Omnigent MCP wiring for session %s.",
+                session_id,
+                exc_info=True,
+            )
+        else:
+            mcp_args = ["--mcp-config", str(mcp_config)]
 
     # The dual-output + input-file flags wire qwen to the bridge; any user
     # ``terminal_launch_args`` (e.g. ``-m <model>``) precede them. Approval stays

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2857,22 +2857,32 @@ async def _auto_create_qwen_terminal(
         # next resume reads it from the snapshot and forks can carry history.
         await _persist_qwen_external_session_id(server_client, session_id, qwen_session_id)
     # Expose Omnigent's builtin tools (sys_*, load_skill, web_fetch, …) to qwen
-    # by registering the shared MCP relay in ``<workspace>/.qwen/settings.json``
-    # so qwen connects to it on boot and ``/mcp`` lists it. Written before launch
-    # so the relay's ``bridge.json`` token exists when qwen spawns ``serve-mcp``;
-    # the server connection is added to that file by ``ensure_comment_relay``
-    # below. Only when the relay will actually start (``ensure_comment_relay``
-    # present), else the registered tools would be dead (serve-mcp with nothing
-    # to route calls back to) — mirrors the opencode-native gating.
+    # by registering the shared MCP relay in ``<workspace>/.mcp.json`` (qwen's
+    # dedicated project-MCP file) so qwen connects to it on boot and ``/mcp``
+    # lists it. Written before launch so the relay's ``bridge.json`` token exists
+    # when qwen spawns ``serve-mcp``; the live tool surface is advertised by the
+    # ``tool_relay.json`` that ``ensure_comment_relay`` writes below. Only when
+    # the relay will actually start (``ensure_comment_relay`` present), else the
+    # registered tools would be dead (serve-mcp with nothing to route calls back
+    # to) — mirrors the opencode-native gating.
     mcp_enabled = server_client is not None and ensure_comment_relay is not None
     if mcp_enabled:
-        write_mcp_config(Path(workspace), bridge_dir)
+        # ``None`` means an existing ``.mcp.json`` couldn't be parsed and was
+        # left untouched (fail-safe, see ``write_mcp_config``); skip the rest of
+        # the MCP wiring so the TUI doesn't read a stale/absent approval.
+        if write_mcp_config(Path(workspace), bridge_dir) is None:
+            mcp_enabled = False
+            _logger.warning(
+                "qwen-native: existing .mcp.json could not be parsed; skipping "
+                "Omnigent MCP wiring to avoid overwriting it (session %s).",
+                session_id,
+            )
         # A project-scoped MCP server is gated behind qwen's "Untrusted MCP
         # server" startup prompt; pre-approve it non-interactively (qwen's own
         # ``mcp approve``, hash-exact) so the relay starts and ``/mcp`` lists it
         # without a manual in-terminal step. Run with the SAME cwd + approvals
         # env the TUI launches with (see ``mcp_launch_env`` in the spec below).
-        if not approve_mcp_server(Path(workspace), bridge_dir, qwen_command=qwen_command):
+        elif not approve_mcp_server(Path(workspace), bridge_dir, qwen_command=qwen_command):
             _logger.warning(
                 "qwen-native: could not pre-approve the omnigent MCP server for "
                 "session %s; qwen will show its in-terminal trust prompt.",

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2796,11 +2796,9 @@ async def _auto_create_qwen_terminal(
     # drop the prior terminal's stale forward cursor + queued input.
     await _cancel_auto_forwarder_task(session_id)
     from omnigent.qwen_native_bridge import (
-        approve_mcp_server,
         bridge_dir_for_session_id,
         events_file_path,
         input_file_path,
-        mcp_launch_env,
         prepare_bridge_files,
         qwen_session_id_for_conversation,
         qwen_session_recording_exists,
@@ -2857,37 +2855,22 @@ async def _auto_create_qwen_terminal(
         # next resume reads it from the snapshot and forks can carry history.
         await _persist_qwen_external_session_id(server_client, session_id, qwen_session_id)
     # Expose Omnigent's builtin tools (sys_*, load_skill, web_fetch, …) to qwen
-    # by registering the shared MCP relay in ``<workspace>/.mcp.json`` (qwen's
-    # dedicated project-MCP file) so qwen connects to it on boot and ``/mcp``
-    # lists it. Written before launch so the relay's ``bridge.json`` token exists
-    # when qwen spawns ``serve-mcp``; the live tool surface is advertised by the
-    # ``tool_relay.json`` that ``ensure_comment_relay`` writes below. Only when
-    # the relay will actually start (``ensure_comment_relay`` present), else the
+    # via the shared MCP relay, passed through qwen's ``--mcp-config`` flag (the
+    # claude-native model). The config lives in the bridge dir — never the
+    # workspace — so we drop no file in the user's repo and concurrent
+    # same-workspace sessions can't collide; CLI-provided servers are also ungated
+    # (no "Untrusted MCP server" prompt), so no pre-approval step is needed.
+    # Written before launch so the relay's ``bridge.json`` token exists when qwen
+    # spawns ``serve-mcp``; the live tool surface is advertised by the
+    # ``tool_relay.json`` that ``ensure_comment_relay`` writes below. Only when the
+    # relay will actually start (``ensure_comment_relay`` present), else the
     # registered tools would be dead (serve-mcp with nothing to route calls back
     # to) — mirrors the opencode-native gating.
     mcp_enabled = server_client is not None and ensure_comment_relay is not None
+    mcp_args: list[str] = []
     if mcp_enabled:
-        # ``None`` means an existing ``.mcp.json`` couldn't be parsed and was
-        # left untouched (fail-safe, see ``write_mcp_config``); skip the rest of
-        # the MCP wiring so the TUI doesn't read a stale/absent approval.
-        if write_mcp_config(Path(workspace), bridge_dir) is None:
-            mcp_enabled = False
-            _logger.warning(
-                "qwen-native: existing .mcp.json could not be parsed; skipping "
-                "Omnigent MCP wiring to avoid overwriting it (session %s).",
-                session_id,
-            )
-        # A project-scoped MCP server is gated behind qwen's "Untrusted MCP
-        # server" startup prompt; pre-approve it non-interactively (qwen's own
-        # ``mcp approve``, hash-exact) so the relay starts and ``/mcp`` lists it
-        # without a manual in-terminal step. Run with the SAME cwd + approvals
-        # env the TUI launches with (see ``mcp_launch_env`` in the spec below).
-        elif not approve_mcp_server(Path(workspace), bridge_dir, qwen_command=qwen_command):
-            _logger.warning(
-                "qwen-native: could not pre-approve the omnigent MCP server for "
-                "session %s; qwen will show its in-terminal trust prompt.",
-                session_id,
-            )
+        mcp_config = write_mcp_config(bridge_dir)
+        mcp_args = ["--mcp-config", str(mcp_config)]
 
     # The dual-output + input-file flags wire qwen to the bridge; any user
     # ``terminal_launch_args`` (e.g. ``-m <model>``) precede them. Approval stays
@@ -2896,6 +2879,7 @@ async def _auto_create_qwen_terminal(
     qwen_args = [
         *(launch_config.terminal_launch_args or []),
         *resume_args,
+        *mcp_args,
         "--input-file",
         str(in_path),
         "--json-file",
@@ -2910,9 +2894,6 @@ async def _auto_create_qwen_terminal(
             os_env=OSEnvSpec(type="caller_process", cwd=workspace),
             command=qwen_command,
             args=qwen_args,
-            # Point qwen at the per-session MCP-approvals store the pre-approval
-            # above wrote, so the TUI reads our approval (not ~/.qwen's).
-            env=mcp_launch_env(bridge_dir) if mcp_enabled else {},
             scrollback=100_000,
             tmux_allow_passthrough=True,
             tmux_start_on_attach=False,

--- a/tests/test_qwen_native_bridge.py
+++ b/tests/test_qwen_native_bridge.py
@@ -82,9 +82,7 @@ def test_mcp_launch_env_points_at_per_session_approvals(tmp_path: Path) -> None:
     """The launch env isolates the approvals store inside the bridge dir."""
     bridge_dir = tmp_path / "bridge"
     env = qwen_native_bridge.mcp_launch_env(bridge_dir)
-    assert env == {
-        "QWEN_CODE_MCP_APPROVALS_PATH": str(bridge_dir / "mcpApprovals.json")
-    }
+    assert env == {"QWEN_CODE_MCP_APPROVALS_PATH": str(bridge_dir / "mcpApprovals.json")}
 
 
 def test_approve_mcp_server_runs_qwen_with_workspace_cwd_and_env(
@@ -110,9 +108,7 @@ def test_approve_mcp_server_runs_qwen_with_workspace_cwd_and_env(
     assert calls["cwd"] == str(workspace)
     # The approve must target the SAME isolated store the TUI will read.
     assert isinstance(calls["env"], dict)
-    assert calls["env"]["QWEN_CODE_MCP_APPROVALS_PATH"] == str(
-        bridge_dir / "mcpApprovals.json"
-    )
+    assert calls["env"]["QWEN_CODE_MCP_APPROVALS_PATH"] == str(bridge_dir / "mcpApprovals.json")
 
 
 def test_approve_mcp_server_returns_false_on_failure(

--- a/tests/test_qwen_native_bridge.py
+++ b/tests/test_qwen_native_bridge.py
@@ -1,0 +1,143 @@
+"""Unit tests for qwen-native MCP bridge config wiring."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omnigent import qwen_native_bridge
+
+
+def test_write_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
+    """``write_mcp_config`` writes the omnigent server into ``.qwen/settings.json``."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    bridge_dir = tmp_path / "bridge"
+
+    path = qwen_native_bridge.write_mcp_config(workspace, bridge_dir)
+
+    assert path == workspace / ".qwen" / "settings.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    server = data["mcpServers"]["omnigent"]
+    # Points at the shared stdio relay implemented in claude_native_bridge.
+    assert server["args"][:4] == ["-I", "-m", "omnigent.claude_native_bridge", "serve-mcp"]
+    assert str(bridge_dir) in server["args"]
+    # trust:true auto-approves qwen's own MCP gate (Omnigent gates separately).
+    assert server["trust"] is True
+    # The relay's bearer token was written for ``serve-mcp`` to read at startup.
+    assert (bridge_dir / "bridge.json").is_file()
+    token = json.loads((bridge_dir / "bridge.json").read_text())["token"]
+    assert isinstance(token, str) and token
+
+
+def test_write_mcp_config_preserves_existing_settings(tmp_path: Path) -> None:
+    """Merging into an existing settings.json keeps unrelated keys and servers."""
+    workspace = tmp_path / "ws"
+    settings_dir = workspace / ".qwen"
+    settings_dir.mkdir(parents=True)
+    settings = settings_dir / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "theme": "dark",
+                "mcpServers": {"other": {"command": "x"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
+
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["theme"] == "dark"
+    assert set(data["mcpServers"]) == {"other", "omnigent"}
+
+
+def test_write_mcp_config_recovers_from_malformed_settings(tmp_path: Path) -> None:
+    """A malformed settings.json is replaced rather than crashing the launch."""
+    workspace = tmp_path / "ws"
+    settings_dir = workspace / ".qwen"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.json").write_text("{ not json", encoding="utf-8")
+
+    qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
+
+    data = json.loads((settings_dir / "settings.json").read_text(encoding="utf-8"))
+    assert "omnigent" in data["mcpServers"]
+
+
+def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:
+    """The relay token is generated once and preserved across re-launches."""
+    bridge_dir = tmp_path / "bridge"
+    qwen_native_bridge.write_mcp_bridge_config(bridge_dir)
+    first = (bridge_dir / "bridge.json").read_text()
+    qwen_native_bridge.write_mcp_bridge_config(bridge_dir)
+    assert (bridge_dir / "bridge.json").read_text() == first
+
+
+def test_mcp_launch_env_points_at_per_session_approvals(tmp_path: Path) -> None:
+    """The launch env isolates the approvals store inside the bridge dir."""
+    bridge_dir = tmp_path / "bridge"
+    env = qwen_native_bridge.mcp_launch_env(bridge_dir)
+    assert env == {
+        "QWEN_CODE_MCP_APPROVALS_PATH": str(bridge_dir / "mcpApprovals.json")
+    }
+
+
+def test_approve_mcp_server_runs_qwen_with_workspace_cwd_and_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``approve_mcp_server`` invokes ``qwen mcp approve`` with the launch cwd/env."""
+    calls: dict[str, object] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls["cmd"] = cmd
+        calls["cwd"] = kwargs.get("cwd")
+        calls["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(qwen_native_bridge.subprocess, "run", _fake_run)
+    workspace = tmp_path / "ws"
+    bridge_dir = tmp_path / "bridge"
+
+    assert qwen_native_bridge.approve_mcp_server(
+        workspace, bridge_dir, qwen_command="/usr/bin/qwen"
+    )
+    assert calls["cmd"] == ["/usr/bin/qwen", "mcp", "approve", "omnigent"]
+    assert calls["cwd"] == str(workspace)
+    # The approve must target the SAME isolated store the TUI will read.
+    assert isinstance(calls["env"], dict)
+    assert calls["env"]["QWEN_CODE_MCP_APPROVALS_PATH"] == str(
+        bridge_dir / "mcpApprovals.json"
+    )
+
+
+def test_approve_mcp_server_returns_false_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-zero ``qwen`` exit degrades to False (caller falls back to prompt)."""
+
+    def _fail(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 1, "", "boom")
+
+    monkeypatch.setattr(qwen_native_bridge.subprocess, "run", _fail)
+    assert not qwen_native_bridge.approve_mcp_server(
+        tmp_path / "ws", tmp_path / "bridge", qwen_command="/usr/bin/qwen"
+    )
+
+
+def test_approve_mcp_server_handles_missing_executable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing qwen binary (OSError) degrades to False, never raising."""
+
+    def _raise(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise OSError("no such file")
+
+    monkeypatch.setattr(qwen_native_bridge.subprocess, "run", _raise)
+    assert not qwen_native_bridge.approve_mcp_server(
+        tmp_path / "ws", tmp_path / "bridge", qwen_command="/nope/qwen"
+    )

--- a/tests/test_qwen_native_bridge.py
+++ b/tests/test_qwen_native_bridge.py
@@ -3,23 +3,21 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
-
-import pytest
 
 from omnigent import qwen_native_bridge
 
 
-def test_write_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
-    """``write_mcp_config`` writes the omnigent server into ``.mcp.json``."""
-    workspace = tmp_path / "ws"
-    workspace.mkdir()
+def test_write_mcp_config_writes_into_bridge_dir_not_workspace(tmp_path: Path) -> None:
+    """``write_mcp_config`` writes the ``--mcp-config`` file inside the bridge dir."""
     bridge_dir = tmp_path / "bridge"
 
-    path = qwen_native_bridge.write_mcp_config(workspace, bridge_dir)
+    path = qwen_native_bridge.write_mcp_config(bridge_dir)
 
-    assert path == workspace / ".mcp.json"
+    # The config lives in the bridge dir — never the workspace (no repo pollution).
+    assert path == bridge_dir / "mcp_config.json"
+    assert path.parent == bridge_dir
+
     data = json.loads(path.read_text(encoding="utf-8"))
     server = data["mcpServers"]["omnigent"]
     # Points at the shared stdio relay implemented in claude_native_bridge.
@@ -33,70 +31,36 @@ def test_write_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
     assert isinstance(token, str) and token
 
 
-def test_write_mcp_config_preserves_existing_servers(tmp_path: Path) -> None:
-    """Merging into an existing .mcp.json keeps a user's own mcpServers."""
-    workspace = tmp_path / "ws"
-    workspace.mkdir()
-    mcp_json = workspace / ".mcp.json"
-    mcp_json.write_text(
-        json.dumps({"mcpServers": {"other": {"command": "x"}}}),
-        encoding="utf-8",
-    )
-
-    qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
-
-    data = json.loads(mcp_json.read_text(encoding="utf-8"))
-    assert set(data["mcpServers"]) == {"other", "omnigent"}
-
-
-def test_write_mcp_config_parses_jsonc_and_preserves_keys(tmp_path: Path) -> None:
-    """A JSONC .mcp.json (comments) is parsed; user servers/keys are preserved."""
-    workspace = tmp_path / "ws"
-    workspace.mkdir()
-    mcp_json = workspace / ".mcp.json"
-    mcp_json.write_text(
-        """{
-          // a user's own server
-          "mcpServers": {
-            "other": {"command": "x"} /* inline */
-          }
-        }""",
-        encoding="utf-8",
-    )
-
-    path = qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
-
-    assert path is not None
+def test_write_mcp_config_is_valid_for_qwen_mcp_config_flag(tmp_path: Path) -> None:
+    """The payload is the ``{"mcpServers": {...}}`` shape qwen's --mcp-config expects."""
+    path = qwen_native_bridge.write_mcp_config(tmp_path / "bridge")
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert set(data["mcpServers"]) == {"other", "omnigent"}
+    assert set(data) == {"mcpServers"}
+    assert set(data["mcpServers"]) == {"omnigent"}
 
 
-def test_write_mcp_config_aborts_on_unparseable_file(tmp_path: Path) -> None:
-    """A non-empty file we can't parse even as JSONC is left untouched (returns None)."""
-    workspace = tmp_path / "ws"
-    workspace.mkdir()
-    mcp_json = workspace / ".mcp.json"
-    original = '{ "deeply": broken not json'
-    mcp_json.write_text(original, encoding="utf-8")
+def test_write_mcp_config_path_is_per_session(tmp_path: Path) -> None:
+    """Two sessions get independent config files carrying their own bridge dir."""
+    bridge_a = tmp_path / "a"
+    bridge_b = tmp_path / "b"
+    path_a = qwen_native_bridge.write_mcp_config(bridge_a)
+    path_b = qwen_native_bridge.write_mcp_config(bridge_b)
 
-    result = qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
+    assert path_a != path_b
+    args_a = json.loads(path_a.read_text())["mcpServers"]["omnigent"]["args"]
+    args_b = json.loads(path_b.read_text())["mcpServers"]["omnigent"]["args"]
+    assert str(bridge_a) in args_a
+    assert str(bridge_b) in args_b
+    # No cross-contamination: A's config never points at B's bridge dir.
+    assert str(bridge_b) not in args_a
 
-    assert result is None
-    # The user's file must be left exactly as it was — never overwritten.
-    assert mcp_json.read_text(encoding="utf-8") == original
 
-
-def test_write_mcp_config_aborts_on_non_object_json(tmp_path: Path) -> None:
-    """A valid-but-non-object .mcp.json (e.g. a list) is not clobbered."""
-    workspace = tmp_path / "ws"
-    workspace.mkdir()
-    mcp_json = workspace / ".mcp.json"
-    mcp_json.write_text("[1, 2, 3]", encoding="utf-8")
-
-    result = qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
-
-    assert result is None
-    assert mcp_json.read_text(encoding="utf-8") == "[1, 2, 3]"
+def test_mcp_config_path_matches_written_path(tmp_path: Path) -> None:
+    """``mcp_config_path`` reports the same path ``write_mcp_config`` writes."""
+    bridge_dir = tmp_path / "bridge"
+    assert qwen_native_bridge.write_mcp_config(bridge_dir) == (
+        qwen_native_bridge.mcp_config_path(bridge_dir)
+    )
 
 
 def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:
@@ -106,64 +70,3 @@ def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:
     first = (bridge_dir / "bridge.json").read_text()
     qwen_native_bridge.write_mcp_bridge_config(bridge_dir)
     assert (bridge_dir / "bridge.json").read_text() == first
-
-
-def test_mcp_launch_env_points_at_per_session_approvals(tmp_path: Path) -> None:
-    """The launch env isolates the approvals store inside the bridge dir."""
-    bridge_dir = tmp_path / "bridge"
-    env = qwen_native_bridge.mcp_launch_env(bridge_dir)
-    assert env == {"QWEN_CODE_MCP_APPROVALS_PATH": str(bridge_dir / "mcpApprovals.json")}
-
-
-def test_approve_mcp_server_runs_qwen_with_workspace_cwd_and_env(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``approve_mcp_server`` invokes ``qwen mcp approve`` with the launch cwd/env."""
-    calls: dict[str, object] = {}
-
-    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls["cmd"] = cmd
-        calls["cwd"] = kwargs.get("cwd")
-        calls["env"] = kwargs.get("env")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    monkeypatch.setattr(qwen_native_bridge.subprocess, "run", _fake_run)
-    workspace = tmp_path / "ws"
-    bridge_dir = tmp_path / "bridge"
-
-    assert qwen_native_bridge.approve_mcp_server(
-        workspace, bridge_dir, qwen_command="/usr/bin/qwen"
-    )
-    assert calls["cmd"] == ["/usr/bin/qwen", "mcp", "approve", "omnigent"]
-    assert calls["cwd"] == str(workspace)
-    # The approve must target the SAME isolated store the TUI will read.
-    assert isinstance(calls["env"], dict)
-    assert calls["env"]["QWEN_CODE_MCP_APPROVALS_PATH"] == str(bridge_dir / "mcpApprovals.json")
-
-
-def test_approve_mcp_server_returns_false_on_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A non-zero ``qwen`` exit degrades to False (caller falls back to prompt)."""
-
-    def _fail(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(cmd, 1, "", "boom")
-
-    monkeypatch.setattr(qwen_native_bridge.subprocess, "run", _fail)
-    assert not qwen_native_bridge.approve_mcp_server(
-        tmp_path / "ws", tmp_path / "bridge", qwen_command="/usr/bin/qwen"
-    )
-
-
-def test_approve_mcp_server_handles_missing_executable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A missing qwen binary (OSError) degrades to False, never raising."""
-
-    def _raise(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise OSError("no such file")
-
-    monkeypatch.setattr(qwen_native_bridge.subprocess, "run", _raise)
-    assert not qwen_native_bridge.approve_mcp_server(
-        tmp_path / "ws", tmp_path / "bridge", qwen_command="/nope/qwen"
-    )

--- a/tests/test_qwen_native_bridge.py
+++ b/tests/test_qwen_native_bridge.py
@@ -12,14 +12,14 @@ from omnigent import qwen_native_bridge
 
 
 def test_write_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
-    """``write_mcp_config`` writes the omnigent server into ``.qwen/settings.json``."""
+    """``write_mcp_config`` writes the omnigent server into ``.mcp.json``."""
     workspace = tmp_path / "ws"
     workspace.mkdir()
     bridge_dir = tmp_path / "bridge"
 
     path = qwen_native_bridge.write_mcp_config(workspace, bridge_dir)
 
-    assert path == workspace / ".qwen" / "settings.json"
+    assert path == workspace / ".mcp.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     server = data["mcpServers"]["omnigent"]
     # Points at the shared stdio relay implemented in claude_native_bridge.
@@ -33,40 +33,70 @@ def test_write_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
     assert isinstance(token, str) and token
 
 
-def test_write_mcp_config_preserves_existing_settings(tmp_path: Path) -> None:
-    """Merging into an existing settings.json keeps unrelated keys and servers."""
+def test_write_mcp_config_preserves_existing_servers(tmp_path: Path) -> None:
+    """Merging into an existing .mcp.json keeps a user's own mcpServers."""
     workspace = tmp_path / "ws"
-    settings_dir = workspace / ".qwen"
-    settings_dir.mkdir(parents=True)
-    settings = settings_dir / "settings.json"
-    settings.write_text(
-        json.dumps(
-            {
-                "theme": "dark",
-                "mcpServers": {"other": {"command": "x"}},
-            }
-        ),
+    workspace.mkdir()
+    mcp_json = workspace / ".mcp.json"
+    mcp_json.write_text(
+        json.dumps({"mcpServers": {"other": {"command": "x"}}}),
         encoding="utf-8",
     )
 
     qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
 
-    data = json.loads(settings.read_text(encoding="utf-8"))
-    assert data["theme"] == "dark"
+    data = json.loads(mcp_json.read_text(encoding="utf-8"))
     assert set(data["mcpServers"]) == {"other", "omnigent"}
 
 
-def test_write_mcp_config_recovers_from_malformed_settings(tmp_path: Path) -> None:
-    """A malformed settings.json is replaced rather than crashing the launch."""
+def test_write_mcp_config_parses_jsonc_and_preserves_keys(tmp_path: Path) -> None:
+    """A JSONC .mcp.json (comments) is parsed; user servers/keys are preserved."""
     workspace = tmp_path / "ws"
-    settings_dir = workspace / ".qwen"
-    settings_dir.mkdir(parents=True)
-    (settings_dir / "settings.json").write_text("{ not json", encoding="utf-8")
+    workspace.mkdir()
+    mcp_json = workspace / ".mcp.json"
+    mcp_json.write_text(
+        """{
+          // a user's own server
+          "mcpServers": {
+            "other": {"command": "x"} /* inline */
+          }
+        }""",
+        encoding="utf-8",
+    )
 
-    qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
+    path = qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
 
-    data = json.loads((settings_dir / "settings.json").read_text(encoding="utf-8"))
-    assert "omnigent" in data["mcpServers"]
+    assert path is not None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert set(data["mcpServers"]) == {"other", "omnigent"}
+
+
+def test_write_mcp_config_aborts_on_unparseable_file(tmp_path: Path) -> None:
+    """A non-empty file we can't parse even as JSONC is left untouched (returns None)."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    mcp_json = workspace / ".mcp.json"
+    original = '{ "deeply": broken not json'
+    mcp_json.write_text(original, encoding="utf-8")
+
+    result = qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
+
+    assert result is None
+    # The user's file must be left exactly as it was — never overwritten.
+    assert mcp_json.read_text(encoding="utf-8") == original
+
+
+def test_write_mcp_config_aborts_on_non_object_json(tmp_path: Path) -> None:
+    """A valid-but-non-object .mcp.json (e.g. a list) is not clobbered."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    mcp_json = workspace / ".mcp.json"
+    mcp_json.write_text("[1, 2, 3]", encoding="utf-8")
+
+    result = qwen_native_bridge.write_mcp_config(workspace, tmp_path / "bridge")
+
+    assert result is None
+    assert mcp_json.read_text(encoding="utf-8") == "[1, 2, 3]"
 
 
 def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_qwen_native_bridge.py
+++ b/tests/test_qwen_native_bridge.py
@@ -5,13 +5,27 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from omnigent import qwen_native_bridge
 
 
-def test_write_mcp_config_writes_into_bridge_dir_not_workspace(tmp_path: Path) -> None:
-    """``write_mcp_config`` writes the ``--mcp-config`` file inside the bridge dir."""
-    bridge_dir = tmp_path / "bridge"
+@pytest.fixture
+def bridge_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A bridge dir under a production-shaped qwen root (passes secure validation).
 
+    ``write_mcp_bridge_config`` now hardens the bridge tree via
+    ``_ensure_secure_dir``, which requires the dir to live below a known bridge
+    root. Mirror the real layout (``<uid-scoped temp>/qwen-native/<digest>``) so
+    the owner-only ancestor walk anchors at ``tmp_path``.
+    """
+    root = tmp_path / "omnigent-test" / "qwen-native"
+    monkeypatch.setattr(qwen_native_bridge, "_BRIDGE_ROOT", root)
+    return qwen_native_bridge.bridge_dir_for_session_id("sess")
+
+
+def test_write_mcp_config_writes_into_bridge_dir_not_workspace(bridge_dir: Path) -> None:
+    """``write_mcp_config`` writes the ``--mcp-config`` file inside the bridge dir."""
     path = qwen_native_bridge.write_mcp_config(bridge_dir)
 
     # The config lives in the bridge dir — never the workspace (no repo pollution).
@@ -31,18 +45,22 @@ def test_write_mcp_config_writes_into_bridge_dir_not_workspace(tmp_path: Path) -
     assert isinstance(token, str) and token
 
 
-def test_write_mcp_config_is_valid_for_qwen_mcp_config_flag(tmp_path: Path) -> None:
+def test_write_mcp_config_is_valid_for_qwen_mcp_config_flag(bridge_dir: Path) -> None:
     """The payload is the ``{"mcpServers": {...}}`` shape qwen's --mcp-config expects."""
-    path = qwen_native_bridge.write_mcp_config(tmp_path / "bridge")
+    path = qwen_native_bridge.write_mcp_config(bridge_dir)
     data = json.loads(path.read_text(encoding="utf-8"))
     assert set(data) == {"mcpServers"}
     assert set(data["mcpServers"]) == {"omnigent"}
 
 
-def test_write_mcp_config_path_is_per_session(tmp_path: Path) -> None:
+def test_write_mcp_config_path_is_per_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Two sessions get independent config files carrying their own bridge dir."""
-    bridge_a = tmp_path / "a"
-    bridge_b = tmp_path / "b"
+    root = tmp_path / "omnigent-test" / "qwen-native"
+    monkeypatch.setattr(qwen_native_bridge, "_BRIDGE_ROOT", root)
+    bridge_a = qwen_native_bridge.bridge_dir_for_session_id("a")
+    bridge_b = qwen_native_bridge.bridge_dir_for_session_id("b")
     path_a = qwen_native_bridge.write_mcp_config(bridge_a)
     path_b = qwen_native_bridge.write_mcp_config(bridge_b)
 
@@ -55,18 +73,41 @@ def test_write_mcp_config_path_is_per_session(tmp_path: Path) -> None:
     assert str(bridge_b) not in args_a
 
 
-def test_mcp_config_path_matches_written_path(tmp_path: Path) -> None:
+def test_mcp_config_path_matches_written_path(bridge_dir: Path) -> None:
     """``mcp_config_path`` reports the same path ``write_mcp_config`` writes."""
-    bridge_dir = tmp_path / "bridge"
     assert qwen_native_bridge.write_mcp_config(bridge_dir) == (
         qwen_native_bridge.mcp_config_path(bridge_dir)
     )
 
 
-def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:
+def test_write_mcp_bridge_config_is_idempotent(bridge_dir: Path) -> None:
     """The relay token is generated once and preserved across re-launches."""
-    bridge_dir = tmp_path / "bridge"
     qwen_native_bridge.write_mcp_bridge_config(bridge_dir)
     first = (bridge_dir / "bridge.json").read_text()
     qwen_native_bridge.write_mcp_bridge_config(bridge_dir)
     assert (bridge_dir / "bridge.json").read_text() == first
+
+
+def test_write_mcp_bridge_config_rejects_symlinked_ancestor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A symlinked bridge-tree ancestor is refused — the token is never written.
+
+    bridge.json holds a bearer token, so the dir must pass owner-only ancestor
+    validation. If an attacker pre-creates an ancestor as a symlink, writing the
+    token must fail loudly rather than land it in attacker-redirectable storage.
+    """
+    real_root = tmp_path / "omnigent-test"
+    qwen_root = real_root / "qwen-native"
+    monkeypatch.setattr(qwen_native_bridge, "_BRIDGE_ROOT", qwen_root)
+    bridge_dir = qwen_native_bridge.bridge_dir_for_session_id("sess")
+
+    # Redirect an ancestor (the uid-scoped dir) through a symlink.
+    elsewhere = tmp_path / "attacker"
+    elsewhere.mkdir()
+    real_root.symlink_to(elsewhere, target_is_directory=True)
+
+    with pytest.raises(RuntimeError):
+        qwen_native_bridge.write_mcp_bridge_config(bridge_dir)
+    # No token leaked into the redirected location.
+    assert not (elsewhere / "qwen-native").exists()


### PR DESCRIPTION
## What

Supports Omnigent MCPs in native-qwen mode — the qwen TUI now connects to Omnigent's builtin tools (`sys_*`, `load_skill`, `web_fetch`, …) and `/mcp` lists the `omnigent` server.

## How

- **Pass the relay via `--mcp-config`.** The runner writes a per-session MCP config (`{"mcpServers": {"omnigent": …}}`, `trust: true`) and passes its path to qwen via the `--mcp-config <path>` launch flag — the same model claude-native uses (`--mcp-config`, no workspace file). It points at the **shared** stdio relay (`omnigent.claude_native_bridge serve-mcp`) that cursor-/claude-/opencode-native already reuse. Written before launch so the relay's `bridge.json` token exists when qwen spawns `serve-mcp`; the live tool surface is advertised by the `tool_relay.json` that the existing `ensure_comment_relay` writes.
- **Config lives in the bridge dir, never the workspace.** This drops no file in the user's (often git) repo, is per-session by construction (so concurrent same-workspace sessions can't collide on a shared file or its `--bridge-dir`), and — because CLI-provided MCP servers carry no project/workspace scope — is **not** gated behind qwen's "Untrusted MCP server" prompt, so no pre-approval step is needed.
- `trust: true` suppresses qwen's per-tool-call confirmation; Omnigent's own policy/elicitation gate still runs (every relayed call goes through `ProxyMcpManager.call_tool`).

All wiring is gated on the comment relay being present (else the registered tools would be dead), mirroring the opencode-native gating.

## Review history

An earlier revision wrote into a project file (first `.qwen/settings.json`, then `.mcp.json`) and pre-approved it via `qwen mcp approve`. Review (Polly + these findings) flagged: clobbering the shared JSONC `settings.json`, a last-writer-wins race on the shared workspace file for concurrent same-workspace sessions, and workspace-root pollution with no teardown. Verifying qwen's source showed `--mcp-config` servers are ungated and need no workspace file — so this revision switches to `--mcp-config`, which resolves all of those at the root and deletes the JSONC-merge and pre-approval machinery entirely.

## Testing

- `tests/test_qwen_native_bridge.py`: config shape for `--mcp-config`, per-session isolation (each session's config carries only its own bridge dir), config-path accessor, relay-token idempotency.
- Verified end-to-end against real `qwen` v0.18.x: launching with `--mcp-config` spawns the `omnigent serve-mcp` relay on boot with no trust prompt, and the workspace stays clean (no file dropped).
- Existing qwen suites pass; ruff format + check clean.