### PR TITLE
feat(skills): add polly-e2e-dev skill for orchestrator CUJ testing

### DIFF
--- a/.claude/skills/polly-e2e-dev/SKILL.md
+++ b/.claude/skills/polly-e2e-dev/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: polly-e2e-dev
+description: End-to-end test the polly multi-agent coding orchestrator's critical user journeys (CUJs). Two halves — a deterministic mock-LLM driver (polly_cuj.py) that boots a throwaway local server + mock LLM and asserts the substrate (boot, bridged sys_* tool dispatch, the blast_radius / spawn_bounds / headless_subagent_purpose_guard guardrails, fan-out delegation), and a live real-CLI recipe (real claude/codex/pi, real worktrees/PRs) for polly's actual judgment. Load when developing, testing, or debugging examples/polly — its config.yaml, the claude_code/codex/pi sub-agents, the investigate/fanout/cross-review skills, or the omnigent.inner.nessie.policies guardrails — or reproducing a polly orchestration bug.
+---
+
+# polly orchestrator: end-to-end CUJ dev & testing
+
+`polly` (`examples/polly/`) is a multi-agent **coding orchestrator**: a
+`claude-sdk` "brain" that writes no code itself and delegates everything to three
+coding sub-agents — `claude_code` (claude-native), `codex` (codex-native), and
+`pi` (headless, multi-model). Its critical user journeys are orchestration
+behaviors, not single-turn answers:
+
+- **roster preflight** — first turn runs `command -v claude codex pi`, routes
+  only to workers whose CLI resolved.
+- **investigate** — read-only work fanned to `explore`/`search` sub-agents;
+  synthesize from their reports.
+- **fanout** — independent tasks, each in its own git worktree + sub-agent, each
+  opening its own PR.
+- **cross-review** — an implementer's diff is verified by a **different-vendor**
+  sub-agent (diff + contract only); blocking issues become fix-tasks.
+- **plan gate / inbox** — pull the human in at the plan gate; supervise via the
+  inbox + autowake, never busy-poll.
+- **guardrails** (`omnigent.inner.nessie.policies`) — `blast_radius` (deny
+  force-push / `rm -rf /`), `spawn_bounds` (cap dispatches per turn),
+  `headless_subagent_purpose_guard` (every dispatch needs `args.purpose`).
+
+This skill tests those CUJs two ways. Use **both** — they cover different things:
+
+| Half | What it proves | Needs |
+|------|----------------|-------|
+| **Mock loop** (`polly_cuj.py`) | The **substrate/mechanics** — the brain is *scripted*, so this proves bundle load, server-side policy resolution, bridged `sys_*` tool dispatch, the guardrail DENYs, and fan-out — deterministically, with no creds | nothing (mock LLM) |
+| **Live recipe** | polly's **judgment** — does the real brain preflight, decompose, delegate, cross-review, and pull in the human correctly | real `claude`/`codex`/`pi` + model creds + network |
+
+> Like the sibling harness skills, turns run from your **current checkout**
+> (`omni run <bundle> --server <url>` = local runner + remote server), so testing
+> exercises exactly the code you're on.
+
+## Interpreter
+
+The driver and CLI need the repo's Python ≥3.12 env. If `.venv/` is missing,
+create it once from the checkout:
+
+```bash
+uv run --frozen python -c "import omnigent; print('ok')"   # builds .venv
+```
+
+Then use `.venv/bin/python` / `.venv/bin/omni` below.
+
+---
+
+## Part A — the deterministic mock loop (`polly_cuj.py`)
+
+The driver boots a throwaway local Omnigent server (which carries
+`omnigent.inner.nessie.policies` — the module polly's guardrails resolve) plus
+the repo's mock-LLM server, rewrites the polly bundle to the `openai-agents`
+harness wired to the mock, then runs `omnigent run` turns where the brain is
+*scripted* (text or tool calls). It prints one `SUMMARY {json}` per scenario and
+exits non-zero if any check failed.
+
+```bash
+.venv/bin/python .claude/skills/polly-e2e-dev/polly_cuj.py --list-scenarios
+.venv/bin/python .claude/skills/polly-e2e-dev/polly_cuj.py --scenario all
+.venv/bin/python .claude/skills/polly-e2e-dev/polly_cuj.py --scenario guardrail_purpose --keep
+```
+
+Read the result with `… | grep '^SUMMARY' | python -m json.tool`. Each run takes
+~45–55s for all five scenarios; no credentials or egress are required.
+
+### Scenario catalog
+
+| Scenario | Scripts the brain to… | Hard check |
+|---|---|---|
+| `boot` | reply with text | exit 0 + non-trivial reply (bundle load, server-side policy resolve, turn completes) |
+| `tool_dispatch` | call `sys_os_shell` to write a sentinel | the file appears on disk (bridged `sys_*` dispatch works; `blast_radius` ALLOWs benign shell) |
+| `guardrail_purpose` | `sys_session_send` with **no** `args.purpose` | tool output carries `Denied by policy: … must declare what kind of work it is` (`headless_subagent_purpose_guard`) |
+| `guardrail_blast_radius` | `sys_os_shell("git push --force …")` | tool output carries `Denied by policy: … blast-radius policy` |
+| `fanout_dispatch` | emit 6 `sys_session_send` in one turn | ≥2 sub-agent dispatch handles created (fan-out substrate). **Finding:** reports whether the `spawn_bounds` cap fired (see Known sharp edges) |
+
+### The verifiable before→after loop
+
+The driver exists for a *loop*, not a one-shot. To prove a fix:
+
+1. On the **unfixed** code, run the scenario → a check is `false` (baseline).
+2. Make the change.
+3. Run the **same** scenario → the check **flips** to `true`.
+
+A fix is "verifiable" only if a check flips. If it doesn't flip, you can't prove
+the change did anything — keep working. To cover a new mechanism, add a
+`scenario_*` function + a row in `_SCENARIOS` (each builds a bundle, scripts the
+mock, runs a turn, and asserts an **observable effect** — a session item, a deny
+sentinel, a file on disk).
+
+### What the mock loop can and can't prove
+
+It tests **mechanics** because the brain is scripted: tool dispatch, the
+guardrail gate, session persistence, fan-out plumbing. It does **not** test
+polly's judgment (whether the *real* brain preflights, decomposes, picks the
+right vendor, cross-reviews). That is the live recipe.
+
+---
+
+## Part B — the live recipe (real claude/codex/pi)
+
+### Prereqs (check first)
+
+1. **You're on the branch you want to test.**
+2. **A Claude provider for the brain** (`omni setup`, or `ANTHROPIC_API_KEY`, or
+   a Databricks default). Verify booleans only — never print keys.
+3. **Worker CLIs on PATH** — this *is* the roster preflight:
+   ```bash
+   command -v claude codex pi || true
+   ```
+   A worker is launchable only if its binary resolved. Cross-review needs **two
+   different vendors** available.
+4. **Network egress** to the model backends; **`gh`** authed if you want real PRs.
+
+### Run a live turn
+
+```bash
+.venv/bin/omni server start && .venv/bin/omni server status   # prints $SERVER, e.g. http://127.0.0.1:6767
+SERVER=http://127.0.0.1:6767
+timeout 280 .venv/bin/omni run examples/polly \
+  -p "Investigate how the runner enforces tool-call policies and report file:line evidence." \
+  --server "$SERVER" 2>&1
+```
+
+Always pass `--server "$SERVER"`; omitting it routes to the configured **remote**
+deploy, which may be stale and reject parts of the bundle.
+
+### Observe CUJs (CLI + HTTP API + filesystem)
+
+Grab the session id, then read the transcript and the side effects:
+
+```bash
+SID=$(curl -s "$SERVER/v1/sessions?kind=default&order=desc&limit=1" | python -c "import sys,json;print(json.load(sys.stdin)['data'][0]['id'])")
+curl -s "$SERVER/v1/sessions/$SID/items"          | python -m json.tool | tail -60   # brain transcript + tool calls
+curl -s "$SERVER/v1/sessions/$SID/child_sessions" | python -m json.tool             # dispatched sub-agents
+git worktree list                                  # fanout: one per task
+cat .polly/registry.json 2>/dev/null               # polly's task list
+gh pr list --author "@me"                          # each implementer opens its own PR
+```
+
+### Per-CUJ live playbook
+
+| CUJ | Drive it | Look for |
+|---|---|---|
+| roster preflight | first live turn on a box missing a CLI | polly tells you which worker is unavailable; routes around it |
+| investigate | prompt a read-only question ("explain/audit/why does X…") | `child_sessions` with `purpose: explore/search`; answer cites their reports, not polly's own deep reads |
+| fanout | prompt 2–3 independent changes | one worktree + one sub-agent + one PR per task |
+| cross-review | let an implementer finish | a **different-vendor** reviewer child with `purpose: review`; blocking issues sent back to the **same** implementer session |
+| plan gate / inbox | a multi-step task | polly pauses for human approval at the plan gate; ends its turn after dispatch and is autowoken by the inbox (no busy-poll) |
+| guardrails (ASK) | a task that pushes/merges | the runner surfaces an approval card; `ask_timeout: 86400` keeps it open |
+
+For the guardrail **DENY** set (force-push, `rm -rf /`, unmarked dispatch,
+fan-out cap), prefer the **mock loop** — it's deterministic and creates no real
+side effects.
+
+---
+
+## CUJ coverage map
+
+| CUJ | Mock loop | Live recipe |
+|---|---|---|
+| boot / turn completes | `boot` | any live turn |
+| bridged `sys_*` dispatch | `tool_dispatch` | tool calls in `…/items` |
+| `headless_subagent_purpose_guard` | `guardrail_purpose` ✅ | (deny — prefer mock) |
+| `blast_radius` | `guardrail_blast_radius` ✅ | ASK card on push/merge |
+| `spawn_bounds` | `fanout_dispatch` (finding) ⚠️ | verify cap live |
+| fanout delegation | `fanout_dispatch` (handles) | `child_sessions` + worktrees + PRs |
+| investigate / cross-review / plan gate / inbox | — (needs judgment) | live playbook above |
+
+---
+
+## Known sharp edges (found while building this skill — verify, may change)
+
+- **`spawn_bounds` per-turn cap does not trip in the local server-side path.**
+  The cap is a *stateful* per-turn counter, but the server rebuilds the policy
+  engine per `tools/call` (`_build_policy_engine_from_spec`, `sessions.py`), so
+  the counter resets every call. Stateless policies (`purpose_guard`,
+  `blast_radius`) are unaffected. `fanout_dispatch` reports this as a finding
+  rather than failing. Verify the cap **live**, where a persistent per-turn
+  engine applies.
+- **Two deny formats.** Bridged `sys_*` tools surface a denial as
+  `{"error": "Denied by policy: <reason>"}`; SDK function tools use
+  `[Denied by policy: <name>] {json}`. Both share the `Denied by policy:`
+  marker — match on that plus a policy-specific reason fragment (the driver does).
+- **Live fan-out needs the worker CLIs.** In the mock loop, sub-agents are
+  rewritten to `openai-agents` so a dispatch needs no binary. Live, a missing
+  `claude`/`codex`/`pi` makes that worker fail to boot — treat it as UNAVAILABLE.
+- **Default server gotcha.** `config.yaml`'s `server:` points at a remote deploy;
+  always pass `--server "$SERVER"` for local testing.
+
+## Code & tests
+
+- **Bundle / prompt / guardrails:** `examples/polly/config.yaml`
+- **Sub-agents:** `examples/polly/agents/{claude_code,codex,pi}/config.yaml`
+- **Orchestration skills:** `examples/polly/skills/{investigate,fanout,cross-review}/SKILL.md`
+- **Guardrail policies:** `omnigent/inner/nessie/policies.py`
+- **Runner-side gate:** `omnigent/runner/policy.py`; server-side tool-call
+  enforcement: `omnigent/server/routes/sessions.py`
+- **Mock LLM server:** `tests/server/integration/mock_llm_server.py`
+
+```bash
+# Existing pytest e2e for polly (mock-LLM) — complementary to this skill:
+uv run --frozen --extra dev python -m pytest \
+  tests/e2e/test_polly_e2e.py \
+  tests/e2e/test_polly_cost_advisor_e2e.py \
+  tests/e2e/test_polly_subagent_model_e2e.py -q
+```
+
+## Teardown — non-negotiable
+
+The driver reaps everything it starts, including the per-conversation
+`omnigent.host._daemon_entry` / `runner._entry` / `harnesses._runner`
+subprocesses an `omni run` turn spawns (a plain server SIGTERM leaves these
+orphaned). The sweep is scoped to this interpreter, so it never touches another
+worktree. After a **live** session, sweep manually:
+
+```bash
+.venv/bin/omni server stop
+pgrep -af "$(pwd)/.venv/bin/python -m omnigent" | grep -E "_entry|_runner|_daemon" || echo clean
+```
+
+## Honesty
+
+If a worker CLI, credential, or egress isn't available, say the live CUJ was
+**skipped** — don't claim it passed. The strongest evidence is a reproduced
+baseline plus the flipped check (mock loop) or the observed round trip in
+`…/items` + `…/child_sessions` (live). Report the real `SUMMARY` lines, not a
+summary of a summary.

