### PR TITLE
feat(tools): add Keenable backend to web_search

### DIFF
--- a/omnigent/tools/builtins/web_search.py
+++ b/omnigent/tools/builtins/web_search.py
@@ -5,12 +5,12 @@ Backend selection is fully determined by the agent spec:
 - **OpenAI model** → passthrough to OpenAI's native
   ``web_search_preview`` (server-side, uses the LLM API key).
 - **Other models** → use the ``search_provider`` named in the spec:
-  ``"duckduckgo"`` (keyless, no API key) or ``"google"`` / ``"perplexity"`` /
-  ``"nimble"`` / ``"tavily"`` with credentials for a sturdier / higher-rate
-  backend. ``web_search`` never picks an engine for you — with no
-  ``search_provider`` set it returns an error naming the options, so it is
-  always explicit which engine ran. No env var fallbacks — the spec is
-  self-contained.
+  ``"duckduckgo"`` or ``"keenable"`` (both keyless, no API key) or
+  ``"google"`` / ``"perplexity"`` / ``"nimble"`` / ``"tavily"`` with
+  credentials for a sturdier / higher-rate backend. ``web_search`` never
+  picks an engine for you — with no ``search_provider`` set it returns an
+  error naming the options, so it is always explicit which engine ran. No
+  env var fallbacks — the spec is self-contained.
 
 Usage in config.yaml::
 
@@ -181,10 +181,11 @@ def _search(query: str, config: dict[str, str]) -> str:
     :param query: The search query string.
     :param config: Spec-level config. Required keys:
 
-        - ``search_provider`` (required; no default): ``"duckduckgo"``
-          (keyless), ``"google"``, ``"perplexity"``, ``"nimble"``, or
-          ``"tavily"``
-        - ``api_key``: API key for the chosen backend (not for duckduckgo)
+        - ``search_provider`` (required; no default): ``"duckduckgo"`` or
+          ``"keenable"`` (keyless), ``"google"``, ``"perplexity"``,
+          ``"nimble"``, or ``"tavily"``
+        - ``api_key``: API key for the chosen backend (not for duckduckgo;
+          optional for keenable)
         - ``engine_id``: Required for Google only
 
     :returns: Search results, or an error message (including when no
@@ -207,18 +208,21 @@ def _search(query: str, config: dict[str, str]) -> str:
     if backend == "duckduckgo":
         return _run_duckduckgo(query, config)
 
+    if backend == "keenable":
+        return _run_keenable(query, config)
+
     # Fail loudly instead of silently picking an engine, so the user always
     # knows which engine ran and opts in explicitly (per maintainer review).
     if backend:
         return (
             f"web_search error: unknown search_provider {backend!r}. "
-            "Set search_provider to one of: duckduckgo (keyless, no API key), "
-            "google, perplexity, nimble, tavily."
+            "Set search_provider to one of: duckduckgo or keenable (keyless, "
+            "no API key), google, perplexity, nimble, tavily."
         )
     return (
         "web_search error: no search_provider configured. Set one in the "
-        "web_search tool config — e.g. search_provider: duckduckgo (keyless, "
-        "no API key), or google / perplexity / nimble / tavily with "
+        "web_search tool config — e.g. search_provider: duckduckgo or keenable "
+        "(keyless, no API key), or google / perplexity / nimble / tavily with "
         "credentials for a sturdier, higher-rate backend."
     )
 
@@ -317,3 +321,22 @@ def _run_duckduckgo(query: str, config: dict[str, str]) -> str:
     )
 
     return _search_duckduckgo(query, config)
+
+
+def _run_keenable(query: str, config: dict[str, str]) -> str:
+    """
+    Run a Keenable web search query.
+
+    Keyless by default: unlike the other backends, ``api_key`` is optional.
+    Without it the keyless public endpoint is used; with it the
+    authenticated endpoint is used and rate limits are lifted.
+
+    :param query: The search query.
+    :param config: May contain ``api_key`` and ``max_results`` (both optional).
+    :returns: Formatted results or an error message.
+    """
+    from omnigent.tools.builtins.web_search_keenable import (
+        _search_keenable,
+    )
+
+    return _search_keenable(query, config)

