### PR TITLE
fix(tools): scope search_conversations to the caller's session (cross-tenant leak)

### DIFF
--- a/omnigent/tools/builtins/search_conversations.py
+++ b/omnigent/tools/builtins/search_conversations.py
@@ -10,12 +10,14 @@ from omnigent.tools.base import Tool, ToolContext
 
 class SearchConversationsTool(Tool):
     """
-    Full-text search across all conversations.
+    Full-text search within the caller's own conversation.
 
     Uses the FTS index to find past messages, tool calls, and
     results that match a query. Returns matching items with
     surrounding context so the agent can recall information
-    from prior interactions.
+    from prior interactions. Results are scoped to the current
+    session's ``conversation_id`` so the search never reads
+    other users'/sessions' data.
     """
 
     @classmethod
@@ -83,7 +85,8 @@ class SearchConversationsTool(Tool):
         :param arguments: JSON with ``"query"`` and optional
             ``"limit"`` keys, e.g.
             ``'{"query": "database config", "limit": 5}'``.
-        :param ctx: Server-side execution context (unused).
+        :param ctx: Server-side execution context; ``ctx.conversation_id``
+            scopes the search to the caller's own session.
         :returns: JSON string with search results.
         """
         args: dict[str, Any] = json.loads(arguments)
@@ -92,10 +95,22 @@ class SearchConversationsTool(Tool):
             return json.dumps({"error": "missing required 'query' argument"})
         limit = args.get("limit", 10)
 
+        # Scope the search to the caller's own session using the
+        # server-trusted conversation id (never an LLM-supplied
+        # argument). The store treats ``conversation_id=None`` as
+        # "search the entire shared DB", so an unscoped call would
+        # leak other sessions'/users' messages, tool-call arguments,
+        # and outputs. Fail closed when there is no session context
+        # rather than falling back to an unscoped search.
+        if ctx.conversation_id is None:
+            return json.dumps(
+                {"error": "no conversation context — cannot scope conversation search"}
+            )
+
         from omnigent.runtime import get_conversation_store
 
         conv_store = get_conversation_store()
-        items = conv_store.search(query, limit=limit)
+        items = conv_store.search(query, conversation_id=ctx.conversation_id, limit=limit)
 
         if not items:
             return json.dumps({"results": [], "message": "No matching conversations found."})

--- a/tests/tools/builtins/test_search_conversations.py
+++ b/tests/tools/builtins/test_search_conversations.py
@@ -20,7 +20,7 @@ from omnigent.tools.builtins.search_conversations import (
     _format_results,
 )
 
-_CTX = ToolContext(task_id="task_test", agent_id="agent_test")
+_CTX = ToolContext(task_id="task_test", agent_id="agent_test", conversation_id="conv_test")
 
 
 # ── Stubs ────────────────────────────────────────────────
@@ -28,21 +28,42 @@ _CTX = ToolContext(task_id="task_test", agent_id="agent_test")
 
 @dataclass
 class _FakeItem:
-    """Minimal stub for ConversationItem."""
+    """Minimal stub for ConversationItem.
+
+    ``conversation_id`` models the store's per-session scoping
+    column (the real :class:`ConversationItem` does not carry it;
+    the store filters rows by it). The tool reports ``response_id``
+    as the result's ``conversation_id``.
+    """
 
     id: str
     response_id: str
     created_at: int
     type: str
     data: Any
+    conversation_id: str | None = None
 
 
 class _FakeConversationStore:
+    """Scope-aware stand-in for the conversation store.
+
+    Mirrors the real store's contract: ``conversation_id=None``
+    searches every conversation (the unscoped path), while a
+    concrete id restricts results to that session. ``search_calls``
+    records the scope passed on each call so tests can assert the
+    tool always scopes to the caller's trusted session id.
+    """
+
     def __init__(self, items: list[Any]) -> None:
         self._items = items
+        self.search_calls: list[str | None] = []
 
-    def search(self, query: str, limit: int = 10) -> list[Any]:
-        return self._items[:limit]
+    def search(self, query: str, conversation_id: str | None = None, limit: int = 10) -> list[Any]:
+        self.search_calls.append(conversation_id)
+        items = self._items
+        if conversation_id is not None:
+            items = [it for it in items if it.conversation_id == conversation_id]
+        return items[:limit]
 
 
 def _message_data(text: str = "Hello world", role: str = "assistant") -> MessageData:
@@ -105,6 +126,7 @@ def test_invoke_returns_results(monkeypatch: pytest.MonkeyPatch) -> None:
             created_at=1000,
             type="message",
             data=_message_data(),
+            conversation_id="conv_test",
         ),
     ]
     monkeypatch.setattr(
@@ -142,7 +164,10 @@ def test_invoke_missing_query() -> None:
 
 def test_invoke_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     """invoke() passes limit to the store."""
-    items = [_FakeItem(f"item_{i}", f"conv_{i}", i, "message", _message_data()) for i in range(20)]
+    items = [
+        _FakeItem(f"item_{i}", f"conv_{i}", i, "message", _message_data(), "conv_test")
+        for i in range(20)
+    ]
     store = _FakeConversationStore(items)
     monkeypatch.setattr(
         "omnigent.runtime.get_conversation_store",
@@ -152,6 +177,85 @@ def test_invoke_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     tool = SearchConversationsTool()
     result = json.loads(tool.invoke('{"query": "test", "limit": 3}', _CTX))
     assert len(result["results"]) == 3
+
+
+def test_invoke_scopes_to_caller_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A caller cannot retrieve another session's messages.
+
+    Two sessions hold items matching the same query. The tool must
+    pass the caller's trusted ``ctx.conversation_id`` to the store so
+    only the caller's own session is searched — the other session's
+    content must never appear in the result.
+    """
+    mine = _FakeItem(
+        id="item_mine",
+        response_id="resp_mine",
+        created_at=1000,
+        type="message",
+        data=_message_data("my own secret"),
+        conversation_id="conv_mine",
+    )
+    theirs = _FakeItem(
+        id="item_theirs",
+        response_id="resp_theirs",
+        created_at=1001,
+        type="message",
+        data=_message_data("their private secret"),
+        conversation_id="conv_theirs",
+    )
+    store = _FakeConversationStore([mine, theirs])
+    monkeypatch.setattr(
+        "omnigent.runtime.get_conversation_store",
+        lambda: store,
+    )
+
+    ctx = ToolContext(task_id="t", agent_id="a", conversation_id="conv_mine")
+    tool = SearchConversationsTool()
+    result = json.loads(tool.invoke('{"query": "secret"}', ctx))
+
+    # Only the caller's own session item is returned.
+    assert len(result["results"]) == 1
+    assert result["results"][0]["item_id"] == "item_mine"
+    assert result["results"][0]["text"] == "my own secret"
+
+    # The store was scoped to the caller's trusted session id, not an
+    # unscoped (``None``) search across the shared DB.
+    assert store.search_calls == ["conv_mine"]
+
+    # The other session's content never leaks into the output.
+    blob = json.dumps(result)
+    assert "their private secret" not in blob
+    assert "item_theirs" not in blob
+
+
+def test_invoke_fails_closed_without_session_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no session context the tool refuses to run an unscoped search."""
+    store = _FakeConversationStore(
+        [
+            _FakeItem(
+                id="item_other",
+                response_id="resp_other",
+                created_at=1000,
+                type="message",
+                data=_message_data("someone else's secret"),
+                conversation_id="conv_other",
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.get_conversation_store",
+        lambda: store,
+    )
+
+    ctx = ToolContext(task_id="t", agent_id="a")  # conversation_id defaults to None
+    tool = SearchConversationsTool()
+    result = json.loads(tool.invoke('{"query": "secret"}', ctx))
+
+    assert "error" in result
+    # Fail closed: the unscoped store search must never be reached.
+    assert store.search_calls == []
 
 
 # ── _extract_text ────────────────────────────────────────


### PR DESCRIPTION
## Related issue

N/A — reported via internal security audit (audit's #1 issue). One security fix per PR.

## Summary

**Vulnerability — cross-tenant / cross-session data leak.** `search_conversations` called the conversation store's `search()` with no `conversation_id` scope. The store treats `conversation_id=None` as "search the entire shared DB", so any agent invoking this tool could retrieve **other users'/sessions'** message content, tool-call arguments, and tool outputs — data the caller never owned.

**Fix.** Scope the search to the *server-trusted* `ctx.conversation_id` and fail closed when no session context is present, instead of falling back to an unscoped search:

- `invoke()` now returns an error when `ctx.conversation_id is None` (fail closed) and passes `conversation_id=ctx.conversation_id` to the store. This mirrors how `list_comments` / `list_files` already scope by `ctx.conversation_id`.
- The scope id is **server-set** (`ToolContext.conversation_id`), never an LLM-supplied argument, so the model can't widen its own scope.
- The store already supported the `conversation_id` predicate (a separately-tested low-level capability); the tool simply never passed it. No store/runner changes were needed: `search_conversations` is AP-dispatched (it has a real `invoke()`; there is no `search_conversations` handler in `runner/tool_dispatch.py`), and the tool is the only production caller of `ConversationStore.search()`.

## Test Plan

- Extended `tests/tools/builtins/test_search_conversations.py`:
  - `test_invoke_scopes_to_caller_session` — two sessions hold items matching the same query; asserts only the caller's own session item is returned, the store is called with the caller's `conversation_id`, and the other session's content never appears in the output.
  - `test_invoke_fails_closed_without_session_context` — with `conversation_id=None`, the tool returns an error and the store's `search()` is never reached.
  - Made the test's fake store scope-aware and updated the existing happy-path tests to pass a scoped context.
- Ran inside the worktree:
  - `uv run --extra dev pytest tests/tools/builtins/test_search_conversations.py -q` → **13 passed**
  - `uv run --extra dev pytest tests/stores/test_conversation_store.py -k search -q` → **5 passed** (confirms the store's scoped/unscoped contract is unchanged)

## Demo

N/A — backend security fix, no UI / frontend change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests assert the security property directly (a caller cannot retrieve another session's messages) plus the fail-closed path. The store's `-k search` tests confirm the scoping predicate the fix relies on still behaves as before.