### PR TITLE
fix(antigravity-native): disable agy feedback survey so it can't swallow web turns (#1494)

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -90,6 +90,7 @@ from omnigent.antigravity_native_bridge import (
     AntigravityNativeBridgeState,
     bridge_dir_for_bridge_id,
     clear_bridge_state,
+    ensure_agy_feedback_survey_disabled,
     ensure_agy_onboarding_complete,
     is_placeholder_conversation_id,
     prepare_bridge_dir,
@@ -973,6 +974,14 @@ async def _launch_and_record(
         permission_mode=permission_mode,
         headless=headless,
         extra_args=antigravity_args,
+    )
+    # agy's feedback survey shares its "esc to cancel" footer with the running-turn
+    # marker, so a web turn injected into this CLI-launched session while the survey
+    # is up would be silently lost (#1494). Disable it in the launch HOME before agy
+    # starts. This path emits no HOME override, so agy runs under the real ~/.gemini.
+    await asyncio.to_thread(
+        ensure_agy_feedback_survey_disabled,
+        Path(env_overrides.get("HOME") or Path.home()),
     )
     _update_progress(startup_progress, "Starting Antigravity terminal...")
     launched = await _launch_antigravity_terminal(

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -506,6 +506,121 @@ def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
     return {"HOME": str(iso_home)}
 
 
+# agy's periodic engagement survey ("How's the CLI experience so far?") is gated by
+# this ``settings.json`` key. Its modal footer line ``esc to cancel`` is identical
+# to :data:`_AGY_ACTIVE_MARKER` (the running-turn signal the TUI inject path keys
+# on), so a web turn typed into the pane while the survey is up is misread as a
+# mid-turn steer and silently lost (#1494). Disabling the survey removes the
+# trigger. Verified live: toggling agy's ``/config`` "Show Feedback Survey" off
+# writes exactly ``"showFeedbackSurvey": false`` here (``disableFeedback`` is an
+# unrelated internal proto field, NOT a settings key — it would be ignored).
+_AGY_FEEDBACK_SURVEY_SETTING = "showFeedbackSurvey"
+
+
+def ensure_agy_feedback_survey_disabled(home: Path) -> None:
+    """
+    Disable agy's feedback survey in the launch HOME's ``settings.json``.
+
+    agy periodically renders an engagement survey whose modal footer
+    (``esc to cancel``) collides with :data:`_AGY_ACTIVE_MARKER`; with it up, a
+    web turn injected into the TUI is mistaken for a running turn and lost
+    (#1494). The survey is governed by ``showFeedbackSurvey`` in
+    ``<home>/.gemini/antigravity-cli/settings.json`` — set it ``false`` before
+    launch so the survey never appears (deterministic prevention; text-matching
+    the survey itself would be brittle to agy wording changes).
+
+    Merge-only + idempotent: existing keys (``model``, ``trustedWorkspaces``,
+    ``enableTelemetry``, …) are preserved; a missing file is created with just
+    this key; a malformed / non-object file is left UNTOUCHED rather than
+    clobbered. Best-effort — a read/write failure is logged and the launch
+    proceeds (the survey is a degradation, not a hard blocker).
+
+    :param home: The HOME agy launches under (the per-session isolated home, or
+        the real home when the harness runs agy under it). Settings live at
+        ``<home>/.gemini/antigravity-cli/settings.json``.
+    :returns: None.
+    """
+    # resolve() follows a symlinked settings.json (e.g. a dotfiles-managed file) to
+    # its real target, so the atomic os.replace below rewrites the linked file rather
+    # than silently replacing the symlink with a regular one. strict=False is a no-op
+    # for a normal or not-yet-existing path (it only resolves parent symlinks).
+    settings_path = (home / ".gemini" / "antigravity-cli" / "settings.json").resolve(strict=False)
+    data: dict[str, object] = {}
+    try:
+        raw = settings_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raw = ""  # no settings yet -> create a fresh one carrying just this key
+    except OSError:
+        # An EXISTING but unreadable file (perms, stale NFS, …) must NOT be
+        # recreated from scratch — that would drop the user's real settings.
+        _logger.warning(
+            "could not read agy settings.json at %s; leaving it untouched",
+            settings_path,
+            exc_info=True,
+        )
+        return
+    except UnicodeDecodeError:
+        # read_text raises this (a ValueError, not an OSError) on non-UTF-8 bytes;
+        # treat it like malformed JSON and never clobber the file (mirrors the
+        # ``(OSError, ValueError)`` read guard in ensure_agy_onboarding_complete).
+        _logger.warning(
+            "agy settings.json at %s is not valid UTF-8; leaving it untouched",
+            settings_path,
+        )
+        return
+    if raw.strip():
+        try:
+            loaded = json.loads(raw)
+        except ValueError:
+            # json.JSONDecodeError subclasses ValueError; catch the supertype to
+            # match the decode-family guard in ensure_agy_onboarding_complete.
+            _logger.warning(
+                "agy settings.json at %s is not valid JSON; leaving it untouched "
+                "(the feedback survey may still appear)",
+                settings_path,
+            )
+            return
+        if not isinstance(loaded, dict):
+            _logger.warning(
+                "agy settings.json at %s is not a JSON object; leaving it untouched",
+                settings_path,
+            )
+            return
+        data = loaded
+    if data.get(_AGY_FEEDBACK_SURVEY_SETTING) is False:
+        return  # already disabled — avoid a needless rewrite
+    data[_AGY_FEEDBACK_SURVEY_SETTING] = False
+    # The write is atomic (mkstemp + os.replace) so a concurrent reader/writer
+    # never sees a torn file. On macOS the harness runs agy under the user's REAL
+    # ~/.gemini (the #1477 Keychain trade-off), so this file is shared across
+    # concurrent sessions and with agy itself: the atomic replace prevents
+    # corruption but not lost updates. That window is self-limiting — the
+    # idempotent short-circuit above makes every launch after the first disable
+    # read-only, so a racing agy trust/model write can only be clobbered on the
+    # one-time first disable, and the clobbered values fail safe (lost trust is
+    # re-prompted, lost model defaults). A cross-process lock is intentionally not
+    # taken (a separately-launched agy would not honor it).
+    try:
+        settings_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix="settings.json.", dir=str(settings_path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())  # crash-safe, mirrors ensure_agy_onboarding_complete
+            os.replace(tmp_name, settings_path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+    except OSError:
+        _logger.warning(
+            "could not write agy settings.json at %s to disable the feedback survey",
+            settings_path,
+            exc_info=True,
+        )
+
+
 def write_bridge_state(bridge_dir: Path, state: AntigravityNativeBridgeState) -> None:
     """
     Persist shared native Antigravity state atomically.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4091,6 +4091,7 @@ async def _auto_create_antigravity_terminal(
         ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY,
         AntigravityNativeBridgeState,
         clear_bridge_state,
+        ensure_agy_feedback_survey_disabled,
         ensure_agy_onboarding_complete,
         prepare_bridge_dir,
         seed_isolated_agy_home,
@@ -4197,6 +4198,10 @@ async def _auto_create_antigravity_terminal(
         **env_overrides,
         **await asyncio.to_thread(seed_isolated_agy_home, bridge_dir),
     }
+    # agy's periodic feedback survey shares its "esc to cancel" footer with the
+    # running-turn marker, so a web turn injected while it is up is misread as an
+    # active turn and lost (#1494). Disable it in the launch HOME before agy starts.
+    await asyncio.to_thread(ensure_agy_feedback_survey_disabled, Path(env_overrides["HOME"]))
     # Start the shared comment/sys_* relay against THIS session's bridge dir before
     # launch so its tool_relay.json is on disk when agy first scans the MCP server.
     # ``await_notify=False``: agy starts its MCP client lazily, so awaiting the

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -18,6 +18,7 @@ from omnigent.antigravity_native_bridge import (
     build_antigravity_native_spawn_env,
     build_mcp_config,
     clear_bridge_state,
+    ensure_agy_feedback_survey_disabled,
     ensure_agy_onboarding_complete,
     inject_user_message_via_tui,
     prepare_bridge_dir,
@@ -1215,3 +1216,141 @@ def test_send_interaction_keys_via_tui_rejects_empty_keys(tmp_path: Path) -> Non
     """No keys is a programming error, not an empty send-keys call."""
     with pytest.raises(RuntimeError, match="at least one key"):
         send_interaction_keys_via_tui(tmp_path / "bridge")
+
+
+def _agy_settings_path(home: Path) -> Path:
+    return home / ".gemini" / "antigravity-cli" / "settings.json"
+
+
+def test_ensure_agy_feedback_survey_disabled_creates_missing_settings(tmp_path: Path) -> None:
+    """A home with no settings.json gets one carrying just the disable key."""
+    ensure_agy_feedback_survey_disabled(tmp_path)
+    assert json.loads(_agy_settings_path(tmp_path).read_text(encoding="utf-8")) == {
+        "showFeedbackSurvey": False
+    }
+
+
+def test_ensure_agy_feedback_survey_disabled_merges_preserving_keys(tmp_path: Path) -> None:
+    """The user's other settings (model/trustedWorkspaces/…) survive the merge."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps(
+            {
+                "enableTelemetry": False,
+                "model": "Gemini 3.5 Flash (High)",
+                "trustedWorkspaces": ["/work/a"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    ensure_agy_feedback_survey_disabled(tmp_path)
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data["showFeedbackSurvey"] is False
+    assert data["model"] == "Gemini 3.5 Flash (High)"
+    assert data["trustedWorkspaces"] == ["/work/a"]
+    assert data["enableTelemetry"] is False
+
+
+def test_ensure_agy_feedback_survey_disabled_idempotent_no_rewrite(tmp_path: Path) -> None:
+    """Already-false short-circuits before any (reformatting) rewrite."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    original = '{"showFeedbackSurvey": false, "model": "x"}'  # compact + unsorted
+    settings.write_text(original, encoding="utf-8")
+    ensure_agy_feedback_survey_disabled(tmp_path)
+    # Untouched byte-for-byte: the function returned at the already-disabled guard
+    # rather than rewriting (which would indent + sort the keys).
+    assert settings.read_text(encoding="utf-8") == original
+
+
+def test_ensure_agy_feedback_survey_disabled_skips_malformed(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A malformed settings.json is left untouched (never clobbered)."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text("{ not valid json", encoding="utf-8")
+    with caplog.at_level(logging.WARNING):
+        ensure_agy_feedback_survey_disabled(tmp_path)
+    assert settings.read_text(encoding="utf-8") == "{ not valid json"
+    assert "not valid JSON" in caplog.text
+
+
+def test_ensure_agy_feedback_survey_disabled_skips_non_dict(tmp_path: Path) -> None:
+    """A JSON file that isn't an object is left untouched."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text('["a", "b"]', encoding="utf-8")
+    ensure_agy_feedback_survey_disabled(tmp_path)
+    assert settings.read_text(encoding="utf-8") == '["a", "b"]'
+
+
+def test_ensure_agy_feedback_survey_disabled_leaves_non_utf8_untouched(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Non-UTF-8 bytes must not crash the launch nor clobber the file (#1494 review)."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_bytes(b"\xff\xfe not valid utf-8 \x00")
+    with caplog.at_level(logging.WARNING):
+        ensure_agy_feedback_survey_disabled(tmp_path)  # must NOT raise
+    assert settings.read_bytes() == b"\xff\xfe not valid utf-8 \x00"
+    assert "not valid UTF-8" in caplog.text
+
+
+def test_ensure_agy_feedback_survey_disabled_skips_unreadable_existing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An existing-but-unreadable file (OSError != FileNotFoundError) is not clobbered."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text('{"model": "x"}', encoding="utf-8")
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> str:
+        raise PermissionError("unreadable")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    with caplog.at_level(logging.WARNING):
+        ensure_agy_feedback_survey_disabled(tmp_path)
+    # Path.read_text is patched, so read back via the builtin open.
+    with open(settings, encoding="utf-8") as handle:
+        assert handle.read() == '{"model": "x"}'
+    assert "could not read" in caplog.text
+
+
+def test_ensure_agy_feedback_survey_disabled_on_empty_file(tmp_path: Path) -> None:
+    """An empty settings.json is treated as create-fresh."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text("", encoding="utf-8")
+    ensure_agy_feedback_survey_disabled(tmp_path)
+    assert json.loads(settings.read_text(encoding="utf-8")) == {"showFeedbackSurvey": False}
+
+
+def test_ensure_agy_feedback_survey_disabled_flips_true_to_false(tmp_path: Path) -> None:
+    """An explicit ``true`` is flipped to ``false`` (other keys preserved)."""
+    settings = _agy_settings_path(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({"showFeedbackSurvey": True, "model": "x"}), encoding="utf-8")
+    ensure_agy_feedback_survey_disabled(tmp_path)
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    assert data == {"showFeedbackSurvey": False, "model": "x"}
+
+
+def test_ensure_agy_feedback_survey_disabled_follows_symlink(tmp_path: Path) -> None:
+    """A symlinked settings.json (dotfiles) is followed, not replaced (agy review)."""
+    real = tmp_path / "dotfiles" / "agy-settings.json"
+    real.parent.mkdir(parents=True)
+    real.write_text(json.dumps({"model": "x"}), encoding="utf-8")
+    link = _agy_settings_path(tmp_path)
+    link.parent.mkdir(parents=True)
+    link.symlink_to(real)
+    ensure_agy_feedback_survey_disabled(tmp_path)
+    # The symlink is preserved (not clobbered into a regular file) and the real
+    # target gained the key.
+    assert link.is_symlink()
+    assert json.loads(real.read_text(encoding="utf-8")) == {
+        "model": "x",
+        "showFeedbackSurvey": False,
+    }


### PR DESCRIPTION
## Summary

Takes over #1501 (author @btli / Bryan Li) to fix #1494.

agy periodically renders an engagement survey ("How's the CLI experience so far?") whose modal footer line `esc to cancel` is **byte-identical** to `_AGY_ACTIVE_MARKER` in `omnigent/antigravity_native_bridge.py` — the running-turn signal the TUI turn-injection path keys on. While the survey is up:

- `_wait_for_agy_prompt_ready` falsely reports "ready" (the marker is present), and
- `_submit_and_verify` takes its **mid-turn-steer** branch and returns success *without* verifying,

so a web/mobile turn typed into the pane is pasted into the survey menu and **silently lost while reported delivered**.

## Fix

Disable the survey deterministically *before* agy launches by setting `"showFeedbackSurvey": false` in agy's `settings.json`, so the colliding footer never renders. Prevention beats text-matching the survey, which would be brittle to agy wording changes.

New `ensure_agy_feedback_survey_disabled(home)` in `antigravity_native_bridge.py`:
- merge-only (preserves `model` / `trustedWorkspaces` / `enableTelemetry` / …),
- idempotent (no rewrite once already `false`),
- never clobbers data — `FileNotFoundError` creates a fresh file; other `OSError` / `UnicodeDecodeError` / malformed-JSON / non-object files are left untouched; a symlinked `settings.json` (dotfiles) is followed via `resolve()` so the link is not replaced with a regular file,
- atomic write (`mkstemp` + `os.replace`) with `flush()` + `fsync()`, best-effort (logs and proceeds on error — the survey is a degradation, not a hard blocker).

Wired into **both** launch paths against the resolved launch HOME, before agy starts:
- `omnigent/runner/app.py::_auto_create_antigravity_terminal` (Linux isolated home), and
- `omnigent/antigravity_native.py::_launch_and_record` (the `omnigent antigravity` CLI; real `~/.gemini` on macOS).

## Tests

10 new unit tests in `tests/test_antigravity_native_bridge.py` (create / merge / idempotent-no-rewrite / malformed / non-dict / non-UTF-8 / unreadable-existing / empty-file / flip-true→false / follow-symlink).

- `python -m pytest tests/test_antigravity_native*.py -q` → **428 passed**.
- `ruff check` on all touched files → clean.

## Provenance

Cherry-picked Bryan Li's commit from #1501 onto current `main` (cleanly — git auto-merged the `app.py` hunk despite line drift, no conflicts). Bryan Li's authorship is preserved; credited as co-author.

Closes #1494.

This pull request and its description were written by Isaac.
