### PR TITLE
fix(web): refocus composer after attaching a file

### DIFF
--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1071,6 +1071,57 @@ describe("Composer reply-quote focus", () => {
   });
 });
 
+// Attaching a file via the paperclip button routes through the hidden file
+// <input>, whose click (and the OS file dialog) pulls focus off the composer.
+// The change handler must hand focus back so the user can keep typing the
+// message that goes with the attachment — without this the caret is lost and
+// the next keystroke does nothing until the chat box is clicked again.
+describe("Composer file-attachment focus", () => {
+  beforeEach(() => {
+    useChatStore.setState({ conversationId: "conv_test", skills: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  /** The hidden attachment file <input> (the paperclip button proxies to it). */
+  function fileInput(): HTMLInputElement {
+    const el = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+    if (!el) throw new Error("file input not found");
+    return el;
+  }
+
+  it("focuses the textarea after a file is attached", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    // The mount effect focuses on conversation bind; blur so the assertion
+    // proves the attach handler re-focused, not the leftover mount focus.
+    ta.blur();
+    expect(document.activeElement).not.toBe(ta);
+
+    const file = new File([new Uint8Array(10)], "shot.png", { type: "image/png" });
+    fireEvent.change(fileInput(), { target: { files: [file] } });
+
+    expect(document.activeElement).toBe(ta);
+  });
+
+  it("does not focus the textarea when the attachment is rejected", () => {
+    // An unsupported type is dropped by validateAttachments, so no file is
+    // added — and with nothing attached there's no reason to yank focus back.
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    ta.blur();
+    expect(document.activeElement).not.toBe(ta);
+
+    const bad = new File([new Uint8Array(10)], "clip.mp4", { type: "video/mp4" });
+    fireEvent.change(fileInput(), { target: { files: [bad] } });
+
+    expect(document.activeElement).not.toBe(ta);
+  });
+});
+
 // The "Chatting with sub-agent …" tray peeks above the composer only when a
 // sub-agent label is passed (the active session is a child). It must name the
 // sub-agent so the composer reads as messaging the child, not the orchestrator.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3953,6 +3953,9 @@ export function Composer({
     if (accepted.length > 0) {
       setFiles((prev) => [...prev, ...accepted]);
       dirtyRef.current = true;
+      // Return focus to the composer so the user can keep typing right
+      // after attaching (the file picker / paperclip button steals it).
+      if (!isMobileRef.current) textareaRef.current?.focus();
     }
     setAttachmentError(errors.length > 0 ? errors.join("\n") : null);
   };


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Attaching a file via the paperclip/link icon in the chat box left the composer unfocused: clicking the button (and the OS file dialog it opens) pulls focus off the textarea, and nothing handed it back after the file was selected — so the caret was lost and the next keystroke did nothing until the user clicked the chat box again.
- Restore focus to the composer once an attachment is accepted in `addFiles`, guarded by the same `isMobileRef` check used by the other focus-restoration paths (session switch, reply-quote insertion, mic input). This also covers drag-and-drop, since it flows through the same helper.

## Test Plan

- Added unit tests in `web/src/pages/ChatPage.composer.test.tsx` ("Composer file-attachment focus"): a valid attachment re-focuses the textarea; a rejected (unsupported-type) attachment does not.
- `cd web && npm test` — all suites pass (3344 passed).
- `cd web && npm run build` — clean.

## Demo

N/A — focus behaviour; covered by the new unit tests.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — the new unit tests cover both the accepted and rejected attachment paths.