### PR TITLE
fix(runner): redact secrets from sys_agent_download bundle

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import io
 import json
 import logging
 import os
+import tarfile
 import tempfile
 import uuid
 from collections.abc import Callable
@@ -35,6 +37,7 @@ if TYPE_CHECKING:
     from omnigent.runtime.filesystem_registry import FilesystemRegistry
 
 import httpx
+import yaml
 
 from omnigent._wrapper_labels import (
     CLAUDE_NATIVE_WRAPPER_VALUE,
@@ -55,6 +58,7 @@ from omnigent.session_lifecycle import (
     is_session_closed,
     title_without_closed_marker,
 )
+from omnigent.spec.tar_utils import extract_safe
 from omnigent.tools import ToolManager
 from omnigent.tools.base import ToolContext
 from omnigent.tools.builtins.async_inbox import (
@@ -3247,6 +3251,154 @@ def _agent_bundle_filename(
     return f"{safe_name}-v{agent_version}.tar.gz"
 
 
+# ``sys_agent_download`` writes the agent bundle to the caller's local disk for
+# ``sys_os_read``, gated only at LEVEL_READ — the same gate as the secret-free
+# ``sys_agent_get``. The server's :class:`MCPServerSummary` deliberately strips
+# the secret-bearing ``headers`` / ``env`` fields out of ``get``; the runner
+# applies the symmetric redaction to the downloaded bundle so a READ-level
+# session SHARER (intended only to view a conversation) cannot exfiltrate the
+# agent's credential VALUES via the download path. Key NAMES are kept so the
+# bundle stays useful for inspection / forking — the sharer still learns which
+# credentials the agent needs, just not their values.
+_BUNDLE_REDACTION_PLACEHOLDER = "[REDACTED]"
+_BUNDLE_SECRET_MAPPING_KEYS = frozenset({"headers", "env"})
+
+
+def _redact_secret_mappings(node: object) -> bool:
+    """
+    Redact secret VALUES under ``headers`` / ``env`` mappings, in place.
+
+    Walks a parsed-YAML structure (the shape :func:`yaml.safe_load`
+    returns) and, for every mapping keyed ``headers`` or ``env`` whose
+    value is itself a mapping, replaces each value with
+    :data:`_BUNDLE_REDACTION_PLACEHOLDER` while preserving the key names.
+    Matches the exact fields the server's
+    :class:`~omnigent.server.schemas.MCPServerSummary` excludes from
+    ``sys_agent_get``, covering both inline ``tools:`` MCP entries in
+    ``config.yaml`` and standalone ``tools/mcp/*.yaml`` files, recursing
+    into sub-agent configs.
+
+    :param node: A parsed-YAML node (mapping, sequence, or scalar).
+    :returns: ``True`` if any value was redacted, else ``False``.
+    """
+    changed = False
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in _BUNDLE_SECRET_MAPPING_KEYS and isinstance(value, dict):
+                # Reassigning existing keys' values (not adding/removing
+                # keys) is safe during iteration; list() guards regardless.
+                for secret_key in list(value):
+                    if value[secret_key] != _BUNDLE_REDACTION_PLACEHOLDER:
+                        value[secret_key] = _BUNDLE_REDACTION_PLACEHOLDER
+                        changed = True
+            elif _redact_secret_mappings(value):
+                changed = True
+    elif isinstance(node, list):
+        for item in node:
+            if _redact_secret_mappings(item):
+                changed = True
+    return changed
+
+
+def _redact_bundle_yaml_file(path: Path) -> None:
+    """
+    Redact secret values in a single bundle YAML file, in place.
+
+    Parses *path* and, if it carries any ``headers`` / ``env`` secret
+    mapping, rewrites the file with those values replaced. A file that
+    fails to parse or does not parse to a mapping/sequence is left
+    untouched — it carries no recognized secret structure. Best effort by
+    design: the server validated the bundle at upload, so well-formed
+    ``config.yaml`` / ``tools/mcp/*.yaml`` parse cleanly here.
+
+    :param path: A ``.yaml`` / ``.yml`` file inside the extracted bundle.
+    """
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return
+    if not isinstance(loaded, (dict, list)):
+        return
+    if _redact_secret_mappings(loaded):
+        path.write_text(
+            yaml.safe_dump(loaded, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
+
+
+def _redact_bundle_dotenv_file(path: Path) -> None:
+    """
+    Redact values in a single ``.env``-style file, in place.
+
+    Replaces the value of each ``KEY=VALUE`` assignment with
+    :data:`_BUNDLE_REDACTION_PLACEHOLDER`, preserving blank lines,
+    comments, and key names. Defensive coverage for an agent that ships a
+    dotenv file alongside the spec; the structured YAML ``headers`` /
+    ``env`` fields are the primary secret vector.
+
+    :param path: A ``.env`` (or ``*.env``) file inside the extracted
+        bundle.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return
+    new_lines: list[str] = []
+    changed = False
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#") or "=" not in line:
+            new_lines.append(line)
+            continue
+        key, _, _value = line.partition("=")
+        new_lines.append(f"{key}={_BUNDLE_REDACTION_PLACEHOLDER}")
+        changed = True
+    if changed:
+        path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
+def _redact_agent_bundle_sync(bundle_bytes: bytes) -> bytes:
+    """
+    Unpack, redact secret values, and repack an agent bundle.
+
+    Extracts *bundle_bytes* (a ``.tar.gz``) into a temp directory with the
+    project's hardened :func:`~omnigent.spec.tar_utils.extract_safe`,
+    redacts secret values in every ``*.yaml`` / ``*.yml`` (the
+    ``headers`` / ``env`` mappings) and ``.env`` file, then repacks into a
+    fresh gzip tarball. The bundle the agent later reads from disk
+    therefore never contains credential VALUES — only their key names —
+    mirroring the secret-free projection ``sys_agent_get`` already returns.
+
+    Synchronous (filesystem + CPU bound); call via
+    :func:`asyncio.to_thread` off the event loop.
+
+    :param bundle_bytes: Raw bytes of the server's ``.tar.gz`` bundle.
+    :returns: Raw bytes of the redacted ``.tar.gz`` bundle.
+    :raises Exception: If *bundle_bytes* cannot be safely unpacked /
+        repacked — an unsafe tarball
+        (:class:`~omnigent.spec.tar_utils.ExtractionError`), corrupt gzip
+        (e.g. ``EOFError``), or decode error. The caller fails closed and
+        writes nothing rather than persisting an unredacted bundle.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir) / "bundle"
+        extract_safe(bundle_bytes, root)
+        for file_path in root.rglob("*"):
+            if not file_path.is_file():
+                continue
+            name = file_path.name
+            if name.endswith((".yaml", ".yml")):
+                _redact_bundle_yaml_file(file_path)
+            elif name == ".env" or name.endswith(".env"):
+                _redact_bundle_dotenv_file(file_path)
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+            for file_path in sorted(root.rglob("*")):
+                if file_path.is_file():
+                    tf.add(str(file_path), arcname=str(file_path.relative_to(root)))
+        return buf.getvalue()
+
+
 async def _agent_download_via_rest(
     session_id: str,
     args: dict[str, Any],
@@ -3259,12 +3411,17 @@ async def _agent_download_via_rest(
     """
     Download a session's agent bundle and write it to the agent's disk.
 
-    Fetches the ``.tar.gz`` from ``GET /v1/sessions/{id}/agent/contents``
-    and writes the bytes into the agent's os_env working directory — the
-    same cwd the agent's ``sys_os_*`` tools operate on (resolved via
+    Fetches the ``.tar.gz`` from ``GET /v1/sessions/{id}/agent/contents``,
+    redacts secret VALUES (MCP ``headers`` / ``env``, plus any ``.env``
+    file) out of the archive via :func:`_redact_agent_bundle_sync`, then
+    writes the redacted bytes into the agent's os_env working directory —
+    the same cwd the agent's ``sys_os_*`` tools operate on (resolved via
     :func:`_effective_runner_os_env_spec`, so a ``caller_process``
     os_env's cwd is the ``runner_workspace`` or the per-conversation
-    tmpdir). The default filename is ``"<agent_name>-v<version>.tar.gz"``
+    tmpdir). Redaction keeps the secret-disclosure posture of this
+    LEVEL_READ-gated path in line with the secret-free ``sys_agent_get``;
+    an unpackable bundle fails closed (nothing is written). The default
+    filename is ``"<agent_name>-v<version>.tar.gz"``
     (from the ``X-Agent-*`` response headers); a caller-supplied
     ``dest_filename`` overrides it. Returns the written path so the
     orchestrator can extract (``sys_os_shell``) and read
@@ -3298,6 +3455,19 @@ async def _agent_download_via_rest(
         return json.dumps({"error": f"sys_agent_download returned {resp.status_code}"})
     agent_name = resp.headers.get("X-Agent-Name", "agent")
     agent_version = resp.headers.get("X-Agent-Version", "0")
+    # Strip secret VALUES (MCP ``headers`` / ``env``) before the bundle ever
+    # touches disk: the server's contents route is gated only at LEVEL_READ,
+    # the same gate as the secret-free ``sys_agent_get``, so a read-only
+    # session sharer must not be able to read raw credentials off the
+    # downloaded bundle. Fail closed — if the bundle can't be unpacked, write
+    # nothing rather than persist an unredacted archive.
+    try:
+        bundle_bytes = await asyncio.to_thread(_redact_agent_bundle_sync, resp.content)
+    except Exception as exc:  # noqa: BLE001
+        # Fail closed on ANY unpack/redact failure (unsafe tarball,
+        # corrupt gzip, decode error, ...): never persist bytes we could
+        # not scrub.
+        return json.dumps({"error": f"sys_agent_download could not redact agent bundle: {exc}"})
     filename = _agent_bundle_filename(args.get("dest_filename"), agent_name, agent_version)
     if filename is None:
         return json.dumps(
@@ -3317,13 +3487,13 @@ async def _agent_download_via_rest(
         return json.dumps(
             {"error": "sys_agent_download resolved destination escapes the working directory"}
         )
-    await asyncio.to_thread(dest.write_bytes, resp.content)
+    await asyncio.to_thread(dest.write_bytes, bundle_bytes)
     return json.dumps(
         {
             "path": str(dest),
             "agent_name": agent_name,
             "agent_version": agent_version,
-            "bytes_written": len(resp.content),
+            "bytes_written": len(bundle_bytes),
         }
     )
 
@@ -3373,8 +3543,6 @@ def _scan_local_agent_configs(configs_dir: Path) -> list[dict[str, str | None]]:
         ``<cwd>/.omnigent/agent-configs``.
     :returns: ``[{"name", "path", "description"}, ...]``, sorted by path.
     """
-    import yaml
-
     if not configs_dir.is_dir():
         return []
     entries: list[dict[str, str | None]] = []

--- a/omnigent/tools/builtins/agents.py
+++ b/omnigent/tools/builtins/agents.py
@@ -109,6 +109,11 @@ class SysAgentDownloadTool(Tool):
     ``sys_os_shell`` operate on) and the tool returns the path —
     path-only by design. To inspect the config, extract the archive
     (``sys_os_shell``) then read ``config.yaml`` (``sys_os_read``).
+    Secret VALUES (MCP server ``headers`` / ``env`` and any ``.env``
+    file) are **redacted** from the written bundle — key names are kept
+    but each value becomes ``[REDACTED]`` — so the download discloses no
+    more than the secret-free ``sys_agent_get``. A fork therefore needs
+    its credentials re-supplied.
     The download exists for inspecting or forking a config — launching
     an already-registered agent needs no download: pass its
     ``agent_id`` (from ``sys_agent_list`` / ``sys_agent_get``) to
@@ -137,10 +142,12 @@ class SysAgentDownloadTool(Tool):
             "and return the path. Global read — any session you can "
             "access. Requires session_id. Path-only: extract the "
             "archive with sys_os_shell, then read config.yaml with "
-            "sys_os_read. Optionally pass dest_filename to control the "
-            "output filename. Only needed to inspect or fork an "
-            "agent's config — launching an existing agent needs no "
-            "download: pass its agent_id to sys_session_create."
+            "sys_os_read. Secret values (MCP headers/env, .env) are "
+            "redacted to [REDACTED] in the bundle; key names are kept. "
+            "Optionally pass dest_filename to control the output "
+            "filename. Only needed to inspect or fork an agent's config "
+            "— launching an existing agent needs no download: pass its "
+            "agent_id to sys_session_create."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -32,9 +32,11 @@ The unkeyed test asserts on plumbing only (handler is reached,
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import logging
 import os
+import tarfile
 import tempfile
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
@@ -45,6 +47,7 @@ from typing import Any, cast
 
 import httpx
 import pytest
+import yaml
 from fastapi import FastAPI
 
 from omnigent.runner import create_runner_app
@@ -5665,22 +5668,59 @@ async def test_sys_agent_download_rejects_symlink_escape_from_cwd(tmp_path: Path
     assert not outside_target.exists()
 
 
+def _build_agent_bundle(
+    config: dict[str, Any],
+    extra_files: dict[str, str] | None = None,
+) -> bytes:
+    """
+    Pack a minimal agent bundle (``.tar.gz``) for download tests.
+
+    :param config: ``config.yaml`` contents, dumped to YAML.
+    :param extra_files: Optional ``{arcname: text}`` extra members, e.g.
+        ``tools/mcp/github.yaml`` or ``.env``.
+    :returns: Raw ``.tar.gz`` bytes shaped like a real server bundle.
+    """
+    files = {"config.yaml": yaml.safe_dump(config, sort_keys=False)}
+    if extra_files:
+        files.update(extra_files)
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for arcname, text in files.items():
+            data = text.encode("utf-8")
+            info = tarfile.TarInfo(name=arcname)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _extract_bundle_files(bundle_bytes: bytes) -> dict[str, str]:
+    """Extract a ``.tar.gz`` into ``{arcname: text}`` for assertions."""
+    out: dict[str, str] = {}
+    with tarfile.open(fileobj=io.BytesIO(bundle_bytes), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            if member.isfile():
+                fh = tf.extractfile(member)
+                assert fh is not None
+                out[member.name] = fh.read().decode("utf-8")
+    return out
+
+
 @pytest.mark.asyncio
 async def test_sys_agent_download_writes_bundle_to_workspace(tmp_path: Path) -> None:
     """
-    ``sys_agent_download`` writes the fetched ``.tar.gz`` bytes into the
+    ``sys_agent_download`` writes the (redacted) ``.tar.gz`` into the
     agent's os_env cwd (here ``runner_workspace`` = tmp_path) and returns
     the path. Proves the full path: fetch bytes, derive the default
-    filename from the X-Agent-* headers, and persist to the agent-visible
-    disk. If the write regressed, the file wouldn't exist or the bytes
-    wouldn't match.
+    filename from the X-Agent-* headers, and persist a valid archive to
+    the agent-visible disk. If the write regressed, the file wouldn't
+    exist or wouldn't round-trip as a tarball.
 
     :param tmp_path: Pytest temp dir used as the runner workspace, so the
         resolved os_env cwd is a real local directory.
     """
     from omnigent.runner.tool_dispatch import execute_tool
 
-    bundle_bytes = b"\x1f\x8b\x08fake-tar-gz-bytes"
+    bundle_bytes = _build_agent_bundle({"spec_version": 1, "name": "my agent"})
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/v1/sessions/conv_x/agent/contents":
@@ -5707,10 +5747,154 @@ async def test_sys_agent_download_writes_bundle_to_workspace(tmp_path: Path) -> 
     # Default filename: agent name sanitized (space → "_") + version.
     expected = tmp_path / "my_agent-v5.tar.gz"
     assert info["path"] == str(expected)
-    assert info["bytes_written"] == len(bundle_bytes)
-    # The bundle actually landed on disk with the exact bytes — a
-    # mismatch means the write path or byte handling broke.
-    assert expected.read_bytes() == bundle_bytes
+    # bytes_written reflects the redacted/repacked archive actually on disk.
+    written = expected.read_bytes()
+    assert info["bytes_written"] == len(written)
+    # The written bytes are a valid tarball that round-trips to the spec.
+    files = _extract_bundle_files(written)
+    assert yaml.safe_load(files["config.yaml"])["name"] == "my agent"
+
+
+@pytest.mark.asyncio
+async def test_sys_agent_download_redacts_secret_values(tmp_path: Path) -> None:
+    """
+    ``sys_agent_download`` strips secret VALUES out of the bundle it
+    writes to disk — MCP ``headers`` / ``env`` (inline in ``config.yaml``
+    and standalone ``tools/mcp/*.yaml``) plus ``.env`` values — while
+    keeping key names. The ``.../agent/contents`` route is gated only at
+    LEVEL_READ, the same gate as the secret-free ``sys_agent_get``, so a
+    read-only session SHARER must not be able to read raw credentials off
+    the downloaded archive. If redaction regressed, the literal secret
+    tokens below would survive into the on-disk bundle.
+
+    :param tmp_path: Pytest temp dir used as the runner workspace.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    http_header_secret = "Bearer sk-HTTP-HEADER-SECRET"
+    stdio_env_secret = "ghp_STDIO-ENV-SECRET"
+    mcp_file_secret = "Bearer tok-MCP-FILE-SECRET"
+    dotenv_secret = "DOTENV-SECRET-VALUE"
+    secrets = [http_header_secret, stdio_env_secret, mcp_file_secret, dotenv_secret]
+
+    config = {
+        "spec_version": 1,
+        "name": "researcher",
+        "tools": {
+            "search": {
+                "type": "mcp",
+                "url": "https://mcp.example.com/sse",
+                "headers": {"Authorization": http_header_secret},
+            },
+            "github": {
+                "type": "mcp",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-github"],
+                "env": {"GITHUB_TOKEN": stdio_env_secret},
+            },
+        },
+    }
+    mcp_file = yaml.safe_dump(
+        {
+            "name": "deployed",
+            "transport": "http",
+            "url": "https://deployed.example.com/sse",
+            "headers": {"Authorization": mcp_file_secret},
+        },
+        sort_keys=False,
+    )
+    bundle_bytes = _build_agent_bundle(
+        config,
+        extra_files={
+            "tools/mcp/deployed.yaml": mcp_file,
+            ".env": f"GITHUB_TOKEN={dotenv_secret}\n# keep this comment\n",
+        },
+    )
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_x/agent/contents":
+            return httpx.Response(
+                200,
+                content=bundle_bytes,
+                headers={"X-Agent-Name": "researcher", "X-Agent-Version": "3"},
+            )
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_agent_download",
+            arguments=json.dumps({"session_id": "conv_x"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            runner_workspace=tmp_path,
+        )
+
+    info = json.loads(output)
+    assert "error" not in info, info
+    written = Path(info["path"])
+    assert written.exists()
+
+    # No literal secret value survives anywhere in the written archive.
+    raw = written.read_bytes()
+    for secret in secrets:
+        assert secret.encode("utf-8") not in raw, f"secret leaked: {secret!r}"
+
+    files = _extract_bundle_files(raw)
+    # Inline config.yaml MCP servers: key names kept, values redacted.
+    config_out = yaml.safe_load(files["config.yaml"])
+    assert config_out["tools"]["search"]["headers"] == {"Authorization": "[REDACTED]"}
+    assert config_out["tools"]["github"]["env"] == {"GITHUB_TOKEN": "[REDACTED]"}
+    # Non-secret structure is preserved (so the bundle stays inspectable).
+    assert config_out["tools"]["github"]["args"] == ["-y", "@modelcontextprotocol/server-github"]
+    assert config_out["name"] == "researcher"
+    # Standalone tools/mcp/*.yaml file redacted too.
+    mcp_out = yaml.safe_load(files["tools/mcp/deployed.yaml"])
+    assert mcp_out["headers"] == {"Authorization": "[REDACTED]"}
+    assert mcp_out["url"] == "https://deployed.example.com/sse"
+    # .env values redacted, comments/keys preserved.
+    assert "GITHUB_TOKEN=[REDACTED]" in files[".env"]
+    assert "# keep this comment" in files[".env"]
+
+
+@pytest.mark.asyncio
+async def test_sys_agent_download_fails_closed_on_unpackable_bundle(tmp_path: Path) -> None:
+    """
+    ``sys_agent_download`` fails closed when the fetched bundle is not a
+    valid tarball: it returns an error and writes NOTHING, rather than
+    persisting raw (potentially secret-bearing) bytes it could not
+    redact. Real server bundles are always ``.tar.gz``; a non-tarball is
+    anomalous and must never reach disk unredacted.
+
+    :param tmp_path: Pytest temp dir used as the runner workspace.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"\x1f\x8b\x08not-actually-a-tarball",
+            headers={"X-Agent-Name": "a", "X-Agent-Version": "1"},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_agent_download",
+            arguments=json.dumps({"session_id": "conv_x"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            runner_workspace=tmp_path,
+        )
+
+    info = json.loads(output)
+    assert "error" in info
+    # Nothing was written under the workspace.
+    assert list(tmp_path.iterdir()) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A — assigned P0 security issue (no separate GitHub issue filed).

## Summary

**Vulnerability + impact.** `sys_agent_get` deliberately returns a secret-free view: the server projects `MCPServerSummary`, which excludes the secret-bearing `mcp_servers[].headers` and `env` fields. But `sys_agent_download` wrote the **raw** agent bundle (`config.yaml` + `tools/mcp/*.yaml`, including `headers`, `env`, and any literal hardcoded secrets) to the agent's local disk for `sys_os_read`. Both tools are gated only at `LEVEL_READ`, so a **read-only session SHARER** — someone granted access only to *view* a conversation — could download the bundle and read the agent's full credential structure and any literal secret value. That is strictly more disclosure than `get` allows.

**Fix (runner-side redaction).** In the `sys_agent_download` runner handler (`_agent_download_via_rest`), after fetching the `.tar.gz` we now unpack it (via the hardened `extract_safe`), replace the **values** under every `headers` / `env` mapping in each `config.yaml` / `tools/mcp/*.yaml` — and the values in any `.env` file — with `[REDACTED]` (key names preserved), repack, and only then write to disk. So a READ sharer still gets a usable, inspectable, secret-free bundle, matching the posture of `sys_agent_get`. If the bundle can't be unpacked, the handler **fails closed** and writes nothing rather than persist an unredacted archive.

Scope is limited to the download path. The shared server route `GET /v1/sessions/{id}/agent/contents` is intentionally left untouched — the runner's legitimate agent-load path uses it on cache miss and must still receive real credentials to run the agent.

<details>
<summary>ELI5 + flow</summary>

"Look at this agent" already hides the passwords. "Download this agent" was handing over the password sheet. Now the download path crosses out the password values (but keeps the labels) before saving the file.

```mermaid
flowchart LR
  S[Session SHARER, LEVEL_READ] -->|sys_agent_download| R[runner handler]
  R -->|GET .../agent/contents| SRV[server: raw .tar.gz]
  SRV --> R
  R -->|unpack, redact headers/env/.env, repack| RD[redacted .tar.gz]
  RD -->|write_bytes| D[(agent local disk / sys_os_read)]
```
</details>

## Test Plan

`tests/runner/test_runner_dispatch.py` (new + updated, runner-dispatched download path):

- `test_sys_agent_download_redacts_secret_values` — bundle with secret HTTP `headers`, stdio `env` (inline in `config.yaml`), a standalone `tools/mcp/*.yaml`, and a `.env`; asserts no literal secret survives in the written archive, values become `[REDACTED]`, and key names / non-secret structure are preserved.
- `test_sys_agent_download_fails_closed_on_unpackable_bundle` — a non-tarball response yields an error and writes **nothing**.
- `test_sys_agent_download_writes_bundle_to_workspace` — updated to use a real bundle (redaction repacks, so exact-byte equality no longer holds); asserts the written archive round-trips.

Commands run in the worktree:

```
uv run --extra dev pytest tests/runner/test_runner_dispatch.py -k "sys_agent_download" -q   # 5 passed
uv run --extra dev pytest tests/tools/builtins/test_agents.py tests/runner/test_runner_dispatch.py \
  -k "test_agents or sys_agent or scan_local or agent_list" -q                              # 20 passed
uv run --extra dev ruff check <changed files>                                               # All checks passed
uv run --extra dev ruff format --check <changed files>                                      # already formatted
```

## Demo

N/A — backend-only security fix, no user-visible UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage added in `tests/runner/test_runner_dispatch.py` (the home of the runner-dispatched download tests): the positive redaction case (inline + file-based MCP secrets + `.env`), the fail-closed case, and the updated happy-path write. No integration/E2E added — the behavior is fully exercised at the handler level via a mocked server transport.