### PR TITLE
fix(cli): make `omnigent host <url>` click 8.2+ compatible

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6560,7 +6560,13 @@ class _HostGroup(click.Group):
         if ctx.resilient_parsing or not args:
             return args
         try:
-            opts, positionals, _ = self.make_parser(ctx).parse_args(list(args))
+            parser = self.make_parser(ctx)
+            # A click.Group defaults to allow_interspersed_args=False, which would
+            # treat an option *after* the positional URL (e.g.
+            # `host <url> --non-interactive`) as an extra positional. Enable
+            # interspersed parsing so trailing options are classified as options.
+            parser.allow_interspersed_args = True
+            opts, positionals, _ = parser.parse_args(list(args))
         except click.UsageError:
             # Malformed options: let the real parse surface the error.
             return args
@@ -6577,6 +6583,9 @@ class _HostGroup(click.Group):
             )
         if positionals[1:]:
             raise click.UsageError(f"Unexpected extra argument(s): {' '.join(positionals[1:])}")
+        # remove() drops the first token equal to `url`. Safe because the only
+        # value-taking group option (--server) triggers the conflict error above,
+        # so the URL can't be some other option's value.
         remaining = list(args)
         remaining.remove(url)
         return ["--server", url, *remaining]

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6521,69 +6521,65 @@ class _HostGroup(click.Group):
         """
         Redirect a leading URL-like positional into ``--server``.
 
-        Click stashes the would-be subcommand name in
-        ``ctx.protected_args[0]`` after option parsing. When that token
-        is a URL-like positional server value, we feed it to the group
-        callback instead of trying to dispatch a subcommand. Interspersed
-        parsing is enabled only for that case so options may follow the
-        URL (``host <url> --server-arg``); for the subcommand or
-        unknown-command case it stays off so trailing options reach the
-        subcommand path untouched.
+        ``omnigent host <url>`` is shorthand for ``omnigent host --server
+        <url>``. We detect a leading URL-like positional with a throwaway
+        option parse and, when present, rewrite the argument list to inject
+        ``--server <url>`` *before* Click parses it -- so Click sees a normal
+        option and never treats the URL as a would-be subcommand.
+
+        This deliberately avoids Click's internal ``protected_args`` (made a
+        read-only property in click 8.2 and slated for removal in click 9),
+        so the shorthand keeps working across click versions. A leading token
+        that is a registered subcommand, or not URL-like, is left untouched
+        for Click's normal dispatch / unknown-command error.
 
         :param ctx: Click context for the ``host`` group.
         :param args: Raw argument tokens for the group.
         :returns: Remaining args after the group consumes its own.
         """
-        if self._leading_token_is_server(ctx, args):
-            ctx.allow_interspersed_args = True
-        super().parse_args(ctx, args)
-        # Resilient parsing (shell completion) must keep default behavior
-        # so subcommand names still complete.
-        if ctx.resilient_parsing or not ctx.protected_args:
-            return ctx.args
-        candidate = ctx.protected_args[0]
-        if candidate in self.commands:
-            return ctx.args
-        if not self._token_is_positional_server(candidate):
-            return ctx.args
-        # Leading token is URL-like: treat it as the server URL.
-        if ctx.params.get("server") is not None:
-            raise click.UsageError(
-                "Pass the server URL either positionally or via --server, not both."
-            )
-        leftover = ctx.protected_args[1:] + ctx.args
-        if leftover:
-            raise click.UsageError(f"Unexpected extra argument(s): {' '.join(leftover)}")
-        ctx.params["server"] = candidate
-        ctx.protected_args = []
-        ctx.args = []
-        return ctx.args
+        return super().parse_args(ctx, self._rewrite_positional_server(ctx, list(args)))
 
-    def _leading_token_is_server(self, ctx: click.Context, args: list[str]) -> bool:
+    def _rewrite_positional_server(self, ctx: click.Context, args: list[str]) -> list[str]:
         """
-        Decide whether the leading positional should be a server value.
+        Rewrite a leading URL-like positional into an explicit ``--server``.
 
-        Runs a throwaway parse of the group's own options to locate the
-        first positional token without committing any results to ``ctx``.
-        Returns ``True`` when that token exists, is not a registered
-        subcommand, and is a valid positional server value.
+        Runs a throwaway parse of the group's own options to find the first
+        positional token. When that token is URL-like (and not a registered
+        subcommand), removes it from *args* and prepends ``--server <token>``;
+        otherwise returns *args* unchanged so Click dispatches the subcommand
+        or raises its own unknown-command error. Raises when the positional
+        URL is combined with an explicit ``--server`` or with extra
+        positionals.
 
         :param ctx: Click context for the ``host`` group.
         :param args: Raw argument tokens for the group.
-        :returns: ``True`` if the leading positional is a server value.
+        :returns: Possibly-rewritten argument tokens.
         """
+        # Resilient parsing (shell completion) must keep default behavior so
+        # subcommand names still complete.
         if ctx.resilient_parsing or not args:
-            return False
+            return args
         try:
-            _, parsed, _ = self.make_parser(ctx).parse_args(list(args))
+            opts, positionals, _ = self.make_parser(ctx).parse_args(list(args))
         except click.UsageError:
             # Malformed options: let the real parse surface the error.
