### PR TITLE
feat(read-state): per-user unread/seen synced across devices

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -905,6 +905,26 @@ def _set_read_state(user_id: str | None, session_id: str, last_seen: int, unread
             unread_set.discard(session_id)
 
 
+def _prune_session_read_state(session_id: str) -> None:
+    """
+    Drop a session's read-state from every user's caches.
+
+    Called when a session leaves the default view for good — on delete, and
+    on archive (archived sessions are hidden and never show the unread dot).
+    This bounds the otherwise-monotonic ``_read_last_seen`` growth to live,
+    non-archived sessions. Read-state is a session-level removal (the session
+    is gone/archived for everyone), so it clears across all users. Unarchiving
+    does NOT restore the prior state — the session reads as seen, which is the
+    intended "done with it" semantics of archiving.
+
+    :param session_id: Session/conversation identifier.
+    """
+    for seen in _read_last_seen.values():
+        seen.pop(session_id, None)
+    for unread in _read_explicit_unread.values():
+        unread.discard(session_id)
+
+
 # Sessions whose current turn was Stopped: the relay drops the turn's trailing
 # response.* output (no forward, no persist). The fence lifts on the next
 # turn's "running" status or on any terminal response.* event.
@@ -14873,6 +14893,11 @@ def create_sessions_router(
                 "Session not found",
                 code=ErrorCode.NOT_FOUND,
             )
+        # Archiving hides the session from the default view (and its unread
+        # dot), so drop its per-user read-state to bound in-memory growth.
+        # Only on archive→true; unarchiving leaves it pruned (reads as seen).
+        if body.archived is True:
+            _prune_session_read_state(session_id)
         # Notify the runner of effort / model changes so harnesses
         # that can't re-read these from store at turn boundaries
         # (today: claude-native, whose ``claude`` binary has
@@ -19276,6 +19301,10 @@ def create_sessions_router(
         # failed-launch session would leak one entry for the process
         # lifetime.
         _session_sandbox_status_cache.pop(session_id, None)
+        # Drop the deleted session's per-user read-state from every user's
+        # caches so they don't accumulate orphan entries for the process
+        # lifetime.
+        _prune_session_read_state(session_id)
         # Same for the tracker's entry — a deleted session's launch can
         # never be rendezvoused again (access checks 404 first), so a
         # retained failure is dead weight. ``finish`` also settles a

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -904,6 +904,7 @@ def _set_read_state(user_id: str | None, session_id: str, last_seen: int, unread
         if unread_set is not None:
             unread_set.discard(session_id)
 
+
 # Sessions whose current turn was Stopped: the relay drops the turn's trailing
 # response.* output (no forward, no persist). The fence lifts on the next
 # turn's "running" status or on any terminal response.* event.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -213,6 +213,7 @@ from omnigent.server.schemas import (
     PaginatedList,
     PermissionObject,
     PolicySummary,
+    ReadStatePutRequest,
     ReasoningStartedEvent,
     ReasoningTextDeltaEvent,
     ResponseObject,
@@ -854,6 +855,54 @@ _session_status_cache: dict[str, str] = {}
 # TUI's own turn-boundary update of its "N shells still running" banner.
 # In-memory only — repopulates from live edges, exactly like the status cache.
 _session_background_task_count_cache: dict[str, int] = {}
+
+# Per-user read tracking, keyed by the user's discovery key (user id, or
+# the shared key in single-user mode) then by session id. Mirrors the two
+# values the web client used to keep in localStorage: a "last seen"
+# wall-clock baseline and an explicit "marked unread" override set.
+# In-memory only — like _session_status_cache it does NOT survive a server
+# restart. Unlike status (rederivable from the runner), read state has no
+# durable source, so a restart resets it; this is an accepted tradeoff for
+# keeping it server-side (shared across a user's devices while up) without
+# a DB. Entries are never pruned on session delete (bounded by churn,
+# wiped on restart).
+_read_last_seen: dict[str, dict[str, int]] = {}
+_read_explicit_unread: dict[str, set[str]] = {}
+
+
+def _read_state_entry(user_id: str | None, session_id: str) -> tuple[int | None, bool]:
+    """
+    Read the caller's read-state for one session, for embedding in the
+    per-user ``GET /v1/sessions`` list items.
+
+    :param user_id: Authenticated user id, or ``None`` in single-user mode.
+    :param session_id: Session/conversation identifier.
+    :returns: ``(last_seen, unread)`` — the wall-clock baseline (or ``None``
+        when the user has never seen the session) and the explicit-unread flag.
+    """
+    key = _discovery_key(user_id)
+    last_seen = _read_last_seen.get(key, {}).get(session_id)
+    unread = session_id in _read_explicit_unread.get(key, set())
+    return last_seen, unread
+
+
+def _set_read_state(user_id: str | None, session_id: str, last_seen: int, unread: bool) -> None:
+    """
+    Set the caller's read-state for one session.
+
+    :param user_id: Authenticated user id, or ``None`` in single-user mode.
+    :param session_id: Session/conversation identifier.
+    :param last_seen: Wall-clock baseline in seconds.
+    :param unread: Whether the session is explicitly flagged unread.
+    """
+    key = _discovery_key(user_id)
+    _read_last_seen.setdefault(key, {})[session_id] = last_seen
+    if unread:
+        _read_explicit_unread.setdefault(key, set()).add(session_id)
+    else:
+        unread_set = _read_explicit_unread.get(key)
+        if unread_set is not None:
+            unread_set.discard(session_id)
 
 # Sessions whose current turn was Stopped: the relay drops the turn's trailing
 # response.* output (no forward, no persist). The fence lifts on the next
@@ -1998,6 +2047,10 @@ def _build_session_list_item(
     assert conv.agent_id is not None
     level = _permission_level_from_grants(user_id, grants, user_is_admin)
     owner = _owner_from_grants(grants) if permissions_enabled else None
+    # Per-viewer read tracking, embedded so the client hydrates the unread
+    # dots straight from the list (no separate fetch). Built per-user here —
+    # `user_id` is the requesting caller, never broadcast to other viewers.
+    viewer_last_seen, viewer_unread = _read_state_entry(user_id, conv.id)
     return SessionListItem(
         id=conv.id,
         agent_id=conv.agent_id,
@@ -2021,6 +2074,8 @@ def _build_session_list_item(
         comments_updated_at=(
             comments_fingerprint.last_updated_at if comments_fingerprint else None
         ),
+        viewer_last_seen=viewer_last_seen,
+        viewer_unread=viewer_unread,
     )
 
 
@@ -13843,6 +13898,45 @@ def create_sessions_router(
             conversation_store.list_projects,
             accessible_by=user_id,
         )
+
+    # ── PUT /sessions/{session_id}/read-state ─────────────────────
+    #
+    # The per-user read-state *write* path. The *read* path is the
+    # per-viewer ``viewer_last_seen`` / ``viewer_unread`` fields embedded in
+    # the ``GET /v1/sessions`` list items — no separate read endpoint.
+
+    @router.put(
+        "/sessions/{session_id}/read-state",
+        status_code=204,
+    )
+    async def put_read_state(
+        request: Request,
+        session_id: str,
+        body: ReadStatePutRequest,
+    ) -> Response:
+        """
+        Set the calling user's read-state for one session.
+
+        Requires ``LEVEL_READ`` on the session in multi-user mode — you can
+        only track read-state for sessions you can see. Stores the values
+        verbatim (the client enforces the baseline's monotonicity and the
+        unread semantics); the server does not interpret them against
+        session status. Returns ``204`` — the client already has the
+        optimistic state and re-reads the authoritative value on the next
+        ``GET /v1/sessions`` poll.
+
+        :param request: The incoming FastAPI request (for auth).
+        :param session_id: Session/conversation identifier.
+        :param body: The validated :class:`ReadStatePutRequest`.
+        :returns: An empty ``204 No Content`` response.
+        :raises OmnigentError: 403 if the caller lacks read access.
+        """
+        user_id = _require_user(request, auth_provider)
+        await _require_access_and_level(
+            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+        )
+        _set_read_state(user_id, session_id, body.last_seen, body.unread)
+        return Response(status_code=204)
 
     # ── GET /sessions/{session_id} ───────────────────────────────
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1957,6 +1957,31 @@ class SessionForkRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class ReadStatePutRequest(BaseModel):
+    """
+    Request body for ``PUT /v1/sessions/{session_id}/read-state``.
+
+    Sets the *calling user's* read tracking for one session. Mirrors the
+    two values the web client keeps per session: a "last seen" wall-clock
+    baseline (seconds since epoch) and an explicit "marked unread"
+    override. The unread dot shows when ``updated_at > last_seen`` and the
+    session is finished; ``unread`` separately pins the override so the
+    thread the user is *viewing* (or a running one) still surfaces the dot
+    where the automatic "seen" logic would otherwise suppress it.
+
+    :param last_seen: Wall-clock baseline in seconds, e.g. ``1717000000``.
+        Marking seen sets this to "now"; marking unread pins it to
+        ``updated_at - 1`` so the row reads unseen.
+    :param unread: Whether this session is explicitly flagged unread for
+        the caller.
+    """
+
+    last_seen: int
+    unread: bool
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class SessionSwitchAgentRequest(BaseModel):
     """
     Request body for ``POST /v1/sessions/{id}/switch-agent``.
@@ -2060,6 +2085,16 @@ class SessionListItem(BaseModel):
         distinguishable while staying an exact integer in JavaScript;
         clients only compare it for change. ``None`` when the session
         has no comments or the server has no comment store wired.
+    :param viewer_last_seen: The *requesting user's* "last seen"
+        wall-clock baseline in seconds for this session, or ``None``
+        when they have never seen it. Per-viewer (built from the
+        server's in-memory per-user read-state, written by
+        ``PUT /v1/sessions/{id}/read-state``); the unread dot shows
+        when ``updated_at > viewer_last_seen`` and the session is
+        finished. In-memory only — resets on a server restart.
+    :param viewer_unread: Whether the *requesting user* explicitly
+        marked this session unread. Per-viewer; lifts the active-row
+        dot suppression on the client. ``False`` by default.
     """
 
     id: str
@@ -2084,6 +2119,8 @@ class SessionListItem(BaseModel):
     archived: bool = False
     comments_count: int = 0
     comments_updated_at: int | None = None
+    viewer_last_seen: int | None = None
+    viewer_unread: bool = False
 
 
 class SessionList(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -2250,6 +2250,28 @@
         "title": "QueuedEvent",
         "type": "object"
       },
+      "ReadStatePutRequest": {
+        "additionalProperties": false,
+        "description": "Request body for `PUT /v1/sessions/{session_id}/read-state`.\n\nSets the *calling user's* read tracking for one session. Mirrors the\ntwo values the web client keeps per session: a \"last seen\" wall-clock\nbaseline (seconds since epoch) and an explicit \"marked unread\"\noverride. The unread dot shows when `updated_at > last_seen` and the\nsession is finished; `unread` separately pins the override so the\nthread the user is *viewing* (or a running one) still surfaces the dot\nwhere the automatic \"seen\" logic would otherwise suppress it.",
+        "properties": {
+          "last_seen": {
+            "description": "Wall-clock baseline in seconds, e.g. `1717000000`. Marking seen sets this to \"now\"; marking unread pins it to `updated_at - 1` so the row reads unseen.",
+            "title": "Last Seen",
+            "type": "integer"
+          },
+          "unread": {
+            "description": "Whether this session is explicitly flagged unread for the caller.",
+            "title": "Unread",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "last_seen",
+          "unread"
+        ],
+        "title": "ReadStatePutRequest",
+        "type": "object"
+      },
       "ReasoningData": {
         "description": "Data for a reasoning item.\n\n**Parameters**\n\n- `agent` \u2014 Agent name. Serialized as `\"model\"` in JSON.",
         "properties": {
@@ -3802,6 +3824,24 @@
             "description": "Unix epoch seconds of last update.",
             "title": "Updated At",
             "type": "integer"
+          },
+          "viewer_last_seen": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The *requesting user's* \"last seen\" wall-clock baseline in seconds for this session, or `None` when they have never seen it. Per-viewer (built from the server's in-memory per-user read-state, written by `PUT /v1/sessions/{id}/read-state`); the unread dot shows when `updated_at > viewer_last_seen` and the session is finished. In-memory only \u2014 resets on a server restart.",
+            "title": "Viewer Last Seen"
+          },
+          "viewer_unread": {
+            "default": false,
+            "description": "Whether the *requesting user* explicitly marked this session unread. Per-viewer; lifts the active-row dot suppression on the client. `False` by default.",
+            "title": "Viewer Unread",
+            "type": "boolean"
           },
           "workspace": {
             "anyOf": [
@@ -8833,6 +8873,53 @@
         "summary": "Update Policy",
         "tags": [
           "session_policies"
+        ]
+      }
+    },
+    "/v1/sessions/{session_id}/read-state": {
+      "put": {
+        "description": "Set the calling user's read-state for one session.\n\nRequires `LEVEL_READ` on the session in multi-user mode \u2014 you can\nonly track read-state for sessions you can see. Stores the values\nverbatim (the client enforces the baseline's monotonicity and the\nunread semantics); the server does not interpret them against\nsession status. Returns `204` \u2014 the client already has the\noptimistic state and re-reads the authoritative value on the next\n`GET /v1/sessions` poll.\n\n**Parameters**\n\n- `body` \u2014 The validated `ReadStatePutRequest`.\n\n**Returns:** An empty `204 No Content` response.\n\n**Raises**\n\n- `OmnigentError` \u2014 403 if the caller lacks read access.",
+        "operationId": "put_read_state_v1_sessions__session_id__read_state_put",
+        "parameters": [
+          {
+            "description": "Session/conversation identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReadStatePutRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Read State",
+        "tags": [
+          "sessions"
         ]
       }
     },

--- a/tests/e2e_ui/sessions/test_sidebar_mark_unread.py
+++ b/tests/e2e_ui/sessions/test_sidebar_mark_unread.py
@@ -1,0 +1,74 @@
+"""Browser e2e for "Mark as unread" from the sidebar.
+
+The row kebab's "Mark as unread" item re-lights the row's unread dot
+(``SessionStateBadge`` with ``data-state="unseen"``) and writes the
+caller's read-state to the server via ``PUT /v1/sessions/{id}/read-state``.
+
+Read-state is server-backed and per-user (no ``localStorage``), so this
+guards the wiring the mocked unit tests can't:
+
+- The PUT actually fires (and doesn't 4xx on wire drift), so the dot
+  survives a full page reload — a fresh page load has no client state and
+  re-seeds the dot only from ``GET /v1/sessions``'s ``viewer_unread``.
+- The server persists it per-user: the list endpoint returns
+  ``viewer_unread = true`` for the session, which is what another device
+  would read.
+
+A reload (not just an in-tab assertion) is the key signal: since there's
+no ``localStorage`` fallback, a dot that reappears after reload proves the
+round-trip through the server (the PUT persisted it and a fresh
+``GET /v1/sessions`` re-seeded ``viewer_unread``), not a client-only cache
+patch.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Locator, Page, expect
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _unread_dot(row: Locator) -> Locator:
+    """Locate the row's unread (pink) dot — the unseen session-state badge."""
+    return row.locator('[data-testid="session-state-badge"][data-state="unseen"]')
+
+
+def test_mark_unread_lights_the_dot_and_persists_across_reload(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Marking a session unread lights the dot and survives a reload + server.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound (idle) session.
+    """
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+    # The row starts seen — no unread dot.
+    expect(_unread_dot(row)).to_have_count(0)
+
+    # Open the row kebab and pick "Mark as unread". Hover first so the
+    # desktop hover-revealed kebab trigger is interactable.
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("mark-unread-conversation").click()
+
+    # The dot lights immediately (optimistic mirror write), even though this
+    # is the session you're currently viewing.
+    expect(_unread_dot(row)).to_be_visible()
+
+    # Reload: a fresh page has no client state, so the dot can only come back
+    # from the server's per-user read-state (the PUT persisted it; a fresh
+    # GET /v1/sessions re-seeds viewer_unread). A client-only patch would be
+    # lost here — this is what another device would read too.
+    page.reload()
+    expect(_row(page, session_id)).to_be_visible()
+    expect(_unread_dot(_row(page, session_id))).to_be_visible()

--- a/tests/server/routes/test_sessions_read_state.py
+++ b/tests/server/routes/test_sessions_read_state.py
@@ -1,0 +1,166 @@
+"""Tests for the per-user read-state feature:
+
+  * ``PUT /v1/sessions/{session_id}/read-state`` — set the caller's
+    read-state for one session (returns ``204``).
+  * ``viewer_last_seen`` / ``viewer_unread`` embedded per-user in the
+    ``GET /v1/sessions`` list items (built by ``_build_session_list_item``).
+
+Read state is per-user and in-memory on the server (module-level dicts in
+``omnigent.server.routes.sessions``); each test resets those globals so
+state doesn't leak between cases. Runs without auth (``permission_store``
+is ``None``), so the caller is the single-user ``None`` identity and the
+PUT's access check short-circuits.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from omnigent.entities import Conversation
+from omnigent.errors import OmnigentError
+from omnigent.server.routes import sessions as sessions_mod
+from omnigent.server.routes.sessions import create_sessions_router
+
+
+class _ConversationStore:
+    """Conversation store stub — unused by the PUT when auth is off."""
+
+    def get_conversation(self, conversation_id: str) -> None:
+        """Return ``None`` (no conversation lookups happen without auth)."""
+        return
+
+
+class _AgentStore:
+    """Agent store stub — present only to satisfy the router factory."""
+
+    def get(self, agent_id: str) -> None:
+        """Return ``None``."""
+        return
+
+
+def _build_app() -> FastAPI:
+    """Build a FastAPI app exposing the sessions router with no auth."""
+    router = create_sessions_router(
+        conversation_store=_ConversationStore(),  # type: ignore[arg-type]
+        agent_store=_AgentStore(),  # type: ignore[arg-type]
+    )
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(request: Request, exc: OmnigentError) -> JSONResponse:
+        del request
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    app.include_router(router, prefix="/v1")
+    return app
+
+
+def _make_conversation(conv_id: str = "conv_a") -> Conversation:
+    """A minimal session-shaped conversation for the list-item builder."""
+    return Conversation(
+        id=conv_id,
+        created_at=100,
+        updated_at=200,
+        root_conversation_id=conv_id,
+        title="A session",
+        agent_id="ag_test",
+    )
+
+
+def _build_item(user_id: str | None, conv: Conversation) -> object:
+    """Call the list-item builder the way ``GET /v1/sessions`` does."""
+    return sessions_mod._build_session_list_item(
+        conv,
+        agent_names_by_id={"ag_test": "test-agent"},
+        grants=[],
+        user_id=user_id,
+        user_is_admin=False,
+        permissions_enabled=False,
+        pending_count=0,
+        child_session_ids=[],
+        comments_fingerprint=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_read_state() -> Iterator[None]:
+    """Clear the module-level read-state caches around each test."""
+    sessions_mod._read_last_seen.clear()
+    sessions_mod._read_explicit_unread.clear()
+    yield
+    sessions_mod._read_last_seen.clear()
+    sessions_mod._read_explicit_unread.clear()
+
+
+def test_put_mark_unread_returns_204_and_updates_cache() -> None:
+    """Marking unread persists the baseline + override and returns 204."""
+    client = TestClient(_build_app())
+
+    resp = client.put(
+        "/v1/sessions/conv_a/read-state",
+        json={"last_seen": 4_999, "unread": True},
+    )
+    assert resp.status_code == 204, resp.text
+    assert resp.content == b""
+    # The single-user (None) caller maps to the shared discovery key.
+    key = sessions_mod._discovery_key(None)
+    assert sessions_mod._read_last_seen[key]["conv_a"] == 4_999
+    assert "conv_a" in sessions_mod._read_explicit_unread[key]
+
+
+def test_put_mark_seen_clears_unread_and_advances_baseline() -> None:
+    """Marking seen (unread=false) drops the override and moves last_seen up."""
+    client = TestClient(_build_app())
+    client.put("/v1/sessions/conv_a/read-state", json={"last_seen": 4_999, "unread": True})
+
+    resp = client.put(
+        "/v1/sessions/conv_a/read-state",
+        json={"last_seen": 9_000, "unread": False},
+    )
+    assert resp.status_code == 204, resp.text
+    key = sessions_mod._discovery_key(None)
+    assert sessions_mod._read_last_seen[key]["conv_a"] == 9_000
+    assert "conv_a" not in sessions_mod._read_explicit_unread.get(key, set())
+
+
+def test_list_item_embeds_viewer_read_state() -> None:
+    """``_build_session_list_item`` reflects the caller's read-state."""
+    client = TestClient(_build_app())
+    client.put("/v1/sessions/conv_a/read-state", json={"last_seen": 4_999, "unread": True})
+
+    item = _build_item(None, _make_conversation("conv_a"))
+    assert item.viewer_last_seen == 4_999  # type: ignore[attr-defined]
+    assert item.viewer_unread is True  # type: ignore[attr-defined]
+
+
+def test_list_item_defaults_when_user_never_saw_session() -> None:
+    """A session the user never touched has no baseline and reads as seen."""
+    item = _build_item(None, _make_conversation("conv_untouched"))
+    assert item.viewer_last_seen is None  # type: ignore[attr-defined]
+    assert item.viewer_unread is False  # type: ignore[attr-defined]
+
+
+def test_read_state_is_scoped_per_user() -> None:
+    """One user's read-state doesn't leak into another user's list items."""
+    app = _build_app()
+    client = TestClient(app)
+    # Alice marks conv_a unread (her X-Forwarded-Email identifies her). With
+    # auth off the server treats all callers as the shared user, so to prove
+    # per-user scoping we write directly into Bob's and Alice's caches.
+    sessions_mod._set_read_state("alice@example.com", "conv_a", 4_999, True)
+
+    alice_item = _build_item("alice@example.com", _make_conversation("conv_a"))
+    bob_item = _build_item("bob@example.com", _make_conversation("conv_a"))
+
+    assert alice_item.viewer_unread is True  # type: ignore[attr-defined]
+    assert bob_item.viewer_unread is False  # type: ignore[attr-defined]
+    assert bob_item.viewer_last_seen is None  # type: ignore[attr-defined]
+    del client, app

--- a/tests/server/routes/test_sessions_read_state.py
+++ b/tests/server/routes/test_sessions_read_state.py
@@ -164,3 +164,18 @@ def test_read_state_is_scoped_per_user() -> None:
     assert bob_item.viewer_unread is False  # type: ignore[attr-defined]
     assert bob_item.viewer_last_seen is None  # type: ignore[attr-defined]
     del client, app
+
+
+def test_prune_clears_read_state_across_all_users() -> None:
+    """Pruning a session drops its read-state from every user's caches."""
+    sessions_mod._set_read_state("alice@example.com", "conv_a", 4_999, True)
+    sessions_mod._set_read_state("bob@example.com", "conv_a", 100, False)
+    sessions_mod._set_read_state("alice@example.com", "conv_b", 200, True)  # untouched
+
+    sessions_mod._prune_session_read_state("conv_a")
+
+    # conv_a is gone for both users...
+    assert sessions_mod._read_state_entry("alice@example.com", "conv_a") == (None, False)
+    assert sessions_mod._read_state_entry("bob@example.com", "conv_a") == (None, False)
+    # ...but other sessions are untouched.
+    assert sessions_mod._read_state_entry("alice@example.com", "conv_b") == (200, True)

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -118,6 +118,19 @@ export interface Conversation {
    * detection only — never displayed. See `comments_count`.
    */
   comments_updated_at?: number | null;
+  /**
+   * The requesting user's "last seen" wall-clock baseline (seconds) for
+   * this session, or null/undefined when they've never seen it. Per-viewer,
+   * served by the per-user read-state cache; the sidebar's unread dot shows
+   * when `updated_at > viewer_last_seen` and the session is finished. The
+   * client seeds {@link useUnseenConversations}'s mirror from this on load.
+   */
+  viewer_last_seen?: number | null;
+  /**
+   * Whether the requesting user explicitly marked this session unread.
+   * Per-viewer; lifts the active-row dot suppression on the client.
+   */
+  viewer_unread?: boolean;
 }
 
 export interface ConversationsPage {

--- a/web/src/hooks/useIdleNotifications.test.tsx
+++ b/web/src/hooks/useIdleNotifications.test.tsx
@@ -43,7 +43,11 @@ import {
 } from "@/lib/browserNotifications";
 import { isNativeShell, onNativeNotificationActivated, setBadgeCount } from "@/lib/nativeBridge";
 import { fetchLastAssistantText } from "@/lib/lastAssistantText";
-import { markConversationSeen } from "@/hooks/useUnseenConversations";
+import {
+  __resetReadStateForTests,
+  markConversationSeen,
+  seedReadState,
+} from "@/hooks/useUnseenConversations";
 import { useIdleNotifications } from "./useIdleNotifications";
 
 const useConvMock = vi.mocked(useConversations);
@@ -109,10 +113,13 @@ beforeEach(() => {
   // "user looked away" case). Focus-specific tests override this.
   setWindowFocused(false);
   setConversations([]);
-  // The badge derivation reads the real last-seen baselines from
-  // localStorage (useUnseenConversations is intentionally NOT mocked);
-  // start each test with a clean slate.
-  window.localStorage.clear();
+  // The badge derivation reads the real last-seen baselines from the
+  // in-memory read-state mirror (useUnseenConversations is intentionally
+  // NOT mocked); start each test with a clean slate, and seed an empty list
+  // to flip `hydrated` so markConversationSeen writes (it is gated until the
+  // first seed to avoid the reload-clobber race).
+  __resetReadStateForTests();
+  seedReadState([]);
 });
 
 afterEach(() => {

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -32,9 +32,8 @@ function lastPutBody(): { last_seen: number; unread: boolean } | undefined {
 }
 
 function putCount(): number {
-  return authFetch.mock.calls.filter(
-    ([, i]) => (i as { method?: string })?.method === "PUT",
-  ).length;
+  return authFetch.mock.calls.filter(([, i]) => (i as { method?: string })?.method === "PUT")
+    .length;
 }
 
 function setWindowFocused(focused: boolean): void {

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -70,6 +70,28 @@ describe("seedReadState", () => {
     mod.seedReadState([{ id: "conv-1", viewer_last_seen: 1_000, viewer_unread: false }]);
     expect(mod.isExplicitlyUnread("conv-1")).toBe(true);
   });
+
+  it("keeps the mark-seen gate closed while the list is still loading (undefined)", async () => {
+    // useSeedReadState(undefined) — the query hasn't loaded — must NOT flip
+    // `hydrated`, or an automatic mark-seen on a deep-link/reload would write
+    // a 'seen' baseline before the server's viewer_* arrives (clobbering a
+    // cross-device unread). Only a loaded list (even empty []) releases it.
+    const mod = await loadFresh();
+    vi.useFakeTimers({ now: 5_000_000 });
+    const { rerender } = renderHook(
+      ({ c }: { c: readonly { id: string }[] | undefined }) => mod.useSeedReadState(c),
+      { initialProps: { c: undefined as readonly { id: string }[] | undefined } },
+    );
+
+    // Loading: gate closed — mark-seen is a no-op (no baseline written).
+    mod.markConversationSeen("conv-1");
+    expect(mod.isConversationUnseen("conv-1", 6_000, "idle")).toBe(false);
+
+    // Loaded (empty) list arrives: gate releases, mark-seen now writes.
+    rerender({ c: [] });
+    mod.markConversationSeen("conv-1");
+    expect(mod.isConversationUnseen("conv-1", 6_000, "idle")).toBe(true); // 6000 > 5000 baseline
+  });
 });
 
 describe("isConversationUnseen", () => {

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -1,353 +1,249 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import {
-  clearUnreadOverride,
-  isConversationUnseen,
-  isExplicitlyUnread,
-  markConversationSeen,
-  markConversationUnread,
-  nowSeconds,
-  useMarkConversationSeen,
-  useUnseenTick,
-} from "./useUnseenConversations";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-const STORAGE_KEY = "omnigent:last-seen-timestamps";
-const UNREAD_KEY = "omnigent:explicit-unread-ids";
+// `authenticatedFetch` is mocked so we can assert the read-state PUT
+// round-trips without a server (the read path is the conversation list, fed
+// directly via seedReadState). Declared via vi.hoisted so the (hoisted)
+// vi.mock factory can reference it.
+const { authFetch } = vi.hoisted(() => ({ authFetch: vi.fn() }));
+vi.mock("@/lib/identity", () => ({ authenticatedFetch: authFetch }));
 
-beforeEach(() => {
-  localStorage.clear();
-  // The explicit-unread override set is module-level (in-memory, not
-  // localStorage), so clear the ids these tests use to avoid leaking
-  // a mark-unread from one test into the next.
-  clearUnreadOverride("conv-1");
-  clearUnreadOverride("conv-2");
+type Mod = typeof import("./useUnseenConversations");
+
+/**
+ * The module keeps its read-state mirror in module-level singletons
+ * (lastSeenMap / explicitlyUnread / seeded / hydrated), so each test
+ * re-imports a fresh copy to reset that state. PUTs resolve 204.
+ */
+async function loadFresh(): Promise<Mod> {
+  vi.resetModules();
+  authFetch.mockReset();
+  authFetch.mockResolvedValue({ ok: true, status: 204, json: async () => ({}) });
+  return import("./useUnseenConversations");
+}
+
+/** The body of the most recent PUT, or undefined if none. */
+function lastPutBody(): { last_seen: number; unread: boolean } | undefined {
+  for (let i = authFetch.mock.calls.length - 1; i >= 0; i--) {
+    const [, init] = authFetch.mock.calls[i] as [string, { method?: string; body?: string }];
+    if (init?.method === "PUT" && init.body) return JSON.parse(init.body);
+  }
+  return undefined;
+}
+
+function putCount(): number {
+  return authFetch.mock.calls.filter(
+    ([, i]) => (i as { method?: string })?.method === "PUT",
+  ).length;
+}
+
+function setWindowFocused(focused: boolean): void {
+  vi.spyOn(document, "hasFocus").mockReturnValue(focused);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
-afterEach(() => {
-  vi.useRealTimers();
-});
+describe("seedReadState", () => {
+  it("seeds baselines and unread flags from the conversation list", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([
+      { id: "conv-1", viewer_last_seen: 1_000 },
+      { id: "conv-2", viewer_unread: true },
+    ]);
 
-describe("markConversationSeen", () => {
-  it("stores the current wall-clock time for a conversation", () => {
-    vi.useFakeTimers({ now: 5_000_000 });
-    markConversationSeen("conv-1");
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored["conv-1"]).toBe(5_000);
+    expect(mod.isConversationUnseen("conv-1", 2_000, "idle")).toBe(true); // 2000 > 1000
+    expect(mod.isConversationUnseen("conv-1", 500, "idle")).toBe(false); // 500 < 1000
+    expect(mod.isExplicitlyUnread("conv-2")).toBe(true);
   });
 
-  it("advances the timestamp on subsequent calls", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1");
-    vi.setSystemTime(2_000_000);
-    markConversationSeen("conv-1");
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored["conv-1"]).toBe(2_000);
-  });
+  it("seeds a session only once — a later list value can't clobber a local write", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 1_000 }]);
+    // User marks it unread locally (optimistic).
+    mod.markConversationUnread("conv-1", 5_000);
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(true);
 
-  it("tracks multiple conversations independently", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1");
-    vi.setSystemTime(2_000_000);
-    markConversationSeen("conv-2");
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored["conv-1"]).toBe(1_000);
-    expect(stored["conv-2"]).toBe(2_000);
-  });
-
-  it("accepts an explicit `atSeconds` baseline (server-time anchor)", () => {
-    // Anchoring to a server timestamp avoids client-clock skew false
-    // positives after a self-initiated PATCH bumps server updated_at.
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1", 5_000);
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored["conv-1"]).toBe(5_000);
-  });
-
-  it("dismisses a same-second updated_at after explicit mark-seen", () => {
-    // Real-world scenario: user renames an off-screen conversation;
-    // server returns updated_at = T; we mark seen at T. The next
-    // refetch shows updated_at = T, which is NOT greater than stored.
-    markConversationSeen("conv-1", 5_000);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
-  });
-
-  it("does not move the baseline backwards when explicit atSeconds is older", () => {
-    vi.useFakeTimers({ now: 10_000_000 });
-    markConversationSeen("conv-1");
-    markConversationSeen("conv-1", 5_000);
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored["conv-1"]).toBe(10_000);
-  });
-});
-
-describe("markConversationUnread", () => {
-  it("flags a previously-seen conversation as unseen", () => {
-    markConversationSeen("conv-1", 5_000);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
-    markConversationUnread("conv-1", 5_000);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
-  });
-
-  it("writes a baseline just below updated_at (not a cleared entry)", () => {
-    // A missing entry reads as *seen*, so unread must pin the baseline
-    // strictly below updated_at rather than delete it.
-    markConversationUnread("conv-1", 5_000);
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
-    expect(stored["conv-1"]).toBe(4_999);
-  });
-
-  it("persists the override to localStorage (survives a reload)", () => {
-    markConversationUnread("conv-1", 5_000);
-    const ids = JSON.parse(localStorage.getItem(UNREAD_KEY)!);
-    expect(ids).toContain("conv-1");
-    // Clearing it removes the id from the persisted set.
-    clearUnreadOverride("conv-1");
-    expect(JSON.parse(localStorage.getItem(UNREAD_KEY)!)).not.toContain("conv-1");
-  });
-
-  it("survives an automatic mark-seen (the active-thread clobber guard)", () => {
-    // Marking the thread you're viewing unread must stick: the automatic
-    // mark-seen (navigation away / poll / focus) is suppressed until an
-    // explicit clearUnreadOverride. Without the override, mark-seen below
-    // would immediately undo the unread.
-    markConversationUnread("conv-1", 5_000);
-    markConversationSeen("conv-1", 6_000);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
-  });
-
-  it("is reversed by mark-seen once the override is cleared (reopen)", () => {
-    markConversationUnread("conv-1", 5_000);
-    // Reopening the thread clears the override, then mark-seen takes hold.
-    clearUnreadOverride("conv-1");
-    markConversationSeen("conv-1", 5_000);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
-  });
-
-  it("still defers to status — a running session shows no dot", () => {
-    markConversationUnread("conv-1", 5_000);
-    expect(isConversationUnseen("conv-1", 5_000, "running")).toBe(false);
-  });
-});
-
-describe("isExplicitlyUnread", () => {
-  it("tracks the explicit-unread override and clears on reopen", () => {
-    expect(isExplicitlyUnread("conv-1")).toBe(false);
-    markConversationUnread("conv-1", 5_000);
-    // True even though the row may be active/running — the explicit flag
-    // overrides those suppressions so the dot shows.
-    expect(isExplicitlyUnread("conv-1")).toBe(true);
-    clearUnreadOverride("conv-1");
-    expect(isExplicitlyUnread("conv-1")).toBe(false);
-  });
-});
-
-describe("useUnseenTick", () => {
-  it("re-renders subscribers when the last-seen map is written", () => {
-    const { result } = renderHook(() => useUnseenTick());
-    const before = result.current;
-    act(() => markConversationUnread("conv-1", 5_000));
-    expect(result.current).not.toBe(before);
-  });
-});
-
-describe("nowSeconds", () => {
-  it("returns Date.now() divided by 1000, floored", () => {
-    vi.useFakeTimers({ now: 1_716_800_500 });
-    expect(nowSeconds()).toBe(1_716_800);
+    // A stale poll arrives still showing it as seen — must be ignored.
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 1_000, viewer_unread: false }]);
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(true);
   });
 });
 
 describe("isConversationUnseen", () => {
-  it("returns false for a conversation with no stored baseline", () => {
-    expect(isConversationUnseen("conv-1", 5000, "idle")).toBe(false);
+  it("returns false with no baseline, when running, or when status is undefined", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 1_000 }]);
+    expect(mod.isConversationUnseen("missing", 2_000, "idle")).toBe(false);
+    expect(mod.isConversationUnseen("conv-1", 2_000, "running")).toBe(false);
+    expect(mod.isConversationUnseen("conv-1", 2_000, undefined)).toBe(false);
   });
 
-  it("returns false when status is running", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1");
-    expect(isConversationUnseen("conv-1", 2_000, "running")).toBe(false);
+  it("returns true when finished and updated_at exceeds the baseline", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 1_000 }]);
+    expect(mod.isConversationUnseen("conv-1", 2_000, "idle")).toBe(true);
+    expect(mod.isConversationUnseen("conv-1", 2_000, "failed")).toBe(true);
+    expect(mod.isConversationUnseen("conv-1", 1_000, "idle")).toBe(false); // equal, not greater
+  });
+});
+
+describe("markConversationSeen", () => {
+  it("does nothing before the first seed (reload-clobber guard)", async () => {
+    const mod = await loadFresh();
+    vi.useFakeTimers({ now: 5_000_000 });
+    mod.markConversationSeen("conv-1");
+    // No PUT, and no baseline recorded (can't clobber a server unread the
+    // list is about to seed).
+    expect(putCount()).toBe(0);
+    expect(mod.isConversationUnseen("conv-1", 6_000, "idle")).toBe(false);
   });
 
-  it("returns false when status is undefined", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1");
-    expect(isConversationUnseen("conv-1", 2_000, undefined)).toBe(false);
+  it("records the baseline and PUTs it after the first seed", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]); // flips hydrated, even for an empty list
+    vi.useFakeTimers({ now: 5_000_000 });
+
+    mod.markConversationSeen("conv-1");
+
+    expect(mod.isConversationUnseen("conv-1", 4_000, "idle")).toBe(false); // 4000 < 5000 baseline
+    expect(lastPutBody()).toEqual({ last_seen: 5_000, unread: false });
   });
 
-  it("returns false when updated_at equals the stored timestamp", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1");
-    expect(isConversationUnseen("conv-1", 1_000, "idle")).toBe(false);
+  it("is a no-op for an explicitly-unread conversation", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 4_999, viewer_unread: true }]);
+    authFetch.mockClear();
+
+    mod.markConversationSeen("conv-1", 6_000);
+
+    expect(authFetch).not.toHaveBeenCalled(); // guarded: no write, no PUT
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+  });
+});
+
+describe("markConversationUnread", () => {
+  it("pins the baseline just below updated_at and flags + PUTs unread", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
+    authFetch.mockClear();
+
+    mod.markConversationUnread("conv-1", 5_000);
+
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(true);
+    expect(lastPutBody()).toEqual({ last_seen: 4_999, unread: true });
   });
 
-  it("returns true when idle and updated_at exceeds stored", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1");
-    expect(isConversationUnseen("conv-1", 2_000, "idle")).toBe(true);
+  it("still defers to status — a running session shows no dot", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
+    mod.markConversationUnread("conv-1", 5_000);
+    expect(mod.isConversationUnseen("conv-1", 5_000, "running")).toBe(false);
   });
 
-  it("returns true when failed and updated_at exceeds stored", () => {
-    vi.useFakeTimers({ now: 1_000_000 });
-    markConversationSeen("conv-1");
-    expect(isConversationUnseen("conv-1", 2_000, "failed")).toBe(true);
+  it("survives an automatic mark-seen (the active-thread clobber guard)", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
+    mod.markConversationUnread("conv-1", 5_000);
+    mod.markConversationSeen("conv-1", 6_000); // suppressed by the override
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
   });
+});
 