--- a/omnigent/tools/builtins/web_search.py
+++ b/omnigent/tools/builtins/web_search.py
@@ -4,13 +4,14 @@ Backend selection is fully determined by the agent spec:
 
 - **OpenAI model** → passthrough to OpenAI's native
   ``web_search_preview`` (server-side, uses the LLM API key).
-- **Other models** → use the ``search_provider`` named in the spec:
-  ``"duckduckgo"`` or ``"keenable"`` (both keyless, no API key) or
-  ``"google"`` / ``"perplexity"`` / ``"nimble"`` / ``"tavily"`` with
-  credentials for a sturdier / higher-rate backend. ``web_search`` never
-  picks an engine for you — with no ``search_provider`` set it returns an
-  error naming the options, so it is always explicit which engine ran. No
-  env var fallbacks — the spec is self-contained.
+- **Other models** → use the ``search_provider`` named in the spec. Both
+  keyless backends (no ``api_key``) and keyed ones (credentials for a
+  sturdier / higher-rate backend) are supported; the ``_BACKENDS`` registry
+  at the bottom of this module is the single source of truth for which
+  engines exist. ``web_search`` never picks an engine for you — with no
+  ``search_provider`` set it returns an error naming the options, so it is
+  always explicit which engine ran. No env var fallbacks — the spec is
+  self-contained.
 
 Usage in config.yaml::
 
@@ -23,7 +24,7 @@ Usage in config.yaml::
     tools:
       builtins:
         - name: web_search
-          search_provider: duckduckgo   # keyless; or google/perplexity/nimble
+          search_provider: duckduckgo   # a keyless backend, as an example
           # api_key: ${PERPLEXITY_API_KEY}   # required for keyed backends
 """
 
@@ -31,6 +32,8 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
@@ -38,16 +41,28 @@ from omnigent.tools.base import Tool, ToolContext
 _logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class _Backend:
+    """A selectable ``search_provider`` engine in the ``_BACKENDS`` registry.
+
+    :param run: Callable ``(query, config) -> result_or_error`` for the engine.
+    :param keyless: True if the engine needs no ``api_key`` (drives hint text).
+    """
+
+    run: Callable[[str, dict[str, str]], str]
+    keyless: bool
+
+
 class WebSearchTool(Tool):
     """
     Unified web search tool with backend determined by the agent spec.
 
     When the agent uses an OpenAI model, this emits the native
-    ``web_search_preview`` passthrough schema. For other models,
-    the spec must set ``search_provider`` (``"duckduckgo"`` is
-    keyless; ``"google"`` / ``"perplexity"`` / ``"nimble"`` need
-    credentials) — there is no default and no env var fallback, so
-    the spec is self-contained and the engine used is explicit.
+    ``web_search_preview`` passthrough schema. For other models, the
+    spec must set ``search_provider`` to one of the engines in the
+    ``_BACKENDS`` registry (some keyless, some needing credentials) —
+    there is no default and no env var fallback, so the spec is
+    self-contained and the engine used is explicit.
 
     :param config: Spec-level config from config.yaml, e.g.
         ``{"search_provider": "perplexity", "api_key": "pplx-..."}``.
@@ -181,11 +196,10 @@ def _search(query: str, config: dict[str, str]) -> str:
     :param query: The search query string.
     :param config: Spec-level config. Required keys:
 
