### PR TITLE
ci: per-PR UI preview deploys to Databricks Apps

### DIFF
--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -1,0 +1,47 @@
+# UI Preview
+
+Deploy a live, per-PR preview of the Omnigent web UI as a
+[Databricks App](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/)
+when a PR changes the frontend (`web/`).
+
+This is a close port of [MLflow's UI Preview](https://github.com/mlflow/mlflow/blob/master/.github/workflows/ui-preview.yml).
+
+## How it works
+
+1. A maintainer adds the `ui-preview` label to a PR (the workflow is gated to
+   `OWNER`/`MEMBER`/`COLLABORATOR` authors).
+2. The [UI Preview workflow](../workflows/ui-preview.yml) builds the SPA + the
+   Omnigent wheels and deploys them to an ephemeral Databricks App
+   (`omnigent-ui-preview-pr-<N>`).
+3. A comment with the preview URL is posted on the PR and updated on each push.
+4. The app is deleted automatically when the PR is closed.
+
+## What it is
+
+Unlike Omnigent's production Databricks deploy (`deploy/databricks/`, backed by
+Lakebase Postgres + UC Volumes), the preview is intentionally ephemeral and
+self-contained: a **SQLite** database + local-disk artifact store, thrown away
+on teardown.
+
+There is **no LLM or runner baked into the preview** -- Omnigent runs agent
+turns on a runner the user connects from their own machine or sandbox
+(`omnigent run … --server <preview-url>`), where the model credentials live. So
+the preview is for reviewing the UI's look-and-feel and navigation; to drive a
+real session, connect your own host to the preview URL.
+
+## Access
+
+Preview apps are only accessible to maintainers with Databricks workspace
+access (the Apps proxy injects `X-Forwarded-Email`, so the app runs in header
+auth mode).
+
+## Setup (one-time, by a maintainer)
+
+Add these repo secrets (same names MLflow uses):
+
+- `DATABRICKS_HOST`
+- `DATABRICKS_CLIENT_ID`
+- `DATABRICKS_CLIENT_SECRET`
+
+Create a `ui-preview` label. If the workspace IP-allowlists, register a
+static-IP runner and point the `deploy`/`cleanup` jobs at it.

--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -4,8 +4,6 @@ Deploy a live, per-PR preview of the Omnigent web UI as a
 [Databricks App](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/)
 when a PR changes the frontend (`web/`).
 
