### PR TITLE
feat(kiro-native): wire the Omnigent MCP into kiro sessions (#1680)

### DIFF
--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -6,7 +6,9 @@ import contextlib
 import hashlib
 import json
 import os
+import secrets
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -19,6 +21,12 @@ _BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}
 _TMUX_FILE = "tmux.json"
 _FORWARDER_READY_FILE = "kiro_session_forwarder_ready.json"
 _ACP_RECORD_FILE = "kiro_acp_record.jsonl"
+# Shared Omnigent MCP relay (serve-mcp) registration for kiro.
+_MCP_SERVER_NAME = "omnigent"
+_MCP_BRIDGE_CONFIG_FILE = "bridge.json"
+# kiro reads workspace-scoped MCP servers from ``<workspace>/.kiro/settings/mcp.json``
+# (confirmed against kiro-cli 2.10.0). Mirrors cursor-native's ``.cursor/mcp.json``.
+_WORKSPACE_MCP_CONFIG_REL = Path(".kiro") / "settings" / "mcp.json"
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 10.0
 _POLL_INTERVAL_S = 0.2
@@ -105,6 +113,90 @@ def prepare_bridge_dir(session_id: str) -> Path:
 def acp_record_path(bridge_dir: Path) -> Path:
     """Return the per-session Kiro TUI ACP recorder file path."""
     return bridge_dir / _ACP_RECORD_FILE
