### PR TITLE
fix(tools): fail closed when srt sandbox required but unavailable

### DIFF
--- a/omnigent/tools/_srt.py
+++ b/omnigent/tools/_srt.py
@@ -36,6 +36,25 @@ import shlex
 import shutil
 
 
+class SandboxUnavailableError(RuntimeError):
+    """
+    Raised when sandboxing is *required* but the ``srt`` runtime is missing.
+
+    This is the fail-closed signal: a deployment that demands OS-level
+    sandboxing (``sandbox_enabled=True`` AND ``sandbox_required=True``)
+    must never silently downgrade to a plain, full-privilege subprocess
+    when ``srt`` is absent from ``PATH``. :func:`wrap_with_srt` raises
+    this instead of returning the unwrapped command so the caller
+    refuses to run untrusted tool code rather than running it
+    unsandboxed.
+
+    Callers that spawn spec-author code (e.g.
+    :class:`~omnigent.tools.local.LocalPythonTool`) translate this into
+    a clear tool-level error so the refusal is visible to the agent and
+    operators rather than crashing the whole run.
+    """
+
+
 def is_srt_available() -> bool:
     """
     Return ``True`` when the ``srt`` CLI is on ``PATH``.
@@ -56,16 +75,32 @@ def wrap_with_srt(
     sandbox_enabled: bool,
     srt_available: bool,
     settings_file: str | None = None,
+    sandbox_required: bool = False,
 ) -> list[str]:
     """
     Prepend ``srt`` to *cmd* when sandboxing is enabled AND available.
 
-    When either condition is false, returns *cmd* unchanged so the
-    caller spawns the plain subprocess. This is the project's
-    "sandbox-if-possible, subprocess-otherwise" contract — any
-    caller that spawns a subprocess and wants optional srt wrapping
-    should go through this function rather than hand-rolling the
-    same 3-line branch.
+    Behaviour by (``sandbox_enabled``, ``srt_available``,
+    ``sandbox_required``):
+
+    - ``sandbox_enabled=False`` → return *cmd* unchanged (explicit
+      opt-out; never wrap, never raise).
+    - enabled, ``srt_available=True`` → wrap with ``srt``.
+    - enabled, ``srt_available=False``, ``sandbox_required=False`` →
+      return *cmd* unchanged. This is the **documented dev escape
+      hatch**: dev boxes / CI without ``srt`` installed still run the
+      plain subprocess so they remain usable.
+    - enabled, ``srt_available=False``, ``sandbox_required=True`` →
+      raise :class:`SandboxUnavailableError` (**fail closed**). A
+      deployment that demands sandboxing must never silently downgrade
+      to a full-privilege subprocess just because ``srt`` is missing or
+      renamed on ``PATH``.
+
+    Historically this helper failed *open* in the missing-``srt`` case
+    regardless of intent, so a deployment that believed it was
+    sandboxing could silently run untrusted spec-author code with full
+    host privileges. ``sandbox_required`` closes that hole while
+    keeping the dev fallback opt-in.
 
     When wrapping, the returned form is ``srt [-s <settings>] -c
     <quoted>``. The ``-c`` flag takes a single quoted command string
