### PR TITLE
feat(web): add "Mark as unread" sidebar action

### DIFF
--- a/web/src/hooks/useIdleNotifications.ts
+++ b/web/src/hooks/useIdleNotifications.ts
@@ -45,7 +45,7 @@ import {
   detectIdleTransitions,
   detectNewElicitations,
 } from "@/lib/idleTransitions";
-import { isConversationUnseen } from "@/hooks/useUnseenConversations";
+import { isConversationUnseen, useUnseenTick } from "@/hooks/useUnseenConversations";
 import { conversationDisplayLabel } from "@/shell/sidebarNav";
 
 const IDLE_BODY = "Agent finished and is ready for your input.";
@@ -168,6 +168,23 @@ export function useIdleNotifications(activeConversationId?: string): void {
     // pushBadge only touches refs, so the once-mounted listener stays fresh.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Marking a row read/unread in the sidebar rewrites the last-seen map;
+  // recompute the dock badge from the current list so it agrees with the
+  // dot immediately, without waiting for the next conversations poll.
+  const unseenTick = useUnseenTick();
+  useEffect(() => {
+    if (latestConversations.current === null) return;
+    const next = computeUnreadBadgeIds(
+      latestConversations.current,
+      activeIdRef.current,
+      isWindowFocused(),
+      isConversationUnseen,
+    );
+    pushBadge(next.size);
+    // pushBadge/isWindowFocused read refs; rerun only when the map changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [unseenTick]);
 
   useEffect(() => {
     // Still loading — don't compute a badge from an absent list (and don't

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -1,16 +1,25 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import {
+  clearUnreadOverride,
   isConversationUnseen,
+  isExplicitlyUnread,
   markConversationSeen,
+  markConversationUnread,
   nowSeconds,
   useMarkConversationSeen,
+  useUnseenTick,
 } from "./useUnseenConversations";
 
 const STORAGE_KEY = "omnigent:last-seen-timestamps";
 
 beforeEach(() => {
   localStorage.clear();
+  // The explicit-unread override set is module-level (in-memory, not
+  // localStorage), so clear the ids these tests use to avoid leaking
+  // a mark-unread from one test into the next.
+  clearUnreadOverride("conv-1");
+  clearUnreadOverride("conv-2");
   vi.restoreAllMocks();
 });
 
@@ -68,6 +77,67 @@ describe("markConversationSeen", () => {
     markConversationSeen("conv-1", 5_000);
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
     expect(stored["conv-1"]).toBe(10_000);
+  });
+});
+
+describe("markConversationUnread", () => {
+  it("flags a previously-seen conversation as unseen", () => {
+    markConversationSeen("conv-1", 5_000);
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
+    markConversationUnread("conv-1", 5_000);
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+  });
+
+  it("writes a baseline just below updated_at (not a cleared entry)", () => {
+    // A missing entry reads as *seen*, so unread must pin the baseline
+    // strictly below updated_at rather than delete it.
+    markConversationUnread("conv-1", 5_000);
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored["conv-1"]).toBe(4_999);
+  });
+
+  it("survives an automatic mark-seen (the active-thread clobber guard)", () => {
+    // Marking the thread you're viewing unread must stick: the automatic
+    // mark-seen (navigation away / poll / focus) is suppressed until an
+    // explicit clearUnreadOverride. Without the override, mark-seen below
+    // would immediately undo the unread.
+    markConversationUnread("conv-1", 5_000);
+    markConversationSeen("conv-1", 6_000);
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+  });
+
+  it("is reversed by mark-seen once the override is cleared (reopen)", () => {
+    markConversationUnread("conv-1", 5_000);
+    // Reopening the thread clears the override, then mark-seen takes hold.
+    clearUnreadOverride("conv-1");
+    markConversationSeen("conv-1", 5_000);
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
+  });
+
+  it("still defers to status — a running session shows no dot", () => {
+    markConversationUnread("conv-1", 5_000);
+    expect(isConversationUnseen("conv-1", 5_000, "running")).toBe(false);
+  });
+});
+
+describe("isExplicitlyUnread", () => {
+  it("tracks the explicit-unread override and clears on reopen", () => {
+    expect(isExplicitlyUnread("conv-1")).toBe(false);
+    markConversationUnread("conv-1", 5_000);
+    // True even though the row may be active/running — the explicit flag
+    // overrides those suppressions so the dot shows.
+    expect(isExplicitlyUnread("conv-1")).toBe(true);
+    clearUnreadOverride("conv-1");
+    expect(isExplicitlyUnread("conv-1")).toBe(false);
+  });
+});
+
+describe("useUnseenTick", () => {
+  it("re-renders subscribers when the last-seen map is written", () => {
+    const { result } = renderHook(() => useUnseenTick());
+    const before = result.current;
+    act(() => markConversationUnread("conv-1", 5_000));
+    expect(result.current).not.toBe(before);
   });
 });
 
@@ -216,5 +286,38 @@ describe("useMarkConversationSeen", () => {
     const blurred = renderHook(() => useMarkConversationSeen("conv-2", 500));
     blurred.unmount();
     expect(storedBaseline("conv-2")).toBeUndefined();
+  });
+
+  it("does not re-mark seen after the active thread is marked unread", () => {
+    // User views conv-1 (marked seen on mount), then marks it unread from
+    // the kebab. Navigating away (unmount) must NOT re-mark it seen, so the
+    // dot lights once the row is no longer active.
+    setWindowFocused(true);
+    vi.useFakeTimers({ now: 1_000_000 });
+    const view = renderHook(() => useMarkConversationSeen("conv-1", 5_000));
+    expect(storedBaseline("conv-1")).toBe(1_000);
+
+    act(() => markConversationUnread("conv-1", 5_000));
+    expect(storedBaseline("conv-1")).toBe(4_999);
+
+    // Navigation away while focused would normally advance the baseline.
+    view.unmount();
+    expect(storedBaseline("conv-1")).toBe(4_999);
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+  });
+
+  it("re-marks seen when the thread is reopened (override cleared on mount)", () => {
+    setWindowFocused(true);
+    vi.useFakeTimers({ now: 1_000_000 });
+    const first = renderHook(() => useMarkConversationSeen("conv-1", 5_000));
+    act(() => markConversationUnread("conv-1", 5_000));
+    first.unmount();
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+
+    // Reopening clears the override on mount, so the thread reads seen again.
+    vi.setSystemTime(9_000_000);
+    renderHook(() => useMarkConversationSeen("conv-1", 5_000));
+    expect(storedBaseline("conv-1")).toBe(9_000);
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
   });
 });

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./useUnseenConversations";
 
 const STORAGE_KEY = "omnigent:last-seen-timestamps";