-This is a close port of [MLflow's UI Preview](https://github.com/mlflow/mlflow/blob/master/.github/workflows/ui-preview.yml).
-
 ## How it works
 
 1. A maintainer adds the `ui-preview` label to a PR (the workflow is gated to
@@ -37,7 +35,7 @@ auth mode).
 
 ## Setup (one-time, by a maintainer)
 
-Add these repo secrets (same names MLflow uses):
+Add these repo secrets:
 
 - `DATABRICKS_HOST`
 - `DATABRICKS_CLIENT_ID`

--- a/.github/ui-preview/app.py
+++ b/.github/ui-preview/app.py
@@ -1,0 +1,82 @@
+"""Entry point for the per-PR UI Preview app (Databricks Apps).
+
+Port of MLflow's ``.github/ui-preview/app.py`` adapted to Omnigent.
+
+Unlike Omnigent's production Databricks deploy (``deploy/databricks/``, which
+uses Lakebase Postgres + UC Volumes), this preview is deliberately *ephemeral
+and self-contained* so a fresh app can be created and torn down per PR with no
+external state: a SQLite database + local-disk artifact store under a temp dir.
+
+There is no bundled LLM or runner. Omnigent executes agent turns on a runner
+that the user connects from their own machine/sandbox (``omnigent run … --server
+<url>``), so the preview only needs to serve the web UI + API. A reviewer browses
+the UI as-is, and can connect their own host to drive a real session.
+
+The prebuilt web SPA is shipped separately as ``build.tar.gz`` (keeping the
+wheel small, like MLflow) and extracted into the installed ``omnigent`` package
+so the server mounts it at ``/``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr, force=True)
+logger = logging.getLogger("omnigent-ui-preview")
+
+HERE = Path(__file__).parent.resolve()
+# Databricks Apps expects the app to listen on DATABRICKS_APP_PORT (8000 by
+# convention); fall back to 8000 for local runs of this script.
+PORT = int(os.environ.get("DATABRICKS_APP_PORT", "8000"))
+WORK_DIR = Path(os.environ.get("OMNIGENT_PREVIEW_WORKDIR", "/tmp/omnigent-preview"))
+DB_PATH = WORK_DIR / "omnigent.db"
+ARTIFACT_DIR = WORK_DIR / "artifacts"
+
+
+def _extract_spa() -> None:
+    """Extract the prebuilt SPA into the installed omnigent package.
+
+    The build job ships ``build.tar.gz`` (containing a ``web-ui`` dir) next to
+    this file; the server serves ``omnigent/server/static/web-ui`` at ``/``.
+    """
+    tar_path = HERE / "build.tar.gz"
+    if not tar_path.is_file():
+        logger.warning("No build.tar.gz found at %s -- UI will be API-only", tar_path)
+        return
+    import omnigent.server
+
+    target = Path(omnigent.server.__file__).parent / "static"
+    target.mkdir(parents=True, exist_ok=True)
+    logger.info("Extracting SPA from %s into %s", tar_path, target)
+    with tarfile.open(tar_path) as tar:
+        tar.extractall(target)
+
+
+def main() -> None:
+    WORK_DIR.mkdir(parents=True, exist_ok=True)
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    _extract_spa()
+
+    # The Databricks Apps proxy injects X-Forwarded-Email on every request, so
+    # run in header auth mode (matches deploy/databricks/src/app.py) -- no login
+    # page, and the proxy is the trust boundary.
+    os.environ.setdefault("OMNIGENT_AUTH_PROVIDER", "header")
+
+    cmd = [
+        sys.executable, "-m", "omnigent.cli", "server",
+        "--host", "0.0.0.0",
+        "--port", str(PORT),
+        "--database-uri", f"sqlite:///{DB_PATH}",
+        "--artifact-location", str(ARTIFACT_DIR),
+        "--no-open",
+    ]
+    logger.info("Starting Omnigent server: %s", " ".join(cmd))
+    os.execvp(cmd[0], cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/ui-preview/app.py
+++ b/.github/ui-preview/app.py
@@ -1,7 +1,5 @@
 """Entry point for the per-PR UI Preview app (Databricks Apps).
 
-Port of MLflow's ``.github/ui-preview/app.py`` adapted to Omnigent.
-
 Unlike Omnigent's production Databricks deploy (``deploy/databricks/``, which
 uses Lakebase Postgres + UC Volumes), this preview is deliberately *ephemeral
 and self-contained* so a fresh app can be created and torn down per PR with no