-  it("returns false when updated_at is older than stored", () => {
-    vi.useFakeTimers({ now: 2_000_000 });
-    markConversationSeen("conv-1");
-    expect(isConversationUnseen("conv-1", 1_000, "idle")).toBe(false);
+describe("clearUnreadOverride", () => {
+  it("removes the override, PUTs the cleared state, and re-enables mark-seen", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 4_999, viewer_unread: true }]);
+    authFetch.mockClear();
+
+    mod.clearUnreadOverride("conv-1");
+
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(false);
+    expect(lastPutBody()).toEqual({ last_seen: 4_999, unread: false });
+    mod.markConversationSeen("conv-1", 5_000); // now takes hold
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
   });
+});
 
-  it("handles corrupt localStorage gracefully", () => {
-    localStorage.setItem(STORAGE_KEY, "not valid json!!!");
-    expect(isConversationUnseen("conv-1", 1000, "idle")).toBe(false);
+describe("isExplicitlyUnread", () => {
+  it("tracks the explicit-unread override and clears on reopen", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(false);
+    mod.markConversationUnread("conv-1", 5_000);
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(true);
+    mod.clearUnreadOverride("conv-1");
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(false);
   });
+});
 
-  it("handles non-object localStorage values gracefully", () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify([1, 2, 3]));
-    expect(isConversationUnseen("conv-1", 1000, "idle")).toBe(false);
+describe("useUnseenTick", () => {
+  it("re-renders subscribers when the mirror is written", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
+    const { result } = renderHook(() => mod.useUnseenTick());
+    const before = result.current;
+    act(() => mod.markConversationUnread("conv-1", 5_000));
+    expect(result.current).not.toBe(before);
   });
 });
 
 describe("useMarkConversationSeen", () => {
-  /** Force the window-focus reading used by the hook (document.hasFocus). */
-  function setWindowFocused(focused: boolean): void {
-    vi.spyOn(document, "hasFocus").mockReturnValue(focused);
-  }
-
-  /** The stored last-seen baseline for an id, or undefined when absent. */
-  function storedBaseline(id: string): number | undefined {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw)[id] : undefined;
-  }
-
-  afterEach(() => {
-    cleanup();
-  });
-
-  it("marks the thread seen on mount when the window is focused", () => {
+  it("marks the active thread seen on mount when focused (after seed)", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
     setWindowFocused(true);
     vi.useFakeTimers({ now: 5_000_000 });
-    renderHook(() => useMarkConversationSeen("conv-1", 4_000));
-    expect(storedBaseline("conv-1")).toBe(5_000);
+
+    renderHook(() => mod.useMarkConversationSeen("conv-1", 4_000));
+
+    expect(mod.isConversationUnseen("conv-1", 4_000, "idle")).toBe(false);
+    expect(lastPutBody()).toEqual({ last_seen: 5_000, unread: false });
   });
 
-  it("does NOT mark the thread seen while the window is blurred", () => {
-    // The thread is open but the app isn't focused — the user isn't
-    // reading it. Marking it seen here would silently drop the session
-    // from the dock badge the moment its turn finishes in the background.
+  it("does NOT mark seen while the window is blurred", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([]);
     setWindowFocused(false);
-    renderHook(() => useMarkConversationSeen("conv-1", 4_000));
-    expect(storedBaseline("conv-1")).toBeUndefined();
+    vi.useFakeTimers({ now: 5_000_000 });
+
+    renderHook(() => mod.useMarkConversationSeen("conv-1", 4_000));
+
+    expect(mod.isConversationUnseen("conv-1", 6_000, "idle")).toBe(false); // no baseline written
   });
 
-  it("does not advance the baseline on updatedAt changes while blurred", () => {
+  it("preserves a seeded explicit-unread on reload (first mount does not clear)", async () => {
+    // Reload landing back on /c/conv-1: the list seeds the server's unread,
+    // and the first mount must neither clear the override nor mark seen.
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 4_999, viewer_unread: true }]);
     setWindowFocused(true);
-    vi.useFakeTimers({ now: 1_000_000 });
-    const { rerender } = renderHook(
-      ({ updatedAt }) => useMarkConversationSeen("conv-1", updatedAt),
-      {
-        initialProps: { updatedAt: 500 },
-      },
-    );
-    expect(storedBaseline("conv-1")).toBe(1_000);
 
-    // The agent finishes a turn (updated_at bumps) while the window is
-    // blurred: the baseline must stay at 1_000 so the session reads
-    // unseen — even though it's the open thread.
-    setWindowFocused(false);
-    vi.setSystemTime(3_000_000);
-    rerender({ updatedAt: 2_000 });
-    expect(storedBaseline("conv-1")).toBe(1_000);
-    expect(isConversationUnseen("conv-1", 2_000, "idle")).toBe(true);
+    renderHook(() => mod.useMarkConversationSeen("conv-1", 5_000));
+
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(true);
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
   });
 
-  it("marks the thread seen when the window regains focus", () => {
-    setWindowFocused(false);
-    vi.useFakeTimers({ now: 2_000_000 });
-    renderHook(() => useMarkConversationSeen("conv-1", 1_500));
-    expect(storedBaseline("conv-1")).toBeUndefined();
-
-    // The user comes back to the window with the thread still open —
-    // NOW they're reading it, so the baseline advances past updated_at.
-    setWindowFocused(true);
-    vi.setSystemTime(4_000_000);
-    act(() => {
-      window.dispatchEvent(new Event("focus"));
-    });
-    expect(storedBaseline("conv-1")).toBe(4_000);
-    expect(isConversationUnseen("conv-1", 1_500, "idle")).toBe(false);
-  });
-
-  it("marks seen on unmount only when the window is focused", () => {
-    setWindowFocused(true);
-    vi.useFakeTimers({ now: 1_000_000 });
-    const focused = renderHook(() => useMarkConversationSeen("conv-1", 500));
-    vi.setSystemTime(2_000_000);
-    focused.unmount();
-    // Focused navigation away counts as having read up to now.
-    expect(storedBaseline("conv-1")).toBe(2_000);
-
-    // A blurred unmount (e.g. the session deleted from another client)
-    // must not advance the baseline — the user never saw the updates.
-    setWindowFocused(false);
-    vi.setSystemTime(3_000_000);
-    const blurred = renderHook(() => useMarkConversationSeen("conv-2", 500));
-    blurred.unmount();
-    expect(storedBaseline("conv-2")).toBeUndefined();
-  });
-
-  it("does not re-mark seen after the active thread is marked unread", () => {
-    // User views conv-1 (marked seen on mount), then marks it unread from
-    // the kebab. Navigating away (unmount) must NOT re-mark it seen, so the
-    // dot lights once the row is no longer active.
-    setWindowFocused(true);
-    vi.useFakeTimers({ now: 1_000_000 });
-    const view = renderHook(() => useMarkConversationSeen("conv-1", 5_000));
-    expect(storedBaseline("conv-1")).toBe(1_000);
-
-    act(() => markConversationUnread("conv-1", 5_000));
-    expect(storedBaseline("conv-1")).toBe(4_999);
-
-    // Navigation away while focused would normally advance the baseline.
-    view.unmount();
-    expect(storedBaseline("conv-1")).toBe(4_999);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
-  });
-
-  it("preserves a persisted explicit-unread on reload (a fresh mount does not clear)", () => {
-    // A reload landing back on /c/conv-1 is a fresh mount. It must NOT clear
-    // a persisted override — otherwise the dot the user set silently vanishes
-    // on refresh. The first-mount skip + the markConversationSeen guard keep
-    // the baseline pinned below updated_at.
+  it("clears the override on a genuine in-app reopen (id changes while mounted)", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 4_999, viewer_unread: true }]);
     setWindowFocused(true);
     vi.useFakeTimers({ now: 9_000_000 });
-    markConversationUnread("conv-1", 5_000);
 
-    renderHook(() => useMarkConversationSeen("conv-1", 5_000));
-
-    expect(storedBaseline("conv-1")).toBe(4_999);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
-  });
-
-  it("clears the override on a genuine in-app reopen (id changes while mounted)", () => {
-    // ChatPage stays mounted across /c/:id navigations, so a real reopen is
-    // the id changing on the live hook — not a remount. Navigating away and
-    // back marks the thread seen again.
-    setWindowFocused(true);
-    vi.useFakeTimers({ now: 1_000_000 });
-    const { rerender } = renderHook(({ id }) => useMarkConversationSeen(id, 5_000), {
+    const { rerender } = renderHook(({ id }) => mod.useMarkConversationSeen(id, 5_000), {
       initialProps: { id: "conv-1" as string },
     });
-    act(() => markConversationUnread("conv-1", 5_000));
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(true);
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(true); // still unread after mount
 
-    rerender({ id: "conv-2" }); // navigate away to another thread
-    vi.setSystemTime(9_000_000);
-    rerender({ id: "conv-1" }); // reopen conv-1 → override cleared, marked seen
+    rerender({ id: "conv-2" }); // navigate away
+    rerender({ id: "conv-1" }); // reopen → override cleared, marked seen
 
-    expect(storedBaseline("conv-1")).toBe(9_000);
-    expect(isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
+    expect(mod.isExplicitlyUnread("conv-1")).toBe(false);
+    expect(mod.isConversationUnseen("conv-1", 5_000, "idle")).toBe(false);
   });
 });

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -1,26 +1,28 @@
-// Client-side tracking of which conversations have unseen messages.
+// Per-user tracking of which conversations have unseen messages.
 //
-// Stores { conversationId: wallClockSeconds } in localStorage.
-// The value is the wall-clock time (seconds since epoch) when the
-// user last had the conversation open. A conversation is "unseen"
-// when its server-side updated_at exceeds the stored timestamp.
-// Conversations with no stored entry are treated as seen (no
-// baseline) so first-deploy doesn't light up every row.
+// The "last seen" baseline (a wall-clock second per conversation) and the
+// explicit "marked unread" override live on the SERVER, in-memory and
+// per-user. The read path is the per-viewer `viewer_last_seen` /
+// `viewer_unread` fields embedded in the `GET /v1/sessions` list; the write
+// path is `PUT /v1/sessions/{id}/read-state`. This client keeps an in-memory
+// mirror, seeded from the conversation list and written back on every
+// mark-seen / mark-unread. That makes read-state shared across a user's
+// devices while the server is up. It is NOT persisted server-side, so a
+// server restart resets it (an accepted tradeoff — read-state has no
+// durable source to rederive from).
+//
+// A conversation is "unseen" when its server-side updated_at exceeds the
+// stored baseline. Conversations with no stored entry are treated as seen
+// (no baseline) so a fresh load / post-restart doesn't light up every row.
 
 import { useEffect, useRef, useSyncExternalStore } from "react";
 
-const STORAGE_KEY = "omnigent:last-seen-timestamps";
-// Persisted alongside the timestamps so an explicit "Mark as unread"
-// survives a page reload — including on the thread you were viewing,
-// where the auto mark-seen would otherwise clear it on remount. Like
-// the timestamps, this is per-device (localStorage); cross-device
-// unread would need server-side state.
-const UNREAD_KEY = "omnigent:explicit-unread-ids";
+import { authenticatedFetch } from "@/lib/identity";
 
-// Bumped whenever the last-seen map is written, so in-tab subscribers
-// (the sidebar rows, the dock badge) can recompute unseen state right
-// away — localStorage writes don't fire `storage` events in the same
-// tab, and the conversations poll is too slow for a click to feel live.
+// Bumped whenever the local mirror is written, so in-tab subscribers (the
+// sidebar rows, the dock badge) recompute unseen state right away — a PUT's
+// network round-trip is too slow for a click to feel live, and the
+// conversations poll is slower still.
 const subscribers = new Set<() => void>();
 let writeVersion = 0;
 
@@ -29,95 +31,130 @@ function notifySubscribers(): void {
   for (const cb of subscribers) cb();
 }
 
-function readExplicitUnread(): Set<string> {
-  if (typeof window === "undefined") return new Set();
-  try {
-    const raw = window.localStorage.getItem(UNREAD_KEY);
-    if (!raw) return new Set();
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return new Set();
-    return new Set(parsed.filter((x): x is string => typeof x === "string"));
-  } catch {
-    return new Set();
-  }
-}
-
-function writeExplicitUnread(): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(UNREAD_KEY, JSON.stringify([...explicitlyUnread]));
-  } catch {
-    // localStorage quota or access errors shouldn't break the app.
-  }
-}
-
-// Conversations the user explicitly marked unread. While an id is in
-// this set, the automatic "active view is being read" mark-seen
-// (mount / poll / focus / navigation-away in useMarkConversationSeen)
-// is suppressed for it — otherwise marking the *current* thread unread
-// would be clobbered the instant the user navigates away or the list
-// polls. The flag is cleared by a genuine re-open (see
-// clearUnreadOverride), which then lets the normal mark-seen run.
-// Hydrated from localStorage so an explicit unread survives a reload.
-const explicitlyUnread = readExplicitUnread();
-
-/**
- * Clears the explicit-unread override for a conversation, re-enabling
- * automatic mark-seen. Called when the user genuinely (re)opens a
- * thread, since opening it *is* reading it. Persists the change and
- * notifies subscribers when it actually removed an override so the dot
- * clears immediately.
- */
-export function clearUnreadOverride(conversationId: string): void {
-  if (explicitlyUnread.delete(conversationId)) {
-    writeExplicitUnread();
-    notifySubscribers();
-  }
-}
-
-/**
- * True when the user explicitly marked this conversation unread (and
- * hasn't reopened it since). Callers use this to lift the *active-row*
- * dot suppression — flagging the thread you're viewing shows the dot at
- * once. It does NOT lift the running-status suppression: a working
- * session's dot still waits for the turn to finish (see the dot
- * condition in Sidebar's ConversationRow).
- */
-export function isExplicitlyUnread(conversationId: string): boolean {
-  return explicitlyUnread.has(conversationId);
-}
-
 type LastSeenMap = Record<string, number>;
 
