### PR TITLE
fix(xai): stream top-level reasoning_content from Grok and DeepSeek

### DIFF
--- a/omnigent/llms/_responses_to_chat.py
+++ b/omnigent/llms/_responses_to_chat.py
@@ -350,6 +350,18 @@ async def chat_stream_to_response_events(
 
         delta = choices[0].get("delta", {})
 
+        # Top-level reasoning content (xAI Grok, DeepSeek) arrives as a sibling
+        # ``reasoning_content`` string while ``content`` is null during the
+        # thinking phase. Surface it as reasoning so Grok thinking is not
+        # dropped — the typed-block path below only handles Kimi-style blocks
+        # nested inside ``content``.
+        reasoning_content = delta.get("reasoning_content")
+        if isinstance(reasoning_content, str) and reasoning_content:
+            if not reasoning_started:
+                yield ResponseReasoningStartedEvent()
+                reasoning_started = True
+            yield ResponseReasoningTextDeltaEvent(delta=reasoning_content)
+
         # Content delta — may be a plain string or a list of typed blocks
         # (Kimi and some Databricks models use typed blocks).
         content = delta.get("content")

--- a/tests/llms/test_responses_to_chat.py
+++ b/tests/llms/test_responses_to_chat.py
@@ -674,6 +674,42 @@ async def test_kimi_reasoning_started_emitted_once_per_run() -> None:
     assert [e.delta for e in reasoning_deltas] == ["part 1", " part 2"]
 
 
+@pytest.mark.asyncio
+async def test_grok_top_level_reasoning_content_streams() -> None:
+    """
+    xAI Grok / DeepSeek emit chain-of-thought as a top-level
+    ``delta.reasoning_content`` string (with ``content`` null during the
+    thinking phase), not as typed blocks nested inside ``content``. It must
+    surface as ``ResponseReasoningStartedEvent`` + ``ResponseReasoningTextDeltaEvent``
+    and stay out of the final answer text.
+    """
+    chunks = [
+        {"choices": [{"delta": {"reasoning_content": "Let me think..."}, "finish_reason": None}]},
+        {"choices": [{"delta": {"reasoning_content": " still thinking"}, "finish_reason": None}]},
+        {"choices": [{"delta": {"content": "42"}, "finish_reason": None}]},
+        {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+    ]
+    events = [
+        e async for e in chat_stream_to_response_events(_aiter(chunks), model="xai/grok-4.3")
+    ]
+
+    reasoning_started = [e for e in events if isinstance(e, ResponseReasoningStartedEvent)]
+    reasoning_deltas = [e for e in events if isinstance(e, ResponseReasoningTextDeltaEvent)]
+    text_deltas = [e for e in events if isinstance(e, ResponseTextDeltaEvent)]
+    completed = events[-1]
+
+    # One reasoning.started sentinel; both reasoning deltas surfaced in order.
+    assert len(reasoning_started) == 1
+    assert [e.delta for e in reasoning_deltas] == ["Let me think...", " still thinking"]
+
+    # Reasoning is hidden from the main answer text.
+    assert len(text_deltas) == 1
+    assert text_deltas[0].delta == "42"
+
+    assert isinstance(completed, ResponseCompletedEvent)
+    assert completed.response.output[0].content[0].text == "42"
+
+
 # ── _extract_delta_content unit tests ──────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #1687

## Summary

- `chat_stream_to_response_events` only extracted reasoning from Kimi-style typed blocks nested inside `delta.content`, so xAI Grok and DeepSeek (which emit chain-of-thought as a sibling `delta.reasoning_content` string while `content` is null) had their reasoning silently dropped.
- Surface a non-empty `delta.reasoning_content` as `ResponseReasoningStartedEvent` + `ResponseReasoningTextDeltaEvent`, reusing the existing `reasoning_started` sentinel so it interleaves correctly with answer text and stays out of the final message output. The typed-block path is unchanged.

## Test Plan

`.venv/bin/python -m pytest -o addopts="" tests/llms/test_responses_to_chat.py -q` (42 passed). New test: two `reasoning_content` deltas then an answer yields one reasoning-started, both reasoning deltas in order, the answer text, and reasoning excluded from the completed output. Ruff clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
