### PR TITLE
fix(web): don't show bridge path chip for uploaded image/file attachments

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -195,6 +195,14 @@ function extractUserText(content: MessageContentBlock[]): string {
  * user message, so the bubble can show what was attached (the marker text
  * itself is stripped from the rendered text by {@link extractUserText}). A
  * trailing "/" marks a folder. Returns [] for ordinary messages.
+ *
+ * Explicitly *uploaded* files share this marker wording: the native executor
+ * materializes the upload to disk and injects `[Attached: <abs-path>]` so the
+ * vendor CLI can read it. Those uploads already ride in as an
+ * `input_image`/`input_file` block (rendered as the image / a file chip), so
+ * surfacing them again here would double-render — as the path of an internal
+ * bridge temp dir, no less. "@"-mention paths are always workspace-relative
+ * while upload markers are absolute, so skip absolute paths.
  */
 function extractAttachedPaths(content: MessageContentBlock[]): MentionItem[] {
   const text = content
@@ -207,6 +215,8 @@ function extractAttachedPaths(content: MessageContentBlock[]): MentionItem[] {
   for (const m of text.matchAll(ATTACHED_RE)) {
     const raw = m[1].trim();
     if (!raw) continue;
+    // Absolute path → a materialized upload, already shown via its file block.
+    if (raw.startsWith("/")) continue;
     // Split a trailing ":start-end" line span back out so the chip can show
     // it without truncation (it's the whole point of a partial-file attach).
     const range = /^(.*):(\d+)-(\d+)$/.exec(raw);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -202,8 +202,18 @@ function extractUserText(content: MessageContentBlock[]): string {
  * `input_image`/`input_file` block (rendered as the image / a file chip), so
  * surfacing them again here would double-render — as the path of an internal
  * bridge temp dir, no less. "@"-mention paths are always workspace-relative
- * while upload markers are absolute, so skip absolute paths.
+ * while upload markers are absolute, so skip absolute paths (see
+ * {@link isAbsolutePath}).
  */
+// An absolute filesystem path in any form a native executor might materialize
+// an upload to: POSIX ("/…"), Windows drive ("C:\…" or "C:/…"), or UNC
+// ("\\host\share"). Workspace "@"-mention paths are always relative, so this
+// reliably tells a materialized upload apart from a tagged workspace file
+// regardless of the host OS the runner happens to be on.
+function isAbsolutePath(p: string): boolean {
+  return /^(\/|[A-Za-z]:[\\/]|\\\\)/.test(p);
+}
+
 function extractAttachedPaths(content: MessageContentBlock[]): MentionItem[] {
   const text = content
     .filter(
@@ -216,7 +226,7 @@ function extractAttachedPaths(content: MessageContentBlock[]): MentionItem[] {
     const raw = m[1].trim();
     if (!raw) continue;
     // Absolute path → a materialized upload, already shown via its file block.
-    if (raw.startsWith("/")) continue;
+    if (isAbsolutePath(raw)) continue;
     // Split a trailing ":start-end" line span back out so the chip can show
     // it without truncation (it's the whole point of a partial-file attach).
     const range = /^(.*):(\d+)-(\d+)$/.exec(raw);

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -158,6 +158,19 @@ describe("UserBubble @-mention attachment chips", () => {
     expect(screen.getByText("what is this")).toBeInTheDocument();
   });
 
+  // The absolute-path heuristic is OS-agnostic so it still suppresses the
+  // chip if an executor ever materializes an upload on a Windows host
+  // (drive-letter or UNC root), where the marker wouldn't start with "/".
+  it.each([
+    ["C:\\Users\\me\\AppData\\Local\\Temp\\omnigent\\uploads\\image.png", "drive (backslash)"],
+    ["C:/Users/me/AppData/Local/Temp/omnigent/uploads/image.png", "drive (forward slash)"],
+    ["\\\\host\\share\\omnigent\\uploads\\image.png", "UNC"],
+  ])("does not chip a Windows-style absolute upload marker (%s)", (path) => {
+    renderBubble(userBubble(`[Attached: ${path}]\n\nwhat is this`));
+    expect(screen.queryByText(/uploads/)).toBeNull();
+    expect(screen.getByText("what is this")).toBeInTheDocument();
+  });
+
   it("chips a relative @-mention but not an absolute upload in the same message", () => {
     renderBubble(
       userBubble(

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -138,4 +138,36 @@ describe("UserBubble @-mention attachment chips", () => {
     expect(screen.getByText("@bob-max-gain/docker-compose.yml")).toBeInTheDocument();
     expect(screen.getByText(":2-9")).toBeInTheDocument();
   });
+
+  // An explicit upload is materialized to disk by the native executor, which
+  // injects an *absolute* "[Attached: <bridge>/uploads/…]" marker for the CLI.
+  // The upload already rides in as an input_image / input_file block, so the
+  // marker must NOT also surface as a path chip (it would double-render, and
+  // the path is an internal temp dir).
+  it("does not chip an absolute upload marker (already shown via its file block)", () => {
+    renderBubble(
+      userBubble(
+        "[Attached: /var/folders/x/omnigent-1/claude-native/abc/uploads/image.png]\n\nwhat is this",
+      ),
+    );
+    // No "@…" chip for the absolute upload path.
+    expect(screen.queryByText(/^@\//)).toBeNull();
+    expect(screen.queryByText(/uploads\/image\.png/)).toBeNull();
+    // The marker is still stripped from the body and the prose survives.
+    expect(screen.queryByText(/\[Attached:/)).toBeNull();
+    expect(screen.getByText("what is this")).toBeInTheDocument();
+  });
+
+  it("chips a relative @-mention but not an absolute upload in the same message", () => {
+    renderBubble(
+      userBubble(
+        "[Attached: /tmp/omnigent/claude-native/abc/uploads/image.png]\n" +
+          "[Attached: src/server.ts]\n\ncompare",
+      ),
+    );
+    // Workspace @-mention still chips...
+    expect(screen.getByText("@src/server.ts")).toBeInTheDocument();
+    // ...the materialized upload does not.
+    expect(screen.queryByText(/uploads\/image\.png/)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Related issue

N/A — regression introduced by #1038.

## Summary

When you attach (upload) an image or file in a native coding-agent session, the bubble was showing the **internal bridge temp path** (e.g. `@…/uploads/image.png`) as a chip instead of just rendering the image.

- #1038 added `@`-mention workspace attachments, delivered as `[Attached: <path>]` text markers that `extractAttachedPaths()` turns into path chips.
- But explicitly *uploaded* files share that marker wording: the native executor materializes the upload to disk and injects an **absolute** `[Attached: <bridge>/uploads/…]` marker so the vendor CLI can read it. The upload also already rides in as its own `input_image`/`input_file` block (rendered as the image / a file chip), so the marker was **double-rendering** — surfacing the bridge temp path as a redundant chip.
- Fix: `extractAttachedPaths()` now skips **absolute-path** markers. `@`-mention paths are always workspace-relative, while materialized uploads are absolute, so the absolute path reliably identifies an already-rendered upload.

## Test Plan

- `npm test` (full `ap-web` vitest suite): **3344 passed**, incl. 2 new tests in `ChatPage.userBubble.test.tsx`:
  - absolute upload marker → no chip, marker still stripped, prose preserved.
  - mixed message → relative `@`-mention chips, absolute upload does not.
- `npm run build` (`tsc -b && vite build`): clean.

## Demo

No screen recording available from this environment. Behavior summary:

| Scenario | Before (#1038) | After |
|---|---|---|
| Image upload | inline image **+** redundant `@…/uploads/image.png` path chip | inline image only |
| File upload (PDF) | file chip **+** redundant bridge-path chip | file chip only |
| `@`-mention file/folder/line-range | `@src/foo.ts` chip | `@src/foo.ts` chip (unchanged) |
| Upload + `@`-mention in one message | both, plus bogus upload path chip | image/file + `@`-mention chip, no bridge-path chip |

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit coverage for the absolute-upload-marker case (alone and mixed with a relative `@`-mention) in `ChatPage.userBubble.test.tsx`. Manually traced the full path: upload → server file resource (`file_id`) → `content_resolver` base64 → `materialize_attachment` (absolute bridge `uploads/` path) → `[Attached: …]` marker → durable message retains the `input_image`/`input_file` block via `_merge_pending_file_blocks`, confirming the block (not the marker) is the correct render source.