### PR TITLE
feat(kiro-native): launch-time model picker in the Web UI (#1697)

### DIFF
--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -43,6 +43,47 @@ from omnigent.native_terminal import url_component
 _DEFAULT_KIRO_COMMAND = "kiro-cli"
 _KIRO_PATH_ENV = "OMNIGENT_KIRO_PATH"
 _AGENT_NAME = "kiro-native-ui"
+
+# Curated kiro-cli base models for the Web UI picker. Static (like cursor-native,
+# the other launch-only-model vendor) rather than runner-discovered: the list is
+# global and fixed, not account-scoped. ids match what ``kiro-cli --model`` accepts
+# (and ``--list-models`` reports); ``auto`` is kiro's default and a real literal id.
+# Refresh by hand from ``kiro-cli chat --list-models --format json`` if Kiro
+# ships/renames a model.
+_KIRO_BASE_MODELS: list[dict[str, Any]] = [
+    {"id": "auto", "displayName": "Auto", "isDefault": True},
+    {"id": "claude-sonnet-4.5", "displayName": "Claude Sonnet 4.5"},
+    {"id": "claude-sonnet-4", "displayName": "Claude Sonnet 4"},
+    {"id": "claude-haiku-4.5", "displayName": "Claude Haiku 4.5"},
+    {"id": "deepseek-3.2", "displayName": "DeepSeek V3.2"},
+    {"id": "minimax-m2.5", "displayName": "MiniMax M2.5"},
+    {"id": "minimax-m2.1", "displayName": "MiniMax M2.1"},
+    {"id": "glm-5", "displayName": "GLM-5"},
+    {"id": "qwen3-coder-next", "displayName": "Qwen3 Coder Next"},
+]
+
+
+def kiro_base_model_options() -> list[dict[str, Any]]:
+    """Return the curated kiro base-model options for the Web UI picker.
+
+    Mirrors :func:`omnigent.cursor_native.cursor_base_model_options`: each option
+    carries ``id`` (the value ``kiro-cli --model`` accepts), ``displayName``, and
+    ``isDefault``/``isCurrent`` flags. kiro applies the model only at launch, so
+    the picked id is persisted as ``model_override`` and consumed by the runner.
+
+    :returns: Fresh option dicts (callers may mutate); base order preserved.
+    """
+    return [
+        {
+            "id": m["id"],
+            "displayName": m["displayName"],
+            "isDefault": bool(m.get("isDefault", False)),
+            "isCurrent": False,
+        }
+        for m in _KIRO_BASE_MODELS
+    ]
+
+
 _TERMINAL_NAME = "kiro"
 _TERMINAL_SESSION_KEY = "main"
 _TMUX_ATTACH_ENV_ALLOWLIST = (

--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -694,3 +694,65 @@ def send_kiro_permission_verdict(
     time.sleep(_PERMISSION_ENTER_SETTLE_S)
     _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
     time.sleep(_PERMISSION_KEY_INTERVAL_S)
+
+
+# kiro prints "Model changed to <id> (saved as default)" after a successful
+# ``/model`` switch; the injector polls for this to confirm the switch landed.
+_MODEL_CHANGED_MARKER = "Model changed to"
+# The switch itself takes a couple of seconds (kiro round-trips the change), so
+# the confirmation poll uses its own timeout rather than the short pane-readiness
+# ``timeout_s`` the runner passes to fail fast when the pane isn't attached.
+_MODEL_CONFIRM_TIMEOUT_S = 10.0
+
+
+def inject_model_command(
+    bridge_dir: Path,
+    *,
+    model: str,
+    timeout_s: float = _TMUX_READY_TIMEOUT_S,
+) -> None:
+    """Switch the live kiro model by typing ``/model <id>`` into the TUI.
+
+    kiro-cli's ``--model`` is baked in at spawn, so a mid-session web pick can't
+    be applied by re-reading the persisted ``model_override`` — it has to be
+    typed into the running pane. kiro's ``/model <id>`` switches directly (no
+    picker) and prints ``Model changed to <id>``; poll for that so a typo'd or
+    unavailable id fails loudly rather than silently leaving the model unchanged.
+    The cursor-native analog is
+    :func:`omnigent.cursor_native_bridge.inject_model_command`.
+
+    Note: kiro persists the switch as its own global default ("saved as
+    default"), so a live switch also affects the next fresh kiro launch.
+
+    :param bridge_dir: The kiro-native bridge dir holding ``tmux.json``.
+    :param model: kiro model id, e.g. ``"claude-haiku-4.5"`` (a ``--list-models`` id).
+    :param timeout_s: Per-readiness-gate / confirmation timeout.
+    :raises RuntimeError: If the tmux target is never advertised, the TUI has
+        exited, a tmux command fails, or kiro never confirms the switch.
+    """
+    model = model.strip()
+    if not model:
+        raise RuntimeError("kiro-native model switch requires a non-empty model id")
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    socket_path = info["socket_path"]
+    tmux_target = info["tmux_target"]
+    if not _session_alive(socket_path, tmux_target):
+        raise RuntimeError(
+            "kiro terminal is no longer running (the TUI exited); restart the session"
+        )
+    _wait_for_kiro_input_ready(socket_path, tmux_target, timeout_s=timeout_s)
+    # Clear any leftover draft so the slash command isn't appended to it.
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-a")
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-k")
+    # ``-l`` sends literal characters so ``/`` opens the slash command and the id
+    # is not parsed as tmux key names.
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "-l", f"/model {model}")
+    time.sleep(_TYPE_SETTLE_S)
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+    # Confirm via kiro's "Model changed to <id>" line so a bad id fails loudly.
+    deadline = time.monotonic() + _MODEL_CONFIRM_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if f"{_MODEL_CHANGED_MARKER} {model}" in _capture_pane(socket_path, tmux_target):
+            return
+        time.sleep(_POLL_INTERVAL_S)
+    raise RuntimeError(f"kiro-native did not confirm the model switch to {model!r}")

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -407,6 +407,60 @@ def _read_kiro_cumulative_credits(metadata_path: Path) -> tuple[float | None, st
     return total, model_id
 
 
+def _read_kiro_current_model(metadata_path: Path) -> str | None:
+    """Return kiro's current model id from the session ``.json`` snapshot.
+
+    Reads ``session_state.rts_model_state.model_info.model_id`` (e.g. ``"auto"``
+    or ``"claude-haiku-4.5"``), independent of the metering read above so it is
+    available at launch before any turn. kiro updates it in place on a ``/model``
+    switch, so polling it mirrors both the launched model and live TUI switches.
+
+    :returns: The model id, or ``None`` when the file is missing/unparseable or
+        carries no model state yet.
+    """
+    try:
+        raw = metadata_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    session_state = data.get("session_state")
+    if not isinstance(session_state, dict):
+        return None
+    rts_model_state = session_state.get("rts_model_state")
+    if not isinstance(rts_model_state, dict):
+        return None
+    model_info = rts_model_state.get("model_info")
+    if not isinstance(model_info, dict):
+        return None
+    model_id = model_info.get("model_id")
+    return model_id if isinstance(model_id, str) and model_id else None
+
+
+async def _post_external_model_change(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    model: str,
+) -> None:
+    """Mirror kiro's current model to the web as ``external_model_change``.
+
+    The server persists this as ``model_override`` (so the picker shows the real
+    model instead of falling back to the harness name) and deliberately does NOT
+    forward a ``/model`` back to the runner, so mirroring the model the TUI is
+    already on cannot loop. Mirrors cursor-native's terminal->web model mirror.
+    """
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_model_change", "data": {"model": model}},
+    )
+    resp.raise_for_status()
+
+
 async def _post_session_cost(
     client: httpx.AsyncClient,
     *,
@@ -452,6 +506,7 @@ async def forward_kiro_session_to_omnigent(
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     mirrored_external_session_id: str | None = None
     last_posted_cost: float | None = None
+    last_posted_model: str | None = None
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
@@ -528,6 +583,18 @@ async def forward_kiro_session_to_omnigent(
                             model=cost_model,
                         )
                         last_posted_cost = cumulative_cost
+                    # Mirror kiro's current model so the web picker shows the real
+                    # model (not the harness name) at launch and after a live
+                    # ``/model`` switch. Read independently of metering so it is
+                    # available before the first turn; posted only when it changes.
+                    current_model = await asyncio.to_thread(
+                        _read_kiro_current_model, jsonl_path.with_suffix(".json")
+                    )
+                    if current_model is not None and current_model != last_posted_model:
+                        await _post_external_model_change(
+                            client, session_id=session_id, model=current_model
+                        )
+                        last_posted_model = current_model
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -557,6 +557,7 @@ class _KiroNativeLaunchConfig:
     workspace: Path
     terminal_launch_args: list[str] | None
     external_session_id: str | None
+    model_override: str | None = None
 
 
 def _required_runner_env(name: str) -> str:
@@ -672,12 +673,23 @@ async def _kiro_native_launch_config(
         not isinstance(external_session_id, str) or not external_session_id.strip()
     ):
         raise RuntimeError(f"Invalid external_session_id for Kiro session {session_id!r}.")
+    model_override = snapshot.get("model_override")
+    if model_override is not None:
+        if not isinstance(model_override, str) or not model_override:
+            raise RuntimeError(f"Invalid model_override for Kiro session {session_id!r}.")
+        try:
+            model_override = validate_model_override(model_override)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Invalid model_override for Kiro session {session_id!r}: {exc}"
+            ) from exc
     return _KiroNativeLaunchConfig(
         workspace=_kiro_session_workspace(session_workspace),
         terminal_launch_args=terminal_launch_args,
         external_session_id=external_session_id.strip()
         if isinstance(external_session_id, str)
         else None,
+        model_override=model_override if isinstance(model_override, str) else None,
     )
 
 
@@ -2723,6 +2735,7 @@ async def _auto_create_kiro_terminal(
     kiro_launch = build_kiro_launch(
         launch_config.terminal_launch_args or [],
         resume_id=launch_config.external_session_id,
+        model=launch_config.model_override,
     )
     launch_epoch_ms = int(time.time() * 1000)
     terminal_view = await resource_registry.launch_required_terminal(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11687,6 +11687,57 @@ def create_runner_app(
             )
         return Response(status_code=204)
 
+    async def _handle_kiro_native_model_change(
+        conv_id: str,
+        model: str | None,
+    ) -> Response:
+        """
+        Switch a running kiro-native session's model via its TUI ``/model``.
+
+        kiro-cli's ``--model`` is baked in at spawn (see
+        ``_auto_create_kiro_terminal``), so a live web-UI / REPL ``/model`` switch
+        can't be applied by re-reading the persisted ``model_override`` —
+        ``inject_model_command`` types ``/model <id>`` into the tmux pane, which
+        kiro applies directly (confirmed by its ``Model changed to <id>`` line).
+        Mirrors ``_handle_cursor_native_model_change``.
+
+        Skipped silently when *model* is ``None`` or blank — kiro has no slash
+        form for "use the spawn default", so a clear only takes effect on the
+        next spawn.
+
+        :param conv_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
+        :param model: New persisted kiro model id, e.g. ``"claude-haiku-4.5"``;
+            ``None`` when the user cleared the override.
+        :returns: 204 on success or skip; 503 if the tmux pane isn't advertised
+            yet (best-effort — the persisted value applies on the next spawn).
+        """
+        from omnigent.kiro_native_bridge import (
+            bridge_dir_for_session_id,
+            inject_model_command,
+        )
+
+        if model is None or not model.strip():
+            return Response(status_code=204)
+        bridge_dir = bridge_dir_for_session_id(conv_id)
+        try:
+            # Short pane-readiness timeout: a missing tmux.json means the pane
+            # isn't attached; the persisted model still applies on the next spawn.
+            await asyncio.to_thread(
+                inject_model_command,
+                bridge_dir,
+                model=model.strip(),
+                timeout_s=1.0,
+            )
+        except (RuntimeError, ValueError) as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "kiro_native_model_failed",
+                    "detail": _client_safe_error_detail(exc, context="kiro-native model change"),
+                },
+            )
+        return Response(status_code=204)
+
     async def _handle_claude_native_compact(conv_id: str) -> Response:
         """
         Type ``/compact`` into Claude's tmux pane.
@@ -15103,7 +15154,13 @@ def create_runner_app(
             # update. Other harnesses pick up the persisted value on the
             # next turn and 204 here.
             harness = _session_harness_name(conversation_id)
-            if harness in ("claude-native", "codex-native", "cursor-native", "opencode-native"):
+            if harness in (
+                "claude-native",
+                "codex-native",
+                "cursor-native",
+                "opencode-native",
+                "kiro-native",
+            ):
                 model = body.get("model") if isinstance(body, dict) else None
                 if model is not None and not isinstance(model, str):
                     return JSONResponse(
@@ -15127,6 +15184,11 @@ def create_runner_app(
                     )
                 if harness == "opencode-native":
                     return await _handle_opencode_native_model_change(
+                        conversation_id,
+                        model,
+                    )
+                if harness == "kiro-native":
+                    return await _handle_kiro_native_model_change(
                         conversation_id,
                         model,
                     )

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -93,6 +93,7 @@ from omnigent.native_coding_agents import (
     CLAUDE_NATIVE_CODING_AGENT,
     CODEX_NATIVE_CODING_AGENT,
     CURSOR_NATIVE_CODING_AGENT,
+    KIRO_NATIVE_CODING_AGENT,
     NativeCodingAgent,
     native_coding_agent_for_agent_name,
     native_coding_agent_for_harness,
@@ -530,6 +531,7 @@ _CODEX_NATIVE_WRAPPER_LABEL_VALUE = CODEX_NATIVE_CODING_AGENT.wrapper_label
 _CODEX_NATIVE_HARNESS = CODEX_NATIVE_CODING_AGENT.harness
 _CODEX_NATIVE_MODEL = CODEX_NATIVE_CODING_AGENT.agent_name
 _CURSOR_NATIVE_WRAPPER_LABEL_VALUE = CURSOR_NATIVE_CODING_AGENT.wrapper_label
+_KIRO_NATIVE_WRAPPER_LABEL_VALUE = KIRO_NATIVE_CODING_AGENT.wrapper_label
 _CLAUDE_NATIVE_MESSAGE_TIMEOUT_S = 30.0
 _NATIVE_TERMINAL_START_FAILED_CODE = "native_terminal_start_failed"
 _NATIVE_TERMINAL_ENSURE_FAILED_CODE = "native_terminal_ensure_failed"
@@ -20290,6 +20292,10 @@ async def _fetch_model_options(
         from omnigent.cursor_native import cursor_base_model_options
 
         return cursor_base_model_options()
+    if wrapper == _KIRO_NATIVE_WRAPPER_LABEL_VALUE:
+        from omnigent.kiro_native import kiro_base_model_options
+
+        return kiro_base_model_options()
     endpoint = _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER.get(wrapper or "")
     if endpoint is None:
         return []

--- a/tests/e2e_ui/chat/test_kiro_model_metadata.py
+++ b/tests/e2e_ui/chat/test_kiro_model_metadata.py
@@ -1,0 +1,116 @@
+"""E2E: kiro-native model picker renders the kiro catalog and persists a pick."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+
+def _patch_session_as_kiro_native(page: Page, session_id: str) -> list[dict]:
+    """Patch the browser's session snapshot into a kiro-native response.
+
+    The server fixture seeds a normal session so the page boots against the real
+    app/server. This route patch rewrites only ``GET``/``PATCH
+    /v1/sessions/{session_id}`` as seen by the browser into a kiro-native
+    snapshot carrying the curated kiro ``model_options`` (the shape
+    :func:`omnigent.kiro_native.kiro_base_model_options` serves) and a persisted
+    ``model_override``.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    :returns: Captured PATCH request bodies.
+    """
+    latest_payload: dict | None = None
+    patch_bodies: list[dict] = []
+
+    def _handle(route: Route) -> None:
+        nonlocal latest_payload
+        request = route.request
+        parsed = urlparse(request.url)
+        if parsed.path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+
+        headers = {"content-type": "application/json"}
+        if request.method == "GET":
+            response = route.fetch()
+            payload = response.json()
+            headers = {**response.headers, **headers}
+        elif request.method == "PATCH":
+            request_body = json.loads(request.post_data or "{}")
+            patch_bodies.append(request_body)
+            payload = dict(latest_payload or {})
+            if "model_override" in request_body:
+                payload["model_override"] = request_body["model_override"]
+        else:
+            route.continue_()
+            return
+
+        payload["labels"] = {
+            **payload.get("labels", {}),
+            "omnigent.wrapper": "kiro-native-ui",
+        }
+        payload["harness"] = "kiro-native"
+        payload["model_options"] = [
+            {"id": "auto", "displayName": "Auto", "isDefault": True, "isCurrent": False},
+            {
+                "id": "claude-haiku-4.5",
+                "displayName": "Claude Haiku 4.5",
+                "isDefault": False,
+                "isCurrent": False,
+            },
+            {"id": "glm-5", "displayName": "GLM-5", "isDefault": False, "isCurrent": False},
+        ]
+        payload.setdefault("model_override", "claude-haiku-4.5")
+        latest_payload = dict(payload)
+        route.fulfill(status=200, headers=headers, body=json.dumps(payload))
+
+    page.route("**/v1/sessions/**", _handle)
+    return patch_bodies
+
+
+def test_kiro_native_picker_lists_models_and_persists_pick(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The kiro-native picker renders the curated catalog and persists a pick.
+
+    kiro applies the chosen model as ``--model`` at launch, so the picker writes
+    the selection to ``model_override`` (no in-session mirror). This covers the
+    snapshot-driven picker render and the PATCH that carries the pick.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser snapshot is patched to kiro-native.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    patch_bodies = _patch_session_as_kiro_native(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    trigger = page.get_by_test_id("agent-picker-trigger")
+    expect(trigger).to_be_visible(timeout=15_000)
+    trigger.click()
+
+    # The curated kiro catalog renders with its display names.
+    haiku_row = page.locator('[data-testid="model-picker-item"][data-model-id="claude-haiku-4.5"]')
+    expect(haiku_row).to_be_visible()
+    expect(haiku_row).to_contain_text("Claude Haiku 4.5")
+    expect(
+        page.locator('[data-testid="model-picker-item"][data-model-id="glm-5"]')
+    ).to_be_visible()
+
+    # Picking a model PATCHes model_override (consumed at launch via --model).
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH"
+            and urlparse(response.url).path == f"/v1/sessions/{session_id}"
+            and response.status == 200
+        )
+    ):
+        page.locator('[data-testid="model-picker-item"][data-model-id="glm-5"]').click()
+
+    assert patch_bodies[-1] == {"model_override": "glm-5"}

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -12764,6 +12764,72 @@ async def test_events_model_change_on_native_session_types_slash_command(
 
 
 @pytest.mark.asyncio
+async def test_events_model_change_on_kiro_session_types_slash_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    POST ``/events`` ``{"type":"model_change","model":"claude-haiku-4.5"}`` on a
+    kiro-native session drives ``inject_model_command`` (which types
+    ``/model claude-haiku-4.5`` into the live kiro TUI).
+
+    Pins that the runner dispatch routes model_change to the kiro handler.
+    Mirrors ``test_events_model_change_on_native_session_types_slash_command``.
+    """
+    from omnigent.runner.app import _session_event_queues_ref
+    from omnigent.spec.types import ExecutorSpec
+
+    captured: list[Any] = []
+
+    def _fake_inject(bridge_dir: Any, *, model: str, timeout_s: float) -> None:
+        """Record the call and return without touching tmux."""
+        captured.append((bridge_dir, model, timeout_s))
+
+    monkeypatch.setattr(kiro_native_bridge, "inject_model_command", _fake_inject)
+
+    native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "kiro-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the kiro-native spec for any agent_id."""
+        del agent_id, session_id
+        return native_spec
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_kiro_model", "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        # Drain kiro auto-create events so nothing below trips on them.
+        _drain_session_event_queue(_session_event_queues_ref.get("conv_kiro_model"))
+
+        resp = await client.post(
+            "/v1/sessions/conv_kiro_model/events",
+            json={"type": "model_change", "model": "claude-haiku-4.5"},
+        )
+
+    assert resp.status_code == 204, (
+        f"Kiro model_change must return 204 from /events; got {resp.status_code}: {resp.text}"
+    )
+    assert len(captured) == 1, (
+        f"Expected one inject_model_command call from kiro model_change, got {len(captured)}."
+    )
+    _bridge_dir, model, timeout_s = captured[0]
+    assert model == "claude-haiku-4.5"
+    assert timeout_s == 1.0
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "model_value",
     # Claude Code has no slash form for "use spawn default", so

--- a/tests/test_kiro_native.py
+++ b/tests/test_kiro_native.py
@@ -30,6 +30,7 @@ from omnigent.kiro_native import (
     _update_startup_progress,
     _wait_for_kiro_terminal_ready,
     build_kiro_launch,
+    kiro_base_model_options,
     kiro_terminal_resource_id,
     resolve_kiro_executable,
     run_kiro_native,
@@ -543,3 +544,18 @@ async def test_wait_for_kiro_terminal_ready_times_out() -> None:
 
     with pytest.raises(ClickException, match="did not create the Kiro terminal"):
         await _wait_for_kiro_terminal_ready(client, "conv", timeout_s=0.05)
+
+
+def test_kiro_base_model_options_shape_and_default() -> None:
+    """The curated kiro catalog exposes picker option dicts with one default."""
+    options = kiro_base_model_options()
+    ids = [o["id"] for o in options]
+
+    # Canonical ids confirmed against ``kiro-cli --list-models`` (2.10.0).
+    assert ids[0] == "auto"
+    assert "claude-haiku-4.5" in ids and "glm-5" in ids
+    # Exactly one default, and every option carries the picker fields.
+    assert [o["id"] for o in options if o["isDefault"]] == ["auto"]
+    for option in options:
+        assert set(option) == {"id", "displayName", "isDefault", "isCurrent"}
+        assert option["isCurrent"] is False

--- a/tests/test_kiro_native_bridge.py
+++ b/tests/test_kiro_native_bridge.py
@@ -541,3 +541,39 @@ def test_write_kiro_workspace_mcp_config_merges_preserving_user_servers(tmp_path
     assert "serve-mcp" in written["mcpServers"]["omnigent"]["args"]
     # serve-mcp's token file is written alongside.
     assert (bridge_dir / "bridge.json").exists()
+
+
+def test_inject_model_command_switches_and_confirms(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/model <id>`` is typed literally and confirmed via kiro's success line."""
+    monkeypatch.setattr(bridge, "_POLL_INTERVAL_S", 0.0)
+    monkeypatch.setattr(bridge, "_TYPE_SETTLE_S", 0.0)
+    bridge_dir = tmp_path / "bridge"
+    marker_pane = "Model changed to claude-haiku-4.5 (saved as default)\n" + _READY_PANE
+    calls = _install_fake_tmux(monkeypatch, pane_outputs=[_READY_PANE, marker_pane])
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/tmux.sock"), tmux_target="main")
+
+    bridge.inject_model_command(bridge_dir, model="claude-haiku-4.5", timeout_s=0.1)
+
+    sent = [call[-1] for call in calls if "send-keys" in call]
+    # Clear the draft (C-a/C-k), send the literal slash command, then Enter.
+    assert sent == ["C-a", "C-k", "/model claude-haiku-4.5", "Enter"]
+
+
+def test_inject_model_command_raises_when_switch_not_confirmed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing ``Model changed to <id>`` line fails loudly (bad/unavailable id)."""
+    monkeypatch.setattr(bridge, "_POLL_INTERVAL_S", 0.0)
+    monkeypatch.setattr(bridge, "_TYPE_SETTLE_S", 0.0)
+    monkeypatch.setattr(bridge, "_MODEL_CONFIRM_TIMEOUT_S", 0.05)
+    bridge_dir = tmp_path / "bridge"
+    # Pane stays at the input prompt and never shows the confirmation line.
+    _install_fake_tmux(monkeypatch, pane_outputs=[_READY_PANE])
+    write_tmux_target(bridge_dir, socket_path=Path("/tmp/tmux.sock"), tmux_target="main")
+
+    with pytest.raises(RuntimeError, match="did not confirm the model switch"):
+        bridge.inject_model_command(bridge_dir, model="bogus-model", timeout_s=0.1)

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -459,7 +459,11 @@ async def test_forward_kiro_session_posts_cumulative_cost_once(
         if calls["n"] >= 2:
             raise asyncio.CancelledError
 
+    async def _noop_model(client: httpx.AsyncClient, *, session_id: str, model: str) -> None:
+        del client
+
     monkeypatch.setattr(forwarder, "_post_session_cost", _fake_post_cost)
+    monkeypatch.setattr(forwarder, "_post_external_model_change", _noop_model)
     monkeypatch.setattr(forwarder, "_post_conversation_message", _noop_message)
     monkeypatch.setattr(forwarder, "_patch_external_session_id", _noop_patch)
     monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_after_two_polls)
@@ -744,3 +748,86 @@ async def test_forward_kiro_session_does_not_post_session_status(
     assert "external_conversation_item" in posted_event_types
     # …but the forwarder posts no session status (the PTY watcher owns it).
     assert "external_session_status" not in posted_event_types
+
+
+def test_read_kiro_current_model_reads_without_metering(tmp_path: Path) -> None:
+    """The model id is read from rts_model_state even before any turn/metering."""
+    sessions_dir = tmp_path / "cli"
+    _write_kiro_session(sessions_dir, session_id="k", cwd=tmp_path, model_id="claude-haiku-4.5")
+    assert forwarder._read_kiro_current_model(sessions_dir / "k.json") == "claude-haiku-4.5"
+
+    # Missing file and a session with no model state both yield None.
+    assert forwarder._read_kiro_current_model(sessions_dir / "missing.json") is None
+    _write_kiro_session(sessions_dir, session_id="bare", cwd=tmp_path)
+    assert forwarder._read_kiro_current_model(sessions_dir / "bare.json") is None
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_mirrors_current_model_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The forwarder mirrors kiro's current model via external_model_change, deduped."""
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            {
+                "version": "v1",
+                "kind": "AssistantMessage",
+                "data": {"message_id": "a1", "content": [{"kind": "text", "data": "hi"}]},
+            },
+        ],
+        # No metering: proves the model mirror fires at launch, before a turn's cost.
+        model_id="claude-haiku-4.5",
+    )
+    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    models: list[tuple[str, str]] = []
+
+    async def _fake_post_model(client: httpx.AsyncClient, *, session_id: str, model: str) -> None:
+        del client
+        models.append((session_id, model))
+
+    async def _noop_message(
+        client: httpx.AsyncClient,
+        *,
+        session_id: str,
+        agent_name: str,
+        message: forwarder._KiroConversationMessage,
+    ) -> None:
+        del client
+
+    async def _noop_patch(
+        client: httpx.AsyncClient, *, session_id: str, external_session_id: str
+    ) -> None:
+        del client
+
+    calls = {"n": 0}
+
+    async def _cancel_after_two_polls(_seconds: float) -> None:
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder, "_post_external_model_change", _fake_post_model)
+    monkeypatch.setattr(forwarder, "_post_conversation_message", _noop_message)
+    monkeypatch.setattr(forwarder, "_patch_external_session_id", _noop_patch)
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_after_two_polls)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+    # Mirrored once; the unchanged second poll does not re-post.
+    assert models == [("conv_kiro", "claude-haiku-4.5")]

--- a/web/src/pages/ChatPage.capabilities.test.ts
+++ b/web/src/pages/ChatPage.capabilities.test.ts
@@ -62,6 +62,8 @@ describe("shouldShowModelPicker", () => {
     expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": "opencode-native-ui" } })).toBe(
       true,
     );
+    // kiro applies the picked model as --model at launch (no in-session mirror).
+    expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": "kiro-native-ui" } })).toBe(true);
   });
 
   it("hides the picker for other wrappers and missing labels (fail closed)", () => {
@@ -103,6 +105,12 @@ describe("shouldShowEffortPicker", () => {
     expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": "opencode-native-ui" } })).toBe(
       false,
     );
+  });
+
+  it("hides effort controls for kiro-native (model selection only)", () => {
+    // WHY: kiro exposes only launch-time --model selection; its --effort knob is
+    // not surfaced in the Web UI (deferred), so no effort dial.
+    expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": "kiro-native-ui" } })).toBe(false);
   });
 });
 

--- a/web/src/pages/ChatPage.capabilities.test.ts
+++ b/web/src/pages/ChatPage.capabilities.test.ts
@@ -110,7 +110,9 @@ describe("shouldShowEffortPicker", () => {
   it("hides effort controls for kiro-native (model selection only)", () => {
     // WHY: kiro exposes only launch-time --model selection; its --effort knob is
     // not surfaced in the Web UI (deferred), so no effort dial.
-    expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": "kiro-native-ui" } })).toBe(false);
+    expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": "kiro-native-ui" } })).toBe(
+      false,
+    );
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3311,6 +3311,7 @@ export function composerHarnessLabel(
   if (modelPickerKind === "claude") return "Claude";
   if (modelPickerKind === "codex") return "Codex";
   if (modelPickerKind === "cursor") return "Cursor";
+  if (modelPickerKind === "kiro") return "Kiro";
   if (modelPickerKind === "opencode") return "OpenCode";
   const display = agentName ? agentDisplayLabel(agentName) : null;
   const harness = sessionHarness ? (BRAIN_HARNESS_LABELS[sessionHarness] ?? null) : null;
@@ -4847,7 +4848,7 @@ const EFFORT_LEVELS = ["low", "medium", "high"] as const;
 /** Anthropic-side efforts for claude-native sessions (matches ANTHROPIC_EFFORTS in reasoning_effort.py). */
 const CLAUDE_NATIVE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
-type NativeModelPickerKind = "claude" | "codex" | "cursor" | "opencode";
+type NativeModelPickerKind = "claude" | "codex" | "cursor" | "kiro" | "opencode";
 
 type LabelSource = { labels?: Record<string, string | null> | null } | null | undefined;
 
@@ -4911,6 +4912,11 @@ export function modelPickerKindForConv(
       return "codex";
     case "cursor-native-ui":
       return "cursor";
+    case "kiro-native-ui":
+      // Launch-only model selection: kiro applies ``--model`` at launch. Unlike
+      // cursor/opencode there is no terminal->web model mirror, so the picker
+      // reflects the pre-launch ``model_override`` selection.
+      return "kiro";
     case "opencode-native-ui":
       // Like cursor: a vendor-owns-model wrapper that mirrors its live TUI
       // model into the session ``model_override`` (the forwarder's terminal→web
@@ -5031,7 +5037,8 @@ function AgentPicker({
   // Codex and cursor both populate the picker from the server-provided
   // ``codexModelOptions`` channel (the snapshot's ``model_options`` field);
   // claude uses the static local catalog.
-  const usesServerModelOptions = modelPickerKind === "codex" || modelPickerKind === "cursor";
+  const usesServerModelOptions =
+    modelPickerKind === "codex" || modelPickerKind === "cursor" || modelPickerKind === "kiro";
   const modelOptions: ReadonlyArray<{ id: string; label?: string; displayName?: string }> =
     modelPickerKind === "claude"
       ? CLAUDE_NATIVE_MODELS
@@ -5063,8 +5070,12 @@ function AgentPicker({
   // carried over from some other session) nor the meaningless `llmModel`
   // default. The other vendor-owns wrappers have no Omnigent-visible model and
   // stay null.
+  // kiro is launch-only: the picked model is persisted as ``model_override`` and
+  // applied via ``--model`` at launch. There is no terminal→web mirror, so the
+  // picker reflects that pre-launch selection (``sessionModelOverride``), like
+  // cursor/opencode surface theirs.
   const pickerSelectedModel =
-    modelPickerKind === "cursor" || modelPickerKind === "opencode"
+    modelPickerKind === "cursor" || modelPickerKind === "kiro" || modelPickerKind === "opencode"
       ? sessionModelOverride
       : selectedModel;
   // SDK/bundle agents (no native picker) never have the cross-session sticky
@@ -5076,8 +5087,11 @@ function AgentPicker({
   const nonNativeModel =
     modelPickerKind === null ? (sessionModelOverride ?? llmModel) : (selectedModel ?? llmModel);
   const effectiveModel = nativeVendorOwnsModel
-    ? modelPickerKind === "cursor"
-      ? sessionModelOverride
+    ? modelPickerKind === "cursor" || modelPickerKind === "kiro"
+      ? // cursor mirrors its live TUI model into ``model_override``; kiro has no
+        // mirror but persists the launch-time pick there. Either way the
+        // Omnigent-visible model is ``model_override``.
+        sessionModelOverride
       : modelPickerKind === "opencode"
         ? // opencode mirrors its live TUI model into ``model_override`` (set at
           // launch and updated by the forwarder on a TUI switch); show that,

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5107,6 +5107,15 @@ function AgentPicker({
       : null;
   const hasPickerActions = showAgents || modelOptions.length > 0 || showEffort;
 
+  // Until kiro mirrors its live model (its first session ``.json`` write), there
+  // is no resolved model to show; fall back to the catalog default (e.g. "Auto")
+  // so the trigger reads as a model rather than the harness name ("Kiro").
+  const kiroDefaultOption =
+    modelPickerKind === "kiro"
+      ? (codexModelOptions.find((m) => m.isDefault) ?? codexModelOptions[0])
+      : undefined;
+  const kiroLaunchFallbackLabel = kiroDefaultOption?.displayName ?? kiroDefaultOption?.id;
+
   // Model in foreground (black), effort in muted (grey). Static fallbacks
   // first; the final `else` returns null so a session with nothing to show
   // and nothing to switch doesn't render an empty disabled pill — its
@@ -5136,8 +5145,10 @@ function AgentPicker({
     // spec may carry no executor model and no sticky/override is set), but the
     // dropdown still has model rows to switch. Keep the trigger rendered — and
     // the model dropdown + bare-`/model` open path reachable — with a stable
-    // identity fallback rather than hiding the picker entirely.
-    triggerContent = agentDisplayName ?? "Model";
+    // identity fallback rather than hiding the picker entirely. For kiro, prefer
+    // the catalog default (e.g. "Auto") over the agent name so the launch-window
+    // label reads as a model.
+    triggerContent = kiroLaunchFallbackLabel ?? agentDisplayName ?? "Model";
   } else {
     return null;
   }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5070,9 +5070,10 @@ function AgentPicker({
   // carried over from some other session) nor the meaningless `llmModel`
   // default. The other vendor-owns wrappers have no Omnigent-visible model and
   // stay null.
-  // kiro is launch-only: the picked model is persisted as ``model_override`` and
-  // applied via ``--model`` at launch. There is no terminal→web mirror, so the
-  // picker reflects that pre-launch selection (``sessionModelOverride``), like
+  // kiro persists the pick as ``model_override`` (applied via ``--model`` at
+  // launch) and, mid-session, the runner types ``/model <id>`` into the live TUI.
+  // There is no terminal→web mirror, so the picker reflects the web-side
+  // ``sessionModelOverride`` (which stays correct since a web pick sets it), like
   // cursor/opencode surface theirs.
   const pickerSelectedModel =
     modelPickerKind === "cursor" || modelPickerKind === "kiro" || modelPickerKind === "opencode"
@@ -5088,9 +5089,9 @@ function AgentPicker({
     modelPickerKind === null ? (sessionModelOverride ?? llmModel) : (selectedModel ?? llmModel);
   const effectiveModel = nativeVendorOwnsModel
     ? modelPickerKind === "cursor" || modelPickerKind === "kiro"
-      ? // cursor mirrors its live TUI model into ``model_override``; kiro has no
-        // mirror but persists the launch-time pick there. Either way the
-        // Omnigent-visible model is ``model_override``.
+      ? // cursor mirrors its live TUI model into ``model_override``; kiro sets it
+        // on a web pick (which also drives a live ``/model`` switch). Either way
+        // the Omnigent-visible model is ``model_override``.
         sessionModelOverride
       : modelPickerKind === "opencode"
         ? // opencode mirrors its live TUI model into ``model_override`` (set at


### PR DESCRIPTION
## Summary

Closes #1697. Adds a kiro-native model picker to the Omnigent Web UI, with both launch-time selection and a live mid-session switch. Mirrors cursor-native (static catalog + `/model` TUI injection).

- **Launch:** the picked model is persisted as `model_override` and applied via `kiro-cli --model <id>` when the kiro terminal spawns.
- **Mid-session:** a pick also drives a live switch — the runner types `/model <id>` into the running kiro TUI (kiro switches directly and confirms with `Model changed to <id>`), so it takes effect immediately, not just on the next launch.

## What changed

**Backend**
- `omnigent/kiro_native.py`: `_KIRO_BASE_MODELS` + `kiro_base_model_options()` — the 9 ids confirmed live against `kiro-cli chat --list-models --format json` (2.10.0); `auto` is the default and a real literal id.
- `omnigent/server/routes/sessions.py`: `_fetch_model_options` serves the static kiro catalog for the `kiro-native-ui` wrapper (like cursor; not the runner endpoint). The server already forwards `model_change` harness-agnostically on a `model_override` PATCH.
- `omnigent/runner/app.py`: `_KiroNativeLaunchConfig` carries `model_override`; `_kiro_native_launch_config` reads+validates it; `_auto_create_kiro_terminal` passes it to `build_kiro_launch(model=...)`. New `_handle_kiro_native_model_change` + a `kiro-native` branch in the `model_change` dispatch ladder, mirroring cursor-native.
- `omnigent/kiro_native_bridge.py`: `inject_model_command` clears the draft, sends `/model <id>` literally + Enter, and confirms via kiro's `Model changed to <id>` line so a bad id fails loudly (its own confirm timeout, since the switch takes ~2s). kiro switches directly (no picker), so it's simpler than cursor's variant.

**Frontend** (`web/src/pages/ChatPage.tsx`)
- Route `kiro-native-ui` through the server-model-options picker (kind `kiro`); surface `model_override` as the selected/effective model; label it "Kiro". Effort stays hidden (kiro `--effort` deferred).

## Design notes

- **Precedent:** this is the established native-harness pattern — cursor-native is the exact analog (tmux TUI, `--model` baked at spawn, `/model <id>` injection). claude-/opencode-native use the same dispatch path.
- **Static catalog** (like cursor): kiro's model list is global/fixed, not account-scoped, so a hand-maintained constant (refreshable from `--list-models`) beats a runner-discovered endpoint.
- **Nuance:** a kiro `/model` switch is persisted by kiro as its own global default ("saved as default"), so a live switch also affects the next fresh kiro launch. `--effort` selection is deferred to a follow-up.

## Testing

- Backend: `kiro_base_model_options` shape/default; `inject_model_command` types the guarded `/model` sequence and confirms on the success line (and fails loudly without it).
- Frontend unit: `ChatPage.capabilities.test.ts` — picker shown for `kiro-native-ui`, effort hidden.
- E2E (`tests/e2e_ui/chat/test_kiro_model_metadata.py`): the picker renders the kiro catalog and a pick PATCHes `model_override` (satisfies the E2E-UI gate).
- `tsc -b`, `ruff`, `prettier` clean; backend + vitest green.

> A live kiro session selecting a non-default model (confirming both the launch `--model` and the mid-session `/model` switch) is the natural final smoke.

This pull request and its description were written by Isaac.
