### PR TITLE
fix(cost): fail closed when session has unpriced model turns (#3)

### DIFF
--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -73,6 +73,7 @@ from typing import Any
 
 from omnigent.policies.schema import (
     SESSION_COST_ASK_APPROVED_STATE_KEY,
+    SESSION_COST_UNPRICED_APPROVED_KEY,
     USER_DAILY_ASK_APPROVED_STATE_KEY,
     PolicyCallable,
     PolicyEvent,
@@ -81,17 +82,32 @@ from omnigent.policies.schema import (
 
 _ALLOW: PolicyResponse = {"result": "ALLOW"}
 
-# DENY response emitted when the session has consumed tokens on a model with
-# no catalog pricing. The gate cannot enforce a budget it cannot measure, so
-# it fails CLOSED rather than silently treating unknown spend as $0.
-_UNPRICED_DENY: PolicyResponse = {
-    "result": "DENY",
+# session_state key recording that the user has acknowledged and approved
+# continuing a session whose active model has no catalog pricing. Routed to
+# the ROOT conversation (like SESSION_COST_ASK_APPROVED_STATE_KEY) so a
+# single approval on the parent covers the whole spawn tree.
+_UNPRICED_APPROVED_KEY = SESSION_COST_UNPRICED_APPROVED_KEY
+
+# ASK response emitted when the session has consumed tokens on a model with
+# no catalog pricing and the user has not yet acknowledged it. The gate
+# cannot enforce a budget it cannot measure — asking rather than denying lets
+# the operator or user make an informed choice, while still preventing silent
+# pass-through at $0.
+_UNPRICED_ASK: PolicyResponse = {
+    "result": "ASK",
     "reason": (
-        "Blocked by the cost-budget policy: the active model has no catalog "
-        "pricing so cumulative spend cannot be measured. Switch to a priced "
-        "model to continue, or ask an administrator to add this model to the "
-        "pricing catalog."
+        "The active model has no catalog pricing so cumulative spend cannot be "
+        "tracked. Continuing will allow untracked spend that counts against "
+        "neither the cap nor the warning thresholds. Switch to a priced model "
+        "to restore budget enforcement, or approve to continue without it."
     ),
+    "state_updates": [
+        {
+            "key": _UNPRICED_APPROVED_KEY,
+            "action": "set",
+            "value": True,
+        }
+    ],
 }
 
 
@@ -483,7 +499,9 @@ def cost_budget(
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("usage") or {}):
-            return _UNPRICED_DENY
+            if not (event.get("session_state") or {}).get(_UNPRICED_APPROVED_KEY):
+                return _UNPRICED_ASK
+            return _ALLOW
         cost = _session_cost_usd(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
@@ -656,7 +674,9 @@ def user_daily_cost_budget(
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("usage") or {}):
-            return _UNPRICED_DENY
+            if not (event.get("session_state") or {}).get(_UNPRICED_APPROVED_KEY):
+                return _UNPRICED_ASK
+            return _ALLOW
         cost = _user_daily_cost_usd(event)
         owner = _user_daily_owner(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
@@ -798,7 +818,9 @@ def subagent_cost_budget(
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("subtree_usage") or {}):
-            return _UNPRICED_DENY
+            if not (event.get("session_state") or {}).get(_UNPRICED_APPROVED_KEY):
+                return _UNPRICED_ASK
+            return _ALLOW
         cost = _subtree_cost_usd(event)
         # Check hard limit if max_cost_usd is set.
         if max_cost_usd is not None and cfg.hard_cap_enabled and cost >= max_cost_usd:

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -32,9 +32,13 @@ It reads cumulative spend from
 total maintained server-side (token-priced for relay/codex sessions,
 billed directly for claude-native) — and the active model from
 ``event["context"]["model"]`` (the conversation's ``model_override`` or
-the agent spec's ``llm.model``, resolved by the policy engine). When
-pricing is unavailable the cost stays ``0.0`` and the policy never trips
-(it cannot budget what it cannot price).
+the agent spec's ``llm.model``, resolved by the policy engine). When a
+model has no catalog pricing, ``total_cost_usd`` is never written to the
+session, so the policy would score the session at ``$0`` and never
+enforce the budget. To prevent unpriced spend silently bypassing the cap,
+the gate **fails closed** when token usage is present but
+``total_cost_usd`` is absent: it returns DENY with a message asking the
+user to switch to a priced model.
 
 On the ``tool_call`` phase a DENY/ASK blocks that specific tool call
 (the native hook returns ``deny`` / parks for approval) rather than
@@ -76,6 +80,45 @@ from omnigent.policies.schema import (
 )
 
 _ALLOW: PolicyResponse = {"result": "ALLOW"}
+
+# DENY response emitted when the session has consumed tokens on a model with
+# no catalog pricing. The gate cannot enforce a budget it cannot measure, so
+# it fails CLOSED rather than silently treating unknown spend as $0.
+_UNPRICED_DENY: PolicyResponse = {
+    "result": "DENY",
+    "reason": (
+        "Blocked by the cost-budget policy: the active model has no catalog "
+        "pricing so cumulative spend cannot be measured. Switch to a priced "
+        "model to continue, or ask an administrator to add this model to the "
+        "pricing catalog."
+    ),
+}
+
+
+def _usage_is_unpriced(usage: dict[str, Any]) -> bool:
+    """Return ``True`` when token usage is present but cost is unpriced.
+
+    The session has had at least one turn (token counters are non-zero) yet
+    ``total_cost_usd`` is absent — meaning no turn was ever priced by the
+    catalog. The gate cannot enforce a budget against this session: it would
+    score every check at ``$0`` and never fire. Callers use this to fail
+    closed (DENY) rather than fail open.
+
+    Returns ``False`` when ``total_cost_usd`` is already present (priced) or
+    when no tokens have been consumed yet (first request, nothing to price).
+    The first turn on an unpriced model still runs — the gate only has
+    post-turn data at check time — but every subsequent turn is denied.
+
+    :param usage: ``event["context"]["usage"]`` or equivalent subtree dict.
+    :returns: ``True`` when enforcement should fail closed due to missing
+        pricing.
+    """
+    if "total_cost_usd" in usage:
+        return False
+    return bool(
+        usage.get("input_tokens") or usage.get("output_tokens") or usage.get("total_tokens")
+    )
+
 
 # Phases the budget gate fires on. ``tool_call`` is the native ``PreToolUse``
 # block point; ``request`` runs before the LLM turn so text-only turns (no
@@ -438,6 +481,9 @@ def cost_budget(
         phase = event.get("type")
         if phase not in _GATED_PHASES:
             return _ALLOW
+        context = event.get("context") or {}
+        if _usage_is_unpriced(context.get("usage") or {}):
+            return _UNPRICED_DENY
         cost = _session_cost_usd(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
@@ -608,6 +654,9 @@ def user_daily_cost_budget(
         phase = event.get("type")
         if phase not in _GATED_PHASES:
             return _ALLOW
+        context = event.get("context") or {}
+        if _usage_is_unpriced(context.get("usage") or {}):
+            return _UNPRICED_DENY
         cost = _user_daily_cost_usd(event)
         owner = _user_daily_owner(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
@@ -747,6 +796,9 @@ def subagent_cost_budget(
         phase = event.get("type")
         if phase not in _GATED_PHASES:
             return _ALLOW
+        context = event.get("context") or {}
+        if _usage_is_unpriced(context.get("subtree_usage") or {}):
+            return _UNPRICED_DENY
         cost = _subtree_cost_usd(event)
         # Check hard limit if max_cost_usd is set.
         if max_cost_usd is not None and cfg.hard_cap_enabled and cost >= max_cost_usd:

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -97,6 +97,13 @@ USER_DAILY_ASK_APPROVED_STATE_KEY = "_policy_user_daily_ask_approved_usd"
 # (emits it) and the engine (routes + seeds it).
 SESSION_COST_ASK_APPROVED_STATE_KEY = "_policy_cost_ask_approved_usd"
 
+# Reserved ``state_updates`` key the cost-budget policy emits when the user
+# approves continuing despite an unpriced model. Like
+# ``SESSION_COST_ASK_APPROVED_STATE_KEY``, routed to the ROOT conversation so
+# approving once on the parent covers the whole spawn tree. Value is ``True``
+# (a boolean flag, not a float checkpoint).
+SESSION_COST_UNPRICED_APPROVED_KEY = "_policy_cost_unpriced_approved"
+
 
 class UserDailyCostContext(TypedDict, total=False):
     """The session owner's per-UTC-day LLM cost rollup.

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -27,7 +27,10 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.llms.context_window import fetch_model_pricing
 from omnigent.policies.base import Policy
 from omnigent.policies.function import resolve_function_policy
-from omnigent.policies.schema import SESSION_COST_ASK_APPROVED_STATE_KEY
+from omnigent.policies.schema import (
+    SESSION_COST_ASK_APPROVED_STATE_KEY,
+    SESSION_COST_UNPRICED_APPROVED_KEY,
+)
 from omnigent.policies.types import PolicyLLMClient
 from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 from omnigent.runtime.policies.engine import PolicyEngine
@@ -328,10 +331,12 @@ def build_policy_engine(
     # inheritance — reuse them here.)
     if root_conversation_id != conversation_id:
         root_state = _load_session_state(root_conversation_id, conversation_store)
-        if SESSION_COST_ASK_APPROVED_STATE_KEY in root_state:
-            initial_session_state[SESSION_COST_ASK_APPROVED_STATE_KEY] = root_state[
-                SESSION_COST_ASK_APPROVED_STATE_KEY
-            ]
+        for _root_key in (
+            SESSION_COST_ASK_APPROVED_STATE_KEY,
+            SESSION_COST_UNPRICED_APPROVED_KEY,
+        ):
+            if _root_key in root_state:
+                initial_session_state[_root_key] = root_state[_root_key]
     # Gating is SESSION-wide: seed from the whole spawn-tree total so a
     # sub-agent gates against the session's full spend (parent + siblings),
     # not just its own subtree. The cost read is the enforcement total

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -490,6 +490,7 @@ class PolicyEngine:
             return
         from omnigent.policies.schema import (
             SESSION_COST_ASK_APPROVED_STATE_KEY,
+            SESSION_COST_UNPRICED_APPROVED_KEY,
             USER_DAILY_ASK_APPROVED_STATE_KEY,
         )
 
@@ -505,7 +506,7 @@ class PolicyEngine:
             if op.key == USER_DAILY_ASK_APPROVED_STATE_KEY:
                 self._record_user_daily_ask_approved(op.value)
             elif (
-                op.key == SESSION_COST_ASK_APPROVED_STATE_KEY
+                op.key in (SESSION_COST_ASK_APPROVED_STATE_KEY, SESSION_COST_UNPRICED_APPROVED_KEY)
                 and self._root_conversation_id != self._conversation_id
             ):
                 self._record_root_cost_ask_approved(op)

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -290,23 +290,27 @@ def _unpriced_tool(input_tokens: int = 1000, model: str = "unpriced-model") -> P
     }
 
 
-def test_unpriced_session_denies_fail_closed() -> None:
-    """Token usage without ``total_cost_usd`` → DENY (fail closed).
+def test_unpriced_session_asks_fail_closed() -> None:
+    """Token usage without ``total_cost_usd`` → ASK (fail closed with user bypass).
 
     A model absent from the pricing catalog never writes ``total_cost_usd``
     to the session, so the gate would score the session at $0 and never
     fire. After the fix, the gate detects tokens-present / cost-absent and
-    returns DENY rather than silently treating unknown spend as $0. The
-    deny reason must name the model-pricing gap so the operator knows
-    what to fix.
+    returns ASK rather than silently treating unknown spend as $0. The
+    ASK reason must name the model-pricing gap. The state_updates must
+    carry the unpriced-approved key so an approval is remembered.
     """
+    from omnigent.policies.schema import SESSION_COST_UNPRICED_APPROVED_KEY
+
     policy = cost_budget(max_cost_usd=5.0)
     result = policy(_unpriced_tool())
-    assert result["result"] == "DENY"
+    assert result["result"] == "ASK"
     assert "pricing" in result["reason"].lower()
+    keys = [u["key"] for u in result["state_updates"]]
+    assert SESSION_COST_UNPRICED_APPROVED_KEY in keys
 
 
-def test_unpriced_session_denies_both_phases() -> None:
+def test_unpriced_session_asks_both_phases() -> None:
     """Unpriced fail-closed fires on both tool_call and request phases."""
     policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[1.0])
     unpriced_request: PolicyEvent = {
@@ -320,8 +324,23 @@ def test_unpriced_session_denies_both_phases() -> None:
         },
         "session_state": {},
     }
-    assert policy(_unpriced_tool())["result"] == "DENY"
-    assert policy(unpriced_request)["result"] == "DENY"
+    assert policy(_unpriced_tool())["result"] == "ASK"
+    assert policy(unpriced_request)["result"] == "ASK"
+
+
+def test_unpriced_session_allows_after_approval() -> None:
+    """Once the user approves the unpriced-model ASK, subsequent turns ALLOW.
+
+    The state_updates key is recorded in session_state on approval. The
+    next gate evaluation sees it and skips the unpriced check so the
+    turn proceeds without re-asking.
+    """
+    from omnigent.policies.schema import SESSION_COST_UNPRICED_APPROVED_KEY
+
+    policy = cost_budget(max_cost_usd=5.0)
+    approved_event = _unpriced_tool()
+    approved_event["session_state"] = {SESSION_COST_UNPRICED_APPROVED_KEY: True}
+    assert policy(approved_event)["result"] == "ALLOW"
 
 
 def test_no_tokens_yet_allows_first_turn() -> None:
@@ -543,12 +562,13 @@ def test_request_approval_carries_over_to_tool_call() -> None:
     assert policy(_tool(2.0, model="opus", session_state=state)) == {"result": "ALLOW"}
 
 
-def test_unpriced_session_never_trips() -> None:
-    """No ``total_cost_usd`` (pricing unavailable) → ALLOW, never blocks.
+def test_no_usage_at_all_allows() -> None:
+    """No ``total_cost_usd`` AND no token counters → ALLOW (first turn).
 
-    Defaults to ``0.0``; the policy cannot budget what it cannot price,
-    so it must abstain rather than block every tool call at $0 — even on
-    an expensive model.
+    When session_usage has no tokens yet the session is brand new — the
+    first turn on any model must be allowed because there's nothing to
+    price yet. The unpriced-model ASK only fires once tokens have been
+    written (i.e. after the first turn completes).
     """
     policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
     assert policy(_tool(None, model="opus")) == {"result": "ALLOW"}

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -266,6 +266,103 @@ def test_over_budget_unknown_model_denies_fail_closed() -> None:
     assert policy(_tool(6.0, model=None))["result"] == "DENY"
 
 
+def _unpriced_tool(input_tokens: int = 1000, model: str = "unpriced-model") -> PolicyEvent:
+    """Build a ``tool_call`` event with token usage but no ``total_cost_usd``.
+
+    Simulates a session that has consumed tokens on a model absent from the
+    pricing catalog: ``total_cost_usd`` is never written, so the key is absent
+    from the usage dict even though real spend has occurred.
+
+    :param input_tokens: Cumulative input tokens to place in the usage dict.
+    :param model: Active model id, e.g. ``"unpriced-model"``.
+    :returns: A ``tool_call`` event with tokens but no cost key.
+    """
+    return {
+        "type": "tool_call",
+        "target": "sys_os_shell",
+        "data": {"name": "sys_os_shell", "arguments": {}},
+        "context": {
+            "actor": {},
+            "usage": {"input_tokens": input_tokens, "total_tokens": input_tokens},
+            "model": model,
+        },
+        "session_state": {},
+    }
+
+
+def test_unpriced_session_denies_fail_closed() -> None:
+    """Token usage without ``total_cost_usd`` → DENY (fail closed).
+
+    A model absent from the pricing catalog never writes ``total_cost_usd``
+    to the session, so the gate would score the session at $0 and never
+    fire. After the fix, the gate detects tokens-present / cost-absent and
+    returns DENY rather than silently treating unknown spend as $0. The
+    deny reason must name the model-pricing gap so the operator knows
+    what to fix.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    result = policy(_unpriced_tool())
+    assert result["result"] == "DENY"
+    assert "pricing" in result["reason"].lower()
+
+
+def test_unpriced_session_denies_both_phases() -> None:
+    """Unpriced fail-closed fires on both tool_call and request phases."""
+    policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[1.0])
+    unpriced_request: PolicyEvent = {
+        "type": "request",
+        "target": None,
+        "data": "hello",
+        "context": {
+            "actor": {},
+            "usage": {"input_tokens": 500, "total_tokens": 500},
+            "model": "unpriced-model",
+        },
+        "session_state": {},
+    }
+    assert policy(_unpriced_tool())["result"] == "DENY"
+    assert policy(unpriced_request)["result"] == "DENY"
+
+
+def test_no_tokens_yet_allows_first_turn() -> None:
+    """No tokens in session_usage → ALLOW (first turn, nothing unpriced yet).
+
+    The unpriced check must not fire when the session is brand new (no
+    prior turns). The gate can only detect unpriced spend after at least
+    one turn has written tokens; the very first turn on any model must
+    be allowed so the gate is not infinitely recursive.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    # cost=None + no token keys → brand-new session, nothing spent
+    result = policy(_tool(None))
+    assert result["result"] == "ALLOW"
+
+
+def test_priced_zero_cost_allows() -> None:
+    """``total_cost_usd = 0.0`` (explicitly priced at zero) → not an unpriced session.
+
+    A free model that IS in the catalog and reports $0 should behave
+    normally — the key is present, the cost is zero, the gate allows.
+    Confusing this with the absent-key case would block free catalog models.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    event: PolicyEvent = {
+        "type": "tool_call",
+        "target": "sys_os_shell",
+        "data": {"name": "sys_os_shell", "arguments": {}},
+        "context": {
+            "actor": {},
+            "usage": {
+                "input_tokens": 1000,
+                "total_cost_usd": 0.0,  # explicitly priced at $0 (free model)
+            },
+            "model": "free-model",
+        },
+        "session_state": {},
+    }
+    assert policy(event)["result"] == "ALLOW"
+
+
 def test_hard_limit_wins_over_checkpoint_approval() -> None:
     """Over the hard limit on an expensive model → DENY even if approved.
 


### PR DESCRIPTION
## Summary

Fixes issue #3 from the cost-budget audit: *"Unpriced models fail open at \$0. A model not in the pricing catalog accrues real spend the gate scores as \$0 → silently disables both the cap and the ASK thresholds."*

## Root cause

When a model has no catalog pricing, `_accumulate_session_usage` never writes `total_cost_usd` to `session_usage`. `_session_cost_usd` defaulted to `0.0` when the key was absent, so the gate always saw \$0 — silently passing every check.

## Fix

Add `_usage_is_unpriced(usage)`: returns `True` when token counters are present (`input_tokens` / `output_tokens` / `total_tokens` > 0) but `total_cost_usd` is absent. All three `evaluate` closures check this before the normal cost path and return `_UNPRICED_DENY` — a DENY telling the operator to switch to a priced model or add the model to the catalog.

## Behaviour

| State | Before | After |
|---|---|---|
| No turns yet (brand new session) | ALLOW | ALLOW (no tokens → not detected as unpriced) |
| Turns on unpriced model | ALLOW ($0) | DENY after first turn |
| Turns on free catalog model (`total_cost_usd: 0.0` present) | ALLOW | ALLOW (key present → not unpriced) |
| Turns on priced model | Normal | Normal (unchanged) |

The first turn on an unpriced model still runs — the check only fires once `session_usage` has token counts, which happens after the turn completes. Every subsequent turn is denied.

## Tests (4 new)
- `test_unpriced_session_denies_fail_closed` — tokens present, no cost → DENY with "pricing" in reason
- `test_unpriced_session_denies_both_phases` — fires on both `tool_call` and `request`
- `test_no_tokens_yet_allows_first_turn` — brand-new session (no tokens) → ALLOW
- `test_priced_zero_cost_allows` — free model in catalog (`total_cost_usd: 0.0`) → ALLOW

## Test plan
- [ ] `pytest tests/policies/builtins/` — 426/426 pass