### PR TITLE
fix(terminal): enforce cwd-override containment for placeholder-cwd terminals

### DIFF
--- a/omnigent/tools/builtins/sys_terminal.py
+++ b/omnigent/tools/builtins/sys_terminal.py
@@ -23,7 +23,10 @@ singleton; both are passed in at registration time by
 :meth:`ToolManager._register_terminal_tools`.
 
 Cwd resolution at launch follows the §4.6 precedence list — see
-:meth:`SysTerminalLaunchTool._resolve_cwd` for the implementation.
+:meth:`SysTerminalLaunchTool._resolve_anchor_cwd` for the trusted
+containment anchor. The LLM ``cwd`` override is applied and
+containment-checked separately by the inner guard, never folded into
+the anchor.
 """
 
 from __future__ import annotations
@@ -574,8 +577,8 @@ class SysTerminalLaunchTool(Tool):
             # Validation hit an error envelope — already JSON-encoded.
             return validated
 
-        # §4.6 cwd resolution. Two synthesis points feed the result
-        # into the inner builder, because the inner code's
+        # §4.6 cwd resolution. Two synthesis points feed the trusted
+        # ANCHOR cwd into the inner builder, because the inner code's
         # ``effective_os_env_spec`` selection prefers
         # ``terminal_spec.os_env`` over ``parent_os_env`` whenever
         # the terminal declares its own — so we can't just patch
@@ -590,13 +593,21 @@ class SysTerminalLaunchTool(Tool):
         #   ``os.getcwd()`` — AP's process cwd — instead of the
         #   §4.6-resolved workspace.
         #
-        # Neither path uses the inner builder's ``cwd_override``
-        # parameter — that one enforces ``allow_cwd_override``,
-        # an LLM-untrusted gate.
-        resolved_cwd = self._resolve_cwd(validated.cwd_override, validated.terminal_spec, ctx)
-        parent_os_env = _synthesize_parent_os_env(self._spec.os_env, resolved_cwd)
+        # SECURITY: the anchor is resolved WITHOUT the LLM ``cwd``
+        # override. The override must never become its own
+        # containment anchor — it flows ONLY through the inner
+        # builder's ``cwd_override`` parameter (see
+        # :meth:`_perform_launch`), where the guard validates it
+        # against this anchor. Feeding the override in here as the
+        # effective cwd (as a prior version did for placeholder-cwd
+        # specs) makes the inner guard compare the override against
+        # itself, so it accepts ANY path — a sandbox escape for the
+        # idiomatic ``os_env.cwd: "."`` + ``allow_cwd_override:
+        # true`` terminal.
+        anchor_cwd = self._resolve_anchor_cwd(validated.terminal_spec, ctx)
+        parent_os_env = _synthesize_parent_os_env(self._spec.os_env, anchor_cwd)
         materialized_terminal_spec = _materialize_terminal_spec_for_launch(
-            validated.terminal_spec, resolved_cwd
+            validated.terminal_spec, anchor_cwd
         )
 
         # Snapshot whether the registry already has a live instance
@@ -629,7 +640,7 @@ class SysTerminalLaunchTool(Tool):
         Orchestrates :meth:`_perform_launch` and
         :func:`_format_launch_envelope`. All arguments are
         pre-validated by :meth:`_validate_launch_args` /
-        :meth:`_resolve_cwd` / :func:`_synthesize_parent_os_env`.
+        :meth:`_resolve_anchor_cwd` / :func:`_synthesize_parent_os_env`.
 
         :param ctx: Tool execution context — supplies
             ``conversation_id`` for the resource-publish event.
@@ -688,10 +699,12 @@ class SysTerminalLaunchTool(Tool):
                     validated.session_key,
                     terminal_spec,
                     parent_os_env=parent_os_env,
-                    # cwd_override is reserved for LLM-supplied
-                    # per-call overrides (already validated against
-                    # allow_cwd_override above). The §4.6
-                    # precedence flows through parent_os_env.
+                    # cwd_override is reserved for the LLM-supplied
+                    # per-call override (already validated against
+                    # allow_cwd_override above). The trusted anchor
+                    # flows separately through parent_os_env / the
+                    # materialized terminal spec; the inner guard
+                    # contains this override within that anchor.
                     cwd_override=validated.cwd_override,
                     sandbox_override=validated.sandbox_override,
                 )
@@ -749,35 +762,43 @@ class SysTerminalLaunchTool(Tool):
             sandbox_override=sandbox_override,
         )
 
-    def _resolve_cwd(
+    def _resolve_anchor_cwd(
         self,
-        cwd_override: str | None,
         terminal_spec: TerminalEnvSpec,
         ctx: ToolContext,
     ) -> str | None:
         """
