### PR TITLE
fix(cost): make request-phase (UserPromptSubmit) fail closed on eval error

### DIFF
--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -61,6 +61,10 @@ _EVAL_UNAVAILABLE_REASON = (
     "Omnigent policy evaluation unavailable (could not reach or authenticate to the "
     "Omnigent server); failing closed for this tool call."
 )
+_EVAL_UNAVAILABLE_REQUEST_REASON = (
+    "Omnigent policy evaluation unavailable (could not reach or authenticate to the "
+    "Omnigent server); failing closed for this request."
+)
 
 
 # Env var carrying the one-shot auth + workspace-routing headers from the
@@ -398,15 +402,18 @@ def fail_closed_hook_output(hook_event: str) -> dict[str, object] | None:
     - ``PreToolUse`` (``PHASE_TOOL_CALL``) fails CLOSED → ``deny``. This is
       the authoritative pre-execution gate; an unevaluable policy must not
       let the call through.
-    - ``UserPromptSubmit`` (``PHASE_REQUEST``) and ``PostToolUse``
-      (``PHASE_TOOL_RESULT``) fail OPEN → ``None``. The request gate is
-      advisory (the tool-call gate still catches dangerous actions) and by
-      the result phase the tool has already executed, so denying would only
-      block an already-incurred side effect.
+    - ``UserPromptSubmit`` (``PHASE_REQUEST``) fails CLOSED →
+      ``{"decision": "block", ...}``. This is the sole pre-turn enforcement
+      point for native sessions; a server hiccup must not let an over-budget
+      or otherwise-blocked request proceed.
+    - ``PostToolUse`` (``PHASE_TOOL_RESULT``) fails OPEN → ``None``. By the
+      result phase the tool has already executed, so denying would only block
+      an already-incurred side effect.
 
     :param hook_event: Hook event name, e.g. ``"PreToolUse"``.
     :returns: A ``permissionDecision: "deny"`` hook output for
-        ``PreToolUse``; ``None`` for every other event (fail open).
+        ``PreToolUse``; a ``decision: "block"`` output for
+        ``UserPromptSubmit``; ``None`` for every other event (fail open).
     """
     if hook_event == _PRE_TOOL_USE:
         return {
@@ -415,6 +422,11 @@ def fail_closed_hook_output(hook_event: str) -> dict[str, object] | None:
                 "permissionDecision": "deny",
                 "permissionDecisionReason": _EVAL_UNAVAILABLE_REASON,
             },
+        }
+    if hook_event == _USER_PROMPT_SUBMIT:
+        return {
+            "decision": "block",
+            "reason": _EVAL_UNAVAILABLE_REQUEST_REASON,
         }
     return None
 

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -41,18 +41,24 @@ if TYPE_CHECKING:
 # cross the harness↔runner boundary) for which an unavailable policy
 # evaluation must fail CLOSED (default ``POLICY_ACTION_DENY``).
 #
-# Only ``PHASE_TOOL_CALL`` qualifies: for connector-native MCP tools the
-# in-band verdict is the only enforcement point — the call is never
-# re-checked server-side — so an unevaluable policy must not let the call
-# through. ``PHASE_TOOL_RESULT`` is intentionally NOT here: by the time the
-# result phase runs the tool has already executed, so failing it closed
-# would only block an already-incurred side effect; it fails OPEN like the
-# advisory LLM phases.
+# ``PHASE_TOOL_CALL``: for connector-native MCP tools the in-band verdict is
+# the only enforcement point — the call is never re-checked server-side — so
+# an unevaluable policy must not let the call through.
 #
-# Defined once here so the two enforcement sites
+# ``PHASE_REQUEST``: the request gate runs before the LLM turn and is the
+# sole pre-turn enforcement point for native sessions (UserPromptSubmit). A
+# server hiccup must not let an over-budget or otherwise-blocked request
+# proceed, so this phase also fails CLOSED.
+#
+# ``PHASE_TOOL_RESULT`` is intentionally NOT here: by the time the result
+# phase runs the tool has already executed, so failing it closed would only
+# block an already-incurred side effect; it fails OPEN like the advisory LLM
+# phases.
+#
+# Defined once here so the enforcement sites
 # (``omnigent.runner.app`` and ``omnigent.runtime.harnesses._scaffold``)
 # can't drift if the set of fail-closed phases changes.
-FAIL_CLOSED_PHASES: tuple[str, ...] = ("PHASE_TOOL_CALL",)
+FAIL_CLOSED_PHASES: tuple[str, ...] = ("PHASE_TOOL_CALL", "PHASE_REQUEST")
 
 
 @dataclass(frozen=True)

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1756,30 +1756,17 @@ def test_evaluate_policy_pre_tool_use_fails_closed_when_verdict_unavailable(
     assert result["hookSpecificOutput"]["permissionDecisionReason"]
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        {
-            "hook_event_name": "PostToolUse",
-            "tool_name": "Bash",
-            "tool_input": {"command": "ls"},
-            "tool_output": "ok",
-        },
-        {"hook_event_name": "UserPromptSubmit", "prompt": "hello"},
-    ],
-)
-def test_evaluate_policy_non_tool_call_phases_fail_open_on_error(
+def test_evaluate_policy_user_prompt_submit_fails_closed_on_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    payload: dict[str, object],
 ) -> None:
     """
