### PR TITLE
feat(host): pre-install Kimi Code CLI in sandbox host image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -18,7 +18,7 @@
 # and server-launched managed hosts. It bakes the full omnigent
 # install plus the tools a host needs at runtime — git (workspaces /
 # worktrees), tmux (terminal sessions spawned by native harnesses),
-# and the coding-harness CLIs (claude / codex / pi, via Node; kiro-cli via
+# and the coding-harness CLIs (claude / codex / pi / kimi, via Node; kiro-cli via
 # Kiro's installer) — and
 # skips everything server-only: no SPA bundle, no psycopg, no
 # uvicorn entrypoint. Modal's `Image.from_registry` requirements shape
@@ -55,7 +55,8 @@
 
 # Must satisfy pyproject requires-python (>=3.12); 3.11 fails dependency resolution.
 ARG PYTHON_VERSION=3.12
-ARG NODE_VERSION=20
+# Node 22+ is required for @moonshot-ai/kimi-code (Kimi Code CLI).
+ARG NODE_VERSION=22
 
 # ── Web UI builder ──────────────────────────────────────
 # Builds the web SPA so `docker build` works from a clean checkout —
@@ -169,8 +170,8 @@ FROM node:${NODE_VERSION}-slim AS node-runtime
 # port" and breaks web-turn injection), bubblewrap to OS-sandbox the
 # native harness terminals (mandatory and fail-loud on Linux), curl + CA
 # certificates for outbound HTTPS and in-sandbox downloads, plus the
-# coding-harness CLIs (claude / codex / pi / kiro-cli) so claude-sdk,
-# claude-native, codex, pi, and kiro-native agents can run in managed
+# coding-harness CLIs (claude / codex / pi / kimi / kiro-cli) so claude-sdk,
+# claude-native, codex, pi, kimi-native, and kiro-native agents can run in managed
 # sandboxes without an in-sandbox install. No SPA, no psycopg, no server
 # entrypoint.
 #
@@ -244,6 +245,7 @@ RUN npm install -g --no-audit --no-fund \
       @anthropic-ai/claude-code \
       @openai/codex \
       @earendil-works/pi-coding-agent \
+      @moonshot-ai/kimi-code \
  && npm cache clean --force
 
 # Kiro CLI is not published as an npm package; use its official installer and

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -18,7 +18,7 @@
 # and server-launched managed hosts. It bakes the full omnigent
 # install plus the tools a host needs at runtime — git (workspaces /
 # worktrees), tmux (terminal sessions spawned by native harnesses),
-# and the coding-harness CLIs (claude / codex / pi / kimi, via Node; kiro-cli via
+# and the coding-harness CLIs (claude / codex / pi, via Node; kiro-cli via
 # Kiro's installer) — and
 # skips everything server-only: no SPA bundle, no psycopg, no
 # uvicorn entrypoint. Modal's `Image.from_registry` requirements shape
@@ -55,7 +55,8 @@
 
 # Must satisfy pyproject requires-python (>=3.12); 3.11 fails dependency resolution.
 ARG PYTHON_VERSION=3.12
-# Node 22+ is required for @moonshot-ai/kimi-code (Kimi Code CLI).
+# Node 22+ is required by the harness CLIs installed below (claude-code and
+# pi-coding-agent declare engines.node >= 22).
 ARG NODE_VERSION=22
 
 # ── Web UI builder ──────────────────────────────────────
@@ -170,8 +171,8 @@ FROM node:${NODE_VERSION}-slim AS node-runtime
 # port" and breaks web-turn injection), bubblewrap to OS-sandbox the
 # native harness terminals (mandatory and fail-loud on Linux), curl + CA
 # certificates for outbound HTTPS and in-sandbox downloads, plus the
-# coding-harness CLIs (claude / codex / pi / kimi / kiro-cli) so claude-sdk,
-# claude-native, codex, pi, kimi-native, and kiro-native agents can run in managed
+# coding-harness CLIs (claude / codex / pi / kiro-cli) so claude-sdk,
+# claude-native, codex, pi, and kiro-native agents can run in managed
 # sandboxes without an in-sandbox install. No SPA, no psycopg, no server
 # entrypoint.
 #
@@ -245,7 +246,6 @@ RUN npm install -g --no-audit --no-fund \
       @anthropic-ai/claude-code \
       @openai/codex \
       @earendil-works/pi-coding-agent \
