### PR TITLE
feat(native-forwarders): replay proven-undelivered dead-lettered items on codex startup (bounded)

### DIFF
--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -362,6 +362,8 @@ async def replay_dead_letters(
     repost: Callable[[dict[str, object]], Coroutine[None, None, RepostResult]],
     retryable_status_codes: frozenset[int],
     logger_name: str | None = None,
+    max_records: int | None = None,
+    deadline_seconds: float | None = None,
 ) -> int:
     """
     Re-POST proven-undelivered dead-lettered forwards on forwarder startup (#1579).
@@ -375,6 +377,13 @@ async def replay_dead_letters(
     again. Ambiguous and permanent-4xx records are left untouched as a forensic
     record.
 
+    Bounded so a large dead-letter file or a slow/hung server cannot stall
+    startup: at most ``max_records`` records are re-POSTed and the whole drain
+    is abandoned once ``deadline_seconds`` elapses. Records left over by either
+    bound are retained unchanged (deferred to a later startup) and logged — never
+    silently dropped. The remaining latency lever, a short per-POST timeout and a
+    single attempt, is the caller's responsibility (via ``repost``).
+
     Intended to run once at startup, before live forwarding begins, so no other
     writer races the dead-letter files for this ``bridge_dir``.
 
@@ -387,6 +396,12 @@ async def replay_dead_letters(
         recoverable.
     :param logger_name: Optional logger name for the recovery summary line;
         defaults to this module's logger.
+    :param max_records: Maximum number of records to re-POST this run, e.g.
+        ``500``; ``None`` for no cap. Bounds the number of network POSTs (and
+        thus startup latency) even against a healthy server.
+    :param deadline_seconds: Wall-clock budget for the whole drain, e.g.
+        ``30.0``; ``None`` for no deadline. Once exceeded, the remaining
+        replayable records are deferred to a later startup.
     :returns: The number of records successfully replayed (and removed).
     """
     log = logging.getLogger(logger_name) if logger_name else _logger
