### PR TITLE
[web] Remove "getting your terminal ready" from startup copy

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2455,8 +2455,7 @@ export function RunnerStartingIndicator({ variant }: { variant: "hero" | "row" }
   if (sandboxLabel === undefined && !terminalSpinUp) {
     return null;
   }
-  const line =
-    sandboxLabel !== undefined ? `${sandboxLabel}…` : "Starting up… getting your terminal ready.";
+  const line = sandboxLabel !== undefined ? `${sandboxLabel}…` : "Starting up…";
   // role=status + aria-live so assistive tech announces the transient wait;
   // the spinner glyph itself is decorative (aria-hidden).
   if (variant === "hero") {
@@ -2470,7 +2469,7 @@ export function RunnerStartingIndicator({ variant }: { variant: "hero" | "row" }
         description={
           sandboxLabel !== undefined
             ? "Setting up your sandbox — this can take a minute."
-            : "Getting your terminal ready — this can take a few seconds."
+            : "This can take a few seconds."
         }
       />
     );

--- a/web/src/pages/RunnerStartingIndicator.test.tsx
+++ b/web/src/pages/RunnerStartingIndicator.test.tsx
@@ -58,7 +58,6 @@ describe("RunnerStartingIndicator", () => {
     // The exact copy is the user-facing contract — assert the value, not just
     // that *something* rendered (a null/empty state would also pass length>=1).
     expect(indicator).toHaveTextContent(/starting up/i);
-    expect(indicator).toHaveTextContent(/getting your terminal ready/i);
     // The animated spinner is what makes "work is happening" obvious.
     expect(indicator.querySelector(".animate-spin")).not.toBeNull();
     // Announced to assistive tech as a transient status, not a static region.
@@ -73,7 +72,6 @@ describe("RunnerStartingIndicator", () => {
     const indicator = screen.getByTestId("runner-starting-indicator");
     expect(indicator).toBeInTheDocument();
     expect(indicator).toHaveTextContent(/starting up/i);
-    expect(indicator).toHaveTextContent(/getting your terminal ready/i);
     expect(indicator.querySelector(".animate-spin")).not.toBeNull();
     expect(indicator).toHaveAttribute("role", "status");
     expect(indicator).toHaveAttribute("aria-live", "polite");
@@ -145,7 +143,7 @@ describe("RunnerStartingIndicator", () => {
     renderWithContext("row", makeCtx({ terminalStartingUp: true }));
     const indicator = screen.getByTestId("runner-starting-indicator");
     expect(indicator).toHaveTextContent(/cloning repository/i);
-    expect(indicator).not.toHaveTextContent(/getting your terminal ready/i);
+    expect(indicator).not.toHaveTextContent(/starting up/i);
   });
 
   it.each(["hero", "row"] as const)(


### PR DESCRIPTION
## Related issue

N/A

## Summary

The terminal spin-up indicator showed "Starting up… getting your terminal ready." — the second clause was redundant. Trimmed to just "Starting up…" (row variant) and "This can take a few seconds." (hero description).

## Test Plan

- [x] Unit tests updated to match new copy
- [x] `npx vitest run src/pages/RunnerStartingIndicator.test.tsx` — 13/13 passed

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes