### PR TITLE
build(docker): pin kiro-cli in the managed images (#1137)

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -246,14 +246,43 @@ RUN npm install -g --no-audit --no-fund \
       @earendil-works/pi-coding-agent \
  && npm cache clean --force
 
-# Kiro CLI is not published as an npm package; use its official installer and
-# copy the resulting root-local binaries onto the global PATH for all sandbox
-# users.
-RUN curl -fsSL https://cli.kiro.dev/install | bash \
- && install -m 0755 /root/.local/bin/kiro-cli /usr/local/bin/kiro-cli \
- && if [ -f /root/.local/bin/kiro-cli-chat ]; then \
+# Kiro CLI is not published as an npm package, and its installer has NO version
+# flag — `curl …/install | bash` always fetches `latest`, so the image was
+# non-deterministic. The kiro-native harness is behaviorally coupled to a
+# specific kiro-cli build (Escape-interrupt leaves an empty composer, the
+# bracketed-paste multi-line path, the session-JSONL layout — all verified
+# against 2.10.0; grep `kiro-cli 2.10.0`). So pin it the same way as `agy` below:
+# fetch the immutable per-arch zip from the versioned CDN path and verify its
+# sha256, run the package's own (network-free) install.sh, then copy the binaries
+# onto a system PATH dir every sandbox user shares. A trailing `kiro-cli
+# --version` check asserts the unpacked binary really is the pinned version — a
+# cheap sanity guard atop the sha256. To adopt a new kiro-cli: re-verify the
+# coupled behavior, then bump KIRO_CLI_VERSION + both
+# SHA256s (the `sha256` fields in
+# https://prod.download.cli.kiro.dev/stable/latest/manifest.json). Keep in sync
+# with deploy/docker/Dockerfile.ubi.
+ARG KIRO_CLI_VERSION=2.10.0
+ARG KIRO_CLI_SHA256_AMD64=be9d8b6d7c44f93a83ca22466043d98ad058e6ed3c12fffd068f3fb8a60b3b70
+ARG KIRO_CLI_SHA256_ARM64=0afb37399b9e2847c2f2e3f5d9052c8bc52bbf1e30401ea284a602661bce34bc
+RUN set -eu; \
+    case "$(uname -m)" in \
+      x86_64)  asset="kirocli-x86_64-linux.zip";  sha="$KIRO_CLI_SHA256_AMD64" ;; \
+      aarch64) asset="kirocli-aarch64-linux.zip"; sha="$KIRO_CLI_SHA256_ARM64" ;; \
+      *) echo "ERROR: unsupported arch '$(uname -m)' for kiro-cli" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/kiro.zip "https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/${asset}"; \
+    echo "${sha}  /tmp/kiro.zip" | sha256sum -c -; \
+    unzip -q /tmp/kiro.zip -d /tmp/kiro; \
+    KIRO_CLI_SKIP_SETUP=1 sh /tmp/kiro/kirocli/install.sh; \
+    install -m 0755 /root/.local/bin/kiro-cli /usr/local/bin/kiro-cli; \
+    if [ -f /root/.local/bin/kiro-cli-chat ]; then \
       install -m 0755 /root/.local/bin/kiro-cli-chat /usr/local/bin/kiro-cli-chat; \
-    fi
+    fi; \
+    rm -rf /tmp/kiro /tmp/kiro.zip; \
+    installed="$(/usr/local/bin/kiro-cli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"; \
+    [ "$installed" = "$KIRO_CLI_VERSION" ] || { \
+      echo "ERROR: kiro-cli reports '${installed:-<none>}', expected '$KIRO_CLI_VERSION'." >&2; exit 1; }; \
+    echo "kiro-cli ${KIRO_CLI_VERSION} pinned (sha256 verified)"
 # Antigravity CLI (`agy`) — the antigravity-native harness shells out to `agy`
 # on the host, launching it in a tmux pane (see omnigent/antigravity_native*.py),
 # so a managed host image must carry it. It is NOT an npm package

