### PR TITLE
feat: filter changed files by git staged/unstaged state

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -16292,7 +16292,8 @@ def create_runner_app(
             e.g. ``"conv_abc123"``.
         :param environment_id: Environment resource id,
             e.g. ``"default"``.
-        :returns: JSON list of changed file entries with ``status`` field.
+        :returns: JSON list of changed file entries with ``status`` plus
+            optional ``staged`` / ``unstaged`` fields.
         """
         await _require_os_env(session_id)
         await _ensure_session_registered(session_id)
@@ -16305,8 +16306,9 @@ def create_runner_app(
             if session_registry is not None
             else []
         )
-        data = [
-            {
+        data: list[dict[str, Any]] = []
+        for rec in raw_changes:
+            entry: dict[str, Any] = {
                 "object": "session.environment.filesystem.entry",
                 "path": rec["path"],
                 "name": rec["path"].split("/")[-1],
@@ -16314,8 +16316,11 @@ def create_runner_app(
                 "bytes": rec.get("bytes"),
                 "modified_at": rec.get("modified_at"),
             }
-            for rec in raw_changes
-        ]
+            if "staged" in rec:
+                entry["staged"] = rec["staged"]
+            if "unstaged" in rec:
+                entry["unstaged"] = rec["unstaged"]
+            data.append(entry)
         return JSONResponse(
             status_code=200,
             content={"object": "list", "data": data, "has_more": False},

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -224,12 +224,12 @@ def _strip_git_quotes(path_part: str) -> str:
     return path_part
 
 
-def _parse_git_porcelain_line(line: str) -> tuple[str, str] | None:
+def _parse_git_porcelain_line(line: str) -> tuple[str, str, bool, bool] | None:
     """Parse one line of ``git status --porcelain`` output.
 
-    Returns ``(git_relative_path, operation)`` where *operation* is one of
-    ``"created"``, ``"modified"``, or ``"deleted"``, or ``None`` when the
-    line is too short or otherwise malformed.
+    Returns ``(git_relative_path, operation, staged, unstaged)`` where
+    *operation* is one of ``"created"``, ``"modified"``, or ``"deleted"``,
+    or ``None`` when the line is too short or otherwise malformed.
 
     Status mapping:
 
@@ -237,13 +237,17 @@ def _parse_git_porcelain_line(line: str) -> tuple[str, str] | None:
     - ``D`` in either column → ``"deleted"``
     - Everything else (``M``, ``R``, ``C``, ``U``, …) → ``"modified"``
 
+    The ``staged`` flag reflects the index column (X), and ``unstaged``
+    reflects the working-tree column (Y).  A path may be both staged and
+    unstaged when it has partially-staged changes.
+
     Renames appear as ``R  old -> new``; only the destination path is
     returned.  Git-quoted paths (wrapping double-quotes for names with
     spaces or special characters, including non-ASCII octal sequences) are
     fully unquoted and unescaped via :func:`_unquote_git_path`.
 
     :param line: A single line from ``git status --porcelain`` output.
-    :returns: ``(path, operation)`` tuple or ``None``.
+    :returns: ``(path, operation, staged, unstaged)`` tuple or ``None``.
     """
     if len(line) < 4:
         return None
@@ -266,7 +270,9 @@ def _parse_git_porcelain_line(line: str) -> tuple[str, str] | None:
     else:
         operation = "modified"
 
-    return path_part, operation
+    staged = x not in (" ", "?")
+    unstaged = y != " "
+    return path_part, operation, staged, unstaged
 
 
 # ── Data model ────────────────────────────────────────────────────────────────
@@ -283,6 +289,8 @@ class _FileEvent:
         or the file was deleted.
     :param modified_at: File modification time as Unix timestamp (int),
         or ``None`` if stat failed or the file was deleted.
+    :param staged: Whether the change is staged in the git index.
+    :param unstaged: Whether the change exists in the working tree.
     """
 
     path: str
@@ -290,6 +298,8 @@ class _FileEvent:
     timestamp: float
     bytes: int | None
     modified_at: int | None
+    staged: bool = False
+    unstaged: bool = True
 
 
 # ── Abstract base ─────────────────────────────────────────────────────────────
@@ -391,7 +401,8 @@ class FilesystemRegistry(ABC):
         :param conversation_id: The session to query, e.g. ``"conv_abc123"``.
         :param limit: Maximum number of records to return.
         :returns: List of file-record dicts with ``path``, ``status``,
-            ``bytes``, and ``modified_at`` fields, newest first.
+            ``bytes``, ``modified_at``, ``staged``, and ``unstaged`` fields,
+            newest first.
         """
 
     @abstractmethod
@@ -400,8 +411,9 @@ class FilesystemRegistry(ABC):
 
         :param session_id: The session to query, e.g. ``"conv_abc123"``.
         :param path: Path relative to the workspace root, e.g. ``"src/foo.py"``.
-        :returns: A file-record dict with ``path``, ``status``, ``bytes``, and
-            ``modified_at`` fields, or ``None`` when the file has no changes.
+        :returns: A file-record dict with ``path``, ``status``, ``bytes``,
+            ``modified_at``, ``staged``, and ``unstaged`` fields, or ``None``
+            when the file has no changes.
         """
 
     @abstractmethod
@@ -496,6 +508,8 @@ class AgentEditFilesystemRegistry(FilesystemRegistry):
             timestamp=time.time(),
             bytes=bytes_,
             modified_at=modified_at,
+            staged=False,
+            unstaged=True,
         )
         with self._lock:
             self._session_events.setdefault(session_id, []).append(fe)
