### PR TITLE
feat(polly): add plan execution skills

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -194,8 +194,15 @@ prompt: |
   - investigate — answer read-only investigation/debug/audit questions by
     dispatching `explore` / `search` sub-agents; synthesize only from their
     reports.
+  - plan-work: select and slice existing repo plans such as `docs/plans/*.md`,
+    maintain `.polly/registry.json`, update the plan's durable high-level
+    execution status, then dispatch implement workers with `follow
+    implement-plan`.
   - fanout — run independent tasks in parallel, each in its own worktree +
     sub-agent, each opening its own PR.
+  - implement-plan: worker-side execution discipline included in every
+    `purpose: "implement"` task packet; Polly tells workers to follow it, but
+    Polly itself keeps orchestration and tracking outside that skill.
   - cross-review — verify a PR's diff with the opposite-vendor sub-agent;
     blocking issues become fix-tasks; the human merges.
 
@@ -240,6 +247,15 @@ prompt: |
     the roster and do NOT re-dispatch to it (re-dispatching only hits the same
     missing-binary wall). This is different from a worker that booted, ran, and
     failed the task — only the latter is worth a fresh re-dispatch.
+  - Treat provider availability failures like per-run worker availability
+    failures, not normal task failures. If `claude_code` boots but fails with
+    Claude quota, rate limit, credit, billing, auth, subscription, or overloaded
+    provider errors, mark `claude_code` UNAVAILABLE for the rest of the run,
+    cancel any stale Claude child if needed, and do NOT keep retrying it. Prefer
+    `codex` for implementation and `pi` for review / explore work while Claude
+    is unavailable. If fewer than two different vendors remain available for
+    cross-review, stop at the plan gate or after the current deterministic gates
+    and ask the human how to proceed.
   - Do not infer success from git status alone — read the sub-agent's reported
     result and run the test / lint / typecheck gates yourself.
 

--- a/examples/polly/skills/fanout/SKILL.md
+++ b/examples/polly/skills/fanout/SKILL.md
@@ -16,12 +16,15 @@ dependency).
 2. Dispatch one implementation sub-agent per task, scoped to its worktree:
    `sys_session_send(agent="claude_code"|"codex", title="<task_slug>",
    args={purpose: "implement", input: "<task + acceptance contract +
-   worktree path>"})`. Use a short task-based title such as `auth-refactor` or
-   `fix-sse-error`, never the raw vendor name. State the scope and that it must
-   work only inside `.worktrees/<task_id>`. The worker drives the task to green
-   and opens its OWN PR for the branch. Every commit the worker authors must
-   end with a blank line followed by the exact co-sign trailer as its final
-   line — `Co-authored-by: omnigent <noreply@omnigent.ai>`.
+   worktree path + follow implement-plan instruction>"})`. Use a short
+   task-based title such as `auth-refactor` or `fix-sse-error`, never the raw
+   vendor name. State that the worker must follow `implement-plan` for plan
+   reading, unit tracking, test discovery, focused verification, commits, PR
+   creation, and final reporting, and include the scope and worktree path. The
+   worker drives the task to green and opens its OWN PR for the branch. Every
+   commit the worker authors must end with a blank line followed by the exact
+   co-sign trailer as its final line:
+   `Co-authored-by: omnigent <noreply@omnigent.ai>`.
    Record each handle's `conversation_id`
    in the registry. Emit the worktree + `sys_session_send` tool calls in THIS
    turn — never end a turn having only said you will dispatch; the dispatch

