### PR TITLE
feat(antigravity-native): session fork via text-preamble replay

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -643,6 +644,179 @@ def update_conversation_id(
         ),
     )
     return True
+
+
+# ── Fork history via text-preamble replay ────────────────────────────────────
+#
+# agy owns its cascade/conversation history in its own store and exposes NO
+# transcript-export / history-rebuild API, so a fork CANNOT reconstruct the
+# native conversation (unlike claude/codex/pi/qwen-native, which rebuild a
+# resumable on-disk session file from the copied Omnigent items and relaunch
+# ``--resume`` / ``--conversation``). antigravity-native therefore carries fork
+# history exactly like cursor-native: TEXT-PREAMBLE REPLAY. The runner renders
+# the prior Omnigent transcript into a seed/preamble and the executor prepends it
+# to the FIRST injected user turn of a FRESH agy conversation, fenced in
+# fork-history sentinels.
+#
+# DOCUMENTED LIMITATION (consistent with cursor-native): this is text-prefix
+# replay ONLY. There is NO rollout / native-conversation reconstruction — the
+# agy TUI sees the prior turns as a single contextual block on turn 1, not as
+# replayed native chat bubbles, and tool-call history is NOT carried. This is the
+# closest single-message analog agy's surface allows.
+#
+# These helpers mirror :mod:`omnigent.cursor_native_bridge` 1:1 (file name,
+# sentinel tags, read/clear split, sentinel defanging) so the two native
+# preamble-replay harnesses stay aligned; no shared helper exists, so the small
+# primitives are duplicated per the established per-harness convention (same as
+# the tmux-injection primitives below).
+
+#: File the runner drops into a fork's bridge dir holding the prior-conversation
+#: text preamble, consumed once by the executor on the first injected message.
+_FORK_PREAMBLE_FILE = "fork_preamble.txt"
+#: Sentinel framing the replayed history inside the first injected message. agy
+#: records the typed turn as a ``USER_INPUT`` step that the RPC reader mirrors
+#: back into the Omnigent timeline as a user ``message`` item — so the reader
+#: strips this block (:func:`strip_fork_history`) when mirroring the user turn,
+#: else the copied history would be DUPLICATED in the timeline (it already lives
+#: there as the source conversation's items). Mirrors cursor's forwarder strip.
+FORK_HISTORY_OPEN_TAG = "<omnigent_fork_history>"
+FORK_HISTORY_CLOSE_TAG = "</omnigent_fork_history>"
+
+#: Human-readable lead-in / sign-off framing the replayed transcript inside the
+#: sentinel, so the block reads as a contained "here's the prior conversation"
+#: note to agy rather than a raw dump.
+_FORK_HISTORY_HEADER = "This session was forked. Here is the conversation so far:"
+_FORK_HISTORY_FOOTER = "(End of prior conversation. Please continue from here.)"
+
+# On a fork into agy the first typed turn carries the preamble fenced in the
+# sentinel tags above. agy stores it inside the ``USER_INPUT`` step text; the
+# reader strips the whole block so the mirrored user bubble shows only the user's
+# real text. The match is non-greedy so it stops at the FIRST close tag: that is
+# always the real one, because :func:`wrap_fork_preamble` defangs any literal
+# sentinels inside the replayed transcript (so the block holds exactly one real
+# open/close pair), and stopping at the first close preserves a tag in the user's
+# own message that sits after it. The trailing alternative strips an UNTERMINATED
+# open block (a truncated turn with no close tag) to end-of-text, so it degrades
+# gracefully instead of mirroring the whole raw block. Mirrors
+# :data:`omnigent.cursor_native_forwarder._FORK_HISTORY_RE`.
+_FORK_HISTORY_RE = re.compile(
+    rf"{re.escape(FORK_HISTORY_OPEN_TAG)}.*?{re.escape(FORK_HISTORY_CLOSE_TAG)}"
+    rf"|{re.escape(FORK_HISTORY_OPEN_TAG)}.*",
+    re.DOTALL,
+)
+
+
+def write_fork_preamble(bridge_dir: Path, preamble: str) -> None:
+    """Persist a fork's prior-conversation preamble for the executor to consume.
+
+    :param bridge_dir: The session's antigravity-native bridge dir.
+    :param preamble: Rendered prior-conversation text (``""`` is not written).
+    """
+    if not preamble:
+        return
+    bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    (bridge_dir / _FORK_PREAMBLE_FILE).write_text(preamble, encoding="utf-8")
+
+
+def read_fork_preamble(bridge_dir: Path) -> str | None:
+    """Read the fork preamble WITHOUT consuming it (else ``None``).
+
+    Read and clear are deliberately split: the executor reads the preamble,
+    injects it, and only calls :func:`clear_fork_preamble` on a SUCCESSFUL
+    injection. Consuming on read would lose the forked history permanently if
+    the first injection fails (e.g. the agy TUI exited) and the turn is retried.
+
+    :param bridge_dir: The session's antigravity-native bridge dir.
+    :returns: The preamble text, or ``None`` when absent/empty.
+    """
+    try:
+        text = (bridge_dir / _FORK_PREAMBLE_FILE).read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    return text or None
+
+
+def clear_fork_preamble(bridge_dir: Path) -> None:
+    """Remove the fork preamble so it rides only the FIRST injected message.
+
+    Called by the executor only after a turn's injection succeeds; subsequent
+    turns then inject the plain user text. A no-op when the file is absent.
+
+    :param bridge_dir: The session's antigravity-native bridge dir.
+    """
+    with contextlib.suppress(OSError):
+        (bridge_dir / _FORK_PREAMBLE_FILE).unlink()
+
+
+def _neutralize_fork_sentinels(text: str) -> str:
+    """Defang any literal fork sentinel tags inside replayed transcript text.
+
+    The preamble is rendered from prior user/assistant turns verbatim, so a turn
+    could literally contain ``<omnigent_fork_history>`` /
+    ``</omnigent_fork_history>`` (a user typed it, pasted logs, etc.). If left
+    intact, an embedded close tag would let the reader's strip stop early and
+    leak the rest of the transcript into the mirrored user bubble. Replacing the
+    angle brackets guarantees the framed block contains exactly ONE real
+    open/close pair, so the (non-greedy) strip is unambiguous. The bracketed form
+    stays readable for the agy agent.
+
+    :param text: Rendered transcript text.
+    :returns: The text with any literal sentinel tags defanged.
+    """
+    return text.replace(FORK_HISTORY_OPEN_TAG, "[omnigent_fork_history]").replace(
+        FORK_HISTORY_CLOSE_TAG, "[/omnigent_fork_history]"
+    )
+
+
+def wrap_fork_preamble(preamble: str, user_text: str) -> str:
+    """Combine a fork preamble with the latest user text for one injection.
+
+    The transcript is framed by a human lead-in / sign-off and fenced in
+    :data:`FORK_HISTORY_OPEN_TAG` / :data:`FORK_HISTORY_CLOSE_TAG`. agy can't
+    reconstruct native chat bubbles from a fork (it owns its conversation store
+    and exposes no history-import API), so this is the closest single-message
+    analog: the agy agent reads the framed transcript as context, and the reader
+    strips the whole sentinel block from the mirrored user turn so the copied
+    history isn't duplicated in the Omnigent timeline (text-prefix replay ONLY —
+    NO native-conversation reconstruction).
+
+    Any literal sentinel tags inside *preamble* are defanged
+    (:func:`_neutralize_fork_sentinels`) so the framed block holds exactly one
+    real open/close pair — this keeps the reader's non-greedy strip unambiguous
+    and prevents embedded tags from leaking history. *user_text* is left
+    untouched (it sits after the close tag; the non-greedy strip stops at the
+    real close, so a tag in the user's own message is preserved).
+
+    :param preamble: Rendered prior-conversation transcript.
+    :param user_text: The user's first message in the fork.
+    :returns: The framed, fenced transcript followed by the user text.
+    """
+    return (
+        f"{FORK_HISTORY_OPEN_TAG}\n"
+        f"{_FORK_HISTORY_HEADER}\n\n"
+        f"{_neutralize_fork_sentinels(preamble)}\n\n"
+        f"{_FORK_HISTORY_FOOTER}\n"
+        f"{FORK_HISTORY_CLOSE_TAG}\n\n"
+        f"{user_text}"
+    )
+
+
+def strip_fork_history(text: str) -> str:
+    """Strip the fork-history sentinel block from a mirrored user turn.
+
+    On a fork the first typed turn carries the replayed transcript fenced in the
+    sentinel tags (:func:`wrap_fork_preamble`). agy records that whole text as
+    the ``USER_INPUT`` step, so the RPC reader — which mirrors USER_INPUT steps
+    into the Omnigent timeline as user ``message`` items — must drop the fenced
+    block, else the copied prior conversation would be DUPLICATED in the
+    timeline. Applied to every mirrored user turn; a no-op on the common case
+    (no sentinel present). Mirrors cursor's forwarder ``_FORK_HISTORY_RE`` strip.
+
+    :param text: The user turn text as recorded by agy.
+    :returns: The text with any fork-history block removed, stripped of
+        surrounding whitespace.
+    """
+    return _FORK_HISTORY_RE.sub("", text).strip()
 
 
 # ── Web-turn TUI delivery (tmux send-keys) ───────────────────────────────────

