### PR TITLE
fix(pi-native): self-heal the extension + cost popup past the ~1h token lapse

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2619,8 +2619,8 @@ def display_cost_approval_popup(
     checkpoint. The popup script resolves the **same** elicitation Future
     (via the same resolve endpoint the web card uses), so whichever
     surface answers first wins and the other clears. The popup reads AP
-    routing (base URL + auth headers) from this bridge's
-    ``permission_hook.json`` so no token lands on the command line.
+    routing (base URL + auth headers) from *config_file* so no token lands
+    on the command line.
 
     Fire-and-forget by design: ``tmux display-popup`` blocks its tmux
     client until the popup closes, so it is spawned **detached**
@@ -2630,16 +2630,15 @@ def display_cost_approval_popup(
     Claude-native resolver for the harness-agnostic
     :func:`omnigent.native_cost_popup.launch_cost_popup`: it reads the
     pane's tmux socket/target from this bridge's ``tmux.json`` and points
-    the popup at this bridge's ``permission_hook.json`` for Omnigent routing
-    (base URL + auth headers, so no token lands on the command line), then
-    delegates. The launcher pops the modal on every attached client and
-    skips silently when none is attached (e.g. the Terminal tab is closed)
-    — the web ``ApprovalCard`` remains the answer surface.
+    the popup at *config_file* for Omnigent routing (base URL + auth
+    headers, so no token lands on the command line), then delegates. The
+    launcher pops the modal on every attached client and skips silently when
+    none is attached (e.g. the Terminal tab is closed) — the web
+    ``ApprovalCard`` remains the answer surface.
 
     :param bridge_dir: Bridge directory path, e.g.
-        ``/tmp/omnigent/claude-native/<digest>``. Supplies both the
-        tmux target (``tmux.json``) and the AP-routing config
-        (``permission_hook.json``).
+        ``/tmp/omnigent/claude-native/<digest>``. Supplies the tmux target
+        (``tmux.json``); the AP-routing config comes from *config_file*.
     :param session_id: Omnigent session id that owns the elicitation, e.g.
         ``"conv_abc123"``. Used in the resolve URL the popup POSTs to.
     :param elicitation_id: Outstanding elicitation correlation id, e.g.

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2608,6 +2608,7 @@ def display_cost_approval_popup(
     policy_name: str | None = None,
     python_executable: str | None = None,
     timeout_s: float = _TMUX_READY_TIMEOUT_S,
+    config_file: Path | None = None,
 ) -> None:
     """
     Overlay a cost-budget approval modal on the Claude Code tmux pane.
@@ -2652,6 +2653,11 @@ def display_cost_approval_popup(
         valid on the host the tmux server runs on).
     :param timeout_s: Seconds to wait for ``tmux.json`` to be advertised,
         e.g. ``30.0``.
+    :param config_file: AP-routing config the popup reads (base URL + auth
+        headers). ``None`` falls back to this bridge's ``permission_hook.json``
+        — but that carries the one-shot launch token, which dies with the ~1h
+        Databricks OAuth lifetime, so callers should pass a freshly-minted
+        snapshot to keep a late-firing verdict POST from 401-ing.
     :returns: None.
     :raises RuntimeError: If the tmux target is not advertised within
         *timeout_s* (the pane isn't up yet); the caller treats this as a
@@ -2663,7 +2669,7 @@ def display_cost_approval_popup(
     launch_cost_popup(
         info["socket_path"],
         info["tmux_target"],
-        bridge_dir / _PERMISSION_HOOK_FILE,
+        config_file if config_file is not None else bridge_dir / _PERMISSION_HOOK_FILE,
         session_id=session_id,
         elicitation_id=elicitation_id,
         message=message,

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -125,9 +125,7 @@ class PiNativeExecutor(Executor):
             factory = _make_auth_token_factory()
             token = factory() if factory is not None else None
             if token:
-                refresh_config_auth_headers(
-                    self._bridge_dir, {"Authorization": f"Bearer {token}"}
-                )
+                refresh_config_auth_headers(self._bridge_dir, {"Authorization": f"Bearer {token}"})
         except Exception:  # noqa: BLE001 — best-effort refresh; never block a turn
             pass
 

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -21,6 +21,7 @@ from omnigent.pi_native_bridge import (
     PI_NATIVE_BRIDGE_DIR_ENV_VAR,
     PI_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     enqueue_user_message,
+    refresh_config_auth_headers,
 )
 
 
@@ -68,6 +69,7 @@ class PiNativeExecutor(Executor):
         text = _content_to_text(content, self._bridge_dir)
         if not text:
             return False
+        self._refresh_auth_headers()
         enqueue_user_message(self._bridge_dir, text)
         return True
 
@@ -95,8 +97,39 @@ class PiNativeExecutor(Executor):
         if not text:
             yield ExecutorError(message="Pi native turn had no user text to send")
             return
+        self._refresh_auth_headers()
         enqueue_user_message(self._bridge_dir, text)
         yield TurnComplete(response=None)
+
+    def _refresh_auth_headers(self) -> None:
+        """
+        Re-mint the extension's bearer so a long session survives token expiry.
+
+        The bearer baked into ``config.json`` at launch dies with the ~1h
+        Databricks OAuth lifetime, and the resident extension re-reads the
+        config per request (``freshAuthHeaders``). Refreshing it at each turn
+        keeps its policy/MCP POSTs authenticated instead of failing closed —
+        the same outcome the refresh-capable runtime auth and the native
+        policy hooks already get via re-mint. Minting runs in-runner through
+        the same factory those use. Best-effort: any failure (no factory in
+        local/unauthenticated runs, transient SDK error) leaves the existing
+        headers in place rather than blocking the turn.
+
+        ponytail: refreshes per turn, so a *single* turn running past ~1h
+        still risks expiry mid-turn; add a background refresh task keyed to
+        the pi terminal if that case ever bites.
+        """
+        try:
+            from omnigent.runner._entry import _make_auth_token_factory
+
+            factory = _make_auth_token_factory()
+            token = factory() if factory is not None else None
+            if token:
+                refresh_config_auth_headers(
+                    self._bridge_dir, {"Authorization": f"Bearer {token}"}
+                )
+        except Exception:  # noqa: BLE001 — best-effort refresh; never block a turn
+            pass
 
 
 def _bridge_dir_from_env() -> Path:

--- a/omnigent/native_cost_popup.py
+++ b/omnigent/native_cost_popup.py
@@ -13,16 +13,16 @@ The process is launched by the runner-side popup helper (e.g.
 :func:`omnigent.claude_native_bridge.display_cost_approval_popup`) as::
 
     python -I -m omnigent.native_cost_popup \
-        --config-file <bridge_dir>/permission_hook.json \
+        --config-file <bridge_dir>/cost_popup.json \
         --session-id conv_abc123 \
         --elicitation-id elicit_deadbeef \
         --message "Session cost $0.12 crossed the $0.10 checkpoint. Continue?"
 
 AP routing (base URL + auth headers) is read from ``--config-file``
 rather than argv so the bearer token never lands in the process list /
-tmux command line. The file is the harness's existing AP-routing config
-(``permission_hook.json`` for claude-native, ``policy_hook.json`` for
-codex-native); both carry ``ap_server_url`` + ``ap_auth_headers``.
+tmux command line. The runner writes a freshly-minted ``cost_popup.json``
+snapshot at popup launch (a stale launch-token snapshot would 401 the
+verdict POST); the file carries ``ap_server_url`` + ``ap_auth_headers``.
 
 Dismissing the popup (Escape / Ctrl-C / EOF) exits **without** posting a
 verdict, leaving the elicitation outstanding so it can still be answered
@@ -150,8 +150,9 @@ def launch_cost_popup(
         ``"/tmp/.../tmux.sock"``.
     :param tmux_target: tmux target of the pane, e.g. ``"main"``.
     :param config_file: AP-routing config the popup reads for
-        ``ap_server_url`` + ``ap_auth_headers`` — ``permission_hook.json``
-        for claude-native, ``policy_hook.json`` for codex-native.
+        ``ap_server_url`` + ``ap_auth_headers`` — the runner mints a fresh
+        ``cost_popup.json`` snapshot per launch so the verdict POST carries a
+        live bearer rather than the stale launch token.
     :param session_id: Omnigent session id that owns the elicitation, e.g.
         ``"conv_abc123"``. Used in the resolve URL the popup POSTs to.
     :param elicitation_id: Outstanding elicitation correlation id, e.g.

--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -256,6 +256,39 @@ def write_extension_files(
     return extension_path(bridge_dir), config_path(bridge_dir)
 
 
+def refresh_config_auth_headers(bridge_dir: Path, auth_headers: dict[str, str]) -> bool:
+    """
+    Rewrite only the ``authHeaders`` of an existing extension config.
+
+    The bearer baked into ``config.json`` at launch dies with the ~1h
+    Databricks OAuth lifetime. The resident extension re-reads the config on
+    every outbound request (``freshAuthHeaders``), so refreshing this one key
+    — e.g. at the start of each turn — keeps its ``/policies/evaluate`` and
+    ``/mcp`` POSTs authenticated instead of failing closed mid-session.
+    Best-effort and behavior-preserving: it touches only ``authHeaders``,
+    leaving ``serverUrl`` / ``tools`` / etc. intact.
+
+    :param bridge_dir: Native Pi bridge directory.
+    :param auth_headers: Fresh outbound auth headers, e.g.
+        ``{"Authorization": "Bearer <token>"}``.
+    :returns: ``True`` when the config was rewritten; ``False`` when
+        *auth_headers* is empty (local/unauthenticated), the config is
+        missing/unreadable, or the headers already match.
+    """
+    if not auth_headers:
+        return False
+    path = config_path(bridge_dir)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if not isinstance(payload, dict) or payload.get("authHeaders") == auth_headers:
+        return False
+    payload["authHeaders"] = auth_headers
+    _atomic_json(path, payload)
+    return True
+
+
 def _extension_source() -> str:
     """
     Return the packaged Pi extension source.

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -85,6 +85,20 @@ function readConfig() {
   }
 }
 
+// Re-read authHeaders from config.json on each outbound request. The bearer
+// baked at launch dies with the ~1h Databricks OAuth lifetime; the runner
+// re-mints it into config.json each turn (PiNativeExecutor), so re-reading
+// here keeps the policy/MCP/event POSTs authenticated instead of failing
+// closed mid-session. Falls back to the closed-over headers when the re-read
+// fails (a torn config) so a transient read can't drop auth.
+function freshAuthHeaders(fallback) {
+  const latest = readConfig();
+  if (latest && latest.authHeaders && typeof latest.authHeaders === "object") {
+    return latest.authHeaders;
+  }
+  return fallback || {};
+}
+
 /**
  * Evaluate a TOOL_CALL policy for a native Pi tool via the Omnigent server's
  * session-level HTTP endpoint (POST /v1/sessions/{sessionId}/policies/evaluate).
@@ -156,7 +170,7 @@ async function evalNativePolicyHttp(config, toolName, args) {
   });
   const reqHeaders = {
     "content-type": "application/json",
-    ...(config.authHeaders || {}),
+    ...freshAuthHeaders(config.authHeaders),
   };
 
   const parkDeadline = Date.now() + _PARK_TOTAL_BUDGET_MS;
@@ -398,7 +412,7 @@ async function postMcpToolsCall(config, toolName, args, rpcId, extraParams) {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        ...(config.authHeaders || {}),
+        ...freshAuthHeaders(config.authHeaders),
       },
       body,
     });
@@ -661,7 +675,7 @@ function extractPiUsage(message) {
 function headers(config) {
   return {
     "content-type": "application/json",
-    ...(config.authHeaders || {}),
+    ...freshAuthHeaders(config.authHeaders),
   };
 }
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -12098,6 +12098,10 @@ def create_runner_app(
             session_id=conv_id,
         )
         bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+        # Mint a fresh AP-routing snapshot rather than letting the popup read
+        # this bridge's permission_hook.json, whose launch token goes stale at
+        # ~1h and would 401 the verdict POST (silently losing the approval).
+        config_file = await _native_cost_popup_config_file(conv_id, "claude-native")
         try:
             # Short timeout: missing tmux.json means the pane isn't
             # attached, so there is no client to render the modal — the
@@ -12110,6 +12114,7 @@ def create_runner_app(
                 message=message,
                 policy_name=policy_name,
                 timeout_s=1.0,
+                config_file=config_file,
             )
         except (RuntimeError, ValueError) as exc:
             return JSONResponse(
@@ -12135,9 +12140,10 @@ def create_runner_app(
         a ``tmux.json`` (its terminal is launched through the resource
         registry), so the pane's socket/target come from the registry
         instance — the same source the web-terminal attach uses — and AP
-        routing comes from this bridge's ``policy_hook.json``. Resolution
-        differs; the actual popup launch is the shared, harness-agnostic
-        :func:`omnigent.native_cost_popup.launch_cost_popup`.
+        routing comes from a freshly-minted snapshot (see
+        :func:`_native_cost_popup_config_file`) rather than the stale launch
+        token. Resolution differs; the actual popup launch is the shared,
+        harness-agnostic :func:`omnigent.native_cost_popup.launch_cost_popup`.
 
         Best-effort: skips (204) when no live codex terminal is registered
         for the session, so the web ApprovalCard remains the surface.
@@ -12152,7 +12158,6 @@ def create_runner_app(
         :returns: 204 once the popup is dispatched (or skipped when no
             terminal is registered). 503 if launching raised.
         """
-        from omnigent.codex_native_bridge import _POLICY_HOOK_FILE, bridge_dir_for_bridge_id
         from omnigent.native_cost_popup import launch_cost_popup
 
         registry = resource_registry.terminal_registry
@@ -12160,7 +12165,10 @@ def create_runner_app(
         if instance is None or not instance.running:
             # No live codex terminal to render on; web card is the surface.
             return Response(status_code=204)
-        config_file = bridge_dir_for_bridge_id(conv_id) / _POLICY_HOOK_FILE
+        # Mint a fresh AP-routing snapshot rather than reading this bridge's
+        # policy_hook.json, whose launch token goes stale at ~1h and would 401
+        # the verdict POST (silently losing the approval).
+        config_file = await _native_cost_popup_config_file(conv_id, "codex-native")
         try:
             await asyncio.to_thread(
                 launch_cost_popup,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -12291,54 +12291,55 @@ def create_runner_app(
 
     async def _native_cost_popup_config_file(conv_id: str, harness: str) -> Path:
         """
-        Resolve the AP-routing config file the cost popup reads, per harness.
+        Mint the AP-routing config the cost popup reads, per harness.
 
-        The popup script reads ``ap_server_url`` + ``ap_auth_headers`` from
-        this file: ``permission_hook.json`` in the claude-native bridge dir,
-        ``policy_hook.json`` in the codex-native bridge dir. opencode-native
-        has no permission/policy hook of its own (it gates via the SSE
-        forwarder), so there is no such file at rest — write a fresh snapshot
-        here (the only consumer is this popup).
+        The popup subprocess reads ``ap_server_url`` + ``ap_auth_headers``
+        from this file and replays the static headers when POSTing its
+        verdict. claude/codex used to point it at their long-lived
+        ``permission_hook.json`` / ``policy_hook.json`` — but those carry the
+        one-shot launch token, which dies with the ~1h Databricks OAuth
+        lifetime, so a cost gate firing late in a session would 401 the
+        verdict and silently lose the approval. Mint a fresh bearer here (the
+        popup launches right after) and pair it with the workspace-routing
+        header — bearer alone misroutes the POST to the account — for every
+        harness uniformly.
 
         :param conv_id: Session/conversation id, e.g. ``"conv_abc123"``.
         :param harness: ``"claude-native"``, ``"codex-native"``, or
             ``"opencode-native"``.
-        :returns: Path to the harness's AP-routing config file.
+        :returns: Path to the freshly-written popup config file.
         """
+        from omnigent.cli_auth import databricks_request_headers
+        from omnigent.opencode_native_bridge import write_cost_popup_config
+        from omnigent.runner._entry import _make_auth_token_factory
+
         if harness == "claude-native":
             from omnigent import claude_native_bridge as _cnb
 
             bridge_id = await _claude_native_bridge_id_for_session(
                 server_client=server_client, session_id=conv_id
             )
-            return _cnb.bridge_dir_for_bridge_id(bridge_id) / _cnb._PERMISSION_HOOK_FILE
-        if harness == "opencode-native":
-            # opencode is the one harness whose popup config is minted fresh here
-            # (claude/codex reuse their permission/policy hook files, which carry
-            # the routing header already). The popup subprocess replays these
-            # static headers, so pair the bearer with the workspace-routing
-            # header — bearer alone misroutes the popup's POST to the account.
-            from omnigent.cli_auth import databricks_request_headers
+            bridge_dir = _cnb.bridge_dir_for_bridge_id(bridge_id)
+        elif harness == "opencode-native":
             from omnigent.opencode_native_bridge import (
                 bridge_dir_for_bridge_id as _oc_bridge_dir,
             )
-            from omnigent.opencode_native_bridge import (
-                write_cost_popup_config,
-            )
-            from omnigent.runner._entry import _make_auth_token_factory
 
-            _server_url = _required_runner_env("RUNNER_SERVER_URL")
-            _factory = _make_auth_token_factory()
-            _token = _factory() if _factory is not None else None
-            return await asyncio.to_thread(
-                write_cost_popup_config,
-                _oc_bridge_dir(conv_id),
-                ap_server_url=_server_url,
-                ap_auth_headers=databricks_request_headers(_server_url, bearer_token=_token),
-            )
-        from omnigent import codex_native_bridge as _cxb
+            bridge_dir = _oc_bridge_dir(conv_id)
+        else:  # codex-native
+            from omnigent import codex_native_bridge as _cxb
 
-        return _cxb.bridge_dir_for_bridge_id(conv_id) / _cxb._POLICY_HOOK_FILE
+            bridge_dir = _cxb.bridge_dir_for_bridge_id(conv_id)
+
+        _server_url = _required_runner_env("RUNNER_SERVER_URL")
+        _factory = _make_auth_token_factory()
+        _token = _factory() if _factory is not None else None
+        return await asyncio.to_thread(
+            write_cost_popup_config,
+            bridge_dir,
+            ap_server_url=_server_url,
+            ap_auth_headers=databricks_request_headers(_server_url, bearer_token=_token),
+        )
 
     async def _repop_pending_cost_popup_on_attach(
         conv_id: str,

--- a/tests/inner/test_pi_native_executor.py
+++ b/tests/inner/test_pi_native_executor.py
@@ -104,3 +104,47 @@ async def test_enqueue_session_message_queues_steering(tmp_path: Path, monkeypat
     # Empty content is a no-op (nothing queued, returns False).
     assert await ex.enqueue_session_message("main", "") is False
     assert seen == ["steer"]
+
+
+async def test_turn_refreshes_baked_bearer(tmp_path: Path, monkeypatch) -> None:
+    """Each turn re-mints the bearer into the config the extension re-reads.
+
+    The token baked into ``config.json`` at launch dies with the ~1h
+    Databricks OAuth lifetime; without a per-turn refresh the resident
+    extension's policy/MCP POSTs fail closed once the session outlives it.
+    Both turn paths (``run_turn`` and live steering) must refresh.
+    """
+    import omnigent.runner._entry as entry
+
+    monkeypatch.setattr(entry, "_make_auth_token_factory", lambda *a, **k: lambda: "tok")
+    monkeypatch.setattr(pne, "enqueue_user_message", lambda *a: "msg")
+    refreshed: list[dict[str, str]] = []
+    monkeypatch.setattr(
+        pne,
+        "refresh_config_auth_headers",
+        lambda bridge_dir, headers: bool(refreshed.append(headers)),
+    )
+    ex = pne.PiNativeExecutor(bridge_dir=tmp_path)
+
+    [_ async for _ in ex.run_turn([{"role": "user", "content": "hi"}], [], "")]
+    assert await ex.enqueue_session_message("main", "steer") is True
+    assert refreshed == [{"Authorization": "Bearer tok"}, {"Authorization": "Bearer tok"}]
+
+
+async def test_turn_refresh_is_best_effort(tmp_path: Path, monkeypatch) -> None:
+    """A mint failure never blocks the turn (best-effort refresh)."""
+    import omnigent.runner._entry as entry
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("sdk down")
+
+    monkeypatch.setattr(entry, "_make_auth_token_factory", _boom)
+    monkeypatch.setattr(pne, "enqueue_user_message", lambda *a: "msg")
+    called: list[object] = []
+    monkeypatch.setattr(pne, "refresh_config_auth_headers", lambda *a: called.append(a))
+    ex = pne.PiNativeExecutor(bridge_dir=tmp_path)
+
+    events = [e async for e in ex.run_turn([{"role": "user", "content": "hi"}], [], "")]
+    # Turn still completes; the swallowed mint error means no rewrite was tried.
+    assert len(events) == 1 and isinstance(events[0], TurnComplete)
+    assert called == []

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4688,6 +4688,45 @@ def test_display_cost_approval_popup_builds_detached_tmux_command(
     assert captured["kwargs"]["stderr"] == subprocess.DEVNULL
 
 
+def test_display_cost_approval_popup_honors_config_file_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``config_file`` override is forwarded instead of permission_hook.json.
+
+    The runner passes a freshly-minted AP-routing snapshot here so a cost gate
+    firing late in a session reads a live bearer, not the stale launch token in
+    permission_hook.json. Without honoring the override the verdict POST would
+    401 and silently lose the approval.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "tmux.json").write_text(
+        json.dumps({"socket_path": "/tmp/x.sock", "tmux_target": "claude:0.0"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(native_cost_popup, "_list_tmux_clients", lambda _s, _t: ["/dev/pts/9"])
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda args, **kwargs: captured.setdefault("args", args)
+    )
+    fresh = bridge_dir / "cost_popup.json"
+
+    display_cost_approval_popup(
+        bridge_dir,
+        session_id="conv_abc123",
+        elicitation_id="elicit_deadbeef",
+        message="continue?",
+        timeout_s=1.0,
+        config_file=fresh,
+    )
+
+    inner = shlex.split(captured["args"][-1])
+    cfg = inner[inner.index("--config-file") + 1]
+    assert cfg == str(fresh)
+    assert not cfg.endswith("permission_hook.json")
+
+
 def test_display_cost_approval_popup_skips_when_no_client_attached(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_pi_native_bridge.py
+++ b/tests/test_pi_native_bridge.py
@@ -241,9 +241,7 @@ def test_refresh_config_auth_headers_replaces_only_auth(tmp_path: Path) -> None:
     )
 
     assert (
-        pi_native_bridge.refresh_config_auth_headers(
-            bridge_dir, {"Authorization": "Bearer fresh"}
-        )
+        pi_native_bridge.refresh_config_auth_headers(bridge_dir, {"Authorization": "Bearer fresh"})
         is True
     )
     payload = json.loads(pi_native_bridge.config_path(bridge_dir).read_text(encoding="utf-8"))

--- a/tests/test_pi_native_bridge.py
+++ b/tests/test_pi_native_bridge.py
@@ -220,3 +220,58 @@ def test_write_extension_files_defaults_tools_to_empty(tmp_path: Path) -> None:
 
     payload = json.loads(cfg.read_text(encoding="utf-8"))
     assert payload["tools"] == []
+
+
+def test_refresh_config_auth_headers_replaces_only_auth(tmp_path: Path) -> None:
+    """Refreshing the bearer rewrites only ``authHeaders``, leaving the rest.
+
+    The baked launch token dies with the ~1h Databricks OAuth lifetime; the
+    runner re-mints it into ``config.json`` each turn and the extension
+    re-reads per request. The rewrite must touch only ``authHeaders`` so
+    ``serverUrl`` / ``tools`` (read once at startup) stay intact.
+    """
+    bridge_dir = tmp_path / "bridge"
+    pi_native_bridge.write_extension_files(
+        bridge_dir,
+        session_id="conv_abc",
+        server_url="http://omnigent.test",
+        conversation_url="http://omnigent.test/c/conv_abc",
+        auth_headers={"Authorization": "Bearer stale"},
+        tools=[{"name": "t"}],
+    )
+
+    assert (
+        pi_native_bridge.refresh_config_auth_headers(
+            bridge_dir, {"Authorization": "Bearer fresh"}
+        )
+        is True
+    )
+    payload = json.loads(pi_native_bridge.config_path(bridge_dir).read_text(encoding="utf-8"))
+    assert payload["authHeaders"] == {"Authorization": "Bearer fresh"}
+    # Untouched: the static fields the extension reads once at startup.
+    assert payload["serverUrl"] == "http://omnigent.test"
+    assert payload["tools"] == [{"name": "t"}]
+
+
+def test_refresh_config_auth_headers_noops(tmp_path: Path) -> None:
+    """No-op (returns False) on empty headers, a missing config, or no change."""
+    bridge_dir = tmp_path / "bridge"
+    # Missing config: nothing to rewrite.
+    assert pi_native_bridge.refresh_config_auth_headers(bridge_dir, {"a": "b"}) is False
+
+    pi_native_bridge.write_extension_files(
+        bridge_dir,
+        session_id="conv_abc",
+        server_url="http://omnigent.test",
+        conversation_url="http://omnigent.test/c/conv_abc",
+        auth_headers={"Authorization": "Bearer x"},
+    )
+    # Empty headers (local/unauthenticated) must never blank out a live token.
+    assert pi_native_bridge.refresh_config_auth_headers(bridge_dir, {}) is False
+    payload = json.loads(pi_native_bridge.config_path(bridge_dir).read_text(encoding="utf-8"))
+    assert payload["authHeaders"] == {"Authorization": "Bearer x"}
+    # Identical headers: skip the rewrite.
+    assert (
+        pi_native_bridge.refresh_config_auth_headers(bridge_dir, {"Authorization": "Bearer x"})
+        is False
+    )

--- a/tests/test_pi_native_extension.py
+++ b/tests/test_pi_native_extension.py
@@ -2518,3 +2518,78 @@ def test_policy_fast_error_racing_abort_is_bounded_fails_closed(
 });
 """
     _run_policy_node_script(_extension_path(), tmp_path, body)
+
+
+def test_outbound_requests_reread_refreshed_bearer(tmp_path: Path) -> None:
+    """Each outbound POST re-reads ``authHeaders``, picking up the runner's re-mint.
+
+    The bearer baked into ``config.json`` at launch dies with the ~1h
+    Databricks OAuth lifetime. The runner re-mints it into the config each
+    turn; the extension must read the bearer fresh per request (not the
+    launch snapshot it closed over at startup) so its POSTs stay
+    authenticated mid-session instead of failing closed. Drives two
+    ``message_end`` flushes with a config rewrite between them and asserts the
+    second POST carries the new bearer.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = r"""
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+
+const extensionPath = process.argv[1];
+const configPath = path.join(require("os").tmpdir(), `pi-reauth-${process.pid}.json`);
+function writeConfig(bearer) {
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      serverUrl: "http://omnigent.test",
+      sessionId: "session-1",
+      authHeaders: { authorization: bearer },
+    }),
+  );
+}
+writeConfig("Bearer stale");
+process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
+
+const sentAuth = [];
+global.fetch = async (_url, request) => {
+  sentAuth.push(request.headers.authorization);
+  return { ok: true };
+};
+global.setInterval = () => ({ fakeInterval: true });
+
+const handlers = {};
+const pi = { registerCommand() {}, on(name, handler) { handlers[name] = handler; } };
+require(extensionPath)(pi);
+const ctx = { ui: { setTitle() {}, setStatus() {}, notify() {} } };
+
+function usage(id) {
+  return {
+    message: {
+      id,
+      role: "assistant",
+      model: "databricks-claude-sonnet-4-6",
+      usage: { input: 10, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 11 },
+    },
+  };
+}
+
+(async () => {
+  await handlers.message_end(usage("m1"), ctx);
+  // The runner re-mints the bearer into config.json mid-session.
+  writeConfig("Bearer fresh");
+  await handlers.message_end(usage("m2"), ctx);
+
+  // First POST used the launch token; the second re-read the rewritten config
+  // and carried the fresh bearer — not the stale one closed over at startup.
+  assert.deepEqual(sentAuth, ["Bearer stale", "Bearer fresh"], JSON.stringify(sentAuth));
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+    _run_extension_script(node, _extension_path(), script)


### PR DESCRIPTION
Follow-up to #1439 / #1482. Those re-minted the expired hook token for the five **Python** policy-hook channels (claude / codex / kimi / cursor / hermes). An audit of the *remaining* channels that bake a one-shot `ap_auth_headers` snapshot at launch found two more that still die with the ~1h Databricks OAuth lifetime.

### 1. pi-native — fails **closed**
The Node extension reads `config.json` **once** at module load and POSTs that frozen bearer to `/policies/evaluate` and `/mcp`; nothing rewrites the file. Past ~1h on a remote Apps deployment, every native Pi tool call **and** policy check 401s/302s and fails closed — the exact symptom #1439 fixed for claude. The Python `policy_hook_reauth` can't reach a Node subprocess, so the fix is two-sided:

- the extension re-reads `authHeaders` from `config.json` on **every** outbound request (`freshAuthHeaders`), and
- `PiNativeExecutor` re-mints the bearer into `config.json` at the **start of each turn** (the in-runner per-turn touchpoint), through the same factory the refresh-capable runtime auth uses. Best-effort and behavior-preserving — a mint failure leaves the existing headers in place rather than blocking the turn.

A *single* turn running past ~1h is still a residual gap (documented in a `ponytail:` comment); a background refresh task keyed to the pi terminal is the upgrade path if it ever bites.

### 2. cost popup — claude/codex
The popup subprocess pointed at the long-lived `permission_hook.json` / `policy_hook.json`, whose launch token goes stale, so a cost gate firing late in a session 401s the verdict POST and silently loses the approval. The runner now mints a fresh bearer (+ workspace-routing header) for **every** harness at popup launch — opencode already did this; claude/codex now match.

### Out of scope
opencode's policy plugin has the same root snapshot but fails **open** and is already flagged in-code as a separate follow-up (env-var → refreshable file). In-process channels (forwarders / SDK executors / antigravity audit / goose) use the runner's refresh-capable httpx auth and refresh transparently.

### Verified
`ruff` clean; 59 targeted tests + the 33-test JS-driven extension suite + the standalone `node` extension unit test all pass. New coverage:
- `refresh_config_auth_headers` rewrites only `authHeaders`; no-ops on empty / missing / unchanged.
- `PiNativeExecutor` re-mints on both turn paths and is best-effort on a mint failure.
- a Node test proves an outbound POST picks up a bearer rewritten into `config.json` mid-session (stale → fresh).

This pull request and its description were written by Isaac.