### PR TITLE
fix(harnesses): keep idle reaper alive when release() raises

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1118,7 +1118,22 @@ class HarnessProcessManager:
                     "reaping idle harness subprocess for conversation %s",
                     conv_id,
                 )
-                await self.release(conv_id)
+                try:
+                    await self.release(conv_id)
+                except Exception:
+                    # A release failure (e.g. ``client.aclose()`` on a broken
+                    # transport, or ``process.wait()`` raising) must not escape
+                    # the loop: an unguarded raise here exits the reaper task
+                    # permanently — and silently, since nothing awaits it — so
+                    # the instance never reclaims another idle subprocess for
+                    # the rest of its lifetime (FD / memory / socket leak). Log
+                    # and continue; the entry stays registered and is retried
+                    # on a later pass.
+                    _logger.exception(
+                        "failed to reap idle harness subprocess for "
+                        "conversation %s; will retry on a later pass",
+                        conv_id,
+                    )
 
     async def _sweep_orphans(self) -> None:
         """

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -519,6 +519,66 @@ async def test_idle_reaper_releases_stale_entries(
         await fast.shutdown()
 
 
+async def test_idle_reaper_survives_release_error(
+    register_test_harness: None,
+    short_tmp_parent: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``release`` failure during reaping must not kill the reaper loop.
+
+    ``_idle_reaper_loop`` awaits ``self.release(conv_id)`` for each stale
+    entry with no guard around it. ``release`` -> ``_close_entry`` awaits
+    ``client.aclose()`` and ``process.wait()``, any of which can raise
+    (broken transport, dead process, ``ProcessLookupError``). An unguarded
+    raise propagates out of the ``while True`` loop and the reaper task
+    exits permanently — and silently, since nothing awaits the dead task —
+    so the AP instance never reclaims another idle subprocess for the rest
+    of its lifetime (FD / memory / socket leak).
+
+    Inject a one-shot ``release`` failure on the first reaper-triggered
+    call and assert the loop keeps going: the still-stale entry is reaped
+    on a later pass. Before the fix the socket never disappears (the loop
+    died); after it, a subsequent pass reclaims it.
+    """
+    fast = HarnessProcessManager(
+        idle_timeout_s=2.0,
+        reaper_interval_s=0.1,
+        tmp_parent=short_tmp_parent,
+    )
+    await fast.start()
+    try:
+        await fast.get_client("conv_a", _TEST_HARNESS_NAME)
+        socket_path = fast.instance_dir / "conv-conv_a.sock"
+        assert socket_path.exists()
+
+        # Make the first reaper-triggered release raise, then defer to the
+        # real release on later calls — a transient teardown failure.
+        real_release = fast.release
+        calls = {"n": 0}
+
+        async def flaky_release(conversation_id: str) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("simulated close failure")
+            await real_release(conversation_id)
+
+        monkeypatch.setattr(fast, "release", flaky_release)
+
+        # Across many reaper passes: with the bug the first raise kills the
+        # loop and the socket lingers; with the guard a later pass reaps it.
+        for _ in range(60):
+            if not socket_path.exists():
+                break
+            await asyncio.sleep(0.1)
+        assert calls["n"] >= 1, "reaper never attempted to release the stale entry"
+        assert not socket_path.exists(), (
+            "reaper died on the first release error and never reclaimed the "
+            "stale subprocess on a later pass"
+        )
+    finally:
+        await fast.shutdown()
+
+
 async def test_idle_reaper_skips_in_flight_turn(
     register_test_harness: None,
     short_tmp_parent: Path,


### PR DESCRIPTION
### What

`HarnessProcessManager._idle_reaper_loop` awaited `self.release(conv_id)` for
each stale entry with no exception guard. `release` → `_close_entry` awaits
`client.aclose()` and `process.wait()`, any of which can raise (a broken
transport, an already-dead process, `ProcessLookupError`). An unguarded raise
propagated out of the `while True` loop, so the reaper task exited
**permanently** — and silently, since nothing awaits it — and the instance
never reclaimed another idle subprocess for the rest of its lifetime
(FD / memory / socket leak).

This wraps the per-entry `release` in `try/except Exception`, logs via
`_logger.exception`, and continues. The entry stays registered and is retried
on a later reaper pass.

### Test

Adds `test_idle_reaper_survives_release_error`: it injects a one-shot
`release` failure on the first reaper-triggered call and asserts the loop
survives and reaps the still-stale entry on a later pass.

- Before the fix the test fails — the injected error propagates out of
  `_idle_reaper_loop` (surfaced when `shutdown()` awaits the dead task) and
  the subprocess is never reaped.
- After the fix it passes, and the full `test_process_manager.py` suite stays
  green (28 passed). `ruff check` / `ruff format --check` clean.

Fixes #1629

---

Note for maintainers: this is a fork PR, so the secret-bearing CI won't run
until you trigger it. Happy to adjust the guard's scope or logging if you'd
prefer a narrower `except`.
