### PR TITLE
[codex] pass hermes skills filter through

### DIFF
--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -295,6 +295,7 @@ def _build_hermes_args(
     *,
     model: str | None = None,
     session_id: str | None = None,
+    skills_filter: str | list[str] | None = None,
 ) -> list[str]:
     """
     Build the argument list for a Hermes subprocess call.
@@ -303,6 +304,7 @@ def _build_hermes_args(
     :param message: The user message text.
     :param model: Optional model override (``-m`` flag).
     :param session_id: Optional session ID to resume (``--resume``).
+    :param skills_filter: Optional skill filter forwarded to Hermes.
     :returns: A list of CLI arguments.
     """
     args = [
@@ -316,6 +318,10 @@ def _build_hermes_args(
     ]
     if model:
         args.extend(["-m", model])
+    if skills_filter == "none":
+        args.append("--ignore-rules")
+    elif isinstance(skills_filter, list) and skills_filter:
+        args.extend(["-s", ",".join(skills_filter)])
     if session_id:
         args.extend(["--resume", session_id])
     return args
@@ -470,6 +476,7 @@ class HermesExecutor(Executor):
             message=user_text,
             model=model,
             session_id=hermes_sid,
+            skills_filter=self._skills_filter,
         )
 
         # Build subprocess env with per-session HERMES_HOME for policy hooks.

--- a/omnigent/inner/hermes_harness.py
+++ b/omnigent/inner/hermes_harness.py
@@ -32,9 +32,7 @@ Env vars read at startup:
   ``str | list[str]`` carrying ``spec.skills_filter``. When
   unset, falls back to ``"all"``.
 - ``HARNESS_HERMES_BUNDLE_DIR``: Absolute path to the agent
-  bundle's extracted root. When set, the executor sources
-  bundled skills from ``<bundle>/skills/<name>/``. Unset for
-  agents without a bundled-skill directory.
+  bundle's extracted root. Reserved for future skill wiring.
 - ``HARNESS_HERMES_AGENT_NAME``: Agent display name. Reserved for
   future use; currently unused by Hermes.
 """

--- a/tests/inner/test_hermes_executor.py
+++ b/tests/inner/test_hermes_executor.py
@@ -120,6 +120,20 @@ class TestUtils:
         idx = args.index("--resume")
         assert args[idx + 1] == "20260620_abc123"
 
+    def test_build_hermes_args_with_skills_filter_list(self) -> None:
+        args = _build_hermes_args(
+            "hermes",
+            "Hi",
+            skills_filter=["skill-a", "skill-b"],
+        )
+        assert "-s" in args
+        idx = args.index("-s")
+        assert args[idx + 1] == "skill-a,skill-b"
+
+    def test_build_hermes_args_with_skills_filter_none(self) -> None:
+        args = _build_hermes_args("hermes", "Hi", skills_filter="none")
+        assert "--ignore-rules" in args
+
 
 # ---------------------------------------------------------------------------
 # HERMES_HOME population tests


### PR DESCRIPTION
## What changed
- Threaded `skills_filter` through Hermes CLI argument construction.
- Added handling for `skills_filter="none"` via `--ignore-rules`.
- Updated the Hermes harness docstring so `bundle_dir` and `agent_name` are clearly documented as reserved.
- Added unit tests for Hermes argument construction with both named skills and `none`.

## Why
The Hermes harness accepted `skills_filter` but dropped it before spawning the CLI, so configured skills were silently ignored. This made the harness configuration misleading and prevented skill-preload behavior from working as expected.

## Validation
- `uv run pytest -q tests/inner/test_hermes_executor.py`
- `uv run pytest -q tests/inner/test_hermes_harness.py`
