### PR TITLE
fix(repl): remove --no-internal-beta from provider-switch hint

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -4872,8 +4872,7 @@ def _build_model_readout_lines(
         # provider; switching the active provider mid-session is not wired,
         # so it goes through `configure harnesses` + a restart.
         lines.append(
-            "  /model <name> changes the model. To switch provider: "
-            "omnigent setup --no-internal-beta (then restart)."
+            "  /model <name> changes the model. To switch provider: omnigent setup (then restart)."
         )
     return lines
 


### PR DESCRIPTION
## Summary
- Removes `--no-internal-beta` flag from the provider-switch hint shown in the model readout (`/model` help line in the REPL)
- The hint now reads: `omnigent setup (then restart)` instead of `omnigent setup --no-internal-beta (then restart)`

## Test plan
- [ ] Run `omnigent` and check the model readout line shows the updated hint