### PR TITLE
fix(ci): skip CI/E2E runs triggered by non-security-gate labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: ['web/**', 'tests/e2e_ui/**']
   push:
     branches:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,11 @@ env:
 jobs:
   # Security gate: untrusted PRs wait on the deterministic scan
   # (security-gate.yml); trusted authors and non-PR events pass instantly.
+  # Skip when the automerge label is applied/removed -- safe to short-circuit
+  # here because every non-gate job is transitively downstream of gate, so
+  # no skipped check-run can overwrite an existing result on this SHA.
   gate:
+    if: github.event.label.name != 'automerge'
     uses: ./.github/workflows/security-gate.yml
 
   # Shard matrix (e2e-shard-matrix.sh, shared with e2e-ui.yml). Fork PRs run by


### PR DESCRIPTION
## Summary

Prevents the `automerge` label from triggering spurious CI and E2E runs.

**ci.yml** — removes `labeled`/`unlabeled` from the `pull_request` trigger entirely. The previous approach (skipping `gate` via `if:`) was unsafe: skipping the `gate` job still emits `skipped` check-runs on the unchanged head SHA, and `merge-ready`'s newest-wins + `ALLOW_SKIP` logic could overwrite a prior `failure` with `skipped`, letting a red PR auto-merge once `automerge` is enabled. Removing the trigger prevents any run — and any check-run — from being emitted. The `skip-security-scan` self-recovery path is unaffected; it goes through the `rerun-security-gate-run.yml` relay.

**e2e.yml** — guards `gate` with `if: github.event.label.name != 'automerge'`. This is safe here because every non-`gate` job is transitively downstream of `gate`; no new check-runs are emitted on the same SHA that could overwrite an existing result.

## Test plan

- [ ] Adding `automerge` to a PR with a known-failing `pytest` run does not flip `Merge Ready` to success
- [ ] Normal PR events (`opened`, `synchronize`, `push`) still trigger CI/E2E
- [ ] Adding/removing `skip-security-scan` still triggers CI/E2E (security gate self-recovery)