### PR TITLE
Add Demo (video/images) section to PR template + agent guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,10 @@ component or module it touches. If a behaviour change ships without one, flag it
   under `tests/e2e_ui/`. That requirement is already enforced by the
   `E2E UI Required` status check, so do not re-flag it here — focus the review
   on the colocated unit test.
+- A UI / frontend PR should also include a **video or images** in the `Demo`
+  section of the PR description (with the "UI / frontend change" box checked).
+  If a UI PR has an empty Demo section, flag it as a request for a screenshot
+  or recording.
 - Do not ask for a test for styling/formatting-only changes, copy tweaks with
   no flow change, type-only changes, dependency bumps, or refactors with no
   observable behaviour change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,11 @@
 <!--
 For AI-written descriptions:
-- Follow this template (Related issue, Summary, Test Plan, Type of change, Test coverage, Coverage notes).
+- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
 - Keep it concise; reviewers skim long descriptions.
 - For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
-- Leave every checkbox in place. The PR Template check fails if required sections
-  or checkbox rows are removed.
+- Keep every section and checkbox row in place so reviewers can skim them.
+- For UI changes (the "UI / frontend change" box below), fill in the Demo
+  section: attach a screenshot or screen recording of the new behaviour.
 -->
 
 ## Related issue
@@ -27,10 +28,20 @@ Closes #
 
 <!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->
 
+## Demo
+
+<!--
+Video or images demonstrating the change. Drag-and-drop a screenshot or screen
+recording, or paste a link. Expected for UI / frontend changes (check the
+"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
+use `N/A` for non-visual changes.
+-->
+
 ## Type of change
 
 - [ ] Bug fix
 - [ ] Feature
+- [ ] UI / frontend change
 - [ ] Refactor / chore
 - [ ] Docs
 - [ ] Test / CI

--- a/.github/scripts/pr-template/format_body.py
+++ b/.github/scripts/pr-template/format_body.py
@@ -48,6 +48,12 @@ def format_body(body: str) -> str:
     )
     body = _append_section(
         body,
+        "Demo",
+        "<!-- Video or images demonstrating the change. Mandatory for UI / "
+        "frontend changes; use 'N/A' otherwise. -->",
+    )
+    body = _append_section(
+        body,
         "ELI5",
         "<!-- Optional: explain the change in plain language. -->",
     )

