### PR TITLE
fix(tools/mcp): stop leaking host env and Databricks token to untrusted MCP servers

### DIFF
--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -14,9 +14,9 @@ is the only production consumer; see designs/RUNNER_MCP.md.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 import logging
-import os
 import shlex
 import time
 from collections.abc import Awaitable, Callable
@@ -34,7 +34,7 @@ from anyio.streams.memory import (
 from cachetools import TTLCache
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
-from mcp.client.stdio import stdio_client
+from mcp.client.stdio import get_default_environment, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.exceptions import McpError
 from mcp.shared.message import SessionMessage
@@ -51,7 +51,6 @@ from mcp.types import (
 )
 from mcp.types import Tool as McpToolDef
 
-from omnigent.runner.identity import strip_runner_auth_secrets
 from omnigent.spec.types import MCPServerConfig, RetryPolicy
 
 _T = TypeVar("_T")
@@ -121,6 +120,58 @@ def _resolve_databricks_token(profile: str) -> str:
         raise RuntimeError(
             f"Failed to resolve Databricks token from profile {profile!r}: {exc}"
         ) from exc
+
+
+# First-party Databricks host suffixes that may receive the runner's
+# workspace OAuth token. The token resolved from ``databricks_profile``
+# is the runner's own workspace credential, so it must only ever be
+# attached to Databricks-owned control-plane hosts. A spec author
+# controls both ``url`` and ``databricks_profile``; without this gate a
+# malicious spec could point ``url`` at an attacker host (or a
+# cloud-metadata / loopback endpoint) and exfiltrate the credential.
+_DATABRICKS_TOKEN_HOST_SUFFIXES: tuple[str, ...] = (
+    ".cloud.databricks.com",
+    ".gcp.databricks.com",
+    ".azuredatabricks.net",
+)
+
+
+def _is_databricks_token_host_allowed(url: str | None) -> bool:
+    """
+    Return whether the runner's Databricks token may be sent to *url*.
+
+    Only first-party Databricks hosts reached over HTTPS qualify.
+    Bearer tokens never travel over plaintext, and IP-literal hosts are
+    rejected outright: the Databricks control plane is always addressed
+    by hostname, so an IP here is the signature of an SSRF attempt at
+    loopback (``127.0.0.0/8`` / ``::1``), link-local / cloud-metadata
+    (``169.254.169.254``), or a private range.
+
+    :param url: The configured MCP endpoint URL, or ``None``.
+    :returns: ``True`` only for an ``https`` URL whose hostname ends in
+        a :data:`_DATABRICKS_TOKEN_HOST_SUFFIXES` entry and is not an IP
+        literal; ``False`` otherwise.
+    """
+    if not url:
+        return False
+    parsed = urlparse(url)
+    # A bearer token must travel over TLS only — never attach it to a
+    # plaintext scheme where the credential is exposed on the wire.
+    if parsed.scheme != "https":
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+    host = host.lower()
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass  # Not an IP literal — fall through to the host allowlist.
+    else:
+        # IP literals can never be on the first-party allowlist and are
+        # the primary SSRF / metadata-exfiltration vector; reject them.
+        return False
+    return any(host.endswith(suffix) for suffix in _DATABRICKS_TOKEN_HOST_SUFFIXES)
 
 
 # Seconds to wait after tripping before allowing a single
@@ -934,10 +985,24 @@ class McpServerConnection:
             are needed (empty config headers and no profile).
         """
         merged = dict(self.config.headers) if self.config.headers else {}
-        if self.config.databricks_profile is not None:
+        # Attach the runner's Databricks workspace token only when BOTH
+        # gates pass: (1) the author has not already supplied an explicit
+        # Authorization header (case-insensitive — HTTP header names are),
+        # and (2) the destination is a first-party Databricks host (see
+        # :func:`_is_databricks_token_host_allowed`). The token is the
+        # runner's own credential and a spec controls both ``url`` and
+        # ``databricks_profile``, so an unconditional attach lets a
+        # malicious spec exfiltrate it to an arbitrary host. Resolve the
+        # token only after both gates pass — never fetch a credential for
+        # a request that will not carry it.
+        has_authorization = any(name.lower() == "authorization" for name in merged)
+        if (
+            self.config.databricks_profile is not None
+            and not has_authorization
+            and _is_databricks_token_host_allowed(self.config.url)
+        ):
             token = _resolve_databricks_token(self.config.databricks_profile)
-            # Explicit Authorization header wins — don't overwrite.
-            merged.setdefault("Authorization", f"Bearer {token}")
+            merged["Authorization"] = f"Bearer {token}"
         return merged or None
 
     async def _open_streamable_http_transport(
@@ -1043,14 +1108,19 @@ class McpServerConnection:
             command=self.config.command,
             args=list(self.config.args),
             cwd=self.cwd,
-            # ``env=None`` inherits the SDK's ``get_default_environment``
-            # allowlist (no runner-auth secret). The ``config.env`` branch
-            # overlays author-declared vars (e.g. ``GITHUB_TOKEN``) on the
-            # full parent env, so strip the runner tunnel binding token
-            # first: an MCP server command is spec-author code.
-            env=(strip_runner_auth_secrets(os.environ) | self.config.env)
-            if self.config.env
-            else None,
+            # Base the subprocess env on the MCP SDK's minimal
+            # inherited-var allowlist (HOME, PATH, SHELL, ... — see
+            # ``get_default_environment``), NOT the runner's full
+            # ``os.environ``. An MCP server command is spec-author code we
+            # do not fully trust; inheriting the entire parent environment
+            # would hand it every host secret in the runner's scope
+            # (AWS_*, OPENAI_API_KEY, Databricks creds, other MCP tokens,
+            # ...). Author-declared ``config.env`` is overlaid on top.
+            # ``env=None`` resolves to this same allowlist inside the SDK,
+            # so the empty-env and non-empty-env paths are symmetric — a
+            # single benign ``env:`` entry no longer flips on full
+            # inheritance.
+            env=(get_default_environment() | self.config.env) if self.config.env else None,
         )
         read_stream, write_stream = await stack.enter_async_context(stdio_client(params))
         return read_stream, write_stream

--- a/tests/tools/test_mcp.py
+++ b/tests/tools/test_mcp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -1970,17 +1971,19 @@ def test_open_stdio_transport_spawns_unwrapped() -> None:
     assert params.args == ["--flag", "value"]
 
 
-def test_open_stdio_transport_overlays_env_on_parent() -> None:
+def test_open_stdio_transport_overlays_env_on_minimal_allowlist() -> None:
     """
-    ``config.env`` is overlaid on ``os.environ`` so the spawned
-    subprocess inherits ``PATH``, ``HOME``, etc., plus the
-    MCP-specific overrides.
+    ``config.env`` is overlaid on the MCP SDK's minimal inherited-var
+    allowlist (``get_default_environment`` — HOME, PATH, SHELL, ...),
+    NOT the runner's full ``os.environ``. The author-declared overlay
+    reaches the subprocess and PATH is still inherited (so the server
+    can resolve its own binaries), but unrelated host secrets in the
+    runner environment are withheld.
 
-    What breaks if this fails: an MCP subprocess that needs
-    ``GITHUB_TOKEN=ghp_xyz`` but also needs ``PATH`` to resolve
-    its own binaries would lose PATH (getting only the caller's
-    env overlay) and fail at spawn with "fake-mcp: command not
-    found".
+    What breaks if this fails (security, P0): a non-empty ``env:`` made
+    the stdio launch forward the runner's entire environment to
+    spec-author MCP code — AWS_*, OPENAI_API_KEY, Databricks creds,
+    other MCP tokens — silently flipped on by a single benign entry.
     """
 
     config = _make_stdio_config(
@@ -1998,20 +2001,32 @@ def test_open_stdio_transport_overlays_env_on_parent() -> None:
 
     conn = McpServerConnection(config=config)
 
-    with patch("omnigent.tools.mcp.stdio_client", side_effect=_capture_stdio_client):
-        with patch(
-            "omnigent.tools.mcp.ClientSession",
-            return_value=_mock_session(),
-        ):
-            asyncio.run(conn.connect())
+    # Seed a host secret into the runner env that must NOT leak into
+    # the spec-author subprocess, and keep a real PATH so the SDK
+    # allowlist has something to inherit.
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_SECRET_ACCESS_KEY": "leaked-aws-secret",
+            "PATH": os.environ.get("PATH", "/usr/bin"),
+        },
+        clear=False,
+    ):
+        with patch("omnigent.tools.mcp.stdio_client", side_effect=_capture_stdio_client):
+            with patch(
+                "omnigent.tools.mcp.ClientSession",
+                return_value=_mock_session(),
+            ):
+                asyncio.run(conn.connect())
 
     env = captured["params"].env
-    # Config overlay reached the subprocess
+    # Config overlay reached the subprocess.
     assert env["GITHUB_TOKEN"] == "ghp_xyz"
-    # Parent env merged — PATH is always in os.environ on any
-    # realistic test runner, so its presence confirms the dict
-    # union didn't wipe the inherited environment.
+    # PATH is on the SDK allowlist, so the subprocess can still resolve
+    # its own binaries.
     assert "PATH" in env
+    # The unrelated host secret is NOT forwarded — the core P0 fix.
+    assert "AWS_SECRET_ACCESS_KEY" not in env
 
 
 def test_open_stdio_transport_empty_env_inherits_fully() -> None:
@@ -2050,6 +2065,130 @@ def test_open_stdio_transport_empty_env_inherits_fully() -> None:
     # None tells stdio_client to inherit the parent env as-is —
     # matches its documented behavior.
     assert captured["params"].env is None
+
+
+def _make_databricks_http_config(
+    *,
+    url: str,
+    headers: dict[str, str] | None = None,
+) -> MCPServerConfig:
+    """
+    Build an HTTP MCP config with ``databricks_profile`` set, for
+    Databricks token-attach tests.
+
+    :param url: The HTTP endpoint URL under test.
+    :param headers: Optional explicit headers (e.g. an author-supplied
+        ``Authorization``).
+    :returns: An ``MCPServerConfig`` with ``transport="http"`` and
+        ``databricks_profile="oss"``.
+    """
+    return MCPServerConfig(
+        name="dbx",
+        transport="http",
+        url=url,
+        headers=dict(headers) if headers is not None else {},
+        databricks_profile="oss",
+    )
+
+
+def test_resolve_http_headers_attaches_databricks_token_to_allowed_host() -> None:
+    """
+    A first-party Databricks HTTPS host receives the resolved
+    workspace token as a ``Bearer`` Authorization header.
+
+    What breaks if this fails: legitimate Databricks MCP gateways
+    (``*.cloud.databricks.com`` etc.) would no longer authenticate.
+    """
+    conn = McpServerConnection(
+        config=_make_databricks_http_config(
+            url="https://myworkspace.cloud.databricks.com/mcp",
+        )
+    )
+    with patch(
+        "omnigent.tools.mcp._resolve_databricks_token",
+        return_value="tok_abc",
+    ) as mock_resolve:
+        headers = conn._resolve_http_headers()
+
+    assert headers == {"Authorization": "Bearer tok_abc"}
+    mock_resolve.assert_called_once_with("oss")
+
+
+def test_resolve_http_headers_rejects_databricks_token_for_disallowed_host() -> None:
+    """
+    The runner's Databricks token is NOT attached when ``url`` points
+    at a non-Databricks host, and the token is never even resolved.
+
+    What breaks if this fails (security, P0): a spec controlling both
+    ``url`` and ``databricks_profile`` could exfiltrate the runner's
+    workspace credential to an attacker-controlled host.
+    """
+    conn = McpServerConnection(
+        config=_make_databricks_http_config(
+            url="https://attacker.example.com/mcp",
+        )
+    )
+    with patch(
+        "omnigent.tools.mcp._resolve_databricks_token",
+        return_value="tok_abc",
+    ) as mock_resolve:
+        headers = conn._resolve_http_headers()
+
+    assert headers is None
+    mock_resolve.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://169.254.169.254/mcp",  # cloud metadata / link-local
+        "https://127.0.0.1/mcp",  # loopback (IPv4)
+        "https://[::1]/mcp",  # loopback (IPv6)
+        "http://myworkspace.cloud.databricks.com/mcp",  # non-TLS
+        "https://databricks.com.attacker.example/mcp",  # suffix-spoof
+    ],
+)
+def test_resolve_http_headers_rejects_databricks_token_for_unsafe_url(url: str) -> None:
+    """
+    Loopback / link-local / cloud-metadata IP literals, plaintext
+    HTTP, and suffix-spoofing hosts never receive the Databricks
+    token, and the token is never resolved for them.
+    """
+    conn = McpServerConnection(config=_make_databricks_http_config(url=url))
+    with patch(
+        "omnigent.tools.mcp._resolve_databricks_token",
+        return_value="tok_abc",
+    ) as mock_resolve:
+        headers = conn._resolve_http_headers()
+
+    assert headers is None, f"token must not attach for {url!r}"
+    mock_resolve.assert_not_called()
+
+
+def test_resolve_http_headers_preserves_explicit_authorization() -> None:
+    """
+    An explicit ``Authorization`` header wins and the Databricks token
+    is not resolved — even for an allowed host (case-insensitive: a
+    lowercase ``authorization`` still suppresses the injected token).
+
+    What breaks if this fails: the runner would fetch (and could
+    attach) its own credential for a request the author already
+    authenticated, shadowing intent and leaking the token needlessly.
+    """
+    conn = McpServerConnection(
+        config=_make_databricks_http_config(
+            url="https://myworkspace.cloud.databricks.com/mcp",
+            headers={"authorization": "Bearer explicit-token"},
+        )
+    )
+    with patch(
+        "omnigent.tools.mcp._resolve_databricks_token",
+        return_value="tok_abc",
+    ) as mock_resolve:
+        headers = conn._resolve_http_headers()
+
+    assert headers == {"authorization": "Bearer explicit-token"}
+    mock_resolve.assert_not_called()
 
 
 def _mock_session() -> AsyncMock:


### PR DESCRIPTION
## Related issue

N/A — proactively reported P0 in the MCP connection layer; no tracked issue.

## Summary

Two credential-exfiltration bugs in `omnigent/tools/mcp.py`, where MCP server config is spec-author-controlled and therefore untrusted.

- **Host env leak to stdio servers (`_open_stdio_transport`).** When a stdio MCP config declared a non-empty `env`, the launch forwarded the runner's **entire `os.environ`** to the subprocess, stripping only `RUNNER_TUNNEL_BINDING_TOKEN`. So `AWS_*`, `OPENAI_API_KEY`, Databricks creds, and every other MCP token reached untrusted server code. It was also asymmetric: an empty `env` got the SDK's minimal allowlist, but a single benign var flipped on full inheritance. **Fix:** base the spawn env on the MCP SDK's minimal inherited-var allowlist (`get_default_environment()` — `HOME`, `PATH`, `SHELL`, …) overlaid with the author-declared `config.env`. This matches what the empty-`env` path (`env=None`) already does, so the two paths are now symmetric and no host secret is inherited implicitly.

- **Databricks token attached to any host (`_resolve_http_headers`).** With `databricks_profile` set, the runner's workspace OAuth token was injected into requests to the configured `url` with **no host allowlist** — a spec controlling `url` + `databricks_profile` could point at an attacker host (or a loopback / cloud-metadata endpoint) and exfiltrate the runner's credential. The token was also resolved even when an explicit `Authorization` header already existed. **Fix:** only resolve and attach the token when (1) no `Authorization` header is present (case-insensitive) **and** (2) the URL is `https` to a first-party Databricks host (`*.cloud.databricks.com`, `*.gcp.databricks.com`, `*.azuredatabricks.net`). IP-literal hosts (loopback `127.0.0.0/8` / `::1`, link-local / cloud-metadata `169.254.169.254`) and non-allowlisted hosts are rejected, and the token is never fetched for a request that will not carry it.

Both sub-fixes are minimal and scoped to the two call sites. The now-unused `os` and `strip_runner_auth_secrets` imports were removed; `get_default_environment` / `ipaddress` were added.

## Test Plan

- `uv run --extra dev pytest tests/tools/test_mcp.py -x -q` → **92 passed**.
- Targeted run of the new/updated tests (`-k "databricks or minimal_allowlist or explicit_authorization"`) → **9 passed**:
  - `test_open_stdio_transport_overlays_env_on_minimal_allowlist` — a seeded `AWS_SECRET_ACCESS_KEY` in the runner env is **not** forwarded, while `config.env` overlay and `PATH` still reach the subprocess.
  - `test_resolve_http_headers_attaches_databricks_token_to_allowed_host` — token attaches for `*.cloud.databricks.com`.
  - `test_resolve_http_headers_rejects_databricks_token_for_disallowed_host` — non-Databricks host gets no token and the token is never resolved.
  - `test_resolve_http_headers_rejects_databricks_token_for_unsafe_url[...]` — metadata/loopback IPv4, IPv6 `::1`, non-TLS, and suffix-spoof URLs all rejected.
  - `test_resolve_http_headers_preserves_explicit_authorization` — explicit (lowercase) `authorization` header wins; token never resolved.
- `uv run --extra dev ruff check` + `ruff format --check` on both files → clean.

## Demo

N/A — backend security fix, no UI/behavioural surface for end users.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests in `tests/tools/test_mcp.py` cover both sub-fixes: the stdio env allowlist (host secret withheld, overlay + `PATH` preserved) and the Databricks token host allowlist (allowed host, disallowed host, metadata/loopback/non-TLS/suffix-spoof rejection, and explicit-Authorization precedence). Manual verification: imported the module and exercised `_is_databricks_token_host_allowed` directly — `https://x.cloud.databricks.com/mcp` → `True`, `https://169.254.169.254/` → `False`, `http://x.cloud.databricks.com/` → `False`. Note (behaviour change, intended): stdio MCP servers that previously relied on implicitly inheriting non-allowlisted host vars (e.g. `HTTPS_PROXY`, `NODE_EXTRA_CA_CERTS`) must now declare them explicitly in `env:`; this matches the SDK's documented safe default and the existing empty-`env` path.