-        Apply the §4.6 cwd-resolution precedence.
+        Resolve the trusted containment *anchor* cwd for a launch.
 
-        Order (first match wins):
-        1. ``cwd_override`` from the LLM (already vetted against
-           ``allow_cwd_override`` by the caller).
-        2. The terminal's own ``os_env.cwd`` if the terminal spec
+        This is the directory the terminal is anchored to and the
+        root that an LLM-supplied ``cwd`` override is contained
+        within. It is resolved **without** the override on purpose:
+        the override must never become its own anchor, or the inner
+        containment guard
+        (:func:`omnigent.inner.terminal.build_terminal_os_env_spec`)
+        would compare it against itself — ``relative_to`` always
+        passes — and accept ANY path (``/``, ``~/.ssh``, ``/etc``).
+        That is a sandbox escape for placeholder-cwd terminals
+        (``os_env.cwd: "."`` + ``allow_cwd_override: true``). The
+        override instead flows separately as the registry's
+        ``cwd_override``, where the guard validates it against this
+        anchor.
+
+        Precedence (first match wins):
+        1. The terminal's own ``os_env.cwd`` if the terminal spec
            declares a meaningful cwd (not ``None``, ``""``,
            ``"."``, or ``"./"``).
-        3. ``spec.os_env.cwd`` if it's set to a meaningful path
+        2. ``spec.os_env.cwd`` if it's set to a meaningful path
            (not ``None``, ``""``, ``"."``, or ``"./"``).
-        4. ``ctx.workspace`` — the per-task workspace Omnigent creates
-           in ``runtime/workflow.py``.
+        3. ``ctx.workspace`` — the per-task workspace Omnigent creates
+           in ``runtime/workflow.py`` (the trusted root).
 
-        :param cwd_override: Per-call override (or ``None``).
         :param terminal_spec: The :class:`TerminalEnvSpec`.
         :param ctx: Tool context with the per-task workspace.