@@ -560,6 +574,8 @@ class AgentEditFilesystemRegistry(FilesystemRegistry):
                 "status": r.operation,
                 "bytes": r.bytes,
                 "modified_at": r.modified_at,
+                "staged": r.staged,
+                "unstaged": r.unstaged,
             }
             for r in records[:limit]
         ]
@@ -576,8 +592,8 @@ class AgentEditFilesystemRegistry(FilesystemRegistry):
         :param path: Path relative to the workspace root, e.g.
             ``"src/foo.py"``.
         :returns: A file-record dict (``path``, ``status``, ``bytes``,
-            ``modified_at``) when the file was changed this session, or
-            ``None`` when it was not touched.
+            ``modified_at``, ``staged``, ``unstaged``) when the file was
+            changed this session, or ``None`` when it was not touched.
         """
         norm = _normalize_path(path, self._cwd)
         if norm is None:
@@ -597,6 +613,8 @@ class AgentEditFilesystemRegistry(FilesystemRegistry):
             "status": op,
             "bytes": last_event.bytes,
             "modified_at": last_event.modified_at,
+            "staged": last_event.staged,
+            "unstaged": last_event.unstaged,
         }
 
     def get_baseline(self, path: str) -> str | None:
@@ -707,7 +725,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
             parsed = _parse_git_porcelain_line(line)
             if parsed is None:
                 continue
-            git_path, operation = parsed
+            git_path, operation, staged, unstaged = parsed
             rel_path = self._git_to_rel(git_path)
             if rel_path is None:
                 continue
@@ -718,7 +736,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
             first_component = Path(rel_path).parts[0] if Path(rel_path).parts else ""
             if first_component in _SKIP_DIRS:
                 continue
-            records.append(self._make_record(rel_path, operation))
+            records.append(self._make_record(rel_path, operation, staged, unstaged))
 
         records.sort(key=lambda r: (r["modified_at"] or 0, r["path"]), reverse=True)
         return records[:limit]
@@ -766,8 +784,8 @@ class GitFilesystemRegistry(FilesystemRegistry):
             parsed = _parse_git_porcelain_line(line)
             if parsed is None:
                 continue
-            _, operation = parsed
-            return self._make_record(norm, operation)
+            _, operation, staged, unstaged = parsed
+            return self._make_record(norm, operation, staged, unstaged)
 
         return None
 
@@ -819,13 +837,21 @@ class GitFilesystemRegistry(FilesystemRegistry):
         except ValueError:
             return None
 
-    def _make_record(self, rel_path: str, operation: str) -> dict[str, Any]:
+    def _make_record(
+        self,
+        rel_path: str,
+        operation: str,
+        staged: bool,
+        unstaged: bool,
+    ) -> dict[str, Any]:
         """Build a file-record dict for *rel_path*.
 
         :param rel_path: Path relative to ``self._cwd``.
         :param operation: One of ``"created"``, ``"modified"``, ``"deleted"``.
