### PR TITLE
fix(antigravity-native): re-scan on bridge clear to surface deferred chained-&& gates (#1472)

### DIFF
--- a/omnigent/antigravity_native_interactions.py
+++ b/omnigent/antigravity_native_interactions.py
@@ -272,6 +272,40 @@ def _freshest_waiting(
     return same_kind
 
 
+def _waiting_step_at(
+    steps: list[dict[str, object]],
+    *,
+    trajectory_id: str,
+    step_index: int,
+) -> PendingInteraction | None:
+    """
+    Return the WAITING interaction at an EXACT ``(trajectory_id, step_index)``.
+
+    Used to PIN delivery to the step the elicitation was surfaced for: when that
+    step is still WAITING at verdict time, the verdict must go to IT — never to a
+    *different*, higher-index gate that appeared meanwhile (which
+    :func:`_freshest_waiting` would wrongly pick, mis-delivering verdict-A to
+    gate-B). Returns ``None`` when that exact step is no longer WAITING — it timed
+    out (→ ERROR) or was answered — so the caller falls back to the freshest
+    WAITING, which is agy's genuine same-gate timeout-retry at a higher index
+    (§2.1). agy gates sequentially today (one WAITING step of a kind at a time), so
+    this only ever differs from ``_freshest_waiting`` if agy were to expose two
+    distinct same-kind gates at once; the pin makes delivery correct even then.
+
+    :param steps: A trajectory steps snapshot (from ``get_steps``).
+    :param trajectory_id: The surfaced step's trajectory id.
+    :param step_index: The surfaced step's index.
+    :returns: The matching WAITING :class:`PendingInteraction`, or ``None``.
+    """
+    for step in steps:
+        pending = pending_interaction(step)
+        if pending is None:
+            continue
+        if pending["trajectory_id"] == trajectory_id and pending["step_index"] == step_index:
+            return pending
+    return None
+
+
 async def bridge_interaction(
     cascade_id: str,
     pending: PendingInteraction,
@@ -351,9 +385,16 @@ async def bridge_interaction(
             )
             return
 
-        # Re-read the freshest WAITING step BEFORE delivering: the captured ids
-        # may be stale if agy timed out + retried while the human deliberated.
-        fresh = _freshest_waiting(await get_steps(), kind=current["kind"])
+        # Re-read the steps BEFORE delivering: the captured ids may be stale if agy
+        # timed out + retried while the human deliberated. PIN to the step we
+        # surfaced if it is STILL WAITING — deliver THIS verdict to THAT gate, never
+        # to a different higher-index gate that appeared meanwhile (#1472 review).
+        # Only when our captured step is gone (timed out → ERROR) do we fall back to
+        # the freshest WAITING, which is agy's same-gate timeout-retry (§2.1).
+        steps = await get_steps()
+        fresh = _waiting_step_at(
+            steps, trajectory_id=current["trajectory_id"], step_index=current["step_index"]
+        ) or _freshest_waiting(steps, kind=current["kind"])
         if fresh is None:
             _logger.warning(
                 "agy elicitation %s resolved but no WAITING step remains to "

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -1059,7 +1059,14 @@ async def supervise_reader(
             for pending in inflight:
                 pending.cancel()
             for pending in inflight:
-                with contextlib.suppress(asyncio.CancelledError):
+                # Await each cancelled task to completion. Suppress not only the
+                # expected CancelledError but ANY exception: a task that had already
+                # finished with a real error (before the cancel landed) would re-raise
+                # it here and abort the drain, stranding the remaining tasks
+                # uncancelled (resource leak). Its own done-callback already logged
+                # that error, so swallowing it here is safe (asyncio.CancelledError is
+                # a BaseException, hence listed explicitly alongside Exception).
+                with contextlib.suppress(asyncio.CancelledError, Exception):
                     await pending
 
     # Report how many committed steps (turns) this run mirrored for the bound

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -123,6 +123,12 @@ _DEFAULT_ROTATION_INTERVAL_S = 3.0
 # exception, never a clean immediate return.
 _STREAM_REENTRY_BACKOFF_S = 0.5
 
+# Bound on the teardown drain of the interaction bridge + its chained re-scan tasks
+# (#1472). Cancelling a bridge stops it scheduling a re-scan and cancelling a re-scan
+# stops it spawning a bridge, so the chain collapses in ~2 passes; a few extra give
+# slack without risking an unbounded loop.
+_INTERACTION_DRAIN_PASSES = 4
+
 # POST retry policy, kept identical to the transcript forwarder's so mirrored
 # items are delivered with the same transient-retry semantics. Conversation
 # items persist with a random primary key and are NOT deduped server-side, so an
@@ -1030,11 +1036,25 @@ async def supervise_reader(
             body_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await body_task
-        active = state.interaction_task
-        if active is not None and not active.done():
-            active.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await active
+        # Drain the off-loop interaction bridge AND any re-scan tasks it chained
+        # (#1472: a cleared bridge re-scans for a deferred gate, which may spawn the
+        # next bridge). A cancelled bridge does NOT schedule a re-scan and a cancelled
+        # re-scan cannot spawn a bridge (its only spawn point runs after an await it is
+        # cancelled at), so cancelling both reaches quiescence in a few bounded passes
+        # — never an unbounded chain.
+        for _ in range(_INTERACTION_DRAIN_PASSES):
+            inflight = [
+                pending
+                for pending in (state.interaction_task, *state.interaction_rescans)
+                if pending is not None and not pending.done()
+            ]
+            if not inflight:
+                break
+            for pending in inflight:
+                pending.cancel()
+            for pending in inflight:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await pending
 
     # Report how many committed steps (turns) this run mirrored for the bound
     # cascade. The caller uses a count of 0 to distinguish "first TUI-minted
@@ -1105,6 +1125,14 @@ class _ReaderState:
         is later seen NO LONGER WAITING (answered in the agy TUI, or agy timed
         out) to WITHDRAW the still-parked web card (#1200, direction 2). An entry
         is removed once withdrawn so the withdraw posts at most once.
+    :param interaction_rescans: In-flight "re-scan after a bridge cleared" tasks.
+        When an interaction bridge finishes, its done-callback re-reads the freshest
+        steps and re-dispatches them (:func:`_resurface_pending_interaction`) so a
+        WAITING gate the single-in-flight guard DEFERRED — e.g. the next segment of a
+        chained ``a && b`` command, gated separately — is surfaced without waiting
+        for a fresh stream frame (agy emits none while parked on that gate, #1472).
+        Held as strong refs so a fire-and-forget re-scan is not GC'd mid-run; each is
+        discarded on completion and all are cancelled on reader teardown.
     """
 
     allocator: _ToolCallIdAllocator
@@ -1121,6 +1149,7 @@ class _ReaderState:
     cumulative_cache_read_input_tokens: int = 0
     interaction_task: asyncio.Task[None] | None = None
     surfaced_elicitations: dict[_StepKey, str] = field(default_factory=dict)
+    interaction_rescans: set[asyncio.Task[None]] = field(default_factory=set)
 
 
 async def _poll_loop(
@@ -1719,8 +1748,11 @@ def _maybe_handle_interaction(
     ``bridge_interaction`` already owns those retries via its own freshest-WAITING
     re-read, so spawning a second task for a retry step would surface a duplicate
     elicitation and a competing delivery. Subsequent WAITING steps are skipped
-    while a task is active; its done-callback then clears the slot so a genuinely
-    new later interaction can fire.
+    while a task is active; its done-callback then clears the slot AND re-scans the
+    freshest steps (:func:`_resurface_pending_interaction`) so a genuinely-NEW gate
+    deferred during that window — e.g. the next segment of a chained ``a && b``
+    command, each gated separately — is surfaced even when no further stream frame
+    will carry it (agy stays parked on that gate, emitting none) (#1472).
 
     The callback gets the SAME ``cascade_id`` + ``port`` (from ``state``) the
     reader discovered, so the bridge targets agy's live conversation without
@@ -1760,21 +1792,104 @@ def _maybe_handle_interaction(
     async def _run_bridge() -> None:
         await on_pending_interaction(cascade_id, state.port, pending)
 
-    def _clear_slot(completed: asyncio.Task[None]) -> None:
-        if state.interaction_task is completed:
-            state.interaction_task = None
-        if not completed.cancelled():
-            exc = completed.exception()
+    def _clear_rescan(done: asyncio.Task[None]) -> None:
+        state.interaction_rescans.discard(done)
+        if not done.cancelled():
+            exc = done.exception()
             if exc is not None:
                 _logger.warning(
-                    "agy interaction bridge task failed (cascade=%s): %r",
+                    "agy interaction re-scan task failed (cascade=%s): %r",
                     cascade_id,
                     exc,
                 )
 
+    def _clear_slot(completed: asyncio.Task[None]) -> None:
+        if state.interaction_task is completed:
+            state.interaction_task = None
+        if completed.cancelled():
+            # Reader teardown cancelled the bridge — the run is ending, so do NOT
+            # spawn a re-scan (teardown drains these tasks; a fresh one would race it).
+            return
+        exc = completed.exception()
+        if exc is not None:
+            _logger.warning(
+                "agy interaction bridge task failed (cascade=%s): %r",
+                cascade_id,
+                exc,
+            )
+        # The single-in-flight guard may have DEFERRED a genuinely-new WAITING gate
+        # (e.g. the next segment of a chained ``a && b`` command, gated separately)
+        # while this bridge ran. The stream only re-presents a step on a NEW frame,
+        # and agy emits none while parked awaiting that gate — so re-scan now rather
+        # than hang (#1472). ``state.interacted`` makes an already-surfaced step a
+        # no-op, so this surfaces only a not-yet-seen gate and self-terminates.
+        rescan = asyncio.create_task(
+            _resurface_pending_interaction(
+                cascade_id=cascade_id,
+                state=state,
+                on_pending_interaction=on_pending_interaction,
+            ),
+            name="antigravity-interaction-rescan",
+        )
+        state.interaction_rescans.add(rescan)
+        rescan.add_done_callback(_clear_rescan)
+
     task = asyncio.create_task(_run_bridge(), name="antigravity-interaction-bridge")
     state.interaction_task = task
     task.add_done_callback(_clear_slot)
+
+
+async def _resurface_pending_interaction(
+    *,
+    cascade_id: str,
+    state: _ReaderState,
+    on_pending_interaction: OnPendingInteraction,
+) -> None:
+    """
+    Re-surface a WAITING interaction the single-in-flight guard DEFERRED.
+
+    Scheduled by an interaction bridge's done-callback (``_clear_slot`` in
+    :func:`_maybe_handle_interaction`). While one bridge runs, the guard skips any
+    other WAITING step so two bridges never race agy's freshest-WAITING delivery
+    (which targets the highest-index WAITING step of a kind, with no per-step
+    pinning). A genuinely-new gate that arrived during that window — e.g. the next
+    segment of a chained ``a && b`` command, each gated separately — is therefore
+    deferred; on the stream path agy emits no further frame while parked on it, so
+    without this re-scan it would hang forever (#1472).
+
+    This re-reads the freshest trajectory snapshot and re-dispatches every step
+    through :func:`_maybe_handle_interaction`. ``state.interacted`` makes any
+    already-surfaced step a no-op, so at most the one not-yet-seen WAITING gate is
+    surfaced — which spawns the next bridge, whose own clear re-scans again, draining
+    a chain of sequential gates one at a time. A poll failure is logged and swallowed
+    (mirrors :func:`_poll_loop`): the poll fallback or a later frame still catches the
+    gate, so a transient read error must not crash the re-scan.
+
+    :param cascade_id: agy cascade id (equal to the conversation id).
+    :param state: Per-run reader state — ``port`` is read; ``interacted`` and the
+        ``interaction_task`` slot may be mutated by the re-dispatch.
+    :param on_pending_interaction: Async callback for a distinct interaction.
+    :returns: None.
+    """
+    try:
+        steps = await asyncio.to_thread(get_trajectory_steps, state.port, cascade_id)
+    except (httpx.HTTPError, ValueError) as exc:
+        _logger.warning(
+            "agy interaction re-scan poll failed (cascade=%s, port=%s); the poll "
+            "fallback or a later frame will catch the deferred gate: %r",
+            cascade_id,
+            state.port,
+            exc,
+        )
+        return
+    for step in steps:
+        _maybe_handle_interaction(
+            step,
+            key=_step_key(step),
+            cascade_id=cascade_id,
+            state=state,
+            on_pending_interaction=on_pending_interaction,
+        )
 
 
 async def _maybe_withdraw_interaction(

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -1043,6 +1043,12 @@ async def supervise_reader(
         # cancelled at), so cancelling both reaches quiescence in a few bounded passes
         # — never an unbounded chain.
         for _ in range(_INTERACTION_DRAIN_PASSES):
+            # Flush queued done-callbacks first: a bridge that completed NORMALLY just
+            # before teardown has a pending ``_clear_slot`` that still schedules a
+            # re-scan — yield once so it lands in ``interaction_rescans`` before the
+            # snapshot below, else it would escape the drain and run post-teardown
+            # (#1472 review).
+            await asyncio.sleep(0)
             inflight = [
                 pending
                 for pending in (state.interaction_task, *state.interaction_rescans)
@@ -1849,13 +1855,16 @@ async def _resurface_pending_interaction(
     Re-surface a WAITING interaction the single-in-flight guard DEFERRED.
 
     Scheduled by an interaction bridge's done-callback (``_clear_slot`` in
-    :func:`_maybe_handle_interaction`). While one bridge runs, the guard skips any
-    other WAITING step so two bridges never race agy's freshest-WAITING delivery
-    (which targets the highest-index WAITING step of a kind, with no per-step
-    pinning). A genuinely-new gate that arrived during that window — e.g. the next
-    segment of a chained ``a && b`` command, each gated separately — is therefore
-    deferred; on the stream path agy emits no further frame while parked on it, so
-    without this re-scan it would hang forever (#1472).
+    :func:`_maybe_handle_interaction`). The guard surfaces one interaction at a time
+    because mis-delivery is otherwise possible: agy gates SEQUENTIALLY (one WAITING
+    step of a kind at a time — the next tool step stays PENDING until the current
+    resolves), and ``bridge_interaction`` pins its verdict to the surfaced step (or,
+    if that step timed out, its same-gate retry — see ``_waiting_step_at``). Serial
+    surfacing keeps the human's answer matched to the gate it was shown for. A
+    genuinely-new gate that arrives while a bridge runs — e.g. the next segment of a
+    chained ``a && b`` command, each gated separately — is therefore deferred; on the
+    stream path agy emits no further frame while parked on it, so without this re-scan
+    it would hang forever (#1472).
 
     This re-reads the freshest trajectory snapshot and re-dispatches every step
     through :func:`_maybe_handle_interaction`. ``state.interacted`` makes any

--- a/tests/test_antigravity_native_interactions.py
+++ b/tests/test_antigravity_native_interactions.py
@@ -525,6 +525,39 @@ async def test_freshest_waiting_overrides_stale_captured_index() -> None:
     assert deliver.calls[0]["step_index"] == 6  # NOT the stale 5
 
 
+@pytest.mark.asyncio
+async def test_delivery_pins_to_captured_step_over_distinct_higher_gate() -> None:
+    """Captured step STILL WAITING + a DISTINCT higher-index same-kind WAITING gate
+    in the snapshot → deliver to the CAPTURED step, never the higher one.
+
+    Guards the mis-delivery the #1472 review flagged: ``_freshest_waiting`` alone
+    picks the highest index, so verdict-A could land on gate-B if agy ever exposes
+    two same-kind gates at once. The pin (``_waiting_step_at``) keeps the verdict on
+    the gate it was surfaced for. The complementary timeout-retry case — captured
+    gone, deliver to the fresher index — is covered by
+    ``test_freshest_waiting_overrides_stale_captured_index``.
+    """
+    pending = _pending_question(step_index=5)  # the gate we surfaced
+    captured = _question_step(step_index=5)  # still WAITING at verdict time
+    distinct = _question_step(step_index=6)  # a DIFFERENT same-kind gate, higher index
+    request, _ = _elicitation_returner(ElicitationResult(action="accept", content={"0": "First"}))
+    deliver = _DeliverRecorder()
+    inject_tui = _InjectTuiRecorder()
+
+    await bridge_interaction(
+        _CASCADE,
+        pending,
+        port=52548,
+        get_steps=_steps_returner([captured, distinct]),
+        request_elicitation=request,
+        deliver=deliver,
+        inject_tui=inject_tui,
+    )
+
+    assert len(deliver.calls) == 1
+    assert deliver.calls[0]["step_index"] == 5  # pinned to captured, NOT the higher 6
+
+
 # ---------------------------------------------------------------------------
 # (e) elicitation returns None (timeout / cancel)
 # ---------------------------------------------------------------------------

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -782,8 +782,10 @@ async def test_clear_slot_resurfaces_deferred_gate(monkeypatch: pytest.MonkeyPat
     gate2 = copy.deepcopy(gate1)  # a distinct later gate (the `ls` segment)
     gate2["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"] = 8
     gate2["runCommand"]["commandLine"] = "ls"
-    # The freshest snapshot the re-scan re-reads: gate1 is still present (already
-    # surfaced → must NOT re-fire) and gate2 is the newly-arrived, deferred gate.
+    # The freshest snapshot the re-scan re-reads. gate1 still reads WAITING here —
+    # the dedup-race case: its verdict landed but the DONE transition has not yet
+    # propagated to the snapshot, so ``state.interacted`` (not status) is what stops
+    # it re-firing. gate2 is the newly-arrived, deferred gate.
     monkeypatch.setattr(reader, "get_trajectory_steps", lambda _port, _cascade_id: [gate1, gate2])
 
     fired: list[int] = []
@@ -807,6 +809,123 @@ async def test_clear_slot_resurfaces_deferred_gate(monkeypatch: pytest.MonkeyPat
     assert fired == [6, 8]  # gate1 directly; gate2 via the clear's re-scan
     assert reader._step_key(gate1) in state.interacted  # gate1 was not re-surfaced
     assert reader._step_key(gate2) in state.interacted
+
+
+@pytest.mark.asyncio
+async def test_clear_slot_rescan_empty_then_stream_frame_surfaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Case B (#1472 review): the clear's re-scan finds NOTHING because gate-2 is
+    not WAITING yet (agy must run segment 1 first). The re-scan must then leave the
+    slot OPEN so gate-2's later live stream frame surfaces it directly — proving the
+    single-shot re-scan does not strand a gate that arrives after it runs.
+    """
+    state = reader._ReaderState(
+        allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+        seen=set(),
+        interacted=set(),
+        port=_PORT,
+    )
+    gate1 = _load("run_command_waiting")  # stepIndex 6
+    gate1_done = copy.deepcopy(gate1)  # answered → DONE, no longer WAITING
+    gate1_done["status"] = "CORTEX_STEP_STATUS_DONE"
+    gate1_done.pop("requestedInteraction", None)
+    gate2 = copy.deepcopy(gate1)  # the next segment — arrives only LATER
+    gate2["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"] = 8
+    gate2["runCommand"]["commandLine"] = "ls"
+    # Re-scan snapshot: gate-1 resolved (DONE), gate-2 not present yet → the re-scan
+    # surfaces nothing and must leave the slot open.
+    monkeypatch.setattr(reader, "get_trajectory_steps", lambda _port, _cascade_id: [gate1_done])
+
+    fired: list[int] = []
+
+    async def _quick(_cascade_id: str, _port: int, pending: PendingInteraction) -> None:
+        fired.append(pending["step_index"])
+
+    reader._maybe_handle_interaction(
+        gate1,
+        key=reader._step_key(gate1),
+        cascade_id=_CASCADE_ID,
+        state=state,
+        on_pending_interaction=cast(Any, _quick),
+    )
+    first = state.interaction_task
+    assert first is not None
+    await first
+    await _drain_interactions(state)  # re-scan runs, finds no pending gate
+
+    assert fired == [6]  # only gate-1 so far
+    assert state.interaction_task is None  # slot OPEN — re-scan neither hung nor held it
+
+    # gate-2 now arrives as a live stream frame: with the slot open the guard passes
+    # and it surfaces directly (the backstop that makes the single-shot re-scan safe).
+    reader._maybe_handle_interaction(
+        gate2,
+        key=reader._step_key(gate2),
+        cascade_id=_CASCADE_ID,
+        state=state,
+        on_pending_interaction=cast(Any, _quick),
+    )
+    second = state.interaction_task
+    assert second is not None
+    await second
+    await _drain_interactions(state)
+
+    assert fired == [6, 8]  # gate-2 surfaced via the live frame, not lost
+
+
+@pytest.mark.asyncio
+async def test_rescan_skips_auto_allowed_step_and_surfaces_next_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ALREADY-ALLOWED segment in a chain (e.g. ``rm a && echo hi && rm b`` with
+    ``echo`` auto-allowed) runs WITHOUT a gate — a DONE step with no
+    ``requestedInteraction`` — so it must be transparent to the re-scan: skipped (not
+    surfaced), and the NEXT real gate after it still surfaces. Guards the edge case
+    where not every chained command is permission-gated.
+    """
+    state = reader._ReaderState(
+        allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+        seen=set(),
+        interacted=set(),
+        port=_PORT,
+    )
+    gate1 = _load("run_command_waiting")  # stepIndex 6 — the `rm a` gate
+    gate1_done = copy.deepcopy(gate1)
+    gate1_done["status"] = "CORTEX_STEP_STATUS_DONE"
+    gate1_done.pop("requestedInteraction", None)
+    allowed = copy.deepcopy(gate1)  # the auto-allowed `echo hi` — ran, NEVER gated
+    allowed["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"] = 7
+    allowed["runCommand"]["commandLine"] = "echo hi"
+    allowed["status"] = "CORTEX_STEP_STATUS_DONE"
+    allowed.pop("requestedInteraction", None)  # no interaction → never a delivery target
+    gate2 = copy.deepcopy(gate1)  # the next real gate `rm b`
+    gate2["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"] = 8
+    gate2["runCommand"]["commandLine"] = "rm b"
+    # Re-scan snapshot: gate-1 resolved, the allowed command DONE (no gate), gate-2 WAITING.
+    monkeypatch.setattr(
+        reader, "get_trajectory_steps", lambda _port, _cascade_id: [gate1_done, allowed, gate2]
+    )
+
+    fired: list[int] = []
+
+    async def _quick(_cascade_id: str, _port: int, pending: PendingInteraction) -> None:
+        fired.append(pending["step_index"])
+
+    reader._maybe_handle_interaction(
+        gate1,
+        key=reader._step_key(gate1),
+        cascade_id=_CASCADE_ID,
+        state=state,
+        on_pending_interaction=cast(Any, _quick),
+    )
+    first = state.interaction_task
+    assert first is not None
+    await first
+    await _drain_interactions(state)
+
+    assert fired == [6, 8]  # gate-1, then gate-2 — the allowed step (7) was NEVER surfaced
+    assert reader._step_key(allowed) not in state.interacted  # not an interaction at all
 
 
 @pytest.mark.asyncio

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -697,9 +697,12 @@ async def test_single_in_flight_guard_skips_second_interaction() -> None:
 
 
 @pytest.mark.asyncio
-async def test_interaction_done_callback_clears_slot() -> None:
+async def test_interaction_done_callback_clears_slot(monkeypatch: pytest.MonkeyPatch) -> None:
     """When an interaction task completes, the slot clears so a later distinct
     interaction can fire."""
+    # The clear now ALSO re-scans the freshest steps (#1472); keep that a no-op here
+    # so this test stays focused on slot-clearing + the manual re-fire.
+    monkeypatch.setattr(reader, "get_trajectory_steps", lambda _port, _cascade_id: [])
     state = reader._ReaderState(
         allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
         seen=set(),
@@ -736,6 +739,106 @@ async def test_interaction_done_callback_clears_slot() -> None:
     assert second is not None
     await second
     assert len(fired) == 2  # the slot cleared, so the second interaction fired
+    await _drain_interactions(state)  # settle the no-op re-scans both clears scheduled
+
+
+async def _drain_interactions(state: reader._ReaderState) -> None:
+    """Await the interaction bridge + any chained re-scan tasks to quiescence.
+
+    A cleared bridge schedules a re-scan (#1472) that may spawn the next bridge,
+    whose clear re-scans again; this awaits each link (letting done-callbacks run
+    between rounds) so a test ends with no pending interaction tasks. Bounded so a
+    bug that keeps respawning surfaces as a test hang in CI rather than an infinite
+    loop here.
+    """
+    for _ in range(10):
+        inflight = [
+            task
+            for task in (state.interaction_task, *state.interaction_rescans)
+            if task is not None and not task.done()
+        ]
+        if not inflight:
+            return
+        await asyncio.gather(*inflight, return_exceptions=True)
+        await asyncio.sleep(0)  # let each done-callback schedule the next link
+
+
+@pytest.mark.asyncio
+async def test_clear_slot_resurfaces_deferred_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bridge clearing re-scans and surfaces a gate the guard DEFERRED (#1472).
+
+    Models a chained ``a && b`` command where each segment is permission-gated: the
+    first gate surfaces and is answered; the second arrives while the first bridge
+    is still finishing and is skipped by the single-in-flight guard. On the stream
+    path no further frame carries it, so the clear's re-scan is what surfaces it.
+    """
+    state = reader._ReaderState(
+        allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+        seen=set(),
+        interacted=set(),
+        port=_PORT,
+    )
+    gate1 = _load("run_command_waiting")  # stepIndex 6 (the `pwd` segment)
+    gate2 = copy.deepcopy(gate1)  # a distinct later gate (the `ls` segment)
+    gate2["metadata"]["sourceTrajectoryStepInfo"]["stepIndex"] = 8
+    gate2["runCommand"]["commandLine"] = "ls"
+    # The freshest snapshot the re-scan re-reads: gate1 is still present (already
+    # surfaced → must NOT re-fire) and gate2 is the newly-arrived, deferred gate.
+    monkeypatch.setattr(reader, "get_trajectory_steps", lambda _port, _cascade_id: [gate1, gate2])
+
+    fired: list[int] = []
+
+    async def _quick(_cascade_id: str, _port: int, pending: PendingInteraction) -> None:
+        fired.append(pending["step_index"])
+
+    reader._maybe_handle_interaction(
+        gate1,
+        key=reader._step_key(gate1),
+        cascade_id=_CASCADE_ID,
+        state=state,
+        on_pending_interaction=cast(Any, _quick),
+    )
+    first = state.interaction_task
+    assert first is not None
+    await first
+    await asyncio.sleep(0)  # let _clear_slot run → schedule the re-scan
+    await _drain_interactions(state)  # re-scan surfaces gate2 → its bridge fires
+
+    assert fired == [6, 8]  # gate1 directly; gate2 via the clear's re-scan
+    assert reader._step_key(gate1) in state.interacted  # gate1 was not re-surfaced
+    assert reader._step_key(gate2) in state.interacted
+
+
+@pytest.mark.asyncio
+async def test_resurface_pending_interaction_swallows_poll_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A re-scan whose steps re-read fails is logged and swallowed, not raised."""
+
+    def _boom(_port: int, _cascade_id: str) -> list[dict[str, Any]]:
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(reader, "get_trajectory_steps", _boom)
+    state = reader._ReaderState(
+        allocator=reader._ToolCallIdAllocator(conversation_id=_CASCADE_ID),
+        seen=set(),
+        interacted=set(),
+        port=_PORT,
+    )
+    fired: list[int] = []
+
+    async def _quick(_cascade_id: str, _port: int, pending: PendingInteraction) -> None:
+        fired.append(pending["step_index"])
+
+    # Must not raise despite the read failing.
+    await reader._resurface_pending_interaction(
+        cascade_id=_CASCADE_ID,
+        state=state,
+        on_pending_interaction=cast(Any, _quick),
+    )
+
+    assert fired == []  # no gate surfaced
+    assert state.interaction_task is None  # no bridge spawned
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Takes over #1473 (author **Bryan Li / btli**) to fix #1472: on antigravity-native only the **first** approval gate in a conversation surfaced in the web UI. A subsequent gate in a chained command like `cmd1 && cmd2` (each segment permission-gated) **never rendered an approval card and the agent hung**.

## Root cause

The single-in-flight guard in `_maybe_handle_interaction` skips any new WAITING step while an interaction bridge is in flight, on the assumption that a later WAITING step is only ever a timeout *retry* of the gate the bridge already owns. That holds for retries but not for a genuinely-new distinct gate. The deferred step was never recorded in `state.interacted`, so it could surface later — but only the poll fallback re-reads the full snapshot. The primary stream path acts only on frames, and agy emits none while parked awaiting the gate, so the deferral became permanent (hang).

## Fix

Rather than weaken the one-at-a-time invariant (needed so `bridge_interaction` does not mis-target two concurrent same-kind bridges), the bridge done-callback (`_clear_slot`) now **re-scans the freshest trajectory steps** (`_resurface_pending_interaction`) and re-dispatches them when a bridge clears normally. `state.interacted` makes an already-surfaced step a no-op, so the re-scan surfaces only the not-yet-seen gate and self-terminates — draining a chain of sequential gates one at a time (`cmd1` clears → re-scan surfaces `cmd2` → its bridge clears → re-scan finds nothing → done).

Review-driven hardening (from the PR's adversarial review):
- **Per-step delivery pin** (`_waiting_step_at`): `bridge_interaction` delivers the verdict to the step it was *surfaced for* when that step is still WAITING, falling back to `_freshest_waiting` only when the captured step is gone (the genuine same-gate timeout-retry). Removes the "agy never parallel-gates same-kind" assumption so a verdict can never land on a different higher-index gate.
- **Teardown drain**: reader teardown now drains the bridge **and** any chained re-scan tasks to quiescence (bounded passes), flushing queued done-callbacks first so a normally-completed bridge's scheduled re-scan does not escape the drain and run post-teardown. The drain suppresses any task exception so it always runs to completion (no stranded/uncancelled tasks on a real error).

## Tests

`python -m pytest tests/test_antigravity_native*.py -q` → **423 passed** (includes the 5 new tests: deferred-gate re-surfacing, stream-backstop "case B", delivery-pin, auto-allowed-segment edge case, re-scan poll-error swallow). The full touched suite (`test_antigravity_native_interactions.py` + `test_antigravity_native_reader.py`) is **98 passed**.

## Attribution

Cherry-picked from #1473 with Bryan Li's authorship preserved; `Co-authored-by: Isaac` trailer added to each commit. The 4 touched files are byte-identical to the PR tip — the cherry-pick onto current `main` applied with **zero conflicts** and no semantic drift.

Fixes #1472. Supersedes #1473.

This pull request and its description were written by Isaac.
