### PR TITLE
feat(openai-agents): stream reasoning deltas as ReasoningChunk

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -37,6 +37,7 @@ from .executor import (
     ExecutorError,
     ExecutorEvent,
     Message,
+    ReasoningChunk,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -1594,6 +1595,15 @@ class OpenAIAgentsSDKExecutor(Executor):
                             if text:
                                 response_text += text
                                 yield TextChunk(text=text)
+                        elif data.type in (
+                            "response.reasoning_summary_text.delta",
+                            "response.reasoning_text.delta",
+                        ):
+                            reasoning_delta = data.delta
+                            if reasoning_delta:
+                                yield ReasoningChunk(
+                                    delta=reasoning_delta, event_type="reasoning_text"
+                                )
 
                     elif event.type == "run_item_stream_event":
                         item_event = cast(_RunItemEvent, event)

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -21,6 +21,7 @@ import databricks.sdk.config as _sdk_config_mod
 from omnigent.inner.executor import (
     ExecutorConfig,
     ExecutorError,
+    ReasoningChunk,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -80,6 +81,12 @@ class _FakeToolOutputItem:
 class _FakeRawTextDelta:
     delta: str
     type: str = "response.output_text.delta"
+
+
+@dataclass
+class _FakeRawReasoningDelta:
+    delta: str
+    type: str = "response.reasoning_summary_text.delta"
 
 
 @dataclass
@@ -500,6 +507,40 @@ class TestOpenAIAgentsSDKExecutor(unittest.TestCase):
             self.assertIsNone(
                 _FakeRunner.last_calls[0]["agent"].model_settings.parallel_tool_calls
             )
+
+        _run(_t())
+
+    def test_streams_reasoning_deltas(self):
+        async def _t():
+            _FakeRunner.last_calls = []
+            _FakeRunner.next_result = _FakeResult(
+                events=[
+                    _FakeRawEvent(_FakeRawReasoningDelta("thinking...")),
+                    _FakeRawEvent(_FakeRawReasoningDelta("")),
+                    _FakeRawEvent(_FakeRawTextDelta("Hello")),
+                ],
+                final_output="Hello",
+            )
+            executor = OpenAIAgentsSDKExecutor(client=object())
+            with patch(
+                "omnigent.inner.openai_agents_sdk_executor._ensure_agents_sdk",
+                return_value=_fake_agents_sdk(),
+            ):
+                events = [
+                    e
+                    async for e in executor.run_turn(
+                        [{"role": "user", "content": "hi", "session_id": "s1"}],
+                        [],
+                        "Be helpful.",
+                    )
+                ]
+
+            reasoning = [e for e in events if isinstance(e, ReasoningChunk)]
+            self.assertEqual(len(reasoning), 1)
+            self.assertEqual(reasoning[0].delta, "thinking...")
+            self.assertEqual(reasoning[0].event_type, "reasoning_text")
+            text = [e for e in events if isinstance(e, TextChunk)]
+            self.assertEqual([t.text for t in text], ["Hello"])
 
         _run(_t())
 


### PR DESCRIPTION
## Related issue

Closes #1642

## Summary

- The openai-agents harness only handled `response.output_text.delta`, so a flagship harness forwarded no reasoning while claude/codex/antigravity all emit `ReasoningChunk`.
- Surface the Responses-API reasoning deltas (`response.reasoning_summary_text.delta` and `response.reasoning_text.delta`) as `ReasoningChunk(event_type="reasoning_text")` when non-empty, mirroring codex. `_NON_OUTPUT_ITEM_TYPES` is unchanged; only the streaming deltas are mirrored.

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/inner/test_openai_agents_sdk_executor.py -q` (70 passed). New test: a reasoning-summary delta yields a ReasoningChunk; an empty delta yields nothing. Ruff clean.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