-    Off the tool-call gate, an unobtainable verdict stays fail-open.
+    A governed UserPromptSubmit blocks when no usable verdict is returned.
 
-    PostToolUse runs after the tool executed and the request gate is
-    advisory, so neither denies on a transport error — mirroring the
-    runner-side ``FAIL_CLOSED_PHASES`` (PR #163).
+    The request gate is the sole pre-turn enforcement point for native
+    sessions — a server outage must not let an over-budget or otherwise-
+    blocked request proceed. The output must be ``decision: "block"``.
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
@@ -1788,6 +1775,44 @@ def test_evaluate_policy_non_tool_call_phases_fail_open_on_error(
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_active")
     build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hello"})),
+    )
+
+    exit_code = claude_native_hook.main(["evaluate-policy", "--bridge-dir", str(bridge_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    result = json.loads(captured.out)
+    assert result["decision"] == "block"
+    assert result["reason"]
+
+
+def test_evaluate_policy_post_tool_use_fails_open_on_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    PostToolUse fails OPEN on a transport error — the tool already ran.
+
+    Mirroring the runner-side ``FAIL_CLOSED_PHASES``.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", make_failing_client("connect_error"))
+    monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
+    bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
+    write_active_session_id(bridge_dir, "conv_active")
+    build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+        "tool_output": "ok",
+    }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
 
     exit_code = claude_native_hook.main(["evaluate-policy", "--bridge-dir", str(bridge_dir)])

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -428,34 +428,50 @@ def test_pre_tool_use_fails_closed_when_verdict_unavailable(
     assert result["hookSpecificOutput"]["permissionDecisionReason"]
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        {
-            "hook_event_name": "PostToolUse",
-            "tool_name": "Bash",
-            "tool_input": {"command": "ls"},
-            "tool_output": "ok",
-        },
-        {"hook_event_name": "UserPromptSubmit", "prompt": "hello"},
-    ],
-)
-def test_non_tool_call_phases_fail_open_on_error(
+def test_user_prompt_submit_fails_closed_on_error(
     bridge_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    payload: dict[str, object],
 ) -> None:
     """
-    Off the tool-call gate, an unobtainable verdict stays fail-open.
+    A governed UserPromptSubmit blocks when no usable verdict is returned.
 
-    PostToolUse runs after the tool executed and the request gate is
-    advisory, so neither denies on a transport error — mirroring the
-    runner-side ``FAIL_CLOSED_PHASES`` (PR #163).
+    The request gate is the sole pre-turn enforcement point for native
+    sessions — a server outage must not let a blocked request proceed.
     """
     write_policy_hook_config(bridge_dir, ap_server_url="http://127.0.0.1:8787", ap_auth_headers={})
     monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
     monkeypatch.setattr(native_policy_hook.httpx, "Client", make_failing_client("connect_error"))
+
+    payload: dict[str, object] = {"hook_event_name": "UserPromptSubmit", "prompt": "hello"}
+    exit_code = _run_hook(bridge_dir, payload, monkeypatch)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    result = json.loads(captured.out)
+    assert result["decision"] == "block"
+    assert result["reason"]
+
+
+def test_post_tool_use_fails_open_on_error(
+    bridge_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    PostToolUse fails OPEN on a transport error — the tool already ran.
+
+    Mirroring the runner-side ``FAIL_CLOSED_PHASES``.
+    """
+    write_policy_hook_config(bridge_dir, ap_server_url="http://127.0.0.1:8787", ap_auth_headers={})
+    monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", make_failing_client("connect_error"))
+    payload: dict[str, object] = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+        "tool_output": "ok",
+    }
 
     exit_code = _run_hook(bridge_dir, payload, monkeypatch)
 

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -336,17 +336,31 @@ def test_fail_closed_pre_tool_use_denies() -> None:
     assert hook_specific["permissionDecisionReason"]
 
 
-@pytest.mark.parametrize("hook_event", ["UserPromptSubmit", "PostToolUse"])
-def test_fail_closed_non_tool_call_phases_fail_open(hook_event: str) -> None:
+def test_fail_closed_user_prompt_submit_fails_closed() -> None:
     """
-    Off the tool-call gate, an unobtainable verdict fails OPEN (``None``).
+    ``UserPromptSubmit`` (``PHASE_REQUEST``) fails CLOSED on an unobtainable verdict.
 
-    The request gate is advisory (the tool-call gate still catches
-    dangerous actions) and PostToolUse runs after the tool has executed, so
-    denying there only blocks an already-incurred side effect. This mirrors
-    the runner-side ``FAIL_CLOSED_PHASES`` (PR #163).
+    The request gate is the sole pre-turn enforcement point for native
+    sessions — a server hiccup must not let an over-budget or otherwise-
+    blocked request proceed. The output must be a top-level
+    ``decision: "block"`` with a non-empty reason (both Claude Code and
+    Codex drop a block with an empty reason).
     """
-    assert fail_closed_hook_output(hook_event) is None
+    output = fail_closed_hook_output("UserPromptSubmit")
+    assert output is not None
+    assert output["decision"] == "block"
+    assert output["reason"]
+
+
+def test_fail_closed_post_tool_use_fails_open() -> None:
+    """
+    ``PostToolUse`` (``PHASE_TOOL_RESULT``) fails OPEN (``None``).
+
+    The tool has already executed by this point, so denying would only
+    block an already-incurred side effect. Mirrors the runner-side
+    ``FAIL_CLOSED_PHASES``.
+    """
+    assert fail_closed_hook_output("PostToolUse") is None
 
 
 def test_fail_closed_unknown_event_fails_open() -> None:


### PR DESCRIPTION
## Summary

- Fixes issue from the cost-budget audit: *"Native request-phase hooks fail OPEN on evaluation error — a server hiccup lets an over-budget session keep going."*
- `FAIL_CLOSED_PHASES` previously only included `PHASE_TOOL_CALL`. A transport error on the `UserPromptSubmit` (pre-turn) gate silently let the request through.
- `PHASE_REQUEST` is now in `FAIL_CLOSED_PHASES`, and `fail_closed_hook_output` emits `{"decision": "block", ...}` for `UserPromptSubmit` — mirroring the existing `PreToolUse → deny` behaviour.
- `PostToolUse` (`PHASE_TOOL_RESULT`) still fails open — the tool has already executed by that point.

## Changes

- `omnigent/policies/types.py`: add `"PHASE_REQUEST"` to `FAIL_CLOSED_PHASES` (fixes runner-side enforcement in `runner/app.py`, `runtime/harnesses/_scaffold.py`, `runtime/harnesses/_executor_adapter.py`)
- `omnigent/native_policy_hook.py`: add `_EVAL_UNAVAILABLE_REQUEST_REASON`; `fail_closed_hook_output` now returns `{"decision": "block", "reason": ...}` for `UserPromptSubmit`
- `tests/test_native_policy_hook.py`: split old `test_fail_closed_non_tool_call_phases_fail_open` into separate tests for `UserPromptSubmit` (now asserts block) and `PostToolUse` (still asserts open)
- `tests/test_claude_native_hook.py` / `tests/test_codex_native_hook.py`: same split — new test asserts `decision: "block"` for `UserPromptSubmit` on transport error