--- a/.github/scripts/pr-template/validate.py
+++ b/.github/scripts/pr-template/validate.py
@@ -22,6 +22,7 @@ REQUIRED_HEADINGS = (
 TYPE_LABELS = (
     "Bug fix",
     "Feature",
+    "UI / frontend change",
     "Refactor / chore",
     "Docs",
     "Test / CI",
@@ -134,6 +135,19 @@ def validate_pr_body(body: str) -> ValidationResult:
     checked_types = _checked_labels(type_section, TYPE_LABELS)
     if not checked_types:
         errors.append("Check at least one Type of change checkbox.")
+
+    # The Demo section is mandatory for UI / frontend changes — reviewers need
+    # a screenshot or recording of the new behaviour. It stays optional for
+    # everything else.
+    if "UI / frontend change" in checked_types:
+        demo = _meaningful_text(_section(body, spans, "Demo"))
+        if not demo:
+            errors.append(
+                "Demo is required for UI / frontend changes — attach a screenshot "
+                "or screen recording demonstrating the new behaviour."
+            )
+        elif _contains_placeholder(demo):
+            errors.append("Demo still contains template placeholder text.")
 
     test_section = _section(body, spans, "Test coverage")
     missing_test_labels = _missing_labels(test_section, TEST_LABELS)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent guidance
+
+Guidance for AI agents (Claude Code, Copilot, Cursor, etc.) working in this
+repository. See `CONTRIBUTING.md` for the full contributor workflow.
+
+## Pull requests
+
+When you open a pull request, fill in the repo's PR template at
+`.github/pull_request_template.md` (case-sensitive on Linux — note the lowercase
+filename). Keep every section and checkbox row so reviewers can skim them.
+
+- **Summary** — what changed and why.
+- **Test Plan** — how you verified it.
+- **Demo** — a **video or images** showing the change. Expected on contributor
+  PRs for UI / frontend changes (check the "UI / frontend change" box under
+  *Type of change*) so reviewers can see the new behaviour without checking out
+  the branch. Use `N/A` for non-visual changes.
+- **Type of change** / **Test coverage** — check all that apply (at least one
+  each).
+- **Coverage notes** — required if you checked "Manual verification completed"
+  or "Not applicable".
+
+Generate the description from the actual diff and this session's context — lead
+with the motivation, then the change. Don't pass a `--body` that skips these
+sections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,3 +142,7 @@ Frontend changes follow the same expectation with a different toolchain:
 
 - Branch from `main`, keep changes focused, and include tests or docs when relevant.
 - Sign off your commits with `git commit -s` (Developer Certificate of Origin).
+- Fill in the PR template. For **UI / frontend changes**, check the
+  "UI / frontend change" box and attach a **video or images** in the `Demo`
+  section showing the new behaviour, so reviewers can see it without checking
+  out the branch.

--- a/tests/github/test_pr_template_validate.py
+++ b/tests/github/test_pr_template_validate.py
@@ -24,6 +24,7 @@ def _valid_body(
     type_checkboxes: str = """
 - [x] Bug fix
 - [ ] Feature
+- [ ] UI / frontend change
 - [ ] Refactor / chore
 - [ ] Docs
 - [ ] Test / CI
@@ -38,8 +39,10 @@ def _valid_body(
 - [ ] Not applicable
 """,
     coverage_notes: str | None = None,
+    demo: str | None = None,
 ) -> str:
     notes_section = "" if coverage_notes is None else f"\n## Coverage notes\n\n{coverage_notes}\n"
+    demo_section = "" if demo is None else f"\n## Demo\n\n{demo}\n"
     return f"""
 ## Summary
 
@@ -48,11 +51,22 @@ def _valid_body(
 ## Test Plan
 
 {test_plan}
-
+{demo_section}
 ## Type of change
 {type_checkboxes}
 ## Test coverage
 {test_checkboxes}{notes_section}"""
+
+
+_UI_CHANGE = """
+- [ ] Bug fix
+- [ ] Feature
+- [x] UI / frontend change
+- [ ] Refactor / chore
+- [ ] Docs
+- [ ] Test / CI
+- [ ] Breaking change
+"""
 
 
 _MANUAL_ONLY = """
@@ -194,3 +208,35 @@ def test_not_applicable_with_empty_coverage_notes_after_comment_is_rejected() ->
     result = module.validate_pr_body(body)
     assert not result.ok
     assert any(error.startswith("Coverage notes are required") for error in result.errors)
+
+
+def test_demo_optional_for_non_ui_change() -> None:
+    # Default body is a bug fix with no Demo section.
+    result = module.validate_pr_body(_valid_body())
+    assert result.ok, result.errors
+
+
+def test_ui_change_requires_demo() -> None:
+    body = _valid_body(type_checkboxes=_UI_CHANGE)
+    result = module.validate_pr_body(body)
+    assert not result.ok
+    assert any(error.startswith("Demo is required") for error in result.errors)
+
+
+def test_ui_change_with_empty_demo_after_comment_is_rejected() -> None:
+    body = _valid_body(
+        type_checkboxes=_UI_CHANGE,
+        demo="<!-- nothing meaningful here -->",
+    )
+    result = module.validate_pr_body(body)
+    assert not result.ok
+    assert any(error.startswith("Demo is required") for error in result.errors)
+
+
+def test_ui_change_with_demo_passes() -> None:
+    body = _valid_body(
+        type_checkboxes=_UI_CHANGE,
+        demo="![new settings panel](https://github.com/org/repo/assets/1/screenshot.png)",
+    )
+    result = module.validate_pr_body(body)
+    assert result.ok, result.errors


### PR DESCRIPTION
## Related issue

N/A — process/tooling improvement.

## Summary

- Adds a **Demo** section to the PR template for a screenshot or screen recording of the change, plus a **UI / frontend change** checkbox under *Type of change*.
- Teaches the template tooling about it: `format_body.py` scaffolds the Demo section on `/autoformat`, and `validate.py` (with unit coverage) treats Demo as required when the UI box is checked — dormant until/unless the PR Template check is re-enabled.
- Adds a root **`AGENTS.md`** (with a `CLAUDE.md` symlink) plus notes in `CONTRIBUTING.md` and `.github/copilot-instructions.md` so agents and contributors attach a Demo for UI PRs.

All wording is **advisory**: the PR Template required check was dropped in `0d4d63617` to avoid blocking fork PRs, so nothing here re-introduces a CI gate.

## Test Plan

`ruff format --check` + `ruff check` on the changed scripts, and `pytest tests/github/test_pr_template_validate.py tests/github/test_pr_autoformat.py` — 18 passed. New tests cover Demo optional for non-UI PRs, required when the UI box is checked, comment-only Demo rejected, and a valid Demo passing.

## Demo

N/A — no user-facing UI change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable