### PR TITLE
fix(installer): correct post-install hint to `omnigent setup`

### DIFF
--- a/scripts/install_oss.sh
+++ b/scripts/install_oss.sh
@@ -615,10 +615,10 @@ print_next_steps() {
   printf '  %somnigent claude          # Claude Code\n' "$command_prefix"
   printf '  %somnigent codex           # Codex\n\n' "$command_prefix"
   printf 'Manage model credentials any time:\n'
-  printf '  %somnigent configure harness\n\n' "$command_prefix"
+  printf '  %somnigent setup\n\n' "$command_prefix"
   printf '%sUsing a Databricks workspace as your model provider? Install the\n' "$DIM"
   printf 'Databricks CLI (https://docs.databricks.com/aws/en/dev-tools/cli/install)\n'
-  printf 'and add it via: omnigent configure harness -> Databricks.%s\n' "$RESET"
+  printf 'and add it via: omnigent setup -> Databricks.%s\n' "$RESET"
 }
 
 main() {


### PR DESCRIPTION
## Related issue

N/A

## Summary

The post-install next-steps message printed by `scripts/install_oss.sh` pointed users at `omnigent configure harness`, which is not a real command:

```
$ omnigent configure harness
Error: No such command 'configure'.
```

The correct entry point for managing model credentials and adding a Databricks provider is `omnigent setup` (`@cli.command("setup")` in `omnigent/cli.py`). This replaces both occurrences in the printed message — text-only, no behavior change. Surfaced by a user who ran the published `omnigent.ai/install.sh` and hit the dead command.

## Test Plan

```
ok uv tool install

  ⠀⠀⠀⢠⣿⡄⠀⠀⠀   ██████╗ ███╗   ███╗███╗   ██╗██╗ ██████╗ ███████╗███╗
██╗████████╗
  ⢴⣶⣶⠉⣿⠉⣶⣶⡦  ██╔═══██╗████╗ ████║████╗  ██║██║██╔════╝ ██╔════╝████╗
██║╚══██╔══╝
  ⠀⠙⣿⣶⣿⣶⣿⠋⠀  ██║   ██║██╔████╔██║██╔██╗ ██║██║██║  ███╗█████╗  ██╔██╗ ██║
██║
  ⠀⢠⣿⡿⠿⢿⣿⡄⠀  ╚██████╔╝██║ ╚═╝ ██║██║ ╚████║██║╚██████╔╝███████╗██║ ╚████║
██║
  ⠀⠈⠁⠀⠀⠀⠈⠁⠀   ╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═══╝╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝
╚═╝
  all your agents, one cli

  Version       0.3.0
  Get started   omnigent setup

==> Verified /home/bryan.qiu/.local/bin/omnigent
==> /home/bryan.qiu/.local/bin is already on PATH

Omnigent installed successfully.

Start chatting — first run sets up a model and a local web UI:
  omnigent

Or launch a specific coding harness:
  omnigent claude          # Claude Code
  omnigent codex           # Codex

Manage model credentials any time:
  omnigent setup

Using a Databricks workspace as your model provider? Install the
Databricks CLI (https://docs.databricks.com/aws/en/dev-tools/cli/install)
and add it via: omnigent setup -> Databricks.
```

- Verified `setup` is a registered command (`@cli.command("setup")`, `omnigent/cli.py:11325`) and that `configure` is not.
- Inspected the rendered install message; both `configure harness` references now read `omnigent setup`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: confirmed the corrected command exists in the CLI and that the install script now prints `omnigent setup` in both spots. The text is not covered by automated tests; no logic changed.