### PR TITLE
fix(nessie): gate the sys_terminal_* command channel in blast_radius

### DIFF
--- a/omnigent/inner/nessie/policies.py
+++ b/omnigent/inner/nessie/policies.py
@@ -343,6 +343,55 @@ def _push_severity(argv: list[str]) -> str | None:
     return "ASK"
 
 
+# Command channels blast_radius classifies, mapped to the arg key the command
+# string lives in. Two kinds of channel reach the same shell:
+#   * One-shot shell — ``sys_os_shell`` (Omnigent built-in), plus the
+#     Claude/Codex native ``Bash`` and Pi native lowercase ``bash`` tools
+#     (surfaced via the PreToolUse / tool_call hooks). All carry a ``command``.
+#   * Terminal bridge — ``sys_terminal_send`` types its ``text`` into a
+#     registered terminal (e.g. polly's ``bash`` terminal) and the default
+#     ``keys: "Enter"`` runs it, so ``text`` IS a shell command and must be
+#     gated identically. (``keys`` holds tmux key chords like ``"C-c"`` /
+#     ``"Enter"``, never a command, so it is not classified.)
+#     ``sys_terminal_launch`` carries no command in Omnigent's schema (the
+#     terminal's program comes from the spec), but a launch shape that bakes a
+#     ``command`` is classified too — ordinary launches extract nothing → ALLOW.
+# Without the terminal entries, a destructive command routed through a
+# registered terminal bypasses the DENY/ASK guard entirely.
+_BLAST_RADIUS_COMMAND_KEY: dict[str, str] = {
+    "sys_os_shell": "command",
+    "Bash": "command",
+    "bash": "command",
+    "sys_terminal_send": "text",
+    "sys_terminal_launch": "command",
+}
+_BLAST_RADIUS_TOOLS: frozenset[str] = frozenset(_BLAST_RADIUS_COMMAND_KEY)
+
+
+def _blast_radius_command(tool_name: str, args: _Json) -> str | None:
+    """
+    Return the shell command a matched tool call would run, else ``None``.
+
+    Routes each blast-radius tool to the argument key its command lives in
+    (:data:`_BLAST_RADIUS_COMMAND_KEY`) — ``command`` for the one-shot shell
+    tools and ``sys_terminal_launch``, ``text`` for ``sys_terminal_send`` (the
+    literal text typed into the terminal, run by the default ``Enter``). A
+    missing or non-string value yields ``None`` so the caller ALLOWs: there is
+    nothing for the patterns to classify (e.g. a bare ``sys_terminal_launch``
+    or a key-only ``sys_terminal_send``).
+
+    :param tool_name: The matched ``tool_call`` name, e.g.
+        ``"sys_terminal_send"``.
+    :param args: The tool's argument dict.
+    :returns: The command string to classify, or ``None``.
+    """
+    key = _BLAST_RADIUS_COMMAND_KEY.get(tool_name)
+    if key is None:
+        return None
+    value = args.get(key)
+    return value if isinstance(value, str) else None
+
+
 def blast_radius(
     *,
     gate_pushes: bool = True,
@@ -358,6 +407,13 @@ def blast_radius(
     they run. Everything else — reads, tests, edits, and local git
     (commit / merge / worktree) — is ALLOWED.
 
+    The same classification covers every command channel
+    (:data:`_BLAST_RADIUS_COMMAND_KEY`): the one-shot shell tools
+    (``sys_os_shell`` / native ``Bash`` / ``bash``) and the terminal bridge
+    (``sys_terminal_send`` ``text`` and ``sys_terminal_launch`` ``command``),
+    so a destructive command routed through a registered ``bash`` terminal is
+    gated the same as ``sys_os_shell`` rather than slipping past the guard.
+
     :param gate_pushes: When ``True`` (default), recoverable-but-outward
         commands return ASK. When ``False`` only the catastrophic DENY
         set is enforced — use only for trusted unattended batch runs.
@@ -367,27 +423,30 @@ def blast_radius(
 
     def _evaluate(event: _Json, config: _Json) -> _Json:  # noqa: ARG001
         """
-        Classify a ``sys_os_shell`` command by blast radius.
+        Classify a shell command by blast radius across all command channels.
 
-        :param event: V0 ``tool_call`` event for ``sys_os_shell``.
+        Covers the one-shot shell tools (``sys_os_shell`` / native ``Bash`` /
+        ``bash``) and the terminal bridge (``sys_terminal_send`` ``text`` /
+        ``sys_terminal_launch`` ``command``), routing each to its command via
+        :func:`_blast_radius_command` so a destructive command typed into a
+        registered terminal is gated the same as ``sys_os_shell``.
+
+        :param event: V0 ``tool_call`` event for a blast-radius tool.
         :param config: Runtime config dict (unused; bounds come from the
             factory params).
         :returns: ALLOW / ASK / DENY decision dict.
         """
-        # Match the Omnigent built-in OS shell, the Claude/Codex native
-        # Bash tool, and Pi's native lowercase ``bash``. The PreToolUse hook
-        # reports BOTH CLI harnesses' shell tool as ``Bash`` with a string
-        # ``command`` (codex normalizes to this shape); Pi's ``tool_call``
-        # hook reports ``bash`` with the same ``command`` key — so one match
-        # set covers all three.
-        args = _tool_call(event, {"sys_os_shell", "Bash", "bash"})
+        args = _tool_call(event, _BLAST_RADIUS_TOOLS)
         if args is None:
             return _ALLOW
-        command = args.get("command")
-        # A Bash / sys_os_shell call always carries a string ``command`` by
-        # contract; a non-str is a malformed payload no pattern can classify, so
-        # there is nothing to gate.
-        if not isinstance(command, str):
+        # ``_tool_call`` confirmed a tool_call event whose name is in the set,
+        # so ``data.name`` is present and selects the command-carrying arg.
+        command = _blast_radius_command(event["data"]["name"], args)
+        # A shell / terminal call normally carries a string command; a missing
+        # or non-str value (a bare ``sys_terminal_launch``, a key-only
+        # ``sys_terminal_send``, or a malformed payload) is nothing a pattern
+        # can classify, so there is nothing to gate.
+        if command is None:
             return _ALLOW
         # rm + git push are classified by flag/refspec-robust helpers (a regex
         # missed split/long rm flags, root children, and force/delete refspecs);
@@ -633,8 +692,9 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
         "kind": "factory",
         "name": "Block Dangerous Shell Commands (force-push, rm -rf)",
         "description": "Classifies shell commands (sys_os_shell, Claude/Codex native Bash, "
-        "and Pi native bash) as safe, risky (ASK), or catastrophic (DENY) to prevent "
-        "destructive operations like force-push or rm -rf /",
+        "Pi native bash, and the sys_terminal_send/sys_terminal_launch terminal channel) as "
+        "safe, risky (ASK), or catastrophic (DENY) to prevent destructive operations like "
+        "force-push or rm -rf /",
     },
     {
         "handler": "omnigent.inner.nessie.policies.spawn_bounds",

--- a/tests/inner/nessie/test_policies.py
+++ b/tests/inner/nessie/test_policies.py
@@ -112,11 +112,89 @@ def test_blast_radius_gates_pi_native_bash_tool() -> None:
     assert _result(evaluate(_tool_call("bash", command="git status"), {})) == "ALLOW"
 
 
+def test_blast_radius_gates_terminal_send_channel() -> None:
+    """
+    blast_radius must gate a command typed into a terminal via
+    ``sys_terminal_send`` the same way it gates ``sys_os_shell``.
+
+    polly (and any agent with a ``terminals:`` block) registers a ``bash``
+    terminal; ``sys_terminal_send`` types its ``text`` into that shell and the
+    default ``keys: "Enter"`` runs it. Before this gate the ``text`` channel
+    was unclassified, so a destructive command routed through the terminal
+    bypassed the entire DENY/ASK guard. ``text`` must now classify identically
+    to a ``sys_os_shell`` ``command``.
+    """
+    evaluate = blast_radius()
+    # Catastrophic via the terminal channel — should DENY.
+    assert (
+        _result(evaluate(_tool_call("sys_terminal_send", text="git push --force origin main"), {}))
+        == "DENY"
+    )
+    assert _result(evaluate(_tool_call("sys_terminal_send", text="rm -rf /"), {})) == "DENY"
+    # Recoverable-but-outward via the terminal channel — should ASK.
+    push = _tool_call("sys_terminal_send", text="git push origin main")
+    assert _result(evaluate(push, {})) == "ASK"
+    # Safe via the terminal channel — should ALLOW.
+    assert _result(evaluate(_tool_call("sys_terminal_send", text="git status"), {})) == "ALLOW"
+
+
+def test_blast_radius_terminal_send_catastrophic_denies_when_pushes_ungated() -> None:
+    """
+    The catastrophic DENY tier covers the terminal channel even with
+    ``gate_pushes=False`` — the setting polly ships for its unattended ``bash``
+    terminal. Without this, polly's terminal could run ``rm -rf /`` or
+    force-push entirely ungated.
+    """
+    evaluate = blast_radius(gate_pushes=False)
+    assert _result(evaluate(_tool_call("sys_terminal_send", text="rm -rf /"), {})) == "DENY"
+    assert (
+        _result(evaluate(_tool_call("sys_terminal_send", text="git push --force origin main"), {}))
+        == "DENY"
+    )
+    # Recoverable-but-outward is dropped to ALLOW once pushes aren't gated.
+    assert (
+        _result(evaluate(_tool_call("sys_terminal_send", text="git push origin main"), {}))
+        == "ALLOW"
+    )
+
+
+def test_blast_radius_terminal_send_non_command_payloads_allow() -> None:
+    """
+    A key-only ``sys_terminal_send`` (no ``text``) carries no command to
+    classify and must ALLOW — gating kicks in only on a real command string,
+    so ordinary control keystrokes (``C-c``, ``Enter``) pass through.
+    """
+    evaluate = blast_radius()
+    assert _result(evaluate(_tool_call("sys_terminal_send", keys="C-c"), {})) == "ALLOW"
+    assert _result(evaluate(_tool_call("sys_terminal_send", keys="Enter"), {})) == "ALLOW"
+
+
+def test_blast_radius_gates_terminal_launch_command() -> None:
+    """
+    ``sys_terminal_launch`` is covered too: an ordinary launch names no
+    command (the terminal's program comes from the spec) and ALLOWs, but a
+    launch shape that bakes a destructive ``command`` is classified like any
+    other shell command rather than slipping past the gate.
+    """
+    evaluate = blast_radius()
+    # Ordinary launch — no command arg to classify → ALLOW.
+    assert (
+        _result(evaluate(_tool_call("sys_terminal_launch", terminal="bash", session="s1"), {}))
+        == "ALLOW"
+    )
+    # A baked destructive command — DENY.
+    launch_rm = _tool_call(
+        "sys_terminal_launch", terminal="bash", session="s1", command="rm -rf /"
+    )
+    assert _result(evaluate(launch_rm, {})) == "DENY"
+
+
 def test_blast_radius_ignores_non_shell_tools() -> None:
     """
-    Non-shell tool calls pass through ALLOW — blast_radius only inspects
-    ``sys_os_shell`` and ``Bash``. A failure here means the guard is matching
-    on the wrong tool and would corrupt unrelated tool dispatch.
+    Non-command tool calls pass through ALLOW — blast_radius only inspects the
+    shell / terminal command channels (:data:`_BLAST_RADIUS_COMMAND_KEY`). A
+    failure here means the guard is matching on the wrong tool and would
+    corrupt unrelated tool dispatch.
     """
     evaluate = blast_radius()
     assert _result(evaluate(_tool_call("sys_session_send", agent="impl_claude"), {})) == "ALLOW"


### PR DESCRIPTION
## Related issue

N/A — P0 security hardening; no tracking issue filed.

## Summary

**Vulnerability + impact.** The `blast_radius` guardrail
(`omnigent/inner/nessie/policies.py`) is the runner-side safety net that
DENIES catastrophic shell commands (`rm -rf /`, `git push --force`,
hard-reset to a remote ref) and ASKs for outward/destructive-but-recoverable
ones. It only classified commands from the **one-shot shell tool set**
(`{sys_os_shell, Bash, bash}`), reading `args["command"]`.

But any agent with a `terminals:` block also runs arbitrary commands through
the **terminal bridge** — and the shipped **polly** example
(`examples/polly/config.yaml`) registers a `bash` terminal. `sys_terminal_send`
types its `text` into that shell and the default `keys: "Enter"` runs it;
`sys_terminal_launch` brings the shell up. Because those tool names were never
in the match set, a destructive command routed through the terminal channel
**bypassed the entire DENY/ASK guard** — e.g. `sys_terminal_send(text="rm -rf /")`
or `git push --force` ran ungated, even under polly's `gate_pushes: false`
(which still relies on the catastrophic DENY tier).

```
              sys_os_shell / Bash / bash ──► blast_radius ──► DENY / ASK / ALLOW
   BEFORE     sys_terminal_send (text) ─────────────────────► (unclassified) ► runs
              sys_terminal_launch (command) ────────────────► (unclassified) ► runs

              sys_os_shell / Bash / bash ──┐
   AFTER      sys_terminal_send (text) ─────┼─► blast_radius ─► DENY / ASK / ALLOW
              sys_terminal_launch (command)─┘
```

**Fix.** Extend the policy so the terminal command channel is classified by the
*same* DENY/ASK rules as `sys_os_shell`. A small tool→arg-key map
(`_BLAST_RADIUS_COMMAND_KEY`) routes each tool to the argument that carries its
command — `command` for the shell tools and `sys_terminal_launch`, `text` for
`sys_terminal_send` — and a `_blast_radius_command()` helper extracts it. The
classifier logic (`_rm_severity` / `_push_severity` / regex tiers) is **unchanged**;
only the command-extraction step learned the new channels. `keys` (tmux key
chords like `C-c` / `Enter`) is intentionally not classified, and a missing/non-string
value yields ALLOW so ordinary launches and key-only sends pass through.

> ELI5: the bouncer was only checking IDs at the front door (`sys_os_shell`).
> There was a side door (the `bash` terminal) with no bouncer. This adds the
> same bouncer to the side door.

**Complementary hardening (not in this PR):** running polly under a real OS
sandbox is the defense-in-depth layer; this policy fix closes the
classification gap in the guard itself, which is the deliverable here.

## Test Plan

- Added focused unit tests in `tests/inner/nessie/test_policies.py` asserting a
  destructive command sent via `sys_terminal_send` is gated identically to
  `sys_os_shell` (DENY for `rm -rf /` / `git push --force`, ASK for
  `git push origin main`, ALLOW for `git status`), including the
  `gate_pushes=False` catastrophic tier polly ships, plus key-only sends and the
  `sys_terminal_launch` command path.
- `uv run --extra dev pytest tests/inner/nessie/test_policies.py -x -q` → **95 passed**.
- `uv run --extra dev ruff check` + `ruff format --check` on both changed files → clean.

## Demo

N/A — backend security fix, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the terminal channel directly (`sys_terminal_send` text and
`sys_terminal_launch` command) at both `gate_pushes` settings, mirroring the
existing `sys_os_shell` / native-`Bash` / pi-`bash` cases. The shared classifier
is already exercised by the existing `blast_radius` parametrized suite, so the
new tests target only the added extraction paths.