-        - ``search_provider`` (required; no default): ``"duckduckgo"`` or
-          ``"keenable"`` (keyless), ``"google"``, ``"perplexity"``,
-          ``"nimble"``, or ``"tavily"``
-        - ``api_key``: API key for the chosen backend (not for duckduckgo;
-          optional for keenable)
+        - ``search_provider`` (required; no default): one of the engine
+          names in the ``_BACKENDS`` registry
+        - ``api_key``: API key for the chosen backend (keyless backends
+          ignore it)
         - ``engine_id``: Required for Google only
 
     :returns: Search results, or an error message (including when no
@@ -193,38 +207,15 @@ def _search(query: str, config: dict[str, str]) -> str:
     """
     backend = config.get("search_provider")
 
-    if backend == "google":
-        return _run_google(query, config)
-
-    if backend == "perplexity":
-        return _run_perplexity(query, config)
-
-    if backend == "nimble":
-        return _run_nimble(query, config)
-
-    if backend == "tavily":
-        return _run_tavily(query, config)
-
-    if backend == "duckduckgo":
-        return _run_duckduckgo(query, config)
-
-    if backend == "keenable":
-        return _run_keenable(query, config)
+    engine = _BACKENDS.get(backend) if backend else None
+    if engine is not None:
+        return engine.run(query, config)
 
     # Fail loudly instead of silently picking an engine, so the user always
     # knows which engine ran and opts in explicitly (per maintainer review).
     if backend:
-        return (
-            f"web_search error: unknown search_provider {backend!r}. "
-            "Set search_provider to one of: duckduckgo or keenable (keyless, "
-            "no API key), google, perplexity, nimble, tavily."
-        )
-    return (
-        "web_search error: no search_provider configured. Set one in the "
-        "web_search tool config — e.g. search_provider: duckduckgo or keenable "
-        "(keyless, no API key), or google / perplexity / nimble / tavily with "
-        "credentials for a sturdier, higher-rate backend."
-    )
+        return f"web_search error: unknown search_provider {backend!r}. {_backend_hint()}"
+    return f"web_search error: no search_provider configured. {_backend_hint()}"
 
 
 def _run_google(query: str, config: dict[str, str]) -> str:
@@ -340,3 +331,34 @@ def _run_keenable(query: str, config: dict[str, str]) -> str:
     )
 
     return _search_keenable(query, config)
+
+
+# Single source of truth for the selectable backends. To add an engine, write
+# its ``_run_*`` above and add one row here — the dispatch in ``_search`` and
+# the error hint below both derive from this map, so nothing else needs editing.
+# ``keyless`` drives only the hint wording (which engines need no ``api_key``).
+_BACKENDS: dict[str, _Backend] = {
+    "duckduckgo": _Backend(_run_duckduckgo, keyless=True),
+    "keenable": _Backend(_run_keenable, keyless=True),
+    "google": _Backend(_run_google, keyless=False),
+    "perplexity": _Backend(_run_perplexity, keyless=False),
+    "nimble": _Backend(_run_nimble, keyless=False),
+    "tavily": _Backend(_run_tavily, keyless=False),
+}
+
+
+def _backend_hint() -> str:
+    """Build the "set search_provider to one of ..." hint from ``_BACKENDS``.
+
+    Derived from the registry so the error text can never drift from the set of
+    engines that actually dispatch.
+
+    :returns: A one-line hint naming the keyless and keyed engines.
+    """
+    keyless = [name for name, b in _BACKENDS.items() if b.keyless]
+    keyed = [name for name, b in _BACKENDS.items() if not b.keyless]
+    return (
+        f"Set search_provider to one of: {', '.join(keyless)} (keyless, no API "
+        f"key), or {', '.join(keyed)} with credentials for a sturdier, "
+        "higher-rate backend. No env var fallbacks — the spec is self-contained."
+    )

--- a/omnigent/tools/builtins/web_search_keenable.py
+++ b/omnigent/tools/builtins/web_search_keenable.py
@@ -1,0 +1,136 @@
+"""Built-in tool: Keenable web search.
+
+Uses Keenable's agent-optimized search endpoint (``POST /v1/search``) to
+return a list of grounded results (title, URL, description). Good for
+non-OpenAI models (Anthropic, Llama, Databricks-hosted, etc.) that cannot
+use OpenAI's native ``web_search_preview``.
+
+Unlike the other backends, Keenable works **without an API key**: with no
+``api_key`` in the spec it calls the keyless public endpoint
+(``/v1/search/public``), so it runs out of the box. Supplying an ``api_key``
+switches to the authenticated endpoint (``/v1/search``) and lifts rate limits.
+
+Configured in the agent spec::
+
+    tools:
+      builtins:
+        - name: web_search
+          search_provider: keenable
+          # api_key is optional — omit it to use the keyless free tier:
+          # api_key: ${KEENABLE_API_KEY}
+          # max_results: 5            # 1-20 (default 5)
+
+See https://docs.keenable.ai
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# Any: Keenable's JSON response is a heterogeneous dict with string keys
+# and mixed value types (str, list, dict, None).
+from typing import Any
+
+import httpx
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_KEENABLE_URL = "https://api.keenable.ai"
+
+# Default number of results when the spec does not set ``max_results``.
+# Keenable returns a ranked list; we slice client-side to this many.
+_DEFAULT_MAX_RESULTS: int = 5
+
+# Identifies this integration to Keenable via the ``X-Keenable-Title`` header
+# so traffic from the Omnigent provider is attributable.
+_CLIENT_TITLE = "Omnigent"
+
+
+def _keenable_base_url() -> str:
+    """Resolve the Keenable base URL; ``OMNIGENT_KEENABLE_BASE_URL`` overrides for tests."""
+    return os.environ.get("OMNIGENT_KEENABLE_BASE_URL", _DEFAULT_KEENABLE_URL).rstrip("/")
+
+
+def _resolve_max_results(config: dict[str, str]) -> int:
+    """
+    Read ``max_results`` from spec config, clamped to a 1-20 range.
+
+    :param config: Spec-level config; ``max_results`` may be a str or int.
+    :returns: A valid result count, or the default on missing/invalid input.
+    """
+    raw = config.get("max_results")
+    if raw is None:
+        return _DEFAULT_MAX_RESULTS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_RESULTS
+    return max(1, min(value, 20))
+
+
+def _search_keenable(
+    query: str,
+    config: dict[str, str],
+) -> str:
+    """
+    Call the Keenable web search API and format the results.
+
+    Keyless by default: with no ``api_key`` the public endpoint is used.
+    With an ``api_key`` the authenticated endpoint is used and the key is
+    sent in the ``X-API-Key`` header.
+
+    :param query: The search query string.
+    :param config: Spec-level config; checks ``api_key`` and ``max_results``
+        (both optional).
+    :returns: Formatted results or an error message.
+    """
+    api_key = (config.get("api_key") or "").strip()
+    # Keyed endpoint with a key; keyless public endpoint without one.
+    path = "/v1/search" if api_key else "/v1/search/public"
+    headers = {
+        "Content-Type": "application/json",
+        "X-Keenable-Title": _CLIENT_TITLE,
+    }
+    if api_key:
+        headers["X-API-Key"] = api_key
+    try:
+        resp = httpx.post(
+            f"{_keenable_base_url()}{path}",
+            headers=headers,
+            json={"query": query, "mode": "pro"},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return f"Keenable search error: HTTP {exc.response.status_code}"
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        return f"Keenable search error: {exc}"
+
+    return _format_results(resp.json(), _resolve_max_results(config))
+
+
+def _format_results(data: dict[str, Any], max_results: int) -> str:
+    """
+    Format Keenable's ``/v1/search`` JSON response into readable text.
+
+    Keenable returns ``{"results": [{"title", "url", "description", ...}]}``.
+    The list is sliced to ``max_results`` and rendered as numbered entries.
+
+    :param data: The parsed JSON response from Keenable.
+    :param max_results: Maximum number of results to render.
+    :returns: Numbered results, or a "no results" message.
+    """
+    results = data.get("results") if isinstance(data, dict) else None
+    if not isinstance(results, list) or not results:
+        return "No results found."
+
+    formatted: list[str] = []
+    for i, item in enumerate(results[:max_results]):
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title", "")
+        url = item.get("url", "")
+        snippet = item.get("description") or ""
+        formatted.append(f"{i + 1}. {title}\n   {url}\n   {snippet}")
+    return "\n\n".join(formatted) if formatted else "No results found."

--- a/tests/tools/builtins/test_web_search.py
+++ b/tests/tools/builtins/test_web_search.py
@@ -11,6 +11,9 @@ import pytest
 from omnigent.tools.base import ToolContext
 from omnigent.tools.builtins import get_builtin_tool
 from omnigent.tools.builtins.web_search import WebSearchTool
+from omnigent.tools.builtins.web_search_keenable import (
+    _resolve_max_results as _resolve_max_results_keenable,
+)
 from omnigent.tools.builtins.web_search_nimble import _resolve_max_results
 from omnigent.tools.builtins.web_search_tavily import (
     _resolve_max_results as _resolve_max_results_tavily,
@@ -577,6 +580,165 @@ def test_no_search_provider_fails_loudly(
     assert "perplexity" in result.lower()
     assert "nimble" in result.lower()
     assert "tavily" in result.lower()
+    assert "keenable" in result.lower()
+
+
+# ── search_provider: keenable ────────────────────────
+
+
+def test_keenable_backend_via_spec_config(tool_ctx: ToolContext) -> None:
+    """
+    With search_provider=keenable, the tool delegates to Keenable web
+    search and the result list flows through the unified pipeline.
+    """
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "results": [
+            {
+                "title": "Keenable Docs",
+                "url": "https://docs.keenable.ai",
+                "description": "Web search API for AI agents.",
+            },
+        ],
+    }
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "keenable"}), tool_ctx)
+
+    assert "1. Keenable Docs" in result
+    assert "https://docs.keenable.ai" in result
+    assert "Web search API for AI agents." in result
+
+
+def test_keenable_keyless_by_default(tool_ctx: ToolContext) -> None:
+    """
+    Without api_key, Keenable hits the keyless public endpoint and sends
+    no auth header — it must NOT error like the other backends do.
+    """
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"results": []}
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    url = mock_post.call_args.args[0]
+    headers = mock_post.call_args.kwargs["headers"]
+    assert url.endswith("/v1/search/public"), f"Expected keyless endpoint, got {url!r}"
+    assert "X-API-Key" not in headers
+    assert "api_key" not in result  # no "missing api_key" error
+
+
+def test_keenable_keyed_uses_x_api_key_and_authed_endpoint(tool_ctx: ToolContext) -> None:
+    """With an api_key, Keenable uses /v1/search and the X-API-Key header."""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"results": []}
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable", "api_key": "spec-keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    url = mock_post.call_args.args[0]
+    headers = mock_post.call_args.kwargs["headers"]
+    body = mock_post.call_args.kwargs["json"]
+    assert url.endswith("/v1/search"), f"Expected authed endpoint, got {url!r}"
+    assert headers["X-API-Key"] == "spec-keenable"
+    assert body["query"] == "test"
+    assert body["mode"] == "pro"
+
+
+def test_keenable_sends_x_keenable_title_header(tool_ctx: ToolContext) -> None:
+    """Keenable tags traffic with the ``X-Keenable-Title`` attribution header."""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"results": []}
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers["X-Keenable-Title"] == "Omnigent"
+
+
+def test_keenable_http_error_returns_error_string(tool_ctx: ToolContext) -> None:
+    """An HTTP error from Keenable is returned as a readable string, not raised."""
+    fake_response = MagicMock()
+    fake_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=MagicMock(status_code=500)
+    )
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    assert "Keenable search error" in result
+
+
+def test_keenable_empty_results_returns_no_results(tool_ctx: ToolContext) -> None:
+    """An empty result list yields the 'No results found.' message."""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"results": []}
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    assert result == "No results found."
+
+
+def test_keenable_max_results_slices_output(tool_ctx: ToolContext) -> None:
+    """``max_results`` limits how many results are rendered."""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "results": [
+            {"title": f"R{i}", "url": f"https://e.com/{i}", "description": "d"} for i in range(10)
+        ],
+    }
+
+    tool = WebSearchTool(
+        config={"search_provider": "keenable", "max_results": "2"},
+        llm_provider="anthropic",
+    )
+    with patch("omnigent.tools.builtins.web_search_keenable.httpx.post") as mock_post:
+        mock_post.return_value = fake_response
+        result = tool.invoke(json.dumps({"query": "test"}), tool_ctx)
+
+    assert "1. R0" in result
+    assert "2. R1" in result
+    assert "R2" not in result
+
+
+def test_keenable_max_results_clamped() -> None:
+    """``max_results`` is coerced + clamped to a 1-20 range; junk → default."""
+    assert _resolve_max_results_keenable({}) == 5  # missing → default
+    assert _resolve_max_results_keenable({"max_results": "0"}) == 1  # below min → clamped up
+    assert _resolve_max_results_keenable({"max_results": "500"}) == 20  # above max → clamped down
+    assert _resolve_max_results_keenable({"max_results": "abc"}) == 5  # non-numeric → default
 
 
 # ── Spec config passed through ───────────────────────


