### PR TITLE
feat(web): preserve new-session draft across navigation

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -18,6 +18,7 @@ import {
   normalizeWorkspacePath,
   sessionsSharingDirectory,
   NewChatLandingScreen,
+  resetLandingDraft,
 } from "./NewChatDialog";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 import type { ServerInfo } from "@/lib/capabilities";
@@ -548,6 +549,7 @@ function setupLandingMocks() {
   useDirectorySessionsMock.mockReset();
   useRunnerHealthMock.mockReset();
   setOmnigentHostConfig({});
+  resetLandingDraft();
   localStorage.clear();
   // host_1's most-recent workspace seeds the field (so submit can enable
   // without manual picks). Tests that exercise the home fallback clear this.
@@ -646,6 +648,29 @@ describe("NewChatLandingScreen", () => {
     // the placeholder, the composer input would be absent and this fails.
     expect(screen.getByText("What should we do?")).toBeTruthy();
     expect(screen.getByTestId("new-chat-landing-input")).toBeTruthy();
+  });
+
+  it("preserves the typed message and attachments when the landing screen unmounts and remounts", () => {
+    // Navigating into an existing session and back unmounts the landing
+    // screen; the draft is stashed at module scope so the half-composed
+    // message and its attachments survive the round-trip instead of being
+    // discarded.
+    const first = renderLanding();
+    const box = screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement;
+    fireEvent.change(box, { target: { value: "half-typed thought" } });
+    const file = new File(["data"], "diagram.png", { type: "image/png" });
+    fireEvent.change(screen.getByTestId("new-chat-landing-file-input"), {
+      target: { files: [file] },
+    });
+    expect(screen.getByText("diagram.png")).toBeTruthy();
+    first.unmount();
+
+    renderLanding();
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "half-typed thought",
+    );
+    // The attachment chip re-renders from the restored draft.
+    expect(screen.getByText("diagram.png")).toBeTruthy();
   });
 
   it("enables submit only once a message, host, agent and valid workspace are set", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1630,6 +1630,40 @@ function AgentHarnessPicker({
   );
 }
 
+// In-memory draft for the new-session landing screen, so a half-composed
+// message, attachments and picker selections survive the unmount that happens
+// when the user navigates into an existing session and back. Module-scoped,
+// not persisted to storage (a page refresh starts clean); cleared on create.
+type LandingDraft = {
+  message: string;
+  files: File[];
+  pickedAgentId: string | null;
+  selectedHostId: string | null;
+  sandboxSelected: boolean;
+  sandboxRepoUrl: string;
+  sandboxRepoBranch: string;
+  workspace: string;
+  branchName: string;
+  baseBranch: string;
+  permissionMode: string;
+  approvalMode: string;
+  bypassSandbox: boolean;
+  cursorExecMode: string;
+  pickedHarness: string | null;
+  pickedModel: string;
+  pickedEffort: string;
+  costControlMode: CostControlMode;
+};
+
+let landingDraft: LandingDraft | null = null;
+
+// Test-only: clears the preserved landing draft so each case starts from a
+// clean module state (the draft is module-scoped and survives unmount by
+// design, which would otherwise leak between tests).
+export function resetLandingDraft(): void {
+  landingDraft = null;
+}
+
 export function NewChatLandingScreen() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -1674,7 +1708,7 @@ export function NewChatLandingScreen() {
   const [landingSurface, setLandingSurface] = useState<HTMLElement | null>(null);
   useNativeServerSwitcherForMainSurface(landingSurface, true);
 
-  const [message, setMessage] = useState<string>("");
+  const [message, setMessage] = useState<string>(() => landingDraft?.message ?? "");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isComposingRef = useRef(false);
   // maxRows 9 = 180px of 20px lines, matching the composer's 200px
@@ -1684,7 +1718,7 @@ export function NewChatLandingScreen() {
   // Attachments for the first message — same affordances as the in-session
   // composer (paperclip + paste); carried to ChatPage via the pending
   // initial prompt and sent with the auto-dispatched first turn.
-  const [files, setFiles] = useState<File[]>([]);
+  const [files, setFiles] = useState<File[]>(() => landingDraft?.files ?? []);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const addFiles = (incoming: File[]) => setFiles((prev) => [...prev, ...incoming]);
   const removeFile = (index: number) => setFiles((prev) => prev.filter((_, i) => i !== index));
@@ -1745,12 +1779,18 @@ export function NewChatLandingScreen() {
   // Seeded from the persisted last pick so a returning user starts on the
   // agent they used last; validated against the live list in
   // effectiveAgentId below (a stale id falls back to the default).
-  const [pickedAgentId, setPickedAgentId] = useState<string | null>(() => readLastAgentId());
-  const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
+  const [pickedAgentId, setPickedAgentId] = useState<string | null>(
+    () => landingDraft?.pickedAgentId ?? readLastAgentId(),
+  );
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(
+    () => landingDraft?.selectedHostId ?? null,
+  );
   // True when the user picked the sandbox option instead of a connected
   // host — the server provisions a sandbox host at create time
   // (host_type: "managed"), so no host_id or workspace is sent.
-  const [sandboxSelected, setSandboxSelected] = useState(false);
+  const [sandboxSelected, setSandboxSelected] = useState(
+    () => landingDraft?.sandboxSelected ?? false,
+  );
   // Desktop-shell host status for THIS machine (null outside Electron), so the
   // picker can tag the current machine and offer to auto-connect it.
   const [desktopHost, setDesktopHost] = useState<HostIdentity | null>(null);
@@ -1762,11 +1802,15 @@ export function NewChatLandingScreen() {
   // Sandbox repository inputs — composed into the managed create's
   // `workspace` string (`<url>[#<branch>]`); both blank = empty
   // server-created workspace.
-  const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>("");
-  const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>("");
-  const [workspace, setWorkspace] = useState<string>("");
-  const [branchName, setBranchName] = useState<string>("");
-  const [baseBranch, setBaseBranch] = useState<string>("");
+  const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>(
+    () => landingDraft?.sandboxRepoUrl ?? "",
+  );
+  const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
+    () => landingDraft?.sandboxRepoBranch ?? "",
+  );
+  const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
+  const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
+  const [baseBranch, setBaseBranch] = useState<string>(() => landingDraft?.baseBranch ?? "");
   // Project to file the new session under (an implicit collection stored as a
   // conversation_labels row). Empty = unfiled. Applied right after create.
   // Pre-filled from a `?project=` query param so the sidebar's per-project
@@ -1783,42 +1827,84 @@ export function NewChatLandingScreen() {
   // meaningful for the claude-native wrapper; ignored otherwise. Lives in
   // the footer tray's Advanced settings menu.
   const [permissionMode, setPermissionMode] = useState<string>(
-    CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
+    () => landingDraft?.permissionMode ?? CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
   );
   // Approval mode for Codex (codex --approval-mode). Only meaningful for
   // the codex-native wrapper; ignored otherwise. Lives in the footer
   // tray's Advanced settings menu.
-  const [approvalMode, setApprovalMode] = useState<string>(CODEX_NATIVE_DEFAULT_APPROVAL_MODE);
+  const [approvalMode, setApprovalMode] = useState<string>(
+    () => landingDraft?.approvalMode ?? CODEX_NATIVE_DEFAULT_APPROVAL_MODE,
+  );
   // DANGEROUS codex full-bypass opt-in (Codex only). OFF by default and only
   // flippable on after the user types the confirmation phrase, so it can
   // never be enabled by an accidental click. Persisted as a conversation
   // label so it survives reload. When on, a persistent red banner warns and
   // the runner ignores the approval-mode preset's flags.
-  const [bypassSandbox, setBypassSandbox] = useState<boolean>(false);
+  const [bypassSandbox, setBypassSandbox] = useState<boolean>(
+    () => landingDraft?.bypassSandbox ?? false,
+  );
   // Execution mode for Cursor (cursor-agent --mode / --yolo). Only meaningful
   // for the cursor-native wrapper; ignored otherwise.
-  const [cursorExecMode, setCursorExecMode] = useState<string>(CURSOR_NATIVE_DEFAULT_EXEC_MODE);
+  const [cursorExecMode, setCursorExecMode] = useState<string>(
+    () => landingDraft?.cursorExecMode ?? CURSOR_NATIVE_DEFAULT_EXEC_MODE,
+  );
   // Per-session brain-harness override for bundle agents (polly / debby).
   // null = the agent spec's declared harness (no override sent); cleared on
   // every agent switch so a pick never leaks across agents.
-  const [pickedHarness, setPickedHarness] = useState<string | null>(null);
+  const [pickedHarness, setPickedHarness] = useState<string | null>(
+    () => landingDraft?.pickedHarness ?? null,
+  );
   // Per-session model + reasoning effort for the claude-native model picker.
   // "" = unselected: nothing is checked and `model_override` / `reasoning_effort`
   // are omitted from the create, so Claude Code uses its own configured model.
   // An explicit pick rides along and is remembered (seeded back on a later visit
   // via the harness-seed effect below).
-  const [pickedModel, setPickedModel] = useState<string>("");
-  const [pickedEffort, setPickedEffort] = useState<string>("");
+  const [pickedModel, setPickedModel] = useState<string>(() => landingDraft?.pickedModel ?? "");
+  const [pickedEffort, setPickedEffort] = useState<string>(() => landingDraft?.pickedEffort ?? "");
   // Per-session cost-control switch ("Cost Optimized" pill). Unset
   // (null) defers to the agent spec's default and is omitted from
   // the create body.
-  const [costControlMode, setCostControlMode] = useState<CostControlMode>(null);
+  const [costControlMode, setCostControlMode] = useState<CostControlMode>(
+    () => landingDraft?.costControlMode ?? null,
+  );
   // Controls the working-directory popover so picking a directory closes it.
   const [workspacePopoverOpen, setWorkspacePopoverOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   // "Connect a host" instructions modal, opened from the host dropdown.
   const [connectOpen, setConnectOpen] = useState(false);
+
+  // Mirror the current draft fields into a ref every render so the unmount
+  // cleanup below can snapshot the latest values without re-subscribing.
+  // `submittedRef` is flipped just before we navigate to a freshly-created
+  // session so the snapshot is dropped instead of resurrected.
+  const submittedRef = useRef(false);
+  const draftRef = useRef<LandingDraft>(null as unknown as LandingDraft);
+  draftRef.current = {
+    message,
+    files,
+    pickedAgentId,
+    selectedHostId,
+    sandboxSelected,
+    sandboxRepoUrl,
+    sandboxRepoBranch,
+    workspace,
+    branchName,
+    baseBranch,
+    permissionMode,
+    approvalMode,
+    bypassSandbox,
+    cursorExecMode,
+    pickedHarness,
+    pickedModel,
+    pickedEffort,
+    costControlMode,
+  };
+  useEffect(() => {
+    return () => {
+      landingDraft = submittedRef.current ? null : draftRef.current;
+    };
+  }, []);
 
   const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
 
@@ -2431,6 +2517,11 @@ export function NewChatLandingScreen() {
       // the freshly-opened chat (whose composer reads the same per-conversation
       // key). Sanitized text so recall reproduces exactly what was sent.
       appendPromptHistoryEntry(initialPrompt, data.id);
+      // The session was created — drop the preserved draft so the next visit
+      // to the landing screen starts clean (and the unmount cleanup below
+      // doesn't resurrect what we just sent).
+      submittedRef.current = true;
+      landingDraft = null;
       navigate(`/c/${data.id}`);
     } catch {
       setCreateError("Couldn't reach the server. Check your connection and try again.");


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The new-session landing screen held the typed message, attachments, and picker selections in component-local `useState`. Navigating into an existing session and back unmounts the landing screen, so the half-composed draft was discarded.
- Stash the draft in a module-level object (mirroring the in-session composer's draft pattern at `ChatPage.tsx`) so it survives the unmount and restores on remount. Restored fields: message, attachments, agent/harness/model/effort, host & sandbox selection, workspace/branch/base-branch, repo URL/branch, permission/approval/cursor modes, bypass flag, and cost-control mode.
- In-memory only by design — a full page refresh starts clean — and cleared once a session is actually created (so a sent message isn't resurrected).

## Test Plan

- `npm test` — full web suite passes (3343 passing); added a focused test that types a message, attaches an image, unmounts the landing screen, and asserts both the text and the attachment chip are restored on remount.
- `npm run build` — passes (`tsc -b && vite build`).
- Lint/format clean for the changed files (no new findings).

## Demo

N/A — behavior-only change with no new visual surface. To verify manually: type a message (and attach a file) on the new-session screen, click into another session in the sidebar, then return to the new-session screen — the draft and attachment are still there.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit test in `NewChatDialog.test.tsx` covering the unmount->remount round-trip for both message text and attachments. Manually verified the navigate-away-and-back flow. Picker-selection restore is exercised indirectly by the existing landing-screen suite plus the new draft test; the module singleton is reset between tests via an exported `resetLandingDraft()`.