### PR TITLE
fix(runner): tree-scope sys_session_share and gate public/manage grants

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2998,6 +2998,75 @@ def _omnigent_error_message(resp: httpx.Response) -> str | None:
     return None
 
 
+async def _share_tree_scope_error(
+    target_id: str,
+    caller_conversation_id: str,
+    server_client: httpx.AsyncClient,
+) -> str | None:
+    """
+    Enforce ``sys_session_share``'s spawn-tree gate over REST.
+
+    Share MUTATES access control, so a target other than the caller's own
+    session MUST live in the caller's spawn tree — i.e. share the caller's
+    ``root_conversation_id``. Mirrors :func:`_close_tree_scope_error`:
+    without it a prompt-injected agent could enumerate ids via the
+    always-on ``sys_session_list`` and expose the owner's OTHER, unrelated
+    sessions (the always-on list + an ambient-identity PUT was the whole
+    attack). Both roots are resolved from session snapshots — a session
+    can always read itself, so the caller fetch is a 200 on the happy
+    path; a non-200 is surfaced as an error rather than failing open, and
+    a ``None`` root on either side is treated as out-of-tree (never a
+    match).
+
+    Unlike close this does NOT also require the target to be a sub-agent:
+    sharing the caller's own (possibly top-level) session is the common
+    case, handled by the ``target == caller`` short-circuit in the caller
+    before this is even reached, and any other in-tree session — root
+    included — is a legitimate share target.
+
+    :param target_id: The session to share, e.g. ``"conv_abc123"``.
+    :param caller_conversation_id: The calling session's own id, e.g.
+        ``"conv_caller"``, whose ``root_conversation_id`` anchors the tree.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :returns: ``None`` when the target is in the caller's tree; otherwise
+        a JSON error string (``session_not_found`` or
+        ``session_out_of_tree``) suitable for returning verbatim.
+    """
+    try:
+        target_snap = await server_client.get(f"/v1/sessions/{target_id}", timeout=30.0)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"sys_session_share failed: {exc}"})
+    if target_snap.status_code == 404:
+        return json.dumps({"error": "session_not_found", "session_id": target_id})
+    if target_snap.status_code in (401, 403):
+        # Can't even read it ⇒ it is not in the caller's tree (or access
+        # was revoked) — refuse before attempting the grant.
+        return json.dumps({"error": "session_out_of_tree", "session_id": target_id})
+    if target_snap.status_code != 200:
+        return json.dumps({"error": f"sys_session_share returned {target_snap.status_code}"})
+    try:
+        caller_snap = await server_client.get(
+            f"/v1/sessions/{caller_conversation_id}", timeout=30.0
+        )
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"sys_session_share failed: {exc}"})
+    if caller_snap.status_code != 200:
+        return json.dumps(
+            {
+                "error": (
+                    "sys_session_share could not resolve caller session "
+                    f"{caller_conversation_id!r}"
+                ),
+                "session_id": target_id,
+            }
+        )
+    caller_root = caller_snap.json().get("root_conversation_id")
+    target_root = target_snap.json().get("root_conversation_id")
+    if caller_root is None or target_root != caller_root:
+        return json.dumps({"error": "session_out_of_tree", "session_id": target_id})
+    return None
+
+
 async def _session_share_via_rest(
     args: dict[str, Any],
     conversation_id: str,
@@ -3023,6 +3092,20 @@ async def _session_share_via_rest(
     ToolManager, but an unadvertised-yet-named call must still be denied
     so a prompt-injected agent can't escalate by emitting the tool name.
 
+    Two further runner-side gates harden share against prompt injection:
+
+    * **Spawn-tree scope** — a target other than the caller's own session
+      must live in the caller's spawn tree (same ``root_conversation_id``;
+      see :func:`_share_tree_scope_error`). Mirrors
+      :func:`_session_close_via_rest`'s gate, since the always-on
+      ``sys_session_list`` would otherwise let an injected agent enumerate
+      and share the owner's UNRELATED sessions.
+    * **Sensitive-grant confirmation** — granting ``__public__`` (anonymous
+      read of the whole transcript) or ``manage`` (which lets the grantee
+      re-share) is refused unless the call carries
+      ``confirm_sensitive_grant: true``. Fails closed; ``read``/``edit`` to
+      a named user need no confirmation.
+
     Maps 404 to ``session_not_found`` and 401/403 to ``access_denied``;
     other 4xx/5xx surface the server's own error message when present
     (e.g. the "public is read-only" rejection of a ``__public__`` grant
@@ -3030,7 +3113,10 @@ async def _session_share_via_rest(
 
     :param args: Parsed tool arguments. Requires ``user_id`` (grantee
         email or ``"__public__"``); optional ``level`` (``"read"``
-        default / ``"edit"`` / ``"manage"``) and ``session_id``.
+        default / ``"edit"`` / ``"manage"`` — a null/empty value also
+        defaults to ``"read"``), ``session_id`` (defaults to the caller's
+        own session), and ``confirm_sensitive_grant`` (``bool``; must be
+        ``true`` to grant ``__public__`` or ``manage``).
     :param conversation_id: The caller's own session id, used as the
         default target when ``session_id`` is omitted.
     :param server_client: HTTP client pointed at the Omnigent server.
@@ -3038,8 +3124,11 @@ async def _session_share_via_rest(
         ``agent_session_sharing`` policy gates this call. ``None`` (or
         ``agent_session_sharing: none``) fails closed — no grant is
         attempted.
-    :returns: JSON ``{"shared": true, ...}`` on success, or a JSON
-        error object.
+    :returns: JSON ``{"shared": true, ...}`` on success, or a JSON error
+        object: ``session_not_found`` (404), ``access_denied`` (PUT
+        401/403), ``session_out_of_tree`` (target outside the caller's
+        spawn tree), or a confirmation/level/policy refusal emitted before
+        any PUT.
     """
     target = args.get("session_id") or conversation_id
     if not isinstance(target, str) or not target:
@@ -3075,12 +3164,54 @@ async def _session_share_via_rest(
         )
     # Friendly level name -> the server's numeric permission level
     # (GrantPermissionRequest accepts 1=read, 2=edit, 3=manage).
+    # ``args.get("level", "read")`` would return None for an explicit
+    # ``"level": null`` (key present, value null) and then fail the enum
+    # check below instead of defaulting; ``or "read"`` coerces a
+    # null/empty/missing level to the documented "read" default.
     level_by_name = {"read": 1, "edit": 2, "manage": 3}
-    level_name = args.get("level", "read")
+    level_name = args.get("level") or "read"
     if level_name not in level_by_name:
         return json.dumps(
             {"error": f"sys_session_share: level must be one of {sorted(level_by_name)}"}
         )
+    # Defense-in-depth confirmation gate for the two irreversible /
+    # high-privilege grants a prompt-injected agent could otherwise issue
+    # silently:
+    #   * ``__public__`` — anonymous read of the FULL transcript (anyone
+    #     with the link), effectively un-revocable once the link leaks; and
+    #   * ``manage`` — lets the grantee re-share (including to
+    #     ``__public__``) and otherwise control the session — i.e.
+    #     privilege escalation.
+    # Both are refused unless the call carries an explicit
+    # ``confirm_sensitive_grant: true`` opt-in; we fail closed (deny) when
+    # it is absent. A full human-in-the-loop elicitation would be stronger,
+    # but the runner share path has no elicitation plumbing reaching here
+    # (no minted elicitation id / publish_event), so this is the documented
+    # fail-closed fallback. ``read``/``edit`` grants to a NAMED user stay
+    # frictionless.
+    is_sensitive_grant = user_id == _PUBLIC_USER_SENTINEL or level_name == "manage"
+    if is_sensitive_grant and args.get("confirm_sensitive_grant") is not True:
+        return json.dumps(
+            {
+                "error": (
+                    "sys_session_share: granting public ('__public__') access or "
+                    "'manage' level is high-impact and requires explicit "
+                    "confirmation — re-issue with confirm_sensitive_grant: true only "
+                    "if the session owner truly intends this; otherwise grant a "
+                    "named user 'read'/'edit' instead"
+                ),
+                "session_id": target,
+            }
+        )
+    # Tree-scope gate: share MUTATES access control, so a target other than
+    # the caller's own session must live in the caller's spawn tree. The
+    # common "share this session" case (target == caller) is always allowed
+    # and skips the lookup; any other id is refused unless it shares the
+    # caller's root_conversation_id (see _share_tree_scope_error).
+    if target != conversation_id:
+        scope_error = await _share_tree_scope_error(target, conversation_id, server_client)
+        if scope_error is not None:
+            return scope_error
     try:
         resp = await server_client.put(
             f"/v1/sessions/{target}/permissions",

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -659,18 +659,27 @@ class SysSessionShareTool(Tool):
 
     ``session_id`` is optional — when omitted, the caller's own session
     is shared, which is the common case ("share this session with X").
-    ``user_id`` is the grantee's email, or (when ``allow_public``) the
-    sentinel ``"__public__"`` for anonymous read-only access. ``level``
-    is ``"read"`` (default), ``"edit"``, or ``"manage"``; the server
-    caps public grants at read.
+    A non-default ``session_id`` must name another session in the
+    caller's OWN spawn tree; sharing an unrelated session (e.g. one
+    enumerated from ``sys_session_list``) is refused
+    (``session_out_of_tree``). ``user_id`` is the grantee's email, or
+    (when ``allow_public``) the sentinel ``"__public__"`` for anonymous
+    read-only access. ``level`` is ``"read"`` (default), ``"edit"``, or
+    ``"manage"``; the server caps public grants at read. Granting
+    ``__public__`` or ``manage`` is high-impact and requires an explicit
+    ``confirm_sensitive_grant=true`` opt-in — without it the runner
+    refuses the grant (fail-closed); ``read``/``edit`` to a named user
+    need no confirmation.
 
     Runner-dispatched: the runner proxies ``PUT
     /v1/sessions/{id}/permissions`` using its authenticated server
     client, so the grant runs with the session user's own identity and
     is subject to the server's permission checks (the caller needs
-    manage-level access — which the session owner has). Returns
-    ``access_denied`` when the server refuses and ``session_not_found``
-    for an unknown id.
+    manage-level access — which the session owner has). The spawn-tree
+    scope and sensitive-grant confirmation are ALSO enforced in the
+    runner (the server can't see them), so a prompt-injected call naming
+    the tool can't bypass them. Returns ``access_denied`` when the server
+    refuses and ``session_not_found`` for an unknown id.
 
     :param allow_public: Whether ``__public__`` grants are permitted —
         ``True`` only when the spec's ``agent_session_sharing:`` flag is
@@ -698,8 +707,11 @@ class SysSessionShareTool(Tool):
             "Share a session with another user by granting them access "
             "(level 'read' default, 'edit', or 'manage'). Omit "
             "session_id to share the calling session itself, or pass it "
-            "to share another session you manage. Requires manage-level "
-            "access (the session owner has it)."
+            "to share another session in your own spawn tree (sharing an "
+            "unrelated session is refused). Requires manage-level access "
+            "(the session owner has it). Granting '__public__' or "
+            "'manage' is high-impact and requires confirm_sensitive_grant"
+            "=true."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -744,7 +756,9 @@ class SysSessionShareTool(Tool):
                             "description": (
                                 "Permission level to grant. Defaults to "
                                 "'read'. Public grants are capped at "
-                                "'read' regardless of this value."
+                                "'read' regardless of this value. 'manage' "
+                                "is high-impact (the grantee can re-share) "
+                                "and requires confirm_sensitive_grant=true."
                             ),
                         },
                         "session_id": {
@@ -752,7 +766,20 @@ class SysSessionShareTool(Tool):
                             "description": (
                                 "The session (conversation_id) to share, "
                                 "e.g. 'conv_abc123'. Omit to share the "
-                                "calling session itself."
+                                "calling session itself. Must be your own "
+                                "session or another in your spawn tree — "
+                                "sharing an unrelated session is refused."
+                            ),
+                        },
+                        "confirm_sensitive_grant": {
+                            "type": "boolean",
+                            "description": (
+                                "Explicit confirmation for a high-impact "
+                                "grant. Must be true to grant '__public__' "
+                                "(anonymous read of the whole transcript) "
+                                "or 'manage'; such grants are refused "
+                                "without it. Not needed for 'read'/'edit' "
+                                "to a named user."
                             ),
                         },
                     },

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6331,10 +6331,12 @@ async def test_sys_session_share_maps_error_statuses(
     expected_error: str,
 ) -> None:
     """
-    A 404 maps to ``session_not_found``; 401/403 map to ``access_denied``
-    — a typed reason instead of a raw status, matching the sibling
-    session tools so the LLM can distinguish "no such session" from
-    "you can't manage it".
+    For an IN-TREE target, a 404 on the PUT maps to ``session_not_found``
+    and 401/403 map to ``access_denied`` — a typed reason instead of a raw
+    status, matching the sibling session tools so the LLM can distinguish
+    "no such session" from "you can't manage it". (The snapshot GETs that
+    resolve the spawn-tree scope gate return 200 with a shared root, so the
+    parametrized status is the PUT's.)
 
     :param status_code: HTTP status the mocked Omnigent server returns.
     :param expected_error: The typed error string the tool should emit.
@@ -6342,6 +6344,11 @@ async def test_sys_session_share_maps_error_statuses(
     from omnigent.runner.tool_dispatch import execute_tool
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
+        # The caller + target snapshot GETs resolve the tree-scope gate;
+        # a shared root puts conv_x in-tree so the parametrized status
+        # below exercises the PUT-status mapping (not the scope gate).
+        if request.method == "GET":
+            return httpx.Response(200, json={"root_conversation_id": "conv_root"})
         return httpx.Response(status_code, json={"detail": "x"})
 
     async with httpx.AsyncClient(
@@ -6412,6 +6419,10 @@ async def test_sys_session_share_surfaces_server_message_on_4xx() -> None:
     server_message = "Public access is limited to read-only (level 1)"
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
+        # In-tree snapshot GETs pass the scope gate; the PUT returns the
+        # server's public-above-read 400 envelope to be surfaced.
+        if request.method == "GET":
+            return httpx.Response(200, json={"root_conversation_id": "conv_root"})
         return httpx.Response(
             400, json={"error": {"code": "INVALID_INPUT", "message": server_message}}
         )
@@ -6423,7 +6434,15 @@ async def test_sys_session_share_surfaces_server_message_on_4xx() -> None:
         output = await execute_tool(
             tool_name="sys_session_share",
             arguments=json.dumps(
-                {"user_id": "__public__", "level": "edit", "session_id": "conv_x"}
+                {
+                    "user_id": "__public__",
+                    "level": "edit",
+                    "session_id": "conv_x",
+                    # __public__ is a sensitive grant; the explicit opt-in
+                    # lets it past the runner's confirmation gate so the
+                    # server's own level>read rejection is what surfaces.
+                    "confirm_sensitive_grant": True,
+                }
             ),
             server_client=server_client,
             conversation_id="conv_caller",
@@ -6552,7 +6571,9 @@ async def test_sys_session_share_public_allows_public_grant() -> None:
     ) as server_client:
         output = await execute_tool(
             tool_name="sys_session_share",
-            arguments=json.dumps({"user_id": "__public__"}),
+            # __public__ is a sensitive grant — the explicit opt-in is
+            # required for it to pass the runner's confirmation gate.
+            arguments=json.dumps({"user_id": "__public__", "confirm_sensitive_grant": True}),
             server_client=server_client,
             conversation_id="conv_caller",
             agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.PUBLIC),
@@ -6568,6 +6589,248 @@ async def test_sys_session_share_public_allows_public_grant() -> None:
         "session_id": "conv_caller",
         "user_id": "__public__",
         "level": "read",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sys_session_share_refuses_out_of_tree_target() -> None:
+    """
+    Sharing a session in a DIFFERENT spawn tree is refused before any
+    grant: the runner resolves the caller's and target's
+    ``root_conversation_id`` and, when they differ, returns
+    ``session_out_of_tree`` without PUTting. This is the core fix — the
+    always-on ``sys_session_list`` lets a prompt-injected agent enumerate
+    the owner's other session ids, and without this gate the ambient-
+    identity PUT would happily expose them. A permissions PUT reaching the
+    handler would mean the tree-scope gate regressed.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    requests: list[tuple[str, str]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path))
+        if request.url.path == "/v1/sessions/conv_caller":
+            return httpx.Response(200, json={"root_conversation_id": "conv_tree_a"})
+        if request.url.path == "/v1/sessions/conv_other":
+            return httpx.Response(200, json={"root_conversation_id": "conv_tree_b"})
+        # A PUT here = the scope gate let an out-of-tree grant through.
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "alice@example.com", "session_id": "conv_other"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
+        )
+
+    result = json.loads(output)
+    assert result["error"] == "session_out_of_tree"
+    assert result["session_id"] == "conv_other"
+    # Only the two snapshot GETs ran — the permissions PUT was never sent.
+    assert all(method == "GET" for method, _ in requests)
+    assert ("PUT", "/v1/sessions/conv_other/permissions") not in requests
+
+
+@pytest.mark.asyncio
+async def test_sys_session_share_in_tree_target_succeeds() -> None:
+    """
+    A non-self target that shares the caller's spawn-tree root passes the
+    scope gate and PUTs the grant — the positive case the out-of-tree
+    refusal excludes. If the gate wrongly blocked it, an orchestrator
+    couldn't share a child it legitimately spawned.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    puts: list[tuple[str, dict[str, Any]]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            # Caller and target share a root ⇒ in-tree.
+            return httpx.Response(200, json={"root_conversation_id": "conv_tree"})
+        puts.append((request.url.path, json.loads(request.content)))
+        return httpx.Response(
+            200,
+            json={"user_id": "alice@example.com", "conversation_id": "conv_child", "level": 1},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "alice@example.com", "session_id": "conv_child"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
+        )
+
+    assert puts == [
+        ("/v1/sessions/conv_child/permissions", {"user_id": "alice@example.com", "level": 1})
+    ]
+    result = json.loads(output)
+    assert result == {
+        "shared": True,
+        "session_id": "conv_child",
+        "user_id": "alice@example.com",
+        "level": "read",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sys_session_share_null_level_defaults_to_read() -> None:
+    """
+    An explicit ``"level": null`` (key present, value null) defaults to
+    ``read`` rather than failing the enum check. The old
+    ``args.get("level", "read")`` returned None for a present-but-null key
+    and fell through to "level must be one of ..."; ``args.get("level") or
+    "read"`` coerces it to the documented default.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path, json.loads(request.content)))
+        return httpx.Response(
+            200,
+            json={"user_id": "alice@example.com", "conversation_id": "conv_caller", "level": 1},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "alice@example.com", "level": None}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
+        )
+
+    # level null → read (numeric 1), not an enum rejection.
+    assert requests == [
+        (
+            "PUT",
+            "/v1/sessions/conv_caller/permissions",
+            {"user_id": "alice@example.com", "level": 1},
+        )
+    ]
+    result = json.loads(output)
+    assert result["level"] == "read"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "share_args,policy",
+    [
+        pytest.param({"user_id": "__public__"}, SharePolicy.PUBLIC, id="public-no-confirm"),
+        pytest.param(
+            {"user_id": "alice@example.com", "level": "manage"},
+            SharePolicy.NON_PUBLIC,
+            id="manage-no-confirm",
+        ),
+    ],
+)
+async def test_sys_session_share_sensitive_grant_refused_without_confirm(
+    share_args: dict[str, Any],
+    policy: SharePolicy,
+) -> None:
+    """
+    Granting ``__public__`` (anonymous read of the whole transcript) or
+    ``manage`` (the grantee can re-share) is refused — fail-closed —
+    unless the call carries ``confirm_sensitive_grant: true``. The refusal
+    is client-side: no snapshot GET and no PUT, so a prompt-injected call
+    can't silently expose or escalate. Any server I/O here would mean the
+    confirmation gate regressed.
+
+    :param share_args: The share arguments under test (sans confirmation).
+    :param policy: The spec's ``agent_session_sharing`` policy enabling the
+        grant tier (so the call reaches the confirmation gate, not the
+        policy gate).
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    called = False
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps(share_args),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=policy),
+        )
+
+    assert called is False  # the gate must short-circuit before any I/O
+    assert "confirm_sensitive_grant" in json.loads(output)["error"]
+
+
+@pytest.mark.asyncio
+async def test_sys_session_share_manage_with_confirm_succeeds() -> None:
+    """
+    With ``confirm_sensitive_grant: true`` a ``manage`` grant passes the
+    confirmation gate and PUTs the numeric level 3 — proving the gate
+    blocks the unconfirmed grant (sibling test) without breaking the
+    confirmed one.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path, json.loads(request.content)))
+        return httpx.Response(
+            200,
+            json={"user_id": "alice@example.com", "conversation_id": "conv_caller", "level": 3},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps(
+                {
+                    "user_id": "alice@example.com",
+                    "level": "manage",
+                    "confirm_sensitive_grant": True,
+                }
+            ),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
+        )
+
+    assert requests == [
+        (
+            "PUT",
+            "/v1/sessions/conv_caller/permissions",
+            {"user_id": "alice@example.com", "level": 3},
+        )
+    ]
+    result = json.loads(output)
+    assert result == {
+        "shared": True,
+        "session_id": "conv_caller",
+        "user_id": "alice@example.com",
+        "level": "manage",
     }
 
 


### PR DESCRIPTION
## Related issue

N/A — P0 security hardening of `sys_session_share`; no separate tracking issue.

## Summary

`sys_session_share` is runner-dispatched: the schema-only tool lives in
`omnigent/tools/builtins/spawn.py` and the real logic in
`omnigent/runner/tool_dispatch.py::_session_share_via_rest`, which proxies
`PUT /v1/sessions/{id}/permissions` with the runner's authenticated client.

**Vulnerability (access-control mutation without scope or confirmation).**
Unlike its sibling `sys_session_close` — which enforces a spawn-tree gate so an
agent can't tombstone a session in a *different* tree — `share` forwarded **any**
`session_id` to the permissions endpoint, scoped only by the runner's ambient
identity. So a prompt-injected agent could:

- enumerate session ids via the always-on `sys_session_list`, then **share the
  owner's OTHER, unrelated sessions**; and/or
- grant `__public__` (anonymous read of the *full* transcript, anyone with the
  link) or `manage` (grantee can re-share) — an **irreversible disclosure with
  no human-in-the-loop**.

There was also a `level: null` bug: `args.get("level", "read")` returns `None`
when the key is present-but-null, failing the enum check instead of defaulting
to `read`.

**ELI5.** The "share this chat" button trusted whatever id the model handed it
and would happily make a chat public with no confirmation. Now it can only share
chats inside its own conversation tree, and making something public (or handing
over `manage`) needs an explicit, deliberate opt-in.

**Fix (surgical, share-only).**
1. **Tree-scope gate** — new `_share_tree_scope_error`, mirroring close's
   `_close_tree_scope_error`. A non-self `session_id` must share the caller's
   `root_conversation_id`, else `session_out_of_tree`. Sharing the caller's own
   session (the common "share this session" case) is always allowed and skips
   the lookup; unlike close it does **not** require the target to be a sub-agent
   (you may share your own top-level session).
2. **Sensitive-grant confirmation** — granting `__public__` or `manage` is
   refused (fail-closed) unless the call carries `confirm_sensitive_grant: true`
   (a new optional boolean arg). `read`/`edit` to a named user are unaffected.
   A full human-in-the-loop elicitation would be stronger, but the runner share
   path has no elicitation plumbing reaching it (no minted elicitation id /
   `publish_event`), so this is the documented fail-closed fallback — enforced
   in the runner so an unadvertised-yet-named call can't bypass it.
3. **`level: null` default** — `args.get("level") or "read"` coerces a
   null/empty/missing level to the documented default.

```
sys_session_share(session_id=X, user_id=Y, level=L)
        |
   target = session_id or caller
        |
  policy gate (agent_session_sharing)            # unchanged
        |
  level default (null -> read)                   # FIX (c)
        |
  sensitive-grant gate (__public__ / manage)     # NEW (b): needs confirm
        |
  target == caller ? --no--> tree-scope gate     # NEW (a): same root or refuse
        |  yes / in-tree
   PUT /v1/sessions/{target}/permissions
```

## Test Plan

Focused unit tests in the worktree (`uv run --extra dev pytest`):

- `tests/runner/test_runner_dispatch.py -k share` — **16 passed**. New/updated:
  out-of-tree target refused (no PUT), in-tree non-self target succeeds,
  `level: null` defaults to read, `__public__`/`manage` refused without
  `confirm_sensitive_grant` (no I/O), `manage` allowed with it; existing public
  + 4xx-message tests updated for the in-tree snapshot + opt-in.
- `tests/runner/test_runner_dispatch.py -k "session_close or session_share"` — 19 passed (close gate unaffected).
- `tests/tools/test_manager.py -k share` — 2 passed (share-tool gating/schema intact).
- `ruff check` + `ruff format --check` on all three changed files — clean.

## Demo

N/A — backend security fix, no UI/frontend change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover each behavioral change: the tree-scope gate (refusal + in-tree
success), the sensitive-grant confirmation gate (refused without / allowed with
`confirm_sensitive_grant`), and the `level: null` default. The schema addition
(`confirm_sensitive_grant`) is exercised end-to-end through the runner dispatch
path via `execute_tool`. Not run: the full suite / integration / e2e — out of
scope for this focused, runner-local change.