### PR TITLE
feat(codex): post policy_cost_usd mid-turn from cumulative token counts

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -1179,11 +1179,45 @@ class _SessionUsageCoalescer:
             return
         # Attach the model to every token-bearing post (not via the
         # changed-keys dedup, so it rides along even when only token
-        # counts changed) — the server reprices cumulative tokens into
-        # ``total_cost_usd`` per turn and needs the model each time.
+        # counts changed) — the server needs it to price cumulative
+        # tokens into ``total_cost_usd`` and for per-model attribution.
         payload: dict[str, Any] = dict(data)
         if self._model:
             payload["model"] = self._model
+        # Compute ``policy_cost_usd`` client-side from the cumulative token
+        # counts so the cost-budget gate sees a real-time figure mid-turn
+        # (issue #6). The server already prices tokens server-side into
+        # ``total_cost_usd``, but the policy engine prefers an explicit
+        # ``policy_cost_usd`` field and falls back to ``total_cost_usd``
+        # only when it's absent. Setting it here makes the enforcement
+        # value unambiguous and independent of server-side repricing timing.
+        #
+        # Token layout: Codex's ``cumulative_input_tokens`` is INCLUSIVE of
+        # cached tokens, so subtract ``cumulative_cache_read_input_tokens``
+        # to get the non-cached portion that ``compute_llm_cost`` expects
+        # (same split the server applies in ``_persist_external_session_usage``).
+        if self._model:
+            cin: int = self._pending.get("cumulative_input_tokens", 0)
+            cout: int = self._pending.get("cumulative_output_tokens", 0)
+            ccache: int = self._pending.get("cumulative_cache_read_input_tokens", 0)
+            if cin or cout:
+                from omnigent.llms.context_window import (
+                    compute_llm_cost,
+                    fetch_model_pricing,
+                )
+
+                pricing = fetch_model_pricing(self._model)
+                if pricing is not None:
+                    cached = min(ccache, cin)
+                    policy_cost = compute_llm_cost(
+                        {
+                            "input_tokens": cin - cached,
+                            "output_tokens": cout,
+                            "cache_read_input_tokens": cached,
+                        },
+                        pricing,
+                    )
+                    payload["policy_cost_usd"] = policy_cost
         response = await _post_session_event(
             self._client,
             self._session_id,

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -478,6 +478,86 @@ async def test_usage_coalescer_unseeded_omits_model() -> None:
     assert "model" not in body["data"]
 
 
+@pytest.mark.asyncio
+async def test_usage_coalescer_posts_policy_cost_usd_from_token_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """flush() computes and posts policy_cost_usd from cumulative token counts.
+
+    The cost-budget policy engine prefers an explicit ``policy_cost_usd`` field
+    over the server-computed ``total_cost_usd``. By computing cost client-side
+    from the cumulative token counts and posting it as ``policy_cost_usd``, the
+    coalescer gives the gate a real-time enforcement figure mid-turn (issue #6).
+
+    The cached-input split must be applied correctly: Codex's
+    ``cumulative_input_tokens`` is INCLUSIVE of cache reads, so the non-cached
+    portion passed to ``compute_llm_cost`` is
+    ``cumulative_input_tokens - cumulative_cache_read_input_tokens``.
+    """
+    from omnigent.llms.context_window import ModelPricing
+
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: (
+            ModelPricing(input_per_token=1e-6, output_per_token=2e-6)
+            if model == "gpt-5.5"
+            else None
+        ),
+    )
+
+    client = _RecordingClient()
+    coalescer = fwd._SessionUsageCoalescer(client, "conv_x", model="gpt-5.5")
+    # 1000 total input (200 cached + 800 non-cached), 500 output.
+    # expected cost = 800*1e-6 + 200*1e-6 + 500*2e-6 = 0.0008 + 0.0002 + 0.001 = 0.0020
+    # (cache_read at input rate because ModelPricing has no separate cache rate)
+    coalescer.record(
+        {
+            "tokenUsage": {
+                "total": {
+                    "inputTokens": 1000,
+                    "outputTokens": 500,
+                    "cachedInputTokens": 200,
+                }
+            }
+        }
+    )
+    await coalescer.flush()
+
+    assert len(client.posts) == 1
+    data = client.posts[0][1]["data"]
+    assert data["cumulative_input_tokens"] == 1000
+    assert data["cumulative_output_tokens"] == 500
+    assert data["cumulative_cache_read_input_tokens"] == 200
+    assert "policy_cost_usd" in data
+    # non-cached input = 800 @ 1e-6 = 0.00080
+    # cache_read      = 200 @ 0.10 * 1e-6 (fallback ratio) = 0.00002
+    # output          = 500 @ 2e-6 = 0.00100
+    # total = 0.00182
+    assert data["policy_cost_usd"] == pytest.approx(0.00182)
+
+
+@pytest.mark.asyncio
+async def test_usage_coalescer_omits_policy_cost_usd_when_model_unpriced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No policy_cost_usd in the payload when the model has no catalog pricing.
+
+    An unpriced model must not block the turn (the gate fails open on $0).
+    The coalescer should omit the field entirely rather than posting $0.
+    """
+    monkeypatch.setattr(
+        "omnigent.llms.context_window.fetch_model_pricing",
+        lambda model: None,
+    )
+    client = _RecordingClient()
+    coalescer = fwd._SessionUsageCoalescer(client, "conv_x", model="unknown-model")
+    coalescer.record({"tokenUsage": {"total": {"inputTokens": 100, "outputTokens": 50}}})
+    await coalescer.flush()
+
+    data = client.posts[0][1]["data"]
+    assert "policy_cost_usd" not in data
+
+
 class _FlakyElicitationClient:
     """
     Elicitation client stub: configurable failures, then HTTP 200.


### PR DESCRIPTION
## Summary

Closes the mid-turn cost gating gap for codex-native (issue #6 from the cost-budget audit).

The cost-budget policy engine prefers an explicit `policy_cost_usd` field and falls back to `total_cost_usd` only when it's absent. `_SessionUsageCoalescer` was already posting cumulative token counts mid-turn on every `thread/tokenUsage/updated` notification, and the server was pricing them into `total_cost_usd` — but never setting `policy_cost_usd`, leaving the gate on the implicit fallback path.

## Changes

**`omnigent/codex_native_forwarder.py`** — `_SessionUsageCoalescer.flush()`:
- After building the token payload, if a model is known and token counts are present, calls `fetch_model_pricing` + `compute_llm_cost` to compute `policy_cost_usd` client-side
- Adds `policy_cost_usd` to the payload so the server stores it directly as the enforcement figure
- Applies the same cached-input split as the server: `cumulative_input_tokens` is inclusive of cache reads, so `non_cached = cumulative_input - cumulative_cache_read`
- Omits `policy_cost_usd` entirely when the model has no catalog pricing (gate stays open at $0, unchanged behaviour)

## Why not relay?

Relay harnesses don't emit any token counts until `response.completed` — there's no mid-turn signal to compute from. That requires protocol changes at the executor level (new `response.usage_checkpoint` event type). Codex already had the data; it just wasn't computing cost from it.

## Test plan

- [ ] `pytest tests/test_codex_native_forwarder.py -k "coalescer"` — 4/4 pass (2 new)
- [ ] `pytest tests/test_codex_native_forwarder.py tests/test_codex_native.py` — 248/248 pass