### PR TITLE
fix(policies): gate Claude MultiEdit in worktree_guard

### DIFF
--- a/omnigent/inner/nessie/policies.py
+++ b/omnigent/inner/nessie/policies.py
@@ -538,12 +538,13 @@ def worktree_guard(
     :returns: An evaluator ``fn(event, config)`` returning a V0 decision.
     """
 
-    # Match Omnigent built-in OS write/edit, Claude/Codex native Write/Edit
-    # (surfaced via the PreToolUse hook), and Pi's native lowercase
+    # Match Omnigent built-in OS write/edit, Claude/Codex native Write/Edit/
+    # MultiEdit (surfaced via the PreToolUse hook), and Pi's native lowercase
     # write/edit (surfaced via the pi ``tool_call`` hook). Pi uses the same
     # ``path`` argument key as the Omnigent tools, so no Pi-specific arg
-    # branch is needed below.
-    _write_tools = {"sys_os_write", "sys_os_edit", "Write", "Edit", "write", "edit"}
+    # branch is needed below. ``MultiEdit`` carries ``file_path`` like the
+    # other Claude native edit tools, so the extraction below already covers it.
+    _write_tools = {"sys_os_write", "sys_os_edit", "Write", "Edit", "MultiEdit", "write", "edit"}
 
     def _evaluate(event: _Json, config: _Json) -> _Json:  # noqa: ARG001
         """

--- a/tests/inner/nessie/test_policies.py
+++ b/tests/inner/nessie/test_policies.py
@@ -402,6 +402,12 @@ def test_worktree_guard_blocks_escapes(path: str, expected: str) -> None:
         # Claude native Edit also uses ``file_path``.
         ("Edit", "file_path", "main.py", "ALLOW"),
         ("Edit", "file_path", "~/.bashrc", "DENY"),
+        # Claude native MultiEdit also uses ``file_path``. Without it in the
+        # gated set, an unsandboxed worker could escape its worktree via a
+        # multi-file edit -- the gap these cases pin.
+        ("MultiEdit", "file_path", "src/app.py", "ALLOW"),
+        ("MultiEdit", "file_path", "/etc/passwd", "DENY"),
+        ("MultiEdit", "file_path", "../escape.py", "DENY"),
         # Pi native write/edit (lowercase) use ``path`` (Omnigent convention).
         ("write", "path", "src/app.py", "ALLOW"),
         ("write", "path", "/etc/passwd", "DENY"),
@@ -413,6 +419,9 @@ def test_worktree_guard_blocks_escapes(path: str, expected: str) -> None:
         "Write-escape",
         "Edit-in-tree",
         "Edit-home-escape",
+        "MultiEdit-in-tree",
+        "MultiEdit-absolute",
+        "MultiEdit-escape",
         "pi-write-in-tree",
         "pi-write-absolute",
         "pi-edit-escape",


### PR DESCRIPTION
## Summary

`worktree_guard` confines an unsandboxed worker's file writes to its worktree by DENYING write/edit tool calls whose path is absolute or escapes upward. Its gated tool set omitted Claude's **`MultiEdit`**, so a worker could write *outside* its worktree via a multi-file edit -- bypassing the confinement that makes unsandboxed workers safe.

This was surfaced while reviewing #1196: the `read_only_os` policy added there already lists `MultiEdit` and its comment claims the set is "the same tool set worktree_guard gates" -- but it wasn't. This brings `worktree_guard` in lockstep and makes that comment accurate.

## Fix

- Add `"MultiEdit"` to `worktree_guard`'s gated set. `MultiEdit` carries `file_path` like the other Claude native edit tools, so the existing path extraction (`args.get("path") or args.get("file_path")`) already covers it -- only the set membership was missing.

## Test Plan

- Added `MultiEdit` cases (in-tree `ALLOW`, absolute/escape `DENY`) to `test_worktree_guard_gates_native_write_edit`.
- Confirmed they are genuine regression tests: on the pre-fix code the two DENY cases return `ALLOW` (the gap); after the fix all pass.
- `uv run --extra dev pytest tests/inner/nessie/test_policies.py -k worktree_guard` -> 18 passed.
- `ruff check` / `ruff format --check` on both files -> clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

This pull request and its description were written by Isaac.