-        :returns: The resolved cwd as a string, or ``None`` if no
-            tier matched (caller falls back to host cwd, mirroring
+        :returns: The resolved anchor cwd as a string, or ``None`` if
+            no tier matched (caller falls back to host cwd, mirroring
             legacy behavior).
         """
-        if cwd_override is not None:
-            return cwd_override
         terminal_os_env = getattr(terminal_spec, "os_env", None)
         # ``os_env`` on a TerminalEnvSpec may be the literal string
         # ``"inherit"`` (legacy sentinel for "use parent's"). That

--- a/tests/terminals/test_registry_io.py
+++ b/tests/terminals/test_registry_io.py
@@ -157,7 +157,7 @@ async def test_launched_shell_starts_in_spec_cwd(
 ) -> None:
     """``pwd`` in a freshly launched shell reports the spec's cwd.
 
-    The behavioral half of ``_resolve_cwd``'s precedence logic, which is
+    The behavioral half of ``_resolve_anchor_cwd``'s precedence logic, which is
     unit-tested in isolation but never proven against a live shell.
     """
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))

--- a/tests/tools/builtins/test_sys_terminal.py
+++ b/tests/tools/builtins/test_sys_terminal.py
@@ -515,8 +515,7 @@ def test_cwd_resolution_uses_workspace_when_spec_cwd_is_dot(
     # warrants direct testing rather than only being covered
     # transitively through a launched tmux. Public-API coverage
     # comes from the round-trip integration test above.
-    resolved = tool._resolve_cwd(
-        cwd_override=None,
+    resolved = tool._resolve_anchor_cwd(
         terminal_spec=spec.terminals["bash"],
         ctx=ctx,
     )
@@ -543,8 +542,7 @@ def test_cwd_resolution_uses_workspace_when_terminal_cwd_is_dot(
     )
     tool = SysTerminalLaunchTool(spec=spec, registry=registry)
 
-    resolved = tool._resolve_cwd(
-        cwd_override=None,
+    resolved = tool._resolve_anchor_cwd(
         terminal_spec=spec.terminals["bash"],
         ctx=ctx,
     )
@@ -566,34 +564,150 @@ def test_cwd_resolution_explicit_spec_cwd_wins_over_workspace(
         os_env=OSEnvSpec(type="caller_process", cwd=explicit_cwd),
     )
     tool = SysTerminalLaunchTool(spec=spec, registry=registry)
-    resolved = tool._resolve_cwd(
-        cwd_override=None,
+    resolved = tool._resolve_anchor_cwd(
         terminal_spec=spec.terminals["bash"],
         ctx=ctx,
     )
     assert resolved == explicit_cwd
 
 
-def test_cwd_resolution_per_call_override_wins(
+def test_anchor_cwd_ignores_per_call_override(
     registry: TerminalRegistry, ctx: ToolContext, tmp_path: Path
 ) -> None:
     """
-    The per-call ``cwd`` argument (already vetted against
-    ``allow_cwd_override``) wins over every spec-level setting.
+    The trusted containment anchor is resolved WITHOUT the LLM's
+    per-call ``cwd`` override. The override must never become its own
+    anchor — it flows separately through the inner guard's
+    ``cwd_override``, which contains it within this anchor.
+
+    Regression guard for the P0 where the launch tool folded the
+    override into the effective cwd for a placeholder-cwd terminal
+    (``os_env.cwd: "."`` + ``allow_cwd_override: true``), so the
+    inner containment check compared the override against itself and
+    accepted any path (``/``, ``~/.ssh``, ``/etc``). The anchor must
+    stay pinned to the explicit spec cwd (or the workspace), no
+    matter what override the LLM later supplies.
     """
     spec_cwd = str(tmp_path / "spec_cwd")
-    override_cwd = str(tmp_path / "override")
     spec = _make_spec(
         terminals={"bash": TerminalEnvSpec(command="bash", allow_cwd_override=True)},
         os_env=OSEnvSpec(type="caller_process", cwd=spec_cwd),
     )
     tool = SysTerminalLaunchTool(spec=spec, registry=registry)
-    resolved = tool._resolve_cwd(
-        cwd_override=override_cwd,
+    # ``_resolve_anchor_cwd`` takes no override by construction — the
+    # anchor is the trusted spec cwd, never the (out-of-band) override.
+    anchor = tool._resolve_anchor_cwd(
         terminal_spec=spec.terminals["bash"],
         ctx=ctx,
     )
-    assert resolved == override_cwd
+    assert anchor == spec_cwd
+
+
+# ── cwd-override containment guard (sandbox escape) ───────────
+
+
+async def test_launch_rejects_out_of_root_cwd_override_for_placeholder_spec(
+    registry: TerminalRegistry,
+    ctx: ToolContext,
+    cleanup_registry: None,
+    tmp_path: Path,
+) -> None:
+    """
+    A ``cwd`` override pointing OUTSIDE the terminal's root is
+    rejected even when the terminal spec uses the placeholder cwd
+    ``"."`` together with ``allow_cwd_override: true`` — exactly
+    polly's ``shell`` terminal.
+
+    This is the P0 regression target. The launch tool used to fold
+    the override into the effective cwd whenever the spec cwd was a
+    placeholder (``None`` / ``""`` / ``"."`` / ``"./"``) AND also
+    pass it as ``cwd_override``, so the inner containment guard
+    compared the override against itself (``relative_to`` of a path
+    against itself always passes) and accepted ANY path — ``/``,
+    ``~/.ssh``, ``/etc``. With the anchor resolved without the
+    override, the guard anchors at ``ctx.workspace`` and rejects an
+    override that escapes it.
+
+    What breaks if this fails: a sandboxed adopter's agent can
+    repoint its terminal anchor anywhere on the host, escaping the
+    project sandbox's filesystem / dotfile-masking anchors.
+    """
+    del cleanup_registry  # registered for its teardown side-effect
+    # A sibling of the workspace is guaranteed to be outside it.
+    outside_root = tmp_path.parent / "p0_outside_root_escape"
+    outside_root.mkdir(exist_ok=True)
+    spec = _make_spec(
+        terminals={
+            "bash": TerminalEnvSpec(
+                command="bash",
+                allow_cwd_override=True,
+                os_env=OSEnvSpec(
+                    type="caller_process",
+                    cwd=".",  # placeholder — the vulnerable idiom
+                    sandbox=OSEnvSandboxSpec(type="none"),
+                ),
+            )
+        },
+    )
+    tool = SysTerminalLaunchTool(spec=spec, registry=registry)
+
+    result = await _invoke(
+        tool,
+        {"terminal": "bash", "session": "s1", "cwd": str(outside_root)},
+        ctx,
+    )
+
+    assert "error" in result, (
+        "out-of-root cwd override was accepted for a placeholder-cwd "
+        f"terminal — the containment guard is a no-op (sandbox escape). Got {result!r}"
+    )
+    assert "outside the allowed root" in result["error"], (
+        f"expected a containment-guard rejection, got {result['error']!r}"
+    )
+    # The rejected launch must not register a tmux session.
+    assert registry.get(ctx.conversation_id, "bash", "s1") is None
+
+
+async def test_launch_accepts_in_root_cwd_override_for_placeholder_spec(
+    registry: TerminalRegistry,
+    ctx: ToolContext,
+    cleanup_registry: None,
+    tmp_path: Path,
+) -> None:
+    """
+    A ``cwd`` override that stays INSIDE the terminal's root still
+    launches for a placeholder-cwd terminal. The containment fix must
+    reject escapes without breaking the legitimate in-root override
+    (the whole point of ``allow_cwd_override: true``).
+    """
+    del cleanup_registry
+    in_root = tmp_path / "workdir"
+    in_root.mkdir()
+    spec = _make_spec(
+        terminals={
+            "bash": TerminalEnvSpec(
+                command="bash",
+                allow_cwd_override=True,
+                os_env=OSEnvSpec(
+                    type="caller_process",
+                    cwd=".",
+                    sandbox=OSEnvSandboxSpec(type="none"),
+                ),
+            )
+        },
+    )
+    tool = SysTerminalLaunchTool(spec=spec, registry=registry)
+
+    result = await _invoke(
+        tool,
+        {"terminal": "bash", "session": "s1", "cwd": str(in_root)},
+        ctx,
+    )
+
+    assert result.get("status") == "launched", (
+        "in-root cwd override was rejected — the containment fix over-blocked a "
+        f"legitimate override under the workspace root. Got {result!r}"
+    )
 
 
 # ── §9.1 concurrent-send race ─────────────────────


### PR DESCRIPTION
## Related issue

N/A — P0 security finding (no tracked GitHub issue).

## Summary

**Vulnerability + impact.** The `sys_terminal_launch` cwd-containment guard
(`build_terminal_os_env_spec`, `omnigent/inner/terminal.py`) is a **no-op for
placeholder-cwd terminals** — the idiomatic `os_env.cwd: "."` +
`allow_cwd_override: true` config (exactly polly's `shell` terminal). The
launch tool resolved the LLM-supplied `cwd` override as the *effective* cwd
(folding it into the materialized terminal spec / synthesized `parent_os_env`)
**and** passed the same value again as `cwd_override`. The inner guard then
compared the override against itself — `Path(x).relative_to(x)` always
succeeds — so it accepted **any** path (`/`, `~/.ssh`, `/etc`). For any
sandboxed adopter this is a **sandbox escape**: the agent can repoint the
terminal anchor anywhere on the host, breaking the bwrap workspace root and the
seatbelt dotfile/credential-masking anchors, and resolving `write_paths: ["."]`
to the attacker-chosen root.

**Fix.** Compute the containment **anchor without the override** — anchor =
explicit spec cwd if set, else `ctx.workspace` (the trusted root) — and pass
the LLM override **only** via `cwd_override`, so the inner guard validates it
against the true anchor. `_resolve_cwd` is renamed to `_resolve_anchor_cwd` and
the override tier is removed entirely, so **no code path** can turn the override
into its own anchor. The legitimate in-root override on an explicit-cwd spec is
preserved.

ELI5: the bouncer was checking the guest's ID against a copy of the same ID the
guest handed him, so everyone got in. Now he checks the guest's ID against the
real guest list (the workspace root).

```
BEFORE (no-op guard)
  LLM cwd override ──┬──> effective cwd  ── used as anchor ─┐
                     └──> cwd_override ───────────────────┘ relative_to(itself) -> ACCEPTS ANY PATH

AFTER (contained)
  spec cwd / ctx.workspace ──> effective cwd (trusted anchor) ─┐
  LLM cwd override ──────────> cwd_override ───────────────────┘ relative_to(anchor) -> reject if outside
```

## Test Plan

- `uv run --extra dev --extra all python -m pytest tests/tools/builtins/test_sys_terminal.py -x -q` → **19 passed**.
- `uv run --extra dev --extra all python -m pytest tests/tools/builtins/test_sys_terminal.py tests/terminals/ -q` → **111 passed** (no regressions in the registry / IO / ws-bridge suites).
- `uv run --extra dev python -m ruff check` on the changed files → **All checks passed**.
- **Regression proof.** Temporarily re-introduced the pre-fix behavior (override folded back in as the anchor) and re-ran the new tests: `test_launch_rejects_out_of_root_cwd_override_for_placeholder_spec` **FAILED** with `status: launched` (the escape), while the in-root test still passed. Reverted; both pass. This confirms the new test genuinely catches the P0.

## Demo

N/A — backend-only security fix, no UI/frontend change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added two tool-level tests against a placeholder-cwd spec (`os_env.cwd: "."` +
`allow_cwd_override: true`): an out-of-root override is rejected with an
"outside the allowed root" error and registers no tmux session (this test fails
on the pre-fix code), and an in-root override still launches. Updated the
`_resolve_anchor_cwd` unit tests for the new signature and replaced the old
"override wins" test with one asserting the anchor never absorbs the override.
Manual verification = the regression proof described in the Test Plan
(reintroduced the bug and observed the new test fail, then revert).