-      @moonshot-ai/kimi-code \
  && npm cache clean --force
 
 # Kiro CLI is not published as an npm package; use its official installer and

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -124,7 +124,7 @@ For Databricks, use `auth: {type: databricks, profile: …}`.
 `harness: kimi` runs the agent through Moonshot AI's
 [Kimi Code CLI](https://github.com/MoonshotAI/Kimi-Code) headlessly via
 `kimi --print --output-format stream-json` per turn. Install the binary
-with `curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash`
+with `npm install -g @moonshot-ai/kimi-code`
 and authenticate once with `kimi login` (OAuth or a Moonshot API key).
 
 ```yaml

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10133,19 +10133,18 @@ def _manage_kimi_harness() -> None:
     from omnigent.onboarding.harness_install import (
         KIMI_KEY,
         harness_cli_installed,
-        harness_install_spec,
+        harness_install_command,
         harness_login,
         harness_logout,
     )
     from omnigent.onboarding.interactive import console, select
 
-    # Gate on the CLI. Kimi ships a single binary via a curl installer (not
-    # npm), so there's no in-process auto-install — name the command and let
-    # the user run it, then re-open. Mirrors how ``harness_setup_hint`` treats
-    # the other curl-installed CLI (cursor-agent).
+    # Gate on the CLI. Kimi ships as the ``@moonshot-ai/kimi-code`` npm
+    # package, so name its install command and let the user run it, then
+    # re-open. Mirrors how the other npm-installed CLIs surface their
+    # install command (e.g. ``harness_install_command`` in the picker rows).
     if not harness_cli_installed(KIMI_KEY):
-        spec = harness_install_spec(KIMI_KEY)
-        hint = (spec.install_hint if spec else None) or "see Kimi Code docs"
+        hint = " ".join(harness_install_command(KIMI_KEY))
         console.print(
             "  Kimi Code's CLI isn't installed. Install it with:\n"
             f"    [bold]{hint}[/bold]\n"
@@ -11244,15 +11243,15 @@ def _run_configure_harnesses_interactive() -> None:
             rows.append((_KIRO, "Kiro", "Not installed", "missing", _install_hint(kiro_hint)))
 
         # Kimi Code — native CLI, own auth via `kimi login`; there is no local
-        # login status probe yet. Curl-installed (no npm package), so use its
-        # install_hint when absent and show "not configured" when present.
+        # login status probe yet. npm-installed (``@moonshot-ai/kimi-code``),
+        # so show the npm install command when absent and "not configured"
+        # when present.
         if harness_cli_installed(KIMI_KEY):
             rows.append(
                 (_KIMI, "Kimi Code", "Not configured", "warn", "Sign in with `kimi login`.")
             )
         else:
-            kimi_spec = harness_install_spec(KIMI_KEY)
-            kimi_hint = (kimi_spec.install_hint if kimi_spec else None) or "see Kimi Code docs"
+            kimi_hint = " ".join(harness_install_command(KIMI_KEY))
             rows.append((_KIMI, "Kimi Code", "Not installed", "missing", _install_hint(kimi_hint)))
         return rows
 

--- a/omnigent/inner/kimi_executor.py
+++ b/omnigent/inner/kimi_executor.py
@@ -1,8 +1,8 @@
 """Kimi Code CLI executor.
 
 Drives Moonshot AI's upstream ``kimi`` CLI from
-https://github.com/MoonshotAI/Kimi-Code (the curl-installed
-single-binary build at https://code.kimi.com/kimi-code/install.sh).
+https://github.com/MoonshotAI/Kimi-Code (the ``@moonshot-ai/kimi-code``
+npm package).
 The legacy pypi ``kimi-cli`` package is **not** supported — its
 command-line surface (``--print``, list-of-blocks content, etc.) is
 incompatible with the upstream binary the issue (#271) targets.
@@ -423,7 +423,7 @@ class KimiExecutor(Executor):
             yield ExecutorError(
                 message=(
                     f"kimi harness: binary {self._binary_path!r} not found on PATH. "
-                    "Install via `curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash` "
+                    "Install via `npm install -g @moonshot-ai/kimi-code` "
                     "or set HARNESS_KIMI_PATH to its absolute location."
                 ),
                 retryable=False,

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -135,7 +135,7 @@ def resolve_kimi_executable(
     if resolved is None:
         raise click.ClickException(
             "Native Kimi requires the 'kimi' CLI on PATH. Install it with: "
-            "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash, then "
+            "npm install -g @moonshot-ai/kimi-code, then "
             f"run 'kimi login'. You can also set {_KIMI_PATH_ENV}=/path/to/kimi."
         )
     return resolved

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -58,8 +58,9 @@ QWEN_KEY = "qwen"
 CURSOR_KEY = "cursor"
 
 # Kimi authenticates against Moonshot AI's backend (``kimi login`` OAuth or a
-# Moonshot API key), not via the ambient provider config; like Cursor it ships
-# via a curl installer rather than npm, so it carries an ``install_hint``.
+# Moonshot API key), not via the ambient provider config. It ships as the
+# ``@moonshot-ai/kimi-code`` npm package, so ``omnigent setup`` can install it
+# the same way it installs Claude / Codex / Pi.
 KIMI_KEY = "kimi"
 
 # Kiro authenticates against its own backend and ships as a standalone native
@@ -188,20 +189,19 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         install_hint="curl https://cursor.com/install -fsS | bash",
         login_status_key="isAuthenticated",
     ),
-    # Kimi Code CLI ships a single-binary ``kimi`` via a curl installer (no
-    # npm). ``kimi login`` is the interactive provider login (OAuth or a
-    # Moonshot API key). ``status_args`` is intentionally ``None``: kimi has
-    # no first-class "am I logged in?" exit-code probe — login state is
-    # only inspected interactively. With ``None`` the login path runs every
-    # time the operator asks for it (interactive, so they can cancel if
-    # already authenticated).
+    # Kimi Code CLI ships as the ``@moonshot-ai/kimi-code`` npm package and
+    # exposes the ``kimi`` binary. ``kimi login`` is the interactive provider
+    # login (OAuth or a Moonshot API key). ``status_args`` is intentionally
+    # ``None``: kimi has no first-class "am I logged in?" exit-code probe —
+    # login state is only inspected interactively. With ``None`` the login path
+    # runs every time the operator asks for it (interactive, so they can cancel
+    # if already authenticated).
     KIMI_KEY: HarnessInstallSpec(
         "Kimi",
         "kimi",
-        package=None,
+        package="@moonshot-ai/kimi-code",
         login_args=("login",),
         logout_args=("logout",),
-        install_hint="curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
     ),
     KIRO_KEY: HarnessInstallSpec(
         "Kiro",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -4957,10 +4957,10 @@ def test_manage_goose_harness_configure_launches(
 def test_manage_kimi_harness_not_installed_shows_hint_returns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A missing kimi CLI shows the curl install_hint and returns.
+    """A missing kimi CLI shows the npm install command and returns.
 
-    Kimi is curl-installed (no npm ``package``), so the drill-in can't
-    auto-install it — it must surface the install_hint and bail without
+    The drill-in gates on the CLI: it must surface the
+    ``@moonshot-ai/kimi-code`` npm install command and bail without
     touching login / logout.
     """
     import omnigent.onboarding.harness_install as hi
@@ -4980,9 +4980,9 @@ def test_manage_kimi_harness_not_installed_shows_hint_returns(
 
     login.assert_not_called()
     logout.assert_not_called()
-    # The curl install command was surfaced to the user.
+    # The npm install command was surfaced to the user.
     printed = " ".join(str(c.args[0]) for c in console.print.call_args_list if c.args)
-    assert "code.kimi.com/kimi-code/install.sh" in printed
+    assert "npm install -g @moonshot-ai/kimi-code" in printed
 
 
 def test_manage_kimi_harness_back_does_not_login(

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -200,9 +200,10 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     forwarder unit tests plus the ``test_native_kiro_render_parity`` e2e_ui suite.
 
     ``kimi`` is excluded for the same reason as ``hermes``: it requires the
-    ``kimi`` CLI binary (installed via Moonshot's curl installer) and
-    authenticates through ``kimi login`` (OAuth or a Moonshot API key), not the
-    shared Databricks gateway/profile probe wiring this matrix drives.
+    ``kimi`` CLI binary (installed via the ``@moonshot-ai/kimi-code`` npm
+    package) and authenticates through ``kimi login`` (OAuth or a Moonshot
+    API key), not the shared Databricks gateway/profile probe wiring this
+    matrix drives.
 
     ``kimi-native`` is excluded for the same reason as ``goose-native`` /
     ``qwen-native`` / ``kiro-native``: it is a terminal-first TUI launched via

--- a/tests/e2e/test_kimi_executor_e2e.py
+++ b/tests/e2e/test_kimi_executor_e2e.py
@@ -38,7 +38,7 @@ pytestmark = pytest.mark.skipif(
     reason=(
         "Real-binary e2e: requires OMNIGENT_E2E_KIMI=1 and the ``kimi`` (or "
         "HARNESS_KIMI_PATH) binary on PATH. Install via "
-        "`curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash` and "
+        "`npm install -g @moonshot-ai/kimi-code` and "
         "run ``kimi login`` once, then re-run with OMNIGENT_E2E_KIMI=1."
     ),
 )

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -32,17 +32,23 @@ def test_install_spec_and_command(key: str, binary: str, package: str) -> None:
     assert hi.harness_install_command(key) == ["npm", "install", "-g", package]
 
 
-def test_kimi_install_spec_is_login_only_no_npm() -> None:
-    """Kimi ships via a curl installer (no npm package) and authenticates
-    through its own ``kimi login`` (OAuth or Moonshot API key), so it carries
-    an ``install_hint`` instead of a ``package`` and intentionally has no
+def test_kimi_install_spec_is_login_only_npm() -> None:
+    """Kimi ships as the ``@moonshot-ai/kimi-code`` npm package and
+    authenticates through its own ``kimi login`` (OAuth or Moonshot API key),
+    so it carries a ``package`` (no ``install_hint``) and intentionally has no
     ``status_args`` (no exit-code "am I logged in?" probe to read).
     """
     spec = hi.harness_install_spec(hi.KIMI_KEY)
     assert spec is not None
     assert spec.binary == "kimi"
-    assert spec.package is None
-    assert spec.install_hint is not None and "code.kimi.com" in spec.install_hint
+    assert spec.package == "@moonshot-ai/kimi-code"
+    assert spec.install_hint is None
+    assert hi.harness_install_command(hi.KIMI_KEY) == [
+        "npm",
+        "install",
+        "-g",
+        "@moonshot-ai/kimi-code",
+    ]
     assert spec.login_args == ("login",)
     assert spec.logout_args == ("logout",)
     assert spec.status_args is None
@@ -226,10 +232,11 @@ def test_setup_hint_for_native_kiro_points_at_vendor_installer(harness: str) -> 
     assert "omnigent setup" not in hint
 
 
-@pytest.mark.parametrize("harness", ["claude-native", "codex", "pi", "claude-sdk", None])
+@pytest.mark.parametrize("harness", ["claude-native", "codex", "pi", "kimi", "claude-sdk", None])
 def test_setup_hint_defaults_to_omnigent_setup(harness: str | None) -> None:
-    """Harnesses whose CLI ``omnigent setup`` installs (npm CLIs) — and the
-    SDK / unknown / ``None`` cases — route to the ``omnigent setup`` hint."""
+    """Harnesses whose CLI ``omnigent setup`` installs (npm CLIs, incl. kimi
+    via ``@moonshot-ai/kimi-code``) — and the SDK / unknown / ``None`` cases —
+    route to the ``omnigent setup`` hint."""
     hint = hi.harness_setup_hint(harness)
     assert "omnigent setup" in hint
 


### PR DESCRIPTION
## Summary

Omnigent v0.2.0 added Kimi Code as a native harness, but the official `omnigent-host` image does not currently ship the `kimi` binary. As a result, `kimi`, `kimi-native`, and `native-kimi` agents fail in managed sandboxes (Modal, Daytona, etc.) with a missing CLI.

This PR fixes that by pre-installing the official npm package `@moonshot-ai/kimi-code` in the host image, and updating `omnigent/onboarding/harness_install.py` so `omnigent setup` can auto-install it too.

## Changes

- `deploy/docker/Dockerfile`:
  - Bump `NODE_VERSION` from `20` to `22` because `@moonshot-ai/kimi-code` requires Node `>=22.19.0`.
  - Add `@moonshot-ai/kimi-code` to the global `npm install -g` harness CLI set, alongside Claude, Codex, Pi, and OpenCode.
  - Update comments to list Kimi alongside the other pre-installed harness CLIs.

- `omnigent/onboarding/harness_install.py`:
  - Set `package="@moonshot-ai/kimi-code"` for the Kimi harness spec.
  - Remove the curl `install_hint` so `omnigent setup` installs Kimi the same way it installs Claude / Codex / Pi.
  - Update docstrings to reflect the npm distribution.

## Notes

The host Dockerfile comment states:

> The harness CLI set mirrors `omnigent/onboarding/harness_install.py` — keep the two in sync.

This PR restores that sync for Kimi.