--- a/.claude/skills/polly-e2e-dev/polly_cuj.py
+++ b/.claude/skills/polly-e2e-dev/polly_cuj.py
@@ -124,9 +124,7 @@ def _mock_reset(mock_url: str) -> None:
     _post_json(f"{mock_url}/mock/reset", {})
 
 
-def _mock_configure(
-    mock_url: str, responses: list[dict], *, key: str = "default"
-) -> None:
+def _mock_configure(mock_url: str, responses: list[dict], *, key: str = "default") -> None:
     """Load a keyed response queue on the mock server."""
     _post_json(f"{mock_url}/mock/configure", {"key": key, "responses": responses})
 
@@ -164,9 +162,7 @@ def _sys_os_shell_call(command: str, *, call_id: str = "call_sh") -> dict:
 # ── Bundle rewrite (inlined from tests/e2e/test_polly_e2e.py) ─────────────────
 
 
-def _mock_polly_bundle(
-    tmp: Path, mock_url: str, *, rewrite_subagents: bool = False
-) -> Path:
+def _mock_polly_bundle(tmp: Path, mock_url: str, *, rewrite_subagents: bool = False) -> Path:
     """Copy ``examples/polly`` into *tmp* and rewrite it to use the mock LLM.
 
     Switches the brain harness from ``claude-sdk`` to ``openai-agents``, pins the
@@ -419,9 +415,7 @@ def _latest_session_id(server_url: str) -> str | None:
 
 def _session_items(server_url: str, session_id: str) -> list[dict]:
     """All items in a session, chronological."""
-    page = _get_json(
-        f"{server_url}/v1/sessions/{session_id}/items?order=asc&limit=300"
-    )
+    page = _get_json(f"{server_url}/v1/sessions/{session_id}/items?order=asc&limit=300")
     data = page.get("data", []) if isinstance(page, dict) else []
     return [item for item in data if isinstance(item, dict)]
 
@@ -566,9 +560,7 @@ def _guardrail_scenario(
     # Drain any stray sub-agent child LLM calls with a trivial fallback.
     _mock_set_fallback(s.mock_url, "default", "ok")
     _mock_configure(s.mock_url, responses, key=_BRAIN_MODEL)
-    bundle = _mock_polly_bundle(
-        ctx.tmp / name, s.mock_url, rewrite_subagents=rewrite_subagents
-    )
+    bundle = _mock_polly_bundle(ctx.tmp / name, s.mock_url, rewrite_subagents=rewrite_subagents)
     proc = _run_polly(bundle, s.server_url, prompt, s.mock_url)
     _add_exit_check(res, proc)
 

--- a/.claude/skills/polly-e2e-dev/polly_cuj.py
+++ b/.claude/skills/polly-e2e-dev/polly_cuj.py
@@ -1,0 +1,740 @@
+#!/usr/bin/env python3
+"""Deterministic mock-LLM CUJ driver for the polly coding orchestrator.
+
+This is the *reproducible loop* half of the ``polly-e2e-dev`` skill. It boots a
+throwaway local Omnigent server from the current checkout (which carries
+``omnigent.inner.nessie.policies`` — the module polly's guardrails resolve) plus
+the repo's mock-LLM server, rewrites the ``examples/polly`` bundle to the
+``openai-agents`` harness wired to the mock, then drives ``omnigent run`` turns
+where the brain is *scripted* (text or tool calls). Because the brain is mocked,
+the loop tests the **substrate / mechanics** of each critical user journey —
+tool dispatch, the three runner-side guardrails, session persistence — not
+polly's live judgment (that is the live recipe in ``SKILL.md``).
+
+Each scenario prints one machine-readable ``SUMMARY {json}`` line and the driver
+exits non-zero if any check failed (a ``skipped`` check never fails the run).
+
+Run it (use the repo venv so subprocesses import the checkout, not a stale wheel)::
+
+    .venv/bin/python .claude/skills/polly-e2e-dev/polly_cuj.py --scenario all
+    .venv/bin/python .claude/skills/polly-e2e-dev/polly_cuj.py --list-scenarios
+    .venv/bin/python .claude/skills/polly-e2e-dev/polly_cuj.py --scenario guardrail_purpose --keep
+
+No credentials or network egress are required — the mock LLM stands in for every
+provider. See ``SKILL.md`` for the live (real claude/codex/pi) recipe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator
+from contextlib import closing, contextmanager, suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# ── Paths & constants ────────────────────────────────────────────────────────
+
+# polly_cuj.py -> polly-e2e-dev -> skills -> .claude -> <repo root>
+_REPO_DEFAULT = Path(__file__).resolve().parents[3]
+_MOCK_SERVER_REL = Path("tests") / "server" / "integration" / "mock_llm_server.py"
+
+_SERVER_BOOT_TIMEOUT_S = 90.0
+_MOCK_BOOT_TIMEOUT_S = 15.0
+_RUN_TIMEOUT_S = 180
+_MIN_REPLY_CHARS = 12
+
+# The mock routes /v1/responses by the request's ``model`` field; the polly
+# brain spec is rewritten to send this exact key so we own its response queue.
+_BRAIN_MODEL = "mock-polly-brain"
+
+# Native harnesses that need a CLI binary on PATH; rewritten to ``openai-agents``
+# (SDK-based, no binary) for the one scenario that actually dispatches workers.
+_NATIVE_HARNESSES = frozenset(
+    {
+        "claude-native",
+        "native-claude",
+        "codex-native",
+        "native-codex",
+        "pi",
+        "pi-native",
+        "native-pi",
+        "cursor-native",
+        "native-cursor",
+    }
+)
+
+
+# ── HTTP helpers (stdlib only) ───────────────────────────────────────────────
+
+
+def _free_port() -> int:
+    """Reserve an ephemeral loopback port."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _get_json(url: str, timeout: float = 10.0) -> object:
+    """GET *url* and parse JSON."""
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _post_json(url: str, payload: dict, timeout: float = 10.0) -> object:
+    """POST *payload* as JSON to *url* and parse the JSON reply."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"content-type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _wait_for_http(url: str, deadline: float) -> None:
+    """Block until *url* answers HTTP 200, or raise past *deadline*."""
+    last: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                if resp.status == 200:
+                    return
+        except (urllib.error.URLError, OSError) as err:
+            last = err
+        time.sleep(0.5)
+    raise TimeoutError(f"{url} never became healthy: {last}")
+
+
+# ── Mock LLM controls ────────────────────────────────────────────────────────
+
+
+def _mock_reset(mock_url: str) -> None:
+    _post_json(f"{mock_url}/mock/reset", {})
+
+
+def _mock_configure(
+    mock_url: str, responses: list[dict], *, key: str = "default"
+) -> None:
+    """Load a keyed response queue on the mock server."""
+    _post_json(f"{mock_url}/mock/configure", {"key": key, "responses": responses})
+
+
+def _mock_set_fallback(mock_url: str, key: str, text: str) -> None:
+    """Set a non-resettable fallback response for *key* (drains stray child calls)."""
+    _post_json(f"{mock_url}/mock/set_fallback", {"key": key, "text": text})
+
+
+def _sys_session_send_call(
+    agent: str, title: str, child_args: object, *, call_id: str = "call_1"
+) -> dict:
+    """Build a ``tool_calls`` entry for ``sys_session_send``.
+
+    *child_args* may be a string (bare input) or a dict
+    (``{"input": ..., "purpose": ...}``) — the latter is what
+    ``headless_subagent_purpose_guard`` requires.
+    """
+    return {
+        "call_id": call_id,
+        "name": "sys_session_send",
+        "arguments": json.dumps({"agent": agent, "title": title, "args": child_args}),
+    }
+
+
+def _sys_os_shell_call(command: str, *, call_id: str = "call_sh") -> dict:
+    """Build a ``tool_calls`` entry for ``sys_os_shell``."""
+    return {
+        "call_id": call_id,
+        "name": "sys_os_shell",
+        "arguments": json.dumps({"command": command}),
+    }
+
+
+# ── Bundle rewrite (inlined from tests/e2e/test_polly_e2e.py) ─────────────────
+
+
+def _mock_polly_bundle(
+    tmp: Path, mock_url: str, *, rewrite_subagents: bool = False
+) -> Path:
+    """Copy ``examples/polly`` into *tmp* and rewrite it to use the mock LLM.
+
+    Switches the brain harness from ``claude-sdk`` to ``openai-agents``, pins the
+    deterministic model key, and bakes ``auth`` + ``connection`` blocks at the
+    mock so neither the brain nor the runner-side cost judge reaches a real
+    provider. When *rewrite_subagents* is set, native sub-agent harnesses become
+    ``openai-agents`` too (so a dispatch doesn't need claude/codex/pi on PATH).
+    """
+    src = (_repo() / "examples" / "polly").resolve()
+    dst = tmp / "polly"
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, symlinks=False)
+
+    cfg_path = dst / "config.yaml"
+    spec = yaml.safe_load(cfg_path.read_text())
+    executor = spec.setdefault("executor", {})
+    exec_cfg = executor.pop("config", {}) or {}
+    exec_cfg["harness"] = "openai-agents"
+    executor["config"] = exec_cfg
+    executor["model"] = _BRAIN_MODEL
+    executor["auth"] = {
+        "type": "api_key",
+        "api_key": "mock-key",
+        "base_url": f"{mock_url}/v1",
+    }
+    executor["connection"] = {"base_url": f"{mock_url}/v1", "api_key": "mock-key"}
+    cfg_path.write_text(yaml.safe_dump(spec, sort_keys=False))
+
+    if rewrite_subagents:
+        agents_dir = dst / "agents"
+        for sub_cfg in agents_dir.glob("*/config.yaml") if agents_dir.is_dir() else []:
+            sub = yaml.safe_load(sub_cfg.read_text())
+            sub_exec = sub.get("executor") or {}
+            sub_inner = sub_exec.get("config") or {}
+            harness = sub_inner.get("harness") or sub_exec.get("type") or ""
+            if harness in _NATIVE_HARNESSES:
+                sub_inner["harness"] = "openai-agents"
+                sub_exec["config"] = sub_inner
+                sub["executor"] = sub_exec
+                sub_cfg.write_text(yaml.safe_dump(sub, sort_keys=False))
+    return dst
+
+
+# ── Subprocess env ───────────────────────────────────────────────────────────
+
+_CREDENTIAL_VARS = (
+    "DATABRICKS_TOKEN",
+    "DATABRICKS_HOST",
+    "DATABRICKS_CLIENT_ID",
+    "DATABRICKS_CLIENT_SECRET",
+    "DATABRICKS_CONFIG_PROFILE",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE",
+    "CLAUDECODE",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "CODEX",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+)
+
+
+def _run_env(mock_url: str) -> dict[str, str]:
+    """Env for the ``omnigent run`` subprocess: isolated config, mock provider."""
+    env = dict(os.environ)
+    env["OMNIGENT_SKIP_ONBOARD"] = "1"
+    env["OMNIGENT_NO_UPDATE_CHECK"] = "1"
+    config_home = Path(tempfile.mkdtemp(prefix="polly-cuj-config-"))
+    (config_home / "config.yaml").write_text("", encoding="utf-8")
+    env["OMNIGENT_CONFIG_HOME"] = str(config_home)
+    for stale in _CREDENTIAL_VARS:
+        env.pop(stale, None)
+    env["OPENAI_BASE_URL"] = f"{mock_url}/v1"
+    env["OPENAI_API_KEY"] = "mock-key"
+    return env
+
+
+# ── Server lifecycle ─────────────────────────────────────────────────────────
+
+_REPO_HOLDER: dict[str, Path] = {}
+
+
+def _repo() -> Path:
+    """The repo root the driver operates on (set in :func:`main`)."""
+    return _REPO_HOLDER["repo"]
+
+
+def _runner_pids() -> set[int]:
+    """PIDs of runner/harness subprocesses spawned by *this* interpreter.
+
+    Scoped to ``sys.executable`` so a sweep can never touch another worktree's
+    server or a real ``omnigent`` session running under a different venv.
+    """
+    pids: set[int] = set()
+    for module in (
+        "omnigent.host._daemon_entry",
+        "omnigent.runner._entry",
+        "omnigent.runtime.harnesses._runner",
+    ):
+        try:
+            out = subprocess.run(
+                ["pgrep", "-f", f"{sys.executable} -m {module}"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            return pids  # no pgrep — skip the sweep rather than guess
+        pids |= {int(x) for x in out.stdout.split() if x.isdigit()}
+    return pids
+
+
+def _kill(pids: set[int]) -> None:
+    """SIGTERM then SIGKILL a set of PIDs, tolerating already-dead ones."""
+    for pid in pids:
+        with suppress(ProcessLookupError, PermissionError):
+            os.kill(pid, signal.SIGTERM)
+    if not pids:
+        return
+    time.sleep(2)
+    for pid in pids:
+        with suppress(ProcessLookupError, PermissionError):
+            os.kill(pid, signal.SIGKILL)
+
+
+@dataclass
+class _Servers:
+    """Handles for the mock LLM + local Omnigent server."""
+
+    mock_url: str
+    server_url: str
+    _mock_proc: subprocess.Popen
+    _server_proc: subprocess.Popen
+    _logdir: Path
+
+
+@contextmanager
+def _servers(tmp: Path) -> Iterator[_Servers]:
+    """Start the mock LLM and a throwaway local Omnigent server; reap both.
+
+    ``omni run`` turns make the server spawn per-conversation runner/harness
+    subprocesses that a plain server SIGTERM does not reap. We snapshot runner
+    PIDs before boot and, on teardown, sweep any that appeared during the run
+    (scoped to this interpreter) so nothing leaks.
+    """
+    repo = _repo()
+    logdir = tmp / "logs"
+    logdir.mkdir(parents=True, exist_ok=True)
+    baseline_pids = _runner_pids()
+
+    mock_port = _free_port()
+    mock_url = f"http://127.0.0.1:{mock_port}"
+    mock_log = open(logdir / "mock_llm.log", "w")  # noqa: SIM115
+    mock_proc = subprocess.Popen(
+        [sys.executable, str(repo / _MOCK_SERVER_REL), str(mock_port)],
+        env={**os.environ, "PYTHONPATH": str(repo)},
+        stdout=mock_log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    server_port = _free_port()
+    server_url = f"http://127.0.0.1:{server_port}"
+    server_log = open(logdir / "server.log", "w")  # noqa: SIM115
+    server_proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(server_port),
+            "--database-uri",
+            f"sqlite:///{tmp / 'polly_cuj.db'}",
+            "--artifact-location",
+            str(tmp / "artifacts"),
+        ],
+        cwd=str(repo),
+        env={**os.environ, "OMNIGENT_SKIP_ONBOARD": "1", "OMNIGENT_NO_UPDATE_CHECK": "1"},
+        stdout=server_log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    try:
+        _wait_for_http(f"{mock_url}/stats", time.monotonic() + _MOCK_BOOT_TIMEOUT_S)
+        _wait_for_http(f"{server_url}/", time.monotonic() + _SERVER_BOOT_TIMEOUT_S)
+        yield _Servers(mock_url, server_url, mock_proc, server_proc, logdir)
+    finally:
+        for proc in (server_proc, mock_proc):
+            proc.terminate()
+            try:
+                proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        # Reap runner/harness subprocesses that appeared during this run.
+        _kill(_runner_pids() - baseline_pids)
+        mock_log.close()
+        server_log.close()
+
+
+def _run_polly(
+    bundle: Path, server_url: str, prompt: str, mock_url: str
+) -> subprocess.CompletedProcess:
+    """``omnigent run <bundle> --server <url> -p <prompt>`` against the mock."""
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "run",
+            str(bundle),
+            "--server",
+            server_url,
+            "-p",
+            prompt,
+        ],
+        cwd=str(_repo()),
+        env=_run_env(mock_url),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_S,
+    )
+
+
+# ── Session observation ──────────────────────────────────────────────────────
+
+
+def _latest_session_id(server_url: str) -> str | None:
+    """Newest top-level session id, or None."""
+    try:
+        page = _get_json(f"{server_url}/v1/sessions?kind=default&order=desc&limit=5")
+    except (urllib.error.URLError, OSError):
+        return None
+    data = page.get("data", []) if isinstance(page, dict) else []
+    for row in data:
+        for key in ("id", "session_id", "conversation_id"):
+            if isinstance(row, dict) and isinstance(row.get(key), str):
+                return row[key]
+    return None
+
+
+def _session_items(server_url: str, session_id: str) -> list[dict]:
+    """All items in a session, chronological."""
+    page = _get_json(
+        f"{server_url}/v1/sessions/{session_id}/items?order=asc&limit=300"
+    )
+    data = page.get("data", []) if isinstance(page, dict) else []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _tool_outputs(items: list[dict]) -> list[str]:
+    """Every ``function_call_output`` payload, stringified."""
+    outs: list[str] = []
+    for item in items:
+        if item.get("type") == "function_call_output":
+            out = item.get("output")
+            outs.append(out if isinstance(out, str) else json.dumps(out))
+    return outs
+
+
+def _assistant_text(items: list[dict]) -> str:
+    """Concatenate assistant message text blocks."""
+    parts: list[str] = []
+    for item in items:
+        if item.get("type") == "message" and item.get("role") == "assistant":
+            for block in item.get("content", []) or []:
+                if isinstance(block, dict) and block.get("text"):
+                    parts.append(str(block["text"]))
+    return "\n".join(parts)
+
+
+# ── Scenario framework ───────────────────────────────────────────────────────
+
+
+@dataclass
+class Result:
+    """One scenario's outcome."""
+
+    scenario: str
+    checks: list[tuple[str, bool, str]] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def add(self, name: str, ok: bool, detail: str = "") -> None:
+        self.checks.append((name, ok, detail))
+
+    def skip(self, name: str, detail: str) -> None:
+        # A skip is recorded as a note + a passing "skipped" marker so it never
+        # fails the run but is visible in the SUMMARY.
+        self.notes.append(f"SKIP {name}: {detail}")
+
+    @property
+    def ok(self) -> bool:
+        return all(ok for _, ok, _ in self.checks)
+
+    def summary(self) -> dict:
+        return {
+            "scenario": self.scenario,
+            "ok": self.ok,
+            "checks": [{"name": n, "ok": ok, "detail": d} for n, ok, d in self.checks],
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class Ctx:
+    """Shared scenario context."""
+
+    servers: _Servers
+    tmp: Path
+
+
+def _add_exit_check(res: Result, proc: subprocess.CompletedProcess) -> None:
+    """Record the standard exit-0 check, keeping trailing stderr for context."""
+    detail = f"rc={proc.returncode}; stderr={proc.stderr[-300:]}"
+    res.add("exit_zero", proc.returncode == 0, detail)
+
+
+# ── Scenarios ────────────────────────────────────────────────────────────────
+
+
+def scenario_boot(ctx: Ctx) -> Result:
+    """Bundle loads, server-side policies resolve, a turn streams back."""
+    res = Result("boot")
+    s = ctx.servers
+    _mock_reset(s.mock_url)
+    _mock_configure(
+        s.mock_url,
+        [{"text": "I am polly: I plan a coding task and delegate it to sub-agents."}],
+        key=_BRAIN_MODEL,
+    )
+    bundle = _mock_polly_bundle(ctx.tmp / "boot", s.mock_url)
+    proc = _run_polly(bundle, s.server_url, "In one sentence, what are you?", s.mock_url)
+    _add_exit_check(res, proc)
+    reply = proc.stdout.strip()
+    res.add("non_empty_reply", len(reply) >= _MIN_REPLY_CHARS, f"{len(reply)} chars")
+    return res
+
+
+def scenario_tool_dispatch(ctx: Ctx) -> Result:
+    """Brain emits a benign ``sys_os_shell``; it runs and touches disk."""
+    res = Result("tool_dispatch")
+    s = ctx.servers
+    sentinel = ctx.tmp / "tool_dispatch_sentinel.txt"
+    sentinel.unlink(missing_ok=True)
+    token = "polly-tool-dispatch-ok"
+    _mock_reset(s.mock_url)
+    _mock_configure(
+        s.mock_url,
+        [
+            {"tool_calls": [_sys_os_shell_call(f"printf '{token}' > {sentinel}")]},
+            {"text": "Wrote the sentinel file."},
+        ],
+        key=_BRAIN_MODEL,
+    )
+    bundle = _mock_polly_bundle(ctx.tmp / "tool", s.mock_url)
+    proc = _run_polly(bundle, s.server_url, "Write the sentinel via shell.", s.mock_url)
+    _add_exit_check(res, proc)
+    wrote = sentinel.exists() and token in sentinel.read_text()
+    res.add("shell_touched_disk", wrote, f"sentinel={sentinel} exists={sentinel.exists()}")
+    return res
+
+
+# Common marker both deny formats share — ``[Denied by policy: <name>] {json}``
+# for SDK function tools and ``{"error": "Denied by policy: <reason>"}`` for the
+# bridged ``sys_*`` tools the orchestrator uses.
+_DENY_MARKER = "Denied by policy:"
+
+
+def _guardrail_scenario(
+    ctx: Ctx,
+    name: str,
+    responses: list[dict],
+    *,
+    check_name: str,
+    expect: str,
+    prompt: str,
+    rewrite_subagents: bool = False,
+) -> Result:
+    """Script the brain into a tool call the policy must refuse, then prove it.
+
+    A pass requires BOTH the generic deny marker and *expect* (a reason fragment
+    unique to the target policy) in the tool outputs — so the check proves the
+    *right* guardrail fired, not merely that something was refused.
+    """
+    res = Result(name)
+    s = ctx.servers
+    _mock_reset(s.mock_url)
+    # Drain any stray sub-agent child LLM calls with a trivial fallback.
+    _mock_set_fallback(s.mock_url, "default", "ok")
+    _mock_configure(s.mock_url, responses, key=_BRAIN_MODEL)
+    bundle = _mock_polly_bundle(
+        ctx.tmp / name, s.mock_url, rewrite_subagents=rewrite_subagents
+    )
+    proc = _run_polly(bundle, s.server_url, prompt, s.mock_url)
+    _add_exit_check(res, proc)
+
+    sid = _latest_session_id(s.server_url)
+    if sid is None:
+        res.add(check_name, False, "no session found to inspect")
+        return res
+    outs = _tool_outputs(_session_items(s.server_url, sid))
+    combined = "\n".join(outs)
+    denied = _DENY_MARKER in combined and expect in combined
+    detail = f"denied={denied} ({len(outs)} tool outputs)"
+    if not denied:
+        detail += f" | outputs={combined[:600]!r}"
+    res.add(check_name, denied, detail)
+    res.notes.append(f"session={sid}")
+    return res
+
+
+def scenario_guardrail_purpose(ctx: Ctx) -> Result:
+    """A ``sys_session_send`` with no ``args.purpose`` is denied at the gate."""
+    return _guardrail_scenario(
+        ctx,
+        "guardrail_purpose",
+        responses=[
+            # args is a bare string -> no object purpose -> DENY.
+            {"tool_calls": [_sys_session_send_call("pi", "no-purpose", "investigate the bug")]},
+            {"text": "acknowledged the denial"},
+        ],
+        check_name="headless_subagent_purpose_guard_denied",
+        expect="must declare what kind of work it is",
+        prompt="Dispatch a worker (the driver scripts a malformed dispatch).",
+    )
+
+
+def scenario_guardrail_blast_radius(ctx: Ctx) -> Result:
+    """A catastrophic ``sys_os_shell`` (rm -rf /etc) is denied."""
+    return _guardrail_scenario(
+        ctx,
+        "guardrail_blast_radius",
+        responses=[
+            # Force-push is catastrophic (DENY) but harmless if it ever runs:
+            # no remote/auth in the sandbox, so a missed gate fails closed.
+            {"tool_calls": [_sys_os_shell_call("git push --force origin main")]},
+            {"text": "acknowledged the denial"},
+        ],
+        check_name="blast_radius_denied",
+        expect="blast-radius policy",
+        prompt="Run a destructive command (the driver scripts it).",
+    )
+
+
+def scenario_fanout_dispatch(ctx: Ctx) -> Result:
+    """Six-wide fan-out: many dispatch handles are created in one turn.
+
+    Hard check: the fan-out *substrate* works — emitting N ``sys_session_send``
+    calls in one response creates N sub-agent dispatch handles. The
+    ``spawn_bounds`` per-turn cap (max 5) is reported as a non-failing
+    *finding*: it is a stateful counter, but the server rebuilds the policy
+    engine per ``tools/call`` (``_build_policy_engine_from_spec``), so the
+    counter resets each call and the cap does not trip in this local
+    server-side path. See SKILL.md "Known sharp edges". Verify the cap live.
+    """
+    res = Result("fanout_dispatch")
+    s = ctx.servers
+    _mock_reset(s.mock_url)
+    _mock_set_fallback(s.mock_url, "default", "ok")
+    calls = [
+        _sys_session_send_call(
+            "pi",
+            f"probe-{i}",
+            {"input": "noop", "purpose": "explore"},
+            call_id=f"call_{i}",
+        )
+        for i in range(1, 7)
+    ]
+    _mock_configure(
+        s.mock_url,
+        [{"tool_calls": calls}, {"text": "dispatched a wave"}],
+        key=_BRAIN_MODEL,
+    )
+    bundle = _mock_polly_bundle(ctx.tmp / "fanout", s.mock_url, rewrite_subagents=True)
+    proc = _run_polly(bundle, s.server_url, "Fan out a wave of workers.", s.mock_url)
+    _add_exit_check(res, proc)
+
+    sid = _latest_session_id(s.server_url)
+    if sid is None:
+        res.add("fanout_dispatched", False, "no session found to inspect")
+        return res
+    outs = _tool_outputs(_session_items(s.server_url, sid))
+    combined = "\n".join(outs)
+    handles = sum(1 for o in outs if '"kind": "sub_agent"' in o or '"status": "launching"' in o)
+    res.add("fanout_dispatched", handles >= 2, f"{handles} handles / {len(outs)} outputs")
+    cap_fired = "worker dispatches this turn" in combined
+    res.notes.append(
+        f"finding: spawn_bounds per-turn cap fired={cap_fired} "
+        "(expected False in this server-side path; verify the cap live)"
+    )
+    res.notes.append(f"session={sid}")
+    return res
+
+
+_SCENARIOS: dict[str, Callable[[Ctx], Result]] = {
+    "boot": scenario_boot,
+    "tool_dispatch": scenario_tool_dispatch,
+    "guardrail_purpose": scenario_guardrail_purpose,
+    "guardrail_blast_radius": scenario_guardrail_blast_radius,
+    "fanout_dispatch": scenario_fanout_dispatch,
+}
+
+
+# ── Entrypoint ───────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario",
+        default="all",
+        help="Scenario to run, or 'all' (default). See --list-scenarios.",
+    )
+    parser.add_argument("--list-scenarios", action="store_true", help="Print scenarios and exit.")
+    parser.add_argument("--repo", type=Path, default=_REPO_DEFAULT, help="Repo root to test.")
+    parser.add_argument("--keep", action="store_true", help="Keep the sandbox temp dir.")
+    args = parser.parse_args(argv)
+
+    if args.list_scenarios:
+        for name in _SCENARIOS:
+            print(name)
+        return 0
+
+    _REPO_HOLDER["repo"] = args.repo.resolve()
+    polly_dir = _repo() / "examples" / "polly" / "config.yaml"
+    if not polly_dir.exists():
+        print(f"error: {polly_dir} not found — is --repo correct?", file=sys.stderr)
+        return 2
+
+    if args.scenario == "all":
+        chosen = list(_SCENARIOS)
+    elif args.scenario in _SCENARIOS:
+        chosen = [args.scenario]
+    else:
+        print(f"error: unknown scenario {args.scenario!r}; try --list-scenarios", file=sys.stderr)
+        return 2
+
+    tmp = Path(tempfile.mkdtemp(prefix="polly-cuj-"))
+    all_ok = True
+    try:
+        with _servers(tmp) as servers:
+            ctx = Ctx(servers=servers, tmp=tmp)
+            for name in chosen:
+                try:
+                    res = _SCENARIOS[name](ctx)
+                except Exception as exc:  # noqa: BLE001 — report, don't crash the suite
+                    res = Result(name)
+                    res.add("ran", False, f"{type(exc).__name__}: {exc}")
+                all_ok = all_ok and res.ok
+                print("SUMMARY " + json.dumps(res.summary()))
+    finally:
+        if args.keep:
+            print(f"[kept sandbox] {tmp}", file=sys.stderr)
+        else:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    print("SUMMARY " + json.dumps({"scenario": "ALL", "ok": all_ok, "ran": chosen}))
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a `polly-e2e-dev` agent skill that end-to-end tests the **polly** multi-agent coding orchestrator's critical user journeys (CUJs).
- **Deterministic mock-LLM driver** (`polly_cuj.py`): boots a throwaway local server + the repo's mock LLM, rewrites `examples/polly` to the `openai-agents` harness, and scripts the brain to assert the *substrate* — boot, bridged `sys_*` tool dispatch, the `blast_radius` and `headless_subagent_purpose_guard` guardrail DENYs, and 6-wide fan-out delegation. Emits one machine-readable `SUMMARY {json}` per scenario for a before→after verifiable loop.
- **Live recipe** (`SKILL.md`): real `claude`/`codex`/`pi`, worktrees, and PRs for polly's judgment-level journeys (roster preflight, investigate, fanout, cross-review, plan gate / inbox), observed via CLI + HTTP API + filesystem.
- Driver reaps the host-daemon / runner subprocesses an `omni run` turn spawns (scoped to the invoking interpreter), so runs never leak processes.

