### PR TITLE
fix(hermes): mirror native reasoning to the web conversation

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -92,6 +92,10 @@ _DISCOVERY_SKEW_S = 10.0
 
 _STATE_FILE = "hermes_forwarder.json"
 
+#: Event type for a one-shot reasoning (thinking) mirror, matching the
+#: codex-/opencode-native forwarders' transient reasoning contract.
+_EXTERNAL_OUTPUT_REASONING_DELTA = "external_output_reasoning_delta"
+
 # A sibling session's persisted claim (naming the same ``hermes_session_id``)
 # counts as a LIVE owner only if its heartbeat was refreshed within this window;
 # an older claim is treated as a dead session and may be taken over. Generous
@@ -482,13 +486,17 @@ def _message_to_items(
     tool_calls: object,
     tool_call_id: object,
     tool_name: object,  # noqa: ARG001 — reserved for future use (e.g. logging)
+    reasoning_content: object,
+    reasoning: object,
     agent_name: str,
 ) -> list[_MirrorItem]:
     """Convert one ``messages`` row to mirror items.
 
-    An assistant row with ``tool_calls`` emits a ``function_call`` item per
-    call, followed by a ``message`` item if it also has prose content. A tool
-    row emits a ``function_call_output`` item. Returns an empty list to skip.
+    An assistant row with reasoning emits a one-shot
+    ``external_output_reasoning_delta`` item first, then a ``function_call``
+    item per call, followed by a ``message`` item if it also has prose content.
+    A tool row emits a ``function_call_output`` item. Returns an empty list to
+    skip.
     """
     if not isinstance(role, str):
         return []
