### PR TITLE
fix(runner): hide internal -native-ui agent name from session tools

### DIFF
--- a/omnigent/native_coding_agents.py
+++ b/omnigent/native_coding_agents.py
@@ -170,6 +170,25 @@ def native_coding_agent_for_agent_name(name: str | None) -> NativeCodingAgent | 
     return _BY_AGENT_NAME.get(name or "")
 
 
+def public_agent_name(name: str | None) -> str | None:
+    """Return a user-facing agent name, hiding internal native-UI wrapper names.
+
+    Native coding-agent wrappers carry an internal ``<tool>-native-ui`` agent
+    name (e.g. ``pi-native-ui``) that is an Omnigent implementation detail. When
+    such a name is projected into tool output the model reads — and may repeat
+    back to the user (``sys_session_get_info`` answering "what agent are you?")
+    — expose the clean public display name (e.g. ``Pi``) instead, so the
+    ``-native-ui`` wrapper name never leaks. Any non-wrapper name, including
+    ``None``, passes through unchanged.
+
+    :param name: The raw bound agent name from a session snapshot, or ``None``.
+    :returns: The wrapper's display name when *name* is a native-UI wrapper,
+        else *name* unchanged.
+    """
+    agent = native_coding_agent_for_agent_name(name)
+    return agent.display_name if agent is not None else name
+
+
 def native_coding_agent_for_harness(harness: str | None) -> NativeCodingAgent | None:
     """Return the native coding-agent metadata for *harness*, if any.
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -47,6 +47,7 @@ from omnigent.model_override import (
     normalize_model_for_provider,
     validate_model_override,
 )
+from omnigent.native_coding_agents import public_agent_name
 from omnigent.runtime import pending_elicitations
 from omnigent.session_lifecycle import (
     CLOSED_LABEL_KEY,
@@ -2933,7 +2934,12 @@ async def _session_get_info_via_rest(
             "status": snap.get("status"),
             "title": snap.get("title"),
             "agent_id": snap.get("agent_id"),
-            "agent_name": snap.get("agent_name"),
+            # Present the public agent name: a native-UI wrapper session
+            # (e.g. ``pi-native-ui``) reports its clean display name (``Pi``)
+            # so the internal ``-native-ui`` wrapper name never leaks to the
+            # model answering "what agent are you?". Non-wrapper names are
+            # unchanged.
+            "agent_name": public_agent_name(snap.get("agent_name")),
             "runner_id": snap.get("runner_id"),
             "runner_online": await _runner_online_or_none(snap.get("runner_id"), server_client),
             "host_id": snap.get("host_id"),
@@ -3617,7 +3623,11 @@ async def _collect_global_sessions(
     return [
         {
             "session_id": r.get("id"),
-            "agent_name": r.get("agent_name"),
+            # Hide the internal ``-native-ui`` wrapper name (e.g.
+            # ``pi-native-ui`` -> ``Pi``) in the global listing too, matching
+            # ``sys_session_get_info``. The server-side ``agent_name`` filter
+            # above still receives the caller's raw argument unchanged.
+            "agent_name": public_agent_name(r.get("agent_name")),
             "title": r.get("title"),
             "status": r.get("status"),
             "runner_id": r.get("runner_id"),

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6653,6 +6653,53 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
 
 
 @pytest.mark.asyncio
+async def test_sys_session_get_info_hides_native_ui_wrapper_agent_name() -> None:
+    """A native-UI session describes itself with its clean public name.
+
+    Regression for the leak where ``sys_session_get_info`` returned the raw
+    bound ``agent_name`` ``"pi-native-ui"``, which the Pi agent then repeated to
+    the user ("I'm pi (agent name: pi-native-ui)"). The projection must map the
+    internal ``-native-ui`` wrapper name to its display name (``"Pi"``) so the
+    implementation detail never reaches the model.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_pi":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "conv_pi",
+                    "agent_id": "ag_pi",
+                    "agent_name": "pi-native-ui",
+                    "status": "running",
+                    "title": "hi what agent are you?",
+                    "runner_id": "runner_1",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/runners/runner_1/status":
+            return httpx.Response(200, json={"runner_id": "runner_1", "online": True})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_get_info",
+            arguments=json.dumps({"session_id": "conv_pi"}),
+            server_client=server_client,
+            conversation_id="conv_pi",
+        )
+
+    info = json.loads(output)
+    # The internal wrapper name is rewritten to the public display name; the
+    # raw ``pi-native-ui`` must not appear anywhere in the tool output.
+    assert info["agent_name"] == "Pi"
+    assert "pi-native-ui" not in output
+
+
+@pytest.mark.asyncio
 async def test_sys_session_send_session_id_posts_to_direct_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_native_coding_agents.py
+++ b/tests/test_native_coding_agents.py
@@ -14,6 +14,7 @@ from omnigent.native_coding_agents import (
     PI_NATIVE_CODING_AGENT,
     native_coding_agent_for_harness,
     native_coding_agent_for_wrapper_label,
+    public_agent_name,
 )
 
 