--- a/examples/polly/skills/implement-plan/SKILL.md
+++ b/examples/polly/skills/implement-plan/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: implement-plan
+description: Worker-side implementation discipline for Polly implement tasks. Follow when dispatched with purpose "implement", especially for plan-backed or U-unit work.
+---
+
+# implement-plan
+
+Use this inside a Polly implementation worker. Polly handles orchestration,
+worktrees, registry state, PR routing, and cross-review. Your job is to ship
+the assigned implementation slice inside the worktree Polly gave you.
+
+## 1. Lock The Work Source
+
+Resolve the task source before editing:
+
+- If Polly supplied a plan path, read it and treat it as the authority.
+- If Polly supplied a task packet with acceptance criteria, treat that packet as
+  the authority.
+- If the packet references implementation units, preserve their IDs in your
+  task notes and final report.
+- If scope is ambiguous enough to change behavior, stop and report the blocking
+  question to Polly instead of guessing.
+
+Completion criterion: you can state the behavior to ship, what is out of
+scope, and how you will verify it.
+
+## 2. Read The Contract
+
+For plan-driven work, read only the sections needed for execution:
+
+- product contract, requirements, and acceptance criteria
+- non-goals and scope boundaries
+- implementation units and file hints
+- verification commands
+- risks, open questions, and deferred decisions
+
+Do not rewrite the plan during implementation unless Polly explicitly assigned
+that as part of the task. Progress belongs in commits, the PR, and your final
+worker report.
+
+## 3. Confirm Worktree State
+
+Before editing:
+
+1. Run `git branch --show-current`.
+2. Run `git status --short`.
+3. Confirm you are in Polly's assigned worktree and branch.
+4. Do not touch files outside the assigned scope unless the plan requires it.
+5. Do not revert unrelated changes unless Polly explicitly told you they are
+   yours to replace.
+
+Completion criterion: the branch and dirty state are understood before edits.
+
+## 4. Slice The Work
+
+For non-trivial work, keep a short local checklist in your own reasoning or
+native task tracker:
+
+- derive tasks from implementation units when present
+- include test discovery and verification tasks
+- keep one slice in progress at a time
+- mark slices complete only after focused verification passes
+
+Completion criterion: your work can be traced back to the task packet or plan.
+
+## 5. Implement In Thin Slices
+
+For each slice:
+
+1. Read the relevant files before editing.
+2. Search for existing helpers, tests, and local patterns.
+3. If the requested behavior already exists, verify it and report that.
+4. Add or update tests for behavior changes.
+5. Make the smallest coherent change that satisfies the slice.
+6. Run focused verification for the touched area.
+7. Fix failures before moving to the next slice.
+
+Use diagnosis discipline when the task becomes an unknown failure investigation
+instead of straightforward implementation.
+
+## 6. Discover Tests Before Editing
+
+Before changing behavior in a file, find relevant tests:
+
+- tests named in the plan or task packet
+- adjacent tests
+- tests importing or referencing the changed module/component
+- integration tests when behavior crosses UI, API, store, hook, CLI, or
+  persistence boundaries
+
+If you do not add a test for behavior-bearing work, explain why in the final
+worker report and PR body.
+
+## 7. Commit And PR Rules
+
+Polly implementers are expected to create the deliverable branch and PR.
+
+- Stage only files for this task.
+- Do not use `git add .`.
+- Commit only after relevant checks pass.
+- Use a meaningful commit message, never `WIP`.
+- End every commit message with a blank line followed by:
+  `Co-authored-by: omnigent <noreply@omnigent.ai>`
+- Push only your task branch.
+- Open a PR with what changed and how it was verified.
+- Never merge the PR.
+
+## 8. Quality Tail
+
+Before reporting done:
+
+1. Run the plan's verification commands, or the nearest focused repo checks.
+2. Broaden to build, typecheck, lint, or wider tests when the slice touches
+   shared behavior or user-facing flows.
+3. Re-check `git status --short`.
+4. Make sure untracked files that belong to the task are included.
+
+Completion criterion: the diff is reviewable, verification is recorded, and
+remaining risks are explicit.
+
+## 9. Worker Report
+
+Return a concise structured report to Polly:
+
+- work source: plan path, issue, or task packet
+- shipped behavior, tied to implementation unit IDs when present
+- changed files
+- PR URL
+- verification run and result
+- tests not run, with reason
+- remaining risks or follow-ups
+
+Do not claim the whole plan is complete unless every acceptance criterion
+assigned to you is satisfied.

