### PR TITLE
feat(kiro-native): register the kiro bridge root for the shared MCP relay (#1680)

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -53,6 +53,7 @@ from urllib import error, request
 
 from omnigent._platform import stable_user_id
 from omnigent.claude_native_message_display_hook import MESSAGE_DELTAS_FILE
+from omnigent.kiro_native_bridge import bridge_root as kiro_bridge_root
 
 if TYPE_CHECKING:
     from omnigent.llms.context_window import ModelPricing
@@ -269,10 +270,18 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
             trusted_parent = opencode_root.parent.parent
         return _absolute_syntactic_path(trusted_parent)
 
+    kiro_root = _absolute_syntactic_path(kiro_bridge_root())
+    if target.is_relative_to(kiro_root):
+        # Same shape as cursor-native ($TMPDIR/omnigent-<uid>/kiro-native): trust
+        # the uid-scoped temp dir's parent and validate/chmod the two
+        # bridge-owned directories below it.
+        return _absolute_syntactic_path(kiro_root.parent.parent)
+
     raise RuntimeError(
         f"bridge dir {target!s} is not under an allowed bridge root "
         f"({claude_root!s}, {codex_root!s}, {cursor_root!s}, "
-        f"{antigravity_root!s}, {qwen_root!s}, {hermes_root!s}, {opencode_root!s})"
+        f"{antigravity_root!s}, {qwen_root!s}, {hermes_root!s}, {opencode_root!s}, "
+        f"{kiro_root!s})"
     )
 
 

--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -77,6 +77,16 @@ _CHILD_ENV_ALLOWLIST = [
 ]
 
 
+def bridge_root() -> Path:
+    """Return the uid-scoped Kiro-native bridge root.
+
+    Mirrors the sibling harnesses' ``bridge_root`` accessor so the shared
+    ``serve-mcp`` / relay infrastructure in ``claude_native_bridge`` can
+    recognize Kiro bridge dirs as a trusted root.
+    """
+    return _BRIDGE_ROOT
+
+
 def bridge_dir_for_session_id(session_id: str) -> Path:
     """Return the per-session Kiro bridge directory."""
     digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -369,6 +369,37 @@ def test_trusted_parent_accepts_qwen_native_bridge_dir(
     assert trusted == claude_native_bridge._absolute_syntactic_path(qwen_root.parent.parent)
 
 
+def test_trusted_parent_accepts_kiro_native_bridge_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The relay's bridge-root allowlist accepts kiro-native bridge dirs.
+
+    kiro-native reuses the shared ``serve-mcp`` / relay infrastructure but keeps
+    files under its own root (``$TMPDIR/omnigent-<uid>/kiro-native``). Without the
+    kiro branch, ``start_tool_relay`` -> ``_ensure_secure_dir`` ->
+    ``_trusted_parent_for_bridge_dir`` raises ``not under an allowed bridge root``
+    and the relay (and serve-mcp's own ``server.json`` write) never start. This
+    pins the kiro-native branch.
+    """
+    from omnigent import kiro_native_bridge
+
+    # Distinct claude root so the kiro target can't match the claude branch
+    # first (the autouse fixture points the claude root at ``tmp_path``).
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native")
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    # kiro root mirrors production shape: <uid-scoped temp>/kiro-native.
+    kiro_root = tmp_path / "omnigent-test" / "kiro-native"
+    monkeypatch.setattr(kiro_native_bridge, "_BRIDGE_ROOT", kiro_root)
+
+    target = claude_native_bridge._absolute_syntactic_path(kiro_root / "abc123")
+    trusted = claude_native_bridge._trusted_parent_for_bridge_dir(target)
+
+    # Same anchor as cursor-native: the uid-scoped temp dir's parent.
+    assert trusted == claude_native_bridge._absolute_syntactic_path(kiro_root.parent.parent)
+
+
 def test_trusted_parent_rejects_path_outside_all_roots_and_names_qwen(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Part of #1680 (wire the Omnigent MCP into kiro-native). This is the first of two small PRs: the foundation that lets the shared `serve-mcp` / tool-relay infrastructure recognize kiro bridge dirs. The launch wiring (workspace `mcp.json` + relay seeding) follows in a second PR.

## Why

The shared relay/MCP code in `claude_native_bridge` validates that bridge files live under a known bridge root via `_trusted_parent_for_bridge_dir` (used by `start_tool_relay` -> `_ensure_secure_dir`, and by serve-mcp's own `server.json` write at boot). The kiro-native root (`$TMPDIR/omnigent-<uid>/kiro-native`) was not in the allowlist, so any attempt to start the relay or boot serve-mcp for kiro would raise `bridge dir ... is not under an allowed bridge root`.

## What changed

- `omnigent/kiro_native_bridge.py`: add a `bridge_root()` accessor (mirrors the sibling harnesses' accessor).
- `omnigent/claude_native_bridge.py`: add the kiro branch to `_trusted_parent_for_bridge_dir`, using the same anchor as cursor/qwen/hermes (`$TMPDIR/omnigent-<uid>/kiro-native` -> trust the uid-scoped temp dir's parent), and name the kiro root in the error message.

No behavior change on its own (nothing wires serve-mcp for kiro yet); this just unblocks the follow-up.

## Testing

`uv run --extra dev pytest tests/test_claude_native_bridge.py -k trusted_parent tests/test_kiro_native_bridge.py tests/runtime/test_kiro_spawn_env.py -q` -> all pass, including a new `test_trusted_parent_accepts_kiro_native_bridge_dir` mirroring the qwen guard. `ruff check` + `ruff format --check` clean.

This pull request and its description were written by Isaac.
