### PR TITLE
feat(runner): self-heal a reaped native pane on the turn path (#1349)

### DIFF
--- a/omnigent/harness_aliases.py
+++ b/omnigent/harness_aliases.py
@@ -114,3 +114,25 @@ def is_native_harness(harness: str | None) -> bool:
     if harness is None:
         return False
     return (canonicalize_harness(harness) or harness) in NATIVE_HARNESSES
+
+
+def native_terminal_name(harness: str | None) -> str | None:
+    """Return the tmux terminal short-name a native harness runs its CLI in.
+
+    Native CLI panes are keyed ``(conversation_id, <short-name>, "main")`` in the
+    terminal registry, where the short name is the canonical native harness id
+    with the ``-native`` suffix dropped — e.g. ``"claude-native"`` -> ``"claude"``,
+    ``"native-codex"`` -> ``"codex"``, ``"opencode-native"`` -> ``"opencode"``.
+
+    :param harness: A harness id (canonical or reversed alias), e.g.
+        ``"cursor-native"``; ``None`` or a non-native harness returns ``None``.
+    :returns: The terminal short-name, e.g. ``"cursor"``, or ``None`` when
+        *harness* is not a native CLI harness.
+    """
+    if not is_native_harness(harness):
+        return None
+    canonical = canonicalize_harness(harness) or harness
+    # Canonical native ids are ``<name>-native``; some accepted aliases keep the
+    # reversed ``native-<name>`` spelling (not all are folded by
+    # ``canonicalize_harness``), so strip either affix.
+    return canonical.removesuffix("-native").removeprefix("native-")

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -45,7 +45,11 @@ from omnigent.entities.session_resources import (
     terminal_resource_id,
 )
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.harness_aliases import canonicalize_harness, is_native_harness
+from omnigent.harness_aliases import (
+    canonicalize_harness,
+    is_native_harness,
+    native_terminal_name,
+)
 from omnigent.llms.summarize import (
     build_summarization_input,
     build_summarization_prompt,
@@ -7671,6 +7675,21 @@ def get_session_agent_id(session_id: str) -> str | None:
 _SESSION_SKILLS_CACHE_TTL_SECONDS = 60.0
 
 
+class _BodyRequest:
+    """Minimal stand-in for a Starlette ``Request`` exposing only ``json()``.
+
+    Lets internal callers reuse a route handler that consumes the request
+    solely for its JSON body (e.g. ``create_session_terminal``) without
+    constructing a real ASGI ``Request``. Not a general Request substitute.
+    """
+
+    def __init__(self, body: dict[str, Any]) -> None:
+        self._body = body
+
+    async def json(self) -> dict[str, Any]:
+        return self._body
+
+
 def create_runner_app(
     *,
     process_manager: HarnessProcessManager | None = None,
@@ -13609,6 +13628,14 @@ def create_runner_app(
             and name not in _spec_names
         )
 
+        # Self-heal (#1349): the native-pane idle reaper may have reclaimed this
+        # conversation's pane while it sat idle. The native forward below assumes
+        # a live pane, so re-create it first when missing — otherwise a turn that
+        # arrives without a client handshake (sub-agent / API forward) injects
+        # into a dead tmux target and the message is lost. No-op for SDK harnesses
+        # and when the pane is already live; resumes via the vendor ``--resume``.
+        await _ensure_native_terminal_for_turn(conv, harness_name)
+
         # Fallback for native sessions whose terminal was launched
         # outside the runner terminal route (e.g. tests, UI-launched
         # terminals): make sure the comment-tool relay is running before the
@@ -16070,6 +16097,65 @@ def create_runner_app(
             status_code=200,
             content=session_resource_view_to_dict(resource_view),
         )
+
+    async def _ensure_native_terminal_for_turn(conv_id: str, harness_name: str | None) -> None:
+        """Re-create a reaped native pane before forwarding a turn (#1349 self-heal).
+
+        The native-pane idle reaper may reclaim an idle pane while a session sits
+        between turns. ``NativeServerHarness.run_turn`` forwards into the live
+        pane and assumes it exists, so a turn arriving WITHOUT a client handshake
+        (a sub-agent or API forward to a long-idle session) would otherwise inject
+        into a dead tmux target and lose the message. This re-ensures the pane
+        first. Idempotent: a no-op when the harness is not a native CLI harness or
+        the pane is already live. Reuses ``create_session_terminal``'s
+        ``ensure_native_terminal`` path, so the pane resumes via the vendor CLI's
+        own ``--resume`` (no fresh-start, no lost history).
+
+        Detection relies on the reaper POPPING the registry entry when it reaps
+        (``registry.close()`` -> ``get()`` returns ``None``) — exactly the
+        reaped-pane window this targets. The membership check stays cheap and
+        in-memory on purpose: no per-turn tmux probe, and it doesn't perturb the
+        normal native turn path (a registered pane short-circuits). A
+        crashed-but-registered pane (tmux killed externally without ``close()``)
+        is out of scope here. Every native short-name this can target has a
+        matching ``ensure_native_terminal`` branch in ``create_session_terminal``
+        (kept in lockstep with ``harness_aliases.NATIVE_HARNESSES``).
+        """
+        terminal_name = native_terminal_name(harness_name)
+        if terminal_name is None:
+            return
+        terminal_registry = resource_registry.terminal_registry if resource_registry else None
+        if terminal_registry is None:
+            return
+        if terminal_registry.get(conv_id, terminal_name, "main") is not None:
+            return  # a pane is still registered — nothing to heal
+        _logger.info(
+            "native pane missing for conv=%s harness=%s; re-ensuring before turn (#1349)",
+            conv_id,
+            harness_name,
+        )
+        try:
+            resp = await create_session_terminal(
+                conv_id,
+                _BodyRequest(
+                    {
+                        "terminal": terminal_name,
+                        "session_key": "main",
+                        "ensure_native_terminal": True,
+                    }
+                ),
+            )
+        except Exception:
+            _logger.exception("native pane self-heal failed for conv=%s", conv_id)
+            return
+        status = getattr(resp, "status_code", 200)
+        if status >= 400:
+            _logger.warning(
+                "native pane self-heal returned status %s for conv=%s (%s)",
+                status,
+                conv_id,
+                terminal_name,
+            )
 
     @app.get("/v1/sessions/{session_id}/resources/terminals/{terminal_id}")
     async def get_session_terminal(

--- a/tests/test_harness_aliases.py
+++ b/tests/test_harness_aliases.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from omnigent.harness_aliases import canonicalize_harness, is_native_harness
+from omnigent.harness_aliases import (
+    canonicalize_harness,
+    is_native_harness,
+    native_terminal_name,
+)
 from omnigent.spec._omnigent_compat import OMNIGENT_HARNESSES
 
 
@@ -85,3 +89,39 @@ def test_kiro_native_is_valid_omnigent_harness_but_plain_kiro_is_not() -> None:
     """Kiro's native identity is canonical; plain ``kiro`` is not a generic harness."""
     assert "kiro-native" in OMNIGENT_HARNESSES
     assert "kiro" not in OMNIGENT_HARNESSES
+
+
+@pytest.mark.parametrize(
+    ("harness", "expected"),
+    [
+        ("claude-native", "claude"),
+        ("native-claude", "claude"),  # reversed alias
+        ("codex-native", "codex"),
+        ("cursor-native", "cursor"),
+        ("goose-native", "goose"),
+        ("hermes-native", "hermes"),
+        ("kiro-native", "kiro"),
+        ("qwen-native", "qwen"),
+        ("kimi-native", "kimi"),
+        ("pi-native", "pi"),
+        ("antigravity-native", "antigravity"),
+        ("opencode-native", "opencode"),
+        ("opencode", "opencode"),  # alias folds to opencode-native
+        # Non-native harnesses (and the SDK shorthands) have no native pane.
+        ("claude-sdk", None),
+        ("claude", None),
+        ("codex", None),
+        ("cursor", None),
+        ("agents_sdk", None),
+        ("some-unknown-harness", None),
+        (None, None),
+    ],
+)
+def test_native_terminal_name(harness: str | None, expected: str | None) -> None:
+    """``native_terminal_name`` maps native harness ids to their tmux pane name.
+
+    The native-pane idle reaper (#1349) and its turn-path self-heal key panes on
+    ``(conv, <short-name>, "main")``; a wrong mapping would reap/relaunch the
+    wrong pane or silently skip a harness.
+    """
+    assert native_terminal_name(harness) == expected


### PR DESCRIPTION
## Related issue
Part of #1349 (PR 2 of 2). Companion to #1624 (the native-pane idle reaper).

## Summary
`NativeServerHarness.run_turn` forwards a turn into the live tmux pane via `transport.send_prompt` and **assumes the pane exists**. Once the idle reaper (#1624) can reclaim an idle pane, a turn that arrives **without a client handshake** — a sub-agent completion forward, or an API client posting to a long-idle native session — would inject into a dead tmux target and the message would be lost. (Web re-engagement is already safe: the browser reconnect hits `create_session_terminal`'s `ensure_native_terminal` path and re-creates the pane before any turn.)

This closes that gap: before the native forward in `_run_turn_bg`, re-ensure the pane when it's missing.

- `_ensure_native_terminal_for_turn(conv, harness_name)` — **idempotent**: a no-op for SDK harnesses and when the pane is already live, so existing flows are untouched; it only acts in the exact reaped-pane window.
- It **reuses `create_session_terminal`'s `ensure_native_terminal` path** (via a tiny dict-backed `_BodyRequest` shim) rather than duplicating the per-harness create logic — so it covers all native harnesses and resumes via the vendor CLI's own `--resume` (history preserved, no fresh start).
- New `harness_aliases.native_terminal_name(harness)` maps a harness id to its tmux pane short-name (`claude-native` → `claude`), handling both `<name>-native` and reversed `native-<name>` spellings.

## Ordering / safety
Independent of #1624 and safe to merge in either order: until the reaper exists, native panes are never reaped, so this guard simply never fires. The shim only adds `.json()`; `create_session_terminal` uses the request solely for its body (verified).

## Test plan
`uv run --extra dev pytest tests/test_harness_aliases.py tests/runner/test_comment_relay.py` → 56 passed. `native_terminal_name` is unit-tested across all native harnesses + their aliases + the SDK/non-native negatives (the mapping is the load-bearing correctness bit). `test_comment_relay` exercises `create_runner_app` construction with the new helper wired. Lint clean. The reaped-pane→next-turn relaunch itself is exercised by the native e2e suites in CI.

This pull request and its description were written by Isaac.
