### PR TITLE
fix(antigravity-native): pretrust TUI workspace

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -270,6 +270,20 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
 # (2) gives each session its own config so concurrent sessions never clobber one
 # another. Known file-based OAuth markers are copied best-effort for platforms
 # whose agy auth provider uses them, but HOME is deliberately not relocated.
+#
+# WHY NOT RELOCATE HOME (#1477). An earlier isolation design pointed ``HOME`` at
+# the per-session tree. That broke auth on macOS: agy stores its OAuth token in
+# the OS keyring (verified against agy 1.0.12 — the binary's auth path is
+# ``keyring`` / "load token from keyring", NOT a ``~/.gemini`` file), and the
+# keyring item is bound to the real login HOME, so any relocated HOME stalled
+# every turn at the interactive OAuth prompt. The alternative of dropping HOME
+# isolation entirely on macOS (#1493) restored auth but reintroduced the
+# HOME-global ``mcp_config.json`` footgun (#1194) there — concurrent sessions
+# would clobber one another's relay config. ``--gemini_dir`` resolves both at
+# once: real HOME ⇒ keyring auth works on every platform; isolated gemini dir ⇒
+# per-session MCP config. Verified live (agy 1.0.12): ``agy --gemini_dir=<dir>``
+# materializes its ``antigravity-cli`` + ``config`` state under ``<dir>`` while
+# authenticating from the real-HOME keyring.
 _MCP_CONFIG_DIR = "config"
 _MCP_CONFIG_FILE = "mcp_config.json"
 _BRIDGE_CONFIG_FILE = "bridge.json"

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -1089,11 +1089,7 @@ def _agy_input_region(pane: str) -> str:
     currently editable input box, mirroring Kiro's input-region guard.
     """
     lines = pane.splitlines()
-    separator_indexes = [
-        index
-        for index, line in enumerate(lines)
-        if _agy_separator_line(line)
-    ]
+    separator_indexes = [index for index, line in enumerate(lines) if _agy_separator_line(line)]
     if len(separator_indexes) >= 2:
         start = separator_indexes[-2] + 1
         end = separator_indexes[-1]
@@ -1336,9 +1332,7 @@ def inject_user_message_via_tui(
         while time.monotonic() < commit_deadline:
             pane = _capture_pane(socket_path, tmux_target)
             last_commit_pane = pane or last_commit_pane
-            if _draft_in_input_region(
-                pane, needle, baseline_region
-            ):
+            if _draft_in_input_region(pane, needle, baseline_region):
                 draft_seen = True
                 break
             time.sleep(_TMUX_POLL_INTERVAL_S)

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -261,17 +261,15 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
 # two antigravity-native sessions (or a session + the user's interactive agy)
 # would fight over the one global file.
 #
-# CHOSEN DESIGN — per-session ISOLATED HOME. The runner launches agy with
-# ``HOME`` pointed at a per-bridge-dir tree (:func:`agy_home_dir`) seeded with a
-# COPY of the user's OAuth token + onboarding/migration markers and a
-# bridge-scoped ``config/mcp_config.json`` written by :func:`write_mcp_config`.
-# This (1) NEVER touches the user's real ``~/.gemini``, (2) gives each session its
-# own ``mcp_config.json`` so concurrent sessions never clobber one another, and
-# (3) was verified live: agy under the isolated HOME does NOT re-demand OAuth and
-# its ``/mcp`` panel shows ``✓ omnigent`` with the ``sys_*`` tools discovered. agy
-# resolves ``GeminiDir`` from ``$HOME/.gemini`` (its hardcoded default), so the
-# only thing the isolated HOME relocates is the *config + state* tree; auth still
-# works because the seeded token is a copy of the user's real one.
+# CHOSEN DESIGN — per-session ISOLATED GEMINI DIR. The runner keeps agy's real
+# ``HOME`` intact (needed for platform auth such as macOS keyring-backed tokens)
+# and launches agy with its hidden ``--gemini_dir=<bridge_dir>/agy-home/.gemini``
+# flag. That isolated Gemini dir is seeded with onboarding/migration markers and
+# a bridge-scoped ``config/mcp_config.json`` written by :func:`write_mcp_config`.
+# This (1) NEVER touches the user's real ``~/.gemini/config/mcp_config.json`` and
+# (2) gives each session its own config so concurrent sessions never clobber one
+# another. Known file-based OAuth markers are copied best-effort for platforms
+# whose agy auth provider uses them, but HOME is deliberately not relocated.
 _MCP_CONFIG_DIR = "config"
 _MCP_CONFIG_FILE = "mcp_config.json"
 _BRIDGE_CONFIG_FILE = "bridge.json"
@@ -311,29 +309,45 @@ _AGY_ENABLED_TOOLS = [
 ]
 
 # Files copied from the user's real ``~/.gemini`` into the per-session isolated
-# HOME so agy does not re-run OAuth / onboarding. The OAuth token is the only
-# secret; it is COPIED (the real file is never moved or modified). Missing files
-# are skipped (agy regenerates onboarding/migration state, and a missing token
-# only means agy re-auths in that session — never a corruption of the real tree).
+# Gemini dir for platforms whose agy auth provider uses file-backed credentials,
+# plus installation markers. Keep the OAuth credential paths in sync with
+# ``omnigent.onboarding.gemini_auth``: macOS writes ``oauth_creds.json`` while
+# Linux writes ``antigravity-cli/antigravity-oauth-token``. The OAuth credential
+# is the only secret; it is COPIED (the real file is never moved or modified).
+# Missing files are skipped (agy regenerates onboarding/migration state, and a
+# missing credential only means agy re-auths in that session — never corruption
+# of the real tree).
 _AGY_SEED_FILES = (
+    Path("oauth_creds.json"),
     Path("antigravity-cli") / "antigravity-oauth-token",
+    Path("installation_id"),
     Path("antigravity-cli") / "installation_id",
 )
 
 
 def agy_home_dir(bridge_dir: Path) -> Path:
-    """Return the per-session isolated ``HOME`` for an agy launch.
+    """Return the parent directory for this session's isolated agy state.
 
-    A subdirectory of *bridge_dir* so it is naturally per-session (the bridge dir
-    is hash-scoped to the bridge id) and torn down with the bridge. agy reads its
-    MCP config + state from ``$HOME/.gemini``; pinning ``HOME`` here keeps the
-    relay's ``mcp_config.json`` out of the user's real ``~/.gemini`` and prevents
-    two concurrent sessions from sharing one global config.
+    The actual agy config/state root is :func:`agy_gemini_dir`, passed to agy via
+    ``--gemini_dir``. Keeping this parent below *bridge_dir* makes it naturally
+    per-session and easy to tear down with the bridge, while preserving the real
+    ``HOME`` for auth providers that depend on platform state such as macOS
+    Keychain.
 
     :param bridge_dir: Native Antigravity bridge directory.
-    :returns: Absolute path to this session's isolated agy HOME.
+    :returns: Absolute parent path for this session's isolated agy state.
     """
     return bridge_dir / "agy-home"
