### PR TITLE
fix(antigravity-native): isolate agy gemini dir without relocating HOME (#1477)

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -261,17 +261,15 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
 # two antigravity-native sessions (or a session + the user's interactive agy)
 # would fight over the one global file.
 #
-# CHOSEN DESIGN — per-session ISOLATED HOME. The runner launches agy with
-# ``HOME`` pointed at a per-bridge-dir tree (:func:`agy_home_dir`) seeded with a
-# COPY of the user's OAuth token + onboarding/migration markers and a
-# bridge-scoped ``config/mcp_config.json`` written by :func:`write_mcp_config`.
-# This (1) NEVER touches the user's real ``~/.gemini``, (2) gives each session its
-# own ``mcp_config.json`` so concurrent sessions never clobber one another, and
-# (3) was verified live: agy under the isolated HOME does NOT re-demand OAuth and
-# its ``/mcp`` panel shows ``✓ omnigent`` with the ``sys_*`` tools discovered. agy
-# resolves ``GeminiDir`` from ``$HOME/.gemini`` (its hardcoded default), so the
-# only thing the isolated HOME relocates is the *config + state* tree; auth still
-# works because the seeded token is a copy of the user's real one.
+# CHOSEN DESIGN — per-session ISOLATED GEMINI DIR. The runner keeps agy's real
+# ``HOME`` intact (needed for platform auth such as macOS keyring-backed tokens)
+# and launches agy with its hidden ``--gemini_dir=<bridge_dir>/agy-home/.gemini``
+# flag. That isolated Gemini dir is seeded with onboarding/migration markers and
+# a bridge-scoped ``config/mcp_config.json`` written by :func:`write_mcp_config`.
+# This (1) NEVER touches the user's real ``~/.gemini/config/mcp_config.json`` and
+# (2) gives each session its own config so concurrent sessions never clobber one
+# another. Known file-based OAuth markers are copied best-effort for platforms
+# whose agy auth provider uses them, but HOME is deliberately not relocated.
 _MCP_CONFIG_DIR = "config"
 _MCP_CONFIG_FILE = "mcp_config.json"
 _BRIDGE_CONFIG_FILE = "bridge.json"
@@ -311,29 +309,45 @@ _AGY_ENABLED_TOOLS = [
 ]
 
 # Files copied from the user's real ``~/.gemini`` into the per-session isolated
-# HOME so agy does not re-run OAuth / onboarding. The OAuth token is the only
-# secret; it is COPIED (the real file is never moved or modified). Missing files
-# are skipped (agy regenerates onboarding/migration state, and a missing token
-# only means agy re-auths in that session — never a corruption of the real tree).
+# Gemini dir for platforms whose agy auth provider uses file-backed credentials,
+# plus installation markers. Keep the OAuth credential paths in sync with
+# ``omnigent.onboarding.gemini_auth``: macOS writes ``oauth_creds.json`` while
+# Linux writes ``antigravity-cli/antigravity-oauth-token``. The OAuth credential
+# is the only secret; it is COPIED (the real file is never moved or modified).
+# Missing files are skipped (agy regenerates onboarding/migration state, and a
+# missing credential only means agy re-auths in that session — never corruption
+# of the real tree).
 _AGY_SEED_FILES = (
+    Path("oauth_creds.json"),
     Path("antigravity-cli") / "antigravity-oauth-token",
+    Path("installation_id"),
     Path("antigravity-cli") / "installation_id",
 )
 
 
 def agy_home_dir(bridge_dir: Path) -> Path:
-    """Return the per-session isolated ``HOME`` for an agy launch.
+    """Return the parent directory for this session's isolated agy state.
 
-    A subdirectory of *bridge_dir* so it is naturally per-session (the bridge dir
-    is hash-scoped to the bridge id) and torn down with the bridge. agy reads its
-    MCP config + state from ``$HOME/.gemini``; pinning ``HOME`` here keeps the
-    relay's ``mcp_config.json`` out of the user's real ``~/.gemini`` and prevents
-    two concurrent sessions from sharing one global config.
+    The actual agy config/state root is :func:`agy_gemini_dir`, passed to agy via
+    ``--gemini_dir``. Keeping this parent below *bridge_dir* makes it naturally
+    per-session and easy to tear down with the bridge, while preserving the real
+    ``HOME`` for auth providers that depend on platform state such as macOS
+    Keychain.
 
     :param bridge_dir: Native Antigravity bridge directory.
-    :returns: Absolute path to this session's isolated agy HOME.
+    :returns: Absolute parent path for this session's isolated agy state.
     """
     return bridge_dir / "agy-home"
+
+
+def agy_gemini_dir(bridge_dir: Path) -> Path:
+    """Return the per-session ``--gemini_dir`` path for an agy launch.
+
+    :param bridge_dir: Native Antigravity bridge directory.
+    :returns: Absolute ``.gemini`` directory that should receive agy's session
+        config/state and the Omnigent MCP config.
+    """
+    return agy_home_dir(bridge_dir) / ".gemini"
 
 
 def build_mcp_config(
@@ -350,14 +364,12 @@ def build_mcp_config(
     The server command is the SAME shared relay claude/codex/cursor use:
     ``<python> -I -m omnigent.claude_native_bridge serve-mcp --bridge-dir <dir>``.
 
-    **HOME pinning (critical for the isolated-HOME design).** agy spawns this relay
-    as a child, so the relay inherits agy's environment — including the per-session
-    isolated ``HOME`` agy runs under. But the relay validates its ``--bridge-dir``
-    against ``bridge_root()`` (``$HOME/.omnigent/antigravity-native``), which must
-    resolve to the RUNNER's real home where the bridge dir actually lives — not the
-    isolated agy HOME (a child of the bridge dir). So the relay's ``env`` pins
-    ``HOME`` back to the runner's real home. ``-I`` does not clear ``HOME``; it only
-    ignores ``PYTHON*`` vars and user site-packages, so this override takes effect.
+    **HOME pinning.** agy spawns this relay as a child. The relay validates its
+    ``--bridge-dir`` against ``bridge_root()`` (``$HOME/.omnigent/antigravity-native``),
+    which must resolve to the RUNNER's real home where the bridge dir actually
+    lives. Pinning ``HOME`` in the relay env keeps that invariant true even when a
+    future agy launch path customizes process environment. ``-I`` does not clear
+    ``HOME``; it only ignores ``PYTHON*`` vars and user site-packages.
 
     :param bridge_dir: Native Antigravity bridge directory whose relay this
         config points at.
@@ -382,8 +394,7 @@ def build_mcp_config(
                 "env": {
                     "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
                     # Pin the relay to the RUNNER's real home so its bridge-root
-                    # validation matches where the bridge dir lives (agy runs under
-                    # an isolated HOME; the relay must not inherit it). See docstring.
+                    # validation matches where the bridge dir lives. See docstring.
                     "HOME": str(Path.home()),
                 },
             }
@@ -417,25 +428,25 @@ def write_mcp_config(
     *,
     python_executable: str | None = None,
 ) -> Path:
-    """Write the per-session agy MCP config + relay token into the isolated HOME.
+    """Write the per-session agy MCP config + relay token.
 
     Writes (1) ``bridge.json`` (the relay token) into *bridge_dir* and (2) the
     ``mcp_config.json`` for the Omnigent relay into the per-session isolated agy
-    HOME at ``<agy_home>/.gemini/config/mcp_config.json`` — the path agy actually
-    loads MCP servers from. Because the HOME is per-session and never the user's
-    real ``~``, this never clobbers the user's interactive agy config and two
-    concurrent sessions never share one config. Mirrors cursor #742's
-    :func:`omnigent.cursor_native_bridge.write_mcp_config`, adapted to agy's
-    HOME-global config path + isolated-HOME scoping.
+    Gemini dir at ``<bridge_dir>/agy-home/.gemini/config/mcp_config.json`` — the
+    path agy loads when launched with ``--gemini_dir``. Because the Gemini dir is
+    per-session and not the user's real ``~/.gemini``, this never clobbers the
+    user's interactive agy config and two concurrent sessions never share one
+    config. Mirrors cursor #742's :func:`omnigent.cursor_native_bridge.write_mcp_config`,
+    adapted to agy's hidden ``--gemini_dir`` flag.
 
     :param bridge_dir: Native Antigravity bridge directory (holds ``bridge.json``
-        and the isolated agy HOME).
+        and the isolated agy Gemini dir).
     :param python_executable: Python interpreter for the relay command;
         defaults to the current interpreter.
     :returns: Absolute path to the written ``mcp_config.json``.
     """
     write_mcp_bridge_config(bridge_dir)
-    config_dir = agy_home_dir(bridge_dir) / ".gemini" / _MCP_CONFIG_DIR
+    config_dir = agy_gemini_dir(bridge_dir) / _MCP_CONFIG_DIR
     config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     path = config_dir / _MCP_CONFIG_FILE
     payload = build_mcp_config(bridge_dir, python_executable=python_executable)
@@ -446,26 +457,23 @@ def write_mcp_config(
 
 
 def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
-    """Seed the per-session isolated agy HOME and return the launch env override.
+    """Seed the per-session isolated agy Gemini dir and return env overrides.
 
-    Copies the user's real agy OAuth token + onboarding/migration state (NEVER
-    moving or modifying the real files) into ``<bridge_dir>/agy-home/.gemini`` so
-    a launch under this isolated HOME does not re-demand OAuth or re-run the
-    onboarding wizard. The relay's ``mcp_config.json`` is written separately by
-    :func:`write_mcp_config` so it lands in this same isolated tree rather than
-    the user's real ``~/.gemini`` (the footgun this whole design avoids).
-
-    Verified live (agy 1.0.12): under this isolated HOME agy logs in as the real
-    user from the seeded token and its ``/mcp`` panel shows ``✓ omnigent`` with the
-    ``sys_*`` tools discovered.
+    Copies known file-based agy OAuth markers + onboarding/migration state (NEVER
+    moving or modifying the real files) into ``<bridge_dir>/agy-home/.gemini``.
+    The runner keeps agy's real ``HOME`` intact and passes this directory through
+    ``--gemini_dir``; on macOS that is required because agy uses keyring-backed
+    auth that is not portable to a relocated ``HOME``. The relay's
+    ``mcp_config.json`` is written separately by :func:`write_mcp_config` so it
+    lands in this same isolated tree rather than the user's real ``~/.gemini``
+    (the footgun this whole design avoids).
 
     :param bridge_dir: Native Antigravity bridge directory.
-    :returns: An env-override mapping (``{"HOME": <iso_home>}``) to layer onto the
-        agy launch environment.
+    :returns: Env overrides to layer onto the agy launch environment. Currently
+        empty because ``HOME`` must stay real for platform auth.
     """
     real_home = Path.home()
-    iso_home = agy_home_dir(bridge_dir)
-    iso_gemini = iso_home / ".gemini"
+    iso_gemini = agy_gemini_dir(bridge_dir)
     (iso_gemini / "antigravity-cli" / "cache").mkdir(mode=0o700, parents=True, exist_ok=True)
     (iso_gemini / _MCP_CONFIG_DIR).mkdir(mode=0o700, parents=True, exist_ok=True)
 
@@ -499,11 +507,11 @@ def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
         )
 
     # Seed the migration marker so agy does not churn a from-scratch migration on
-    # first launch under the fresh HOME (cosmetic; agy creates it itself otherwise).
+    # first launch under the fresh Gemini dir (cosmetic; agy creates it itself otherwise).
     with contextlib.suppress(OSError):
         (iso_gemini / _MCP_CONFIG_DIR / ".migrated").touch()
 
-    return {"HOME": str(iso_home)}
+    return {}
 
 
 def write_bridge_state(bridge_dir: Path, state: AntigravityNativeBridgeState) -> None:

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -270,6 +270,20 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
 # (2) gives each session its own config so concurrent sessions never clobber one
 # another. Known file-based OAuth markers are copied best-effort for platforms
 # whose agy auth provider uses them, but HOME is deliberately not relocated.
+#
+# WHY NOT RELOCATE HOME (#1477). An earlier isolation design pointed ``HOME`` at
+# the per-session tree. That broke auth on macOS: agy stores its OAuth token in
+# the OS keyring (verified against agy 1.0.12 — the binary's auth path is
+# ``keyring`` / "load token from keyring", NOT a ``~/.gemini`` file), and the
+# keyring item is bound to the real login HOME, so any relocated HOME stalled
+# every turn at the interactive OAuth prompt. The alternative of dropping HOME
+# isolation entirely on macOS (#1493) restored auth but reintroduced the
+# HOME-global ``mcp_config.json`` footgun (#1194) there — concurrent sessions
+# would clobber one another's relay config. ``--gemini_dir`` resolves both at
+# once: real HOME ⇒ keyring auth works on every platform; isolated gemini dir ⇒
+# per-session MCP config. Verified live (agy 1.0.12): ``agy --gemini_dir=<dir>``
+# materializes its ``antigravity-cli`` + ``config`` state under ``<dir>`` while
+# authenticating from the real-HOME keyring.
 _MCP_CONFIG_DIR = "config"
 _MCP_CONFIG_FILE = "mcp_config.json"
 _BRIDGE_CONFIG_FILE = "bridge.json"

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4090,6 +4090,7 @@ async def _auto_create_antigravity_terminal(
     from omnigent.antigravity_native_bridge import (
         ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY,
         AntigravityNativeBridgeState,
+        agy_gemini_dir,
         clear_bridge_state,
         ensure_agy_onboarding_complete,
         prepare_bridge_dir,
@@ -4184,19 +4185,21 @@ async def _auto_create_antigravity_terminal(
     # Wire the Omnigent MCP relay so the wrapped agy gets the sys_* tools
     # (spawn sub-agent sessions, drive Omnigent terminals, list agents/models,
     # sys_os_*) — the only native harness that otherwise lacks them (#1194).
-    # agy has no --mcp-config flag and ignores ANTIGRAVITY_* env knobs; it loads
-    # MCP servers ONLY from the HOME-global ~/.gemini/config/mcp_config.json. To
-    # avoid clobbering the user's interactive agy config (and the concurrency
-    # footgun of a single shared file), launch agy under a per-session ISOLATED
-    # HOME seeded with a copy of the user's OAuth token + onboarding state and a
-    # bridge-scoped mcp_config.json. The relay subprocess is the same shared
-    # ``serve-mcp`` claude/codex/cursor use. Offloaded to a thread (file I/O) and
-    # done BEFORE the terminal launch so agy sees the config on its first MCP scan.
+    # agy has no --mcp-config flag and ignores ANTIGRAVITY_* env knobs. It does
+    # accept the hidden --gemini_dir flag, so keep the process HOME real for auth
+    # providers such as macOS Keychain, but point agy's config/state root at a
+    # per-session isolated Gemini dir. This avoids clobbering the user's
+    # interactive ~/.gemini/config/mcp_config.json and avoids the concurrency
+    # footgun of one shared bridge-specific config file. The relay subprocess is
+    # the same shared ``serve-mcp`` claude/codex/cursor use. Offloaded to a thread
+    # (file I/O) and done BEFORE terminal launch so agy sees the config on its
+    # first MCP scan.
     await asyncio.to_thread(write_mcp_config, bridge_dir)
     env_overrides = {
         **env_overrides,
         **await asyncio.to_thread(seed_isolated_agy_home, bridge_dir),
     }
+    argv = [argv[0], f"--gemini_dir={agy_gemini_dir(bridge_dir)}", *argv[1:]]
     # Start the shared comment/sys_* relay against THIS session's bridge dir before
     # launch so its tool_relay.json is on disk when agy first scans the MCP server.
     # ``await_notify=False``: agy starts its MCP client lazily, so awaiting the

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -3426,11 +3426,12 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     * the relay starter (``ensure_comment_relay``) is invoked for THIS session's
       bridge dir before launch, so its ``tool_relay.json`` is on disk when agy
       first scans the MCP server;
-    * the relay ``mcp_config.json`` is written into the per-session ISOLATED agy
-      HOME (``<bridge_dir>/agy-home/.gemini/config``), NOT the user's real
+    * the relay ``mcp_config.json`` is written into the per-session isolated agy
+      Gemini dir (``<bridge_dir>/agy-home/.gemini/config``), NOT the user's real
       ``~/.gemini`` — the config-scoping footgun the design avoids;
-    * the launch env carries ``HOME`` = that isolated home, so agy actually loads
-      the bridge-scoped config (and never the user's interactive agy config).
+    * the launch args carry ``--gemini_dir=<isolated .gemini>`` while the launch
+      env does not override ``HOME``, so agy keeps platform auth such as macOS
+      Keychain but loads the bridge-scoped config.
     """
     import omnigent.antigravity_native_bridge as bridge_mod
     import omnigent.antigravity_native_launch as launch_mod
@@ -3449,8 +3450,8 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     monkeypatch.setattr(runner_app_mod, "_terminal_tmux_pane", lambda *_a, **_k: (None, None))
     monkeypatch.setattr(rpc_mod, "_candidate_agy_rpc_ports", list)
 
-    # Capture the env build_agy_launch starts from so we can assert HOME is layered
-    # on top of it (the launch env is the captured spec's ``env`` below).
+    # Capture the env build_agy_launch starts from so we can assert it is preserved
+    # without a HOME override (the launch env is the captured spec's ``env`` below).
     monkeypatch.setattr(
         launch_mod, "build_agy_launch", lambda **_kwargs: (("agy",), {"AGY_ENV": "1"})
     )
@@ -3494,6 +3495,7 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
             resource_role: str | None = None,
             **_kwargs: Any,
         ) -> SessionResourceView:
+            captured_spec["args"] = list(spec.args)
             captured_spec["env"] = dict(spec.env)
             return SessionResourceView(
                 id="terminal_antigravity_main",
@@ -3516,6 +3518,7 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
 
     bridge_dir = bridge_mod.bridge_dir_for_bridge_id(session_id)
     iso_home = bridge_mod.agy_home_dir(bridge_dir)
+    iso_gemini = bridge_mod.agy_gemini_dir(bridge_dir)
 
     # 1) The relay starter was invoked for this session's bridge dir.
     assert len(relay_calls) == 1
@@ -3534,9 +3537,10 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     # The bridge token the shared relay needs was written into the bridge dir.
     assert (bridge_dir / "bridge.json").is_file()
 
-    # 3) The launch env carries HOME = the isolated home, layered over the
-    #    build_agy_launch base env.
-    assert captured_spec["env"]["HOME"] == str(iso_home)
+    # 3) The launch args point agy at the isolated Gemini dir, while HOME stays
+    #    real so platform auth such as macOS Keychain keeps working.
+    assert captured_spec["args"] == [f"--gemini_dir={iso_gemini}"]
+    assert "HOME" not in captured_spec["env"]
     assert captured_spec["env"]["AGY_ENV"] == "1"
 
 

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -14,6 +14,7 @@ from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
     ANTIGRAVITY_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     AntigravityNativeBridgeState,
+    agy_gemini_dir,
     agy_home_dir,
     build_antigravity_native_spawn_env,
     build_mcp_config,
@@ -1039,9 +1040,8 @@ def test_build_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
     assert server["enabledTools"] == sorted(server["enabledTools"])
     assert server["env"]["TMPDIR"]
     # The relay's HOME is pinned to the runner's real home so its bridge-root
-    # validation matches where the bridge dir lives — agy runs the relay under a
-    # per-session isolated HOME (a child of the bridge dir), which the relay must
-    # NOT inherit, or it would reject its own --bridge-dir.
+    # validation matches where the bridge dir lives, even if a future agy launch
+    # path customizes process environment.
     assert server["env"]["HOME"] == str(Path.home())
 
 
@@ -1053,15 +1053,15 @@ def test_build_mcp_config_defaults_python_to_current_interpreter(tmp_path: Path)
     assert server["command"] == sys.executable
 
 
-def test_write_mcp_config_targets_isolated_agy_home(tmp_path: Path) -> None:
-    """write_mcp_config writes into the per-session isolated agy HOME, not ~/.gemini."""
+def test_write_mcp_config_targets_isolated_agy_gemini_dir(tmp_path: Path) -> None:
+    """write_mcp_config writes into the isolated agy Gemini dir, not ~/.gemini."""
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
     path = write_mcp_config(bridge_dir, python_executable="python-test")
 
-    # The config lands under the isolated HOME's ~/.gemini/config — the path agy
-    # actually loads MCP servers from — so the user's real ~/.gemini is untouched.
-    assert path == agy_home_dir(bridge_dir) / ".gemini" / "config" / "mcp_config.json"
+    # The config lands under the isolated --gemini_dir config path, so the user's
+    # real ~/.gemini is untouched.
+    assert path == agy_gemini_dir(bridge_dir) / "config" / "mcp_config.json"
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["mcpServers"]["omnigent"]["command"] == "python-test"
     # The bridge token the shared relay requires is written into the bridge dir.
@@ -1076,17 +1076,21 @@ def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:
     assert (tmp_path / "bridge.json").read_text(encoding="utf-8") == first
 
 
-def test_seed_isolated_agy_home_returns_home_override_and_seeds_state(
+def test_seed_isolated_agy_home_seeds_platform_credentials_and_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """seed_isolated_agy_home copies the OAuth token + markers and returns HOME."""
+    """seed_isolated_agy_home copies platform OAuth markers + state."""
     fake_home = tmp_path / "real-home"
     (fake_home / ".gemini" / "antigravity-cli").mkdir(parents=True)
+    (fake_home / ".gemini" / "oauth_creds.json").write_text(
+        '{"access_token":"mac-token"}', encoding="utf-8"
+    )
+    (fake_home / ".gemini" / "installation_id").write_text("root-install-id", encoding="utf-8")
     (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").write_text(
-        "real-token", encoding="utf-8"
+        "linux-token", encoding="utf-8"
     )
     (fake_home / ".gemini" / "antigravity-cli" / "installation_id").write_text(
-        "install-id", encoding="utf-8"
+        "cli-install-id", encoding="utf-8"
     )
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
 
@@ -1094,19 +1098,28 @@ def test_seed_isolated_agy_home_returns_home_override_and_seeds_state(
     bridge_dir.mkdir()
     env = seed_isolated_agy_home(bridge_dir)
 
-    iso = agy_home_dir(bridge_dir)
-    assert env == {"HOME": str(iso)}
-    # OAuth token is COPIED (never moved) into the isolated tree.
-    token = iso / ".gemini" / "antigravity-cli" / "antigravity-oauth-token"
-    assert token.read_text(encoding="utf-8") == "real-token"
-    # The real token file is left in place.
+    iso_gemini = agy_gemini_dir(bridge_dir)
+    assert env == {}
+    # OAuth credentials are COPIED (never moved) into the isolated tree.
+    macos_token = iso_gemini / "oauth_creds.json"
+    linux_token = iso_gemini / "antigravity-cli" / "antigravity-oauth-token"
+    assert macos_token.read_text(encoding="utf-8") == '{"access_token":"mac-token"}'
+    assert linux_token.read_text(encoding="utf-8") == "linux-token"
+    assert (iso_gemini / "installation_id").read_text(encoding="utf-8") == "root-install-id"
+    assert (iso_gemini / "antigravity-cli" / "installation_id").read_text(
+        encoding="utf-8"
+    ) == "cli-install-id"
+    # The real credential files are left in place.
+    assert (fake_home / ".gemini" / "oauth_creds.json").read_text(encoding="utf-8") == (
+        '{"access_token":"mac-token"}'
+    )
     assert (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").read_text(
         encoding="utf-8"
-    ) == "real-token"
+    ) == "linux-token"
     # Onboarding + migration markers seeded so a headless launch never blocks.
-    onboarding = iso / ".gemini" / "antigravity-cli" / "cache" / "onboarding.json"
+    onboarding = iso_gemini / "antigravity-cli" / "cache" / "onboarding.json"
     assert json.loads(onboarding.read_text(encoding="utf-8"))["onboardingComplete"] is True
-    assert (iso / ".gemini" / "config" / ".migrated").is_file()
+    assert (iso_gemini / "config" / ".migrated").is_file()
 
 
 def test_seed_isolated_agy_home_tolerates_missing_credential(
@@ -1121,17 +1134,23 @@ def test_seed_isolated_agy_home_tolerates_missing_credential(
     bridge_dir.mkdir()
     env = seed_isolated_agy_home(bridge_dir)
 
-    iso = agy_home_dir(bridge_dir)
-    assert env == {"HOME": str(iso)}
-    # No token copied (none existed), but the isolated HOME + markers still exist.
-    assert not (iso / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").exists()
-    assert (iso / ".gemini" / "antigravity-cli" / "cache" / "onboarding.json").is_file()
+    iso_gemini = agy_gemini_dir(bridge_dir)
+    assert env == {}
+    # No token copied (none existed), but the isolated Gemini dir + markers still exist.
+    assert not (iso_gemini / "antigravity-cli" / "antigravity-oauth-token").exists()
+    assert (iso_gemini / "antigravity-cli" / "cache" / "onboarding.json").is_file()
 
 
 def test_agy_home_dir_is_under_bridge_dir(tmp_path: Path) -> None:
-    """The isolated HOME is a child of the (hash-scoped, per-session) bridge dir."""
+    """The isolated state parent is a child of the per-session bridge dir."""
     bridge_dir = tmp_path / "bridge"
     assert agy_home_dir(bridge_dir).parent == bridge_dir
+
+
+def test_agy_gemini_dir_is_under_agy_home_dir(tmp_path: Path) -> None:
+    """The isolated Gemini dir is passed to agy via --gemini_dir."""
+    bridge_dir = tmp_path / "bridge"
+    assert agy_gemini_dir(bridge_dir) == agy_home_dir(bridge_dir) / ".gemini"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (#1477)

`agy` (Antigravity CLI) could not authenticate under the per-session isolated `$HOME` on macOS. The merged Linux design relocated agy's `HOME` to a per-bridge tree so the relay's `mcp_config.json` stayed isolated (#1194). On macOS that broke auth: **agy stores its OAuth token in the OS keyring, and the keyring item is bound to the real login HOME** — so under any relocated HOME, every turn stalled at the interactive OAuth prompt.

## Decision — gemini-dir isolation, keep the real HOME (reconciles #1493 ⊕ #1412)

Two open PRs proposed different fixes; I reconciled them into one coherent change and chose the **#1412 approach (PREFERRED)**:

- **#1412 (davidtandoh) — CHOSEN.** Keep agy's real `HOME` intact and point its config/state root at a per-session dir via the hidden `--gemini_dir=<bridge>/agy-home/.gemini` flag. Real HOME ⇒ keyring auth works on every platform; isolated gemini dir ⇒ per-session MCP config (no #1194 footgun). This preserves **both** Keychain auth **and** the `sys_*` relay tools on macOS.
- **#1493 (btli) — DISCARDED as the primary mechanism.** It ran agy under the real HOME on macOS with **no** isolation, which restored auth but reintroduced the HOME-global `mcp_config.json` footgun (#1194) on mac: concurrent sessions (or a session + the user's interactive agy) would clobber one another's relay config, and the `sys_*` tools were dropped on macOS. I folded in its key contribution — the root-cause finding that macOS auth is keyring-bound to the real HOME — as a design comment, and credited Bryan Li.

### Why the gemini-dir override is viable (empirically verified, agy 1.0.12)

`--gemini_dir` is hidden from `agy --help`, so I verified it against the binary + at runtime:

- The binary contains the literal flag `--gemini_dir=` and the help text *"Path where application data is stored, relative to GeminiDir"*.
- Running `agy --gemini_dir=/tmp/... -p "..."` materialized agy's `antigravity-cli/` + `config/` state **inside** that dir while still reaching auth — i.e. it relocates config/state **without** relocating HOME.
- The binary's auth path is `keyring` / *"load token from keyring"* (no `oauth_creds.json` string), confirming auth is keyring-backed (bound to the real HOME), not a `~/.gemini` file. So keeping the real HOME is what actually authenticates; the seeded credential files are harmless best-effort.

Because `--gemini_dir` works on Linux too, this is one cross-platform path (no `sys.platform` branch), simpler than #1493.

## Changes

- `seed_isolated_agy_home` no longer returns a `HOME` override (returns `{}`); seeds the isolated **gemini dir** instead. `_AGY_SEED_FILES` now also copies macOS `oauth_creds.json` + `installation_id` markers, kept in sync with `omnigent.onboarding.gemini_auth`.
- New `agy_gemini_dir(bridge_dir)` → `<bridge>/agy-home/.gemini`; `write_mcp_config` targets it.
- Launch path (`runner/app.py`) splices `--gemini_dir=<iso .gemini>` right after the agy binary and stops overriding `HOME`.
- Module-level design comment records the #1477 decision, what was discarded (#1493), and the keyring finding.

## Conflicts resolved

PR #1412 was based on an older `main` (`5e208047`); the `seed_isolated_agy_home` / relay-test region overlapped with subsequently-merged work (incl. #1493's region). The cherry-pick **auto-merged cleanly** (no manual conflict resolution needed) against current `main`. The relay-wiring test now asserts `--gemini_dir=<iso>` in the launch args and `HOME` absent from the launch env.

## Tests

- `tests/test_antigravity_native*.py` — **419 passed**
- `tests/test_antigravity_native_bridge.py` — **58 passed**
- antigravity/agy/gemini-selected tests in `tests/runner/test_app_sessions_native.py` (incl. `test_auto_create_antigravity_wires_omnigent_mcp_relay`) — **passed**
- Combined touched-file run — **435 passed**

## Credits

- David Tandoh (#1412) — the gemini-dir isolation implementation (cherry-picked, authorship preserved).
- Bryan Li (#1493) — the macOS keyring root-cause investigation (folded into the design comment).

Refs #1477, #1493, #1412, #1194.

This pull request and its description were written by Isaac.