-function readLastSeenMap(): LastSeenMap {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return {};
-    }
-    return parsed as LastSeenMap;
-  } catch {
-    return {};
-  }
-}
+// In-memory mirror of the server's per-user read-state, seeded from the
+// conversation list and updated optimistically on each mutation before the
+// PUT lands.
+const lastSeenMap: LastSeenMap = {};
+const explicitlyUnread = new Set<string>();
 
-function writeLastSeenMap(map: LastSeenMap): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
-  } catch {
-    // localStorage quota or access errors shouldn't break the app.
-  }
-  // Even if the persist threw, notify: an in-memory recompute is
-  // harmless and keeps the UI consistent with the attempted change.
-  notifySubscribers();
-}
+// Sessions already seeded from the list. Seeding is once-per-session: the
+// first time a conversation is seen we copy its server `viewer_*` into the
+// mirror, then ignore later list values so an in-flight poll can't clobber a
+// local optimistic write. Cross-device changes after first load surface on a
+// reload (a deliberate Phase-1 scope: live merge is a follow-up).
+const seeded = new Set<string>();
+
+// Until the first seed runs we don't know the server's baselines, so the
+// automatic mark-seen (useMarkConversationSeen) must NOT write — a deep-link
+// / reload into /c/{id} mounts ChatPage synchronously, before the list loads,
+// and an early "seen" PUT would clobber an explicit unread the server is
+// about to hand us. Explicit user actions still apply.
+let hydrated = false;
 
 export function nowSeconds(): number {
   return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Pushes the calling user's read-state for one conversation to the server.
+ * Best-effort and fire-and-forget: a failed PUT leaves the optimistic local
+ * mirror in place, which the next mutation or a reload reconciles. Skips the
+ * call when there's no baseline to report (nothing meaningful to sync).
+ */
+async function syncReadState(conversationId: string): Promise<void> {
+  const lastSeen = lastSeenMap[conversationId];
+  if (lastSeen === undefined) return;
+  try {
+    await authenticatedFetch(`/v1/sessions/${encodeURIComponent(conversationId)}/read-state`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ last_seen: lastSeen, unread: explicitlyUnread.has(conversationId) }),
+    });
+  } catch {
+    // Network/auth errors must not break the UI; local state stays.
+  }
+}
+
+/** The read-state fields the seed reads off a conversation list item. */
+export interface ReadStateSeed {
+  id: string;
+  viewer_last_seen?: number | null;
+  viewer_unread?: boolean;
+}
+
+/**
+ * Seeds the local mirror from the conversation list (the server's per-viewer
+ * read path). Once-per-session: a conversation's server values are copied the
+ * first time it appears, then ignored, so an in-flight list poll can't clobber
+ * a local optimistic write. Flips {@link hydrated} on the first call (even for
+ * an empty list) so the automatic mark-seen can resume. Notifies subscribers
+ * when anything changed so rows recompute.
+ */
+export function seedReadState(conversations: readonly ReadStateSeed[]): void {
+  let changed = false;
+  for (const conv of conversations) {
+    if (seeded.has(conv.id)) continue;
+    seeded.add(conv.id);
+    if (typeof conv.viewer_last_seen === "number") {
+      lastSeenMap[conv.id] = conv.viewer_last_seen;
+      changed = true;
+    }
+    if (conv.viewer_unread) {
+      explicitlyUnread.add(conv.id);
+      changed = true;
+    }
+  }
+  if (!hydrated) {
+    hydrated = true;
+    changed = true;
+  }
+  if (changed) notifySubscribers();
+}
+
+/** Seeds the read-state mirror from the conversation list as it loads. */
+export function useSeedReadState(conversations: readonly ReadStateSeed[]): void {
+  useEffect(() => {
+    seedReadState(conversations);
+  }, [conversations]);
+}
+
+/**
+ * Test-only: reset the module-level read-state mirror so it doesn't leak
+ * between tests (the mirror is intentionally module-scoped, not React state).
+ * Not used in production.
+ */
+export function __resetReadStateForTests(): void {
+  for (const id of Object.keys(lastSeenMap)) delete lastSeenMap[id];
+  explicitlyUnread.clear();
+  seeded.clear();
+  hydrated = false;
+}
+
+/**
+ * Clears the explicit-unread override for a conversation, re-enabling
+ * automatic mark-seen. Called when the user genuinely (re)opens a thread,
+ * since opening it *is* reading it. Notifies subscribers and syncs the
+ * cleared state to the server when it actually removed an override.
+ */
+export function clearUnreadOverride(conversationId: string): void {
+  if (explicitlyUnread.delete(conversationId)) {
+    notifySubscribers();
+    void syncReadState(conversationId);
+  }
+}
+
+/**
+ * True when the user explicitly marked this conversation unread (and hasn't
+ * reopened it since). Callers use this to lift the *active-row* dot
+ * suppression — flagging the thread you're viewing shows the dot at once. It
+ * does NOT lift the running-status suppression: a working session's dot still
+ * waits for the turn to finish (see the dot condition in Sidebar's
+ * ConversationRow).
+ */
+export function isExplicitlyUnread(conversationId: string): boolean {
+  return explicitlyUnread.has(conversationId);
 }
 
 // `atSeconds` lets callers anchor the baseline to a server timestamp