+
+
+def agy_gemini_dir(bridge_dir: Path) -> Path:
+    """Return the per-session ``--gemini_dir`` path for an agy launch.
+
+    :param bridge_dir: Native Antigravity bridge directory.
+    :returns: Absolute ``.gemini`` directory that should receive agy's session
+        config/state and the Omnigent MCP config.
+    """
+    return agy_home_dir(bridge_dir) / ".gemini"
 
 
 def build_mcp_config(
@@ -350,14 +364,12 @@ def build_mcp_config(
     The server command is the SAME shared relay claude/codex/cursor use:
     ``<python> -I -m omnigent.claude_native_bridge serve-mcp --bridge-dir <dir>``.
 
-    **HOME pinning (critical for the isolated-HOME design).** agy spawns this relay
-    as a child, so the relay inherits agy's environment — including the per-session
-    isolated ``HOME`` agy runs under. But the relay validates its ``--bridge-dir``
-    against ``bridge_root()`` (``$HOME/.omnigent/antigravity-native``), which must
-    resolve to the RUNNER's real home where the bridge dir actually lives — not the
-    isolated agy HOME (a child of the bridge dir). So the relay's ``env`` pins
-    ``HOME`` back to the runner's real home. ``-I`` does not clear ``HOME``; it only
-    ignores ``PYTHON*`` vars and user site-packages, so this override takes effect.
+    **HOME pinning.** agy spawns this relay as a child. The relay validates its
+    ``--bridge-dir`` against ``bridge_root()`` (``$HOME/.omnigent/antigravity-native``),
+    which must resolve to the RUNNER's real home where the bridge dir actually
+    lives. Pinning ``HOME`` in the relay env keeps that invariant true even when a
+    future agy launch path customizes process environment. ``-I`` does not clear
+    ``HOME``; it only ignores ``PYTHON*`` vars and user site-packages.
 
     :param bridge_dir: Native Antigravity bridge directory whose relay this
         config points at.
@@ -382,8 +394,7 @@ def build_mcp_config(
                 "env": {
                     "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
                     # Pin the relay to the RUNNER's real home so its bridge-root
-                    # validation matches where the bridge dir lives (agy runs under
-                    # an isolated HOME; the relay must not inherit it). See docstring.
+                    # validation matches where the bridge dir lives. See docstring.
                     "HOME": str(Path.home()),
                 },
             }
@@ -417,25 +428,25 @@ def write_mcp_config(
     *,
     python_executable: str | None = None,
 ) -> Path:
-    """Write the per-session agy MCP config + relay token into the isolated HOME.
+    """Write the per-session agy MCP config + relay token.
 
     Writes (1) ``bridge.json`` (the relay token) into *bridge_dir* and (2) the
     ``mcp_config.json`` for the Omnigent relay into the per-session isolated agy
-    HOME at ``<agy_home>/.gemini/config/mcp_config.json`` — the path agy actually
-    loads MCP servers from. Because the HOME is per-session and never the user's
-    real ``~``, this never clobbers the user's interactive agy config and two
-    concurrent sessions never share one config. Mirrors cursor #742's
-    :func:`omnigent.cursor_native_bridge.write_mcp_config`, adapted to agy's
-    HOME-global config path + isolated-HOME scoping.
+    Gemini dir at ``<bridge_dir>/agy-home/.gemini/config/mcp_config.json`` — the
+    path agy loads when launched with ``--gemini_dir``. Because the Gemini dir is
+    per-session and not the user's real ``~/.gemini``, this never clobbers the
+    user's interactive agy config and two concurrent sessions never share one
+    config. Mirrors cursor #742's :func:`omnigent.cursor_native_bridge.write_mcp_config`,
+    adapted to agy's hidden ``--gemini_dir`` flag.
 
     :param bridge_dir: Native Antigravity bridge directory (holds ``bridge.json``
-        and the isolated agy HOME).
+        and the isolated agy Gemini dir).
     :param python_executable: Python interpreter for the relay command;
         defaults to the current interpreter.
     :returns: Absolute path to the written ``mcp_config.json``.
     """
     write_mcp_bridge_config(bridge_dir)
-    config_dir = agy_home_dir(bridge_dir) / ".gemini" / _MCP_CONFIG_DIR
+    config_dir = agy_gemini_dir(bridge_dir) / _MCP_CONFIG_DIR
     config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     path = config_dir / _MCP_CONFIG_FILE
     payload = build_mcp_config(bridge_dir, python_executable=python_executable)
@@ -446,26 +457,23 @@ def write_mcp_config(
 
 
 def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
-    """Seed the per-session isolated agy HOME and return the launch env override.
+    """Seed the per-session isolated agy Gemini dir and return env overrides.
 
-    Copies the user's real agy OAuth token + onboarding/migration state (NEVER
-    moving or modifying the real files) into ``<bridge_dir>/agy-home/.gemini`` so
-    a launch under this isolated HOME does not re-demand OAuth or re-run the
-    onboarding wizard. The relay's ``mcp_config.json`` is written separately by
-    :func:`write_mcp_config` so it lands in this same isolated tree rather than
-    the user's real ``~/.gemini`` (the footgun this whole design avoids).
-
-    Verified live (agy 1.0.12): under this isolated HOME agy logs in as the real
-    user from the seeded token and its ``/mcp`` panel shows ``✓ omnigent`` with the
-    ``sys_*`` tools discovered.
+    Copies known file-based agy OAuth markers + onboarding/migration state (NEVER
+    moving or modifying the real files) into ``<bridge_dir>/agy-home/.gemini``.
+    The runner keeps agy's real ``HOME`` intact and passes this directory through
+    ``--gemini_dir``; on macOS that is required because agy uses keyring-backed
+    auth that is not portable to a relocated ``HOME``. The relay's
+    ``mcp_config.json`` is written separately by :func:`write_mcp_config` so it
+    lands in this same isolated tree rather than the user's real ``~/.gemini``
+    (the footgun this whole design avoids).
 
     :param bridge_dir: Native Antigravity bridge directory.
-    :returns: An env-override mapping (``{"HOME": <iso_home>}``) to layer onto the
-        agy launch environment.
+    :returns: Env overrides to layer onto the agy launch environment. Currently
+        empty because ``HOME`` must stay real for platform auth.
     """
     real_home = Path.home()
-    iso_home = agy_home_dir(bridge_dir)
-    iso_gemini = iso_home / ".gemini"
+    iso_gemini = agy_gemini_dir(bridge_dir)
     (iso_gemini / "antigravity-cli" / "cache").mkdir(mode=0o700, parents=True, exist_ok=True)
     (iso_gemini / _MCP_CONFIG_DIR).mkdir(mode=0o700, parents=True, exist_ok=True)
 
@@ -499,11 +507,11 @@ def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
         )
 
     # Seed the migration marker so agy does not churn a from-scratch migration on
-    # first launch under the fresh HOME (cosmetic; agy creates it itself otherwise).
+    # first launch under the fresh Gemini dir (cosmetic; agy creates it itself otherwise).
     with contextlib.suppress(OSError):
         (iso_gemini / _MCP_CONFIG_DIR / ".migrated").touch()
 
-    return {"HOME": str(iso_home)}
+    return {}
 
 
 # agy's periodic engagement survey ("How's the CLI experience so far?") is gated by

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -851,11 +851,33 @@ _MAX_SUBMIT_ATTEMPTS = 3
 _PASTE_BUFFER = "omnigent-agy-paste"
 # agy TUI footer when idle (input box mounted, ready for a turn).
 _AGY_IDLE_MARKER = "? for shortcuts"
-# agy TUI footer while a turn is running — the positive "submit took" signal.
+# agy TUI footer while a turn is running. Used as a readiness hint and to detect
+# a mid-turn steer; submission itself is verified by draft disappearance, NOT by
+# this marker (footer text can change across agy builds or be truncated).
 _AGY_ACTIVE_MARKER = "esc to cancel"
+# Patterns redacted from a pane tail before it is surfaced in a delivery-failure
+# error. The agy header shows the signed-in account email, and the transcript
+# region can echo tokens/keys agy printed; redaction is best-effort and biased
+# toward over-redaction so a secret never leaks into a user-facing error.
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+")
+_SECRET_RES = (
+    re.compile(r"\b(?:sk|rk)-[A-Za-z0-9_-]{16,}"),  # OpenAI-style keys
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"),  # GitHub tokens
+    re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}"),  # Slack tokens
+    re.compile(r"\bya29\.[A-Za-z0-9._-]{10,}"),  # Google OAuth access tokens
+    re.compile(r"\bAIza[A-Za-z0-9_-]{30,}"),  # Google API keys
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),  # AWS access key ids
+    re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}"),  # JWTs
+    re.compile(r"(?i)\b(?:bearer|token|api[_-]?key|secret|password)\b\s*[:=]?\s*\S{6,}"),
+)
 # TUI horizontal separator around agy's bottom composer.
 _AGY_SEPARATOR_CHAR = "─"
