### PR TITLE
fix(credentials): resolve OAuth Databricks profiles via the databricks CLI when the SDK is absent

### DIFF
--- a/omnigent/runtime/credentials/databricks.py
+++ b/omnigent/runtime/credentials/databricks.py
@@ -18,6 +18,15 @@ token) by checking, in order:
 3. The ``[DEFAULT]`` section of the same config file via raw
    configparser, used either when no profile is requested or when
    the requested profile is missing.
+4. The ``databricks`` CLI binary (``databricks auth describe`` for the
+   host, ``databricks auth token`` for the bearer). This mirrors the
+   per-request ``auth_command`` the harnesses run, so OAuth
+   (``auth_type = databricks-cli``) profiles — whose cfg sections carry
+   NO static ``token`` — still resolve when the Python ``databricks-sdk``
+   is not installed (it now lives in the optional ``databricks`` / ``all``
+   extra, so SDK-less installs are expected). Consulted only after the SDK
+   and the plaintext-cfg paths come up empty, so static-token profiles
+   never pay the subprocess cost.
 
 If none of the above yield both a host and a token, the resolver raises
 ``OSError`` with a message that lists every source it tried.
@@ -48,8 +57,11 @@ demand (which performs refresh-token handling transparently).
 from __future__ import annotations
 
 import configparser
+import json
 import logging
 import os
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -214,6 +226,106 @@ def _read_section(config: configparser.ConfigParser, section: str) -> WorkspaceC
     )
 
 