@@ -411,6 +426,10 @@ async def replay_dead_letters(
         return 0
 
     replayed = 0
+    attempted = 0
+    deferred = 0
+    stop = False
+    deadline = time.monotonic() + deadline_seconds if deadline_seconds is not None else None
     # ``loaded`` preserves the .1-then-current source order, so records replay
     # in the order they were originally dropped.
     for path, entries in loaded:
@@ -420,9 +439,24 @@ async def replay_dead_letters(
             if not _dead_letter_record_replayable(
                 entry, retryable_status_codes=retryable_status_codes
             ):
+                # Forensic record (ambiguous / permanent-4xx / malformed) — keep as is.
+                retained.append(entry)
+                continue
+            if stop:
+                deferred += 1
+                retained.append(entry)
+                continue
+            over_records = max_records is not None and attempted >= max_records
+            over_deadline = deadline is not None and time.monotonic() >= deadline
+            if over_records or over_deadline:
+                # Out of budget — defer this and every later replayable record
+                # to the next startup rather than stall here.
+                stop = True
+                deferred += 1
                 retained.append(entry)
                 continue
             assert isinstance(entry, dict)  # narrowed by _dead_letter_record_replayable
+            attempted += 1
             result = await repost(entry)
             if result.delivered:
                 replayed += 1
@@ -445,5 +479,13 @@ async def replay_dead_letters(
         log.info(
             "replayed %d proven-undelivered dead-lettered forward(s) on startup",
             replayed,
+        )
+    if deferred:
+        log.info(
+            "deferred %d replayable dead-lettered forward(s) to a later startup "
+            "(replay budget reached: max_records=%s deadline_seconds=%s)",
+            deferred,
+            max_records,
+            deadline_seconds,
         )
     return replayed

--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -19,10 +19,12 @@ the codex/antigravity forwarders so a single implementation is maintained.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import time
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
@@ -43,12 +45,17 @@ def append_dead_letter(
     event_type: str,
     payload: dict[str, object],
     reason: str,
+    delivered_ambiguous: bool = False,
+    http_status: int | None = None,
+    transport_error: str | None = None,
 ) -> None:
     """
     Append one undeliverable forward payload to ``{bridge_dir}/dead_letter.jsonl`` (#1120).
 
     Write-only recovery artifact so a permanently-failed transcript/usage POST is
-    recoverable on disk instead of silently lost. Replay is tracked separately (#1579).
+    recoverable on disk instead of silently lost. Conservative startup replay of the
+    *proven-undelivered* records is layered on top (#1579) and reads the structured
+    classification fields below to decide what is safe to re-POST.
     Best-effort: never raises (a dead-letter failure must not disrupt forwarding). When
     the file reaches :data:`_DEAD_LETTER_MAX_BYTES` it is rotated to a single ``.1``
     backup and a fresh file is started, so the most recent drops are kept (the oldest
@@ -62,6 +69,13 @@ def append_dead_letter(
     :param payload: The event ``data`` payload that failed to deliver.
     :param reason: Short human-readable cause, e.g.
         ``"permanent HTTP failure after retries"``.
+    :param delivered_ambiguous: Whether the failure was ambiguous (request sent,
+        response lost), so the server may have committed the item. Such records are
+        NEVER replayed — a re-POST risks a duplicate (no server-side dedup).
+    :param http_status: Final HTTP status code when the server responded, e.g.
+        ``503`` or ``400``; ``None`` for a transport failure that saw no response.
+    :param transport_error: Transport-error class name when the POST raised without a
+        response, e.g. ``"ConnectError"``; ``None`` when the server responded.
     :returns: None.
     """
     try:
@@ -85,6 +99,9 @@ def append_dead_letter(
                 "session_id": session_id,
                 "event_type": event_type,
                 "reason": reason,
+                "delivered_ambiguous": delivered_ambiguous,
+                "http_status": http_status,
+                "transport_error": transport_error,
                 "payload": payload,
             }
         )
@@ -215,3 +232,218 @@ async def post_session_event_with_retry(
             return response
         await sleep(retry_delay(attempt))
     return None
+
+
+@dataclass(frozen=True)
+class RepostResult:
+    """
+    Outcome of one dead-letter replay re-POST attempt (#1579).
+
+    Returned by the forwarder-supplied ``repost`` callable so
+    :func:`replay_dead_letters` can decide whether to drop the record or keep
+    it, and refresh its classification when a retained record's safety changed
+    (e.g. a proven-undelivered transport record that now fails *ambiguously*
+    must never be auto-replayed again).
+
+    :param delivered: ``True`` when the server accepted the re-POST (a sub-400
+        response). The record is removed on success.
+    :param delivered_ambiguous: ``True`` when the re-POST failed ambiguously
+        (request sent, response lost), so the item may now be committed. The
+        record is kept but reclassified so replay never touches it again.
+    :param http_status: Final HTTP status code when the server responded, or
+        ``None`` for a transport failure that saw no response. Used to refresh
+        the retained record's classification.
+    """
+
+    delivered: bool
+    delivered_ambiguous: bool = False
+    http_status: int | None = None
+
+
+def _dead_letter_record_replayable(
+    record: object,
+    *,
+    retryable_status_codes: frozenset[int],
+) -> bool:
+    """
+    Return whether a dead-letter record is safe to re-POST on startup (#1579).
+
+    Only *proven-undelivered* records are replayable: a transport failure that
+    never reached the server, or a retryable status (e.g. ``503``) exhausted
+    after the forwarder's bounded retries. Ambiguous failures (the server may
+    have committed the item) and permanent rejections (a 4xx the server will
+    just reject again) are never replayed.
+
+    Records written before classification was added (#1579) lack the
+    ``delivered_ambiguous`` field; they are treated as unsafe (forensic only)
+    so a pre-classification ambiguous drop is never replayed into a duplicate.
+
+    :param record: One parsed dead-letter record, or any non-dict entry
+        (malformed line) which is never replayable.
+    :param retryable_status_codes: HTTP statuses the forwarder treats as
+        transient/retryable, e.g. ``frozenset({429, 500, 503})``. A recorded
+        status in this set is proven-undelivered-but-recoverable.
+    :returns: ``True`` only for proven-undelivered records with the routing
+        fields (``session_id``, ``event_type``, ``payload``) needed to re-POST.
+    """
+    if not isinstance(record, dict):
+        return False
+    session_id = record.get("session_id")
+    event_type = record.get("event_type")
+    if not (isinstance(session_id, str) and session_id):
+        return False
+    if not (isinstance(event_type, str) and event_type):
+        return False
+    if not isinstance(record.get("payload"), dict):
+        return False
+    if "delivered_ambiguous" not in record:
+        return False
+    if record.get("delivered_ambiguous"):
+        return False
+    http_status = record.get("http_status")
+    if http_status is None:
+        # Transport failure with no response (ambiguous already excluded above)
+        # — proven undelivered, so safe to re-POST.
+        return True
+    # The server responded: only a retryable status is recoverable; a permanent
+    # 4xx would just be rejected again.
+    return http_status in retryable_status_codes
+
+
+def _read_dead_letter_entries(path: Path) -> list[object] | None:
+    """
+    Read one dead-letter file into ordered entries, preserving malformed lines.
+
+    :param path: Dead-letter file path (current or ``.1`` backup).
+    :returns: Ordered entries — parsed ``dict`` records, or the raw ``str`` line
+        for any line that failed to parse (kept verbatim so a rewrite never
+        drops forensic data) — or ``None`` when the file does not exist.
+    """
+    if not path.exists():
+        return None
+    entries: list[object] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            entries.append(json.loads(stripped))
+        except json.JSONDecodeError:
+            entries.append(line)
+    return entries
+
+
+def _rewrite_dead_letter_entries(path: Path, entries: list[object]) -> None:
+    """
+    Atomically rewrite one dead-letter file with the retained entries (#1579).
+
+    Writes a sibling ``.tmp`` then ``os.replace``-es it into place so a crash
+    mid-rewrite never leaves a half-written file. An empty entry list removes
+    the file.
+
+    :param path: Dead-letter file path to rewrite.
+    :param entries: Retained entries in original order (``dict`` records are
+        re-serialized; raw ``str`` lines are written verbatim).
+    :returns: None.
+    """
+    if not entries:
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+        return
+    lines = [entry if isinstance(entry, str) else json.dumps(entry) for entry in entries]
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+async def replay_dead_letters(
+    bridge_dir: Path,
+    *,
+    repost: Callable[[dict[str, object]], Coroutine[None, None, RepostResult]],
+    retryable_status_codes: frozenset[int],
+    logger_name: str | None = None,
+) -> int:
+    """
+    Re-POST proven-undelivered dead-lettered forwards on forwarder startup (#1579).
+
+    Reads the ``.1`` backup first, then the current file, preserving append
+    order, and re-POSTs only *proven-undelivered* records (see
+    :func:`_dead_letter_record_replayable`) via the supplied ``repost``
+    callable. A delivered record is removed; a still-failing one is retained,
+    with its classification refreshed from the latest attempt so a record that
+    now fails ambiguously (or is permanently rejected) is never auto-replayed
+    again. Ambiguous and permanent-4xx records are left untouched as a forensic
+    record.
+
+    Intended to run once at startup, before live forwarding begins, so no other
+    writer races the dead-letter files for this ``bridge_dir``.
+
+    :param bridge_dir: Native forwarder bridge directory holding the dead-letter
+        files.
+    :param repost: Async callable that re-POSTs one record's
+        ``(session_id, event_type, payload)`` and returns a :class:`RepostResult`.
+    :param retryable_status_codes: HTTP statuses the forwarder treats as
+        transient/retryable, used to classify which recorded statuses are
+        recoverable.
+    :param logger_name: Optional logger name for the recovery summary line;
+        defaults to this module's logger.
+    :returns: The number of records successfully replayed (and removed).
+    """
+    log = logging.getLogger(logger_name) if logger_name else _logger
+    sources = [
+        bridge_dir / _DEAD_LETTER_BACKUP_FILE,
+        bridge_dir / _DEAD_LETTER_FILE,
+    ]
+    loaded: list[tuple[Path, list[object]]] = []
+    any_replayable = False
+    for path in sources:
+        entries = _read_dead_letter_entries(path)
+        if entries is None:
+            continue
+        loaded.append((path, entries))
+        if any(
+            _dead_letter_record_replayable(entry, retryable_status_codes=retryable_status_codes)
+            for entry in entries
+        ):
+            any_replayable = True
+    if not any_replayable:
+        # Nothing recoverable — leave the forensic files untouched.
+        return 0
+
+    replayed = 0
+    # ``loaded`` preserves the .1-then-current source order, so records replay
+    # in the order they were originally dropped.
+    for path, entries in loaded:
+        retained: list[object] = []
+        changed = False
+        for entry in entries:
+            if not _dead_letter_record_replayable(
+                entry, retryable_status_codes=retryable_status_codes
+            ):
+                retained.append(entry)
+                continue
+            assert isinstance(entry, dict)  # narrowed by _dead_letter_record_replayable
+            result = await repost(entry)
+            if result.delivered:
+                replayed += 1
+                changed = True
+                continue
+            if (
+                entry.get("delivered_ambiguous") != result.delivered_ambiguous
+                or entry.get("http_status") != result.http_status
+            ):
+                entry = {
+                    **entry,
+                    "delivered_ambiguous": result.delivered_ambiguous,
+                    "http_status": result.http_status,
+                }
+                changed = True
+            retained.append(entry)
+        if changed:
+            _rewrite_dead_letter_entries(path, retained)
+    if replayed:
+        log.info(
+            "replayed %d proven-undelivered dead-lettered forward(s) on startup",
+            replayed,
+        )
+    return replayed

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -1292,6 +1292,11 @@ async def _forward_available_subagents(
                         "tool_use_id": meta["toolUseId"],
                     },
                     reason="permanent HTTP failure after retries",
+                    # Claude only dead-letters permanent 4xx (it retries
+                    # transient failures forever), so the server proved it
+                    # rejected the item: never ambiguous, never replayable (#1579).
+                    delivered_ambiguous=False,
+                    http_status=_http_status_for_log(exc),
                 )
                 # Park this sub-agent: insert a sentinel entry so we
                 # don't keep retrying. ``child_conversation_id=""``
@@ -1400,6 +1405,11 @@ async def _forward_available_subagents(
                             "response_id": item.response_id,
                         },
                         reason="permanent HTTP failure after retries",
+                        # Claude only dead-letters permanent 4xx (it retries
+                        # transient failures forever), so the server proved it
+                        # rejected the item: never ambiguous, never replayable (#1579).
+                        delivered_ambiguous=False,
+                        http_status=_http_status_for_log(exc),
                     )
                     # Skip this item and continue — alternative is to
                     # block the whole sub-agent forever on one poison
@@ -2889,6 +2899,11 @@ async def _forward_available_items(
                         "response_id": item.response_id,
                     },
                     reason="permanent HTTP failure after retries",
+                    # Claude only dead-letters permanent 4xx (it retries
+                    # transient failures forever), so the server proved it
+                    # rejected the item: never ambiguous, never replayable (#1579).
+                    delivered_ambiguous=False,
+                    http_status=_http_status_for_log(exc),
                 )
                 await _post_forwarder_failed_status(
                     client,

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -64,6 +64,15 @@ _EMPTY_ROLLOUT_FRAGMENT = "is empty"
 _POST_MAX_ATTEMPTS = 3
 _POST_RETRY_DELAY_SECONDS = 0.1
 _POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+# Startup dead-letter replay budget (#1579). Bounded so a large dead-letter file
+# or a slow/hung server cannot stall forwarder startup: each re-POST is a single
+# attempt (its natural retry is the next startup) with a short timeout (vs the
+# 30s live client default) so a hung server fails fast; at most
+# ``_REPLAY_MAX_RECORDS`` are sent and the whole drain is abandoned after
+# ``_REPLAY_DEADLINE_SECONDS``. Leftovers are deferred to a later startup.
+_REPLAY_MAX_RECORDS = 500
+_REPLAY_POST_TIMEOUT_SECONDS = 5.0
+_REPLAY_DEADLINE_SECONDS = 30.0
 _DELTA_FLUSH_INTERVAL_SECONDS = 0.05
 _DELTA_FLUSH_CHAR_THRESHOLD = 64
 _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE = "external_reasoning_effort_change"
@@ -5429,7 +5438,12 @@ async def _replay_dead_letters_on_startup(
         assert isinstance(event_type, str)
         assert isinstance(payload, dict)
         result = await _post_session_event_inner(
-            ap_client, session_id, event_type=event_type, data=payload
+            ap_client,
+            session_id,
+            event_type=event_type,
+            data=payload,
+            max_attempts=1,
+            timeout=_REPLAY_POST_TIMEOUT_SECONDS,
         )
         response = result.response
         if response is None:
@@ -5451,6 +5465,8 @@ async def _replay_dead_letters_on_startup(
             repost=_repost,
             retryable_status_codes=_POST_RETRY_STATUS_CODES,
             logger_name=__name__,
+            max_records=_REPLAY_MAX_RECORDS,
+            deadline_seconds=_REPLAY_DEADLINE_SECONDS,
         )
     except Exception:  # noqa: BLE001 - replay must never block forwarder startup.
         _logger.warning("Codex forwarder dead-letter replay failed", exc_info=True)
@@ -5540,6 +5556,8 @@ async def _post_session_event_inner(
     *,
     event_type: str,
     data: dict[str, Any],
+    max_attempts: int = _POST_MAX_ATTEMPTS,
+    timeout: float | None = None,
 ) -> _PostResult:
     """
     Post one Omnigent session event with bounded transient retries.
@@ -5550,6 +5568,12 @@ async def _post_session_event_inner(
         ``"external_conversation_item"``.
     :param data: Event data payload, e.g.
         ``{"status": "running"}``.
+    :param max_attempts: Maximum POST attempts before giving up, e.g. ``3``.
+        Startup dead-letter replay passes ``1`` — its natural retry cadence is
+        the next startup, so an in-call retry loop only adds latency (#1579).
+    :param timeout: Optional per-request timeout in seconds overriding the
+        client default, e.g. ``5.0``. Replay passes a short value so a hung
+        server fails fast instead of stalling startup on the 30s client default.
     :returns: A :class:`_PostResult` carrying the final response, or — when no
         response was seen — whether the POST was abandoned after an ambiguous
         transport failure (``external_conversation_item`` only; the item may
@@ -5558,9 +5582,12 @@ async def _post_session_event_inner(
     """
     url = f"/v1/sessions/{url_component(session_id)}/events"
     payload = {"type": event_type, "data": data}
-    for attempt in range(1, _POST_MAX_ATTEMPTS + 1):
+    for attempt in range(1, max_attempts + 1):
         try:
-            response = await client.post(url, json=payload)
+            if timeout is None:
+                response = await client.post(url, json=payload)
+            else:
+                response = await client.post(url, json=payload, timeout=timeout)
         except httpx.HTTPError as exc:
             # Conversation items persist with a random primary key and no
             # server-side dedup, so an ambiguous failure (request sent,
@@ -5581,55 +5608,58 @@ async def _post_session_event_inner(
                     delivered_ambiguous=True,
                     transport_error=type(exc).__name__,
                 )
-            if _is_final_post_attempt(attempt):
-                _log_post_transport_failure(event_type, exc)
+            if _is_final_post_attempt(attempt, max_attempts):
+                _log_post_transport_failure(event_type, exc, max_attempts)
                 return _PostResult(response=None, transport_error=type(exc).__name__)
             await _sleep(_post_retry_delay(attempt))
             continue
-        if _post_response_is_final(response, attempt):
+        if _post_response_is_final(response, attempt, max_attempts):
             return _PostResult(response=response)
         await _sleep(_post_retry_delay(attempt))
     return _PostResult(response=None)
 
 
-def _post_response_is_final(response: httpx.Response, attempt: int) -> bool:
+def _post_response_is_final(response: httpx.Response, attempt: int, max_attempts: int) -> bool:
     """
     Return whether a session-event POST response should stop retries.
 
     :param response: HTTP response from AP.
     :param attempt: One-based attempt number, e.g. ``1``.
+    :param max_attempts: Maximum POST attempts allowed, e.g. ``3``.
     :returns: ``True`` when the caller should return ``response``.
     """
     if response.status_code < 400:
         return True
     if not _should_retry_post_status(response.status_code):
         return True
-    return _is_final_post_attempt(attempt)
+    return _is_final_post_attempt(attempt, max_attempts)
 
 
-def _is_final_post_attempt(attempt: int) -> bool:
+def _is_final_post_attempt(attempt: int, max_attempts: int) -> bool:
     """
     Return whether an Omnigent event POST attempt is the final try.
 
     :param attempt: One-based attempt number, e.g. ``3``.
+    :param max_attempts: Maximum POST attempts allowed, e.g. ``3``.
     :returns: ``True`` when no further retry is allowed.
     """
-    return attempt >= _POST_MAX_ATTEMPTS
+    return attempt >= max_attempts
 
 
-def _log_post_transport_failure(event_type: str, exc: httpx.HTTPError) -> None:
+def _log_post_transport_failure(event_type: str, exc: httpx.HTTPError, max_attempts: int) -> None:
     """
     Log an exhausted Omnigent session-event transport failure.
 
     :param event_type: Session event type, e.g.
         ``"external_conversation_item"``.
     :param exc: Final transport error.
+    :param max_attempts: Number of attempts that were made, e.g. ``3``.
     :returns: None.
     """
     _logger.warning(
         "failed to post Codex session event after retries: type=%s attempts=%s error=%r",
         event_type,
-        _POST_MAX_ATTEMPTS,
+        max_attempts,
         exc,
     )
 

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -14,7 +14,12 @@ from typing import Any
 
 import httpx
 
-from omnigent._native_post_delivery import append_dead_letter, post_may_have_been_delivered
+from omnigent._native_post_delivery import (
+    RepostResult,
+    append_dead_letter,
+    post_may_have_been_delivered,
+    replay_dead_letters,
+)
 from omnigent.claude_native_bridge import url_component
 from omnigent.codex_native_app_server import (
     CodexAppServerClient,
@@ -1542,6 +1547,11 @@ async def supervise_forwarder(
         timeout=httpx.Timeout(30.0),
         transport=ap_transport,
     ) as ap_client:
+        # Recover proven-undelivered dead-lettered forwards now that the
+        # server may be reachable again (host/server returned after an
+        # outage or restart). Runs before live forwarding begins, so no
+        # other writer races the dead-letter files (#1579).
+        await _replay_dead_letters_on_startup(ap_client, bridge_dir)
         target = _ForwarderTarget(
             session_id=session_id,
             thread_id=thread_id,
@@ -5392,6 +5402,85 @@ def _note_forward_failure(event_type: str) -> None:
         _forward_health.degraded_logged = True
 
 
+async def _replay_dead_letters_on_startup(
+    ap_client: httpx.AsyncClient,
+    bridge_dir: Path,
+) -> None:
+    """
+    Re-POST proven-undelivered dead-lettered forwards on forwarder startup (#1579).
+
+    Best-effort recovery for the realistic case — the host/server returned after
+    an outage or a restart. Delegates to the shared
+    :func:`replay_dead_letters` drain, supplying a re-POST that routes each
+    record to its recorded session via :func:`_post_session_event_inner` (the
+    inner so a re-failure does not double dead-letter through the wrapper).
+    Never raises: a replay failure must not block live forwarding.
+
+    :param ap_client: HTTP client for Omnigent event posts.
+    :param bridge_dir: Native Codex bridge directory holding the dead-letter files.
+    :returns: None.
+    """
+
+    async def _repost(record: dict[str, object]) -> RepostResult:
+        session_id = record["session_id"]
+        event_type = record["event_type"]
+        payload = record["payload"]
+        assert isinstance(session_id, str)
+        assert isinstance(event_type, str)
+        assert isinstance(payload, dict)
+        result = await _post_session_event_inner(
+            ap_client, session_id, event_type=event_type, data=payload
+        )
+        response = result.response
+        if response is None:
+            return RepostResult(
+                delivered=False,
+                delivered_ambiguous=result.delivered_ambiguous,
+                http_status=None,
+            )
+        delivered = response.status_code < 400
+        return RepostResult(
+            delivered=delivered,
+            delivered_ambiguous=False,
+            http_status=None if delivered else response.status_code,
+        )
+
+    try:
+        await replay_dead_letters(
+            bridge_dir,
+            repost=_repost,
+            retryable_status_codes=_POST_RETRY_STATUS_CODES,
+            logger_name=__name__,
+        )
+    except Exception:  # noqa: BLE001 - replay must never block forwarder startup.
+        _logger.warning("Codex forwarder dead-letter replay failed", exc_info=True)
+
+
+@dataclass(frozen=True)
+class _PostResult:
+    """
+    Classified outcome of one :func:`_post_session_event_inner` call (#1579).
+
+    Surfaces *why* a POST failed so the caller can dead-letter with the
+    structured classification replay needs — distinguishing the two ``None``
+    cases the inner used to conflate: an ambiguous-skip (the item may already
+    be committed) from a proven-undelivered transport failure after retries.
+
+    :param response: Final HTTP response, or ``None`` when no response was
+        seen (a transport failure, or an ambiguous conversation-item skip).
+    :param delivered_ambiguous: ``True`` when the POST was abandoned after an
+        ambiguous transport failure (request sent, response lost), so the item
+        may already be committed server-side — never safe to replay.
+    :param transport_error: Transport-error class name when a POST raised
+        without a response, e.g. ``"ConnectError"``; ``None`` when the server
+        responded.
+    """
+
+    response: httpx.Response | None
+    delivered_ambiguous: bool = False
+    transport_error: str | None = None
+
+
 async def _post_session_event(
     client: httpx.AsyncClient,
     session_id: str,
@@ -5406,31 +5495,41 @@ async def _post_session_event(
     outcome — a sub-400 response is a success; ``None`` or a >=400 final
     response is a permanent failure — and updates :data:`_forward_health`
     so a sustained outage escalates to a single ERROR instead of silently
-    dropping events.
+    dropping events. On a durable-event failure it dead-letters the dropped
+    payload with the structured classification replay needs (#1579).
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param event_type: Session event type, e.g.
         ``"external_conversation_item"``.
     :param data: Event data payload, e.g. ``{"status": "running"}``.
-    :returns: The same value as :func:`_post_session_event_inner`.
+    :returns: The final HTTP response, or ``None`` (see
+        :func:`_post_session_event_inner`).
     """
-    response = await _post_session_event_inner(
-        client, session_id, event_type=event_type, data=data
-    )
+    result = await _post_session_event_inner(client, session_id, event_type=event_type, data=data)
+    response = result.response
     if response is not None and response.status_code < 400:
         _note_forward_success()
     else:
         _note_forward_failure(event_type)
         dl_dir = _dead_letter_dir.get()
         if event_type in _DEAD_LETTER_EVENT_TYPES and dl_dir is not None:
-            reason = f"http {response.status_code}" if response is not None else "post failed"
+            http_status = response.status_code if response is not None else None
+            if response is not None:
+                reason = f"http {response.status_code}"
+            elif result.delivered_ambiguous:
+                reason = "ambiguous transport failure (may already be committed)"
+            else:
+                reason = "proven-undelivered transport failure after retries"
             append_dead_letter(
                 dl_dir,
                 session_id=session_id,
                 event_type=event_type,
                 payload=data,
                 reason=reason,
+                delivered_ambiguous=result.delivered_ambiguous,
+                http_status=http_status,
+                transport_error=result.transport_error,
             )
     return response
 
@@ -5441,7 +5540,7 @@ async def _post_session_event_inner(
     *,
     event_type: str,
     data: dict[str, Any],
-) -> httpx.Response | None:
+) -> _PostResult:
     """
     Post one Omnigent session event with bounded transient retries.
 
@@ -5451,10 +5550,11 @@ async def _post_session_event_inner(
         ``"external_conversation_item"``.
     :param data: Event data payload, e.g.
         ``{"status": "running"}``.
-    :returns: Final HTTP response, or ``None`` when all attempts raised
-        transport errors — or, for ``external_conversation_item``, after
-        a single ambiguous transport failure (the item may already be
-        committed server-side, so retrying risks a duplicate).
+    :returns: A :class:`_PostResult` carrying the final response, or — when no
+        response was seen — whether the POST was abandoned after an ambiguous
+        transport failure (``external_conversation_item`` only; the item may
+        already be committed, so retrying risks a duplicate) versus a
+        proven-undelivered transport failure after all retries.
     """
     url = f"/v1/sessions/{url_component(session_id)}/events"
     payload = {"type": event_type, "data": data}
@@ -5476,16 +5576,20 @@ async def _post_session_event_inner(
                     event_type,
                     exc,
                 )
-                return None
+                return _PostResult(
+                    response=None,
+                    delivered_ambiguous=True,
+                    transport_error=type(exc).__name__,
+                )
             if _is_final_post_attempt(attempt):
                 _log_post_transport_failure(event_type, exc)
-                return None
+                return _PostResult(response=None, transport_error=type(exc).__name__)
             await _sleep(_post_retry_delay(attempt))
             continue
         if _post_response_is_final(response, attempt):
-            return response
+            return _PostResult(response=response)
         await _sleep(_post_retry_delay(attempt))
-    return None
+    return _PostResult(response=None)
 
 
 def _post_response_is_final(response: httpx.Response, attempt: int) -> bool:

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1695,10 +1695,18 @@ async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
         transport_error="ConnectError",
     )
 
-    posted: list[tuple[str, str, dict]] = []
+    posted: list[dict] = []
 
-    async def _ok_inner(client, session_id, *, event_type, data):
-        posted.append((session_id, event_type, data))
+    async def _ok_inner(client, session_id, *, event_type, data, max_attempts, timeout):
+        posted.append(
+            {
+                "session_id": session_id,
+                "event_type": event_type,
+                "data": data,
+                "max_attempts": max_attempts,
+                "timeout": timeout,
+            }
+        )
         return fwd._PostResult(
             response=httpx.Response(200, request=httpx.Request("POST", "http://test"))
         )
@@ -1706,7 +1714,14 @@ async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
     monkeypatch.setattr(fwd, "_post_session_event_inner", _ok_inner)
     await fwd._replay_dead_letters_on_startup(MagicMock(), tmp_path)
 
-    assert posted == [("conv_codex1", "external_conversation_item", {"item_type": "message"})]
+    assert len(posted) == 1
+    assert posted[0]["session_id"] == "conv_codex1"
+    assert posted[0]["event_type"] == "external_conversation_item"
+    assert posted[0]["data"] == {"item_type": "message"}
+    # Replay re-POSTs with a single attempt and a short timeout so a large file
+    # or a hung server cannot stall startup.
+    assert posted[0]["max_attempts"] == 1
+    assert posted[0]["timeout"] == fwd._REPLAY_POST_TIMEOUT_SECONDS
     # Delivered → record removed.
     assert not (tmp_path / "dead_letter.jsonl").exists()
 
@@ -1732,7 +1747,7 @@ async def test_replay_dead_letters_on_startup_skips_ambiguous(
 
     called = False
 
-    async def _inner(client, session_id, *, event_type, data):
+    async def _inner(client, session_id, *, event_type, data, **_kwargs):
         nonlocal called
         called = True
         return fwd._PostResult(
@@ -1745,3 +1760,40 @@ async def test_replay_dead_letters_on_startup_skips_ambiguous(
     assert called is False
     # Ambiguous record retained as a forensic record.
     assert (tmp_path / "dead_letter.jsonl").exists()
+
+
+class _RecordingPostClient:
+    """Async client stub that records each ``post`` call's kwargs."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    async def post(self, url: str, **kwargs: object) -> httpx.Response:
+        self.calls.append(kwargs)
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_inner_single_attempt_and_timeout() -> None:
+    """
+    ``max_attempts=1`` makes one POST (no retry) and ``timeout`` is threaded through.
+
+    Replay relies on both so a hung server fails fast and startup is bounded (#1579).
+    """
+    client = _RecordingPostClient(
+        httpx.Response(503, request=httpx.Request("POST", "http://test"))
+    )
+    result = await fwd._post_session_event_inner(
+        client,
+        "conv_codex1",
+        event_type="external_conversation_item",
+        data={"item_type": "message"},
+        max_attempts=1,
+        timeout=5.0,
+    )
+    # A single attempt even though 503 is normally retryable.
+    assert len(client.calls) == 1
+    assert client.calls[0]["timeout"] == 5.0
+    assert result.response is not None
+    assert result.response.status_code == 503

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1433,7 +1433,9 @@ async def test_post_session_event_dead_letters_durable_event_on_permanent_failur
     fwd._reset_forward_health()
 
     async def _failing_inner(client, session_id, *, event_type, data):
-        return httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        return fwd._PostResult(
+            response=httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        )
 
     monkeypatch.setattr(fwd, "_post_session_event_inner", _failing_inner)
     token = fwd._dead_letter_dir.set(tmp_path)
@@ -1471,7 +1473,9 @@ async def test_post_session_event_does_not_dead_letter_ephemeral_event(
     fwd._reset_forward_health()
 
     async def _failing_inner(client, session_id, *, event_type, data):
-        return httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        return fwd._PostResult(
+            response=httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        )
 
     monkeypatch.setattr(fwd, "_post_session_event_inner", _failing_inner)
     token = fwd._dead_letter_dir.set(tmp_path)
@@ -1507,7 +1511,9 @@ async def test_post_session_event_dead_letters_usage_on_permanent_failure(
     fwd._reset_forward_health()
 
     async def _failing_inner(client, session_id, *, event_type, data):
-        return httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        return fwd._PostResult(
+            response=httpx.Response(500, request=httpx.Request("POST", "http://test"))
+        )
 
     monkeypatch.setattr(fwd, "_post_session_event_inner", _failing_inner)
     token = fwd._dead_letter_dir.set(tmp_path)
@@ -1530,3 +1536,212 @@ async def test_post_session_event_dead_letters_usage_on_permanent_failure(
     assert record["session_id"] == "conv_codex_usage"
     assert record["event_type"] == "external_session_usage"
     assert record["payload"] == data
+
+
+class _RaisingPostClient:
+    """Async client stub whose ``post`` always raises a fixed transport error."""
+
+    def __init__(self, exc: httpx.HTTPError) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    async def post(self, url: str, json: object) -> httpx.Response:
+        self.calls += 1
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_inner_classifies_ambiguous_skip() -> None:
+    """
+    An ambiguous conversation-item transport failure surfaces as ambiguous (#1579).
+
+    The inner used to conflate this with a proven-undelivered failure (both
+    returned ``None``); replay must be able to tell them apart.
+    """
+    client = _RaisingPostClient(
+        httpx.ReadTimeout("response lost", request=httpx.Request("POST", "http://test"))
+    )
+    result = await fwd._post_session_event_inner(
+        client,
+        "conv_codex1",
+        event_type="external_conversation_item",
+        data={"item_type": "message"},
+    )
+    assert result.response is None
+    assert result.delivered_ambiguous is True
+    assert result.transport_error == "ReadTimeout"
+    # Ambiguous items are abandoned immediately — no retries.
+    assert client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_inner_classifies_proven_undelivered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A connect failure exhausted after retries is proven-undelivered, not ambiguous.
+    """
+    monkeypatch.setattr(fwd, "_sleep", AsyncMock())
+    client = _RaisingPostClient(
+        httpx.ConnectError("refused", request=httpx.Request("POST", "http://test"))
+    )
+    result = await fwd._post_session_event_inner(
+        client,
+        "conv_codex1",
+        event_type="external_conversation_item",
+        data={"item_type": "message"},
+    )
+    assert result.response is None
+    assert result.delivered_ambiguous is False
+    assert result.transport_error == "ConnectError"
+    # Connect failures are safe to retry, so all attempts are spent.
+    assert client.calls == fwd._POST_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_dead_letters_ambiguous_classification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    An ambiguous-skip drop is dead-lettered with ``delivered_ambiguous=True`` (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
+    """
+    import json as _json
+
+    fwd._reset_forward_health()
+
+    async def _ambiguous_inner(client, session_id, *, event_type, data):
+        return fwd._PostResult(
+            response=None, delivered_ambiguous=True, transport_error="ReadTimeout"
+        )
+
+    monkeypatch.setattr(fwd, "_post_session_event_inner", _ambiguous_inner)
+    token = fwd._dead_letter_dir.set(tmp_path)
+    try:
+        await fwd._post_session_event(
+            MagicMock(),
+            "conv_codex1",
+            event_type="external_conversation_item",
+            data={"item_type": "message"},
+        )
+    finally:
+        fwd._dead_letter_dir.reset(token)
+        fwd._reset_forward_health()
+
+    record = _json.loads((tmp_path / "dead_letter.jsonl").read_text().splitlines()[0])
+    assert record["delivered_ambiguous"] is True
+    assert record["http_status"] is None
+    assert record["transport_error"] == "ReadTimeout"
+
+
+@pytest.mark.asyncio
+async def test_post_session_event_dead_letters_records_http_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A status-bearing failure records ``http_status`` and is not ambiguous (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
+    """
+    import json as _json
+
+    fwd._reset_forward_health()
+
+    async def _failing_inner(client, session_id, *, event_type, data):
+        return fwd._PostResult(
+            response=httpx.Response(503, request=httpx.Request("POST", "http://test"))
+        )
+
+    monkeypatch.setattr(fwd, "_post_session_event_inner", _failing_inner)
+    token = fwd._dead_letter_dir.set(tmp_path)
+    try:
+        await fwd._post_session_event(
+            MagicMock(),
+            "conv_codex1",
+            event_type="external_conversation_item",
+            data={"item_type": "message"},
+        )
+    finally:
+        fwd._dead_letter_dir.reset(token)
+        fwd._reset_forward_health()
+
+    record = _json.loads((tmp_path / "dead_letter.jsonl").read_text().splitlines()[0])
+    assert record["http_status"] == 503
+    assert record["delivered_ambiguous"] is False
+    assert record["transport_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    On startup, a proven-undelivered record is re-POSTed and removed (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
+    """
+    fwd.append_dead_letter(
+        tmp_path,
+        session_id="conv_codex1",
+        event_type="external_conversation_item",
+        payload={"item_type": "message"},
+        reason="proven-undelivered transport failure after retries",
+        delivered_ambiguous=False,
+        http_status=None,
+        transport_error="ConnectError",
+    )
+
+    posted: list[tuple[str, str, dict]] = []
+
+    async def _ok_inner(client, session_id, *, event_type, data):
+        posted.append((session_id, event_type, data))
+        return fwd._PostResult(
+            response=httpx.Response(200, request=httpx.Request("POST", "http://test"))
+        )
+
+    monkeypatch.setattr(fwd, "_post_session_event_inner", _ok_inner)
+    await fwd._replay_dead_letters_on_startup(MagicMock(), tmp_path)
+
+    assert posted == [("conv_codex1", "external_conversation_item", {"item_type": "message"})]
+    # Delivered → record removed.
+    assert not (tmp_path / "dead_letter.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_replay_dead_letters_on_startup_skips_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    On startup, an ambiguous record is never re-POSTed and is retained (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for the bridge dir.
+    :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
+    """
+    fwd.append_dead_letter(
+        tmp_path,
+        session_id="conv_codex1",
+        event_type="external_conversation_item",
+        payload={"item_type": "message"},
+        reason="ambiguous transport failure (may already be committed)",
+        delivered_ambiguous=True,
+    )
+
+    called = False
+
+    async def _inner(client, session_id, *, event_type, data):
+        nonlocal called
+        called = True
+        return fwd._PostResult(
+            response=httpx.Response(200, request=httpx.Request("POST", "http://test"))
+        )
+
+    monkeypatch.setattr(fwd, "_post_session_event_inner", _inner)
+    await fwd._replay_dead_letters_on_startup(MagicMock(), tmp_path)
+
+    assert called is False
+    # Ambiguous record retained as a forensic record.
+    assert (tmp_path / "dead_letter.jsonl").exists()

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -453,6 +453,68 @@ async def test_replay_with_no_dead_letter_files_is_a_noop(tmp_path: Path) -> Non
     assert called is False
 
 
+async def test_replay_respects_max_records(tmp_path: Path) -> None:
+    """
+    At most ``max_records`` records are re-POSTed; the rest are deferred (#1579).
+
+    Bounds startup latency even against a healthy server with a huge file. The
+    deferred records are retained unchanged for a later startup, not dropped.
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    current = tmp_path / _DEAD_LETTER_FILE
+    _write_records(current, [_dead_letter_record(payload={"n": i}) for i in range(3)])
+
+    seen: list[int] = []
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        seen.append(record["payload"]["n"])  # type: ignore[index]
+        return RepostResult(delivered=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE, max_records=2
+    )
+
+    assert replayed == 2
+    # Only the first two were attempted, in order.
+    assert seen == [0, 1]
+    # The third was deferred and kept for next startup.
+    retained = _read_records(current)
+    assert [record["payload"]["n"] for record in retained] == [2]
+
+
+async def test_replay_respects_deadline(tmp_path: Path) -> None:
+    """
+    Once the deadline is exceeded, replay defers everything (no re-POST) (#1579).
+
+    A zero budget defers before the first attempt, leaving the file untouched.
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    current = tmp_path / _DEAD_LETTER_FILE
+    _write_records(
+        current,
+        [_dead_letter_record(payload={"n": 0}), _dead_letter_record(payload={"n": 1})],
+    )
+    before = current.read_bytes()
+
+    called = False
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        nonlocal called
+        called = True
+        return RepostResult(delivered=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE, deadline_seconds=0.0
+    )
+
+    assert replayed == 0
+    assert called is False
+    # Nothing changed, so the file is left byte-identical for the next startup.
+    assert current.read_bytes() == before
+
+
 async def test_replay_preserves_malformed_lines(tmp_path: Path) -> None:
     """
     A malformed (unparseable) line is retained verbatim across a replay rewrite.

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -12,9 +12,52 @@ from omnigent._native_post_delivery import (
     _DEAD_LETTER_BACKUP_FILE,
     _DEAD_LETTER_FILE,
     _DEAD_LETTER_MAX_BYTES,
+    RepostResult,
+    _dead_letter_record_replayable,
     append_dead_letter,
     post_may_have_been_delivered,
+    replay_dead_letters,
 )
+
+# Status codes a forwarder treats as transient/retryable, used by the replay
+# classifier to tell a recoverable exhausted-503 from a permanent 4xx.
+_RETRYABLE = frozenset({429, 500, 503})
+
+
+def _dead_letter_record(
+    *,
+    session_id: str = "conv_abc123",
+    event_type: str = "external_conversation_item",
+    payload: dict[str, object] | None = None,
+    reason: str = "proven-undelivered transport failure after retries",
+    delivered_ambiguous: bool = False,
+    http_status: int | None = None,
+    transport_error: str | None = None,
+) -> dict[str, object]:
+    """Build a classified dead-letter record for replay fixtures."""
+    return {
+        "ts": 1.0,
+        "session_id": session_id,
+        "event_type": event_type,
+        "reason": reason,
+        "delivered_ambiguous": delivered_ambiguous,
+        "http_status": http_status,
+        "transport_error": transport_error,
+        "payload": payload if payload is not None else {"item_type": "message"},
+    }
+
+
+def _write_records(path: Path, records: list[dict[str, object]]) -> None:
+    """Write records as one JSON line each, mirroring the dead-letter format."""
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _read_records(path: Path) -> list[dict[str, object]]:
+    """Parse a dead-letter file back into records."""
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
 
 
 @pytest.mark.parametrize(
@@ -143,3 +186,293 @@ def test_append_dead_letter_never_raises_on_unwritable_dir() -> None:
         payload={"item_type": "message"},
         reason="post failed",
     )
+
+
+def test_append_dead_letter_writes_classification_fields(tmp_path: Path) -> None:
+    """
+    The structured classification replay reads is persisted on each record (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    append_dead_letter(
+        tmp_path,
+        session_id="conv_abc123",
+        event_type="external_conversation_item",
+        payload={"item_type": "message"},
+        reason="ambiguous transport failure (may already be committed)",
+        delivered_ambiguous=True,
+        http_status=None,
+        transport_error="ReadTimeout",
+    )
+
+    record = _read_records(tmp_path / _DEAD_LETTER_FILE)[0]
+    assert record["delivered_ambiguous"] is True
+    assert record["http_status"] is None
+    assert record["transport_error"] == "ReadTimeout"
+
+
+def test_append_dead_letter_classification_defaults(tmp_path: Path) -> None:
+    """A record written without classification args defaults to non-ambiguous."""
+    append_dead_letter(
+        tmp_path,
+        session_id="conv_abc123",
+        event_type="external_session_usage",
+        payload={"context_tokens": 1},
+        reason="post failed",
+    )
+
+    record = _read_records(tmp_path / _DEAD_LETTER_FILE)[0]
+    assert record["delivered_ambiguous"] is False
+    assert record["http_status"] is None
+    assert record["transport_error"] is None
+
+
+@pytest.mark.parametrize(
+    "record,replayable",
+    [
+        # Proven-undelivered transport failure (no response, not ambiguous).
+        (_dead_letter_record(), True),
+        # Retryable status exhausted after the forwarder's bounded retries.
+        (_dead_letter_record(http_status=503), True),
+        # Ambiguous: the server may have committed it — never replay.
+        (_dead_letter_record(delivered_ambiguous=True), False),
+        # Permanent 4xx: the server rejected it; a replay just re-rejects.
+        (_dead_letter_record(http_status=400), False),
+        # Non-retryable 5xx that is not in the retry set is also not recoverable.
+        (_dead_letter_record(http_status=501), False),
+        # Missing routing fields — cannot be re-POSTed.
+        (_dead_letter_record(session_id=""), False),
+        # A non-dict (malformed line) is never replayable.
+        ("not-a-record", False),
+        # Legacy record written before classification existed (#1579): no
+        # ``delivered_ambiguous`` field, so treated as unsafe (forensic only).
+        (
+            {
+                "ts": 1.0,
+                "session_id": "conv_abc123",
+                "event_type": "external_conversation_item",
+                "reason": "post failed",
+                "payload": {"item_type": "message"},
+            },
+            False,
+        ),
+    ],
+)
+def test_dead_letter_record_replayable_classification(record: object, replayable: bool) -> None:
+    """
+    Only proven-undelivered records are replayable; everything else is forensic.
+
+    A wrong classification either duplicates a committed item (ambiguous or
+    permanent record wrongly replayed) or re-rejects forever.
+
+    :param record: A parsed dead-letter record (or non-dict) to classify.
+    :param replayable: Whether the record is safe to re-POST.
+    """
+    assert _dead_letter_record_replayable(record, retryable_status_codes=_RETRYABLE) is replayable
+
+
+async def test_replay_drains_backup_then_current_in_order(tmp_path: Path) -> None:
+    """
+    Replay re-POSTs the ``.1`` backup first, then the current file, in order (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    backup = tmp_path / _DEAD_LETTER_BACKUP_FILE
+    current = tmp_path / _DEAD_LETTER_FILE
+    _write_records(
+        backup, [_dead_letter_record(payload={"n": 0}), _dead_letter_record(payload={"n": 1})]
+    )
+    _write_records(
+        current, [_dead_letter_record(payload={"n": 2}), _dead_letter_record(payload={"n": 3})]
+    )
+
+    seen: list[int] = []
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        seen.append(record["payload"]["n"])  # type: ignore[index]
+        return RepostResult(delivered=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE
+    )
+
+    assert replayed == 4
+    # .1 backup (0, 1) precedes the current file (2, 3), each in append order.
+    assert seen == [0, 1, 2, 3]
+    # All delivered, so both files are removed.
+    assert not backup.exists()
+    assert not current.exists()
+
+
+async def test_replay_skips_ambiguous_and_permanent_4xx(tmp_path: Path) -> None:
+    """
+    Ambiguous and permanent-4xx records are never re-POSTed; they stay forensic.
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    current = tmp_path / _DEAD_LETTER_FILE
+    _write_records(
+        current,
+        [
+            _dead_letter_record(payload={"n": 0}, delivered_ambiguous=True),
+            _dead_letter_record(payload={"n": 1}, http_status=400),
+            _dead_letter_record(payload={"n": 2}),
+            _dead_letter_record(payload={"n": 3}, http_status=503),
+        ],
+    )
+
+    seen: list[int] = []
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        seen.append(record["payload"]["n"])  # type: ignore[index]
+        return RepostResult(delivered=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE
+    )
+
+    assert replayed == 2
+    # Only the proven-undelivered transport (2) and exhausted-503 (3) replayed.
+    assert seen == [2, 3]
+    # Ambiguous (0) and permanent-4xx (1) retained, untouched, in order.
+    retained = _read_records(current)
+    assert [record["payload"]["n"] for record in retained] == [0, 1]
+
+
+async def test_replay_success_removes_and_failure_retains(tmp_path: Path) -> None:
+    """
+    A delivered record is removed; one that still fails is retained (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    current = tmp_path / _DEAD_LETTER_FILE
+    _write_records(
+        current,
+        [_dead_letter_record(payload={"n": 0}), _dead_letter_record(payload={"n": 1})],
+    )
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        if record["payload"]["n"] == 0:  # type: ignore[index]
+            return RepostResult(delivered=True)
+        # Still proven-undelivered (transport failed again).
+        return RepostResult(delivered=False, http_status=None)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE
+    )
+
+    assert replayed == 1
+    retained = _read_records(current)
+    assert [record["payload"]["n"] for record in retained] == [1]
+    # The retained record stays proven-undelivered (replayable on a later run).
+    assert retained[0]["delivered_ambiguous"] is False
+    assert retained[0]["http_status"] is None
+
+
+async def test_replay_reclassifies_record_that_now_fails_ambiguously(tmp_path: Path) -> None:
+    """
+    A replay attempt that fails *ambiguously* reclassifies the record so it is
+    never auto-replayed again — guarding against a duplicate (#1579).
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    current = tmp_path / _DEAD_LETTER_FILE
+    _write_records(current, [_dead_letter_record(payload={"n": 0})])
+
+    async def repost_ambiguous(record: dict[str, object]) -> RepostResult:
+        return RepostResult(delivered=False, delivered_ambiguous=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost_ambiguous, retryable_status_codes=_RETRYABLE
+    )
+    assert replayed == 0
+    retained = _read_records(current)
+    assert len(retained) == 1
+    assert retained[0]["delivered_ambiguous"] is True
+
+    # A second startup must NOT re-POST the now-ambiguous record.
+    calls: list[object] = []
+
+    async def repost_record(record: dict[str, object]) -> RepostResult:
+        calls.append(record)
+        return RepostResult(delivered=True)
+
+    replayed_again = await replay_dead_letters(
+        tmp_path, repost=repost_record, retryable_status_codes=_RETRYABLE
+    )
+    assert replayed_again == 0
+    assert calls == []
+
+
+async def test_replay_no_replayable_records_leaves_files_untouched(tmp_path: Path) -> None:
+    """
+    With nothing recoverable, replay never calls ``repost`` or rewrites the file.
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    current = tmp_path / _DEAD_LETTER_FILE
+    _write_records(
+        current,
+        [
+            _dead_letter_record(payload={"n": 0}, delivered_ambiguous=True),
+            _dead_letter_record(payload={"n": 1}, http_status=404),
+        ],
+    )
+    before = current.read_bytes()
+
+    called = False
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        nonlocal called
+        called = True
+        return RepostResult(delivered=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE
+    )
+
+    assert replayed == 0
+    assert called is False
+    # File is byte-identical: forensic records are left exactly as written.
+    assert current.read_bytes() == before
+
+
+async def test_replay_with_no_dead_letter_files_is_a_noop(tmp_path: Path) -> None:
+    """Replay on a bridge dir with no dead-letter file does nothing."""
+    called = False
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        nonlocal called
+        called = True
+        return RepostResult(delivered=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE
+    )
+    assert replayed == 0
+    assert called is False
+
+
+async def test_replay_preserves_malformed_lines(tmp_path: Path) -> None:
+    """
+    A malformed (unparseable) line is retained verbatim across a replay rewrite.
+
+    :param tmp_path: Pytest temp dir standing in for a bridge dir.
+    """
+    current = tmp_path / _DEAD_LETTER_FILE
+    current.write_text(
+        "not-json garbage line\n" + json.dumps(_dead_letter_record(payload={"n": 0})) + "\n",
+        encoding="utf-8",
+    )
+
+    async def repost(record: dict[str, object]) -> RepostResult:
+        return RepostResult(delivered=True)
+
+    replayed = await replay_dead_letters(
+        tmp_path, repost=repost, retryable_status_codes=_RETRYABLE
+    )
+
+    assert replayed == 1
+    # The parseable record was delivered and removed; the garbage line survives.
+    remaining = current.read_text(encoding="utf-8").splitlines()
+    assert remaining == ["not-json garbage line"]


### PR DESCRIPTION
## What

Follow-up to #1588 (native-forwarder dead-lettering). Adds conservative, startup-triggered replay of recoverable dead-lettered transcript/usage POSTs for the **codex** native forwarder, plus the record classification it depends on and a bounded replay budget so the drain can never stall startup.

Replay is a codex concern: codex dead-letters a mix of failure classes (bounded retries, then drop), so replaying the transient ones genuinely recovers messages. Claude retries transient failures forever and only dead-letters permanent 4xx, so its dead-letter is forensic-only (nothing to replay) - it just gains the new classification fields.

## Phase 1 - enrich the dead-letter record (prerequisite)

- `append_dead_letter` now persists structured classification alongside the human-readable `reason`: `delivered_ambiguous` (bool), `http_status` (int|null), `transport_error` (str|null).
- codex's `_post_session_event_inner` previously returned `httpx.Response | None` and conflated two `None` cases - an ambiguous-skip (the item may already be committed) versus a proven-undelivered transport failure after retries. It now returns a small `_PostResult` that surfaces which, and `_post_session_event` passes the correct classification into the dead-letter.
- claude's three drop sites set `http_status` from `_http_status_for_log` and `delivered_ambiguous=False`.

## Phase 2 - conservative replay (codex, startup-triggered)

- `supervise_forwarder` drains `dead_letter.jsonl` on startup (`.1` backup first, then current, preserving append order) via a shared `replay_dead_letters` helper in `_native_post_delivery.py`.
- Only **proven-undelivered** records are re-POSTed: transport failures with no response, and retryable statuses (e.g. 503) exhausted after the forwarder's bounded retries. **Ambiguous** and **permanent-4xx** records are never replayed (no duplicate, no re-reject) and are left in place as a forensic record.
- A delivered record is removed; a still-failing one is retained, with its classification refreshed from the latest attempt - so a record that now fails ambiguously (or is permanently rejected) is never auto-replayed again. Files are rewritten atomically (temp + `os.replace`); malformed lines are preserved verbatim.
- Records written before classification existed (pre-#1579) lack `delivered_ambiguous` and are treated as unsafe (forensic only), so a pre-classification ambiguous drop is never replayed into a duplicate.
- Replay runs before live forwarding begins (no concurrent writer) and never raises (it must not block startup).

## Bounded so replay cannot stall startup

Replay is awaited before live forwarding, so an unbounded drain against a slow or hung server would delay startup. It is bounded on three axes:

- **Single attempt per record.** `_post_session_event_inner` takes `max_attempts` (default 3, unchanged for the live path); replay passes `max_attempts=1`. Its natural retry cadence is the next startup, so an in-call retry loop is pure latency.
- **Short per-POST timeout.** The same function takes an optional per-request `timeout`; replay passes 5s instead of inheriting the 30s live client default, so a hung server fails fast.
- **Record cap and wall-clock deadline.** `replay_dead_letters` takes `max_records` and `deadline_seconds`; codex caps replay at 500 records and a 30s budget. Records left over by either bound are retained unchanged (deferred to a later startup) and logged, never silently dropped.

Net worst case goes from `N x 90s` (3 attempts x 30s timeout, unbounded by record count) to a flat ~30s. The whole-file read remains bounded by the existing 50MB dead-letter rotation cap.

## Out of scope

Server-side idempotency for `external_conversation_item` - which would make ambiguous items safely replayable, and would close the narrow crash-mid-rewrite duplicate window - is tracked separately in #1594. No server or DB changes here.

## Tests

`tests/test_native_post_delivery.py`: classification field persistence; `_dead_letter_record_replayable` decision table (proven-undelivered, exhausted-503, ambiguous, permanent-4xx, missing fields, legacy records); replay drains `.1` then current in order; ambiguous + 4xx skipped; success removes / failure retains; reclassify-on-ambiguous-refailure; no-op cases; malformed-line preservation; `max_records` cap and `deadline_seconds` budget defer-and-retain.

`tests/test_codex_native_forwarder.py`: `_post_session_event_inner` ambiguous vs proven-undelivered classification and single-attempt + timeout threading; wrapper dead-letters with the right classification; startup replay re-POSTs proven-undelivered (with the bounded single-attempt + short-timeout budget) and skips ambiguous.

Closes #1579

This pull request and its description were written by Isaac.