### PR TITLE
fix(harnesses): make _close_entry teardown best-effort so a failing aclose() still kills the process

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1082,25 +1082,43 @@ class HarnessProcessManager:
         Close the httpx client, terminate the subprocess, and
         remove its socket file.
 
+        Teardown is best-effort and ordered so the process kill — the
+        step that actually reclaims the OS resource — always runs even
+        if an earlier step raises. ``release`` has already popped the
+        entry from ``_entries`` before calling this, so a bare
+        ``client.aclose()`` raise (a broken transport, a wedged client)
+        that skipped the kill would otherwise leak an *un-tracked*
+        subprocess. ``CancelledError`` (a ``BaseException``, not
+        ``Exception``) still propagates, so shutdown cancellation is
+        unaffected.
+
         :param entry: The bookkeeping record to tear down.
         """
-        await entry.client.aclose()
-        if entry.process.returncode is None:
-            try:
-                entry.process.send_signal(signal.SIGTERM)
-                await asyncio.wait_for(entry.process.wait(), timeout=_RELEASE_GRACE_S)
-            except asyncio.TimeoutError:
-                # Wedged subprocess — kill outright. The harness
-                # author is responsible for clean SIGTERM handling
-                # if they want graceful shutdown of in-flight
-                # responses.
-                entry.process.kill()
-                await entry.process.wait()
-        close_subprocess_transport(entry.process)
-        # Best-effort socket cleanup. uvicorn's atexit usually
-        # handles this when SIGTERM lands cleanly, but a
-        # hard-killed runner won't. No-op for TCP endpoints.
-        entry.endpoint.cleanup()
+        try:
+            await entry.client.aclose()
+        except Exception:
+            # A broken transport must not skip the subprocess kill below.
+            _logger.exception("error closing harness client during teardown; continuing")
+        finally:
+            if entry.process.returncode is None:
+                try:
+                    entry.process.send_signal(signal.SIGTERM)
+                    await asyncio.wait_for(entry.process.wait(), timeout=_RELEASE_GRACE_S)
+                except Exception:
+                    # Graceful SIGTERM didn't complete — it timed out, or
+                    # send_signal/wait raised (e.g. the process vanished
+                    # mid-teardown). Force-kill best-effort; a process that
+                    # is already gone is already done.
+                    with contextlib.suppress(Exception):
+                        entry.process.kill()
+                        await entry.process.wait()
+            with contextlib.suppress(Exception):
+                close_subprocess_transport(entry.process)
+            # Best-effort socket cleanup. uvicorn's atexit usually
+            # handles this when SIGTERM lands cleanly, but a
+            # hard-killed runner won't. No-op for TCP endpoints.
+            with contextlib.suppress(Exception):
+                entry.endpoint.cleanup()
 
     async def _idle_reaper_loop(self) -> None:
         """

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -326,6 +326,44 @@ async def test_release_terminates_subprocess(
         await manager.shutdown()
 
 
+async def test_close_entry_kills_process_when_aclose_raises(
+    manager: HarnessProcessManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing ``client.aclose()`` must not skip the subprocess kill.
+
+    ``_close_entry`` used to ``await client.aclose()`` first with no guard, so a
+    raise there (a broken transport, a wedged client) skipped the SIGTERM/SIGKILL
+    below and the subprocess leaked un-killed — and untracked, since ``release``
+    already popped the entry. Force ``aclose()`` to raise and assert the process
+    is still terminated (and ``release`` itself doesn't raise, since teardown is
+    now best-effort).
+    """
+    await manager.start()
+    try:
+        client = await manager.get_client("conv_a", _TEST_HARNESS_NAME)
+        pid = (await client.get("/pid")).json()["pid"]
+        entry = manager._entries["conv_a"]
+
+        async def _boom() -> None:
+            raise RuntimeError("simulated aclose failure")
+
+        monkeypatch.setattr(entry.client, "aclose", _boom)
+
+        # release() -> _close_entry(): the aclose failure must not prevent the
+        # kill, and best-effort teardown means release itself completes.
+        await manager.release("conv_a")
+        assert "conv_a" not in manager._entries
+
+        for _ in range(20):
+            if not _pid_alive(pid):
+                break
+            await asyncio.sleep(0.05)
+        assert not _pid_alive(pid), "subprocess survived a teardown where aclose() raised"
+    finally:
+        await manager.shutdown()
+
+
 async def test_get_client_respawns_after_crash(
     manager: HarnessProcessManager,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #1671. Follow-up to the #1635 review (Tagar's persistent-failure note + the
Polly AI review observation that a half-torn-down process/FD/socket isn't retried).

## Summary

- `_close_entry` tore down a harness subprocess in a fixed sequence with a bare
  `await entry.client.aclose()` first. If that raised (a broken transport, a
  wedged client), the SIGTERM/SIGKILL + transport/socket cleanup below it never
  ran — the subprocess was left **alive**, and (since `release` already popped
  the entry from `_entries`) **untracked**, reclaimed only later by the
  `--parent-pid` watchdog or the next-boot orphan sweep.
- Make teardown best-effort: `aclose()` failures are logged and the teardown
  continues in a `finally`, with the SIGTERM→SIGKILL escalation and the
  transport/socket cleanup each guarded, so the **process kill always runs**.
- `CancelledError` (a `BaseException`, not `Exception`) still propagates, so
  shutdown cancellation is unaffected.
- No process-group kill (`killpg`) — omnigent intentionally uses the
  `--parent-pid` watchdog for orphan prevention rather than process groups, so
  the fix stays scoped to making the single-process teardown robust.

This complements #1635: that guarded the reaper *loop* against a failed
`release`; this hardens the *teardown itself*, which benefits all three callers
of `release()` → `_close_entry()` (normal close, idle reaping, shutdown).

## Test Plan

`uv run pytest tests/runtime/harnesses/test_process_manager.py` → **30 passed**.

Added `test_close_entry_kills_process_when_aclose_raises`: forces
`client.aclose()` to raise and asserts the subprocess is still terminated (and
`release` itself doesn't raise). **Fails before** the change (the `aclose`
exception escapes `release`), **passes after**. `ruff check` /
`ruff format --check` clean.

## Demo

N/A — non-visual.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the added unit test.
