### PR TITLE
fix(harnesses): write AP_PID sentinel with exclusive create

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -615,9 +615,18 @@ class HarnessProcessManager:
         # Write the AP_PID sentinel so other instances' sweeps can
         # tell our dir is live. Strict ``"x"`` because the dir is
         # exclusively ours; a pre-existing sentinel would mean the
-        # uuid collided with a still-running instance — fail loud.
+        # uuid collided with a still-running instance — fail loud
+        # rather than silently clobber its AP_PID (which would break
+        # that instance's orphan sweep).
         sentinel = self._instance_dir / _AP_PID_FILE
-        sentinel.write_text(str(os.getpid()), encoding="utf-8")
+        try:
+            with open(sentinel, "x", encoding="utf-8") as fh:
+                fh.write(str(os.getpid()))
+        except FileExistsError as exc:
+            raise RuntimeError(
+                f"AP_PID sentinel already exists at {sentinel}: instance-dir "
+                "uuid collided with a still-running Omnigent instance"
+            ) from exc
         self._reaper_task = asyncio.create_task(
             self._idle_reaper_loop(),
             name="harness-process-manager-idle-reaper",

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -157,6 +157,33 @@ async def test_start_creates_instance_dir_with_sentinel(
         await manager.shutdown()
 
 
+async def test_start_fails_loud_on_sentinel_collision(
+    manager: HarnessProcessManager,
+) -> None:
+    """A pre-existing AP_PID sentinel makes start() fail loud, not clobber it.
+
+    The instance dir is uuid-named, so a sentinel already present at boot means
+    the uuid collided with a still-running instance. The docstring promises
+    strict ``"x"`` semantics ("fail loud") precisely so we don't silently
+    overwrite the live sibling's AP_PID — which records *our* pid over theirs
+    and breaks their orphan sweep (a later boot would misread the dir's owner).
+
+    Pre-seed the sentinel with a live pid (``os.getppid()`` — alive, so the
+    orphan sweep treats the dir as live and leaves it; distinct from this
+    process's pid so a clobber is detectable) and assert start() raises rather
+    than overwriting it.
+    """
+    live_pid = os.getppid()
+    manager.instance_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    sentinel = manager.instance_dir / _AP_PID_FILE
+    sentinel.write_text(str(live_pid), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="sentinel"):
+        await manager.start()
+    # The live sibling's sentinel must be untouched — not clobbered with our pid.
+    assert sentinel.read_text(encoding="utf-8").strip() == str(live_pid)
+
+
 async def test_start_is_idempotent(manager: HarnessProcessManager) -> None:
     """A second start() is a no-op; doesn't recreate / relaunch.
 


### PR DESCRIPTION
## Related issue

N/A — small correctness fix (comment/implementation mismatch in
`HarnessProcessManager.start()`); no separate issue.

## Summary

- `start()` documents the AP_PID sentinel write as strict `"x"` — *"a
  pre-existing sentinel would mean the uuid collided with a still-running
  instance — fail loud"* — but used `Path.write_text`, which truncates.
- On a uuid collision with a **live** instance it would therefore silently
  overwrite that instance's `AP_PID` with our pid, corrupting the sibling's
  orphan-sweep identity (a later boot would misread the dir's owner) instead
  of failing loud.
- Write the sentinel with `open(..., "x")` and raise `RuntimeError` on
  `FileExistsError`, so the code matches the documented contract. `start()` is
  idempotent via the `self._started` early-return, so the sentinel is written
  exactly once per instance and exclusive mode can't false-trip a re-entrant
  `start()`.

## Test Plan

`uv run pytest tests/runtime/harnesses/test_process_manager.py` → **29 passed**.

Added `test_start_fails_loud_on_sentinel_collision`: pre-seeds the sentinel
with a live pid (so the orphan sweep treats the dir as live and leaves it) and
asserts `start()` raises instead of overwriting. **Fails before** the change
(`DID NOT RAISE RuntimeError`), **passes after**. `test_start_is_idempotent`
still passes (re-entrant `start()` unaffected). `ruff check` /
`ruff format --check` clean.

## Demo

N/A — non-visual.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the added unit test.
