### PR TITLE
docs: align advertised harness list with the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### The open-source meta-harness for all your AI agents.
 
-Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
+Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, Kimi, Qwen, Goose, Antigravity, Copilot, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
 
 [![PyPI version](https://img.shields.io/pypi/v/omnigent.svg)](https://pypi.org/project/omnigent/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/omnigent-ai/omnigent/blob/main/LICENSE)
@@ -30,9 +30,10 @@ Omnigent lets you:
   your phone. Messages, sub-agents, terminals, and files stay in sync.
 
 - **🤖 Supervise multiple agents.** Mix Claude Code, Codex, Cursor, OpenCode,
-  Hermes, Pi, and custom agents (defined in YAML) together in the same
-  session. Ask one agent to review another's work, or split a task across
-  agents that are each good at different things.
+  Hermes, Pi, Kimi, Qwen, Goose, Antigravity, Copilot, and custom agents
+  (defined in YAML) together in the same session. Ask one agent to review
+  another's work, or split a task across agents that are each good at
+  different things.
 
 - **🔌 Use any model.** A first-party API key, a Claude/ChatGPT subscription,
   or any compatible gateway. All first-class.
@@ -474,8 +475,11 @@ prompt: You are a helpful data analyst.
 
 executor:
   harness: claude-sdk          # or: claude-native, codex, codex-native, cursor,
-                               # cursor-native, hermes, hermes-native, opencode,
-                               # pi, pi-native, openai-agents
+                               # cursor-native, antigravity, antigravity-native,
+                               # copilot, goose, goose-native, hermes,
+                               # hermes-native, kimi, kimi-native, kiro-native,
+                               # opencode, openai-agents, pi, pi-native, qwen,
+                               # qwen-native
 
 tools:
   # A local Python function (schema auto-generated from the signature)

--- a/README.md
+++ b/README.md
@@ -474,12 +474,7 @@ name: my_agent
 prompt: You are a helpful data analyst.
 
 executor:
-  harness: claude-sdk          # or: claude-native, codex, codex-native, cursor,
-                               # cursor-native, antigravity, antigravity-native,
-                               # copilot, goose, goose-native, hermes,
-                               # hermes-native, kimi, kimi-native, kiro-native,
-                               # opencode, openai-agents, pi, pi-native, qwen,
-                               # qwen-native
+  harness: claude-sdk          # See docs/AGENT_YAML_SPEC.md for available harnesses.
 
 tools:
   # A local Python function (schema auto-generated from the signature)

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -49,7 +49,7 @@ resolved from the YAML file's directory.
 
 ```yaml
 executor:
-  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, kiro-native, pi, antigravity, qwen, kimi, copilot, hermes, ...
+  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, goose, kiro-native, pi, antigravity, qwen, kimi, copilot, hermes, opencode, ...
   model: databricks-claude-opus-4-7
   auth:
     type: databricks
@@ -162,6 +162,37 @@ executor:
 
 CLI flags such as `--harness qwen` and `--model <id>` can override or supply
 missing executor values.
+
+## Goose
+
+`harness: goose` runs the agent through Block's
+[Goose](https://github.com/block/goose) CLI in ACP mode (`goose acp`), the
+chat-first counterpart to the terminal-first `goose-native` TUI harness used by
+`omnigent goose`. Install the CLI with `brew install block-goose-cli` and
+configure it with `goose configure`; it authenticates against its own provider
+config (keyring) and does not use the Databricks gateway. Tool approvals surface
+as web elicitation cards.
+
+```yaml
+executor:
+  harness: goose               # terminal twin: goose-native
+  model: gpt-5
+```
+
+## OpenCode
+
+`harness: opencode` runs the agent through the
+[OpenCode](https://github.com/sst/opencode) server (`npm install -g
+opencode-ai@~1.17.7`). It is a native-server harness: the runner owns
+`opencode serve` and forwards events over loopback HTTP, the same path used by
+`omnigent opencode`. `opencode` is the friendly alias for the canonical
+`opencode-native` id (there is no separate SDK harness).
+
+```yaml
+executor:
+  harness: opencode            # canonical id: opencode-native
+  model: anthropic/claude-sonnet-4-20250514
+```
 
 ## Local OS access
 


### PR DESCRIPTION
## Related issue

Closes #1688

## Summary

- Align the README harness overview with the registered harnesses.
- Document Goose and OpenCode in `docs/AGENT_YAML_SPEC.md`.
- Link the README YAML example to the spec instead of duplicating the harness list.

## Test Plan

`uv run --python 3.12 pre-commit run --files README.md docs/AGENT_YAML_SPEC.md`

## Demo

N/A, documentation-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change; no code paths are affected. Harness IDs were checked against the runtime registry.