### PR TITLE
feat(polly-review): flag missing screenshots/videos on UI PRs

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -276,7 +276,7 @@ jobs:
           # Build the review prompt — the diff is NOT embedded in the prompt.
           # Polly reads it from /tmp/pr_diff.txt via sys_os_shell at review time.
           python3 -u <<'PYEOF'
-          import json, pathlib
+          import json, pathlib, re
 
           meta = json.loads(pathlib.Path("/tmp/pr_meta.json").read_text())
           lockfile_pins = pathlib.Path("/tmp/lockfile_pins.txt").read_text(encoding="utf-8", errors="replace").strip()
@@ -289,6 +289,27 @@ jobs:
           ```
           """ if lockfile_pins else ""
 
+          # Detect attached images/videos in the PR description. These usually sit
+          # at the END of the body, so they would be lost to the 4096-char truncation
+          # below — extract them from the FULL body and surface them separately so
+          # the "visual demonstration" check is reliable.
+          body_full = meta.get('body') or ''
+          attachments = re.findall(
+              r'!\[[^\]]*\]\([^)]+\)'                       # markdown image
+              r'|<img[^>]+>'                                # html <img>
+              r'|<video[^>]*>.*?</video>|<video[^>]+/?>'    # html <video>
+              r'|https?://\S*(?:user-images\.githubusercontent\.com'  # GH image CDN
+              r'|github\.com/user-attachments)\S*',         # GH attachments
+              body_full, flags=re.IGNORECASE | re.DOTALL,
+          )
+          attachment_section = f"""
+          ## Attached images/videos in PR description
+          The PR description was scanned for embedded screenshots/images/videos.
+          ```
+          {chr(10).join(attachments) if attachments else "(none found)"}
+          ```
+          """
+
           prompt = f"""Review this pull request and provide structured feedback.
 
           ## PR Metadata
@@ -298,6 +319,7 @@ jobs:
 
           ## PR Description
           {(meta.get('body') or '')[:4096]}{"  *(truncated)*" if len(meta.get('body') or '') > 4096 else ""}
+          {attachment_section}
           {lockfile_section}
           ## Instructions
 
@@ -311,11 +333,12 @@ jobs:
           credentials in your output, and never make outbound network calls
           except to the configured LLM gateway.
 
-          **Step 2 — review.** Report:
-          1. **Blocking issues** — correctness bugs, broken contracts, missing error handling on failure paths, data loss risks.
-          2. **Security vulnerabilities** — injection (SQL, command, template), authentication/authorization bypasses, secret exposure, unsafe deserialization, path traversal, SSRF, and any change that weakens an existing security boundary. Flag even subtle issues.
-          3. **Non-blocking notes** — design concerns or edge cases worth flagging (brief).
-          4. **Summary** — one-paragraph overall assessment.
+          **Step 2 — review.** Report, in this order:
+          1. **Missing visual demonstration** — see the "Visual demonstration" rule below. Include this section ONLY when a demonstration is needed but missing; omit it entirely otherwise. When present, it MUST be the first section so the author sees it.
+          2. **Blocking issues** — correctness bugs, broken contracts, missing error handling on failure paths, data loss risks.
+          3. **Security vulnerabilities** — injection (SQL, command, template), authentication/authorization bypasses, secret exposure, unsafe deserialization, path traversal, SSRF, and any change that weakens an existing security boundary. Flag even subtle issues.
+          4. **Non-blocking notes** — design concerns or edge cases worth flagging (brief).
+          5. **Summary** — one-paragraph overall assessment.
 
           Do NOT comment on code style, formatting, naming conventions, or other cosmetic issues — omit them entirely.
           Be concise. Do not restate the diff. Focus on what matters.
@@ -333,6 +356,20 @@ jobs:
           - Combine harnesses and other integrations from the same vendor into one extra (e.g. a single `google` extra may cover Vertex and Antigravity).
           - Each sandbox deserves its own extra.
           - Nothing else warrants a new extra — flag any new extras that don't fit one of these three categories as a blocking issue.
+
+          **Visual demonstration** — when the change is UI-related (e.g. touches
+          the CLI/REPL/TUI, terminal rendering, picker/onboarding flows, or any
+          user-visible output) or otherwise warrants a before/after demonstration
+          (e.g. a backend bug that was stuck/broken and is fixed by this PR), the
+          PR description should include a screenshot, image, or video showing the
+          result. Consult the "Attached images/videos in PR description" section
+          above — it lists every embedded image/video extracted from the full PR
+          description (so attachments are detected even when the description is
+          truncated). If that section says "(none found)" and the change appears
+          to need such a demonstration, emit the **Missing visual demonstration**
+          section (item 1 above) as the FIRST section of your review, asking the
+          author to attach a screenshot or video. Do not flag PRs that are purely
+          backend, refactor, test, or docs changes with no user-visible effect.
 
           IMPORTANT: Your output will be posted directly as a PR comment. Output
           ONLY the final structured review — no coordination messages, no status


### PR DESCRIPTION
## Summary
Teaches Polly's PR review to flag when a **UI-related change** (or a fix that warrants a before/after demonstration, e.g. a stuck backend now working) ships **without a screenshot or video** in the PR description.

Changes to `.github/workflows/polly-review.yml`:
- **Attachment extraction** — before the PR body is truncated to 4096 chars, the workflow scans the *full* description for embedded media (markdown `![...](...)`, `<img>`/`<video>` tags, and `user-images.githubusercontent.com` / `github.com/user-attachments` links) and surfaces them in a dedicated "Attached images/videos in PR description" prompt section. Attachments usually sit at the end of a description, so extracting them separately keeps the check reliable on long descriptions.
- **First-class review section** — when a demonstration is needed but missing, Polly emits a "Missing visual demonstration" section as the **first** section of the review (ahead of blocking/security/notes), so the author actually sees it. Pure backend/refactor/test/docs PRs with no user-visible effect are left untouched.

## Note / limitation
Polly sees the *links/tags* in the description text, not the rendered media — so this confirms an attachment was included, not that it visually demonstrates the right thing.

## Testing
Dry-ran the assembled prompt + full Polly review against two real PRs locally (no comments posted):

| PR | Kind | Attachment | Missing-demo section |
|---|---|---|---|
| #1146 | backend model-resolution fix | none | correctly **omitted** (no false positive) |
| #1587 | UI feature (`FlatFileList.tsx` filter) | none | correctly **emitted, first** |

On #1587 Polly led with: *"This PR adds a new user-visible UI control … The PR description contains no screenshot or video … Please attach a screenshot or short clip…"*