### PR TITLE
feat(harness): support interrupt_session for hermes and qwen

### DIFF
--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -39,6 +39,7 @@ Env vars read at construction:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import re
@@ -267,6 +268,9 @@ class HermesExecutor(Executor):
         self._session_map: dict[str, str] = {}
         # Per-session HERMES_HOME with policy hook config.
         self._hermes_home: Path | None = None
+        # Active per-turn subprocess; promoted from a local so the Stop
+        # button can interrupt it. None outside a running turn.
+        self._proc: asyncio.subprocess.Process | None = None
         self._setup_hermes_home()
 
     def _setup_hermes_home(self) -> None:
@@ -392,6 +396,7 @@ class HermesExecutor(Executor):
                 cwd=self._cwd,
                 env=proc_env,
             )
+            self._proc = proc
 
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
                 proc.communicate(),
@@ -420,6 +425,8 @@ class HermesExecutor(Executor):
                 retryable=True,
             )
             return
+        finally:
+            self._proc = None
 
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
@@ -477,6 +484,16 @@ class HermesExecutor(Executor):
         """
         self._session_map.pop(session_key, None)
         await super().close_session(session_key)
+
+    async def interrupt_session(self, session_key: str) -> bool:  # noqa: ARG002
+        """Terminate the active hermes subprocess to cancel the running turn."""
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            return False
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+            return True
+        return False
 
     async def close(self) -> None:
         """Release executor-wide resources."""

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -91,6 +91,7 @@ def _looks_like_missing_file(message: str) -> bool:
 _AGENT_METHOD_INITIALIZE = "initialize"
 _AGENT_METHOD_SESSION_NEW = "session/new"
 _AGENT_METHOD_SESSION_PROMPT = "session/prompt"
+_AGENT_METHOD_SESSION_CANCEL = "session/cancel"
 
 # Notifications sent *from* the agent to the client
 _CLIENT_NOTIFICATION_SESSION_UPDATE = "session/update"
@@ -1292,6 +1293,28 @@ class QwenExecutor(Executor):
 
     async def close_session(self, session_key: str) -> None:
         """Close a named session (no-op; sessions are per-process)."""
+
+    async def interrupt_session(self, session_key: str) -> bool:  # noqa: ARG002
+        """Cancel the active Qwen turn, falling back to process termination."""
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            return False
+        if self._session_id is not None:
+            try:
+                await self._send(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": _AGENT_METHOD_SESSION_CANCEL,
+                        "params": {"sessionId": self._session_id},
+                    }
+                )
+                return True
+            except Exception as exc:  # noqa: BLE001 — interrupt is best-effort
+                logger.warning("qwen session/cancel failed; falling back to SIGTERM: %s", exc)
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+            return True
+        return False
 
     async def close(self) -> None:
         """Terminate the qwen subprocess and clean up."""

--- a/tests/inner/test_hermes_executor.py
+++ b/tests/inner/test_hermes_executor.py
@@ -515,3 +515,30 @@ async def test_run_turn_passes_hermes_home_env(
         _, call_kwargs = mock_create.call_args
         assert "env" in call_kwargs
         assert call_kwargs["env"]["HERMES_HOME"] == str(executor._hermes_home)
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_terminates_live_process(tmp_path: pathlib.Path) -> None:
+    """A live subprocess (returncode None) is terminated and True returned."""
+    executor = HermesExecutor(hermes_path="/usr/bin/hermes-fake", cwd=str(tmp_path))
+    mock_proc = MagicMock()
+    mock_proc.returncode = None
+    executor._proc = mock_proc
+
+    assert await executor.interrupt_session("some-key") is True
+    mock_proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_returns_false_when_finished_or_absent(
+    tmp_path: pathlib.Path,
+) -> None:
+    """No process, or an already-exited one, yields False with no terminate."""
+    executor = HermesExecutor(hermes_path="/usr/bin/hermes-fake", cwd=str(tmp_path))
+    assert await executor.interrupt_session("some-key") is False
+
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    executor._proc = mock_proc
+    assert await executor.interrupt_session("some-key") is False
+    mock_proc.terminate.assert_not_called()

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -972,6 +972,71 @@ async def test_close_session_is_noop() -> None:
 
 
 # ---------------------------------------------------------------------------
+# interrupt_session cancels the active ACP turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_sends_session_cancel() -> None:
+    """An established ACP session is cancelled without terminating the process."""
+    executor = QwenExecutor()
+    mock_proc = MagicMock()
+    mock_proc.returncode = None
+    executor._proc = mock_proc
+    executor._session_id = "qwen-session"
+    executor._send = AsyncMock()
+
+    assert await executor.interrupt_session("some-key") is True
+    executor._send.assert_awaited_once_with(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/cancel",
+            "params": {"sessionId": "qwen-session"},
+        }
+    )
+    mock_proc.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_terminates_before_session_exists() -> None:
+    """A live process without an ACP session falls back to SIGTERM."""
+    executor = QwenExecutor()
+    mock_proc = MagicMock()
+    mock_proc.returncode = None
+    executor._proc = mock_proc
+
+    assert await executor.interrupt_session("some-key") is True
+    mock_proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_terminates_when_cancel_fails() -> None:
+    """A failed ACP cancellation falls back to SIGTERM."""
+    executor = QwenExecutor()
+    mock_proc = MagicMock()
+    mock_proc.returncode = None
+    executor._proc = mock_proc
+    executor._session_id = "qwen-session"
+    executor._send = AsyncMock(side_effect=OSError("closed"))
+
+    assert await executor.interrupt_session("some-key") is True
+    mock_proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_returns_false_when_finished_or_absent() -> None:
+    """No process, or an already-exited one, yields False with no terminate."""
+    executor = QwenExecutor()
+    assert await executor.interrupt_session("some-key") is False
+
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    executor._proc = mock_proc
+    assert await executor.interrupt_session("some-key") is False
+    mock_proc.terminate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # system_prompt folded into the first turn (ACP has no system field)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Related issue

Closes #1638

## Summary

- Track Hermes' active per-turn subprocess so Stop can terminate it.
- Cancel established Qwen turns with ACP `session/cancel`, preserving the long-lived session.
- Fall back to SIGTERM before Qwen session setup or when cancellation cannot be sent.

## Test Plan

- `uv run --python 3.12 pytest -o addopts="" tests/inner/test_qwen_executor.py tests/inner/test_hermes_executor.py -q` (118 passed)
- `uv run --python 3.12 pre-commit run --files omnigent/inner/qwen_executor.py omnigent/inner/hermes_executor.py tests/inner/test_qwen_executor.py tests/inner/test_hermes_executor.py`

## Demo

Deterministic cancellation evidence from the focused tests:

- Hermes: a live subprocess receives `terminate()` and interruption returns `True`; absent or finished processes return `False`.
- Qwen: an established session sends `session/cancel` with its session ID without terminating the process. Before session setup, or if the ACP send fails, it falls back to `terminate()`.

No frontend files are changed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

The Stop action now interrupts active Hermes and Qwen turns.