--- a/examples/polly/skills/plan-work/SKILL.md
+++ b/examples/polly/skills/plan-work/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: plan-work
+description: Select, slice, and track implementation from repo plans, especially docs/plans. Use when the user asks Polly to pick up an existing plan, work from docs/plans, or execute planned work.
+---
+
+# plan-work
+
+Use this when Polly is asked to execute existing planned work. Polly owns plan
+selection, task slicing, registry tracking, dispatch, and plan status updates.
+Workers receive scoped task packets and follow `implement-plan`.
+
+## 1. Resolve The Plan
+
+Select exactly one source of work before dispatching:
+
+- If the user named a plan path, read it and treat it as the authority.
+- If the request is blank or says to pick up planned work, scan `docs/plans/`
+  for candidate `.md` plans and choose the newest plausible implementation
+  plan. If multiple candidates are plausible, ask the human which one to use.
+- Skip plans marked complete, superseded, archived, or not implementation work.
+- If no implementation-ready plan exists, stop and ask whether to write a plan
+  first.
+
+Completion criterion: one plan path is selected, or the human has the exact
+blocking choice.
+
+## 2. Read The Contract
+
+Read only the plan sections needed to create task packets:
+
+- goal, scope, non-goals, and assumptions
+- requirements, product contract, or acceptance criteria
+- implementation units and stable IDs
+- dependencies and ordering constraints
+- verification commands and test scenarios
+- risks, blockers, and deferred decisions
+
+Do not change product scope while preparing execution. If the plan has product
+ambiguity that changes behavior, stop at the plan gate and ask the human.
+
+Completion criterion: Polly can name the implementable units, sequencing, and
+verification gates without inventing scope.
+
+## 3. Track In The Registry
+
+Create or update `.polly/registry.json` before dispatching.
+
+For each implementation unit, record:
+
+- plan path
+- unit ID
+- task slug
+- acceptance contract
+- dependencies
+- status: `queued`, `running`, `reviewing`, `fixing`, `ready`, `blocked`
+- worktree path and branch
+- worker agent and conversation ID after dispatch
+- PR URL when available
+- verification summary when available
+- blocking review findings
+- follow-ups
+
+The registry is the live task tracker. Do not put per-worker transient state in
+the plan document.
+
+Completion criterion: every planned worker task has a registry entry before it
+is dispatched.
+
+## 4. Update Plan Status
+
+Plans carry durable high-level status only. Update the plan at these points:
+
+- If Polly initializes tracking without dispatching yet, leave or mark it
+  `not_started` and record the registry path.
+- When execution starts, mark it `in_progress` and record the registry path.
+- When Polly hits a hard blocker that needs the human, mark it `blocked` with a
+  short blocker note.
+- When every in-scope task has an open PR, deterministic gates are green, and
+  cross-review has no blocking findings, mark it `complete` and list the PRs.
+
+If the plan has YAML frontmatter, use these fields:
+
+```yaml
+polly_status: not_started
+polly_registry: .polly/registry.json
+polly_prs: []
+polly_blocker: null
+```
+
+If the plan has no frontmatter, add or update a `## Polly Status` section near
+the top with status, registry path, PRs, and blocker notes. Do not rewrite the
+rest of the plan while tracking execution.
+
+Completion criterion: the plan tells a reader whether execution has not started,
+is running, is blocked, or is complete, while details remain in the registry.
+
+Allowed plan status values are `not_started`, `in_progress`, `blocked`, and
+`complete`. Do not use the plan as a task tracker. It stays portable and
+reviewable, while `.polly/registry.json` owns execution progress.
+
+## 5. Dispatch Work
+
+For each parallel-safe unit:
+
+1. Create a dedicated worktree and branch.
+2. Dispatch an implement worker with `purpose: "implement"`.
+3. Include the plan path, unit ID, acceptance contract, worktree path, and the
+   exact instruction `follow implement-plan`.
+4. Record the returned conversation ID in the registry.
+
+Use `fanout` for independent units. Keep ordered or shared-file units in later
+waves.
+
+Completion criterion: every running worker has a scoped task packet, worktree,
+branch, registry entry, and conversation ID.
+
+## 6. Review And Close
+
+When workers return:
+
+1. Record PR URLs and verification summaries in the registry.
+2. Run deterministic gates before model review.
+3. Send each PR through `cross-review`.
+4. Route blocking findings back to the original implementer conversation.
+5. Mark registry entries `ready` only after gates and cross-review pass.
+6. Update the plan to `complete` only when every in-scope unit is ready.
+
+Do not merge PRs. The human merges.
+
+Completion criterion: registry state, plan status, and PR readiness agree.

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -120,7 +120,9 @@ def test_spine_skills_present(polly_spec: AgentSpec) -> None:
     assert sorted(s.name for s in polly_spec.skills) == [
         "cross-review",
         "fanout",
+        "implement-plan",
         "investigate",
+        "plan-work",
     ]
 
 
