### PR TITLE
fix(ap-web): harden math rendering

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      katex:
+        specifier: ^0.16.47
+        version: 0.16.47
       lucide-react:
         specifier: ^1.12.0
         version: 1.25.0(react@18.3.1)

--- a/web/package.json
+++ b/web/package.json
@@ -64,6 +64,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "katex": "^0.16.47",
     "lucide-react": "^1.12.0",
     "monaco-editor": "^0.55.1",
     "nanoid": "^5.1.9",

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -1,0 +1,45 @@
+/**
+ * LLMs often emit TeX delimiters (`\(...\)` and `\[...\]`), while remark-math
+ * parses dollar delimiters. Normalize only outside code so formulas render
+ * without corrupting fenced snippets or inline code examples.
+ */
+export function normalizeExplicitMathDelimiters(text: string): string {
+  let result = "";
+  let inFence = false;
+  let inInlineCode = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const atLineStart = i === 0 || text[i - 1] === "\n";
+    if (!inInlineCode && atLineStart && (text.startsWith("```", i) || text.startsWith("~~~", i))) {
+      inFence = !inFence;
+      result += text.slice(i, i + 3);
+      i += 2;
+      continue;
+    }
+
+    const char = text[i];
+    if (!inFence && char === "`") {
+      inInlineCode = !inInlineCode;
+      result += char;
+      continue;
+    }
+
+    if (!inFence && !inInlineCode) {
+      const pair = text.slice(i, i + 2);
+      if (pair === "\\(" || pair === "\\)") {
+        result += "$";
+        i += 1;
+        continue;
+      }
+      if (pair === "\\[" || pair === "\\]") {
+        result += "$$";
+        i += 1;
+        continue;
+      }
+    }
+
+    result += char;
+  }
+
+  return result;
+}

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -36,7 +36,7 @@ export function normalizeExplicitMathDelimiters(text: string): string {
     const atLineStart = i === 0 || text[i - 1] === "\n";
 
     if (!inlineCodeTicks && atLineStart) {
-      const fence = FENCE_RE.exec(text.slice(i));
+      const fence = text.slice(i).match(FENCE_RE);
       if (fence) {
         inFence = !inFence;
         result += fence[0];

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -23,7 +23,10 @@ const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
  */
 export function normalizeExplicitMathDelimiters(text: string): string {
   let result = "";
-  let inFence = false;
+  // The marker (`` ``` `` / `~~~` run) that opened the current fenced block, or
+  // "" when outside a fence. CommonMark closes a fence only with the same char
+  // and a run at least as long, so a stray `~~~` inside a ``` block stays code.
+  let openFence = "";
   // Length of the backtick run that opened the current inline-code span, or 0
   // when not in inline code. Tracking the run length lets a ``…`` span close
   // only on a matching-length run, so single backticks inside it don't leak.
@@ -38,13 +41,18 @@ export function normalizeExplicitMathDelimiters(text: string): string {
     if (!inlineCodeTicks && atLineStart) {
       const fence = text.slice(i).match(FENCE_RE);
       if (fence) {
-        inFence = !inFence;
+        const marker = fence[1];
+        if (!openFence) {
+          openFence = marker;
+        } else if (marker[0] === openFence[0] && marker.length >= openFence.length) {
+          openFence = "";
+        }
         result += fence[0];
         i += fence[0].length - 1;
         continue;
       }
     }
-    if (inFence) {
+    if (openFence) {
       result += char;
       continue;
     }

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -1,30 +1,77 @@
 /**
  * LLMs often emit TeX delimiters (`\(...\)` and `\[...\]`), while remark-math
- * parses dollar delimiters. Normalize only outside code so formulas render
- * without corrupting fenced snippets or inline code examples.
+ * parses dollar delimiters. Convert them to `$`/`$$`, but only where doing so
+ * is safe:
+ *
+ * - Not inside fenced or inline code, so code examples stay verbatim.
+ * - Not inside an already `$`/`$$`-delimited math span, so a LaTeX line break
+ *   (`\\[1em]`) inside `$$\begin{aligned}…\end{aligned}$$` isn't mistaken for a
+ *   display-math opener and turned into `\$$1em]`.
+ * - A literal `\\` (escaped backslash / LaTeX line break) is copied verbatim so
+ *   its trailing `\[`/`\(` isn't read as an explicit delimiter.
  */
 export function normalizeExplicitMathDelimiters(text: string): string {
   let result = "";
   let inFence = false;
-  let inInlineCode = false;
+  // Length of the backtick run that opened the current inline-code span, or 0
+  // when not in inline code. Tracking the run length lets a ``…`` span close
+  // only on a matching-length run, so single backticks inside it don't leak.
+  let inlineCodeTicks = 0;
+  // Inside a pre-existing `$…$` / `$$…$$` span (toggled on each run of `$`).
+  let inMath = false;
 
   for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
     const atLineStart = i === 0 || text[i - 1] === "\n";
-    if (!inInlineCode && atLineStart && (text.startsWith("```", i) || text.startsWith("~~~", i))) {
+
+    if (
+      !inlineCodeTicks &&
+      atLineStart &&
+      (text.startsWith("```", i) || text.startsWith("~~~", i))
+    ) {
       inFence = !inFence;
       result += text.slice(i, i + 3);
       i += 2;
       continue;
     }
-
-    const char = text[i];
-    if (!inFence && char === "`") {
-      inInlineCode = !inInlineCode;
+    if (inFence) {
       result += char;
       continue;
     }
 
-    if (!inFence && !inInlineCode) {
+    if (char === "`") {
+      let run = 1;
+      while (text[i + run] === "`") run += 1;
+      if (inlineCodeTicks === 0) {
+        inlineCodeTicks = run;
+      } else if (run === inlineCodeTicks) {
+        inlineCodeTicks = 0;
+      }
+      result += text.slice(i, i + run);
+      i += run - 1;
+      continue;
+    }
+    if (inlineCodeTicks) {
+      result += char;
+      continue;
+    }
+
+    if (char === "\\" && text[i + 1] === "\\") {
+      result += "\\\\";
+      i += 1;
+      continue;
+    }
+
+    if (char === "$") {
+      let run = 1;
+      while (text[i + run] === "$") run += 1;
+      inMath = !inMath;
+      result += text.slice(i, i + run);
+      i += run - 1;
+      continue;
+    }
+
+    if (!inMath) {
       const pair = text.slice(i, i + 2);
       if (pair === "\\(" || pair === "\\)") {
         result += "$";

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -1,3 +1,8 @@
+// Optional 1–3 space indent + a fence run, per CommonMark. Matching the full
+// run (not just the first three chars) also keeps a ````-fenced block from
+// leaking its fourth backtick into inline-code tracking.
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+
 /**
  * LLMs often emit TeX delimiters (`\(...\)` and `\[...\]`), while remark-math
  * parses dollar delimiters. Convert them to `$`/`$$`, but only where doing so
@@ -7,8 +12,14 @@
  * - Not inside an already `$`/`$$`-delimited math span, so a LaTeX line break
  *   (`\\[1em]`) inside `$$\begin{aligned}…\end{aligned}$$` isn't mistaken for a
  *   display-math opener and turned into `\$$1em]`.
- * - A literal `\\` (escaped backslash / LaTeX line break) is copied verbatim so
- *   its trailing `\[`/`\(` isn't read as an explicit delimiter.
+ * - A literal `\\` or `\$` is copied verbatim so its trailing `\[`/`\(` isn't
+ *   read as an explicit delimiter and an escaped dollar isn't re-toggled.
+ *
+ * A single `$` immediately before a digit reads as currency ($5), not an inline
+ * math opener, so it's escaped and doesn't flip the math span — otherwise, with
+ * single-dollar math enabled, prose like "it costs $5 or $10" renders as a
+ * garbled formula. (Genuine inline math that starts with a digit, e.g. `$3x$`,
+ * is the rare casualty; digit-led currency in prose is far more common.)
  */
 export function normalizeExplicitMathDelimiters(text: string): string {
   let result = "";
@@ -24,15 +35,14 @@ export function normalizeExplicitMathDelimiters(text: string): string {
     const char = text[i];
     const atLineStart = i === 0 || text[i - 1] === "\n";
 
-    if (
-      !inlineCodeTicks &&
-      atLineStart &&
-      (text.startsWith("```", i) || text.startsWith("~~~", i))
-    ) {
-      inFence = !inFence;
-      result += text.slice(i, i + 3);
-      i += 2;
-      continue;
+    if (!inlineCodeTicks && atLineStart) {
+      const fence = FENCE_RE.exec(text.slice(i));
+      if (fence) {
+        inFence = !inFence;
+        result += fence[0];
+        i += fence[0].length - 1;
+        continue;
+      }
     }
     if (inFence) {
       result += char;
@@ -56,8 +66,8 @@ export function normalizeExplicitMathDelimiters(text: string): string {
       continue;
     }
 
-    if (char === "\\" && text[i + 1] === "\\") {
-      result += "\\\\";
+    if (char === "\\" && (text[i + 1] === "\\" || text[i + 1] === "$")) {
+      result += text.slice(i, i + 2);
       i += 1;
       continue;
     }
@@ -65,6 +75,11 @@ export function normalizeExplicitMathDelimiters(text: string): string {
     if (char === "$") {
       let run = 1;
       while (text[i + run] === "$") run += 1;
+      const isCurrency = run === 1 && !inMath && /\d/.test(text[i + 1] ?? "");
+      if (isCurrency) {
+        result += "\\$";
+        continue;
+      }
       inMath = !inMath;
       result += text.slice(i, i + run);
       i += run - 1;

--- a/web/src/components/ai-elements/message.test.tsx
+++ b/web/src/components/ai-elements/message.test.tsx
@@ -28,6 +28,20 @@ describe("MessageResponse", () => {
     expect(document.querySelector('img[src^="https://attacker.example"]')).toBeNull();
     expect(await screen.findByText("[Image blocked: leak]")).toBeTruthy();
   });
+
+  it("re-renders when rendering props change even if the text is unchanged", async () => {
+    const { container, rerender } = render(
+      <MessageResponse className="math-config-a">same text</MessageResponse>,
+    );
+
+    expect(container.firstElementChild).toHaveClass("math-config-a");
+
+    rerender(<MessageResponse className="math-config-b">same text</MessageResponse>);
+
+    await waitFor(() => {
+      expect(container.firstElementChild).toHaveClass("math-config-b");
+    });
+  });
 });
 
 describe("MessageResponse code-block copy", () => {

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -51,8 +51,8 @@ export const MessageContent = ({ children, className, ...props }: MessageContent
       // 15px text / 24px line-height at the 16px desktop root, in rem so the
       // mobile root-font-size bump (index.css) still scales both. User and
       // assistant prose share this wrapper, so they stay in lockstep.
-      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-[0.9375rem] leading-6 tracking-[-0.01em]",
-      "group-[.is-user]:ml-auto group-[.is-user]:rounded-2xl group-[.is-user]:bg-muted group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground group-[.is-user]:ring-1 group-[.is-user]:ring-border/60",
+      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 text-[0.9375rem] leading-6 tracking-[-0.01em]",
+      "group-[.is-user]:ml-auto group-[.is-user]:overflow-hidden group-[.is-user]:rounded-2xl group-[.is-user]:bg-muted group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground group-[.is-user]:ring-1 group-[.is-user]:ring-border/60",
       // Tighter than the user bubble's gap-2 so muted single-line tool
       // ("See N steps") / reasoning rows don't look orphaned between prose.
       "group-[.is-assistant]:gap-1.5 group-[.is-assistant]:text-foreground",
@@ -447,8 +447,6 @@ export const MessageResponse = memo(
       />
     );
   },
-  (prevProps, nextProps) =>
-    prevProps.children === nextProps.children && nextProps.isAnimating === prevProps.isAnimating,
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/web/src/components/ai-elements/reasoning.test.tsx
+++ b/web/src/components/ai-elements/reasoning.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "./reasoning";
 
@@ -24,6 +24,21 @@ describe("Reasoning — auto-expand", () => {
 
     expect(document.querySelector('img[src^="https://attacker.example"]')).toBeNull();
     expect(await screen.findByText("[Image blocked: leak]")).toBeTruthy();
+  });
+
+  it("renders explicit inline TeX delimiters inside reasoning content", async () => {
+    const { container } = render(
+      <Reasoning isStreaming={true}>
+        <ReasoningTrigger />
+        <ReasoningContent>{String.raw`Check \(\sqrt{x + 1}\).`}</ReasoningContent>
+      </Reasoning>,
+    );
+
+    await waitFor(() => expect(container.querySelector(".katex")).not.toBeNull());
+    const katex = container.querySelector(".katex") as HTMLElement;
+    expect(katex.querySelector(".sqrt")).not.toBeNull();
+    expect(katex.textContent).toContain("x");
+    expect(katex.textContent).toContain("1");
   });
 
   it("renders the trigger button in the open state when isStreaming=true on mount", () => {

--- a/web/src/components/ai-elements/reasoning.tsx
+++ b/web/src/components/ai-elements/reasoning.tsx
@@ -7,6 +7,7 @@ import type { ComponentProps, ReactNode } from "react";
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
 
+import { normalizeExplicitMathDelimiters } from "./mathMarkdown";
 import { Shimmer } from "./shimmer";
 import {
   CHAT_LINK_SAFETY,
@@ -179,6 +180,7 @@ export type ReasoningContentProps = ComponentProps<typeof CollapsibleContent> & 
 
 export const ReasoningContent = memo(({ className, children, ...props }: ReasoningContentProps) => {
   const { expandable } = useReasoning();
+  const normalizedChildren = useMemo(() => normalizeExplicitMathDelimiters(children), [children]);
 
   // Non-expandable section has no content to reveal — render nothing so
   // there's no empty collapsible region under the flat header.
@@ -201,7 +203,7 @@ export const ReasoningContent = memo(({ className, children, ...props }: Reasoni
         // Block remote image fetches that can exfiltrate data through URLs.
         rehypePlugins={SECURE_STREAMDOWN_REHYPE_PLUGINS}
       >
-        {children}
+        {normalizedChildren}
       </Streamdown>
     </CollapsibleContent>
   );

--- a/web/src/components/ai-elements/streamdown-security.ts
+++ b/web/src/components/ai-elements/streamdown-security.ts
@@ -1,5 +1,5 @@
 import { cjk } from "@streamdown/cjk";
-import { math } from "@streamdown/math";
+import { createMathPlugin } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import { defaultRehypePlugins, type LinkSafetyConfig, type StreamdownProps } from "streamdown";
 import { lazyCodePlugin } from "./lazyCodePlugin";
@@ -18,7 +18,12 @@ type StreamdownHardenPlugin = StreamdownPluginTuple & {
   1: StreamdownHardenOptions;
 };
 
-export const STREAMDOWN_PLUGINS = { cjk, code: lazyCodePlugin, math, mermaid };
+export const STREAMDOWN_PLUGINS = {
+  cjk,
+  code: lazyCodePlugin,
+  math: createMathPlugin({ singleDollarTextMath: true }),
+  mermaid,
+};
 export const SECURE_STREAMDOWN_REHYPE_PLUGINS = createSecureStreamdownRehypePlugins();
 
 // Streamdown enables a link-safety confirmation modal by default: clicking any

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -326,6 +326,23 @@ describe("BlockRenderer dispatch", () => {
       ).toBe(["```", String.raw`\(\sqrt{x}\)`, "```"].join("\n"));
     });
 
+    it("leaves LaTeX line breaks inside existing display math untouched", () => {
+      // `\\[1em]` is a spaced line break, not an explicit display-math opener;
+      // converting its `\[` to `$$` would corrupt the already-`$$`-delimited block.
+      const aligned = String.raw`$$\begin{aligned} a &= b \\[1em] c &= d \end{aligned}$$`;
+      expect(normalizeExplicitMathDelimiters(aligned)).toBe(aligned);
+    });
+
+    it("does not convert delimiters already inside a dollar-math span", () => {
+      const inline = String.raw`$\[x\]$`;
+      expect(normalizeExplicitMathDelimiters(inline)).toBe(inline);
+    });
+
+    it("skips normalization inside multi-backtick inline code", () => {
+      const doubleTick = "``" + String.raw`\(x\)` + "``";
+      expect(normalizeExplicitMathDelimiters(doubleTick)).toBe(doubleTick);
+    });
+
     it("loads required Streamdown and KaTeX styles at the app entrypoint", () => {
       // KaTeX's DOM is mostly positioned spans. Without its stylesheet, radicals
       // and fractions can leave only the root bar/outer shell visible while the

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -343,6 +343,28 @@ describe("BlockRenderer dispatch", () => {
       expect(normalizeExplicitMathDelimiters(doubleTick)).toBe(doubleTick);
     });
 
+    it("escapes currency dollar amounts so prose isn't parsed as inline math", () => {
+      // With single-dollar math enabled, "it costs $5 or $10" would otherwise
+      // parse "5 or " as inline math. Escaping the digit-led `$` renders literal
+      // dollar figures and stops the run from flipping the math toggle.
+      expect(normalizeExplicitMathDelimiters("it costs $5 or $10")).toBe(
+        String.raw`it costs \$5 or \$10`,
+      );
+      // Delimiters after the currency text still normalize — the toggle didn't flip.
+      expect(normalizeExplicitMathDelimiters(String.raw`$5 then \(x\)`)).toBe(
+        String.raw`\$5 then $x$`,
+      );
+    });
+
+    it("does not double-escape an already-escaped dollar", () => {
+      expect(normalizeExplicitMathDelimiters(String.raw`\$5`)).toBe(String.raw`\$5`);
+    });
+
+    it("detects indented code fences per CommonMark", () => {
+      const indentedFence = ["   ```", String.raw`\(\sqrt{x}\)`, "   ```"].join("\n");
+      expect(normalizeExplicitMathDelimiters(indentedFence)).toBe(indentedFence);
+    });
+
     it("loads required Streamdown and KaTeX styles at the app entrypoint", () => {
       // KaTeX's DOM is mostly positioned spans. Without its stylesheet, radicals
       // and fractions can leave only the root bar/outer shell visible while the

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -2,12 +2,15 @@
 // to break by removing a case — neither the walker nor the
 // individual card tests catch that. Drive it directly here.
 
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RenderItem } from "@/lib/renderItems";
 import { FileViewerContext } from "@/shell/FileViewerContext";
+import { normalizeExplicitMathDelimiters } from "@/components/ai-elements/mathMarkdown";
 import { BlockRenderer } from "./BlockRenderer";
 
 afterEach(cleanup);
@@ -19,6 +22,16 @@ const FILE_VIEWER_NOOP = {
   workspaceRoot: null,
   workspaceHome: null,
 };
+
+const renderMarkdownText = (text: string) =>
+  render(
+    <FileViewerContext.Provider value={FILE_VIEWER_NOOP}>
+      <BlockRenderer
+        items={[{ kind: "text", itemId: "t1", text, final: true }]}
+        sessionStatus="idle"
+      />
+    </FileViewerContext.Provider>,
+  );
 
 describe("BlockRenderer dispatch", () => {
   it("renders a slash_command RenderItem via SlashCommandCard", () => {
@@ -295,6 +308,104 @@ describe("BlockRenderer dispatch", () => {
     expect(screen.getByText("Ran 2 shell commands, called 3 other tools")).toBeDefined();
     expect(screen.queryByText(/tool_5/)).toBeNull();
     expect(screen.queryByText(/Bash/)).toBeNull();
+  });
+
+  describe("math rendering", () => {
+    it("normalizes explicit TeX delimiters outside code", () => {
+      expect(normalizeExplicitMathDelimiters(String.raw`中文 \(\sqrt{x}\) 文本`)).toBe(
+        String.raw`中文 $\sqrt{x}$ 文本`,
+      );
+      expect(normalizeExplicitMathDelimiters(String.raw`\[\sqrt{x}\]`)).toBe(
+        String.raw`$$\sqrt{x}$$`,
+      );
+      expect(normalizeExplicitMathDelimiters(String.raw`\`\(\sqrt{x}\)\``)).toBe(
+        String.raw`\`\(\sqrt{x}\)\``,
+      );
+      expect(
+        normalizeExplicitMathDelimiters(["```", String.raw`\(\sqrt{x}\)`, "```"].join("\n")),
+      ).toBe(["```", String.raw`\(\sqrt{x}\)`, "```"].join("\n"));
+    });
+
+    it("loads required Streamdown and KaTeX styles at the app entrypoint", () => {
+      // KaTeX's DOM is mostly positioned spans. Without its stylesheet, radicals
+      // and fractions can leave only the root bar/outer shell visible while the
+      // radicand appears missing. Keep this as a source-level guard because
+      // jsdom cannot catch visual CSS layout failures.
+      const entrypoints = ["src/main.tsx", "src/embed.tsx"].map((file) =>
+        readFileSync(path.join(process.cwd(), file), "utf8"),
+      );
+      const indexCss = readFileSync(path.join(process.cwd(), "src/index.css"), "utf8");
+
+      for (const source of entrypoints) {
+        expect(source).toContain('import "katex/dist/katex.min.css"');
+        expect(source).toContain('import "streamdown/styles.css"');
+      }
+      expect(indexCss).toContain('@source "../node_modules/streamdown/dist/*.js"');
+    });
+
+    it("renders radicals, fractions, and superscripts without dropping the radicand", async () => {
+      const { container } = renderMarkdownText(
+        String.raw`$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$`,
+      );
+
+      await waitFor(() => expect(container.querySelector(".katex")).not.toBeNull());
+      const katex = container.querySelector(".katex") as HTMLElement;
+
+      expect(katex.querySelector(".mfrac")).not.toBeNull();
+      expect(katex.querySelector(".sqrt")).not.toBeNull();
+      expect(katex.querySelector(".vlist")).not.toBeNull();
+      expect(katex.textContent).toContain("b");
+      expect(katex.textContent).toContain("2");
+      expect(katex.textContent).toContain("4");
+      expect(katex.textContent).toContain("a");
+      expect(katex.textContent).toContain("c");
+    });
+
+    it("renders multi-term square roots used by distance formulas", async () => {
+      const { container } = renderMarkdownText(
+        String.raw`$$d = \sqrt{(x_2 - x_1)^2 + (y_2 - y_1)^2}$$`,
+      );
+
+      await waitFor(() => expect(container.querySelector(".katex")).not.toBeNull());
+      const katex = container.querySelector(".katex") as HTMLElement;
+
+      expect(katex.querySelector(".sqrt")).not.toBeNull();
+      expect(katex.textContent).toContain("x");
+      expect(katex.textContent).toContain("y");
+      expect(katex.textContent).toContain("1");
+      expect(katex.textContent).toContain("2");
+    });
+
+    it("keeps invalid math visible instead of swallowing the message", async () => {
+      const { container } = renderMarkdownText(String.raw`$$\sqrt{$$`);
+
+      await waitFor(() => {
+        expect(container.textContent).toContain("\\sqrt");
+      });
+      expect(container.textContent).not.toBe("");
+    });
+
+    it("recovers from an incomplete streamed radical to the final KaTeX output", async () => {
+      const streamingItem = (text: string): RenderItem[] => [
+        { kind: "text", itemId: null, text, final: false },
+      ];
+      const renderStreamingMath = (text: string) => (
+        <FileViewerContext.Provider value={FILE_VIEWER_NOOP}>
+          <BlockRenderer items={streamingItem(text)} sessionStatus="running" />
+        </FileViewerContext.Provider>
+      );
+
+      const { container, rerender } = render(renderStreamingMath(String.raw`$$\sqrt{`));
+      await waitFor(() => expect(container.textContent).toContain("\\sqrt"));
+
+      rerender(renderStreamingMath(String.raw`$$\sqrt{x + 1}$$`));
+
+      await waitFor(() => expect(container.querySelector(".katex")).not.toBeNull());
+      const katex = container.querySelector(".katex") as HTMLElement;
+      expect(katex.querySelector(".sqrt")).not.toBeNull();
+      expect(katex.textContent).toContain("x");
+      expect(katex.textContent).toContain("1");
+    });
   });
 
   // Proves the markdown throttle is actually wired into the render path (not

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -4,6 +4,7 @@
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
@@ -365,15 +366,24 @@ describe("BlockRenderer dispatch", () => {
       expect(normalizeExplicitMathDelimiters(indentedFence)).toBe(indentedFence);
     });
 
+    it("keeps a mismatched fence marker inside a code block as literal text", () => {
+      // A `~~~` line inside a ``` block does not close it (CommonMark requires
+      // the same fence char), so delimiters there must stay verbatim.
+      const block = ["```", "~~~", String.raw`\(\sqrt{x}\)`, "```"].join("\n");
+      expect(normalizeExplicitMathDelimiters(block)).toBe(block);
+    });
+
     it("loads required Streamdown and KaTeX styles at the app entrypoint", () => {
       // KaTeX's DOM is mostly positioned spans. Without its stylesheet, radicals
       // and fractions can leave only the root bar/outer shell visible while the
       // radicand appears missing. Keep this as a source-level guard because
-      // jsdom cannot catch visual CSS layout failures.
-      const entrypoints = ["src/main.tsx", "src/embed.tsx"].map((file) =>
-        readFileSync(path.join(process.cwd(), file), "utf8"),
+      // jsdom cannot catch visual CSS layout failures. Resolve relative to this
+      // file (not process.cwd()) so the test is independent of the runner's dir.
+      const srcDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+      const entrypoints = ["main.tsx", "embed.tsx"].map((file) =>
+        readFileSync(path.join(srcDir, file), "utf8"),
       );
-      const indexCss = readFileSync(path.join(process.cwd(), "src/index.css"), "utf8");
+      const indexCss = readFileSync(path.join(srcDir, "index.css"), "utf8");
 
       for (const source of entrypoints) {
         expect(source).toContain('import "katex/dist/katex.min.css"');

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -18,6 +18,7 @@ import { useMemo } from "react";
 import type React from "react";
 import { defaultRemarkPlugins } from "streamdown";
 import remarkBreaks from "remark-breaks";
+import { normalizeExplicitMathDelimiters } from "@/components/ai-elements/mathMarkdown";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { ZoomableImage } from "@/components/ImageLightbox";
 import { useThrottledValue } from "@/hooks/useThrottledValue";
@@ -262,10 +263,11 @@ export function FilePathAwareMessageResponse({
   // streaming path. The hook must be called unconditionally (rules of hooks), so
   // non-string children (none today) pass an inert "" and bypass the result.
   const isString = typeof children === "string";
-  const throttledText = useThrottledValue(
-    isString ? (children as string) : "",
-    STREAM_MARKDOWN_THROTTLE_MS,
+  const normalizedText = useMemo(
+    () => (isString ? normalizeExplicitMathDelimiters(children as string) : ""),
+    [isString, children],
   );
+  const throttledText = useThrottledValue(normalizedText, STREAM_MARKDOWN_THROTTLE_MS);
 
   // Defense-in-depth: a string child that is huge or carries a
   // giant unbroken token (e.g. a base64 data URL serialized into the text

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -144,8 +144,8 @@ function ZoomableMarkdownImage({ src, alt, ...props }: React.ComponentProps<"img
   return <ZoomableImage {...props} src={resolvedSrc} alt={alt ?? ""} />;
 }
 
-// Stable module-level override map so MessageResponse's memo (which ignores
-// `components` changes) never sees a new identity.
+// Stable module-level override map so MessageResponse's shallow prop compare
+// never sees a new `components` identity and re-parses needlessly.
 const FILE_PATH_AWARE_COMPONENTS = {
   inlineCode: WorkspacePathInlineCode,
   img: ZoomableMarkdownImage,

--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -42,6 +42,8 @@ import {
   reactRouterRouting,
 } from "./lib/routing";
 import { initChatStore } from "./store/chatStore";
+import "katex/dist/katex.min.css";
+import "streamdown/styles.css";
 import "./index.css";
 import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -7,7 +7,11 @@
 /* Streamdown ships utility classes pre-compiled in its dist; this @source
  * pragma tells Tailwind v4 to scan those files so the classes survive the
  * production build. Required by ai-elements/MessageResponse, which uses
- * Streamdown to render markdown (code blocks, math, GFM, mermaid). */
+ * Streamdown to render markdown (code blocks, math, GFM, mermaid).
+ *
+ * Runtime styles for Streamdown and KaTeX are imported in each app entrypoint.
+ * Keep those imports there so package-required CSS is loaded independently of
+ * app theme customization in this file. */
 @source "../node_modules/streamdown/dist/*.js";
 
 @custom-variant dark (&:is(.dark *));
@@ -826,6 +830,20 @@
 :is([data-streamdown="table-cell"], [data-streamdown="table-header-cell"])
   [data-streamdown="link"] {
   overflow-wrap: break-word;
+}
+
+/* KaTeX lays out radicals/fractions with positioned spans. Display math can be
+ * both wider and taller than normal prose, so give it its own scroll surface
+ * instead of relying on the surrounding chat bubble to clip or wrap it. */
+.katex-display {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+  padding-block: 0.25rem;
+}
+
+.katex {
+  max-width: 100%;
 }
 
 /* Flatten Streamdown's loud heading ramp (text-3xl..xl) to em sizes proportional to body. */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -832,13 +832,13 @@
   overflow-wrap: break-word;
 }
 
-/* KaTeX lays out radicals/fractions with positioned spans. Display math can be
- * both wider and taller than normal prose, so give it its own scroll surface
- * instead of relying on the surrounding chat bubble to clip or wrap it. */
+/* KaTeX lays out radicals/fractions with positioned spans. Wide display math
+ * gets its own horizontal scroll surface instead of relying on the surrounding
+ * chat bubble to clip or wrap it. (No overflow-y override: with overflow-x
+ * non-visible the browser forces overflow-y to compute as auto anyway.) */
 .katex-display {
   max-width: 100%;
   overflow-x: auto;
-  overflow-y: visible;
   padding-block: 0.25rem;
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -24,6 +24,8 @@ import {
 import { applyThemePalette, readThemePalette } from "./lib/themePalette";
 import { applyCustomTheme, readCustomTheme } from "./lib/customTheme";
 import { initChatStore } from "./store/chatStore";
+import "katex/dist/katex.min.css";
+import "streamdown/styles.css";
 import "./index.css";
 
 // Start tracing before any request fires so fetch/XHR are patched in time

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -201,6 +201,14 @@ describe("BubbleView dispatch", () => {
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
   });
 
+  it("uses full-width layout for assistant display math", () => {
+    render(<BubbleView bubble={assistantText(String.raw`$$d = \sqrt{x^2 + y^2}$$`)} />);
+
+    const bubble = screen.getByTestId("message-bubble");
+    expect(bubble).toHaveClass("max-w-full");
+    expect(bubble.firstElementChild).toHaveClass("w-full");
+  });
+
   it("marks a cancelled assistant turn as Interrupted", () => {
     // WHY: the cancelled lifecycle branch surfaces an explicit Interrupted
     // note so a truncated turn doesn't read as a complete answer.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -289,6 +289,7 @@ export function collectBubbleMarkdown(items: RenderItem[]): string {
 const CHAT_COLUMN_WIDTH = "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-5xl";
 
 const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+const DISPLAY_MATH_RE = /(^|\n)\s*(\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\])/;
 
 function isMarkdownTableRow(line: string): boolean {
   return line.trim().includes("|");
@@ -307,6 +308,10 @@ export function containsMarkdownTable(items: RenderItem[]): boolean {
         isMarkdownTableRow(lines[index + 1] ?? ""),
     );
   });
+}
+
+export function containsDisplayMath(items: RenderItem[]): boolean {
+  return items.some((item) => item.kind === "text" && DISPLAY_MATH_RE.test(item.text));
 }
 
 /**
@@ -3357,7 +3362,8 @@ function AssistantBubble({
   // Elicitation cards (e.g. AskUserQuestion form) want full chat-column
   // width to match the composer, not the default w-fit shrink-to-content.
   const hasElicitation = bubble.items.some((it) => it.kind === "elicitation");
-  const isWide = hasElicitation || containsMarkdownTable(bubble.items);
+  const isWide =
+    hasElicitation || containsMarkdownTable(bubble.items) || containsDisplayMath(bubble.items);
 
   return (
     <>

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -99,6 +99,18 @@ describe("UserBubble markdown rendering", () => {
     const cell = await screen.findByText("1", { selector: "td, td *" });
     expect(cell.closest("table")).not.toBeNull();
   });
+
+  it("renders CJK text around explicit inline math", async () => {
+    const { container } = renderBubble(userBubble(String.raw`中文 \(\sqrt{x + 1}\) 文本`));
+
+    await waitFor(() => expect(container.querySelector(".katex")).not.toBeNull());
+    expect(container.textContent).toContain("中文");
+    expect(container.textContent).toContain("文本");
+    const katex = container.querySelector(".katex") as HTMLElement;
+    expect(katex.querySelector(".sqrt")).not.toBeNull();
+    expect(katex.textContent).toContain("x");
+    expect(katex.textContent).toContain("1");
+  });
 });
 
 describe("UserBubble system messages", () => {


### PR DESCRIPTION
## Summary
- Load Streamdown and KaTeX runtime styles from every web entrypoint so radicals/fractions render with the required layout CSS.
- Normalize explicit TeX delimiters outside code blocks and enable single-dollar inline math for AI-generated formulas.
- Add regression coverage for radicals, streamed incomplete math recovery, reasoning/user bubble math, and full-width display math layout.

## Demo

Before this change, AI-generated math that arrived with explicit TeX delimiters or KaTeX-heavy structures could render inconsistently across chat surfaces:

- radicals/fractions could miss the Streamdown/KaTeX layout CSS in some web entrypoints
- explicit `\(...\)`, `\[...\]`, and single-dollar inline math could remain unnormalized outside code blocks
- streamed incomplete math could leave visibly broken formula output while content was still arriving

After this change, the same math paths are normalized and styled consistently in assistant messages, reasoning output, user bubbles, and block-rendered content:

- KaTeX and Streamdown styles are loaded from both the main app and embed entrypoints
- TeX delimiters are normalized before markdown rendering, while code blocks are preserved
- regression tests cover radicals, streamed incomplete math recovery, reasoning/user bubble math, and full-width display math layout

Evidence:

- UI Snapshot run passed and uploaded screenshot artifact `ui-snapshot-28428445970`: https://github.com/omnigent-ai/omnigent/actions/runs/28428445970
- Screenshot artifact download: https://api.github.com/repos/omnigent-ai/omnigent/actions/artifacts/7974027848/zip
- E2E UI Tests passed across all shards: https://github.com/omnigent-ai/omnigent/actions/runs/28428446114
- Web tests passed, including the math rendering regression tests: https://github.com/omnigent-ai/omnigent/actions/runs/28428446201

## Test plan
- `npx vitest run src/components/blocks/BlockRenderer.test.tsx src/components/ai-elements/message.test.tsx src/components/ai-elements/reasoning.test.tsx src/pages/ChatPage.userBubble.test.tsx src/pages/ChatPage.indicators.test.tsx`
- `npm run type-check`
- `npm run build`
- `npm run build:embed`
