### PR TITLE
fix(cost): expensive_models=[] now blocks all models (true hard stop)

### DIFF
--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -90,28 +90,6 @@ _GATED_PHASES = frozenset({"request", "tool_call"})
 # as its own conversation).
 _ASK_APPROVED_KEY = SESSION_COST_ASK_APPROVED_STATE_KEY
 
-# Default substring tokens (case-insensitive) identifying the "expensive"
-# model tiers that must be downgraded once the session passes
-# ``max_cost_usd``. Matched as substrings of the active model id so a single
-# token hits every deployment spelling AND the tier aliases the native
-# ``/model`` command stores: ``"opus"`` matches ``claude-opus-4-8``,
-# ``databricks-claude-opus-4-7``, and the bare alias ``"opus"``; ``"gpt-5"``
-# matches the whole GPT-5 family (``gpt-5``, ``gpt-5.5``, the dash spelling
-# ``databricks-gpt-5-5``, …) EXCEPT the cheap variants carved out by
-# ``_DEFAULT_EXPENSIVE_EXCLUDES`` below. Fable (``claude-fable-5``, the tier
-# above Opus at 2x its price), Opus, and GPT-5 are the costly tiers today.
-_DEFAULT_EXPENSIVE_MODELS = ("fable", "opus", "gpt-5")
-
-# Default substring tokens (case-insensitive) that OVERRIDE a match in
-# ``_DEFAULT_EXPENSIVE_MODELS`` back to "not expensive". The broad ``"gpt-5"``
-# token above also matches the cheap ``gpt-5-mini`` / ``gpt-5-nano`` variants,
-# which should NOT be budget-blocked, so they are excluded here. The leading
-# dash is deliberate: a bare ``"mini"`` would also match unrelated models like
-# ``gemini``. Applied only to the built-in default set — when the caller passes
-# an explicit ``expensive_models`` list, those tokens are matched literally
-# with no exclusions (the caller controls the set exactly).
-_DEFAULT_EXPENSIVE_EXCLUDES = ("-mini", "-nano")
-
 
 def _session_cost_usd(event: PolicyEvent) -> float:
     """Read cumulative session cost (USD) from a policy event.
@@ -346,42 +324,29 @@ def _resolve_expensive_models(expensive_models: list[str] | None) -> _ExpensiveM
     Shared by :func:`cost_budget` and :func:`user_daily_cost_budget` so
     both treat the argument identically:
 
-    - ``None`` → the built-in default set
-      (:data:`_DEFAULT_EXPENSIVE_MODELS`) with the cheap-variant
-      exclusions (:data:`_DEFAULT_EXPENSIVE_EXCLUDES`) applied; hard gate
-      on.
+    - ``None`` or ``[]`` → **all models blocked** once over budget
+      (``block_all_models=True``, hard gate on). This is a true hard
+      stop: no model can continue once the limit is reached.
     - a non-empty list → those tokens (lowercased), matched literally
-      with NO exclusions (the caller controls the set exactly); hard gate
-      on.
-    - ``[]`` → **all models blocked** once over budget (``block_all_models=True``,
-      hard gate on). This is a true hard stop: no model can continue once
-      the limit is reached, instead of just being a downgrade gate.
+      with no exclusions (the caller controls the set exactly); hard gate
+      on (downgrade gate — cheaper models still allowed over budget).
 
     :param expensive_models: The factory argument, e.g.
         ``["opus", "gpt-5"]``, ``None``, or ``[]``.
     :returns: The resolved :class:`_ExpensiveModelConfig`.
     :raises ValueError: If any entry is not a non-empty string.
     """
-    if expensive_models is None:
-        return _ExpensiveModelConfig(
-            expensive_tokens=_DEFAULT_EXPENSIVE_MODELS,
-            exclude_tokens=_DEFAULT_EXPENSIVE_EXCLUDES,
-            hard_cap_enabled=True,
-        )
-    for m in expensive_models:
-        if not isinstance(m, str) or not m:
-            raise ValueError(f"each expensive_models value must be a non-empty string, got {m!r}")
-    expensive_tokens = tuple(m.lower() for m in expensive_models)
-    if not expensive_tokens:
-        # Empty list → block all models once over budget (hard stop, not just a
-        # downgrade gate). hard_cap_enabled stays True; block_all_models signals
-        # _model_blocked_over_budget to short-circuit to True for any model.
+    if expensive_models is None or len(expensive_models) == 0:
         return _ExpensiveModelConfig(
             expensive_tokens=(),
             exclude_tokens=(),
             hard_cap_enabled=True,
             block_all_models=True,
         )