@@ -127,17 +164,21 @@ export function nowSeconds(): number {
 // the server's new updated_at can land slightly past the client's
 // nowSeconds() under clock skew.
 export function markConversationSeen(conversationId: string, atSeconds?: number): void {
-  // A conversation the user explicitly marked unread stays unread until
-  // they reopen it (which clears the override first). This guards every
-  // caller — the automatic active-view marks and the self-action anchors
+  // A conversation the user explicitly marked unread stays unread until they
+  // reopen it (which clears the override first). This guards every caller —
+  // the automatic active-view marks and the self-action anchors
   // (rename / archive / move) alike.
   if (explicitlyUnread.has(conversationId)) return;
+  // Before hydrate resolves we don't have the server's baselines; writing
+  // now could clobber an explicit unread we're about to load (the reload
+  // race). Explicit user actions below are exempt — they reflect intent.
+  if (!hydrated) return;
   const baseline = atSeconds ?? nowSeconds();
-  const map = readLastSeenMap();
-  const stored = map[conversationId];
+  const stored = lastSeenMap[conversationId];
   if (stored !== undefined && stored >= baseline) return;
-  map[conversationId] = baseline;
-  writeLastSeenMap(map);
+  lastSeenMap[conversationId] = baseline;
+  notifySubscribers();
+  void syncReadState(conversationId);
 }
 
 /**
@@ -152,22 +193,21 @@ export function markConversationSeen(conversationId: string, atSeconds?: number)
  * Setting {@link explicitlyUnread} keeps the flag from being instantly
  * undone by the automatic mark-seen on the *active* thread (navigation
  * away, polls, focus) — so marking the conversation you're looking at
- * sticks. The override is persisted, so it also survives a reload; it
- * clears when you reopen the thread.
+ * sticks. Both the baseline and the override are synced to the server, so
+ * the flag also survives a reload and shows on the user's other devices.
  */
 export function markConversationUnread(conversationId: string, updatedAt: number): void {
   explicitlyUnread.add(conversationId);
-  writeExplicitUnread();
-  const map = readLastSeenMap();
-  map[conversationId] = updatedAt - 1;
-  writeLastSeenMap(map);
+  lastSeenMap[conversationId] = updatedAt - 1;
+  notifySubscribers();
+  void syncReadState(conversationId);
 }
 
 /**
- * Subscribes the caller to last-seen map writes and returns the
- * current write version, so a component re-renders (and recomputes
- * `isConversationUnseen`) the instant the user marks a row read/unread
- * — not on the next conversations poll.
+ * Subscribes the caller to read-state mirror writes and returns the current
+ * write version, so a component re-renders (and recomputes
+ * `isConversationUnseen`) the instant the user marks a row read/unread — not
+ * on the next conversations poll.
  */
 export function useUnseenTick(): number {
   return useSyncExternalStore(
@@ -193,8 +233,7 @@ export function isConversationUnseen(
   status: string | undefined,
 ): boolean {
   if (status === "running" || status === undefined) return false;
-  const map = readLastSeenMap();
-  const stored = map[conversationId];
+  const stored = lastSeenMap[conversationId];
   if (stored === undefined) return false;
   return updatedAt > stored;
 }
@@ -230,7 +269,7 @@ export function useMarkConversationSeen(
   // open must NOT re-clear an override the user just set on it.
   //
   // The very first mount is skipped: an initial page load / reload while
-  // sitting on a thread must NOT clear a *persisted* explicit-unread
+  // sitting on a thread must NOT clear the hydrated explicit-unread
   // override (otherwise the dot you set silently vanishes on refresh).
   // ChatPage stays mounted across in-app /c/:id navigations, so this ref
   // only resets on a real reload — genuine reopens (the id changing while

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -113,9 +113,17 @@ export function seedReadState(conversations: readonly ReadStateSeed[]): void {
   if (changed) notifySubscribers();
 }
 
-/** Seeds the read-state mirror from the conversation list as it loads. */
-export function useSeedReadState(conversations: readonly ReadStateSeed[]): void {
+/**
+ * Seeds the read-state mirror from the conversation list once it loads.
+ * Pass `undefined` while the list query is still loading: until a real
+ * (possibly empty) list arrives we must NOT seed or flip `hydrated`, or the
+ * transient empty list on a deep-link/reload would release the mark-seen
+ * gate before the server's `viewer_*` read-state is known — clobbering a
+ * cross-device unread (the very race the gate guards).
+ */
+export function useSeedReadState(conversations: readonly ReadStateSeed[] | undefined): void {
   useEffect(() => {
+    if (conversations === undefined) return;
     seedReadState(conversations);
   }, [conversations]);
 }

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -7,6 +7,7 @@ import { useApproveHotkey } from "@/hooks/useApproveHotkey";
 import { useSidebarToggleHotkeys } from "@/hooks/useSidebarToggleHotkeys";
 import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
+import { useSeedReadState } from "@/hooks/useUnseenConversations";
 import { useIOSViewportLock } from "@/hooks/useIOSViewportLock";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
@@ -254,6 +255,13 @@ export function AppShell() {
   // the active conversation id, which suppresses the notification/badge for
   // the session the user is actively viewing.
   useIdleNotifications(conversationId);
+  // Seed the per-user read-state (unread/seen) mirror from the conversation
+  // list, so the sidebar dots reflect what the user did on any device.
+  const allConversations = useMemo(
+    () => conversationsData?.pages.flatMap((p) => p.data) ?? [],
+    [conversationsData],
+  );
+  useSeedReadState(allConversations);
   const activeConv = useMemo(() => {
     if (!conversationId) return null;
     return (

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -257,8 +257,11 @@ export function AppShell() {
   useIdleNotifications(conversationId);
   // Seed the per-user read-state (unread/seen) mirror from the conversation
   // list, so the sidebar dots reflect what the user did on any device.
+  // `undefined` while the query is still loading (vs `[]` for a loaded-but-
+  // empty list) so the seed — and the `hydrated` gate it flips — waits for
+  // the real read-state, not the transient empty list on a deep-link/reload.
   const allConversations = useMemo(
-    () => conversationsData?.pages.flatMap((p) => p.data) ?? [],
+    () => conversationsData?.pages.flatMap((p) => p.data),
     [conversationsData],
   );
   useSeedReadState(allConversations);

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -50,7 +50,7 @@ vi.mock("./ReportIssueButton", () => ({ ReportIssueButton: () => null }));
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
 
 import { type Conversation, useConversations } from "@/hooks/useConversations";
-import { clearUnreadOverride } from "@/hooks/useUnseenConversations";
+import { __resetReadStateForTests, seedReadState } from "@/hooks/useUnseenConversations";
 import { Sidebar } from "./Sidebar";
 
 const useConvMock = vi.mocked(useConversations);
@@ -115,10 +115,9 @@ function renderSidebar(activeId?: string) {
 beforeEach(() => {
   mocks.rename.mutate.mockReset();
   useConvMock.mockReset();
-  localStorage.clear();
-  // The explicit-unread override is module-level (in-memory), so reset it
-  // between tests to avoid a mark-unread leaking into later rows.
-  clearUnreadOverride("conv_1");
+  // The read-state mirror is module-level (in-memory), so reset it between
+  // tests to avoid a mark-unread leaking into later rows.
+  __resetReadStateForTests();
   mockConversations([CONV]);
 });
 
@@ -251,7 +250,7 @@ describe("double-click to rename", () => {
 });
 
 describe("mark as unread", () => {
-  it("re-lights the row's unread dot and persists the baseline below updated_at", () => {
+  it("re-lights the row's unread dot via an explicit mark-unread", () => {
     renderSidebar();
 
     // The row starts seen (no baseline) — no unread marker.
@@ -260,29 +259,25 @@ describe("mark as unread", () => {
     fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
     fireEvent.click(screen.getByTestId("mark-unread-conversation"));
 
-    // The dot's accessible label appears immediately (in-tab tick), and the
-    // baseline is pinned just under updated_at so the dot survives a reload.
+    // The dot's accessible label appears immediately (in-tab tick on the
+    // optimistic mirror write); the baseline is also synced to the server.
     expect(screen.getByText("(unread)")).toBeInTheDocument();
-    const stored = JSON.parse(localStorage.getItem("omnigent:last-seen-timestamps")!);
-    expect(stored.conv_1).toBe(CONV.updated_at - 1);
   });
 
-  it("records the baseline on a running session but holds the dot until the turn finishes", () => {
+  it("holds the dot on a running session until the turn finishes", () => {
     mockConversations([{ ...CONV, status: "running" }]);
     renderSidebar();
 
     fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
     fireEvent.click(screen.getByTestId("mark-unread-conversation"));
 
-    // The unread baseline is persisted...
-    const stored = JSON.parse(localStorage.getItem("omnigent:last-seen-timestamps")!);
-    expect(stored.conv_1).toBe(CONV.updated_at - 1);
-    // ...but the dot stays suppressed mid-turn (the explicit override lifts
-    // the active-row suppression, not the running one).
+    // The dot stays suppressed mid-turn (the explicit override lifts the
+    // active-row suppression, not the running one).
     expect(screen.queryByText("(unread)")).toBeNull();
 
     // Once the turn finishes (row re-renders as idle), the dot lights — the
-    // persisted baseline now reads unseen for a finished session.
+    // baseline (kept in the in-memory mirror) now reads unseen for a
+    // finished session.
     cleanup();
     mockConversations([{ ...CONV, status: "idle" }]);
     renderSidebar();
@@ -297,17 +292,13 @@ describe("mark as unread", () => {
     fireEvent.pointerDown(screen.getByTestId("conversation-actions"), { button: 0 });
     fireEvent.click(screen.getByTestId("mark-unread-conversation"));
 
-    const stored = JSON.parse(localStorage.getItem("omnigent:last-seen-timestamps")!);
-    expect(stored.conv_1).toBe(CONV.updated_at - 1);
     expect(screen.getByText("(unread)")).toBeInTheDocument();
   });
 
   it("is hidden once the row is already unread", () => {
-    // Seed a baseline below updated_at so the row is already unseen.
-    localStorage.setItem(
-      "omnigent:last-seen-timestamps",
-      JSON.stringify({ conv_1: CONV.updated_at - 1 }),
-    );
+    // Seed a baseline below updated_at (as the conversation list would) so
+    // the row is already unseen.
+    seedReadState([{ id: "conv_1", viewer_last_seen: CONV.updated_at - 1 }]);
     renderSidebar();
 
     expect(screen.getByText("(unread)")).toBeInTheDocument();


### PR DESCRIPTION
## Related issue

N/A — follow-up to #1660 (the "Mark as unread" sidebar action).

## Summary

Moves read-state (the per-conversation "last seen" baseline + the explicit "mark as unread" override) off per-device `localStorage` and onto the server, keyed **per user**, so unread/seen is shared across a user's devices (e.g. mark unread on desktop, see it on mobile).

- **Server** (in-memory, mirrors `_session_status_cache`; resets on restart — read-state has no durable source to rederive, an accepted tradeoff):
  - Per-user caches `_read_last_seen` / `_read_explicit_unread`, keyed `user -> session`.
  - **Write:** `PUT /v1/sessions/{id}/read-state` (requires `LEVEL_READ`, returns `204`).
  - **Read:** `viewer_last_seen` / `viewer_unread` embedded **per-viewer** in `SessionListItem` — built per-request (GET list) and per-connection (WS updates), never broadcast across users. No separate read endpoint (the list carries it).
- **Web:**
  - Drop `localStorage`; keep an in-memory mirror seeded from the conversation list (`seedReadState`, once-per-session so a stale poll can't clobber an optimistic write) and written back via the PUT.
  - A `hydrated` gate keeps the automatic mark-seen from clobbering a server unread before the list loads (the reload race). Dot / override / reopen logic is unchanged from #1660.

Cross-device updates surface on reload / next list poll; live SSE push is a deliberate follow-up.

## Test Plan

- `cd web && npm test` → 3343 passed; `npm run build` clean.
- Python: `ruff format` + `ruff check` clean; `tests/server/routes/test_sessions_read_state.py` (new, 5), plus `test_session_updates_ws.py`, `test_schemas.py`, `integration/test_sessions_endpoints.py` all pass (additive `viewer_*` fields don't break list/snapshot/stream).
- Updated web suites: `useUnseenConversations` (17), `Sidebar.rowActions` (11), `useIdleNotifications` (27).

## Demo

_Per-user read-state: marking a session unread on one device shows the dot on another after reload/next poll; running/active gating unchanged._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Read-state is in-memory and per-user; a server restart resets it (no durable source to rederive — deliberate). `__resetReadStateForTests` is test-only infra (the client mirror is module-scoped, so tests need a reset hook). Manual verification: marked sessions unread/seen and confirmed the dot, the running→idle gating, active-thread flagging, and reopen-clears behavior against the in-memory mirror; server PUT/list embedding covered by unit tests.