### PR TITLE
feat: Work items / Tasks below Inbox (#3)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3007,6 +3007,7 @@ def server(
     _ensure_sqlite_parent_dir(db_uri)
 
     from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+    from omnigent.stores.work_item_store.sqlalchemy_store import SqlAlchemyWorkItemStore
 
     agent_store = SqlAlchemyAgentStore(db_uri)
     file_store = SqlAlchemyFileStore(db_uri)
@@ -3014,6 +3015,7 @@ def server(
     comment_store = SqlAlchemyCommentStore(db_uri)
     policy_store = SqlAlchemyPolicyStore(db_uri)
     permission_store = SqlAlchemyPermissionStore(db_uri)
+    work_item_store = SqlAlchemyWorkItemStore(db_uri)
     artifact_store = _create_artifact_store(art_loc)
 
     # Initialize the runtime with store references so workflow code
@@ -3066,6 +3068,7 @@ def server(
         artifact_store=artifact_store,
         comment_store=comment_store,
         policy_store=policy_store,
+        work_item_store=work_item_store,
         caps=caps,
     )
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3153,6 +3153,8 @@ def server(
 
         account_store = SqlAlchemyAccountStore(db_uri)
 
+    from omnigent.server.routes.work_items import create_work_items_router
+
     app = create_app(
         agent_store=agent_store,
         file_store=file_store,
@@ -3170,6 +3172,15 @@ def server(
         admins=config_str_list(cfg.get("admins")),
         allowed_domains=config_str_list(cfg.get("allowed_domains")),
         sandbox_config=sandbox_config,
+        # Tasks/Work-Items REST API (#3). Mounted via the generic
+        # extra_routers seam so create_app's signature stays untouched.
+        extra_routers=[
+            (
+                create_work_items_router(work_item_store, auth_provider, permission_store),
+                "/v1",
+                ["work-items"],
+            ),
+        ],
     )
 
     click.echo(f"Starting omnigent server on {host}:{port}")

--- a/omnigent/db/__init__.py
+++ b/omnigent/db/__init__.py
@@ -8,6 +8,7 @@ from omnigent.db.db_models import (
     SqlFile,
     SqlSessionPermission,
     SqlUser,
+    SqlWorkItem,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "SqlFile",
     "SqlSessionPermission",
     "SqlUser",
+    "SqlWorkItem",
 ]

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -675,6 +675,71 @@ class SqlPolicy(Base):
     )
 
 
+class SqlWorkItem(Base):
+    """
+    SQLAlchemy model for the ``work_items`` table.
+
+    A work item is a tracked unit of work — created by hand or ingested
+    from Slack / email / GitHub / Jira — that an agent processes in a
+    linked conversation. It is a thin layer over conversations (the
+    conversation tree already provides each item's sub-session/thread,
+    plan, and history); it deliberately does NOT revive the removed
+    ``tasks`` table.
+
+    :param id: Opaque PK, e.g. ``"wi_a1b2c3..."``.
+    :param source: Intake source: ``"manual"``, ``"slack"``, ``"email"``,
+        ``"github"``, or ``"jira"``.
+    :param external_id: Source-native id (issue/PR number, message ts),
+        or ``None`` for manual items.
+    :param dedup_key: Globally-UNIQUE idempotency key, e.g.
+        ``"github:acme/app#123"`` — a repeated intake of the same event
+        resolves to the existing row instead of inserting a duplicate.
+    :param title: Short human-readable title.
+    :param body: Optional longer description / original payload text.
+    :param status: Lifecycle state: ``"new"``, ``"planned"``,
+        ``"in_progress"``, ``"blocked"``, ``"needs_review"``, ``"done"``.
+        Defaults to ``"new"``.
+    :param pr_url: Optional pull-request URL once produced.
+    :param conversation_id: FK to ``conversations.id`` for the
+        conversation/sub-session doing the work. ``ON DELETE SET NULL`` so
+        deleting that conversation keeps the work-item record.
+    :param assignee_user_id: Assigned user id, or ``None``.
+    :param created_by: Creating user id, or ``None`` (service-ingested).
+    :param plan: Optional free-text/JSON plan recorded by the agent.
+    :param created_at: Unix epoch seconds at row creation.
+    :param updated_at: Unix epoch seconds of the last write, ``None`` if
+        never updated.
+    """
+
+    __tablename__ = "work_items"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    source: Mapped[str] = mapped_column(String(16))
+    external_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    dedup_key: Mapped[str] = mapped_column(String(512))
+    title: Mapped[str] = mapped_column(Text)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), server_default=text("'new'"))
+    pr_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    conversation_id: Mapped[str | None] = mapped_column(
+        String(64),
+        ForeignKey("conversations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    assignee_user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    plan: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[int] = mapped_column(Integer)
+    updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("dedup_key", name="uq_work_items_dedup_key"),
+        Index("ix_work_items_status", "status"),
+        Index("ix_work_items_conversation_id", "conversation_id"),
+        Index("ix_work_items_created_at", "created_at"),
+    )
+
+
 class SqlHost(Base):
     """
     SQLAlchemy model for the ``hosts`` table.

--- a/omnigent/db/migrations/versions/f0e1d2c3b4a5_add_work_items_table.py
+++ b/omnigent/db/migrations/versions/f0e1d2c3b4a5_add_work_items_table.py
@@ -1,0 +1,65 @@
+"""add work_items table
+
+Revision ID: f0e1d2c3b4a5
+Revises: n1a2b3c4d5e6
+Create Date: 2026-06-28 00:00:00.000000
+
+Adds the ``work_items`` table: tracked units of work (manual, or ingested
+from Slack / email / GitHub / Jira) that an agent processes in a linked
+conversation. A globally-unique ``dedup_key`` makes intake idempotent. The
+table is a thin layer over conversations — it does NOT revive the removed
+``tasks`` table; the conversation tree still owns sub-sessions/threads.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f0e1d2c3b4a5"
+down_revision: str | None = "n1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "work_items",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("source", sa.String(length=16), nullable=False),
+        sa.Column("external_id", sa.String(length=256), nullable=True),
+        sa.Column("dedup_key", sa.String(length=512), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default=sa.text("'new'"),
+            nullable=False,
+        ),
+        sa.Column("pr_url", sa.Text(), nullable=True),
+        sa.Column("conversation_id", sa.String(length=64), nullable=True),
+        sa.Column("assignee_user_id", sa.String(length=128), nullable=True),
+        sa.Column("created_by", sa.String(length=128), nullable=True),
+        sa.Column("plan", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("dedup_key", name="uq_work_items_dedup_key"),
+    )
+    op.create_index("ix_work_items_status", "work_items", ["status"], unique=False)
+    op.create_index(
+        "ix_work_items_conversation_id", "work_items", ["conversation_id"], unique=False
+    )
+    op.create_index("ix_work_items_created_at", "work_items", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_work_items_created_at", table_name="work_items")
+    op.drop_index("ix_work_items_conversation_id", table_name="work_items")
+    op.drop_index("ix_work_items_status", table_name="work_items")
+    op.drop_table("work_items")

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -626,6 +626,16 @@ def generate_conversation_id() -> str:
     return f"conv_{uuid.uuid4().hex}"
 
 
+def generate_work_item_id() -> str:
+    """
+    Generate a unique work-item identifier.
+
+    :returns: A string of the form ``"wi_<32-char hex>"``,
+        e.g. ``"wi_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
+    """
+    return f"wi_{uuid.uuid4().hex}"
+
+
 def generate_task_id() -> str:
     """
     Generate a unique task (response) identifier.

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -34,10 +34,17 @@ from omnigent.entities.session_resources import (
     get_resource_by_id,
     resolve_terminal_entry_by_resource_id,
 )
+from omnigent.entities.work_item import (
+    WORK_ITEM_SOURCES,
+    WORK_ITEM_STATUSES,
+    WorkItem,
+)
 
 __all__ = [
     "DEFAULT_ENVIRONMENT_ID",
     "NON_CONTENT_ITEM_TYPES",
+    "WORK_ITEM_SOURCES",
+    "WORK_ITEM_STATUSES",
     "Account",
     "AccountToken",
     "Agent",
@@ -65,6 +72,7 @@ __all__ = [
     "SlashCommandData",
     "StoredFile",
     "TerminalCommandData",
+    "WorkItem",
     "filter_resources_by_type",
     "get_resource_by_id",
     "parse_item_data",

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -38,6 +38,7 @@ from omnigent.entities.work_item import (
     WORK_ITEM_SOURCES,
     WORK_ITEM_STATUSES,
     WorkItem,
+    is_http_url,
 )
 
 __all__ = [
@@ -75,6 +76,7 @@ __all__ = [
     "WorkItem",
     "filter_resources_by_type",
     "get_resource_by_id",
+    "is_http_url",
     "parse_item_data",
     "resolve_terminal_entry_by_resource_id",
     "synthesize_conversation_title",

--- a/omnigent/entities/work_item.py
+++ b/omnigent/entities/work_item.py
@@ -1,0 +1,70 @@
+"""Work-item entity — persisted in the ``work_items`` table.
+
+A work item is a unit of tracked work — created by hand or ingested from
+Slack, email, GitHub, or Jira — that an agent can pick up and process in a
+linked conversation (the conversation tree already gives each item its own
+sub-session/thread, plan, and history). Work items are deliberately a thin
+layer *over* conversations rather than a revival of the old, removed ``tasks``
+table: the item row carries lifecycle/source/dedup metadata and points at the
+conversation that does the work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Allowed lifecycle states. Single source of truth for the store, tools, and
+# API so they validate the same set.
+WORK_ITEM_STATUSES: frozenset[str] = frozenset(
+    {"new", "planned", "in_progress", "blocked", "needs_review", "done"}
+)
+
+# Allowed intake sources.
+WORK_ITEM_SOURCES: frozenset[str] = frozenset({"manual", "slack", "email", "github", "jira"})
+
+
+@dataclass
+class WorkItem:
+    """
+    A work item persisted in the ``work_items`` table.
+
+    :param id: Opaque primary key, e.g. ``"wi_a1b2c3..."``.
+    :param source: Where the item came from — one of
+        :data:`WORK_ITEM_SOURCES` (``"manual"``, ``"slack"``,
+        ``"email"``, ``"github"``, ``"jira"``).
+    :param title: Short human-readable title.
+    :param dedup_key: Idempotency key (globally UNIQUE), e.g.
+        ``"github:acme/app#123"``. Re-ingesting the same external event
+        resolves to the existing row instead of creating a duplicate.
+    :param status: Lifecycle state — one of :data:`WORK_ITEM_STATUSES`.
+    :param created_at: Unix epoch seconds at row creation.
+    :param external_id: The source's native identifier (issue/PR number,
+        message ts, …), or ``None`` for ``"manual"`` items.
+    :param body: Optional longer description / original payload text.
+    :param pr_url: Optional pull-request URL once the work produces one.
+    :param conversation_id: The conversation/sub-session processing this
+        item, or ``None`` before one is started. Cleared (``SET NULL``) if
+        that conversation is deleted.
+    :param assignee_user_id: User the item is assigned to, or ``None``.
+    :param created_by: User id that created the item, or ``None`` (e.g. a
+        service-ingested item).
+    :param plan: Optional free-text / JSON plan the agent recorded for the
+        item, surfaced in the UI.
+    :param updated_at: Unix epoch seconds of the last write, or ``None`` if
+        the row has never been updated.
+    """
+
+    id: str
+    source: str
+    title: str
+    dedup_key: str
+    status: str
+    created_at: int
+    external_id: str | None = None
+    body: str | None = None
+    pr_url: str | None = None
+    conversation_id: str | None = None
+    assignee_user_id: str | None = None
+    created_by: str | None = None
+    plan: str | None = None
+    updated_at: int | None = None

--- a/omnigent/entities/work_item.py
+++ b/omnigent/entities/work_item.py
@@ -12,6 +12,7 @@ conversation that does the work.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 # Allowed lifecycle states. Single source of truth for the store, tools, and
 # API so they validate the same set.
@@ -21,6 +22,23 @@ WORK_ITEM_STATUSES: frozenset[str] = frozenset(
 
 # Allowed intake sources.
 WORK_ITEM_SOURCES: frozenset[str] = frozenset({"manual", "slack", "email", "github", "jira"})
+
+
+def is_http_url(url: str) -> bool:
+    """Return ``True`` iff ``url`` is a syntactically valid http/https URL.
+
+    A work item's ``pr_url`` is rendered as a clickable link in the UI, so a
+    non-http(s) scheme (``javascript:``, ``file:``, ``data:``…) must be
+    rejected to avoid a stored-XSS / phishing link.
+
+    :param url: The candidate URL.
+    :returns: ``True`` only for an ``http``/``https`` URL with a host.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
 
 
 @dataclass

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -304,6 +304,17 @@ _AGENT_TOOLS = frozenset({"sys_agent_get", "sys_agent_download", "sys_agent_list
 # The runner proxies the Omnigent server's session policy REST endpoint.
 _POLICY_TOOLS = frozenset({"sys_add_policy", "sys_policy_registry"})
 
+# Work-item (#3), schedule/loop (#6), and canvas (#2) builtins (#12). Like the
+# comment tools, the runner has no in-process store for these, so they proxy to
+# the server's REST API over server_client (see _execute_work_management_tool).
+_WORK_MANAGEMENT_TOOLS = frozenset(
+    {
+        "create_work_item",
+        "list_work_items",
+        "update_work_item",
+    }
+)
+
 # Builtin tools the claude-native / codex-native relay advertises to the
 # real CLI, beyond the always-relayed ``sys_os_*`` family. Native harnesses
 # ignore the harness ``tools`` list, so the relay is their ONLY tool
@@ -331,6 +342,11 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
     | _AGENT_TOOLS
     | _POLICY_TOOLS
     | _TERMINAL_TOOLS
+    # Work-item (#3) builtins (#12): native harnesses ignore the harness
+    # ``tools`` list, so they must be advertised through the relay too, or a
+    # native Claude/Codex agent can't create or track work. They dispatch via
+    # the same runner→server REST proxy as the non-native path.
+    | _WORK_MANAGEMENT_TOOLS
 )
 
 
@@ -467,6 +483,7 @@ _ALL_LOCAL_TOOLS = (
     | _COMMENT_TOOLS
     | _AGENT_TOOLS
     | _POLICY_TOOLS
+    | _WORK_MANAGEMENT_TOOLS
 )
 _PLACEHOLDER_CWDS = (None, "", ".", "./")
 
@@ -2559,6 +2576,90 @@ async def _execute_comment_tool(
         return json.dumps({"error": f"update_comment failed: {exc}"})
 
 
+async def _execute_work_management_tool(
+    tool_name: str,
+    arguments: str,
+    *,
+    conversation_id: str | None,
+    server_client: httpx.AsyncClient | None,
+) -> str:
+    """
+    Runner-local handler for the work-item builtins (#3, #12).
+
+    The runner has no in-process WorkItem store, so — like the comment tools —
+    these proxy to the Omnigent server's REST API over ``server_client``:
+    ``/v1/work-items`` (POST/GET/PATCH).
+
+    :param tool_name: One of :data:`_WORK_MANAGEMENT_TOOLS`.
+    :param arguments: JSON-encoded args from the LLM.
+    :param conversation_id: Current session id, used as the default scope.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :returns: A JSON result/error string for the agent.
+    """
+    if server_client is None:
+        return json.dumps({"error": f"{tool_name} requires server access"})
+    try:
+        args: dict[str, Any] = json.loads(arguments) if arguments.strip() else {}
+    except json.JSONDecodeError:
+        return json.dumps({"error": f"{tool_name}: malformed JSON arguments"})
+
+    def _result(resp: httpx.Response) -> str:
+        if resp.status_code >= 400:
+            return json.dumps(
+                {"error": f"{tool_name} returned HTTP {resp.status_code}: {resp.text[:300]}"}
+            )
+        return json.dumps(resp.json())
+
+    try:
+        if tool_name == "create_work_item":
+            body = {
+                k: args[k]
+                for k in (
+                    "title",
+                    "source",
+                    "body",
+                    "dedup_key",
+                    "external_id",
+                    "status",
+                    "plan",
+                    "conversation_id",
+                )
+                if args.get(k) is not None
+            }
+            return _result(await server_client.post("/v1/work-items", json=body, timeout=30.0))
+
+        if tool_name == "list_work_items":
+            params: dict[str, Any] = {
+                k: args[k]
+                for k in ("status", "conversation_id", "limit")
+                if args.get(k) is not None
+            }
+            return _result(
+                await server_client.get("/v1/work-items", params=params, timeout=30.0)
+            )
+
+        if tool_name == "update_work_item":
+            work_item_id = args.get("work_item_id")
+            if not work_item_id:
+                return json.dumps({"error": "missing required argument: work_item_id"})
+            body = {
+                k: args[k]
+                for k in ("title", "body", "status", "pr_url", "conversation_id", "plan")
+                if args.get(k) is not None
+            }
+            if args.get("needs_review") is True:
+                body["status"] = "needs_review"
+            return _result(
+                await server_client.patch(
+                    f"/v1/work-items/{work_item_id}", json=body, timeout=30.0
+                )
+            )
+
+        return json.dumps({"error": f"unknown work-management tool: {tool_name}"})
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"{tool_name} failed: {exc}"})
+
+
 async def _execute_policy_tool(
     tool_name: str,
     arguments: str,
@@ -4157,6 +4258,13 @@ async def execute_tool(
             )
         elif tool_name in _COMMENT_TOOLS:
             output = await _execute_comment_tool(
+                tool_name,
+                arguments,
+                conversation_id=conversation_id,
+                server_client=server_client,
+            )
+        elif tool_name in _WORK_MANAGEMENT_TOOLS:
+            output = await _execute_work_management_tool(
                 tool_name,
                 arguments,
                 conversation_id=conversation_id,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2626,6 +2626,10 @@ async def _execute_work_management_tool(
                 )
                 if args.get(k) is not None
             }
+            # Default the item to the current session so an agent-created work
+            # item links back to where it came from (overridable via args).
+            if conversation_id and body.get("conversation_id") is None:
+                body["conversation_id"] = conversation_id
             return _result(await server_client.post("/v1/work-items", json=body, timeout=30.0))
 
         if tool_name == "list_work_items":
@@ -2634,9 +2638,7 @@ async def _execute_work_management_tool(
                 for k in ("status", "conversation_id", "limit")
                 if args.get(k) is not None
             }
-            return _result(
-                await server_client.get("/v1/work-items", params=params, timeout=30.0)
-            )
+            return _result(await server_client.get("/v1/work-items", params=params, timeout=30.0))
 
         if tool_name == "update_work_item":
             work_item_id = args.get("work_item_id")

--- a/omnigent/runtime/__init__.py
+++ b/omnigent/runtime/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     )
     from omnigent.stores.comment_store import CommentStore
     from omnigent.stores.policy_store import PolicyStore
+    from omnigent.stores.work_item_store import WorkItemStore
     from omnigent.terminals import TerminalRegistry
     from omnigent.tools import ToolManager
 
@@ -37,6 +38,7 @@ def init(
     artifact_store: ArtifactStore | None = None,
     comment_store: CommentStore | None = None,
     policy_store: PolicyStore | None = None,
+    work_item_store: WorkItemStore | None = None,
     caps: RuntimeCaps | None = None,
 ) -> None:
     """
@@ -72,6 +74,7 @@ def init(
         artifact_store=artifact_store,
         comment_store=comment_store,
         policy_store=policy_store,
+        work_item_store=work_item_store,
         caps=caps,
     )
 
@@ -154,6 +157,19 @@ def get_policy_store() -> PolicyStore | None:
     :returns: The PolicyStore set during :func:`init`, or ``None``.
     """
     return _globals._policy_store
+
+
+def get_work_item_store() -> WorkItemStore | None:
+    """
+    Return the WorkItemStore instance, or ``None`` if not configured.
+
+    Returns ``None`` (rather than raising) because work_item_store is
+    optional — the work-item tools surface a clear error to the agent
+    when invoked without a configured store.
+
+    :returns: The WorkItemStore set during :func:`init`, or ``None``.
+    """
+    return _globals._work_item_store
 
 
 def get_agent_cache() -> AgentCache:

--- a/omnigent/runtime/_globals.py
+++ b/omnigent/runtime/_globals.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     )
     from omnigent.stores.comment_store import CommentStore
     from omnigent.stores.policy_store import PolicyStore
+    from omnigent.stores.work_item_store import WorkItemStore
     from omnigent.terminals import TerminalRegistry
     from omnigent.tools import ToolManager
     from omnigent.tools.base import ToolContext
@@ -36,6 +37,7 @@ _file_store: FileStore | None = None
 _artifact_store: ArtifactStore | None = None
 _comment_store: CommentStore | None = None
 _policy_store: PolicyStore | None = None
+_work_item_store: WorkItemStore | None = None
 _caps: RuntimeCaps = RuntimeCaps()
 
 # Server-resident tmux terminal registry. Initialized in
@@ -169,6 +171,7 @@ def init(
     artifact_store: ArtifactStore | None = None,
     comment_store: CommentStore | None = None,
     policy_store: PolicyStore | None = None,
+    work_item_store: WorkItemStore | None = None,
     caps: RuntimeCaps | None = None,
 ) -> None:
     """
@@ -205,7 +208,7 @@ def init(
 
     global _conversation_store, _agent_store
     global _agent_cache, _file_store, _artifact_store, _caps
-    global _terminal_registry, _comment_store, _policy_store
+    global _terminal_registry, _comment_store, _policy_store, _work_item_store
     _conversation_store = conversation_store
     _agent_store = agent_store
     _agent_cache = agent_cache
@@ -213,6 +216,7 @@ def init(
     _artifact_store = artifact_store
     _comment_store = comment_store
     _policy_store = policy_store
+    _work_item_store = work_item_store
     _caps = caps if caps is not None else RuntimeCaps()
     # Tmux terminal registry: server-resident, conversation-scoped
     # ``inner.terminal.TerminalInstance`` map. See

--- a/omnigent/server/routes/work_items.py
+++ b/omnigent/server/routes/work_items.py
@@ -10,18 +10,138 @@ email, GitHub, Jira) can safely retry.
 
 from __future__ import annotations
 
+import json
+import os
 from typing import Any
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
+from starlette.datastructures import Headers
 
 from omnigent.db.utils import generate_work_item_id
 from omnigent.entities import WORK_ITEM_SOURCES, WORK_ITEM_STATUSES, WorkItem
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import get_user_id
+from omnigent.server.webhook_verify import (
+    verify_bearer,
+    verify_github_signature,
+    verify_slack_signature,
+)
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.work_item_store import WorkItemStore
+
+# Intake sources accepted at /work-items/intake/{source}. "generic" maps to the
+# "manual" work-item source; the rest map to themselves (all in
+# WORK_ITEM_SOURCES). Each verifies a different way (see _verify_and_map).
+_INTAKE_SOURCES = frozenset({"github", "slack", "jira", "email", "generic"})
+
+
+class _Verified(BaseModel):
+    """Normalized result of verifying + mapping an inbound intake payload."""
+
+    work_item_source: str
+    title: str
+    dedup_key: str
+    external_id: str | None = None
+    body: str | None = None
+
+
+def _verify_and_map(source: str, headers: Headers, raw: bytes) -> _Verified:
+    """Authenticate an inbound webhook and map its payload to a work item.
+
+    :param source: The intake source path segment (in :data:`_INTAKE_SOURCES`).
+    :param headers: The request headers (for signatures / bearer).
+    :param raw: The exact raw request body bytes (signatures cover these).
+    :returns: A :class:`_Verified` with the fields for ``create``.
+    :raises OmnigentError: 400 (bad source/payload), 401 (bad signature),
+        404 (the source's secret isn't configured on this server).
+    """
+    if source not in _INTAKE_SOURCES:
+        raise OmnigentError(f"unknown intake source {source!r}", code=ErrorCode.INVALID_INPUT)
+
+    def _payload() -> dict[str, Any]:
+        try:
+            data = json.loads(raw or b"{}")
+        except json.JSONDecodeError as exc:
+            raise OmnigentError(f"invalid JSON body: {exc}", code=ErrorCode.INVALID_INPUT) from exc
+        if not isinstance(data, dict):
+            raise OmnigentError("body must be a JSON object", code=ErrorCode.INVALID_INPUT)
+        return data
+
+    if source == "github":
+        secret = os.environ.get("OMNIGENT_GITHUB_WEBHOOK_SECRET", "")
+        if not secret:
+            raise OmnigentError("github intake not configured", code=ErrorCode.NOT_FOUND)
+        if not verify_github_signature(secret, raw, headers.get("X-Hub-Signature-256")):
+            raise OmnigentError("invalid github signature", code=ErrorCode.UNAUTHORIZED)
+        data = _payload()
+        item = data.get("issue") or data.get("pull_request") or {}
+        repo = (data.get("repository") or {}).get("full_name") or "repo"
+        number = item.get("number")
+        if not isinstance(item, dict) or number is None:
+            raise OmnigentError("no issue/pull_request in payload", code=ErrorCode.INVALID_INPUT)
+        ext = f"{repo}#{number}"
+        return _Verified(
+            work_item_source="github",
+            title=str(item.get("title") or ext),
+            dedup_key=f"github:{ext}",
+            external_id=ext,
+            body=item.get("body"),
+        )
+
+    if source == "slack":
+        secret = os.environ.get("OMNIGENT_SLACK_SIGNING_SECRET", "")
+        if not secret:
+            raise OmnigentError("slack intake not configured", code=ErrorCode.NOT_FOUND)
+        ok = verify_slack_signature(
+            secret,
+            headers.get("X-Slack-Request-Timestamp"),
+            raw,
+            headers.get("X-Slack-Signature"),
+        )
+        if not ok:
+            raise OmnigentError("invalid slack signature", code=ErrorCode.UNAUTHORIZED)
+        payload = _payload()
+        event = payload.get("event")
+        if not isinstance(event, dict):
+            event = {}
+        text = str(event.get("text") or "").strip()
+        channel = event.get("channel") or "?"
+        ts = event.get("ts") or "?"
+        ext = f"{channel}/{ts}"
+        title = (text.splitlines()[0] if text else f"Slack message {ext}")[:200]
+        return _Verified(
+            work_item_source="slack",
+            title=title,
+            dedup_key=f"slack:{ext}",
+            external_id=ext,
+            body=text or None,
+        )
+
+    # generic / jira / email: shared bearer token + a simple JSON envelope.
+    secret = os.environ.get("OMNIGENT_INTAKE_SECRET", "")
+    if not secret:
+        raise OmnigentError(f"{source} intake not configured", code=ErrorCode.NOT_FOUND)
+    if not verify_bearer(secret, headers.get("Authorization")):
+        raise OmnigentError("invalid intake bearer token", code=ErrorCode.UNAUTHORIZED)
+    data = _payload()
+    title = str(data.get("title") or "").strip()
+    if not title:
+        raise OmnigentError("title is required", code=ErrorCode.INVALID_INPUT)
+    external_id = data.get("external_id")
+    work_item_source = "manual" if source == "generic" else source
+    dedup_key = data.get("dedup_key") or (
+        f"{source}:{external_id}" if external_id else f"{source}:{generate_work_item_id()}"
+    )
+    return _Verified(
+        work_item_source=work_item_source,
+        title=title,
+        dedup_key=dedup_key,
+        external_id=external_id,
+        body=data.get("body"),
+    )
+
 
 _SOURCES = sorted(WORK_ITEM_SOURCES)
 _STATUSES = sorted(WORK_ITEM_STATUSES)
@@ -200,5 +320,25 @@ def create_work_items_router(
         _require_auth(request, auth_provider, permission_store)
         deleted = store.delete(work_item_id)
         return {"deleted": deleted}
+
+    @router.post("/work-items/intake/{source}")
+    async def intake(request: Request, source: str) -> dict[str, Any]:
+        """Inbound webhook → work item. Authenticated per-source (GitHub HMAC,
+        Slack signing, or a shared bearer for generic/jira/email), and
+        idempotent by dedup_key so a sender's retries don't duplicate."""
+        raw = await request.body()
+        verified = _verify_and_map(source, request.headers, raw)
+        existing = store.get_by_dedup_key(verified.dedup_key)
+        if existing is not None:
+            return {"created": False, **_entity_to_response(existing)}
+        item = store.create(
+            generate_work_item_id(),
+            verified.work_item_source,
+            verified.title,
+            dedup_key=verified.dedup_key,
+            external_id=verified.external_id,
+            body=verified.body,
+        )
+        return {"created": True, **_entity_to_response(item)}
 
     return router

--- a/omnigent/server/routes/work_items.py
+++ b/omnigent/server/routes/work_items.py
@@ -1,0 +1,204 @@
+"""REST routes for work-items (Tasks).
+
+CRUD over the ``work_items`` table at ``/work-items[/{work_item_id}]``.
+Work items are global to all signed-in users (the row carries
+``created_by``/``assignee_user_id`` for future per-user scoping); in
+multi-user mode every endpoint requires authentication, but none requires
+admin. Creation is idempotent by ``dedup_key`` so external intake (Slack,
+email, GitHub, Jira) can safely retry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from omnigent.db.utils import generate_work_item_id
+from omnigent.entities import WORK_ITEM_SOURCES, WORK_ITEM_STATUSES, WorkItem
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes._auth_helpers import get_user_id
+from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.work_item_store import WorkItemStore
+
+_SOURCES = sorted(WORK_ITEM_SOURCES)
+_STATUSES = sorted(WORK_ITEM_STATUSES)
+
+
+class CreateWorkItemBody(BaseModel):
+    """Request body for ``POST /work-items``."""
+
+    title: str
+    source: str
+    body: str | None = None
+    dedup_key: str | None = None
+    external_id: str | None = None
+    status: str = "new"
+    conversation_id: str | None = None
+    assignee_user_id: str | None = None
+    plan: str | None = None
+
+
+class UpdateWorkItemBody(BaseModel):
+    """Request body for ``PATCH /work-items/{id}``. Unset fields are unchanged."""
+
+    title: str | None = None
+    body: str | None = None
+    status: str | None = None
+    pr_url: str | None = None
+    conversation_id: str | None = None
+    assignee_user_id: str | None = None
+    plan: str | None = None
+
+
+def _entity_to_response(item: WorkItem) -> dict[str, Any]:
+    """Serialize a :class:`WorkItem` to a response dict.
+
+    :param item: The entity to serialize.
+    :returns: A JSON-friendly dict with ``object="work_item"``.
+    """
+    return {
+        "id": item.id,
+        "object": "work_item",
+        "source": item.source,
+        "external_id": item.external_id,
+        "dedup_key": item.dedup_key,
+        "title": item.title,
+        "body": item.body,
+        "status": item.status,
+        "pr_url": item.pr_url,
+        "conversation_id": item.conversation_id,
+        "assignee_user_id": item.assignee_user_id,
+        "created_by": item.created_by,
+        "plan": item.plan,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+    }
+
+
+def _require_auth(
+    request: Request,
+    auth_provider: AuthProvider | None,
+    permission_store: PermissionStore | None,
+) -> str | None:
+    """Identify the caller; require authentication in multi-user mode.
+
+    :param request: The incoming request.
+    :param auth_provider: Auth provider, or ``None`` in single-user mode.
+    :param permission_store: When set, marks multi-user mode (auth required).
+    :returns: The user id, or ``None`` in single-user mode.
+    :raises OmnigentError: 401 if unauthenticated in multi-user mode.
+    """
+    user_id = get_user_id(request, auth_provider)
+    if permission_store is not None and user_id is None:
+        raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+    return user_id
+
+
+def create_work_items_router(
+    store: WorkItemStore,
+    auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+) -> APIRouter:
+    """Build the work-items router (mounted at ``/work-items``).
+
+    :param store: The shared :class:`WorkItemStore`.
+    :param auth_provider: Auth provider identifying the caller, or ``None``.
+    :param permission_store: When set, enables auth enforcement (multi-user).
+    :returns: A configured :class:`APIRouter`.
+    """
+    router = APIRouter()
+
+    @router.post("/work-items")
+    async def create_work_item(request: Request, body: CreateWorkItemBody) -> dict[str, Any]:
+        """Create a work item (idempotent by ``dedup_key``)."""
+        user_id = _require_auth(request, auth_provider, permission_store)
+        if not body.title.strip():
+            raise OmnigentError("title is required", code=ErrorCode.INVALID_INPUT)
+        if body.source not in WORK_ITEM_SOURCES:
+            raise OmnigentError(f"source must be one of {_SOURCES}", code=ErrorCode.INVALID_INPUT)
+        if body.status not in WORK_ITEM_STATUSES:
+            raise OmnigentError(f"status must be one of {_STATUSES}", code=ErrorCode.INVALID_INPUT)
+
+        work_item_id = generate_work_item_id()
+        dedup_key = body.dedup_key or (
+            f"{body.source}:{body.external_id}" if body.external_id else f"manual:{work_item_id}"
+        )
+        existing = store.get_by_dedup_key(dedup_key)
+        if existing is not None:
+            return {"created": False, **_entity_to_response(existing)}
+
+        item = store.create(
+            work_item_id,
+            body.source,
+            body.title.strip(),
+            dedup_key=dedup_key,
+            external_id=body.external_id,
+            body=body.body,
+            status=body.status,
+            conversation_id=body.conversation_id,
+            assignee_user_id=body.assignee_user_id,
+            created_by=user_id,
+            plan=body.plan,
+        )
+        return {"created": True, **_entity_to_response(item)}
+
+    @router.get("/work-items")
+    async def list_work_items(
+        request: Request,
+        status: str | None = None,
+        conversation_id: str | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        """List work items, newest first, optionally filtered."""
+        _require_auth(request, auth_provider, permission_store)
+        if status is not None and status not in WORK_ITEM_STATUSES:
+            raise OmnigentError(f"status must be one of {_STATUSES}", code=ErrorCode.INVALID_INPUT)
+        items = store.list(
+            status=status,
+            conversation_id=conversation_id,
+            limit=max(1, min(limit, 1000)),
+        )
+        return {"object": "list", "data": [_entity_to_response(i) for i in items]}
+
+    @router.get("/work-items/{work_item_id}")
+    async def get_work_item(request: Request, work_item_id: str) -> dict[str, Any]:
+        """Get a single work item, or 404."""
+        _require_auth(request, auth_provider, permission_store)
+        item = store.get(work_item_id)
+        if item is None:
+            raise OmnigentError("Work item not found", code=ErrorCode.NOT_FOUND)
+        return _entity_to_response(item)
+
+    @router.patch("/work-items/{work_item_id}")
+    async def update_work_item(
+        request: Request, work_item_id: str, body: UpdateWorkItemBody
+    ) -> dict[str, Any]:
+        """Update a work item's mutable fields."""
+        _require_auth(request, auth_provider, permission_store)
+        if body.status is not None and body.status not in WORK_ITEM_STATUSES:
+            raise OmnigentError(f"status must be one of {_STATUSES}", code=ErrorCode.INVALID_INPUT)
+        item = store.update(
+            work_item_id,
+            title=body.title,
+            body=body.body,
+            status=body.status,
+            pr_url=body.pr_url,
+            conversation_id=body.conversation_id,
+            assignee_user_id=body.assignee_user_id,
+            plan=body.plan,
+        )
+        if item is None:
+            raise OmnigentError("Work item not found", code=ErrorCode.NOT_FOUND)
+        return _entity_to_response(item)
+
+    @router.delete("/work-items/{work_item_id}")
+    async def delete_work_item(request: Request, work_item_id: str) -> dict[str, Any]:
+        """Delete a work item. Idempotent."""
+        _require_auth(request, auth_provider, permission_store)
+        deleted = store.delete(work_item_id)
+        return {"deleted": deleted}
+
+    return router

--- a/omnigent/server/routes/work_items.py
+++ b/omnigent/server/routes/work_items.py
@@ -16,10 +16,11 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from starlette.datastructures import Headers
 
 from omnigent.db.utils import generate_work_item_id
-from omnigent.entities import WORK_ITEM_SOURCES, WORK_ITEM_STATUSES, WorkItem
+from omnigent.entities import WORK_ITEM_SOURCES, WORK_ITEM_STATUSES, WorkItem, is_http_url
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import get_user_id
@@ -38,13 +39,19 @@ _INTAKE_SOURCES = frozenset({"github", "slack", "jira", "email", "generic"})
 
 
 class _Verified(BaseModel):
-    """Normalized result of verifying + mapping an inbound intake payload."""
+    """Normalized result of verifying + mapping an inbound intake payload.
 
-    work_item_source: str
-    title: str
-    dedup_key: str
+    When ``challenge`` is set, the payload was a handshake (e.g. Slack's
+    ``url_verification``) rather than a work item — the route echoes it back
+    and creates nothing.
+    """
+
+    work_item_source: str = ""
+    title: str = ""
+    dedup_key: str = ""
     external_id: str | None = None
     body: str | None = None
+    challenge: str | None = None
 
 
 def _verify_and_map(source: str, headers: Headers, raw: bytes) -> _Verified:
@@ -103,6 +110,11 @@ def _verify_and_map(source: str, headers: Headers, raw: bytes) -> _Verified:
         if not ok:
             raise OmnigentError("invalid slack signature", code=ErrorCode.UNAUTHORIZED)
         payload = _payload()
+        # Slack Events API handshake: when the request URL is (re)configured,
+        # Slack POSTs a signed url_verification and expects its challenge echoed
+        # back. Handle it after the signature check; create no work item.
+        if payload.get("type") == "url_verification":
+            return _Verified(challenge=str(payload.get("challenge") or ""))
         event = payload.get("event")
         if not isinstance(event, dict):
             event = {}
@@ -250,19 +262,26 @@ def create_work_items_router(
         if existing is not None:
             return {"created": False, **_entity_to_response(existing)}
 
-        item = store.create(
-            work_item_id,
-            body.source,
-            body.title.strip(),
-            dedup_key=dedup_key,
-            external_id=body.external_id,
-            body=body.body,
-            status=body.status,
-            conversation_id=body.conversation_id,
-            assignee_user_id=body.assignee_user_id,
-            created_by=user_id,
-            plan=body.plan,
-        )
+        try:
+            item = store.create(
+                work_item_id,
+                body.source,
+                body.title.strip(),
+                dedup_key=dedup_key,
+                external_id=body.external_id,
+                body=body.body,
+                status=body.status,
+                conversation_id=body.conversation_id,
+                assignee_user_id=body.assignee_user_id,
+                created_by=user_id,
+                plan=body.plan,
+            )
+        except IntegrityError:
+            # Lost a dedup_key race to a concurrent create — return the winner.
+            existing = store.get_by_dedup_key(dedup_key)
+            if existing is None:
+                raise
+            return {"created": False, **_entity_to_response(existing)}
         return {"created": True, **_entity_to_response(item)}
 
     @router.get("/work-items")
@@ -300,6 +319,8 @@ def create_work_items_router(
         _require_auth(request, auth_provider, permission_store)
         if body.status is not None and body.status not in WORK_ITEM_STATUSES:
             raise OmnigentError(f"status must be one of {_STATUSES}", code=ErrorCode.INVALID_INPUT)
+        if body.pr_url is not None and body.pr_url != "" and not is_http_url(body.pr_url):
+            raise OmnigentError("pr_url must be an http(s) URL", code=ErrorCode.INVALID_INPUT)
         item = store.update(
             work_item_id,
             title=body.title,
@@ -328,17 +349,28 @@ def create_work_items_router(
         idempotent by dedup_key so a sender's retries don't duplicate."""
         raw = await request.body()
         verified = _verify_and_map(source, request.headers, raw)
+        if verified.challenge is not None:
+            return {"challenge": verified.challenge}
         existing = store.get_by_dedup_key(verified.dedup_key)
         if existing is not None:
             return {"created": False, **_entity_to_response(existing)}
-        item = store.create(
-            generate_work_item_id(),
-            verified.work_item_source,
-            verified.title,
-            dedup_key=verified.dedup_key,
-            external_id=verified.external_id,
-            body=verified.body,
-        )
+        try:
+            item = store.create(
+                generate_work_item_id(),
+                verified.work_item_source,
+                verified.title,
+                dedup_key=verified.dedup_key,
+                external_id=verified.external_id,
+                body=verified.body,
+            )
+        except IntegrityError:
+            # A concurrent intake with the same dedup_key won the race and
+            # tripped the UNIQUE constraint. Re-fetch and return that row so a
+            # sender's retries stay idempotent instead of surfacing a 500.
+            existing = store.get_by_dedup_key(verified.dedup_key)
+            if existing is None:
+                raise
+            return {"created": False, **_entity_to_response(existing)}
         return {"created": True, **_entity_to_response(item)}
 
     return router

--- a/omnigent/server/webhook_verify.py
+++ b/omnigent/server/webhook_verify.py
@@ -1,0 +1,82 @@
+"""Inbound-webhook signature verification (pure, dependency-free).
+
+Used by the work-item intake endpoint to authenticate external senders:
+
+- **GitHub** — ``X-Hub-Signature-256: sha256=<hmac>`` over the raw body.
+- **Slack** — ``X-Slack-Signature: v0=<hmac>`` over ``v0:{ts}:{body}`` plus a
+  freshness window on ``X-Slack-Request-Timestamp``.
+- **Bearer** — a shared secret in ``Authorization: Bearer <secret>`` (the
+  fallback for sources without their own signing scheme, e.g. Jira/email/generic).
+
+All comparisons are constant-time. These functions take the secret explicitly
+so they're trivially unit-testable; the route resolves secrets from env.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+# Reject Slack requests whose timestamp is older/newer than this (replay guard).
+_SLACK_MAX_SKEW_SECONDS = 60 * 5
+
+
+def verify_github_signature(secret: str, body: bytes, signature_header: str | None) -> bool:
+    """Verify a GitHub ``X-Hub-Signature-256`` header against the raw body.
+
+    :param secret: The configured webhook secret.
+    :param body: The exact raw request body bytes.
+    :param signature_header: The ``sha256=<hex>`` header value, or ``None``.
+    :returns: ``True`` iff the signature is present and valid.
+    """
+    if not secret or not signature_header:
+        return False
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def verify_slack_signature(
+    secret: str,
+    timestamp: str | None,
+    body: bytes,
+    signature_header: str | None,
+    *,
+    now: float | None = None,
+) -> bool:
+    """Verify a Slack ``X-Slack-Signature`` (v0 scheme) with a freshness check.
+
+    :param secret: The Slack signing secret.
+    :param timestamp: The ``X-Slack-Request-Timestamp`` header (epoch seconds).
+    :param body: The exact raw request body bytes.
+    :param signature_header: The ``v0=<hex>`` header value, or ``None``.
+    :param now: Current epoch seconds (injectable for tests).
+    :returns: ``True`` iff fresh and validly signed.
+    """
+    if not secret or not timestamp or not signature_header:
+        return False
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    current = time.time() if now is None else now
+    if abs(current - ts) > _SLACK_MAX_SKEW_SECONDS:
+        return False
+    basestring = b"v0:" + timestamp.encode() + b":" + body
+    expected = "v0=" + hmac.new(secret.encode(), basestring, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def verify_bearer(secret: str, authorization_header: str | None) -> bool:
+    """Verify an ``Authorization: Bearer <secret>`` header (constant-time).
+
+    :param secret: The configured shared intake secret.
+    :param authorization_header: The ``Authorization`` header value, or ``None``.
+    :returns: ``True`` iff the bearer token matches the secret.
+    """
+    if not secret or not authorization_header:
+        return False
+    prefix = "Bearer "
+    if not authorization_header.startswith(prefix):
+        return False
+    return hmac.compare_digest(authorization_header[len(prefix) :], secret)

--- a/omnigent/server/webhook_verify.py
+++ b/omnigent/server/webhook_verify.py
@@ -33,7 +33,9 @@ def verify_github_signature(secret: str, body: bytes, signature_header: str | No
     if not secret or not signature_header:
         return False
     expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature_header)
+    # Compare as bytes: comparing two str raises TypeError on a non-ASCII header
+    # (a malformed/hostile signature), which would 500 instead of cleanly failing.
+    return hmac.compare_digest(expected.encode(), signature_header.encode())
 
 
 def verify_slack_signature(
@@ -64,7 +66,7 @@ def verify_slack_signature(
         return False
     basestring = b"v0:" + timestamp.encode() + b":" + body
     expected = "v0=" + hmac.new(secret.encode(), basestring, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature_header)
+    return hmac.compare_digest(expected.encode(), signature_header.encode())
 
 
 def verify_bearer(secret: str, authorization_header: str | None) -> bool:
@@ -79,4 +81,4 @@ def verify_bearer(secret: str, authorization_header: str | None) -> bool:
     prefix = "Bearer "
     if not authorization_header.startswith(prefix):
         return False
-    return hmac.compare_digest(authorization_header[len(prefix) :], secret)
+    return hmac.compare_digest(authorization_header[len(prefix) :].encode(), secret.encode())

--- a/omnigent/stores/work_item_store/__init__.py
+++ b/omnigent/stores/work_item_store/__init__.py
@@ -1,0 +1,126 @@
+"""Work-item store — CRUD over the ``work_items`` table.
+
+Work items are tracked units of work (manual, or ingested from Slack /
+email / GitHub / Jira) that an agent processes in a linked conversation.
+The store enforces idempotency through a globally-unique ``dedup_key`` so a
+repeated intake of the same external event resolves to the existing row.
+"""
+
+from abc import ABC, abstractmethod
+
+from omnigent.entities import WorkItem
+
+
+class WorkItemStore(ABC):
+    """Abstract base for work-item persistence."""
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        :param storage_location: Backend-specific storage URI,
+            e.g. ``"sqlite:///chat.db"`` for SQLAlchemy.
+        """
+        self.storage_location = storage_location
+
+    @abstractmethod
+    def create(
+        self,
+        work_item_id: str,
+        source: str,
+        title: str,
+        *,
+        dedup_key: str,
+        external_id: str | None = None,
+        body: str | None = None,
+        status: str = "new",
+        conversation_id: str | None = None,
+        assignee_user_id: str | None = None,
+        created_by: str | None = None,
+        plan: str | None = None,
+    ) -> WorkItem:
+        """
+        Insert a new work item. ``dedup_key`` is globally UNIQUE; a
+        duplicate raises ``IntegrityError`` (callers wanting idempotency
+        should consult :meth:`get_by_dedup_key` first).
+
+        :param work_item_id: Pre-generated id, e.g. ``"wi_a1b2c3..."``.
+        :param source: One of :data:`~omnigent.entities.WORK_ITEM_SOURCES`.
+        :param title: Short human-readable title.
+        :param dedup_key: Idempotency key, globally unique.
+        :param external_id: Source-native id, or ``None``.
+        :param body: Optional longer description.
+        :param status: Initial lifecycle state (default ``"new"``).
+        :param conversation_id: Linked conversation, or ``None``.
+        :param assignee_user_id: Assignee, or ``None``.
+        :param created_by: Creating user id, or ``None``.
+        :param plan: Optional plan text/JSON.
+        :returns: The created :class:`WorkItem`.
+        """
+        ...
+
+    @abstractmethod
+    def get(self, work_item_id: str) -> WorkItem | None:
+        """
+        :param work_item_id: Opaque work-item id.
+        :returns: The :class:`WorkItem`, or ``None`` if not found.
+        """
+        ...
+
+    @abstractmethod
+    def get_by_dedup_key(self, dedup_key: str) -> WorkItem | None:
+        """
+        Look up a work item by its idempotency key — the basis for an
+        idempotent ``create_work_item``.
+
+        :param dedup_key: The globally-unique idempotency key.
+        :returns: The :class:`WorkItem`, or ``None`` if none matches.
+        """
+        ...
+
+    @abstractmethod
+    def list(
+        self,
+        *,
+        status: str | None = None,
+        conversation_id: str | None = None,
+        limit: int = 200,
+    ) -> list[WorkItem]:
+        """
+        List work items, newest first, optionally filtered.
+
+        :param status: Restrict to this lifecycle state, or ``None`` for all.
+        :param conversation_id: Restrict to items linked to this
+            conversation, or ``None`` for all.
+        :param limit: Maximum rows to return.
+        :returns: List of :class:`WorkItem`, ordered ``created_at DESC``.
+        """
+        ...
+
+    @abstractmethod
+    def update(
+        self,
+        work_item_id: str,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+        status: str | None = None,
+        pr_url: str | None = None,
+        conversation_id: str | None = None,
+        assignee_user_id: str | None = None,
+        plan: str | None = None,
+    ) -> WorkItem | None:
+        """
+        Update mutable fields. ``source``/``dedup_key`` are immutable.
+        Only provided (non-``None``) fields change.
+
+        :returns: The updated :class:`WorkItem`, or ``None`` if not found.
+        """
+        ...
+
+    @abstractmethod
+    def delete(self, work_item_id: str) -> bool:
+        """
+        Delete a work item. Idempotent.
+
+        :returns: ``True`` if a row was removed; ``False`` if not found.
+        """
+        ...

--- a/omnigent/stores/work_item_store/sqlalchemy_store.py
+++ b/omnigent/stores/work_item_store/sqlalchemy_store.py
@@ -1,0 +1,173 @@
+"""SQLAlchemy-backed work-item store."""
+
+from __future__ import annotations
+
+from sqlalchemy import desc, select
+
+from omnigent.db.db_models import SqlWorkItem
+from omnigent.db.utils import (
+    get_or_create_engine,
+    make_managed_session_maker,
+    now_epoch,
+)
+from omnigent.entities import WorkItem
+from omnigent.stores.work_item_store import WorkItemStore
+
+
+def _to_entity(row: SqlWorkItem) -> WorkItem:
+    """
+    Convert a :class:`SqlWorkItem` ORM row to a :class:`WorkItem` entity.
+
+    :param row: The SQLAlchemy ORM row to convert.
+    :returns: A :class:`WorkItem` dataclass instance.
+    """
+    return WorkItem(
+        id=row.id,
+        source=row.source,
+        title=row.title,
+        dedup_key=row.dedup_key,
+        status=row.status,
+        created_at=row.created_at,
+        external_id=row.external_id,
+        body=row.body,
+        pr_url=row.pr_url,
+        conversation_id=row.conversation_id,
+        assignee_user_id=row.assignee_user_id,
+        created_by=row.created_by,
+        plan=row.plan,
+        updated_at=row.updated_at,
+    )
+
+
+class SqlAlchemyWorkItemStore(WorkItemStore):
+    """SQLAlchemy-backed implementation of :class:`WorkItemStore`."""
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Create or reuse a SQLAlchemy engine + session factory.
+
+        :param storage_location: SQLAlchemy database URI,
+            e.g. ``"sqlite:///chat.db"``.
+        """
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        self._session = make_managed_session_maker(self._engine)
+
+    def create(
+        self,
+        work_item_id: str,
+        source: str,
+        title: str,
+        *,
+        dedup_key: str,
+        external_id: str | None = None,
+        body: str | None = None,
+        status: str = "new",
+        conversation_id: str | None = None,
+        assignee_user_id: str | None = None,
+        created_by: str | None = None,
+        plan: str | None = None,
+    ) -> WorkItem:
+        """Insert a new work item.
+
+        Raises ``IntegrityError`` on a ``dedup_key`` collision.
+        """
+        row = SqlWorkItem(
+            id=work_item_id,
+            source=source,
+            title=title,
+            dedup_key=dedup_key,
+            status=status,
+            external_id=external_id,
+            body=body,
+            conversation_id=conversation_id,
+            assignee_user_id=assignee_user_id,
+            created_by=created_by,
+            plan=plan,
+            created_at=now_epoch(),
+            updated_at=None,
+        )
+        with self._session() as session:
+            session.add(row)
+            session.flush()
+            return _to_entity(row)
+
+    def get(self, work_item_id: str) -> WorkItem | None:
+        """Return the work item by id, or ``None``."""
+        with self._session() as session:
+            row = session.get(SqlWorkItem, work_item_id)
+            return _to_entity(row) if row is not None else None
+
+    def get_by_dedup_key(self, dedup_key: str) -> WorkItem | None:
+        """Return the work item with this dedup key, or ``None``."""
+        with self._session() as session:
+            row = (
+                session.execute(select(SqlWorkItem).where(SqlWorkItem.dedup_key == dedup_key))
+                .scalars()
+                .first()
+            )
+            return _to_entity(row) if row is not None else None
+
+    def list(
+        self,
+        *,
+        status: str | None = None,
+        conversation_id: str | None = None,
+        limit: int = 200,
+    ) -> list[WorkItem]:
+        """List work items newest-first, optionally filtered."""
+        with self._session() as session:
+            stmt = select(SqlWorkItem)
+            if status is not None:
+                stmt = stmt.where(SqlWorkItem.status == status)
+            if conversation_id is not None:
+                stmt = stmt.where(SqlWorkItem.conversation_id == conversation_id)
+            # Newest first; tie-break on id descending for a stable order
+            # when two rows share a created_at second.
+            stmt = stmt.order_by(desc(SqlWorkItem.created_at), desc(SqlWorkItem.id)).limit(limit)
+            rows = session.execute(stmt).scalars().all()
+            return [_to_entity(r) for r in rows]
+
+    def update(
+        self,
+        work_item_id: str,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+        status: str | None = None,
+        pr_url: str | None = None,
+        conversation_id: str | None = None,
+        assignee_user_id: str | None = None,
+        plan: str | None = None,
+    ) -> WorkItem | None:
+        """Update mutable fields. Returns ``None`` if not found."""
+        with self._session() as session:
+            row = session.get(SqlWorkItem, work_item_id)
+            if row is None:
+                return None
+            changed = False
+            for field, value in (
+                ("title", title),
+                ("body", body),
+                ("status", status),
+                ("pr_url", pr_url),
+                ("conversation_id", conversation_id),
+                ("assignee_user_id", assignee_user_id),
+                ("plan", plan),
+            ):
+                if value is not None and getattr(row, field) != value:
+                    setattr(row, field, value)
+                    changed = True
+            if changed:
+                row.updated_at = now_epoch()
+            session.flush()
+            return _to_entity(row)
+
+    def delete(self, work_item_id: str) -> bool:
+        """Delete a work item. Idempotent: returns ``False`` if not found."""
+        with self._session() as session:
+            row = session.get(SqlWorkItem, work_item_id)
+            if row is None:
+                return False
+            session.delete(row)
+            return True

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -62,11 +62,18 @@ from omnigent.tools.builtins.timer import (
 )
 from omnigent.tools.builtins.update_comment import UpdateCommentTool
 from omnigent.tools.builtins.web_search import WebSearchTool
+from omnigent.tools.builtins.work_items import (
+    CreateWorkItemTool,
+    ListTasksTool,
+    UpdateWorkItemTool,
+)
 
 __all__ = [
     "BUILTIN_NAMES",
     "INSTANTIABLE_BUILTINS",
+    "CreateWorkItemTool",
     "ListCommentsTool",
+    "ListTasksTool",
     "LoadSkillTool",
     "ReadSkillFileTool",
     "SysAdviseModelsTool",
@@ -87,6 +94,7 @@ __all__ = [
     "SysTimerCancelTool",
     "SysTimerSetTool",
     "UpdateCommentTool",
+    "UpdateWorkItemTool",
     "WebSearchTool",
     "any_skill_has_resources",
     "find_skill_by_name",
@@ -168,6 +176,39 @@ def _create_export_agent(config: dict[str, str]) -> Tool:
     return ExportAgentTool()
 
 
+def _create_work_item(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for CreateWorkItemTool.
+
+    :param config: Tool config (unused).
+    :returns: A CreateWorkItemTool instance.
+    """
+    del config
+    return CreateWorkItemTool()
+
+
+def _create_list_tasks(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for ListTasksTool.
+
+    :param config: Tool config (unused).
+    :returns: A ListTasksTool instance.
+    """
+    del config
+    return ListTasksTool()
+
+
+def _create_update_work_item(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for UpdateWorkItemTool.
+
+    :param config: Tool config (unused).
+    :returns: An UpdateWorkItemTool instance.
+    """
+    del config
+    return UpdateWorkItemTool()
+
+
 # Unified registry for every reserved builtin name. The value
 # is either a factory callable (for user-enablable tools) or
 # ``None`` for framework-owned names that occupy the name-space
@@ -190,6 +231,10 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     "download_file": _create_download_file,
     "search_conversations": _create_search_conversations,
     "export_agent": _create_export_agent,
+    # Tasks / Work-Items (#3, #12) — backed by the WorkItemStore.
+    "create_work_item": _create_work_item,
+    "list_tasks": _create_list_tasks,
+    "update_work_item": _create_update_work_item,
     # Framework-owned: need runtime context. ``web_fetch`` is
     # constructed by ToolManager before reaching this registry.
     # ``list_comments`` and ``update_comment`` are auto-registered by

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -64,7 +64,7 @@ from omnigent.tools.builtins.update_comment import UpdateCommentTool
 from omnigent.tools.builtins.web_search import WebSearchTool
 from omnigent.tools.builtins.work_items import (
     CreateWorkItemTool,
-    ListTasksTool,
+    ListWorkItemsTool,
     UpdateWorkItemTool,
 )
 
@@ -73,7 +73,7 @@ __all__ = [
     "INSTANTIABLE_BUILTINS",
     "CreateWorkItemTool",
     "ListCommentsTool",
-    "ListTasksTool",
+    "ListWorkItemsTool",
     "LoadSkillTool",
     "ReadSkillFileTool",
     "SysAdviseModelsTool",
@@ -187,15 +187,15 @@ def _create_work_item(config: dict[str, str]) -> Tool:
     return CreateWorkItemTool()
 
 
-def _create_list_tasks(config: dict[str, str]) -> Tool:
+def _create_list_work_items(config: dict[str, str]) -> Tool:
     """
-    Lazy factory for ListTasksTool.
+    Lazy factory for ListWorkItemsTool.
 
     :param config: Tool config (unused).
-    :returns: A ListTasksTool instance.
+    :returns: A ListWorkItemsTool instance.
     """
     del config
-    return ListTasksTool()
+    return ListWorkItemsTool()
 
 
 def _create_update_work_item(config: dict[str, str]) -> Tool:
@@ -233,7 +233,7 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     "export_agent": _create_export_agent,
     # Tasks / Work-Items (#3, #12) — backed by the WorkItemStore.
     "create_work_item": _create_work_item,
-    "list_tasks": _create_list_tasks,
+    "list_work_items": _create_list_work_items,
     "update_work_item": _create_update_work_item,
     # Framework-owned: need runtime context. ``web_fetch`` is
     # constructed by ToolManager before reaching this registry.

--- a/omnigent/tools/builtins/work_items.py
+++ b/omnigent/tools/builtins/work_items.py
@@ -5,7 +5,7 @@ Three LLM-callable tools backed by the :class:`WorkItemStore`:
 - :class:`CreateWorkItemTool` (``create_work_item``) — create a tracked
   work item, idempotently by ``dedup_key`` (so the same external event
   ingested twice resolves to one row).
-- :class:`ListTasksTool` (``list_tasks``) — list work items, optionally
+- :class:`ListWorkItemsTool` (``list_work_items``) — list work items, optionally
   filtered by status / conversation.
 - :class:`UpdateWorkItemTool` (``update_work_item``) — update an item's
   status, PR URL, plan, title, or linked conversation.
@@ -187,13 +187,13 @@ class CreateWorkItemTool(Tool):
         return json.dumps({"created": True, "work_item": _item_dict(item)})
 
 
-class ListTasksTool(Tool):
+class ListWorkItemsTool(Tool):
     """List work items, optionally filtered by status / conversation."""
 
     @classmethod
     def name(cls) -> str:
-        """:returns: ``"list_tasks"``."""
-        return "list_tasks"
+        """:returns: ``"list_work_items"``."""
+        return "list_work_items"
 
     @classmethod
     def description(cls) -> str:
@@ -204,7 +204,7 @@ class ListTasksTool(Tool):
         )
 
     def get_schema(self) -> dict[str, Any]:
-        """:returns: OpenAI tool schema for ``list_tasks``."""
+        """:returns: OpenAI tool schema for ``list_work_items``."""
         return {
             "type": "function",
             "function": {

--- a/omnigent/tools/builtins/work_items.py
+++ b/omnigent/tools/builtins/work_items.py
@@ -1,0 +1,351 @@
+"""Built-in tools for the Tasks / Work-Items feature.
+
+Three LLM-callable tools backed by the :class:`WorkItemStore`:
+
+- :class:`CreateWorkItemTool` (``create_work_item``) — create a tracked
+  work item, idempotently by ``dedup_key`` (so the same external event
+  ingested twice resolves to one row).
+- :class:`ListTasksTool` (``list_tasks``) — list work items, optionally
+  filtered by status / conversation.
+- :class:`UpdateWorkItemTool` (``update_work_item``) — update an item's
+  status, PR URL, plan, title, or linked conversation.
+
+These run AP-side (synchronous ``invoke``) and resolve the store lazily via
+:func:`omnigent.runtime.get_work_item_store`, mirroring the other
+store-backed builtins (e.g. ``search_conversations``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from omnigent.entities import WORK_ITEM_SOURCES, WORK_ITEM_STATUSES, WorkItem
+from omnigent.tools.base import Tool, ToolContext
+
+# Sorted for stable schema enums / deterministic error messages.
+_SOURCES = sorted(WORK_ITEM_SOURCES)
+_STATUSES = sorted(WORK_ITEM_STATUSES)
+
+
+def _item_dict(item: WorkItem) -> dict[str, Any]:
+    """
+    Serialize a :class:`WorkItem` to a JSON-friendly dict for tool output.
+
+    :param item: The work item to serialize.
+    :returns: A dict of the item's fields.
+    """
+    return {
+        "id": item.id,
+        "source": item.source,
+        "external_id": item.external_id,
+        "dedup_key": item.dedup_key,
+        "title": item.title,
+        "status": item.status,
+        "pr_url": item.pr_url,
+        "conversation_id": item.conversation_id,
+        "assignee_user_id": item.assignee_user_id,
+        "plan": item.plan,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+    }
+
+
+def _store_or_error() -> tuple[Any, str | None]:
+    """
+    Resolve the work-item store, or an error message if unconfigured.
+
+    :returns: ``(store, None)`` when available, else ``(None, json_error)``.
+    """
+    from omnigent.runtime import get_work_item_store
+
+    store = get_work_item_store()
+    if store is None:
+        return None, json.dumps({"error": "work item store is not configured on this server"})
+    return store, None
+
+
+class CreateWorkItemTool(Tool):
+    """Create a tracked work item (idempotent by ``dedup_key``)."""
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"create_work_item"``."""
+        return "create_work_item"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Description visible to the LLM."""
+        return (
+            "Create a tracked work item (a task) — e.g. turning a Slack "
+            "message, email, or GitHub/Jira issue into something an agent "
+            "can work on. Pass a stable dedup_key (e.g. 'github:org/repo#123') "
+            "to make repeated ingestion idempotent: a second call with the "
+            "same dedup_key returns the existing item instead of creating a "
+            "duplicate."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """:returns: OpenAI tool schema for ``create_work_item``."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "Short task title."},
+                        "source": {
+                            "type": "string",
+                            "enum": _SOURCES,
+                            "description": "Where the task came from.",
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Optional longer description / original text.",
+                        },
+                        "dedup_key": {
+                            "type": "string",
+                            "description": (
+                                "Stable idempotency key, e.g. 'github:org/repo#123'. "
+                                "Omit for a one-off manual task (a unique key is generated)."
+                            ),
+                        },
+                        "external_id": {
+                            "type": "string",
+                            "description": "Source-native id (issue/PR number, message ts).",
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": _STATUSES,
+                            "description": "Initial status (default 'new').",
+                        },
+                        "conversation_id": {
+                            "type": "string",
+                            "description": "Conversation/sub-session that will process this item.",
+                        },
+                        "plan": {
+                            "type": "string",
+                            "description": "Optional plan for the work.",
+                        },
+                    },
+                    "required": ["title", "source"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        """Create (or resolve an existing) work item; return it as JSON."""
+        del ctx
+        try:
+            args = json.loads(arguments) if arguments else {}
+        except json.JSONDecodeError as exc:
+            return json.dumps({"error": f"invalid arguments: {exc}"})
+
+        title = args.get("title")
+        source = args.get("source")
+        if not isinstance(title, str) or not title.strip():
+            return json.dumps({"error": "title is required"})
+        if source not in WORK_ITEM_SOURCES:
+            return json.dumps({"error": f"source must be one of {_SOURCES}"})
+
+        status = args.get("status", "new")
+        if status not in WORK_ITEM_STATUSES:
+            return json.dumps({"error": f"status must be one of {_STATUSES}"})
+
+        external_id = args.get("external_id")
+        from omnigent.db.utils import generate_work_item_id
+
+        work_item_id = generate_work_item_id()
+        # Idempotency key: caller-supplied, else derived from source+external_id,
+        # else the freshly-minted id (so a keyless manual task always inserts).
+        dedup_key = args.get("dedup_key")
+        if not dedup_key:
+            dedup_key = f"{source}:{external_id}" if external_id else f"manual:{work_item_id}"
+
+        store, err = _store_or_error()
+        if err is not None:
+            return err
+
+        existing = store.get_by_dedup_key(dedup_key)
+        if existing is not None:
+            return json.dumps({"created": False, "work_item": _item_dict(existing)})
+
+        item = store.create(
+            work_item_id,
+            source,
+            title.strip(),
+            dedup_key=dedup_key,
+            external_id=external_id,
+            body=args.get("body"),
+            status=status,
+            conversation_id=args.get("conversation_id"),
+            plan=args.get("plan"),
+        )
+        return json.dumps({"created": True, "work_item": _item_dict(item)})
+
+
+class ListTasksTool(Tool):
+    """List work items, optionally filtered by status / conversation."""
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"list_tasks"``."""
+        return "list_tasks"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Description visible to the LLM."""
+        return (
+            "List tracked work items (tasks), newest first. Optionally filter "
+            "by status or by the conversation processing them."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """:returns: OpenAI tool schema for ``list_tasks``."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "status": {
+                            "type": "string",
+                            "enum": _STATUSES,
+                            "description": "Only items in this status.",
+                        },
+                        "conversation_id": {
+                            "type": "string",
+                            "description": "Only items linked to this conversation.",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Max items to return (default 50).",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        """List work items as JSON."""
+        del ctx
+        try:
+            args = json.loads(arguments) if arguments else {}
+        except json.JSONDecodeError as exc:
+            return json.dumps({"error": f"invalid arguments: {exc}"})
+
+        status = args.get("status")
+        if status is not None and status not in WORK_ITEM_STATUSES:
+            return json.dumps({"error": f"status must be one of {_STATUSES}"})
+
+        limit_raw = args.get("limit", 50)
+        try:
+            limit = max(1, min(int(limit_raw), 1000))
+        except (TypeError, ValueError):
+            return json.dumps({"error": "limit must be an integer"})
+
+        store, err = _store_or_error()
+        if err is not None:
+            return err
+
+        items = store.list(
+            status=status,
+            conversation_id=args.get("conversation_id"),
+            limit=limit,
+        )
+        return json.dumps({"count": len(items), "work_items": [_item_dict(i) for i in items]})
+
+
+class UpdateWorkItemTool(Tool):
+    """Update a work item's status / PR URL / plan / title / conversation."""
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"update_work_item"``."""
+        return "update_work_item"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Description visible to the LLM."""
+        return (
+            "Update a work item: change its status, attach a PR URL, record a "
+            "plan, rename it, or link the conversation working on it. Pass "
+            "needs_review=true as a shortcut to set status='needs_review'."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """:returns: OpenAI tool schema for ``update_work_item``."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "work_item_id": {
+                            "type": "string",
+                            "description": "The id of the work item to update.",
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": _STATUSES,
+                            "description": "New status.",
+                        },
+                        "needs_review": {
+                            "type": "boolean",
+                            "description": "Shortcut for status='needs_review'.",
+                        },
+                        "pr_url": {"type": "string", "description": "Pull-request URL."},
+                        "plan": {"type": "string", "description": "Updated plan text."},
+                        "title": {"type": "string", "description": "New title."},
+                        "conversation_id": {
+                            "type": "string",
+                            "description": "Conversation/sub-session processing this item.",
+                        },
+                    },
+                    "required": ["work_item_id"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        """Update a work item; return the updated item as JSON."""
+        del ctx
+        try:
+            args = json.loads(arguments) if arguments else {}
+        except json.JSONDecodeError as exc:
+            return json.dumps({"error": f"invalid arguments: {exc}"})
+
+        work_item_id = args.get("work_item_id")
+        if not isinstance(work_item_id, str) or not work_item_id:
+            return json.dumps({"error": "work_item_id is required"})
+
+        status = args.get("status")
+        if args.get("needs_review") is True and status is None:
+            status = "needs_review"
+        if status is not None and status not in WORK_ITEM_STATUSES:
+            return json.dumps({"error": f"status must be one of {_STATUSES}"})
+
+        store, err = _store_or_error()
+        if err is not None:
+            return err
+
+        updated = store.update(
+            work_item_id,
+            status=status,
+            pr_url=args.get("pr_url"),
+            plan=args.get("plan"),
+            title=args.get("title"),
+            conversation_id=args.get("conversation_id"),
+        )
+        if updated is None:
+            return json.dumps({"error": "not_found", "work_item_id": work_item_id})
+        return json.dumps({"work_item": _item_dict(updated)})

--- a/omnigent/tools/builtins/work_items.py
+++ b/omnigent/tools/builtins/work_items.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from omnigent.entities import WORK_ITEM_SOURCES, WORK_ITEM_STATUSES, WorkItem
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.entities import WORK_ITEM_SOURCES, WORK_ITEM_STATUSES, WorkItem, is_http_url
 from omnigent.tools.base import Tool, ToolContext
 
 # Sorted for stable schema enums / deterministic error messages.
@@ -138,7 +140,6 @@ class CreateWorkItemTool(Tool):
 
     def invoke(self, arguments: str, ctx: ToolContext) -> str:
         """Create (or resolve an existing) work item; return it as JSON."""
-        del ctx
         try:
             args = json.loads(arguments) if arguments else {}
         except json.JSONDecodeError as exc:
@@ -173,17 +174,27 @@ class CreateWorkItemTool(Tool):
         if existing is not None:
             return json.dumps({"created": False, "work_item": _item_dict(existing)})
 
-        item = store.create(
-            work_item_id,
-            source,
-            title.strip(),
-            dedup_key=dedup_key,
-            external_id=external_id,
-            body=args.get("body"),
-            status=status,
-            conversation_id=args.get("conversation_id"),
-            plan=args.get("plan"),
-        )
+        # Default to the ambient conversation (like the runner proxy) so an
+        # item created mid-session links back to the session that spawned it.
+        conversation_id = args.get("conversation_id") or ctx.conversation_id
+        try:
+            item = store.create(
+                work_item_id,
+                source,
+                title.strip(),
+                dedup_key=dedup_key,
+                external_id=external_id,
+                body=args.get("body"),
+                status=status,
+                conversation_id=conversation_id,
+                plan=args.get("plan"),
+            )
+        except IntegrityError:
+            # Lost a dedup_key race — return the existing item (stay idempotent).
+            existing = store.get_by_dedup_key(dedup_key)
+            if existing is None:
+                raise
+            return json.dumps({"created": False, "work_item": _item_dict(existing)})
         return json.dumps({"created": True, "work_item": _item_dict(item)})
 
 
@@ -334,6 +345,10 @@ class UpdateWorkItemTool(Tool):
         if status is not None and status not in WORK_ITEM_STATUSES:
             return json.dumps({"error": f"status must be one of {_STATUSES}"})
 
+        pr_url = args.get("pr_url")
+        if pr_url is not None and pr_url != "" and not is_http_url(pr_url):
+            return json.dumps({"error": "pr_url must be an http(s) URL"})
+
         store, err = _store_or_error()
         if err is not None:
             return err
@@ -341,7 +356,7 @@ class UpdateWorkItemTool(Tool):
         updated = store.update(
             work_item_id,
             status=status,
-            pr_url=args.get("pr_url"),
+            pr_url=pr_url,
             plan=args.get("plan"),
             title=args.get("title"),
             conversation_id=args.get("conversation_id"),

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -179,13 +179,11 @@ class ToolManager:
         # Comment tools are always auto-registered so agents can
         # list and update review comments without the spec opting in.
         self._register_comment_tools()
-        # Work-item (#3), schedule/loop (#6), and canvas (#2) builtins are
-        # likewise always auto-registered, so an agent — and the Omnigent MCP
-        # surface — can create/track work items, manage loops & monitors, and
-        # set the conversation canvas without the spec opting in (#12).
-        # Registered directly (like the comment tools) rather than declared in
-        # ``tools.builtins``, which sidesteps the function-tool callable-
-        # recovery translation path.
+        # Work-item builtins (#3, #12) are likewise always auto-registered, so
+        # an agent — and the Omnigent MCP surface — can create and track work
+        # items without the spec opting in. Registered directly (like the
+        # comment tools) rather than declared in ``tools.builtins``, which
+        # sidesteps the function-tool callable-recovery translation path.
         self._register_work_management_tools()
         # Policy tool is always auto-registered so agents can add
         # inline CEL policies at runtime without spec changes.

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -179,6 +179,14 @@ class ToolManager:
         # Comment tools are always auto-registered so agents can
         # list and update review comments without the spec opting in.
         self._register_comment_tools()
+        # Work-item (#3), schedule/loop (#6), and canvas (#2) builtins are
+        # likewise always auto-registered, so an agent — and the Omnigent MCP
+        # surface — can create/track work items, manage loops & monitors, and
+        # set the conversation canvas without the spec opting in (#12).
+        # Registered directly (like the comment tools) rather than declared in
+        # ``tools.builtins``, which sidesteps the function-tool callable-
+        # recovery translation path.
+        self._register_work_management_tools()
         # Policy tool is always auto-registered so agents can add
         # inline CEL policies at runtime without spec changes.
         self._register_policy_tools()
@@ -521,6 +529,27 @@ class ToolManager:
         """
         self._tools[ListCommentsTool.name()] = ListCommentsTool()
         self._tools[UpdateCommentTool.name()] = UpdateCommentTool()
+
+    def _register_work_management_tools(self) -> None:
+        """
+        Auto-register the work-item builtins (#3, #12).
+
+        These are framework-owned and always available so an agent — and the
+        Omnigent MCP surface — can create and track work items without the spec
+        opting in. They're instantiated straight from the builtin registry
+        (like the comment tools) rather than declared in ``tools.builtins``,
+        which avoids the declared-builtin function-tool callable-recovery path.
+        Each tool returns a clear error at invoke time when its backing store
+        isn't configured, so registering them unconditionally is safe.
+        """
+        for name in (
+            "create_work_item",
+            "list_work_items",
+            "update_work_item",
+        ):
+            tool = get_builtin_tool(name)
+            if tool is not None:
+                self._tools[name] = tool
 
     def _register_os_env_tools(self) -> None:
         """

--- a/tests/e2e/test_work_items_e2e.py
+++ b/tests/e2e/test_work_items_e2e.py
@@ -1,0 +1,25 @@
+"""E2E: the work-items REST round-trips on the live server (#3).
+
+Creates a work item via ``POST /v1/work-items`` and reads it back from the
+listing — proving the store + routes are wired end to end. The agent-tool path
+(create_work_item etc.) is unit-covered in
+``tests/runner/test_work_management_dispatch.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+
+def test_work_item_create_then_list(http_client: httpx.Client) -> None:
+    title = f"e2e-task-{uuid.uuid4().hex[:8]}"
+    created = http_client.post("/v1/work-items", json={"title": title, "source": "manual"})
+    created.raise_for_status()
+    assert created.json()["title"] == title
+
+    items = http_client.get("/v1/work-items").json()["data"]
+    assert any(w["title"] == title for w in items), (
+        f"{title!r} not in {[w['title'] for w in items]}"
+    )

--- a/tests/e2e_ui/tasks/test_tasks_panel.py
+++ b/tests/e2e_ui/tasks/test_tasks_panel.py
@@ -1,0 +1,26 @@
+"""UI e2e: the left-pane Tasks panel lists work items (#3).
+
+Seeds a work item via REST, loads ``/tasks``, and asserts the panel renders it —
+covering the useWorkItems hook + TasksPage + the /v1/work-items read in a real
+browser.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from playwright.sync_api import Page, expect
+
+
+def test_tasks_panel_lists_a_seeded_work_item(page: Page, live_server: str) -> None:
+    title = f"e2e-task-{uuid.uuid4().hex[:8]}"
+    httpx.post(
+        f"{live_server}/v1/work-items",
+        json={"title": title, "source": "manual"},
+        timeout=10.0,
+    ).raise_for_status()
+
+    page.goto(f"{live_server}/tasks")
+    expect(page.get_by_role("heading", name="Tasks")).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("task-row").filter(has_text=title)).to_be_visible(timeout=30_000)

--- a/tests/runner/test_work_management_dispatch.py
+++ b/tests/runner/test_work_management_dispatch.py
@@ -1,0 +1,84 @@
+"""Unit tests for the runner-side work-management tool proxy (#12).
+
+``_execute_work_management_tool`` maps each builtin to a server REST call over
+``server_client``. These drive it against an ``httpx.MockTransport`` that
+records the request, asserting method/path/body/params per tool plus the
+guard errors — locking the mapping the live agent test exercised end to end.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from omnigent.runner.tool_dispatch import _execute_work_management_tool
+
+
+def _recording_client(recorder: list[httpx.Request]) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorder.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://srv")
+
+
+async def test_create_work_item_posts_body() -> None:
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    out = await _execute_work_management_tool(
+        "create_work_item",
+        json.dumps({"title": "T", "source": "manual", "body": "b"}),
+        conversation_id="conv_1",
+        server_client=client,
+    )
+    await client.aclose()
+    assert reqs[0].method == "POST"
+    assert reqs[0].url.path == "/v1/work-items"
+    assert json.loads(reqs[0].content) == {"title": "T", "source": "manual", "body": "b"}
+    assert json.loads(out) == {"ok": True}
+
+
+async def test_list_work_items_passes_filters_as_query() -> None:
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    await _execute_work_management_tool(
+        "list_work_items", json.dumps({"status": "new"}), conversation_id="conv_1", server_client=client
+    )
+    await client.aclose()
+    assert reqs[0].method == "GET"
+    assert reqs[0].url.path == "/v1/work-items"
+    assert reqs[0].url.params.get("status") == "new"
+
+
+async def test_update_work_item_needs_review_maps_to_status() -> None:
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    await _execute_work_management_tool(
+        "update_work_item",
+        json.dumps({"work_item_id": "wi_1", "needs_review": True}),
+        conversation_id=None,
+        server_client=client,
+    )
+    await client.aclose()
+    assert reqs[0].method == "PATCH"
+    assert reqs[0].url.path == "/v1/work-items/wi_1"
+    assert json.loads(reqs[0].content) == {"status": "needs_review"}
+
+
+async def test_guards() -> None:
+    # No server client -> clear error, no crash.
+    out = await _execute_work_management_tool(
+        "list_work_items", "{}", conversation_id="c", server_client=None
+    )
+    assert "requires server access" in out
+
+    # Missing required id -> error, no request made.
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    out = await _execute_work_management_tool(
+        "update_work_item", "{}", conversation_id="c", server_client=client
+    )
+    await client.aclose()
+    assert "work_item_id" in out
+    assert reqs == []  # the errored call did not hit the network

--- a/tests/runner/test_work_management_dispatch.py
+++ b/tests/runner/test_work_management_dispatch.py
@@ -35,7 +35,13 @@ async def test_create_work_item_posts_body() -> None:
     await client.aclose()
     assert reqs[0].method == "POST"
     assert reqs[0].url.path == "/v1/work-items"
-    assert json.loads(reqs[0].content) == {"title": "T", "source": "manual", "body": "b"}
+    # The current session id is defaulted onto the item when not supplied.
+    assert json.loads(reqs[0].content) == {
+        "title": "T",
+        "source": "manual",
+        "body": "b",
+        "conversation_id": "conv_1",
+    }
     assert json.loads(out) == {"ok": True}
 
 
@@ -43,7 +49,10 @@ async def test_list_work_items_passes_filters_as_query() -> None:
     reqs: list[httpx.Request] = []
     client = _recording_client(reqs)
     await _execute_work_management_tool(
-        "list_work_items", json.dumps({"status": "new"}), conversation_id="conv_1", server_client=client
+        "list_work_items",
+        json.dumps({"status": "new"}),
+        conversation_id="conv_1",
+        server_client=client,
     )
     await client.aclose()
     assert reqs[0].method == "GET"

--- a/tests/server/test_webhook_verify.py
+++ b/tests/server/test_webhook_verify.py
@@ -1,0 +1,60 @@
+"""Unit tests for inbound-webhook signature verification."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from omnigent.server.webhook_verify import (
+    verify_bearer,
+    verify_github_signature,
+    verify_slack_signature,
+)
+
+
+def _gh_sig(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _slack_sig(secret: str, ts: str, body: bytes) -> str:
+    base = b"v0:" + ts.encode() + b":" + body
+    return "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+
+
+def test_github_signature() -> None:
+    body = b'{"x":1}'
+    assert verify_github_signature("s3cret", body, _gh_sig("s3cret", body)) is True
+    assert verify_github_signature("s3cret", body, _gh_sig("wrong", body)) is False
+    assert verify_github_signature("s3cret", body, None) is False
+    assert verify_github_signature("", body, _gh_sig("s3cret", body)) is False
+    # Signature must cover the exact bytes.
+    assert verify_github_signature("s3cret", b'{"x":2}', _gh_sig("s3cret", body)) is False
+
+
+def test_slack_signature_valid_and_fresh() -> None:
+    body = b"payload"
+    ts = "1000"
+    sig = _slack_sig("sign", ts, body)
+    assert verify_slack_signature("sign", ts, body, sig, now=1000) is True
+    # Within the 5-minute window.
+    assert verify_slack_signature("sign", ts, body, sig, now=1000 + 120) is True
+
+
+def test_slack_signature_rejects_stale_and_bad() -> None:
+    body = b"payload"
+    ts = "1000"
+    sig = _slack_sig("sign", ts, body)
+    assert verify_slack_signature("sign", ts, body, sig, now=1000 + 9999) is False  # stale
+    assert (
+        verify_slack_signature("sign", ts, body, _slack_sig("nope", ts, body), now=1000) is False
+    )
+    assert verify_slack_signature("sign", None, body, sig, now=1000) is False
+    assert verify_slack_signature("sign", "notanint", body, sig, now=1000) is False
+
+
+def test_bearer() -> None:
+    assert verify_bearer("tok", "Bearer tok") is True
+    assert verify_bearer("tok", "Bearer nope") is False
+    assert verify_bearer("tok", "tok") is False  # missing prefix
+    assert verify_bearer("tok", None) is False
+    assert verify_bearer("", "Bearer ") is False

--- a/tests/server/test_webhook_verify.py
+++ b/tests/server/test_webhook_verify.py
@@ -58,3 +58,12 @@ def test_bearer() -> None:
     assert verify_bearer("tok", "tok") is False  # missing prefix
     assert verify_bearer("tok", None) is False
     assert verify_bearer("", "Bearer ") is False
+
+
+def test_non_ascii_signatures_fail_cleanly() -> None:
+    # A non-ASCII signature/token must return False, not raise TypeError —
+    # comparisons happen on bytes, so a hostile header can't 500 the endpoint.
+    body = b'{"x":1}'
+    assert verify_github_signature("s3cret", body, "sha256=café") is False
+    assert verify_slack_signature("sign", "1000", body, "v0=café", now=1000) is False
+    assert verify_bearer("tok", "Bearer café") is False

--- a/tests/server/test_work_item_intake.py
+++ b/tests/server/test_work_item_intake.py
@@ -1,0 +1,106 @@
+"""Tests for the work-item intake webhook (/v1/work-items/intake/{source})."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from omnigent.errors import OmnigentError
+from omnigent.server.routes.work_items import create_work_items_router
+from omnigent.stores.work_item_store.sqlalchemy_store import SqlAlchemyWorkItemStore
+
+
+@pytest.fixture()
+def client(db_uri: str) -> TestClient:
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(_request: Request, exc: OmnigentError) -> JSONResponse:
+        return JSONResponse(status_code=exc.http_status, content={"error": exc.code})
+
+    app.include_router(create_work_items_router(SqlAlchemyWorkItemStore(db_uri)), prefix="/v1")
+    return TestClient(app)
+
+
+def _gh_headers(secret: str, body: bytes) -> dict[str, str]:
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {"X-Hub-Signature-256": sig, "Content-Type": "application/json"}
+
+
+def test_github_intake_creates_and_is_idempotent(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMNIGENT_GITHUB_WEBHOOK_SECRET", "ghs")
+    payload = {
+        "repository": {"full_name": "acme/app"},
+        "issue": {"number": 42, "title": "Bug: deploy fails", "body": "details"},
+    }
+    raw = json.dumps(payload).encode()
+
+    res = client.post("/v1/work-items/intake/github", content=raw, headers=_gh_headers("ghs", raw))
+    assert res.status_code == 200
+    out = res.json()
+    assert out["created"] is True
+    assert out["source"] == "github"
+    assert out["external_id"] == "acme/app#42"
+    assert out["title"] == "Bug: deploy fails"
+
+    # Same event again → idempotent (no duplicate).
+    again = client.post(
+        "/v1/work-items/intake/github", content=raw, headers=_gh_headers("ghs", raw)
+    )
+    assert again.json()["created"] is False
+    assert again.json()["id"] == out["id"]
+
+
+def test_github_intake_rejects_bad_signature(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMNIGENT_GITHUB_WEBHOOK_SECRET", "ghs")
+    raw = b"{}"
+    res = client.post(
+        "/v1/work-items/intake/github", content=raw, headers=_gh_headers("WRONG", raw)
+    )
+    assert res.status_code == 401
+
+
+def test_intake_not_configured_is_404(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OMNIGENT_GITHUB_WEBHOOK_SECRET", raising=False)
+    res = client.post("/v1/work-items/intake/github", content=b"{}")
+    assert res.status_code == 404
+
+
+def test_generic_bearer_intake(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_INTAKE_SECRET", "tok")
+    raw = json.dumps({"title": "Manual task", "external_id": "x1"}).encode()
+    ok = client.post(
+        "/v1/work-items/intake/generic",
+        content=raw,
+        headers={"Authorization": "Bearer tok", "Content-Type": "application/json"},
+    )
+    assert ok.status_code == 200
+    assert ok.json()["created"] is True
+    assert ok.json()["source"] == "manual"  # "generic" maps to manual
+
+    bad = client.post(
+        "/v1/work-items/intake/generic",
+        content=raw,
+        headers={"Authorization": "Bearer nope"},
+    )
+    assert bad.status_code == 401
+
+
+def test_unknown_source_is_400(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_INTAKE_SECRET", "tok")
+    res = client.post(
+        "/v1/work-items/intake/telepathy",
+        content=b"{}",
+        headers={"Authorization": "Bearer tok"},
+    )
+    assert res.status_code == 400

--- a/tests/server/test_work_item_intake.py
+++ b/tests/server/test_work_item_intake.py
@@ -33,6 +33,36 @@ def _gh_headers(secret: str, body: bytes) -> dict[str, str]:
     return {"X-Hub-Signature-256": sig, "Content-Type": "application/json"}
 
 
+def _slack_headers(secret: str, body: bytes, ts: str) -> dict[str, str]:
+    base = b"v0:" + ts.encode() + b":" + body
+    sig = "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return {
+        "X-Slack-Request-Timestamp": ts,
+        "X-Slack-Signature": sig,
+        "Content-Type": "application/json",
+    }
+
+
+def test_slack_url_verification_echoes_challenge(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Slack's Events API handshake: a signed url_verification must get its
+    # challenge echoed back — and must NOT create a work item.
+    import time
+
+    monkeypatch.setenv("OMNIGENT_SLACK_SIGNING_SECRET", "shh")
+    ts = str(int(time.time()))
+    raw = json.dumps({"type": "url_verification", "challenge": "c123"}).encode()
+
+    res = client.post(
+        "/v1/work-items/intake/slack", content=raw, headers=_slack_headers("shh", raw, ts)
+    )
+    assert res.status_code == 200
+    assert res.json() == {"challenge": "c123"}
+    # The handshake created nothing.
+    assert client.get("/v1/work-items").json()["data"] == []
+
+
 def test_github_intake_creates_and_is_idempotent(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/server/test_work_items_routes.py
+++ b/tests/server/test_work_items_routes.py
@@ -1,0 +1,88 @@
+"""Tests for the work-items REST routes (single-user mode)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from omnigent.errors import OmnigentError
+from omnigent.server.routes.work_items import create_work_items_router
+from omnigent.stores.work_item_store.sqlalchemy_store import SqlAlchemyWorkItemStore
+
+
+@pytest.fixture()
+def client(db_uri: str) -> TestClient:
+    """A TestClient over a minimal app mounting only the work-items router.
+
+    No auth_provider/permission_store → single-user mode (no auth required),
+    which keeps the test focused on the route behavior.
+    """
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(_request: Request, exc: OmnigentError) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": exc.code, "message": exc.message},
+        )
+
+    store = SqlAlchemyWorkItemStore(db_uri)
+    app.include_router(create_work_items_router(store), prefix="/v1")
+    return TestClient(app)
+
+
+def test_crud_flow(client: TestClient) -> None:
+    created = client.post(
+        "/v1/work-items",
+        json={"title": "Fix deploy", "source": "github", "external_id": "123"},
+    )
+    assert created.status_code == 200
+    payload = created.json()
+    assert payload["created"] is True
+    assert payload["object"] == "work_item"
+    wid = payload["id"]
+
+    listed = client.get("/v1/work-items").json()
+    assert listed["object"] == "list"
+    assert [i["id"] for i in listed["data"]] == [wid]
+
+    got = client.get(f"/v1/work-items/{wid}")
+    assert got.status_code == 200
+    assert got.json()["title"] == "Fix deploy"
+
+    patched = client.patch(
+        f"/v1/work-items/{wid}",
+        json={"status": "needs_review", "pr_url": "https://github.com/acme/app/pull/9"},
+    ).json()
+    assert patched["status"] == "needs_review"
+    assert patched["pr_url"].endswith("/pull/9")
+
+    assert client.get("/v1/work-items", params={"status": "needs_review"}).json()["data"]
+    assert client.get("/v1/work-items", params={"status": "done"}).json()["data"] == []
+
+    assert client.delete(f"/v1/work-items/{wid}").json() == {"deleted": True}
+    assert client.get(f"/v1/work-items/{wid}").status_code == 404
+
+
+def test_create_is_idempotent_by_dedup_key(client: TestClient) -> None:
+    first = client.post(
+        "/v1/work-items",
+        json={"title": "t", "source": "slack", "dedup_key": "slack:C1/1.2"},
+    ).json()
+    assert first["created"] is True
+    second = client.post(
+        "/v1/work-items",
+        json={"title": "dup", "source": "slack", "dedup_key": "slack:C1/1.2"},
+    ).json()
+    assert second["created"] is False
+    assert second["id"] == first["id"]
+
+
+def test_validation_and_not_found(client: TestClient) -> None:
+    bad = client.post("/v1/work-items", json={"title": "x", "source": "bogus"})
+    assert bad.status_code == 400
+
+    missing = client.patch("/v1/work-items/wi_nope", json={"status": "done"})
+    assert missing.status_code == 404

--- a/tests/server/test_work_items_routes.py
+++ b/tests/server/test_work_items_routes.py
@@ -86,3 +86,15 @@ def test_validation_and_not_found(client: TestClient) -> None:
 
     missing = client.patch("/v1/work-items/wi_nope", json={"status": "done"})
     assert missing.status_code == 404
+
+
+def test_patch_rejects_non_http_pr_url(client: TestClient) -> None:
+    # pr_url is rendered as a link, so a non-http(s) scheme is rejected.
+    created = client.post("/v1/work-items", json={"title": "t", "source": "manual"}).json()
+    wid = created["id"]
+    bad = client.patch(f"/v1/work-items/{wid}", json={"pr_url": "javascript:alert(1)"})
+    assert bad.status_code == 400
+    ok = client.patch(
+        f"/v1/work-items/{wid}", json={"pr_url": "https://github.com/acme/app/pull/1"}
+    )
+    assert ok.status_code == 200

--- a/tests/stores/conftest.py
+++ b/tests/stores/conftest.py
@@ -12,6 +12,7 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
+from omnigent.stores.work_item_store.sqlalchemy_store import SqlAlchemyWorkItemStore
 
 
 @pytest.fixture()
@@ -44,3 +45,11 @@ def artifact_store(tmp_path: Path) -> LocalArtifactStore:
     :returns: A LocalArtifactStore in a temp directory.
     """
     return LocalArtifactStore(str(tmp_path / "artifacts"))
+
+
+@pytest.fixture()
+def work_item_store(db_uri: str) -> SqlAlchemyWorkItemStore:
+    """
+    :returns: A SqlAlchemyWorkItemStore backed by the test database.
+    """
+    return SqlAlchemyWorkItemStore(db_uri)

--- a/tests/stores/test_work_item_store.py
+++ b/tests/stores/test_work_item_store.py
@@ -1,0 +1,95 @@
+"""Tests for SqlAlchemyWorkItemStore."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.stores.work_item_store.sqlalchemy_store import SqlAlchemyWorkItemStore
+
+
+def test_create_and_get(work_item_store: SqlAlchemyWorkItemStore) -> None:
+    item = work_item_store.create(
+        "wi_1",
+        "github",
+        "Fix the deploy script",
+        dedup_key="github:acme/app#123",
+        external_id="123",
+        body="The Friday deploy fails on the migration step.",
+    )
+    assert item.id == "wi_1"
+    assert item.source == "github"
+    assert item.status == "new"
+    assert item.dedup_key == "github:acme/app#123"
+    assert item.created_at > 0
+    assert item.updated_at is None
+
+    fetched = work_item_store.get("wi_1")
+    assert fetched is not None
+    assert fetched.title == "Fix the deploy script"
+    assert fetched.external_id == "123"
+
+
+def test_get_nonexistent(work_item_store: SqlAlchemyWorkItemStore) -> None:
+    assert work_item_store.get("wi_missing") is None
+
+
+def test_duplicate_dedup_key_raises(work_item_store: SqlAlchemyWorkItemStore) -> None:
+    work_item_store.create("wi_a", "slack", "First", dedup_key="slack:C1/167.1")
+    with pytest.raises(IntegrityError):
+        work_item_store.create("wi_b", "slack", "Dup", dedup_key="slack:C1/167.1")
+
+
+def test_get_by_dedup_key(work_item_store: SqlAlchemyWorkItemStore) -> None:
+    assert work_item_store.get_by_dedup_key("jira:OPS-7") is None
+    work_item_store.create("wi_j", "jira", "Rotate keys", dedup_key="jira:OPS-7")
+    found = work_item_store.get_by_dedup_key("jira:OPS-7")
+    assert found is not None
+    assert found.id == "wi_j"
+
+
+def test_list_filters_and_orders_newest_first(
+    work_item_store: SqlAlchemyWorkItemStore,
+) -> None:
+    work_item_store.create("wi_old", "manual", "Old", dedup_key="m:old", status="done")
+    work_item_store.create("wi_new", "manual", "New", dedup_key="m:new", status="new")
+
+    all_items = work_item_store.list()
+    assert {i.id for i in all_items} == {"wi_old", "wi_new"}
+    # Ordered newest-first: created_at must be non-increasing down the list.
+    # (Two rows written in the same wall-clock second tie on created_at, so we
+    # assert the ordering invariant rather than a specific tie order.)
+    created = [i.created_at for i in all_items]
+    assert created == sorted(created, reverse=True)
+
+    only_new = work_item_store.list(status="new")
+    assert [i.id for i in only_new] == ["wi_new"]
+
+    assert work_item_store.list(status="blocked") == []
+
+
+def test_update_sets_fields_and_timestamp(
+    work_item_store: SqlAlchemyWorkItemStore,
+) -> None:
+    work_item_store.create("wi_u", "github", "Add metric", dedup_key="github:acme/app#9")
+
+    updated = work_item_store.update(
+        "wi_u",
+        status="needs_review",
+        pr_url="https://github.com/acme/app/pull/9",
+        plan="1. add counter  2. wire dashboard",
+    )
+    assert updated is not None
+    assert updated.status == "needs_review"
+    assert updated.pr_url.endswith("/pull/9")
+    assert updated.plan.startswith("1.")
+    assert updated.updated_at is not None
+
+    assert work_item_store.update("wi_missing", status="done") is None
+
+
+def test_delete_is_idempotent(work_item_store: SqlAlchemyWorkItemStore) -> None:
+    work_item_store.create("wi_d", "manual", "Temp", dedup_key="m:temp")
+    assert work_item_store.delete("wi_d") is True
+    assert work_item_store.get("wi_d") is None
+    assert work_item_store.delete("wi_d") is False

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -120,6 +120,9 @@ def test_builtin_names_size_matches_registry() -> None:
                 "download_file",
                 "search_conversations",
                 "export_agent",
+                "create_work_item",
+                "list_tasks",
+                "update_work_item",
                 # Framework-owned (need runtime context, not
                 # user-instantiable). Policy ASKs surface as
                 # MCP-shape elicitations on the SSE stream and

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -121,7 +121,7 @@ def test_builtin_names_size_matches_registry() -> None:
                 "search_conversations",
                 "export_agent",
                 "create_work_item",
-                "list_tasks",
+                "list_work_items",
                 "update_work_item",
                 # Framework-owned (need runtime context, not
                 # user-instantiable). Policy ASKs surface as

--- a/tests/tools/builtins/test_work_item_tools.py
+++ b/tests/tools/builtins/test_work_item_tools.py
@@ -1,0 +1,103 @@
+"""Tests for the work-item builtin tools (create / list / update)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omnigent.stores.work_item_store.sqlalchemy_store import SqlAlchemyWorkItemStore
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins.work_items import (
+    CreateWorkItemTool,
+    ListTasksTool,
+    UpdateWorkItemTool,
+)
+
+_CTX = ToolContext(task_id="t1", agent_id="a1")
+
+
+@pytest.fixture()
+def wired_store(db_uri: str, monkeypatch: pytest.MonkeyPatch) -> SqlAlchemyWorkItemStore:
+    """A work-item store wired into ``runtime.get_work_item_store`` (lazy bind)."""
+    store = SqlAlchemyWorkItemStore(db_uri)
+    monkeypatch.setattr("omnigent.runtime.get_work_item_store", lambda: store)
+    return store
+
+
+def test_create_list_update_flow(wired_store: SqlAlchemyWorkItemStore) -> None:
+    create = CreateWorkItemTool()
+    out = json.loads(
+        create.invoke(
+            json.dumps(
+                {
+                    "title": "Fix deploy",
+                    "source": "github",
+                    "external_id": "123",
+                    "dedup_key": "github:acme/app#123",
+                }
+            ),
+            _CTX,
+        )
+    )
+    assert out["created"] is True
+    wid = out["work_item"]["id"]
+    assert out["work_item"]["status"] == "new"
+    # Cross-check it actually landed in the store.
+    assert wired_store.get(wid) is not None
+
+    # Same dedup_key → idempotent, resolves to the existing row.
+    dup = json.loads(
+        create.invoke(
+            json.dumps({"title": "dup", "source": "github", "dedup_key": "github:acme/app#123"}),
+            _CTX,
+        )
+    )
+    assert dup["created"] is False
+    assert dup["work_item"]["id"] == wid
+
+    listed = json.loads(ListTasksTool().invoke(json.dumps({}), _CTX))
+    assert listed["count"] == 1
+    assert listed["work_items"][0]["id"] == wid
+
+    upd = json.loads(
+        UpdateWorkItemTool().invoke(
+            json.dumps(
+                {
+                    "work_item_id": wid,
+                    "needs_review": True,
+                    "pr_url": "https://github.com/acme/app/pull/9",
+                }
+            ),
+            _CTX,
+        )
+    )
+    assert upd["work_item"]["status"] == "needs_review"
+    assert upd["work_item"]["pr_url"].endswith("/pull/9")
+
+    only_review = json.loads(ListTasksTool().invoke(json.dumps({"status": "needs_review"}), _CTX))
+    assert only_review["count"] == 1
+    assert json.loads(ListTasksTool().invoke(json.dumps({"status": "done"}), _CTX))["count"] == 0
+
+
+def test_validation_errors(wired_store: SqlAlchemyWorkItemStore) -> None:
+    create = CreateWorkItemTool()
+    assert "error" in json.loads(
+        create.invoke(json.dumps({"title": "x", "source": "bogus"}), _CTX)
+    )
+    assert "error" in json.loads(
+        create.invoke(json.dumps({"source": "manual"}), _CTX)
+    )  # missing title
+
+    not_found = json.loads(
+        UpdateWorkItemTool().invoke(
+            json.dumps({"work_item_id": "wi_nope", "status": "done"}), _CTX
+        )
+    )
+    assert not_found["error"] == "not_found"
+
+
+def test_store_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("omnigent.runtime.get_work_item_store", lambda: None)
+    out = json.loads(ListTasksTool().invoke(json.dumps({}), _CTX))
+    assert "error" in out

--- a/tests/tools/builtins/test_work_item_tools.py
+++ b/tests/tools/builtins/test_work_item_tools.py
@@ -75,9 +75,13 @@ def test_create_list_update_flow(wired_store: SqlAlchemyWorkItemStore) -> None:
     assert upd["work_item"]["status"] == "needs_review"
     assert upd["work_item"]["pr_url"].endswith("/pull/9")
 
-    only_review = json.loads(ListWorkItemsTool().invoke(json.dumps({"status": "needs_review"}), _CTX))
+    only_review = json.loads(
+        ListWorkItemsTool().invoke(json.dumps({"status": "needs_review"}), _CTX)
+    )
     assert only_review["count"] == 1
-    assert json.loads(ListWorkItemsTool().invoke(json.dumps({"status": "done"}), _CTX))["count"] == 0
+    assert (
+        json.loads(ListWorkItemsTool().invoke(json.dumps({"status": "done"}), _CTX))["count"] == 0
+    )
 
 
 def test_validation_errors(wired_store: SqlAlchemyWorkItemStore) -> None:

--- a/tests/tools/builtins/test_work_item_tools.py
+++ b/tests/tools/builtins/test_work_item_tools.py
@@ -105,3 +105,33 @@ def test_store_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("omnigent.runtime.get_work_item_store", lambda: None)
     out = json.loads(ListWorkItemsTool().invoke(json.dumps({}), _CTX))
     assert "error" in out
+
+
+def test_create_defaults_conversation_id_from_ctx(
+    wired_store: SqlAlchemyWorkItemStore, db_uri: str
+) -> None:
+    # Like the runner proxy, an item created mid-session links to the ambient
+    # conversation when none is given explicitly.
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="c").id
+    ctx = ToolContext(task_id="t1", agent_id="a1", conversation_id=conv)
+    out = json.loads(
+        CreateWorkItemTool().invoke(json.dumps({"title": "T", "source": "manual"}), ctx)
+    )
+    assert out["work_item"]["conversation_id"] == conv
+
+
+def test_update_rejects_non_http_pr_url(wired_store: SqlAlchemyWorkItemStore) -> None:
+    created = json.loads(
+        CreateWorkItemTool().invoke(json.dumps({"title": "T", "source": "manual"}), _CTX)
+    )
+    wid = created["work_item"]["id"]
+    bad = json.loads(
+        UpdateWorkItemTool().invoke(
+            json.dumps({"work_item_id": wid, "pr_url": "file:///etc/passwd"}), _CTX
+        )
+    )
+    assert "error" in bad and "pr_url" in bad["error"]

--- a/tests/tools/builtins/test_work_item_tools.py
+++ b/tests/tools/builtins/test_work_item_tools.py
@@ -10,7 +10,7 @@ from omnigent.stores.work_item_store.sqlalchemy_store import SqlAlchemyWorkItemS
 from omnigent.tools.base import ToolContext
 from omnigent.tools.builtins.work_items import (
     CreateWorkItemTool,
-    ListTasksTool,
+    ListWorkItemsTool,
     UpdateWorkItemTool,
 )
 
@@ -56,7 +56,7 @@ def test_create_list_update_flow(wired_store: SqlAlchemyWorkItemStore) -> None:
     assert dup["created"] is False
     assert dup["work_item"]["id"] == wid
 
-    listed = json.loads(ListTasksTool().invoke(json.dumps({}), _CTX))
+    listed = json.loads(ListWorkItemsTool().invoke(json.dumps({}), _CTX))
     assert listed["count"] == 1
     assert listed["work_items"][0]["id"] == wid
 
@@ -75,9 +75,9 @@ def test_create_list_update_flow(wired_store: SqlAlchemyWorkItemStore) -> None:
     assert upd["work_item"]["status"] == "needs_review"
     assert upd["work_item"]["pr_url"].endswith("/pull/9")
 
-    only_review = json.loads(ListTasksTool().invoke(json.dumps({"status": "needs_review"}), _CTX))
+    only_review = json.loads(ListWorkItemsTool().invoke(json.dumps({"status": "needs_review"}), _CTX))
     assert only_review["count"] == 1
-    assert json.loads(ListTasksTool().invoke(json.dumps({"status": "done"}), _CTX))["count"] == 0
+    assert json.loads(ListWorkItemsTool().invoke(json.dumps({"status": "done"}), _CTX))["count"] == 0
 
 
 def test_validation_errors(wired_store: SqlAlchemyWorkItemStore) -> None:
@@ -99,5 +99,5 @@ def test_validation_errors(wired_store: SqlAlchemyWorkItemStore) -> None:
 
 def test_store_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("omnigent.runtime.get_work_item_store", lambda: None)
-    out = json.loads(ListTasksTool().invoke(json.dumps({}), _CTX))
+    out = json.loads(ListWorkItemsTool().invoke(json.dumps({}), _CTX))
     assert "error" in out

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -70,6 +70,12 @@ _ALWAYS_PRESENT_TOOLS: frozenset[str] = frozenset(
         # browse the registry and add policies at runtime.
         "sys_add_policy",
         "sys_policy_registry",
+        # Work-item (#3) builtins are always auto-registered (#12) so agents +
+        # the Omnigent MCP can create and track work items without the spec
+        # opting in.
+        "create_work_item",
+        "list_work_items",
+        "update_work_item",
     }
 )
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ const ApprovePage = lazy(() =>
   import("@/pages/ApprovePage").then((m) => ({ default: m.ApprovePage })),
 );
 const InboxPage = lazy(() => import("@/pages/InboxPage").then((m) => ({ default: m.InboxPage })));
+const TasksPage = lazy(() => import("@/pages/TasksPage").then((m) => ({ default: m.TasksPage })));
 const SettingsPage = lazy(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 );
@@ -119,6 +120,7 @@ function App({ basename }: AppProps = {}) {
           <Route path={prefix || "/"} element={<ChatPage />} />
           <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
           <Route path={`${prefix}/inbox`} element={<InboxPage />} />
+          <Route path={`${prefix}/tasks`} element={<TasksPage />} />
           {/* Settings renders into the chat outlet so the conversations
               sidebar stays put — entering settings only swaps the card's
               content (the section nav) and the main area. The active section

--- a/web/src/hooks/useWorkItems.test.ts
+++ b/web/src/hooks/useWorkItems.test.ts
@@ -1,0 +1,117 @@
+// Unit tests for the work-items hooks: the request URL/method/body contract,
+// the {object,data} envelope unwrap, throw-on-non-2xx, and that mutations
+// invalidate the shared ["work-items"] key so the Tasks list refreshes.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDeleteWorkItem, useUpdateWorkItem, useWorkItems } from "./useWorkItems";
+import type { WorkItem } from "@/lib/workItemsApi";
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function makeItem(overrides: Partial<WorkItem> & { id: string }): WorkItem {
+  return {
+    object: "work_item",
+    source: "manual",
+    external_id: null,
+    dedup_key: `manual:${overrides.id}`,
+    title: "t",
+    body: null,
+    status: "new",
+    pr_url: null,
+    conversation_id: null,
+    assignee_user_id: null,
+    created_by: null,
+    plan: null,
+    created_at: 0,
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+describe("useWorkItems", () => {
+  it("GETs /v1/work-items and unwraps the data array", async () => {
+    const items = [makeItem({ id: "wi1" }), makeItem({ id: "wi2" })];
+    fetchMock.mockResolvedValue(mockResponse({ object: "list", data: items }));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useWorkItems(), { wrapper: wrapperWith(queryClient) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/work-items");
+    expect(result.current.data).toEqual(items);
+  });
+
+  it("passes a status filter as a query param", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ object: "list", data: [] }));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useWorkItems({ status: "needs_review" }), {
+      wrapper: wrapperWith(queryClient),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/work-items?status=needs_review");
+  });
+
+  it("surfaces an error on non-2xx", async () => {
+    fetchMock.mockResolvedValue(mockResponse({}, { ok: false, status: 500 }));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useWorkItems(), { wrapper: wrapperWith(queryClient) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useUpdateWorkItem", () => {
+  it("PATCHes the encoded id with the patch and invalidates the list", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(makeItem({ id: "wi 1", status: "done" })));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateWorkItem(), { wrapper: wrapperWith(queryClient) });
+    result.current.mutate({ id: "wi 1", patch: { status: "done" } });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/work-items/wi%201");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ status: "done" });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["work-items"] });
+  });
+});
+
+describe("useDeleteWorkItem", () => {
+  it("DELETEs the encoded id and invalidates the list", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ deleted: true }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useDeleteWorkItem(), { wrapper: wrapperWith(queryClient) });
+    result.current.mutate("wi9");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/work-items/wi9");
+    expect(init.method).toBe("DELETE");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["work-items"] });
+  });
+});

--- a/web/src/hooks/useWorkItems.ts
+++ b/web/src/hooks/useWorkItems.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  deleteWorkItem,
+  listWorkItems,
+  updateWorkItem,
+  type ListWorkItemsParams,
+  type UpdateWorkItemPatch,
+  type WorkItem,
+} from "@/lib/workItemsApi";
+
+const QUERY_KEY = ["work-items"];
+
+/**
+ * List work items (Tasks), newest first. Polls so agent-created items appear
+ * without a manual refresh (the server has no work-item push channel yet).
+ */
+export function useWorkItems(params: ListWorkItemsParams = {}) {
+  return useQuery<WorkItem[]>({
+    queryKey: [...QUERY_KEY, params.status ?? null, params.conversationId ?? null],
+    queryFn: () => listWorkItems(params),
+    staleTime: 5_000,
+    refetchInterval: 15_000,
+  });
+}
+
+/** PATCH /v1/work-items/{id} — update status / pr_url / etc. */
+export function useUpdateWorkItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: UpdateWorkItemPatch }) =>
+      updateWorkItem(id, patch),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+}
+
+/** DELETE /v1/work-items/{id}. */
+export function useDeleteWorkItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteWorkItem(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+}

--- a/web/src/lib/workItemsApi.ts
+++ b/web/src/lib/workItemsApi.ts
@@ -1,0 +1,80 @@
+/**
+ * Typed client for the `/v1/work-items` endpoints.
+ * Mirrors `omnigent/server/routes/work_items.py`.
+ */
+
+import { authenticatedFetch } from "./identity";
+
+/** Lifecycle states, matching `omnigent.entities.WORK_ITEM_STATUSES`. */
+export const WORK_ITEM_STATUSES = [
+  "new",
+  "planned",
+  "in_progress",
+  "blocked",
+  "needs_review",
+  "done",
+] as const;
+
+export type WorkItemStatus = (typeof WORK_ITEM_STATUSES)[number];
+
+/** A work item returned by the REST API. */
+export interface WorkItem {
+  id: string;
+  object: "work_item";
+  source: string;
+  external_id: string | null;
+  dedup_key: string;
+  title: string;
+  body: string | null;
+  status: string;
+  pr_url: string | null;
+  conversation_id: string | null;
+  assignee_user_id: string | null;
+  created_by: string | null;
+  plan: string | null;
+  created_at: number;
+  updated_at: number | null;
+}
+
+export interface ListWorkItemsParams {
+  status?: string;
+  conversationId?: string;
+}
+
+export async function listWorkItems(params: ListWorkItemsParams = {}): Promise<WorkItem[]> {
+  const qs = new URLSearchParams();
+  if (params.status) qs.set("status", params.status);
+  if (params.conversationId) qs.set("conversation_id", params.conversationId);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  const res = await authenticatedFetch(`/v1/work-items${suffix}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  const body = (await res.json()) as { object: string; data: WorkItem[] };
+  return body.data;
+}
+
+export interface UpdateWorkItemPatch {
+  title?: string;
+  body?: string;
+  status?: string;
+  pr_url?: string;
+  conversation_id?: string;
+  assignee_user_id?: string;
+  plan?: string;
+}
+
+export async function updateWorkItem(id: string, patch: UpdateWorkItemPatch): Promise<WorkItem> {
+  const res = await authenticatedFetch(`/v1/work-items/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as WorkItem;
+}
+
+export async function deleteWorkItem(id: string): Promise<void> {
+  const res = await authenticatedFetch(`/v1/work-items/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tasks / Work-Items page (``/tasks``).
+ *
+ * Lists work items from ``/v1/work-items`` (agent- or externally-created),
+ * lets you change a task's status, open the conversation working on it, or
+ * delete it. Reached from the left-pane Tasks button (below Inbox).
+ */
+
+import { ExternalLinkIcon, RefreshCwIcon, TrashIcon } from "lucide-react";
+import { PageScroll } from "@/components/PageScroll";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/lib/routing";
+import { WORK_ITEM_STATUSES, type WorkItem } from "@/lib/workItemsApi";
+import { useDeleteWorkItem, useUpdateWorkItem, useWorkItems } from "@/hooks/useWorkItems";
+
+function TaskRow({ item }: { item: WorkItem }) {
+  const update = useUpdateWorkItem();
+  const remove = useDeleteWorkItem();
+
+  return (
+    <li className="flex items-center gap-3 rounded-lg border px-3 py-2" data-testid="task-row">
+      <select
+        aria-label="Status"
+        className="shrink-0 rounded-md border bg-background px-2 py-1 text-xs"
+        value={item.status}
+        onChange={(e) => update.mutate({ id: item.id, patch: { status: e.target.value } })}
+        disabled={update.isPending}
+      >
+        {WORK_ITEM_STATUSES.map((s) => (
+          <option key={s} value={s}>
+            {s.replace(/_/g, " ")}
+          </option>
+        ))}
+      </select>
+
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">
+          {item.conversation_id ? (
+            <Link className="hover:underline" to={`/c/${item.conversation_id}`}>
+              {item.title}
+            </Link>
+          ) : (
+            item.title
+          )}
+        </div>
+        <div className="truncate text-xs text-muted-foreground">
+          {item.source}
+          {item.external_id ? ` · ${item.external_id}` : ""}
+        </div>
+      </div>
+
+      {item.pr_url && (
+        <a
+          href={item.pr_url}
+          target="_blank"
+          rel="noreferrer"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label="Open pull request"
+        >
+          <ExternalLinkIcon className="size-4" />
+        </a>
+      )}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Delete task"
+        onClick={() => remove.mutate(item.id)}
+        disabled={remove.isPending}
+      >
+        <TrashIcon className="size-4" />
+      </Button>
+    </li>
+  );
+}
+
+export function TasksPage() {
+  const { data: items, isLoading, isError, refetch, isFetching } = useWorkItems();
+
+  return (
+    <PageScroll>
+      <div className="mx-auto w-full max-w-3xl px-4 py-6">
+        <div className="mb-4 flex items-center justify-between">
+          <h1 className="text-lg font-semibold">Tasks</h1>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Refresh tasks"
+            onClick={() => void refetch()}
+            disabled={isFetching}
+          >
+            <RefreshCwIcon className="size-4" />
+          </Button>
+        </div>
+
+        {isLoading && <p className="text-sm text-muted-foreground">Loading tasks…</p>}
+        {isError && <p className="text-sm text-destructive">Failed to load tasks.</p>}
+        {items && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No tasks yet. Agents create them with <code>create_work_item</code>, or push them in
+            from Slack/email/GitHub/Jira.
+          </p>
+        )}
+        {items && items.length > 0 && (
+          <ul className="flex flex-col gap-2">
+            {items.map((item) => (
+              <TaskRow key={item.id} item={item} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </PageScroll>
+  );
+}
+
+export default TasksPage;

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -182,13 +182,19 @@ interface SidebarProps {
  * which is `inbox` in both standalone and embedded modes. Conversation ids are
  * `conv_…`-prefixed, so a chat route's leaf can never collide with `inbox`.
  */
-function useActiveNavItem(): { isNewChatPage: boolean; isInboxPage: boolean } {
+function useActiveNavItem(): {
+  isNewChatPage: boolean;
+  isInboxPage: boolean;
+  isTasksPage: boolean;
+} {
   const { conversationId: activeConversationId } = useParams<{ conversationId: string }>();
-  const isInboxPage = useLocation().pathname.split("/").filter(Boolean).at(-1) === "inbox";
-  // Exclude inbox: it also has no `:conversationId`, so it would otherwise
-  // light up the "New session" button.
-  const isNewChatPage = activeConversationId == null && !isInboxPage;
-  return { isNewChatPage, isInboxPage };
+  const lastSegment = useLocation().pathname.split("/").filter(Boolean).at(-1);
+  const isInboxPage = lastSegment === "inbox";
+  const isTasksPage = lastSegment === "tasks";
+  // Exclude inbox/tasks: they also have no `:conversationId`, so they'd
+  // otherwise light up the "New session" button.
+  const isNewChatPage = activeConversationId == null && !isInboxPage && !isTasksPage;
+  return { isNewChatPage, isInboxPage, isTasksPage };
 }
 
 /**
@@ -299,7 +305,7 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   }
 
   // Which top-level nav button to highlight for the current route.
-  const { isNewChatPage, isInboxPage } = useActiveNavItem();
+  const { isNewChatPage, isInboxPage, isTasksPage } = useActiveNavItem();
 
   // On /settings the card keeps its chrome but swaps the conversation list
   // for the settings section nav (see settingsNav.tsx) — entering settings
@@ -443,6 +449,24 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">Inbox</TooltipContent>
+              </Tooltip>
+              {/* Tasks lives just below Inbox — the work-items list (#3). */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    asChild
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Tasks"
+                    className={cn("relative rounded-full", isTasksPage && "bg-muted")}
+                    data-testid="tasks-button"
+                  >
+                    <Link to="/tasks" onClick={onNavClick}>
+                      <ListChecksIcon className="size-4" />
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Tasks</TooltipContent>
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
## Related issue

Closes #1701.

Independent, single-feature PR off `main` (re-doing the earlier stacked set as one-PR-per-feature, per @serena-ruan on #1600). First of the series.

## Summary

Adds the **Work items / Tasks** layer (#3):
- `work_items` table + store + `/v1/work-items` REST (CRUD) + **idempotent** intake webhooks (Slack/email/GitHub/Jira → task, dedup by `dedup_key`, signed).
- Agent tools `create_work_item` / `list_work_items` / `update_work_item`, framework-auto-registered and dispatched on **both** the proxy and native (Claude/Codex) relay paths (proxy to `/v1/work-items`). A created item defaults to its originating session.
- Left-pane **Tasks** panel (`web/`) listing work items.

## Test Plan

- `uv run pytest tests/stores/test_work_item_store.py tests/server/test_work_items_routes.py tests/server/test_work_item_intake.py tests/server/test_webhook_verify.py tests/tools/builtins/test_work_item_tools.py tests/runner/test_work_management_dispatch.py tests/tools/test_manager.py` — **75 passed**; ruff clean.
- `web/`: `tsc -b` clean; `vitest` (useWorkItems) 5 passed.
- E2E: `tests/e2e/test_work_items_e2e.py` (REST round-trip) + `tests/e2e_ui/tasks/test_tasks_panel.py` (Playwright: Tasks panel renders a seeded item).
- Demo video attached on #1701.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The agent-driven tool path is unit-covered (`test_work_management_dispatch.py` pins the REST mapping); the agent→runner→server happy-path needs a real LLM (the mock + native bridge replays canned tool calls without driving proxied-tool dispatch). Manual: ran an isolated server, POSTed intake payloads, and viewed the Tasks panel.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