+
+
+def write_mcp_bridge_config(bridge_dir: Path) -> None:
+    """Write the token config the shared Omnigent MCP bridge requires at boot.
+
+    ``serve-mcp`` (``omnigent.claude_native_bridge``) reads ``bridge.json`` and
+    refuses to start without a ``token``. Mirrors cursor-native's writer;
+    idempotent so a resume reuses the existing token.
+    """
+    bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    config_path = bridge_dir / _MCP_BRIDGE_CONFIG_FILE
+    if config_path.exists():
+        return
+    payload = {"token": secrets.token_urlsafe(32)}
+    tmp = bridge_dir / (_MCP_BRIDGE_CONFIG_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, config_path)
+
+
+def build_kiro_mcp_config(
+    bridge_dir: Path, *, python_executable: str | None = None
+) -> dict[str, Any]:
+    """Build the kiro ``mcpServers`` entry for the Omnigent relay MCP server.
+
+    Reuses the shared stdio ``serve-mcp`` server (the same one cursor/claude use)
+    pointed at this session's bridge dir. kiro's mcp.json schema is
+    ``{"mcpServers": {name: {command, args, env}}}`` (kiro-cli 2.10.0); it has no
+    per-server auto-approve field, so Omnigent MCP tool calls surface through
+    kiro's approval prompt (mirrored to the web as elicitation cards) rather than
+    being auto-trusted here.
+    """
+    python = python_executable or sys.executable
+    return {
+        "mcpServers": {
+            _MCP_SERVER_NAME: {
+                "command": python,
+                "args": [
+                    "-I",
+                    "-m",
+                    "omnigent.claude_native_bridge",
+                    "serve-mcp",
+                    "--bridge-dir",
+                    str(bridge_dir),
+                ],
+                "env": {"TMPDIR": os.environ.get("TMPDIR", "/tmp")},
+            }
+        }
+    }
+
+
+def write_kiro_workspace_mcp_config(
+    workspace: Path,
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> Path:
+    """Write the workspace-scoped kiro MCP config declaring the Omnigent server.
+
+    kiro-cli has no launch-time mcp-config flag, so the server is declared in the
+    workspace's ``.kiro/settings/mcp.json`` (mirrors cursor-native's
+    ``.cursor/mcp.json``). The Omnigent entry is *merged* into any existing
+    workspace config so a user's own workspace MCP servers are preserved. Also
+    writes the bridge ``token`` ``serve-mcp`` needs. Returns the config path.
+    """
+    write_mcp_bridge_config(bridge_dir)
+    path = workspace / _WORKSPACE_MCP_CONFIG_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    config: dict[str, Any] = {}
+    if path.exists():
+        with contextlib.suppress(OSError, ValueError):
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                config = loaded
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+    servers[_MCP_SERVER_NAME] = build_kiro_mcp_config(
+        bridge_dir, python_executable=python_executable
+    )["mcpServers"][_MCP_SERVER_NAME]
+    config["mcpServers"] = servers
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+    return path
 
 
 def build_kiro_native_spawn_env(session_id: str) -> dict[str, str]:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2693,6 +2693,7 @@ async def _auto_create_kiro_terminal(
     publish_event: Callable[[str, dict[str, Any]], None],
     *,
     server_client: httpx.AsyncClient | None,
+    ensure_comment_relay: Callable[..., Awaitable[None]] | None = None,
 ) -> SessionResourceView:
     """Auto-create the Kiro TUI terminal for a kiro-native session."""
     from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
@@ -2701,6 +2702,7 @@ async def _auto_create_kiro_terminal(
         KIRO_NATIVE_ENV_UNSET,
         build_kiro_native_terminal_env,
         prepare_bridge_dir,
+        write_kiro_workspace_mcp_config,
     )
 
     launch_config = await _kiro_native_launch_config(
@@ -2712,6 +2714,12 @@ async def _auto_create_kiro_terminal(
         raise RuntimeError(f"Kiro workspace does not exist for session {session_id!r}.")
     workspace = str(workspace_path)
     bridge_dir = prepare_bridge_dir(session_id)
+    # Declare the Omnigent MCP server in the workspace-scoped kiro config so
+    # kiro-cli can call Omnigent tools. Only when the tool relay will actually
+    # start (server_client + ensure_comment_relay present), else serve-mcp would
+    # launch with no relay to route calls back to. Mirrors cursor-native.
+    if server_client is not None and ensure_comment_relay is not None:
+        write_kiro_workspace_mcp_config(workspace_path, bridge_dir)
     kiro_launch = build_kiro_launch(
         launch_config.terminal_launch_args or [],
         resume_id=launch_config.external_session_id,
@@ -2757,6 +2765,17 @@ async def _auto_create_kiro_terminal(
 
     server_url = _required_runner_env("RUNNER_SERVER_URL")
     _runner_auth = _RunnerDatabricksAuth(_make_auth_token_factory())
+
+    # Start the Omnigent builtin-tool relay (writes tool_relay.json into the kiro
+    # bridge dir) so the serve-mcp server declared in the workspace mcp.json can
+    # route Omnigent tool calls back through the session's policy/elicitation
+    # gate. Mirrors cursor-native.
+    if server_client is not None and ensure_comment_relay is not None:
+        await ensure_comment_relay(
+            session_id,
+            explicit_bridge_dir=bridge_dir,
+            await_notify=False,
+        )
 
     from omnigent.kiro_native_permissions import supervise_kiro_permission_mirror
     from omnigent.kiro_native_session_forwarder import supervise_kiro_session_forwarder
@@ -9177,6 +9196,7 @@ def create_runner_app(
                             resource_registry,
                             _publish_event,
                             server_client=server_client,
+                            ensure_comment_relay=_ensure_comment_relay_started,
                         )
                     except Exception as exc:
                         _logger.exception(
@@ -15809,6 +15829,7 @@ def create_runner_app(
                         resource_registry,
                         _publish_event,
                         server_client=server_client,
+                        ensure_comment_relay=_ensure_comment_relay_started,
                     )
                 except Exception as exc:
                     _logger.exception(

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -13413,6 +13413,11 @@ async def test_auto_create_kiro_terminal_launches_required_terminal_with_isolate
     async def _fake_supervise_kiro_permission_mirror(**kwargs: Any) -> None:
         permission_mirror_calls.append(kwargs)
 
+    relay_calls: list[dict[str, Any]] = []
+
+    async def _spy_ensure_relay(session_id: str, **kwargs: Any) -> None:
+        relay_calls.append({"session_id": session_id, **kwargs})
+
     monkeypatch.setattr(
         "omnigent.kiro_native_session_forwarder.supervise_kiro_session_forwarder",
         _fake_supervise_kiro_session_forwarder,
@@ -13468,6 +13473,7 @@ async def test_auto_create_kiro_terminal_launches_required_terminal_with_isolate
         _FakeResourceRegistry(),  # type: ignore[arg-type]
         lambda _sid, evt: published.append(evt),
         server_client=NullServerClient(),  # type: ignore[arg-type]
+        ensure_comment_relay=_spy_ensure_relay,
     )
     for _ in range(20):
         if forwarder_calls and permission_mirror_calls:
@@ -13510,6 +13516,19 @@ async def test_auto_create_kiro_terminal_launches_required_terminal_with_isolate
     assert permission_mirror_calls
     assert permission_mirror_calls[0]["base_url"] == "http://127.0.0.1:6767"
     assert permission_mirror_calls[0]["session_id"] == "conv_kiro"
+    # The Omnigent MCP tool relay is seeded for this session's bridge dir.
+    assert relay_calls == [
+        {
+            "session_id": "conv_kiro",
+            "explicit_bridge_dir": kiro_native_bridge.bridge_dir_for_session_id("conv_kiro"),
+            "await_notify": False,
+        }
+    ]
+    # And the Omnigent MCP server is declared in the workspace-scoped kiro config.
+    workspace_mcp = tmp_path / ".kiro" / "settings" / "mcp.json"
+    assert workspace_mcp.exists()
+    mcp_servers = json.loads(workspace_mcp.read_text())["mcpServers"]
+    assert "serve-mcp" in mcp_servers["omnigent"]["args"]
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -13532,6 +13532,83 @@ async def test_auto_create_kiro_terminal_launches_required_terminal_with_isolate
 
 
 @pytest.mark.asyncio
+async def test_auto_create_kiro_terminal_skips_mcp_wiring_without_relay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a comment-relay callback, the Omnigent MCP is NOT wired.
+
+    The workspace mcp.json write + relay seed are gated on ``server_client`` AND
+    ``ensure_comment_relay`` together, so serve-mcp never launches with no relay
+    to route calls back to. With ``ensure_comment_relay`` absent the gate must
+    short-circuit: no workspace ``mcp.json`` is written.
+    """
+    import omnigent.kiro_native as kiro_native
+
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+    monkeypatch.setattr(kiro_native_bridge, "_BRIDGE_ROOT", tmp_path / "kiro-bridge")
+    monkeypatch.setattr(
+        kiro_native,
+        "resolve_kiro_executable",
+        lambda **_kwargs: "/usr/bin/kiro-cli",
+    )
+
+    async def _noop_supervise(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "omnigent.kiro_native_session_forwarder.supervise_kiro_session_forwarder",
+        _noop_supervise,
+    )
+    monkeypatch.setattr(
+        "omnigent.kiro_native_permissions.supervise_kiro_permission_mirror",
+        _noop_supervise,
+    )
+    mcp_writes: list[Any] = []
+    monkeypatch.setattr(
+        kiro_native_bridge,
+        "write_kiro_workspace_mcp_config",
+        lambda *args, **kwargs: mcp_writes.append((args, kwargs)),
+    )
+
+    async def _fake_launch_config(**_kwargs: Any) -> _KiroNativeLaunchConfig:
+        return _KiroNativeLaunchConfig(
+            workspace=tmp_path,
+            terminal_launch_args=["hello"],
+            external_session_id=None,
+        )
+
+    monkeypatch.setattr("omnigent.runner.app._kiro_native_launch_config", _fake_launch_config)
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self, *, session_id: str, **_kwargs: Any
+        ) -> SessionResourceView:
+            return SessionResourceView(
+                id="terminal_kiro_main",
+                type="terminal",
+                session_id=session_id,
+                name="kiro:main",
+                metadata={"terminal_name": "kiro", "session_key": "main", "running": True},
+            )
+
+    # No ``ensure_comment_relay`` argument -> the MCP wiring gate stays closed.
+    await _auto_create_kiro_terminal(
+        "conv_kiro_no_relay",
+        _FakeResourceRegistry(),  # type: ignore[arg-type]
+        lambda _sid, _evt: None,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    assert mcp_writes == []
+    assert not (tmp_path / ".kiro" / "settings" / "mcp.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_auto_create_pi_terminal_inherits_agent_sandbox(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_kiro_native_bridge.py
+++ b/tests/test_kiro_native_bridge.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -484,3 +486,58 @@ def test_kill_session_kills_target(
     bridge.kill_session(tmp_path)
 
     assert calls == [("kill-session", "-t", "t")]
+
+
+def test_write_mcp_bridge_config_writes_token_idempotently(tmp_path: Path) -> None:
+    """serve-mcp's bridge.json gets a token; a second call keeps the same one."""
+    bridge_dir = tmp_path / "bridge"
+    bridge.write_mcp_bridge_config(bridge_dir)
+    config_path = bridge_dir / "bridge.json"
+    first = json.loads(config_path.read_text())
+    assert isinstance(first.get("token"), str) and first["token"]
+
+    bridge.write_mcp_bridge_config(bridge_dir)
+
+    assert json.loads(config_path.read_text())["token"] == first["token"]
+
+
+def test_build_kiro_mcp_config_targets_serve_mcp(tmp_path: Path) -> None:
+    """The mcp.json entry runs the shared serve-mcp against the bridge dir."""
+    bridge_dir = tmp_path / "bridge"
+    server = bridge.build_kiro_mcp_config(bridge_dir, python_executable="/usr/bin/python3")[
+        "mcpServers"
+    ]["omnigent"]
+    assert server["command"] == "/usr/bin/python3"
+    assert server["args"] == [
+        "-I",
+        "-m",
+        "omnigent.claude_native_bridge",
+        "serve-mcp",
+        "--bridge-dir",
+        str(bridge_dir),
+    ]
+    # Defaults to the running interpreter when no executable is given.
+    default_cmd = bridge.build_kiro_mcp_config(bridge_dir)["mcpServers"]["omnigent"]["command"]
+    assert default_cmd == sys.executable
+
+
+def test_write_kiro_workspace_mcp_config_merges_preserving_user_servers(tmp_path: Path) -> None:
+    """The Omnigent server is merged into <workspace>/.kiro/settings/mcp.json
+    without clobbering a user's pre-existing workspace servers."""
+    workspace = tmp_path / "repo"
+    settings = workspace / ".kiro" / "settings"
+    settings.mkdir(parents=True)
+    (settings / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"user_server": {"command": "x", "args": []}}}),
+        encoding="utf-8",
+    )
+    bridge_dir = tmp_path / "bridge"
+
+    path = bridge.write_kiro_workspace_mcp_config(workspace, bridge_dir)
+
+    assert path == workspace / ".kiro" / "settings" / "mcp.json"
+    written = json.loads(path.read_text())
+    assert set(written["mcpServers"]) == {"user_server", "omnigent"}
+    assert "serve-mcp" in written["mcpServers"]["omnigent"]["args"]
+    # serve-mcp's token file is written alongside.
+    assert (bridge_dir / "bridge.json").exists()


### PR DESCRIPTION
## Summary

Closes #1680 (with #1706). Second of two PRs: wires the Omnigent MCP server into kiro-native sessions so `kiro-cli` can call Omnigent tools.

**Stacked on #1706** (registers the kiro bridge root so serve-mcp / the relay can boot). Base is `kiro-mcp-allowlist`; I'll retarget to `main` once #1706 merges.

## What changed

- `omnigent/kiro_native_bridge.py`:
  - `write_mcp_bridge_config` - writes the `bridge.json` token serve-mcp requires at boot.
  - `build_kiro_mcp_config` - the `mcpServers` entry running the shared `omnigent.claude_native_bridge serve-mcp` against this session's bridge dir.
  - `write_kiro_workspace_mcp_config` - writes `<workspace>/.kiro/settings/mcp.json` (mirrors cursor-native's `.cursor/mcp.json`), **merging** into any existing workspace config so a user's own servers are preserved; additive to the user's global kiro config.
- `omnigent/runner/app.py` (`_auto_create_kiro_terminal`): writes the workspace `mcp.json` before launch and awaits `ensure_comment_relay` after, both gated on `server_client` + `ensure_comment_relay` (so serve-mcp never launches with no relay to route to). Both call sites pass `_ensure_comment_relay_started`. Mirrors cursor-native.

## Design notes

- **Workspace-scoped, not a config-home hijack.** kiro-cli has no launch-time mcp-config flag. I confirmed live that `KIRO_HOME` redirects config but `KIRO_CONFIG_HOME` is ignored, and that workspace scope writes `.kiro/settings/mcp.json`. Following cursor's precedent (workspace-scoped, additive) keeps the user's global kiro config inherited and avoids touching it.
- **Approval** flows through the existing kiro permission elicitation (#1293) - each Omnigent tool call surfaces as a Chat approval card. kiro's mcp.json has no per-server auto-approve field and `--trust-all-tools` is too broad, so auto-trust is deferred to a follow-up once the kiro `--trust-tools` MCP tool-name format is confirmed live.

## Testing

`uv run --extra dev pytest tests/test_kiro_native_bridge.py tests/runner/test_app_sessions_native.py::test_auto_create_kiro_terminal_launches_required_terminal_with_isolated_env tests/test_claude_native_bridge.py -k trusted_parent tests/runtime/test_kiro_spawn_env.py -q` -> all pass. New: bridge token idempotency, mcp.json shape, workspace-merge-preserves-user-servers, and the runner test now asserts the relay is seeded for the session bridge dir + the workspace mcp.json declares the server. `ruff check` + `ruff format --check` clean.

> End-to-end (kiro actually calling an Omnigent tool) should be confirmed on a live kiro session as the final gate.

This pull request and its description were written by Isaac.
