### PR TITLE
feat(runner): idle reaper for native terminal panes (#1349)

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -840,12 +840,19 @@ def create_app(
                 )
             except Exception:
                 _logger.exception("runner MCP prewarm failed for %s", prewarm_path)
+        # Native-pane idle reaper (#1349): reclaims idle native CLI panes.
+        _pane_reaper = getattr(app.state, "native_pane_reaper", None)
+        if _pane_reaper is not None:
+            await _pane_reaper.start()
 
     async def _stop_pm() -> None:
         """Stop runner-owned resources for graceful process exit.
 
         :returns: None.
         """
+        _pane_reaper = getattr(app.state, "native_pane_reaper", None)
+        if _pane_reaper is not None:
+            await _pane_reaper.shutdown()
         await pm.shutdown()
         await _terminal_registry.shutdown()
         if mcp_manager is not None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7831,6 +7831,14 @@ def create_runner_app(
     _repl_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     # Turn sequencing (SESSION_REARCHITECTURE Step 5 / SESSION_STEERING_MIGRATION Step 1)
     _active_turns: dict[str, asyncio.Task[None] | None] = {}
+    # Latest working status per session ("running"/"idle"/...), mirrored from
+    # every session.status edge at the _publish_event chokepoint (so it covers the
+    # PTY watcher's roles AND codex/antigravity/opencode, whose edges are published
+    # directly). The native-pane idle reaper (#1349) reads this as its "currently
+    # working" signal: native turns clear _active_turns right after the prompt is
+    # pasted, so for a long autonomous turn this status is the only reliable
+    # in-memory liveness signal.
+    _native_pane_status: dict[str, str] = {}
     _session_message_buffers: dict[str, list[dict[str, Any]]] = {}
     # Per-conversation message-ingest ordering (RUNNER_MESSAGE_INGEST.md
     # Part A). Each inbound ``message`` event takes a monotonic arrival
@@ -7922,6 +7930,18 @@ def create_runner_app(
             queue = asyncio.Queue()
             _session_event_queues[session_id] = queue
         queue.put_nowait(event)
+        # Mirror the latest session.status edge so the native-pane idle reaper
+        # (#1349) can tell a pane working autonomously ("running") from an idle
+        # one. This is the single chokepoint every session.status publish flows
+        # through, so it covers BOTH the PTY watcher's roles (via
+        # _publish_session_status) AND codex/antigravity/opencode, whose
+        # running/idle edges are published here directly rather than by the PTY
+        # watcher. Recorded for every session (SDK too); the reaper only consults
+        # it for native panes.
+        if event.get("type") == "session.status":
+            _status_value = event.get("status")
+            if isinstance(_status_value, str):
+                _native_pane_status[session_id] = _status_value
         # Mirror a child sub-agent's status / preview deltas onto the
         # PARENT's stream. No-op for non-child sessions. Single chokepoint
         # so every session.status publish is covered.
@@ -8158,6 +8178,8 @@ def create_runner_app(
             ``"conv_abc123"``.
         :param status: New working status, ``"running"`` or ``"idle"``.
         """
+        # (The native-pane reaper's status mirror is recorded centrally in
+        # _publish_event, which this routes through — see #1349.)
         _publish_event(
             session_id,
             {"type": "session.status", "status": status},
@@ -9663,6 +9685,7 @@ def create_runner_app(
                 await turn_task
         _session_message_buffers.pop(session_id, None)
         _live_response_id.pop(session_id, None)
+        _native_pane_status.pop(session_id, None)
         _ingest_next_seq.pop(session_id, None)
         _ingest_now_serving.pop(session_id, None)
         _ingest_cond.pop(session_id, None)
@@ -18289,6 +18312,83 @@ def create_runner_app(
 
     # Expose catch-up scan so _entry.py can wire it as on_reconnect.
     app.state.catch_up_scan = _catch_up_scan
+
+    # Native-pane idle reaper (#1349): reclaim idle native CLI panes
+    # (claude/codex/... + their MCP fleets), which — unlike the SDK harness
+    # proxies the process manager reaps — would otherwise be held for the whole
+    # conversation lifetime and OOM a shared runner. Started/stopped by the runner
+    # lifespan (_entry.py). ``app.state.native_pane_reaper`` is ``None`` for the
+    # registry-less lightweight app factory and minimal test doubles
+    # (``getattr`` + ``native_panes`` capability check, not a bare access, so the
+    # ``_CapturingResourceRegistry`` / ``_TrackingTerminalRegistry`` doubles
+    # don't break app construction — they just get no reaper).
+    _pane_reaper_registry = getattr(resource_registry, "terminal_registry", None)
+    if (
+        resource_registry is not None
+        and _pane_reaper_registry is not None
+        and hasattr(_pane_reaper_registry, "native_panes")
+    ):
+        # NB: do NOT import terminal_resource_id locally here — it is a
+        # module-level import (top of file) used by handlers defined far above
+        # (e.g. create_session_terminal). A function-local ``from ... import``
+        # would rebind it as a create_runner_app local for the WHOLE function,
+        # leaving those earlier uses unbound on any path where this branch does
+        # not run (registry-less app factory / test doubles) → NameError.
+        from omnigent.native_cost_popup import _list_tmux_clients
+        from omnigent.runner.tool_dispatch import _publish_terminal_deleted_event
+        from omnigent.terminals.pane_reaper import NativePaneReaper, PaneRef
+
+        def _native_panes_for_reaper() -> list[PaneRef]:
+            panes: list[PaneRef] = []
+            for conv_id, name, socket_path in _pane_reaper_registry.native_panes():
+                terminal_id = terminal_resource_id(name, "main")
+                # Role gate (not just the name match native_panes does): only a
+                # terminal whose resource ROLE is a native harness is reapable, so
+                # a user terminal that merely shares a harness name is never
+                # reclaimed.
+                if is_native_harness(
+                    resource_registry.terminal_resource_role(conv_id, terminal_id)
+                ):
+                    panes.append(PaneRef(conv_id, terminal_id, name, socket_path))
+            return panes
+
+        async def _native_pane_is_busy(pane: PaneRef) -> bool:
+            conv_id = pane.conversation_id
+            if conv_id in _active_turns or (
+                process_manager is not None and process_manager.has_active_turn(conv_id)
+            ):
+                return True
+            # The vendor CLI working autonomously between runner turns (native
+            # turns clear _active_turns right after the prompt is pasted).
+            if _native_pane_status.get(conv_id) == "running":
+                return True
+            # A human attached to the pane. The tmux probe is a blocking
+            # subprocess, so run it off the event loop.
+            clients = await asyncio.to_thread(_list_tmux_clients, str(pane.socket_path), "main")
+            return bool(clients)
+
+        async def _reap_native_pane(pane: PaneRef) -> None:
+            # Pane-scoped teardown: close ONLY this native terminal (its MCP
+            # children die by parent-death), leaving the conversation's other
+            # terminals + primary OSEnv intact. The next message re-creates it and
+            # the vendor CLI resumes via --resume.
+            try:
+                await resource_registry.close_terminal(pane.conversation_id, pane.terminal_id)
+            finally:
+                _publish_terminal_deleted_event(
+                    conversation_id=pane.conversation_id,
+                    terminal_name=pane.terminal_name,
+                    session_key="main",
+                    publish_event=_publish_event,
+                )
+
+        app.state.native_pane_reaper = NativePaneReaper(
+            list_native_panes=_native_panes_for_reaper,
+            is_busy=_native_pane_is_busy,
+            reap=_reap_native_pane,
+        )
+    else:
+        app.state.native_pane_reaper = None
 
     return app
 

--- a/omnigent/terminals/pane_reaper.py
+++ b/omnigent/terminals/pane_reaper.py
@@ -1,0 +1,248 @@
+"""Idle reaper for native-harness terminal panes (issue #1349).
+
+Native CLI sessions (``claude-native`` / ``codex-native`` / ``cursor-native`` /
+...) run their vendor CLI plus a full MCP fleet inside a persistent tmux pane
+held for the whole conversation lifetime. Unlike the SDK harness proxies — which
+``HarnessProcessManager._idle_reaper_loop`` reaps after an idle window — these
+panes have no idle reaper, so on a shared/multi-conversation runner memory grows
+without bound as idle conversations accumulate, independent of how many are
+actually active (#1349).
+
+This reaps a single native pane only when it is genuinely unused. "Busy" is the
+disjunction of three signals (any one spares the pane):
+
+  * an in-flight runner turn (``has_active_turn``), OR
+  * the pane's PTY watcher currently reports ``running`` — i.e. the vendor CLI is
+    working autonomously *between* runner turns (native turns clear the runner's
+    ``_active_turns`` right after the prompt is pasted, so this is the load-bearing
+    signal for a long autonomous turn), OR
+  * a tmux client is attached (a human is watching the pane).
+
+A pane idle on all three for longer than the window is reaped, with a **second
+busy re-check immediately before teardown** to close the select→reap race. The
+tmux client probe is a blocking ``subprocess`` call, so it runs off the event
+loop via ``asyncio.to_thread``.
+
+Teardown is **pane-scoped** (``reap`` closes only the one native terminal, not
+the conversation's other terminals), leaving the session's primary OSEnv +
+server-side transcript intact — the next message re-creates the pane and the
+vendor CLI resumes via its own ``--resume``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import NamedTuple
+
+_logger = logging.getLogger(__name__)
+
+# Native CLI panes are keyed (conversation_id, <harness short name>, "main") in
+# the terminal registry. These short names match the ``terminal_name`` the
+# per-harness ``_auto_create_<harness>_terminal`` paths launch with. This is the
+# cheap name pre-filter; the wiring additionally confirms the registry resource
+# ROLE is a native harness (so a user terminal that merely shares the name is not
+# reaped — see ``create_runner_app``).
+NATIVE_PANE_TERMINAL_NAMES: frozenset[str] = frozenset(
+    {
+        "claude",
+        "codex",
+        "cursor",
+        "goose",
+        "hermes",
+        "kiro",
+        "qwen",
+        "kimi",
+        "pi",
+        "antigravity",
+        "opencode",
+    }
+)
+
+# Default idle window before an unused native pane is reaped. Mirrors
+# ``HarnessProcessManager``'s 30-minute SDK-proxy default for consistency.
+_DEFAULT_IDLE_TIMEOUT_S = 30 * 60
+_DEFAULT_REAPER_INTERVAL_S = 60.0
+_IDLE_TIMEOUT_ENV = "OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S"
+
+
+class PaneRef(NamedTuple):
+    """A live native CLI pane the reaper may reclaim.
+
+    :param conversation_id: AP-allocated conversation id, e.g. ``"conv_abc123"``.
+    :param terminal_id: Resource id of the native terminal, e.g.
+        ``terminal_resource_id("claude", "main")`` — used for pane-scoped close.
+    :param terminal_name: Harness short-name, e.g. ``"claude"``.
+    :param socket_path: tmux socket for the attached-client probe.
+    """
+
+    conversation_id: str
+    terminal_id: str
+    terminal_name: str
+    socket_path: Path
+
+
+def resolve_native_pane_idle_timeout_s() -> float:
+    """Resolve the native-pane idle window in seconds.
+
+    Honors :envvar:`OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S` (``0`` disables pane
+    reaping); otherwise the 30-minute default. An unparseable or negative value
+    logs a warning and falls back to the default rather than failing the runner
+    at boot — an env typo shouldn't take the runner down or (worse) make the
+    reaper act on a bogus window.
+    """
+    raw = os.environ.get(_IDLE_TIMEOUT_ENV)
+    if not raw:
+        return float(_DEFAULT_IDLE_TIMEOUT_S)
+    try:
+        value = float(raw)
+    except ValueError:
+        _logger.warning(
+            "%s=%r is not a number; using default %ss",
+            _IDLE_TIMEOUT_ENV,
+            raw,
+            _DEFAULT_IDLE_TIMEOUT_S,
+        )
+        return float(_DEFAULT_IDLE_TIMEOUT_S)
+    if value < 0:
+        _logger.warning(
+            "%s=%r is negative; using default %ss",
+            _IDLE_TIMEOUT_ENV,
+            raw,
+            _DEFAULT_IDLE_TIMEOUT_S,
+        )
+        return float(_DEFAULT_IDLE_TIMEOUT_S)
+    return value
+
+
+class NativePaneReaper:
+    """Background task that reaps idle, unattended native terminal panes.
+
+    :param list_native_panes: Returns the currently-live native panes (already
+        role-confirmed by the caller) as :class:`PaneRef` values.
+    :param is_busy: ``async`` predicate — ``True`` if the pane has an in-flight
+        turn, is reporting ``running``, or has an attached tmux client. Async so
+        the (blocking) tmux probe runs off the event loop.
+    :param reap: ``async`` pane-scoped teardown — closes only this one native
+        terminal, leaving the session resumable.
+    :param idle_timeout_s: Idle window before reaping. ``None`` resolves the env
+        knob; ``<= 0`` disables reaping.
+    :param reaper_interval_s: Seconds between scans.
+    """
+
+    def __init__(
+        self,
+        *,
+        list_native_panes: Callable[[], list[PaneRef]],
+        is_busy: Callable[[PaneRef], Awaitable[bool]],
+        reap: Callable[[PaneRef], Awaitable[None]],
+        idle_timeout_s: float | None = None,
+        reaper_interval_s: float = _DEFAULT_REAPER_INTERVAL_S,
+    ) -> None:
+        self._list_native_panes = list_native_panes
+        self._is_busy = is_busy
+        self._reap = reap
+        self._idle_timeout_s = (
+            idle_timeout_s if idle_timeout_s is not None else resolve_native_pane_idle_timeout_s()
+        )
+        self._reaper_interval_s = reaper_interval_s
+        # conversation_id -> monotonic time it was last observed busy.
+        self._last_busy_at: dict[str, float] = {}
+        self._task: asyncio.Task[None] | None = None
+        self._started = False
+
+    async def start(self) -> None:
+        """Spawn the reaper loop (idempotent)."""
+        if self._started:
+            return
+        self._started = True
+        self._task = asyncio.create_task(self._reap_loop(), name="native-pane-idle-reaper")
+        _logger.info(
+            "native pane reaper started (idle_timeout=%ss, interval=%ss%s)",
+            self._idle_timeout_s,
+            self._reaper_interval_s,
+            "; DISABLED" if self._idle_timeout_s <= 0 else "",
+        )
+
+    async def shutdown(self) -> None:
+        """Cancel the reaper loop."""
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        self._started = False
+
+    def _classify(self, now: float, panes: list[PaneRef], busy_convs: set[str]) -> list[PaneRef]:
+        """Pure idle-clock decision: which panes are reapable right now.
+
+        Given the set of conversation ids observed busy this scan, maintain the
+        per-conversation idle clock and return the panes idle for at least
+        ``idle_timeout_s``. A busy pane re-arms its clock; a newly-observed idle
+        pane gets one full window of grace before it is eligible. No I/O, so it is
+        unit-testable with an injected ``now`` and ``busy_convs``.
+        """
+        live: set[str] = set()
+        reapable: list[PaneRef] = []
+        for pane in panes:
+            conv = pane.conversation_id
+            live.add(conv)
+            if conv in busy_convs:
+                self._last_busy_at[conv] = now
+                continue
+            last = self._last_busy_at.get(conv)
+            if last is None:
+                self._last_busy_at[conv] = now
+                continue
+            if now - last >= self._idle_timeout_s:
+                reapable.append(pane)
+        # Forget conversations whose pane is gone so the clock map can't grow.
+        for gone in self._last_busy_at.keys() - live:
+            del self._last_busy_at[gone]
+        return reapable
+
+    async def _reap_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._reaper_interval_s)
+            except asyncio.CancelledError:
+                return
+            # ``<= 0`` disables reaping entirely (mirrors the SDK reaper guard).
+            if self._idle_timeout_s <= 0:
+                continue
+            try:
+                await self._scan_once()
+            except Exception:  # never let a scan error kill the loop
+                _logger.exception("native pane reaper: scan failed")
+
+    async def _scan_once(self) -> None:
+        panes = self._list_native_panes()
+        now = time.monotonic()
+        busy_convs = {p.conversation_id for p in panes if await self._is_busy(p)}
+        for pane in self._classify(now, panes, busy_convs):
+            # Re-check immediately before teardown: selection happened above with
+            # possibly-stale signals, and a turn / client / autonomous run may
+            # have started since (the select→reap race). Re-arm and skip if so.
+            if await self._is_busy(pane):
+                self._last_busy_at[pane.conversation_id] = time.monotonic()
+                continue
+            _logger.info(
+                "reaping idle native pane for conversation %s (%s; idle > %.0fs)",
+                pane.conversation_id,
+                pane.terminal_name,
+                self._idle_timeout_s,
+            )
+            # Drop the clock entry up front: a reap failure then re-arms the grace
+            # window next scan instead of permanently skipping the conversation.
+            self._last_busy_at.pop(pane.conversation_id, None)
+            try:
+                await self._reap(pane)
+            except Exception:
+                _logger.exception(
+                    "native pane reaper: reap failed for conversation %s", pane.conversation_id
+                )

--- a/omnigent/terminals/registry.py
+++ b/omnigent/terminals/registry.py
@@ -40,6 +40,7 @@ import asyncio
 import logging
 import threading
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import quote
 
 from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
@@ -350,6 +351,30 @@ class TerminalRegistry:
             )
             for (name, key), instance in slot.items()
         ]
+
+    def native_panes(self) -> list[tuple[str, str, Path]]:
+        """Return live native-harness CLI panes as ``(conversation_id, name, socket_path)``.
+
+        A "native pane" is a terminal whose name is a native harness short name
+        (``claude`` / ``codex`` / ``cursor`` / ...) with session key ``"main"``.
+        This is a cheap NAME pre-filter for the native idle reaper
+        (:mod:`omnigent.terminals.pane_reaper`); the reaper's wiring additionally
+        confirms the resource ROLE is a native harness before reaping, so a user
+        terminal that merely shares the name is never reclaimed. Snapshot
+        semantics; sync (map read only, no tmux I/O).
+
+        :returns: ``(conversation_id, terminal_name, tmux_socket_path)`` per live
+            name-matching native pane.
+        """
+        from omnigent.terminals.pane_reaper import NATIVE_PANE_TERMINAL_NAMES
+
+        out: list[tuple[str, str, Path]] = []
+        with self._lock:
+            for conv_id, slot in self._by_conversation.items():
+                for (name, key), instance in slot.items():
+                    if key == "main" and name in NATIVE_PANE_TERMINAL_NAMES:
+                        out.append((conv_id, name, instance.socket_path))
+        return out
 
     def transfer(
         self,

--- a/tests/terminals/test_pane_reaper.py
+++ b/tests/terminals/test_pane_reaper.py
@@ -1,0 +1,189 @@
+"""Tests for the native-pane idle reaper (issue #1349)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from omnigent.terminals.pane_reaper import (
+    _DEFAULT_IDLE_TIMEOUT_S,
+    _IDLE_TIMEOUT_ENV,
+    NativePaneReaper,
+    PaneRef,
+    resolve_native_pane_idle_timeout_s,
+)
+
+
+def _pane(conv: str, name: str = "claude") -> PaneRef:
+    return PaneRef(conv, f"terminal:{name}:main", name, Path(f"/tmp/omni-test/{conv}.sock"))
+
+
+class _Fakes:
+    """Mutable test doubles so a test can flip busy/panes between scans."""
+
+    def __init__(self) -> None:
+        self.panes: list[PaneRef] = []
+        self.busy: set[str] = set()
+        self.reaped: list[str] = []
+        # Optional per-call override: (pane, call_index) -> bool. Lets a test make
+        # is_busy answer differently on the classify pass vs the re-check pass.
+        self.busy_override: Callable[[PaneRef, int], bool] | None = None
+        self.busy_calls = 0
+
+    async def is_busy(self, pane: PaneRef) -> bool:
+        self.busy_calls += 1
+        if self.busy_override is not None:
+            return self.busy_override(pane, self.busy_calls)
+        return pane.conversation_id in self.busy
+
+    async def reap(self, pane: PaneRef) -> None:
+        self.reaped.append(pane.conversation_id)
+        self.panes = [p for p in self.panes if p.conversation_id != pane.conversation_id]
+
+
+def _make(fakes: _Fakes, *, timeout: float = 100.0, interval: float = 0.01) -> NativePaneReaper:
+    return NativePaneReaper(
+        list_native_panes=lambda: list(fakes.panes),
+        is_busy=fakes.is_busy,
+        reap=fakes.reap,
+        idle_timeout_s=timeout,
+        reaper_interval_s=interval,
+    )
+
+
+# ── Pure idle-clock decision (_classify) ────────────────────────────────────
+
+
+def test_classify_reaps_only_after_full_window() -> None:
+    f = _Fakes()
+    p = _pane("conv_a")
+    f.panes = [p]
+    r = _make(f, timeout=100.0)
+    assert r._classify(1000.0, [p], busy_convs=set()) == []  # first obs: grace
+    assert r._classify(1099.0, [p], busy_convs=set()) == []  # 99s < 100s
+    assert r._classify(1100.0, [p], busy_convs=set()) == [p]  # window elapsed
+
+
+def test_classify_busy_rearms_clock() -> None:
+    f = _Fakes()
+    p = _pane("conv_a")
+    r = _make(f, timeout=10.0)
+    r._classify(0.0, [p], busy_convs={"conv_a"})
+    assert r._classify(1000.0, [p], busy_convs={"conv_a"}) == []  # busy re-arms
+    r._classify(1000.0, [p], busy_convs=set())  # now idle, grace
+    assert r._classify(1010.0, [p], busy_convs=set()) == [p]
+
+
+def test_classify_first_observation_grace() -> None:
+    f = _Fakes()
+    p = _pane("conv_a")
+    r = _make(f, timeout=0.001)
+    assert r._classify(5.0, [p], busy_convs=set()) == []  # clock seeded this pass
+
+
+def test_classify_forgets_gone_panes() -> None:
+    f = _Fakes()
+    p = _pane("conv_a")
+    r = _make(f, timeout=10.0)
+    r._classify(0.0, [p], busy_convs=set())
+    assert "conv_a" in r._last_busy_at
+    r._classify(1.0, [], busy_convs=set())  # pane gone
+    assert "conv_a" not in r._last_busy_at
+
+
+# ── Scan behaviour (_scan_once): reap, skip-busy, TOCTOU re-check ────────────
+
+
+async def test_scan_reaps_idle_unbusy_pane() -> None:
+    f = _Fakes()
+    p = _pane("conv_a")
+    f.panes = [p]
+    r = _make(f, timeout=10.0)
+    r._last_busy_at["conv_a"] = time.monotonic() - 1000  # already idle past window
+    await r._scan_once()
+    assert f.reaped == ["conv_a"]
+
+
+async def test_scan_skips_busy_pane() -> None:
+    f = _Fakes()
+    p = _pane("conv_a")
+    f.panes = [p]
+    f.busy = {"conv_a"}
+    r = _make(f, timeout=10.0)
+    r._last_busy_at["conv_a"] = time.monotonic() - 1000
+    await r._scan_once()
+    assert f.reaped == []  # busy → not reaped, clock re-armed
+
+
+async def test_scan_recheck_spares_pane_that_became_busy() -> None:
+    """TOCTOU guard: a pane idle at selection but busy at the pre-reap re-check
+    must NOT be reaped (a turn/client/autonomous run started in between)."""
+    f = _Fakes()
+    p = _pane("conv_a")
+    f.panes = [p]
+    # is_busy: False on the classify-phase call (call 1), True on the re-check
+    # call (call 2) — simulating a turn starting between selection and teardown.
+    f.busy_override = lambda pane, n: n >= 2
+    r = _make(f, timeout=10.0)
+    r._last_busy_at["conv_a"] = time.monotonic() - 1000
+    await r._scan_once()
+    assert f.reaped == []  # spared by the re-check
+    assert f.busy_calls == 2  # classify + re-check
+
+
+# ── Env resolver ────────────────────────────────────────────────────────────
+
+
+def test_resolve_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_IDLE_TIMEOUT_ENV, raising=False)
+    assert resolve_native_pane_idle_timeout_s() == float(_DEFAULT_IDLE_TIMEOUT_S)
+
+
+def test_resolve_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_IDLE_TIMEOUT_ENV, "120")
+    assert resolve_native_pane_idle_timeout_s() == 120.0
+
+
+def test_resolve_zero_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_IDLE_TIMEOUT_ENV, "0")
+    assert resolve_native_pane_idle_timeout_s() == 0.0
+
+
+@pytest.mark.parametrize("bad", ["abc", "-5", ""])
+def test_resolve_invalid_falls_back(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    monkeypatch.setenv(_IDLE_TIMEOUT_ENV, bad)
+    assert resolve_native_pane_idle_timeout_s() == float(_DEFAULT_IDLE_TIMEOUT_S)
+
+
+# ── Loop smoke (start/shutdown + disable) ───────────────────────────────────
+
+
+async def test_loop_reaps_idle_pane() -> None:
+    f = _Fakes()
+    f.panes = [_pane("conv_a")]
+    r = _make(f, timeout=0.0001, interval=0.01)
+    await r.start()
+    try:
+        for _ in range(100):
+            if f.reaped:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        await r.shutdown()
+    assert f.reaped == ["conv_a"]
+
+
+async def test_loop_disabled_when_timeout_non_positive() -> None:
+    f = _Fakes()
+    f.panes = [_pane("conv_a")]
+    r = _make(f, timeout=0.0, interval=0.01)  # 0 disables
+    await r.start()
+    try:
+        await asyncio.sleep(0.1)
+    finally:
+        await r.shutdown()
+    assert f.reaped == []


### PR DESCRIPTION
## Related issue
Part of #1349 (PR 1 of 2).

## Summary
Native CLI sessions (`claude-native` / `codex-native` / ...) hold their vendor CLI plus a full MCP fleet in a persistent tmux pane for the whole conversation lifetime. Unlike the SDK harness proxies (reaped by `HarnessProcessManager._idle_reaper_loop`), these panes had **no idle reaper**, so on a shared/multi-conversation runner memory grows without bound as idle conversations accumulate — driving the host to swap exhaustion (#1349).

This adds `NativePaneReaper`, which reaps a native pane only when it is genuinely unused:
- no in-flight turn (`conv in _active_turns or process_manager.has_active_turn(conv)`), **and**
- no tmux client attached to the pane (`_list_tmux_clients(...) == []` — nobody is watching), **and**
- idle for longer than the configured window.

Teardown is **pane-only** (`_teardown_session_terminals`): it drops the tmux pane (its MCP children die by parent-death) but leaves the session's primary OSEnv + server-side transcript intact, so the session stays resumable. The next message re-creates the pane and the vendor CLI resumes via its own `--resume`.

- Knob: `OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S` (`0` disables; 30-min default, mirroring the SDK reaper); invalid/negative falls back to the default.
- The reaper owns its idle clock (derived from its own busy/attached observations), so it needs **no new per-instance state** and no `terminal.py` changes.
- Mounts in the runner lifespan next to `HarnessProcessManager`.

## Scope (PR 1 of 2)
This is the reaper. It is safe for the dominant case — web re-engagement of an idle session reconnects and re-ensures the pane via the existing handshake (`--resume`). The **no-handshake relaunch path** (a sub-agent / API forward to a long-idle native session, where `NativeServerHarness.run_turn` would otherwise inject into a reaped pane) is handled by a **follow-up self-heal PR** that re-ensures the pane on the turn path. Until that lands, the gating (no active turn + unattended + idle window) keeps the risk confined to that narrow path.

Out of scope here: the turn-path self-heal (PR 2); an optional per-runner LRU cap on concurrently-live panes.

## Test plan
`uv run --extra dev pytest tests/terminals/test_pane_reaper.py tests/terminals/test_registry.py` → 47 passed. Covers the decision logic (idle-after-window, active-turn blocks, attached-client blocks, first-observation grace, gone-pane forgetting), the env resolver (unset / value / 0 / invalid), and the loop (reaps an idle pane; disabled when timeout ≤ 0). Lint clean (`ruff check` + `format`). `tests/runner/test_comment_relay.py` green (exercises `create_runner_app` construction with the reaper wired).

This pull request and its description were written by Isaac.
