### PR TITLE
fix(hermes): pass skills_filter to the CLI and fix bundle docstring

### DIFF
--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -295,6 +295,7 @@ def _build_hermes_args(
     *,
     model: str | None = None,
     session_id: str | None = None,
+    skills_filter: str | list[str] | None = None,
 ) -> list[str]:
     """
     Build the argument list for a Hermes subprocess call.
@@ -303,6 +304,9 @@ def _build_hermes_args(
     :param message: The user message text.
     :param model: Optional model override (``-m`` flag).
     :param session_id: Optional session ID to resume (``--resume``).
+    :param skills_filter: Skills to preload. A non-empty list preloads
+        those named skills (``-s a,b``); ``"none"`` skips preloaded
+        skills (``--ignore-rules``); ``"all"``/``None``/empty adds nothing.
     :returns: A list of CLI arguments.
     """
     args = [
@@ -318,6 +322,10 @@ def _build_hermes_args(
         args.extend(["-m", model])
     if session_id:
         args.extend(["--resume", session_id])
+    if isinstance(skills_filter, list) and skills_filter:
+        args.extend(["-s", ",".join(skills_filter)])
+    elif skills_filter == "none":
+        args.append("--ignore-rules")
     return args
 
 
@@ -470,6 +478,7 @@ class HermesExecutor(Executor):
             message=user_text,
             model=model,
             session_id=hermes_sid,
+            skills_filter=self._skills_filter,
         )
 
         # Build subprocess env with per-session HERMES_HOME for policy hooks.

--- a/omnigent/inner/hermes_harness.py
+++ b/omnigent/inner/hermes_harness.py
@@ -32,9 +32,9 @@ Env vars read at startup:
   ``str | list[str]`` carrying ``spec.skills_filter``. When
   unset, falls back to ``"all"``.
 - ``HARNESS_HERMES_BUNDLE_DIR``: Absolute path to the agent
-  bundle's extracted root. When set, the executor sources
-  bundled skills from ``<bundle>/skills/<name>/``. Unset for
-  agents without a bundled-skill directory.
+  bundle's extracted root. Accepted but reserved: there is no
+  ``hermes chat`` flag for it yet, so the executor does not pass
+  it through. Unset for agents without a bundled-skill directory.
 - ``HARNESS_HERMES_AGENT_NAME``: Agent display name. Reserved for
   future use; currently unused by Hermes.
 """

--- a/tests/inner/test_hermes_executor.py
+++ b/tests/inner/test_hermes_executor.py
@@ -120,6 +120,26 @@ class TestUtils:
         idx = args.index("--resume")
         assert args[idx + 1] == "20260620_abc123"
 
+    def test_build_hermes_args_skills_filter_list(self) -> None:
+        args = _build_hermes_args("hermes", "Hi", skills_filter=["a", "b"])
+        assert "-s" in args
+        idx = args.index("-s")
+        assert args[idx + 1] == "a,b"
+
+    def test_build_hermes_args_skills_filter_none(self) -> None:
+        args = _build_hermes_args("hermes", "Hi", skills_filter="none")
+        assert "--ignore-rules" in args
+
+    def test_build_hermes_args_skills_filter_all(self) -> None:
+        args = _build_hermes_args("hermes", "Hi", skills_filter="all")
+        assert "-s" not in args
+        assert "--ignore-rules" not in args
+
+    def test_build_hermes_args_skills_filter_default(self) -> None:
+        args = _build_hermes_args("hermes", "Hi")
+        assert "-s" not in args
+        assert "--ignore-rules" not in args
+
 
 # ---------------------------------------------------------------------------
 # HERMES_HOME population tests


### PR DESCRIPTION
## Related issue

Closes #1639

## Summary

- `skills_filter` was decoded and stored but never reached the Hermes CLI: `_build_hermes_args` never emitted `-s/--skills`, so a configured skill set was dropped, while the harness docstring claimed `bundle_dir` sourced bundled skills.
- Thread `skills_filter` into the args (a list preloads named skills via `-s a,b`; `"none"` maps to `--ignore-rules`; `"all"`/None add nothing) and correct the docstring to note `bundle_dir`/`agent_name` are reserved (no hermes chat flag yet). Verified vs hermes v0.17.0.

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/inner/test_hermes_executor.py tests/inner/test_hermes_harness.py -q` (42 passed). New `_build_hermes_args` cases: list -> `-s a,b`; `"none"` -> `--ignore-rules`; `"all"`/None -> neither. Ruff clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
