### PR TITLE
feat(cost): make max_cost_usd optional for cost_budget

### DIFF
--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -414,34 +414,35 @@ def _resolve_expensive_models(expensive_models: list[str] | None) -> _ExpensiveM
 
 
 def cost_budget(
-    max_cost_usd: float,
+    max_cost_usd: float | None = None,
     ask_thresholds_usd: list[float] | None = None,
     expensive_models: list[str] | None = None,
 ) -> PolicyCallable:
     """Factory: gate a session on cumulative LLM spend (USD).
 
-    The hard limit gates BOTH the ``request`` phase (blocking the whole
-    turn before the LLM runs, so text-only turns are budgeted too) and
-    the ``tool_call`` phase: once the limit is reached, DENY while the
-    session is still on an expensive model — telling the user to
-    ``/model`` to a cheaper one. The soft warning checkpoints (ASK
+    The hard limit (when set) gates BOTH the ``request`` phase (blocking
+    the whole turn before the LLM runs, so text-only turns are budgeted
+    too) and the ``tool_call`` phase: once the limit is reached, DENY
+    while the session is still on an expensive model — telling the user
+    to ``/model`` to a cheaper one. The soft warning checkpoints (ASK
     "continue?"; recorded on approve so they don't re-prompt, re-asked
     after a decline) fire on BOTH the ``request`` and ``tool_call``
     phases — both have a server-side approval round-trip (see
     ``evaluate``). Abstains (ALLOW) on every other phase and whenever
     cost is unpriced (``0.0``).
 
-    :param max_cost_usd: Hard limit in USD. Once cumulative session cost
-        reaches this, tool calls are DENYed while the session is on an
-        expensive model, e.g. ``5.0``. Must be ``> 0``.
+    :param max_cost_usd: Optional hard limit in USD. Once cumulative
+        session cost reaches this, tool calls are DENYed while the
+        session is on an expensive model, e.g. ``5.0``. Must be ``> 0``
+        if provided. Either this or *ask_thresholds_usd* must be set.
     :param ask_thresholds_usd: Optional soft warning checkpoints in USD,
         e.g. ``[1.0, 2.5]``. Each ASKs for approval the first time
         cumulative cost crosses it (approval remembered via
         ``session_state``, so an approved checkpoint prompts at most
         once; a decline blocks the one turn / tool call and re-asks next
         time). ``None`` or ``[]`` disables the soft gate. Every value must be
-        ``> 0`` and strictly less than *max_cost_usd*. Order does not
-        matter — they are sorted internally.
+        ``> 0`` and strictly less than *max_cost_usd* when both are set.
+        Order does not matter — they are sorted internally.
     :param expensive_models: Optional case-insensitive substring tokens
         identifying the model tiers blocked once over *max_cost_usd*,
         e.g. ``["opus", "gpt-5"]``. A token matches when it is a
@@ -453,15 +454,19 @@ def cost_budget(
         the named tiers, letting cheaper models continue over budget.
         Each value must be a non-empty string.
     :returns: A policy callable implementing the budget gate.
-    :raises ValueError: If *max_cost_usd* is not positive, any
-        *ask_thresholds_usd* value is not in ``(0, max_cost_usd)``, or
-        any *expensive_models* entry is not a non-empty string.
+    :raises ValueError: If neither *max_cost_usd* nor *ask_thresholds_usd*
+        is provided, *max_cost_usd* is not positive, any
+        *ask_thresholds_usd* value is not in ``(0, max_cost_usd)`` when
+        both are set, or any *expensive_models* entry is not a non-empty
+        string.
     """
-    if max_cost_usd <= 0:
+    if max_cost_usd is None and not ask_thresholds_usd:
+        raise ValueError("cost_budget requires max_cost_usd and/or ask_thresholds_usd")
+    if max_cost_usd is not None and max_cost_usd <= 0:
         raise ValueError(f"max_cost_usd must be > 0, got {max_cost_usd!r}")
     thresholds = sorted({float(t) for t in (ask_thresholds_usd or [])})
     for t in thresholds:
-        if not (0 < t < max_cost_usd):
+        if max_cost_usd is not None and not (0 < t < max_cost_usd):
             raise ValueError(
                 f"each ask_thresholds_usd value must be in "
                 f"(0, max_cost_usd={max_cost_usd}), got {t!r}"
@@ -503,7 +508,7 @@ def cost_budget(
                 return _UNPRICED_ASK
             return _ALLOW
         cost = _session_cost_usd(event)
-        if cfg.hard_cap_enabled and cost >= max_cost_usd:
+        if max_cost_usd is not None and cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
                 _current_model(event),
                 cfg.expensive_tokens,
@@ -530,11 +535,12 @@ def cost_budget(
                 state = event.get("session_state") or {}
                 approved_up_to = float(state.get(_ASK_APPROVED_KEY, 0.0) or 0.0)
                 if crossed > approved_up_to:
+                    limit_str = f" (limit ${max_cost_usd:.2f})" if max_cost_usd is not None else ""
                     return {
                         "result": "ASK",
                         "reason": (
                             f"Session cost ${cost:.2f} passed the ${crossed:.2f} "
-                            f"warning threshold (limit ${max_cost_usd:.2f}). Continue?"
+                            f"warning threshold{limit_str}. Continue?"
                         ),
                         # Applied only on approve → this and every lower
                         # checkpoint won't re-prompt; higher ones still will.
@@ -888,15 +894,16 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
             "properties": {
                 "max_cost_usd": {
                     "type": "number",
-                    "description": "Hard limit in USD; once cumulative session cost reaches "
-                    "it, tool calls are blocked while the session is on an expensive model.",
+                    "description": "Optional hard limit in USD; once cumulative session cost "
+                    "reaches it, tool calls are blocked while the session is on an expensive "
+                    "model. Either this or ask_thresholds_usd must be set.",
                 },
                 "ask_thresholds_usd": {
                     "type": "array",
                     "items": {"type": "number"},
                     "description": "Optional soft warning checkpoints in USD; the session asks "
                     "for approval the first time spend crosses each (every value must be < "
-                    "max_cost_usd).",
+                    "max_cost_usd when both are set).",
                 },
                 "expensive_models": {
                     "type": "array",
@@ -907,7 +914,6 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "only blocks the named tiers.",
                 },
             },
-            "required": ["max_cost_usd"],
         },
     },
     {

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -577,6 +577,7 @@ def test_no_usage_at_all_allows() -> None:
 @pytest.mark.parametrize(
     "kwargs",
     [
+        {},  # neither max_cost_usd nor ask_thresholds_usd
         {"max_cost_usd": 0.0},  # non-positive hard limit
         {"max_cost_usd": -1.0},  # negative hard limit
         {"max_cost_usd": 5.0, "ask_thresholds_usd": [5.0]},  # not strictly below max
@@ -590,13 +591,29 @@ def test_no_usage_at_all_allows() -> None:
 def test_factory_rejects_invalid_config(kwargs: dict[str, Any]) -> None:
     """Bad config fails loud at factory time (ValueError), not silently.
 
-    A non-positive limit, a checkpoint outside ``(0, max_cost_usd)``, or a
-    non-string / empty ``expensive_models`` entry is a misconfiguration
-    that could never enforce correctly, so it must raise rather than build
-    a dead gate.
+    Neither limit nor thresholds, a non-positive limit, a checkpoint outside
+    ``(0, max_cost_usd)``, or a non-string / empty ``expensive_models`` entry
+    is a misconfiguration that could never enforce correctly, so it must raise
+    rather than build a dead gate.
     """
     with pytest.raises(ValueError):
         cost_budget(**kwargs)
+
+
+def test_ask_thresholds_only_no_hard_cap() -> None:
+    """cost_budget with only ask_thresholds_usd never denies, only asks."""
+    policy = cost_budget(ask_thresholds_usd=[1.0, 3.0])
+    # Below threshold — allow.
+    assert policy(_tool(0.5, model="opus")) == {"result": "ALLOW"}
+    # Crossed threshold — ask.
+    result = policy(_tool(2.0, model="opus"))
+    assert result["result"] == "ASK"
+    assert "1.00" in result["reason"]
+    # No hard-cap message (no max_cost_usd in reason).
+    assert "limit" not in result["reason"]
+    # Way over threshold — still only asks, never denies.
+    result = policy(_tool(100.0, model="opus"))
+    assert result["result"] == "ASK"
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -725,8 +742,9 @@ def test_registry_discovers_cost_budget() -> None:
 def test_registry_validates_factory_params() -> None:
     """The registry schema accepts good params and rejects bad ones."""
     load_registry()
-    # Valid: required hard limit alone, with the soft gate, and with models.
+    # Valid: hard limit alone, soft gate alone, both together, and with models.
     assert validate_factory_params(_HANDLER, {"max_cost_usd": 5.0}) is None
+    assert validate_factory_params(_HANDLER, {"ask_thresholds_usd": [1.0]}) is None
     assert (
         validate_factory_params(_HANDLER, {"max_cost_usd": 5.0, "ask_thresholds_usd": [2.0]})
         is None
@@ -745,8 +763,6 @@ def test_registry_validates_factory_params() -> None:
         validate_factory_params(_HANDLER, {"max_cost_usd": 5.0, "expensive_models": "opus"})
         is not None
     )
-    # Missing the required hard limit.
-    assert validate_factory_params(_HANDLER, {}) is not None
     # Unknown param.
     err_unknown = validate_factory_params(_HANDLER, {"max_cost_usd": 5.0, "bogus": 1})
     assert err_unknown is not None and "bogus" in err_unknown


### PR DESCRIPTION
## Related issue

N/A

## Summary

`cost_budget` previously required `max_cost_usd` as a hard limit. This change makes it optional, mirroring the existing behaviour of `subagent_cost_budget`:

- **Signature change**: `max_cost_usd: float` → `max_cost_usd: float | None = None`
- **Validation**: at least one of `max_cost_usd` or `ask_thresholds_usd` must be provided; passing neither raises `ValueError` at factory time
- **Hard-cap path**: guarded by `max_cost_usd is not None`, so a thresholds-only budget never DENYs, it only ASKs
- **POLICY_REGISTRY schema**: removed `required: ["max_cost_usd"]`, updated description text

This lets callers attach a soft-warning-only budget (ask for approval at spend thresholds without ever hard-blocking), which was already possible on subagents via `subagent_cost_budget` but not on top-level sessions via `cost_budget`.

## Test Plan

```
python -m pytest tests/policies/builtins/test_cost.py -q
# 57 passed
```

- Added `test_ask_thresholds_only_no_hard_cap`: verifies a thresholds-only policy never DENYs, only ASKs, with no limit text in the reason
- Added `{}` to `test_factory_rejects_invalid_config` (neither field → `ValueError`)
- Updated `test_registry_validates_factory_params`: replaced the old `{}` schema-rejection assertion with a positive `ask_thresholds_usd`-only valid case

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All behaviour changes are covered by unit tests in `tests/policies/builtins/test_cost.py`.