### PR TITLE
Move the host badge into the composer status line

### DIFF
--- a/web/src/components/HostBadge.tsx
+++ b/web/src/components/HostBadge.tsx
@@ -56,12 +56,12 @@ const STATUS_WORD: Record<HostBadgeStatus, string> = {
 };
 
 /**
- * Host indicator for the open conversation, rendered at the top of the
- * chat window (ChatHeader's left slot). Reads its own data and renders
- * nothing when the session isn't host-bound — same self-contained shape
- * as PresenceAvatars. Shows the friendly host name (or sandbox-provider
- * label) plus a status circle: green online, red offline, neutral while
- * liveness is still unknown.
+ * Host indicator for the open conversation, rendered in the composer's
+ * status-line tray, immediately left of the worktree branch
+ * (ComposerStatusLine). Reads its own data and renders nothing when the
+ * session isn't host-bound — same self-contained shape as PresenceAvatars.
+ * Shows the friendly host name (or sandbox-provider label) plus a status
+ * circle: green online, red offline, neutral while liveness is still unknown.
  */
 export function HostBadge({ sessionId }: { sessionId: string }) {
   const { session } = useSession(sessionId);

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -14,6 +14,21 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
     useWorkspaceDirectory: () => ({ data: undefined }),
   };
 });
+// HostBadge now renders in the composer's status-line tray and reads the
+// session's host binding via TanStack Query. Stub the hooks so it self-hides
+// (no host bound) without needing a QueryClient provider around these renders.
+vi.mock("@/hooks/useSession", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  useSession: () => ({ session: { hostId: null }, isLoading: false, error: null }),
+}));
+vi.mock("@/hooks/useHosts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useHosts")>()),
+  useHosts: () => ({ data: [] }),
+}));
+vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/RunnerHealthProvider")>()),
+  useSessionHostOnline: () => undefined,
+}));
 import type { ElicitationBlock } from "@/lib/blocks";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Composer } from "./ChatPage";

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -47,6 +47,21 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
     }),
   };
 });
+// HostBadge now renders in the composer's status-line tray and reads the
+// session's host binding via TanStack Query. Stub the hooks so it self-hides
+// (no host bound) without needing a QueryClient provider around these renders.
+vi.mock("@/hooks/useSession", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  useSession: () => ({ session: { hostId: null }, isLoading: false, error: null }),
+}));
+vi.mock("@/hooks/useHosts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useHosts")>()),
+  useHosts: () => ({ data: [] }),
+}));
+vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/RunnerHealthProvider")>()),
+  useSessionHostOnline: () => undefined,
+}));
 
 import { Composer, detectMentionAt, mentionMarkerFor } from "./ChatPage";
 

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -15,6 +15,29 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
   };
 });
 
+// HostBadge now lives in the status-line tray (left of the worktree branch).
+// It reads the session's host binding via these hooks; stub them so the badge
+// renders deterministically without a QueryClient / RunnerHealth provider. The
+// default is "not host-bound", so the badge self-hides and the existing branch/
+// ring/harness assertions are unchanged; host-aware tests override per case.
+const { useSessionMock, useHostsMock, useSessionHostOnlineMock } = vi.hoisted(() => ({
+  useSessionMock: vi.fn(),
+  useHostsMock: vi.fn(),
+  useSessionHostOnlineMock: vi.fn(),
+}));
+vi.mock("@/hooks/useSession", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  useSession: (id: string | null | undefined) => useSessionMock(id),
+}));
+vi.mock("@/hooks/useHosts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useHosts")>()),
+  useHosts: (opts: unknown) => useHostsMock(opts),
+}));
+vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/RunnerHealthProvider")>()),
+  useSessionHostOnline: (id: string | undefined) => useSessionHostOnlineMock(id),
+}));
+
 import { Composer, composerHarnessLabel, formatModelEffortStatusLabel } from "./ChatPage";
 
 // Pins the visibility rules for the status-line tray under the composer:
