### PR TITLE
fix(runner): block sys_session_create config_path symlink bundle escape

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2020,6 +2020,36 @@ async def _post_child_first_message(
     return None
 
 
+def _directory_bundle_escapes_cwd(source: Path, resolved_cwd: Path) -> bool:
+    """
+    Report whether a directory bundle reaches outside the working dir.
+
+    The top-level ``config_path`` guard only resolves the directory
+    itself, but a directory bundle is copied recursively. Without a
+    symlink-aware check an agent could author ``helper/config.yaml``
+    alongside an in-tree symlink (e.g.
+    ``helper/leak -> /home/<user>/.ssh/id_rsa``) and exfiltrate that
+    host file's contents through the uploaded, session-scoped bundle
+    (readable back via ``sys_agent_download``). Resolving every nested
+    entry's realpath and rejecting any that escapes ``resolved_cwd``
+    keeps containment robust against symlinks anywhere in the tree, not
+    just the top-level path. ``rglob`` does not descend into symlinked
+    directories, so a symlinked subdirectory is itself checked (and
+    rejected) without following it.
+
+    :param source: A directory already confirmed to live under
+        ``resolved_cwd``.
+    :param resolved_cwd: The os_env working directory — the containment
+        boundary.
+    :returns: ``True`` if any nested entry resolves outside
+        ``resolved_cwd``; ``False`` when the whole tree is contained.
+    """
+    return any(
+        not Path(os.path.realpath(entry)).is_relative_to(resolved_cwd)
+        for entry in source.rglob("*")
+    )
+
+
 async def _upload_config_bundle(
     config_path: str,
     args: dict[str, Any],
@@ -2058,6 +2088,20 @@ async def _upload_config_bundle(
         )
     if not source.exists():
         return json.dumps({"error": "config_not_found", "config_path": config_path})
+    # The top-level guard above only resolves config_path itself. A
+    # directory bundle is copied recursively, so an in-tree symlink
+    # pointing at a host file outside the working dir would otherwise be
+    # bundled (its target's contents) and exfiltrated. Reject any nested
+    # entry whose realpath escapes the working directory.
+    if source.is_dir() and _directory_bundle_escapes_cwd(source, resolved_cwd):
+        return json.dumps(
+            {
+                "error": (
+                    "sys_session_create config_path contains a link that "
+                    "escapes the working directory"
+                )
+            }
+        )
     try:
         bundle_bytes = await asyncio.to_thread(_bundle_local_agent_source, source)
     except Exception as exc:  # noqa: BLE001 — disk/tar errors become a typed tool error.

--- a/omnigent/spec/__init__.py
+++ b/omnigent/spec/__init__.py
@@ -113,17 +113,26 @@ def materialize_bundle(source: Path, dest: Path) -> Path:
     :param dest: Destination directory to populate. Created if it
         does not exist; may be empty or already contain the copied
         contents from a prior call (``shutil.copytree`` is invoked
-        with ``dirs_exist_ok=True``).
+        with ``dirs_exist_ok=True`` and ``symlinks=True``).
     :returns: *dest*, always as a populated directory. For the
         directory case the contents are a recursive copy of
-        *source*. For the file case the YAML is placed at the root
+        *source* with symlinks preserved (copied as links, never
+        dereferenced, so a link's external target contents stay out
+        of the bundle). For the file case the YAML is placed at the root
         of *dest* so
         :func:`omnigent.spec._find_omnigent_yaml_in_dir` picks
         it up on a subsequent :func:`load` call.
     :raises FileNotFoundError: If *source* does not exist.
     """
     if source.is_dir():
-        shutil.copytree(source, dest, dirs_exist_ok=True)
+        # symlinks=True copies links verbatim instead of dereferencing
+        # them. With the default (symlinks=False) an in-tree symlink to a
+        # file outside the source (e.g. an agent-authored
+        # ``helper/leak -> ~/.ssh/id_rsa``) would have its *target's*
+        # contents copied into the bundle, escaping the caller's
+        # containment guard. Preserving the link keeps external file
+        # contents out of the materialized bundle.
+        shutil.copytree(source, dest, dirs_exist_ok=True, symlinks=True)
         return dest
     if source.is_file():
         dest.mkdir(parents=True, exist_ok=True)

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6142,6 +6142,65 @@ async def test_sys_session_create_config_path_escape_rejected(
 
 
 @pytest.mark.asyncio
+async def test_sys_session_create_config_path_dir_symlink_not_dereferenced(
+    tmp_path: Path,
+) -> None:
+    """
+    A ``config_path`` DIRECTORY containing an in-tree symlink to a host
+    file outside the working directory must not bundle that file's
+    contents.
+
+    The top-level guard only resolves ``config_path`` itself, but a
+    directory bundle is copied recursively. Without symlink-aware
+    containment an agent could author ``helper/config.yaml`` plus
+    ``helper/leak -> <secret>`` and exfiltrate the secret's contents
+    through the uploaded, session-scoped bundle (readable back via
+    ``sys_agent_download`` — polly runs unsandboxed). The upload must be
+    refused before any server call, and the secret must never be read.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    # A host secret living OUTSIDE the working directory.
+    secret = tmp_path / "id_rsa"
+    secret.write_text("TOP-SECRET-HOST-FILE\n")
+
+    # An agent-authored config directory under the working dir holding a
+    # valid config plus an in-tree symlink that points at the host
+    # secret. The default copytree(symlinks=False) would dereference it.
+    config_dir = workdir / "helper"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text("name: helper\n")
+    (config_dir / "leak").symlink_to(secret)
+
+    server_calls: list[str] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        server_calls.append(str(request.url))
+        raise AssertionError(f"server must not be reached when a bundle escapes: {request.url}")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_create",
+            arguments=json.dumps({"config_path": "helper"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            runner_workspace=workdir,
+        )
+
+    info = json.loads(output)
+    assert "escapes the working directory" in info["error"]
+    # The escape is caught before bundling/upload — the secret's
+    # contents never leave the host.
+    assert server_calls == []
+
+
+@pytest.mark.asyncio
 async def test_sys_session_create_config_not_found(tmp_path: Path) -> None:
     """
     A missing ``config_path`` returns the typed ``config_not_found``


### PR DESCRIPTION
## Related issue

<!-- P0 security report; no GitHub issue number provided. -->

N/A

## Summary

**Vulnerability (host-file exfiltration).** `sys_session_create`'s `config_path` containment guard only validated the *top-level* path:

```
source = (resolved_cwd / config_path).resolve()
if not source.is_relative_to(resolved_cwd): reject
```

That correctly rejects a top-level symlink/`..` escape, but when `config_path` is a **directory**, bundling materializes it with `shutil.copytree(..., dirs_exist_ok=True)` using the default `symlinks=False`, which **dereferences symlinks inside the directory** and copies the real target's contents into the bundle. So an agent (polly runs unsandboxed) can author:

```
helper/config.yaml
helper/leak -> /home/<user>/.ssh/id_rsa
```

and the host file's contents get bundled + uploaded as a session-scoped agent, readable back via `sys_agent_download` → arbitrary host-file exfiltration.

**ELI5.** The guard checked that the front door is inside the house, but a directory could contain a "shortcut" pointing at a file outside the house, and the copy step quietly followed the shortcut and packed up that outside file.

```
config_path dir ──► copytree(symlinks=False) ──► tar ──► upload
   helper/leak ─┐         (dereferences!)
                └─► /home/<user>/.ssh/id_rsa  ← contents pulled into bundle
```

**Fix (defense in depth, both layers):**
- `omnigent/spec/__init__.py` `materialize_bundle`: copy with `symlinks=True`, so links are preserved verbatim and a link's external target contents are never pulled into the bundle.
- `omnigent/runner/tool_dispatch.py` `_upload_config_bundle`: for a directory `config_path`, reject the upload if **any nested entry's `realpath` escapes `resolved_cwd`** (`_directory_bundle_escapes_cwd`). This makes containment robust to symlinks anywhere in the tree, not just the top level (`rglob` does not descend into symlinked dirs, so a symlinked subdirectory is itself checked and rejected without being followed).

In scope: only this issue. No behavior change for legitimate bundles (regular files and in-tree contents under the working dir copy as before).

## Test Plan

Ran in the worktree with `uv run --extra dev pytest ... -p no:cacheprovider`:

- `tests/runner/test_runner_dispatch.py -k "config_path or config_not_found"` → **3 passed** (incl. the new symlink-escape test).
- `tests/runner/test_runner_dispatch.py -k "session_create"` → **9 passed** (happy-path bundle upload still works).
- `tests/spec/test_load.py -k materialize` → **6 passed** (`symlinks=True` is behavior-compatible).
- `ruff check` on the three changed files → **All checks passed!**

New test `test_sys_session_create_config_path_dir_symlink_not_dereferenced`: a `config_path` directory containing `leak -> <outside secret>` is rejected with an `"escapes the working directory"` error and the server is never reached (the secret never leaves the host).

## Demo

N/A — backend security fix, no UI/frontend change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a focused runner unit test reproducing the in-directory symlink escape (rejected before any bundle/upload). Existing `materialize_bundle` and `sys_session_create` bundle-mode tests guard against regressions in the normal directory/file bundling path.