### PR DESCRIPTION
## Summary

Adds a **Keenable** search backend to the `web_search` built-in tool, alongside
the existing google / perplexity / nimble / tavily backends, giving non-OpenAI
models another grounded-search option.

Unlike the other backends, **Keenable is keyless by default**: with no `api_key`
it calls the public endpoint (`/v1/search/public`), so it works out of the box.
Supplying an `api_key` switches to the authenticated endpoint (`/v1/search`,
`X-API-Key` header) and lifts rate limits.

- New `web_search_keenable.py`, mirroring the Tavily/Nimble backends: optional
  `api_key`, `max_results` clamped 1–20, `X-Keenable-Title: Omnigent` attribution
  header, error-as-string contract, and the `OMNIGENT_KEENABLE_BASE_URL` test
  override.
- `web_search.py` gains a `_run_keenable` dispatch branch (no required key —
  this is the only keyless backend) plus updated help text and module/`_search`
  docstrings.

## Test Plan

- `uv run pytest tests/tools/builtins/test_web_search.py` → 45 passed (8 new
  Keenable cases: keyed path, keyless-by-default, X-API-Key/endpoint switch,
  X-Keenable-Title header, HTTP error, empty results, max_results slice + clamp).
- `uv run ruff check . && uv run ruff format --check .` → clean on the touched files.
- Manually smoke-tested against the live Keenable API and an offline stub via
  `OMNIGENT_KEENABLE_BASE_URL`; request shape and result formatting confirmed.

## Demo

This is a core-tool backend with no UI surface, so the user-visible behaviour is
the tool's returned text. Live run through the unified `web_search` tool with
`search_provider: keenable` and **no API key** (keyless public endpoint):

```
$ web_search(query="what is retrieval augmented generation")   # search_provider: keenable, max_results: 3

1. Retrieval-Augmented Generation (RAG)
   https://link.springer.com/article/10.1007/s12599-025-00945-3
   Business & Information Systems Engineering -

2. Retrieval-augmented generation
   https://en.wikipedia.org/wiki/Retrieval-augmented_generation

3. What Is Retrieval-Augmented Generation (RAG)? [2026]
   https://atlan.com/know/what-is-retrieval-augmented-generation
   Atlan is the context layer for enterprise AI. It continuously reads your
   warehouses, databases, pipelines, BI tools, and business systems ...
```

Same call with an `api_key` in the spec transparently switches to the
authenticated endpoint (`/v1/search`, `X-API-Key`) and returns the same shape.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