@@ -64,8 +87,31 @@ function statusLine(): Element | null {
   return document.querySelector('[data-testid="composer-status-line"]');
 }
 
+/** Bind the active session to an online host named `name` so HostBadge shows. */
+function bindHost(name: string) {
+  useSessionMock.mockReturnValue({
+    session: { hostId: "host_a1b2" },
+    isLoading: false,
+    error: null,
+  });
+  useHostsMock.mockReturnValue({
+    data: [
+      { host_id: "host_a1b2", name, owner: "alice", status: "online", sandbox_provider: null },
+    ],
+  });
+  useSessionHostOnlineMock.mockReturnValue(true);
+}
+
 describe("Composer status line (branch + context ring)", () => {
   beforeEach(() => {
+    // Default: no host bound, so HostBadge renders nothing.
+    useSessionMock.mockReset().mockReturnValue({
+      session: { hostId: null },
+      isLoading: false,
+      error: null,
+    });
+    useHostsMock.mockReset().mockReturnValue({ data: [] });
+    useSessionHostOnlineMock.mockReset().mockReturnValue(undefined);
     useChatStore.setState({
       conversationId: "conv_test",
       skills: [],
@@ -246,6 +292,32 @@ describe("Composer status line (branch + context ring)", () => {
     expect(plan.compareDocumentPosition(harness) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+  });
+
+  it("shows the host badge to the left of the worktree branch", () => {
+    // The host indicator moved out of the chat header into this tray; it
+    // sits immediately left of the worktree branch.
+    bindHost("mac-laptop");
+    useChatStore.setState({ gitBranch: "geist" });
+    renderComposer();
+
+    const host = screen.getByTestId("host-badge");
+    const branch = screen.getByTestId("composer-git-branch");
+    expect(host).toHaveTextContent("mac-laptop");
+    expect(host.compareDocumentPosition(branch) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("hides the host badge on a sub-agent session", () => {
+    // A child session repurposes the header's left slot for the back
+    // affordance, so the host badge stays hidden there as it did before.
+    bindHost("mac-laptop");
+    useChatStore.setState({ gitBranch: "geist" });
+    renderComposer({ subAgentLabel: "check-eligibility" });
+
+    expect(screen.queryByTestId("host-badge")).toBeNull();
+    expect(screen.getByTestId("composer-git-branch")).toBeInTheDocument();
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -137,6 +137,7 @@ import {
 import { useMarkConversationSeen } from "@/hooks/useUnseenConversations";
 import { useUserMessageNav } from "@/hooks/useUserMessageNav";
 import { UserMessageNav } from "@/components/UserMessageNav";
+import { HostBadge } from "@/components/HostBadge";
 import {
   BUILTIN_SLASH_COMMANDS,
   isSlashCommandText,
@@ -3291,9 +3292,11 @@ export function composerHarnessLabel(
 function ComposerStatusLine({
   harnessLabel,
   codexGoal,
+  isSubAgentSession,
 }: {
   harnessLabel: string | null;
   codexGoal: CodexGoal | null;
+  isSubAgentSession: boolean;
 }) {
   const conversationId = useChatStore((s) => s.conversationId);
   const contextWindow = useChatStore((s) => s.contextWindow);
@@ -3305,6 +3308,12 @@ function ComposerStatusLine({
   const gitBranch = useChatStore((s) => s.gitBranch);
 
   const showBranch = !!conversationId && !!gitBranch;
+  // Host indicator (green/red dot + host name), left of the worktree branch.
+  // Hidden on sub-agent sessions — the header's child-session slot owns the
+  // back affordance there, mirroring where this badge used to live. HostBadge
+  // self-hides when the session isn't host-bound, so this is a visibility gate,
+  // not a host-presence claim.
+  const showHost = !!conversationId && !isSubAgentSession;
   // The harness/agent identity (e.g. "Claude", "Polly (Pi)") lives here now;
   // the picker trigger above owns the model/effort label since it's the
   // control that changes them.
@@ -3332,19 +3341,20 @@ function ComposerStatusLine({
         CHAT_COLUMN_WIDTH,
       )}
     >
-      {/* Left: worktree branch. Always holds the flex-1 slot so the
-          right cluster stays pinned right even with no branch, and
-          truncates to an ellipsis so the tray never wraps. */}
-      <span className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground">
+      {/* Left: host badge then worktree branch. Always holds the flex-1 slot
+          so the right cluster stays pinned right even when both are absent;
+          each item truncates to an ellipsis so the tray never wraps. */}
+      <div className="flex min-w-0 flex-1 items-center gap-3 text-xs text-muted-foreground">
+        {showHost && conversationId && <HostBadge sessionId={conversationId} />}
         {showBranch && (
-          <>
+          <span className="flex min-w-0 items-center gap-1.5">
             <GitBranchIcon className="size-3.5 shrink-0" />
             <span data-testid="composer-git-branch" className="min-w-0 truncate" title={gitBranch}>
               {gitBranch}
             </span>
-          </>
+          </span>
         )}
-      </span>
+      </div>
       {/* Right: model/effort and context ring, never shrinks. */}
       <div className="flex min-w-0 shrink-0 items-center gap-3">
         {showPlanMode && (
@@ -4614,7 +4624,11 @@ export function Composer({
           </div>
         </div>
       </div>
-      <ComposerStatusLine harnessLabel={harnessLabel} codexGoal={codexGoal} />
+      <ComposerStatusLine
+        harnessLabel={harnessLabel}
+        codexGoal={codexGoal}
+        isSubAgentSession={subAgentLabel != null}
+      />
     </form>
   );
 }

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AgentInfoButton } from "@/components/AgentInfo";
 import { PresenceAvatars } from "@/components/PresenceAvatars";
-import { HostBadge } from "@/components/HostBadge";
 import type { Agent } from "@/hooks/useAgents";
 import { cn } from "@/lib/utils";
 import { TAB_BADGE_BASE } from "./railTabs";
@@ -215,7 +214,6 @@ export function ChatHeader({
             <TooltipContent side="bottom">Open sidebar</TooltipContent>
           </Tooltip>
         )}
-        {!isChildSession && conversationId && <HostBadge sessionId={conversationId} />}
         {isChildSession && parentSessionId && (
           <>
             {/* Back affordance. Ghost (not a filled pill) so it sits on the


### PR DESCRIPTION
## What

Moves the host indicator (status dot + host name) out of the chat header and into the composer's status-line tray, immediately **left of the worktree branch**.

Before: the badge sat in the top-left header of the conversation pane.
After: it sits in the footer status line, left of the worktree branch (e.g. `● mac-laptop   ⌥ geist`), beside the harness label and context ring.

## Why

The header's left slot is otherwise empty/repurposed; grouping the host indicator with the worktree branch and harness/context cues puts all the "where/what is this session running" signals in one place — the status-line tray.

## Changes

- `web/src/shell/ChatHeader.tsx` — remove the `HostBadge` from the header's left slot (and its now-unused import).
- `web/src/pages/ChatPage.tsx` — render `HostBadge` in `ComposerStatusLine`, left of the branch. New `isSubAgentSession` prop keeps the badge hidden on sub-agent sessions, preserving the header's prior behavior (its left slot is repurposed for the back affordance there). The tray's visibility guard is deliberately unchanged — `HostBadge` self-hides when a session isn't host-bound, so it rides along whenever the tray already shows (active sessions always have a harness + context ring); gating the tray on the host flag would resurrect the empty "dead shelf" the tests forbid.
- `web/src/components/HostBadge.tsx` — docstring updated to its new location.

## Tests

- Updated `ChatPage.statusLine.test.tsx`: stub the host hooks (default "not host-bound" so existing assertions are unchanged) + two new cases — badge renders left of the worktree branch; badge hidden on a sub-agent session.
- `vitest` (statusLine + HostBadge + ChatHeader suites), `tsc -b`, `oxlint`, and `prettier --check` all pass locally.