### PR TITLE
feat(web): use a grey spinner for the running session indicator

### DIFF
--- a/web/src/components/RunningDot.tsx
+++ b/web/src/components/RunningDot.tsx
@@ -1,10 +1,12 @@
+import { Loader2Icon } from "lucide-react";
+
 export function RunningDot() {
   return (
-    <span
+    <Loader2Icon
       aria-hidden
       role="presentation"
       data-testid="running-dot"
-      className="running-pulse-dot size-2 shrink-0 rounded-full bg-brand-accent"
+      className="size-3 shrink-0 animate-spin text-muted-foreground"
     />
   );
 }

--- a/web/src/components/SessionStateBadge.test.tsx
+++ b/web/src/components/SessionStateBadge.test.tsx
@@ -33,16 +33,16 @@ describe("SessionStateBadge — per-state rendering", () => {
     );
   });
 
-  it("renders running with a pulsing brand-pink dot", () => {
+  it("renders running with a spinning grey spinner", () => {
     const { container } = renderBadge({ kind: "running" });
     const badge = screen.getByTestId("session-state-badge");
     expect(badge).toHaveAttribute("data-state", "running");
-    // The running indicator is a single pulsing brand-pink dot; a missing dot
+    // The running indicator is a grey spinner; a missing spinner
     // (or the old success-tone dot grid) means it regressed.
-    const dot = container.querySelector('[data-testid="running-dot"]');
-    expect(dot).not.toBeNull();
-    expect(dot?.getAttribute("class")).toContain("running-pulse-dot");
-    expect(dot?.getAttribute("class")).toContain("bg-brand-accent");
+    const spinner = container.querySelector('[data-testid="running-dot"]');
+    expect(spinner).not.toBeNull();
+    expect(spinner?.getAttribute("class")).toContain("animate-spin");
+    expect(spinner?.getAttribute("class")).toContain("text-muted-foreground");
     expect(container.querySelector(".bg-success")).toBeNull();
   });
 

--- a/web/src/components/SessionStateBadge.tsx
+++ b/web/src/components/SessionStateBadge.tsx
@@ -41,8 +41,8 @@ function describe(state: SessionState): Visual {
         render: () => <RunningDot />,
       };
     case "unseen":
-      // Solid (non-pulsing) brand-pink dot — distinguished from the running
-      // indicator, which is the same pink but pulsing.
+      // Solid brand-pink dot — distinguished from the running indicator,
+      // which is a grey spinner.
       return {
         kind: state.kind,
         ariaLabel: "New messages",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -818,32 +818,6 @@
   }
 }
 
-/* "Running / working" status indicator — a single brand-pink dot that fades
- * between faint and full opacity. Subtle yet noticeable, and cheaper than a
- * spinner. Shared by the sidebar SessionStateBadge and the SubagentsPanel. */
-@keyframes running-pulse {
-  0%,
-  100% {
-    opacity: 0.35;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-
-.running-pulse-dot {
-  animation: running-pulse 1.4s ease-in-out infinite;
-}
-
-/* Reduced-motion: hold the dot at a steady mid-opacity so the state is still
- * legible without motion. */
-@media (prefers-reduced-motion: reduce) {
-  .running-pulse-dot {
-    animation: none;
-    opacity: 0.8;
-  }
-}
-
 /* ── Intelligent model router — composer sparkle toggle ──────────────────
  * (components/CostRoutingControl.tsx.) Two stacked sparkle layers cross-fade
  * with a slight spring as the toggle flips; a soft monochrome halo backs the

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -850,11 +850,13 @@ describe("SubagentsPanel", () => {
 
     const { container } = renderPanel();
 
-    // Working reuses the sidebar RunningDot in the brand-pink tone —
+    // Working reuses the sidebar RunningDot in the grey tone —
     // identical to the sidebar's running indicator; a wrong tone drops
-    // bg-brand-accent.
+    // text-muted-foreground.
     expect(
-      childRow(container, "c_work").querySelector('[data-testid="running-dot"].bg-brand-accent'),
+      childRow(container, "c_work").querySelector(
+        '[data-testid="running-dot"].text-muted-foreground',
+      ),
     ).not.toBeNull();
     // Terminal states use design tokens, not raw 500-weight Tailwind. "done"
     // is a quiet, expected outcome, so it reads as a muted dot (not green);

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -323,7 +323,7 @@ function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
 
 /**
  * Indicator + optional label shared by the main and child rows. The working
- * state reuses the sidebar's RunningDot in the same brand-pink tone, so
+ * state reuses the sidebar's RunningDot in the same grey tone, so
  * "active" reads identically across the app; other states are a single
  * tokenized dot.
  *


### PR DESCRIPTION
## What

Replaces the pulsing brand-pink dot used as the "running / working" session indicator with a grey spinning loader (`Loader2Icon`).

- `RunningDot.tsx` — swap the custom pulsing `<span>` dot for a spinning `Loader2Icon` (`animate-spin text-muted-foreground`)
- `SessionStateBadge.tsx` — the sidebar running badge picks up the spinner; comment for the `unseen` state updated to reflect the new distinction (solid pink dot vs. grey spinner)
- `SubagentsPanel.tsx` — the subagent "working" row reuses the same spinner so active state reads identically across the app
- `index.css` — remove the now-unused `running-pulse` keyframes, `.running-pulse-dot` class, and its reduced-motion override
- Tests updated accordingly (`SessionStateBadge.test.tsx`, `SubagentsPanel.test.tsx`)

## Why

A grey spinner reads more clearly as "in progress" than a same-color pulsing dot, and keeps the running state visually distinct from the solid brand-pink `unseen` (new messages) indicator.