### PR TITLE
fix(runtime): stop pi-native assistant text double-rendering on reload

### DIFF
--- a/omnigent/runtime/inflight_text.py
+++ b/omnigent/runtime/inflight_text.py
@@ -562,7 +562,7 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> bool:
 
     if event_type == "response.output_text.delta":
         delta = event.get("delta")
-        if not isinstance(delta, str) or not delta:
+        if not isinstance(delta, str):
             return False
         message_id = event.get("message_id")
         if isinstance(message_id, str) and message_id:
@@ -570,6 +570,17 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> bool:
             # track per message_id, NOT in the response-scoped blob (it
             # has no response.created and interleaves multiple messages
             # per turn). ``index`` orders chunks and de-dupes a replay.
+            #
+            # An EMPTY delta is NOT dropped on this path: a finalize marker
+            # (``delta="", final=true`` — pi-native's end-of-message signal,
+            # see the extension's ``finalizeStreamingMessage``) carries no
+            # text but IS the completion signal that flips ``final_seen``,
+            # which in turn gates the byte-equal retire on
+            # ``output_item.done``. The old ``not delta`` guard dropped that
+            # marker before ``final_seen`` could be set, so pi-native
+            # messages were NEVER retired — ``snapshot_for`` then replayed
+            # the committed message on every reconnect/cold-load and it
+            # double-rendered beside the snapshot's persisted copy.
             index = event.get("index")
             final = bool(event.get("final"))
             with _lock:
@@ -583,13 +594,25 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> bool:
                 messages = _native_inflight.setdefault(conversation_id, {})
                 message = messages.get(message_id)
                 if message is None:
+                    if not delta and not final:
+                        # An empty, non-final delta for an untracked message
+                        # carries neither text nor a completion signal —
+                        # don't create an empty entry (``snapshot_for`` would
+                        # skip its blank text anyway; this just keeps the
+                        # index from holding inert keys).
+                        if not messages:
+                            _native_inflight.pop(conversation_id, None)
+                        return False
                     message = _NativeMessage()
                     messages[message_id] = message
                 if isinstance(index, int) and not isinstance(index, bool):
                     if index <= message.last_index:
                         return False
                     message.last_index = index
-                message.parts.append(delta)
+                # Only real text advances the buffer; the finalize marker's
+                # empty string is a signal, not content.
+                if delta:
+                    message.parts.append(delta)
                 if final:
                     message.final_seen = True
                     # The message's text is now complete. If its committed
@@ -602,6 +625,11 @@ def record_publish(conversation_id: str, event: dict[str, Any]) -> bool:
                     if _consume_committed_fingerprint(conversation_id, message.parts):
                         _retire_native_message(conversation_id, message_id)
                         return True
+            return False
+        if not delta:
+            # Response-scoped (in-process) path: an empty delta carries no
+            # text and, lacking a ``message_id``, no message-scoped
+            # completion signal — there is nothing to accumulate.
             return False
         with _lock:
             entry = _inflight.get(conversation_id)

--- a/tests/runtime/test_inflight_text.py
+++ b/tests/runtime/test_inflight_text.py
@@ -509,6 +509,66 @@ def test_native_output_item_done_retires_by_content_not_position() -> None:
     )
 
 
