### PR TITLE
refactor(antigravity-native): drop dead RPC write path, fix stale USER_INPUT docstring

### DIFF
--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -15,9 +15,13 @@ Key differences from the retired transcript-based ``step_to_events`` mapper:
    steps (no token streaming), so the delta round-trip causes a double-render
    in the UI. This mapper drops it entirely.
 
-2. **USER_INPUT → ``[]`` (skip).** The user turn is already persisted by the
-   direct ``POST /events`` that the server hook fires before agy processes it.
-   Emitting it again from the RPC transcript would duplicate the user message.
+2. **USER_INPUT is committed (not skipped).** The user turn is mapped to a
+   ``message`` item via :func:`_user_message_event` so the web UI reconciles its
+   optimistic bubble against a committed item. This is NOT redundant: the
+   TUI-inject write path (and the prior pure-RPC ``SendUserCascadeMessage`` path)
+   fire no ``POST /events`` for the user turn, so without this the user message
+   would never be committed (#1155). The reader dedups USER_INPUT by its per-turn
+   ``executionId``, so the message commits exactly once per turn.
 
 3. **RPC field names.** The RPC response uses ``CORTEX_STEP_TYPE_*`` type
    enums, camelCase keys (``plannerResponse``, ``runCommand``, ``stepIndex``),
@@ -878,17 +882,20 @@ def map_step_to_events(
     """
     Map one agy RPC step to Omnigent conversation-item events.
 
-    This is the pure, no-delta, no-USER_INPUT mapping layer for the RPC-based
-    read path. It produces ``external_conversation_item`` events
+    This is the pure, no-delta mapping layer for the RPC-based read path. It
+    produces ``external_conversation_item`` events
     (``message`` / ``function_call`` / ``function_call_output``) and emits no
-    ``external_output_text_delta`` and no user-message mirror (the user turn is
-    persisted by the direct ``POST /events`` hook).
+    ``external_output_text_delta``. The user turn IS mirrored here (see below) —
+    nothing else commits it on the TUI-inject write path.
 
     Mapping:
 
-    * ``CORTEX_STEP_TYPE_USER_INPUT`` → ``[]`` (skipped — the user turn is
-      already persisted by the direct ``POST /events`` hook; emitting it here
-      would duplicate the user message).
+    * ``CORTEX_STEP_TYPE_USER_INPUT`` → one ``message`` item (role user)
+      committing the user's turn, so the web UI reconciles its optimistic bubble
+      against a committed item. The write path fires no ``POST /events`` for the
+      user turn, so without this the user message would never be committed
+      (#1155). The reader dedups USER_INPUT by its per-turn ``executionId``, so
+      this commits exactly once. An empty user turn → ``[]``.
     * ``CORTEX_STEP_TYPE_PLANNER_RESPONSE`` **at status DONE** → one ``message``
       item (role assistant) when ``plannerResponse.modifiedResponse`` (or
       ``response``) is non-empty, then one ``function_call`` item per
@@ -917,7 +924,8 @@ def map_step_to_events(
 
     Step-index handling: ``sourceTrajectoryStepInfo.stepIndex`` is proto-omitted
     when zero.  A missing index is treated as ``0`` so slot-0 steps (which in
-    practice are USER_INPUT and are already skipped) are never silently dropped.
+    practice are the turn-opening USER_INPUT, committed as a ``message`` item)
+    are never silently dropped.
 
     :param step: One step dict from ``GetCascadeTrajectorySteps``.
     :param conversation_id: agy conversation id (namespaces response ids and

--- a/omnigent/inner/antigravity_native_executor.py
+++ b/omnigent/inner/antigravity_native_executor.py
@@ -23,11 +23,6 @@ read/control transport only (``StreamAgentStateUpdates`` /
 ``GetAllCascadeTrajectories`` / ``CancelCascadeSteps`` /
 ``HandleCascadeUserInteraction``). The same path serves mid-turn steering.
 
-.. note:: The now-unused RPC-delivery helpers below
-   (``_resolve_ready_cascade_id`` / ``_resolve_plan_model`` / ``_wait_for_state``
-   and the model-resolution module functions) are retained pending a focused
-   follow-up cleanup; the live write path is :meth:`_deliver` → the TUI inject.
-
 Because agy owns its own model loop and emits output via the read path, this
 executor:
 
@@ -67,20 +62,15 @@ import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-import httpx
-
 from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
     ANTIGRAVITY_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
-    AntigravityNativeBridgeState,
     inject_user_message_via_tui,
     is_placeholder_conversation_id,
     read_bridge_state,
 )
 from omnigent.antigravity_native_rpc import (
     cancel_cascade_steps,
-    get_available_models,
-    get_trajectory_steps,
     resolve_language_server_port,
 )
 from omnigent.inner.executor import (
@@ -97,14 +87,6 @@ from omnigent.llms.errors import PermanentLLMError
 from omnigent.reasoning_effort import ANTIGRAVITY_EFFORTS, validate_effort_or_llm_error
 
 _logger = logging.getLogger(__name__)
-
-# How long run_turn waits for the bridge state to carry agy's REAL conversation
-# id on the first turn (the runner cold-starts agy + mints the conversation, then
-# the read path persists the real id over the launcher's ``agy_conv_*``
-# placeholder — see Task 11). Mirrors the codex executor's
-# one-second-poll-up-to-60s contract.
-_STATE_WAIT_ATTEMPTS = 60
-_STATE_WAIT_INTERVAL_S = 1.0
 
 # agy step type for a committed user turn; its ``userConfig`` carries the model
 # the user was on for that turn (the tier-1 model-echo source, design §10.4).
@@ -319,109 +301,6 @@ class AntigravityNativeExecutor(Executor):
                 state.session_id,
             )
             return None
-
-    async def _resolve_ready_cascade_id(self, state: AntigravityNativeBridgeState) -> str | None:
-        """
-        Return agy's real conversation/cascade id, waiting on a fresh session.
-
-        On a settled session bridge state already carries agy's real id and this
-        returns it immediately. On a fresh session it still holds the launcher's
-        ``agy_conv_*`` placeholder until the runner cold-starts agy, mints the
-        conversation, and the read path persists the real id; this polls bridge
-        state (:meth:`_wait_for_state`) until that real id appears. The caller
-        holds :attr:`_send_lock`, so a later turn cannot race ahead of this wait.
-
-        :param state: The already-read bridge state for this turn.
-        :returns: agy's real (non-placeholder) conversation id, or ``None`` when a
-            fresh session's real id never appeared within the wait window.
-        """
-        if not is_placeholder_conversation_id(state.conversation_id):
-            return state.conversation_id
-        confirmed = await self._wait_for_state()
-        if confirmed is None or is_placeholder_conversation_id(confirmed.conversation_id):
-            return None
-        _logger.info(
-            "antigravity native first turn: conversation registered as %s",
-            confirmed.conversation_id,
-        )
-        return confirmed.conversation_id
-
-    async def _resolve_plan_model(self, port: int, cascade_id: str) -> str | None:
-        """
-        Resolve the per-turn agy ``planModel`` enum (two-tier; design §10.4).
-
-        ``SendUserCascadeMessage`` requires a ``planModel`` per turn and the enum
-        names are version-volatile, so the model is resolved at runtime:
-
-        1. **Echo agy's current model** — read the latest ``USER_INPUT`` step's
-           ``userInput.userConfig.plannerConfig.planModel`` (a string on the live
-           wire, with the older ``requestedModel.model`` shape as a fallback) from
-           :func:`omnigent.antigravity_native_rpc.get_trajectory_steps`. This
-           reflects the user's TUI ``/model`` choice without new plumbing.
-        2. **Recommended fallback** — when no prior model is observable (a first
-           turn), pick the ``recommended`` entry from
-           :func:`omnigent.antigravity_native_rpc.get_available_models`.
-
-        Both RPC reads are best-effort: a transport/parse failure on either is
-        logged and treated as "no model from this tier", so a flaky read of the
-        trajectory still falls through to the catalog rather than aborting.
-
-        :param port: Validated agy connect-RPC port.
-        :param cascade_id: agy cascade id (equal to the conversation id).
-        :returns: An agy model enum string, or ``None`` when neither tier yields
-            one (the caller surfaces a clear error — a turn cannot omit the
-            model).
-        """
-        # Both RPC reads raise httpx.HTTPError (transport / non-2xx) or ValueError
-        # (a non-JSON 200) per their contracts; either is best-effort here, so a
-        # tier-1 failure falls through to the catalog and a tier-2 failure returns
-        # None (the caller then surfaces a clear "no model" error).
-        try:
-            steps = await asyncio.to_thread(get_trajectory_steps, port, cascade_id)
-        except (httpx.HTTPError, ValueError):
-            _logger.debug(
-                "antigravity native model echo: trajectory read failed for conversation=%s",
-                cascade_id,
-                exc_info=True,
-            )
-            steps = []
-        echoed = _latest_requested_model(steps)
-        if echoed is not None:
-            return echoed
-        try:
-            catalog = await asyncio.to_thread(get_available_models, port)
-        except (httpx.HTTPError, ValueError):
-            _logger.debug(
-                "antigravity native model fallback: catalog read failed for conversation=%s",
-                cascade_id,
-                exc_info=True,
-            )
-            return None
-        return _recommended_model(catalog)
-
-    async def _wait_for_state(self) -> AntigravityNativeBridgeState | None:
-        """
-        Read bridge state, polling until agy's REAL conversation id is known.
-
-        Called by :meth:`_resolve_ready_cascade_id` when the bridge state still
-        holds the launcher's ``agy_conv_*`` placeholder on a fresh session: the
-        runner cold-starts agy + mints the conversation (Task 11), then the read
-        path overwrites the placeholder with agy's real id. This polls until that
-        real id appears. Settled turns read the real id immediately (no
-        placeholder), so this is not on their path.
-
-        :returns: Bridge state carrying a real (non-placeholder) conversation id;
-            the last-read state (possibly a placeholder, or ``None``) when the
-            real id never appeared within the wait window.
-        """
-        state: AntigravityNativeBridgeState | None = None
-        for attempt in range(_STATE_WAIT_ATTEMPTS + 1):
-            state = await asyncio.to_thread(read_bridge_state, self._bridge_dir)
-            if state is not None and not is_placeholder_conversation_id(state.conversation_id):
-                return state
-            if attempt < _STATE_WAIT_ATTEMPTS:
-                await asyncio.sleep(_STATE_WAIT_INTERVAL_S)
-        return state
 
 
 def _bridge_dir_from_env() -> Path:


### PR DESCRIPTION
## What

Cleanup of tech debt left by the antigravity-native merge wave. **No live behavior change** — this only deletes genuinely-dead code and corrects stale docstrings.

### Item 1 — stale USER_INPUT docstring (`omnigent/antigravity_native_steps.py`)

The header docstring and the `map_step_to_events` docstring still claimed that `CORTEX_STEP_TYPE_USER_INPUT` steps map to `[]` (skipped) because "the user turn is already persisted by a direct `POST /events` hook." That has been stale since **#1155**: the mapper now **commits** the user message via `_user_message_event(...)`. The pure-RPC write path (and now the TUI-inject write path) fire **no** `POST /events` for the user turn, so without this commit the optimistic web bubble would have no committed counterpart and the user message would be lost.

Updated three docstring spots (module header item 2, the `map_step_to_events` summary + USER_INPUT mapping bullet, and the slot-0/step-index note) to accurately describe: USER_INPUT is committed as a `message` item, deduped by per-turn `executionId` so it commits exactly once. **The code is unchanged.**

### Item 2 — dead RPC write path (`omnigent/inner/antigravity_native_executor.py`)

The module docstring flagged these helpers as "retained pending a focused follow-up cleanup." They were superseded when the write path switched from headless `SendUserCascadeMessage` RPC to TUI-inject (#1156/#1158). Removed:

- `_resolve_ready_cascade_id`
- `_resolve_plan_model`
- `_wait_for_state`
- the `.. note::` in the module docstring that referenced them
- now-unused imports they pulled in: `httpx`, `AntigravityNativeBridgeState`, `get_available_models`, `get_trajectory_steps`
- now-unused constants `_STATE_WAIT_ATTEMPTS` / `_STATE_WAIT_INTERVAL_S`

**Kept (live / load-bearing):** the TUI-inject write path (`_deliver`, `inject_user_message_via_tui`, `enqueue_session_message`) and the model-echo helpers (`_latest_requested_model`, `_recommended_model`), which still have their own dedicated tests in `tests/inner/test_antigravity_native_executor.py`.

## Grep evidence (no live callers)

Repo-wide `rg` for each removed symbol across `omnigent/` and `tests/`: the only references were the executor's own docstring + definitions. After removal, a final sweep finds **zero** references to any removed symbol, and `ruff check` reports no unused imports.

## Tests

- `tests/test_antigravity_native*.py` — **418 passed**
- `tests/inner/test_antigravity_native_executor.py` (the executor's own suite) — **33 passed**
- `ruff check` — clean on both modified files

This pull request and its description were written by Isaac.