+# Box-drawing glyphs agy may use to frame/decorate the composer rule. A rule is
+# detected when its non-space chars are all box-drawing AND it carries a run of
+# the horizontal rule char, so a future agy that frames the composer with
+# corner/join glyphs (e.g. ``╭────╮``) is still detected, while ordinary text
+# (which carries non-box chars) never matches.
+_AGY_BOX_GLYPHS = frozenset("─━╌╍┄┅┈┉╭╮╰╯┌┐└┘├┤┬┴┼│║╔╗╚╝═╠╣╦╩╬╴╵╶╷")
 
 
 def write_tmux_target(
@@ -1065,17 +1087,31 @@ def _submit_needle(content: str) -> str:
     return stripped[:24] if len(stripped) >= 4 else ""
 
 
+def _redact_pane_secrets(text: str) -> str:
+    """Redact emails and common secret shapes from a pane tail.
+
+    Best-effort and biased toward over-redaction: the tail is embedded in a
+    user-facing delivery error, and agy may have printed the signed-in account
+    email or tokens/keys in the transcript region.
+    """
+    redacted = _EMAIL_RE.sub("[REDACTED_EMAIL]", text)
+    for pattern in _SECRET_RES:
+        redacted = pattern.sub("[REDACTED_SECRET]", redacted)
+    return redacted
+
+
 def _format_pane_debug_tail(pane: str) -> str:
     """
     Return a short, redacted pane tail for delivery failure diagnostics.
 
-    The agy pane header can include the authenticated user's email address. Keep
-    this diagnostic safe to surface in an executor error by redacting email-like
-    tokens and limiting the output to a small tail.
+    The agy pane header can include the authenticated user's email address and
+    the transcript region can echo secrets agy printed. Keep this diagnostic safe
+    to surface in an executor error by redacting emails + common secret shapes
+    (see :func:`_redact_pane_secrets`) and limiting the output to a small tail.
     """
     lines = [line.rstrip() for line in pane.splitlines() if line.strip()]
     tail = "\n".join(lines[-12:])
-    return _EMAIL_RE.sub("[REDACTED_EMAIL]", tail) or "<empty pane>"
+    return _redact_pane_secrets(tail) or "<empty pane>"
 
 
 def _agy_input_region(pane: str) -> str:
@@ -1098,9 +1134,17 @@ def _agy_input_region(pane: str) -> str:
 
 
 def _agy_separator_line(line: str) -> bool:
-    """Return whether *line* is one of agy's composer separator rules."""
+    """Return whether *line* is one of agy's composer separator rules.
+
+    Accepts a pure ``─`` rule (agy 1.0.14) and a box-decorated rule (corner/join
+    glyphs) so a future agy that frames the composer is still detected, while an
+    ordinary text/draft line (which carries non-box chars) never matches. A short
+    dash run (< 8 rule chars) is not treated as a separator.
+    """
     stripped = line.strip()
-    return len(stripped) >= 8 and set(stripped) == {_AGY_SEPARATOR_CHAR}
+    if stripped.count(_AGY_SEPARATOR_CHAR) < 8:
+        return False
+    return all(char in _AGY_BOX_GLYPHS for char in stripped if not char.isspace())
 
 
 def _draft_in_input_region(pane: str, needle: str, baseline_region: str) -> bool:
@@ -1110,35 +1154,46 @@ def _draft_in_input_region(pane: str, needle: str, baseline_region: str) -> bool
     The baseline region prevents matching the empty prompt or stale text that was
     already present before this paste. Candidate lines are normalized by removing
     agy's leading ``>`` prompt glyph.
+
+    When *needle* is empty (a message too short for a stable needle, e.g.
+    ``"ok"``), any draft-like content in a composer that differs from the
+    pre-paste baseline counts as present — so short messages are still render- and
+    submit-verified by composer state instead of being submitted blind.
     """
-    if not needle:
-        return False
     region = _agy_input_region(pane)
     if region == baseline_region:
         return False
-    normalized_needle = needle.strip()
+    candidates = _agy_draft_candidate_lines(region)
+    normalized_needle = needle.strip() if needle else ""
     if not normalized_needle:
-        return False
+        return bool(candidates)
     return any(
         line == normalized_needle
         or line.startswith(normalized_needle)
         or normalized_needle in line
-        for line in _agy_draft_candidate_lines(region)
+        for line in candidates
     )
 
 
 def _agy_draft_candidate_lines(region: str) -> list[str]:
-    """Return composer lines that can represent editable draft text."""
+    """Return composer lines that can represent editable draft text.
+
+    A line carrying agy's ``>`` prompt glyph is editable draft content and is
+    kept verbatim (after the glyph is stripped) even when the user's own text
+    contains a word like ``Generating`` or a footer phrase — otherwise a
+    legitimate message would be filtered out and misread as "never rendered".
+    Status/footer rows (idle/active/"Generating …") carry no ``>`` prompt, so the
+    chrome filters apply only to those non-draft lines.
+    """
     candidates: list[str] = []
     for raw_line in region.splitlines():
         line = raw_line.strip()
-        if not line:
-            continue
-        if line == ">":
+        if not line or line == ">":
             continue
         if line.startswith(">"):
-            line = line[1:].strip()
-        if not line:
+            draft = line[1:].strip()
+            if draft:
+                candidates.append(draft)
             continue
         if _AGY_IDLE_MARKER in line or _AGY_ACTIVE_MARKER in line:
             continue
@@ -1189,11 +1244,18 @@ def _submit_and_verify(
     only a readiness hint: it can change across agy builds, be truncated in narrow
     panes, or redraw independently from the editable draft. The reliable local
     submit signal is that the draft which was visible before Enter is no longer
-    present in the live bottom composer region. If the same draft remains visible,
-    Enter was likely folded into the paste burst and is re-sent within a bounded
-    retry budget. If no usable needle exists, submit once and return — absence
-    checks would be vacuous. ``inject_user_message_via_tui`` fails earlier when a
-    normal text draft never renders.
+    present in the live bottom composer region (for an empty needle this keys off
+    the composer returning to the pre-paste baseline). If the same draft remains
+    visible, Enter was likely folded into the paste burst and is re-sent within a
+    bounded retry budget. ``inject_user_message_via_tui`` fails earlier when a
+    text draft never renders into an idle composer.
+
+    **Mid-turn steer.** When agy already shows :data:`_AGY_ACTIVE_MARKER`, a turn
+    is running: the draft-disappearance signal is unreliable (agy queues the steer
+    as the next ``USER_INPUT`` and the composer may not clear promptly) and a
+    second Enter could queue a spurious empty turn. So a single best-effort Enter
+    is sent and the function returns without re-sending or hard-failing — the
+    forwarder is the system-of-record for whether the queued steer registered.
 
     :param socket_path: tmux server socket path.
     :param tmux_target: tmux pane target.
@@ -1205,6 +1267,12 @@ def _submit_and_verify(
         raise RuntimeError(
             "the agy terminal exited before the message could be submitted; restart the session"
         )
+    # Mid-turn steer: a turn is already running, so verifying via draft
+    # disappearance is unreliable and a re-sent Enter could queue an empty turn.
+    # Deliver one best-effort Enter and return (see the docstring).
+    if _AGY_ACTIVE_MARKER in _capture_pane(socket_path, tmux_target):
+        _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+        return
     if not draft_seen:
         _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
         return
@@ -1323,24 +1391,33 @@ def inject_user_message_via_tui(
             with contextlib.suppress(OSError):
                 os.unlink(paste_path)
     # Wait until the paste is visibly committed to the input box before Enter, so
-    # the submit is not folded into the paste burst (see _submit_and_verify).
+    # the submit is not folded into the paste burst (see _submit_and_verify). This
+    # runs for EVERY message — including short ones with no stable needle — so a
+    # paste that never lands in the composer is caught rather than submitted blind
+    # (``_draft_in_input_region`` keys off composer change when the needle is "").
     needle = _submit_needle(content)
+    # A mid-turn steer (agy already running a turn) is delivered best-effort: agy
+    # queues it as the next turn and may not surface the draft in the composer the
+    # same way an idle turn does, so a non-render is NOT a swallowed message here.
+    # The render hard-fail below is for the idle/sequential case, where a paste
+    # that never lands in the composer (e.g. eaten by an unhooked modal such as
+    # the first-run trust gate) must fail loudly instead of vanishing.
+    mid_turn = _AGY_ACTIVE_MARKER in _capture_pane(socket_path, tmux_target)
     draft_seen = False
     last_commit_pane = ""
-    if needle:
-        commit_deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
-        while time.monotonic() < commit_deadline:
-            pane = _capture_pane(socket_path, tmux_target)
-            last_commit_pane = pane or last_commit_pane
-            if _draft_in_input_region(pane, needle, baseline_region):
-                draft_seen = True
-                break
-            time.sleep(_TMUX_POLL_INTERVAL_S)
-        if not draft_seen:
-            raise RuntimeError(
-                "agy did not render the pasted message in its input box before submit; "
-                f"pane_tail:\n{_format_pane_debug_tail(last_commit_pane)}"
-            )
+    commit_deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
+    while time.monotonic() < commit_deadline:
+        pane = _capture_pane(socket_path, tmux_target)
+        last_commit_pane = pane or last_commit_pane
+        if _draft_in_input_region(pane, needle, baseline_region):
+            draft_seen = True
+            break
+        time.sleep(_TMUX_POLL_INTERVAL_S)
+    if not draft_seen and not mid_turn:
+        raise RuntimeError(
+            "agy did not render the pasted message in its input box before submit; "
+            f"pane_tail:\n{_format_pane_debug_tail(last_commit_pane)}"
+        )
     time.sleep(_PASTE_SETTLE_S)
     _submit_and_verify(
         socket_path,

--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -470,7 +471,11 @@ def write_mcp_config(
     return path
 
 
-def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
+def seed_isolated_agy_home(
+    bridge_dir: Path,
+    *,
+    trusted_workspace: Path | str | None = None,
+) -> dict[str, str]:
     """Seed the per-session isolated agy Gemini dir and return env overrides.
 
     Copies known file-based agy OAuth markers + onboarding/migration state (NEVER
@@ -483,6 +488,11 @@ def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
     (the footgun this whole design avoids).
 
     :param bridge_dir: Native Antigravity bridge directory.
+    :param trusted_workspace: Optional workspace path to pre-trust inside the
+        isolated agy settings file. This suppresses agy's unhookable first-run
+        "Do you trust this project?" TUI gate for host-spawned sessions, mirroring
+        ``ensure_claude_workspace_trusted`` while keeping trust scoped to this
+        bridge-owned ``--gemini_dir``.
     :returns: Env overrides to layer onto the agy launch environment. Currently
         empty because ``HOME`` must stay real for platform auth.
     """
@@ -524,6 +534,9 @@ def seed_isolated_agy_home(bridge_dir: Path) -> dict[str, str]:
     # first launch under the fresh Gemini dir (cosmetic; agy creates it itself otherwise).
     with contextlib.suppress(OSError):
         (iso_gemini / _MCP_CONFIG_DIR / ".migrated").touch()
+
+    if trusted_workspace is not None:
+        _seed_isolated_agy_workspace_trust(iso_gemini, Path(trusted_workspace))
 
     return {}
 
@@ -641,6 +654,30 @@ def ensure_agy_feedback_survey_disabled(home: Path) -> None:
             settings_path,
             exc_info=True,
         )
+
+
+def _seed_isolated_agy_workspace_trust(iso_gemini: Path, workspace: Path) -> None:
+    """Add *workspace* to isolated agy ``trustedWorkspaces`` settings."""
+    settings_path = iso_gemini / "antigravity-cli" / "settings.json"
+    data: dict[str, object] = {}
+    if settings_path.is_file():
+        try:
+            loaded = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            loaded = None
+        if isinstance(loaded, dict):
+            data = loaded
+    workspace_key = str(workspace.resolve())
+    existing = data.get("trustedWorkspaces")
+    trusted = list(existing) if isinstance(existing, list) else []
+    if workspace_key in trusted:
+        return
+    trusted.append(workspace_key)
+    data["trustedWorkspaces"] = trusted
+    settings_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    tmp = settings_path.with_suffix(settings_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, settings_path)
 
 
 def write_bridge_state(bridge_dir: Path, state: AntigravityNativeBridgeState) -> None:
@@ -816,6 +853,9 @@ _PASTE_BUFFER = "omnigent-agy-paste"
 _AGY_IDLE_MARKER = "? for shortcuts"
 # agy TUI footer while a turn is running — the positive "submit took" signal.
 _AGY_ACTIVE_MARKER = "esc to cancel"
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+")
+# TUI horizontal separator around agy's bottom composer.
+_AGY_SEPARATOR_CHAR = "─"
 
 
 def write_tmux_target(
@@ -1025,6 +1065,93 @@ def _submit_needle(content: str) -> str:
     return stripped[:24] if len(stripped) >= 4 else ""
 
 
+def _format_pane_debug_tail(pane: str) -> str:
+    """
+    Return a short, redacted pane tail for delivery failure diagnostics.
+
+    The agy pane header can include the authenticated user's email address. Keep
+    this diagnostic safe to surface in an executor error by redacting email-like
+    tokens and limiting the output to a small tail.
+    """
+    lines = [line.rstrip() for line in pane.splitlines() if line.strip()]
+    tail = "\n".join(lines[-12:])
+    return _EMAIL_RE.sub("[REDACTED_EMAIL]", tail) or "<empty pane>"
+
+
+def _agy_input_region(pane: str) -> str:
+    """
+    Return agy's live bottom composer region, excluding transcript history.
+
+    agy renders the editable composer between horizontal separator lines. After
+    a successful submit, the submitted prompt remains in transcript history
+    above a fresh empty composer, so checking the full pane would falsely think
+    the draft is still present. The last separator pair scopes matching to the
+    currently editable input box, mirroring Kiro's input-region guard.
+    """
+    lines = pane.splitlines()
+    separator_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if _agy_separator_line(line)
+    ]
+    if len(separator_indexes) >= 2:
+        start = separator_indexes[-2] + 1
+        end = separator_indexes[-1]
+        return "\n".join(lines[start:end])
+    return "\n".join(lines[-8:])
+
+
+def _agy_separator_line(line: str) -> bool:
+    """Return whether *line* is one of agy's composer separator rules."""
+    stripped = line.strip()
+    return len(stripped) >= 8 and set(stripped) == {_AGY_SEPARATOR_CHAR}
+
+
+def _draft_in_input_region(pane: str, needle: str, baseline_region: str) -> bool:
+    """
+    Return whether the pasted draft is still visible in agy's composer.
+
+    The baseline region prevents matching the empty prompt or stale text that was
+    already present before this paste. Candidate lines are normalized by removing
+    agy's leading ``>`` prompt glyph.
+    """
+    if not needle:
+        return False
+    region = _agy_input_region(pane)
+    if region == baseline_region:
+        return False
+    normalized_needle = needle.strip()
+    if not normalized_needle:
+        return False
+    return any(
+        line == normalized_needle
+        or line.startswith(normalized_needle)
+        or normalized_needle in line
+        for line in _agy_draft_candidate_lines(region)
+    )
+
+
+def _agy_draft_candidate_lines(region: str) -> list[str]:
+    """Return composer lines that can represent editable draft text."""
+    candidates: list[str] = []
+    for raw_line in region.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line == ">":
+            continue
+        if line.startswith(">"):
+            line = line[1:].strip()
+        if not line:
+            continue
+        if _AGY_IDLE_MARKER in line or _AGY_ACTIVE_MARKER in line:
+            continue
+        if "Generating" in line:
+            continue
+        candidates.append(line)
+    return candidates
+
+
 def _wait_for_agy_prompt_ready(socket_path: str, tmux_target: str, *, timeout_s: float) -> None:
     """
     Best-effort wait until agy's input box is mounted (its footer is rendered).
@@ -1051,51 +1178,44 @@ def _wait_for_agy_prompt_ready(socket_path: str, tmux_target: str, *, timeout_s:
         time.sleep(_TMUX_POLL_INTERVAL_S)
 
 
-def _submit_and_verify(socket_path: str, tmux_target: str) -> None:
+def _submit_and_verify(
+    socket_path: str,
+    tmux_target: str,
+    *,
+    needle: str = "",
+    baseline_region: str = "",
+    draft_seen: bool = False,
+) -> None:
     """
-    Press Enter to submit the pasted draft, verifying the submit where possible.
+    Press Enter to submit the pasted draft, verifying by composer state.
 
-    There are two cases, distinguished by the footer BEFORE the Enter:
-
-    **Idle (a sequential turn — the common case).** agy shows
-    :data:`_AGY_IDLE_MARKER`. The agy TUI coalesces a rapid stdin burst into a
-    paste, so an Enter that lands while the paste is still being consumed is
-    folded in as a newline and the draft sits unsent. After each Enter this polls
-    for the footer leaving idle — :data:`_AGY_ACTIVE_MARKER` appears (accepted on
-    first sighting) OR :data:`_AGY_IDLE_MARKER` is gone for TWO consecutive polls
-    (robust to a future agy renaming/truncating the running footer, while a single
-    transient redraw frame cannot be misread as started). If neither holds within
-    :data:`_SUBMIT_VERIFY_TIMEOUT_S` the Enter is re-sent (the draft is still in
-    the box; an Enter on an emptied box is a no-op).
-
-    **Mid-turn (a steer).** agy already shows :data:`_AGY_ACTIVE_MARKER`, so the
-    idle→running transition this function watches for is unavailable and a second
-    Enter could queue a spurious empty turn. agy queues a mid-turn paste as the
-    next ``USER_INPUT`` (verified against agy 1.0.10), and the caller's
-    paste-commit poll already confirmed the draft rendered in the input box, so a
-    single best-effort Enter is sent and the function returns WITHOUT a footer
-    confirmation. The forwarder is the system-of-record for whether the steer
-    actually registered (it mirrors the resulting ``USER_INPUT`` step); this path
-    deliberately does not re-send or hard-fail on the unverifiable mid-turn case.
+    This mirrors the stronger Claude/Kiro native bridge contract. Footer text is
+    only a readiness hint: it can change across agy builds, be truncated in narrow
+    panes, or redraw independently from the editable draft. The reliable local
+    submit signal is that the draft which was visible before Enter is no longer
+    present in the live bottom composer region. If the same draft remains visible,
+    Enter was likely folded into the paste burst and is re-sent within a bounded
+    retry budget. If no usable needle exists, submit once and return — absence
+    checks would be vacuous. ``inject_user_message_via_tui`` fails earlier when a
+    normal text draft never renders.
 
     :param socket_path: tmux server socket path.
     :param tmux_target: tmux pane target.
     :returns: None.
-    :raises RuntimeError: When the agy TUI exits mid-submit, or (idle case only)
-        the footer never leaves idle after :data:`_MAX_SUBMIT_ATTEMPTS` attempts.
+    :raises RuntimeError: When the agy TUI exits mid-submit, or the visible
+        draft remains in the composer after :data:`_MAX_SUBMIT_ATTEMPTS` attempts.
     """
     if not _session_alive(socket_path, tmux_target):
         raise RuntimeError(
             "the agy terminal exited before the message could be submitted; restart the session"
         )
-    if _AGY_ACTIVE_MARKER in _capture_pane(socket_path, tmux_target):
-        # Mid-turn steer: footer-transition verification is unavailable (see the
-        # docstring). Deliver one best-effort Enter; do not re-send.
+    if not draft_seen:
         _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
         return
+    last_pane = _capture_pane(socket_path, tmux_target)
     for _ in range(_MAX_SUBMIT_ATTEMPTS):
         # Re-check liveness each attempt: if the TUI exited between the paste and
-        # now, every capture returns "" and the footer never changes — so fail
+        # now, every capture returns "" and the draft never clears — so fail
         # fast with the real cause instead of spinning the full budget and then
         # blaming paste-coalescing.
         if not _session_alive(socket_path, tmux_target):
@@ -1105,23 +1225,22 @@ def _submit_and_verify(socket_path: str, tmux_target: str) -> None:
             )
         _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
         deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
-        non_idle_polls = 0
         while time.monotonic() < deadline:
+            if not _session_alive(socket_path, tmux_target):
+                raise RuntimeError(
+                    "the agy terminal exited before the message could be submitted; "
+                    "restart the session"
+                )
             pane = _capture_pane(socket_path, tmux_target)
-            if pane and _AGY_ACTIVE_MARKER in pane:
+            last_pane = pane or last_pane
+            if pane and not _draft_in_input_region(pane, needle, baseline_region):
                 return
-            if pane and _AGY_IDLE_MARKER not in pane:
-                non_idle_polls += 1
-                if non_idle_polls >= 2:
-                    return
-            else:
-                # Idle footer present, or an empty capture (tmux failure): reset
-                # so the two confirmations must be consecutive, not cumulative.
-                non_idle_polls = 0
             time.sleep(_TMUX_POLL_INTERVAL_S)
+    draft_visible = _draft_in_input_region(last_pane, needle, baseline_region)
     raise RuntimeError(
-        "agy did not start a turn after the message was submitted to its terminal "
-        "(the submit Enter may have been folded into the paste)"
+        "agy did not accept the submitted message; the draft is still visible "
+        "in the input box; "
+        f"draft_visible={draft_visible}; pane_tail:\n{_format_pane_debug_tail(last_pane)}"
     )
 
 
@@ -1146,7 +1265,7 @@ def inject_user_message_via_tui(
     kill-to-end), stream the content through a named tmux buffer
     (``load-buffer``/``paste-buffer -p`` so interior newlines stay data and a
     large message is not capped by the send-keys argv limit), wait for the draft
-    to render, then submit (footer-verified when idle; best-effort mid-turn — see
+    to render, then submit and verify the draft left the live composer (see
     :func:`_submit_and_verify`).
 
     :param bridge_dir: Native Antigravity bridge directory holding ``tmux.json``.
@@ -1181,6 +1300,7 @@ def inject_user_message_via_tui(
     # Clear any leftover draft before typing: Home (C-a) + kill-to-end (C-k).
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
+    baseline_region = _agy_input_region(_capture_pane(socket_path, tmux_target))
     # ``delete=False`` + name captured BEFORE the write, so a write failure still
     # leaves a path the finally can unlink (no leaked temp file in the bridge dir).
     paste_path: str | None = None
@@ -1209,14 +1329,32 @@ def inject_user_message_via_tui(
     # Wait until the paste is visibly committed to the input box before Enter, so
     # the submit is not folded into the paste burst (see _submit_and_verify).
     needle = _submit_needle(content)
+    draft_seen = False
+    last_commit_pane = ""
     if needle:
         commit_deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
         while time.monotonic() < commit_deadline:
-            if needle in _capture_pane(socket_path, tmux_target):
+            pane = _capture_pane(socket_path, tmux_target)
+            last_commit_pane = pane or last_commit_pane
+            if _draft_in_input_region(
+                pane, needle, baseline_region
+            ):
+                draft_seen = True
                 break
             time.sleep(_TMUX_POLL_INTERVAL_S)
+        if not draft_seen:
+            raise RuntimeError(
+                "agy did not render the pasted message in its input box before submit; "
+                f"pane_tail:\n{_format_pane_debug_tail(last_commit_pane)}"
+            )
     time.sleep(_PASTE_SETTLE_S)
-    _submit_and_verify(socket_path, tmux_target)
+    _submit_and_verify(
+        socket_path,
+        tmux_target,
+        needle=needle,
+        baseline_region=baseline_region,
+        draft_seen=draft_seen,
+    )
 
 
 def send_interaction_keys_via_tui(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4110,6 +4110,8 @@ async def _auto_create_antigravity_terminal(
     from omnigent.antigravity_native_bridge import (
         ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY,
         AntigravityNativeBridgeState,
+        agy_gemini_dir,
+        agy_home_dir,
         clear_bridge_state,
         ensure_agy_feedback_survey_disabled,
         ensure_agy_onboarding_complete,
@@ -4205,14 +4207,15 @@ async def _auto_create_antigravity_terminal(
     # Wire the Omnigent MCP relay so the wrapped agy gets the sys_* tools
     # (spawn sub-agent sessions, drive Omnigent terminals, list agents/models,
     # sys_os_*) — the only native harness that otherwise lacks them (#1194).
-    # agy has no --mcp-config flag and ignores ANTIGRAVITY_* env knobs; it loads
-    # MCP servers ONLY from the HOME-global ~/.gemini/config/mcp_config.json. To
-    # avoid clobbering the user's interactive agy config (and the concurrency
-    # footgun of a single shared file), launch agy under a per-session ISOLATED
-    # HOME seeded with a copy of the user's OAuth token + onboarding state and a
-    # bridge-scoped mcp_config.json. The relay subprocess is the same shared
-    # ``serve-mcp`` claude/codex/cursor use. Offloaded to a thread (file I/O) and
-    # done BEFORE the terminal launch so agy sees the config on its first MCP scan.
+    # agy has no --mcp-config flag and ignores ANTIGRAVITY_* env knobs. It does
+    # accept the hidden --gemini_dir flag, so keep the process HOME real for auth
+    # providers such as macOS Keychain, but point agy's config/state root at a
+    # per-session isolated Gemini dir. This avoids clobbering the user's
+    # interactive ~/.gemini/config/mcp_config.json and avoids the concurrency
+    # footgun of one shared bridge-specific config file. The relay subprocess is
+    # the same shared ``serve-mcp`` claude/codex/cursor use. Offloaded to a thread
+    # (file I/O) and done BEFORE terminal launch so agy sees the config on its
+    # first MCP scan.
     await asyncio.to_thread(write_mcp_config, bridge_dir)
     env_overrides = {
         **env_overrides,
@@ -4220,8 +4223,13 @@ async def _auto_create_antigravity_terminal(
     }
     # agy's periodic feedback survey shares its "esc to cancel" footer with the
     # running-turn marker, so a web turn injected while it is up is misread as an
-    # active turn and lost (#1494). Disable it in the launch HOME before agy starts.
-    await asyncio.to_thread(ensure_agy_feedback_survey_disabled, Path(env_overrides["HOME"]))
+    # active turn and lost (#1494). Disable it before launch. agy now runs under
+    # the real HOME with an isolated --gemini_dir, so the survey setting must be
+    # written into that isolated dir (ensure_agy_feedback_survey_disabled appends
+    # /.gemini/antigravity-cli/settings.json to its arg), NOT the user's real
+    # HOME — env_overrides no longer carries a HOME key.
+    await asyncio.to_thread(ensure_agy_feedback_survey_disabled, agy_home_dir(bridge_dir))
+    argv = [argv[0], f"--gemini_dir={agy_gemini_dir(bridge_dir)}", *argv[1:]]
     # Start the shared comment/sys_* relay against THIS session's bridge dir before
     # launch so its tool_relay.json is on disk when agy first scans the MCP server.
     # ``await_notify=False``: agy starts its MCP client lazily, so awaiting the

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4219,7 +4219,11 @@ async def _auto_create_antigravity_terminal(
     await asyncio.to_thread(write_mcp_config, bridge_dir)
     env_overrides = {
         **env_overrides,
-        **await asyncio.to_thread(seed_isolated_agy_home, bridge_dir),
+        **await asyncio.to_thread(
+            seed_isolated_agy_home,
+            bridge_dir,
+            trusted_workspace=workspace,
+        ),
     }
     # agy's periodic feedback survey shares its "esc to cancel" footer with the
     # running-turn marker, so a web turn injected while it is up is misread as an

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -3895,6 +3895,17 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     assert "HOME" not in captured_spec["env"]
     assert captured_spec["env"]["AGY_ENV"] == "1"
 
+    # 4) The session workspace is pre-trusted AND the feedback survey is disabled
+    #    in the SAME isolated settings.json agy reads under --gemini_dir (#1598 +
+    #    #1494), proving the trust seed and the survey-disable compose in the
+    #    isolated dir without one clobbering the other (the rebase conflict point).
+    settings = iso_gemini / "antigravity-cli" / "settings.json"
+    assert settings.is_file()
+    settings_data = json.loads(settings.read_text(encoding="utf-8"))
+    workspace_key = str((tmp_path / "workspace").resolve())
+    assert workspace_key in settings_data.get("trustedWorkspaces", [])
+    assert settings_data.get("showFeedbackSurvey") is False
+
 
 @pytest.mark.parametrize("parent_host_id", ["host_parent", None])
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -3778,11 +3778,12 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     * the relay starter (``ensure_comment_relay``) is invoked for THIS session's
       bridge dir before launch, so its ``tool_relay.json`` is on disk when agy
       first scans the MCP server;
-    * the relay ``mcp_config.json`` is written into the per-session ISOLATED agy
-      HOME (``<bridge_dir>/agy-home/.gemini/config``), NOT the user's real
+    * the relay ``mcp_config.json`` is written into the per-session isolated agy
+      Gemini dir (``<bridge_dir>/agy-home/.gemini/config``), NOT the user's real
       ``~/.gemini`` — the config-scoping footgun the design avoids;
-    * the launch env carries ``HOME`` = that isolated home, so agy actually loads
-      the bridge-scoped config (and never the user's interactive agy config).
+    * the launch args carry ``--gemini_dir=<isolated .gemini>`` while the launch
+      env does not override ``HOME``, so agy keeps platform auth such as macOS
+      Keychain but loads the bridge-scoped config.
     """
     import omnigent.antigravity_native_bridge as bridge_mod
     import omnigent.antigravity_native_launch as launch_mod
@@ -3801,8 +3802,8 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     monkeypatch.setattr(runner_app_mod, "_terminal_tmux_pane", lambda *_a, **_k: (None, None))
     monkeypatch.setattr(rpc_mod, "_candidate_agy_rpc_ports", list)
 
-    # Capture the env build_agy_launch starts from so we can assert HOME is layered
-    # on top of it (the launch env is the captured spec's ``env`` below).
+    # Capture the env build_agy_launch starts from so we can assert it is preserved
+    # without a HOME override (the launch env is the captured spec's ``env`` below).
     monkeypatch.setattr(
         launch_mod, "build_agy_launch", lambda **_kwargs: (("agy",), {"AGY_ENV": "1"})
     )
@@ -3846,6 +3847,7 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
             resource_role: str | None = None,
             **_kwargs: Any,
         ) -> SessionResourceView:
+            captured_spec["args"] = list(spec.args)
             captured_spec["env"] = dict(spec.env)
             return SessionResourceView(
                 id="terminal_antigravity_main",
@@ -3868,6 +3870,7 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
 
     bridge_dir = bridge_mod.bridge_dir_for_bridge_id(session_id)
     iso_home = bridge_mod.agy_home_dir(bridge_dir)
+    iso_gemini = bridge_mod.agy_gemini_dir(bridge_dir)
 
     # 1) The relay starter was invoked for this session's bridge dir.
     assert len(relay_calls) == 1
@@ -3886,9 +3889,10 @@ async def test_auto_create_antigravity_wires_omnigent_mcp_relay(
     # The bridge token the shared relay needs was written into the bridge dir.
     assert (bridge_dir / "bridge.json").is_file()
 
-    # 3) The launch env carries HOME = the isolated home, layered over the
-    #    build_agy_launch base env.
-    assert captured_spec["env"]["HOME"] == str(iso_home)
+    # 3) The launch args point agy at the isolated Gemini dir, while HOME stays
+    #    real so platform auth such as macOS Keychain keeps working.
+    assert captured_spec["args"] == [f"--gemini_dir={iso_gemini}"]
+    assert "HOME" not in captured_spec["env"]
     assert captured_spec["env"]["AGY_ENV"] == "1"
 
 

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -14,6 +14,7 @@ from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
     ANTIGRAVITY_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     AntigravityNativeBridgeState,
+    agy_gemini_dir,
     agy_home_dir,
     build_antigravity_native_spawn_env,
     build_mcp_config,
@@ -1040,9 +1041,8 @@ def test_build_mcp_config_registers_omnigent_relay(tmp_path: Path) -> None:
     assert server["enabledTools"] == sorted(server["enabledTools"])
     assert server["env"]["TMPDIR"]
     # The relay's HOME is pinned to the runner's real home so its bridge-root
-    # validation matches where the bridge dir lives — agy runs the relay under a
-    # per-session isolated HOME (a child of the bridge dir), which the relay must
-    # NOT inherit, or it would reject its own --bridge-dir.
+    # validation matches where the bridge dir lives, even if a future agy launch
+    # path customizes process environment.
     assert server["env"]["HOME"] == str(Path.home())
 
 
@@ -1054,15 +1054,15 @@ def test_build_mcp_config_defaults_python_to_current_interpreter(tmp_path: Path)
     assert server["command"] == sys.executable
 
 
-def test_write_mcp_config_targets_isolated_agy_home(tmp_path: Path) -> None:
-    """write_mcp_config writes into the per-session isolated agy HOME, not ~/.gemini."""
+def test_write_mcp_config_targets_isolated_agy_gemini_dir(tmp_path: Path) -> None:
+    """write_mcp_config writes into the isolated agy Gemini dir, not ~/.gemini."""
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
     path = write_mcp_config(bridge_dir, python_executable="python-test")
 
-    # The config lands under the isolated HOME's ~/.gemini/config — the path agy
-    # actually loads MCP servers from — so the user's real ~/.gemini is untouched.
-    assert path == agy_home_dir(bridge_dir) / ".gemini" / "config" / "mcp_config.json"
+    # The config lands under the isolated --gemini_dir config path, so the user's
+    # real ~/.gemini is untouched.
+    assert path == agy_gemini_dir(bridge_dir) / "config" / "mcp_config.json"
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["mcpServers"]["omnigent"]["command"] == "python-test"
     # The bridge token the shared relay requires is written into the bridge dir.
@@ -1077,17 +1077,21 @@ def test_write_mcp_bridge_config_is_idempotent(tmp_path: Path) -> None:
     assert (tmp_path / "bridge.json").read_text(encoding="utf-8") == first
 
 
-def test_seed_isolated_agy_home_returns_home_override_and_seeds_state(
+def test_seed_isolated_agy_home_seeds_platform_credentials_and_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """seed_isolated_agy_home copies the OAuth token + markers and returns HOME."""
+    """seed_isolated_agy_home copies platform OAuth markers + state."""
     fake_home = tmp_path / "real-home"
     (fake_home / ".gemini" / "antigravity-cli").mkdir(parents=True)
+    (fake_home / ".gemini" / "oauth_creds.json").write_text(
+        '{"access_token":"mac-token"}', encoding="utf-8"
+    )
+    (fake_home / ".gemini" / "installation_id").write_text("root-install-id", encoding="utf-8")
     (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").write_text(
-        "real-token", encoding="utf-8"
+        "linux-token", encoding="utf-8"
     )
     (fake_home / ".gemini" / "antigravity-cli" / "installation_id").write_text(
-        "install-id", encoding="utf-8"
+        "cli-install-id", encoding="utf-8"
     )
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
 
@@ -1095,19 +1099,28 @@ def test_seed_isolated_agy_home_returns_home_override_and_seeds_state(
     bridge_dir.mkdir()
     env = seed_isolated_agy_home(bridge_dir)
 
-    iso = agy_home_dir(bridge_dir)
-    assert env == {"HOME": str(iso)}
-    # OAuth token is COPIED (never moved) into the isolated tree.
-    token = iso / ".gemini" / "antigravity-cli" / "antigravity-oauth-token"
-    assert token.read_text(encoding="utf-8") == "real-token"
-    # The real token file is left in place.
+    iso_gemini = agy_gemini_dir(bridge_dir)
+    assert env == {}
+    # OAuth credentials are COPIED (never moved) into the isolated tree.
+    macos_token = iso_gemini / "oauth_creds.json"
+    linux_token = iso_gemini / "antigravity-cli" / "antigravity-oauth-token"
+    assert macos_token.read_text(encoding="utf-8") == '{"access_token":"mac-token"}'
+    assert linux_token.read_text(encoding="utf-8") == "linux-token"
+    assert (iso_gemini / "installation_id").read_text(encoding="utf-8") == "root-install-id"
+    assert (iso_gemini / "antigravity-cli" / "installation_id").read_text(
+        encoding="utf-8"
+    ) == "cli-install-id"
+    # The real credential files are left in place.
+    assert (fake_home / ".gemini" / "oauth_creds.json").read_text(encoding="utf-8") == (
+        '{"access_token":"mac-token"}'
+    )
     assert (fake_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").read_text(
         encoding="utf-8"
-    ) == "real-token"
+    ) == "linux-token"
     # Onboarding + migration markers seeded so a headless launch never blocks.
-    onboarding = iso / ".gemini" / "antigravity-cli" / "cache" / "onboarding.json"
+    onboarding = iso_gemini / "antigravity-cli" / "cache" / "onboarding.json"
     assert json.loads(onboarding.read_text(encoding="utf-8"))["onboardingComplete"] is True
-    assert (iso / ".gemini" / "config" / ".migrated").is_file()
+    assert (iso_gemini / "config" / ".migrated").is_file()
 
 
 def test_seed_isolated_agy_home_tolerates_missing_credential(
@@ -1122,17 +1135,23 @@ def test_seed_isolated_agy_home_tolerates_missing_credential(
     bridge_dir.mkdir()
     env = seed_isolated_agy_home(bridge_dir)
 
-    iso = agy_home_dir(bridge_dir)
-    assert env == {"HOME": str(iso)}
-    # No token copied (none existed), but the isolated HOME + markers still exist.
-    assert not (iso / ".gemini" / "antigravity-cli" / "antigravity-oauth-token").exists()
-    assert (iso / ".gemini" / "antigravity-cli" / "cache" / "onboarding.json").is_file()
+    iso_gemini = agy_gemini_dir(bridge_dir)
+    assert env == {}
+    # No token copied (none existed), but the isolated Gemini dir + markers still exist.
+    assert not (iso_gemini / "antigravity-cli" / "antigravity-oauth-token").exists()
+    assert (iso_gemini / "antigravity-cli" / "cache" / "onboarding.json").is_file()
 
 
 def test_agy_home_dir_is_under_bridge_dir(tmp_path: Path) -> None:
-    """The isolated HOME is a child of the (hash-scoped, per-session) bridge dir."""
+    """The isolated state parent is a child of the per-session bridge dir."""
     bridge_dir = tmp_path / "bridge"
     assert agy_home_dir(bridge_dir).parent == bridge_dir
+
+
+def test_agy_gemini_dir_is_under_agy_home_dir(tmp_path: Path) -> None:
+    """The isolated Gemini dir is passed to agy via --gemini_dir."""
+    bridge_dir = tmp_path / "bridge"
+    assert agy_gemini_dir(bridge_dir) == agy_home_dir(bridge_dir) / ".gemini"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -1047,6 +1047,151 @@ def test_inject_user_message_via_tui_rejects_empty_content(tmp_path: Path) -> No
 
 
 # ---------------------------------------------------------------------------
+# Composer-region detection robustness (#1598 review follow-ups)
+# ---------------------------------------------------------------------------
+
+
+def test_agy_separator_line_accepts_pure_and_decorated_rules() -> None:
+    """Separator detection accepts a pure ─ rule and corner/join-decorated rules.
+
+    agy 1.0.14 renders a pure ``─`` composer rule, but a future build could frame
+    it with box-drawing corners; detection must tolerate that without matching
+    ordinary text or a short dash run.
+    """
+    assert _mod._agy_separator_line("─" * 60)
+    assert _mod._agy_separator_line("╭" + "─" * 40 + "╮")
+    assert _mod._agy_separator_line("├" + "─" * 20 + "┤")
+    # Not separators: ordinary text, ASCII dashes, and < 8 rule chars.
+    assert not _mod._agy_separator_line("> Generating the answer now")
+    assert not _mod._agy_separator_line("--- short ---")
+    assert not _mod._agy_separator_line("─────")
+
+
+def test_draft_candidate_lines_keep_prompt_text_with_status_words() -> None:
+    """A draft line carrying the ``>`` prompt is kept even if it contains a status word.
+
+    The chrome filters (``Generating``/idle/active markers) must apply only to
+    non-prompt rows; otherwise a legitimate message whose first line contains such
+    a word is filtered out and the turn is misread as "never rendered".
+    """
+    region = "> Generating a fix for the esc to cancel bug\n? for shortcuts"
+    candidates = _mod._agy_draft_candidate_lines(region)
+    assert "Generating a fix for the esc to cancel bug" in candidates
+    # The non-prompt idle footer row is still filtered.
+    assert "? for shortcuts" not in candidates
+
+
+def test_draft_in_input_region_keeps_prompt_text_with_status_words() -> None:
+    """A draft whose first line contains 'Generating' is detected, not hard-failed."""
+    sep = "─" * 60
+    baseline = _mod._agy_input_region(f"{sep}\n>\n{sep}\n? for shortcuts")
+    content = "Generating the migration is slow, please fix it"
+    needle = _mod._submit_needle(content)
+    pane = f"{sep}\n> {content}\n{sep}\n? for shortcuts"
+    assert _mod._draft_in_input_region(pane, needle, baseline)
+
+
+def test_draft_in_input_region_matches_short_message_by_composer_change() -> None:
+    """An empty needle (short message) is detected by a changed composer, not text.
+
+    A draft in a composer that differs from the pre-paste baseline counts as
+    present; the unchanged baseline (or a fresh empty composer after submit) does
+    not — so short messages are render/submit-verified instead of submitted blind.
+    """
+    sep = "─" * 60
+    baseline = _mod._agy_input_region(f"{sep}\n>\n{sep}\n? for shortcuts")
+    pane_with_draft = f"{sep}\n> ok\n{sep}\n? for shortcuts"
+    pane_after_submit = f"{sep}\n> ok\n{sep}\n>\n{sep}\nesc to cancel"
+    assert _mod._draft_in_input_region(pane_with_draft, "", baseline)
+    assert not _mod._draft_in_input_region(pane_after_submit, "", baseline)
+
+
+def test_format_pane_debug_tail_redacts_email_and_secrets() -> None:
+    """The diagnostic pane tail redacts emails and common secret shapes (#1598)."""
+    pane = (
+        "signed in as alice@example.com\n"
+        "key sk-ABCDEF0123456789ABCDEF\n"
+        "export GH=ghp_ABCDEFGHIJ0123456789ABCDEFGHIJ\n"
+        "Authorization: Bearer abcdef123456\n"
+        "> draft text"
+    )
+    out = _mod._format_pane_debug_tail(pane)
+    assert "alice@example.com" not in out
+    assert "sk-ABCDEF0123456789ABCDEF" not in out
+    assert "ghp_ABCDEFGHIJ0123456789ABCDEFGHIJ" not in out
+    assert "[REDACTED_EMAIL]" in out
+    assert "[REDACTED_SECRET]" in out
+    assert "> draft text" in out  # non-secret context is preserved
+    assert _mod._format_pane_debug_tail("") == "<empty pane>"
+
+
+def test_inject_user_message_via_tui_delivers_short_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _fast_tmux_timeouts: None,
+) -> None:
+    """A short message with no stable needle ('ok') is render- and submit-verified.
+
+    The empty-needle path must not submit blind: the draft is confirmed to render
+    by composer change, and submission is confirmed by the draft clearing — so a
+    legitimate short turn is delivered with exactly one verified Enter.
+    """
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+    enters = {"n": 0}
+    tui = {"pane": "> \n? for shortcuts"}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """Idle, draft after paste, composer clears after Enter."""
+        del kwargs
+        if "has-session" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "> ok\n? for shortcuts"
+        if cmd[-1] == "Enter":
+            enters["n"] += 1
+            tui["pane"] = "> \n? for shortcuts"
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    inject_user_message_via_tui(bridge_dir, content="ok", timeout_s=0.5)
+    assert enters["n"] == 1
+
+
+def test_inject_user_message_via_tui_short_message_raises_when_not_submitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _fast_tmux_timeouts: None,
+) -> None:
+    """A short message whose draft never clears fails loudly, not silently.
+
+    Regression guard for the empty-needle path: previously a no-needle message was
+    submitted with a single unverified Enter, so a folded Enter left it stuck in
+    the composer and the turn was silently lost. It must now raise.
+    """
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+    tui = {"pane": "> \n? for shortcuts"}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """Draft renders but never clears (Enter folded into the paste burst)."""
+        del kwargs
+        if "has-session" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "> ok\n? for shortcuts"
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(RuntimeError, match="draft is still visible"):
+        inject_user_message_via_tui(bridge_dir, content="ok", timeout_s=0.5)
+
+
+# ---------------------------------------------------------------------------
 # Omnigent MCP relay wiring (sys_* tools) — #1194
 # ---------------------------------------------------------------------------
 

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -790,7 +790,7 @@ def test_inject_user_message_via_tui_resends_enter_when_coalesced(
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
     enters = {"n": 0}
-    tui = {"pane": "> hi there\n? for shortcuts"}
+    tui = {"pane": "> \n? for shortcuts"}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """Activate the turn only on the second Enter."""
@@ -799,6 +799,8 @@ def test_inject_user_message_via_tui_resends_enter_when_coalesced(
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if "capture-pane" in cmd:
             return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "> hi there\n? for shortcuts"
         if cmd[-1] == "Enter":
             enters["n"] += 1
             if enters["n"] >= 2:
@@ -816,17 +818,16 @@ def test_inject_user_message_via_tui_accepts_changed_active_footer(
     _fast_tmux_timeouts: None,
 ) -> None:
     """
-    The submit is confirmed when the footer leaves idle, even if the running
-    footer text differs from the known marker.
+    The submit is confirmed when the draft leaves the composer, even if the
+    running footer text differs from the known marker.
 
     A future agy build could rename the running footer or a narrow pane could
-    truncate it; as long as the idle ``? for shortcuts`` marker is gone from a
-    non-empty pane, the turn is treated as started — so a working submit is not
-    misread as stuck and falsely failed.
+    truncate it; delivery must key off draft disappearance instead.
     """
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
-    tui = {"pane": "> hi\n? for shortcuts"}
+    content = "hello there"
+    tui = {"pane": "> \n? for shortcuts"}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """Idle until Enter; then a non-idle footer that is NOT the known marker."""
@@ -835,13 +836,14 @@ def test_inject_user_message_via_tui_accepts_changed_active_footer(
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if "capture-pane" in cmd:
             return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = f"> {content}\n? for shortcuts"
         if cmd[-1] == "Enter":
             tui["pane"] = "> \n(generating response, press the cancel key to stop)"
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    # Must not raise: the idle marker is gone, so the submit is confirmed.
-    inject_user_message_via_tui(bridge_dir, content="hi", timeout_s=0.5)
+    inject_user_message_via_tui(bridge_dir, content=content, timeout_s=0.5)
 
 
 def test_inject_user_message_via_tui_mid_turn_sends_one_enter(
@@ -862,16 +864,20 @@ def test_inject_user_message_via_tui_mid_turn_sends_one_enter(
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
     enters = {"n": 0}
+    tui = {"pane": "> \nesc to cancel"}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
-        """agy is mid-turn the entire time: the footer never leaves ``esc to cancel``."""
+        """agy stays mid-turn, but the draft clears after Enter."""
         del kwargs
         if "has-session" in cmd:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout="> steer me\nesc to cancel", stderr="")
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "> steer me\nesc to cancel"
         if cmd[-1] == "Enter":
             enters["n"] += 1
+            tui["pane"] = "> \nesc to cancel"
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
@@ -879,48 +885,45 @@ def test_inject_user_message_via_tui_mid_turn_sends_one_enter(
     assert enters["n"] == 1, "mid-turn submit must send exactly one Enter (no re-send)"
 
 
-def test_submit_verify_ignores_single_transient_nonidle_frame(
+def test_inject_user_message_via_tui_ignores_transcript_echo_after_submit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     _fast_tmux_timeouts: None,
 ) -> None:
     """
-    A lone non-idle capture (a mid-repaint frame) must not be read as submitted.
+    The submitted prompt remaining in transcript history is not a stuck draft.
 
-    The "idle marker gone" signal is only accepted on two CONSECUTIVE polls. A
-    single transient frame with neither marker — followed by the idle footer
-    again — resets the counter, so the submit is confirmed only once the active
-    marker actually appears. Otherwise an early return on a redraw glitch could
-    cost the caller a full state-wait before a "did not register" error.
+    Claude/Kiro-style verification must scope matching to agy's live composer.
+    After Enter, agy echoes the prompt above a fresh empty composer; matching the
+    whole pane would falsely retry Enter and could submit an empty follow-up.
     """
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
-    # capture-pane sequence after Enter: idle, one transient blank frame, idle
-    # again, then the running footer. A correct 2-consecutive rule reaches index 3.
-    panes = [
-        "> hi\n? for shortcuts",  # idle
-        "> \n",  # transient: neither marker (mid-repaint)
-        "> hi\n? for shortcuts",  # idle again — resets the non-idle counter
-        "> \nesc to cancel",  # turn running — the real confirmation
-    ]
-    captures = {"n": 0}
+    content = "Reply exactly: transcript echo ok"
+    enters = {"n": 0}
+    separator = "────────────────────────────────────────────────────────────────────────────────"
+    tui = {"pane": f"{separator}\n>\n{separator}\n? for shortcuts"}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
-        """Serve the scripted pane sequence; never empty so liveness stays true."""
+        """After Enter, keep the prompt only in transcript history."""
         del kwargs
         if "has-session" in cmd:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if "capture-pane" in cmd:
-            idx = min(captures["n"], len(panes) - 1)
-            captures["n"] += 1
-            return SimpleNamespace(returncode=0, stdout=panes[idx], stderr="")
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = f"{separator}\n> {content}\n{separator}\n? for shortcuts"
+        if cmd[-1] == "Enter":
+            enters["n"] += 1
+            tui["pane"] = (
+                f"{separator}\n> {content}\n⣾  Generating...\n{separator}\n"
+                f">\n{separator}\nesc to cancel"
+            )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    inject_user_message_via_tui(bridge_dir, content="hi", timeout_s=0.5)
-    # Must have polled past the transient frame to the running footer (index 3),
-    # i.e. it did NOT return early on the lone non-idle frame at index 1.
-    assert captures["n"] >= 4
+    inject_user_message_via_tui(bridge_dir, content=content, timeout_s=0.5)
+    assert enters["n"] == 1
 
 
 def test_inject_user_message_via_tui_raises_when_target_never_advertised(
@@ -966,6 +969,7 @@ def test_inject_user_message_via_tui_raises_when_session_dies_before_submit(
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
     has_session_calls = {"n": 0}
+    tui = {"pane": "> \n? for shortcuts"}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """Alive at the entry check; dead by the time the submit re-checks."""
@@ -975,11 +979,34 @@ def test_inject_user_message_via_tui_raises_when_session_dies_before_submit(
             # 1st call = entry gate (alive); later calls = per-submit re-check (dead).
             return SimpleNamespace(returncode=0 if has_session_calls["n"] == 1 else 1, stdout="")
         if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout="> draft\n? for shortcuts", stderr="")
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "> draft message\n? for shortcuts"
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
     with pytest.raises(RuntimeError, match="exited before the message could be submitted"):
+        inject_user_message_via_tui(bridge_dir, content="draft message", timeout_s=0.5)
+
+
+def test_inject_user_message_via_tui_raises_when_paste_never_renders(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _fast_tmux_timeouts: None,
+) -> None:
+    """A successful tmux paste command is not enough; the draft must render."""
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        """Pane stays empty even after paste-buffer returns successfully."""
+        del kwargs
+        if "capture-pane" in cmd:
+            return SimpleNamespace(returncode=0, stdout="> \n? for shortcuts", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    with pytest.raises(RuntimeError, match="did not render the pasted message"):
         inject_user_message_via_tui(bridge_dir, content="draft message", timeout_s=0.5)
 
 
@@ -991,21 +1018,25 @@ def test_inject_user_message_via_tui_raises_when_turn_never_starts(
     """
     If no turn ever starts after the submit attempts, the delivery raises.
 
-    The pane stays idle forever (Enter never takes), so after the bounded
-    re-send budget the executor gets a clear error rather than a false success.
+    The pasted draft stays visible forever (Enter never takes), so after the
+    bounded re-send budget the executor gets a clear error rather than a false
+    success.
     """
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(bridge_dir, socket_path=Path("/tmp/ex/tmux.sock"), tmux_target="main")
+    tui = {"pane": "> \n? for shortcuts"}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         """Pane never leaves idle — the submit never starts a turn."""
         del kwargs
         if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout="> draft\n? for shortcuts", stderr="")
+            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+        if "paste-buffer" in cmd:
+            tui["pane"] = "> draft message\n? for shortcuts"
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    with pytest.raises(RuntimeError, match="did not start a turn"):
+    with pytest.raises(RuntimeError, match="draft is still visible"):
         inject_user_message_via_tui(bridge_dir, content="draft message", timeout_s=0.5)
 
 
@@ -1121,6 +1152,43 @@ def test_seed_isolated_agy_home_seeds_platform_credentials_and_state(
     onboarding = iso_gemini / "antigravity-cli" / "cache" / "onboarding.json"
     assert json.loads(onboarding.read_text(encoding="utf-8"))["onboardingComplete"] is True
     assert (iso_gemini / "config" / ".migrated").is_file()
+
+
+def test_seed_isolated_agy_home_trusts_workspace_in_isolated_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Workspace trust is seeded under isolated --gemini_dir, not real ~/.gemini."""
+    fake_home = tmp_path / "real-home"
+    real_settings = fake_home / ".gemini" / "antigravity-cli" / "settings.json"
+    real_settings.parent.mkdir(parents=True)
+    real_settings.write_text(
+        json.dumps({"colorScheme": "dark", "trustedWorkspaces": ["/real/repo"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    workspace = tmp_path / "worktrees" / "feature-x"
+    workspace.mkdir(parents=True)
+    iso_gemini = agy_gemini_dir(bridge_dir)
+    isolated_settings = iso_gemini / "antigravity-cli" / "settings.json"
+    isolated_settings.parent.mkdir(parents=True)
+    isolated_settings.write_text(
+        json.dumps({"colorScheme": "solarized dark", "trustedWorkspaces": ["/existing"]}),
+        encoding="utf-8",
+    )
+
+    seed_isolated_agy_home(bridge_dir, trusted_workspace=workspace)
+
+    isolated = json.loads(isolated_settings.read_text(encoding="utf-8"))
+    assert isolated["colorScheme"] == "solarized dark"
+    assert isolated["trustedWorkspaces"] == ["/existing", str(workspace.resolve())]
+    # The user's real agy settings are never modified by this bridge-scoped seed.
+    assert json.loads(real_settings.read_text(encoding="utf-8")) == {
+        "colorScheme": "dark",
+        "trustedWorkspaces": ["/real/repo"],
+    }
 
 
 def test_seed_isolated_agy_home_tolerates_missing_credential(


### PR DESCRIPTION
## Summary

Stacked follow-up to #1412.

#1412 preserves macOS keyring auth while isolating agy config/MCP state via `--gemini_dir`. This PR fixes the next native-TUI delivery gate: fresh isolated agy sessions can stop on Antigravity's workspace trust prompt, so Omnigent's tmux paste can land in the trust picker instead of the normal input composer.

This mirrors the Claude/Kiro native pattern:
- pre-accept the unhookable first-run workspace trust gate before host-spawned sessions;
- verify turn delivery by checking the live composer draft, not only footer text.

While #1412 is still open, this PR intentionally includes #1412's commits plus one additional TUI-delivery commit. After #1412 merges, I can rebase this branch so the diff collapses to the follow-up change only.

## Changes

- Seed `trustedWorkspaces` in the isolated agy settings file under the bridge-owned `--gemini_dir`.
- Keep the user's real `~/.gemini` untouched.
- Scope submit verification to agy's live composer region so transcript echoes do not look like stuck drafts.
- Retry Enter only while the same draft is still visible.
- Fail loudly when `paste-buffer` succeeds but the draft never appears in the composer.

## macOS live smoke

Ran locally on macOS with the current Antigravity CLI.

Before this change, the smoke failed because agy showed:

`Do you trust the contents of this project?`

After rebasing onto latest `upstream/main`, this command:

`uv run --extra dev --python /opt/homebrew/bin/python3.13 omnigent run /private/tmp/agy-pr1412-smoke.yaml --no-session --no-log -p "Reply exactly: AGY_REBASED_TUI_OK"`

returned:

`AGY_REBASED_TUI_OK`

This includes the live macOS smoke requested in #1412's review thread.

## Tests

- `uv run --extra dev --python /opt/homebrew/bin/python3.13 python -m pytest -q -p no:cacheprovider -p no:unraisableexception tests/test_antigravity_native_bridge.py tests/runner/test_app_sessions_native.py::test_auto_create_antigravity_wires_omnigent_mcp_relay` -> 61 passed
- `uv run --extra dev --python /opt/homebrew/bin/python3.13 ruff check omnigent/antigravity_native_bridge.py omnigent/runner/app.py tests/test_antigravity_native_bridge.py tests/runner/test_app_sessions_native.py` -> passed
- `git diff --check upstream/main...HEAD` -> passed