+def test_pi_native_empty_final_marker_retires_message_on_commit() -> None:
+    """
+    A pi-native turn is retired even though its ``final`` chunk is empty.
+
+    pi-native (and any harness using the web UI's ``finalizeStreamingMessage``
+    contract) signals end-of-message with an EMPTY marker — ``delta=""`` with
+    ``final=true`` — after the text chunks. The completion flag, not the
+    (absent) text, is what flips ``final_seen`` and makes the message eligible
+    for the byte-equal retire on ``output_item.done``.
+
+    Regression: the old ``not delta`` guard dropped that empty marker before
+    ``final_seen`` could be set, so the message was never retired. ``snapshot_for``
+    then replayed the fully-committed message on every reconnect / cold-load,
+    double-rendering it beside the snapshot's persisted copy (the reported bug).
+    """
+    cid = "conv_pi_empty_final"
+    text = "I'm Claude, made by Anthropic."
+    # Text chunk(s), then the separate empty finalize marker.
+    inflight_text.record_publish(cid, _native_delta("pi:msg:0", 0, text, final=False))
+    marker = _native_delta("pi:msg:0", 1, "", final=True)
+    suppress_marker = inflight_text.record_publish(cid, marker)
+    # The empty marker is broadcast (not suppressed) while the message is still
+    # uncommitted — its live preview must finalize on the web client.
+    assert suppress_marker is False
+
+    # The empty marker recorded text only via its earlier chunk; the join key
+    # is the full message text, so the commit retires it by content.
+    suppress_done = inflight_text.record_publish(cid, _message_done("ci_pi", text=text))
+    assert suppress_done is False, "a committed item is broadcast, never suppressed from live"
+
+    # No replay: a reconnect / cold-load shows ONLY the snapshot's copy.
+    assert inflight_text.snapshot_for(cid) == [], (
+        "a committed pi-native message must not replay (it would double-render)"
+    )
+
+
+def test_pi_native_empty_final_marker_suppresses_when_commit_races_ahead() -> None:
+    """
+    The empty finalize marker also retires when the commit raced ahead.
+
+    The committed ``output_item.done`` can arrive BEFORE the deltas (the
+    single-chunk race): no in-flight message matches yet, so its fingerprint
+    is buffered. When the text chunk then the empty ``final`` marker land, the
+    marker — now honored rather than dropped — completes the message, matches
+    the buffered fingerprint, retires it, and is suppressed from the live tail
+    so the duplicate trailing chunk never reaches the client.
+    """
+    cid = "conv_pi_empty_final_race"
+    text = "PONG"
+    # Commit lands first (deltas raced behind): fingerprint buffered.
+    inflight_text.record_publish(cid, _message_done("ci_pong", text=text))
+    # Text chunk, then the empty finalize marker completes + matches it.
+    inflight_text.record_publish(cid, _native_delta("pi:msg:0", 0, text, final=False))
+    marker = _native_delta("pi:msg:0", 1, "", final=True)
+    suppress_marker = inflight_text.record_publish(cid, marker)
+    assert suppress_marker is True, "the duplicate trailing chunk must be suppressed from live"
+
+    assert inflight_text.snapshot_for(cid) == [], "the committed message must not replay"
+
+
 def test_codex_output_item_done_retires_matching_preview_without_final_delta() -> None:
     """
     Codex-native retires previews on commit even without ``final: true``.

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -6600,6 +6600,59 @@ describe("chatStore — live delta streaming (claude-native)", () => {
     controller.abort();
   });
 
+  it("does not double-render pi-native text when the harness response completes before the deltas", async () => {
+    // Faithful replay of a real pi-native turn (captured from a live
+    // `omnigent pi` server). The harness PiNativeExecutor completes its
+    // Omnigent response the instant it enqueues the user message — so
+    // `response.in_progress` + `response.completed` arrive BEFORE Pi's
+    // extension streams the assistant text deltas and the authoritative
+    // item. The early `response.completed` (response_end) is the missing
+    // ingredient the other tests never exercised.
+    useChatStore.setState({
+      conversationId: "conv_pi",
+      blocks: [],
+      isNativeTerminalSession: true,
+    });
+    const { sink, controller } = startPump("conv_pi");
+
+    // Harness turn opens and immediately completes (enqueue → TurnComplete).
+    sink.push(
+      sse("response.in_progress", {
+        id: "resp_harness",
+        status: "in_progress",
+        model: "pi-native-ui",
+        output: [],
+      }),
+    );
+    sink.push(
+      sse("response.completed", {
+        id: "resp_harness",
+        status: "completed",
+        model: "pi-native-ui",
+        output: [],
+      }),
+    );
+    await tick();
+
+    // Pi then streams the assistant text and posts the authoritative item.
+    sink.push(nativeDelta("pi-turn-0:msg:0", 0, "PONG", false));
+    sink.push(nativeDelta("pi-turn-0:msg:0", 1, "", true));
+    await tick();
+    sink.push(messageDone("msg_real", "pi-turn-0", "PONG"));
+    await tick();
+
+    // The provisional preview must be retired and replaced — exactly one
+    // assistant text bubble, not the preview AND the authoritative item.
+    expect(provisional()).toBeUndefined();
+    const dones = useChatStore
+      .getState()
+      .blocks.filter((b): b is Extract<AnyBlock, { type: "text_done" }> => b.type === "text_done");
+    expect(dones.map((b) => b.ctx.itemId)).toEqual(["msg_real"]);
+    expect(dones).toHaveLength(1);
+
+    controller.abort();
+  });
+
   it("keeps an interrupted native partial item marked cancelled", async () => {
     useChatStore.setState({
       conversationId: "conv_interrupt",


### PR DESCRIPTION
## Related issue

N/A — reported via screenshot (pi-native web UI shows the assistant reply twice, reliably reproducible).

## Summary

- pi-native ends each streamed assistant message with an **empty finalize marker** (`delta: ""`, `final: true`). `inflight_text.record_publish` dropped that empty delta before `final_seen` could be set, so the byte-equal retire on the message's `response.output_item.done` never matched.
- The message was therefore **never evicted** from the in-flight-text index, and `snapshot_for` replayed its full text on every reconnect / cold-load — the SPA rendered it **twice** (snapshot's persisted copy + the replayed `live:` preview).
- Fix: honor the finalize marker on the message-scoped (native) path so an empty `final: true` still sets `final_seen` and triggers the retire; the response-scoped path keeps ignoring empty deltas. `GET /items` was always single, so this is purely a replay fix and is general across native harnesses.

**ELI5:** the server keeps a scratch copy of the text it's streaming so a browser that connects mid-answer can catch up. pi-native says "I'm done" with an empty message; the server ignored that "done" signal, so it never threw the scratch copy away and re-sent it to every browser that reloaded — on top of the real saved copy. Now it listens for the empty "done" and discards the scratch copy.

```mermaid
sequenceDiagram
  participant Pi as pi-native ext
  participant S as inflight_text
  Pi->>S: delta "PONG" (final=false)
  Pi->>S: delta "" (final=true)   %% before: dropped → final_seen never set
  Pi->>S: output_item.done "PONG"  %% before: no final_seen → not retired
  Note over S: before: snapshot_for replays "PONG" forever → double render
  Note over S: after: empty marker sets final_seen → retired on commit → no replay
```

## Test Plan

- `tests/runtime/test_inflight_text.py` — 37 pass (incl. 2 new regression tests covering both delta/commit orderings).
- `web/src/store/chatStore.test.ts` — 230 pass (incl. 1 new test for the pi-native event ordering).
- Safety sweep: `tests/runtime/test_session_stream.py` + `tests/runtime/harnesses/` (176 pass), `tests/test_pi_native_bridge.py` + `tests/test_pi_native_credentials.py` (73 pass), pi-native extension JS unit tests (pass), `ruff` clean.
- Live e2e (`pi-native-e2e-dev`): real `omnigent server` + `omnigent pi` TUI in tmux; posted a turn; confirmed `/items` had one copy and a **fresh SSE connect replayed 0 deltas** after the fix (vs. the full committed message before).

## Demo

Backend fix (no frontend code change), but the effect is UI-visible. Verified by cold-loading the same conversation in headless Chromium and counting `[data-testid="assistant-text-section"]`:

| | `GET /items` | fresh-connect SSE replay | rendered assistant bubbles |
|---|---|---|---|
| **Before** | 1 × `PONG` | replays full committed text | **2** (duplicate) |
| **After** | 1 × `PONG` | 0 replayed deltas | **1** |

Before/after screenshots were captured during verification (the "before" matches the original report: the reply rendered twice; "after" shows a single bubble). Happy to attach the PNGs to the PR.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was a full live e2e of the `pi-native` harness (`pi-native-e2e-dev` skill): started a local `omnigent server` from this checkout, launched the real `omnigent pi` TUI, posted a turn, and confirmed the duplicate by toggling only the one-line guard each way — a fresh cold-load rendered 2 assistant bubbles before the fix and 1 after, while `GET /items` stayed single throughout. The unit regression tests pin the underlying `inflight_text` state machine (empty-final-marker retire + the commit-races-ahead ordering); an automated browser e2e wasn't added since the `e2e_ui` suite is gated to its own pinned-runner workflow.