--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -43,6 +43,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Literal, TypedDict
 
+from omnigent.antigravity_native_bridge import strip_fork_history
+
 _logger = logging.getLogger(__name__)
 
 # Omnigent ``agent`` label stamped on mirrored assistant/function-call items so
@@ -602,6 +604,15 @@ def _user_input_text(user_input: object) -> str:
     :func:`omnigent.antigravity_native_rpc.send_user_cascade_message` sends).
     Prefer ``userResponse``; fall back to joining the item texts.
 
+    On a forked session the first typed turn carries the replayed prior
+    transcript fenced in fork-history sentinels (text-preamble replay, see
+    :func:`omnigent.antigravity_native_bridge.wrap_fork_preamble`). agy records
+    that whole text as the USER_INPUT step, so the block is stripped here
+    (:func:`omnigent.antigravity_native_bridge.strip_fork_history`) — otherwise
+    the copied prior conversation would be DUPLICATED in the mirrored timeline
+    (it already lives there as the source conversation's items). A no-op on the
+    common case (no sentinel).
+
     :param user_input: The step's ``userInput`` value (expected ``dict``).
     :returns: The user's text, or ``""`` when absent/unparseable.
     """
@@ -609,7 +620,7 @@ def _user_input_text(user_input: object) -> str:
         return ""
     response = user_input.get("userResponse")
     if isinstance(response, str) and response.strip():
-        return response
+        return strip_fork_history(response)
     items = user_input.get("items")
     if isinstance(items, list):
         parts = [
@@ -619,7 +630,7 @@ def _user_input_text(user_input: object) -> str:
         ]
         joined = "\n".join(part for part in parts if part)
         if joined.strip():
-            return joined
+            return strip_fork_history(joined)
     return ""
 
 

--- a/omnigent/inner/antigravity_native_executor.py
+++ b/omnigent/inner/antigravity_native_executor.py
@@ -73,9 +73,12 @@ from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
     ANTIGRAVITY_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     AntigravityNativeBridgeState,
+    clear_fork_preamble,
     inject_user_message_via_tui,
     is_placeholder_conversation_id,
     read_bridge_state,
+    read_fork_preamble,
+    wrap_fork_preamble,
 )
 from omnigent.antigravity_native_rpc import (
     cancel_cascade_steps,
@@ -255,11 +258,31 @@ class AntigravityNativeExecutor(Executor):
         if not text:
             yield ExecutorError(message="Antigravity native turn had no user text to send")
             return
+        # A fork into agy carries history as a text preamble: agy owns its
+        # conversation store and exposes no history-import / transcript-rebuild
+        # API (unlike claude/codex/pi/qwen native, which seed a resumable
+        # session file), so the runner stashed the prior turns and we prepend
+        # them to the FIRST typed turn (text-prefix replay ONLY — NO native
+        # conversation reconstruction). We READ the preamble here but only CLEAR
+        # it after a successful deliver (below): consuming it up front would lose
+        # the forked history permanently if delivery fails (e.g. the agy TUI
+        # exited) and the turn is retried. The RPC reader strips the sentinel
+        # block when mirroring this turn back, so the copied history isn't
+        # duplicated in the Omnigent timeline (antigravity_native_steps). Only
+        # the initiating turn carries it; mid-turn steering
+        # (enqueue_session_message) deliberately does not.
+        preamble = await asyncio.to_thread(read_fork_preamble, self._bridge_dir)
+        if preamble:
+            text = wrap_fork_preamble(preamble, text)
         outcome = await self._deliver(text)
         if outcome is not None:
             yield ExecutorError(message=outcome)
-        else:
-            yield TurnComplete(response=None)
+            return
+        # Delivery landed — now it's safe to consume the preamble so later turns
+        # type the plain user text.
+        if preamble:
+            await asyncio.to_thread(clear_fork_preamble, self._bridge_dir)
+        yield TurnComplete(response=None)
 
     async def _deliver(self, text: str) -> str | None:
         """

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4095,11 +4095,13 @@ async def _auto_create_antigravity_terminal(
         prepare_bridge_dir,
         seed_isolated_agy_home,
         write_bridge_state,
+        write_fork_preamble,
         write_mcp_config,
         write_tmux_target,
     )
     from omnigent.antigravity_native_launch import build_agy_launch
     from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
+    from omnigent.stores.conversation_store import FORK_CARRY_HISTORY_LABEL_KEY
 
     if server_client is None:
         raise RuntimeError("server_client is required for runner-owned Antigravity terminals.")
@@ -4148,10 +4150,16 @@ async def _auto_create_antigravity_terminal(
     # else the session id.
     labels = snapshot.get("labels")
     bridge_id = session_id
+    fork_carry_history = False
     if isinstance(labels, dict):
         _bid = labels.get(ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY)
         if isinstance(_bid, str) and _bid:
             bridge_id = _bid
+        # The fork route stamps this on a clone bound to a native harness that
+        # carries prior history (see _CURSOR_FORK_HISTORY_HARNESSES). agy can't
+        # rebuild a native transcript, so on a fresh fork it carries history as
+        # a text preamble replayed onto the first turn (see below).
+        fork_carry_history = labels.get(FORK_CARRY_HISTORY_LABEL_KEY) == "1"
 
     # Cancel any surviving reader BEFORE clearing its conversation state, else it
     # keeps mirroring with stale state alongside the one spawned below (mirrors the
@@ -4161,6 +4169,33 @@ async def _auto_create_antigravity_terminal(
     # Clear stale turn/conversation state so the reader binds this run's real agy
     # conversation id (the cold-start mints it below) instead of a prior run's.
     clear_bridge_state(bridge_dir)
+
+    # A fork bound to antigravity-native carries history as a text preamble: agy
+    # owns its conversation store and exposes NO transcript-export / history-
+    # rebuild API, so a fork CANNOT reconstruct the native conversation the way
+    # claude/codex/pi/qwen-native do (those rebuild a resumable session file from
+    # the copied items). Instead — exactly like cursor-native — render the copied
+    # Omnigent items once and stash them; the executor prepends them to the fork's
+    # FIRST typed turn (text-prefix replay ONLY, NO native-conversation
+    # reconstruction). Only on a FRESH fork (``not resume``): a resumed agy
+    # conversation already holds its own history. Best-effort — a failure just
+    # starts the agy turn without the prior context.
+    if fork_carry_history and not resume and server_client is not None:
+        try:
+            from omnigent.claude_native import _fetch_all_session_items_for_claude_resume
+
+            fork_items = await _fetch_all_session_items_for_claude_resume(
+                server_client, session_id
+            )
+            await asyncio.to_thread(
+                write_fork_preamble, bridge_dir, _cursor_fork_history_preamble(fork_items)
+            )
+        except Exception:  # noqa: BLE001 — context carry-over is best-effort
+            _logger.warning(
+                "antigravity-native: could not build fork history preamble (session=%s).",
+                session_id,
+                exc_info=True,
+            )
 
     # Pre-accept agy's first-run onboarding wizard (HOME-global) before launch:
     # a host-spawned agy terminal has no TTY to answer it and would hang with a
@@ -4863,10 +4898,13 @@ def _cursor_fork_history_preamble(items: list[dict[str, Any]]) -> str:
     prefix on the fork's first message (text-prefix replay). Only user/assistant
     message text is replayed — cursor's TUI has no surface to import tool-call
     history or reconstruct native bubbles, so this formats the turns as a clean
-    speaker-labelled transcript (the closest single-block analog), mirroring the
-    antigravity executor's documented text-prefix fallback. The human framing +
-    strip sentinel are added by
-    :func:`omnigent.cursor_native_bridge.wrap_fork_preamble`.
+    speaker-labelled transcript (the closest single-block analog). SHARED with
+    antigravity-native, which has the same constraint (agy owns its conversation
+    store and exposes no transcript-export API) and replays this preamble onto
+    its first typed turn (see :func:`_auto_create_antigravity_terminal`); the
+    per-harness human framing + strip sentinel are added by
+    :func:`omnigent.cursor_native_bridge.wrap_fork_preamble` /
+    :func:`omnigent.antigravity_native_bridge.wrap_fork_preamble`.
 
     :param items: Committed Omnigent items (``GET /v1/sessions/{id}/items``),
         chronological.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10007,9 +10007,21 @@ _FORK_HISTORY_NATIVE_HARNESSES: frozenset[str] = frozenset(
 # _auto_create_cursor_terminal / cursor_native_executor and the opencode
 # resume/fork rehydration in _auto_create_opencode_terminal). opencode-native
 # joins cursor here: opencode has no history-import API, so a fork seeds prior
-# context as a noReply preamble rather than a rebuilt session.
+# context as a noReply preamble rather than a rebuilt session. antigravity-native
+# joins too: agy owns its conversation store and exposes no transcript-export /
+# history-rebuild API, so a fork replays the prior turns as a text preamble on
+# the first typed turn (see _auto_create_antigravity_terminal /
+# antigravity_native_executor). Both id spellings are listed because
+# canonicalize_harness passes the reversed native ids through unchanged.
 _CURSOR_FORK_HISTORY_HARNESSES: frozenset[str] = frozenset(
-    {"cursor-native", "native-cursor", "opencode-native", "native-opencode"}
+    {
+        "cursor-native",
+        "native-cursor",
+        "opencode-native",
+        "native-opencode",
+        "antigravity-native",
+        "native-antigravity",
+    }
 )
 
 
@@ -10045,15 +10057,17 @@ def _agent_carries_native_fork_history(agent: Agent) -> bool:
 def _agent_carries_cursor_fork_history(agent: Agent) -> bool:
     """Return whether *agent*'s native harness carries FORK history via preamble.
 
-    Cursor's conversation is server-backed and opencode has no history-import
-    API, so neither can seed a local store for a rebuilt resume; instead the
-    runner replays prior turns as a text preamble on the fork (cursor: the
-    first message; opencode: a ``noReply`` context message). Fork-only —
-    switch-agent does not call this, so switching into one still launches fresh.
-    Returns ``False`` when the bundle can't be loaded.
+    Cursor's conversation is server-backed, opencode has no history-import API,
+    and agy owns its conversation store with no transcript-export API, so none
+    can seed a local store for a rebuilt resume; instead the runner replays prior
+    turns as a text preamble on the fork (cursor / antigravity: the first typed
+    message; opencode: a ``noReply`` context message). Fork-only — switch-agent
+    does not call this, so switching into one still launches fresh. Returns
+    ``False`` when the bundle can't be loaded.
 
     :param agent: The agent whose harness to classify.
-    :returns: ``True`` for the cursor-native / opencode-native harnesses.
+    :returns: ``True`` for the cursor-native / opencode-native /
+        antigravity-native harnesses.
     """
     from omnigent.harness_aliases import canonicalize_harness
 

--- a/tests/inner/test_antigravity_native_executor.py
+++ b/tests/inner/test_antigravity_native_executor.py
@@ -20,8 +20,11 @@ import pytest
 
 import omnigent.inner.antigravity_native_executor as executor_mod
 from omnigent.antigravity_native_bridge import (
+    FORK_HISTORY_OPEN_TAG,
     AntigravityNativeBridgeState,
+    read_fork_preamble,
     write_bridge_state,
+    write_fork_preamble,
 )
 from omnigent.inner.antigravity_native_executor import AntigravityNativeExecutor
 from omnigent.inner.executor import ExecutorError, ExecutorEvent, TurnComplete
@@ -375,6 +378,97 @@ def test_run_turn_tui_inject_error_surfaces(tmp_path: Path, injected: dict[str, 
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
     assert "the agy TUI" in events[0].message
+
+
+# ---------------------------------------------------------------------------
+# run_turn — fork history (text-preamble replay)
+# ---------------------------------------------------------------------------
+
+
+def test_run_turn_first_fork_turn_injects_preamble_then_consumes_it(
+    tmp_path: Path, injected: dict[str, object]
+) -> None:
+    """
+    A fork's FIRST turn prepends the fenced preamble; the second is plain text.
+
+    agy owns its conversation store and exposes no history-rebuild API, so a fork
+    carries history as a text preamble replayed onto the first typed turn
+    (text-prefix replay). The runner stashed it in the bridge dir; the executor
+    fences it in the fork-history sentinel ahead of the user's real text and
+    consumes it only after a successful inject, so a later turn types plain text.
+    """
+    _seed_state(tmp_path)
+    write_fork_preamble(tmp_path, "You: earlier")
+    executor = _executor(tmp_path)
+
+    asyncio.run(_run(executor, "first"))
+    first = _injected(injected)[0]["content"]
+    assert isinstance(first, str)
+    assert FORK_HISTORY_OPEN_TAG in first
+    assert "You: earlier" in first
+    assert first.endswith("first")
+    # Consumed on success.
+    assert read_fork_preamble(tmp_path) is None
+
+    asyncio.run(_run(executor, "second"))
+    assert _injected(injected)[1]["content"] == "second"
+
+
+def test_run_turn_failed_fork_injection_preserves_preamble_for_retry(
+    tmp_path: Path, injected: dict[str, object]
+) -> None:
+    """
+    A failed first fork inject must NOT consume the preamble (retry keeps history).
+
+    Consuming on read would lose the forked history permanently if the first
+    inject fails (e.g. the agy pane exited); the executor reads but only clears
+    after a successful inject, so a retried first turn still replays the history.
+    """
+    _seed_state(tmp_path)
+    write_fork_preamble(tmp_path, "You: earlier")
+    executor = _executor(tmp_path)
+
+    injected["raise"] = RuntimeError("the agy terminal is no longer running")
+    events = asyncio.run(_run(executor, "first"))
+    assert any(isinstance(e, ExecutorError) for e in events)
+    # Preamble survives the failed inject for a retry.
+    assert read_fork_preamble(tmp_path) == "You: earlier"
+
+    injected["raise"] = None
+    asyncio.run(_run(executor, "first"))
+    retried = _injected(injected)[1]["content"]
+    assert isinstance(retried, str)
+    assert "You: earlier" in retried
+    assert read_fork_preamble(tmp_path) is None
+
+
+def test_run_turn_no_fork_preamble_injects_plain_text(
+    tmp_path: Path, injected: dict[str, object]
+) -> None:
+    """A non-fork session (no preamble file) injects the plain user text."""
+    _seed_state(tmp_path)
+    asyncio.run(_run(_executor(tmp_path), "hello"))
+    assert _injected(injected)[0]["content"] == "hello"
+
+
+def test_enqueue_steer_does_not_carry_fork_preamble(
+    tmp_path: Path, injected: dict[str, object]
+) -> None:
+    """
+    Mid-turn steering does NOT prepend the fork preamble (only the initiating turn does).
+
+    ``enqueue_session_message`` is the steering path; the fork preamble rides
+    only ``run_turn`` (the initiating turn), so a steer delivers plain text and
+    leaves the preamble untouched for the still-pending first turn.
+    """
+    _seed_state(tmp_path)
+    write_fork_preamble(tmp_path, "You: earlier")
+    result = asyncio.run(_executor(tmp_path).enqueue_session_message("main", "steer"))
+    assert result is True
+    assert _injected(injected)[0]["content"] == "steer"
+    assert FORK_HISTORY_OPEN_TAG not in str(_injected(injected)[0]["content"])
+    # The initiating turn still owns the preamble.
+    assert read_fork_preamble(tmp_path) == "You: earlier"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -817,6 +817,20 @@ async def test_fork_switch_404_unknown_target() -> None:
             False,
             {"omnigent.ui": "terminal", "omnigent.wrapper": "cursor-native-ui"},
         ),
+        # antigravity target carries history via a text preamble too: agy owns
+        # its conversation store and exposes no transcript-export / history-
+        # rebuild API, so the runner can't seed a native transcript — it replays
+        # the prior turns on the first typed turn. So carry_history_into_native
+        # IS stamped, model settings reset (cross-family), and the source's
+        # native session id is NOT stamped (no clone — it carries via preamble).
+        (
+            "claude_sdk",
+            "antigravity-native",
+            False,
+            True,
+            False,
+            {"omnigent.ui": "terminal", "omnigent.wrapper": "antigravity-native-ui"},
+        ),
         # pi-native CAN carry fork history: the runner rebuilds Pi's JSONL
         # session file from the copied Omnigent items. Cross-family from a
         # claude SDK source, so model settings reset and the source's native
@@ -977,6 +991,10 @@ async def test_fork_no_switch_native_source_carries_history(
         # (it is in _FORK_HISTORY_NATIVE_HARNESSES), so a same-agent fork marks
         # native carry — parity with claude/codex.
         ("pi-native", True),
+        # antigravity carries history via a text preamble too: agy owns its
+        # conversation store and exposes no transcript-export API, so a fork
+        # replays prior turns on the first typed turn (parity with cursor).
+        ("antigravity-native", True),
     ],
 )
 @pytest.mark.asyncio
@@ -1025,6 +1043,9 @@ async def test_fork_cursor_pi_native_carry_gating(
         ("native-codex", True),
         ("native-cursor", True),
         ("native-pi", True),
+        # native-antigravity is NOT aliased to antigravity-native, so it passes
+        # through unchanged — the carry gate lists both spellings explicitly.
+        ("native-antigravity", True),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -13,20 +13,27 @@ import omnigent.antigravity_native_bridge as _mod
 from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
     ANTIGRAVITY_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    FORK_HISTORY_CLOSE_TAG,
+    FORK_HISTORY_OPEN_TAG,
     AntigravityNativeBridgeState,
     agy_home_dir,
     build_antigravity_native_spawn_env,
     build_mcp_config,
     clear_bridge_state,
+    clear_fork_preamble,
     ensure_agy_onboarding_complete,
     inject_user_message_via_tui,
     prepare_bridge_dir,
     read_bridge_state,
+    read_fork_preamble,
     read_tmux_info,
     seed_isolated_agy_home,
     send_interaction_keys_via_tui,
+    strip_fork_history,
     update_conversation_id,
+    wrap_fork_preamble,
     write_bridge_state,
+    write_fork_preamble,
     write_mcp_bridge_config,
     write_mcp_config,
     write_tmux_target,
@@ -1215,3 +1222,80 @@ def test_send_interaction_keys_via_tui_rejects_empty_keys(tmp_path: Path) -> Non
     """No keys is a programming error, not an empty send-keys call."""
     with pytest.raises(RuntimeError, match="at least one key"):
         send_interaction_keys_via_tui(tmp_path / "bridge")
+
+
+# ---------------------------------------------------------------------------
+# Fork history via text-preamble replay
+# ---------------------------------------------------------------------------
+#
+# agy owns its conversation store and exposes no transcript-export / history-
+# rebuild API, so a fork CANNOT reconstruct the native conversation; instead it
+# replays the prior Omnigent transcript as a fenced text preamble on the first
+# typed turn (text-prefix replay ONLY — NO native-conversation reconstruction),
+# exactly like cursor-native. These mirror the cursor-native fork tests.
+
+
+class TestForkPreamble:
+    """The fork preamble file + sentinel framing (text-prefix replay)."""
+
+    def test_read_does_not_consume_clear_does(self, tmp_path: Path) -> None:
+        write_fork_preamble(tmp_path, "You: hi")
+        # Read is idempotent (the file survives) so a failed/retried inject can
+        # re-read it; only clear consumes.
+        assert read_fork_preamble(tmp_path) == "You: hi"
+        assert read_fork_preamble(tmp_path) == "You: hi"
+        clear_fork_preamble(tmp_path)
+        assert read_fork_preamble(tmp_path) is None
+
+    def test_empty_preamble_is_not_written(self, tmp_path: Path) -> None:
+        write_fork_preamble(tmp_path, "")
+        assert read_fork_preamble(tmp_path) is None
+
+    def test_read_missing_is_none_and_clear_is_noop(self, tmp_path: Path) -> None:
+        assert read_fork_preamble(tmp_path) is None
+        clear_fork_preamble(tmp_path)  # no file -> no error
+
+    def test_wrap_fences_preamble_before_user_text(self) -> None:
+        wrapped = wrap_fork_preamble("You: hi\n\nAssistant: yo", "do it")
+        assert wrapped.startswith(FORK_HISTORY_OPEN_TAG)
+        assert FORK_HISTORY_CLOSE_TAG in wrapped
+        # The user's real text follows the fenced block.
+        assert wrapped.endswith("do it")
+        assert wrapped.index(FORK_HISTORY_CLOSE_TAG) < wrapped.index("do it")
+
+    def test_wrap_defangs_sentinels_inside_preamble(self) -> None:
+        # A literal close tag in the replayed transcript must not produce a second
+        # real close tag inside the block (which would let the reader's strip stop
+        # early and leak history). The framed block holds exactly one pair.
+        wrapped = wrap_fork_preamble(f"You: see {FORK_HISTORY_CLOSE_TAG} here", "go")
+        assert wrapped.count(FORK_HISTORY_CLOSE_TAG) == 1
+        assert wrapped.count(FORK_HISTORY_OPEN_TAG) == 1
+        # The defanged form stays readable.
+        assert "[/omnigent_fork_history]" in wrapped
+
+
+class TestStripForkHistory:
+    """The reader's user-bubble strip: the fenced block must not be mirrored."""
+
+    def test_strips_whole_block_leaving_user_text(self) -> None:
+        wrapped = wrap_fork_preamble("You: hi\n\nAssistant: yo", "continue please")
+        # The RPC reader mirrors a USER_INPUT step as a user message; the fenced
+        # preamble must be removed so the copied history isn't duplicated.
+        assert strip_fork_history(wrapped) == "continue please"
+
+    def test_noop_when_no_sentinel(self) -> None:
+        assert strip_fork_history("just a normal turn") == "just a normal turn"
+
+    def test_strips_unterminated_block_to_end(self) -> None:
+        # A truncated paste with an open tag but no close strips to end-of-text
+        # (degrades gracefully) rather than mirroring the whole raw block.
+        text = f"{FORK_HISTORY_OPEN_TAG}\nprior stuff with no close"
+        assert strip_fork_history(text) == ""
+
+    def test_preserves_user_close_tag_after_real_close(self) -> None:
+        # The non-greedy first alternative stops at the FIRST close tag (always
+        # the real one, since the preamble is defanged to hold exactly one pair),
+        # so a literal CLOSE tag in the user's OWN text after the block survives.
+        wrapped = wrap_fork_preamble("You: hi", f"now do {FORK_HISTORY_CLOSE_TAG} this")
+        stripped = strip_fork_history(wrapped)
+        assert stripped == f"now do {FORK_HISTORY_CLOSE_TAG} this"

--- a/tests/test_antigravity_native_steps.py
+++ b/tests/test_antigravity_native_steps.py
@@ -115,6 +115,42 @@ class TestUserInputCommitted:
         assert events == []
 
 
+class TestUserInputForkHistoryStripped:
+    """A fork's first turn carries the fenced preamble; the mirror strips it.
+
+    On a fork, the executor types the prior transcript fenced in fork-history
+    sentinels ahead of the user's text (text-prefix replay). agy records that
+    whole text as the USER_INPUT step, so the read path must strip the fenced
+    block before mirroring the user bubble — else the copied prior conversation
+    would be DUPLICATED in the timeline (it already lives there as the source
+    conversation's items).
+    """
+
+    def test_fork_preamble_is_stripped_from_mirrored_user_bubble(self) -> None:
+        from omnigent.antigravity_native_bridge import wrap_fork_preamble
+
+        wrapped = wrap_fork_preamble("You: earlier\n\nAssistant: ok", "now continue")
+        step = {
+            "type": "CORTEX_STEP_TYPE_USER_INPUT",
+            "userInput": {"userResponse": wrapped},
+        }
+        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        assert len(events) == 1
+        content = events[0].data["item_data"]["content"]
+        # Only the user's real text is mirrored — the fenced history is gone.
+        assert content == [{"type": "input_text", "text": "now continue"}]
+
+    def test_plain_user_turn_unchanged(self) -> None:
+        step = {
+            "type": "CORTEX_STEP_TYPE_USER_INPUT",
+            "userInput": {"userResponse": "a normal turn"},
+        }
+        events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
+        assert events[0].data["item_data"]["content"] == [
+            {"type": "input_text", "text": "a normal turn"}
+        ]
+
+
 # ---------------------------------------------------------------------------
 # PLANNER_RESPONSE (text only) → one message, NO delta
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Closes the last fully-missing P1 native-parity gap for antigravity-native: session **FORK**.

agy owns its cascade/conversation history in its own store and exposes **no transcript-export / history-rebuild API**, so a fork CANNOT reconstruct the native conversation the way claude/codex/pi/qwen-native do (those rebuild a resumable on-disk session file from the copied Omnigent items and relaunch `--resume` / `--conversation`). This wires fork via the established **TEXT-PREAMBLE REPLAY** pattern already used by cursor-native: serialize the prior Omnigent transcript into a fenced seed/preamble and prepend it to the **first** injected user turn of a **fresh** agy conversation, with the same fork-history sentinel convention.

## How

- **`antigravity_native_bridge.py`** — add the fork-preamble file + sentinel helpers mirroring `cursor_native_bridge` 1:1: `write_fork_preamble` / `read_fork_preamble` / `clear_fork_preamble` (read/clear split so a failed inject doesn't lose history), `wrap_fork_preamble` (+ sentinel defang so the framed block holds exactly one real open/close pair), and `strip_fork_history` (the reader-side strip).
- **`inner/antigravity_native_executor.py`** — `run_turn` reads the preamble, fences it ahead of the user's real text, delivers it by typing into the agy TUI, and clears it **only after a successful inject** (consume-on-success; survives a failed/retried first turn). Mid-turn steering (`enqueue_session_message`) deliberately never carries it.
- **`antigravity_native_steps.py`** — strip the fork-history sentinel block from `_user_input_text` so the mirrored `USER_INPUT` bubble shows only the user's real text (the RPC reader mirrors USER_INPUT steps into the timeline; without the strip the copied history would be **duplicated**).
- **`runner/app.py`** — in `_auto_create_antigravity_terminal`, on a fresh fork (`FORK_CARRY_HISTORY` label set, `not resume`), render the copied items via the shared `_cursor_fork_history_preamble` serializer (+ `_fetch_all_session_items_for_claude_resume`) and stash them for the executor. Best-effort.
- **`server/routes/sessions.py`** — add `antigravity-native` / `native-antigravity` to `_CURSOR_FORK_HISTORY_HARNESSES` so the fork route stamps `carry_history_into_native` and sets `resume_source_native_session=False` (no doomed native-session clone — agy has no transcript export).

## Reused vs. added

- **Reused**: the shared `_cursor_fork_history_preamble` transcript→preamble serializer and `_fetch_all_session_items_for_claude_resume` (runner); the cursor-native fork-history sentinel + strip convention; the existing `FORK_CARRY_HISTORY` label + fork-route gating plumbing.
- **Added**: per-harness bridge preamble helpers in `antigravity_native_bridge` (no shared helper exists — same per-harness duplication convention as the tmux-injection primitives) and the reader-side `strip_fork_history`.

## Where the preamble is injected

The runner stashes `fork_preamble.txt` in the session's bridge dir on a fresh fork. The executor's `run_turn` prepends it (fenced in `<omnigent_fork_history>…</omnigent_fork_history>`) to the **first** typed user turn into the agy TUI, then clears it on success so later turns type plain text.

## Documented limitation

Text-prefix replay **ONLY** — there is **no rollout / native-conversation reconstruction** (consistent with cursor-native). The agy TUI sees the prior turns as a single contextual block on turn 1, not as replayed native chat bubbles, and tool-call history is not carried. This is the closest single-message analog agy's surface allows.

## Tests

Unit tests mirroring the cursor-native fork tests, adapted to antigravity-native:
- bridge preamble round-trip (read-doesn't-consume / clear-does, empty/missing, wrap fences + defang) and `strip_fork_history` (whole-block strip, no-op, unterminated block, user close-tag preserved);
- executor first-turn-injects-then-consumes, failed-inject-preserves-for-retry, no-preamble-plain-text, steering-doesn't-carry;
- steps fork-history-stripped-from-mirrored-bubble;
- server fork-gate parametrized cases (`claude_sdk -> antigravity-native`, same-agent, reversed `native-antigravity` spelling).

`python -m pytest tests/test_antigravity_native*.py` passes, plus the executor + sessions-fork + runner native-app suites (**708 passed**, 0 failures). `ruff check` / `ruff format --check` clean.

This pull request and its description were written by Isaac.