-        :returns: File-record dict with ``path``, ``status``, ``bytes``, and
-            ``modified_at`` fields.
+        :param staged: Whether the change is staged in the git index.
+        :param unstaged: Whether the change exists in the working tree.
+        :returns: File-record dict with ``path``, ``status``, ``bytes``,
+            ``modified_at``, ``staged``, and ``unstaged`` fields.
         """
         bytes_: int | None = None
         modified_at: int | None = None
@@ -836,7 +862,14 @@ class GitFilesystemRegistry(FilesystemRegistry):
                 modified_at = int(st.st_mtime)
             except OSError:
                 pass
-        return {"path": rel_path, "status": operation, "bytes": bytes_, "modified_at": modified_at}
+        return {
+            "path": rel_path,
+            "status": operation,
+            "bytes": bytes_,
+            "modified_at": modified_at,
+            "staged": staged,
+            "unstaged": unstaged,
+        }
 
 
 # ── Factory ───────────────────────────────────────────────────────────────────

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -17361,7 +17361,8 @@ def create_sessions_router(
         :param request: The incoming FastAPI request (for auth).
         :param session_id: Session/conversation identifier.
         :param environment_id: Environment resource id.
-        :returns: Flat list of changed filesystem entries with ``status``.
+        :returns: Flat list of changed filesystem entries with ``status`` and
+            optional ``staged`` / ``unstaged`` fields.
         """
         path = f"/v1/sessions/{session_id}/resources/environments/{environment_id}/changes"
         await _validate_session(session_id, request, LEVEL_READ)

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -566,6 +566,47 @@ class SessionResourcePaginatedList(BaseModel):
     has_more: bool = False
 
 
