### PR TITLE
fix(cost): charge policy/judge LLM calls to session budget (#8)

### DIFF
--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -73,6 +73,7 @@ from typing import Any
 
 from omnigent.policies.schema import (
     SESSION_COST_ASK_APPROVED_STATE_KEY,
+    SESSION_COST_UNPRICED_APPROVED_KEY,
     USER_DAILY_ASK_APPROVED_STATE_KEY,
     PolicyCallable,
     PolicyEvent,
@@ -81,17 +82,32 @@ from omnigent.policies.schema import (
 
 _ALLOW: PolicyResponse = {"result": "ALLOW"}
 
-# DENY response emitted when the session has consumed tokens on a model with
-# no catalog pricing. The gate cannot enforce a budget it cannot measure, so
-# it fails CLOSED rather than silently treating unknown spend as $0.
-_UNPRICED_DENY: PolicyResponse = {
-    "result": "DENY",
+# session_state key recording that the user has acknowledged and approved
+# continuing a session whose active model has no catalog pricing. Routed to
+# the ROOT conversation (like SESSION_COST_ASK_APPROVED_STATE_KEY) so a
+# single approval on the parent covers the whole spawn tree.
+_UNPRICED_APPROVED_KEY = SESSION_COST_UNPRICED_APPROVED_KEY
+
+# ASK response emitted when the session has consumed tokens on a model with
+# no catalog pricing and the user has not yet acknowledged it. The gate
+# cannot enforce a budget it cannot measure — asking rather than denying lets
+# the operator or user make an informed choice, while still preventing silent
+# pass-through at $0.
+_UNPRICED_ASK: PolicyResponse = {
+    "result": "ASK",
     "reason": (
-        "Blocked by the cost-budget policy: the active model has no catalog "
-        "pricing so cumulative spend cannot be measured. Switch to a priced "
-        "model to continue, or ask an administrator to add this model to the "
-        "pricing catalog."
+        "The active model has no catalog pricing so cumulative spend cannot be "
+        "tracked. Continuing will allow untracked spend that counts against "
+        "neither the cap nor the warning thresholds. Switch to a priced model "
+        "to restore budget enforcement, or approve to continue without it."
     ),
+    "state_updates": [
+        {
+            "key": _UNPRICED_APPROVED_KEY,
+            "action": "set",
+            "value": True,
+        }
+    ],
 }
 
 
@@ -483,7 +499,9 @@ def cost_budget(
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("usage") or {}):
-            return _UNPRICED_DENY
+            if not (event.get("session_state") or {}).get(_UNPRICED_APPROVED_KEY):
+                return _UNPRICED_ASK
+            return _ALLOW
         cost = _session_cost_usd(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
@@ -656,7 +674,9 @@ def user_daily_cost_budget(
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("usage") or {}):
-            return _UNPRICED_DENY
+            if not (event.get("session_state") or {}).get(_UNPRICED_APPROVED_KEY):
+                return _UNPRICED_ASK
+            return _ALLOW
         cost = _user_daily_cost_usd(event)
         owner = _user_daily_owner(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
@@ -798,7 +818,9 @@ def subagent_cost_budget(
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("subtree_usage") or {}):
-            return _UNPRICED_DENY
+            if not (event.get("session_state") or {}).get(_UNPRICED_APPROVED_KEY):
+                return _UNPRICED_ASK
+            return _ALLOW
         cost = _subtree_cost_usd(event)
         # Check hard limit if max_cost_usd is set.
         if max_cost_usd is not None and cfg.hard_cap_enabled and cost >= max_cost_usd:

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -32,9 +32,13 @@ It reads cumulative spend from
 total maintained server-side (token-priced for relay/codex sessions,
 billed directly for claude-native) — and the active model from
 ``event["context"]["model"]`` (the conversation's ``model_override`` or
-the agent spec's ``llm.model``, resolved by the policy engine). When
-pricing is unavailable the cost stays ``0.0`` and the policy never trips
-(it cannot budget what it cannot price).
+the agent spec's ``llm.model``, resolved by the policy engine). When a
+model has no catalog pricing, ``total_cost_usd`` is never written to the
+session, so the policy would score the session at ``$0`` and never
+enforce the budget. To prevent unpriced spend silently bypassing the cap,
+the gate **fails closed** when token usage is present but
+``total_cost_usd`` is absent: it returns DENY with a message asking the
+user to switch to a priced model.
 
 On the ``tool_call`` phase a DENY/ASK blocks that specific tool call
 (the native hook returns ``deny`` / parks for approval) rather than
@@ -76,6 +80,45 @@ from omnigent.policies.schema import (
 )
 
 _ALLOW: PolicyResponse = {"result": "ALLOW"}
+
+# DENY response emitted when the session has consumed tokens on a model with
+# no catalog pricing. The gate cannot enforce a budget it cannot measure, so
+# it fails CLOSED rather than silently treating unknown spend as $0.
+_UNPRICED_DENY: PolicyResponse = {
+    "result": "DENY",
+    "reason": (
+        "Blocked by the cost-budget policy: the active model has no catalog "
+        "pricing so cumulative spend cannot be measured. Switch to a priced "
+        "model to continue, or ask an administrator to add this model to the "
+        "pricing catalog."
+    ),
+}
+
+
+def _usage_is_unpriced(usage: dict[str, Any]) -> bool:
+    """Return ``True`` when token usage is present but cost is unpriced.
+
+    The session has had at least one turn (token counters are non-zero) yet
+    ``total_cost_usd`` is absent — meaning no turn was ever priced by the
+    catalog. The gate cannot enforce a budget against this session: it would
+    score every check at ``$0`` and never fire. Callers use this to fail
+    closed (DENY) rather than fail open.
+
+    Returns ``False`` when ``total_cost_usd`` is already present (priced) or
+    when no tokens have been consumed yet (first request, nothing to price).
+    The first turn on an unpriced model still runs — the gate only has
+    post-turn data at check time — but every subsequent turn is denied.
+
+    :param usage: ``event["context"]["usage"]`` or equivalent subtree dict.
+    :returns: ``True`` when enforcement should fail closed due to missing
+        pricing.
+    """
+    if "total_cost_usd" in usage:
+        return False
+    return bool(
+        usage.get("input_tokens") or usage.get("output_tokens") or usage.get("total_tokens")
+    )
+
 
 # Phases the budget gate fires on. ``tool_call`` is the native ``PreToolUse``
 # block point; ``request`` runs before the LLM turn so text-only turns (no
@@ -438,6 +481,9 @@ def cost_budget(
         phase = event.get("type")
         if phase not in _GATED_PHASES:
             return _ALLOW
+        context = event.get("context") or {}
+        if _usage_is_unpriced(context.get("usage") or {}):
+            return _UNPRICED_DENY
         cost = _session_cost_usd(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
             if _model_blocked_over_budget(
@@ -608,6 +654,9 @@ def user_daily_cost_budget(
         phase = event.get("type")
         if phase not in _GATED_PHASES:
             return _ALLOW
+        context = event.get("context") or {}
+        if _usage_is_unpriced(context.get("usage") or {}):
+            return _UNPRICED_DENY
         cost = _user_daily_cost_usd(event)
         owner = _user_daily_owner(event)
         if cfg.hard_cap_enabled and cost >= max_cost_usd:
@@ -747,6 +796,9 @@ def subagent_cost_budget(
         phase = event.get("type")
         if phase not in _GATED_PHASES:
             return _ALLOW
+        context = event.get("context") or {}
+        if _usage_is_unpriced(context.get("subtree_usage") or {}):
+            return _UNPRICED_DENY
         cost = _subtree_cost_usd(event)
         # Check hard limit if max_cost_usd is set.
         if max_cost_usd is not None and cfg.hard_cap_enabled and cost >= max_cost_usd:

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -97,6 +97,13 @@ USER_DAILY_ASK_APPROVED_STATE_KEY = "_policy_user_daily_ask_approved_usd"
 # (emits it) and the engine (routes + seeds it).
 SESSION_COST_ASK_APPROVED_STATE_KEY = "_policy_cost_ask_approved_usd"
 
+# Reserved ``state_updates`` key the cost-budget policy emits when the user
+# approves continuing despite an unpriced model. Like
+# ``SESSION_COST_ASK_APPROVED_STATE_KEY``, routed to the ROOT conversation so
+# approving once on the parent covers the whole spawn tree. Value is ``True``
+# (a boolean flag, not a float checkpoint).
+SESSION_COST_UNPRICED_APPROVED_KEY = "_policy_cost_unpriced_approved"
+
 
 class UserDailyCostContext(TypedDict, total=False):
     """The session owner's per-UTC-day LLM cost rollup.

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -28,6 +28,7 @@ and :class:`PolicyResult` from here (or from the
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -353,12 +354,22 @@ class PolicyLLMClient:
         adapter defaults / env vars.
     :param _request_timeout: Request timeout in seconds from the
         server ``llm:`` config, e.g. ``300``.
+    :param _usage_callback: Optional callback invoked after every
+        successful ``create()`` call with ``(model, usage)`` so the
+        caller can record the policy LLM's token spend against the
+        session budget. ``model`` is the string model id used for this
+        call; ``usage`` is the response's usage object
+        (:class:`~omnigent.llms.types.Usage` or ``None`` when the
+        provider did not report it). ``None`` disables the callback
+        (the caller does not track policy LLM spend — the pre-fix
+        default).
     """
 
     _client: Any  # omnigent.llms.client.Client — Any to avoid import cycle
     _model: str
     _connection: dict[str, str] | None
     _request_timeout: int
+    _usage_callback: Callable[[str, Any], None] | None = None
 
     async def create(
         self,
@@ -373,7 +384,9 @@ class PolicyLLMClient:
         Thin wrapper around ``client.responses.create()`` that
         pre-fills ``model``, ``connection_params``, and ``timeout``
         from the server config. Callers can override any of these
-        via kwargs.
+        via kwargs. When ``_usage_callback`` is set, it is called
+        synchronously after the response returns with ``(model, usage)``
+        so the policy LLM's token spend can be attributed to the session.
 
         :param input: Messages in OpenAI Responses API format,
             e.g. ``[{"role": "user", "content": [{"type": "input_text",
@@ -383,14 +396,18 @@ class PolicyLLMClient:
             ``client.responses.create()``.
         :returns: A :class:`~omnigent.llms.types.Response`.
         """
-        return await self._client.responses.create(
+        effective_model: str = kwargs.pop("model", self._model)
+        response = await self._client.responses.create(
             input=input,
-            model=kwargs.pop("model", self._model),
+            model=effective_model,
             connection_params=kwargs.pop("connection_params", self._connection),
             timeout=kwargs.pop("timeout", self._request_timeout),
             instructions=instructions,
             **kwargs,
         )
+        if self._usage_callback is not None:
+            self._usage_callback(effective_model, getattr(response, "usage", None))
+        return response
 
 
 __all__ = [

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -27,7 +27,10 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.llms.context_window import fetch_model_pricing
 from omnigent.policies.base import Policy
 from omnigent.policies.function import resolve_function_policy
-from omnigent.policies.schema import SESSION_COST_ASK_APPROVED_STATE_KEY
+from omnigent.policies.schema import (
+    SESSION_COST_ASK_APPROVED_STATE_KEY,
+    SESSION_COST_UNPRICED_APPROVED_KEY,
+)
 from omnigent.policies.types import PolicyLLMClient
 from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 from omnigent.runtime.policies.engine import PolicyEngine
@@ -328,10 +331,12 @@ def build_policy_engine(
     # inheritance — reuse them here.)
     if root_conversation_id != conversation_id:
         root_state = _load_session_state(root_conversation_id, conversation_store)
-        if SESSION_COST_ASK_APPROVED_STATE_KEY in root_state:
-            initial_session_state[SESSION_COST_ASK_APPROVED_STATE_KEY] = root_state[
-                SESSION_COST_ASK_APPROVED_STATE_KEY
-            ]
+        for _root_key in (
+            SESSION_COST_ASK_APPROVED_STATE_KEY,
+            SESSION_COST_UNPRICED_APPROVED_KEY,
+        ):
+            if _root_key in root_state:
+                initial_session_state[_root_key] = root_state[_root_key]
     # Gating is SESSION-wide: seed from the whole spawn-tree total so a
     # sub-agent gates against the session's full spend (parent + siblings),
     # not just its own subtree. The cost read is the enforcement total

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -370,7 +370,7 @@ def build_policy_engine(
     # Fall back to the server's gateway connection for prompt-policy
     # classifiers (else they default to api.openai.com).
     effective_connection_override = connection_override or server_connection
-    return PolicyEngine(
+    engine = PolicyEngine(
         policies=[
             _instantiate_policy(
                 s,
@@ -393,6 +393,12 @@ def build_policy_engine(
         root_conversation_id=root_conversation_id,
         llm_client=llm_client,
     )
+    # Wire the engine's usage recorder into the LLM client so every
+    # policy/judge LLM call is charged to the session budget alongside
+    # normal agent LLM spend (fixing issue #8).
+    if llm_client is not None:
+        llm_client._usage_callback = engine.record_usage_from_response
+    return engine
 
 
 def _resolve_server_llm_connection(

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -490,6 +490,7 @@ class PolicyEngine:
             return
         from omnigent.policies.schema import (
             SESSION_COST_ASK_APPROVED_STATE_KEY,
+            SESSION_COST_UNPRICED_APPROVED_KEY,
             USER_DAILY_ASK_APPROVED_STATE_KEY,
         )
 
@@ -505,7 +506,7 @@ class PolicyEngine:
             if op.key == USER_DAILY_ASK_APPROVED_STATE_KEY:
                 self._record_user_daily_ask_approved(op.value)
             elif (
-                op.key == SESSION_COST_ASK_APPROVED_STATE_KEY
+                op.key in (SESSION_COST_ASK_APPROVED_STATE_KEY, SESSION_COST_UNPRICED_APPROVED_KEY)
                 and self._root_conversation_id != self._conversation_id
             ):
                 self._record_root_cost_ask_approved(op)

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -638,6 +638,36 @@ class PolicyEngine:
             self._subtree_usage["total_cost_usd"] += delta_cost
         self._store.set_session_usage(self._conversation_id, dict(self._usage))
 
+    def record_usage_from_response(self, _model: str, usage: Any) -> None:
+        """Record token usage from a policy LLM response.
+
+        Called by :class:`~omnigent.policies.types.PolicyLLMClient` after
+        each ``create()`` call via its ``_usage_callback``. Translates the
+        response's :class:`~omnigent.llms.types.Usage` object into the
+        counters :meth:`record_usage` expects and delegates to it so
+        policy/judge LLM spend is attributed to the session budget alongside
+        normal agent LLM spend.
+
+        No-op when *usage* is ``None`` (provider did not report token counts).
+
+        :param _model: The model id used for this call, e.g.
+            ``"openai/gpt-4o-mini"``. Currently unused (``record_usage``
+            does not attribute per-model; the engine prices via its
+            ``_token_pricing`` which is resolved at build time from the
+            session model, not the policy model). Kept for forward compat.
+        :param usage: The response's ``usage`` attribute — a
+            :class:`~omnigent.llms.types.Usage` dataclass or ``None``.
+        """
+        if usage is None:
+            return
+        self.record_usage(
+            input_tokens=getattr(usage, "input_tokens", None) or 0,
+            output_tokens=getattr(usage, "output_tokens", None) or 0,
+            total_tokens=getattr(usage, "total_tokens", None) or 0,
+            cache_read_input_tokens=getattr(usage, "cache_read_input_tokens", None) or 0,
+            cache_creation_input_tokens=getattr(usage, "cache_creation_input_tokens", None) or 0,
+        )
+
     def _inject_usage(self, ctx: EvaluationContext) -> EvaluationContext:
         """
         Return a copy of *ctx* with ``usage`` populated.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8503,7 +8503,12 @@ async def _forward_event_to_runner(
         _harness = _resolve_harness(conv)
         _user_text = _extract_user_text_for_routing(body)
         if _user_text:
-            _routed_model, _verdict = await route_turn(_harness, _user_text)
+            _routed_model, _verdict = await route_turn(
+                _harness,
+                _user_text,
+                session_id=session_id,
+                conversation_store=conversation_store,
+            )
             if _routed_model is not None:
                 effective_runner_override = _routed_model
                 # Persist as the session's model_override so all
@@ -8711,7 +8716,12 @@ async def _dispatch_session_event_to_runner(
             _harness = _resolve_harness(conv)
             _user_text = _extract_user_text_for_routing(body)
             if _user_text:
-                _routed_model, _verdict = await route_turn(_harness, _user_text)
+                _routed_model, _verdict = await route_turn(
+                    _harness,
+                    _user_text,
+                    session_id=session_id,
+                    conversation_store=conversation_store,
+                )
                 if _routed_model is not None:
                     try:
                         await asyncio.to_thread(

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -94,12 +94,17 @@ class RoutingClient(Protocol):
         self,
         message: str,
         available_tiers: dict[str, list[str]],
+        *,
+        session_id: str | None = None,
+        conversation_store: Any | None = None,
     ) -> RoutingResult | None:
         """Pick the best model for a session's initial message.
 
         :param message: The user's first message text.
         :param available_tiers: Tier name → model ids, e.g.
             ``{"cheap": ["databricks-claude-haiku-4-5"], ...}``.
+        :param session_id: Optional session id for usage attribution.
+        :param conversation_store: Optional store for usage attribution.
         :returns: A :class:`RoutingResult`, or ``None`` to skip
             routing (fail-open — the turn runs on the spec default).
         """
@@ -154,6 +159,58 @@ def _build_rubric(tiers: dict[str, list[str]]) -> str:
     return _JUDGE_SYSTEM_TEMPLATE.format(tier_menu="\n".join(lines))
 
 
+def _record_routing_usage(
+    response: Any,
+    session_id: str,
+    conversation_store: Any,
+) -> None:
+    """Attribute routing LLM token spend to the session budget.
+
+    Called after a successful :class:`LLMRoutingClient` call to record the
+    judge's token usage against the session so it counts toward the cost
+    cap and daily rollup (fixing issue #8 for smart routing).
+
+    Uses :meth:`~omnigent.stores.conversation_store.ConversationStore.increment_session_usage`
+    (atomic, same path as relay completions) with ADD-semantics delta so
+    routing spend is layered on top of whatever tokens the session has
+    already accumulated.
+
+    No-op when the response carries no usage (provider didn't report it).
+
+    :param response: LLM response with a ``.usage`` attribute.
+    :param session_id: Session to attribute the spend to.
+    :param conversation_store: Store for the atomic usage write.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return
+    input_tokens: int = getattr(usage, "input_tokens", None) or 0
+    output_tokens: int = getattr(usage, "output_tokens", None) or 0
+    total_tokens: int = getattr(usage, "total_tokens", None) or 0
+    if not (input_tokens or output_tokens or total_tokens):
+        return
+    from omnigent.llms.context_window import compute_llm_cost, fetch_model_pricing
+
+    delta: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+    # Price the tokens if the routing model is in the catalog.
+    model_id: str = getattr(response, "model", "") or ""
+    pricing = fetch_model_pricing(model_id) if model_id else None
+    if pricing is not None:
+        delta["total_cost_usd"] = compute_llm_cost(delta, pricing)
+    try:
+        conversation_store.increment_session_usage(session_id, delta)
+    except Exception:  # noqa: BLE001 — attribution is best-effort; never block routing
+        _logger.warning(
+            "_record_routing_usage: failed to persist usage for session %s",
+            session_id,
+            exc_info=True,
+        )
+
+
 class LLMRoutingClient:
     """Default routing client that calls the server-level LLM.
 
@@ -170,6 +227,9 @@ class LLMRoutingClient:
         self,
         message: str,
         available_tiers: dict[str, list[str]],
+        *,
+        session_id: str | None = None,
+        conversation_store: Any | None = None,
     ) -> RoutingResult | None:
         rubric = _build_rubric(available_tiers)
         try:
@@ -201,6 +261,11 @@ class LLMRoutingClient:
         except Exception:  # noqa: BLE001  # fail-open: any LLM/parse error skips routing
             _logger.warning("LLMRoutingClient: judge call failed", exc_info=True)
             return None
+        # Attribute routing LLM spend to the session budget (#8).
+        if session_id is not None and conversation_store is not None:
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                _record_routing_usage(response, session_id, conversation_store)
 
         model = verdict.get("model")
         tier = verdict.get("tier")
@@ -234,11 +299,23 @@ class LLMRoutingClient:
 async def route_turn(
     harness: str | None,
     user_message: str,
+    *,
+    session_id: str | None = None,
+    conversation_store: Any | None = None,
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Pick the best model for a turn via :attr:`RuntimeCaps.routing_client`.
 
+    When *session_id* and *conversation_store* are provided, the routing
+    LLM call's token usage is attributed to the session budget via
+    :meth:`~omnigent.stores.conversation_store.ConversationStore.increment_session_usage`
+    — fixing the gap where policy/judge LLM spend was not charged (#8).
+
     :param harness: Canonical harness name, e.g. ``"claude-sdk"``.
     :param user_message: The user's message text.
+    :param session_id: Session to attribute routing LLM spend to. When
+        ``None`` the spend is not recorded (pre-fix behaviour).
+    :param conversation_store: Store for usage attribution. Ignored when
+        *session_id* is ``None``.
     :returns: ``(model_id, verdict_dict)`` or ``(None, None)``.
     """
     tiers = infer_tiers(harness)
@@ -253,7 +330,12 @@ async def route_turn(
     if _caps is None or _caps.routing_client is None:
         return None, None
 
-    result = await _caps.routing_client.route(user_message, tiers)
+    result = await _caps.routing_client.route(
+        user_message,
+        tiers,
+        session_id=session_id,
+        conversation_store=conversation_store,
+    )
     if result is None:
         return None, None
 

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -290,23 +290,27 @@ def _unpriced_tool(input_tokens: int = 1000, model: str = "unpriced-model") -> P
     }
 
 
-def test_unpriced_session_denies_fail_closed() -> None:
-    """Token usage without ``total_cost_usd`` → DENY (fail closed).
+def test_unpriced_session_asks_fail_closed() -> None:
+    """Token usage without ``total_cost_usd`` → ASK (fail closed with user bypass).
 
     A model absent from the pricing catalog never writes ``total_cost_usd``
     to the session, so the gate would score the session at $0 and never
     fire. After the fix, the gate detects tokens-present / cost-absent and
-    returns DENY rather than silently treating unknown spend as $0. The
-    deny reason must name the model-pricing gap so the operator knows
-    what to fix.
+    returns ASK rather than silently treating unknown spend as $0. The
+    ASK reason must name the model-pricing gap. The state_updates must
+    carry the unpriced-approved key so an approval is remembered.
     """
+    from omnigent.policies.schema import SESSION_COST_UNPRICED_APPROVED_KEY
+
     policy = cost_budget(max_cost_usd=5.0)
     result = policy(_unpriced_tool())
-    assert result["result"] == "DENY"
+    assert result["result"] == "ASK"
     assert "pricing" in result["reason"].lower()
+    keys = [u["key"] for u in result["state_updates"]]
+    assert SESSION_COST_UNPRICED_APPROVED_KEY in keys
 
 
-def test_unpriced_session_denies_both_phases() -> None:
+def test_unpriced_session_asks_both_phases() -> None:
     """Unpriced fail-closed fires on both tool_call and request phases."""
     policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[1.0])
     unpriced_request: PolicyEvent = {
@@ -320,8 +324,23 @@ def test_unpriced_session_denies_both_phases() -> None:
         },
         "session_state": {},
     }
-    assert policy(_unpriced_tool())["result"] == "DENY"
-    assert policy(unpriced_request)["result"] == "DENY"
+    assert policy(_unpriced_tool())["result"] == "ASK"
+    assert policy(unpriced_request)["result"] == "ASK"
+
+
+def test_unpriced_session_allows_after_approval() -> None:
+    """Once the user approves the unpriced-model ASK, subsequent turns ALLOW.
+
+    The state_updates key is recorded in session_state on approval. The
+    next gate evaluation sees it and skips the unpriced check so the
+    turn proceeds without re-asking.
+    """
+    from omnigent.policies.schema import SESSION_COST_UNPRICED_APPROVED_KEY
+
+    policy = cost_budget(max_cost_usd=5.0)
+    approved_event = _unpriced_tool()
+    approved_event["session_state"] = {SESSION_COST_UNPRICED_APPROVED_KEY: True}
+    assert policy(approved_event)["result"] == "ALLOW"
 
 
 def test_no_tokens_yet_allows_first_turn() -> None:
@@ -543,12 +562,13 @@ def test_request_approval_carries_over_to_tool_call() -> None:
     assert policy(_tool(2.0, model="opus", session_state=state)) == {"result": "ALLOW"}
 
 
-def test_unpriced_session_never_trips() -> None:
-    """No ``total_cost_usd`` (pricing unavailable) → ALLOW, never blocks.
+def test_no_usage_at_all_allows() -> None:
+    """No ``total_cost_usd`` AND no token counters → ALLOW (first turn).
 
-    Defaults to ``0.0``; the policy cannot budget what it cannot price,
-    so it must abstain rather than block every tool call at $0 — even on
-    an expensive model.
+    When session_usage has no tokens yet the session is brand new — the
+    first turn on any model must be allowed because there's nothing to
+    price yet. The unpriced-model ASK only fires once tokens have been
+    written (i.e. after the first turn completes).
     """
     policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
     assert policy(_tool(None, model="opus")) == {"result": "ALLOW"}

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -266,6 +266,103 @@ def test_over_budget_unknown_model_denies_fail_closed() -> None:
     assert policy(_tool(6.0, model=None))["result"] == "DENY"
 
 
+def _unpriced_tool(input_tokens: int = 1000, model: str = "unpriced-model") -> PolicyEvent:
+    """Build a ``tool_call`` event with token usage but no ``total_cost_usd``.
+
+    Simulates a session that has consumed tokens on a model absent from the
+    pricing catalog: ``total_cost_usd`` is never written, so the key is absent
+    from the usage dict even though real spend has occurred.
+
+    :param input_tokens: Cumulative input tokens to place in the usage dict.
+    :param model: Active model id, e.g. ``"unpriced-model"``.
+    :returns: A ``tool_call`` event with tokens but no cost key.
+    """
+    return {
+        "type": "tool_call",
+        "target": "sys_os_shell",
+        "data": {"name": "sys_os_shell", "arguments": {}},
+        "context": {
+            "actor": {},
+            "usage": {"input_tokens": input_tokens, "total_tokens": input_tokens},
+            "model": model,
+        },
+        "session_state": {},
+    }
+
+
+def test_unpriced_session_denies_fail_closed() -> None:
+    """Token usage without ``total_cost_usd`` → DENY (fail closed).
+
+    A model absent from the pricing catalog never writes ``total_cost_usd``
+    to the session, so the gate would score the session at $0 and never
+    fire. After the fix, the gate detects tokens-present / cost-absent and
+    returns DENY rather than silently treating unknown spend as $0. The
+    deny reason must name the model-pricing gap so the operator knows
+    what to fix.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    result = policy(_unpriced_tool())
+    assert result["result"] == "DENY"
+    assert "pricing" in result["reason"].lower()
+
+
+def test_unpriced_session_denies_both_phases() -> None:
+    """Unpriced fail-closed fires on both tool_call and request phases."""
+    policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[1.0])
+    unpriced_request: PolicyEvent = {
+        "type": "request",
+        "target": None,
+        "data": "hello",
+        "context": {
+            "actor": {},
+            "usage": {"input_tokens": 500, "total_tokens": 500},
+            "model": "unpriced-model",
+        },
+        "session_state": {},
+    }
+    assert policy(_unpriced_tool())["result"] == "DENY"
+    assert policy(unpriced_request)["result"] == "DENY"
+
+
+def test_no_tokens_yet_allows_first_turn() -> None:
+    """No tokens in session_usage → ALLOW (first turn, nothing unpriced yet).
+
+    The unpriced check must not fire when the session is brand new (no
+    prior turns). The gate can only detect unpriced spend after at least
+    one turn has written tokens; the very first turn on any model must
+    be allowed so the gate is not infinitely recursive.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    # cost=None + no token keys → brand-new session, nothing spent
+    result = policy(_tool(None))
+    assert result["result"] == "ALLOW"
+
+
+def test_priced_zero_cost_allows() -> None:
+    """``total_cost_usd = 0.0`` (explicitly priced at zero) → not an unpriced session.
+
+    A free model that IS in the catalog and reports $0 should behave
+    normally — the key is present, the cost is zero, the gate allows.
+    Confusing this with the absent-key case would block free catalog models.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    event: PolicyEvent = {
+        "type": "tool_call",
+        "target": "sys_os_shell",
+        "data": {"name": "sys_os_shell", "arguments": {}},
+        "context": {
+            "actor": {},
+            "usage": {
+                "input_tokens": 1000,
+                "total_cost_usd": 0.0,  # explicitly priced at $0 (free model)
+            },
+            "model": "free-model",
+        },
+        "session_state": {},
+    }
+    assert policy(event)["result"] == "ALLOW"
+
+
 def test_hard_limit_wins_over_checkpoint_approval() -> None:
     """Over the hard limit on an expensive model → DENY even if approved.
 

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -67,6 +67,9 @@ class _FakeRoutingClient:
         self,
         message: str,
         available_tiers: dict[str, list[str]],
+        *,
+        session_id: str | None = None,
+        conversation_store: object | None = None,
     ) -> RoutingResult | None:
         return self._result
 


### PR DESCRIPTION
## Summary

Fixes issue #8 from the cost-budget audit: *"Policy/judge LLM calls aren't charged to the budget. PolicyLLMClient.create never records usage, so classifier/routing spend accrues outside the cap."*

## Two paths, two different fixes

### Policy callables (prompt classifier, routing/difficulty classifier, any future callables)

These run inside a `PolicyEngine` context — the engine already has `record_usage()` and the pricing machinery. The fix:

- `PolicyLLMClient` gets a `_usage_callback: Callable[[str, usage], None] | None` field. `create()` calls it synchronously after every successful response.
- `PolicyEngine.record_usage_from_response(_model, usage)` translates a `Usage` object into the existing `record_usage()` call (which prices tokens, writes to `session_usage`, and updates the daily rollup).
- `builder.py` wires `engine.record_usage_from_response` as the callback after constructing both the client and the engine.

No changes to `prompt.py` or `routing.py` — the callback is wired transparently.

### Smart routing judge (`LLMRoutingClient`)

Built once at server startup before any per-session engine exists, so it can't use the callback path. The fix:

- `_record_routing_usage(response, session_id, conversation_store)` — calls `conversation_store.increment_session_usage()` directly (same atomic path as relay completions, best-effort with logged exception on failure).
- `route_turn()` and `LLMRoutingClient.route()` accept optional `session_id` + `conversation_store` kwargs.
- Both `route_turn()` call sites in `sessions.py` now pass them.

## Test plan
- [ ] `pytest tests/policies/builtins/ tests/runtime/policies/ tests/server/test_smart_routing.py` — 770/770 pass