### PR TITLE
fix(hermes): re-pin to the child session after auto-compression

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -386,6 +386,34 @@ def _discover_session_id(
     return None
 
 
+def _discover_child_session(db_path: Path, parent_session_id: str) -> str | None:
+    """Return the newest Hermes session whose parent is *parent_session_id*.
+
+    Hermes auto-compresses by ending the current session and forking a CHILD
+    (``sessions.parent_session_id`` points at the old id; present in hermes
+    v0.17.0 state.db). The forwarder pins one id for life, so after compaction it
+    keeps polling the dead parent and the chat goes silent. Re-discover the
+    newest child so the mirror re-pins. Mirrors :func:`_discover_session_id`'s
+    read-only connect + swallow-and-warn handling; returns ``None`` on any error.
+    """
+    con = _connect_ro(db_path)
+    if con is None:
+        return None
+    try:
+        row = con.execute(
+            "SELECT id FROM sessions WHERE parent_session_id = ? ORDER BY started_at DESC LIMIT 1",
+            (parent_session_id,),
+        ).fetchone()
+    except sqlite3.Error as exc:
+        _warn_sqlite_once("child discovery", exc)
+        return None
+    finally:
+        con.close()
+    if row and isinstance(row[0], str) and row[0]:
+        return row[0]
+    return None
+
+
 def _same_path(a: str, b: str) -> bool:
     """Return whether two filesystem paths resolve to the same realpath."""
     try:
@@ -765,6 +793,41 @@ async def forward_hermes_store_to_session(
                             except Exception:  # noqa: BLE001
                                 _logger.warning(
                                     "Failed to persist hermes compaction item for %s",
+                                    session_id,
+                                    exc_info=True,
+                                )
+                            # Compaction ends this Hermes session and forks a
+                            # child (parent_session_id chain). Re-pin to the
+                            # newest child so the mirror follows the live session
+                            # instead of polling the dead parent forever. Done at
+                            # most once per compaction (compaction_persisted resets
+                            # to False for the child, which carries no compacted
+                            # rows yet); if no child exists we stay on the parent.
+                            try:
+                                child = await asyncio.to_thread(
+                                    _discover_child_session, db, hermes_session_id
+                                )
+                                if child is not None and not await asyncio.to_thread(
+                                    _session_claimed_by_other, bridge_dir, child, launch_epoch_s
+                                ):
+                                    hermes_session_id = child
+                                    last_id = 0
+                                    compaction_persisted = False
+                                    _external_id_synced = False
+                                    _write_state(
+                                        bridge_dir,
+                                        _ForwardState(
+                                            hermes_session_id=child,
+                                            last_id=0,
+                                            launch_epoch_s=launch_epoch_s,
+                                        ),
+                                    )
+                                    continue
+                            except Exception:  # noqa: BLE001
+                                _logger.warning(
+                                    "hermes forwarder failed to re-pin to child session "
+                                    "after compaction; staying on %s; session=%s",
+                                    hermes_session_id,
                                     session_id,
                                     exc_info=True,
                                 )

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -22,7 +22,8 @@ CREATE TABLE sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
     cwd TEXT,
-    started_at REAL NOT NULL
+    started_at REAL NOT NULL,
+    parent_session_id TEXT
 );
 CREATE TABLE messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -32,7 +33,8 @@ CREATE TABLE messages (
     tool_call_id TEXT,
     tool_calls TEXT,
     tool_name TEXT,
-    active INTEGER NOT NULL DEFAULT 1
+    active INTEGER NOT NULL DEFAULT 1,
+    compacted INTEGER NOT NULL DEFAULT 0
 );
 """
 
@@ -95,6 +97,27 @@ def test_discover_skips_excluded_session(tmp_path: Path) -> None:
     assert (
         f._discover_session_id(db, workspace, 1000.0, excluded=frozenset({"20260620_1"})) is None
     )
+
+
+def test_discover_child_session_returns_newest_child(tmp_path: Path) -> None:
+    """After compaction Hermes forks a child via parent_session_id; pick the newest."""
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.executemany(
+        "INSERT INTO sessions(id, source, cwd, started_at, parent_session_id) VALUES (?,?,?,?,?)",
+        [
+            ("parent", "cli", "/w", 1000.0, None),
+            ("child_old", "cli", "/w", 1005.0, "parent"),
+            ("child_new", "cli", "/w", 1010.0, "parent"),
+            ("unrelated", "cli", "/w", 1011.0, None),
+        ],
+    )
+    con.commit()
+    con.close()
+    assert f._discover_child_session(db, "parent") == "child_new"
+    # No children -> None (forwarder stays pinned to the parent).
+    assert f._discover_child_session(db, "child_new") is None
 
 
 def test_read_new_items_maps_roles_and_strips_attachments(tmp_path: Path) -> None:
@@ -370,6 +393,81 @@ async def test_forward_loop_patches_external_session_id_once(tmp_path, monkeypat
     url, body = patch_calls[0]
     assert url == "/v1/sessions/conv_patch"
     assert body["external_session_id"] == "20260620_1"
+
+
+async def test_forward_loop_repins_to_child_after_compaction(tmp_path, monkeypatch) -> None:
+    """Compaction forks a child session; the forwarder re-pins and mirrors its messages.
+
+    Pre-pins the parent (so discovery is skipped), seeds a compacted parent plus a
+    child whose parent_session_id is the parent, then drives a bounded number of
+    poll cycles. The first cycle persists the compaction and re-pins to the child;
+    the next mirrors the child's messages and persists state under the child id.
+    """
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.executemany(
+        "INSERT INTO sessions(id, source, cwd, started_at, parent_session_id) VALUES (?,?,?,?,?)",
+        [
+            ("parent_1", "cli", workspace, 1000.0, None),
+            ("child_1", "cli", workspace, 1005.0, "parent_1"),
+        ],
+    )
+    con.executemany(
+        "INSERT INTO messages(session_id, role, content, active, compacted) VALUES (?,?,?,?,?)",
+        [
+            ("parent_1", "assistant", "compacted summary", 1, 1),  # parent has compaction
+            ("child_1", "user", "child hi", 1, 0),
+            ("child_1", "assistant", "child reply", 1, 0),
+        ],
+    )
+    con.commit()
+    con.close()
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    # Pre-pin the parent so the loop tails it directly (last_id past the parent's
+    # only message so we don't mirror it; compaction triggers the re-pin).
+    f._write_state(bridge_dir, f._ForwardState(hermes_session_id="parent_1", last_id=1))
+
+    posted: list[f._MirrorItem] = []
+
+    async def _fake_post(_client, *, session_id, item):
+        posted.append(item)
+
+    monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
+    monkeypatch.setattr(f, "_persist_hermes_compaction_item", lambda *a, **k: _noop())
+
+    iteration = {"n": 0}
+
+    async def _sleep(_s):
+        iteration["n"] += 1
+        if iteration["n"] >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://x",
+            headers={},
+            session_id="conv_child",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    # Re-pinned to the child and mirrored its messages.
+    roles = [i.item_data.get("role") for i in posted]
+    assert roles == ["user", "assistant"]
+    assert f._read_state(bridge_dir).hermes_session_id == "child_1"
+
+
+async def _noop() -> None:
+    return None
 
 
 # --- Usage tracker tests ---------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #1641

## Summary

- The hermes-native forwarder pinned one `hermes_session_id` for life. On auto-compression Hermes ends that session and creates a child (`sessions.parent_session_id` chain), so the forwarder kept polling the dead parent and the web conversation went silent mid-run.
- When compaction is detected, discover the newest child via `parent_session_id` and re-pin to it (reset `last_id`, re-PATCH `external_session_id`), staying on the parent when there is no child. Forwarder-only: it reads Hermes' live state.db, which carries `parent_session_id`.

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/test_hermes_native_forwarder.py -q` (22 passed). New tests: `_discover_child_session` picks newest child; the poll loop re-pins to the child after compaction. Ruff clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