+class SessionEnvironmentFilesystemChangeObject(BaseModel):
+    """
+    API representation of a changed file in a session environment.
+
+    :param object: Fixed resource type, always
+        ``"session.environment.filesystem.entry"``.
+    :param path: Path relative to the environment root.
+    :param name: Base filename derived from ``path``.
+    :param status: Change operation: ``"created"``, ``"modified"``, or
+        ``"deleted"``.
+    :param bytes: File size in bytes, or ``None`` for deleted/stat-failed
+        entries.
+    :param modified_at: Unix epoch seconds of last modification, or ``None``
+        for deleted/stat-failed entries.
+    :param staged: Whether the change is staged in the git index. Optional so
+        clients can tolerate older runners that do not send staging metadata.
+    :param unstaged: Whether the change exists in the working tree. Optional
+        so clients can tolerate older runners that do not send staging
+        metadata.
+    """
+
+    object: Literal["session.environment.filesystem.entry"]
+    path: str
+    name: str
+    status: Literal["created", "modified", "deleted"]
+    bytes: int | None = None
+    modified_at: int | None = None
+    staged: bool | None = None
+    unstaged: bool | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class SessionEnvironmentFilesystemChangeList(BaseModel):
+    """Public flat list of changed files in a session environment."""
+
+    object: Literal["list"] = "list"
+    data: list[SessionEnvironmentFilesystemChangeObject] = Field(default_factory=list)
+    has_more: bool = False
+
+
 # ── Conversations ───────────────────────────────────────────────
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -8969,7 +8969,7 @@
     },
     "/v1/sessions/{session_id}/resources/environments/{environment_id}/changes": {
       "get": {
-        "description": "List all files changed since session start (flat, registry-backed).\n\nReturns the watchdog change set for the session \u2014 every file\ncreated, modified, or deleted since the session began, regardless\nof directory depth.  Use for the flat \"changed files\" view.\n\n**Returns:** Flat list of changed filesystem entries with `status`.",
+        "description": "List all files changed since session start (flat, registry-backed).\n\nReturns the watchdog change set for the session \u2014 every file\ncreated, modified, or deleted since the session began, regardless\nof directory depth.  Use for the flat \"changed files\" view.\n\n**Returns:** Flat list of changed filesystem entries with `status` and optional `staged` / `unstaged` fields.",
         "operationId": "list_environment_filesystem_changes_v1_sessions__session_id__resources_environments__environment_id__changes_get",
         "parameters": [
           {

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -754,6 +754,8 @@ async def test_filesystem_changes_modified(
     entries_by_path = {e["path"]: e for e in body["data"]}
     assert "hello.txt" in entries_by_path, "Modified file must appear in changes"
     assert entries_by_path["hello.txt"]["status"] == "modified"
+    assert entries_by_path["hello.txt"]["staged"] is False
+    assert entries_by_path["hello.txt"]["unstaged"] is True
 
 
 @pytest.mark.asyncio
@@ -773,6 +775,8 @@ async def test_filesystem_changes_deleted(
     entries_by_path = {e["path"]: e for e in body["data"]}
     assert "gone.py" in entries_by_path, "Deleted file must appear in changes"
     assert entries_by_path["gone.py"]["status"] == "deleted"
+    assert entries_by_path["gone.py"]["staged"] is False
+    assert entries_by_path["gone.py"]["unstaged"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -85,6 +85,8 @@ def test_created_then_modified_shows_added(registry: AgentEditFilesystemRegistry
         "A 'M' result means the modified event incorrectly replaced the created event."
     )
     assert results[0]["path"] == "trip.md"
+    assert results[0]["staged"] is False
+    assert results[0]["unstaged"] is True
 
 
 def test_modified_only_shows_modified(registry: AgentEditFilesystemRegistry) -> None:
@@ -563,6 +565,8 @@ def test_git_list_changed_files_expands_untracked_nested_dir(tmp_path: Path) -> 
     assert record["status"] == "created", (
         f"Expected status 'created' for the new file, got {record['status']!r}."
     )
+    assert record["staged"] is False
+    assert record["unstaged"] is True
 
 
 # ── _normalize_path ──────────────────────────────────────────────────────────
@@ -712,38 +716,38 @@ def test_create_filesystem_registry_nested_git_workspace(tmp_path: Path) -> None
     "line, expected",
     [
         # Untracked file (both columns '?') → created
-        ("?? new_file.py", ("new_file.py", "created")),
+        ("?? new_file.py", ("new_file.py", "created", False, True)),
         # Staged new file (index 'A') → created
-        ("A  staged.py", ("staged.py", "created")),
+        ("A  staged.py", ("staged.py", "created", True, False)),
         # Staged new + modified in worktree (index 'A' takes precedence) → created
-        ("AM staged_then_modified.py", ("staged_then_modified.py", "created")),
+        ("AM staged_then_modified.py", ("staged_then_modified.py", "created", True, True)),
         # Staged modification (index 'M') → modified
-        ("M  staged_mod.py", ("staged_mod.py", "modified")),
+        ("M  staged_mod.py", ("staged_mod.py", "modified", True, False)),
         # Unstaged modification (worktree 'M') → modified
-        (" M unstaged_mod.py", ("unstaged_mod.py", "modified")),
+        (" M unstaged_mod.py", ("unstaged_mod.py", "modified", False, True)),
         # Both staged and unstaged modifications → modified
-        ("MM both_mod.py", ("both_mod.py", "modified")),
+        ("MM both_mod.py", ("both_mod.py", "modified", True, True)),
         # Staged deletion (index 'D') → deleted
-        ("D  staged_del.py", ("staged_del.py", "deleted")),
+        ("D  staged_del.py", ("staged_del.py", "deleted", True, False)),
         # Unstaged deletion (worktree 'D') → deleted
-        (" D unstaged_del.py", ("unstaged_del.py", "deleted")),
+        (" D unstaged_del.py", ("unstaged_del.py", "deleted", False, True)),
         # Rename: destination path (after ' -> ') is used, operation is modified
-        ("R  old.py -> new.py", ("new.py", "modified")),
+        ("R  old.py -> new.py", ("new.py", "modified", True, False)),
         # git-quoted path (spaces in filename) → quotes are stripped
-        ('?? "dir/file with spaces.py"', ("dir/file with spaces.py", "created")),
+        ('?? "dir/file with spaces.py"', ("dir/file with spaces.py", "created", False, True)),
         # Quoted rename destination
-        ('R  old.py -> "new with spaces.py"', ("new with spaces.py", "modified")),
+        ('R  old.py -> "new with spaces.py"', ("new with spaces.py", "modified", True, False)),
         # Both source and destination git-quoted (both paths have spaces).
         # The outer-quote strip must NOT fire before the ' -> ' split —
         # 'R  "old name.py" -> "new name.py"' starts and ends with '"' so
         # a naive strip would corrupt the separator and leave a dangling quote.
-        ('R  "old name.py" -> "new name.py"', ("new name.py", "modified")),
+        ('R  "old name.py" -> "new name.py"', ("new name.py", "modified", True, False)),
         # Non-rename file whose name literally contains ' -> ': must NOT be
         # treated as a rename — the old path-content heuristic would misfire here.
-        (" M file -> backup.py", ("file -> backup.py", "modified")),
+        (" M file -> backup.py", ("file -> backup.py", "modified", False, True)),
         # Git C-quoted non-ASCII filename (UTF-8 bytes as octal sequences).
         # git encodes 'é' (U+00E9) as the two UTF-8 bytes \303\251.
-        ('?? "caf\\303\\251.py"', ("café.py", "created")),
+        ('?? "caf\\303\\251.py"', ("café.py", "created", False, True)),
         # Lines shorter than 4 characters → None (no valid XY + space + path)
         ("", None),
         ("??", None),
@@ -769,7 +773,10 @@ def test_create_filesystem_registry_nested_git_workspace(tmp_path: Path) -> None
         "three-char-line",
     ],
 )
-def test_parse_git_porcelain_line(line: str, expected: tuple[str, str] | None) -> None:
+def test_parse_git_porcelain_line(
+    line: str,
+    expected: tuple[str, str, bool, bool] | None,
+) -> None:
     """``_parse_git_porcelain_line`` maps every ``git status --porcelain`` status code correctly.
 
     Failure on any case means the corresponding operation will be misclassified

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -75,6 +75,10 @@ export interface WorkspaceChangedFile {
   status: "created" | "modified" | "deleted";
   bytes: number | null;
   modified_at: number | null;
+  /** Whether the change is staged in git's index. Omitted by older runners. */
+  staged?: boolean;
+  /** Whether the change exists in the working tree. Omitted by older runners. */
+  unstaged?: boolean;
 }
 
 export interface WorkspaceChangedFilesResult {
@@ -155,6 +159,8 @@ interface ChangedFilesResponse {
     status: "created" | "modified" | "deleted";
     bytes: number | null;
     modified_at: number | null;
+    staged?: boolean | null;
+    unstaged?: boolean | null;
   }>;
   has_more: boolean;
 }
@@ -184,6 +190,8 @@ async function fetchWorkspaceChangedFiles(
     status: e.status,
     bytes: e.bytes,
     modified_at: e.modified_at,
+    staged: typeof e.staged === "boolean" ? e.staged : undefined,
+    unstaged: typeof e.unstaged === "boolean" ? e.unstaged : undefined,
   }));
   return { available: true, data };
 }

--- a/web/src/shell/FlatFileList.test.tsx
+++ b/web/src/shell/FlatFileList.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { RunnerOfflineError } from "@/hooks/useWorkspaceChangedFiles";
+import { RunnerOfflineError, type WorkspaceChangedFile } from "@/hooks/useWorkspaceChangedFiles";
 import { FlatFileList } from "./FlatFileList";
 
 afterEach(cleanup);
@@ -25,6 +25,20 @@ function renderList(props: Partial<Parameters<typeof FlatFileList>[0]> = {}) {
       />
     </TooltipProvider>,
   );
+}
+
+function changedFile(
+  path: string,
+  staging: Pick<WorkspaceChangedFile, "staged" | "unstaged"> = {},
+): WorkspaceChangedFile {
+  return {
+    path,
+    name: path.split("/").pop() ?? path,
+    status: "modified",
+    bytes: 12,
+    modified_at: 1,
+    ...staging,
+  };
 }
 
 describe("FlatFileList runner-offline state", () => {
@@ -82,5 +96,45 @@ describe("FlatFileList file size / download alignment", () => {
     const overlay = download.closest("span.absolute") as HTMLElement | null;
     expect(overlay).not.toBeNull();
     expect(slot).toContainElement(overlay);
+  });
+});
+
+describe("FlatFileList staged filter", () => {
+  it("filters changed files by staged and unstaged state", () => {
+    renderList({
+      files: [
+        changedFile("src/staged.ts", { staged: true, unstaged: false }),
+        changedFile("src/unstaged.ts", { staged: false, unstaged: true }),
+        changedFile("src/both.ts", { staged: true, unstaged: true }),
+      ],
+    });
+
+    expect(screen.getByText("src/staged.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/unstaged.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/both.ts")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Staged" }));
+    expect(screen.getByText("src/staged.ts")).toBeInTheDocument();
+    expect(screen.queryByText("src/unstaged.ts")).not.toBeInTheDocument();
+    expect(screen.getByText("src/both.ts")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Unstaged" }));
+    expect(screen.queryByText("src/staged.ts")).not.toBeInTheDocument();
+    expect(screen.getByText("src/unstaged.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/both.ts")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "All" }));
+    expect(screen.getByText("src/staged.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/unstaged.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/both.ts")).toBeInTheDocument();
+  });
+
+  it("hides the staged filter for older payloads without staging fields", () => {
+    renderList({
+      files: [changedFile("src/legacy.ts")],
+    });
+
+    expect(screen.queryByRole("radiogroup", { name: "Change stage" })).not.toBeInTheDocument();
+    expect(screen.getByText("src/legacy.ts")).toBeInTheDocument();
   });
 });

--- a/web/src/shell/FlatFileList.tsx
+++ b/web/src/shell/FlatFileList.tsx
@@ -1,4 +1,5 @@
 import { FileIcon } from "lucide-react";
+import { useState } from "react";
 import { RunnerOfflineError, type WorkspaceChangedFile } from "@/hooks/useWorkspaceChangedFiles";
 import { RunnerAsleepHint } from "./RunnerAsleepHint";
 import { cn } from "@/lib/utils";
@@ -9,6 +10,8 @@ import { useCursorTooltip } from "./useCursorTooltip";
 
 export type { ChangedSort } from "@/lib/changedSort";
 import type { ChangedSort } from "@/lib/changedSort";
+
+type ChangedStageFilter = "all" | "staged" | "unstaged";
 
 function fileExtension(name: string): string {
   const dot = name.lastIndexOf(".");
@@ -59,6 +62,71 @@ export function compareChangedFiles(sort: ChangedSort) {
 
 function normalizeSearchQuery(query: string): string {
   return query.trim().toLowerCase();
+}
+
+const STAGE_FILTERS: { value: ChangedStageFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "staged", label: "Staged" },
+  { value: "unstaged", label: "Unstaged" },
+];
+
+function stageChangeLabel(filter: ChangedStageFilter): string {
+  if (filter === "staged") return "staged changes";
+  if (filter === "unstaged") return "unstaged changes";
+  return "changes";
+}
+
+function stageFileLabel(filter: ChangedStageFilter): string {
+  if (filter === "staged") return "staged files";
+  if (filter === "unstaged") return "unstaged files";
+  return "changed files";
+}
+
+function ChangedStageFilterControl({
+  value,
+  onChange,
+}: {
+  value: ChangedStageFilter;
+  onChange: (next: ChangedStageFilter) => void;
+}) {
+  const pill =
+    "flex cursor-pointer items-center rounded-full px-2.5 py-[2px] text-[12px] font-medium leading-5 transition-colors";
+  const activePill =
+    "bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] text-foreground";
+  const idlePill = "text-muted-foreground hover:text-foreground";
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Change stage"
+      className="mb-1 flex items-center gap-1 px-0.5"
+    >
+      {STAGE_FILTERS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          role="radio"
+          aria-checked={value === option.value}
+          aria-label={option.label}
+          onClick={() => onChange(option.value)}
+          className={cn(pill, value === option.value ? activePill : idlePill)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function supportsStageFiltering(files: WorkspaceChangedFile[]): boolean {
+  return files.some(
+    (file) => typeof file.staged === "boolean" || typeof file.unstaged === "boolean",
+  );
+}
+
+function matchesStageFilter(file: WorkspaceChangedFile, filter: ChangedStageFilter): boolean {
+  if (filter === "staged") return file.staged === true;
+  if (filter === "unstaged") return file.unstaged === true;
+  return true;
 }
 
 function FileListItem({
@@ -168,6 +236,8 @@ export function FlatFileList({
    */
   runnerWentOffline?: boolean;
 }) {
+  const [stageFilter, setStageFilter] = useState<ChangedStageFilter>("all");
+
   if (isLoading) {
     return <p className="px-2 py-1 text-muted-foreground text-xs">Loading…</p>;
   }
@@ -189,8 +259,12 @@ export function FlatFileList({
   if (!files || files.length === 0) {
     return <p className="px-2 py-1 text-muted-foreground text-xs">No workspace changes yet</p>;
   }
+  const canFilterByStage = supportsStageFiltering(files);
+  const stageFilteredFiles = canFilterByStage
+    ? files.filter((file) => matchesStageFilter(file, stageFilter))
+    : files;
   const normalizedSearchQuery = normalizeSearchQuery(searchQuery);
-  const visibleFiles = files.filter(
+  const visibleFiles = stageFilteredFiles.filter(
     (f) => showHidden || !f.path.split("/").some((seg) => seg.startsWith(".")),
   );
   const sorted = visibleFiles
@@ -201,30 +275,51 @@ export function FlatFileList({
         f.path.toLowerCase().includes(normalizedSearchQuery),
     )
     .sort(compareChangedFiles(sort));
-  const hiddenCount = files.length - visibleFiles.length;
+  const hiddenCount = stageFilteredFiles.length - visibleFiles.length;
+  const stageControl = canFilterByStage ? (
+    <ChangedStageFilterControl value={stageFilter} onChange={setStageFilter} />
+  ) : null;
+  const stageChange = stageChangeLabel(stageFilter);
+  const stageFiles = stageFileLabel(stageFilter);
+
+  if (stageFilteredFiles.length === 0) {
+    return (
+      <>
+        {stageControl}
+        <p className="px-2 py-1 text-muted-foreground text-xs">No {stageChange}</p>
+      </>
+    );
+  }
   if (visibleFiles.length === 0) {
     return (
-      <p className="px-2 py-1 text-muted-foreground text-xs">
-        All changes are in hidden files.{" "}
-        <button
-          type="button"
-          className="cursor-pointer underline hover:text-foreground"
-          onClick={onShowHidden}
-        >
-          Click to show
-        </button>
-      </p>
+      <>
+        {stageControl}
+        <p className="px-2 py-1 text-muted-foreground text-xs">
+          All {stageChange} are in hidden files.{" "}
+          <button
+            type="button"
+            className="cursor-pointer underline hover:text-foreground"
+            onClick={onShowHidden}
+          >
+            Click to show
+          </button>
+        </p>
+      </>
     );
   }
   if (sorted.length === 0) {
     return (
-      <p className="px-2 py-1 text-muted-foreground text-xs">
-        No changed files match "{searchQuery.trim()}"
-      </p>
+      <>
+        {stageControl}
+        <p className="px-2 py-1 text-muted-foreground text-xs">
+          No {stageFiles} match "{searchQuery.trim()}"
+        </p>
+      </>
     );
   }
   return (
     <>
+      {stageControl}
       {hiddenCount > 0 && (
         <p className="px-2 py-1 text-muted-foreground text-xs">
           {hiddenCount} file{hiddenCount === 1 ? "" : "s"} hidden.{" "}


### PR DESCRIPTION
## Summary
The web changed-files view can now filter by git staged vs unstaged state.

Resubmit of #977, which @daniellok-db closed inviting a fresh PR after recent refactors ("needs a rebase + additional fixes"). This branch is rebased onto current `main` — the `ap-web/` → `web/` move and the new `@/lib/changedSort` module are accounted for, the two frontend merge conflicts are resolved, and the full web + Python suites pass.

## Why this matters
The porcelain parser in `filesystem_registry` already reads both the X (staged) and Y (unstaged) status columns but discarded the staged signal. This threads it through the registry, the session schema, and the route to a segmented staged/unstaged filter in `FlatFileList`. A commenter on #951 asked for exactly this.

## Changes
- `filesystem_registry`: keep the staged/unstaged signal from porcelain.
- `schemas` / `routes/sessions`: expose it.
- web: `useWorkspaceChangedFiles` + `FlatFileList` segmented filter.

## Testing
- web: `type-check`, `lint`, and `FlatFileList` tests pass (6/6).
- Python: `test_filesystem_registry` + `test_environment_filesystem` (110 passed) and the changed-files e2e tests (6 passed).

Fixes #951

AI was used for assistance.