### PR TITLE
fix(web_fetch): close default-off SSRF — locked-down egress sandbox for parentless researcher

### DIFF
--- a/omnigent/inner/egress/rules.py
+++ b/omnigent/inner/egress/rules.py
@@ -8,9 +8,14 @@ Examples::
     "GET,POST api.github.com/repos/myorg/**"  # Multiple methods
     "* pypi.org/**"                           # Any method
     "GET *.github.com/**"                     # Wildcard subdomain
+    "GET,POST *"                              # Any host (public only)
 
 - **Methods**: comma-separated HTTP verbs, or ``*`` for any.
-- **Host**: exact match, or ``*.domain`` for wildcard subdomains.
+- **Host**: exact match, ``*`` for any host, or ``*.domain`` for
+  wildcard subdomains. A bare ``*`` only ever reaches *public* hosts —
+  the proxy's connect-time guard still refuses loopback / link-local /
+  RFC1918 / CGNAT / cloud-metadata addresses unless
+  ``egress_allow_private_destinations`` is explicitly set.
 - **Path**: glob — ``*`` matches one segment, ``**`` matches any depth.
 - Default deny: requests not matching any rule are blocked.
 """
@@ -110,6 +115,17 @@ class EgressRule:
             return False
         host = host.lower()
         pattern = self.host_pattern.lower()
+        # ``*`` matches ANY DNS-safe host. Paired with the proxy's
+        # default-deny on private destinations
+        # (``egress_allow_private_destinations=False``), this is "any
+        # *public* host": the connect-time guard
+        # (``_assert_destination_allowed``) still refuses loopback /
+        # link-local / RFC1918 / CGNAT / cloud-metadata IPs even when a
+        # ``*`` rule is in force, so ``*`` cannot reach internal hosts.
+        # The ``is_dns_safe_host`` gate above runs first, so smuggled
+        # hosts (NUL / CRLF / percent) are rejected here too.
+        if pattern == "*":
+            return True
         if pattern.startswith("*."):
             suffix = pattern[1:]  # e.g. ".github.com"
             return host.endswith(suffix) or host == pattern[2:]

--- a/omnigent/tools/builtins/web_fetch.py
+++ b/omnigent/tools/builtins/web_fetch.py
@@ -19,11 +19,14 @@ Usage in config.yaml::
 from __future__ import annotations
 
 import logging
+import sys
 
 # Any: tool schemas are heterogeneous dicts, AgentSpec.params
 # has heterogeneous values.
 from typing import Any
 
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.spec.types import (
     AgentSpec,
     ExecutorSpec,
@@ -94,6 +97,85 @@ Try ONE alternative approach, then return whatever you have. Don't
 loop endlessly. If nothing works, say so.
 """
 
