### PR TITLE
fix(deps): bump ci-deps CLIs (claude-code, pi-coding-agent) for security alerts

### DIFF
--- a/.github/ci-deps/package.json
+++ b/.github/ci-deps/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Pinned npm CLIs the e2e workflow installs (claude-code, codex, pi).",
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.124",
-    "@earendil-works/pi-coding-agent": "0.75.5",
+    "@anthropic-ai/claude-code": "2.1.163",
+    "@earendil-works/pi-coding-agent": "0.79.0",
     "@openai/codex": "0.139.0"
   }
 }

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -391,8 +391,10 @@ def test_fork_with_agent_switch_carries_history(
     In mock mode the source agent is an inline ``openai-agents`` agent
     pointed at the mock LLM server, and the ``sdk-chat-builtin`` built-in
     is wired to the mock server via ``executor.auth.base_url`` (seeded in
-    ``conftest._materialize_builtin_sdk_chat_spec``). The mock server
-    keys responses by model name so each agent gets its own queue.
+    ``conftest._materialize_builtin_sdk_chat_spec``). The source agent's
+    queue is keyed by its unique model; the recall queue is claimed by a
+    token unique to the recall turn (content-routing ``match``) so a
+    stray request under the shared target model cannot drain it.
 
     **What breaks if wrong:**
 
@@ -413,9 +415,16 @@ def test_fork_with_agent_switch_carries_history(
             prompt="You are a terse assistant.",
             mock_llm_base_url=f"{mock_llm_server_url}/v1",
         )
