### PR TITLE
fix(ci): tag the PR merger as docs reviewer and always attempt the request

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -1,6 +1,6 @@
 # Keep omnigent-site docs in sync with merged PRs: on push to main, resolve the
 # merged PR from the commit, classify its doc impact, label it, and — if it needs
-# docs — draft an omnigent-site PR tagging the author. Plan → classify
+# docs — draft an omnigent-site PR tagging the merging maintainer. Plan → classify
 # (doc-classifier) → label → draft (doc-drafter) → open site PR.
 #
 # Why push:[main], not pull_request_target: a fork PR's `closed` event is gated by
@@ -69,15 +69,16 @@ jobs:
           event = os.environ.get("GITHUB_EVENT_NAME", "")
           payload = json.load(open(os.environ["GITHUB_EVENT_PATH"]))
           classify = predraft = False
-          pr = author = title = ""
+          pr = author = title = merger = ""
 
           repo = os.environ["CODE_REPO"]
           if event == "workflow_dispatch":
               pr = os.environ.get("INPUT_PR", "").strip()
               meta = json.loads(subprocess.run(
                   ["gh", "pr", "view", pr, "--repo", repo,
-                   "--json", "author,title"], capture_output=True, text=True).stdout or "{}")
+                   "--json", "author,title,mergedBy"], capture_output=True, text=True).stdout or "{}")
               author = (meta.get("author") or {}).get("login", "")
+              merger = (meta.get("mergedBy") or {}).get("login", "")
               title = meta.get("title", "")
               classify = True  # manual run: classify, and draft if needs-doc
           elif event == "push":
@@ -100,6 +101,12 @@ jobs:
                   p = prs[0]
                   pr = str(p["number"]); author = p.get("author") or ""; title = p.get("title", "")
                   labels = p.get("labels", [])
+                  # The commits→pulls list omits merged_by; fetch it from the PR
+                  # object. The merger is the maintainer who clicked merge — the right
+                  # docs reviewer even when the author is an outside contributor.
+                  merger = subprocess.run(
+                      ["gh", "api", f"repos/{repo}/pulls/{pr}", "--jq", ".merged_by.login // \"\""],
+                      capture_output=True, text=True).stdout.strip()
                   if NO in labels:
                       pass                       # human set no-doc-update → skip
                   elif NEEDS in labels:
@@ -112,12 +119,13 @@ jobs:
           with open(out, "a") as fh:
               fh.write(f"pr={pr}\n")
               fh.write(f"author={author}\n")
+              fh.write(f"merger={merger}\n")
               fh.write(f"classify={'true' if classify else 'false'}\n")
               fh.write(f"predraft={'true' if predraft else 'false'}\n")
               fh.write(f"proceed={'true' if proceed else 'false'}\n")
           # Title can contain anything → pass via file, not output.
           open("/tmp/pr_title.txt", "w").write(title)
-          print(f"event={event} pr={pr} author={author} classify={classify} predraft={predraft}")
+          print(f"event={event} pr={pr} author={author} merger={merger} classify={classify} predraft={predraft}")
           PYEOF
 
       - name: Check LLM credentials
@@ -477,28 +485,36 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.site-token.outputs.token || github.token }}
           AUTHOR: ${{ steps.plan.outputs.author }}
+          MERGER: ${{ steps.plan.outputs.merger }}
           PR_NUMBER: ${{ steps.plan.outputs.pr }}
         run: |
           set -euo pipefail
           python3 -u <<'PYEOF'
-          import os, re, json, subprocess, pathlib
+          import os, re, pathlib
           site = os.environ["SITE_REPO_SLUG"]; code = os.environ["CODE_REPO"]
-          author = os.environ.get("AUTHOR", ""); pr = os.environ["PR_NUMBER"]
+          author = os.environ.get("AUTHOR", ""); merger = os.environ.get("MERGER", "")
+          pr = os.environ["PR_NUMBER"]
           title = pathlib.Path("/tmp/pr_title.txt").read_text().strip()
           raw = pathlib.Path("/tmp/draft_out.txt").read_text()
           m = re.search(r"<!--\s*DOC_DRAFT_SUMMARY\s*-->", raw)
           summary = raw[m.end():].strip() if m else "_(drafter produced edits but no summary)_"
 
