### PR TITLE
fix(subagents): distinguish runner "Disconnected" from red "Failed"

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9648,13 +9648,23 @@ async def _relay_runner_stream(
         )
         # Publish a failed status so the client's SSE stream sees a
         # clean error event instead of silent truncation (#1114).
-        _publish_status(
+        disconnect_error = ErrorDetail(
+            code="runner_disconnected",
+            message="Runner disconnected unexpectedly.",
+        )
+        _publish_status(session_id, "failed", disconnect_error)
+        # Persist the disconnect cause as durable labels so the
+        # distinction survives into snapshots and child-session
+        # summaries. Without this the relay-fed cache only carries a
+        # generic ``failed`` and ``last_task_error`` is dropped, leaving
+        # the UI unable to tell a benign runner disconnect from a real
+        # task failure (Option B: render a "Disconnected" pill, not the
+        # red "Failed" pill). Cleared on the next ``running`` edge by the
+        # session.status handler, exactly like other failure labels.
+        await _persist_session_status_error_labels(
             session_id,
-            "failed",
-            ErrorDetail(
-                code="runner_disconnected",
-                message="Runner disconnected unexpectedly.",
-            ),
+            disconnect_error,
+            conversation_store,
         )
     except asyncio.CancelledError:
         raise

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -469,3 +469,80 @@ async def test_relay_publishes_failed_status_on_tunnel_close() -> None:
                 await asyncio.wait_for(handle.task, timeout=1.0)
         sessions_module._runner_relay_tasks.clear()
         session_stream.close(session_id)
+
+
+class _RecordingLabelStore:
+    """Minimal conversation store that records ``set_labels`` calls.
+
+    The disconnect path persists the failure cause as durable labels so
+    snapshots and child summaries can tell a benign runner disconnect
+    from a real task failure (Option B). Only ``set_labels`` is exercised
+    by the tunnel-close path, so that is all this fake implements.
+    """
+
+    def __init__(self) -> None:
+        self.labels: dict[str, dict[str, str]] = {}
+
+    def set_labels(self, conversation_id: str, updates: dict[str, str]) -> None:
+        self.labels.setdefault(conversation_id, {}).update(updates)
+
+
+@pytest.mark.asyncio
+async def test_relay_persists_disconnect_error_labels_on_tunnel_close() -> None:
+    """
+    A tunnel close persists the ``runner_disconnected`` cause as labels.
+
+    Option B: a runner that merely disconnected must be distinguishable
+    from a genuine task failure. The relay-fed status cache only carries a
+    generic ``failed``, so the disconnect cause is preserved as durable
+    ``last_task_error`` labels — these survive into snapshots and child
+    summaries, letting the UI render a "Disconnected" pill (not red
+    "Failed"). The code must be ``runner_disconnected`` so the UI can
+    branch on it before the generic failed path.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _TunnelCloseRunnerClient(gate)
+    store = _RecordingLabelStore()
+    session_id = "conv_tunnel_close_labels"
+
+    try:
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_tunnel_close_labels",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+        gate.set()
+
+        # The relay task should finish quickly after the ConnectionError.
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        persisted = store.labels.get(session_id)
+        assert persisted is not None, "disconnect did not persist failure labels"
+        assert persisted[sessions_module._LAST_TASK_ERROR_CODE_LABEL_KEY] == "runner_disconnected"
+        # The message is non-empty so the projection surfaces a typed
+        # ``last_task_error`` (both code and message are required there).
+        assert persisted[sessions_module._LAST_TASK_ERROR_MESSAGE_LABEL_KEY]
+
+        # The persisted labels project back to a code-preserving
+        # ``last_task_error`` — proving the disconnect cause is NOT
+        # collapsed into an indistinguishable generic failure.
+        projected = sessions_module._last_task_error_from_labels(persisted)
+        assert projected == {
+            "code": "runner_disconnected",
+            "message": "Runner disconnected unexpectedly.",
+        }
+    finally:
+        gate.set()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        session_stream.close(session_id)

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -55,6 +55,9 @@
   --color-success: var(--success);
   --color-warning: var(--warning);
   --color-info: var(--info);
+  /* Dedicated blue for the sub-agent "disconnected" dot — distinct from the
+     * shared amber --warning (still used by the "Needs response" badge). */
+  --color-disconnected: var(--disconnected);
   /* Brand pink — reserved for brand moments, not status. */
   --color-brand-accent: var(--brand-accent);
   /* Named status hues — success/warning/info are repointed to the
@@ -178,6 +181,10 @@
   --success: #2ea65c;
   --warning: #d4972a;
   --info: #3b8ff5;
+  /* Disconnected (runner liveness loss) blue — a deeper, saturated azure
+     * that harmonizes with the brand blues (#2272b4 / #3b8ff5) and reads
+     * with strong contrast on the white card surface. */
+  --disconnected: #2f7fd4;
   --border: #e8ecf0;
   /* Stronger divider/outline + a dedicated neutral button border. */
   --border-strong: #a3b1bf;
@@ -255,6 +262,10 @@
   --success: #2ea65c;
   --warning: #d4972a;
   --info: #3b8ff5;
+  /* Disconnected blue, lightened for the dark glass card so the small dot
+     * keeps adequate contrast against the dark canvas (the light-mode
+     * #2f7fd4 reads too dim here). */
+  --disconnected: #5ca4f5;
   /* Brand pink + named status hues (same values as light — the brand
      * status palette is hue-stable across themes). Defined explicitly here
      * rather than inheriting from :root so dark mode is self-contained. */

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -809,13 +809,19 @@ describe("SubagentsPanel", () => {
       // The inline "Disconnected" word is hidden (quiet dot, like idle/done).
       expect(row).not.toHaveTextContent(/Disconnected/);
       expect(row).not.toHaveTextContent(/Failed/);
-      // Blue --disconnected dot — not the red failure tone, and crucially not
-      // the shared amber --warning (still owned by "Needs response").
-      expect(indicator.querySelector(".bg-disconnected")).not.toBeNull();
-      expect(indicator.querySelector(".bg-warning")).toBeNull();
-      expect(indicator.querySelector(".bg-destructive")).toBeNull();
+      // Positive quiet-dot guarantee: disconnected falls through to the
+      // generic quiet-dot path, so the wrapper carries the standard muted text
+      // class (same as idle/done) and the blue --disconnected dot is the ONLY
+      // color hook — no warning/destructive bleed on the wrapper or the dot,
+      // and crucially never the shared amber --warning (owned by "Needs
+      // response").
+      expect(indicator).toHaveClass("text-muted-foreground");
       expect(indicator).not.toHaveClass("text-warning");
       expect(indicator).not.toHaveClass("text-destructive");
+      const dot = indicator.querySelector("span.rounded-full");
+      expect(dot).toHaveClass("bg-disconnected");
+      expect(dot).not.toHaveClass("bg-warning");
+      expect(dot).not.toHaveClass("bg-destructive");
       // The cause is still surfaced in the accessible label / tooltip.
       expect(indicator).toHaveAttribute("aria-label", `Disconnected: ${message}`);
     },
@@ -847,53 +853,62 @@ describe("SubagentsPanel", () => {
     expect(indicator.querySelector(".bg-destructive")).not.toBeNull();
   });
 
-  it("renders a quiet blue disconnected dot on the main row when the parent failed with a runner-disconnect code", () => {
-    // The session snapshot collapses a runner exit to status "failed" but
-    // preserves the cause in lastTaskError.code (runner_failed_to_start /
-    // runner_disconnected). The main row must branch on it to render the
-    // quiet blue disconnected dot rather than the red "Failed" pill.
-    useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
-    useSessionMock.mockReturnValue({
-      session: {
-        id: "conv_root",
-        agentId: "ag_root",
-        agentName: null,
-        runnerId: null,
-        status: "failed",
-        lastTaskError: {
-          code: "runner_failed_to_start",
-          message: "runner exited before the first turn",
+  it.each([
+    ["runner_disconnected", "Runner disconnected unexpectedly."],
+    ["runner_failed_to_start", "runner exited before the first turn"],
+  ])(
+    "renders a quiet blue disconnected dot on the main row when the parent failed with the runner-disconnect code %s",
+    (code, message) => {
+      // The session snapshot collapses a runner exit to status "failed" but
+      // preserves the cause in lastTaskError.code (runner_failed_to_start /
+      // runner_disconnected). The main row must branch on it to render the
+      // quiet blue disconnected dot rather than the red "Failed" pill.
+      // Parametrized over BOTH disconnect codes, mirroring the child-row
+      // it.each above so neither code can regress on the main row.
+      useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
+      useSessionMock.mockReturnValue({
+        session: {
+          id: "conv_root",
+          agentId: "ag_root",
+          agentName: null,
+          runnerId: null,
+          status: "failed",
+          lastTaskError: { code, message },
+          createdAt: 0,
+          title: null,
+          labels: {},
+          items: [],
+          pendingElicitations: [],
+          permissionLevel: 4,
+          parentSessionId: null,
+          subAgentName: null,
         },
-        createdAt: 0,
-        title: null,
-        labels: {},
-        items: [],
-        pendingElicitations: [],
-        permissionLevel: 4,
-        parentSessionId: null,
-        subAgentName: null,
-      },
-      isLoading: false,
-      error: null,
-    } as unknown as ReturnType<typeof useSession>);
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof useSession>);
 
-    renderPanel({ rootSessionId: "conv_root" });
+      renderPanel({ rootSessionId: "conv_root" });
 
-    const mainRow = screen.getByTestId("subagent-main-row");
-    const indicator = within(mainRow).getByTestId("subagent-status-dot");
-    // Quiet blue dot, no inline word — distinct from the red "Failed" pill.
-    expect(mainRow).not.toHaveTextContent(/Disconnected/);
-    expect(mainRow).not.toHaveTextContent(/Failed/);
-    expect(indicator.querySelector(".bg-disconnected")).not.toBeNull();
-    expect(indicator.querySelector(".bg-warning")).toBeNull();
-    expect(indicator).not.toHaveClass("text-warning");
-    expect(indicator).not.toHaveClass("text-destructive");
-    // The disconnect cause stays in the tooltip / accessible label.
-    expect(indicator).toHaveAttribute(
-      "aria-label",
-      "Disconnected: runner exited before the first turn",
-    );
-  });
+      const mainRow = screen.getByTestId("subagent-main-row");
+      const indicator = within(mainRow).getByTestId("subagent-status-dot");
+      // Quiet blue dot, no inline word — distinct from the red "Failed" pill.
+      expect(mainRow).not.toHaveTextContent(/Disconnected/);
+      expect(mainRow).not.toHaveTextContent(/Failed/);
+      // Positive quiet-dot guarantee: the wrapper carries the standard muted
+      // quiet-dot text class (same path as idle/done) and the blue dot is the
+      // ONLY color hook — no warning/destructive class bleeds onto either the
+      // wrapper or the dot.
+      expect(indicator).toHaveClass("text-muted-foreground");
+      expect(indicator).not.toHaveClass("text-warning");
+      expect(indicator).not.toHaveClass("text-destructive");
+      const dot = indicator.querySelector("span.rounded-full");
+      expect(dot).toHaveClass("bg-disconnected");
+      expect(dot).not.toHaveClass("bg-warning");
+      expect(dot).not.toHaveClass("bg-destructive");
+      // The disconnect cause stays in the tooltip / accessible label.
+      expect(indicator).toHaveAttribute("aria-label", `Disconnected: ${message}`);
+    },
+  );
 
   it("renders red 'Failed' on the main row for a genuine parent failure (non-disconnect code)", () => {
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -780,15 +780,15 @@ describe("SubagentsPanel", () => {
     ["runner_disconnected", "Runner disconnected unexpectedly."],
     ["runner_failed_to_start", "runner exited before the first turn"],
   ])(
-    "renders a quiet blue disconnected dot (no word, not red 'Failed') for the runner-disconnect code %s",
+    "renders a quiet grey disconnected dot (no word, not red 'Failed') for the runner-disconnect code %s",
     (code, message) => {
       // Option B: a runner that merely disconnected/exited is NOT a task
       // failure. The child summary still collapses to current_task_status
       // "failed", but last_task_error.code carries the disconnect cause, so
-      // the row must branch to the quiet blue disconnected dot before the red
+      // the row must branch to the quiet disconnected dot before the red
       // "Failed" pill. The dot shows NO inline word — the cause lives in the
-      // tooltip — and uses the dedicated --disconnected token, never the
-      // shared amber --warning.
+      // tooltip — and uses the neutral grey --muted-foreground token, never
+      // the shared amber --warning.
       mockChildTree({
         conv_parent: [
           childInfo({
@@ -811,15 +811,17 @@ describe("SubagentsPanel", () => {
       expect(row).not.toHaveTextContent(/Failed/);
       // Positive quiet-dot guarantee: disconnected falls through to the
       // generic quiet-dot path, so the wrapper carries the standard muted text
-      // class (same as idle/done) and the blue --disconnected dot is the ONLY
-      // color hook — no warning/destructive bleed on the wrapper or the dot,
-      // and crucially never the shared amber --warning (owned by "Needs
-      // response").
+      // class (same as idle/done) and the grey --muted-foreground dot is the
+      // ONLY color hook — no warning/destructive bleed on the wrapper or the
+      // dot, and crucially never the shared amber --warning (owned by "Needs
+      // response"). The blue --disconnected hue is now reserved for the
+      // launching/idle/done dots, so it must NOT appear here.
       expect(indicator).toHaveClass("text-muted-foreground");
       expect(indicator).not.toHaveClass("text-warning");
       expect(indicator).not.toHaveClass("text-destructive");
       const dot = indicator.querySelector("span.rounded-full");
-      expect(dot).toHaveClass("bg-disconnected");
+      expect(dot).toHaveClass("bg-muted-foreground");
+      expect(dot).not.toHaveClass("bg-disconnected");
       expect(dot).not.toHaveClass("bg-warning");
       expect(dot).not.toHaveClass("bg-destructive");
       // The cause is still surfaced in the accessible label / tooltip.
@@ -857,12 +859,12 @@ describe("SubagentsPanel", () => {
     ["runner_disconnected", "Runner disconnected unexpectedly."],
     ["runner_failed_to_start", "runner exited before the first turn"],
   ])(
-    "renders a quiet blue disconnected dot on the main row when the parent failed with the runner-disconnect code %s",
+    "renders a quiet grey disconnected dot on the main row when the parent failed with the runner-disconnect code %s",
     (code, message) => {
       // The session snapshot collapses a runner exit to status "failed" but
       // preserves the cause in lastTaskError.code (runner_failed_to_start /
       // runner_disconnected). The main row must branch on it to render the
-      // quiet blue disconnected dot rather than the red "Failed" pill.
+      // quiet grey disconnected dot rather than the red "Failed" pill.
       // Parametrized over BOTH disconnect codes, mirroring the child-row
       // it.each above so neither code can regress on the main row.
       useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
@@ -891,18 +893,20 @@ describe("SubagentsPanel", () => {
 
       const mainRow = screen.getByTestId("subagent-main-row");
       const indicator = within(mainRow).getByTestId("subagent-status-dot");
-      // Quiet blue dot, no inline word — distinct from the red "Failed" pill.
+      // Quiet grey dot, no inline word — distinct from the red "Failed" pill.
       expect(mainRow).not.toHaveTextContent(/Disconnected/);
       expect(mainRow).not.toHaveTextContent(/Failed/);
       // Positive quiet-dot guarantee: the wrapper carries the standard muted
-      // quiet-dot text class (same path as idle/done) and the blue dot is the
+      // quiet-dot text class (same path as idle/done) and the grey dot is the
       // ONLY color hook — no warning/destructive class bleeds onto either the
-      // wrapper or the dot.
+      // wrapper or the dot. The blue --disconnected hue is reserved for the
+      // launching/idle/done dots, so it must NOT appear here.
       expect(indicator).toHaveClass("text-muted-foreground");
       expect(indicator).not.toHaveClass("text-warning");
       expect(indicator).not.toHaveClass("text-destructive");
       const dot = indicator.querySelector("span.rounded-full");
-      expect(dot).toHaveClass("bg-disconnected");
+      expect(dot).toHaveClass("bg-muted-foreground");
+      expect(dot).not.toHaveClass("bg-disconnected");
       expect(dot).not.toHaveClass("bg-warning");
       expect(dot).not.toHaveClass("bg-destructive");
       // The disconnect cause stays in the tooltip / accessible label.
@@ -1009,12 +1013,21 @@ describe("SubagentsPanel", () => {
           busy: true,
           current_task_status: "in_progress",
         }),
+        childInfo({ id: "c_launch", tool: "researcher", current_task_status: "launching" }),
         childInfo({ id: "c_done", tool: "researcher", current_task_status: "completed" }),
+        childInfo({ id: "c_idle", tool: "researcher" }),
+        // A verbatim "other status" fallthrough — the GREY exception.
+        childInfo({ id: "c_other", tool: "researcher", current_task_status: "cancelled" }),
         childInfo({ id: "c_fail", tool: "researcher", current_task_status: "failed" }),
       ],
     });
 
     const { container } = renderPanel();
+
+    const dotOf = (id: string) =>
+      within(childRow(container, id))
+        .getByTestId("subagent-status-dot")
+        .querySelector("span.rounded-full");
 
     // Working reuses the sidebar RunningDot in the brand-pink tone —
     // identical to the sidebar's running indicator; a wrong tone drops
@@ -1022,10 +1035,28 @@ describe("SubagentsPanel", () => {
     expect(
       childRow(container, "c_work").querySelector('[data-testid="running-dot"].bg-brand-accent'),
     ).not.toBeNull();
-    // Terminal states use design tokens, not raw 500-weight Tailwind. "done"
-    // is a quiet, expected outcome, so it reads as a muted dot (not green);
-    // failures keep destructive text + a destructive dot.
-    expect(childRow(container, "c_done").querySelector(".bg-muted-foreground\\/55")).not.toBeNull();
+
+    // Panel-scoped palette swap: the quiet live/settled states read in the
+    // blue --disconnected hue, each PRESERVING its prior opacity treatment
+    // (launching kept /70, idle + done kept /55) — only the hue flipped from
+    // grey to blue.
+    const launchDot = dotOf("c_launch");
+    expect(launchDot).toHaveClass("bg-disconnected/70");
+    expect(launchDot).not.toHaveClass("bg-muted-foreground/70");
+    const doneDot = dotOf("c_done");
+    expect(doneDot).toHaveClass("bg-disconnected/55");
+    expect(doneDot).not.toHaveClass("bg-muted-foreground/55");
+    const idleDot = dotOf("c_idle");
+    expect(idleDot).toHaveClass("bg-disconnected/55");
+    expect(idleDot).not.toHaveClass("bg-muted-foreground/55");
+
+    // Exception: the verbatim "other status" fallthrough STAYS neutral grey —
+    // it is the one quiet dot the swap deliberately leaves on --muted-foreground.
+    const otherDot = dotOf("c_other");
+    expect(otherDot).toHaveClass("bg-muted-foreground/55");
+    expect(otherDot).not.toHaveClass("bg-disconnected/55");
+
+    // Terminal failures keep destructive text + a destructive dot.
     const failedIndicator = within(childRow(container, "c_fail")).getByTestId(
       "subagent-status-dot",
     );
@@ -1086,9 +1117,22 @@ describe("SubagentsPanel", () => {
     // The unexpected "cancelled" terminal state keeps its word so it stands out.
     expect(childRow(container, "c_cancel")).toHaveTextContent(/cancelled/);
     // Launching is not yet real work, so it shows its word and does not reuse
-    // the active running dot.
+    // the active running dot. Its inline word now reads in the blue
+    // --disconnected hue (matching its dot), not the neutral muted text.
     expect(childRow(container, "c_launch")).toHaveTextContent(/Launching/);
     expect(childRow(container, "c_launch").querySelector('[data-testid="running-dot"]')).toBeNull();
+    const launchIndicator = within(childRow(container, "c_launch")).getByTestId(
+      "subagent-status-dot",
+    );
+    expect(launchIndicator).toHaveClass("text-disconnected");
+    expect(launchIndicator).not.toHaveClass("text-muted-foreground");
+    // The verbatim "other" word stays neutral grey — its wrapper keeps the
+    // muted text class (the GREY exception).
+    const cancelIndicator = within(childRow(container, "c_cancel")).getByTestId(
+      "subagent-status-dot",
+    );
+    expect(cancelIndicator).toHaveClass("text-muted-foreground");
+    expect(cancelIndicator).not.toHaveClass("text-disconnected");
     // Quiet states render no word — the label lives in the tooltip. Working is
     // quiet too: the pulsing pink dot already reads as "active".
     expect(childRow(container, "c_work")).not.toHaveTextContent(/Working/);

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -776,6 +776,144 @@ describe("SubagentsPanel", () => {
     );
   });
 
+  it.each([
+    ["runner_disconnected", "Runner disconnected unexpectedly."],
+    ["runner_failed_to_start", "runner exited before the first turn"],
+  ])(
+    "renders 'Disconnected' (amber, not red 'Failed') for the runner-disconnect code %s",
+    (code, message) => {
+      // Option B: a runner that merely disconnected/exited is NOT a task
+      // failure. The child summary still collapses to current_task_status
+      // "failed", but last_task_error.code carries the disconnect cause, so
+      // the row must branch to the amber "Disconnected" pill before the red
+      // "Failed" one.
+      mockChildTree({
+        conv_parent: [
+          childInfo({
+            id: "conv_child",
+            title: "researcher:auth",
+            tool: "researcher",
+            session_name: "auth",
+            current_task_status: "failed",
+            last_task_error: { code, message },
+          }),
+        ],
+      });
+
+      const { container } = renderPanel();
+
+      const row = childRow(container, "conv_child");
+      const indicator = within(row).getByTestId("subagent-status-dot");
+      expect(row).toHaveTextContent(/Disconnected/);
+      expect(row).not.toHaveTextContent(/Failed/);
+      // Non-destructive amber tone — distinct from the red failure pill.
+      expect(indicator).toHaveClass("text-warning");
+      expect(indicator).not.toHaveClass("text-destructive");
+      expect(indicator.querySelector(".bg-warning")).not.toBeNull();
+      expect(indicator.querySelector(".bg-destructive")).toBeNull();
+      // The cause is still surfaced in the accessible label / tooltip.
+      expect(indicator).toHaveAttribute("aria-label", `Disconnected: ${message}`);
+    },
+  );
+
+  it("keeps rendering red 'Failed' for a genuine task failure (non-disconnect code)", () => {
+    // Guard the hard constraint: only runner-disconnect/exit codes become
+    // "Disconnected"; any other error code is a real failure and stays red.
+    mockChildTree({
+      conv_parent: [
+        childInfo({
+          id: "conv_child",
+          title: "researcher:auth",
+          tool: "researcher",
+          session_name: "auth",
+          current_task_status: "failed",
+          last_task_error: { code: "tool_error", message: "Tool raised ValueError" },
+        }),
+      ],
+    });
+
+    const { container } = renderPanel();
+
+    const row = childRow(container, "conv_child");
+    const indicator = within(row).getByTestId("subagent-status-dot");
+    expect(row).toHaveTextContent(/Failed/);
+    expect(row).not.toHaveTextContent(/Disconnected/);
+    expect(indicator).toHaveClass("text-destructive");
+    expect(indicator.querySelector(".bg-destructive")).not.toBeNull();
+  });
+
+  it("renders 'Disconnected' on the main row when the parent failed with a runner-disconnect code", () => {
+    // The session snapshot collapses a runner exit to status "failed" but
+    // preserves the cause in lastTaskError.code (runner_failed_to_start /
+    // runner_disconnected). The main row must branch on it to render the
+    // amber "Disconnected" pill rather than the red "Failed" one.
+    useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_root",
+        agentId: "ag_root",
+        agentName: null,
+        runnerId: null,
+        status: "failed",
+        lastTaskError: {
+          code: "runner_failed_to_start",
+          message: "runner exited before the first turn",
+        },
+        createdAt: 0,
+        title: null,
+        labels: {},
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: 4,
+        parentSessionId: null,
+        subAgentName: null,
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useSession>);
+
+    renderPanel({ rootSessionId: "conv_root" });
+
+    const mainRow = screen.getByTestId("subagent-main-row");
+    const indicator = within(mainRow).getByTestId("subagent-status-dot");
+    expect(mainRow).toHaveTextContent(/Disconnected/);
+    expect(mainRow).not.toHaveTextContent(/Failed/);
+    expect(indicator).toHaveClass("text-warning");
+    expect(indicator).not.toHaveClass("text-destructive");
+  });
+
+  it("renders red 'Failed' on the main row for a genuine parent failure (non-disconnect code)", () => {
+    useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
+    useSessionMock.mockReturnValue({
+      session: {
+        id: "conv_root",
+        agentId: "ag_root",
+        agentName: null,
+        runnerId: null,
+        status: "failed",
+        lastTaskError: { code: "turn_error", message: "turn setup failed" },
+        createdAt: 0,
+        title: null,
+        labels: {},
+        items: [],
+        pendingElicitations: [],
+        permissionLevel: 4,
+        parentSessionId: null,
+        subAgentName: null,
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useSession>);
+
+    renderPanel({ rootSessionId: "conv_root" });
+
+    const mainRow = screen.getByTestId("subagent-main-row");
+    const indicator = within(mainRow).getByTestId("subagent-status-dot");
+    expect(mainRow).toHaveTextContent(/Failed/);
+    expect(mainRow).not.toHaveTextContent(/Disconnected/);
+    expect(indicator).toHaveClass("text-destructive");
+  });
+
   it("shows the pulsing working dot (no redundant 'Working' word) on the main row when the parent session is running", () => {
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
     useSessionMock.mockReturnValue({

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -780,13 +780,15 @@ describe("SubagentsPanel", () => {
     ["runner_disconnected", "Runner disconnected unexpectedly."],
     ["runner_failed_to_start", "runner exited before the first turn"],
   ])(
-    "renders 'Disconnected' (amber, not red 'Failed') for the runner-disconnect code %s",
+    "renders a quiet blue disconnected dot (no word, not red 'Failed') for the runner-disconnect code %s",
     (code, message) => {
       // Option B: a runner that merely disconnected/exited is NOT a task
       // failure. The child summary still collapses to current_task_status
       // "failed", but last_task_error.code carries the disconnect cause, so
-      // the row must branch to the amber "Disconnected" pill before the red
-      // "Failed" one.
+      // the row must branch to the quiet blue disconnected dot before the red
+      // "Failed" pill. The dot shows NO inline word — the cause lives in the
+      // tooltip — and uses the dedicated --disconnected token, never the
+      // shared amber --warning.
       mockChildTree({
         conv_parent: [
           childInfo({
@@ -804,13 +806,16 @@ describe("SubagentsPanel", () => {
 
       const row = childRow(container, "conv_child");
       const indicator = within(row).getByTestId("subagent-status-dot");
-      expect(row).toHaveTextContent(/Disconnected/);
+      // The inline "Disconnected" word is hidden (quiet dot, like idle/done).
+      expect(row).not.toHaveTextContent(/Disconnected/);
       expect(row).not.toHaveTextContent(/Failed/);
-      // Non-destructive amber tone — distinct from the red failure pill.
-      expect(indicator).toHaveClass("text-warning");
-      expect(indicator).not.toHaveClass("text-destructive");
-      expect(indicator.querySelector(".bg-warning")).not.toBeNull();
+      // Blue --disconnected dot — not the red failure tone, and crucially not
+      // the shared amber --warning (still owned by "Needs response").
+      expect(indicator.querySelector(".bg-disconnected")).not.toBeNull();
+      expect(indicator.querySelector(".bg-warning")).toBeNull();
       expect(indicator.querySelector(".bg-destructive")).toBeNull();
+      expect(indicator).not.toHaveClass("text-warning");
+      expect(indicator).not.toHaveClass("text-destructive");
       // The cause is still surfaced in the accessible label / tooltip.
       expect(indicator).toHaveAttribute("aria-label", `Disconnected: ${message}`);
     },
@@ -842,11 +847,11 @@ describe("SubagentsPanel", () => {
     expect(indicator.querySelector(".bg-destructive")).not.toBeNull();
   });
 
-  it("renders 'Disconnected' on the main row when the parent failed with a runner-disconnect code", () => {
+  it("renders a quiet blue disconnected dot on the main row when the parent failed with a runner-disconnect code", () => {
     // The session snapshot collapses a runner exit to status "failed" but
     // preserves the cause in lastTaskError.code (runner_failed_to_start /
     // runner_disconnected). The main row must branch on it to render the
-    // amber "Disconnected" pill rather than the red "Failed" one.
+    // quiet blue disconnected dot rather than the red "Failed" pill.
     useChildSessionsMock.mockReturnValue({ children: [], isLoading: false, error: null });
     useSessionMock.mockReturnValue({
       session: {
@@ -876,10 +881,18 @@ describe("SubagentsPanel", () => {
 
     const mainRow = screen.getByTestId("subagent-main-row");
     const indicator = within(mainRow).getByTestId("subagent-status-dot");
-    expect(mainRow).toHaveTextContent(/Disconnected/);
+    // Quiet blue dot, no inline word — distinct from the red "Failed" pill.
+    expect(mainRow).not.toHaveTextContent(/Disconnected/);
     expect(mainRow).not.toHaveTextContent(/Failed/);
-    expect(indicator).toHaveClass("text-warning");
+    expect(indicator.querySelector(".bg-disconnected")).not.toBeNull();
+    expect(indicator.querySelector(".bg-warning")).toBeNull();
+    expect(indicator).not.toHaveClass("text-warning");
     expect(indicator).not.toHaveClass("text-destructive");
+    // The disconnect cause stays in the tooltip / accessible label.
+    expect(indicator).toHaveAttribute(
+      "aria-label",
+      "Disconnected: runner exited before the first turn",
+    );
   });
 
   it("renders red 'Failed' on the main row for a genuine parent failure (non-disconnect code)", () => {

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -150,7 +150,7 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
 // label word shows, and whether the row is de-emphasized. ``awaiting`` =
 // parked on an approval / input prompt and needs the user's attention.
 // ``disconnected`` = the runner dropped its tunnel or exited; the task did
-// NOT genuinely fail, so it renders a quiet, non-destructive blue dot rather
+// NOT genuinely fail, so it renders a quiet, non-destructive grey dot rather
 // than the red "Failed" one.
 type AgentActivity =
   | "launching"
@@ -275,18 +275,25 @@ function sessionStatus(
 
 // Dot color per dot-rendered state. Working uses the animated RunningDot
 // and awaiting uses the "Needs response" tag, so both are excluded here.
-// "done" is a quiet, expected outcome, so it reads as a muted dot rather
-// than a loud green one.
+// Panel-scoped palette: the quiet live/settled states (launching, idle,
+// done) read in the blue --disconnected hue, while the disconnected runner
+// reads in the neutral grey --muted-foreground. This is a per-state token
+// REASSIGNMENT scoped to this panel — the global --disconnected (blue) and
+// --muted-foreground (grey) values are unchanged.
 const DOT_TONE: Record<Exclude<AgentActivity, "working" | "awaiting">, string> = {
-  done: "bg-muted-foreground/55",
+  // Blue, quiet — "done" is an expected outcome, so it reads as a subtle
+  // (/55) blue dot rather than a loud green one.
+  done: "bg-disconnected/55",
   failed: "bg-destructive",
-  // Blue, not destructive — a disconnect is a transient liveness loss, not a
-  // task failure, so it reads distinctly from the red "Failed". Its own
-  // --disconnected token (not the shared amber --warning) so the "Needs
-  // response" badge keeps its amber.
-  disconnected: "bg-disconnected",
-  idle: "bg-muted-foreground/55",
-  launching: "bg-muted-foreground/70",
+  // Grey, not destructive — a disconnect is a transient liveness loss, not a
+  // task failure, so it reads distinctly from the red "Failed". Full-strength
+  // neutral --muted-foreground (not the shared amber --warning) so the "Needs
+  // response" badge keeps its amber and the dot stays notable (it is not a
+  // dimmed SETTLED_STATE).
+  disconnected: "bg-muted-foreground",
+  idle: "bg-disconnected/55",
+  launching: "bg-disconnected/70",
+  // Exception: the verbatim "other status" fallthrough stays neutral grey.
   other: "bg-muted-foreground/55",
 };
 
@@ -299,7 +306,7 @@ const QUIET_STATE: Record<AgentActivity, boolean> = {
   working: true,
   awaiting: false,
   failed: false,
-  // Quiet — show only the blue dot (the word lives in the tooltip), like the
+  // Quiet — show only the grey dot (the word lives in the tooltip), like the
   // idle/done/working dot states. The colored dot is enough to flag the
   // liveness loss without adding label text to the row.
   disconnected: true,
@@ -433,15 +440,21 @@ function StatusIndicator({ activity, label, details }: AgentStatus) {
     );
   }
   // ``disconnected`` falls through to the quiet default below: it's a
-  // QUIET_STATE, so only the blue --disconnected dot renders (no inline
+  // QUIET_STATE, so only the grey --muted-foreground dot renders (no inline
   // word) — the cause stays in the tooltip / aria-label. Distinct from the
   // red "Failed" pill above, without repurposing the shared amber --warning.
+  //
+  // Launching's inline word reads in the blue --disconnected hue to match its
+  // dot; every other state here keeps the neutral muted text — the verbatim
+  // "other" word stays grey, and idle/done/disconnected show no word at all.
+  const wrapperTextClass =
+    activity === "launching" ? "text-disconnected" : "text-muted-foreground";
   return (
     <span
       aria-label={title}
       title={title}
       data-testid="subagent-status-dot"
-      className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs"
+      className={cn("inline-flex shrink-0 items-center gap-1 text-xs", wrapperTextClass)}
     >
       {!QUIET_STATE[activity] && <span>{label}</span>}
       {activity === "working" ? (

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -149,7 +149,31 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
 // ``busy`` + ``current_task_status``). Drives the dot tone, whether the
 // label word shows, and whether the row is de-emphasized. ``awaiting`` =
 // parked on an approval / input prompt and needs the user's attention.
-type AgentActivity = "launching" | "working" | "awaiting" | "done" | "failed" | "idle" | "other";
+// ``disconnected`` = the runner dropped its tunnel or exited; the task did
+// NOT genuinely fail, so it renders a non-destructive (amber) pill rather
+// than the red "Failed" one.
+type AgentActivity =
+  | "launching"
+  | "working"
+  | "awaiting"
+  | "done"
+  | "failed"
+  | "disconnected"
+  | "idle"
+  | "other";
+
+// Error codes that mean "the runner went away", not "the task failed".
+// ``runner_disconnected`` is published when the SSE relay's tunnel drops
+// mid-stream; ``runner_failed_to_start`` when a bound runner reports an
+// unexpected exit. Both are surfaced via ``last_task_error.code`` (child
+// rows) / the session snapshot's ``lastTaskError.code`` (main row). A
+// genuine task failure carries any other code (or none), so it still
+// renders the red "Failed" pill.
+const RUNNER_DISCONNECT_CODES = new Set(["runner_disconnected", "runner_failed_to_start"]);
+
+function isRunnerDisconnectCode(code: string | null | undefined): boolean {
+  return code != null && RUNNER_DISCONNECT_CODES.has(code);
+}
 
 interface AgentStatus {
   activity: AgentActivity;
@@ -189,6 +213,18 @@ function childStatus(child: ChildSessionInfo): AgentStatus {
     return { activity: "launching", label: "Launching" };
   }
   if (child.busy) return { activity: "working", label: "Working" };
+  // A runner disconnect/exit is NOT a task failure — branch on the error
+  // code before the generic failed paths so it renders the amber
+  // "Disconnected" pill instead of the red "Failed" one.
+  if (isRunnerDisconnectCode(child.last_task_error?.code)) {
+    return {
+      activity: "disconnected",
+      label: "Disconnected",
+      details: child.last_task_error
+        ? firstErrorLine(child.last_task_error.message)
+        : undefined,
+    };
+  }
   if (child.last_task_error) {
     return {
       activity: "failed",
@@ -209,12 +245,31 @@ function childStatus(child: ChildSessionInfo): AgentStatus {
  *
  * @param status - ``session.status`` from the snapshot, e.g. ``"running"``,
  *   or ``undefined`` while the snapshot is still loading.
+ * @param lastTaskError - The snapshot's ``lastTaskError`` (code + message),
+ *   used to tell a benign runner disconnect/exit apart from a real failure
+ *   when ``status === "failed"``.
  * @returns The collapsed activity + its label.
  */
-function sessionStatus(status: string | undefined): AgentStatus {
+function sessionStatus(
+  status: string | undefined,
+  lastTaskError?: { code: string; message: string } | null,
+): AgentStatus {
   if (status === "launching") return { activity: "launching", label: "Launching" };
   if (status === "running") return { activity: "working", label: "Working" };
-  if (status === "failed") return { activity: "failed", label: "Failed" };
+  if (status === "failed") {
+    // A runner disconnect/exit collapses the snapshot to ``failed`` but
+    // preserves the cause in ``lastTaskError.code`` — branch on it before
+    // the generic failed path so it reads as "Disconnected", not a real
+    // failure.
+    if (isRunnerDisconnectCode(lastTaskError?.code)) {
+      return {
+        activity: "disconnected",
+        label: "Disconnected",
+        details: lastTaskError ? firstErrorLine(lastTaskError.message) : undefined,
+      };
+    }
+    return { activity: "failed", label: "Failed" };
+  }
   return { activity: "idle", label: "Idle" };
 }
 
@@ -225,6 +280,9 @@ function sessionStatus(status: string | undefined): AgentStatus {
 const DOT_TONE: Record<Exclude<AgentActivity, "working" | "awaiting">, string> = {
   done: "bg-muted-foreground/55",
   failed: "bg-destructive",
+  // Amber, not destructive — a disconnect is a transient liveness loss,
+  // not a task failure, so it must read distinctly from the red "Failed".
+  disconnected: "bg-warning",
   idle: "bg-muted-foreground/55",
   launching: "bg-muted-foreground/70",
   other: "bg-muted-foreground/55",
@@ -239,6 +297,9 @@ const QUIET_STATE: Record<AgentActivity, boolean> = {
   working: true,
   awaiting: false,
   failed: false,
+  // Show the "Disconnected" word — the user needs to know the runner
+  // went away, the same way "Failed" keeps its word.
+  disconnected: false,
   other: false,
   done: true,
   idle: true,
@@ -252,6 +313,9 @@ const SETTLED_STATE: Record<AgentActivity, boolean> = {
   working: false,
   awaiting: false,
   failed: false,
+  // Not dimmed — a disconnected runner is something the user may want to
+  // notice and act on (retry/reconnect), so it stays full-strength.
+  disconnected: false,
   other: false,
   done: true,
   idle: true,
@@ -362,6 +426,21 @@ function StatusIndicator({ activity, label, details }: AgentStatus) {
       >
         <span>{label}</span>
         <span className={cn("inline-block size-2 shrink-0 rounded-full", DOT_TONE.failed)} />
+      </span>
+    );
+  }
+  if (activity === "disconnected") {
+    // Amber, non-destructive — a runner disconnect/exit is a liveness loss,
+    // not a task failure, so it must read distinctly from the red "Failed".
+    return (
+      <span
+        aria-label={title}
+        title={title}
+        data-testid="subagent-status-dot"
+        className="inline-flex shrink-0 items-center gap-1 text-warning text-xs"
+      >
+        <span>{label}</span>
+        <span className={cn("inline-block size-2 shrink-0 rounded-full", DOT_TONE.disconnected)} />
       </span>
     );
   }
@@ -526,7 +605,7 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
           <Icon className="size-3.5 shrink-0 text-muted-foreground" />
           <span className="shrink-0 truncate text-xs font-medium">{label}</span>
           <span className="flex-1" />
-          <StatusIndicator {...sessionStatus(session?.status)} />
+          <StatusIndicator {...sessionStatus(session?.status, session?.lastTaskError)} />
         </div>
         {preview && (
           // Indented to align with the title text above: 14px icon + 4px gap.

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -150,7 +150,7 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
 // label word shows, and whether the row is de-emphasized. ``awaiting`` =
 // parked on an approval / input prompt and needs the user's attention.
 // ``disconnected`` = the runner dropped its tunnel or exited; the task did
-// NOT genuinely fail, so it renders a non-destructive (amber) pill rather
+// NOT genuinely fail, so it renders a quiet, non-destructive blue dot rather
 // than the red "Failed" one.
 type AgentActivity =
   | "launching"
@@ -214,8 +214,8 @@ function childStatus(child: ChildSessionInfo): AgentStatus {
   }
   if (child.busy) return { activity: "working", label: "Working" };
   // A runner disconnect/exit is NOT a task failure — branch on the error
-  // code before the generic failed paths so it renders the amber
-  // "Disconnected" pill instead of the red "Failed" one.
+  // code before the generic failed paths so it renders the quiet blue
+  // disconnected dot instead of the red "Failed" pill.
   if (isRunnerDisconnectCode(child.last_task_error?.code)) {
     return {
       activity: "disconnected",
@@ -259,8 +259,8 @@ function sessionStatus(
   if (status === "failed") {
     // A runner disconnect/exit collapses the snapshot to ``failed`` but
     // preserves the cause in ``lastTaskError.code`` — branch on it before
-    // the generic failed path so it reads as "Disconnected", not a real
-    // failure.
+    // the generic failed path so it reads as a quiet blue disconnected dot,
+    // not a real failure.
     if (isRunnerDisconnectCode(lastTaskError?.code)) {
       return {
         activity: "disconnected",
@@ -280,9 +280,11 @@ function sessionStatus(
 const DOT_TONE: Record<Exclude<AgentActivity, "working" | "awaiting">, string> = {
   done: "bg-muted-foreground/55",
   failed: "bg-destructive",
-  // Amber, not destructive — a disconnect is a transient liveness loss,
-  // not a task failure, so it must read distinctly from the red "Failed".
-  disconnected: "bg-warning",
+  // Blue, not destructive — a disconnect is a transient liveness loss, not a
+  // task failure, so it reads distinctly from the red "Failed". Its own
+  // --disconnected token (not the shared amber --warning) so the "Needs
+  // response" badge keeps its amber.
+  disconnected: "bg-disconnected",
   idle: "bg-muted-foreground/55",
   launching: "bg-muted-foreground/70",
   other: "bg-muted-foreground/55",
@@ -297,9 +299,10 @@ const QUIET_STATE: Record<AgentActivity, boolean> = {
   working: true,
   awaiting: false,
   failed: false,
-  // Show the "Disconnected" word — the user needs to know the runner
-  // went away, the same way "Failed" keeps its word.
-  disconnected: false,
+  // Quiet — show only the blue dot (the word lives in the tooltip), like the
+  // idle/done/working dot states. The colored dot is enough to flag the
+  // liveness loss without adding label text to the row.
+  disconnected: true,
   other: false,
   done: true,
   idle: true,
@@ -429,21 +432,10 @@ function StatusIndicator({ activity, label, details }: AgentStatus) {
       </span>
     );
   }
-  if (activity === "disconnected") {
-    // Amber, non-destructive — a runner disconnect/exit is a liveness loss,
-    // not a task failure, so it must read distinctly from the red "Failed".
-    return (
-      <span
-        aria-label={title}
-        title={title}
-        data-testid="subagent-status-dot"
-        className="inline-flex shrink-0 items-center gap-1 text-warning text-xs"
-      >
-        <span>{label}</span>
-        <span className={cn("inline-block size-2 shrink-0 rounded-full", DOT_TONE.disconnected)} />
-      </span>
-    );
-  }
+  // ``disconnected`` falls through to the quiet default below: it's a
+  // QUIET_STATE, so only the blue --disconnected dot renders (no inline
+  // word) — the cause stays in the tooltip / aria-label. Distinct from the
+  // red "Failed" pill above, without repurposing the shared amber --warning.
   return (
     <span
       aria-label={title}


### PR DESCRIPTION
## Related issue

Closes #1589

## Summary

- **Problem:** A runner *disconnect* (SSE tunnel drop or runner exit) was surfaced in the Subagents panel as a red **"Failed"** pill, indistinguishable from a genuine task failure. The relay maps a disconnect to session `status="failed"` with `ErrorDetail(code="runner_disconnected")` (and `runner_failed_to_start` on runner-exit), and the UI rendered any `failed` status as red "Failed".
- **Fix:** Keep publishing the prompt terminal SSE status event (connected clients still get instant feedback — preserves the #1114 silent-truncation guarantee), and **branch the UI on the disconnect error codes** (`runner_disconnected`, `runner_failed_to_start`) to render a distinct **"Disconnected"** state instead of red "Failed". The backend persists the disconnect cause as durable labels so the state survives the ~15s poll and page reloads. Genuine failures still render red "Failed".
- **Styling:** Disconnected renders as a quiet **grey** dot (no inline word; the cause is kept in the hover tooltip/aria-label). The quiet-state palette was also adjusted so launching/idle/done use blue and disconnected uses grey, via a dedicated `--disconnected` token (the shared `--warning`/`--destructive` tokens are untouched, so the amber "Needs response" badge and red "Failed" are unchanged).

ELI5: a dropped connection is a temporary "we lost the runner", not "your task crashed" — so it now reads as a calm **Disconnected** dot rather than an alarming red **Failed**.

## Test Plan

- `ruff check .` and `ruff format --check .` — clean.
- `uv run pytest tests/server/routes` — **501 passed**, including new tests `test_relay_publishes_failed_status_on_tunnel_close` and `test_relay_persists_disconnect_error_labels_on_tunnel_close` (`tests/server/routes/test_sessions_runner_relay.py`).
- `web/`: `npm run type-check` clean; `vitest run src/shell/SubagentsPanel.test.tsx` — **60 passed** (asserts both disconnect codes on the main row and the child row render the Disconnected dot with no inline word, and that genuine failures still render red "Failed"); oxlint clean on the touched files.
- **Manual:** ran a local server + host + `ap-web` dev server, started a session, then killed the host mid-session to force a real tunnel drop. Verified the session snapshot reported `status=failed`, `last_task_error.code=runner_disconnected`, `runner_online=false`, and the row rendered the **Disconnected** dot (not red "Failed"); a genuine failure still rendered red "Failed".

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage: backend relay tests assert that a tunnel close publishes the `failed`+`runner_disconnected` status and persists the disconnect error labels to the snapshot; frontend `SubagentsPanel` tests assert the Disconnected rendering for both disconnect codes on both the main and child rows, that the inline word is hidden while the tooltip/aria-label is retained, and that genuine failures still render red "Failed".

Manual verification: reproduced a real runner disconnect against a locally-run build (server + host + frontend) by killing the host mid-session; confirmed via the API and the UI that the disconnect surfaces as "Disconnected" rather than red "Failed", and that the state persists across the status poll.
