### PR TITLE
feat(triage): assign maintainer-filed issues to the author

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -466,9 +466,19 @@ jobs:
           # Execute the validated commands.
           bash /tmp/triage_commands.sh
 
+          # If the issue was filed by a maintainer, assign it to them directly.
+          author=$(jq -r '.author.login // empty' /tmp/issue.json)
+          maintainer_assigned=false
+          if [ -n "$author" ] && grep -qxF "$author" .github/MAINTAINER; then
+            echo "Issue filed by maintainer $author — assigning to author"
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-assignee "$author"
+            maintainer_assigned=true
+          fi
+
           # Round-robin assign engineer for P0/P1 issues, with domain routing.
+          # Skip if already assigned to the maintainer-author above.
           priority=$(jq -r '.priority // empty' /tmp/triage_result.json)
-          if [ "$priority" = "P0-critical" ] || [ "$priority" = "P1-high" ]; then
+          if [ "$maintainer_assigned" = "false" ] && { [ "$priority" = "P0-critical" ] || [ "$priority" = "P1-high" ]; }; then
             python3 <<'PYEOF'
           import json, pathlib, os
 


### PR DESCRIPTION
## Summary

- When an issue is opened by a user listed in `.github/MAINTAINER`, the triage pipeline now assigns the issue to the author directly
- The existing P0/P1 round-robin assignment is skipped in this case to avoid double-assignment
- For all other authors, behaviour is unchanged

## Test plan

- [ ] Open an issue as a maintainer (username in `.github/MAINTAINER`) — issue should be assigned to them
- [ ] Open a P0/P1 issue as a non-maintainer — round-robin assignment should still fire
- [ ] Open a P2/P3 issue as a non-maintainer — no assignment (unchanged)