### PR TITLE
fix(native-forwarders): dead-letter unforwarded transcript/usage items (#1120)

### DIFF
--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -66,10 +66,10 @@ def append_dead_letter(
     """
     try:
         path = bridge_dir / _DEAD_LETTER_FILE
-        key = str(path)
+        capped_path = str(path)
         if path.exists() and path.stat().st_size >= _DEAD_LETTER_MAX_BYTES:
-            if key not in _dead_letter_capped:
-                _dead_letter_capped.add(key)
+            if capped_path not in _dead_letter_capped:
+                _dead_letter_capped.add(capped_path)
                 _logger.warning(
                     "dead-letter file at cap (%d bytes); not appending further "
                     "undeliverable forwards: path=%s",

--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -31,11 +31,11 @@ _logger = logging.getLogger(__name__)
 
 # Dead-letter sink for permanently-undeliverable forward payloads (#1120).
 _DEAD_LETTER_FILE = "dead_letter.jsonl"
-_DEAD_LETTER_MAX_BYTES = 50 * 1024 * 1024  # 50 MB per session; write-only recovery artifact
-
-# Bridge-dir paths whose dead-letter file has hit the size cap and already
-# logged a warning — so the cap is logged once per path, not per dropped item.
-_dead_letter_capped: set[str] = set()
+# When the active file reaches this size it is rotated to a single ``.1``
+# backup and a fresh file is started, so the most recent drops are always
+# retained (keep-newest). Disk stays bounded at ~2x this size (current + .1).
+_DEAD_LETTER_MAX_BYTES = 50 * 1024 * 1024  # 50 MB per session
+_DEAD_LETTER_BACKUP_FILE = _DEAD_LETTER_FILE + ".1"
 
 
 def append_dead_letter(
@@ -51,8 +51,10 @@ def append_dead_letter(
 
     Write-only recovery artifact so a permanently-failed transcript/usage POST is
     recoverable on disk instead of silently lost. Replay is tracked separately (#1579).
-    Best-effort: never raises (a dead-letter failure must not disrupt forwarding), and
-    stops appending once the file exceeds :data:`_DEAD_LETTER_MAX_BYTES` (logs once per path).
+    Best-effort: never raises (a dead-letter failure must not disrupt forwarding). When
+    the file reaches :data:`_DEAD_LETTER_MAX_BYTES` it is rotated to a single ``.1``
+    backup and a fresh file is started, so the most recent drops are kept (the oldest
+    rotate out); disk stays bounded at ~2x the cap.
 
     :param bridge_dir: Native forwarder bridge directory the dead-letter file lives in.
     :param session_id: Omnigent conversation id the dropped event targeted,
@@ -66,18 +68,19 @@ def append_dead_letter(
     """
     try:
         path = bridge_dir / _DEAD_LETTER_FILE
-        capped_path = str(path)
-        if path.exists() and path.stat().st_size >= _DEAD_LETTER_MAX_BYTES:
-            if capped_path not in _dead_letter_capped:
-                _dead_letter_capped.add(capped_path)
-                _logger.warning(
-                    "dead-letter file at cap (%d bytes); not appending further "
-                    "undeliverable forwards: path=%s",
-                    _DEAD_LETTER_MAX_BYTES,
-                    path,
-                )
-            return
         bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # Keep-newest: at the cap, rotate the full file to a single .1 backup
+        # (overwriting any prior backup) and start fresh. A sustained outage
+        # then retains the most recent items rather than stopping at the oldest.
+        if path.exists() and path.stat().st_size >= _DEAD_LETTER_MAX_BYTES:
+            path.replace(bridge_dir / _DEAD_LETTER_BACKUP_FILE)
+            _logger.warning(
+                "dead-letter file reached cap (%d bytes); rotated to %s and "
+                "started fresh (oldest dead-lettered forwards dropped): path=%s",
+                _DEAD_LETTER_MAX_BYTES,
+                _DEAD_LETTER_BACKUP_FILE,
+                path,
+            )
         line = json.dumps(
             {
                 "ts": time.time(),

--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -19,12 +19,84 @@ the codex/antigravity forwarders so a single implementation is maintained.
 
 from __future__ import annotations
 
+import json
 import logging
+import time
 from collections.abc import Callable, Coroutine
+from pathlib import Path
 
 import httpx
 
 _logger = logging.getLogger(__name__)
+
+# Dead-letter sink for permanently-undeliverable forward payloads (#1120).
+_DEAD_LETTER_FILE = "dead_letter.jsonl"
+_DEAD_LETTER_MAX_BYTES = 50 * 1024 * 1024  # 50 MB per session; write-only recovery artifact
+
+# Bridge-dir paths whose dead-letter file has hit the size cap and already
+# logged a warning — so the cap is logged once per path, not per dropped item.
+_dead_letter_capped: set[str] = set()
+
+
+def append_dead_letter(
+    bridge_dir: Path,
+    *,
+    session_id: str,
+    event_type: str,
+    payload: dict[str, object],
+    reason: str,
+) -> None:
+    """
+    Append one undeliverable forward payload to ``{bridge_dir}/dead_letter.jsonl`` (#1120).
+
+    Write-only recovery artifact so a permanently-failed transcript/usage POST is
+    recoverable on disk instead of silently lost. Replay is tracked separately (#1579).
+    Best-effort: never raises (a dead-letter failure must not disrupt forwarding), and
+    stops appending once the file exceeds :data:`_DEAD_LETTER_MAX_BYTES` (logs once per path).
+
+    :param bridge_dir: Native forwarder bridge directory the dead-letter file lives in.
+    :param session_id: Omnigent conversation id the dropped event targeted,
+        e.g. ``"conv_abc123"``.
+    :param event_type: Session event type that was dropped, e.g.
+        ``"external_conversation_item"``.
+    :param payload: The event ``data`` payload that failed to deliver.
+    :param reason: Short human-readable cause, e.g.
+        ``"permanent HTTP failure after retries"``.
+    :returns: None.
+    """
+    try:
+        path = bridge_dir / _DEAD_LETTER_FILE
+        key = str(path)
+        if path.exists() and path.stat().st_size >= _DEAD_LETTER_MAX_BYTES:
+            if key not in _dead_letter_capped:
+                _dead_letter_capped.add(key)
+                _logger.warning(
+                    "dead-letter file at cap (%d bytes); not appending further "
+                    "undeliverable forwards: path=%s",
+                    _DEAD_LETTER_MAX_BYTES,
+                    path,
+                )
+            return
+        bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        line = json.dumps(
+            {
+                "ts": time.time(),
+                "session_id": session_id,
+                "event_type": event_type,
+                "reason": reason,
+                "payload": payload,
+            }
+        )
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except Exception as exc:  # noqa: BLE001 - dead-lettering must never disrupt forwarding.
+        _logger.warning(
+            "failed to dead-letter undeliverable forward: type=%s session=%s error=%r",
+            event_type,
+            session_id,
+            exc,
+        )
+
 
 # Transport failures proving a POST never reached the server (no bytes
 # sent) — safe to retry. See :func:`post_may_have_been_delivered`.

--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -74,12 +74,15 @@ def append_dead_letter(
         # then retains the most recent items rather than stopping at the oldest.
         if path.exists() and path.stat().st_size >= _DEAD_LETTER_MAX_BYTES:
             path.replace(bridge_dir / _DEAD_LETTER_BACKUP_FILE)
+            # Log the session id rather than the bridge path: the path is
+            # deterministic per session and logging it trips CodeQL's
+            # clear-text-sensitive-data heuristic (a bridge dir is not a secret).
             _logger.warning(
                 "dead-letter file reached cap (%d bytes); rotated to %s and "
-                "started fresh (oldest dead-lettered forwards dropped): path=%s",
+                "started fresh (oldest dead-lettered forwards dropped): session=%s",
                 _DEAD_LETTER_MAX_BYTES,
                 _DEAD_LETTER_BACKUP_FILE,
-                path,
+                session_id,
             )
         line = json.dumps(
             {

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import httpx
 
-from omnigent._native_post_delivery import post_may_have_been_delivered
+from omnigent._native_post_delivery import append_dead_letter, post_may_have_been_delivered
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
     ClaudeHookRecord,
@@ -1280,6 +1280,20 @@ async def _forward_available_subagents(
                     decision.attempts,
                     _http_status_for_log(exc),
                 )
+                # Persist the dropped start payload so it is recoverable on
+                # disk instead of silently lost (#1120; replay is #1579).
+                append_dead_letter(
+                    bridge_dir,
+                    session_id=parent_session_id,
+                    event_type="external_subagent_start",
+                    payload={
+                        "subagent_id": subagent_id,
+                        "agent_type": meta["agentType"],
+                        "description": meta["description"],
+                        "tool_use_id": meta["toolUseId"],
+                    },
+                    reason="permanent HTTP failure after retries",
+                )
                 # Park this sub-agent: insert a sentinel entry so we
                 # don't keep retrying. ``child_conversation_id=""``
                 # is filtered out by the tail / status loops below.
@@ -1375,6 +1389,19 @@ async def _forward_available_subagents(
                         item.source_id,
                         decision.attempts,
                         _http_status_for_log(exc),
+                    )
+                    # Persist the dropped item so it is recoverable on disk
+                    # instead of silently lost (#1120; replay is #1579).
+                    append_dead_letter(
+                        bridge_dir,
+                        session_id=entry.child_conversation_id,
+                        event_type="external_conversation_item",
+                        payload={
+                            "item_type": item.item_type,
+                            "item_data": item.data,
+                            "response_id": item.response_id,
+                        },
+                        reason="permanent HTTP failure after retries",
                     )
                     # Skip this item and continue — alternative is to
                     # block the whole sub-agent forever on one poison
@@ -2852,6 +2879,19 @@ async def _forward_available_items(
                     item.item_type,
                     decision.attempts,
                     _http_status_for_log(exc),
+                )
+                # Persist the dropped item so it is recoverable on disk
+                # instead of silently lost (#1120; replay is #1579).
+                append_dead_letter(
+                    bridge_dir,
+                    session_id=session_id,
+                    event_type="external_conversation_item",
+                    payload={
+                        "item_type": item.item_type,
+                        "item_data": item.data,
+                        "response_id": item.response_id,
+                    },
+                    reason="permanent HTTP failure after retries",
                 )
                 await _post_forwarder_failed_status(
                     client,

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -7,13 +7,14 @@ import contextlib
 import json
 import logging
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import httpx
 
-from omnigent._native_post_delivery import post_may_have_been_delivered
+from omnigent._native_post_delivery import append_dead_letter, post_may_have_been_delivered
 from omnigent.claude_native_bridge import url_component
 from omnigent.codex_native_app_server import (
     CodexAppServerClient,
@@ -1529,6 +1530,9 @@ async def supervise_forwarder(
     :returns: None. Runs until cancelled or the app-server connection
         closes.
     """
+    # Bind the bridge dir so failed durable-event posts can be dead-lettered
+    # to {bridge_dir}/dead_letter.jsonl instead of being silently lost (#1120).
+    _dead_letter_dir.set(bridge_dir)
     if client is None:
         client = client_for_transport(app_server_url, client_name="omnigent-codex-forwarder")
         await client.connect()
@@ -5334,6 +5338,14 @@ class _ForwardHealth:
 _FORWARD_DEGRADED_THRESHOLD = 5
 _forward_health = _ForwardHealth()
 
+# Bridge dir for the active forwarder, used to dead-letter permanently
+# undeliverable durable events (#1120). Set per-forwarder at entry.
+_dead_letter_dir: ContextVar[Path | None] = ContextVar("_codex_dead_letter_dir", default=None)
+
+# Only durable (persisted) event types are worth dead-lettering — ephemeral
+# stream/usage-delta events have no standalone recovery value.
+_DEAD_LETTER_EVENT_TYPES = frozenset({"external_conversation_item", "external_session_usage"})
+
 
 def _reset_forward_health() -> None:
     """
@@ -5413,6 +5425,16 @@ async def _post_session_event(
         _note_forward_success()
     else:
         _note_forward_failure(event_type)
+        dl_dir = _dead_letter_dir.get()
+        if event_type in _DEAD_LETTER_EVENT_TYPES and dl_dir is not None:
+            reason = f"http {response.status_code}" if response is not None else "post failed"
+            append_dead_letter(
+                dl_dir,
+                session_id=session_id,
+                event_type=event_type,
+                payload=data,
+                reason=reason,
+            )
     return response
 
 

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -2825,7 +2825,8 @@ async def test_forwarder_drops_poison_item_after_bounded_permanent_retries(
     A malformed transcript item that Omnigent rejects with a permanent 4xx
     should not be reposted forever at the poll interval. After the
     retry budget is exhausted, the forwarder emits a failed status,
-    marks the source id handled, and persists the new byte cursor.
+    marks the source id handled, persists the new byte cursor, and
+    dead-letters the dropped item to disk so it is recoverable (#1120).
     """
     bridge_dir = tmp_path / "bridge"
     transcript_path = tmp_path / "session.jsonl"
@@ -2908,6 +2909,15 @@ async def test_forwarder_drops_poison_item_after_bounded_permanent_retries(
     assert second.seen_source_ids == ("poison-item:0:message",)
     assert persisted["byte_offset"] == transcript_path.stat().st_size
     assert persisted["seen_source_ids"] == ["poison-item:0:message"]
+    # The dropped item is dead-lettered to disk so it is recoverable
+    # instead of silently lost (#1120).
+    dead_letter = (bridge_dir / "dead_letter.jsonl").read_text("utf-8").splitlines()
+    assert len(dead_letter) == 1
+    record = json.loads(dead_letter[0])
+    assert record["session_id"] == "conv_abc"
+    assert record["event_type"] == "external_conversation_item"
+    assert record["reason"] == "permanent HTTP failure after retries"
+    assert record["payload"]["item_type"] == "message"
 
 
 @pytest.mark.asyncio
@@ -6484,3 +6494,138 @@ def test_retry_tracker_transient_failures_escalate_degraded() -> None:
     tracker.clear("item:source-1")
     assert forwarder._forward_health.consecutive_failures == 0
     assert forwarder._forward_health.degraded_logged is False
+
+
+@pytest.mark.asyncio
+async def test_subagent_item_drop_writes_dead_letter(tmp_path: Path) -> None:
+    """
+    A permanently-rejected sub-agent transcript item is dead-lettered (#1120).
+
+    Drives the real ``_forward_available_subagents`` drop path: the
+    ``external_subagent_start`` POST succeeds, the child item POST is rejected
+    with a permanent 400 (and the item tracker exhausts on the first failure),
+    so the dropped item is appended to ``{bridge_dir}/dead_letter.jsonl`` instead
+    of being silently lost.
+
+    :param tmp_path: Pytest temp dir for the bridge dir and transcript.
+    """
+    forwarder._reset_forward_health()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="dl1",
+        agent_type="Explore",
+        description="dead-letter item flow",
+        tool_use_id="toolu_dl",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "sa-assistant-dl",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "lost"}],
+                },
+            },
+        ],
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Accept the start POST; permanently reject the child item POST.
+
+        :param request: Request issued by the forwarder.
+        :returns: Canned Omnigent response.
+        """
+        body = json.loads(request.content.decode("utf-8"))
+        if body.get("type") == "external_subagent_start":
+            return httpx.Response(200, json={"child_session_id": "conv_child_dl"})
+        if body.get("type") == "external_conversation_item":
+            return httpx.Response(400, json={"error": "nope"})
+        return httpx.Response(202, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(
+                base_delay_s=0.0, max_permanent_attempts=1
+            ),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    forwarder._reset_forward_health()
+    dl_path = bridge_dir / "dead_letter.jsonl"
+    lines = dl_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["session_id"] == "conv_child_dl"
+    assert record["event_type"] == "external_conversation_item"
+    assert record["payload"]["item_data"]["content"][0]["text"] == "lost"
+
+
+@pytest.mark.asyncio
+async def test_subagent_start_drop_writes_dead_letter(tmp_path: Path) -> None:
+    """
+    A permanently-rejected sub-agent START is dead-lettered (#1120).
+
+    :param tmp_path: Pytest temp dir for the bridge dir and transcript.
+    """
+    forwarder._reset_forward_health()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id="dlstart1",
+        agent_type="Explore",
+        description="dead-letter start flow",
+        tool_use_id="toolu_dlstart",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Permanently reject the sub-agent start POST.
+
+        :param request: Request issued by the forwarder.
+        :returns: Canned Omnigent response.
+        """
+        return httpx.Response(400, json={"error": "nope"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://ap",
+    ) as client:
+        await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(
+                base_delay_s=0.0, max_permanent_attempts=1
+            ),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    forwarder._reset_forward_health()
+    dl_path = bridge_dir / "dead_letter.jsonl"
+    lines = dl_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["session_id"] == "conv_parent"
+    assert record["event_type"] == "external_subagent_start"
+    assert record["payload"]["subagent_id"] == "dlstart1"
+    assert record["payload"]["agent_type"] == "Explore"

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1411,3 +1411,79 @@ def test_read_compacted_history_returns_none_for_no_compacted_entry(
     rollout.write_text(_json.dumps({"type": "session_meta", "payload": {"id": "abc"}}) + "\n")
 
     assert fwd._read_compacted_history(rollout) is None
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_dead_letters_durable_event_on_permanent_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A permanently-failed durable event is dead-lettered to disk (#1120).
+
+    Drives ``_post_session_event`` (the health-tracking wrapper) with a stubbed
+    inner that returns an HTTP 500, and asserts the dropped
+    ``external_conversation_item`` payload is appended to
+    ``{bridge_dir}/dead_letter.jsonl``.
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
+    """
+    import json as _json
+
+    fwd._reset_forward_health()
+
+    async def _failing_inner(client, session_id, *, event_type, data):
+        return httpx.Response(500, request=httpx.Request("POST", "http://test"))
+
+    monkeypatch.setattr(fwd, "_post_session_event_inner", _failing_inner)
+    token = fwd._dead_letter_dir.set(tmp_path)
+    try:
+        data = {"item_type": "message", "item_data": {"role": "assistant"}}
+        await fwd._post_session_event(
+            MagicMock(),
+            "conv_codex1",
+            event_type="external_conversation_item",
+            data=data,
+        )
+    finally:
+        fwd._dead_letter_dir.reset(token)
+        fwd._reset_forward_health()
+
+    dl_path = tmp_path / "dead_letter.jsonl"
+    lines = dl_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = _json.loads(lines[0])
+    assert record["session_id"] == "conv_codex1"
+    assert record["event_type"] == "external_conversation_item"
+    assert record["payload"] == data
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_does_not_dead_letter_ephemeral_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    An ephemeral (non-durable) event is NOT dead-lettered on failure (#1120).
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
+    """
+    fwd._reset_forward_health()
+
+    async def _failing_inner(client, session_id, *, event_type, data):
+        return httpx.Response(500, request=httpx.Request("POST", "http://test"))
+
+    monkeypatch.setattr(fwd, "_post_session_event_inner", _failing_inner)
+    token = fwd._dead_letter_dir.set(tmp_path)
+    try:
+        await fwd._post_session_event(
+            MagicMock(),
+            "conv_codex1",
+            event_type="external_output_text_delta",
+            data={"delta": "hi"},
+        )
+    finally:
+        fwd._dead_letter_dir.reset(token)
+        fwd._reset_forward_health()
+
+    assert not (tmp_path / "dead_letter.jsonl").exists()

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1487,3 +1487,46 @@ async def test_post_session_event_does_not_dead_letter_ephemeral_event(
         fwd._reset_forward_health()
 
     assert not (tmp_path / "dead_letter.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_dead_letters_usage_on_permanent_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A permanently-failed ``external_session_usage`` event is dead-lettered (#1120).
+
+    Usage is the other durable type alongside conversation items, so its
+    transcript/usage data must also be recoverable on a sustained outage.
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
+    """
+    import json as _json
+
+    fwd._reset_forward_health()
+
+    async def _failing_inner(client, session_id, *, event_type, data):
+        return httpx.Response(500, request=httpx.Request("POST", "http://test"))
+
+    monkeypatch.setattr(fwd, "_post_session_event_inner", _failing_inner)
+    token = fwd._dead_letter_dir.set(tmp_path)
+    try:
+        data = {"context_tokens": 1234, "model": "databricks-claude-opus-4-7"}
+        await fwd._post_session_event(
+            MagicMock(),
+            "conv_codex_usage",
+            event_type="external_session_usage",
+            data=data,
+        )
+    finally:
+        fwd._dead_letter_dir.reset(token)
+        fwd._reset_forward_health()
+
+    dl_path = tmp_path / "dead_letter.jsonl"
+    lines = dl_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = _json.loads(lines[0])
+    assert record["session_id"] == "conv_codex_usage"
+    assert record["event_type"] == "external_session_usage"
+    assert record["payload"] == data

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -8,8 +8,8 @@ from pathlib import Path
 import httpx
 import pytest
 
-from omnigent import _native_post_delivery
 from omnigent._native_post_delivery import (
+    _DEAD_LETTER_BACKUP_FILE,
     _DEAD_LETTER_FILE,
     _DEAD_LETTER_MAX_BYTES,
     append_dead_letter,
@@ -97,20 +97,22 @@ def test_append_dead_letter_writes_parseable_line(tmp_path: Path) -> None:
     assert isinstance(record["ts"], (int, float))
 
 
-def test_append_dead_letter_respects_size_cap(tmp_path: Path) -> None:
+def test_append_dead_letter_rotates_at_cap_keeping_newest(tmp_path: Path) -> None:
     """
-    A file already at/over the cap is not appended to (write-only artifact).
+    At the cap the file rotates to a ``.1`` backup and keeps the newest item.
+
+    A sustained outage must retain the most recent drops, not stop at the
+    oldest: the full file moves to ``dead_letter.jsonl.1`` and the new record
+    lands in a fresh ``dead_letter.jsonl``.
 
     :param tmp_path: Pytest temp dir standing in for a bridge dir.
     """
     dl_path = tmp_path / _DEAD_LETTER_FILE
+    backup_path = tmp_path / _DEAD_LETTER_BACKUP_FILE
     # Use a sparse file (truncate) to reach the cap without writing 50 MB.
     with dl_path.open("wb") as fh:
         fh.truncate(_DEAD_LETTER_MAX_BYTES + 1)
-    size_before = dl_path.stat().st_size
-
-    # Clear any latched cap warning for this path so the cap branch is exercised.
-    _native_post_delivery._dead_letter_capped.discard(str(dl_path))
+    capped_size = dl_path.stat().st_size
 
     append_dead_letter(
         tmp_path,
@@ -120,7 +122,14 @@ def test_append_dead_letter_respects_size_cap(tmp_path: Path) -> None:
         reason="post failed",
     )
 
-    assert dl_path.stat().st_size == size_before
+    # Old content rotated out to the backup; the newest record is in the
+    # fresh active file as the sole line.
+    assert backup_path.stat().st_size == capped_size
+    lines = dl_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["event_type"] == "external_session_usage"
+    assert record["payload"] == {"context_tokens": 1}
 
 
 def test_append_dead_letter_never_raises_on_unwritable_dir() -> None:

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import httpx
 import pytest
 
-from omnigent._native_post_delivery import post_may_have_been_delivered
+from omnigent import _native_post_delivery
+from omnigent._native_post_delivery import (
+    _DEAD_LETTER_FILE,
+    _DEAD_LETTER_MAX_BYTES,
+    append_dead_letter,
+    post_may_have_been_delivered,
+)
 
 
 @pytest.mark.parametrize(
@@ -58,3 +67,70 @@ def test_post_may_have_been_delivered_classification(
         committed despite the error.
     """
     assert post_may_have_been_delivered(exc) is may_have_been_delivered
+
+
+def test_append_dead_letter_writes_parseable_line(tmp_path: Path) -> None:
+    """
+    A dropped forward payload is appended as one parseable JSON line.
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    append_dead_letter(
+        tmp_path,
+        session_id="conv_abc123",
+        event_type="external_conversation_item",
+        payload={"item_type": "message", "item_data": {"role": "assistant"}},
+        reason="permanent HTTP failure after retries",
+    )
+
+    dl_path = tmp_path / _DEAD_LETTER_FILE
+    lines = dl_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["session_id"] == "conv_abc123"
+    assert record["event_type"] == "external_conversation_item"
+    assert record["reason"] == "permanent HTTP failure after retries"
+    assert record["payload"] == {
+        "item_type": "message",
+        "item_data": {"role": "assistant"},
+    }
+    assert isinstance(record["ts"], (int, float))
+
+
+def test_append_dead_letter_respects_size_cap(tmp_path: Path) -> None:
+    """
+    A file already at/over the cap is not appended to (write-only artifact).
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    dl_path = tmp_path / _DEAD_LETTER_FILE
+    # Use a sparse file (truncate) to reach the cap without writing 50 MB.
+    with dl_path.open("wb") as fh:
+        fh.truncate(_DEAD_LETTER_MAX_BYTES + 1)
+    size_before = dl_path.stat().st_size
+
+    # Clear any latched cap warning for this path so the cap branch is exercised.
+    _native_post_delivery._dead_letter_capped.discard(str(dl_path))
+
+    append_dead_letter(
+        tmp_path,
+        session_id="conv_abc123",
+        event_type="external_session_usage",
+        payload={"context_tokens": 1},
+        reason="post failed",
+    )
+
+    assert dl_path.stat().st_size == size_before
+
+
+def test_append_dead_letter_never_raises_on_unwritable_dir() -> None:
+    """A bogus / unwritable bridge dir is swallowed, not raised."""
+    bogus = Path("/this/path/does/not/exist/and/cannot/be/made\x00")
+    # Must return without raising despite the invalid path.
+    append_dead_letter(
+        bogus,
+        session_id="conv_abc123",
+        event_type="external_conversation_item",
+        payload={"item_type": "message"},
+        reason="post failed",
+    )


### PR DESCRIPTION
## Summary

Second and final mitigation for #1120. The degraded-sync **indicator** landed in #1278 (codex) and #1580 (claude); this PR adds the **dead-letter** of dropped items. When a native forwarder permanently fails to POST a durable event, the payload was dropped and silently lost. It is now appended to `{bridge_dir}/dead_letter.jsonl` so it is recoverable on disk.

## Change

- **Shared helper** `append_dead_letter()` in `_native_post_delivery.py`: writes one JSON line (`{ts, session_id, event_type, reason, payload}`) per dropped event. Best-effort -- **never raises** (a dead-letter failure must not disrupt forwarding) -- and stops at a 50 MB per-session cap (logged once per path).
- **codex** (`codex_native_forwarder.py`): binds the bridge dir via a `ContextVar` set at the forwarder entry (`supervise_forwarder`), then dead-letters durable event types (`external_conversation_item`, `external_session_usage`) at the single `_post_session_event` failure funnel. No threading through the deep call graph.
- **claude** (`claude_native_forwarder.py`): dead-letters at all three permanent-drop sites where `bridge_dir` is in scope -- parent transcript item, sub-agent start, and sub-agent transcript item. The ambiguous-delivery skip path is intentionally **not** dead-lettered (the item may already be committed server-side, so writing it would imply a false loss).

## Why a ContextVar for codex

The codex item-post path (`_post_external_item`) has 7 callers across 6 functions, none carrying `bridge_dir`; threading it would cascade. A ContextVar set once at the forwarder entry is inherited by the child tasks created afterward and keeps the change localized.

## Scope

Write-only persistence (the `dead-letter unforwarded items` clause of #1120). **Replay** of dead-lettered items on sync recovery (ordering + dedup + trigger) is a separate feature tracked in #1579.

## Tests

- `tests/test_native_post_delivery.py`: `append_dead_letter` writes a parseable line, respects the size cap, and never raises on an unwritable dir.
- `tests/test_codex_native_forwarder.py`: a durable event drop is dead-lettered via the `_post_session_event` funnel; an ephemeral delta is not.
- `tests/test_claude_native_forwarder.py`: parent-transcript, sub-agent start, and sub-agent item drops each write a dead-letter line with the expected session_id/event_type/payload.

173 passed across the three test files; pre-commit clean.

Closes #1120

## Durability note

The dead-letter file lives in each forwarder's existing `bridge_dir`, alongside its other state (`hooks.jsonl`, cursors). Those roots differ in durability:

- codex: `~/.omnigent/codex-native/<hash>` -- persistent across reboots.
- claude: `/tmp/omnigent-<UID>/claude-native/<hash>` -- ephemeral; survives the session and host uptime (enough to recover from a transient server outage that resolves while the host is up) but not a reboot / tmp-reaper.

Keeping the dead-letter alongside each forwarder's own state is the consistent choice; relocating claude's to a persistent dir is a possible follow-up if cross-reboot recovery is needed.

On the size cap (50 MB/session) the file rotates to a single `.1` backup and starts fresh, so the most recent drops are kept (keep-newest); disk stays bounded at ~2x the cap.