### PR TITLE
fix(deps): bump faraday to 1.10.6 in web/ios (security)

### DIFF
--- a/web/ios/Gemfile.lock
+++ b/web/ios/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.109.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
## Related issue

N/A (Dependabot security alert; no tracking issue).

## Summary

- Bumps `faraday` 1.10.5 to 1.10.6 in `web/ios/Gemfile.lock` to clear the high-severity Dependabot alert (vulnerable `<= 1.10.5`). faraday is a transitive dependency of fastlane; 1.10.6 satisfies fastlane's `~> 1.0`, so the change is faraday-only with no metadata churn.

## Test Plan

- Lockfile-only change resolved via `bundle lock --update faraday`; the diff is a single version line. CI bundler/iOS jobs cover install.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Dev/CI tooling dependency (iOS fastlane), no shipped-product code. The second open alert in this lockfile (aws-sdk-s3, medium) is not included: bundler will not advance it past 1.188.0 under the current iOS toolchain even when unlocked, so it needs resolution in the iOS Ruby/bundler environment rather than a local bump.
