### PR TITLE
Revert "feat(ap-web): support shift-click range selection in multi-session mode"

### DIFF
--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -225,28 +225,11 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  const lastSelectedIdRef = useRef<string | null>(null);
-  const visibleIdsRef = useRef<string[]>([]);
-
-  const toggleSelected = useCallback((id: string, shiftKey?: boolean) => {
+  const toggleSelected = useCallback((id: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (shiftKey && lastSelectedIdRef.current != null) {
-        const ids = visibleIdsRef.current;
-        const anchorIdx = ids.indexOf(lastSelectedIdRef.current);
-        const currentIdx = ids.indexOf(id);
-        if (anchorIdx !== -1 && currentIdx !== -1) {
-          const [start, end] =
-            anchorIdx < currentIdx ? [anchorIdx, currentIdx] : [currentIdx, anchorIdx];
-          for (let i = start; i <= end; i++) {
-            next.add(ids[i]);
-          }
-          return next;
-        }
-      }
       if (next.has(id)) next.delete(id);
       else next.add(id);
-      lastSelectedIdRef.current = id;
       return next;
     });
   }, []);
@@ -262,7 +245,6 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   const exitSelectionMode = useCallback(() => {
     setSelectionMode(false);
     setSelectedIds(new Set());
-    lastSelectedIdRef.current = null;
   }, []);
 
   // Debounce search input so we don't fire a server request on every
@@ -562,7 +544,6 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
               selectionMode={selectionMode}
               selectedIds={selectedIds}
               onToggleSelected={toggleSelected}
-              visibleIdsRef={visibleIdsRef}
             />
           </nav>
 
@@ -692,7 +673,6 @@ function ProjectFolder({
   selectedIds,
   onToggleSelected,
   onProjectAssigned,
-  projectRenderedIdsRef,
 }: {
   name: string;
   expanded: boolean;
@@ -705,9 +685,8 @@ function ProjectFolder({
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   selectedIds: Set<string>;
-  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
+  onToggleSelected: (conversationId: string) => void;
   onProjectAssigned?: (projectName: string) => void;
-  projectRenderedIdsRef?: RefObject<Map<string, string[]>>;
 }) {
   const query = useProjectSessions(name, expanded);
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
@@ -719,15 +698,6 @@ function ProjectFolder({
       activeOverride,
     );
   }, [query.data, pinnedSet, activeOverride]);
-
-  useEffect(() => {
-    if (!projectRenderedIdsRef) return;
-    const ids = expanded ? conversations.map((c) => c.id) : [];
-    projectRenderedIdsRef.current.set(name, ids);
-    return () => {
-      projectRenderedIdsRef.current.delete(name);
-    };
-  }, [projectRenderedIdsRef, name, expanded, conversations]);
 
   // While the first page loads, show a "Loading…" footer instead of the "No
   // chats" empty state (which would otherwise flash before rows arrive).
@@ -804,8 +774,7 @@ interface ConversationListProps {
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   selectedIds: Set<string>;
-  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
-  visibleIdsRef: RefObject<string[]>;
+  onToggleSelected: (conversationId: string) => void;
 }
 
 // permission_level null (no ACL row / legacy) or >= 4 both mean owner.
@@ -824,7 +793,6 @@ function ConversationList({
   selectionMode,
   selectedIds,
   onToggleSelected,
-  visibleIdsRef,
 }: ConversationListProps) {
   // All loaded conversations from the single paginated list (for pinned
   // backfill, normalization, and the flat session list).
@@ -835,10 +803,6 @@ function ConversationList({
 
   // Project names for grouping sessions by their reserved project label.
   const { data: projectNames = [] } = useProjects();
-
-  // Each ProjectFolder registers its actually-rendered conversation IDs here
-  // so shift-select ranges use the real rendered order, not the global list.
-  const projectRenderedIdsRef = useRef<Map<string, string[]>>(new Map());
 
   // Backfill pinned sessions that aren't in the loaded set.
   const loadedIds = useMemo(() => new Set(allConversations.map((c) => c.id)), [allConversations]);
@@ -1146,21 +1110,6 @@ function ConversationList({
       ...visible("Shared with me", sections.shared),
     ].map((c) => c.id);
   }, [sections, effectiveCollapsedSections, expandedProjects]);
-
-  // Build shift-select visible order from actual rendered data: project folders
-  // report their own IDs (from useProjectSessions), so the range is correct even
-  // when the per-project query diverges from the global paginated list.
-  const visible = (title: string, list: readonly Conversation[]) =>
-    effectiveCollapsedSections.includes(title) ? [] : list.map((c) => c.id);
-  const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
-  visibleIdsRef.current = [
-    ...visible("Pinned", sections.pinned),
-    ...(projectsCollapsed
-      ? []
-      : sections.projectGroups.flatMap((g) => projectRenderedIdsRef.current.get(g.name) ?? [])),
-    ...visible("Chats", sections.sessions),
-    ...visible("Shared with me", sections.shared),
-  ];
   useSessionSwitchHotkey(orderedConversationIds, activeId);
 
   // Cmd/Ctrl+1..9/0 jumps to the first ten pinned sessions (desktop only;
@@ -1345,7 +1294,6 @@ function ConversationList({
                     selectedIds={selectedIds}
                     onToggleSelected={onToggleSelected}
                     onProjectAssigned={expandProject}
-                    projectRenderedIdsRef={projectRenderedIdsRef}
                   />
                 ))}
               </SectionGroup>
@@ -1700,7 +1648,7 @@ function ConversationSection({
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   selectedIds: Set<string>;
-  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
+  onToggleSelected: (conversationId: string) => void;
   /** Placeholder shown when expanded with no rows (e.g. an empty project). */
   emptyMessage?: string;
   /** Indent the rows one extra step (used to nest a project's chats). */
@@ -2087,7 +2035,7 @@ function ConversationRow({
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   isSelected: boolean;
-  onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
+  onToggleSelected: (conversationId: string) => void;
   onProjectAssigned?: (projectName: string) => void;
 }) {
   // `useParams` reads from the active matched route. On `/`, the param is
@@ -2377,7 +2325,7 @@ function ConversationRow({
         if (selectionMode) {
           e.preventDefault();
           e.stopPropagation();
-          onToggleSelected(conversation.id, e.shiftKey);
+          onToggleSelected(conversation.id);
           return;
         }
         onClick(e);


### PR DESCRIPTION
Reverts omnigent-ai/omnigent#1534

@terrytangyuan Reverting this PR since I find it doesn't work with projects still. I shift select sessions in chats but it deletes all my sessions in the projects (probably it deletes all the sessions in the range somehow). Could you fix it and add tests?