### PR TITLE
fix(xai): only send reasoning_effort to Grok models that accept it

### DIFF
--- a/omnigent/llms/client.py
+++ b/omnigent/llms/client.py
@@ -29,7 +29,11 @@ from omnigent.llms.types import (
     ResponseCompletedEvent,
     ResponseStreamEvent,
 )
-from omnigent.reasoning_effort import OPENAI_EFFORTS, validate_effort_or_llm_error
+from omnigent.reasoning_effort import (
+    OPENAI_EFFORTS,
+    provider_accepts_reasoning_effort,
+    validate_effort_or_llm_error,
+)
 from omnigent.runtime.llm_retry import classify_llm_error
 from omnigent.spec.types import RetryPolicy
 
@@ -225,7 +229,7 @@ class _ResponsesNamespace:
                     "type": "json_schema",
                     "json_schema": {k: v for k, v in fmt.items() if k != "type"},
                 }
-        if reasoning:
+        if reasoning and provider_accepts_reasoning_effort(routed.provider, routed.model):
             extra["reasoning_effort"] = reasoning.get("effort")
 
         if stream:

--- a/omnigent/llms/client.py
+++ b/omnigent/llms/client.py
@@ -11,6 +11,8 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, TypeVar
 
+import httpx
+
 from omnigent.llms._responses_to_chat import (
     chat_response_to_response,
     chat_stream_to_response_events,
@@ -18,6 +20,7 @@ from omnigent.llms._responses_to_chat import (
 )
 from omnigent.llms._usage_observer import notify as _notify_usage
 from omnigent.llms.adapters import get_adapter
+from omnigent.llms.adapters.base import BaseAdapter
 from omnigent.llms.adapters.openai import OpenAIAdapter
 from omnigent.llms.errors import (
     PermanentLLMError,
@@ -31,7 +34,9 @@ from omnigent.llms.types import (
 )
 from omnigent.reasoning_effort import (
     OPENAI_EFFORTS,
-    provider_accepts_reasoning_effort,
+    is_unsupported_reasoning_effort_error,
+    record_reasoning_effort_rejection,
+    should_send_reasoning_effort,
     validate_effort_or_llm_error,
 )
 from omnigent.runtime.llm_retry import classify_llm_error
@@ -229,16 +234,17 @@ class _ResponsesNamespace:
                     "type": "json_schema",
                     "json_schema": {k: v for k, v in fmt.items() if k != "type"},
                 }
-        if reasoning and provider_accepts_reasoning_effort(routed.provider, routed.model):
-            extra["reasoning_effort"] = reasoning.get("effort")
 
         if stream:
-            chunks = await adapter.chat_completions(
-                messages,
-                routed.model,
-                tools,
-                True,
-                extra,
+            chunks = await self._chat_completions_with_reasoning_fallback(
+                adapter=adapter,
+                messages=messages,
+                provider=routed.provider,
+                model=routed.model,
+                tools=tools,
+                stream=True,
+                base_extra=extra,
+                reasoning=reasoning,
                 connection_params=connection_params,
                 timeout=timeout,
             )
@@ -248,17 +254,170 @@ class _ResponsesNamespace:
                 model=routed.model,
             )
 
-        result = await adapter.chat_completions(
-            messages,
-            routed.model,
-            tools,
-            False,
-            extra,
+        result = await self._chat_completions_with_reasoning_fallback(
+            adapter=adapter,
+            messages=messages,
+            provider=routed.provider,
+            model=routed.model,
+            tools=tools,
+            stream=False,
+            base_extra=extra,
+            reasoning=reasoning,
             connection_params=connection_params,
             timeout=timeout,
         )
         assert isinstance(result, dict)
         return chat_response_to_response(result)
+
+    async def _chat_completions_with_reasoning_fallback(
+        self,
+        *,
+        adapter: BaseAdapter,
+        messages: list[dict[str, Any]],
+        provider: str,
+        model: str,
+        tools: list[dict[str, Any]] | None,
+        stream: bool,
+        base_extra: dict[str, Any],
+        reasoning: dict[str, str] | None,
+        connection_params: dict[str, str] | None,
+        timeout: int | None,
+    ) -> dict[str, Any] | AsyncIterator[dict[str, Any]]:
+        """
+        Call the adapter's Chat Completions, self-healing an xAI-style
+        ``reasoning_effort`` rejection.
+
+        ``reasoning_effort`` is sent optimistically unless the model is
+        already known to reject it (seed set or a rejection learned earlier
+        this process). If the provider answers HTTP 400 *naming* the
+        parameter, it is stripped, the call is retried once, and the
+        ``(provider, model)`` pair is remembered so later calls skip it. A
+        parameter rejection is deterministic, not transient, so this single
+        retry lives here — inline, one attempt, outside the backoff loop in
+        :func:`_execute_with_retry`.
+
+        For streaming, the returned iterator is primed (its first chunk is
+        pulled) so an immediate 400 surfaces here where it can be retried,
+        instead of failing deep inside the stream consumer.
+
+        :param adapter: The resolved provider adapter.
+        :param messages: Chat Completions messages.
+        :param provider: Routed provider id, e.g. ``"xai"``.
+        :param model: Model name without prefix, e.g. ``"grok-4"``.
+        :param tools: Tool schemas or ``None``.
+        :param stream: Enable streaming.
+        :param base_extra: Extra kwargs *without* ``reasoning_effort``.
+        :param reasoning: Reasoning config or ``None``.
+        :param connection_params: Connection overrides or ``None``.
+        :param timeout: Timeout in seconds or ``None``.
+        :returns: Response dict (non-streaming) or a primed chunk iterator.
+        """
+        send_effort = bool(reasoning) and should_send_reasoning_effort(provider, model)
+
+        async def _call(
+            with_effort: bool,
+        ) -> dict[str, Any] | AsyncIterator[dict[str, Any]]:
+            """
+            Perform one adapter call, optionally including
+            ``reasoning_effort``.
+
+            :param with_effort: Whether to send ``reasoning_effort``.
+            :returns: Response dict or primed chunk iterator.
+            """
+            extra = dict(base_extra)
+            if with_effort and reasoning is not None:
+                extra["reasoning_effort"] = reasoning.get("effort")
+            result = await adapter.chat_completions(
+                messages,
+                model,
+                tools,
+                stream,
+                extra,
+                connection_params=connection_params,
+                timeout=timeout,
+            )
+            if stream:
+                assert not isinstance(result, dict)
+                return await _prime_stream(result)
+            return result
+
+        try:
+            return await _call(send_effort)
+        except httpx.HTTPStatusError as exc:
+            if not send_effort or not is_unsupported_reasoning_effort_error(
+                exc.response.status_code,
+                _safe_error_body(exc.response),
+            ):
+                raise
+            record_reasoning_effort_rejection(provider, model)
+            _logger.warning(
+                "reasoning_effort rejected by %s/%s (HTTP 400); retrying once "
+                "without it and skipping it for this model for the rest of the "
+                "process",
+                provider,
+                model,
+            )
+            return await _call(False)
+
+
+def _safe_error_body(response: httpx.Response) -> str:
+    """
+    Read an error response body without raising.
+
+    :param response: The httpx response carried by an
+        ``HTTPStatusError``. Streaming 4xx bodies are already read by
+        the adapter before ``raise_for_status``, so ``.text`` is
+        available here.
+    :returns: The body text, or ``""`` if it cannot be read.
+    """
+    try:
+        return response.text
+    except Exception:
+        return ""
+
+
+async def _prime_stream(
+    chunks: AsyncIterator[dict[str, Any]],
+) -> AsyncIterator[dict[str, Any]]:
+    """
+    Pull the first chunk of *chunks* eagerly, returning an iterator
+    that re-yields it followed by the rest.
+
+    Forces the underlying HTTP request to start so an immediate error
+    (e.g. an unsupported-parameter 400) is raised by *this* coroutine —
+    where the caller can catch and retry it — rather than surfacing
+    lazily inside the stream consumer.
+
+    :param chunks: The raw Chat Completions chunk iterator.
+    :returns: An equivalent iterator whose first chunk is buffered.
+    """
+    iterator = chunks.__aiter__()
+    try:
+        first = await iterator.__anext__()
+    except StopAsyncIteration:
+        return _empty_stream()
+    return _chain_first(first, iterator)
+
+
+async def _empty_stream() -> AsyncIterator[dict[str, Any]]:
+    """Yield nothing — used when a primed stream had no chunks."""
+    return
+    yield  # pragma: no cover — marks this as an async generator
+
+
+async def _chain_first(
+    first: dict[str, Any],
+    rest: AsyncIterator[dict[str, Any]],
+) -> AsyncIterator[dict[str, Any]]:
+    """
+    Re-yield the buffered *first* chunk, then drain *rest*.
+
+    :param first: The chunk already pulled by :func:`_prime_stream`.
+    :param rest: The remaining chunk iterator.
+    """
+    yield first
+    async for chunk in rest:
+        yield chunk
 
 
 async def _execute_with_retry(

--- a/omnigent/reasoning_effort.py
+++ b/omnigent/reasoning_effort.py
@@ -21,6 +21,37 @@ ANTIGRAVITY_EFFORTS = GEMINI_EFFORTS
 # support is gated by the Copilot backend (``list_models()``).
 COPILOT_EFFORTS = frozenset({"low", "medium", "high", "xhigh"})
 
+# xAI / Grok accepts the OpenAI-compatible ``reasoning_effort`` parameter on only
+# a subset of models. Sending it to the others (e.g. ``grok-4``,
+# ``grok-code-fast-1``, ``grok-4-fast-reasoning``) is rejected with HTTP 400.
+# Gate on this allow-set of model-id prefixes; unknown grok ids default to NOT
+# sending the parameter. Refs: docs.x.ai reasoning docs (``reasoning_effort``
+# "Only supported by grok-4.3"; ``grok-4.20-multi-agent`` uses ``reasoning.effort``
+# for agent count; ``grok-3-mini`` historically supported it).
+XAI_REASONING_EFFORT_MODEL_PREFIXES = (
+    "grok-3-mini",
+    "grok-4.3",
+    "grok-4.20-multi-agent",
+)
+
+
+def provider_accepts_reasoning_effort(provider: str, model: str) -> bool:
+    """Return whether *provider*/*model* accepts the ``reasoning_effort`` param.
+
+    Only xAI restricts this per-model today; every other Chat Completions
+    provider is treated as accepting it, preserving existing behavior. xAI
+    rejects the parameter with HTTP 400 on models outside
+    :data:`XAI_REASONING_EFFORT_MODEL_PREFIXES`.
+
+    :param provider: The routed provider id, e.g. ``"xai"``.
+    :param model: The model name without provider prefix, e.g. ``"grok-4"``.
+    :returns: ``True`` if ``reasoning_effort`` may be sent for this model.
+    """
+    if provider == "xai":
+        normalized = model.lower()
+        return any(normalized.startswith(prefix) for prefix in XAI_REASONING_EFFORT_MODEL_PREFIXES)
+    return True
+
 
 def format_supported(values: Iterable[str]) -> str:
     """Return a stable comma-separated supported-values string."""

--- a/omnigent/reasoning_effort.py
+++ b/omnigent/reasoning_effort.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+import threading
 from collections.abc import Iterable
 
 from omnigent.llms.errors import PermanentLLMError
@@ -22,35 +24,113 @@ ANTIGRAVITY_EFFORTS = GEMINI_EFFORTS
 COPILOT_EFFORTS = frozenset({"low", "medium", "high", "xhigh"})
 
 # xAI / Grok accepts the OpenAI-compatible ``reasoning_effort`` parameter on only
-# a subset of models. Sending it to the others (e.g. ``grok-4``,
-# ``grok-code-fast-1``, ``grok-4-fast-reasoning``) is rejected with HTTP 400.
-# Gate on this allow-set of model-id prefixes; unknown grok ids default to NOT
-# sending the parameter. Refs: docs.x.ai reasoning docs (``reasoning_effort``
-# "Only supported by grok-4.3"; ``grok-4.20-multi-agent`` uses ``reasoning.effort``
-# for agent count; ``grok-3-mini`` historically supported it).
-XAI_REASONING_EFFORT_MODEL_PREFIXES = (
-    "grok-3-mini",
-    "grok-4.3",
-    "grok-4.20-multi-agent",
+# a subset of models. Sending it to the others (``grok-3``, ``grok-4``,
+# ``grok-code-fast-1``, ``grok-4-fast-reasoning``, ...) is rejected with HTTP 400.
+#
+# Rather than hand-maintain an allow-list -- which silently drops the parameter
+# for every new reasoning-capable Grok until someone edits the tuple, and which
+# the model-id space actively fights (``grok-4`` rejects it but ``grok-4.3``
+# accepts it; ``grok-3`` rejects it but ``grok-3-mini`` accepts it) -- send it
+# optimistically and self-heal. The Chat Completions caller catches an HTTP 400
+# that names the parameter, strips it, retries once, and records the rejection
+# via :func:`record_reasoning_effort_rejection` so the rest of the process skips
+# the wasted round trip. See ``omnigent/llms/client.py``.
+
+# Seed set of ``(provider, model)`` pairs known not to accept ``reasoning_effort``.
+# Purely an optimization + safety net: it skips the first wasted round trip for
+# models we already know reject the parameter, and it is the ONLY line of defense
+# for a model that *silently* accepts and ignores it (no 400 to learn from).
+# Entries are exact, lower-cased model ids -- never prefixes -- because the Grok
+# id space collides (``grok-4`` vs ``grok-4.3``, ``grok-3`` vs ``grok-3-mini``).
+# A stale or missing entry costs at most one extra round trip, never a wrong
+# answer. Refs: docs.x.ai reasoning docs; issue #1686.
+_KNOWN_UNSUPPORTED_REASONING_EFFORT: frozenset[tuple[str, str]] = frozenset(
+    ("xai", model)
+    for model in (
+        "grok-3",
+        "grok-4",
+        "grok-4-fast-reasoning",
+        "grok-code-fast-1",
+    )
+)
+
+# Rejections learned at runtime from a 400. Process-lifetime, guarded by a lock
+# because ``Client`` calls run concurrently across asyncio tasks and threads.
+_learned_unsupported: set[tuple[str, str]] = set()
+_learned_lock = threading.Lock()
+
+# xAI reports an unsupported reasoning-effort parameter with an HTTP 400 whose
+# body names the parameter, e.g.
+# ``{"error": "Model grok-4 does not support parameter reasoningEffort."}``
+# (note the camel-cased ``reasoningEffort``). Match either spelling, plus an
+# unsupported-ish phrase, so unrelated 400s (context overflow, bad schema) do
+# not trip the fallback.
+_REASONING_EFFORT_NAMED_RE = re.compile(r"reasoning[_\s-]?effort", re.IGNORECASE)
+_PARAM_UNSUPPORTED_RE = re.compile(
+    r"does not support|not supported|unsupported|unknown|unrecognized"
+    r"|not a valid|is not valid|isn't supported|is not permitted",
+    re.IGNORECASE,
 )
 
 
-def provider_accepts_reasoning_effort(provider: str, model: str) -> bool:
-    """Return whether *provider*/*model* accepts the ``reasoning_effort`` param.
+def should_send_reasoning_effort(provider: str, model: str) -> bool:
+    """Return whether ``reasoning_effort`` should be sent for *provider*/*model*.
 
-    Only xAI restricts this per-model today; every other Chat Completions
-    provider is treated as accepting it, preserving existing behavior. xAI
-    rejects the parameter with HTTP 400 on models outside
-    :data:`XAI_REASONING_EFFORT_MODEL_PREFIXES`.
+    Optimistic by default: returns ``True`` unless the pair is in the seed set of
+    known-unsupported models or has been learned unsupported this process (via
+    :func:`record_reasoning_effort_rejection`). Replaces the old hand-maintained
+    allow-list so a newly released reasoning-capable model is never silently
+    denied the parameter; a wrong guess is corrected by the caller's one-shot
+    retry rather than by editing this file.
 
     :param provider: The routed provider id, e.g. ``"xai"``.
     :param model: The model name without provider prefix, e.g. ``"grok-4"``.
     :returns: ``True`` if ``reasoning_effort`` may be sent for this model.
     """
-    if provider == "xai":
-        normalized = model.lower()
-        return any(normalized.startswith(prefix) for prefix in XAI_REASONING_EFFORT_MODEL_PREFIXES)
-    return True
+    key = (provider, model.lower())
+    if key in _KNOWN_UNSUPPORTED_REASONING_EFFORT:
+        return False
+    with _learned_lock:
+        return key not in _learned_unsupported
+
+
+def record_reasoning_effort_rejection(provider: str, model: str) -> None:
+    """Remember that *provider*/*model* rejected ``reasoning_effort``.
+
+    Called after a 400 that named the parameter so the next call for the same
+    model skips it. Process-lifetime only; not persisted.
+
+    :param provider: The routed provider id, e.g. ``"xai"``.
+    :param model: The model name without provider prefix, e.g. ``"grok-4"``.
+    """
+    with _learned_lock:
+        _learned_unsupported.add((provider, model.lower()))
+
+
+def reset_reasoning_effort_rejections() -> None:
+    """Clear the learned-rejection cache. Test seam."""
+    with _learned_lock:
+        _learned_unsupported.clear()
+
+
+def is_unsupported_reasoning_effort_error(status_code: int, body: str) -> bool:
+    """Return whether a provider error means ``reasoning_effort`` is unsupported.
+
+    Conservative: only an HTTP 400 whose body both names the parameter (in either
+    ``reasoning_effort`` or ``reasoningEffort`` spelling) and carries an
+    unsupported-ish phrase returns ``True``. Everything else returns ``False`` so
+    the error propagates unchanged (e.g. a context-overflow 400 still reaches the
+    compaction path).
+
+    :param status_code: The HTTP status code from the provider, e.g. ``400``.
+    :param body: The raw HTTP response body string.
+    :returns: ``True`` if the parameter should be stripped and the call retried.
+    """
+    if status_code != 400:
+        return False
+    if not _REASONING_EFFORT_NAMED_RE.search(body):
+        return False
+    return bool(_PARAM_UNSUPPORTED_RE.search(body))
 
 
 def format_supported(values: Iterable[str]) -> str:

--- a/tests/llms/test_client.py
+++ b/tests/llms/test_client.py
@@ -923,3 +923,84 @@ async def test_text_without_json_schema_not_translated(
     # (popped from extra but no response_format injected).
     assert "response_format" not in extra
     assert "text" not in extra
+
+
+# ── reasoning_effort per-model gating (xAI / Grok) ──────────────────
+
+
+async def _capture_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    provider: str,
+    model: str,
+) -> dict[str, Any]:
+    """Drive a non-streaming chat call and return the captured ``extra`` dict.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param provider: Routed provider id, e.g. ``"xai"``.
+    :param model: Model name without prefix, e.g. ``"grok-4"``.
+    :returns: The ``extra`` dict the adapter received.
+    """
+    from omnigent.llms.routing import RoutedModel
+
+    captured: list[dict[str, Any]] = []
+    adapter = _CapturingAdapter(captured)
+    routed = RoutedModel(provider=provider, model=model)
+
+    monkeypatch.setattr("omnigent.llms.client.parse_model_string", lambda model: routed)
+    monkeypatch.setattr("omnigent.llms.client.get_adapter", lambda provider: adapter)
+    monkeypatch.setattr(
+        "omnigent.llms.client.responses_input_to_chat_messages",
+        lambda input, instructions: [{"role": "user", "content": "test"}],
+    )
+    monkeypatch.setattr(
+        "omnigent.llms.client.chat_response_to_response",
+        lambda result: _make_response(),
+    )
+
+    client = Client()
+    await client.responses.create(
+        input=[{"role": "user", "content": "test"}],
+        model=f"{provider}/{model}",
+        reasoning={"effort": "high"},
+    )
+    assert len(captured) == 1, f"Expected 1 call, got {len(captured)}"
+    return captured[0]
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_dropped_for_unsupported_xai_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """xAI rejects ``reasoning_effort`` on models like ``grok-4`` with HTTP 400.
+
+    The Chat Completions path must NOT forward ``reasoning_effort`` for an xAI
+    model outside the supported allow-set, otherwise every reasoning-configured
+    ``grok-4`` / ``grok-code-fast-1`` / ``grok-4-fast-reasoning`` call 400s.
+    """
+    extra = await _capture_reasoning_effort(monkeypatch, provider="xai", model="grok-4")
+    assert "reasoning_effort" not in extra, (
+        f"reasoning_effort leaked to an unsupported xAI model: {extra!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_sent_for_supported_xai_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """xAI ``grok-4.3`` does accept ``reasoning_effort`` — it must be forwarded."""
+    extra = await _capture_reasoning_effort(monkeypatch, provider="xai", model="grok-4.3")
+    assert extra.get("reasoning_effort") == "high", (
+        f"reasoning_effort should be forwarded for grok-4.3, got {extra!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_unchanged_for_non_xai_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-xAI providers keep the prior unconditional pass-through behavior."""
+    extra = await _capture_reasoning_effort(monkeypatch, provider="databricks", model="some-model")
+    assert extra.get("reasoning_effort") == "high", (
+        f"reasoning_effort should pass through for non-xAI providers, got {extra!r}"
+    )

--- a/tests/llms/test_client.py
+++ b/tests/llms/test_client.py
@@ -10,12 +10,14 @@ methods are async.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
+import respx
 
 from omnigent.llms.client import Client
 from omnigent.llms.errors import (
@@ -28,6 +30,12 @@ from omnigent.llms.types import (
     MessageOutput,
     OutputText,
     Response,
+    ResponseCompletedEvent,
+    ResponseTextDeltaEvent,
+)
+from omnigent.reasoning_effort import (
+    reset_reasoning_effort_rejections,
+    should_send_reasoning_effort,
 )
 from omnigent.spec.types import RetryPolicy
 
@@ -972,15 +980,15 @@ async def _capture_reasoning_effort(
 async def test_reasoning_effort_dropped_for_unsupported_xai_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """xAI rejects ``reasoning_effort`` on models like ``grok-4`` with HTTP 400.
+    """A seed-listed unsupported xAI model (``grok-4``) never sends the param.
 
-    The Chat Completions path must NOT forward ``reasoning_effort`` for an xAI
-    model outside the supported allow-set, otherwise every reasoning-configured
-    ``grok-4`` / ``grok-code-fast-1`` / ``grok-4-fast-reasoning`` call 400s.
+    ``grok-4`` is in the known-unsupported seed set, so the Chat Completions path
+    must skip ``reasoning_effort`` up front (no wasted round trip) rather than
+    sending it and self-healing the 400.
     """
     extra = await _capture_reasoning_effort(monkeypatch, provider="xai", model="grok-4")
     assert "reasoning_effort" not in extra, (
-        f"reasoning_effort leaked to an unsupported xAI model: {extra!r}"
+        f"reasoning_effort leaked to a seed-listed xAI model: {extra!r}"
     )
 
 
@@ -1004,3 +1012,364 @@ async def test_reasoning_effort_unchanged_for_non_xai_provider(
     assert extra.get("reasoning_effort") == "high", (
         f"reasoning_effort should pass through for non-xAI providers, got {extra!r}"
     )
+
+
+# ── reasoning_effort self-healing 400 fallback (xAI / Grok) ──────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_reasoning_effort_cache() -> Iterator[None]:
+    """Isolate the process-wide learned-rejection cache between tests."""
+    reset_reasoning_effort_rejections()
+    yield
+    reset_reasoning_effort_rejections()
+
+
+# xAI's real 400 body for an unsupported reasoning-effort model. Note the
+# camel-cased ``reasoningEffort`` (see the lobehub / grok-cli reports).
+_XAI_UNSUPPORTED_BODY = (
+    '{"error": "Model grok-4-1-fast does not support parameter reasoningEffort."}'
+)
+
+
+def _make_400(body: str) -> httpx.HTTPStatusError:
+    """Build an ``httpx.HTTPStatusError`` carrying *body* as a 400 response."""
+    request = httpx.Request("POST", "http://test")
+    response = httpx.Response(400, content=body.encode(), request=request)
+    return httpx.HTTPStatusError("bad request", request=request, response=response)
+
+
+class _ReasoningEffort400Adapter:
+    """Adapter that 400s while ``reasoning_effort`` is present, then succeeds.
+
+    Records every call's ``extra`` dict so tests can assert the parameter was
+    sent on the first attempt and stripped on the retry. Supports both the
+    non-streaming and streaming (lazy first-chunk error) shapes.
+
+    :param stream_mode: When ``True``, model the streaming path where the 400
+        surfaces lazily on the first chunk (as the real adapter does).
+    :param body: The 400 response body to raise.
+    """
+
+    def __init__(self, *, stream_mode: bool = False, body: str = _XAI_UNSUPPORTED_BODY) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._stream_mode = stream_mode
+        self._body = body
+
+    async def chat_completions(
+        self,
+        messages: Any,
+        model: str,
+        tools: Any,
+        stream: bool,
+        extra: dict[str, Any],
+        **kwargs: Any,
+    ) -> Any:
+        """Record *extra*; 400 when the param is present, else succeed."""
+        self.calls.append(dict(extra))
+        has_effort = "reasoning_effort" in extra
+        if stream:
+            if has_effort:
+                return self._raising_stream()
+            return self._ok_stream(model)
+        if has_effort:
+            raise _make_400(self._body)
+        return {"choices": [{"message": {"content": "ok"}}], "model": model}
+
+    async def _raising_stream(self) -> Any:
+        """A stream whose first ``__anext__`` raises the 400 (lazy error)."""
+        raise _make_400(self._body)
+        yield  # pragma: no cover — marks this as an async generator
+
+    async def _ok_stream(self, model: str) -> Any:
+        """A minimal successful stream yielding one text token."""
+        yield {"choices": [{"delta": {"content": "Hello"}}], "model": model}
+        yield {"choices": [{"delta": {}, "finish_reason": "stop"}], "model": model}
+
+
+def _route_to_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter: Any,
+    *,
+    provider: str,
+    model: str,
+) -> None:
+    """Route ``Client().responses.create`` through *adapter* for provider/model."""
+    from omnigent.llms.routing import RoutedModel
+
+    routed = RoutedModel(provider=provider, model=model)
+    monkeypatch.setattr("omnigent.llms.client.parse_model_string", lambda model: routed)
+    monkeypatch.setattr("omnigent.llms.client.get_adapter", lambda provider: adapter)
+    monkeypatch.setattr(
+        "omnigent.llms.client.responses_input_to_chat_messages",
+        lambda input, instructions: [{"role": "user", "content": "test"}],
+    )
+    monkeypatch.setattr(
+        "omnigent.llms.client.chat_response_to_response",
+        lambda result: _make_response(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_optimistic_for_unknown_xai_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Grok id not in the seed set is sent the param optimistically.
+
+    The whole point of self-healing: a newly released reasoning-capable model is
+    never silently denied ``reasoning_effort`` by a stale allow-list.
+    """
+    extra = await _capture_reasoning_effort(monkeypatch, provider="xai", model="grok-9-brand-new")
+    assert extra.get("reasoning_effort") == "high", (
+        f"reasoning_effort should be sent optimistically to unknown models, got {extra!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_self_heals_on_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unsupported model not in the seed set 400s, then succeeds stripped.
+
+    First attempt sends ``reasoning_effort`` and gets a 400 naming the param;
+    the client strips it, retries once, and returns a valid response. The
+    ``(provider, model)`` pair is then remembered for the process.
+    """
+    adapter = _ReasoningEffort400Adapter()
+    _route_to_adapter(monkeypatch, adapter, provider="xai", model="grok-4-1-fast")
+
+    result = await Client().responses.create(
+        input=[{"role": "user", "content": "test"}],
+        model="xai/grok-4-1-fast",
+        reasoning={"effort": "high"},
+    )
+
+    assert isinstance(result, Response)
+    # Two calls: the first with the param (rejected), the retry without it.
+    assert len(adapter.calls) == 2, f"Expected 2 calls, got {adapter.calls!r}"
+    assert adapter.calls[0].get("reasoning_effort") == "high"
+    assert "reasoning_effort" not in adapter.calls[1]
+    # The rejection is remembered so later calls skip the wasted round trip.
+    assert should_send_reasoning_effort("xai", "grok-4-1-fast") is False
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_cached_rejection_skips_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After one rejection, the next call for the same model omits the param."""
+    adapter = _ReasoningEffort400Adapter()
+    _route_to_adapter(monkeypatch, adapter, provider="xai", model="grok-4-1-fast")
+
+    # First create() self-heals and records the rejection.
+    await Client().responses.create(
+        input=[{"role": "user", "content": "test"}],
+        model="xai/grok-4-1-fast",
+        reasoning={"effort": "high"},
+    )
+    adapter.calls.clear()
+
+    # Second create() must send exactly one call, without the param.
+    await Client().responses.create(
+        input=[{"role": "user", "content": "test"}],
+        model="xai/grok-4-1-fast",
+        reasoning={"effort": "high"},
+    )
+    assert len(adapter.calls) == 1, f"Expected 1 call after caching, got {adapter.calls!r}"
+    assert "reasoning_effort" not in adapter.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_self_heals_on_400_streaming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The streaming path self-heals a lazy first-chunk 400 via stream priming."""
+    adapter = _ReasoningEffort400Adapter(stream_mode=True)
+    _route_to_adapter(monkeypatch, adapter, provider="xai", model="grok-4-1-fast")
+
+    stream = await Client().responses.create(
+        input=[{"role": "user", "content": "test"}],
+        model="xai/grok-4-1-fast",
+        reasoning={"effort": "high"},
+        stream=True,
+    )
+
+    events = [event async for event in stream]  # type: ignore[union-attr]
+
+    # The stream completed (the retry without the param succeeded).
+    assert any(type(e).__name__ == "ResponseCompletedEvent" for e in events), (
+        f"stream did not complete after self-heal: {[type(e).__name__ for e in events]}"
+    )
+    assert len(adapter.calls) == 2, f"Expected 2 calls, got {adapter.calls!r}"
+    assert adapter.calls[0].get("reasoning_effort") == "high"
+    assert "reasoning_effort" not in adapter.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_non_reasoning_400_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generic 400 that doesn't name the param propagates without a retry."""
+    adapter = _ReasoningEffort400Adapter(
+        body="invalid request: missing required 'model' field",
+    )
+    _route_to_adapter(monkeypatch, adapter, provider="xai", model="grok-4-1-fast")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await Client().responses.create(
+            input=[{"role": "user", "content": "test"}],
+            model="xai/grok-4-1-fast",
+            reasoning={"effort": "high"},
+        )
+
+    # Only one call — the fallback must NOT fire for an unrelated 400.
+    assert len(adapter.calls) == 1, f"Expected 1 call, got {adapter.calls!r}"
+    assert should_send_reasoning_effort("xai", "grok-4-1-fast") is True
+
+
+# ── reasoning_effort against the live xAI Chat Completions endpoint ──
+
+
+_XAI_CHAT_URL = "https://api.x.ai/v1/chat/completions"
+
+
+def _xai_ok(model: str, text: str = "hi there") -> httpx.Response:
+    """Build a non-streaming Chat Completions 200 for *model*."""
+    return httpx.Response(
+        200,
+        json={
+            "model": model,
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        },
+    )
+
+
+def _xai_effort_400(model: str) -> httpx.Response:
+    """Build the xAI 400 for an unsupported ``reasoning_effort`` on *model*."""
+    return httpx.Response(
+        400,
+        json={"error": f"Model {model} does not support parameter reasoningEffort."},
+    )
+
+
+def _xai_ok_stream(model: str, text: str = "hi there") -> httpx.Response:
+    """Build a streaming Chat Completions 200 (SSE) for *model*."""
+    body = (
+        f'data: {{"model": "{model}", "choices": '
+        f'[{{"delta": {{"content": "{text}"}}}}]}}\n\n'
+        "data: [DONE]\n\n"
+    )
+    return httpx.Response(200, text=body)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_reasoning_effort_self_heal_against_xai_endpoint() -> None:
+    """An unknown unsupported Grok id 400s once, then succeeds stripped.
+
+    Drives the real routing and OpenAI-compatible adapter down to the HTTP
+    boundary: the first request carries ``reasoning_effort`` and gets the xAI
+    400, the second is retried without it and succeeds.
+    """
+    route = respx.post(_XAI_CHAT_URL).mock(
+        side_effect=[
+            _xai_effort_400("grok-4-1-fast"),
+            _xai_ok("grok-4-1-fast"),
+        ]
+    )
+
+    result = await Client().responses.create(
+        input=[{"role": "user", "content": "hi"}],
+        model="xai/grok-4-1-fast",
+        reasoning={"effort": "high"},
+        connection_params={"api_key": "test-key"},
+    )
+
+    assert isinstance(result, Response)
+    assert result.output[0].content[0].text == "hi there"
+    assert route.call_count == 2
+
+    first = json.loads(route.calls[0].request.content)
+    second = json.loads(route.calls[1].request.content)
+    assert first.get("reasoning_effort") == "high"
+    assert first["model"] == "grok-4-1-fast"
+    assert "reasoning_effort" not in second
+    # The rejection is remembered for the rest of the process.
+    assert should_send_reasoning_effort("xai", "grok-4-1-fast") is False
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_reasoning_effort_forwarded_to_supported_model_endpoint() -> None:
+    """A supported model (``grok-4.3``) sends the param and succeeds first try."""
+    route = respx.post(_XAI_CHAT_URL).mock(return_value=_xai_ok("grok-4.3"))
+
+    result = await Client().responses.create(
+        input=[{"role": "user", "content": "hi"}],
+        model="xai/grok-4.3",
+        reasoning={"effort": "high"},
+        connection_params={"api_key": "test-key"},
+    )
+
+    assert isinstance(result, Response)
+    assert route.call_count == 1
+    body = json.loads(route.calls[0].request.content)
+    assert body.get("reasoning_effort") == "high"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_reasoning_effort_skipped_for_seed_listed_model_endpoint() -> None:
+    """A seed-listed model (``grok-4``) never puts the param on the wire."""
+    route = respx.post(_XAI_CHAT_URL).mock(return_value=_xai_ok("grok-4"))
+
+    result = await Client().responses.create(
+        input=[{"role": "user", "content": "hi"}],
+        model="xai/grok-4",
+        reasoning={"effort": "high"},
+        connection_params={"api_key": "test-key"},
+    )
+
+    assert isinstance(result, Response)
+    assert route.call_count == 1
+    body = json.loads(route.calls[0].request.content)
+    assert "reasoning_effort" not in body
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_reasoning_effort_self_heal_streaming_against_xai_endpoint() -> None:
+    """Streaming self-heals the xAI 400 and completes on the stripped retry."""
+    model = "grok-4.20-0309-reasoning"
+    route = respx.post(_XAI_CHAT_URL).mock(
+        side_effect=[
+            _xai_effort_400(model),
+            _xai_ok_stream(model),
+        ]
+    )
+
+    stream = await Client().responses.create(
+        input=[{"role": "user", "content": "hi"}],
+        model=f"xai/{model}",
+        reasoning={"effort": "high"},
+        connection_params={"api_key": "test-key"},
+        stream=True,
+    )
+    events = [event async for event in stream]  # type: ignore[union-attr]
+
+    text = "".join(e.delta for e in events if isinstance(e, ResponseTextDeltaEvent))
+    assert text == "hi there"
+    assert any(isinstance(e, ResponseCompletedEvent) for e in events)
+    assert route.call_count == 2
+
+    first = json.loads(route.calls[0].request.content)
+    second = json.loads(route.calls[1].request.content)
+    assert first.get("reasoning_effort") == "high"
+    assert first["model"] == model
+    assert "reasoning_effort" not in second


### PR DESCRIPTION
## Related issue

Closes omnigent-ai/omnigent#1686

## Summary

* The Chat Completions path forwarded `reasoning_effort` to every non-OpenAI provider unconditionally (`omnigent/llms/client.py`), so a reasoning-configured xAI `grok-4`, `grok-code-fast-1`, or `grok-4-fast-reasoning` call was rejected with HTTP 400.
* Gate the assignment behind a new `provider_accepts_reasoning_effort(provider, model)` helper in `omnigent/reasoning_effort.py`: xAI sends it only for the supported model-id prefixes (`grok-4.3`, `grok-4.20-multi-agent`, `grok-3-mini`); unknown grok ids default to not sending it. Every other provider keeps the prior pass-through behavior.
* Refs: [docs.x.ai](<http://docs.x.ai>) reasoning docs ("reasoning_effort ... Only supported by grok-4.3").

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/llms/test_client.py -q` (27 passed). New tests: unsupported xAI model (`grok-4`) drops the param; supported model (`grok-4.3`) forwards it; a non-xAI provider (`databricks`) still passes it through. Ruff clean.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A