### PR TITLE
fix(kimi-native): mirror reasoning (think blocks) to the web transcript

### DIFF
--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -18,8 +18,9 @@ and recency. Relevant wire events:
   → a user message.
 - ``{"type": "context.append_loop_event", "event": {"type": "content.part",
   "part": {"type": "text", "text": …}, "uuid": …}}`` → an assistant message.
-  (``part.type == "think"`` is reasoning and is skipped for v1; ``tool.call`` /
-  ``tool.result`` events are likewise skipped — the embedded terminal shows them.)
+  (``part.type == "think"`` is reasoning, mirrored as a transient
+  ``external_output_reasoning_delta`` from ``part["think"]``; ``tool.call`` /
+  ``tool.result`` events are still skipped — the embedded terminal shows them.)
 
 Each mirrored turn is POSTed as an ``external_conversation_item`` to
 ``/v1/sessions/{id}/events`` (the same shape :mod:`omnigent.kimi_native_hook`
@@ -67,6 +68,9 @@ class _MirrorItem:
     role: str
     text: str
     response_id: str
+    # "message" (a user/assistant turn → external_conversation_item) or
+    # "reasoning" (a think block → external_output_reasoning_delta).
+    kind: str = "message"
 
 
 def clear_kimi_bridge_state(bridge_dir: Path) -> None:
@@ -202,14 +206,33 @@ def _row_to_item(line_no: int, row: dict[str, object]) -> _MirrorItem | None:
         if not isinstance(event, dict) or event.get("type") != "content.part":
             return None
         part = event.get("part")
-        if not isinstance(part, dict) or part.get("type") != "text":
-            return None
-        text = part.get("text")
-        if not isinstance(text, str) or not text:
+        if not isinstance(part, dict):
             return None
         uuid = event.get("uuid")
         response_id = f"kimi:{uuid}" if isinstance(uuid, str) and uuid else f"kimi:line:{line_no}"
-        return _MirrorItem(line_no=line_no, role="assistant", text=text, response_id=response_id)
+        part_type = part.get("type")
+        if part_type == "text":
+            text = part.get("text")
+            if not isinstance(text, str) or not text:
+                return None
+            return _MirrorItem(
+                line_no=line_no, role="assistant", text=text, response_id=response_id
+            )
+        if part_type == "think":
+            # Reasoning lives in ``part["think"]`` (not ``part["text"]``). Mirror it
+            # as a transient reasoning event so the web UI paints a thinking block —
+            # the kimi analogue of codex-native's #1254 reasoning fix.
+            think = part.get("think")
+            if not isinstance(think, str) or not think:
+                return None
+            return _MirrorItem(
+                line_no=line_no,
+                role="assistant",
+                text=think,
+                response_id=response_id,
+                kind="reasoning",
+            )
+        return None
     return None
 
 
@@ -270,6 +293,29 @@ async def _post_conversation_item(
     resp.raise_for_status()
 
 
+async def _post_reasoning_item(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    item: _MirrorItem,
+) -> None:
+    """POST one mirrored think block as a transient reasoning event.
+
+    Mirrors codex-native (#1254): a one-shot ``external_output_reasoning_delta``
+    with ``started: true`` opens a reasoning block in the web UI. Kimi persists
+    completed think parts (not streamed deltas), so one delta per part is correct.
+    """
+    body = {
+        "type": "external_output_reasoning_delta",
+        "data": {"delta": item.text, "started": True},
+    }
+    url = f"{base_url.rstrip('/')}/v1/sessions/{session_id}/events"
+    resp = await client.post(url, headers=headers, json=body)
+    resp.raise_for_status()
+
+
 async def forward_kimi_wire_to_session(
     *,
     base_url: str,
@@ -304,14 +350,23 @@ async def forward_kimi_wire_to_session(
                 items = await asyncio.to_thread(_read_new_items, wire_path, last_line)
                 for item in items:
                     try:
-                        await _post_conversation_item(
-                            client,
-                            base_url=base_url,
-                            headers=headers,
-                            session_id=session_id,
-                            item=item,
-                            agent_name=agent_name,
-                        )
+                        if item.kind == "reasoning":
+                            await _post_reasoning_item(
+                                client,
+                                base_url=base_url,
+                                headers=headers,
+                                session_id=session_id,
+                                item=item,
+                            )
+                        else:
+                            await _post_conversation_item(
+                                client,
+                                base_url=base_url,
+                                headers=headers,
+                                session_id=session_id,
+                                item=item,
+                                agent_name=agent_name,
+                            )
                     except httpx.HTTPError as exc:
                         _logger.warning("kimi forwarder: POST failed (will retry): %s", exc)
                         break

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -50,12 +50,23 @@ class TestRowToItem:
         assert item.text == "This is **Omnigent**."
         assert item.response_id == "kimi:67ce67f7"
 
-    def test_think_part_is_skipped(self) -> None:
+    def test_think_part_is_reasoning(self) -> None:
+        # Reasoning lives in part["think"] (not part["text"]) and is mirrored as a
+        # reasoning item, not skipped — the kimi analogue of codex-native #1254.
         row = {
             "type": "context.append_loop_event",
-            "event": {"type": "content.part", "part": {"type": "think", "think": "reasoning"}},
+            "event": {
+                "type": "content.part",
+                "uuid": "abc123",
+                "part": {"type": "think", "think": "Let me reason about this."},
+            },
         }
-        assert _row_to_item(5, row) is None
+        item = _row_to_item(5, row)
+        assert item is not None
+        assert item.kind == "reasoning"
+        assert item.role == "assistant"
+        assert item.text == "Let me reason about this."
+        assert item.response_id == "kimi:abc123"
 
     def test_tool_call_and_metadata_skipped(self) -> None:
         for row in (


### PR DESCRIPTION
## Related issue

Closes #1676.

## Summary

- The kimi-native forwarder only mirrored `content.part` of type `text`, so
  Kimi's reasoning (the `think` block shown in the TUI) never reached the web
  conversation — the forwarder docstring acknowledged it as *"skipped for v1"*.
- Reasoning text lives in `part["think"]`, not `part["text"]` (verified against a
  live `wire.jsonl`: `{"type": "think", "think": "…"}`), so the fix reads a
  different field, not just a relaxed type check.
- Mirror a `think` part as a one-shot transient `external_output_reasoning_delta`
  (`started: true`) so the web UI paints a reasoning block — the kimi analogue of
  **codex-native #1254**, where the project settled reasoning mirroring as a
  required native-harness capability (hermes-native is getting the same in #1645).
- `tool.call` / `tool.result` mirroring is left as a separate follow-up.

## Test Plan

`uv run pytest tests/test_kimi_native_forwarder.py` → **12 passed**.

Updated the existing `_row_to_item` test that asserted `think` parts are skipped
(`test_think_part_is_skipped`) to assert they now produce a reasoning item
(`test_think_part_is_reasoning`): `kind == "reasoning"`, `text == part["think"]`.
**Fails before** the change (think part returned `None`), **passes after**.
`ruff check` / `ruff format --check` clean.

Also manually verified end-to-end against a live `omnigent kimi` session: before,
the TUI showed a multi-line think block that never appeared in the web chat;
after, the reasoning is mirrored.

## Demo

Same prompt against a live `omnigent kimi` session, before and after this change.

**Before (main)** — Kimi produced a think block (present in the session's `wire.jsonl`), but the web transcript only shows the final reply:

<img width="729" alt="before: no reasoning block in the web transcript" src="https://github.com/user-attachments/assets/9da3d75c-b7ba-484f-ad97-fd6d88ae9534" />

**After (this PR)** — the think block is mirrored as an expandable reasoning block above the reply:

<img width="722" alt="after: think block mirrored as a reasoning block" src="https://github.com/user-attachments/assets/e40d2662-4965-46be-a50a-5e6da3ed871f" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit test covers the `_row_to_item` think→reasoning mapping. Manually verified
the end-to-end mirror against a live `omnigent kimi` session (TUI think block now
appears in the web transcript).