+# Default-deny egress allow-list applied to the researcher when the
+# parent agent declares no ``os_env`` of its own (see
+# ``build_researcher_spec``). Permits the read-oriented HTTP(S) verbs
+# to ANY host; the ``*`` host pattern is load-bearing together with
+# ``egress_allow_private_destinations=False`` below — the MITM proxy
+# still refuses loopback / link-local / RFC1918 / CGNAT and
+# cloud-metadata IPs (e.g. ``169.254.169.254``) at connect time, so the
+# net effect is "any *public* host". The write verbs (PUT/DELETE/PATCH/
+# TRACE) are intentionally omitted: a web researcher reads pages and
+# queries search/JSON APIs, it never needs to mutate remote state.
+_DEFAULT_RESEARCHER_EGRESS_RULES: tuple[str, ...] = ("GET,HEAD,POST,OPTIONS *",)
+
+
+def _platform_egress_backend() -> str | None:
+    """
+    Return this platform's network-isolating sandbox backend, or
+    ``None`` when none can hard-enforce egress here.
+
+    Mirrors the platform decision in
+    ``omnigent.inner.sandbox._default_sandbox_for_platform`` but is
+    narrowed to the backends that actually isolate the network so the
+    L7 egress proxy is the *only* path off the box: ``linux_bwrap`` on
+    Linux (unshared network namespace) and ``darwin_seatbelt`` on macOS
+    (SBPL ``(deny network*)`` with a narrow loopback allow). Any other
+    platform — notably Windows, whose ``windows_jobobject`` backend does
+    not unshare the network and where the Unix-socket egress proxy is
+    unavailable — returns ``None`` so the caller can fail closed instead
+    of falling back to an unsandboxed shell.
+
+    :returns: ``"linux_bwrap"``, ``"darwin_seatbelt"``, or ``None``.
+    """
+    if sys.platform.startswith("linux"):
+        return "linux_bwrap"
+    if sys.platform == "darwin":
+        return "darwin_seatbelt"
+    return None
+
+
+def _default_researcher_sandbox() -> OSEnvSandboxSpec:
+    """
+    Build the locked-down default sandbox for a researcher whose parent
+    declares no ``os_env``.
+
+    The previous default (``sandbox=None``) resolved to the platform's
+    default sandbox with the host network *shared* — handing the child a
+    ``sys_os_shell`` that could reach cloud metadata
+    (``169.254.169.254``), localhost services, and RFC1918 hosts, and
+    that escalated a shell-less parent to an unsandboxed shell. This
+    returns a default-deny egress sandbox instead: pinned to a
+    network-isolating backend, all traffic forced through the MITM proxy
+    (a non-empty ``egress_rules`` is what both starts the proxy and
+    triggers the network-namespace isolation), and private / link-local
+    / metadata destinations refused
+    (``egress_allow_private_destinations=False``).
+
+    :returns: A restrictive :class:`OSEnvSandboxSpec` for the child.
+    :raises OmnigentError: When the host platform has no backend that
+        can hard-enforce network isolation (e.g. Windows), so a secure
+        default cannot be constructed — fail closed rather than fall
+        back to an unsandboxed shell on the shared host network.
+    """
+    backend = _platform_egress_backend()
+    if backend is None:
+        raise OmnigentError(
+            "web_fetch cannot build a secure default sandbox for its "
+            "__web_researcher sub-agent on this platform: no sandbox "
+            "backend here can hard-enforce network isolation (egress "
+            "requires sandbox.type=linux_bwrap on Linux or "
+            "sandbox.type=darwin_seatbelt on macOS). Declare an os_env "
+            "with an egress policy on the parent agent, or run web_fetch "
+            "on a supported platform.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return OSEnvSandboxSpec(
+        type=backend,
+        egress_rules=list(_DEFAULT_RESEARCHER_EGRESS_RULES),
+        egress_allow_private_destinations=False,
+    )
+
 
 def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
     """
@@ -106,35 +188,48 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
       implementation used ``terminal_run``; that family was deleted
       per ``designs/OMNIGENT_TERMINAL_BRIDGE.md`` §3a in favor of
       ``sys_os_shell`` for one-shot cases.
-    - The parent's ``os_env.sandbox`` (filesystem grants, egress
-      rules, private-destination policy). The runner treats the
-      resolved child spec as authoritative for ``sys_os_*`` and only
-      wires the egress proxy from ``spec.sandbox`` (see
-      ``omnigent/inner/os_env.py::create_os_environment``). If the
-      child dropped the parent's sandbox, an egress-restricted parent
-      would silently gain an unrestricted network path through the
-      researcher — so the child must never be more privileged than
-      its parent.
+    - A sandbox that is **never more privileged than the parent**. The
+      runner treats the resolved child spec as authoritative for
+      ``sys_os_*`` and only wires the egress proxy from ``spec.sandbox``
+      (egress_rules / egress_allow_private_destinations — see
+      ``omnigent/inner/os_env.py::create_os_environment``). Two cases:
+
+      * **Parent declares an ``os_env``** → inherit its ``type`` and
+        ``sandbox`` verbatim. Dropping the sandbox here would silently
+        hand an egress-restricted parent an unrestricted network path
+        through the researcher.
+      * **Parent declares no ``os_env``** → it has neither a
+        ``sys_os_shell`` nor a network of its own, so fabricating a
+        bare ``OSEnvSpec(sandbox=None)`` resolved to the platform
+        default sharing the host network: a default-off SSRF +
+        privilege-escalation surface (the child could curl cloud IMDS /
+        localhost / RFC1918 and fold attacker-controlled page content
+        into the same context that runs shell commands). Build a
+        locked-down default-deny egress sandbox instead — see
+        :func:`_default_researcher_sandbox`.
     - Non-conversational mode (one-shot task)
     - Inline instructions for web research
 
     :param parent_spec: The parent agent's parsed spec.
     :returns: A complete AgentSpec for the web researcher sub-agent.
+    :raises OmnigentError: When the parent declares no ``os_env`` and
+        the host platform cannot hard-enforce network isolation, so no
+        secure default sandbox can be built (fail closed).
     """
