### PR TITLE
fix(ap-web): keep host/server picker mounted on login & setup pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,12 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useState, type ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
 import { ChatPage } from "@/pages/ChatPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { AppShell } from "@/shell/AppShell";
+import { TitleBarServerPicker } from "@/shell/TitleBarServerPicker";
+import { TitleBarTitleContext } from "@/shell/titleBarTitleContext";
+import { isMacElectronShell } from "@/lib/nativeBridge";
 
 // Lazy-load the three accounts pages so the bundle a header / OIDC
 // deploy ships (where accounts is off) doesn't include them in the
@@ -87,11 +90,45 @@ function App({ basename }: AppProps = {}) {
   // the original relative route table.
   const prefix = basename ?? "";
   const info = useServerInfo();
+  // Open thread's title, shown in the macOS title-bar picker as
+  // "<title> — <host>". Published by AppShell (the only place with a
+  // conversation in scope) through TitleBarTitleContext and held here, above
+  // the router, so the picker outlives AppShell on the unauthenticated pages.
+  // Undefined off those authed pages → the picker falls back to the brand.
+  const [threadTitle, setThreadTitle] = useState<string | null | undefined>(undefined);
   // While the probe is in flight, render nothing — first paint is
   // ~30ms after boot anyway, and flashing the chrome we may
   // immediately tear down once the probe returns is worse than a
   // tiny blank moment.
   if (info === "loading") return null;
+
+  // macOS Electron frameless-window title-bar chrome: the window-drag strip
+  // plus the server picker. Mounted by `withChrome` below so it wraps BOTH the
+  // authed AppShell subtree AND the unauthenticated /login · /register · setup
+  // branches — switching to a Railway (accounts-enabled) host lands on /login,
+  // and the picker must not vanish there (that was the bug). The picker talks
+  // only to the Electron shell over IPC (getServerPicker / switchServer), never
+  // to the Omnigent server, so it needs no identity/auth and is safe on
+  // unauthenticated pages. Hidden in plain browsers (isMacElectronShell() is
+  // false). The `data-electron-mac` wrapper re-supplies the index.css scope
+  // (drag strip geometry + the no-drag blanket that keeps the picker clickable)
+  // that the strip and picker relied on from AppShell's `.app-shell` element.
+  const titleBar = isMacElectronShell() ? (
+    <div data-electron-mac="true">
+      <div className="electron-drag-strip" aria-hidden="true" />
+      <TitleBarServerPicker threadTitle={threadTitle} />
+    </div>
+  ) : null;
+
+  // Wrap a route subtree with the (router-independent) title bar and the
+  // setter context AppShell uses to feed the picker its thread title. Suspense
+  // is centralized here so the lazy pages below have one boundary.
+  const withChrome = (children: ReactNode) => (
+    <TitleBarTitleContext.Provider value={setThreadTitle}>
+      {titleBar}
+      <Suspense fallback={null}>{children}</Suspense>
+    </TitleBarTitleContext.Provider>
+  );
 
   // First-run: accounts on but no admin claimed yet. Route EVERY path to
   // the Create-admin form so the first visitor lands on it no matter how
@@ -100,46 +137,42 @@ function App({ basename }: AppProps = {}) {
   // flips false the instant it succeeds — so this whole branch disappears
   // after the first admin exists.
   if (info.accounts_enabled && info.needs_setup) {
-    return (
-      <Suspense fallback={null}>
-        <Routes>
-          <Route path={basename ? `${prefix}/*` : "*"} element={<SetupPage />} />
-        </Routes>
-      </Suspense>
+    return withChrome(
+      <Routes>
+        <Route path={basename ? `${prefix}/*` : "*"} element={<SetupPage />} />
+      </Routes>,
     );
   }
 
-  return (
-    <Suspense fallback={null}>
-      <Routes>
-        {info.accounts_enabled && (
-          <>
-            <Route path={`${prefix}/login`} element={<LoginPage />} />
-            <Route path={`${prefix}/register`} element={<RegisterPage />} />
-          </>
-        )}
-        <Route path={`${prefix}/approve/:sessionId/:elicitationId`} element={<ApprovePage />} />
-        <Route element={<AppShell />}>
-          <Route path={prefix || "/"} element={<ChatPage />} />
-          <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
-          <Route path={`${prefix}/inbox`} element={<InboxPage />} />
-          {/* Settings renders into the chat outlet so the conversations
+  return withChrome(
+    <Routes>
+      {info.accounts_enabled && (
+        <>
+          <Route path={`${prefix}/login`} element={<LoginPage />} />
+          <Route path={`${prefix}/register`} element={<RegisterPage />} />
+        </>
+      )}
+      <Route path={`${prefix}/approve/:sessionId/:elicitationId`} element={<ApprovePage />} />
+      <Route element={<AppShell />}>
+        <Route path={prefix || "/"} element={<ChatPage />} />
+        <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
+        <Route path={`${prefix}/inbox`} element={<InboxPage />} />
+        {/* Settings renders into the chat outlet so the conversations
               sidebar stays put — entering settings only swaps the card's
               content (the section nav) and the main area. The active section
               is carried in the URL (/settings/<section>); bare /settings
               defaults to Appearance. */}
-          <Route path={`${prefix}/settings`} element={<SettingsPage />} />
-          <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
-          {info.accounts_enabled && (
-            <>
-              <Route path={`${prefix}/members`} element={<MembersPage />} />
-              <Route path={`${prefix}/policies`} element={<PoliciesPage />} />
-            </>
-          )}
-          <Route path={basename ? `${prefix}/*` : "*"} element={<NotFoundPage />} />
-        </Route>
-      </Routes>
-    </Suspense>
+        <Route path={`${prefix}/settings`} element={<SettingsPage />} />
+        <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
+        {info.accounts_enabled && (
+          <>
+            <Route path={`${prefix}/members`} element={<MembersPage />} />
+            <Route path={`${prefix}/policies`} element={<PoliciesPage />} />
+          </>
+        )}
+        <Route path={basename ? `${prefix}/*` : "*"} element={<NotFoundPage />} />
+      </Route>
+    </Routes>,
   );
 }
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -53,8 +53,8 @@ import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
 import { isMobileViewport, Sidebar } from "./Sidebar";
-import { TitleBarServerPicker } from "./TitleBarServerPicker";
 import { SubagentsPanel } from "./SubagentsPanel";
+import { useSetTitleBarTitle } from "./titleBarTitleContext";
 import { useRootSessionId, useSession } from "@/hooks/useSession";
 import {
   TerminalFirstContextProvider,
@@ -265,6 +265,17 @@ export function AppShell() {
   // is the only path through which the UI learns the user's permission
   // level. ``derivePermissionLevel`` prefers this over ``activeConv``.
   const { session: activeSession, isLoading: sessionLoading } = useSession(conversationId);
+  // Feed the open thread's title to the macOS title-bar server picker, which
+  // now lives above the router (App.tsx) so it survives the unauthenticated
+  // login/setup pages. Mirrors the old inline
+  // `threadTitle={activeSession?.title ?? activeConv?.title}` prop; clearing on
+  // unmount drops the stale title when navigating off to an unauthed page (the
+  // undefined→value pair within one effect flush is batched, so no flicker).
+  const setTitleBarTitle = useSetTitleBarTitle();
+  useEffect(() => {
+    setTitleBarTitle(activeSession?.title ?? activeConv?.title);
+    return () => setTitleBarTitle(undefined);
+  }, [activeSession?.title, activeConv?.title, setTitleBarTitle]);
   // Same liveness the chat surface switches on (see ChatPage / useSessionLiveness).
   // AppShell reads it only to drive the Terminal pill's "loading" state: a session
   // in `starting` (a relaunch the moment a message is sent — `turnActive`) is
@@ -1047,17 +1058,12 @@ export function AppShell() {
             data-electron-mac={isMacElectronShell() ? "true" : undefined}
             data-ios-native={isIOSShell() ? "true" : undefined}
           >
-            {/* Frameless-window titlebar stand-in (macOS Electron only): the
-          sidebar's electron top margin (see index.css) frees this strip of
-          canvas for the traffic lights, and the strip is the window's one
-          drag surface — content below and right stays fully clickable. */}
-            {isMacElectronShell() && <div className="electron-drag-strip" aria-hidden="true" />}
-            {/* Centered title + server picker in the freed title-bar strip. The
-          open thread's title (snapshot first — it's the only source for
-          child sessions — then the sidebar row) replaces the brand label. */}
-            {isMacElectronShell() && (
-              <TitleBarServerPicker threadTitle={activeSession?.title ?? activeConv?.title} />
-            )}
+            {/* The frameless-window title-bar chrome (drag strip + server
+          picker) is mounted once at the top level (App.tsx) so it survives the
+          unauthenticated login/setup pages where this shell isn't rendered;
+          AppShell only feeds it the open thread's title (see the
+          useSetTitleBarTitle effect above). `data-electron-mac` stays on this
+          element to scope the sidebar's top margin + traffic-light clearance. */}
             <Sidebar
               open={sidebarOpen}
               dragProgress={sidebarDragProgress}

--- a/web/src/shell/titleBarTitleContext.ts
+++ b/web/src/shell/titleBarTitleContext.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Lets the authed {@link AppShell} publish the open thread's title up to the
+ * macOS title-bar server picker, which is mounted at the top level (App.tsx) —
+ * ABOVE the router — so it survives the unauthenticated `/login`, `/register`,
+ * and setup pages where `AppShell` (and the picker's old mount) isn't rendered.
+ *
+ * Only `AppShell` has a conversation in scope, so it pushes the current
+ * `<title> — <host>` label up here; on the unauthenticated pages the title is
+ * left undefined and the picker shows just the brand. The default is a no-op so
+ * non-Electron browsers, tests rendering `AppShell` in isolation, and any
+ * consumer outside the provider can call it harmlessly.
+ */
+export type ThreadTitleSetter = (title: string | null | undefined) => void;
+
+export const TitleBarTitleContext = createContext<ThreadTitleSetter>(() => {});
+
+/** Setter for the title-bar picker's thread label. No-op outside the provider. */
+export function useSetTitleBarTitle(): ThreadTitleSetter {
+  return useContext(TitleBarTitleContext);
+}


### PR DESCRIPTION
## Bug

On the macOS desktop app, the in-title-bar host/server selection box disappears when you switch from a local server to a Railway-hosted (accounts-enabled) Omnigent.

## Root cause

(Paths below are this repo's `web/` tree; the original report referenced an `ap-web/` prefix and approximate line numbers — the structure is identical.)

- The picker is `TitleBarServerPicker` (`web/src/shell/TitleBarServerPicker.tsx`).
- It was mounted **only** inside the authenticated chrome — `web/src/shell/AppShell.tsx` (the `isMacElectronShell()`-gated block alongside the `.electron-drag-strip`).
- Switching to the Railway host leaves you unauthenticated there → `GET /v1/me` returns 401 + `login_url` (`web/src/lib/identity.ts`) → the app routes to `/login` (or `SetupPage` on a brand-new deploy).
- In `web/src/App.tsx`, the `/login`, `/register`, and `needs_setup → SetupPage` branches render **outside** the `<Route element={<AppShell />}>` subtree. So `AppShell` — and therefore the picker — is not mounted on those pages, and the box vanishes.
- Local stays in single-user/header mode (`RESERVED_USER_LOCAL`), never hits the login gate, so the picker stays visible there. The native macOS **Server → Change Server** menu is a working escape hatch, so this is a discoverability/UX seam, not a hard lockout.

## Fix

Hoist the macOS title-bar chrome above the auth gate so it survives the unauthenticated pages, still gated by `isMacElectronShell()`:

- **`web/src/App.tsx`** — mount the title-bar chrome (window-drag strip + `TitleBarServerPicker`) once at the top level via a small `withChrome()` wrapper that wraps **both** the authed `AppShell` subtree **and** the unauthenticated `/login` · `/register` · setup branches. The wrapper carries `data-electron-mac` so the `index.css` rules the strip/picker depend on (drag-strip geometry + the no-drag blanket that keeps the picker clickable) apply on every route. Hidden in plain browsers (`isMacElectronShell()` is `false`).
- **`web/src/shell/titleBarTitleContext.ts`** (new) — a tiny context whose setter lets `AppShell` (the only place with a conversation in scope) publish the open thread's title up to the hoisted picker, preserving the existing `"<title> — <host>"` document-window label. No-op default, so non-Electron browsers and isolated renders are safe.
- **`web/src/shell/AppShell.tsx`** — remove the now-redundant drag-strip + picker render and the `TitleBarServerPicker` import (so the picker renders exactly once, no duplicate title bar on authed pages); keep `data-electron-mac` on `.app-shell` for the sidebar top-margin / traffic-light clearance; add a small effect that feeds the thread title through the new context.

The picker talks **only** to the Electron shell over IPC (`getServerPicker` / `switchServer` / `openServerSetup`), never to the Omnigent server, so it needs no identity/auth and is safe to render on unauthenticated pages.

## Gate results

Installed with `npm ci` (committed `web/package-lock.json`), exit 0. Run from `web/`:

| Gate | Command | Result |
|---|---|---|
| Typecheck | `npm run type-check` (`tsc -b`) | **2 pre-existing errors only** — `JSX` namespace in `SessionStateBadge.tsx` + `MarkdownCommentPlugin.tsx` (an `@types/react` 19 issue in files this PR doesn't touch). Verified identical with this PR's changes stashed. **0 new type errors from this PR.** |
| Lint | `npm run lint` (`oxlint .`) | **11 errors — identical set to pristine `main`** (the only delta is the pre-existing `AppShell` `closeFile` exhaustive-deps line shifting 813→824). **0 new lint diagnostics from this PR.** |
| Build (bundler) | `npx vite build` | ✅ **built, exit 0.** (`npm run build` = `tsc -b && vite build` is gated by the 2 pre-existing `tsc` errors above; the bundler step itself is clean.) |
| Unit test (routing) | `npx vitest run src/lib/routing.test.tsx` | ✅ **6/6 passed.** |
| Unit test (AppShell) | `npx vitest run src/shell/AppShell.test.tsx` | ❌ pre-existing — `TypeError: localStorage.clear is not a function` in the suite's `beforeEach`; fails identically on pristine `main` (a jsdom/Node test-harness incompatibility in this environment, unrelated to this change). |

## Notes / limitations

- **No live Electron repro**: this environment can't launch the macOS Electron desktop shell against a live Railway-hosted accounts-enabled server, so the disappear→reappear behavior wasn't visually reproduced. The fix is validated by static analysis of the route tree, the picker's IPC-only contract, and a clean bundler build.
- The pre-existing typecheck/lint/AppShell-test failures look tied to the installed toolchain versions (`@types/react` 19, Node 25 + jsdom) rather than the source; they reproduce on `main` and are out of scope for this focused fix.