--- a/deploy/docker/Dockerfile.ubi
+++ b/deploy/docker/Dockerfile.ubi
@@ -101,13 +101,35 @@ RUN npm install -g --no-audit --no-fund \
       @earendil-works/pi-coding-agent \
  && npm cache clean --force
 
-# Kiro CLI is not published as an npm package; use its official installer and
-# copy the resulting root-local binaries onto the global PATH.
-RUN curl -fsSL https://cli.kiro.dev/install | bash \
- && install -m 0755 /root/.local/bin/kiro-cli /usr/local/bin/kiro-cli \
- && if [ -f /root/.local/bin/kiro-cli-chat ]; then \
+# Kiro CLI is not published as an npm package and its installer has no version
+# flag (always fetches `latest`). Pin it by fetching the immutable per-arch zip
+# from the versioned CDN path + verifying sha256, then running the package's own
+# install.sh and copying the binaries onto the global PATH. The `--version` check
+# asserts the binary is the pinned version (a sanity guard atop the sha256). See
+# the fuller rationale in deploy/docker/Dockerfile — keep KIRO_CLI_VERSION + both
+# SHA256s in sync.
+ARG KIRO_CLI_VERSION=2.10.0
+ARG KIRO_CLI_SHA256_AMD64=be9d8b6d7c44f93a83ca22466043d98ad058e6ed3c12fffd068f3fb8a60b3b70
+ARG KIRO_CLI_SHA256_ARM64=0afb37399b9e2847c2f2e3f5d9052c8bc52bbf1e30401ea284a602661bce34bc
+RUN set -eu; \
+    case "$(uname -m)" in \
+      x86_64)  asset="kirocli-x86_64-linux.zip";  sha="$KIRO_CLI_SHA256_AMD64" ;; \
+      aarch64) asset="kirocli-aarch64-linux.zip"; sha="$KIRO_CLI_SHA256_ARM64" ;; \
+      *) echo "ERROR: unsupported arch '$(uname -m)' for kiro-cli" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/kiro.zip "https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/${asset}"; \
+    echo "${sha}  /tmp/kiro.zip" | sha256sum -c -; \
+    unzip -q /tmp/kiro.zip -d /tmp/kiro; \
+    KIRO_CLI_SKIP_SETUP=1 sh /tmp/kiro/kirocli/install.sh; \
+    install -m 0755 /root/.local/bin/kiro-cli /usr/local/bin/kiro-cli; \
+    if [ -f /root/.local/bin/kiro-cli-chat ]; then \
       install -m 0755 /root/.local/bin/kiro-cli-chat /usr/local/bin/kiro-cli-chat; \
-    fi
+    fi; \
+    rm -rf /tmp/kiro /tmp/kiro.zip; \
+    installed="$(/usr/local/bin/kiro-cli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"; \
+    [ "$installed" = "$KIRO_CLI_VERSION" ] || { \
+      echo "ERROR: kiro-cli reports '${installed:-<none>}', expected '$KIRO_CLI_VERSION'." >&2; exit 1; }; \
+    echo "kiro-cli ${KIRO_CLI_VERSION} pinned (sha256 verified)"
 
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /build /build

--- a/tests/deploy/test_host_image_cli_install.py
+++ b/tests/deploy/test_host_image_cli_install.py
@@ -16,17 +16,28 @@ _ROOT = Path(__file__).resolve().parents[2]
         _ROOT / "deploy/docker/Dockerfile.ubi",
     ],
 )
-def test_host_images_install_kiro_cli_from_official_installer(dockerfile: Path) -> None:
-    """Managed host images must preinstall the real Kiro CLI binary.
+def test_host_images_install_pinned_kiro_cli(dockerfile: Path) -> None:
+    """Managed host images must preinstall a *pinned* Kiro CLI binary.
 
-    The public npm package named ``kiro-cli`` is unrelated and does not expose a
-    ``kiro-cli`` binary, so this pins the official installer path and global PATH
-    copy that makes native Kiro work in managed sandboxes.
+    The public npm package named ``kiro-cli`` is unrelated and exposes no
+    ``kiro-cli`` binary. Kiro's ``curl …/install`` script has no version flag
+    (it always fetches ``latest``), so the images instead pull the immutable,
+    versioned per-arch zip from the CDN, verify its sha256, and copy the binary
+    onto the global PATH (see the pinning rationale in the Dockerfiles). This
+    guards both that the pin stays in place and that the old unpinned installer
+    never creeps back.
     """
     text = dockerfile.read_text()
 
-    assert "https://cli.kiro.dev/install" in text
+    # Pinned to an explicit version, fetched from the immutable versioned CDN
+    # path — not the unpinned ``cli.kiro.dev/install`` script, not ``…/latest/``.
+    assert "ARG KIRO_CLI_VERSION=" in text
+    assert "https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/" in text
+    assert "https://cli.kiro.dev/install" not in text
+    # Integrity-checked, then copied onto the global PATH for all sandbox users.
+    assert "sha256sum -c" in text
     assert "install -m 0755 /root/.local/bin/kiro-cli /usr/local/bin/kiro-cli" in text
+    # kiro-cli is not an npm package, so it must not appear in the npm install list.
     assert "      kiro-cli \\" not in text
 
 


### PR DESCRIPTION
## Related issue

Part of #1137 (kiro-native parity follow-ups — Polish → "Pin the Dockerfile install"). #1137 is a tracked checklist, so this PR references rather than closes it.

## Summary

- `kiro-native`'s install was `curl -fsSL https://cli.kiro.dev/install | bash` in both `deploy/docker/Dockerfile` and `Dockerfile.ubi`. That installer **has no version flag** — it always fetches `latest` — so builds were non-deterministic even though the harness is behaviorally coupled to a specific `kiro-cli` build (verified against 2.10.0).
- Pins it the same way as the existing `agy` block: `ARG KIRO_CLI_VERSION` + per-arch `ARG …SHA256`, fetch the **immutable versioned zip** (`…/stable/<ver>/kirocli-<arch>-linux.zip`), `sha256sum -c`, run the package's own network-free `install.sh`, then a `kiro-cli --version` guard that **asserts the unpacked binary is the pinned version** (a sanity check atop the sha256, mirroring `agy`).
- One block works on both bases (`uname -m`, not `dpkg`). The `/usr/local/bin` binary set (`kiro-cli` + `kiro-cli-chat`) is unchanged — only the *source* becomes pinned + checksum-verified.

**ELI5:** the image used to grab whatever kiro version was newest that day; now it grabs exactly 2.10.0 and checks the bytes, so the build can't silently change under us.

## Test Plan

`docker` isn't available in my environment, so I validated the install-block logic directly against the live CDN rather than via a full image build:

- **Versioned URL is real + immutable:** `…/stable/2.10.0/kirocli-{x86_64,aarch64}-linux.zip` → HTTP 200.
- **Both per-arch sha256s byte-verified** against the downloaded zips (`sha256sum -c` ✓ for amd64 *and* arm64).
- **End-to-end block logic** (download → `sha256sum -c` → `unzip` → `KIRO_CLI_SKIP_SETUP=1 sh kirocli/install.sh` → version guard) run in a sandbox with a fake `HOME`: installs `kiro-cli`/`kiro-cli-chat`/`kiro-cli-term`, and `kiro-cli --version` → `kiro-cli 2.10.0`, so the guard passes.
- Confirmed the inner `install.sh` is network-free, honors `KIRO_CLI_SKIP_SETUP=1`, and that both bases satisfy its glibc ≥ 2.34 gate (Debian bookworm 2.36, UBI9 2.34), so the gnu zip is correct.
- `pre-commit run --files` on both Dockerfiles → pass.

> CI / a reviewer with Docker should confirm a full `docker build` of the `host` target and the UBI image as the final gate.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Dockerfile-only change with no unit-testable surface. Verified manually as above
(versioned-URL reachability, both arch sha256s, and the full
download→verify→install→version-guard sequence end-to-end). The remaining gap is
a full `docker build`, which needs a Docker daemon unavailable in my environment.
