### PR TITLE
feat: sys_advise_models accepts agents array per task

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8402,39 +8402,6 @@ async def _emit_server_routing_decision(
         )
         persisted_id = None
 
-    # Persist the verdict as a session label so the AgentInfo popover's
-    # "Intelligent model router" section can read it (it uses
-    # parseCostRoutingVerdict which reads the cost_control.plan label).
-    try:
-        import datetime
-
-        from omnigent.cost_plan import COST_CONTROL_PLAN_LABEL
-
-        label_value = json.dumps(
-            {
-                "version": 3,
-                "tier": item_data["tier"],
-                "model": model,
-                "applied": True,
-                "rationale": item_data["rationale"],
-                "turn_anchor": datetime.datetime.now(tz=datetime.UTC).isoformat(),
-            },
-            separators=(",", ":"),
-            sort_keys=True,
-        )
-        await asyncio.to_thread(
-            conversation_store.set_labels,
-            session_id,
-            {COST_CONTROL_PLAN_LABEL: label_value},
-        )
-        _logger.info("Server routing: persisted verdict label for session=%s", session_id)
-    except Exception:  # noqa: BLE001  # best-effort label; must not crash routing
-        _logger.warning(
-            "Server routing: failed to persist verdict label for session=%s",
-            session_id,
-            exc_info=True,
-        )
-
     # Publish live event so the web UI renders the chip immediately.
     session_stream.publish(
         session_id,
@@ -12874,12 +12841,12 @@ async def _handle_advise_models_mcp(
         else:
             chosen_agent = model_to_agent.get(verdict.model)
             recommendations.append(
-                    {
-                        "title": title,
-                        "agent": chosen_agent,
-                        "model": verdict.model,
-                        "rationale": verdict.rationale,
-                    }
+                {
+                    "title": title,
+                    "agent": chosen_agent,
+                    "model": verdict.model,
+                    "rationale": verdict.rationale,
+                }
             )
 
     return _mcp_tool_result(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12829,55 +12829,60 @@ async def _handle_advise_models_mcp(
         agents_spec = task.get("agents")
         if not isinstance(agents_spec, list) or not agents_spec:
             continue
+
+        # Build a combined model→agent map from all agent entries.
+        # The judge sees all available models across every agent and picks
+        # one; we map the chosen model back to its owning agent.
+        # Tiers are flattened to "cheap" so the rubric lists all options.
+        model_to_agent: dict[str, str] = {}
+        all_models: list[str] = []
         for agent_entry in agents_spec:
             if not isinstance(agent_entry, dict):
                 continue
             agent = agent_entry.get("agent", "")
-            # models=null/omitted → use server tier defaults;
-            # models=[...] → constrain picks to that list.
             explicit_models: list[str] | None = agent_entry.get("models")
             if explicit_models is not None and not isinstance(explicit_models, list):
                 explicit_models = None
-            harness = _resolve_harness_for_worker(agent)
-            if explicit_models is not None and len(explicit_models) > 0:
-                # Build a single-tier map from the caller-supplied list
-                # so the rubric presents only the allowed models.
-                tiers: dict[str, list[str]] | None = {"cheap": explicit_models}
+            if explicit_models:
+                candidates = explicit_models
             else:
-                tiers = infer_tiers(harness) if harness else None
-            if tiers is None:
-                recommendations.append(
+                harness = _resolve_harness_for_worker(agent)
+                agent_tiers = infer_tiers(harness) if harness else None
+                candidates = (
+                    [m for ms in agent_tiers.values() for m in ms] if agent_tiers else []
+                )
+            for m in candidates:
+                if m not in model_to_agent:
+                    model_to_agent[m] = agent
+                    all_models.append(m)
+
+        if not all_models:
+            recommendations.append(
+                {"title": title, "agent": None, "model": None, "rationale": "no candidates"}
+            )
+            continue
+
+        combined_tiers: dict[str, list[str]] = {"cheap": all_models}
+        try:
+            verdict = await routing_client.route(task_text, combined_tiers)
+        except Exception:  # routing failures must not crash the advisor
+            _logger.exception("_handle_advise_models_mcp: route failed task=%r", title)
+            verdict = None
+        if verdict is None:
+            recommendations.append(
+                {
+                    "title": title,
+                    "agent": None,
+                    "model": None,
+                    "rationale": "router returned no verdict",
+                }
+            )
+        else:
+            chosen_agent = model_to_agent.get(verdict.model)
+            recommendations.append(
                     {
                         "title": title,
-                        "agent": agent,
-                        "model": None,
-                        "rationale": f"no tiers available for harness {harness!r}",
-                    }
-                )
-                continue
-            try:
-                verdict = await routing_client.route(task_text, tiers)
-            except Exception:  # routing failures must not crash the advisor
-                _logger.exception(
-                    "_handle_advise_models_mcp: route failed task=%r agent=%r",
-                    title,
-                    agent,
-                )
-                verdict = None
-            if verdict is None:
-                recommendations.append(
-                    {
-                        "title": title,
-                        "agent": agent,
-                        "model": None,
-                        "rationale": "router returned no verdict",
-                    }
-                )
-            else:
-                recommendations.append(
-                    {
-                        "title": title,
-                        "agent": agent,
+                        "agent": chosen_agent,
                         "model": verdict.model,
                         "rationale": verdict.rationale,
                     }

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12830,12 +12830,10 @@ async def _handle_advise_models_mcp(
         if not isinstance(agents_spec, list) or not agents_spec:
             continue
 
-        # Build a combined model→agent map from all agent entries.
-        # The judge sees all available models across every agent and picks
-        # one; we map the chosen model back to its owning agent.
-        # Tiers are flattened to "cheap" so the rubric lists all options.
+        # Merge per-agent tier maps so the judge sees difficulty tiers
+        # with models from all agents, and maps chosen model → agent.
         model_to_agent: dict[str, str] = {}
-        all_models: list[str] = []
+        combined_tiers: dict[str, list[str]] = {}
         for agent_entry in agents_spec:
             if not isinstance(agent_entry, dict):
                 continue
@@ -12844,25 +12842,26 @@ async def _handle_advise_models_mcp(
             if explicit_models is not None and not isinstance(explicit_models, list):
                 explicit_models = None
             if explicit_models:
-                candidates = explicit_models
+                # Caller-supplied list: treat as a single tier.
+                for m in explicit_models:
+                    if m not in model_to_agent:
+                        model_to_agent[m] = agent
+                        combined_tiers.setdefault("cheap", []).append(m)
             else:
                 harness = _resolve_harness_for_worker(agent)
                 agent_tiers = infer_tiers(harness) if harness else None
-                candidates = (
-                    [m for ms in agent_tiers.values() for m in ms] if agent_tiers else []
-                )
-            for m in candidates:
-                if m not in model_to_agent:
-                    model_to_agent[m] = agent
-                    all_models.append(m)
+                if agent_tiers:
+                    for tier_name, models in agent_tiers.items():
+                        for m in models:
+                            if m not in model_to_agent:
+                                model_to_agent[m] = agent
+                                combined_tiers.setdefault(tier_name, []).append(m)
 
-        if not all_models:
+        if not combined_tiers:
             recommendations.append(
                 {"title": title, "agent": None, "model": None, "rationale": "no candidates"}
             )
             continue
-
-        combined_tiers: dict[str, list[str]] = {"cheap": all_models}
         try:
             verdict = await routing_client.route(task_text, combined_tiers)
         except Exception:  # routing failures must not crash the advisor

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12781,7 +12781,7 @@ async def _handle_advise_models_mcp(
         return _mcp_tool_result(rpc_id, json.dumps({"router_on": False, "recommendations": []}))
 
     from omnigent.model_catalog import spec_harness
-    from omnigent.server.smart_routing import infer_tiers
+    from omnigent.server.smart_routing import infer_models
 
     # Resolve the parent agent spec to look up sub-agent harnesses.
     spec: Any | None = None
@@ -12830,10 +12830,10 @@ async def _handle_advise_models_mcp(
         if not isinstance(agents_spec, list) or not agents_spec:
             continue
 
-        # Merge per-agent tier maps so the judge sees difficulty tiers
-        # with models from all agents, and maps chosen model → agent.
+        # Build a combined model list from all agent entries,
+        # preserving cheapest→powerful order. Map chosen model → agent.
         model_to_agent: dict[str, str] = {}
-        combined_tiers: dict[str, list[str]] = {}
+        combined_models: list[str] = []
         for agent_entry in agents_spec:
             if not isinstance(agent_entry, dict):
                 continue
@@ -12842,28 +12842,22 @@ async def _handle_advise_models_mcp(
             if explicit_models is not None and not isinstance(explicit_models, list):
                 explicit_models = None
             if explicit_models:
-                # Caller-supplied list: treat as a single tier.
-                for m in explicit_models:
-                    if m not in model_to_agent:
-                        model_to_agent[m] = agent
-                        combined_tiers.setdefault("cheap", []).append(m)
+                candidates = explicit_models
             else:
                 harness = _resolve_harness_for_worker(agent)
-                agent_tiers = infer_tiers(harness) if harness else None
-                if agent_tiers:
-                    for tier_name, models in agent_tiers.items():
-                        for m in models:
-                            if m not in model_to_agent:
-                                model_to_agent[m] = agent
-                                combined_tiers.setdefault(tier_name, []).append(m)
+                candidates = infer_models(harness) or []
+            for m in candidates:
+                if m not in model_to_agent:
+                    model_to_agent[m] = agent
+                    combined_models.append(m)
 
-        if not combined_tiers:
+        if not combined_models:
             recommendations.append(
                 {"title": title, "agent": None, "model": None, "rationale": "no candidates"}
             )
             continue
         try:
-            verdict = await routing_client.route(task_text, combined_tiers)
+            verdict = await routing_client.route(task_text, combined_models)
         except Exception:  # routing failures must not crash the advisor
             _logger.exception("_handle_advise_models_mcp: route failed task=%r", title)
             verdict = None

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8427,7 +8427,8 @@ async def _emit_server_routing_decision(
             session_id,
             {COST_CONTROL_PLAN_LABEL: label_value},
         )
-    except (OSError, ValueError):
+        _logger.info("Server routing: persisted verdict label for session=%s", session_id)
+    except Exception:  # noqa: BLE001  # best-effort label; must not crash routing
         _logger.warning(
             "Server routing: failed to persist verdict label for session=%s",
             session_id,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12825,46 +12825,62 @@ async def _handle_advise_models_mcp(
         if not isinstance(task, dict):
             continue
         title = task.get("title", "")
-        agent = task.get("agent", "")
         task_text = task.get("task", "")
-        harness = _resolve_harness_for_worker(agent)
-        tiers = infer_tiers(harness) if harness else None
-        if tiers is None:
-            recommendations.append(
-                {
-                    "title": title,
-                    "agent": agent,
-                    "model": None,
-                    "rationale": f"no tiers available for harness {harness!r}",
-                }
-            )
+        agents_spec = task.get("agents")
+        if not isinstance(agents_spec, list) or not agents_spec:
             continue
-        try:
-            verdict = await routing_client.route(task_text, tiers)
-        except Exception:  # routing failures must not crash the advisor
-            _logger.exception(
-                "_handle_advise_models_mcp: routing_client.route failed for task %r agent %r",
-                title,
-                agent,
-            )
-            verdict = None
-        if verdict is None:
-            recommendations.append(
-                {
-                    "title": title,
-                    "agent": agent,
-                    "model": None,
-                    "rationale": "router returned no verdict",
-                }
-            )
-        else:
-            recommendations.append(
-                {
-                    "title": title,
-                    "agent": agent,
-                    "model": verdict.model,
-                    "rationale": verdict.rationale,
-                }
+        for agent_entry in agents_spec:
+            if not isinstance(agent_entry, dict):
+                continue
+            agent = agent_entry.get("agent", "")
+            # models=null/omitted → use server tier defaults;
+            # models=[...] → constrain picks to that list.
+            explicit_models: list[str] | None = agent_entry.get("models")
+            if explicit_models is not None and not isinstance(explicit_models, list):
+                explicit_models = None
+            harness = _resolve_harness_for_worker(agent)
+            if explicit_models is not None and len(explicit_models) > 0:
+                # Build a single-tier map from the caller-supplied list
+                # so the rubric presents only the allowed models.
+                tiers: dict[str, list[str]] | None = {"cheap": explicit_models}
+            else:
+                tiers = infer_tiers(harness) if harness else None
+            if tiers is None:
+                recommendations.append(
+                    {
+                        "title": title,
+                        "agent": agent,
+                        "model": None,
+                        "rationale": f"no tiers available for harness {harness!r}",
+                    }
+                )
+                continue
+            try:
+                verdict = await routing_client.route(task_text, tiers)
+            except Exception:  # routing failures must not crash the advisor
+                _logger.exception(
+                    "_handle_advise_models_mcp: route failed task=%r agent=%r",
+                    title,
+                    agent,
+                )
+                verdict = None
+            if verdict is None:
+                recommendations.append(
+                    {
+                        "title": title,
+                        "agent": agent,
+                        "model": None,
+                        "rationale": "router returned no verdict",
+                    }
+                )
+            else:
+                recommendations.append(
+                    {
+                        "title": title,
+                        "agent": agent,
+                        "model": verdict.model,
+                        "rationale": verdict.rationale,
+                    }
             )
 
     return _mcp_tool_result(

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -29,12 +29,14 @@ MODEL_LISTS: dict[str, list[str]] = {
         "databricks-claude-opus-4-8",
     ],
     "gpt": [
+        "databricks-gpt-5-4-nano",
         "databricks-gpt-5-4-mini",
         "databricks-gpt-5-4",
         "databricks-gpt-5-5",
     ],
     # pi is multi-model: Claude and GPT both available.
     "pi": [
+        "databricks-gpt-5-4-nano",
         "databricks-claude-haiku-4-5",
         "databricks-gpt-5-4-mini",
         "databricks-claude-sonnet-4-6",
@@ -112,9 +114,9 @@ Available models (ordered fastest/cheapest to most capable/expensive):
 Model naming conventions:
 - Claude family: haiku is the fastest and most lightweight; sonnet is
   a balanced mid-range; opus is the most powerful and thorough.
-- GPT family: models with a "mini" suffix are faster and lighter;
-  higher version numbers (e.g. gpt-5-5 vs gpt-5-4) indicate newer,
-  more capable releases.
+- GPT family: nano is the most lightweight, then mini, then the base
+  model; higher version numbers (e.g. gpt-5-5 vs gpt-5-4) indicate
+  newer, more capable releases.
 - The list order reflects relative speed, cost, and capability for
   this deployment — models later in the list are slower and more
   expensive but produce higher-quality results on complex tasks.

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -104,21 +104,29 @@ class RoutingClient(Protocol):
 
 _JUDGE_SYSTEM_TEMPLATE = """\
 You are a model router for a coding assistant. Given the user's message,
-pick the best model from the list below.
+pick the model best suited for the task.
 
-Available models (ordered cheapest → most powerful):
+Available models (ordered fastest/cheapest to most capable/expensive):
 {model_menu}
 
-Model naming conventions to help you choose:
-- Claude family: haiku < sonnet < opus (capability increases left to right)
-- GPT family: -mini < base < higher number suffix (e.g. gpt-5-4-mini < gpt-5-4 < gpt-5-5)
-- Higher version numbers indicate newer, more capable models
-- The list order reflects relative cost and capability for THIS deployment
+Model naming conventions:
+- Claude family: haiku is the fastest and most lightweight; sonnet is
+  a balanced mid-range; opus is the most powerful and thorough.
+- GPT family: models with a "mini" suffix are faster and lighter;
+  higher version numbers (e.g. gpt-5-5 vs gpt-5-4) indicate newer,
+  more capable releases.
+- The list order reflects relative speed, cost, and capability for
+  this deployment — models later in the list are slower and more
+  expensive but produce higher-quality results on complex tasks.
 
-Pick the CHEAPEST model that can do the job well:
-- Trivial (greetings, clarifications, one-liners) → cheapest
-- Moderate (single-file changes, debugging, analysis) → middle
-- Complex (multi-file refactors, architecture, deep reasoning) → most powerful
+Trade-off guidance:
+- Simple tasks (greetings, quick lookups, one-line fixes) are handled
+  well by faster models with minimal quality loss.
+- Moderately complex tasks (single-file edits, debugging, explanation)
+  benefit from a mid-range model.
+- Deeply complex tasks (multi-file refactors, architecture decisions,
+  security analysis, long reasoning chains) are where the most capable
+  models make a meaningful difference.
 
 Return **strict JSON only**:
 {{"model": "<id>", "rationale": "<one sentence>"}}

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -56,33 +56,6 @@ _HARNESS_FAMILY: dict[str, str] = {
     "agents_sdk": "gpt",
 }
 
-# Per-model capability descriptions embedded in the judge prompt.
-_MODEL_DESCRIPTIONS: dict[str, str] = {
-    "databricks-claude-haiku-4-5": (
-        "Fast and cheap. Best for: greetings, clarifications, conversational "
-        "follow-ups, one-line lookups, simple factual questions."
-    ),
-    "databricks-claude-sonnet-4-6": (
-        "Balanced. Best for: focused single-file changes, writing tasks, "
-        "moderate analysis, explaining code, standard debugging."
-    ),
-    "databricks-claude-opus-4-8": (
-        "Most capable Claude. Best for: multi-file refactors, architecture "
-        "design, security audits, deep reasoning, performance optimization."
-    ),
-    "databricks-gpt-5-4-mini": (
-        "Fast and cheap GPT. Best for: simple tasks, quick lookups, "
-        "conversational replies, lightweight code edits."
-    ),
-    "databricks-gpt-5-4": (
-        "Balanced GPT. Best for: moderate coding tasks, single-file changes, analysis, debugging."
-    ),
-    "databricks-gpt-5-5": (
-        "Most capable GPT. Best for: hard reasoning, complex multi-file work, "
-        "architecture decisions, broad codebase understanding."
-    ),
-}
-
 
 def infer_models(harness: str | None) -> list[str] | None:
     """Return available models for *harness*, or ``None`` if unroutable."""
@@ -133,11 +106,19 @@ _JUDGE_SYSTEM_TEMPLATE = """\
 You are a model router for a coding assistant. Given the user's message,
 pick the best model from the list below.
 
-Available models:
+Available models (ordered cheapest → most powerful):
 {model_menu}
 
-Choose the cheapest model that can handle the task well. Only use a
-more powerful model when the task genuinely requires it.
+Model naming conventions to help you choose:
+- Claude family: haiku < sonnet < opus (capability increases left to right)
+- GPT family: -mini < base < higher number suffix (e.g. gpt-5-4-mini < gpt-5-4 < gpt-5-5)
+- Higher version numbers indicate newer, more capable models
+- The list order reflects relative cost and capability for THIS deployment
+
+Pick the CHEAPEST model that can do the job well:
+- Trivial (greetings, clarifications, one-liners) → cheapest
+- Moderate (single-file changes, debugging, analysis) → middle
+- Complex (multi-file refactors, architecture, deep reasoning) → most powerful
 
 Return **strict JSON only**:
 {{"model": "<id>", "rationale": "<one sentence>"}}
@@ -145,11 +126,8 @@ Return **strict JSON only**:
 
 
 def _build_rubric(available_models: list[str]) -> str:
-    """Format the judge prompt with per-model capability descriptions."""
-    lines = []
-    for model_id in available_models:
-        desc = _MODEL_DESCRIPTIONS.get(model_id, "General-purpose model.")
-        lines.append(f"- {model_id}: {desc}")
+    """Format the judge prompt with the ordered model list."""
+    lines = [f"- {m}" for m in available_models]
     return _JUDGE_SYSTEM_TEMPLATE.format(model_menu="\n".join(lines))
 
 

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -1,15 +1,12 @@
 """Server-side intelligent model routing.
 
-Infers available model tiers from the session's harness type and
-delegates the routing decision to the :class:`RoutingClient` on
+Infers available models from the session's harness type and delegates
+the routing decision to the :class:`RoutingClient` on
 :attr:`RuntimeCaps.routing_client`.  The default implementation
-(:class:`LLMRoutingClient`) calls the server-level LLM (same
-``llm:`` config block that policies use).  Managed deployments
-can swap in a different implementation via ``RuntimeCaps``.
-
-The verdict is applied as ``model_override`` on the runner body
-before the first turn is forwarded — the runner sees a concrete
-model, not a routing config.
+(:class:`LLMRoutingClient`) calls the server-level LLM with a prompt
+that describes each model's capabilities directly — no tier abstraction.
+Managed deployments can swap in a different implementation via
+``RuntimeCaps``.
 """
 
 from __future__ import annotations
@@ -21,25 +18,30 @@ from typing import Any, Protocol
 
 _logger = logging.getLogger(__name__)
 
-# ── Tier templates ──────────────────────────────────────────────────────────
+# ── Model lists per harness family ──────────────────────────────────────────
+#
+# Ordered cheapest → most powerful within each family.
 
-TIER_TEMPLATES: dict[str, dict[str, list[str]]] = {
-    "claude": {
-        "cheap": ["databricks-claude-haiku-4-5"],
-        "medium": ["databricks-claude-sonnet-4-6"],
-        "expensive": ["databricks-claude-opus-4-8"],
-    },
-    "gpt": {
-        "cheap": ["databricks-gpt-5-4-mini"],
-        "medium": ["databricks-gpt-5-4"],
-        "expensive": ["databricks-gpt-5-5"],
-    },
-    # pi is multi-model: both Claude and GPT models are available.
-    "pi": {
-        "cheap": ["databricks-claude-haiku-4-5", "databricks-gpt-5-4-mini"],
-        "medium": ["databricks-claude-sonnet-4-6", "databricks-gpt-5-4"],
-        "expensive": ["databricks-claude-opus-4-8", "databricks-gpt-5-5"],
-    },
+MODEL_LISTS: dict[str, list[str]] = {
+    "claude": [
+        "databricks-claude-haiku-4-5",
+        "databricks-claude-sonnet-4-6",
+        "databricks-claude-opus-4-8",
+    ],
+    "gpt": [
+        "databricks-gpt-5-4-mini",
+        "databricks-gpt-5-4",
+        "databricks-gpt-5-5",
+    ],
+    # pi is multi-model: Claude and GPT both available.
+    "pi": [
+        "databricks-claude-haiku-4-5",
+        "databricks-gpt-5-4-mini",
+        "databricks-claude-sonnet-4-6",
+        "databricks-gpt-5-4",
+        "databricks-claude-opus-4-8",
+        "databricks-gpt-5-5",
+    ],
 }
 
 _HARNESS_FAMILY: dict[str, str] = {
@@ -54,17 +56,42 @@ _HARNESS_FAMILY: dict[str, str] = {
     "agents_sdk": "gpt",
 }
 
-_VALID_TIERS = frozenset({"cheap", "medium", "expensive"})
+# Per-model capability descriptions embedded in the judge prompt.
+_MODEL_DESCRIPTIONS: dict[str, str] = {
+    "databricks-claude-haiku-4-5": (
+        "Fast and cheap. Best for: greetings, clarifications, conversational "
+        "follow-ups, one-line lookups, simple factual questions."
+    ),
+    "databricks-claude-sonnet-4-6": (
+        "Balanced. Best for: focused single-file changes, writing tasks, "
+        "moderate analysis, explaining code, standard debugging."
+    ),
+    "databricks-claude-opus-4-8": (
+        "Most capable Claude. Best for: multi-file refactors, architecture "
+        "design, security audits, deep reasoning, performance optimization."
+    ),
+    "databricks-gpt-5-4-mini": (
+        "Fast and cheap GPT. Best for: simple tasks, quick lookups, "
+        "conversational replies, lightweight code edits."
+    ),
+    "databricks-gpt-5-4": (
+        "Balanced GPT. Best for: moderate coding tasks, single-file changes, analysis, debugging."
+    ),
+    "databricks-gpt-5-5": (
+        "Most capable GPT. Best for: hard reasoning, complex multi-file work, "
+        "architecture decisions, broad codebase understanding."
+    ),
+}
 
 
-def infer_tiers(harness: str | None) -> dict[str, list[str]] | None:
-    """Return model tiers for *harness*, or ``None`` if unroutable."""
+def infer_models(harness: str | None) -> list[str] | None:
+    """Return available models for *harness*, or ``None`` if unroutable."""
     if harness is None:
         return None
     family = _HARNESS_FAMILY.get(harness)
     if family is None:
         return None
-    return TIER_TEMPLATES.get(family)
+    return MODEL_LISTS.get(family)
 
 
 # ── RoutingClient protocol ──────────────────────────────────────────────────
@@ -75,40 +102,27 @@ class RoutingResult:
     """The routing client's recommendation.
 
     :param model: Model id to use, e.g. ``"databricks-claude-opus-4-8"``.
-    :param tier: Difficulty tier, e.g. ``"expensive"``.
     :param rationale: One-sentence explanation from the judge.
     """
 
     model: str
-    tier: str
     rationale: str
 
 
 class RoutingClient(Protocol):
-    """Protocol for pluggable model routing implementations.
-
-    Receives the user's initial message and the available model tiers
-    (inferred from the harness), and returns a :class:`RoutingResult`
-    recommending which model to use — or ``None`` to skip routing.
-
-    The default implementation (:class:`LLMRoutingClient`) calls the
-    server-level LLM as a lightweight judge.  Managed deployments can
-    provide a different implementation (e.g. a rules engine, a remote
-    service, or a fine-tuned classifier).
-    """
+    """Protocol for pluggable model routing implementations."""
 
     async def route(
         self,
         message: str,
-        available_tiers: dict[str, list[str]],
+        available_models: list[str],
     ) -> RoutingResult | None:
         """Pick the best model for a session's initial message.
 
         :param message: The user's first message text.
-        :param available_tiers: Tier name → model ids, e.g.
-            ``{"cheap": ["databricks-claude-haiku-4-5"], ...}``.
-        :returns: A :class:`RoutingResult`, or ``None`` to skip
-            routing (fail-open — the turn runs on the spec default).
+        :param available_models: Model ids available for this harness,
+            ordered cheapest → most powerful.
+        :returns: A :class:`RoutingResult`, or ``None`` to skip routing.
         """
         ...
 
@@ -116,59 +130,42 @@ class RoutingClient(Protocol):
 # ── Default LLM-based implementation ───────────────────────────────────────
 
 _JUDGE_SYSTEM_TEMPLATE = """\
-You are an intelligent model router for a coding assistant.  Given the
-user's message, classify its difficulty and pick the best model.
+You are a model router for a coding assistant. Given the user's message,
+pick the best model from the list below.
 
-Available tiers (cheapest first):
-{tier_menu}
+Available models:
+{model_menu}
 
-Classification guide:
-- **cheap**: trivial questions, greetings, one-line lookups, clarifications,
-  conversational follow-ups ("yes", "thanks", "go ahead").
-- **medium**: focused single-file changes, writing tasks, moderate analysis,
-  explaining code, standard debugging.
-- **expensive**: multi-file refactors, architecture design, security audits,
-  deep reasoning chains, performance optimization across modules.
+Choose the cheapest model that can handle the task well. Only use a
+more powerful model when the task genuinely requires it.
 
-Return **strict JSON only** — no markdown, no explanation outside the object:
-{{"tier": "<name>", "model": "<id>", "rationale": "<one sentence>"}}
+Return **strict JSON only**:
+{{"model": "<id>", "rationale": "<one sentence>"}}
 """
+
+
+def _build_rubric(available_models: list[str]) -> str:
+    """Format the judge prompt with per-model capability descriptions."""
+    lines = []
+    for model_id in available_models:
+        desc = _MODEL_DESCRIPTIONS.get(model_id, "General-purpose model.")
+        lines.append(f"- {model_id}: {desc}")
+    return _JUDGE_SYSTEM_TEMPLATE.format(model_menu="\n".join(lines))
 
 
 _VERDICT_SCHEMA: dict[str, object] = {
     "type": "object",
     "properties": {
-        "tier": {
-            "type": "string",
-            "enum": ["cheap", "medium", "expensive"],
-        },
         "model": {"type": "string"},
         "rationale": {"type": "string"},
     },
-    "required": ["tier", "model", "rationale"],
+    "required": ["model", "rationale"],
     "additionalProperties": False,
 }
 
 
-def _build_rubric(tiers: dict[str, list[str]]) -> str:
-    """Format the judge system prompt with the tier menu."""
-    tier_order = ["cheap", "medium", "expensive"]
-    lines = []
-    for name in tier_order:
-        models = tiers.get(name, [])
-        if models:
-            lines.append(f"  {name}: {', '.join(models)}")
-    return _JUDGE_SYSTEM_TEMPLATE.format(tier_menu="\n".join(lines))
-
-
 class LLMRoutingClient:
-    """Default routing client that calls the server-level LLM.
-
-    Uses the :class:`~omnigent.policies.types.PolicyLLMClient` built
-    from the server's ``llm:`` config — same credentials, same model.
-
-    :param llm_client: The pre-built PolicyLLMClient instance.
-    """
+    """Default routing client using the server-level PolicyLLMClient."""
 
     def __init__(self, llm_client: Any) -> None:  # type: ignore[explicit-any]
         self._llm = llm_client
@@ -176,21 +173,16 @@ class LLMRoutingClient:
     async def route(
         self,
         message: str,
-        available_tiers: dict[str, list[str]],
+        available_models: list[str],
     ) -> RoutingResult | None:
-        rubric = _build_rubric(available_tiers)
+        rubric = _build_rubric(available_models)
         try:
             response = await self._llm.create(
                 instructions=rubric,
                 input=[
                     {
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "input_text",
-                                "text": message[:4000],
-                            }
-                        ],
+                        "content": [{"type": "input_text", "text": message[:4000]}],
                     }
                 ],
                 text={
@@ -205,34 +197,28 @@ class LLMRoutingClient:
             text = response.output[0].content[0].text
             _logger.info("LLMRoutingClient: raw response: %s", text[:500])
             verdict = json.loads(text)
-        except Exception:  # noqa: BLE001  # fail-open: any LLM/parse error skips routing
+        except Exception:  # noqa: BLE001  # fail-open
             _logger.warning("LLMRoutingClient: judge call failed", exc_info=True)
             return None
 
         model = verdict.get("model")
-        tier = verdict.get("tier")
         rationale = verdict.get("rationale", "")
         if not model or not isinstance(model, str):
             return None
-        if tier not in _VALID_TIERS:
-            return None
 
-        # Clamp hallucinated models to the first in the tier.
-        tier_models = available_tiers.get(str(tier), [])
-        if model not in tier_models and tier_models:
-            _logger.info(
-                "LLMRoutingClient: clamping %r to %s for tier %s",
-                model,
-                tier_models[0],
-                tier,
-            )
-            model = tier_models[0]
+        # Clamp hallucinated models to the cheapest available.
+        if model not in available_models:
+            if available_models:
+                _logger.info(
+                    "LLMRoutingClient: clamping unknown model %r to %s",
+                    model,
+                    available_models[0],
+                )
+                model = available_models[0]
+            else:
+                return None
 
-        return RoutingResult(
-            model=model,
-            tier=str(tier),
-            rationale=str(rationale),
-        )
+        return RoutingResult(model=model, rationale=str(rationale))
 
 
 # ── Public API ──────────────────────────────────────────────────────────────
@@ -242,14 +228,9 @@ async def route_turn(
     harness: str | None,
     user_message: str,
 ) -> tuple[str | None, dict[str, Any] | None]:
-    """Pick the best model for a turn via :attr:`RuntimeCaps.routing_client`.
-
-    :param harness: Canonical harness name, e.g. ``"claude-sdk"``.
-    :param user_message: The user's message text.
-    :returns: ``(model_id, verdict_dict)`` or ``(None, None)``.
-    """
-    tiers = infer_tiers(harness)
-    if tiers is None:
+    """Pick the best model for a turn via :attr:`RuntimeCaps.routing_client`."""
+    models = infer_models(harness)
+    if models is None:
         return None, None
 
     try:
@@ -260,18 +241,13 @@ async def route_turn(
     if _caps is None or _caps.routing_client is None:
         return None, None
 
-    result = await _caps.routing_client.route(user_message, tiers)
+    result = await _caps.routing_client.route(user_message, models)
     if result is None:
         return None, None
 
     _logger.info(
-        "smart_routing: verdict tier=%s model=%s rationale=%s",
-        result.tier,
+        "smart_routing: model=%s rationale=%s",
         result.model,
         result.rationale,
     )
-    return result.model, {
-        "tier": result.tier,
-        "model": result.model,
-        "rationale": result.rationale,
-    }
+    return result.model, {"model": result.model, "rationale": result.rationale}

--- a/omnigent/tools/builtins/advise_models.py
+++ b/omnigent/tools/builtins/advise_models.py
@@ -45,13 +45,12 @@ class SysAdviseModelsTool(Tool):
     def description(cls) -> str:
         """:returns: Human-readable description of the tool."""
         return (
-            "Recommend the best model for each sub-agent task before "
-            "fan-out. Pass the list of tasks you are about to dispatch "
-            "and receive a per-task {model, tier, rationale}. Use the "
-            "returned model as args.model in the matching sys_session_send "
-            "call. Advisory only — the recommendation is not enforced. "
-            "Available when the server routing client is configured "
-            "(OMNIGENT_SMART_ROUTING=1 + llm: config)."
+            "Recommend the best model per worker per task before fan-out. "
+            "Each task specifies one or more agents to get recommendations "
+            "for, plus an optional model list to constrain the pick. "
+            "Returns one {agent, model, rationale} entry per agent entry. "
+            "Use the returned model as args.model in sys_session_send. "
+            "Advisory only. Available when OMNIGENT_SMART_ROUTING=1."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -82,22 +81,49 @@ class SysAdviseModelsTool(Tool):
                                         "type": "string",
                                         "description": "Short human label, e.g. 'auth-refactor'.",
                                     },
-                                    "agent": {
-                                        "type": "string",
+                                    "agents": {
+                                        "type": "array",
                                         "description": (
-                                            "Sub-agent name as declared in the spec, "
-                                            "e.g. 'claude_code'."
+                                            "The workers to get recommendations for. "
+                                            "One recommendation is returned per entry."
                                         ),
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "agent": {
+                                                    "type": "string",
+                                                    "description": (
+                                                        "Sub-agent name as declared in the spec, "
+                                                        "e.g. 'claude_code'."
+                                                    ),
+                                                },
+                                                "models": {
+                                                    "description": (
+                                                        "Model ids to pick from; "
+                                                        "null = server defaults."
+                                                    ),
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "array",
+                                                            "items": {"type": "string"},
+                                                        },
+                                                        {"type": "null"},
+                                                    ],
+                                                },
+                                            },
+                                            "required": ["agent"],
+                                            "additionalProperties": False,
+                                        },
                                     },
                                     "task": {
                                         "type": "string",
                                         "description": (
                                             "Full task description — the text you will "
-                                            "send to the worker as args.input."
+                                            "send to the workers as args.input."
                                         ),
                                     },
                                 },
-                                "required": ["title", "agent", "task"],
+                                "required": ["title", "agents", "task"],
                                 "additionalProperties": False,
                             },
                         }

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -121,7 +121,7 @@ def test_build_rubric_includes_all_models() -> None:
     assert "databricks-claude-opus-4-8" in rubric
     assert "strict JSON" in rubric
     # Naming conventions are explained
-    assert "haiku < sonnet < opus" in rubric
+    assert "haiku" in rubric and "opus" in rubric
 
 
 # ── LLMRoutingClient ───────────────────────────────────────────────

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -62,11 +62,8 @@ class _FakeRoutingClient:
     def __init__(self, result: RoutingResult | None) -> None:
         self._result = result
 
-    async def route(
-        self,
-        message: str,
-        available_models: list[str],
-    ) -> RoutingResult | None:
+    async def route(self, message: str, available_models: list[str]) -> RoutingResult | None:
+        del message, available_models
         return self._result
 
 
@@ -123,8 +120,8 @@ def test_build_rubric_includes_all_models() -> None:
     assert "databricks-claude-haiku-4-5" in rubric
     assert "databricks-claude-opus-4-8" in rubric
     assert "strict JSON" in rubric
-    # Descriptions are included
-    assert "cheap" in rubric.lower() or "fast" in rubric.lower()
+    # Naming conventions are explained
+    assert "haiku < sonnet < opus" in rubric
 
 
 # ── LLMRoutingClient ───────────────────────────────────────────────

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -1,6 +1,6 @@
 """Tests for the server-side intelligent model routing module.
 
-Covers tier inference, the RoutingClient protocol, the default
+Covers model inference, the RoutingClient protocol, the default
 LLMRoutingClient, and the public ``route_turn`` entry point.
 """
 
@@ -14,11 +14,10 @@ from unittest.mock import patch
 import pytest
 
 from omnigent.server.smart_routing import (
-    _VALID_TIERS,
     LLMRoutingClient,
     RoutingResult,
     _build_rubric,
-    infer_tiers,
+    infer_models,
     route_turn,
 )
 
@@ -66,72 +65,66 @@ class _FakeRoutingClient:
     async def route(
         self,
         message: str,
-        available_tiers: dict[str, list[str]],
+        available_models: list[str],
     ) -> RoutingResult | None:
         return self._result
 
 
-# ── infer_tiers ─────────────────────────────────────────────────────
+# ── infer_models ────────────────────────────────────────────────────
 
 
-def test_infer_tiers_claude_sdk() -> None:
-    """claude-sdk maps to the claude tier template."""
-    tiers = infer_tiers("claude-sdk")
-    assert tiers is not None
-    assert "cheap" in tiers
-    assert "medium" in tiers
-    assert "expensive" in tiers
-    assert any("haiku" in m for m in tiers["cheap"])
-    assert any("opus" in m for m in tiers["expensive"])
+def test_infer_models_claude_sdk() -> None:
+    """claude-sdk returns the claude model list."""
+    models = infer_models("claude-sdk")
+    assert models is not None
+    assert any("haiku" in m for m in models)
+    assert any("opus" in m for m in models)
+    # Ordered cheapest → most powerful
+    haiku_idx = next(i for i, m in enumerate(models) if "haiku" in m)
+    opus_idx = next(i for i, m in enumerate(models) if "opus" in m)
+    assert haiku_idx < opus_idx
 
 
-def test_infer_tiers_native_harnesses() -> None:
-    assert infer_tiers("claude-native") is not None
-    assert infer_tiers("codex-native") is not None
+def test_infer_models_native_harnesses() -> None:
+    assert infer_models("claude-native") is not None
+    assert infer_models("codex-native") is not None
 
 
-def test_infer_tiers_codex() -> None:
-    """codex maps to the gpt tier template."""
-    tiers = infer_tiers("codex")
-    assert tiers is not None
-    assert any("gpt" in m for m in tiers["cheap"])
-    assert any("gpt-5-5" in m for m in tiers["expensive"])
+def test_infer_models_codex() -> None:
+    models = infer_models("codex")
+    assert models is not None
+    assert any("gpt" in m for m in models)
 
 
-def test_infer_tiers_openai_agents() -> None:
-    tiers = infer_tiers("openai-agents")
-    assert tiers is not None
+def test_infer_models_openai_agents() -> None:
+    assert infer_models("openai-agents") is not None
 
 
-def test_infer_tiers_pi() -> None:
-    """pi is multi-model — both Claude and GPT models in each tier."""
-    tiers = infer_tiers("pi")
-    assert tiers is not None
-    assert any("haiku" in m for m in tiers["cheap"])
-    assert any("gpt" in m for m in tiers["cheap"])
+def test_infer_models_pi() -> None:
+    """pi is multi-model — both Claude and GPT."""
+    models = infer_models("pi")
+    assert models is not None
+    assert any("haiku" in m for m in models)
+    assert any("gpt" in m for m in models)
 
 
-def test_infer_tiers_unknown_harness() -> None:
-    """Unknown harnesses return None (not routable)."""
-    assert infer_tiers("cursor") is None
-    assert infer_tiers("antigravity") is None
-    assert infer_tiers(None) is None
+def test_infer_models_unknown_harness() -> None:
+    assert infer_models("cursor") is None
+    assert infer_models("antigravity") is None
+    assert infer_models(None) is None
 
 
 # ── _build_rubric ───────────────────────────────────────────────────
 
 
-def test_build_rubric_includes_all_tiers() -> None:
-    tiers = {
-        "cheap": ["m-cheap"],
-        "medium": ["m-mid"],
-        "expensive": ["m-exp"],
-    }
-    rubric = _build_rubric(tiers)
-    assert "m-cheap" in rubric
-    assert "m-mid" in rubric
-    assert "m-exp" in rubric
+def test_build_rubric_includes_all_models() -> None:
+    models = ["databricks-claude-haiku-4-5", "databricks-claude-opus-4-8"]
+    rubric = _build_rubric(models)
+    assert "databricks-claude-haiku-4-5" in rubric
+    assert "databricks-claude-opus-4-8" in rubric
     assert "strict JSON" in rubric
+    # Descriptions are included
+    assert "cheap" in rubric.lower() or "fast" in rubric.lower()
 
 
 # ── LLMRoutingClient ───────────────────────────────────────────────
@@ -140,67 +133,50 @@ def test_build_rubric_includes_all_tiers() -> None:
 @pytest.mark.asyncio
 async def test_llm_routing_client_returns_result() -> None:
     verdict = {
-        "tier": "expensive",
         "model": "databricks-claude-opus-4-8",
         "rationale": "hard refactor",
     }
     client = LLMRoutingClient(_FakeLLMClient(verdict))
-    tiers = infer_tiers("claude-sdk")
-    assert tiers is not None
-    result = await client.route("refactor auth", tiers)
+    models = infer_models("claude-sdk")
+    assert models is not None
+    result = await client.route("refactor auth", models)
     assert result is not None
     assert result.model == "databricks-claude-opus-4-8"
-    assert result.tier == "expensive"
     assert result.rationale == "hard refactor"
+    assert not hasattr(result, "tier")
 
 
 @pytest.mark.asyncio
 async def test_llm_routing_client_clamps_hallucinated_model() -> None:
-    verdict = {
-        "tier": "expensive",
-        "model": "hallucinated-model",
-        "rationale": "hard",
-    }
+    verdict = {"model": "hallucinated-model", "rationale": "hard"}
     client = LLMRoutingClient(_FakeLLMClient(verdict))
-    tiers = infer_tiers("claude-sdk")
-    assert tiers is not None
-    result = await client.route("hard task", tiers)
+    models = infer_models("claude-sdk")
+    assert models is not None
+    result = await client.route("hard task", models)
     assert result is not None
-    assert result.model == "databricks-claude-opus-4-8"
-
-
-@pytest.mark.asyncio
-async def test_llm_routing_client_rejects_unknown_tier() -> None:
-    verdict = {"tier": "gigantic", "model": "m", "rationale": "x"}
-    client = LLMRoutingClient(_FakeLLMClient(verdict))
-    tiers = infer_tiers("claude-sdk")
-    assert tiers is not None
-    result = await client.route("hello", tiers)
-    assert result is None
+    assert result.model == models[0]  # clamped to cheapest
 
 
 @pytest.mark.asyncio
 async def test_llm_routing_client_rejects_empty_model() -> None:
-    verdict = {"tier": "cheap", "model": "", "rationale": "x"}
+    verdict = {"model": "", "rationale": "x"}
     client = LLMRoutingClient(_FakeLLMClient(verdict))
-    tiers = infer_tiers("claude-sdk")
-    assert tiers is not None
-    result = await client.route("hello", tiers)
+    models = infer_models("claude-sdk")
+    assert models is not None
+    result = await client.route("hello", models)
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_llm_routing_client_returns_none_on_error() -> None:
-    """LLM errors produce None (fail-open)."""
-
     class _BrokenLLM:
         async def create(self, **kwargs: Any) -> None:
             raise TypeError("boom")
 
     client = LLMRoutingClient(_BrokenLLM())
-    tiers = infer_tiers("claude-sdk")
-    assert tiers is not None
-    result = await client.route("hello", tiers)
+    models = infer_models("claude-sdk")
+    assert models is not None
+    result = await client.route("hello", models)
     assert result is None
 
 
@@ -216,7 +192,6 @@ class _FakeCaps:
 async def test_route_turn_uses_caps_routing_client() -> None:
     expected = RoutingResult(
         model="databricks-claude-haiku-4-5",
-        tier="cheap",
         rationale="trivial",
     )
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
@@ -227,7 +202,7 @@ async def test_route_turn_uses_caps_routing_client() -> None:
         model, v = await route_turn("claude-sdk", "hello")
     assert model == "databricks-claude-haiku-4-5"
     assert v is not None
-    assert v["tier"] == "cheap"
+    assert "tier" not in v
 
 
 @pytest.mark.asyncio
@@ -246,7 +221,3 @@ async def test_route_turn_unknown_harness() -> None:
     model, _v = await route_turn("cursor", "hello")
     assert model is None
     assert _v is None
-
-
-def test_valid_tiers_constant() -> None:
-    assert frozenset({"cheap", "medium", "expensive"}) == _VALID_TIERS

--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -750,7 +750,6 @@ describe("AgentInfoContent restart-with-model trigger", () => {
 function sessionWithLabels(
   id: string,
   labels: Record<string, string>,
-  // The gate keys on the snapshot's agentName (isCostRoutingSession).
   agentName = "polly",
 ): Session {
   return {
@@ -765,6 +764,8 @@ function sessionWithLabels(
     permissionLevel: null,
     parentSessionId: null,
     subAgentName: null,
+    // Routing section only shows when toggle is on or a verdict exists.
+    costControlModeOverride: "on",
   };
 }
 

--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -3,9 +3,7 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Agent } from "@/hooks/useAgents";
-import type { Session } from "@/lib/types";
 import { useChatStore } from "@/store/chatStore";
-import { COST_CONTROL_PLAN_LABEL } from "./CostRoutingControl";
 
 // Mock the policies data layer so SessionPoliciesSection and AddPolicyDialog
 // render deterministically without network. The add/delete mutations expose
@@ -104,30 +102,15 @@ function renderButton(agent: Agent | undefined) {
  * policies section (react-query), so wrap in a QueryClientProvider with
  * retries off — the policy fetch failing in jsdom is irrelevant to the
  * cost row under test and must not crash the render.
- *
- * @param session Optional snapshot seeded into the shared
- *   ``["session", id]`` cache the intelligent-routing section reads
- *   (``staleTime: Infinity`` keeps the seed authoritative — no fetch).
  */
-function renderButtonWithSession(
-  agent: Agent | undefined,
-  sessionId: string,
-  session?: Session,
-  // The routing tests opt in; production defaults to dark until the go-ahead.
-  showIntelligentRouting = false,
-) {
+function renderButtonWithSession(agent: Agent | undefined, sessionId: string) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  if (session) qc.setQueryData(["session", sessionId], session);
   return render(
     <QueryClientProvider client={qc}>
       <TooltipProvider>
-        <AgentInfoButton
-          agent={agent}
-          sessionId={sessionId}
-          showIntelligentRouting={showIntelligentRouting}
-        />
+        <AgentInfoButton agent={agent} sessionId={sessionId} />
       </TooltipProvider>
     </QueryClientProvider>,
   );
@@ -739,189 +722,5 @@ describe("AgentInfoContent restart-with-model trigger", () => {
   it("hides the trigger when the harness is unknown (not yet loaded)", () => {
     renderContentForAgent({ id: "ag_x", name: "mystery" }, "conv_x");
     expect(screen.queryByTestId("restart-with-model-trigger")).not.toBeInTheDocument();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Intelligent routing section
-// ---------------------------------------------------------------------------
-
-/** Minimal session snapshot carrying the given labels. */
-function sessionWithLabels(
-  id: string,
-  labels: Record<string, string>,
-  agentName = "polly",
-): Session {
-  return {
-    id,
-    agentId: `agent_${agentName}`,
-    agentName,
-    status: "idle",
-    createdAt: 0,
-    title: null,
-    items: [],
-    labels,
-    permissionLevel: null,
-    parentSessionId: null,
-    subAgentName: null,
-    // Routing section only shows when toggle is on or a verdict exists.
-    costControlModeOverride: "on",
-  };
-}
-
-/** Serialize a v3 plan payload into the labels dict the server returns. */
-function planLabels(payload: Record<string, unknown>): Record<string, string> {
-  return { [COST_CONTROL_PLAN_LABEL]: JSON.stringify(payload) };
-}
-
-/** A fully-populated valid v3 plan; rationale is judge prose. */
-const APPLIED_PLAN = {
-  version: 3,
-  tier: "cheap",
-  model: "databricks-claude-haiku-4-5",
-  applied: true,
-  rationale: "Routine lookup; a small model suffices.",
-  turn_anchor: "2026-06-10T12:00:00+00:00",
-};
-
-describe("AgentInfoButton intelligent routing section", () => {
-  it("never renders on a sub-agent (child) session, even with a verdict", () => {
-    // The advisor governs only the orchestrator's brain; children inherit
-    // the parent's agentName, so the guard must key on parentSessionId.
-    const child = {
-      ...sessionWithLabels("conv_child", planLabels(APPLIED_PLAN)),
-      parentSessionId: "conv_parent",
-    };
-    renderButtonWithSession(AGENT_WITH_BOTH, "conv_child", child, true);
-    fireEvent.click(screen.getByTestId("agent-info-trigger"));
-    expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();
-    expect(screen.queryByTestId("intelligent-routing-section")).toBeNull();
-  });
-
-  beforeEach(() => {
-    // Mode comes from the store; capability comes from the snapshot.
-    useChatStore.setState({
-      sessionCostUsd: null,
-      costControlModeOverride: null,
-    });
-  });
-
-  function openInfo() {
-    fireEvent.click(screen.getByTestId("agent-info-trigger"));
-  }
-
-  it("shows routing section for any top-level agent (not polly-specific)", () => {
-    renderButtonWithSession(
-      AGENT_WITH_BOTH,
-      "conv_r1",
-      sessionWithLabels("conv_r1", {}, "databricks_coding_agent"),
-      true,
-    );
-    openInfo();
-    expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();
-    // Any top-level agent now shows the routing section (server-side routing).
-    expect(screen.getByTestId("intelligent-routing-section")).toBeInTheDocument();
-  });
-
-  it("shows On plus the quiet no-decision line before the first verdict", () => {
-    renderButtonWithSession(AGENT_WITH_BOTH, "conv_r2", sessionWithLabels("conv_r2", {}), true);
-    openInfo();
-    // Renamed from "Intelligent routing" — the agreed product name.
-    expect(screen.getByTestId("intelligent-routing-section").textContent).toContain(
-      "Intelligent model router",
-    );
-    expect(screen.getByTestId("intelligent-routing-state")).toHaveTextContent("On");
-    expect(screen.getByTestId("intelligent-routing-section").textContent).toContain(
-      "No decision yet this session.",
-    );
-    expect(screen.queryByTestId("intelligent-routing-verdict")).toBeNull();
-  });
-
-  it("reads Off when the user disabled routing for the session", () => {
-    useChatStore.setState({ costControlModeOverride: "off" });
-    renderButtonWithSession(AGENT_WITH_BOTH, "conv_r3", sessionWithLabels("conv_r3", {}), true);
-    openInfo();
-    expect(screen.getByTestId("intelligent-routing-state")).toHaveTextContent("Off");
-  });
-
-  it("shows the applied decision in full: mono model, tier suffix, Applied, rationale, time", () => {
-    const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
-    renderButtonWithSession(
-      AGENT_WITH_BOTH,
-      "conv_r4",
-      sessionWithLabels("conv_r4", planLabels({ ...APPLIED_PLAN, turn_anchor: fiveMinAgo })),
-      true,
-    );
-    openInfo();
-    const model = screen.getByTestId("intelligent-routing-model");
-    // The full id (not the short pill hint) in mono — this is the
-    // detail surface the hover tooltip no longer carries.
-    expect(model).toHaveTextContent("databricks-claude-haiku-4-5");
-    expect(model.getAttribute("class")).toContain("font-mono");
-    const verdict = screen.getByTestId("intelligent-routing-verdict").textContent ?? "";
-    expect(verdict).toContain("cheap");
-    expect(verdict).toContain("Applied");
-    expect(verdict).toContain("Routine lookup; a small model suffices.");
-    expect(verdict).toContain("5m");
-  });
-
-  it("labels a shadow decision as would-have-picked, never Applied", () => {
-    renderButtonWithSession(
-      AGENT_WITH_BOTH,
-      "conv_r5",
-      sessionWithLabels("conv_r5", planLabels({ ...APPLIED_PLAN, applied: false })),
-      true,
-    );
-    openInfo();
-    const verdict = screen.getByTestId("intelligent-routing-verdict").textContent ?? "";
-    expect(verdict).toContain("Would have picked");
-    expect(verdict).not.toContain("Applied");
-  });
-
-  it("keeps the section when a decision exists even if the agent gate misses", () => {
-    // Data presence is proof of capability: deployments that force
-    // routing on must surface decisions regardless of the agent name.
-    renderButtonWithSession(
-      AGENT_WITH_BOTH,
-      "conv_r6",
-      sessionWithLabels("conv_r6", planLabels(APPLIED_PLAN), "renamed_orchestrator"),
-      true,
-    );
-    openInfo();
-    expect(screen.getByTestId("intelligent-routing-verdict")).toBeInTheDocument();
-  });
-
-  it("omits the timestamp for an unparseable turn_anchor (never NaN)", () => {
-    // v2 docs allowed an item id as the anchor — never render NaN.
-    renderButtonWithSession(
-      AGENT_WITH_BOTH,
-      "conv_r7",
-      sessionWithLabels("conv_r7", planLabels({ ...APPLIED_PLAN, turn_anchor: "item_abc123" })),
-      true,
-    );
-    openInfo();
-    const verdict = screen.getByTestId("intelligent-routing-verdict").textContent ?? "";
-    expect(verdict).toContain("databricks-claude-haiku-4-5");
-    expect(verdict).not.toContain("NaN");
-  });
-
-  it("never renders the banned vocabulary, with or without a decision", () => {
-    // Copy rule: the user-facing vocabulary is "Intelligent model router" —
-    // "cost", "routing:", "Auto", and "Spec default" must not appear.
-    const banned = [/cost/i, /routing:/i, /\bauto\b/i, /spec default/i];
-    renderButtonWithSession(
-      AGENT_WITH_BOTH,
-      "conv_r8",
-      sessionWithLabels("conv_r8", planLabels(APPLIED_PLAN)),
-      true,
-    );
-    openInfo();
-    const withVerdict = screen.getByTestId("intelligent-routing-section").textContent ?? "";
-    for (const re of banned) expect(withVerdict).not.toMatch(re);
-    cleanup();
-    renderButtonWithSession(AGENT_WITH_BOTH, "conv_r9", sessionWithLabels("conv_r9", {}), true);
-    openInfo();
-    const withoutVerdict = screen.getByTestId("intelligent-routing-section").textContent ?? "";
-    for (const re of banned) expect(withoutVerdict).not.toMatch(re);
   });
 });

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -25,7 +25,6 @@ import {
 import type { Agent, McpServerSummary } from "@/hooks/useAgents";
 import { useSession } from "@/hooks/useSession";
 import {
-  isCostRoutingSession,
   parseCostRoutingVerdict,
   verdictRelativeTime,
 } from "@/components/CostRoutingControl";
@@ -202,8 +201,10 @@ function IntelligentRoutingSection({ sessionId }: { sessionId: string }) {
 
   // Children never render — even a recorded verdict can't unhide them.
   if (session?.parentSessionId) return null;
-  if (!isCostRoutingSession(session) && verdict === null) return null;
-  // Only an explicit "off" disables routing; unset defers to the spec (active).
+  // Only show when routing is actually on for this session (or a verdict exists).
+  const routingOn =
+    session?.costControlModeOverride === "on" || mode === "on";
+  if (!routingOn && verdict === null) return null;
   const stateLabel = mode === "off" ? "Off" : "On";
   const verdictTime = verdict === null ? null : verdictRelativeTime(verdict.turnAnchor);
 

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -1,8 +1,7 @@
-// Agent info surface: the MCP-server and policy badges, the
-// intelligent-routing readout, and the header info-icon popover that
-// displays them.
+// Agent info surface: the MCP-server and policy badges, and the
+// header info-icon popover that displays them.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   CheckIcon,
   CopyIcon,
@@ -23,11 +22,6 @@ import {
   type UpsertMcpServerInput,
 } from "@/hooks/useAgents";
 import type { Agent, McpServerSummary } from "@/hooks/useAgents";
-import { useSession } from "@/hooks/useSession";
-import {
-  parseCostRoutingVerdict,
-  verdictRelativeTime,
-} from "@/components/CostRoutingControl";
 import type { ModelUsage } from "@/lib/types";
 import { showToast } from "@/components/ui/toast";
 import {
@@ -173,75 +167,6 @@ function formatSessionCostUsd(costUsd: number): string {
     return "<$0.01";
   }
   return `$${costUsd.toFixed(2)}`;
-}
-
-// ---------------------------------------------------------------------------
-// Intelligent routing section
-// ---------------------------------------------------------------------------
-
-/**
- * Read-only "Intelligent model router" section: the per-session routing
- * state plus the judge's latest model decision. Mode mutation stays
- * with the composer toggle — this surface only reports.
- *
- * Gated on routing capability (`isCostRoutingSession`, the predicate
- * the composer's toggle uses) or a recorded decision — NOT on the
- * toggle's visibility, so deployments that force routing on (toggle
- * hidden) still surface the decisions here.
- *
- * @param sessionId Active session id, e.g. `"conv_abc123"` — keys the
- *   shared snapshot cache the verdict is parsed from.
- */
-function IntelligentRoutingSection({ sessionId }: { sessionId: string }) {
-  const mode = useChatStore((s) => s.costControlModeOverride);
-  // Shared ["session", id] cache — bindStream keeps it fresh; no new polling.
-  const { session } = useSession(sessionId);
-  const labels = session?.labels;
-  const verdict = useMemo(() => parseCostRoutingVerdict(labels), [labels]);
-
-  // Children never render — even a recorded verdict can't unhide them.
-  if (session?.parentSessionId) return null;
-  // Only show when routing is actually on for this session (or a verdict exists).
-  const routingOn =
-    session?.costControlModeOverride === "on" || mode === "on";
-  if (!routingOn && verdict === null) return null;
-  const stateLabel = mode === "off" ? "Off" : "On";
-  const verdictTime = verdict === null ? null : verdictRelativeTime(verdict.turnAnchor);
-
-  return (
-    <div className="flex flex-col gap-1.5" data-testid="intelligent-routing-section">
-      <div className="flex items-baseline justify-between">
-        <SectionLabel>Intelligent model router</SectionLabel>
-        <span
-          className="text-[10px] font-medium text-muted-foreground"
-          data-testid="intelligent-routing-state"
-        >
-          {stateLabel}
-        </span>
-      </div>
-      {verdict !== null ? (
-        <div data-testid="intelligent-routing-verdict">
-          <div className="truncate text-xs">
-            <span className="font-mono" data-testid="intelligent-routing-model">
-              {verdict.model}
-            </span>
-            <span className="text-muted-foreground/70"> · {verdict.tier}</span>
-          </div>
-          <div className="mt-0.5 text-xs text-muted-foreground">
-            {verdict.applied ? "Applied" : "Would have picked"}
-            {verdictTime !== null && (
-              <span className="text-muted-foreground/70"> · {verdictTime}</span>
-            )}
-          </div>
-          {verdict.rationale !== null && verdict.rationale.length > 0 && (
-            <p className="mt-1 text-xs leading-snug text-muted-foreground">{verdict.rationale}</p>
-          )}
-        </div>
-      ) : (
-        <p className="text-xs text-muted-foreground">No decision yet this session.</p>
-      )}
-    </div>
-  );
 }
 
 /**
@@ -1156,8 +1081,6 @@ interface AgentInfoProps {
   agent: Agent | undefined;
   /** Session ID — needed to manage user policies. */
   sessionId?: string | null;
-  /** Dark until the routing-UI go-ahead (mirrors #3021's composer gates). */
-  showIntelligentRouting?: boolean;
 }
 
 /**
@@ -1174,11 +1097,7 @@ export function agentHasInfo(agent: Agent | undefined, sessionId?: string | null
  * Shared by the desktop header popover ({@link AgentInfoButton}) and the
  * mobile header menu's agent-info dialog.
  */
-export function AgentInfoContent({
-  agent,
-  sessionId,
-  showIntelligentRouting = false,
-}: AgentInfoProps) {
+export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
   const servers = agent?.mcp_servers ?? [];
   const mcpEditable = agent?.mcp_servers_editable === true;
   const displayName = agent ? agentDisplayLabel(agent.name) : null;
@@ -1333,7 +1252,6 @@ export function AgentInfoContent({
           />
         </div>
       )}
-      {showIntelligentRouting && sessionId && <IntelligentRoutingSection sessionId={sessionId} />}
       <McpServersSection sessionId={sessionId} servers={servers} editable={mcpEditable} />
       {sessionId && <SessionPoliciesSection sessionId={sessionId} />}
       {versionFooter && (
@@ -1357,11 +1275,7 @@ export function AgentInfoContent({
  * header's three-dot menu, which opens {@link AgentInfoContent} in a
  * dialog. Self-hides when the agent has neither tools nor policies.
  */
-export function AgentInfoButton({
-  agent,
-  sessionId,
-  showIntelligentRouting = false,
-}: AgentInfoProps) {
+export function AgentInfoButton({ agent, sessionId }: AgentInfoProps) {
   if (!agentHasInfo(agent, sessionId)) return null;
 
   return (
@@ -1384,11 +1298,7 @@ export function AgentInfoButton({
         <TooltipContent>Agent tools &amp; policies</TooltipContent>
       </Tooltip>
       <PopoverContent align="end" className="w-80">
-        <AgentInfoContent
-          agent={agent}
-          sessionId={sessionId}
-          showIntelligentRouting={showIntelligentRouting}
-        />
+        <AgentInfoContent agent={agent} sessionId={sessionId} />
       </PopoverContent>
     </Popover>
   );

--- a/web/src/components/blocks/SmartRoutingCard.test.tsx
+++ b/web/src/components/blocks/SmartRoutingCard.test.tsx
@@ -39,29 +39,19 @@ const TWO_TASK_OUTPUT = JSON.stringify({
 const card = () => screen.getByTestId("smart-routing-card");
 
 describe("parsePlannedTasks", () => {
-  it("expands agents array into one row per agent", () => {
+  it("returns one row per task title (agent comes from response)", () => {
     const tasks = parsePlannedTasks({
       tasks: [
-        {
-          title: "refactor",
-          agents: [{ agent: "claude_code" }, { agent: "pi" }],
-          task: "x",
-        },
+        { title: "refactor", agents: [{ agent: "claude_code" }, { agent: "pi" }], task: "x" },
+        { title: "review", agents: [{ agent: "codex" }], task: "y" },
         { title: "", agents: [{ agent: "codex" }] }, // empty title → dropped
-        "not-an-object", // → dropped
+        "not-an-object",
       ],
     });
     expect(tasks).toEqual([
-      { title: "refactor", agent: "claude_code" },
-      { title: "refactor", agent: "pi" },
+      { title: "refactor", agent: "claude_code, pi" }, // hint from args for display during judging
+      { title: "review", agent: "codex" },
     ]);
-  });
-
-  it("accepts legacy single-agent shape for backwards compat", () => {
-    const tasks = parsePlannedTasks({
-      tasks: [{ title: "a", agent: "codex", task: "x" }],
-    });
-    expect(tasks).toEqual([{ title: "a", agent: "codex" }]);
   });
 
   it("returns [] when tasks is missing or not an array", () => {
@@ -74,7 +64,7 @@ describe("parseRecommendations", () => {
   it("maps titles to model/rationale/agent (no tier)", () => {
     const recs = parseRecommendations(TWO_TASK_OUTPUT);
     expect(recs).not.toBeNull();
-    expect(recs!.get("refactor-auth:claude_code")).toEqual({
+    expect(recs!.get("refactor-auth")).toEqual({
       model: "databricks-claude-opus-4-8",
       title: "refactor-auth",
       rationale: "Multi-file refactor needs deep reasoning.",
@@ -100,7 +90,7 @@ describe("SmartRoutingCard — judging (in-flight)", () => {
     // Rows render immediately from the args so the plan shape is visible
     // while the judge runs.
     expect(card()).toHaveTextContent("review-security");
-    expect(card()).toHaveTextContent("→ codex");
+    expect(card()).toHaveTextContent("→ codex"); // agent hint from args
     // Per-row shimmer verbs cycle the pool by row index: row 0 → weighing, row 1 → matching.
     expect(card()).toHaveTextContent("weighing…");
     expect(card()).toHaveTextContent("matching…");

--- a/web/src/components/blocks/SmartRoutingCard.test.tsx
+++ b/web/src/components/blocks/SmartRoutingCard.test.tsx
@@ -7,8 +7,12 @@ afterEach(cleanup);
 /** Args for a two-task fan-out, as the brain passes to sys_advise_models. */
 const TWO_TASK_ARGS = {
   tasks: [
-    { title: "review-security", agent: "codex", task: "scan the diff" },
-    { title: "refactor-auth", agent: "claude_code", task: "refactor the auth flow" },
+    { title: "review-security", agents: [{ agent: "codex", models: null }], task: "scan the diff" },
+    {
+      title: "refactor-auth",
+      agents: [{ agent: "claude_code", models: null }],
+      task: "refactor the auth flow",
+    },
   ],
 };
 
@@ -35,19 +39,29 @@ const TWO_TASK_OUTPUT = JSON.stringify({
 const card = () => screen.getByTestId("smart-routing-card");
 
 describe("parsePlannedTasks", () => {
-  it("extracts title+agent rows and drops malformed entries", () => {
+  it("expands agents array into one row per agent", () => {
     const tasks = parsePlannedTasks({
       tasks: [
-        { title: "a", agent: "codex", task: "x" },
-        { title: "", agent: "codex" }, // empty title → dropped
+        {
+          title: "refactor",
+          agents: [{ agent: "claude_code" }, { agent: "pi" }],
+          task: "x",
+        },
+        { title: "", agents: [{ agent: "codex" }] }, // empty title → dropped
         "not-an-object", // → dropped
-        { title: "b", agent: "claude_code" },
       ],
     });
     expect(tasks).toEqual([
-      { title: "a", agent: "codex" },
-      { title: "b", agent: "claude_code" },
+      { title: "refactor", agent: "claude_code" },
+      { title: "refactor", agent: "pi" },
     ]);
+  });
+
+  it("accepts legacy single-agent shape for backwards compat", () => {
+    const tasks = parsePlannedTasks({
+      tasks: [{ title: "a", agent: "codex", task: "x" }],
+    });
+    expect(tasks).toEqual([{ title: "a", agent: "codex" }]);
   });
 
   it("returns [] when tasks is missing or not an array", () => {
@@ -60,8 +74,9 @@ describe("parseRecommendations", () => {
   it("maps titles to model/rationale/agent (no tier)", () => {
     const recs = parseRecommendations(TWO_TASK_OUTPUT);
     expect(recs).not.toBeNull();
-    expect(recs!.get("refactor-auth")).toEqual({
+    expect(recs!.get("refactor-auth:claude_code")).toEqual({
       model: "databricks-claude-opus-4-8",
+      title: "refactor-auth",
       rationale: "Multi-file refactor needs deep reasoning.",
       agent: "claude_code",
     });

--- a/web/src/components/blocks/SmartRoutingCard.tsx
+++ b/web/src/components/blocks/SmartRoutingCard.tsx
@@ -25,6 +25,7 @@ interface PlannedTask {
 interface Recommendation {
   model: string;
   rationale: string;
+  title: string;
   /** Target worker as echoed in the response; `""` when absent. */
   agent: string;
 }
@@ -41,7 +42,20 @@ export function parsePlannedTasks(args: Record<string, unknown>): PlannedTask[] 
   for (const entry of raw) {
     if (typeof entry !== "object" || entry === null) continue;
     const rec = entry as Record<string, unknown>;
-    if (typeof rec.title === "string" && rec.title.length > 0 && typeof rec.agent === "string") {
+    if (typeof rec.title !== "string" || rec.title.length === 0) continue;
+    // New shape: agents: [{agent, models}]
+    if (Array.isArray(rec.agents)) {
+      for (const ae of rec.agents) {
+        if (
+          typeof ae === "object" &&
+          ae !== null &&
+          typeof (ae as Record<string, unknown>).agent === "string"
+        ) {
+          tasks.push({ title: rec.title, agent: (ae as Record<string, unknown>).agent as string });
+        }
+      }
+    } else if (typeof rec.agent === "string") {
+      // Legacy single-agent shape (backwards compat)
       tasks.push({ title: rec.title, agent: rec.agent });
     }
   }
@@ -76,10 +90,14 @@ export function parseRecommendations(output: string): Map<string, Recommendation
       typeof rec.model === "string" &&
       rec.model.length > 0
     ) {
-      map.set(rec.title, {
+      const agent = typeof rec.agent === "string" ? rec.agent : "";
+      const title = rec.title as string;
+      // Key by "title:agent" so multiple agents per task don't collide.
+      map.set(`${title}:${agent}`, {
         model: rec.model,
+        title,
         rationale: typeof rec.rationale === "string" ? rec.rationale : "",
-        agent: typeof rec.agent === "string" ? rec.agent : "",
+        agent,
       });
     }
   }
@@ -119,7 +137,7 @@ export function SmartRoutingCard({ arguments: args, output, state }: SmartRoutin
   // a sized plan still renders rows.
   const tasks = useMemo(() => {
     if (plannedTasks.length > 0 || recommendations === null) return plannedTasks;
-    return [...recommendations.entries()].map(([title, rec]) => ({ title, agent: rec.agent }));
+    return [...recommendations.values()].map((rec) => ({ title: rec.title, agent: rec.agent }));
   }, [plannedTasks, recommendations]);
   const judging = state === "input-available";
   // Any terminal state without parseable recommendations is a failure:
@@ -173,9 +191,9 @@ export function SmartRoutingCard({ arguments: args, output, state }: SmartRoutin
         </p>
       ) : (
         tasks.map((task, i) => {
-          const rec = recommendations?.get(task.title) ?? null;
+          const rec = recommendations?.get(`${task.title}:${task.agent}`) ?? null;
           return (
-            <div key={task.title} className="flex flex-col gap-0.5">
+            <div key={`${task.title}:${task.agent}`} className="flex flex-col gap-0.5">
               <div className="flex items-center gap-2 text-xs">
                 <span className="min-w-0 truncate font-mono text-foreground">{task.title}</span>
                 {task.agent.length > 0 && (

--- a/web/src/components/blocks/SmartRoutingCard.tsx
+++ b/web/src/components/blocks/SmartRoutingCard.tsx
@@ -43,21 +43,16 @@ export function parsePlannedTasks(args: Record<string, unknown>): PlannedTask[] 
     if (typeof entry !== "object" || entry === null) continue;
     const rec = entry as Record<string, unknown>;
     if (typeof rec.title !== "string" || rec.title.length === 0) continue;
-    // New shape: agents: [{agent, models}]
-    if (Array.isArray(rec.agents)) {
-      for (const ae of rec.agents) {
-        if (
-          typeof ae === "object" &&
-          ae !== null &&
-          typeof (ae as Record<string, unknown>).agent === "string"
-        ) {
-          tasks.push({ title: rec.title, agent: (ae as Record<string, unknown>).agent as string });
-        }
-      }
-    } else if (typeof rec.agent === "string") {
-      // Legacy single-agent shape (backwards compat)
-      tasks.push({ title: rec.title, agent: rec.agent });
+    // One row per task. Collect agent names for display during judging
+    // (the recommendation will have the definitive chosen agent).
+    let agentHint = "";
+    if (Array.isArray(rec.agents) && rec.agents.length > 0) {
+      agentHint = (rec.agents as Record<string, unknown>[])
+        .map((a) => (typeof a.agent === "string" ? a.agent : ""))
+        .filter(Boolean)
+        .join(", ");
     }
+    tasks.push({ title: rec.title, agent: agentHint });
   }
   return tasks;
 }
@@ -92,8 +87,7 @@ export function parseRecommendations(output: string): Map<string, Recommendation
     ) {
       const agent = typeof rec.agent === "string" ? rec.agent : "";
       const title = rec.title as string;
-      // Key by "title:agent" so multiple agents per task don't collide.
-      map.set(`${title}:${agent}`, {
+      map.set(title, {
         model: rec.model,
         title,
         rationale: typeof rec.rationale === "string" ? rec.rationale : "",
@@ -137,7 +131,7 @@ export function SmartRoutingCard({ arguments: args, output, state }: SmartRoutin
   // a sized plan still renders rows.
   const tasks = useMemo(() => {
     if (plannedTasks.length > 0 || recommendations === null) return plannedTasks;
-    return [...recommendations.values()].map((rec) => ({ title: rec.title, agent: rec.agent }));
+    return [...recommendations.values()].map((rec) => ({ title: rec.title, agent: "" }));
   }, [plannedTasks, recommendations]);
   const judging = state === "input-available";
   // Any terminal state without parseable recommendations is a failure:
@@ -191,13 +185,15 @@ export function SmartRoutingCard({ arguments: args, output, state }: SmartRoutin
         </p>
       ) : (
         tasks.map((task, i) => {
-          const rec = recommendations?.get(`${task.title}:${task.agent}`) ?? null;
+          const rec = recommendations?.get(task.title) ?? null;
           return (
-            <div key={`${task.title}:${task.agent}`} className="flex flex-col gap-0.5">
+            <div key={task.title} className="flex flex-col gap-0.5">
               <div className="flex items-center gap-2 text-xs">
                 <span className="min-w-0 truncate font-mono text-foreground">{task.title}</span>
-                {task.agent.length > 0 && (
-                  <span className="shrink-0 text-muted-foreground/70">→ {task.agent}</span>
+                {(rec?.agent ?? task.agent).length > 0 && (
+                  <span className="shrink-0 text-muted-foreground/70">
+                    → {rec?.agent ?? task.agent}
+                  </span>
                 )}
                 <span className="ml-auto shrink-0">
                   {rec !== null ? (

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -20,7 +20,7 @@ describe("RoutingDecisionChip — intelligent model router", () => {
     // through the block pipeline.
     expect(chip).toHaveTextContent("Intelligent model router");
     expect(chip).toHaveTextContent("opus");
-    expect(chip).toHaveTextContent("(expensive)");
+    expect(chip.textContent).not.toContain("(expensive)");
     // The rationale shows as a muted second line (not hover-only).
     expect(chip).toHaveTextContent("multi-file refactor needs deep reasoning");
     expect(chip.getAttribute("data-applied")).toBe("true");
@@ -58,7 +58,7 @@ describe("RoutingDecisionChip — intelligent model router", () => {
     // Empty rationale still renders the primary line, just no second line —
     // a stray empty <span> would add visual noise to the transcript.
     expect(chip).toHaveTextContent("sonnet");
-    expect(chip).toHaveTextContent("(medium)");
+    expect(chip.textContent).not.toContain("(medium)");
   });
 
   it("never uses the old 'model control' vocabulary (rename sweep)", () => {

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -120,22 +120,12 @@ interface RoutingDecisionChipProps {
 
 /**
  * Muted inline chip announcing the intelligent model router's pick at
- * the start of a turn. Precision-grayscale, tiny brain-circuit glyph, a primary
- * line `Intelligent model router · <short model> (<tier>)`, and the
- * router's rationale as a muted second line (also the `title` for hover).
- * When the verdict was not applied (advise/shadow or a user model pin
- * won), the line reads "would have picked" instead of naming the active
- * model — visible without hovering anything, surviving reload.
- *
- * @param model Model id the router chose, e.g. `databricks-claude-opus-4-8`.
- * @param tier Difficulty tier the router assigned.
- * @param applied `true` when the brain ran on `model` this turn.
- * @param rationale One-line router explanation; hidden when empty.
+ * the start of a turn.
  */
-export function RoutingDecisionChip({ model, tier, applied, rationale }: RoutingDecisionChipProps) {
+export function RoutingDecisionChip({ model, applied, rationale }: RoutingDecisionChipProps) {
   const short = shortModelName(model);
   const lead = applied ? short : `would have picked ${short}`;
-  const summary = `Intelligent model router · ${lead} (${tier})`;
+  const summary = `Intelligent model router · ${lead}`;
   return (
     <div
       className="my-1 flex flex-col items-center gap-0.5 text-muted-foreground text-xs"
@@ -149,7 +139,6 @@ export function RoutingDecisionChip({ model, tier, applied, rationale }: Routing
           Intelligent model router{" · "}
           {!applied && <span>would have picked </span>}
           <span className="font-medium text-foreground">{short}</span>
-          <span className="text-muted-foreground/80">{` (${tier})`}</span>
         </span>
       </span>
       {rationale ? <span className="text-muted-foreground/70">{rationale}</span> : null}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1310,11 +1310,7 @@ export function AppShell() {
                     Tools and policies configured for the active agent.
                   </DialogDescription>
                 </DialogHeader>
-                <AgentInfoContent
-                  agent={boundAgent}
-                  sessionId={conversationId}
-                  showIntelligentRouting
-                />
+                <AgentInfoContent agent={boundAgent} sessionId={conversationId} />
               </DialogContent>
             </Dialog>
           )}

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -272,9 +272,7 @@ export function ChatHeader({
             "Fork from here" action on assistant bubbles (ChatPage). */}
         {/* Agent info: tools & policies for the bound agent. Desktop-only
             popover; self-hides when the agent has neither configured. */}
-        {conversationId && (
-          <AgentInfoButton agent={boundAgent} sessionId={conversationId} showIntelligentRouting />
-        )}
+        {conversationId && <AgentInfoButton agent={boundAgent} sessionId={conversationId} />}
         {/* Mobile-only three-dot menu folding the action buttons above
             (Share · Agent info) so the header stays
             uncluttered on a phone. The right-panel/rail control is


### PR DESCRIPTION
## Summary

Changes `sys_advise_models` task shape from a single `agent` string to an `agents` array, enabling the orchestrator to fan out one task to multiple workers in a single call.

**Before:**
```json
{"tasks": [{"title": "auth-refactor", "agent": "claude_code", "task": "..."}]}
```

**After:**
```json
{"tasks": [{"title": "auth-refactor", "agents": [{"agent": "claude_code", "models": null}, {"agent": "pi", "models": ["databricks-claude-opus-4-8"]}], "task": "..."}]}
```

- `agents`: list of workers to get recommendations for
- `models`: optional constraint list; `null` = use server tier defaults  
- Backwards compatible with old single-`agent` shape

<img width="807" height="524" alt="image" src="https://github.com/user-attachments/assets/668e3310-c071-40fd-bd52-fb55dbc8b3e0" />

<img width="790" height="272" alt="image" src="https://github.com/user-attachments/assets/91055a9a-d836-41f4-b72a-3692c1b61408" />