### PR TITLE
feat(web): drill into agent picker submenus in place on mobile

### DIFF
--- a/web/src/hooks/useIsMobileViewport.ts
+++ b/web/src/hooks/useIsMobileViewport.ts
@@ -1,0 +1,35 @@
+// Reactive "is this a mobile-width viewport?" hook.
+//
+// The shell's responsive layout pivots on Tailwind's `md` breakpoint
+// (`min-width: 768px`), used both as CSS classes (`md:` / `max-md:`) and as
+// the JS threshold in AppShell's `initialSidebarOpen`. This hook exposes the
+// `max-md` side of that line to component logic that can't be expressed in
+// CSS alone (e.g. swapping a hover flyout for an in-place page on touch).
+
+import { useSyncExternalStore } from "react";
+
+// Mirror Tailwind's `max-md` variant exactly so this hook stays in lockstep
+// with the `max-md:` / `md:` classes already used across the shell.
+const MOBILE_QUERY = "(max-width: 767.98px)";
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const mql = window.matchMedia(MOBILE_QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(MOBILE_QUERY).matches;
+}
+
+/**
+ * True when the viewport is narrower than Tailwind's `md` breakpoint (768px)
+ * — i.e. the "mobile" layout the shell's `max-md:` classes target. Reactive:
+ * components re-render when the viewport crosses the breakpoint. SSR-safe
+ * (returns `false` on the server, matching `initialSidebarOpen`).
+ */
+export function useIsMobileViewport(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1837,3 +1837,99 @@ describe("NewChatLandingScreen @-file-mention", () => {
     expect(screen.queryByText("@README.md")).not.toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Mobile agent picker
+//
+// Touch devices can't hover, so the desktop knob flyout (a Radix sub-menu
+// opened on hover) is unreachable there. Below the `md` breakpoint the picker
+// instead swaps its contents in place: tapping anywhere on a configurable row
+// drills into that agent's knobs on the same surface (and selects it), with a
+// Back row to return. jsdom's matchMedia mock always reports `false`, so these tests
+// force the mobile branch by stubbing it to match the `max-width` query that
+// `useIsMobileViewport()` reads.
+// ---------------------------------------------------------------------------
+
+/**
+ * Make `useIsMobileViewport()` report a mobile (max-md) viewport. Returns a
+ * restore fn. Only the `max-width` query matches, so `min-width` consumers
+ * (e.g. desktop checks) keep reading false.
+ */
+function forceMobileViewport(): () => void {
+  const real = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: /max-width/.test(query),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = real;
+  };
+}
+
+describe("NewChatLandingScreen agent picker (mobile)", () => {
+  let restoreViewport: () => void;
+  beforeEach(() => {
+    setupLandingMocks();
+    restoreViewport = forceMobileViewport();
+  });
+  afterEach(() => {
+    restoreViewport();
+    cleanup();
+    localStorage.clear();
+  });
+
+  /** Open the picker (Radix opens on pointerdown). */
+  function openPicker(): void {
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+  }
+
+  it("drills into an agent's knobs in place when the row is tapped (no hover flyout) and selects it", () => {
+    renderLanding();
+    openPicker();
+    // The list is showing and the knobs are not — there's no hover flyout.
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-approval-full-access")).toBeNull();
+    // Tap anywhere on a2 (Codex)'s row — its approval-mode knobs replace the
+    // list in place, and the tap also commits the pick.
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
+    expect(screen.getByTestId("new-chat-landing-agent-config-page")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-approval-full-access")).toBeTruthy();
+    // The list was replaced (not flown out alongside), so the OTHER agent
+    // row is gone while the knobs page is up.
+    expect(screen.queryByTestId("new-chat-landing-agent-a1")).toBeNull();
+    // Tapping the row selected the agent too — the trigger reflects the pick.
+    expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("Codex");
+  });
+
+  it("returns to the agent list via Back without closing the menu", () => {
+    renderLanding();
+    openPicker();
+    // a1 (Claude Code) is configurable — tapping it drills into its knobs.
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-a1"));
+    expect(screen.getByTestId("new-chat-landing-permission-plan")).toBeTruthy();
+    // Back steps to the list rather than closing: both agents reappear and
+    // the knobs are gone.
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-config-back"));
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-agent-a2")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-permission-plan")).toBeNull();
+  });
+
+  it("reopening after a drill-in lands back on the agent list", () => {
+    renderLanding();
+    openPicker();
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
+    expect(screen.getByTestId("new-chat-landing-agent-config-page")).toBeTruthy();
+    // Close, then reopen — the menu resets to the list, never a stale page.
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    openPicker();
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-agent-config-page")).toBeNull();
+  });
+});

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -7,6 +7,8 @@ import {
   CheckIcon,
   CircleHelpIcon,
   ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   GitBranchIcon,
   ArrowUpIcon,
   FileTextIcon,
@@ -45,6 +47,7 @@ import { sandboxOptionLabel } from "@/lib/capabilities";
 import { isSlashCommandText, SlashCommandMenu } from "@/components/SlashCommandMenu";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { CliCommandBlock } from "./CliCommandBlock";
 import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import { getCliServerUrl } from "@/lib/host";
@@ -1250,11 +1253,44 @@ function AgentHarnessPicker({
   // menu (see the sub-trigger onClick below) without diving into the submenu.
   const [open, setOpen] = useState(false);
 
+  // Touch devices can't hover, so the desktop knob flyout (a Radix sub-menu
+  // that opens on hover) is unreachable there. On mobile we instead swap the
+  // dropdown's contents in place: tapping anywhere on a configurable row
+  // drills into that agent's knobs on the same surface, with a Back row to
+  // return. `mobileKnobsAgentId` is the agent whose knobs are showing (null =
+  // the agent list). Inert on desktop, which keeps the hover flyout.
+  const isMobile = useIsMobileViewport();
+  const [mobileKnobsAgentId, setMobileKnobsAgentId] = useState<string | null>(null);
+
+  // Pin the open direction on mobile. The agent list is tall and often opens
+  // upward (Radix flips it above the trigger when it won't fit below); the
+  // shorter knobs page would fit below and snap back down, so the menu would
+  // jump across the trigger on every drill-in. We instead measure at open
+  // time which side has more room and force it for the whole session
+  // (`avoidCollisions` off), so the in-place swap can't change the direction.
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [mobileSide, setMobileSide] = useState<"top" | "bottom">("bottom");
+
   const hasKnobs = (agent: AvailableAgent): boolean =>
     nativeAgentHasCapability(agent, "permissionMode") ||
     nativeAgentHasCapability(agent, "approvalMode") ||
     nativeAgentHasCapability(agent, "cursorMode") ||
     (agent.harness != null && agent.harness in BRAIN_HARNESS_LABELS);
+
+  // The agent whose knobs page is open, resolved from the live entry lists so
+  // it tracks renames / removals. `showMobileKnobs` gates the page: false on
+  // desktop, or if the agent vanished or lost its knobs (e.g. the list
+  // refreshed) — in which case the effect below clears the id so a reopened
+  // menu lands back on the agent list instead of an empty page.
+  const mobileKnobsAgent =
+    mobileKnobsAgentId != null
+      ? ([...harnessEntries, ...agentEntries].find((a) => a.id === mobileKnobsAgentId) ?? null)
+      : null;
+  const showMobileKnobs = isMobile && mobileKnobsAgent != null && hasKnobs(mobileKnobsAgent);
+
+  useEffect(() => {
+    if (mobileKnobsAgentId != null && !showMobileKnobs) setMobileKnobsAgentId(null);
+  }, [mobileKnobsAgentId, showMobileKnobs]);
 
   // The agent name + optional short blurb, shared by leaf rows and
   // submenu sub-triggers. The hover flyout (full spec description) is kept
@@ -1408,6 +1444,34 @@ function AgentHarnessPicker({
         </DropdownMenuItem>
       );
     }
+    if (isMobile) {
+      // Mobile has no hover, so there's no flyout to reveal the knobs. Tapping
+      // anywhere on a configurable row drills into this agent's knobs page on
+      // the same surface (the trailing chevron signals the drill-in); a Back
+      // row returns to the list. One tap target — the whole row — so no part
+      // of the row behaves differently from the rest.
+      return (
+        <DropdownMenuItem
+          key={agent.id}
+          data-testid={`new-chat-landing-agent-${agent.id}`}
+          data-active={active ? "true" : undefined}
+          onSelect={(e) => {
+            // Keep the menu open and swap to this agent's knobs page instead
+            // of closing. Commit the pick too, mirroring the desktop flyout
+            // where touching a knob selects the entry — so closing from the
+            // knobs page (tap-away / Back-then-elsewhere) lands on this agent.
+            e.preventDefault();
+            onSelectAgent(agent);
+            setMobileKnobsAgentId(agent.id);
+          }}
+          className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+        >
+          {renderRowInner(agent, false)}
+          {renderBadge(agent)}
+          <ChevronRightIcon className="ml-1 size-4 shrink-0 self-center text-muted-foreground/70" />
+        </DropdownMenuItem>
+      );
+    }
     return (
       <DropdownMenuSub key={agent.id}>
         <DropdownMenuSubTrigger
@@ -1436,9 +1500,25 @@ function AgentHarnessPicker({
   };
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (next) {
+          // Lock the open direction to whichever side has more room for the
+          // tall list, so the later drill-in (shorter page) can't flip it.
+          const rect = triggerRef.current?.getBoundingClientRect();
+          if (rect) setMobileSide(window.innerHeight - rect.bottom >= rect.top ? "bottom" : "top");
+        } else {
+          // Closing resets the in-place page so the menu always reopens on the
+          // agent list, never a stale knobs page.
+          setMobileKnobsAgentId(null);
+        }
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <Button
+          ref={triggerRef}
           type="button"
           variant="ghost"
           size="sm"
@@ -1456,44 +1536,77 @@ function AgentHarnessPicker({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        side="bottom"
+        // Desktop keeps the default collision handling (the content never
+        // resizes there — knobs live in hover flyouts). On mobile we force the
+        // measured side and disable flipping so the in-place page swap holds
+        // its direction; `--radix-..-available-height` still caps + scrolls it.
+        side={isMobile ? mobileSide : "bottom"}
+        avoidCollisions={!isMobile}
         className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
       >
-        {/* Harnesses group first — the native terminal CLIs (Claude Code is
-            the default), so the most-used picks lead. */}
-        {harnessEntries.length > 0 && (
-          <>
-            <PickerSectionHeader>Harnesses</PickerSectionHeader>
-            {harnessEntries.map(renderEntry)}
+        {showMobileKnobs && mobileKnobsAgent ? (
+          // Mobile knobs page: the selected agent's run-config knobs shown in
+          // place of the list, led by a Back row that returns to it. The
+          // slide-in keeps the drill-in feel without the fragile
+          // height-measuring the reverted flyout-fold needed (#393).
+          <div
+            data-testid="new-chat-landing-agent-config-page"
+            className="animate-in fade-in-0 slide-in-from-right-2 duration-150"
+          >
+            <DropdownMenuItem
+              data-testid="new-chat-landing-agent-config-back"
+              onSelect={(e) => {
+                // Step back to the list instead of closing the menu.
+                e.preventDefault();
+                setMobileKnobsAgentId(null);
+              }}
+              className="items-center gap-1.5 rounded-sm px-2 py-1.5 text-13 font-medium"
+            >
+              <ChevronLeftIcon className="size-4 shrink-0 opacity-70" />
+              <span className="truncate">{mobileKnobsAgent.display_name}</span>
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
+            {knobSectionsFor(mobileKnobsAgent)}
+          </div>
+        ) : (
+          <>
+            {/* Harnesses group first — the native terminal CLIs (Claude Code is
+            the default), so the most-used picks lead. */}
+            {harnessEntries.length > 0 && (
+              <>
+                <PickerSectionHeader>Harnesses</PickerSectionHeader>
+                {harnessEntries.map(renderEntry)}
+                <DropdownMenuSeparator />
+              </>
+            )}
+            {/* Agents group — SDK / bundle + custom agents. Always rendered so the
+            "Create custom agent" action is reachable even with no bundle agents. */}
+            <PickerSectionHeader>Agents</PickerSectionHeader>
+            {agentEntries.map(renderEntry)}
+            {pendingAgent && (
+              <DropdownMenuItem
+                key={pendingAgentId}
+                data-testid="new-chat-landing-agent-pending"
+                data-active={effectiveAgentId === pendingAgentId ? "true" : undefined}
+                onSelect={onSelectPending}
+                className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+              >
+                <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
+                  <span className="truncate">{pendingAgent.name}</span>
+                  <span className="truncate text-[11px] text-muted-foreground/70">Custom</span>
+                </div>
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              data-testid="new-chat-landing-create-agent"
+              onSelect={onCreateCustomAgent}
+              className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
+            >
+              <PlusIcon className="size-3.5" />
+              Create custom agent
+            </DropdownMenuItem>
           </>
         )}
-        {/* Agents group — SDK / bundle + custom agents. Always rendered so the
-            "Create custom agent" action is reachable even with no bundle agents. */}
-        <PickerSectionHeader>Agents</PickerSectionHeader>
-        {agentEntries.map(renderEntry)}
-        {pendingAgent && (
-          <DropdownMenuItem
-            key={pendingAgentId}
-            data-testid="new-chat-landing-agent-pending"
-            data-active={effectiveAgentId === pendingAgentId ? "true" : undefined}
-            onSelect={onSelectPending}
-            className="items-start gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
-          >
-            <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
-              <span className="truncate">{pendingAgent.name}</span>
-              <span className="truncate text-[11px] text-muted-foreground/70">Custom</span>
-            </div>
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuItem
-          data-testid="new-chat-landing-create-agent"
-          onSelect={onCreateCustomAgent}
-          className="gap-2 rounded-sm px-2 py-1.5 text-13 text-muted-foreground"
-        >
-          <PlusIcon className="size-3.5" />
-          Create custom agent
-        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
## What & why

The new-chat **agent picker** exposes each agent's run-config knobs (model / effort, permission mode, approval mode, Cursor exec mode, brain-harness override) in a Radix **sub-menu that opens on hover**. Touch devices can't hover, so on mobile those knobs were **unreachable** — tapping a configurable row only committed the agent and closed the menu.

This is the spirit of the earlier slide-in sub-page (#393), but scoped to mobile so it doesn't reintroduce the "have to click outside to dismiss" friction on desktop that got #393 reverted (#604).

## How it works

Below the `md` breakpoint (768px) the picker swaps its contents **in place** instead of relying on a flyout:

- Tapping **anywhere on a configurable row** selects that agent and drills into its knobs on the same surface — one tap target, the whole row, so no part of the row behaves differently from the rest. A trailing **chevron** signals the drill-in.
- A **Back** row returns to the agent list; tapping outside closes the menu (committing the selected agent).
- Rows with no knobs still pick-and-close on tap, exactly as before.
- **Desktop is unchanged** — still the Radix hover flyout (`DropdownMenuSub`).

```
Agent list (mobile)          tap row          Agent settings
┌────────────────────────┐   ──────▶   ┌────────────────────────┐
│ Claude Code          › │             │ ‹ Codex                │
│ Codex                › │             │ Approval mode          │
│ Cursor               › │             │  ( ) Read-only         │
└────────────────────────┘             │  (•) Auto              │
  tap anywhere = select +              │  ( ) Full access       │
  drill into settings                  └────────────────────────┘
                                          ‹ Back / tap-away = close
```

Details:
- New reactive `useIsMobileViewport` hook (`max-md` media query via `useSyncExternalStore`, SSR-safe; mirrors the `md` threshold the shell already uses).
- Tapping the row commits the pick (mirroring the desktop flyout, where touching a knob selects the entry) so closing from the knobs page lands on the intended agent.
- The in-place page resets when the menu closes, and a guard effect prevents stranding on an empty page if the selected agent vanishes / loses its knobs or the viewport crosses back to desktop.

## History of this PR

- v1 used a **split row** (tap name = pick + close, tap chevron = open settings). Reverted in review: having different parts of a row do different things was confusing on touch.
- v2 (current) makes the **whole row** drill into settings.

## Tests

- 3 mobile picker tests (drill-in via row tap + selects / Back returns to list / reopen lands on list).
- Existing desktop tests unchanged.
- `tsc -b` clean · `prettier --check` clean · `oxlint` no new findings.
- Full `web` suite: **3236 passed, 3 expected-fail, 2 skipped**.

Not run live (the picker needs a backend for agents/hosts) — a quick visual check on a narrow viewport is welcome.

This pull request and its description were written by Isaac.