+const UNREAD_KEY = "omnigent:explicit-unread-ids";
 
 beforeEach(() => {
   localStorage.clear();
@@ -94,6 +95,15 @@ describe("markConversationUnread", () => {
     markConversationUnread("conv-1", 5_000);
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
     expect(stored["conv-1"]).toBe(4_999);
+  });
+
+  it("persists the override to localStorage (survives a reload)", () => {
+    markConversationUnread("conv-1", 5_000);
+    const ids = JSON.parse(localStorage.getItem(UNREAD_KEY)!);
+    expect(ids).toContain("conv-1");
+    // Clearing it removes the id from the persisted set.
+    clearUnreadOverride("conv-1");
+    expect(JSON.parse(localStorage.getItem(UNREAD_KEY)!)).not.toContain("conv-1");
   });
 
   it("survives an automatic mark-seen (the active-thread clobber guard)", () => {
@@ -306,17 +316,37 @@ describe("useMarkConversationSeen", () => {
     expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
   });
 
-  it("re-marks seen when the thread is reopened (override cleared on mount)", () => {
+  it("preserves a persisted explicit-unread on reload (a fresh mount does not clear)", () => {
+    // A reload landing back on /c/conv-1 is a fresh mount. It must NOT clear
+    // a persisted override — otherwise the dot the user set silently vanishes
+    // on refresh. The first-mount skip + the markConversationSeen guard keep
+    // the baseline pinned below updated_at.
+    setWindowFocused(true);
+    vi.useFakeTimers({ now: 9_000_000 });
+    markConversationUnread("conv-1", 5_000);
+
+    renderHook(() => useMarkConversationSeen("conv-1", 5_000));
+
+    expect(storedBaseline("conv-1")).toBe(4_999);
+    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+  });
+
+  it("clears the override on a genuine in-app reopen (id changes while mounted)", () => {
+    // ChatPage stays mounted across /c/:id navigations, so a real reopen is
+    // the id changing on the live hook — not a remount. Navigating away and
+    // back marks the thread seen again.
     setWindowFocused(true);
     vi.useFakeTimers({ now: 1_000_000 });
-    const first = renderHook(() => useMarkConversationSeen("conv-1", 5_000));
+    const { rerender } = renderHook(({ id }) => useMarkConversationSeen(id, 5_000), {
+      initialProps: { id: "conv-1" as string },
+    });
     act(() => markConversationUnread("conv-1", 5_000));
-    first.unmount();
     expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
 
-    // Reopening clears the override on mount, so the thread reads seen again.
+    rerender({ id: "conv-2" }); // navigate away to another thread
     vi.setSystemTime(9_000_000);
-    renderHook(() => useMarkConversationSeen("conv-1", 5_000));
+    rerender({ id: "conv-1" }); // reopen conv-1 → override cleared, marked seen
+
     expect(storedBaseline("conv-1")).toBe(9_000);
     expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
   });

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -7,9 +7,15 @@
 // Conversations with no stored entry are treated as seen (no
 // baseline) so first-deploy doesn't light up every row.
 
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 
 const STORAGE_KEY = "omnigent:last-seen-timestamps";
+// Persisted alongside the timestamps so an explicit "Mark as unread"
+// survives a page reload — including on the thread you were viewing,
+// where the auto mark-seen would otherwise clear it on remount. Like
+// the timestamps, this is per-device (localStorage); cross-device
+// unread would need server-side state.
+const UNREAD_KEY = "omnigent:explicit-unread-ids";
 
 // Bumped whenever the last-seen map is written, so in-tab subscribers
 // (the sidebar rows, the dock badge) can recompute unseen state right
@@ -23,6 +29,28 @@ function notifySubscribers(): void {
   for (const cb of subscribers) cb();
 }
 
+function readExplicitUnread(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(UNREAD_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((x): x is string => typeof x === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeExplicitUnread(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(UNREAD_KEY, JSON.stringify([...explicitlyUnread]));
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+}
+
 // Conversations the user explicitly marked unread. While an id is in
 // this set, the automatic "active view is being read" mark-seen
 // (mount / poll / focus / navigation-away in useMarkConversationSeen)
@@ -30,16 +58,21 @@ function notifySubscribers(): void {
 // would be clobbered the instant the user navigates away or the list
 // polls. The flag is cleared by a genuine re-open (see
 // clearUnreadOverride), which then lets the normal mark-seen run.
-const explicitlyUnread = new Set<string>();
+// Hydrated from localStorage so an explicit unread survives a reload.
+const explicitlyUnread = readExplicitUnread();
 
 /**
  * Clears the explicit-unread override for a conversation, re-enabling
  * automatic mark-seen. Called when the user genuinely (re)opens a
- * thread, since opening it *is* reading it. Notifies subscribers when
- * it actually removed an override so the dot clears immediately.
+ * thread, since opening it *is* reading it. Persists the change and
+ * notifies subscribers when it actually removed an override so the dot
+ * clears immediately.
  */
 export function clearUnreadOverride(conversationId: string): void {
-  if (explicitlyUnread.delete(conversationId)) notifySubscribers();
+  if (explicitlyUnread.delete(conversationId)) {
+    writeExplicitUnread();
+    notifySubscribers();
+  }
 }
 
 /**
@@ -119,10 +152,12 @@ export function markConversationSeen(conversationId: string, atSeconds?: number)
  * Setting {@link explicitlyUnread} keeps the flag from being instantly
  * undone by the automatic mark-seen on the *active* thread (navigation
  * away, polls, focus) — so marking the conversation you're looking at
- * sticks. The override clears when you reopen the thread.
+ * sticks. The override is persisted, so it also survives a reload; it
+ * clears when you reopen the thread.
  */
 export function markConversationUnread(conversationId: string, updatedAt: number): void {
   explicitlyUnread.add(conversationId);
+  writeExplicitUnread();
   const map = readLastSeenMap();
   map[conversationId] = updatedAt - 1;
   writeLastSeenMap(map);
@@ -193,8 +228,19 @@ export function useMarkConversationSeen(
   // markConversationSeen isn't no-op'd by a stale override). Keyed on
   // the id alone: a poll bumping `updatedAt` while the thread stays
   // open must NOT re-clear an override the user just set on it.
+  //
+  // The very first mount is skipped: an initial page load / reload while
+  // sitting on a thread must NOT clear a *persisted* explicit-unread
+  // override (otherwise the dot you set silently vanishes on refresh).
+  // ChatPage stays mounted across in-app /c/:id navigations, so this ref
+  // only resets on a real reload — genuine reopens (the id changing while
+  // mounted) still clear, matching "reopen = read".
+  const isInitialMount = useRef(true);
   useEffect(() => {
+    const wasInitial = isInitialMount.current;
+    isInitialMount.current = false;
     if (!conversationId) return;
+    if (wasInitial) return;
     clearUnreadOverride(conversationId);
   }, [conversationId]);
 

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -7,9 +7,52 @@
 // Conversations with no stored entry are treated as seen (no
 // baseline) so first-deploy doesn't light up every row.
 
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 
 const STORAGE_KEY = "omnigent:last-seen-timestamps";
+
+// Bumped whenever the last-seen map is written, so in-tab subscribers
+// (the sidebar rows, the dock badge) can recompute unseen state right
+// away — localStorage writes don't fire `storage` events in the same
+// tab, and the conversations poll is too slow for a click to feel live.
+const subscribers = new Set<() => void>();
+let writeVersion = 0;
+
+function notifySubscribers(): void {
+  writeVersion += 1;
+  for (const cb of subscribers) cb();
+}
+
+// Conversations the user explicitly marked unread. While an id is in
+// this set, the automatic "active view is being read" mark-seen
+// (mount / poll / focus / navigation-away in useMarkConversationSeen)
+// is suppressed for it — otherwise marking the *current* thread unread
+// would be clobbered the instant the user navigates away or the list
+// polls. The flag is cleared by a genuine re-open (see
+// clearUnreadOverride), which then lets the normal mark-seen run.
+const explicitlyUnread = new Set<string>();
+
+/**
+ * Clears the explicit-unread override for a conversation, re-enabling
+ * automatic mark-seen. Called when the user genuinely (re)opens a
+ * thread, since opening it *is* reading it. Notifies subscribers when
+ * it actually removed an override so the dot clears immediately.
+ */
+export function clearUnreadOverride(conversationId: string): void {
+  if (explicitlyUnread.delete(conversationId)) notifySubscribers();
+}
+
+/**
+ * True when the user explicitly marked this conversation unread (and
+ * hasn't reopened it since). Callers use this to lift the *active-row*
+ * dot suppression — flagging the thread you're viewing shows the dot at
+ * once. It does NOT lift the running-status suppression: a working
+ * session's dot still waits for the turn to finish (see the dot
+ * condition in Sidebar's ConversationRow).
+ */
+export function isExplicitlyUnread(conversationId: string): boolean {
+  return explicitlyUnread.has(conversationId);
+}
 
 type LastSeenMap = Record<string, number>;
 
@@ -35,6 +78,9 @@ function writeLastSeenMap(map: LastSeenMap): void {
   } catch {
     // localStorage quota or access errors shouldn't break the app.
   }
+  // Even if the persist threw, notify: an in-memory recompute is
+  // harmless and keeps the UI consistent with the attempted change.
+  notifySubscribers();
 }
 
 export function nowSeconds(): number {
@@ -48,12 +94,55 @@ export function nowSeconds(): number {
 // the server's new updated_at can land slightly past the client's
 // nowSeconds() under clock skew.
 export function markConversationSeen(conversationId: string, atSeconds?: number): void {
+  // A conversation the user explicitly marked unread stays unread until
+  // they reopen it (which clears the override first). This guards every
+  // caller — the automatic active-view marks and the self-action anchors
+  // (rename / archive / move) alike.
+  if (explicitlyUnread.has(conversationId)) return;
   const baseline = atSeconds ?? nowSeconds();
   const map = readLastSeenMap();
   const stored = map[conversationId];
   if (stored !== undefined && stored >= baseline) return;
   map[conversationId] = baseline;
   writeLastSeenMap(map);
+}
+
+/**
+ * Forces a conversation back to "unseen" — the inverse of
+ * {@link markConversationSeen}, backing the kebab's "Mark as unread".
+ * The dot's condition is `updated_at > stored`, so the baseline is
+ * pinned just below the conversation's current `updated_at` (rather
+ * than cleared — a missing entry reads as *seen*, not unseen). The
+ * row's status still gates the dot: a "running" session won't surface
+ * it until the turn finishes.
+ *
+ * Setting {@link explicitlyUnread} keeps the flag from being instantly
+ * undone by the automatic mark-seen on the *active* thread (navigation
+ * away, polls, focus) — so marking the conversation you're looking at
+ * sticks. The override clears when you reopen the thread.
+ */
+export function markConversationUnread(conversationId: string, updatedAt: number): void {
+  explicitlyUnread.add(conversationId);
+  const map = readLastSeenMap();
+  map[conversationId] = updatedAt - 1;
+  writeLastSeenMap(map);
+}
+
+/**
+ * Subscribes the caller to last-seen map writes and returns the
+ * current write version, so a component re-renders (and recomputes
+ * `isConversationUnseen`) the instant the user marks a row read/unread
+ * — not on the next conversations poll.
+ */
+export function useUnseenTick(): number {
+  return useSyncExternalStore(
+    (onChange) => {
+      subscribers.add(onChange);
+      return () => subscribers.delete(onChange);
+    },
+    () => writeVersion,
+    () => writeVersion,
+  );
 }
 
 /**
@@ -99,6 +188,16 @@ export function useMarkConversationSeen(
   conversationId: string | undefined,
   updatedAt: number | undefined,
 ): void {
+  // Opening a thread is reading it, so clear any explicit-unread
+  // override before the mark-seen below runs (and runs first, so
+  // markConversationSeen isn't no-op'd by a stale override). Keyed on
+  // the id alone: a poll bumping `updatedAt` while the thread stays
+  // open must NOT re-clear an override the user just set on it.
+  useEffect(() => {
+    if (!conversationId) return;
+    clearUnreadOverride(conversationId);
+  }, [conversationId]);
+
   useEffect(() => {
     if (!conversationId || updatedAt === undefined) return;
     const markIfFocused = () => {

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -8,7 +8,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -50,6 +50,7 @@ vi.mock("./ReportIssueButton", () => ({ ReportIssueButton: () => null }));
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
 
 import { type Conversation, useConversations } from "@/hooks/useConversations";
+import { clearUnreadOverride } from "@/hooks/useUnseenConversations";
 import { Sidebar } from "./Sidebar";
 
 const useConvMock = vi.mocked(useConversations);
@@ -88,13 +89,23 @@ function mockConversations(conversations: Conversation[]) {
   useConvMock.mockImplementation(() => dataResult);
 }
 
-function renderSidebar() {
+// `activeId` mounts the sidebar at `/c/:conversationId` (via a matching
+// Route so `useParams` populates), making that row the active one — the
+// rest of the suite renders at `/` where no row is active.
+function renderSidebar(activeId?: string) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const sidebar = <Sidebar open={true} onClose={vi.fn()} />;
   return render(
     <QueryClientProvider client={qc}>
       <TooltipProvider>
-        <MemoryRouter initialEntries={["/"]}>
-          <Sidebar open={true} onClose={vi.fn()} />
+        <MemoryRouter initialEntries={[activeId ? `/c/${activeId}` : "/"]}>
+          {activeId ? (
+            <Routes>
+              <Route path="/c/:conversationId" element={sidebar} />
+            </Routes>
+          ) : (
+            sidebar
+          )}
         </MemoryRouter>
       </TooltipProvider>
     </QueryClientProvider>,
@@ -105,6 +116,9 @@ beforeEach(() => {
   mocks.rename.mutate.mockReset();
   useConvMock.mockReset();
   localStorage.clear();
+  // The explicit-unread override is module-level (in-memory), so reset it
+  // between tests to avoid a mark-unread leaking into later rows.
+  clearUnreadOverride("conv_1");
   mockConversations([CONV]);
 });
 
@@ -233,6 +247,72 @@ describe("double-click to rename", () => {
 
     expect(screen.queryByTestId("rename-conversation-input")).toBeNull();
     expect(mocks.rename.mutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("mark as unread", () => {
+  it("re-lights the row's unread dot and persists the baseline below updated_at", () => {
+    renderSidebar();
+
+    // The row starts seen (no baseline) — no unread marker.
+    expect(screen.queryByText("(unread)")).toBeNull();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.click(screen.getByTestId("mark-unread-conversation"));
+
+    // The dot's accessible label appears immediately (in-tab tick), and the
+    // baseline is pinned just under updated_at so the dot survives a reload.
+    expect(screen.getByText("(unread)")).toBeInTheDocument();
+    const stored = JSON.parse(localStorage.getItem("omnigent:last-seen-timestamps")!);
+    expect(stored.conv_1).toBe(CONV.updated_at - 1);
+  });
+
+  it("records the baseline on a running session but holds the dot until the turn finishes", () => {
+    mockConversations([{ ...CONV, status: "running" }]);
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.click(screen.getByTestId("mark-unread-conversation"));
+
+    // The unread baseline is persisted...
+    const stored = JSON.parse(localStorage.getItem("omnigent:last-seen-timestamps")!);
+    expect(stored.conv_1).toBe(CONV.updated_at - 1);
+    // ...but the dot stays suppressed mid-turn (the explicit override lifts
+    // the active-row suppression, not the running one).
+    expect(screen.queryByText("(unread)")).toBeNull();
+
+    // Once the turn finishes (row re-renders as idle), the dot lights — the
+    // persisted baseline now reads unseen for a finished session.
+    cleanup();
+    mockConversations([{ ...CONV, status: "idle" }]);
+    renderSidebar();
+    expect(screen.getByText("(unread)")).toBeInTheDocument();
+  });
+
+  it("lights the dot on the active thread you're currently viewing", () => {
+    // The active row normally suppresses the dot (you're reading it), but an
+    // explicit mark-unread is a deliberate flag, so the dot must show.
+    renderSidebar("conv_1");
+
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    fireEvent.click(screen.getByTestId("mark-unread-conversation"));
+
+    const stored = JSON.parse(localStorage.getItem("omnigent:last-seen-timestamps")!);
+    expect(stored.conv_1).toBe(CONV.updated_at - 1);
+    expect(screen.getByText("(unread)")).toBeInTheDocument();
+  });
+
+  it("is hidden once the row is already unread", () => {
+    // Seed a baseline below updated_at so the row is already unseen.
+    localStorage.setItem(
+      "omnigent:last-seen-timestamps",
+      JSON.stringify({ conv_1: CONV.updated_at - 1 }),
+    );
+    renderSidebar();
+
+    expect(screen.getByText("(unread)")).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
+    expect(screen.queryByTestId("mark-unread-conversation")).toBeNull();
   });
 });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
   InboxIcon,
   ListChecksIcon,
   Loader2Icon,
+  MailIcon,
   Maximize2Icon,
   Minimize2Icon,
   MoreHorizontalIcon,
@@ -116,7 +117,12 @@ import { sumPendingApprovals } from "@/lib/inbox";
 import { isSessionStoppable } from "@/lib/sessionStop";
 import { isOwnerLevel } from "@/lib/permissionsApi";
 import { getSessionState, type SessionState } from "@/hooks/useSessionState";
-import { isConversationUnseen } from "@/hooks/useUnseenConversations";
+import {
+  isConversationUnseen,
+  isExplicitlyUnread,
+  markConversationUnread,
+  useUnseenTick,
+} from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
@@ -1783,8 +1789,10 @@ function ConversationMenuItems({
   canEdit,
   canManage,
   canStop,
+  canMarkUnread,
   currentProject,
   onTogglePinned,
+  onMarkUnread,
   onProjectAssigned,
   moveToProject,
   stopSession,
@@ -1804,8 +1812,12 @@ function ConversationMenuItems({
   canEdit: boolean;
   canManage: boolean;
   canStop: boolean;
+  // Whether "Mark as unread" applies: any row not already showing the
+  // unread dot (the active thread and running sessions included).
+  canMarkUnread: boolean;
   currentProject: string | null;
   onTogglePinned: (conversationId: string) => void;
+  onMarkUnread: () => void;
   onProjectAssigned?: (projectName: string) => void;
   moveToProject: ReturnType<typeof useMoveToProject>;
   stopSession: ReturnType<typeof useStopSession>;
@@ -1873,6 +1885,21 @@ function ConversationMenuItems({
             You need edit permissions to rename this session
           </TooltipContent>
         </Tooltip>
+      )}
+      {/* Mark as unread — re-lights the row's pink dot so a session can
+          be flagged to revisit, including the one you're currently
+          viewing. Hidden only when the row already shows the dot. */}
+      {canMarkUnread && (
+        <C.Item
+          data-testid="mark-unread-conversation"
+          onSelect={() => {
+            onMarkUnread();
+            setMenuOpen(false);
+          }}
+        >
+          <MailIcon className="size-3.5" />
+          Mark as unread
+        </C.Item>
       )}
       {canEdit && (
         <C.Sub>
@@ -2120,9 +2147,22 @@ function ConversationRow({
   const currentProject = conversation.labels?.[PROJECT_LABEL_KEY] ?? null;
 
   const label = conversationDisplayLabel(conversation);
+  // Recompute unseen state the moment the last-seen map changes (e.g. the
+  // user picks "Mark as unread" on this row) rather than waiting for the
+  // next conversations poll.
+  useUnseenTick();
+  // The dot shows when the conversation is content-unseen AND either the
+  // row isn't the one you're viewing OR you explicitly marked it unread.
+  // `isConversationUnseen` still gates on status, so a *running* turn never
+  // shows the dot — marking a working session unread is recorded but stays
+  // invisible until the turn finishes (then the dot lights like any unseen
+  // row). The explicit override only lifts the active-row suppression, so
+  // flagging the thread you're currently viewing surfaces the dot at once.
   const hasUnseenMessages =
-    !isActive &&
-    isConversationUnseen(conversation.id, conversation.updated_at, conversation.status);
+    isConversationUnseen(conversation.id, conversation.updated_at, conversation.status) &&
+    (!isActive || isExplicitlyUnread(conversation.id));
+  // "Mark as unread" is offered on any row not already showing the dot.
+  const canMarkUnread = !hasUnseenMessages;
   // Badge precedence: a pending approval ("Needs response") outranks the
   // unread dot — a session that's both unread and awaiting input should
   // surface the actionable approval tag. The row still renders bold (the
@@ -2291,8 +2331,10 @@ function ConversationRow({
     canEdit,
     canManage,
     canStop,
+    canMarkUnread,
     currentProject,
     onTogglePinned,
+    onMarkUnread: () => markConversationUnread(conversation.id, conversation.updated_at),
     onProjectAssigned,
     moveToProject,
     stopSession,


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a **Mark as unread** kebab action to sidebar conversation rows that re-lights the unread dot, so a finished session can be flagged to revisit.
- Works on the **active thread** you're currently viewing: an explicit-unread override prevents the automatic active-view mark-seen (navigation away / poll / focus) from instantly clobbering it; the override clears on a genuine reopen.
- Respects the **running** gate: marking a working session unread records the baseline but the dot stays hidden until the turn finishes, then lights like any unseen row (status is never changed mid-turn).
- The row dot and dock badge recompute the instant the last-seen map is written (`useSyncExternalStore`), not on the next conversations poll.

## Test Plan

- `cd web && npm test` -> 3355 passed, full suite green.
- `cd web && npm run build` -> tsc + vite build clean.
- Added/updated tests in `Sidebar.rowActions.test.tsx` (active-thread dot, running session holds dot until idle, baseline persistence) and `useUnseenConversations.test.ts` (explicit-unread override: clobber guard, clear-on-reopen, `isExplicitlyUnread`).

## Demo

_UI change — marking a session unread re-lights the pink dot; on a running session the dot appears once the turn finishes._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove the sidebar locally — marked the active thread unread (dot shows immediately), marked a running session unread (no dot mid-turn, dot appears after it goes idle), and confirmed reopening a flagged thread clears the dot. The running->idle transition's reliance on the live conversations poll is exercised by the existing `useConversations` machinery; the unit test simulates it via re-render.