-          # Tag the source-PR author: request review if they're a site collaborator,
-          # else @-mention. Skip bots / the CI identity.
-          reviewer = ""; mention = ""
-          if author and not author.endswith("[bot]") and author != "omnigent-ci":
-              r = subprocess.run(["gh", "api", f"repos/{site}/collaborators/{author}", "--silent"],
-                                 capture_output=True, text=True)
-              if r.returncode == 0:
-                  reviewer = author
-              else:
-                  mention = f"@{author}"
+          # Tag the maintainer who MERGED the PR — the author may be an outside
+          # contributor with no site access, but a maintainer always merges. Fall back
+          # to the author when there's no usable merger (e.g. a manual run on an
+          # unmerged PR). Skip bots / the CI identity.
+          def usable(login):
+              return bool(login) and not login.endswith("[bot]") and login != "omnigent-ci"
+          if usable(merger):
+              reviewer, role = merger, "merged by"
+          elif usable(author):
+              reviewer, role = author, "author"
+          else:
+              reviewer, role = "", ""
+          # @-mention in the body AND request review downstream: the review request is
+          # best-effort (GitHub rejects non-collaborators), so the mention is the
+          # durable ping — it reaches concealed org members too.
+          mention = f" · {role} @{reviewer}" if reviewer else ""
 
           body = f"""<!-- doc-sync -->
           Documentation update for **{code}#{pr}** — {title}
@@ -506,7 +522,7 @@ jobs:
           {summary}
 
           ---
-          Source PR: {code}#{pr}{(' · author ' + mention) if mention else ''}
+          Source PR: {code}#{pr}{mention}
           <sub>Drafted automatically by the doc-sync workflow. Review for accuracy before merging.</sub>
           """
           body = "\n".join(l[10:] if l.startswith(" "*10) else l for l in body.splitlines())
@@ -564,24 +580,32 @@ jobs:
           # bot commits.
           git push --force "$PUSH_URL" "$BRANCH"
 
-          REVIEWER_ARG=()
-          [ -n "${REVIEWER}" ] && REVIEWER_ARG=(--reviewer "${REVIEWER}")
           EXISTING="$(gh pr list --repo "$SITE_REPO_SLUG" --head "$BRANCH" --state open \
               --json number --jq '.[0].number // empty' 2>/dev/null || true)"
           if [ -n "$EXISTING" ]; then
             gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" --body-file /tmp/site_pr_body.md || true
-            [ -n "${REVIEWER}" ] && gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" --add-reviewer "${REVIEWER}" || true
             echo "Updated site PR #$EXISTING."
           else
             gh label create automated-docs --repo "$SITE_REPO_SLUG" --color 0E8A16 \
               --description "Automated documentation update" 2>/dev/null || true
             if gh pr create --repo "$SITE_REPO_SLUG" --base main --head "$BRANCH" \
                 --title "docs: document ${CODE_REPO}#${PR_NUMBER}" \
-                --label automated-docs --body-file /tmp/site_pr_body.md "${REVIEWER_ARG[@]}"; then
+                --label automated-docs --body-file /tmp/site_pr_body.md; then
+              EXISTING="$(gh pr list --repo "$SITE_REPO_SLUG" --head "$BRANCH" --state open \
+                  --json number --jq '.[0].number // empty' 2>/dev/null || true)"
               echo "Opened site PR for $BRANCH."
             else
               echo "::warning::Could not open the site PR automatically. Branch '$BRANCH' is pushed."
             fi
+          fi
+
+          # Always attempt the review request, decoupled from PR creation so a
+          # non-addable reviewer can't fail the open. GitHub returns 422 for users it
+          # can't add (non-collaborators / concealed org members); tolerate it — the
+          # reviewer is also @-mentioned in the body as a durable fallback ping.
+          if [ -n "${REVIEWER}" ] && [ -n "${EXISTING}" ]; then
+            gh pr edit "$EXISTING" --repo "$SITE_REPO_SLUG" --add-reviewer "${REVIEWER}" \
+              || echo "::notice::Could not request review from ${REVIEWER} (not addable); they're @-mentioned in the PR body."
           fi
 
       - name: Note draft skipped (no site token)


### PR DESCRIPTION
## Problem

In `doc-sync.yml`, the reviewer on the drafted omnigent-site PR was resolved from the **source-PR author**, and was only added via `--reviewer` if a collaborator pre-check passed (`gh api repos/<site>/collaborators/<user>`); otherwise the author was merely `@`-mentioned. Two failure modes:

1. **Community PRs** are authored by non-maintainers who can't review the docs PR anyway — but a maintainer always merges it.
2. The collaborator pre-check runs with the **omnigent-ci App token**, which can't see *concealed* org members. Maintainers with private org membership (e.g. `@serena-ruan`) silently fell through to a plain `@`-mention and had to be added as reviewers by hand. Maintainers with public membership (e.g. `@fanzeyi`) were tagged correctly — hence the inconsistency.

## Fix

- **Tag the merger, not the author.** Resolve `merged_by` (push path: an extra `gh api .../pulls/<n>` call, since the commits→pulls list omits it; manual path: `mergedBy` added to `gh pr view --json`). Fall back to the author only when there's no usable merger (e.g. a manual run on an unmerged PR). Bots / `omnigent-ci` are still skipped.
- **Always attempt the review request.** Drop the collaborator pre-check entirely. The `--add-reviewer` call is now decoupled from PR creation so a non-addable user can't fail the open, and GitHub's 422 (non-collaborator / concealed member) is tolerated. The reviewer is also `@`-mentioned in the PR body as a durable fallback ping that reaches concealed org members.

## Notes

- Validated: YAML parses and all embedded Python heredocs compile.
- The review request is attempted on every run for a given source PR (the rolling branch is force-pushed and the step re-runs) — this matches prior behavior for collaborators, so it's not a regression, but a reviewer who already approved may get re-requested on a later update.

This pull request and its description were written by Isaac.
