### PR TITLE
#1410 (web): sort Subagents rail by activity

### DIFF
--- a/tests/e2e_ui/agents/test_subagent_sort.py
+++ b/tests/e2e_ui/agents/test_subagent_sort.py
@@ -1,0 +1,159 @@
+"""UI journey: the Agents rail floats active sub-agents above settled ones (#1410).
+
+Critical user journey
+---------------------
+A supervisor fans work out to sub-agents and watches the right-rail Agents tab.
+A sub-agent that's actively working must sort *above* a settled/idle sibling, so
+the live one is never buried. This pins that, end to end, with no model call.
+
+Why this is deliberately minimal
+--------------------------------
+Seeding child *state* over REST is constrained:
+
+* A child is created with JSON ``POST /v1/sessions`` + ``parent_session_id``
+  (see ``agents/test_add_subagent_dialog`` / ``mobile/test_mobile_workflow``).
+* Its status is driven with ``external_session_status`` events — but for a
+  ``sub_agent`` the server relays *terminal* statuses (``idle``/``failed``) to
+  the child's runner inbox, which a REST-seeded child doesn't have, so those
+  return 503. Only the non-terminal ``running`` is settable this way.
+* A freshly-created child with no status already reads as ``idle``
+  (``busy=false``, ``current_task_status=null`` on the snapshot builder).
+
+So this test uses the two states it *can* deterministically produce —
+``working`` (one ``running`` POST) and ``idle`` (an untouched child) — and
+asserts the working row sorts above the idle one. The full ranking
+(``awaiting``/``launching``/``done``/``failed`` and the ``created_at`` tiebreak)
+is covered deterministically by the unit test
+``web/src/shell/SubagentsPanel.test.tsx``; the snapshot read path can't render
+``done``/``launching`` anyway (it only emits ``failed``/``null``).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+_SUBAGENT_ROW = '[data-testid="subagent-row"]'
+
+
+def _agent_id(base_url: str, session_id: str) -> str:
+    """Return the agent id the parent session is bound to."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json()["agent_id"]
+
+
+def _create_child(base_url: str, parent_id: str, agent_id: str, name: str) -> str:
+    """Create a sub-agent child session under *parent_id* (no LLM turn).
+
+    Mirrors the JSON ``POST /v1/sessions`` contract used by
+    ``mobile/test_mobile_workflow``. Retries briefly on 503 — a freshly-bound
+    runner can be momentarily unavailable.
+
+    :returns: The new child session id.
+    """
+    last_exc: Exception | None = None
+    for _ in range(10):
+        resp = httpx.post(
+            f"{base_url}/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "parent_session_id": parent_id,
+                "sub_agent_name": name,
+            },
+            timeout=30.0,
+        )
+        if resp.status_code == 503:
+            last_exc = httpx.HTTPStatusError(
+                "runner unavailable", request=resp.request, response=resp
+            )
+            time.sleep(0.5)
+            continue
+        resp.raise_for_status()
+        body = resp.json()
+        return str(body.get("id") or body["session_id"])
+    raise AssertionError(f"child create kept returning 503 for {name!r}") from last_exc
+
+
+def _set_running(base_url: str, session_id: str) -> None:
+    """Mark a child busy via the route native harnesses use (``running`` only).
+
+    Terminal statuses (``idle``/``failed``) 503 on a REST-seeded child, so this
+    helper is intentionally limited to the non-terminal ``running`` edge.
+    """
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": {"status": "running"}},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _child_summaries(base_url: str, parent_id: str) -> dict[str, dict]:
+    """Return the parent's child-session summaries keyed by child id."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{parent_id}/child_sessions", timeout=10.0)
+    resp.raise_for_status()
+    body = resp.json()
+    data = body.get("data", body) if isinstance(body, dict) else body
+    return {str(c["id"]): c for c in data}
+
+
+def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) -> None:
+    """Poll *predicate* until truthy or the deadline passes."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise AssertionError("server did not reflect the seeded child states in time")
+
+
+@pytest.mark.timeout(120)
+def test_rail_sorts_working_above_idle(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A working sub-agent sorts above an idle one, inverting creation order."""
+    base_url, parent_id = seeded_session
+    agent_id = _agent_id(base_url, parent_id)
+
+    # Create the working one FIRST (older) and the idle one SECOND (newer). The
+    # rail's default order is newest-first, which would put idle on top — so a
+    # working-above-idle result can only come from the activity sort.
+    c_work = _create_child(base_url, parent_id, agent_id, "working-sub")
+    c_idle = _create_child(base_url, parent_id, agent_id, "idle-sub")
+
+    # working = one running POST; idle = leave the child untouched.
+    _set_running(base_url, c_work)
+
+    # Gate the UI assertion on the server reflecting both states.
+    def _ready() -> bool:
+        by = _child_summaries(base_url, parent_id)
+        return (
+            len(by) >= 2
+            and by.get(c_work, {}).get("busy") is True
+            and by.get(c_idle, {}).get("busy") is False
+            and by.get(c_idle, {}).get("current_task_status") is None
+        )
+
+    _wait_for(_ready)
+
+    # Open the Agents tab; scope to the desktop "Workspace" rail so lookups don't
+    # match the hidden mobile drawer that mirrors the same testids.
+    page.goto(f"{base_url}/c/{parent_id}")
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Agents")).click()
+    rows = rail.locator(_SUBAGENT_ROW)
+    expect(rows).to_have_count(2, timeout=30_000)
+
+    # working floats above idle, inverting the default newest-first order.
+    # Per-position expect() auto-retries, riding out the rail's poll/stream refresh.
+    expect(rows.nth(0)).to_have_attribute("data-child-session-id", c_work, timeout=30_000)
+    expect(rows.nth(1)).to_have_attribute("data-child-session-id", c_idle)

--- a/web/src/hooks/useChildSessions.ts
+++ b/web/src/hooks/useChildSessions.ts
@@ -57,6 +57,13 @@ export interface ChildSessionInfo {
    * not routed (routing off, or a server that predates the field).
    */
   routed_model?: string | null;
+  /**
+   * Unix-epoch creation time of the child session. Surfaced only as a
+   * stable tiebreak for the Agents rail's activity sort (newest first).
+   * Optional: cached entries written before this field shipped, and
+   * unit-test fixtures, may omit it.
+   */
+  created_at?: number;
 }
 
 /**
@@ -76,6 +83,7 @@ interface ChildSessionWire {
   last_message_preview?: string | null;
   pending_elicitations_count?: number;
   routed_model?: string | null;
+  created_at?: number;
 }
 
 interface ChildSessionsResponse {
@@ -188,6 +196,7 @@ export async function fetchChildSessions(sessionId: string): Promise<ChildSessio
     last_message_preview: row.last_message_preview ?? null,
     pending_elicitations_count: row.pending_elicitations_count ?? 0,
     routed_model: row.routed_model ?? null,
+    created_at: row.created_at,
   }));
 }
 

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { type ChildSessionInfo, useChildSessions } from "@/hooks/useChildSessions";
 import { useSession } from "@/hooks/useSession";
-import { iconForAgentType, SubagentsPanel } from "./SubagentsPanel";
+import { iconForAgentType, sortSiblingsByActivity, SubagentsPanel } from "./SubagentsPanel";
 
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
   // Keep the real module (MAX_TREE_DEPTH and friends) — only the
@@ -476,8 +476,11 @@ describe("SubagentsPanel", () => {
     expect(screen.getByTestId("subagent-main-row")).toBeInTheDocument();
     const rows = screen.getAllByTestId("subagent-row");
     expect(rows).toHaveLength(2);
-    expect(rows[0]).toHaveAttribute("href", "/c/conv_child_a");
-    expect(rows[1]).toHaveAttribute("href", "/c/conv_child_b");
+    // The rail orders rows by activity (#1410): the working child
+    // (conv_child_b) sorts above the completed one (conv_child_a) regardless of
+    // input order — see the "sibling ordering (#1410)" suite below.
+    expect(rows[0]).toHaveAttribute("href", "/c/conv_child_b");
+    expect(rows[1]).toHaveAttribute("href", "/c/conv_child_a");
     // Status-word display (which states show a word vs. a bare dot) is owned
     // by the dedicated "shows the status word only for notable states" test.
   });
@@ -1504,5 +1507,72 @@ describe("SubagentsPanel", () => {
 
     expect(childRow(container, "conv_grandchild").className.split(/\s+/)).toContain("bg-accent");
     expect(childRow(container, "conv_child").className.split(/\s+/)).not.toContain("bg-accent");
+  });
+});
+
+describe("SubagentsPanel sibling ordering (#1410)", () => {
+  // Each builder yields a child the panel collapses (via childStatus)
+  // to exactly one AgentActivity, so the ordering is unambiguous.
+  const awaiting = (id: string) => childInfo({ id, pending_elicitations_count: 1 });
+  const working = (id: string) => childInfo({ id, busy: true });
+  const launching = (id: string) => childInfo({ id, current_task_status: "launching" });
+  const idle = (id: string) => childInfo({ id });
+  const other = (id: string) => childInfo({ id, current_task_status: "cancelled" });
+  const done = (id: string) => childInfo({ id, current_task_status: "completed" });
+  const failed = (id: string) => childInfo({ id, current_task_status: "failed" });
+
+  const ids = (children: ChildSessionInfo[]) => children.map((c) => c.id);
+
+  /** Ordered child-session ids as actually rendered in the rail DOM. */
+  function renderedChildOrder(container: HTMLElement): string[] {
+    return Array.from(container.querySelectorAll<HTMLElement>('[data-testid="subagent-row"]')).map(
+      (el) => el.getAttribute("data-child-session-id") ?? "",
+    );
+  }
+
+  it("ranks attention-needing and live agents above settled ones", () => {
+    // Supplied worst-first so an identity (no-op) sort would fail.
+    const sorted = sortSiblingsByActivity([
+      failed("f"),
+      done("d"),
+      other("o"),
+      idle("i"),
+      launching("l"),
+      working("w"),
+      awaiting("a"),
+    ]);
+    expect(ids(sorted)).toEqual(["a", "w", "l", "i", "o", "d", "f"]);
+  });
+
+  it("is stable: equal-status rows keep their original (creation) order", () => {
+    // Matters because every list re-polls on TREE_POLL_MS; a non-stable
+    // tiebreak would make same-status rows reshuffle on each refresh.
+    const input = [done("d1"), working("w1"), working("w2"), done("d2")];
+    expect(ids(sortSiblingsByActivity(input))).toEqual(["w1", "w2", "d1", "d2"]);
+  });
+
+  it("returns a new array and does not mutate its input", () => {
+    const input = [done("d"), working("w")];
+    const before = ids(input);
+    sortSiblingsByActivity(input);
+    expect(ids(input)).toEqual(before);
+  });
+
+  it("renders the top-level rows in priority order", () => {
+    mockChildTree({
+      conv_parent: [done("c_done"), awaiting("c_awaiting"), working("c_working")],
+    });
+    const { container } = renderPanel();
+    expect(renderedChildOrder(container)).toEqual(["c_awaiting", "c_working", "c_done"]);
+  });
+
+  it("sorts each sibling group independently, including grandchildren", () => {
+    mockChildTree({
+      conv_parent: [working("c_parent")],
+      c_parent: [done("g_done"), awaiting("g_awaiting")],
+    });
+    const { container } = renderPanel();
+    // Parent row first, then its grandchildren in priority order beneath it.
+    expect(renderedChildOrder(container)).toEqual(["c_parent", "g_awaiting", "g_done"]);
   });
 });

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -1531,22 +1531,40 @@ describe("SubagentsPanel sibling ordering (#1410)", () => {
   }
 
   it("ranks attention-needing and live agents above settled ones", () => {
-    // Supplied worst-first so an identity (no-op) sort would fail.
+    // Each id is named for its activity, supplied worst-first, so the
+    // expected array reads as the priority order and a no-op sort fails.
     const sorted = sortSiblingsByActivity([
-      failed("f"),
-      done("d"),
-      other("o"),
-      idle("i"),
-      launching("l"),
-      working("w"),
-      awaiting("a"),
+      failed("failed"),
+      done("done"),
+      other("other"),
+      idle("idle"),
+      launching("launching"),
+      working("working"),
+      awaiting("awaiting"),
     ]);
-    expect(ids(sorted)).toEqual(["a", "w", "l", "i", "o", "d", "f"]);
+    expect(ids(sorted)).toEqual([
+      "awaiting",
+      "working",
+      "launching",
+      "idle",
+      "other",
+      "done",
+      "failed",
+    ]);
   });
 
-  it("is stable: equal-status rows keep their original (creation) order", () => {
-    // Matters because every list re-polls on TREE_POLL_MS; a non-stable
-    // tiebreak would make same-status rows reshuffle on each refresh.
+  it("breaks ties by created_at, newest child first", () => {
+    // Two working rows supplied oldest-first; the newer one must lead.
+    const input = [
+      childInfo({ id: "w_old", busy: true, created_at: 100 }),
+      childInfo({ id: "w_new", busy: true, created_at: 200 }),
+    ];
+    expect(ids(sortSiblingsByActivity(input))).toEqual(["w_new", "w_old"]);
+  });
+
+  it("falls back to original order when created_at is absent (deterministic)", () => {
+    // With no created_at the tiebreak drops to the original index, so
+    // same-status rows never reshuffle across TREE_POLL_MS re-polls.
     const input = [done("d1"), working("w1"), working("w2"), done("d2")];
     expect(ids(sortSiblingsByActivity(input))).toEqual(["w1", "w2", "d1", "d2"]);
   });

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -242,16 +242,16 @@ const ACTIVITY_SORT_RANK: Record<AgentActivity, number> = {
 
 /**
  * Order a sibling list of child sessions so attention-needing and live
- * agents rise above settled (done/failed) ones, without disturbing the
- * relative order of equal-status rows.
+ * agents rise above settled (done/failed) ones.
  *
- * The sort is stable by original index: every list re-polls on
- * ``TREE_POLL_MS``, so a non-deterministic tiebreak would make
- * same-status rows visibly reshuffle on each refresh. Returns a new
- * array; the input is not mutated.
+ * Within one activity, ties break by ``created_at`` descending (newest
+ * child first), with the original index as a final fallback. Both keys
+ * are immutable, so the order is fully deterministic and never
+ * reshuffles on a ``TREE_POLL_MS`` re-poll. Returns a new array; the
+ * input is not mutated.
  *
  * @param children - One sibling group (the root's direct children, or
- *   any row's grandchildren) in the server's original order.
+ *   any row's grandchildren).
  * @returns A new, priority-ordered array of the same children.
  */
 export function sortSiblingsByActivity(children: ChildSessionInfo[]): ChildSessionInfo[] {
@@ -261,7 +261,12 @@ export function sortSiblingsByActivity(children: ChildSessionInfo[]): ChildSessi
       index,
       rank: ACTIVITY_SORT_RANK[childStatus(child).activity],
     }))
-    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .sort(
+      (a, b) =>
+        a.rank - b.rank ||
+        (b.child.created_at ?? 0) - (a.child.created_at ?? 0) ||
+        a.index - b.index,
+    )
     .map((entry) => entry.child);
 }
 

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -166,7 +166,7 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
       </button>
       <ul className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-1">
         <MainRow rootSessionId={rootSessionId} isActive={conversationId === rootSessionId} />
-        {children.map((child) => (
+        {sortSiblingsByActivity(children).map((child) => (
           <SubagentRow
             key={child.id}
             child={child}
@@ -217,6 +217,52 @@ function ViewModeToggle({
       </Button>
     </div>
   );
+}
+
+// Ordering priority for sibling agents in the rail; lower sorts first.
+// The rail's job is to surface what needs the user *now*, so agents
+// parked on a prompt ("awaiting") lead, then live work
+// ("working"/"launching"), then quiet ("idle"/"other"), with settled
+// rows ("done"/"failed") sinking to the bottom — otherwise active
+// agents get buried among finished ones (#1410). The done-vs-failed
+// order is deliberate but minor; flip if failures should read louder.
+// ``disconnected`` sorts with the settled rows: the runner is gone, so
+// the row is as inert as a finished one, but it is not a genuine
+// failure — it sits just above ``failed``.
+const ACTIVITY_SORT_RANK: Record<AgentActivity, number> = {
+  awaiting: 0,
+  working: 1,
+  launching: 2,
+  idle: 3,
+  other: 4,
+  done: 5,
+  disconnected: 6,
+  failed: 7,
+};
+
+/**
+ * Order a sibling list of child sessions so attention-needing and live
+ * agents rise above settled (done/failed) ones, without disturbing the
+ * relative order of equal-status rows.
+ *
+ * The sort is stable by original index: every list re-polls on
+ * ``TREE_POLL_MS``, so a non-deterministic tiebreak would make
+ * same-status rows visibly reshuffle on each refresh. Returns a new
+ * array; the input is not mutated.
+ *
+ * @param children - One sibling group (the root's direct children, or
+ *   any row's grandchildren) in the server's original order.
+ * @returns A new, priority-ordered array of the same children.
+ */
+export function sortSiblingsByActivity(children: ChildSessionInfo[]): ChildSessionInfo[] {
+  return children
+    .map((child, index) => ({
+      child,
+      index,
+      rank: ACTIVITY_SORT_RANK[childStatus(child).activity],
+    }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map((entry) => entry.child);
 }
 
 // Quiet states show only an indicator — the word lives in the tooltip — so the
@@ -675,7 +721,7 @@ function SubagentRow({
         </Link>
       </li>
       {!collapsed &&
-        grandchildren.map((grandchild) => (
+        sortSiblingsByActivity(grandchildren).map((grandchild) => (
           <SubagentRow
             key={grandchild.id}
             child={grandchild}


### PR DESCRIPTION
## Related issue

Closes #1410

## Summary

The Subagents rail (`web/src/shell/SubagentsPanel.tsx`) rendered child rows in the server's `created_at desc` order with no activity ordering, so an agent that was actively working or awaiting the user got buried among finished/failed siblings.

- Add `sortSiblingsByActivity()`: orders a sibling group by activity priority — **awaiting › working › launching › idle › other › done › failed** — so attention-needing and live agents rise and settled rows sink.
- **Stable** by comparing created_at, so equal-status rows keep their order and don't reshuffle on each `TREE_POLL_MS` poll.
- Applied at both render sites so every tree level is ordered: the top-level children map and the grandchildren map in `SubagentRow`.

Reuses the existing `childStatus()` activity mapping — no API or server change.

## Test Plan

- `npm test -- src/shell/SubagentsPanel.test.tsx` — added a `sibling ordering (#1410)` suite (full rank order, stable tiebreak, no-mutation, top-level DOM order, grandchild ordering) and updated one existing row-order test to the new sorted order. **59 passed.**
- `npm run lint` (oxlint) and `prettier --check` clean.
- `npm run build` (`tsc -b` + vite) clean.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [X] E2E tests added / updated
- [X] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

<img width="2078" height="1488" alt="image" src="https://github.com/user-attachments/assets/e7d74aab-976f-41d2-afb0-0b0d1ea657a7" />


## Coverage notes

Unit tests cover all seven activities deterministically, including `other` and `idle`, which aren't reachable from the live server status map.

Opening as a **draft** pending maintainer input on two choices I'm leaning towards (also raised on #1410): keeping the stable `created_at` tiebreak within an activity to avoid rail jitter (`updated_at` is on `ChildSessionSummary` if most-recently-active-first is preferred), and `done` above `failed` at the bottom. On `E2E UI Required`: a deterministic `e2e_ui` test that seeds children over REST is feasible but flaked on runner readiness (`503`) — happy to land it as a follow-up, or take a waiver if the unit coverage suffices here.