### PR TITLE
Enable persisted policy store in Docker entrypoint

### DIFF
--- a/deploy/docker/POLICY_STORE.md
+++ b/deploy/docker/POLICY_STORE.md
@@ -1,0 +1,85 @@
+# Docker policy store — behavior + verification
+
+Reference for the `deploy/docker` compose stack. This is the canonical
+Docker policy-store verification doc; keep `README.md` operator-facing
+and `config.yaml.example` focused on config keys.
+
+For the policy model itself (phases, ordering, actions), see
+[`docs/POLICIES.md`](../../docs/POLICIES.md).
+
+## Behavior to preserve
+
+- `DATABASE_URL` selects the policy store database. There is no
+  policy-store-specific environment variable.
+- `main()` runs Alembic `upgrade head` before `build_app()` constructs
+  `SqlAlchemyPolicyStore`.
+- `build_app()` passes the same policy store to runtime initialization
+  and `create_app()`.
+- `config.yaml` can register `policy_modules` so API-created Python
+  policies can reference custom handlers through the registry allowlist.
+- `config.yaml` can declare a `policies:` block; the entrypoint parses it
+  through `parse_default_policies`, matching the CLI `omnigent server`
+  path. These merge with the API-backed defaults below.
+- Persisted defaults created through `/v1/policies` join the admin
+  policy layer for every session; session-scoped policies from
+  `/v1/sessions/{session_id}/policies` run before agent and admin
+  policies.
+
+## Completion criteria for a Docker policy-store change
+
+- `/health` returns success after `docker compose up -d --build`.
+- `/openapi.json` includes default and session policy routes.
+- A default policy created through `/v1/policies` can be listed,
+  enforced through `/v1/sessions/{session_id}/policies/evaluate`, and
+  still exists after `docker compose restart omnigent`.
+- A session-scoped policy created through
+  `/v1/sessions/{session_id}/policies` can be listed for that session.
+- The `policies` table exists in the compose Postgres database.
+
+## Local smoke test
+
+```bash
+cd deploy/docker
+./bootstrap.sh
+OMNIGENT_AUTH_ENABLED=0 docker compose down -v
+OMNIGENT_AUTH_ENABLED=0 docker compose up -d --build
+curl -fsS http://localhost:8000/health
+curl -fsS http://localhost:8000/openapi.json \
+  | jq -r '.paths | keys[] | select(test("polic"))'
+
+docker compose exec -T postgres sh -lc \
+'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "
+INSERT INTO users (id, is_admin) VALUES ('\''local'\'', true)
+ON CONFLICT (id) DO UPDATE SET is_admin = true;
+"'
+
+BASE=http://localhost:8000
+DEFAULT_HANDLER=omnigent.policies.builtins.safety.max_tool_calls_per_session
+SESSION_HANDLER=omnigent.policies.builtins.safety.ask_on_os_tools
+
+curl -fsS -X POST "$BASE/v1/policies" \
+  -H 'content-type: application/json' \
+  -d "{\"name\":\"local_default_limit\",\"type\":\"python\",\"handler\":\"$DEFAULT_HANDLER\",\"factory_params\":{\"limit\":0}}"
+curl -fsS "$BASE/v1/policies" | jq '.data'
+
+AGENT_ID=$(curl -fsS "$BASE/v1/agents" | jq -r '.data[0].id // empty')
+test -n "$AGENT_ID"
+SESSION_ID=$(curl -fsS -X POST "$BASE/v1/sessions" \
+  -H 'content-type: application/json' \
+  -d "{\"agent_id\":\"$AGENT_ID\",\"title\":\"policy crud smoke\"}" \
+  | jq -r '.id')
+curl -fsS -X POST "$BASE/v1/sessions/$SESSION_ID/policies" \
+  -H 'content-type: application/json' \
+  -d "{\"name\":\"local_session_policy\",\"type\":\"python\",\"handler\":\"$SESSION_HANDLER\"}"
+curl -fsS "$BASE/v1/sessions/$SESSION_ID/policies" | jq '.data'
+
+curl -fsS -X POST "$BASE/v1/sessions/$SESSION_ID/policies/evaluate" \
+  -H 'content-type: application/json' \
+  -d '{"event":{"type":"PHASE_TOOL_CALL","target":"","data":{"name":"Bash","arguments":{}},"context":{}}}' \
+  | jq -e '.result == "POLICY_ACTION_DENY"'
+
+docker compose restart omnigent
+curl -fsS "$BASE/v1/policies" | jq '.data'
+docker compose exec -T postgres sh -lc \
+'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "\d+ policies"'
+```

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -39,6 +39,32 @@ Reset everything (drops the DB and the artifact store):
 docker compose down -v
 ```
 
+## Runtime policies
+
+The Docker stack uses the same policy store as the rest of the server.
+On startup the entrypoint reads `DATABASE_URL`, runs Alembic
+`upgrade head`, and wires `SqlAlchemyPolicyStore` into the runtime and
+API app. There is no separate policy-store environment variable; policy
+rows follow the same database backup and volume lifecycle as sessions,
+agents, and files.
+
+Policy configuration is API-backed. `config.yaml` (`/data/config.yaml`
+by default, or `OMNIGENT_CONFIG`) can register `policy_modules` so
+custom handlers appear in the registry, but global and session policy
+assignments live in Postgres:
+
+- `POST /v1/policies` creates server-wide defaults that apply to every
+  session.
+- `POST /v1/sessions/{session_id}/policies` creates policies scoped to
+  one session.
+
+Enabled session policies run before agent policies. Server-wide admin
+defaults from `/v1/policies` run after agent policies. If migrations
+fail, the container exits before serving traffic.
+
+For the local Docker policy-store smoke test, use
+[`SKILL.md`](SKILL.md#runtime-policies).
+
 ## Multi-user mode (accounts — default)
 
 Built-in accounts auth: no IdP to register, no proxy to host.

--- a/deploy/docker/SKILL.md
+++ b/deploy/docker/SKILL.md
@@ -43,7 +43,7 @@ Server is on http://localhost:8000.
 |---|---|
 | `Dockerfile` | Multi-stage build with two final targets. `web-builder` (node:20) runs `npm install && npm run build` on `web/`. `builder` (python:3.12) installs omnigent into `/opt/venv`; `server-builder` overlays the SPA bundle from `web-builder` and adds psycopg. The default target (`runtime`) copies the venv + `/build/` from `server-builder` and runs `entrypoint.py`. `--target host` builds the host image instead (from `builder`: omnigent + git/tmux, no SPA/psycopg/entrypoint). |
 | `Dockerfile.dockerignore` | BuildKit-aware exclude. Trims `deploy/databricks/`, `deploy/aws/`, tests, dev tooling — keeps the build context small. |
-| `entrypoint.py` | Server process entrypoint. Reads `DATABASE_URL`, runs Alembic migrations, builds the SQLAlchemy stores, calls `create_app()`, runs uvicorn. Single source of truth for what env vars the container respects. |
+| `entrypoint.py` | Server process entrypoint. Reads `DATABASE_URL`, runs Alembic migrations, builds the SQLAlchemy stores including the policy store, calls `create_app()`, runs uvicorn. Single source of truth for what env vars the container respects. |
 | `docker-compose.yaml` | Two services: `postgres` (16-alpine, persistent volume) and `omnigent` (built from the Dockerfile, depends on postgres healthcheck). Build context is `../..` (repo root). |
 | `.env.example` | Documents every env var the compose file passes through: `POSTGRES_PASSWORD`, `OMNIGENT_PORT`, all the `OMNIGENT_AUTH_*` and `OMNIGENT_OIDC_*` vars. |
 | `README.md` | Customer-facing quickstart + the OIDC walkthrough (GitHub OAuth, Google Workspace, generic OIDC). |
@@ -64,6 +64,17 @@ If you change it in `.env`, you need `docker compose down -v` before
 `up -d` or the server will fail to authenticate against the existing
 cluster.
 
+## Runtime policies
+
+Policies persist in the compose Postgres database — `DATABASE_URL`
+selects the store, and startup runs `alembic upgrade head` to create the
+`policies` table. Server-wide defaults come from `/v1/policies` and the
+`policies:` config block; session-scoped ones from
+`/v1/sessions/{session_id}/policies`.
+
+See [`POLICY_STORE.md`](POLICY_STORE.md) for the behavior contract,
+completion criteria, and the local smoke test.
+
 ## Common debugging
 
 | Symptom | Likely cause | First check |
@@ -71,6 +82,7 @@ cluster.
 | Root URL returns `{"service":"omnigent",…}` instead of the SPA | npm build didn't produce the bundle inside the container | `docker compose exec omnigent ls /build/omnigent/server/static/web-ui/` — empty = the `web-builder` stage didn't run cleanly. Rebuild with `--no-cache`. |
 | `ModuleNotFoundError: No module named 'uvicorn'` at startup | venv copy didn't pick up the install | Sanity-check the Dockerfile's `VIRTUAL_ENV=/opt/venv` is set before the `uv pip install` calls. |
 | `psycopg.OperationalError: password authentication failed` | `POSTGRES_PASSWORD` changed in `.env` after the data volume was initialized | `docker compose down -v` then `up -d` (wipes the DB). |
+| `/v1/policies` missing from OpenAPI, or no `policies` table | Running an image built before policy-store support | Rebuild and restart: `docker compose up -d --build`. Startup runs `alembic upgrade head`, which creates the `policies` table automatically — you don't create it by hand, and existing sessions/agents/files are untouched. (Dev regression check: confirm `entrypoint.py` still passes `policy_store` to both `init_runtime()` and `create_app()`.) |
 | Web UI loads but new chats hang forever | Expected — runners are external. The UI's landing page prints the CLI command to launch a runner. |
 
 ## Extending to a new platform

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -421,6 +421,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         project_store=project_store,
         auth_provider=auth_provider,
         account_store=account_store,
+        policy_modules=cfg.get("policy_modules"),
         # Non-secret auth settings from the config file (admins are the
         # canonical, declarative roster; allowed_domains gates OIDC). Both
         # union with their runtime-editable files under <data_dir>.

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -288,11 +288,13 @@ def build_policy_engine(
     from the post-seed snapshot.
 
     Policy run order: session policies (from the CRUD API)
-    first, then agent spec policies, then *default_policies*
-    (server-wide admin policies). This lets user-configured
-    session policies short-circuit on DENY before agent or
-    admin policies run, and gives admin policies the last
-    word on ALLOW/ASK decisions.
+    first, then agent spec policies, then server-wide admin
+    policies. Admin policies include *default_policies* (parsed
+    from server YAML) plus persisted default policies from
+    ``policy_store.list_defaults()``. This lets user-configured
+    session policies short-circuit on DENY before agent or admin
+    policies run, and gives admin policies the last word on
+    ALLOW/ASK decisions.
 
     For sub-agent conversations, session policies from the
     root (top-level) conversation are inherited and prepended
@@ -334,7 +336,9 @@ def build_policy_engine(
     :param default_policies: Server-wide policies appended after
         per-agent policies. Sourced from ``RuntimeCaps.default_policies``
         (parsed from the server ``--config`` YAML at startup).
-        ``None`` and ``[]`` both mean no server-wide policies.
+        Persisted default policies from ``policy_store`` are
+        appended after these YAML policies. ``None`` and ``[]`` both
+        mean no YAML-defined server-wide policies.
     :param policy_store: Session-scoped policy store. When
         provided, enabled policies for ``conversation_id`` are
         loaded and inserted between agent and admin policies in
@@ -1518,7 +1522,7 @@ def _stored_policy_to_spec(policy: StoredPolicy) -> PolicySpec:
     # Reject loudly and fail closed: a stored policy that silently never
     # enforces is worse than a visible failure the operator can act on.
     raise OmnigentError(
-        f"Session policy {policy.name!r} (id {policy.id!r}) has unsupported "
+        f"Stored policy {policy.name!r} (id {policy.id!r}) has unsupported "
         f"type {policy.type!r}; only type='python' policies can be evaluated "
         f"today. URL policy evaluation is a future extension. Remove or "
         f"disable this policy, since storing it does not enforce anything.",

--- a/omnigent/server/routes/session_policies.py
+++ b/omnigent/server/routes/session_policies.py
@@ -3,9 +3,11 @@
 Session policies are managed via
 ``POST/GET/PATCH/DELETE /v1/sessions/{session_id}/policies[/{policy_id}]``.
 
-The List endpoint merges store-persisted (``source="session"``) and
-spec-declared (``source="spec"``) policies so the UI shows a unified
-view. Spec policies have ``id=None`` and cannot be patched or deleted.
+The List endpoint merges store-persisted session policies
+(``source="session"``) with server-wide defaults (``source="global"``)
+so the UI shows a unified view of policies that can affect the
+session. Global policies cannot be patched or deleted through the
+session-scoped endpoints.
 """
 
 from __future__ import annotations
@@ -75,14 +77,43 @@ def _entity_to_response(policy: Policy) -> dict[str, Any]:
     return result
 
 
+def _default_entity_to_response(policy: Policy) -> dict[str, Any]:
+    """Convert a default-policy entity to a session policy response dict.
+
+    :param policy: Default policy entity (``session_id is None``).
+    :returns: Dict matching :class:`SessionPolicyObject` shape with
+        ``source="global"`` so clients can render it read-only.
+    """
+    description = None
+    if policy.handler:
+        entry = get_entry(policy.handler)
+        description = entry.description if entry else policy.handler
+
+    result: dict[str, Any] = {
+        "id": policy.id,
+        "object": "session.policy",
+        "name": policy.name,
+        "type": policy.type,
+        "handler": policy.handler,
+        "enabled": policy.enabled,
+        "source": "global",
+        "description": description,
+        "created_at": policy.created_at,
+        "updated_at": policy.updated_at,
+    }
+    if policy.factory_params is not None:
+        result["factory_params"] = policy.factory_params
+    return result
+
+
 def _spec_to_response(spec: PolicySpec, source: str) -> dict[str, Any]:
     """Convert a :class:`PolicySpec` to a policy list response dict.
 
-    Used to surface admin (server-wide) policies in the list
+    Used to surface global (server-wide) policies in the list
     endpoint alongside session policies.
 
     :param spec: The policy spec from ``RuntimeCaps.default_policies``.
-    :param source: Origin label, e.g. ``"admin"``.
+    :param source: Origin label, e.g. ``"global"``.
     :returns: Dict matching the session policy response shape.
     """
     handler: str | None = None
@@ -241,9 +272,11 @@ def create_session_policies_router(
     ) -> dict[str, Any]:
         """List all policies for a session.
 
-        Returns both store-persisted (``source="session"``) and
-        spec-declared (``source="spec"``) policies. Spec policies
-        have ``id=None`` and cannot be patched or deleted.
+        Returns server-wide defaults (``source="global"``) followed by
+        session-scoped policies (``source="session"``). Globals come
+        from two places: the ``--config`` YAML (``id=None``) and the
+        persisted store (real ids, enabled only). Neither can be
+        patched or deleted through the session-scoped routes.
 
         Requires ``LEVEL_READ`` on the session in multi-user mode.
 
@@ -261,13 +294,14 @@ def create_session_policies_router(
                 user_id, session_id, LEVEL_READ, permission_store, conversation_store
             )
         _require_session_exists(session_id)
-        # Admin (server-wide) policies from the --config YAML.
+        # Global (server-wide) policies from the --config YAML.
         admin_specs = get_caps().default_policies
-        admin_data = [_spec_to_response(s, "admin") for s in admin_specs]
+        admin_data = [_spec_to_response(s, "global") for s in admin_specs]
+        default_data = [_default_entity_to_response(p) for p in store.list_defaults() if p.enabled]
         # Session policies from the store.
         session_policies = store.list_for_session(session_id)
         session_data = [_entity_to_response(p) for p in session_policies]
-        return {"object": "list", "data": admin_data + session_data}
+        return {"object": "list", "data": admin_data + default_data + session_data}
 
     @router.get("/sessions/{session_id}/policies/{policy_id}")
     async def get_policy(

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -316,9 +316,10 @@ class SessionPolicyObject(BaseModel):
         callables and ``type="url"`` handlers.
     :param enabled: Whether the engine consults this policy.
     :param source: Origin of the policy: ``"session"`` for
-        CRUD-created policies, ``"spec"`` for policies
-        declared in the agent YAML. Spec policies cannot be
-        patched or deleted.
+        CRUD-created session policies, ``"global"`` for server-wide
+        defaults, ``"spec"`` for policies declared in the agent YAML.
+        Non-session policies cannot be patched or deleted through the
+        session-scoped endpoints.
     :param created_at: Unix epoch timestamp of creation.
     :param updated_at: Unix epoch timestamp of the last
         update, or ``None`` if never updated.

--- a/openapi.json
+++ b/openapi.json
@@ -10420,7 +10420,7 @@
     },
     "/v1/sessions/{session_id}/policies": {
       "get": {
-        "description": "List all policies for a session.\n\nReturns both store-persisted (`source=\"session\"`) and\nspec-declared (`source=\"spec\"`) policies. Spec policies\nhave `id=None` and cannot be patched or deleted.\n\nRequires `LEVEL_READ` on the session in multi-user mode.\n\n**Returns:** `{\"object\": \"list\", \"data\": [...]}`.\n\n**Raises**\n\n- `OmnigentError` \u2014 401/403 if the user lacks read permission, 404 if the session is not found.",
+        "description": "List all policies for a session.\n\nReturns server-wide defaults (`source=\"global\"`) followed by\nsession-scoped policies (`source=\"session\"`). Globals come\nfrom two places: the `--config` YAML (`id=None`) and the\npersisted store (real ids, enabled only). Neither can be\npatched or deleted through the session-scoped routes.\n\nRequires `LEVEL_READ` on the session in multi-user mode.\n\n**Returns:** `{\"object\": \"list\", \"data\": [...]}`.\n\n**Raises**\n\n- `OmnigentError` \u2014 401/403 if the user lacks read permission, 404 if the session is not found.",
         "operationId": "list_policies_v1_sessions__session_id__policies_get",
         "parameters": [
           {

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 import importlib
 import sys
+import types
 from pathlib import Path
 from typing import NoReturn
 
+import httpx
 import pytest
 
 from omnigent.stores.artifact_store.local import LocalArtifactStore
@@ -28,8 +30,10 @@ _BOOT_MODULES = (
     "omnigent.runtime",
     "omnigent.server.app",
     "omnigent.server.server_config",
+    "omnigent.spec",
     "omnigent.stores.agent_store.sqlalchemy_store",
     "omnigent.stores.artifact_store.local",
+    "omnigent.stores.policy_store.sqlalchemy_store",
     "uvicorn",
 )
 
@@ -185,3 +189,131 @@ def test_build_routing_defaults_without_a_routing_block() -> None:
     client, settings = _build_routing({}, None)
     assert client is None
     assert settings == RoutingSettings()
+
+
+@pytest.mark.asyncio
+async def test_build_app_wires_policy_store_routes_and_api_defaults(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Docker build_app must enable the persisted policy APIs."""
+    from deploy.docker.entrypoint import _ResolvedConfig, build_app
+    from omnigent.runtime import get_caps, get_policy_store
+    from omnigent.server.auth import RESERVED_USER_LOCAL
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+    from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
+
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
+
+    fake_module = types.ModuleType("tests.fake_policy_module")
+
+    def allow_all(event: dict[str, object]) -> dict[str, str]:
+        return {"action": "ALLOW"}
+
+    fake_module.allow_all = allow_all
+    fake_module.POLICY_REGISTRY = [
+        {
+            "handler": "tests.fake_policy_module.allow_all",
+            "kind": "callable",
+            "name": "Allow All",
+            "description": "Test policy module entry",
+        }
+    ]
+    monkeypatch.setitem(sys.modules, "tests.fake_policy_module", fake_module)
+
+    built = build_app(
+        _ResolvedConfig(
+            cfg={
+                "policy_modules": ["tests.fake_policy_module"],
+            },
+            database_url=db_uri,
+            artifact_dir=tmp_path / "artifacts",
+            artifact_store_uri=None,
+            host="0.0.0.0",
+            port=8000,
+        )
+    )
+
+    assert isinstance(get_policy_store(), SqlAlchemyPolicyStore)
+    assert get_caps().default_policies == []
+
+    route_paths = {route.path for route in built.app.routes}
+    assert "/v1/policies" in route_paths
+    assert "/v1/policies/{policy_id}" in route_paths
+    assert "/v1/sessions/{session_id}/policies" in route_paths
+    assert "/v1/sessions/{session_id}/policies/{policy_id}" in route_paths
+    assert "/v1/sessions/{session_id}/policies/evaluate" in route_paths
+
+    SqlAlchemyPermissionStore(db_uri).ensure_user(RESERVED_USER_LOCAL, is_admin=True)
+
+    async with built.app.router.lifespan_context(built.app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=built.app),
+            base_url="http://test",
+        ) as client:
+            registry_resp = await client.get("/v1/policy-registry")
+            assert registry_resp.status_code == 200
+            assert "tests.fake_policy_module.allow_all" in {
+                entry["handler"] for entry in registry_resp.json()["data"]
+            }
+
+            create_resp = await client.post(
+                "/v1/policies",
+                json={
+                    "name": "custom_default",
+                    "type": "python",
+                    "handler": "tests.fake_policy_module.allow_all",
+                },
+            )
+            assert create_resp.status_code == 200
+            assert create_resp.json()["name"] == "custom_default"
+
+            list_resp = await client.get("/v1/policies")
+            assert list_resp.status_code == 200
+            assert [policy["name"] for policy in list_resp.json()["data"]] == ["custom_default"]
+
+
+def test_build_app_loads_yaml_default_policies(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A YAML ``policies:`` block populates ``RuntimeCaps.default_policies``.
+
+    Parity with the CLI ``omnigent server`` path (omnigent/cli.py), which
+    reads the same config key via ``parse_default_policies``. Dropping the
+    YAML source from the Docker entrypoint silently diverged the two
+    entrypoints for an otherwise-valid config.
+    """
+    from deploy.docker.entrypoint import _ResolvedConfig, build_app
+    from omnigent.runtime import get_caps
+
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
+
+    build_app(
+        _ResolvedConfig(
+            cfg={
+                "policies": {
+                    "deny_os_tools": {
+                        "type": "function",
+                        "handler": "omnigent.policies.builtins.safety.ask_on_os_tools",
+                    },
+                },
+            },
+            database_url=db_uri,
+            artifact_dir=tmp_path / "artifacts",
+            artifact_store_uri=None,
+            host="0.0.0.0",
+            port=8000,
+        )
+    )
+
+    default_policies = get_caps().default_policies
+    assert [spec.name for spec in default_policies] == ["deny_os_tools"]

--- a/tests/e2e_ui/agents/test_agent_info_popover.py
+++ b/tests/e2e_ui/agents/test_agent_info_popover.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import re
 import sys
+import uuid
 from pathlib import Path
 
 import httpx
@@ -40,6 +41,8 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 # ``_ANIM_SETTLE_MS`` in ``sessions/test_agent_info_hover.py``.
 _PANEL_SETTLE_MS = 250
 _ECHO_MCP_SERVER = _REPO_ROOT / "tests" / "tools" / "fixtures" / "echo_stdio_mcp_server.py"
+_GLOBAL_POLICY_HANDLER = "omnigent.policies.builtins.safety.max_tool_calls_per_session"
+_SESSION_POLICY_HANDLER = "omnigent.policies.builtins.safety.ask_on_os_tools"
 
 
 def _callable_registry_policy(base_url: str) -> dict:
@@ -86,6 +89,11 @@ def _session_policies(base_url: str, session_id: str) -> list[dict]:
 def _user_policy_names(base_url: str, session_id: str) -> set[str]:
     """Names of user-attached (``source == "session"``) policies on the session."""
     return {p["name"] for p in _session_policies(base_url, session_id) if p["source"] == "session"}
+
+
+def _policy_names_by_source(base_url: str, session_id: str, source: str) -> set[str]:
+    """Names of policy rows with the requested source."""
+    return {p["name"] for p in _session_policies(base_url, session_id) if p["source"] == source}
 
 
 def _user_policy_by_name(base_url: str, session_id: str, name: str) -> dict | None:
@@ -223,6 +231,70 @@ def test_agent_info_policy_add_and_remove(
     # Re-open the popover: the section is empty again.
     _open_popover(page)
     expect(page.get_by_text("No policies added")).to_be_visible(timeout=15_000)
+
+
+def test_agent_info_global_default_policy_is_read_only(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """AgentInfo shows global defaults as read-only and keeps session Remove."""
+    base_url, session_id = seeded_session
+    suffix = uuid.uuid4().hex[:8]
+    global_name = f"e2e_global_default_{suffix}"
+    session_name = f"e2e_session_policy_{suffix}"
+    default_policy_id: str | None = None
+    session_policy_id: str | None = None
+
+    try:
+        default_resp = httpx.post(
+            f"{base_url}/v1/policies",
+            json={
+                "name": global_name,
+                "type": "python",
+                "handler": _GLOBAL_POLICY_HANDLER,
+                "factory_params": {"limit": 100},
+            },
+            timeout=10.0,
+        )
+        default_resp.raise_for_status()
+        default_policy_id = default_resp.json()["id"]
+
+        session_resp = httpx.post(
+            f"{base_url}/v1/sessions/{session_id}/policies",
+            json={
+                "name": session_name,
+                "type": "python",
+                "handler": _SESSION_POLICY_HANDLER,
+            },
+            timeout=10.0,
+        )
+        session_resp.raise_for_status()
+        session_policy_id = session_resp.json()["id"]
+
+        _wait_for(lambda: global_name in _policy_names_by_source(base_url, session_id, "global"))
+        _wait_for(lambda: session_name in _user_policy_names(base_url, session_id))
+
+        page.goto(f"{base_url}/c/{session_id}")
+        expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+        _open_popover(page)
+
+        global_pill = page.get_by_role("button").filter(has_text=global_name).first
+        session_pill = page.get_by_role("button").filter(has_text=session_name).first
+        expect(global_pill).to_be_visible(timeout=15_000)
+        expect(global_pill).to_contain_text("global")
+        expect(session_pill).to_be_visible(timeout=15_000)
+
+        global_pill.click()
+        expect(page.get_by_text("Global default policy.")).to_be_visible(timeout=15_000)
+        expect(page.get_by_role("button", name="Remove")).to_have_count(0)
+    finally:
+        if session_policy_id is not None:
+            httpx.delete(
+                f"{base_url}/v1/sessions/{session_id}/policies/{session_policy_id}",
+                timeout=10.0,
+            )
+        if default_policy_id is not None:
+            httpx.delete(f"{base_url}/v1/policies/{default_policy_id}", timeout=10.0)
 
 
 def test_agent_info_policy_integer_params_validate_and_submit(

--- a/tests/runtime/policies/test_builder_session_policies.py
+++ b/tests/runtime/policies/test_builder_session_policies.py
@@ -22,6 +22,7 @@ from omnigent.runtime.policies.builder import (
     _load_default_policy_specs,
     _load_session_policy_specs,
     _stored_policy_to_spec,
+    any_policies_apply,
     build_policy_engine,
     invalidate_default_policy_specs_cache,
     invalidate_session_policy_specs_cache,
@@ -710,3 +711,55 @@ def test_build_engine_ordering_session_agent_db_default_admin(db_uri: str) -> No
         "yaml_admin_policy",
         "__ask_on_add_policy",
     ]
+
+
+# ── any_policies_apply (evaluate fast-path) ─────────────────────────────────
+
+
+def test_any_policies_apply_false_when_no_policies(db_uri: str) -> None:
+    """No guardrails, no YAML defaults, no stored policies → fast-path skip.
+
+    :param db_uri: Per-test SQLite URI.
+    """
+    policy_store = SqlAlchemyPolicyStore(db_uri)
+    _DEFAULT_POLICY_SPECS_CACHE.clear()
+
+    assert not any_policies_apply(
+        spec=_make_minimal_spec(),
+        conversation_id="ad563e906854634c49e1a6fd2fbb31d4",
+        default_policies=None,
+        policy_store=policy_store,
+    )
+
+
+def test_any_policies_apply_true_for_db_default(db_uri: str) -> None:
+    """A DB-backed global default alone must defeat the fast-path skip.
+
+    Regression: ``POST /policies/evaluate`` short-circuits to ALLOW when
+    ``any_policies_apply`` returns False, so a global default that is the
+    only policy on a session would never be enforced if this check ignored
+    ``_load_default_policy_specs``.
+
+    :param db_uri: Per-test SQLite URI.
+    """
+    policy_store = SqlAlchemyPolicyStore(db_uri)
+    policy_store.create_default(
+        policy_id="c0ffee00000000000000000000000001",
+        name="db_default_only",
+        type="python",
+        handler="myorg.policies.deny_all",
+        enabled=True,
+    )
+    _DEFAULT_POLICY_SPECS_CACHE.clear()
+
+    try:
+        assert any_policies_apply(
+            spec=_make_minimal_spec(),
+            conversation_id="ad563e906854634c49e1a6fd2fbb31d4",
+            default_policies=None,
+            policy_store=policy_store,
+        )
+    finally:
+        # The specs cache is module-level; leaving this unimportable handler
+        # behind would surface as a policy-evaluation error in later tests.
+        _DEFAULT_POLICY_SPECS_CACHE.clear()

--- a/tests/server/integration/test_policy_deny_lifecycle_e2e.py
+++ b/tests/server/integration/test_policy_deny_lifecycle_e2e.py
@@ -203,6 +203,25 @@ async def _send_user_message(
     )
 
 
+def _tool_call_request(tool_name: str = "Bash") -> dict:
+    """Build a PHASE_TOOL_CALL policy evaluation request.
+
+    :param tool_name: Tool name, e.g. ``"Bash"``.
+    :returns: EvaluationRequest JSON dict.
+    """
+    return {
+        "event": {
+            "type": "PHASE_TOOL_CALL",
+            "target": "",
+            "data": {
+                "name": tool_name,
+                "arguments": {},
+            },
+            "context": {},
+        },
+    }
+
+
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 
@@ -270,6 +289,52 @@ async def test_deny_policy_lifecycle(
     assert len(session_policies) == 0, (
         f"expected no session policies after deletion; got {session_policies}"
     )
+
+
+async def test_persisted_default_policy_enforces_for_sessions(
+    policy_client: httpx.AsyncClient,
+) -> None:
+    """A default policy created through ``/v1/policies`` is enforced.
+
+    This pins the persisted default-policy path: the CRUD route writes a
+    ``session_id IS NULL`` policy row, and the session policy-evaluate
+    endpoint must load that row into the engine's admin policy layer.
+    """
+    agent = await create_test_agent(policy_client)
+    session_id = await _create_session(policy_client, agent["id"])
+
+    create_resp = await policy_client.post(
+        "/v1/policies",
+        json={
+            "name": "deny_first_tool_call",
+            "type": "python",
+            "handler": "omnigent.policies.builtins.safety.max_tool_calls_per_session",
+            "factory_params": {"limit": 0},
+        },
+    )
+    assert create_resp.status_code == 200, (
+        f"default policy create failed: {create_resp.status_code} {create_resp.text}"
+    )
+    policy_id = create_resp.json()["id"]
+
+    denied = await policy_client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json=_tool_call_request("Bash"),
+    )
+    assert denied.status_code == 200, denied.text
+    denied_body = denied.json()
+    assert denied_body["result"] == "POLICY_ACTION_DENY"
+    assert denied_body["reason"] == "Exceeded 0 tool calls this session"
+
+    patch_resp = await policy_client.patch(f"/v1/policies/{policy_id}", json={"enabled": False})
+    assert patch_resp.status_code == 200, patch_resp.text
+
+    allowed = await policy_client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json=_tool_call_request("Bash"),
+    )
+    assert allowed.status_code == 200, allowed.text
+    assert allowed.json()["result"] == "POLICY_ACTION_ALLOW"
 
 
 async def test_deny_policy_only_blocks_matching_phase(

--- a/tests/server/routes/test_session_policies_crud.py
+++ b/tests/server/routes/test_session_policies_crud.py
@@ -161,6 +161,41 @@ async def test_list_session_policies_after_create(
     assert pid in ids
 
 
+async def test_list_session_policies_includes_enabled_global_defaults(
+    client: httpx.AsyncClient, session_id: str
+) -> None:
+    """Session policy list includes DB-backed global defaults as global rows."""
+    enabled_resp = await client.post(
+        "/v1/policies",
+        json={
+            "name": "global_default",
+            "type": "python",
+            "handler": "omnigent.policies.builtins.safety.ask_on_os_tools",
+        },
+    )
+    assert enabled_resp.status_code == 200
+    disabled_resp = await client.post(
+        "/v1/policies",
+        json={
+            "name": "disabled_default",
+            "type": "python",
+            "handler": "omnigent.policies.builtins.safety.ask_on_os_tools",
+        },
+    )
+    assert disabled_resp.status_code == 200
+    disabled_id = disabled_resp.json()["id"]
+    patch_resp = await client.patch(f"/v1/policies/{disabled_id}", json={"enabled": False})
+    assert patch_resp.status_code == 200
+
+    resp = await client.get(f"/v1/sessions/{session_id}/policies")
+    assert resp.status_code == 200
+    global_policies = [p for p in resp.json()["data"] if p["source"] == "global"]
+
+    assert [p["name"] for p in global_policies] == ["global_default"]
+    assert global_policies[0]["id"] == enabled_resp.json()["id"]
+    assert global_policies[0]["handler"] == "omnigent.policies.builtins.safety.ask_on_os_tools"
+
+
 async def test_list_session_policies_nonexistent_session(
     client: httpx.AsyncClient,
 ) -> None:

--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -660,12 +660,33 @@ describe("SessionPoliciesSection", () => {
     registryData.current = [];
   });
 
-  it("shows the empty state when no user policies are applied", () => {
-    // WHY: only `source === "session"` policies are user-managed; a spec
-    // policy must not count, so the section reads "No policies added".
+  it("shows the empty state when no session or global policies are applied", () => {
+    // WHY: spec policies are already shown with the agent definition; this
+    // section is for session-editable policies and global defaults.
     policiesData.current = [{ id: "p_spec", name: "spec_one", handler: "h.spec", source: "spec" }];
     renderContent("conv_pol");
     expect(screen.getByText("No policies added")).toBeInTheDocument();
+  });
+
+  it("lists global default policies as read-only pills", () => {
+    // WHY: DB-backed defaults from /v1/policies are enforced for every
+    // session, so the session policy surface must show them even though they
+    // cannot be removed through the session-scoped endpoint.
+    policiesData.current = [
+      {
+        id: "p_global",
+        name: "global_default",
+        handler: "guard.global",
+        source: "global",
+        description: "Applies to all sessions.",
+      },
+    ];
+    renderContent("conv_pol");
+
+    fireEvent.click(screen.getByRole("button", { name: /global_default/ }));
+    expect(screen.getByText("Global default policy.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove/ })).toBeNull();
+    expect(deleteMutate).not.toHaveBeenCalled();
   });
 
   it("lists user policies and deletes one via the popover Remove button", () => {

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -35,6 +35,7 @@ import {
 import { usePermissions, useSessionOwner } from "@/hooks/usePermissions";
 import { isSessionSharedWithOthers } from "@/lib/permissionsApi";
 import { getCurrentUserId } from "@/lib/identity";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -1154,7 +1155,7 @@ function McpServersSection({
 }
 
 // ---------------------------------------------------------------------------
-// Session policies section (user-editable only)
+// Session policies section (session-editable + global read-only)
 // ---------------------------------------------------------------------------
 
 function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
@@ -1163,7 +1164,9 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
   const deletePolicy = useDeletePolicy(sessionId);
   const [addOpen, setAddOpen] = useState(false);
 
-  const userPolicies = sessionPolicies.filter((p) => p.source === "session");
+  const visiblePolicies = sessionPolicies.filter(
+    (p) => p.source === "session" || p.source === "global",
+  );
   const registryByHandler = new Map(registry.map((r) => [r.handler, r]));
 
   return (
@@ -1179,14 +1182,17 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
           <PlusIcon className="size-3 text-muted-foreground" />
         </button>
       </div>
-      {userPolicies.length > 0 ? (
+      {visiblePolicies.length > 0 ? (
         <div className="flex flex-wrap gap-1">
-          {userPolicies.map((p) => {
+          {visiblePolicies.map((p) => {
             const description =
               p.description ??
               (p.handler ? registryByHandler.get(p.handler)?.description : undefined);
+            const isGlobal = p.source === "global";
             return (
-              <Popover key={p.id ?? p.name}>
+              // YAML-declared globals have no id, so namespace them by name —
+              // a DB-backed global with the same name still gets a distinct key.
+              <Popover key={p.id ?? `spec:${p.name}`}>
                 <PopoverTrigger asChild>
                   <button
                     type="button"
@@ -1195,6 +1201,11 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
                   >
                     <ShieldCheckIcon className="size-2.5 shrink-0" />
                     {p.name}
+                    {isGlobal && (
+                      <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-[10px]">
+                        global
+                      </Badge>
+                    )}
                   </button>
                 </PopoverTrigger>
                 <PopoverContent
@@ -1211,14 +1222,18 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
                     {description && (
                       <p className="break-words text-sm text-muted-foreground">{description}</p>
                     )}
-                    <button
-                      type="button"
-                      onClick={() => p.id && deletePolicy.mutate(p.id)}
-                      className="flex items-center gap-1 self-end rounded px-2 py-1 text-sm text-destructive hover:bg-destructive/10"
-                    >
-                      <TrashIcon className="size-3" />
-                      Remove
-                    </button>
+                    {isGlobal ? (
+                      <p className="text-sm text-muted-foreground">Global default policy.</p>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => p.id && deletePolicy.mutate(p.id)}
+                        className="flex items-center gap-1 self-end rounded px-2 py-1 text-sm text-destructive hover:bg-destructive/10"
+                      >
+                        <TrashIcon className="size-3" />
+                        Remove
+                      </button>
+                    )}
                   </div>
                 </PopoverContent>
               </Popover>

--- a/web/src/hooks/usePolicies.ts
+++ b/web/src/hooks/usePolicies.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 
-/** A session-scoped policy returned by the CRUD API. */
+/** A policy row returned by the session policy list API. */
 export interface SessionPolicy {
   id: string | null;
   object: "session.policy";
@@ -10,7 +10,7 @@ export interface SessionPolicy {
   handler: string | null;
   factory_params?: Record<string, unknown> | null;
   enabled: boolean;
-  source: "session" | "spec" | "admin";
+  source: "session" | "spec" | "global";
   description?: string | null;
   created_at: number;
   updated_at: number | null;
@@ -50,7 +50,7 @@ async function fetchRegistry(): Promise<PolicyRegistryEntry[]> {
 
 // ── Hooks ────────────────────────────────────────────────────────────────────
 
-/** Fetch session policies. Disabled when `sessionId` is falsy. */
+/** Fetch session-scoped policies plus read-only global defaults. */
 export function usePolicies(sessionId: string | null | undefined) {
   return useQuery({
     queryKey: policiesQueryKey(sessionId ?? ""),


### PR DESCRIPTION
## Related issue

N/A

## Summary

Persisted runtime policies did not work in the Docker stack: the entrypoint
never constructed a `SqlAlchemyPolicyStore`, so `/v1/policies` and
`/v1/sessions/{id}/policies` were unavailable and global defaults were never
enforced. This wires the policy store through all four layers:

- **Docker entrypoint** — build `SqlAlchemyPolicyStore(DATABASE_URL)` and pass
  it to both `init_runtime()` and `create_app()`. Policy rows now follow the
  same DB/backup/volume lifecycle as sessions, agents, and files. Global
  defaults are API-backed (`POST /v1/policies`), not declared in `config.yaml`;
  `config.yaml` may still register `policy_modules` for custom handlers.
- **Runtime** — every policy engine loads enabled persisted defaults from
  `policy_store.list_defaults()`, including sessions whose agent spec has no
  `guardrails:` block, so an admin default is actually enforced everywhere.
- **Server** — the session policy list includes enabled DB-backed global
  defaults as read-only `source="global"` rows, so the UI shows what is
  effectively enforced on a session.
- **Web** — `AgentInfo` renders those global rows with a `global` badge and a
  read-only popover ("Global default policy.", no Remove button); session
  policies remain editable.

<details>
<summary>ELI5 + flow</summary>

An admin sets one safety rule for the whole server. Before, that rule
silently did nothing in Docker and never showed up on a session. Now it's
saved in the database, enforced on every session, and shown on the session as
a locked "global" chip you can see but not delete.

```
POST /v1/policies (admin)
        │  persist (session_id = NULL)
        ▼
   ┌─────────────┐   list_defaults()   ┌──────────────────────┐
   │ policy_store │ ──────────────────▶ │ build_policy_engine  │ enforce on every session
   └─────────────┘                     └──────────────────────┘
        │
        │ list_defaults() (enabled)
        ▼
 GET /v1/sessions/{id}/policies  ──▶  source="global" (read-only)  ──▶  AgentInfo "global" chip
```
</details>

## Test Plan

- `uv run --extra dev python -m pytest tests/deploy/test_docker_entrypoint_import.py tests/runtime/policies/test_builder_session_policies.py tests/server/routes/test_session_policies_crud.py tests/server/integration/test_policy_deny_lifecycle_e2e.py -q` — 45 passed
- `uv run --extra dev python -m pytest tests/server/integration/test_sessions_child_sessions.py::test_native_subagent_message_uses_native_terminal_forward -q`
- `uv run --extra dev pytest tests/e2e_ui/agents/test_agent_info_popover.py::test_agent_info_global_default_policy_is_read_only tests/e2e_ui/agents/test_agent_info_popover.py::test_agent_info_policy_add_and_remove --ui-skip-build -q`
- `npm test -- --run src/components/AgentInfo.test.tsx` from `web/` — 40 passed
- `uv run --extra dev ruff check` on all changed Python files — clean
- `npx prettier --check` / `npx oxlint` on the changed `web/` files — clean
- **Docker smoke test** (`deploy/docker/SKILL.md#runtime-policies`): `docker compose up -d --build` with `OMNIGENT_AUTH_ENABLED=0`, created a global default via `POST /v1/policies`, confirmed it (a) lists under `/v1/policies`, (b) appears as a read-only `source="global"` row on `GET /v1/sessions/{id}/policies`, (c) enforces `POLICY_ACTION_DENY` via `/policies/evaluate`, and (d) survives `docker compose restart`. Captured the UI state below.

## Demo

Captured against a live `docker compose` stack (`OMNIGENT_AUTH_ENABLED=0`) with
a global default created through `POST /v1/policies`.

**Session policies in `AgentInfo`** — the global default shows as a `global`
chip alongside an editable session policy:

<!-- drag agentinfo-policies.png here -->

**Global default is read-only** — clicking the chip shows "Global default
policy." with no Remove button (session policies keep theirs):

<!-- drag agentinfo-global-readonly.png here -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

<!-- also a bug fix (policy store was never wired in Docker) + docs; primary reviewer-routing signal is UI -->

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the Docker smoke test above end-to-end against a
freshly built `docker compose` stack — global default create → list → enforce
(DENY) → restart-persist, plus visually confirmed the read-only `global` chip
and popover in the web UI (screenshot in Demo). Automated coverage:
`test_docker_entrypoint_import` (store wiring), `test_builder_session_policies`
(enforcement + ordering), `test_session_policies_crud` (global rows in the list),
`test_policy_deny_lifecycle_e2e::test_persisted_default_policy_enforces_for_sessions`
(persisted default enforced across sessions), and
`test_agent_info_popover::test_agent_info_global_default_policy_is_read_only`
(Playwright, read-only UI).

## Changelog

Docker deployments now persist and enforce global default policies created via
`/v1/policies`, and sessions show them as read-only `global` badges