### ELI5

polly is a "tech lead" agent that splits a coding task and hands pieces to Claude Code / Codex / Pi sub-agents. This skill is its test harness: a fast offline mode that fakes the LLM to prove the wiring + guardrails behave identically every run, and a live mode that drives the real sub-agents for a true end-to-end check.

## Test Plan

Ran the driver from the checkout (no credentials/egress needed):

```
.venv/bin/python .claude/skills/polly-e2e-dev/polly_cuj.py --scenario all
```

All five scenarios pass:

```
SUMMARY {"scenario": "boot", "ok": true, ...}
SUMMARY {"scenario": "tool_dispatch", "ok": true, ...}
SUMMARY {"scenario": "guardrail_purpose", "ok": true, ...}
SUMMARY {"scenario": "guardrail_blast_radius", "ok": true, ...}
SUMMARY {"scenario": "fanout_dispatch", "ok": true, ...}
SUMMARY {"scenario": "ALL", "ok": true, ...}
```

- `ruff check .claude/skills/polly-e2e-dev/polly_cuj.py` → All checks passed.
- Clean teardown verified: `pgrep -af "<repo>/.venv/bin/python -m omnigent" | grep -E "_entry|_runner|_daemon"` → none after a run.
- Verified `--list-scenarios`, single-scenario runs, and non-zero exit when a check fails.

## Demo

N/A (non-visual CLI dev tooling).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This PR adds developer tooling (an agent skill + its mock-LLM driver), not product code, so it carries no automated unit/integration tests of its own. Verified manually: `polly_cuj.py --scenario all` (5/5 scenarios green), `ruff check` (clean), and confirmed no orphaned server/runner/daemon processes remain after teardown. The skill complements — and points at — the existing `tests/e2e/test_polly_*.py` suite.