@@ -13,8 +11,8 @@ that the user connects from their own machine/sandbox (``omnigent run … --serv
 the UI as-is, and can connect their own host to drive a real session.
 
 The prebuilt web SPA is shipped separately as ``build.tar.gz`` (keeping the
-wheel small, like MLflow) and extracted into the installed ``omnigent`` package
-so the server mounts it at ``/``.
+wheel small) and extracted into the installed ``omnigent`` package so the server
+mounts it at ``/``.
 """
 
 from __future__ import annotations
@@ -53,7 +51,9 @@ def _extract_spa() -> None:
     target.mkdir(parents=True, exist_ok=True)
     logger.info("Extracting SPA from %s into %s", tar_path, target)
     with tarfile.open(tar_path) as tar:
-        tar.extractall(target)
+        # filter="data" rejects path-traversal / unsafe members; the tarball is
+        # built from fork-supplied UI output, and this is the 3.14 default.
+        tar.extractall(target, filter="data")
 
 
 def main() -> None:
@@ -67,11 +67,18 @@ def main() -> None:
     os.environ.setdefault("OMNIGENT_AUTH_PROVIDER", "header")
 
     cmd = [
-        sys.executable, "-m", "omnigent.cli", "server",
-        "--host", "0.0.0.0",
-        "--port", str(PORT),
-        "--database-uri", f"sqlite:///{DB_PATH}",
-        "--artifact-location", str(ARTIFACT_DIR),
+        sys.executable,
+        "-m",
+        "omnigent.cli",
+        "server",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(PORT),
+        "--database-uri",
+        f"sqlite:///{DB_PATH}",
+        "--artifact-location",
+        str(ARTIFACT_DIR),
         "--no-open",
     ]
     logger.info("Starting Omnigent server: %s", " ".join(cmd))

--- a/.github/ui-preview/app.yaml
+++ b/.github/ui-preview/app.yaml
@@ -1,0 +1,1 @@
+command: ["python", "app.py"]

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -1,0 +1,372 @@
+name: UI Preview
+
+# Per-PR live preview of the Omnigent web UI, deployed to Databricks Apps.
+# Close port of MLflow's .github/workflows/ui-preview.yml. The preview is
+# ephemeral (SQLite + local artifacts) and ships no LLM/runner -- Omnigent runs
+# agent turns on a runner the reviewer connects from their own machine. See
+# .github/ui-preview/README.md.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - web/**
+      - .github/workflows/ui-preview.yml
+      - .github/ui-preview/**
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - closed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'main' }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  COMMENT_MARKER: "<!-- ui-preview -->"
+
+permissions: {}
+
+jobs:
+  notify:
+    if: >-
+      github.event_name != 'push'
+      && github.event.action != 'closed'
+      && contains(github.event.pull_request.labels.*.name, 'ui-preview')
+      && github.event.pull_request.draft == false
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          BODY="${COMMENT_MARKER}
+
+          **UI Preview** is being deployed for this PR :hourglass_flowing_sand:
+
+          | | |
+          |---|---|
+          | **Commit** | ${HEAD_SHA} |
+          | **Run** | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} |
+
+          > Building and deploying... This comment will be updated with the preview URL."
+
+          # Only post if no existing comment (to avoid overwriting a previous preview URL)
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"$COMMENT_MARKER\")) | .id" \
+            | head -1)
+
+          if [ -z "$COMMENT_ID" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+          fi
+
+  build:
+    if: >-
+      github.event_name == 'push'
+      || (
+        github.event.action != 'closed'
+        && contains(github.event.pull_request.labels.*.name, 'ui-preview')
+        && github.event.pull_request.draft == false
+        && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+          # For PRs, check out the merge ref so the preview reflects what the UI
+          # will look like after merge. For push events, falls back to github.sha.
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          # checkout v7 blocks fork PR checkout on `pull_request_target` by
+          # default; opt in since this job builds the preview from fork code.
+          # Safe: it has no secrets (only `contents: read`), and the
+          # author_association guard above restricts it to OWNER/MEMBER/COLLABORATOR.
+          allow-unsafe-pr-checkout: true
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: ".python-version"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+      - uses: ./.github/actions/setup-node
+
+      - name: Build wheels (no UI)
+        # Build the wheels WITHOUT the SPA so they stay small (Databricks Apps
+        # caps each source wheel at 10MB). The SPA ships separately as
+        # build.tar.gz and is extracted at runtime by app.py. Mirrors MLflow's
+        # wheel-without-UI + tarball split. SKIP_WEB_UI skips build.sh's own npm
+        # build; OMNIGENT_SKIP_WEB_UI makes setup.py skip the in-wheel UI build.
+        env:
+          SKIP_WEB_UI: "1"
+          OMNIGENT_SKIP_WEB_UI: "true"
+        run: bash deploy/databricks/build.sh
+
+      - name: Build UI
+        working-directory: web
+        run: |
+          npm ci --legacy-peer-deps --no-audit --no-fund
+          npm run build
+
+      - name: Package UI assets
+        run: |
+          tar czf /tmp/build.tar.gz -C omnigent/server/static web-ui
+          UI_SIZE=$(stat -c %s /tmp/build.tar.gz)
+          echo "UI assets size: $(numfmt --to=iec "$UI_SIZE")"
+
+      - name: Prepare app files
+        run: |
+          mkdir -p /tmp/app-deploy
+          cp .github/ui-preview/app.py /tmp/app-deploy/
+          cp .github/ui-preview/app.yaml /tmp/app-deploy/
+          cp /tmp/build.tar.gz /tmp/app-deploy/
+          # Copy every built wheel and pin them all in requirements.txt so the
+          # main omnigent wheel resolves its sibling wheels (omnigent-client,
+          # omnigent-ui-sdk) from local files rather than PyPI.
+          : > /tmp/app-deploy/requirements.txt
+          for whl in dist/*.whl; do
+            name=$(basename "$whl")
+            cp "$whl" /tmp/app-deploy/
+            echo "./$name" >> /tmp/app-deploy/requirements.txt
+            size=$(stat -c %s "$whl")
+            echo "Wheel $name: $(numfmt --to=iec "$size")"
+            if [ "$size" -gt 10485760 ]; then
+              echo "::warning::$name exceeds the 10MB Databricks Apps wheel limit"
+            fi
+          done
+          echo "requirements.txt:"
+          cat /tmp/app-deploy/requirements.txt
+
+      - name: Upload app files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: app-deploy
+          path: /tmp/app-deploy/
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy:
+    needs: build
+    # MLflow uses a static-IP runner (`ubuntu-ui-preview`) for workspace IP
+    # allowlisting. Use ubuntu-latest unless/until such a runner exists; switch
+    # `runs-on` if the Databricks workspace IP-allowlists.
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 30
+    steps:
+      - name: Download app files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: app-deploy
+          path: /tmp/app-deploy
+
+      - name: Install Databricks CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/2260866f83a41a2df55e1cfe7ffe038b78325bf6/install.sh | sh
+          databricks --version
+
+      - name: Create or update app
+        id: app
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          APP_NAME: ${{ github.event_name == 'push' && 'omnigent-ui-preview-dev' || format('omnigent-ui-preview-pr-{0}', github.event.pull_request.number) }}
+          APP_DESCRIPTION: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
+        run: |
+          if databricks apps get "$APP_NAME" > /dev/null 2>&1; then
+            echo "App already exists"
+          else
+            echo "Creating app..."
+            databricks apps create \
+              --json "{\"name\": \"$APP_NAME\", \"description\": \"$APP_DESCRIPTION\"}" \
+              --no-wait
+            for i in $(seq 1 40); do
+              STATE=$(databricks apps get "$APP_NAME" -o json | jq -r '.compute_status.state')
+              echo "Compute state: $STATE"
+              if [ "$STATE" = "ACTIVE" ]; then
+                break
+              elif [ "$STATE" = "ERROR" ] || [ "$STATE" = "STOPPED" ]; then
+                echo "::error::Compute entered $STATE state"
+                exit 1
+              fi
+              sleep 15
+            done
+            if [ "$STATE" != "ACTIVE" ]; then
+              echo "::error::Timed out waiting for compute to become ACTIVE (last state: $STATE)"
+              exit 1
+            fi
+          fi
+
+          URL=$(databricks apps get "$APP_NAME" -o json | jq -r '.url')
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Upload files and deploy
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          APP_NAME: ${{ github.event_name == 'push' && 'omnigent-ui-preview-dev' || format('omnigent-ui-preview-pr-{0}', github.event.pull_request.number) }}
+          WORKSPACE_PATH: /Users/${{ secrets.DATABRICKS_CLIENT_ID }}/apps/${{ github.event_name == 'push' && 'omnigent-ui-preview-dev' || format('omnigent-ui-preview-pr-{0}', github.event.pull_request.number) }}
+        run: |
+          databricks workspace mkdirs "/Workspace$WORKSPACE_PATH" 2>/dev/null || true
+          databricks workspace import-dir /tmp/app-deploy "$WORKSPACE_PATH" --overwrite
+          databricks apps deploy "$APP_NAME" --source-code-path "/Workspace$WORKSPACE_PATH"
+
+      - name: Restart app to load the new code
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          APP_NAME: ${{ github.event_name == 'push' && 'omnigent-ui-preview-dev' || format('omnigent-ui-preview-pr-{0}', github.event.pull_request.number) }}
+        run: |
+          # `apps deploy` restarts the app process and re-extracts source, but
+          # reuses the existing Python env, so a freshly built wheel is not
+          # reinstalled. Stop then start so the env is rebuilt from the deployed
+          # source. (Same dance as MLflow's preview.)
+          echo "Stopping app..."
+          databricks apps stop "$APP_NAME"
+          for i in $(seq 1 40); do
+            STATE=$(databricks apps get "$APP_NAME" -o json | jq -r '.compute_status.state')
+            echo "Compute state: $STATE"
+            if [ "$STATE" = "STOPPED" ]; then
+              break
+            elif [ "$STATE" = "ERROR" ]; then
+              echo "::error::Compute entered ERROR state while stopping"
+              exit 1
+            fi
+            sleep 15
+          done
+
+          echo "Starting app..."
+          databricks apps start "$APP_NAME"
+          for i in $(seq 1 40); do
+            STATE=$(databricks apps get "$APP_NAME" -o json | jq -r '.compute_status.state')
+            echo "Compute state: $STATE"
+            if [ "$STATE" = "ACTIVE" ]; then
+              break
+            elif [ "$STATE" = "ERROR" ]; then
+              echo "::error::Compute entered ERROR state"
+              exit 1
+            fi
+            sleep 15
+          done
+          if [ "$STATE" != "ACTIVE" ]; then
+            echo "::error::Timed out waiting for compute to become ACTIVE (last state: $STATE)"
+            exit 1
+          fi
+
+      - name: Print app URL
+        if: github.event_name == 'push'
+        env:
+          APP_URL: ${{ steps.app.outputs.url }}
+        run: echo "Deployed to $APP_URL" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR
+        if: github.event_name != 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_URL: ${{ steps.app.outputs.url }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BODY="${COMMENT_MARKER}
+
+          **UI Preview** is ready for this PR :rocket:
+
+          | | |
+          |---|---|
+          | **URL** | ${APP_URL} |
+          | **Commit** | $COMMIT_SHA |
+          | **Run** | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} |
+
+          > [!NOTE]
+          > This preview is only accessible to maintainers with workspace access.
+          > It serves the UI only -- connect your own host (\`omnigent run … --server <url>\`) to drive a real session.
+          > The preview updates automatically when new commits are pushed."
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$COMMENT_MARKER\")) | .id" \
+            | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+          fi
+
+  cleanup:
+    if: >-
+      github.event_name != 'push'
+      && github.event.action == 'closed'
+      && contains(github.event.pull_request.labels.*.name, 'ui-preview')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - name: Install Databricks CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/2260866f83a41a2df55e1cfe7ffe038b78325bf6/install.sh | sh
+          databricks --version
+
+      - name: Delete app
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          APP_NAME: omnigent-ui-preview-pr-${{ github.event.pull_request.number }}
+        run: |
+          if databricks apps get "$APP_NAME" > /dev/null 2>&1; then
+            SOURCE_PATH=$(databricks apps get "$APP_NAME" -o json \
+              | jq -r '.default_source_code_path // empty')
+            databricks apps delete "$APP_NAME" --auto-approve
+            if [ -n "$SOURCE_PATH" ]; then
+              WS_PATH="${SOURCE_PATH#/Workspace}"
+              databricks workspace delete "$WS_PATH" --recursive 2>/dev/null || true
+            fi
+          fi
+
+      - name: Update PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BODY="${COMMENT_MARKER}
+
+          **UI Preview** for this PR has been removed."
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$COMMENT_MARKER\")) | .id" \
+            | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY"
+          fi

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -153,22 +153,50 @@ jobs:
           cp .github/ui-preview/app.py /tmp/app-deploy/
           cp .github/ui-preview/app.yaml /tmp/app-deploy/
           cp /tmp/build.tar.gz /tmp/app-deploy/
-          # Copy every built wheel and pin them all in requirements.txt so the
-          # main omnigent wheel resolves its sibling wheels (omnigent-client,
-          # omnigent-ui-sdk) from local files rather than PyPI.
-          : > /tmp/app-deploy/requirements.txt
-          for whl in dist/*.whl; do
-            name=$(basename "$whl")
-            cp "$whl" /tmp/app-deploy/
-            echo "./$name" >> /tmp/app-deploy/requirements.txt
+          cp dist/*.whl /tmp/app-deploy/
+          for whl in /tmp/app-deploy/*.whl; do
             size=$(stat -c %s "$whl")
-            echo "Wheel $name: $(numfmt --to=iec "$size")"
+            echo "Wheel $(basename "$whl"): $(numfmt --to=iec "$size")"
             if [ "$size" -gt 10485760 ]; then
-              echo "::warning::$name exceeds the 10MB Databricks Apps wheel limit"
+              echo "::warning::$(basename "$whl") exceeds the 10MB Databricks Apps wheel limit"
             fi
           done
-          echo "requirements.txt:"
-          cat /tmp/app-deploy/requirements.txt
+          # Databricks Apps must install via uv (pyproject.toml + uv.lock), NOT a
+          # plain requirements.txt: the pip path uses the platform's Python 3.11,
+          # but omnigent requires >=3.12 -- uv provisions 3.12. The three wheels
+          # are wired as local path sources so they resolve from disk, not PyPI.
+          # Mirrors deploy/databricks/deploy.py (build_uv_pyproject + run_uv_lock).
+          python - <<'PY'
+          import glob, os
+          d = "/tmp/app-deploy"
+          def whl(prefix):
+              hits = [os.path.basename(p) for p in glob.glob(f"{d}/{prefix}*.whl")]
+              assert len(hits) == 1, (prefix, hits)
+              return hits[0]
+          sources = {
+              "omnigent": whl("omnigent-"),
+              "omnigent-client": whl("omnigent_client-"),
+              "omnigent-ui-sdk": whl("omnigent_ui_sdk-"),
+          }
+          lines = [
+              "[project]",
+              'name = "omnigent-ui-preview"',
+              'version = "0.0.0"',
+              'requires-python = ">=3.12,<3.13"',
+              "dependencies = [",
+              '  "omnigent",',
+              '  "omnigent-client",',
+              '  "omnigent-ui-sdk",',
+              "]",
+              "",
+              "[tool.uv.sources]",
+              *[f'{name} = {{ path = "./{fname}" }}' for name, fname in sources.items()],
+          ]
+          open(f"{d}/pyproject.toml", "w").write("\n".join(lines) + "\n")
+          print(open(f"{d}/pyproject.toml").read())
+          PY
+          ( cd /tmp/app-deploy && uv lock --python 3.12 --index-url https://pypi.org/simple )
+          echo "app-deploy contents:"; ls -1 /tmp/app-deploy
 
       - name: Upload app files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -21,6 +21,21 @@ on:
       - reopened
       - labeled
       - closed
+  # TEMPORARY (pre-merge testing only) -- REMOVE before merging to main.
+  # pull_request_target only runs from the workflow version on the DEFAULT
+  # branch, so a brand-new preview workflow can't be exercised from the PR
+  # branch. This pull_request trigger runs the branch's own copy so the preview
+  # can be validated before it lands on main. Same-repo PRs (like this one) get
+  # repo secrets on pull_request; forks do not -- that's why production uses
+  # pull_request_target. Leaving both enabled on main would double-fire (two
+  # deploys per event), so delete this block at merge time.
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - closed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'main' }}

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -273,7 +273,13 @@ jobs:
           APP_NAME: ${{ github.event_name == 'push' && 'omnigent-ui-preview-dev' || format('omnigent-ui-preview-pr-{0}', github.event.pull_request.number) }}
           WORKSPACE_PATH: /Users/${{ secrets.DATABRICKS_CLIENT_ID }}/apps/${{ github.event_name == 'push' && 'omnigent-ui-preview-dev' || format('omnigent-ui-preview-pr-{0}', github.event.pull_request.number) }}
         run: |
-          databricks workspace mkdirs "/Workspace$WORKSPACE_PATH" 2>/dev/null || true
+          # Wipe the workspace source dir first. import-dir --overwrite only
+          # replaces files it uploads; it does NOT prune orphans. A requirements.txt
+          # left by an earlier deploy would otherwise survive and take precedence
+          # over uv (pyproject.toml + uv.lock), forcing the pip/Python-3.11 install
+          # path that fails omnigent's requires-python >=3.12.
+          databricks workspace delete "$WORKSPACE_PATH" --recursive 2>/dev/null || true
+          databricks workspace mkdirs "$WORKSPACE_PATH" 2>/dev/null || true
           databricks workspace import-dir /tmp/app-deploy "$WORKSPACE_PATH" --overwrite
           databricks apps deploy "$APP_NAME" --source-code-path "/Workspace$WORKSPACE_PATH"
 

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -1,10 +1,9 @@
 name: UI Preview
 
 # Per-PR live preview of the Omnigent web UI, deployed to Databricks Apps.
-# Close port of MLflow's .github/workflows/ui-preview.yml. The preview is
-# ephemeral (SQLite + local artifacts) and ships no LLM/runner -- Omnigent runs
-# agent turns on a runner the reviewer connects from their own machine. See
-# .github/ui-preview/README.md.
+# The preview is ephemeral (SQLite + local artifacts) and ships no LLM/runner --
+# Omnigent runs agent turns on a runner the reviewer connects from their own
+# machine. See .github/ui-preview/README.md.
 
 on:
   push:
@@ -112,9 +111,9 @@ jobs:
       - name: Build wheels (no UI)
         # Build the wheels WITHOUT the SPA so they stay small (Databricks Apps
         # caps each source wheel at 10MB). The SPA ships separately as
-        # build.tar.gz and is extracted at runtime by app.py. Mirrors MLflow's
-        # wheel-without-UI + tarball split. SKIP_WEB_UI skips build.sh's own npm
-        # build; OMNIGENT_SKIP_WEB_UI makes setup.py skip the in-wheel UI build.
+        # build.tar.gz and is extracted at runtime by app.py. SKIP_WEB_UI skips
+        # build.sh's own npm build; OMNIGENT_SKIP_WEB_UI makes setup.py skip the
+        # in-wheel UI build.
         env:
           SKIP_WEB_UI: "1"
           OMNIGENT_SKIP_WEB_UI: "true"
@@ -142,8 +141,12 @@ jobs:
           for whl in /tmp/app-deploy/*.whl; do
             size=$(stat -c %s "$whl")
             echo "Wheel $(basename "$whl"): $(numfmt --to=iec "$size")"
+            # Fail fast: an oversize wheel can't be installed from the app source
+            # snapshot and would otherwise fail later in the deploy with a far
+            # less obvious error. (deploy/databricks/deploy.py raises here too.)
             if [ "$size" -gt 10485760 ]; then
-              echo "::warning::$(basename "$whl") exceeds the 10MB Databricks Apps wheel limit"
+              echo "::error::$(basename "$whl") exceeds the 10MB Databricks Apps wheel limit"
+              exit 1
             fi
           done
           # Databricks Apps must install via uv (pyproject.toml + uv.lock), NOT a
@@ -193,9 +196,8 @@ jobs:
 
   deploy:
     needs: build
-    # MLflow uses a static-IP runner (`ubuntu-ui-preview`) for workspace IP
-    # allowlisting. Use ubuntu-latest unless/until such a runner exists; switch
-    # `runs-on` if the Databricks workspace IP-allowlists.
+    # Use ubuntu-latest. If the Databricks workspace IP-allowlists, register a
+    # static-IP runner and switch `runs-on` to it.
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -279,7 +281,7 @@ jobs:
           # `apps deploy` restarts the app process and re-extracts source, but
           # reuses the existing Python env, so a freshly built wheel is not
           # reinstalled. Stop then start so the env is rebuilt from the deployed
-          # source. (Same dance as MLflow's preview.)
+          # source.
           echo "Stopping app..."
           databricks apps stop "$APP_NAME"
           for i in $(seq 1 40); do
@@ -354,10 +356,13 @@ jobs:
           fi
 
   cleanup:
+    # No `ui-preview` label gate here on purpose: if the label is removed before
+    # the PR closes, a labelled-then-unlabelled PR would otherwise leak its app
+    # and workspace files forever. Run on every close; the delete step is a cheap
+    # no-op (one existence check) for PRs that never had a preview.
     if: >-
       github.event_name != 'push'
       && github.event.action == 'closed'
-      && contains(github.event.pull_request.labels.*.name, 'ui-preview')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -21,21 +21,6 @@ on:
       - reopened
       - labeled
       - closed
-  # TEMPORARY (pre-merge testing only) -- REMOVE before merging to main.
-  # pull_request_target only runs from the workflow version on the DEFAULT
-  # branch, so a brand-new preview workflow can't be exercised from the PR
-  # branch. This pull_request trigger runs the branch's own copy so the preview
-  # can be validated before it lands on main. Same-repo PRs (like this one) get
-  # repo secrets on pull_request; forks do not -- that's why production uses
-  # pull_request_target. Leaving both enabled on main would double-fire (two
-  # deploys per event), so delete this block at merge time.
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - closed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'main' }}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2227,7 +2227,7 @@ export function NewChatLandingScreen() {
         <div className="flex flex-col items-center gap-3.5 sm:flex-row">
           <OttoEyes className="h-18 w-auto shrink-0" />
           <h1 className="text-center text-3xl font-medium tracking-[-0.03em] text-foreground sm:text-left">
-            What should we do?
+            What should we do today?
           </h1>
         </div>
         <div className="relative flex w-full flex-col gap-3">

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2227,7 +2227,7 @@ export function NewChatLandingScreen() {
         <div className="flex flex-col items-center gap-3.5 sm:flex-row">
           <OttoEyes className="h-18 w-auto shrink-0" />
           <h1 className="text-center text-3xl font-medium tracking-[-0.03em] text-foreground sm:text-left">
-            What should we do today?
+            What should we do?
           </h1>
         </div>
         <div className="relative flex w-full flex-col gap-3">


### PR DESCRIPTION
## Related issue

N/A

## Summary

Ports MLflow's per-PR UI preview to Omnigent: a label-gated GitHub Actions workflow that builds the web UI from a PR and deploys it as an ephemeral Databricks App, then comments the live URL on the PR.

- **`.github/workflows/ui-preview.yml`** — `notify` / `build` / `deploy` / `cleanup` jobs. Untrusted fork code is built in the secret-less `build` job (`contents: read`); the secret-bearing `deploy` job only consumes the prebuilt artifact. Gated on the `ui-preview` label **and** `author_association ∈ OWNER/MEMBER/COLLABORATOR`.
- **`.github/ui-preview/app.py`** — Databricks App entrypoint: extracts the SPA tarball into `omnigent/server/static`, sets header auth, and starts `omnigent.cli server` against ephemeral SQLite + a local artifact dir.
- **`.github/ui-preview/app.yaml`** / **`README.md`** — app command + docs.

The preview is **UI-only and ephemeral** (SQLite, local artifacts, torn down on PR close). It ships no LLM/runner — reviewers connect their own host (`omnigent run … --server <url>`) to drive a real session, matching Omnigent's external-runner model.

### ELI5

Add the `ui-preview` label to a PR → CI builds that PR's web UI and puts it on a temporary live URL you can click through. Close the PR → it's deleted.

### Flow

```
PR + ui-preview label
        │
        ▼
   build (no secrets, fork code)  ──►  artifact (wheels + SPA tarball + uv files)
        │
        ▼
   deploy (secrets)  ──►  Databricks App  ──►  comment URL on PR
        │
   PR closed ──► cleanup (delete app + workspace files)
```

### Implementation notes

- Wheels are built **without** the in-wheel SPA (`OMNIGENT_SKIP_WEB_UI`) to stay under the 10 MB Databricks Apps wheel cap; the SPA ships separately as `build.tar.gz` and is extracted at runtime.
- Deploy installs via **uv** (`pyproject.toml` + `uv.lock`), not `requirements.txt` — the plain-pip path uses the platform's Python 3.11, but `omnigent` requires `>=3.12`; uv provisions 3.12. The workspace source dir is wiped before each import so a stale `requirements.txt` can't override the uv path. Mirrors `deploy/databricks/deploy.py`.

## Test Plan

- Validated end-to-end on this PR: the `ui-preview` label triggered build + deploy and the bot commented a working preview URL (`https://omnigent-ui-preview-pr-1568-….aws.databricksapps.com`) serving the UI.
- One-time setup required on `main`: repo secrets `DATABRICKS_HOST`, `DATABRICKS_CLIENT_ID`, `DATABRICKS_CLIENT_SECRET` (OAuth M2M) and the `ui-preview` label. `pull_request_target` only runs from the workflow on the default branch, so previews begin working once this merges.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI-only change with no application logic; verified by running the workflow on this PR and confirming a live, clickable preview deployment plus the posted URL comment. Automated tests aren't practical for a deploy pipeline that depends on Databricks Apps secrets.