+    for m in expensive_models:
+        if not isinstance(m, str) or not m:
+            raise ValueError(f"each expensive_models value must be a non-empty string, got {m!r}")
+    expensive_tokens = tuple(m.lower() for m in expensive_models)
     return _ExpensiveModelConfig(
         expensive_tokens=expensive_tokens,
         exclude_tokens=(),
@@ -423,12 +388,11 @@ def cost_budget(
         e.g. ``["opus", "gpt-5"]``. A token matches when it is a
         substring of the active model id (so ``"opus"`` matches both
         ``"databricks-claude-opus-4-8"`` and the alias ``"opus"``).
-        ``None`` uses the built-in default (Fable + Opus + GPT-5,
-        excluding the cheap ``-mini`` / ``-nano`` variants). An explicit
-        list is matched literally with no exclusions. ``[]`` makes the
-        hard cap a true hard stop: **all** models are blocked once the
-        limit is reached (not just a downgrade gate). Each value must be
-        a non-empty string.
+        ``None`` (the default) or ``[]`` makes the hard cap a true hard
+        stop: **all** models are blocked once the limit is reached. Pass
+        an explicit non-empty list for a downgrade gate that only blocks
+        the named tiers, letting cheaper models continue over budget.
+        Each value must be a non-empty string.
     :returns: A policy callable implementing the budget gate.
     :raises ValueError: If *max_cost_usd* is not positive, any
         *ask_thresholds_usd* value is not in ``(0, max_cost_usd)``, or
@@ -610,11 +574,10 @@ def user_daily_cost_budget(
         ``< max_cost_usd``. ``None`` / ``[]`` disables the soft gate.
     :param expensive_models: Optional case-insensitive substring tokens
         for the model tiers blocked once over the daily limit. ``None``
-        uses the built-in default (Fable + Opus + GPT-5, excluding the
-        cheap ``-mini`` / ``-nano`` variants); an explicit list is
-        matched literally with no exclusions; ``[]`` makes the hard cap a
-        true hard stop — all models are blocked once the limit is
-        reached.
+        (the default) or ``[]`` makes the hard cap a true hard stop —
+        all models are blocked once the limit is reached. Pass an
+        explicit non-empty list for a downgrade gate that only blocks the
+        named tiers.
     :returns: A policy callable implementing the per-user daily budget.
     :raises ValueError: Same validation as :func:`cost_budget`.
     """
@@ -865,9 +828,9 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Optional case-insensitive substring tokens for the model "
-                    "tiers blocked once over budget (default: Fable + Opus + GPT-5, excluding "
-                    "the cheap -mini/-nano variants). An empty list blocks all models once the "
-                    "limit is reached (true hard stop, not just a downgrade gate).",
+                    "tiers blocked once over budget. Omit (or pass []) for a true hard stop "
+                    "that blocks all models; pass a non-empty list for a downgrade gate that "
+                    "only blocks the named tiers.",
                 },
             },
             "required": ["max_cost_usd"],
@@ -902,9 +865,9 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Optional case-insensitive substring tokens for the model "
-                    "tiers blocked once over the daily budget (default: Fable + Opus + GPT-5, "
-                    "excluding the cheap -mini/-nano variants). An empty list blocks all models "
-                    "once the limit is reached (true hard stop, not just a downgrade gate).",
+                    "tiers blocked once over the daily budget. Omit (or pass []) for a true "
+                    "hard stop that blocks all models; pass a non-empty list for a downgrade "
+                    "gate that only blocks the named tiers.",
                 },
             },
             "required": ["max_cost_usd"],

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -171,6 +171,7 @@ def _over_budget_deny_reason(
     policy_label: str = "session cost-budget",
     budget_label: str = "cost budget",
     subject_user: str | None = None,
+    block_all: bool = False,
 ) -> str:
     """Build the over-budget DENY reason for the budget gate.
 
@@ -219,12 +220,30 @@ def _over_budget_deny_reason(
         the session cost-budget output is unchanged.
     :returns: The DENY reason string.
     """
+    spend_subject = f"{subject_user}'s spend" if subject_user else "spend"
+    if block_all:
+        # All models are blocked (expensive_models=[]): no cheaper model exists
+        # to switch to, so the message is a hard stop with no switch hint.
+        verbatim = (
+            f"You've hit the ${max_cost_usd:.2f} {budget_label}. "
+            f"All model calls are blocked over budget."
+        )
+        if phase == "request":
+            return (
+                f"Blocked by the {policy_label} policy: {spend_subject} ${cost:.2f} reached the "
+                f"${max_cost_usd:.2f} limit. {verbatim}"
+            )
+        return (
+            f"Blocked by the {policy_label} policy: {spend_subject} ${cost:.2f} reached the "
+            f"${max_cost_usd:.2f} limit, and all further tool calls are blocked. Relay this to "
+            f"the user verbatim, then stop and wait for them — do not silently re-run the tool "
+            f'right now: "{verbatim}"'
+        )
     expensive_list = ", ".join(expensive_tokens) or "the configured high-cost models"
     if harness is not None and "codex" in harness:
         switch_hint = "in the terminal, run /model and pick a cheaper model to continue"
     else:
         switch_hint = "switch to a cheaper model to continue"
-    spend_subject = f"{subject_user}'s spend" if subject_user else "spend"
     verbatim = (
         f"You've hit the ${max_cost_usd:.2f} {budget_label}. High-cost models "
         f"({expensive_list}) are blocked over budget — {switch_hint}."
@@ -250,6 +269,8 @@ def _model_blocked_over_budget(
     model: str | None,
     expensive_tokens: tuple[str, ...],
     exclude_tokens: tuple[str, ...] = (),
+    *,
+    block_all: bool = False,
 ) -> bool:
     """Decide whether the active model is blocked once over budget.
 
@@ -268,6 +289,9 @@ def _model_blocked_over_budget(
     token (``"gpt-5"``) cover a whole family while exempting its cheap
     variants.
 
+    When ``block_all=True`` (``expensive_models=[]`` was passed to the
+    factory) every model is blocked — the budget is a true hard stop.
+
     :param model: The active model id, or ``None`` when
         undeterminable.
     :param expensive_tokens: Lowercased substring tokens identifying
@@ -275,8 +299,12 @@ def _model_blocked_over_budget(
     :param exclude_tokens: Lowercased substring tokens that override an
         expensive match back to "not expensive", e.g.
         ``("-mini", "-nano")``. Defaults to empty (no exclusions).
+    :param block_all: When ``True``, return ``True`` for every model
+        (``expensive_models=[]`` semantics — all models blocked).
     :returns: ``True`` when tool calls should be DENYed over budget.
     """
+    if block_all:
+        return True
     if model is None:
         return True
     low = model.lower()
@@ -296,13 +324,20 @@ class _ExpensiveModelConfig:
         "-nano")``. Non-empty only for the built-in default set; empty
         when the caller supplies an explicit ``expensive_models`` list.
     :param hard_cap_enabled: Whether the hard over-budget DENY gate is
-        active. ``False`` only when the caller passes an empty
-        ``expensive_models`` list (soft thresholds only).
+        active. Always ``True`` — including when the caller passes an
+        empty ``expensive_models`` list, which means *all* models are
+        blocked once over budget (see ``block_all_models``).
+    :param block_all_models: When ``True`` (set only when the caller
+        passes ``expensive_models=[]``) every model — not just a named
+        expensive tier — is blocked once the hard limit is reached.
+        ``_model_blocked_over_budget`` short-circuits to ``True``
+        regardless of the active model id.
     """
 
     expensive_tokens: tuple[str, ...]
     exclude_tokens: tuple[str, ...]
     hard_cap_enabled: bool
+    block_all_models: bool = False
 
 
 def _resolve_expensive_models(expensive_models: list[str] | None) -> _ExpensiveModelConfig:
@@ -318,7 +353,9 @@ def _resolve_expensive_models(expensive_models: list[str] | None) -> _ExpensiveM
     - a non-empty list → those tokens (lowercased), matched literally
       with NO exclusions (the caller controls the set exactly); hard gate
       on.
-    - ``[]`` → no expensive tokens; hard gate off (soft thresholds only).
+    - ``[]`` → **all models blocked** once over budget (``block_all_models=True``,
+      hard gate on). This is a true hard stop: no model can continue once
+      the limit is reached, instead of just being a downgrade gate.
 
     :param expensive_models: The factory argument, e.g.
         ``["opus", "gpt-5"]``, ``None``, or ``[]``.
@@ -335,10 +372,20 @@ def _resolve_expensive_models(expensive_models: list[str] | None) -> _ExpensiveM
         if not isinstance(m, str) or not m:
             raise ValueError(f"each expensive_models value must be a non-empty string, got {m!r}")
     expensive_tokens = tuple(m.lower() for m in expensive_models)
+    if not expensive_tokens:
+        # Empty list → block all models once over budget (hard stop, not just a
+        # downgrade gate). hard_cap_enabled stays True; block_all_models signals
+        # _model_blocked_over_budget to short-circuit to True for any model.
+        return _ExpensiveModelConfig(
+            expensive_tokens=(),
+            exclude_tokens=(),
+            hard_cap_enabled=True,
+            block_all_models=True,
+        )
     return _ExpensiveModelConfig(
         expensive_tokens=expensive_tokens,
         exclude_tokens=(),
-        hard_cap_enabled=len(expensive_tokens) > 0,
+        hard_cap_enabled=True,
     )
 
 
@@ -378,9 +425,10 @@ def cost_budget(
         ``"databricks-claude-opus-4-8"`` and the alias ``"opus"``).
         ``None`` uses the built-in default (Fable + Opus + GPT-5,
         excluding the cheap ``-mini`` / ``-nano`` variants). An explicit
-        list is matched literally with no exclusions. ``[]`` disables the
-        hard gate entirely (soft thresholds only, no budget block). Each
-        value must be a non-empty string.
+        list is matched literally with no exclusions. ``[]`` makes the
+        hard cap a true hard stop: **all** models are blocked once the
+        limit is reached (not just a downgrade gate). Each value must be
+        a non-empty string.
     :returns: A policy callable implementing the budget gate.
     :raises ValueError: If *max_cost_usd* is not positive, any
         *ask_thresholds_usd* value is not in ``(0, max_cost_usd)``, or
@@ -429,7 +477,10 @@ def cost_budget(
         cost = _session_cost_usd(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
-                _current_model(event), cfg.expensive_tokens, cfg.exclude_tokens
+                _current_model(event),
+                cfg.expensive_tokens,
+                cfg.exclude_tokens,
+                block_all=cfg.block_all_models,
             ):
                 return {
                     "result": "DENY",
@@ -439,6 +490,7 @@ def cost_budget(
                         cfg.expensive_tokens,
                         _current_harness(event),
                         phase=phase,
+                        block_all=cfg.block_all_models,
                     ),
                 }
             # Already on a cheaper model — the downgrade gate is satisfied.
@@ -560,8 +612,9 @@ def user_daily_cost_budget(
         for the model tiers blocked once over the daily limit. ``None``
         uses the built-in default (Fable + Opus + GPT-5, excluding the
         cheap ``-mini`` / ``-nano`` variants); an explicit list is
-        matched literally with no exclusions; ``[]`` disables the hard
-        gate (soft thresholds only).
+        matched literally with no exclusions; ``[]`` makes the hard cap a
+        true hard stop — all models are blocked once the limit is
+        reached.
     :returns: A policy callable implementing the per-user daily budget.
     :raises ValueError: Same validation as :func:`cost_budget`.
     """
@@ -596,7 +649,10 @@ def user_daily_cost_budget(
         owner = _user_daily_owner(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
-                _current_model(event), cfg.expensive_tokens, cfg.exclude_tokens
+                _current_model(event),
+                cfg.expensive_tokens,
+                cfg.exclude_tokens,
+                block_all=cfg.block_all_models,
             ):
                 return {
                     "result": "DENY",
@@ -609,6 +665,7 @@ def user_daily_cost_budget(
                         policy_label="per-user daily cost-budget",
                         budget_label="daily cost budget",
                         subject_user=owner,
+                        block_all=cfg.block_all_models,
                     ),
                 }
             return _ALLOW
@@ -731,7 +788,10 @@ def subagent_cost_budget(
         # Check hard limit if max_cost_usd is set.
         if max_cost_usd is not None and cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
-                _current_model(event), cfg.expensive_tokens, cfg.exclude_tokens
+                _current_model(event),
+                cfg.expensive_tokens,
+                cfg.exclude_tokens,
+                block_all=cfg.block_all_models,
             ):
                 return {
                     "result": "DENY",
@@ -743,6 +803,7 @@ def subagent_cost_budget(
                         phase=phase,
                         policy_label="subagent cost-budget",
                         budget_label="subagent cost budget",
+                        block_all=cfg.block_all_models,
                     ),
                 }
             return _ALLOW
@@ -805,8 +866,8 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "items": {"type": "string"},
                     "description": "Optional case-insensitive substring tokens for the model "
                     "tiers blocked once over budget (default: Fable + Opus + GPT-5, excluding "
-                    "the cheap -mini/-nano variants). An empty list disables the hard limit, "
-                    "leaving only the soft thresholds.",
+                    "the cheap -mini/-nano variants). An empty list blocks all models once the "
+                    "limit is reached (true hard stop, not just a downgrade gate).",
                 },
             },
             "required": ["max_cost_usd"],
@@ -842,8 +903,8 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "items": {"type": "string"},
                     "description": "Optional case-insensitive substring tokens for the model "
                     "tiers blocked once over the daily budget (default: Fable + Opus + GPT-5, "
-                    "excluding the cheap -mini/-nano variants). An empty list disables the hard "
-                    "limit, leaving only the soft thresholds.",
+                    "excluding the cheap -mini/-nano variants). An empty list blocks all models "
+                    "once the limit is reached (true hard stop, not just a downgrade gate).",
                 },
             },
             "required": ["max_cost_usd"],

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -350,19 +350,22 @@ def test_explicit_expensive_models_apply_no_mini_nano_exclusion() -> None:
     assert policy(_tool(6.0, model="gpt-5-nano"))["result"] == "DENY"
 
 
-def test_empty_expensive_models_disables_hard_gate() -> None:
-    """``expensive_models=[]`` disables the hard gate (soft thresholds only).
+def test_empty_expensive_models_blocks_all_models() -> None:
+    """``expensive_models=[]`` makes the hard cap a true hard stop for all models.
 
-    Over budget on Opus must NOT be hard-DENYed (no model is blocked);
-    with the soft checkpoint already approved it ALLOWs. The soft ASK
-    still fires below the limit — proving the empty list scopes off only
-    the hard block, not the whole policy.
+    Over budget on any model — cheap or expensive — must be hard-DENYed.
+    The DENY reason must say "All model calls are blocked" (no switch hint).
+    The soft ASK still fires below the limit.
     """
     policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0], expensive_models=[])
-    # Over budget on Opus, checkpoint already approved → ALLOW (no hard DENY).
-    assert policy(_tool(6.0, model="opus", session_state={_ASK_APPROVED_KEY: 2.0})) == {
-        "result": "ALLOW"
-    }
+    # Over budget on Opus → DENY (all models blocked).
+    result = policy(_tool(6.0, model="opus", session_state={_ASK_APPROVED_KEY: 2.0}))
+    assert result["result"] == "DENY"
+    assert "All model calls are blocked" in result["reason"]
+    # Over budget on a cheap model → also DENY.
+    result_cheap = policy(_tool(6.0, model="haiku"))
+    assert result_cheap["result"] == "DENY"
+    assert "All model calls are blocked" in result_cheap["reason"]
     # Soft checkpoint still asks below the limit.
     assert policy(_tool(2.0, model="opus"))["result"] == "ASK"
 

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -195,32 +195,30 @@ def test_declined_checkpoint_reasks_until_approved() -> None:
     assert second["result"] == "ASK"  # not recorded → re-asks
 
 
-def test_over_budget_on_expensive_model_denies() -> None:
-    """Over the hard limit on an expensive model → DENY (force downgrade).
+def test_over_budget_denies_all_models_by_default() -> None:
+    """Over the hard limit → DENY for any model when expensive_models is unset.
 
-    The default expensive set includes Opus; an over-budget tool call on
-    Opus must be blocked, and the reason must surface the spend figure and
-    the high-cost model tokens so the user knows what to avoid. If this
-    ALLOWed, the budget would never bite on the costly model it targets.
+    The default (None) is a true hard stop: every model is blocked once
+    the limit is reached, not just named expensive tiers. The reason must
+    surface the spend figure and say all model calls are blocked.
     """
     policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
-    result = policy(_tool(6.0, model="databricks-claude-opus-4-8"))
-    assert result["result"] == "DENY"
-    assert "6.00" in result["reason"]  # current cost surfaced
-    # The high-cost tokens are listed so the user knows which to avoid.
-    assert "opus" in result["reason"]
-    assert "gpt-5" in result["reason"]
+    for model in ("databricks-claude-opus-4-8", "claude-sonnet-4-6", "gpt-5-mini", "haiku"):
+        result = policy(_tool(6.0, model=model))
+        assert result["result"] == "DENY", f"expected DENY for {model}"
+        assert "6.00" in result["reason"]
+        assert "All model calls are blocked" in result["reason"]
 
 
 def test_deny_reason_for_codex_points_to_terminal() -> None:
     """A codex-native session's deny reason says to switch in the terminal.
 
     Codex has no web model picker — the only way to switch is the terminal
-    TUI's ``/model`` — so the verbatim instruction must name both. If this
-    regressed to the surface-agnostic wording, a codex user would not be
-    told the one mechanism that actually works for them.
+    TUI's ``/model`` — so the verbatim instruction must name both. Uses an
+    explicit expensive_models list (downgrade-gate mode) so a cheaper model
+    is possible and the switch hint applies.
     """
-    policy = cost_budget(max_cost_usd=5.0)
+    policy = cost_budget(max_cost_usd=5.0, expensive_models=["opus"])
     result = policy(_tool(6.0, model="opus", harness="codex-native"))
     assert result["result"] == "DENY"
     assert "in the terminal" in result["reason"]
@@ -232,10 +230,10 @@ def test_deny_reason_for_non_codex_omits_terminal() -> None:
 
     Claude / web / API sessions are not terminal-only (they have a model
     picker), so the message must NOT tell them to use the terminal or
-    ``/model`` — it would be wrong/confusing. This is the regression guard
-    for "only codex says in the terminal".
+    ``/model`` — it would be wrong/confusing. Uses explicit expensive_models
+    (downgrade-gate mode) so the switch hint is present but terminal-agnostic.
     """
-    policy = cost_budget(max_cost_usd=5.0)
+    policy = cost_budget(max_cost_usd=5.0, expensive_models=["opus"])
     # harness=None mirrors the web/API path (no native hook stamped it).
     result = policy(_tool(6.0, model="opus", harness=None))
     assert result["result"] == "DENY"
@@ -244,14 +242,14 @@ def test_deny_reason_for_non_codex_omits_terminal() -> None:
     assert "switch to a cheaper model" in result["reason"]
 
 
-def test_over_budget_on_cheaper_model_allows() -> None:
-    """Over the hard limit on a cheaper model → ALLOW (downgrade satisfied).
+def test_over_budget_on_cheaper_model_allows_with_explicit_list() -> None:
+    """Over the hard limit on a cheaper model → ALLOW when using an explicit expensive list.
 
-    Once the session has switched off an expensive model, the budget
-    becomes a no-op — the whole point of a "downgrade gate" rather than a
-    hard stop. A DENY here would trap the user even after they complied.
+    With explicit expensive_models (downgrade-gate mode), once the session
+    has switched off a named expensive model, the budget becomes a no-op.
+    A DENY here would trap the user even after they complied.
     """
-    policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
+    policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0], expensive_models=["opus"])
     assert policy(_tool(6.0, model="claude-sonnet-4-6")) == {"result": "ALLOW"}
 
 
@@ -281,47 +279,31 @@ def test_hard_limit_wins_over_checkpoint_approval() -> None:
 
 
 @pytest.mark.parametrize(
-    "model,expected",
+    "model",
     [
-        # Opus — concrete deployment id and the bare picker alias.
-        ("databricks-claude-opus-4-8", "DENY"),
-        ("opus", "DENY"),
-        # GPT-5 family: the broad "gpt-5" token covers bare gpt-5, the
-        # dot-spelled 5.5, and the dash-spelled deployment id.
-        ("gpt-5", "DENY"),
-        ("gpt-5.5", "DENY"),
-        ("databricks-gpt-5-5", "DENY"),
-        # Fable is the costliest tier (above Opus at 2x its price); both the
-        # concrete id and the bare picker alias must be gated, or switching to
-        # Fable becomes a budget bypass for a session downgraded off Opus.
-        ("claude-fable-5", "DENY"),
-        ("fable", "DENY"),
-        # Cheap GPT-5 variants are carved out by the -mini / -nano excludes,
-        # even though they contain the "gpt-5" substring → ALLOW over budget.
-        ("gpt-5-mini", "ALLOW"),
-        ("gpt-5-nano", "ALLOW"),
-        ("databricks-gpt-5-mini", "ALLOW"),
-        # A non-listed model is treated as cheap → allowed over budget.
-        ("databricks-claude-haiku-4-5", "ALLOW"),
-        # "gemini" contains the substring "mini" but NOT "-mini"; the
-        # leading dash in the exclude token keeps it from being wrongly
-        # carved out (it's simply not an expensive token either) → ALLOW.
-        ("databricks-gemini-2-5-pro", "ALLOW"),
+        "databricks-claude-opus-4-8",
+        "opus",
+        "gpt-5",
+        "gpt-5.5",
+        "databricks-gpt-5-5",
+        "claude-fable-5",
+        "fable",
+        # Cheap variants that used to be exempted are now also blocked.
+        "gpt-5-mini",
+        "gpt-5-nano",
+        "databricks-gpt-5-mini",
+        "databricks-claude-haiku-4-5",
+        "databricks-gemini-2-5-pro",
     ],
 )
-def test_default_expensive_set_matches_and_excludes(model: str, expected: str) -> None:
-    """The default set blocks Fable/Opus/GPT-5 but exempts -mini/-nano.
+def test_default_blocks_every_model(model: str) -> None:
+    """The default (expensive_models=None) blocks every model over budget.
 
-    Substring + case-insensitive matching must hit the deployment ids in
-    this stack (``databricks-claude-opus-4-8``, ``databricks-gpt-5-5``)
-    while the cheap ``gpt-5-mini`` / ``gpt-5-nano`` variants — which share
-    the ``gpt-5`` substring — are carved back out so they are NOT blocked.
-    A miss either way would mis-budget the zero-config default: blocking a
-    cheap variant traps users needlessly; letting Opus/GPT-5 through lets
-    the costliest models run past budget.
+    The default is now a true hard stop — no model tier is "cheap enough"
+    to continue once the limit is reached. Every model id must DENY.
     """
     policy = cost_budget(max_cost_usd=5.0)
-    assert policy(_tool(6.0, model=model))["result"] == expected
+    assert policy(_tool(6.0, model=model))["result"] == "DENY"
 
 
 def test_custom_expensive_models_substring_case_insensitive() -> None:
@@ -383,36 +365,33 @@ def test_abstains_on_non_gated_phases(phase: str) -> None:
     assert policy(_event(phase, 9.99)) == {"result": "ALLOW"}
 
 
-def test_request_phase_over_budget_on_expensive_model_denies() -> None:
-    """Over the hard limit on an expensive model DENYs at the request phase.
+def test_request_phase_over_budget_denies_any_model() -> None:
+    """Over the hard limit DENYs at the request phase for any model (default hard stop).
 
-    The request phase fires before the LLM turn, so a text-only turn (no
-    tool call) is now budgeted: an over-budget request on Opus must be
-    blocked. The reason must be the USER-FACING variant (the turn never
-    reaches the model), so it must NOT carry the tool-call directive
-    ("re-issue the tool call" / "Relay this to the user verbatim"). If
-    this regressed, text-only turns would bypass the budget entirely, or
-    the user would see model-directed instructions meant for the agent.
+    The request phase fires before the LLM turn, so a text-only turn is
+    budgeted. With the default (all-models-blocked), both expensive and
+    cheap model ids must be denied. The reason must be the USER-FACING
+    variant (no tool-call directive) and must say all calls are blocked.
     """
     policy = cost_budget(max_cost_usd=5.0)
-    result = policy(_request(6.0, model="databricks-claude-opus-4-8"))
-    assert result["result"] == "DENY"
-    assert "6.00" in result["reason"]  # current cost surfaced to the user
-    # User-facing phrasing only — no tool-call directive leaks through.
-    assert "re-issue the tool call" not in result["reason"]
-    assert "Relay this to the user verbatim" not in result["reason"]
-    # Still names the limit + how to recover so the user can act.
-    assert "switch to a cheaper model" in result["reason"]
+    for model in ("databricks-claude-opus-4-8", "claude-sonnet-4-6"):
+        result = policy(_request(6.0, model=model))
+        assert result["result"] == "DENY", f"expected DENY for {model}"
+        assert "6.00" in result["reason"]
+        assert "All model calls are blocked" in result["reason"]
+        assert "re-issue the tool call" not in result["reason"]
+        assert "Relay this to the user verbatim" not in result["reason"]
 
 
-def test_request_phase_over_budget_on_cheaper_model_allows() -> None:
-    """Over the hard limit on a cheaper model ALLOWs at the request phase.
+def test_request_phase_over_budget_on_cheaper_model_allows_with_explicit_list() -> None:
+    """Over the hard limit on a cheaper model ALLOWs when using an explicit expensive list.
 
-    Mirrors the tool-call downgrade gate: once the session is off an
-    expensive model, an over-budget request must proceed. A DENY here
-    would trap a downgraded user out of starting any new turn.
+    With an explicit expensive_models list (downgrade-gate mode), once the
+    session is off a named expensive model, an over-budget request must
+    proceed. A DENY here would trap a downgraded user out of starting any
+    new turn.
     """
-    policy = cost_budget(max_cost_usd=5.0)
+    policy = cost_budget(max_cost_usd=5.0, expensive_models=["opus"])
     assert policy(_request(6.0, model="claude-sonnet-4-6")) == {"result": "ALLOW"}
 
 
@@ -553,14 +532,16 @@ async def test_resolve_from_spec_denies_over_budget_on_expensive_model() -> None
 async def test_resolve_from_spec_allows_over_budget_on_cheaper_model() -> None:
     """Over-budget on a cheaper model ALLOWs through the engine boundary.
 
-    The model on ``EvaluationContext.model`` must let a downgraded session
-    through — proving the model gate (not just the cost) crosses the
-    boundary.
+    With an explicit expensive_models list (downgrade-gate mode), the model
+    on ``EvaluationContext.model`` lets a downgraded session through —
+    proving the model gate (not just the cost) crosses the boundary.
     """
     spec = FunctionPolicySpec(
         name="cost",
         on=None,
-        function=FunctionRef(path=_HANDLER, arguments={"max_cost_usd": 5.0}),
+        function=FunctionRef(
+            path=_HANDLER, arguments={"max_cost_usd": 5.0, "expensive_models": ["opus"]}
+        ),
     )
     policy: FunctionPolicy = resolve_function_policy(spec)
     result = await policy.evaluate(_tool_ctx(6.0, "claude-sonnet-4-6"), {})

--- a/tests/policies/builtins/test_user_daily_cost.py
+++ b/tests/policies/builtins/test_user_daily_cost.py
@@ -184,20 +184,21 @@ def test_approved_checkpoint_from_daily_store_does_not_reprompt() -> None:
     ]
 
 
-def test_over_daily_budget_on_expensive_model_denies() -> None:
-    """Over the hard daily limit on an expensive model → DENY (force downgrade).
+def test_over_daily_budget_denies_any_model() -> None:
+    """Over the hard daily limit → DENY for any model (default hard stop).
 
-    The reason must surface the spend and the high-cost tokens, and frame
-    it as the DAILY budget (not the session one) so the message is
-    accurate.
+    The default is a true hard stop — all models are blocked. The reason
+    must surface the spend, say all calls are blocked, and frame it as the
+    DAILY budget (not the session one).
     """
     policy = user_daily_cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
-    result = policy(_tool(6.0, model="databricks-claude-opus-4-8"))
-    assert result["result"] == "DENY"
-    assert "6.00" in result["reason"]
-    assert "opus" in result["reason"]
-    # Framed as the per-user daily budget, not the session one.
-    assert "daily" in result["reason"].lower()
+    for model in ("databricks-claude-opus-4-8", "databricks-claude-sonnet-4-6"):
+        result = policy(_tool(6.0, model=model))
+        assert result["result"] == "DENY", f"expected DENY for {model}"
+        assert "6.00" in result["reason"]
+        assert "All model calls are blocked" in result["reason"]
+        # Framed as the per-user daily budget, not the session one.
+        assert "daily" in result["reason"].lower()
 
 
 def test_ask_message_names_the_owner_when_present() -> None:
@@ -231,15 +232,13 @@ def test_deny_message_names_the_owner_when_present() -> None:
     assert "bob@example.com's spend $6.00 reached" in result["reason"]
 
 
-def test_over_daily_budget_on_cheaper_model_allows() -> None:
-    """Over the daily limit but already on a cheaper model → ALLOW (downgrade satisfied).
+def test_over_daily_budget_on_cheaper_model_allows_with_explicit_list() -> None:
+    """Over the daily limit on a cheaper model → ALLOW when using an explicit expensive list.
 
-    Sonnet is outside the default expensive set, so a downgraded session
-    proceeds even over the daily limit. (Note: ``gpt-5-4`` is NOT a cheap
-    model under the broad ``gpt-5`` default token — only the ``-mini`` /
-    ``-nano`` variants are carved out.)
+    With explicit expensive_models (downgrade-gate mode), Sonnet is not in
+    the list, so a downgraded session proceeds even over the daily limit.
     """
-    policy = user_daily_cost_budget(max_cost_usd=5.0)
+    policy = user_daily_cost_budget(max_cost_usd=5.0, expensive_models=["opus"])
     assert policy(_tool(6.0, model="databricks-claude-sonnet-4-6")) == {"result": "ALLOW"}
 
 
@@ -290,10 +289,10 @@ def test_daily_deny_reason_for_codex_points_to_terminal() -> None:
     """The daily DENY reason is harness-aware: codex-native → terminal /model.
 
     Guards that the per-user daily factory wires the harness through to
-    the (shared) deny-reason builder, so a codex user is told the one
-    switch mechanism that works for them.
+    the (shared) deny-reason builder. Uses explicit expensive_models
+    (downgrade-gate mode) so a cheaper model exists and the switch hint applies.
     """
-    policy = user_daily_cost_budget(max_cost_usd=5.0)
+    policy = user_daily_cost_budget(max_cost_usd=5.0, expensive_models=["opus"])
     result = policy(_tool(6.0, model="opus", harness="codex-native"))
     assert result["result"] == "DENY"
     assert "in the terminal" in result["reason"]


### PR DESCRIPTION
## Summary

- **Previously:** `expensive_models=[]` disabled the hard gate entirely — operators who set an empty list expecting a spend cap got none (only soft ASK thresholds remained).
- **Now:** `expensive_models=[]` is a true hard stop — **all** models are blocked once `max_cost_usd` is reached, instead of just gating expensive tiers. The deny message says *"All model calls are blocked over budget."* with no switch-to-cheaper-model hint.

This closes issue #1 from the cost-budget guardrail audit: *"max_cost_usd is a model-downgrade gate, not a hard stop — `expensive_models=[]` disables the cap entirely."*

## Changes

- `_ExpensiveModelConfig`: new `block_all_models: bool` field
- `_resolve_expensive_models`: `[]` → `hard_cap_enabled=True` + `block_all_models=True` (was `hard_cap_enabled=False`)
- `_model_blocked_over_budget`: new `block_all` kwarg — short-circuits to `True` for every model
- `_over_budget_deny_reason`: new `block_all` kwarg — emits hard-stop message without a model-switch hint
- All three `evaluate` closures (`cost_budget`, `user_daily_cost_budget`, `subagent_cost_budget`) pass `block_all=cfg.block_all_models`
- Updated docstrings and `POLICY_REGISTRY` descriptions
- Updated test: `test_empty_expensive_models_disables_hard_gate` → `test_empty_expensive_models_blocks_all_models`, now asserts DENY on both expensive and cheap models with the new message

## Test plan

- [ ] `pytest tests/policies/builtins/test_cost.py` — all 50 pass
- [ ] `pytest tests/policies/builtins/test_user_daily_cost.py` — all 22 pass
- [ ] Verify `expensive_models=["opus"]` behavior is unchanged (only opus blocked, cheap models still allowed over budget)
- [ ] Verify `expensive_models=None` (default) behavior is unchanged