### PR TITLE
fix(export_agent): prevent arbitrary directory deletion and source exfiltration

### DIFF
--- a/omnigent/tools/builtins/export_agent.py
+++ b/omnigent/tools/builtins/export_agent.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins.upload_file import safe_resolve
 
 _SCHEMA: dict[str, Any] = {
     "type": "function",
@@ -59,9 +60,14 @@ class ExportAgentTool(Tool):
 
     The onboarding assistant generates agent files inside the
     conversation's workspace (via ``sys_os_shell``). This tool
-    copies the result to the user's chosen location. The target
-    directory must not already exist (to prevent accidental
-    overwrites).
+    copies the result to the user's chosen location.
+
+    Security: the ``source`` is resolved with workspace containment
+    so it cannot escape the sandbox, symlinks inside ``source`` are
+    copied as links rather than dereferenced (so host files are never
+    read out of the workspace), and an existing ``target`` is refused
+    rather than deleted. The tool never recursively removes a path on
+    the user's filesystem.
     """
 
     @classmethod
@@ -111,7 +117,14 @@ class ExportAgentTool(Tool):
         if ctx.workspace is None:
             return "Error: no workspace available."
 
-        source = ctx.workspace / source_rel
+        # Contain ``source`` inside the workspace so a traversal path
+        # (e.g. "../../etc") or an escaping symlink cannot copy host
+        # files out of the sandbox.
+        try:
+            source = safe_resolve(source_rel, ctx.workspace)
+        except ValueError:
+            return f"Error: source '{source_rel}' escapes the workspace."
+
         target = Path(target_str)
 
         if not source.exists():
@@ -120,10 +133,17 @@ class ExportAgentTool(Tool):
         if not source.is_dir():
             return f"Error: source '{source_rel}' is not a directory."
 
-        if target.exists():
-            # Replace previous export — the onboarding workflow
-            # iterates and re-exports as the user refines the agent.
-            shutil.rmtree(str(target))
+        # Never recursively delete an LLM-controlled target path. The
+        # target lives on the user's filesystem, so refusing an
+        # existing path avoids arbitrary directory deletion.
+        if target.exists() or target.is_symlink():
+            return (
+                f"Error: target '{target}' already exists. Refusing to "
+                "delete or overwrite it; choose a path that does not exist."
+            )
 
-        shutil.copytree(str(source), str(target))
+        # symlinks=True copies links as links instead of dereferencing
+        # them, so a symlink inside ``source`` cannot pull host file
+        # contents into the exported copy.
+        shutil.copytree(str(source), str(target), symlinks=True)
         return f"Exported agent to {target}"

--- a/tests/tools/builtins/test_export_agent.py
+++ b/tests/tools/builtins/test_export_agent.py
@@ -70,23 +70,29 @@ def test_invoke_copies_directory(
     assert (target / "prompt.md").exists()
 
 
-def test_invoke_overwrites_existing_target(
+def test_invoke_refuses_existing_target(
     tool_ctx: ToolContext,
     tmp_path: Path,
 ) -> None:
-    """invoke() replaces an existing target directory."""
-    target = tmp_path / "export-overwrite"
+    """An existing target is refused and never deleted (no rmtree).
+
+    Regression test for arbitrary directory deletion: the old code
+    called ``shutil.rmtree`` on the LLM-controlled absolute target,
+    which could wipe any directory on the user's filesystem.
+    """
+    target = tmp_path / "precious"
     target.mkdir()
-    (target / "old-file.txt").write_text("stale")
+    (target / "important.txt").write_text("do not delete")
 
     tool = ExportAgentTool()
     result = tool.invoke(
         json.dumps({"source": "my-agent", "target": str(target)}),
         tool_ctx,
     )
-    assert "Exported agent to" in result
-    assert (target / "config.yaml").exists()
-    assert not (target / "old-file.txt").exists()
+    assert "Error" in result and "already exists" in result.lower()
+    # The pre-existing directory and its contents are untouched.
+    assert (target / "important.txt").read_text() == "do not delete"
+    assert not (target / "config.yaml").exists()
 
 
 # ── Invoke: error cases ──────────────────────────────────
@@ -143,3 +149,54 @@ def test_invoke_no_workspace() -> None:
         ctx,
     )
     assert "Error" in result and "workspace" in result.lower()
+
+
+# ── Invoke: containment / exfiltration ───────────────────
+
+
+def test_invoke_rejects_source_escaping_workspace(
+    tool_ctx: ToolContext,
+    tmp_path: Path,
+) -> None:
+    """A traversal source path is rejected and nothing is copied."""
+    target = tmp_path / "escape-out"
+    tool = ExportAgentTool()
+    result = tool.invoke(
+        json.dumps({"source": "../../etc", "target": str(target)}),
+        tool_ctx,
+    )
+    assert "Error" in result and "escapes the workspace" in result.lower()
+    assert not target.exists()
+
+
+def test_invoke_does_not_dereference_source_symlink(
+    tool_ctx: ToolContext,
+    tmp_path: Path,
+) -> None:
+    """A symlink inside source is copied as a link, not dereferenced.
+
+    Regression test for host-file exfiltration: copytree's default
+    symlink dereference would copy the *contents* of the symlink's
+    target (a host secret) into the exported directory.
+    """
+    assert tool_ctx.workspace is not None
+    secret = tmp_path / "host-secret.txt"
+    secret.write_text("TOP SECRET")
+    (tool_ctx.workspace / "my-agent" / "leak").symlink_to(secret)
+
+    target = tmp_path / "export-symlink" / "my-agent"
+    tool = ExportAgentTool()
+    result = tool.invoke(
+        json.dumps({"source": "my-agent", "target": str(target)}),
+        tool_ctx,
+    )
+    assert "Exported agent to" in result
+
+    exported_link = target / "leak"
+    # The entry is preserved as a symlink rather than dereferenced
+    # into a regular file holding the secret bytes.
+    assert exported_link.is_symlink()
+    # Removing the host file leaves the export dangling, proving the
+    # secret's contents were never copied out of the workspace.
+    secret.unlink()
+    assert not exported_link.exists()


### PR DESCRIPTION
## Related issue

N/A — P0 security hardening of the `export_agent` built-in tool.

## Summary

`export_agent` is an LLM-driven onboarding tool whose `source` and `target` arguments come straight from the model. Two distinct problems:

- **Arbitrary directory deletion (destructive `rmtree`).** When the LLM-controlled absolute `target` already existed, the tool ran `shutil.rmtree(target)` before copying. Because `target` is fully attacker/LLM-controlled (`/home/user`, `/etc`, …), this allowed recursively deleting any directory on the user's filesystem — and it directly contradicted the tool's own docstring ("target must not already exist").
- **Source exfiltration out of the sandbox.** `source` was joined to the workspace with no containment (`ctx.workspace / source_rel`), so a traversal such as `../../etc` escaped the sandbox. `shutil.copytree` also used its default symlink **dereference**, so a symlink inside `source` pointing at a host secret would have its *contents* copied out into the export.

**Fix (surgical, behavior preserved for the legitimate in-workspace export):**

- Resolve `source` through the existing `safe_resolve` helper (workspace containment) — traversal paths and escaping symlinks are rejected.
- Refuse when `target` already exists (or is a symlink) instead of `rmtree`-ing it. The tool now **never** deletes a path on the user's filesystem, matching its documented "must not already exist" contract.
- Copy with `shutil.copytree(..., symlinks=True)` so symlinks inside `source` are preserved as links rather than dereferenced into the export.

**ELI5:** The "save my agent to disk" tool used to delete whatever already sat at the destination and would follow shortcuts to slurp up the files they point at. Now it refuses to delete anything already there, stays inside the sandbox when reading the source, and copies shortcuts as shortcuts instead of copying their secret contents.

```
source (workspace)                 target (user FS)
  safe_resolve() ── inside? ──no──▶ "Error: escapes the workspace"
        │ yes
        ▼
  target exists / symlink? ──yes──▶ "Error: already exists" (no rmtree)
        │ no
        ▼
  copytree(symlinks=True) ────────▶ links copied as links, never dereferenced
```

## Test Plan

- `uv run --extra dev python -m pytest tests/tools/builtins/test_export_agent.py -x -q` → **11 passed**.
- `uv run --extra dev ruff check omnigent/tools/builtins/export_agent.py tests/tools/builtins/test_export_agent.py` → **All checks passed**.
- Test coverage added/updated in `tests/tools/builtins/test_export_agent.py`:
  - Existing `target` is **refused** and never deleted; pre-existing contents are preserved (regression test for the `rmtree`).
  - Out-of-workspace `source` (`../../etc`) is rejected and nothing is copied.
  - A symlink inside `source` is preserved as a link (not dereferenced); removing the host file leaves the export dangling, proving the secret bytes were never copied out.
  - Existing happy-path / error-path tests still pass unchanged.

## Demo

N/A — backend security fix, no UI / frontend change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The three security behaviors (no destructive `rmtree`, source containment, no symlink dereference) are each covered by a dedicated unit test, alongside the pre-existing happy-path and error-path tests. The only behavioral change to an existing test is the former overwrite test, which now asserts the secure refuse-and-preserve behavior.