@@ -150,6 +152,8 @@ def test_subagent_dispatch_text_advertises_task_titles_and_purpose(
     assert "Bad titles are `claude_code`, `claude-code`, `codex`" in config
     assert 'purpose: "implement"' in fanout
     assert 'title="<task_slug>"' in fanout
+    assert "follow implement-plan" in fanout
+    assert "the worker must follow" in fanout
     assert 'title="review-<task_slug>"' in cross_review
     assert 'purpose: "review"' in cross_review
     assert 'purpose: "implement"' in cross_review
@@ -169,6 +173,74 @@ def test_subagent_dispatch_text_advertises_task_titles_and_purpose(
         "explore",
         "search",
     ]
+
+
+def test_implement_plan_skill_keeps_worker_discipline() -> None:
+    """
+    The ``implement-plan`` skill gives workers plan-driven implementation
+    discipline while Polly keeps orchestration, fan-out, registry state, and
+    cross-review outside the worker workflow.
+    """
+    implement_plan = (
+        _POLLY_BUNDLE / "skills" / "implement-plan" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    compact = " ".join(implement_plan.split())
+
+    assert "Polly handles orchestration, worktrees, registry state, PR routing" in compact
+    assert "If Polly supplied a plan path, read it and treat it as the authority" in compact
+    assert "preserve their IDs in your task notes and final report" in compact
+    assert "Run `git branch --show-current`" in compact
+    assert "Confirm you are in Polly's assigned worktree and branch" in compact
+    assert "Before changing behavior in a file, find relevant tests" in compact
+    assert "Stage only files for this task" in compact
+    assert "Do not use `git add .`" in compact
+    assert "Open a PR with what changed and how it was verified" in compact
+    assert "Do not claim the whole plan is complete" in compact
+
+
+def test_plan_work_skill_selects_tracks_and_closes_repo_plans() -> None:
+    """
+    The ``plan-work`` skill gives Polly the missing plan intake and tracking
+    layer while keeping live task state in the registry.
+    """
+    config = (_POLLY_BUNDLE / "config.yaml").read_text(encoding="utf-8")
+    plan_work = (_POLLY_BUNDLE / "skills" / "plan-work" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    compact_config = " ".join(config.split())
+    compact_plan_work = " ".join(plan_work.split())
+
+    assert "plan-work" in compact_config
+    assert "select and slice existing repo plans such as `docs/plans/*.md`" in compact_config
+    assert "update the plan's durable high-level execution status" in compact_config
+    assert "scan `docs/plans/` for candidate `.md` plans" in compact_plan_work
+    assert "The registry is the live task tracker" in compact_plan_work
+    assert "Do not put per-worker transient state in the plan document" in compact_plan_work
+    for field in [
+        "plan path",
+        "unit ID",
+        "task slug",
+        "acceptance contract",
+        "dependencies",
+    ]:
+        assert field in compact_plan_work
+    assert "worker agent and conversation ID" in compact_plan_work
+    assert "PR URL when available" in compact_plan_work
+    assert "verification summary when available" in compact_plan_work
+    assert "blocking review findings" in compact_plan_work
+    assert "follow-ups" in compact_plan_work
+    assert "leave or mark it `not_started` and record the registry path" in compact_plan_work
+    assert "mark it `in_progress` and record the registry path" in compact_plan_work
+    assert "mark it `blocked` with a short blocker note" in compact_plan_work
+    assert "mark it `complete` and list the PRs" in compact_plan_work
+    assert "polly_status: not_started" in compact_plan_work
+    assert "polly_blocker: null" in compact_plan_work
+    assert (
+        "Allowed plan status values are `not_started`, `in_progress`, `blocked`, "
+        "and `complete`"
+    ) in compact_plan_work
+    assert ".polly/registry.json` owns execution progress" in compact_plan_work
+    assert 'exact instruction `follow implement-plan`' in compact_plan_work
 
 
 def test_orchestrator_keeps_timer_tool_but_forbids_worker_polling(
@@ -236,6 +308,21 @@ def test_orchestrator_forbids_premature_idle_after_announcing_intent() -> None:
     assert "never end a turn having only said you will dispatch" in " ".join(fanout.split())
     assert "never end a turn having only announced" in " ".join(cross_review.split())
     assert "do not end a turn having only said you will dispatch" in " ".join(investigate.split())
+
+
+def test_orchestrator_handles_claude_provider_unavailability() -> None:
+    """
+    Polly should not burn turns retrying Claude when the worker is present but
+    the provider is unavailable due to quota, rate limits, auth, or billing.
+    """
+    config = (_POLLY_BUNDLE / "config.yaml").read_text(encoding="utf-8")
+    compact = " ".join(config.split())
+
+    assert "provider availability failures like per-run worker availability failures" in compact
+    assert "Claude quota, rate limit, credit, billing, auth" in compact
+    assert "mark `claude_code` UNAVAILABLE for the rest of the run" in compact
+    assert "Prefer `codex` for implementation and `pi` for review / explore work" in compact
+    assert "If fewer than two different vendors remain available for cross-review" in compact
 
 
 def test_orchestrator_delegates_substantive_work() -> None:


### PR DESCRIPTION
## Summary

- add Polly-local `implement-plan` worker discipline for implementation dispatches
- add `plan-work` for selecting, slicing, tracking, and closing repo plans
- update fanout to include `follow implement-plan` in every implement dispatch
- document Claude provider unavailability fallback in Polly orchestration rules
- add e2e coverage for the new Polly skill spine and tracking contracts

## Tests

- `uv run pytest tests/e2e/omnigent/test_example_polly.py -q`
- `uv run ruff check tests/e2e/omnigent/test_example_polly.py`
- `git diff --check`