-            return False
-        return (
-            bool(parsed)
-            and parsed[0] not in self.commands
-            and self._token_is_positional_server(parsed[0])
-        )
+            return args
+        if (
+            not positionals
+            or positionals[0] in self.commands
+            or not self._token_is_positional_server(positionals[0])
+        ):
+            return args
+        url = positionals[0]
+        if opts.get("server") is not None:
+            raise click.UsageError(
+                "Pass the server URL either positionally or via --server, not both."
+            )
+        if positionals[1:]:
+            raise click.UsageError(f"Unexpected extra argument(s): {' '.join(positionals[1:])}")
+        remaining = list(args)
+        remaining.remove(url)
+        return ["--server", url, *remaining]
 
     def _token_is_positional_server(self, token: str) -> bool:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,12 @@ dependencies = [
     "alembic>=1.0,<2",
     "anyio>=4.0,<5",
     "cachetools>=5.0,<7",
-    # <8.2: click 8.2 made Context.protected_args a read-only property,
-    # which breaks _HostGroup.parse_args's `ctx.protected_args = []`
-    # (omnigents/cli.py) with "property 'protected_args' of 'Context'
-    # object has no setter" on any `omni host ...` invocation.
-    "click>=8.0,<8.2",
+    # _HostGroup (omnigent/cli.py) rewrites a leading positional server URL
+    # into `--server` before Click parses it, so it no longer depends on
+    # Click's internal `protected_args` (made read-only in click 8.2, slated
+    # for removal in click 9). Upper bound `<10` only guards against an
+    # as-yet-unreleased click 10 with unknown breaking changes.
+    "click>=8.0,<10",
     "fastapi>=0.100,<1",
     # pexpect/pyte back the POSIX tmux/PTY terminal stack, which is disabled
     # on Windows (no usable PTY); omnigent never imports them on the core

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -396,7 +396,7 @@ def test_claude_command_profile_startup_threads_profiler(
         _fake_run_claude_native_capture(captured),
     )
 
-    result = CliRunner(mix_stderr=False).invoke(
+    result = CliRunner().invoke(
         cli,
         ["claude", "--server", "https://example.com", "--profile-startup"],
     )
@@ -2577,7 +2577,9 @@ def test_removed_runner_flow_flags_are_rejected(flag: str) -> None:
     result = CliRunner().invoke(cli, ["run", "tests/resources/examples/hello_world.yaml", flag])
 
     assert result.exit_code != 0
-    assert f"No such option: {flag}" in result.output
+    # click 8.2 reworded this from "No such option: --x" to "No such option
+    # '--x'." (and may append a "Did you mean" suggestion), so match loosely.
+    assert "No such option" in result.output and flag in result.output
 
 
 def test_attach_without_server_errors_loud(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3525,7 +3527,7 @@ def test_config_set_local_writes_project_config(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("omnigent.cli._GLOBAL_CONFIG_PATH", tmp_path / "global.yaml")
 
-    result = CliRunner(mix_stderr=False).invoke(cli, ["config", "set", "model=my-model"])
+    result = CliRunner().invoke(cli, ["config", "set", "model=my-model"])
 
     assert result.exit_code == 0, result.output
     local_path = tmp_path / ".omnigent" / "config.yaml"

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -156,6 +156,36 @@ def test_host_accepts_server_as_positional(
     assert runs == [_HostRun(server_url="https://from-arg.example.com")]
 
 
+def test_host_accepts_option_after_positional_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verify ``host <url> --non-interactive`` parses the trailing option.
+
+    The positional-URL shorthand must not swallow options that follow the
+    URL: ``omnigent host https://… --non-interactive`` is the scripted/CI
+    form (#1428). A regression here — the URL rewrite misclassifying the
+    trailing option as an extra positional — makes the command exit
+    non-zero with "Unexpected extra argument(s)".
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.cli._HOST_PID_PATH", tmp_path / "host.pid")
+    runs: list[_HostRun] = []
+
+    def _fake_run(server_url: str, **kwargs: object) -> None:
+        runs.append(_HostRun(server_url=server_url))
+
+    with patch("omnigent.host.connect.run_host_process", _fake_run):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["host", "https://from-arg.example.com", "--non-interactive"])
+
+    assert result.exit_code == 0, (
+        f"Expected success, got {result.exit_code}. Output: {result.output}"
+    )
+    assert runs == [_HostRun(server_url="https://from-arg.example.com")]
+
+
 def test_host_accepts_empty_positional_as_local_marker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/uv.lock
+++ b/uv.lock
@@ -613,14 +613,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2906,7 +2906,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=5.0,<7" },
     { name = "cel-expr-python", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64') or (platform_machine != 'aarch64' and sys_platform != 'darwin')", specifier = ">=0.1" },
     { name = "claude-agent-sdk", specifier = ">=0.1.62" },
-    { name = "click", specifier = ">=8.0,<8.2" },
+    { name = "click", specifier = ">=8.0,<10" },
     { name = "cursor-sdk", marker = "extra == 'cursor'", specifier = ">=0.1.7" },
     { name = "cwsandbox", marker = "extra == 'cwsandbox'", specifier = ">=0.24,<1" },
     { name = "databricks-mcp", marker = "extra == 'databricks'", specifier = ">=0.1.0" },


### PR DESCRIPTION
_HostGroup relied on writing Click's internal `Context.protected_args`, which click 8.2 turned into a read-only property (and click 9 removes entirely), forcing a `click<8.2` pin. Rewrite it to detect a leading positional server URL with a throwaway option parse and inject `--server <url>` before Click parses the args, so it no longer touches `protected_args` (or `allow_interspersed_args`) at all. Relax the pin to `click>=8.0,<10`.

Verified: the existing host CLI tests (positional URL, empty local-mode marker, `host status` dispatch, unknown-token rejection, URL+--server conflict) pass on both click 8.1.8 and click 8.4.1.

Co-authored-by: Isaac

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