@@ -516,6 +524,24 @@ def _message_to_items(
 
     if role == "assistant":
         items: list[_MirrorItem] = []
+        # Hermes persists completed reasoning rows rather than deltas, so mirror
+        # the first available reasoning field as one event before the response.
+        thinking = ""
+        for raw in (reasoning_content, reasoning):
+            if isinstance(raw, str):
+                stripped = _ATTACHMENT_MARKER_RE.sub("", raw).strip()
+                if stripped:
+                    thinking = stripped
+                    break
+        if thinking:
+            items.append(
+                _MirrorItem(
+                    msg_id=msg_id,
+                    item_type=_EXTERNAL_OUTPUT_REASONING_DELTA,
+                    item_data={"delta": thinking, "started": True},
+                    response_id=response_id,
+                )
+            )
         # Emit the prose FIRST, then the tool calls. An assistant row's text is
         # the model's preamble ("I'll run X…") that precedes the calls it makes
         # in the same step, so the natural order is message → function_call(s).
@@ -596,7 +622,8 @@ def _read_new_items(
         return []
     try:
         rows = con.execute(
-            "SELECT id, role, content, tool_calls, tool_call_id, tool_name "
+            "SELECT id, role, content, tool_calls, tool_call_id, tool_name, "
+            "reasoning_content, reasoning "
             "FROM messages "
             "WHERE session_id = ? AND id > ? AND active = 1 ORDER BY id",
             (hermes_session_id, last_id),
@@ -607,9 +634,26 @@ def _read_new_items(
     finally:
         con.close()
     items: list[_MirrorItem] = []
-    for msg_id, role, content, tool_calls_json, tool_call_id, tool_name_val in rows:
+    for (
+        msg_id,
+        role,
+        content,
+        tool_calls_json,
+        tool_call_id,
+        tool_name_val,
+        reasoning_content,
+        reasoning,
+    ) in rows:
         converted = _message_to_items(
-            msg_id, role, content, tool_calls_json, tool_call_id, tool_name_val, agent_name
+            msg_id,
+            role,
+            content,
+            tool_calls_json,
+            tool_call_id,
+            tool_name_val,
+            reasoning_content,
+            reasoning,
+            agent_name,
         )
         if converted:
             items.extend(converted)
@@ -807,7 +851,22 @@ async def _post_external_session_status(
 async def _post_conversation_item(
     client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
 ) -> None:
-    """POST one mirrored item as an ``external_conversation_item`` event."""
+    """POST one mirrored item as the appropriate session event.
+
+    Reasoning items post a transient ``external_output_reasoning_delta`` (the
+    web finalizes the block when the assistant message lands); all others post
+    an ``external_conversation_item``.
+    """
+    if item.item_type == _EXTERNAL_OUTPUT_REASONING_DELTA:
+        resp = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": _EXTERNAL_OUTPUT_REASONING_DELTA,
+                "data": item.item_data,
+            },
+        )
+        resp.raise_for_status()
+        return
     resp = await client.post(
         f"/v1/sessions/{session_id}/events",
         json={

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -35,6 +35,8 @@ CREATE TABLE messages (
     tool_call_id TEXT,
     tool_calls TEXT,
     tool_name TEXT,
+    reasoning_content TEXT,
+    reasoning TEXT,
     active INTEGER NOT NULL DEFAULT 1,
     compacted INTEGER NOT NULL DEFAULT 0
 );
@@ -48,18 +50,20 @@ def _seed_db(path: Path, *, cwd: str, started_at: float, session_id: str = "2026
         "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
         (session_id, "cli", cwd, started_at),
     )
-    # (session_id, role, content, tool_call_id, tool_calls, tool_name, active)
+    # (session_id, role, content, tool_call_id, tool_calls, tool_name, reasoning_content,
+    #  reasoning, active)
     rows = [
-        (session_id, "user", "hi [Attached: /x.png]", None, None, None, 1),
-        (session_id, "assistant", "hello", None, None, None, 1),
-        (session_id, "tool", "{tool-result}", None, None, None, 1),  # no tool_call_id -> skipped
-        (session_id, "assistant", "", None, None, None, 1),  # no prose, no tool_calls -> skipped
-        (session_id, "user", "soft-deleted", None, None, None, 0),  # inactive -> skipped
+        (session_id, "user", "hi [Attached: /x.png]", None, None, None, None, None, 1),
+        (session_id, "assistant", "hello", None, None, None, None, None, 1),
+        (session_id, "tool", "{tool-result}", None, None, None, None, None, 1),  # no id -> skip
+        (session_id, "assistant", "", None, None, None, None, None, 1),  # no prose/tools -> skip
+        (session_id, "user", "soft-deleted", None, None, None, None, None, 0),  # inactive -> skip
     ]
     con.executemany(
         "INSERT INTO messages"
-        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
-        " VALUES (?,?,?,?,?,?,?)",
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, reasoning_content,"
+        " reasoning, active)"
+        " VALUES (?,?,?,?,?,?,?,?,?)",
         rows,
     )
     con.commit()
@@ -135,6 +139,39 @@ def test_read_new_items_maps_roles_and_strips_attachments(tmp_path: Path) -> Non
     assert posted[1].item_data["role"] == "assistant"
     assert posted[1].item_data["agent"] == "hermes-native-ui"
     assert posted[1].item_data["content"] == [{"type": "output_text", "text": "hello"}]
+
+
+def test_read_new_items_mirrors_reasoning_before_message(tmp_path: Path) -> None:
+    """An assistant row with reasoning posts a one-shot reasoning delta before the message."""
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.execute(
+        "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
+        ("s1", "cli", str(tmp_path), 1000.0),
+    )
+    con.execute(
+        "INSERT INTO messages"
+        "(session_id, role, content, reasoning_content, reasoning, active)"
+        " VALUES (?,?,?,?,?,?)",
+        ("s1", "assistant", "done", "thinking hard [Attached: /x]", "fallback", 1),
+    )
+    con.commit()
+    con.close()
+    items = f._read_new_items(db, "s1", 0, "hermes-native-ui")
+    posted = [i for i in items if i.item_type]
+    assert posted[0].item_type == "external_output_reasoning_delta"
+    assert posted[0].item_data == {"delta": "thinking hard", "started": True}  # marker stripped
+    assert posted[1].item_type == "message"
+    assert posted[1].item_data["content"] == [{"type": "output_text", "text": "done"}]
+
+
+def test_read_new_items_no_reasoning_when_columns_empty(tmp_path: Path) -> None:
+    """An assistant row without reasoning posts no reasoning delta (the seeded "hello" row)."""
+    db = tmp_path / "state.db"
+    _seed_db(db, cwd=str(tmp_path), started_at=1000.0)
+    items = f._read_new_items(db, "20260620_1", 0, "hermes-native-ui")
+    assert not any(i.item_type == "external_output_reasoning_delta" for i in items)
 
 
 def test_read_new_items_mirrors_tool_calls(tmp_path: Path) -> None:
@@ -298,6 +335,21 @@ async def test_post_conversation_item_posts_event(tmp_path) -> None:
     assert url == "/v1/sessions/conv_q/events"
     assert body["type"] == "external_conversation_item"
     assert body["data"]["response_id"] == "hermes:5"
+
+
+async def test_post_conversation_item_posts_reasoning_delta(tmp_path) -> None:
+    client = _FakeClient()
+    item = f._MirrorItem(
+        msg_id=6,
+        item_type="external_output_reasoning_delta",
+        item_data={"delta": "let me think", "started": True},
+        response_id="hermes:6",
+    )
+    await f._post_conversation_item(client, session_id="conv_q", item=item)
+    url, body = client.posts[0]
+    assert url == "/v1/sessions/conv_q/events"
+    assert body["type"] == "external_output_reasoning_delta"
+    assert body["data"] == {"delta": "let me think", "started": True}
 
 
 async def test_forward_loop_discovers_and_mirrors_new_messages(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Related issue

Closes #1640

## Summary

- Read Hermes `reasoning_content`/`reasoning` fields that were omitted from the native forwarder query.
- Emit a transient `external_output_reasoning_delta` before assistant prose, matching the existing native-forwarder event contract.

## Test Plan

- `uv run --python 3.12 pytest -o addopts="" tests/test_hermes_native_forwarder.py -q` (49 passed)
- `uv run --python 3.12 pre-commit run --files omnigent/hermes_native_forwarder.py tests/test_hermes_native_forwarder.py`

## Demo

Deterministic event evidence from `test_read_new_items_mirrors_reasoning_before_message`:

1. A Hermes assistant row contains `reasoning_content="thinking hard [Attached: /x]"` and `content="done"`.
2. The forwarder emits `external_output_reasoning_delta` with `{"delta": "thinking hard", "started": true}`.
3. It then emits the assistant message containing `done`.

No frontend files are changed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Hermes thinking now appears in mirrored web conversations.