-    from omnigent.inner.datamodel import OSEnvSpec
-
     parent_os_env = parent_spec.os_env
-    # Inherit the parent's sandbox so the child is bound by the same
-    # filesystem and egress policy. ``sandbox`` carries
-    # ``egress_rules`` / ``egress_allow_private_destinations``, which
-    # is the only state ``create_os_environment`` reads to start the
-    # MITM egress proxy. ``cwd`` is intentionally left at the default
-    # (inherit the parent process working dir) — the one-shot curl /
-    # python invocations don't need a specific workspace.
-    child_os_env = OSEnvSpec(
-        type=parent_os_env.type if parent_os_env is not None else "caller_process",
-        sandbox=parent_os_env.sandbox if parent_os_env is not None else None,
-    )
+    # ``cwd`` is intentionally left at the default (inherit the parent
+    # process working dir) — the one-shot curl / python invocations
+    # don't need a specific workspace.
+    if parent_os_env is not None:
+        child_os_env = OSEnvSpec(
+            type=parent_os_env.type,
+            sandbox=parent_os_env.sandbox,
+        )
+    else:
+        child_os_env = OSEnvSpec(
+            type="caller_process",
+            sandbox=_default_researcher_sandbox(),
+        )
 
     return AgentSpec(
         spec_version=1,

--- a/tests/inner/egress/test_rules.py
+++ b/tests/inner/egress/test_rules.py
@@ -142,6 +142,37 @@ def test_matches_wildcard_method() -> None:
     assert rule.matches("POST", "pypi.org", "/upload") is True
 
 
+def test_matches_any_host_wildcard() -> None:
+    """A bare ``*`` host pattern matches any DNS-safe host.
+
+    This is the host pattern web_fetch's default researcher egress uses
+    so a parent-less researcher can still reach arbitrary *public* web
+    hosts. The proxy's connect-time guard (not the rule layer) is what
+    keeps ``*`` from reaching private/metadata IPs — see
+    ``EgressProxy._assert_destination_allowed``.
+    """
+    rule = parse_rule("GET,HEAD,POST,OPTIONS *")
+    assert rule.host_pattern == "*"
+    assert rule.matches("GET", "example.com", "/") is True
+    assert rule.matches("GET", "api.github.com", "/repos/x") is True
+    assert rule.matches("POST", "duckduckgo.com", "/html/") is True
+    # Method still gated: a verb outside the allow-list is denied even
+    # though the host wildcard matches.
+    assert rule.matches("DELETE", "example.com", "/") is False
+    # A bare ``*`` host is still subject to the DNS-grammar canonicalization
+    # guard, so smuggled hosts never match even with the any-host wildcard.
+    assert rule.matches("GET", "attacker.com\x00.example.com", "/") is False
+
+
+def test_check_host_any_host_wildcard() -> None:
+    """``check_host`` (the CONNECT fast-path) honors the ``*`` wildcard."""
+    rules = parse_rules(["GET,HEAD,POST,OPTIONS *"])
+    assert check_host(rules, "example.com") is True
+    assert check_host(rules, "raw.githubusercontent.com") is True
+    # Smuggled host still rejected at the fast-path.
+    assert check_host(rules, "evil.com\r\n.example.com") is False
+
+
 def test_matches_case_insensitive_host() -> None:
     rule = parse_rule("GET API.GitHub.COM/repos/**")
     assert rule.matches("GET", "api.github.com", "/repos/x") is True

--- a/tests/tools/builtins/test_web_fetch.py
+++ b/tests/tools/builtins/test_web_fetch.py
@@ -144,15 +144,42 @@ def test_researcher_inherits_parent_sandbox_egress() -> None:
 
 def test_researcher_os_env_without_parent_sandbox() -> None:
     """
-    When the parent declares no os_env, the researcher still gets a
-    valid os_env (so ``sys_os_shell`` registers) with no sandbox —
-    matching the parent's (absent) policy rather than inventing one.
+    When the parent declares no os_env, the researcher must NOT get an
+    unsandboxed shell on the shared host network. It gets a locked-down
+    default-deny egress sandbox instead: a network-isolating backend, a
+    non-empty egress allow-list (so the MITM proxy starts AND the
+    network namespace is unshared), and
+    ``egress_allow_private_destinations=False`` so loopback /
+    link-local / RFC1918 / cloud-metadata (169.254.169.254) destinations
+    are refused at connect time.
+
+    Regression (P0 SSRF + privilege escalation): ``build_researcher_spec``
+    previously set ``sandbox=None`` here, which resolved to the platform
+    default sharing the host network. The child ``sys_os_shell`` could
+    then curl cloud IMDS / localhost / RFC1918, and a shell-less parent
+    was escalated to having an unsandboxed shell.
     """
     parent = _make_parent_spec()
     assert parent.os_env is None
     researcher = build_researcher_spec(parent)
     assert researcher.os_env is not None
-    assert researcher.os_env.sandbox is None
+    sandbox = researcher.os_env.sandbox
+    assert sandbox is not None, (
+        "Researcher must get a locked-down sandbox (not None) when the "
+        "parent declares no os_env — sandbox=None shares the host network."
+    )
+    # Non-empty egress_rules is what both starts the MITM proxy and
+    # triggers network-namespace isolation (``--unshare-net`` on bwrap);
+    # an empty list leaves the helper on the shared host network.
+    assert sandbox.egress_rules, (
+        "Default researcher sandbox must declare egress_rules so the "
+        "egress proxy starts and the network namespace is isolated."
+    )
+    # Private / link-local / metadata destinations must stay blocked.
+    assert sandbox.egress_allow_private_destinations is False
+    # Pinned to a backend that can hard-enforce network isolation
+    # (otherwise the egress rules would be inert decoration).
+    assert sandbox.type in ("linux_bwrap", "darwin_seatbelt")
 
 
 def test_researcher_name_is_internal() -> None:


### PR DESCRIPTION
## Related issue

N/A (P0 security finding — no tracking issue filed)

## Summary

`web_fetch` performs no HTTP itself; it spawns a `__web_researcher`
sub-agent whose only capability is `sys_os_shell` (curl). When the
**parent agent declares no `os_env`**, `build_researcher_spec` fabricated
`OSEnvSpec(type="caller_process", sandbox=None)` for that child.

- **Vulnerability + impact:** `sandbox=None` resolves to the platform
  default sandbox with the **host network shared** (the L7 egress proxy
  only starts when `egress_rules` is non-empty, and bwrap only adds
  `--unshare-net` when egress rules are active). So the child's
  `sys_os_shell` could `curl 169.254.169.254` (cloud IMDS / credentials),
  reach `localhost` services and RFC1918 internal hosts (SSRF), and fold
  attacker-controlled page content into the very context that runs shell
  commands (indirect prompt-injection → RCE). It also **escalated a
  shell-less parent** (no `os_env` → no `sys_os_shell`) into one with an
  unsandboxed shell — the child ending up *more* privileged than its parent.
- **Fix:** when the parent declares no `os_env`, build a **default-deny
  egress sandbox** instead of `sandbox=None`:
  - pinned to a network-isolating backend (`linux_bwrap` / `darwin_seatbelt`);
  - a non-empty `egress_rules` allow-list (this is what both starts the MITM
    proxy **and** triggers `--unshare-net`, so the proxy is the only egress path);
  - `egress_allow_private_destinations=False`, so loopback / link-local /
    RFC1918 / CGNAT / cloud-metadata (`169.254.169.254`, Alibaba/Azure traps)
    destinations are refused at connect time — even under DNS rebinding.
  - If the host has **no** network-isolating backend (e.g. Windows), it
    **fails closed** with a clear `OmnigentError` rather than running unsandboxed.
- The parent-has-`os_env` path is unchanged (inherits the parent's `type` +
  `sandbox` verbatim), so the child is **never more privileged than its parent**.
- The egress rule DSL had no "any host" token (a bare `*` host matched
  nothing), so a default-deny sandbox couldn't also serve the researcher's
  legitimate public-web fetches. Added a minimal, documented `*` = any
  DNS-safe host pattern to the matcher; the proxy's connect-time
  private-destination guard keeps `*` **public-only**, and the existing
  `is_dns_safe_host` canonicalization still rejects smuggled hosts.

ELI5: `web_fetch`'s helper used to get an internet-connected shell with no
guardrails when the agent itself had none. Now that helper runs in a locked
box that can reach the *public* web but is firewalled off from the machine's
own metadata service, localhost, and private network.

```
parent has os_env ──► inherit type + sandbox (unchanged; child ≤ parent)
parent has NO os_env ─► was: sandbox=None ─► platform default, HOST NETWORK SHARED  ✗ SSRF/escalation
                        now: default-deny egress sandbox
                             ├─ backend: linux_bwrap / darwin_seatbelt (--unshare-net)
                             ├─ egress_rules: ["GET,HEAD,POST,OPTIONS *"]  (starts MITM proxy)
                             └─ egress_allow_private_destinations: False   (IMDS/localhost/RFC1918 blocked)
                        no isolating backend (e.g. Windows) ─► fail closed (OmnigentError)
```

## Test Plan

- `uv run --extra dev pytest tests/tools/builtins/test_web_fetch.py tests/inner/egress/test_rules.py -x -q` → **50 passed**.
- `uv run --extra dev pytest tests/inner/egress/ tests/runtime/test_workflow_subagent_resolution.py -q` → **110 passed** (full egress suite + researcher spec resolution, confirming the `*` matcher change is non-regressive).
- `uv run --extra dev ruff check` + `uv run --extra dev --extra all mypy` on both changed source files → clean.
- Updated `test_researcher_os_env_without_parent_sandbox` (it previously asserted `sandbox is None`) to assert the secure default shape: sandbox is not None, `egress_rules` non-empty, `egress_allow_private_destinations is False`, and a network-isolating backend type.
- Added `test_matches_any_host_wildcard` / `test_check_host_any_host_wildcard` covering `*` = any host, that the method allow-list is still enforced, and that smuggled (NUL/CRLF) hosts are still rejected.

## Demo

N/A — backend security fix, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage is the right level here: the fix is pure spec construction
(`build_researcher_spec` shapes the child `OSEnvSpec`) plus a small,
well-tested change to the egress rule matcher. The enforcement mechanisms
this fix wires up (proxy default-deny, `--unshare-net`, connect-time
private-destination blocking) already have dedicated coverage under
`tests/inner/egress/` (e.g. `test_s2_assert_destination_blocks_loopback_by_default`),
which this PR re-ran green.