@@ -88,10 +123,28 @@ def wrap_with_srt(
         pass ``None`` — the MCP server lives inside its own
         filesystem expectations and srt's permissive read defaults
         + the caller's ``cwd`` cover the common case.
+    :param sandbox_required: When ``True``, a missing ``srt`` while
+        sandboxing is enabled is fatal — the function raises
+        :class:`SandboxUnavailableError` instead of returning *cmd*
+        unwrapped. Defaults to ``False`` to preserve the dev
+        fail-open fallback.
     :returns: The wrapped command argv, or *cmd* unchanged when
         not wrapping.
+    :raises SandboxUnavailableError: If sandboxing is enabled and
+        required but ``srt`` is not available.
     """
-    if not (sandbox_enabled and srt_available):
+    if not sandbox_enabled:
+        return cmd
+    if not srt_available:
+        if sandbox_required:
+            raise SandboxUnavailableError(
+                "Sandboxing is required (sandbox_enabled=True, "
+                "sandbox_required=True) but the 'srt' sandbox runtime is not "
+                "available on PATH. Refusing to run the command unsandboxed. "
+                "Install 'srt' (or restore it to PATH); set "
+                "sandbox_required=False only for trusted dev environments to "
+                "allow the unsandboxed fallback."
+            )
         return cmd
     base = ["srt"]
     if settings_file is not None:

--- a/omnigent/tools/local.py
+++ b/omnigent/tools/local.py
@@ -52,7 +52,7 @@ from omnigent_client.tools import ToolMetadata, get_tool_metadata
 from omnigent.runner.identity import strip_runner_auth_secrets
 from omnigent.spec.types import LocalToolInfo, SandboxConfig
 from omnigent.tools._pep723 import parse_inline_metadata
-from omnigent.tools._srt import wrap_with_srt
+from omnigent.tools._srt import SandboxUnavailableError, wrap_with_srt
 from omnigent.tools.base import Tool, ToolContext
 
 _logger = logging.getLogger(__name__)
@@ -97,6 +97,9 @@ class LocalPythonTool(Tool):
     :param srt_available: Whether ``srt`` is on PATH.
     :param uv_available: Whether ``uv`` is on PATH.
     :param sandbox_enabled: Runtime policy for srt sandboxing.
+    :param sandbox_required: When ``True``, refuse to run (fail
+        closed) if sandboxing is enabled but ``srt`` is unavailable,
+        instead of silently downgrading to a plain subprocess.
     """
 
     def __init__(
@@ -108,6 +111,7 @@ class LocalPythonTool(Tool):
         srt_available: bool,
         uv_available: bool,
         sandbox_enabled: bool = True,
+        sandbox_required: bool = False,
     ) -> None:
         """
         Initialize from a discovered ``@tool`` function.
@@ -122,12 +126,18 @@ class LocalPythonTool(Tool):
         :param srt_available: Whether ``srt`` is on PATH.
         :param uv_available: Whether ``uv`` is on PATH.
         :param sandbox_enabled: Runtime policy for srt sandboxing.
+        :param sandbox_required: When ``True``, a missing ``srt`` while
+            sandboxing is enabled is fatal: :meth:`invoke` refuses to
+            run the tool with a clear error rather than spawning an
+            unsandboxed subprocess. Defaults to ``False`` (dev
+            fail-open fallback).
         """
         self._info = info
         self._metadata = metadata
         self._module_path = module_path
         self._sandbox_config = sandbox_config
         self._sandbox_enabled = sandbox_enabled
+        self._sandbox_required = sandbox_required
         self._srt_available = srt_available
         self._uv_available = uv_available
         # Live subprocesses from any in-flight ``invoke()`` — tracked
@@ -245,7 +255,14 @@ class LocalPythonTool(Tool):
         # Python process. Use the stdout protocol instead.
         srt_active = self._srt_available and self._sandbox_enabled
         use_stdout = self._sandbox_config.container_image is not None or srt_active
-        cmd = self._build_command(state_root=state_root)
+        # Fail closed: when sandboxing is required but srt is missing,
+        # _build_command raises rather than yielding an unsandboxed
+        # command. Surface it as a clear tool error instead of letting
+        # untrusted spec-author code run with full host privileges.
+        try:
+            cmd = self._build_command(state_root=state_root)
+        except SandboxUnavailableError as exc:
+            return f"Error: {exc}"
         if use_stdout:
             return self._invoke_stdout(cmd, request, workspace=ctx.workspace)
         return self._invoke_subprocess(cmd, request, workspace=ctx.workspace)
@@ -386,6 +403,19 @@ class LocalPythonTool(Tool):
             # srt -c receives the python command as a quoted string.
             inner = shlex.join(["python", _RUNNER_PATH])
             uv_args.extend(["--", "srt", "-c", inner])
+        elif self._sandbox_enabled and self._sandbox_required:
+            # Sandboxing demanded but srt missing on this (uv/PEP 723)
+            # tier. The plain-srt tier fails closed via wrap_with_srt;
+            # this branch can't use that helper (uv must wrap srt, not
+            # the reverse), so enforce the same fail-closed posture
+            # here. Scope: refuse-when-srt-missing only — the separate
+            # "uv-installed deps run outside srt" gap is out of scope.
+            raise SandboxUnavailableError(
+                "Sandboxing is required (sandbox_enabled=True, "
+                "sandbox_required=True) for a tool with PEP 723 inline "
+                "dependencies, but the 'srt' sandbox runtime is not available "
+                "on PATH. Refusing to run the tool unsandboxed."
+            )
         else:
             uv_args.extend(["--", "python", _RUNNER_PATH])
         return uv_args
@@ -419,11 +449,17 @@ class LocalPythonTool(Tool):
         semantics; this method only builds the per-call
         ``settings_file`` for stateful tools and hands it in.
 
+        When ``sandbox_required`` is set and ``srt`` is unavailable,
+        the helper raises :class:`SandboxUnavailableError` (fail
+        closed) rather than returning the command unwrapped.
+
         :param cmd: The base command to wrap.
         :param state_root: Per-call ToolState directory, or ``None``
             for stateless invocations. A stateless call skips the
             ``-s`` settings file entirely.
         :returns: The wrapped command.
+        :raises SandboxUnavailableError: If sandboxing is required but
+            ``srt`` is unavailable.
         """
         settings_file = _write_srt_settings_file(state_root) if state_root is not None else None
         return wrap_with_srt(
@@ -431,6 +467,7 @@ class LocalPythonTool(Tool):
             sandbox_enabled=self._sandbox_enabled,
             srt_available=self._srt_available,
             settings_file=settings_file,
+            sandbox_required=self._sandbox_required,
         )
 
     def _build_container_command(self) -> list[str]:
@@ -617,6 +654,7 @@ def load_local_python_tools(
     srt_available: bool | None = None,
     uv_available: bool | None = None,
     sandbox_enabled: bool = True,
+    sandbox_required: bool = False,
     *,
     agent_name: str | None = None,
     builtin_tool_names: frozenset[str] | None = None,
@@ -641,6 +679,13 @@ def load_local_python_tools(
     :param uv_available: Whether ``uv`` is on PATH. ``None``
         auto-detects.
     :param sandbox_enabled: Runtime policy for srt sandboxing.
+    :param sandbox_required: When ``True``, demand sandboxing — tools
+        refuse to run (fail closed) if ``srt`` is unavailable while
+        sandboxing is enabled, rather than silently downgrading to a
+        plain subprocess. Defaults to ``False`` (dev fail-open). When
+        sandboxing is enabled but ``srt`` is missing, a WARNING is
+        logged at load time regardless of this flag so operators can
+        detect a missing or renamed ``srt``.
     :param agent_name: The agent's name, used in error messages.
         ``None`` falls back to the workdir basename.
     :param builtin_tool_names: Names of framework-provided built-in
@@ -656,6 +701,35 @@ def load_local_python_tools(
     effective_srt = srt_available if srt_available is not None else shutil.which("srt") is not None
     effective_uv = uv_available if uv_available is not None else shutil.which("uv") is not None
     effective_agent_name = agent_name or workdir.name
+
+    # Observability for the silent-downgrade hazard: sandboxing is
+    # enabled but srt is missing, so subprocess-tier tools would run
+    # unsandboxed. Container-image tools sandbox via the container
+    # runtime (not srt), so they don't trip this. Warn once at load
+    # time so operators can spot a missing/renamed srt; the message
+    # reflects whether the policy fails closed (refuse at invoke) or
+    # open (dev fallback).
+    if (
+        sandbox_enabled
+        and not effective_srt
+        and effective_sandbox.container_image is None
+        and any(info.language == "python" for info in local_tools)
+    ):
+        if sandbox_required:
+            _logger.warning(
+                "Agent %r: sandboxing is REQUIRED but 'srt' is not on PATH — "
+                "local @tool subprocesses will be REFUSED at invocation "
+                "(fail closed). Install 'srt' or restore it to PATH.",
+                effective_agent_name,
+            )
+        else:
+            _logger.warning(
+                "Agent %r: sandboxing is enabled but 'srt' is not on PATH — "
+                "local @tool subprocesses will run UNSANDBOXED with full host "
+                "privileges (dev fail-open fallback). Install 'srt', or set "
+                "sandbox_required=True to fail closed instead.",
+                effective_agent_name,
+            )
 
     # Discover decorated functions per file. Track tool name -> source so
     # we can detect cross-file collisions and surface them with both paths.
@@ -720,6 +794,7 @@ def load_local_python_tools(
             srt_available=effective_srt,
             uv_available=effective_uv,
             sandbox_enabled=sandbox_enabled,
+            sandbox_required=sandbox_required,
         )
         for disc in discovered.values()
     ]

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -108,6 +108,7 @@ class ToolManager:
         client_tool_specs: list[ClientSideToolSpec] | None = None,
         workdir: Path | None = None,
         sandbox_enabled: bool = True,
+        sandbox_required: bool = False,
         os_env: OSEnvironment | None = None,
     ) -> None:
         """
@@ -130,6 +131,11 @@ class ToolManager:
             ``True`` enables sandboxing when ``srt`` is on PATH.
             This is a deployment decision from ``RuntimeCaps``, not
             an agent config setting.
+        :param sandbox_required: Deployment gate to *demand* sandboxing.
+            When ``True``, local Python tools refuse to run (fail
+            closed) if sandboxing is enabled but ``srt`` is unavailable,
+            instead of silently downgrading to an unsandboxed
+            subprocess. Defaults to ``False`` (dev fail-open fallback).
         :param os_env: Pre-resolved primary OSEnvironment from the
             ``SessionResourceRegistry``. When provided, ``sys_os_*``
             tools use this shared instance instead of creating their
@@ -139,6 +145,7 @@ class ToolManager:
         self._spec = spec
         self._workdir = workdir
         self._sandbox_enabled = sandbox_enabled
+        self._sandbox_required = sandbox_required
         self._pre_resolved_os_env = os_env
         self._started = False
         self._tools: dict[str, Tool] = {}
@@ -722,6 +729,7 @@ class ToolManager:
                 srt_available=self._srt_available,
                 uv_available=self._uv_available,
                 sandbox_enabled=self._sandbox_enabled,
+                sandbox_required=self._sandbox_required,
                 agent_name=self._spec.name,
                 # Pass the names of already-registered tools (builtins
                 # at this point) so the loader can detect collisions

--- a/tests/tools/test_local.py
+++ b/tests/tools/test_local.py
@@ -119,6 +119,74 @@ def test_invoke_subprocess_success(tmp_path: Path, tool_ctx: ToolContext) -> Non
     assert "result:" in result
 
 
+def test_invoke_refuses_when_sandbox_required_but_srt_unavailable(
+    tmp_path: Path,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    With ``sandbox_required=True`` and ``srt`` unavailable, ``invoke``
+    REFUSES to run the tool: it returns a clear ``Error:`` string and
+    never spawns the (unsandboxed) subprocess.
+
+    This is the end-to-end view of the P0 fix. The fail-open default
+    (no ``sandbox_required``) is exercised throughout the rest of this
+    module; here we pin the fail-closed posture so a deployment that
+    demands sandboxing can never silently run spec-author code with
+    full host privileges when ``srt`` is missing.
+
+    What breaks if this fails: a ``sandbox_required`` deployment runs
+    untrusted tool code unsandboxed (the original vulnerability) — and
+    the tool body would actually execute (``result:`` would appear).
+    """
+    py_dir = tmp_path / "tools" / "python"
+    _write_decorated_tool(py_dir, "echo_tool.py", func_name="echo_tool")
+    info = LocalToolInfo(name="echo_tool", path="tools/python/echo_tool.py", language="python")
+    tools = load_local_python_tools(
+        [info],
+        tmp_path,
+        srt_available=False,
+        sandbox_enabled=True,
+        sandbox_required=True,
+    )
+    result = tools[0].invoke(json.dumps({"value": "hello"}), tool_ctx)
+    assert result.startswith("Error:")
+    assert "srt" in result
+    # The refusal must short-circuit BEFORE the subprocess runs — the
+    # tool body's "result:" sentinel must be absent.
+    assert "result:" not in result
+
+
+def test_load_warns_when_sandbox_enabled_but_srt_unavailable(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Loading local Python tools with sandboxing enabled but ``srt``
+    missing logs a WARNING so operators can detect a missing/renamed
+    ``srt`` — observability the silent fail-open never provided.
+
+    Default (``sandbox_required=False``) loads fine (dev fail-open) but
+    must still warn.
+
+    What breaks if this fails: a misconfigured deployment (srt removed
+    or renamed) gives no signal that its tools are running unsandboxed.
+    """
+    py_dir = tmp_path / "tools" / "python"
+    _write_decorated_tool(py_dir, "echo_tool.py", func_name="echo_tool")
+    info = LocalToolInfo(name="echo_tool", path="tools/python/echo_tool.py", language="python")
+    with caplog.at_level("WARNING"):
+        tools = load_local_python_tools(
+            [info],
+            tmp_path,
+            srt_available=False,
+            sandbox_enabled=True,
+            agent_name="testagent",
+        )
+    assert len(tools) == 1
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("srt" in m and "testagent" in m for m in warnings), warnings
+
+
 def test_invoke_subprocess_strips_runner_binding_token(
     tmp_path: Path,
     tool_ctx: ToolContext,

--- a/tests/tools/test_srt_wrap.py
+++ b/tests/tools/test_srt_wrap.py
@@ -20,7 +20,11 @@ import shlex
 
 import pytest
 
-from omnigent.tools._srt import is_srt_available, wrap_with_srt
+from omnigent.tools._srt import (
+    SandboxUnavailableError,
+    is_srt_available,
+    wrap_with_srt,
+)
 
 
 def test_wrap_with_srt_passthrough_when_disabled() -> None:
@@ -43,11 +47,16 @@ def test_wrap_with_srt_passthrough_when_disabled() -> None:
 
 def test_wrap_with_srt_passthrough_when_unavailable() -> None:
     """
-    ``srt_available=False`` passes the command through regardless
-    of the caller's sandbox preference. On machines without srt
-    installed, the subprocess runs unsandboxed — silently, by
-    design, so dev boxes that haven't installed the sandbox
+    ``srt_available=False`` with the default ``sandbox_required=False``
+    passes the command through. On machines without srt installed, the
+    subprocess runs unsandboxed — the documented dev fail-open
+    fallback, so dev boxes / CI that haven't installed the sandbox
     runtime still function.
+
+    NOTE: this is the *opt-in* dev posture. Deployments that demand
+    sandboxing pass ``sandbox_required=True`` and get the fail-closed
+    raise instead (see
+    :func:`test_wrap_with_srt_fails_closed_when_required_and_unavailable`).
 
     What breaks if this fails: CI environments and fresh dev
     machines without srt installed would crash at subprocess
@@ -55,6 +64,78 @@ def test_wrap_with_srt_passthrough_when_unavailable() -> None:
     """
     cmd = ["python", "/tmp/foo.py"]
     assert wrap_with_srt(cmd, sandbox_enabled=True, srt_available=False) is cmd
+
+
+def test_wrap_with_srt_fails_closed_when_required_and_unavailable() -> None:
+    """
+    ``sandbox_enabled=True`` + ``srt_available=False`` +
+    ``sandbox_required=True`` raises :class:`SandboxUnavailableError`
+    instead of returning the command unwrapped.
+
+    This is the P0 fix: previously this exact combination failed *open*
+    — ``wrap_with_srt`` returned the bare command and the caller ran
+    untrusted spec-author code as a full-privilege subprocess with no
+    error, warning, or log. A deployment that demanded sandboxing was
+    silently unsandboxed. The fail-closed gate refuses instead.
+
+    What breaks if this fails: the silent-downgrade vulnerability is
+    back — a deployment with ``sandbox_required`` set runs untrusted
+    code unsandboxed whenever ``srt`` is missing or renamed on PATH.
+    """
+    cmd = ["python", "/tmp/foo.py"]
+    with pytest.raises(SandboxUnavailableError):
+        wrap_with_srt(
+            cmd,
+            sandbox_enabled=True,
+            srt_available=False,
+            sandbox_required=True,
+        )
+
+
+def test_wrap_with_srt_required_and_available_wraps() -> None:
+    """
+    ``sandbox_required=True`` does not change the happy path: when srt
+    IS available, the command is wrapped normally. ``sandbox_required``
+    only governs the missing-srt case.
+
+    What breaks if this fails: requiring the sandbox would somehow
+    break wrapping when srt is present — i.e. the gate is conflated
+    with the wrap logic.
+    """
+    cmd = ["python", "/tmp/foo.py"]
+    wrapped = wrap_with_srt(
+        cmd,
+        sandbox_enabled=True,
+        srt_available=True,
+        sandbox_required=True,
+    )
+    assert wrapped[:2] == ["srt", "-c"]
+    assert shlex.split(wrapped[2]) == cmd
+
+
+def test_wrap_with_srt_required_but_disabled_passes_through() -> None:
+    """
+    An explicit ``sandbox_enabled=False`` opt-out wins over
+    ``sandbox_required=True``: the command passes through unchanged and
+    no error is raised. ``sandbox_required`` hardens the
+    *enabled-but-unavailable* case; it does not override a caller that
+    has deliberately turned sandboxing off.
+
+    What breaks if this fails: a caller that sets
+    ``SandboxConfig(enabled=False)`` would crash with
+    :class:`SandboxUnavailableError` instead of running its plain
+    subprocess.
+    """
+    cmd = ["python", "/tmp/foo.py"]
+    assert (
+        wrap_with_srt(
+            cmd,
+            sandbox_enabled=False,
+            srt_available=False,
+            sandbox_required=True,
+        )
+        is cmd
+    )
 
 
 def test_wrap_with_srt_wraps_when_enabled_and_available() -> None:


### PR DESCRIPTION
## Related issue

N/A — internal P0 security hardening (the local `@tool` sandbox fails open when `srt` is missing). No public issue is linked.

## Summary

**Vulnerability (silent fail-open).** The local `@tool` execution sandbox silently failed open. When sandboxing was requested (`sandbox_enabled=True`) but the `srt` sandbox runtime was not on `PATH`, `wrap_with_srt` returned the command **unwrapped** — so spec-author tool code ran as a plain subprocess with **full host privileges**. There was **no error, no warning, and no log**, and no way for a deployment to *demand* sandboxing. A deployment that believed it was sandboxing untrusted code was silently running it unsandboxed (e.g. if `srt` was removed, renamed, or never installed).

**Fix (fail-closed + observability).**
- New `sandbox_required` gate threads deployment intent through `ToolManager` → `load_local_python_tools` → `LocalPythonTool` → `wrap_with_srt`.
- When sandboxing is required but `srt` is unavailable, `wrap_with_srt` (and the uv/PEP 723 tier) raise a new `SandboxUnavailableError`, and `LocalPythonTool.invoke` **refuses to run** the tool — returning a clear `Error: …` instead of downgrading to a full-privilege subprocess.
- A **WARNING is logged at load time** whenever sandboxing is enabled but `srt` is missing, so operators can detect a missing/renamed `srt` — regardless of `sandbox_required`.
- The default (`sandbox_required=False`) preserves the **documented dev escape hatch** (fail-open) so dev boxes / CI without `srt` stay usable — but now with the load-time warning.

**Scope.** Limited to fail-closed + observability. The separate "uv/PEP 723 deps run outside `srt`" gap is intentionally **out of scope** (owned by another PR).

ELI5: before, if the door's lock was missing we just left the door open and said nothing. Now a deployment can declare "this door MUST be locked" — and if the lock is missing we refuse to open the door and tell the operator, instead of quietly letting anyone in.

Decision matrix (`sandbox_enabled`, `srt_available`, `sandbox_required`):

| enabled | srt available | required | result |
|---|---|---|---|
| false | * | * | passthrough (explicit opt-out) |
| true | true | * | wrapped with `srt` |
| true | false | false | passthrough + WARNING (dev fail-open) |
| true | false | true | **refuse** → `SandboxUnavailableError` + WARNING |

## Test Plan

Ran focused unit tests in the worktree (`uv run --extra dev pytest`):

- `tests/tools/test_srt_wrap.py` — added fail-closed cases: raise when required+unavailable; still wrap when required+available; explicit `sandbox_enabled=False` opt-out wins (no raise). Existing fail-open truth-table tests still pass.
- `tests/tools/test_local.py` — added an end-to-end `invoke` test (refuses with a clear `Error:` and never runs the tool body) and a load-time WARNING test.

```
uv run --extra dev pytest tests/tools/test_srt_wrap.py tests/tools/test_local.py -q
# 49 passed
```

Also: `tests/tools/test_tool_collision.py` (6 passed); `ruff check` and `ruff format --check` clean on all touched files. Five pre-existing failures in `tests/tools/test_manager.py` (host-scope skill discovery registering `read_skill_file`) reproduce identically on the pristine base and are unrelated to this change.

## Demo

N/A — backend security fix, no UI/visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the refuse-when-required-but-unavailable path at both the `wrap_with_srt` choke point and end-to-end through `LocalPythonTool.invoke`, plus the load-time WARNING. The fail-open default path stays covered by the existing `test_srt_wrap.py` truth-table tests. No integration/E2E added: this is a localized guard in the tool-execution path with no new external surface, and behavior is fully exercised by unit tests.