@@ -80,3 +81,29 @@ def test_unknown_harness_returns_none() -> None:
     """A non-native harness stays unresolved (no terminal presentation)."""
     assert native_coding_agent_for_harness("claude-sdk") is None
     assert native_coding_agent_for_harness(None) is None
+
+
+def test_public_agent_name_hides_native_ui_wrapper_names() -> None:
+    """Native-UI wrapper agent names map to their clean public display name.
+
+    The raw ``<tool>-native-ui`` name is an internal implementation detail; a
+    session describing itself (``sys_session_get_info``) must surface the
+    display name (e.g. ``Pi``) so the model never repeats ``pi-native-ui`` to
+    the user.
+    """
+    assert public_agent_name("pi-native-ui") == "Pi"
+    assert public_agent_name("claude-native-ui") == "Claude"
+    assert public_agent_name("codex-native-ui") == "Codex"
+    assert public_agent_name("cursor-native-ui") == "Cursor"
+
+
+def test_public_agent_name_passes_through_regular_names() -> None:
+    """Non-wrapper names (and ``None``) are returned unchanged.
+
+    Regular Omnigent agents have user-meaningful names that are safe to expose,
+    so only the native-UI wrappers are rewritten.
+    """
+    assert public_agent_name("researcher") == "researcher"
+    assert public_agent_name("nessie") == "nessie"
+    assert public_agent_name("") == ""
+    assert public_agent_name(None) is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

When a native-UI wrapper session (e.g. the Pi terminal, whose internal agent name is `pi-native-ui`) was asked "what agent are you?", the Pi agent called the Omnigent `sys_session_get_info` tool, whose output included the raw bound `agent_name` — `pi-native-ui` — and the agent then repeated it to the user: *"I'm pi (agent name: `pi-native-ui`)"*. The `-native-ui` suffix is an internal implementation detail and shouldn't leak.

- Add `public_agent_name()` (`omnigent/native_coding_agents.py`) that maps native-UI wrapper agent names to their clean public display name (`pi-native-ui` → `Pi`, `claude-native-ui` → `Claude`, …). Non-wrapper names and `None` pass through unchanged.
- Apply it where a session's bound agent name is projected into model-facing tool output: `sys_session_get_info` and the `sys_session_list` global view (`omnigent/runner/tool_dispatch.py`).

**ELI5:** the agent was reading its own identity off a sticker printed with our internal part number. We now swap the part number for the friendly product name before the agent ever sees it.

```
Pi agent ──"what agent are you?"──▶ sys_session_get_info
                                         │  GET /v1/sessions/{id}  → agent_name: "pi-native-ui"
                                         │  public_agent_name()
                                         ▼
                         tool output  → agent_name: "Pi"   (was "pi-native-ui")
```

## Test Plan

- **Unit / dispatch** (`.venv/bin/python -m pytest tests/runner/test_runner_dispatch.py tests/test_native_coding_agents.py tests/inner/test_pi_harness.py` → **157 passed, 1 skipped**):
  - `public_agent_name`: wrappers → display name; regular names and `None` pass through.
  - new regression: `sys_session_get_info` for a `pi-native-ui` session returns `agent_name: "Pi"` and never emits the string `pi-native-ui`.
  - existing get_info / session-list tests (non-native names like `researcher`) still pass unchanged.
- **Live e2e** via the `pi-native-e2e-dev` workflow — a local server + daemon + runner spawned from this checkout (isolated config home, real Databricks provider), launched the real `pi` TUI, drove turns over the API:
  - "what agent are you?" → *"I'm **Pi**, an expert coding assistant…"* (no `pi-native-ui`).
  - forced the tool path ("call sys_session_get_info and report agent_name verbatim"): tool output `{… "agent_name": "Pi" …}` and reply *"The exact value of the `agent_name` field is: **Pi**"*.

## Demo

**Before** (reported): the Pi agent answered *"I'm **pi** (agent name: `pi-native-ui`)"*.

**After**: the same `sys_session_get_info` call returns `"agent_name": "Pi"`, and the agent answers *"I'm **Pi** …"* — `pi-native-ui` no longer appears anywhere in the transcript.

N/A for screenshots — backend/tool-output change, no frontend code touched.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the `pi-native-e2e-dev` workflow: a local server + host daemon + runner spawned from this checkout (isolated `OMNIGENT_CONFIG_HOME`, Databricks AI-Gateway provider), the real `pi` TUI launched in a runner-owned tmux, and turns driven over the HTTP API. Confirmed the `sys_session_get_info` tool output now carries `agent_name: "Pi"` and the agent never surfaces `pi-native-ui`. No automated e2e test was added because the live pi-native harness is not part of CI; the deterministic projection is covered by the new unit + runner-dispatch tests.