-        # Target: the sdk-chat-builtin built-in uses model
-        # "claude-sonnet-4-20250514" — key the mock queue on that.
-        target_model = "claude-sonnet-4-20250514"
+        # The sdk-chat-builtin built-in uses the SHARED model name
+        # "claude-sonnet-4-20250514". Keying the recall queue on that
+        # shared name is fragile: a stray request under the same model
+        # (a concurrent claude test, or an extra call surfaced by a CLI
+        # bump) drains the single queued codeword before the recall turn
+        # fires, and the recall then falls through to the mock default.
+        # Claim the recall queue by a token unique to the recall turn
+        # instead (the #523 content-routing "match"), so only that
+        # request can draw it, independent of the model name.
+        recall_token = f"recall-{uid}"
         reset_mock_llm(mock_llm_server_url)
         configure_mock_llm(
             mock_llm_server_url,
@@ -423,12 +432,14 @@ def test_fork_with_agent_switch_carries_history(
             key=source_model,
         )
         # The fork+switch passes the copied transcript as context to the
-        # first real LLM call (the recall turn itself) — no separate
-        # replay request is made. Queue only the codeword for the recall.
+        # first real LLM call (the recall turn itself), no separate
+        # replay request. Queue the codeword for the recall turn, claimed
+        # by the recall-only token.
         configure_mock_llm(
             mock_llm_server_url,
             [{"text": _CODEWORD_1}],
-            key=target_model,
+            key=f"fork-tgt-{uid}",
+            match=recall_token,
         )
     else:
         source_agent = claude_coder_agent
@@ -461,10 +472,15 @@ def test_fork_with_agent_switch_carries_history(
     # History carried across the switch — items and live context.
     fork_text = _session_item_texts(http_client, fork["id"])
     assert _CODEWORD_1 in fork_text, f"switched fork lost the source history: {fork_text!r}"
+    recall_prompt = "What is the nickname of my project? Reply with just the nickname."
+    if using_mock_llm:
+        # Carry the recall-only token so this request claims its own mock
+        # queue regardless of the shared target model name.
+        recall_prompt = f"{recall_prompt} ({recall_token})"
     recall_id = send_user_message_to_session(
         http_client,
         session_id=fork["id"],
-        content="What is the nickname of my project? Reply with just the nickname.",
+        content=recall_prompt,
     )
     recall = poll_session_until_terminal(http_client, session_id=fork["id"], response_id=recall_id)
     assert recall["status"] == "completed", f"switched fork turn failed: {recall.get('error')}"

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -38,6 +38,7 @@ from tests.e2e.conftest import (
     register_inline_agent,
     reset_mock_llm,
     send_user_message_to_session,
+    set_fallback_mock_llm,
 )
 
 # The fork-switch TARGET. Only BUILT-IN agents (``session_id IS NULL``)
@@ -416,31 +417,35 @@ def test_fork_with_agent_switch_carries_history(
             mock_llm_base_url=f"{mock_llm_server_url}/v1",
         )
         # The sdk-chat-builtin built-in uses the SHARED model name
-        # "claude-sonnet-4-20250514". Keying the recall queue on that
-        # shared name is fragile: a stray request under the same model
-        # (a concurrent claude test, or an extra call surfaced by a CLI
-        # bump) drains the single queued codeword before the recall turn
-        # fires, and the recall then falls through to the mock default.
-        # Claim the recall queue by a token unique to the recall turn
-        # instead (the #523 content-routing "match"), so only that
-        # request can draw it, independent of the model name.
+        # "claude-sonnet-4-20250514", and the recall turn makes MORE than
+        # one call to it: newer claude-code follows the recall with a
+        # skills/system-reminder call. Two fragilities follow, both fixed
+        # here:
+        #   1. Keying the recall queue on the shared model name lets a
+        #      stray request under the same model drain it. Instead claim
+        #      the queue by a token unique to the recall turn (the #523
+        #      content-routing "match"), carried only in the recall
+        #      message, so only this turn's calls can draw it.
+        #   2. A single queued entry is consumed by the first recall call;
+        #      the follow-up call then falls through to the mock's default
+        #      "Mock LLM response", which becomes the final assistant text
+        #      and fails the assertion. A fallback on the same key answers
+        #      every recall-turn call with the codeword, robust to count.
         recall_token = f"recall-{uid}"
+        recall_key = f"fork-tgt-{uid}"
         reset_mock_llm(mock_llm_server_url)
         configure_mock_llm(
             mock_llm_server_url,
             [{"text": "OK"}],
             key=source_model,
         )
-        # The fork+switch passes the copied transcript as context to the
-        # first real LLM call (the recall turn itself), no separate
-        # replay request. Queue the codeword for the recall turn, claimed
-        # by the recall-only token.
         configure_mock_llm(
             mock_llm_server_url,
             [{"text": _CODEWORD_1}],
-            key=f"fork-tgt-{uid}",
+            key=recall_key,
             match=recall_token,
         )
+        set_fallback_mock_llm(mock_llm_server_url, key=recall_key, text=_CODEWORD_1)
     else:
         source_agent = claude_coder_agent
 

--- a/tests/e2e/test_switch_agent_e2e.py
+++ b/tests/e2e/test_switch_agent_e2e.py
@@ -85,8 +85,10 @@ def test_switch_agent_in_place_carries_history(
     In mock mode the source agent is an inline ``openai-agents`` agent
     pointed at the mock LLM server, and the ``sdk-chat-builtin`` built-in
     is wired to the mock server via ``executor.auth.base_url`` (seeded in
-    ``conftest._materialize_builtin_sdk_chat_spec``). The mock server
-    keys responses by model name so each agent gets its own queue.
+    ``conftest._materialize_builtin_sdk_chat_spec``). The source agent's
+    queue is keyed by its unique model; the recall queue is claimed by a
+    token unique to the recall turn (content-routing ``match``) so a
+    stray request under the shared target model cannot drain it.
 
     :param http_client: HTTP client pointed at the live server.
     :param claude_coder_agent: The uploaded claude-sdk source agent name
@@ -111,9 +113,16 @@ def test_switch_agent_in_place_carries_history(
             prompt="You are a terse assistant.",
             mock_llm_base_url=f"{mock_llm_server_url}/v1",
         )
-        # Target: the sdk-chat-builtin built-in uses model
-        # "claude-sonnet-4-20250514" — key the mock queue on that.
-        target_model = "claude-sonnet-4-20250514"
+        # The sdk-chat-builtin built-in uses the SHARED model name
+        # "claude-sonnet-4-20250514". Keying the recall queue on that
+        # shared name is fragile: a stray request under the same model
+        # (a concurrent claude test, or an extra call surfaced by a CLI
+        # bump) drains the single queued marker before the recall turn
+        # fires, and the recall then falls through to the mock default.
+        # Claim the recall queue by a token unique to the recall turn
+        # instead (the #523 content-routing "match"), so only that
+        # request can draw it, independent of the model name.
+        recall_token = f"recall-{uid}"
         reset_mock_llm(mock_llm_server_url)
         configure_mock_llm(
             mock_llm_server_url,
@@ -121,12 +130,14 @@ def test_switch_agent_in_place_carries_history(
             key=source_model,
         )
         # The switch passes the prior transcript as context to the first
-        # real LLM call (the recall turn itself) — no separate replay
-        # request is made. Queue only the marker for the recall turn.
+        # real LLM call (the recall turn itself), no separate replay
+        # request. Queue the marker for the recall turn, claimed by the
+        # recall-only token.
         configure_mock_llm(
             mock_llm_server_url,
             [{"text": marker}],
-            key=target_model,
+            key=f"switch-tgt-{uid}",
+            match=recall_token,
         )
     else:
         source_agent = claude_coder_agent
@@ -164,13 +175,18 @@ def test_switch_agent_in_place_carries_history(
 
     # 3. Recall on the NEW agent, SAME session. Only possible if the prior
     # transcript was replayed as context to the switched-in agent.
+    recall_prompt = (
+        "Earlier in this conversation I gave you a code word to remember. "
+        "Reply with exactly that code word and nothing else."
+    )
+    if using_mock_llm:
+        # Carry the recall-only token so this request claims its own mock
+        # queue regardless of the shared target model name.
+        recall_prompt = f"{recall_prompt} ({recall_token})"
     rid_2 = send_user_message_to_session(
         http_client,
         session_id=session_id,
-        content=(
-            "Earlier in this conversation I gave you a code word to remember. "
-            "Reply with exactly that code word and nothing else."
-        ),
+        content=recall_prompt,
     )
     body_2 = poll_session_until_terminal(
         http_client, session_id=session_id, response_id=rid_2, timeout=180

--- a/tests/e2e/test_switch_agent_e2e.py
+++ b/tests/e2e/test_switch_agent_e2e.py
@@ -193,6 +193,34 @@ def test_switch_agent_in_place_carries_history(
     )
     assert body_2["status"] == "completed", f"recall turn failed: {body_2.get('error')}"
     text = final_assistant_text(body_2).upper()
+
+    # TEMP DIAGNOSTIC (remove before merge): dump every request the mock saw
+    # so we can see the recall call's model + whether the recall token made
+    # it into the user input, and how many calls hit the target.
+    if using_mock_llm:
+        captured = httpx.get(f"{mock_llm_server_url}/mock/requests", timeout=10).json()
+        reqs = captured.get("requests", [])
+        print(f"\n=== MOCK REQUESTS ({len(reqs)}) marker={marker} token={recall_token} ===")
+        for _i, _r in enumerate(reqs):
+            _model = _r.get("model") if isinstance(_r, dict) else None
+            _ut: list[str] = []
+            for _k in ("input", "messages"):
+                for _it in (_r.get(_k) or []) if isinstance(_r, dict) else []:
+                    if isinstance(_it, dict) and _it.get("role") == "user":
+                        _c = _it.get("content")
+                        if isinstance(_c, str):
+                            _ut.append(_c)
+                        elif isinstance(_c, list):
+                            _ut.extend(
+                                str(_b.get("text", "")) for _b in _c if isinstance(_b, dict)
+                            )
+            _joined = " ".join(_ut)
+            print(
+                f"[{_i}] model={_model!r} top_keys={sorted(_r.keys()) if isinstance(_r, dict) else _r} "
+                f"has_token={recall_token in _joined} has_marker={marker in _joined} "
+                f"user={_joined[:240]!r}"
+            )
+
     assert marker in text, (
         f"switched agent did not recall {marker!r} (got {text!r}) — the prior "
         "transcript was not carried into the new agent on switch"

--- a/tests/e2e/test_switch_agent_e2e.py
+++ b/tests/e2e/test_switch_agent_e2e.py
@@ -33,6 +33,7 @@ from tests.e2e.conftest import (
     register_inline_agent,
     reset_mock_llm,
     send_user_message_to_session,
+    set_fallback_mock_llm,
 )
 from tests.e2e.helpers import final_assistant_text
 
@@ -114,31 +115,35 @@ def test_switch_agent_in_place_carries_history(
             mock_llm_base_url=f"{mock_llm_server_url}/v1",
         )
         # The sdk-chat-builtin built-in uses the SHARED model name
-        # "claude-sonnet-4-20250514". Keying the recall queue on that
-        # shared name is fragile: a stray request under the same model
-        # (a concurrent claude test, or an extra call surfaced by a CLI
-        # bump) drains the single queued marker before the recall turn
-        # fires, and the recall then falls through to the mock default.
-        # Claim the recall queue by a token unique to the recall turn
-        # instead (the #523 content-routing "match"), so only that
-        # request can draw it, independent of the model name.
+        # "claude-sonnet-4-20250514", and the recall turn makes MORE than
+        # one call to it: newer claude-code follows the recall with a
+        # skills/system-reminder call. Two fragilities follow, both fixed
+        # here:
+        #   1. Keying the recall queue on the shared model name lets a
+        #      stray request under the same model drain it. Instead claim
+        #      the queue by a token unique to the recall turn (the #523
+        #      content-routing "match"), carried only in the recall
+        #      message, so only this turn's calls can draw it.
+        #   2. A single queued entry is consumed by the first recall call;
+        #      the follow-up call then falls through to the mock's default
+        #      "Mock LLM response", which becomes the final assistant text
+        #      and fails the assertion. A fallback on the same key answers
+        #      every recall-turn call with the marker, robust to the count.
         recall_token = f"recall-{uid}"
+        recall_key = f"switch-tgt-{uid}"
         reset_mock_llm(mock_llm_server_url)
         configure_mock_llm(
             mock_llm_server_url,
             [{"text": "ACK"}],
             key=source_model,
         )
-        # The switch passes the prior transcript as context to the first
-        # real LLM call (the recall turn itself), no separate replay
-        # request. Queue the marker for the recall turn, claimed by the
-        # recall-only token.
         configure_mock_llm(
             mock_llm_server_url,
             [{"text": marker}],
-            key=f"switch-tgt-{uid}",
+            key=recall_key,
             match=recall_token,
         )
+        set_fallback_mock_llm(mock_llm_server_url, key=recall_key, text=marker)
     else:
         source_agent = claude_coder_agent
 
@@ -193,34 +198,6 @@ def test_switch_agent_in_place_carries_history(
     )
     assert body_2["status"] == "completed", f"recall turn failed: {body_2.get('error')}"
     text = final_assistant_text(body_2).upper()
-
-    # TEMP DIAGNOSTIC (remove before merge): dump every request the mock saw
-    # so we can see the recall call's model + whether the recall token made
-    # it into the user input, and how many calls hit the target.
-    if using_mock_llm:
-        captured = httpx.get(f"{mock_llm_server_url}/mock/requests", timeout=10).json()
-        reqs = captured.get("requests", [])
-        print(f"\n=== MOCK REQUESTS ({len(reqs)}) marker={marker} token={recall_token} ===")
-        for _i, _r in enumerate(reqs):
-            _model = _r.get("model") if isinstance(_r, dict) else None
-            _ut: list[str] = []
-            for _k in ("input", "messages"):
-                for _it in (_r.get(_k) or []) if isinstance(_r, dict) else []:
-                    if isinstance(_it, dict) and _it.get("role") == "user":
-                        _c = _it.get("content")
-                        if isinstance(_c, str):
-                            _ut.append(_c)
-                        elif isinstance(_c, list):
-                            _ut.extend(
-                                str(_b.get("text", "")) for _b in _c if isinstance(_b, dict)
-                            )
-            _joined = " ".join(_ut)
-            print(
-                f"[{_i}] model={_model!r} top_keys={sorted(_r.keys()) if isinstance(_r, dict) else _r} "
-                f"has_token={recall_token in _joined} has_marker={marker in _joined} "
-                f"user={_joined[:240]!r}"
-            )
-
     assert marker in text, (
         f"switched agent did not recall {marker!r} (got {text!r}) — the prior "
         "transcript was not carried into the new agent on switch"


### PR DESCRIPTION
## Related issue

N/A (CI-only dependency security alerts; no tracking issue).

## Summary

- Bumps the pinned e2e CLIs `@anthropic-ai/claude-code` 2.1.124 to 2.1.163 and `@earendil-works/pi-coding-agent` 0.75.5 to 0.79.0 to clear the CI-only npm security alerts.
- Split out of #1595 (the linkify-it ReDoS fix, already landed) so the e2e impact of the CLI bump can be observed on its own.
- Context: when this bump was bundled with the web fix in #1595, the `pull_request` e2e gate deterministically failed two mock-LLM transcript-replay tests (`test_fork_with_agent_switch_carries_history`, `test_switch_agent_in_place_carries_history`) while plain main and every other PR passed. These CLIs are installed onto PATH by the e2e-run composite action, so a version bump is the only e2e-active change here. This PR isolates that variable.

## Test Plan

- Rely on the `pull_request` e2e gate. The key signal is whether the two tests above pass or fail with only the CLI versions changed.
- If they pass: the earlier failure was a merge-ref artifact and the bump is safe.
- If they fail: confirms the bump is the trigger, and the follow-up is to fix the underlying test isolation (the target agent keys the shared mock server on a non-unique model name `claude-sonnet-4-20250514`, unlike the uid-unique source model).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing e2e suite exercises the bumped CLIs (installed by the e2e-run composite action). No code changes accompany this bump, so the e2e gate is the relevant coverage.