+# The `databricks` CLI mints OAuth tokens (and serves PATs) without the Python
+# SDK — the same `databricks auth token` path the harness `auth_command` runs.
+# Refreshing an OAuth access token can make a network round-trip, so allow a
+# few seconds (matches the auth-command budget elsewhere in the codebase).
+_CLI_AUTH_TIMEOUT_S: float = 15.0
+
+
+def _databricks_cli_json(args: list[str], *, timeout: float) -> dict[str, object] | None:
+    """Run a ``databricks`` CLI subcommand with ``--output json`` and parse it.
+
+    Total by contract: any failure (binary absent, non-zero exit, timeout,
+    non-JSON output) returns ``None`` so the credential resolver can fall
+    through cleanly rather than raising from a subprocess.
+
+    :param args: CLI args after the binary, e.g.
+        ``["auth", "token", "--profile", "oss"]``. ``--output json`` is
+        appended here.
+    :param timeout: Seconds to allow the subprocess before giving up.
+    :returns: The parsed JSON object, or ``None`` when the binary is
+        missing, the command fails/times out, or the output is not a
+        JSON object.
+    """
+    binary = shutil.which("databricks")
+    if binary is None:
+        return None
+    try:
+        result = subprocess.run(
+            [binary, *args, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload: object = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _host_from_describe(described: dict[str, object]) -> str | None:
+    """Extract the workspace host from ``databricks auth describe`` JSON.
+
+    The CLI nests the host under ``details.host``; a flat top-level
+    ``host`` is accepted as a defensive fallback across CLI versions.
+
+    :param described: Parsed ``databricks auth describe --output json`` object.
+    :returns: The workspace host, or ``None`` when absent/empty.
+    """
+    details = described.get("details")
+    if isinstance(details, dict):
+        host = details.get("host")
+        if isinstance(host, str) and host:
+            return host
+    host = described.get("host")
+    return host if isinstance(host, str) and host else None
+
+
+def _try_resolve_via_cli(profile: str | None) -> WorkspaceCreds | None:
+    """Resolve credentials via the ``databricks`` CLI binary.
+
+    Mirrors the harness ``auth_command`` (``databricks auth token --profile
+    ...``), so OAuth (``databricks-cli``) profiles — whose cfg sections carry
+    no static ``token`` — resolve even when the Python ``databricks-sdk`` is
+    not installed. The host comes from ``databricks auth describe`` and the
+    bearer from ``databricks auth token``. Never raises (see
+    :func:`_databricks_cli_json`): any failure returns ``None`` so the caller
+    falls through to its final ``OSError``.
+
+    :param profile: The profile to authenticate against, e.g. ``"oss"``;
+        ``None`` lets the CLI use its own resolution order (``DEFAULT`` /
+        ``DATABRICKS_CONFIG_PROFILE`` env var).
+    :returns: A :class:`WorkspaceCreds`, or ``None`` when the CLI is
+        unavailable or cannot mint a token.
+    """
+    profile_args = ["--profile", profile] if profile else []
+    described = _databricks_cli_json(
+        ["auth", "describe", *profile_args], timeout=_CLI_AUTH_TIMEOUT_S
+    )
+    if described is None:
+        return None
+    host = _host_from_describe(described)
+    if host is None:
+        return None
+    minted = _databricks_cli_json(["auth", "token", *profile_args], timeout=_CLI_AUTH_TIMEOUT_S)
+    if minted is None:
+        return None
+    token = minted.get("access_token")
+    if not isinstance(token, str) or not token:
+        return None
+    _logger.debug(
+        "resolved Databricks workspace creds via the databricks CLI (profile=%r)", profile
+    )
+    return WorkspaceCreds(host=_strip_trailing_slash(host), token=token)
+
+
 def _call_sdk_authenticate(profile: str | None) -> WorkspaceCreds | None:
     """
     Call ``databricks-sdk``'s ``Config.authenticate()`` once and unpack
@@ -233,10 +345,13 @@ def _call_sdk_authenticate(profile: str | None) -> WorkspaceCreds | None:
     try:
         from databricks.sdk.config import Config
     except ImportError as exc:
-        # Pinned dep missing = real env bug, not routine auth failure.
-        _logger.warning(
-            "databricks-sdk is not importable: %s — OAuth profiles will be invisible "
-            "to the resolver, falling through to configparser path.",
+        # databricks-sdk now lives in an optional extra, so an SDK-less install
+        # is expected rather than a bug. OAuth profiles are still resolvable via
+        # the `databricks` CLI fallback in resolve_databricks_workspace, so this
+        # is INFO (kept in cli-*.log) rather than a stderr-bound WARNING.
+        _logger.info(
+            "databricks-sdk is not importable: %s — falling through to the "
+            "`databricks` CLI / configparser resolution path.",
             exc,
         )
         return None
@@ -363,7 +478,8 @@ def _build_resolution_error_message(profile: str | None, cfg_path: Path) -> str:
         "(1) databricks-sdk Config(profile="
         f"{profile!r}).authenticate(), "
         f"(2) {profile_clause}, "
-        f"(3) [DEFAULT] section in {cfg_path}."
+        f"(3) [DEFAULT] section in {cfg_path}, "
+        "(4) the `databricks` CLI (`databricks auth token`)."
     )
 
 
@@ -386,7 +502,11 @@ def resolve_databricks_workspace(profile: str | None) -> WorkspaceCreds:
        — no silent fallback to ``[DEFAULT]``.
     3. The ``[DEFAULT]`` section of the Databricks config file via raw
        configparser (only when *profile* is ``None``).
-    4. ``OSError`` listing every source tried.
+    4. The ``databricks`` CLI binary (``databricks auth describe`` +
+       ``databricks auth token``) — covers OAuth (``databricks-cli``)
+       profiles, which carry no static ``token``, when the Python SDK
+       (step 1) is not installed. Mirrors the harness ``auth_command``.
+    5. ``OSError`` listing every source tried.
 
     The config file path is ``$DATABRICKS_CONFIG_FILE`` when that env
     var is set, otherwise ``~/.databrickscfg``.
@@ -417,22 +537,38 @@ def resolve_databricks_workspace(profile: str | None) -> WorkspaceCreds:
     effective_profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
 
     cfg_path = _databrickscfg_path()
+    malformed_exc: _SectionPresentButInvalid | None = None
     try:
         from_cfg = _try_resolve_from_cfg(effective_profile, cfg_path)
     except _SectionAbsent:
         # Named profile explicitly requested but not present in the
         # file — fail loud rather than silently routing to [DEFAULT]
-        # (a different workspace). This is the typo-in-profile guard.
+        # (a different workspace). This is the typo-in-profile guard:
+        # a nonexistent profile is a typo, not an OAuth login, so the
+        # CLI fallback below is deliberately NOT attempted here.
         raise OSError(
             f"Databricks profile [{effective_profile}] not found in {cfg_path}. "
             "Check that the section name matches exactly (case-sensitive) "
             "and that the file exists."
         ) from None
     except _SectionPresentButInvalid as exc:
-        raise OSError(
-            f"Databricks profile [{effective_profile}] in {cfg_path} is malformed: {exc}"
-        ) from exc
+        # Section exists with a host but no static token — the hallmark of an
+        # OAuth (`databricks-cli`) profile. Defer the malformed error so the
+        # `databricks` CLI fallback gets a chance to mint a token first.
+        from_cfg = None
+        malformed_exc = exc
     if from_cfg is not None:
         return from_cfg
 
+    # SDK + plaintext cfg both came up empty. Mint via the `databricks` CLI
+    # binary — the same path the harness `auth_command` uses — so OAuth
+    # profiles resolve without the Python SDK installed.
+    from_cli = _try_resolve_via_cli(effective_profile)
+    if from_cli is not None:
+        return from_cli
+
+    if malformed_exc is not None:
+        raise OSError(
+            f"Databricks profile [{effective_profile}] in {cfg_path} is malformed: {malformed_exc}"
+        ) from malformed_exc
     raise OSError(_build_resolution_error_message(effective_profile, cfg_path))

--- a/tests/runtime/credentials/test_databricks.py
+++ b/tests/runtime/credentials/test_databricks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,12 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     this monkeypatch the suite takes ~35 minutes; with it, ~0.4s.
     Each test that wants to exercise the SDK path explicitly
     overrides this monkeypatch (see ``test_resolves_via_sdk_*``).
+
+    The ``databricks`` CLI fallback is neutralized for the same reason:
+    without this, OAuth/no-token cfg cases would shell out to a real
+    ``databricks`` binary (if installed) against the test's temp cfg,
+    making the suite slow and host-dependent. Tests that exercise the
+    CLI path override ``_databricks_cli_json`` explicitly.
     """
     for var in (
         "DATABRICKS_CONFIG_FILE",
@@ -40,6 +47,10 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         raise ValueError("SDK path disabled in tests by default")
 
     monkeypatch.setattr("databricks.sdk.config.Config", _raise_value_error)
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks._databricks_cli_json",
+        lambda *_args, **_kwargs: None,
+    )
 
 
 def _write_cfg(tmp_path: Path, body: str) -> Path:
@@ -410,3 +421,120 @@ def test_honors_databricks_config_file_env(
     # fails on the decoy host, the env var override is broken.
     assert creds.host == "https://real.example.com"
     assert creds.token == "real-token"
+
+
+def _fake_cli_json(
+    *, host: str | None, token: str | None
+) -> Callable[..., dict[str, object] | None]:
+    """Build a ``_databricks_cli_json`` stand-in keyed by the CLI subcommand.
+
+    ``databricks auth describe`` → ``{"details": {"host": host}}``;
+    ``databricks auth token`` → ``{"access_token": token}``. Passing ``None``
+    for either suppresses that subcommand's output, simulating a CLI that is
+    absent or cannot mint a token for it.
+
+    :param host: Host returned by the simulated ``auth describe``, or ``None``.
+    :param token: Token returned by the simulated ``auth token``, or ``None``.
+    :returns: A callable matching ``_databricks_cli_json``'s signature.
+    """
+
+    def _fake(args: list[str], *, timeout: float) -> dict[str, object] | None:
+        del timeout
+        if "describe" in args:
+            return {"details": {"host": host}} if host else None
+        if "token" in args:
+            return {"access_token": token} if token else None
+        return None
+
+    return _fake
+
+
+def test_resolves_oauth_profile_via_cli_when_no_static_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The exact bug this fixes: a `databricks-cli` (OAuth) profile has a host
+    # but NO static token, and the Python SDK is unavailable (autouse fixture
+    # disables it). The configparser path rejects the tokenless section as
+    # malformed; the `databricks` CLI fallback must mint a bearer so the
+    # profile resolves instead of raising.
+    cfg = _write_cfg(
+        tmp_path,
+        "[oss]\nhost = https://oss.example.com\nauth_type = databricks-cli\n",
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks._databricks_cli_json",
+        _fake_cli_json(host="https://oss.example.com/", token="cli-minted-token"),
+    )
+
+    creds = resolve_databricks_workspace(profile="oss")
+
+    # Host came from `auth describe` (trailing slash stripped), bearer from
+    # `auth token`. If this raises, the CLI fallback isn't wired in.
+    assert creds == WorkspaceCreds(host="https://oss.example.com", token="cli-minted-token")
+
+
+def test_resolves_default_oauth_via_cli_when_cfg_has_no_creds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # profile=None and no cfg file at all → configparser yields nothing. A
+    # `[DEFAULT]` OAuth login (no token in the file) must still resolve via
+    # the CLI binary rather than raising.
+    missing_cfg = tmp_path / "does-not-exist"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(missing_cfg))
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks._databricks_cli_json",
+        _fake_cli_json(host="https://default-oauth.example.com", token="cli-token"),
+    )
+
+    creds = resolve_databricks_workspace(profile=None)
+
+    assert creds == WorkspaceCreds(host="https://default-oauth.example.com", token="cli-token")
+
+
+def test_oauth_profile_raises_malformed_when_cli_cannot_mint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Host present, no token, SDK disabled, AND the CLI cannot mint a token
+    # (binary absent or login expired → every subcommand returns None). The
+    # resolver must fall back to the malformed-profile OSError naming [oss].
+    cfg = _write_cfg(
+        tmp_path,
+        "[oss]\nhost = https://oss.example.com\nauth_type = databricks-cli\n",
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    # autouse already stubs the CLI to None; this is explicit for clarity.
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks._databricks_cli_json",
+        _fake_cli_json(host=None, token=None),
+    )
+
+    with pytest.raises(OSError) as excinfo:
+        resolve_databricks_workspace(profile="oss")
+
+    msg = str(excinfo.value)
+    assert "[oss]" in msg
+    assert "malformed" in msg.lower() or "token" in msg
+
+
+def test_cli_not_attempted_for_absent_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The CLI fallback is for OAuth profiles that EXIST but carry no static
+    # token — never for a typo'd/nonexistent profile. An absent section must
+    # still fail loud immediately (the typo guard), without shelling out.
+    cfg = _write_cfg(
+        tmp_path,
+        "[DEFAULT]\nhost = https://default.example.com\ntoken = default-token\n",
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+
+    def _boom(*_args: object, **_kwargs: object) -> dict[str, object] | None:
+        raise AssertionError("CLI fallback must not run for an absent profile")
+
+    monkeypatch.setattr("omnigent.runtime.credentials.databricks._databricks_cli_json", _boom)
+
+    with pytest.raises(OSError) as excinfo:
+        resolve_databricks_workspace(profile="ghost")
+
+    assert "ghost" in str(excinfo.value)


### PR DESCRIPTION
## Related issue

N/A

## Summary

`sys_list_models` returned `{"source": "none", "note": "model enumeration failed for provider 'databricks': provider credentials or network unavailable"}` for a worker on a Databricks **OAuth** (`auth_type = databricks-cli`) profile — even though the harness itself was authenticated and serving on that same profile.

Root cause: the tool runs in the **runner venv**, which omits the optional `databricks-sdk` extra. `resolve_databricks_workspace` could mint OAuth tokens only through that SDK; its sole SDK-less path is a raw `~/.databrickscfg` read, which rejects a tokenless OAuth section as "malformed". The harness works because it mints tokens via its `auth_command` — the `databricks` **CLI binary** (`databricks auth token --profile ...`), which needs no Python SDK. `model_catalog` simply never used that path.

- Add a `databricks` CLI fallback to `resolve_databricks_workspace` (`auth describe` → host, `auth token` → bearer), mirroring the harness `auth_command`, so OAuth profiles resolve without the Python SDK.
- Consulted only after the SDK and plaintext-cfg paths come up empty (static-PAT profiles never pay the subprocess cost); the typo-guard for genuinely-absent profiles is preserved (the CLI is not attempted there).
- Fixes every caller of the shared resolver in SDK-less deployments: `sys_list_models`, `cost_judge`, policies, and the Databricks adapter.

## Test Plan

- `pytest tests/runtime/credentials/test_databricks.py tests/test_model_catalog.py` → **59 passed** (4 new: OAuth-via-CLI, `[DEFAULT]`-OAuth-via-CLI, CLI-unavailable-still-raises, absent-profile-not-attempted).
- `ruff check` + `ruff format --check` clean; `mypy --strict` clean.
- End-to-end in an SDK-less venv against a real OAuth profile:
  - `resolve_databricks_workspace("oss")` → resolves host + a fresh bearer (previously raised `OSError`).
  - `_listing_for_provider(databricks, profile="oss")` → `source: gateway, verified: True, 38 models` (previously the failure note).

## Demo

N/A — non-visual change (credential resolution / tool output).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added 4 unit tests for the new CLI fallback: success for a named OAuth profile and for a tokenless `[DEFAULT]`, the malformed-profile `OSError` when the CLI cannot mint, and that the absent/typo-profile guard never shells out. Manually verified end-to-end in the actual SDK-less runner venv — the previously-failing `resolve_databricks_workspace("oss")` now resolves, and the databricks model listing returns 38 gateway endpoints.