### PR TITLE
fix(web_fetch): run __web_researcher on the parent leg's harness

### DIFF
--- a/omnigent/tools/builtins/web_fetch.py
+++ b/omnigent/tools/builtins/web_fetch.py
@@ -97,10 +97,18 @@ loop endlessly. If nothing works, say so.
 
 def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
     """
-    Build the ``__web_researcher`` AgentSpec using the parent's LLM config.
+    Build the ``__web_researcher`` AgentSpec from the parent's spec.
 
     The researcher gets:
     - The parent's ``llm`` config (model + connection + extras)
+    - The parent's executor harness, ``auth``, ``model``, and
+      ``connection`` (with ``max_iterations`` capped low) — the
+      researcher runs on the SAME harness leg as its parent and routes
+      through the parent's provider. Without this the child defaults to
+      ``type="omnigent"`` with no harness, which the runner rejects as
+      ``unknown harness 'omnigent'`` before any model routing, and
+      (latently) drops the parent's provider so a gateway model hits the
+      native router with an ``Unknown provider`` error.
     - An ``os_env`` block — registers ``sys_os_shell`` for one-shot
       bash commands (curl, python3 one-liners). The previous
       implementation used ``terminal_run``; that family was deleted
@@ -136,6 +144,33 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
         sandbox=parent_os_env.sandbox if parent_os_env is not None else None,
     )
 
+    # Inherit the parent leg's executor so the researcher runs on the SAME
+    # harness, with the SAME credentials and model, as its parent. The prior
+    # implementation copied only ``llm`` and built a bare
+    # ``ExecutorSpec(max_iterations=5)``, which defaults ``type`` to
+    # ``"omnigent"`` with an empty ``config``. Two failures followed:
+    #
+    # - Layer 1 (active): with no ``config["harness"]``, ``harness_kind``
+    #   resolves to the literal executor type ``"omnigent"``, so the runner
+    #   aborts every researcher spawn with ``RuntimeError: unknown harness
+    #   'omnigent'`` before any model routing — every ``web_fetch`` fails on
+    #   all legs.
+    # - Layer 2 (latent): dropping the parent's harness and ``auth`` also
+    #   strips the researcher off the parent's provider. A gateway model such
+    #   as ``z-ai/glm-5.2`` then hits the in-process native router, which has
+    #   no provider for the ``z-ai`` prefix (``Unknown provider 'z-ai'``), and
+    #   the codex / claude legs fail on missing credentials.
+    #
+    # Carrying the parent's harness / auth / model / connection routes the
+    # researcher through the parent's harness to the parent's provider —
+    # closing both layers. ``os_env`` carried inside ``executor.config`` is an
+    # inline-sub-spec translation artifact and is superseded by the explicit
+    # ``os_env`` above, so it is dropped to avoid re-deriving the sandbox.
+    parent_executor = parent_spec.executor
+    child_executor_config = {
+        key: value for key, value in parent_executor.config.items() if key != "os_env"
+    }
+
     return AgentSpec(
         spec_version=1,
         name=RESEARCHER_NAME,
@@ -145,10 +180,31 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
         tools=ToolsConfig(),
         os_env=child_os_env,
         instructions=_RESEARCHER_INSTRUCTIONS,
-        # Low max_iterations to keep the sub-agent fast.
-        # 1 fetch + 1 retry = 2 tool calls max, plus the
-        # final response = ~3 iterations.
-        executor=ExecutorSpec(max_iterations=5),
+        executor=ExecutorSpec(
+            # Inherit the parent's executor type (e.g. "omnigent") so the
+            # harness/provider routing below is keyed off the same discriminator.
+            type=parent_executor.type,
+            # Low max_iterations to keep the sub-agent fast.
+            # 1 fetch + 1 retry = 2 tool calls max, plus the
+            # final response = ~3 iterations.
+            max_iterations=5,
+            # Routing-relevant config: ``harness`` (closes Layer 1) plus any
+            # ``permission_mode`` / ``use_responses`` / ``profile`` the spawn-env
+            # builders read. ``os_env`` is intentionally excluded (see above).
+            config=child_executor_config,
+            # The harness spawn-env builders resolve the model from
+            # ``executor.model`` (not ``llm.model``) and credentials from
+            # ``executor.auth`` / ``executor.connection`` — inherit all three so
+            # the researcher routes the parent's model through the parent's
+            # provider (closes Layer 2).
+            model=parent_executor.model,
+            connection=parent_executor.connection,
+            context_window=parent_executor.context_window,
+            auth=parent_executor.auth,
+            # Legacy Databricks profile (deprecated path) — carried for parity
+            # with parents that still rely on ``executor.profile``.
+            profile=parent_executor.profile,
+        ),
     )
 
 

--- a/omnigent/tools/builtins/web_fetch.py
+++ b/omnigent/tools/builtins/web_fetch.py
@@ -24,6 +24,7 @@ import logging
 # has heterogeneous values.
 from typing import Any
 
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.spec.types import (
     AgentSpec,
     ExecutorSpec,
@@ -33,6 +34,12 @@ from omnigent.spec.types import (
 from omnigent.tools.base import Tool
 
 _logger = logging.getLogger(__name__)
+
+# ``ExecutorSpec.type`` defaults to this. It is the executor *type*, never a
+# registered harness, so a spec whose ``harness_kind`` resolves to it cannot be
+# spawned — the runner aborts with ``unknown harness 'omnigent'`` (see
+# ``omnigent/runtime/harnesses/process_manager.py::_resolve_module_path``).
+_UNBOOTABLE_DEFAULT_HARNESS: str = "omnigent"
 
 # Internal sub-agent name. Double-underscore prefix prevents
 # collision with user-declared sub-agent names (which use
@@ -128,6 +135,13 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
 
     :param parent_spec: The parent agent's parsed spec.
     :returns: A complete AgentSpec for the web researcher sub-agent.
+    :raises OmnigentError: If the parent leg declares no bootable harness
+        (``executor.type == "omnigent"`` with no ``executor.config["harness"]``).
+        The researcher would otherwise spawn the unspawnable literal harness
+        ``"omnigent"``; failing here names the parent leg instead of surfacing
+        the cryptic runner-side ``unknown harness 'omnigent'`` crash. See the
+        guard at the end of this function for why the resolved harness is not
+        recoverable at this call site.
     """
     from omnigent.inner.datamodel import OSEnvSpec
 
@@ -170,6 +184,58 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
     child_executor_config = {
         key: value for key, value in parent_executor.config.items() if key != "os_env"
     }
+    child_executor = ExecutorSpec(
+        # Inherit the parent's executor type (e.g. "omnigent") so the
+        # harness/provider routing below is keyed off the same discriminator.
+        type=parent_executor.type,
+        # Low max_iterations to keep the sub-agent fast.
+        # 1 fetch + 1 retry = 2 tool calls max, plus the
+        # final response = ~3 iterations.
+        max_iterations=5,
+        # Routing-relevant config: ``harness`` (closes Layer 1) plus any
+        # ``permission_mode`` / ``use_responses`` / ``profile`` the spawn-env
+        # builders read. ``os_env`` is intentionally excluded (see above).
+        config=child_executor_config,
+        # The harness spawn-env builders resolve the model from
+        # ``executor.model`` (not ``llm.model``) and credentials from
+        # ``executor.auth`` / ``executor.connection`` — inherit all three so
+        # the researcher routes the parent's model through the parent's
+        # provider (closes Layer 2).
+        model=parent_executor.model,
+        connection=parent_executor.connection,
+        context_window=parent_executor.context_window,
+        auth=parent_executor.auth,
+        # Legacy Databricks profile (deprecated path) — carried for parity
+        # with parents that still rely on ``executor.profile``.
+        profile=parent_executor.profile,
+    )
+
+    # Fail loud if the inherited executor has no bootable harness. The child
+    # ``__web_researcher`` session is created WITHOUT a per-session
+    # ``harness_override`` (``_execute_web_fetch_tool`` passes only a prompt),
+    # so the runner resolves the child's harness SOLELY from this spec, exactly
+    # as it does for any session: ``executor.config["harness"] or executor.type``
+    # (``ExecutorSpec.harness_kind``; see ``runner/app.py`` create-session and
+    # ``_resolve_harness_and_spawn_env``). A parent whose real harness lives only
+    # in resolved session state — e.g. an API ``harness_override`` on a spec with
+    # no ``executor.config["harness"]`` — is NOT visible here: both call sites
+    # (``WebFetchTool.__init__`` and the ``_find_spec_by_name`` resolve-miss in
+    # ``runtime/workflow.py``) hand us only the static ``AgentSpec``, so the
+    # resolved harness cannot be recovered to inherit. Rather than emit a child
+    # that defaults to the unspawnable literal harness ``"omnigent"`` (which the
+    # runner aborts with ``unknown harness 'omnigent'`` — the original Layer-1
+    # crash), fail at build time with an actionable error naming the parent leg.
+    if child_executor.harness_kind == _UNBOOTABLE_DEFAULT_HARNESS:
+        raise OmnigentError(
+            f"web_fetch cannot build its {RESEARCHER_NAME} sub-agent: parent agent "
+            f"{parent_spec.name or '<unnamed>'!r} declares no bootable harness "
+            f"(executor.type={parent_executor.type!r} with no "
+            f"executor.config['harness']), so the researcher would spawn the "
+            f"unknown harness 'omnigent'. Set executor.config.harness on the parent "
+            f"(e.g. 'claude-sdk', 'codex', or 'pi') so the researcher runs on the "
+            f"parent's harness.",
+            code=ErrorCode.INVALID_INPUT,
+        )
 
     return AgentSpec(
         spec_version=1,
@@ -180,31 +246,7 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
         tools=ToolsConfig(),
         os_env=child_os_env,
         instructions=_RESEARCHER_INSTRUCTIONS,
-        executor=ExecutorSpec(
-            # Inherit the parent's executor type (e.g. "omnigent") so the
-            # harness/provider routing below is keyed off the same discriminator.
-            type=parent_executor.type,
-            # Low max_iterations to keep the sub-agent fast.
-            # 1 fetch + 1 retry = 2 tool calls max, plus the
-            # final response = ~3 iterations.
-            max_iterations=5,
-            # Routing-relevant config: ``harness`` (closes Layer 1) plus any
-            # ``permission_mode`` / ``use_responses`` / ``profile`` the spawn-env
-            # builders read. ``os_env`` is intentionally excluded (see above).
-            config=child_executor_config,
-            # The harness spawn-env builders resolve the model from
-            # ``executor.model`` (not ``llm.model``) and credentials from
-            # ``executor.auth`` / ``executor.connection`` — inherit all three so
-            # the researcher routes the parent's model through the parent's
-            # provider (closes Layer 2).
-            model=parent_executor.model,
-            connection=parent_executor.connection,
-            context_window=parent_executor.context_window,
-            auth=parent_executor.auth,
-            # Legacy Databricks profile (deprecated path) — carried for parity
-            # with parents that still rely on ``executor.profile``.
-            profile=parent_executor.profile,
-        ),
+        executor=child_executor,
     )
 
 

--- a/tests/runtime/test_workflow_subagent_resolution.py
+++ b/tests/runtime/test_workflow_subagent_resolution.py
@@ -53,7 +53,9 @@ def _coordinator_parent(*, web_fetch: bool = True) -> AgentSpec:
         spec_version=1,
         name="concordia",
         llm=LLMConfig(model="openai/gpt-5.4"),
-        executor=ExecutorSpec(max_iterations=40),
+        # A real bootable omnigent-executor coordinator carries a harness; the
+        # researcher inherits it so the reconstructed child is spawnable.
+        executor=ExecutorSpec(max_iterations=40, config={"harness": "claude-sdk"}),
         tools=ToolsConfig(builtins=builtins),
         sub_agents=[panelist],
     )
@@ -76,7 +78,9 @@ def _nested_web_fetch_parent() -> AgentSpec:
         spec_version=1,
         name="researcher_host",
         llm=LLMConfig(model="anthropic/claude-nested-7"),
-        executor=ExecutorSpec(max_iterations=40),
+        # The web_fetch owner needs a real harness so the reconstructed
+        # researcher (built from THIS owner) is bootable.
+        executor=ExecutorSpec(max_iterations=40, config={"harness": "claude-sdk"}),
         tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_fetch")]),
     )
     return AgentSpec(

--- a/tests/tools/builtins/test_web_fetch.py
+++ b/tests/tools/builtins/test_web_fetch.py
@@ -6,6 +6,7 @@ from omnigent.spec.types import (
     AgentSpec,
     ExecutorSpec,
     LLMConfig,
+    ProviderAuth,
 )
 from omnigent.tools.builtins.web_fetch import (
     RESEARCHER_NAME,
@@ -285,6 +286,96 @@ def testbuild_researcher_spec_default_executor() -> None:
     parent = _make_parent_spec()
     researcher = build_researcher_spec(parent)
     assert researcher.executor.type == "omnigent"
+
+
+def test_researcher_inherits_parent_harness_auth_and_model() -> None:
+    """
+    Regression: the reconstructed ``__web_researcher`` must run on the
+    PARENT LEG's harness with the parent's credentials and model.
+
+    ``build_researcher_spec`` previously copied only ``llm`` and built a
+    bare ``ExecutorSpec(max_iterations=5)``. That bare spec defaults
+    ``type`` to ``"omnigent"`` with an empty ``config``, so:
+
+    - Layer 1 (active): ``executor.harness_kind`` resolves to the literal
+      ``"omnigent"`` (no ``config["harness"]``), and the runner aborts the
+      researcher spawn with ``RuntimeError: unknown harness 'omnigent'``
+      before any model routing — every ``web_fetch`` fails on all legs.
+    - Layer 2 (latent): dropping the parent's ``auth`` and model strips the
+      researcher off the parent's provider, so a gateway model such as
+      ``z-ai/glm-5.2`` hits the native router with ``Unknown provider
+      'z-ai'`` and the codex / claude legs fail on missing credentials.
+
+    The harness spawn-env builders read ``executor.config["harness"]``
+    (harness selection), ``executor.model`` (NOT ``llm.model``), and
+    ``executor.auth`` / ``executor.connection`` (credentials), so all of
+    these must carry from the parent.
+    """
+    parent_auth = ProviderAuth(name="openrouter")
+    parent = AgentSpec(
+        spec_version=1,
+        name="pi-parent",
+        llm=LLMConfig(model="z-ai/glm-5.2"),
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "pi"},
+            model="z-ai/glm-5.2",
+            connection={"base_url": "https://openrouter.ai/api/v1"},
+            auth=parent_auth,
+        ),
+    )
+
+    researcher = build_researcher_spec(parent)
+
+    # Layer 1: the child must NOT be the bare "unknown harness 'omnigent'"
+    # spec — it carries the parent's harness selector.
+    assert researcher.executor.config.get("harness") == "pi", (
+        "Researcher dropped the parent's harness — the runner would abort "
+        f"with unknown harness {researcher.executor.harness_kind!r}."
+    )
+    assert researcher.executor.harness_kind == "pi", (
+        "harness_kind must resolve to the parent's harness, not the literal "
+        f"executor type; got {researcher.executor.harness_kind!r}."
+    )
+    assert researcher.executor.harness_kind != "omnigent"
+
+    # Layer 2: credentials + model must carry so the parent's provider routes
+    # the parent's model.
+    assert researcher.executor.auth is parent_auth, (
+        "Researcher dropped the parent's auth — the gateway model would hit "
+        "the native router (Unknown provider 'z-ai')."
+    )
+    assert researcher.executor.model == "z-ai/glm-5.2"
+    assert researcher.executor.connection == {"base_url": "https://openrouter.ai/api/v1"}
+
+    # The fast-cap is preserved.
+    assert researcher.executor.max_iterations == 5
+
+
+def test_researcher_drops_inline_os_env_from_executor_config() -> None:
+    """
+    ``executor.config["os_env"]`` is an inline-sub-spec translation artifact;
+    the researcher declares its own top-level ``os_env``. Carrying the config
+    ``os_env`` would re-introduce a stale sandbox mapping, so it is dropped
+    while every other routing key (e.g. ``harness``) is preserved.
+    """
+    parent = AgentSpec(
+        spec_version=1,
+        name="codex-parent",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex", "os_env": {"type": "caller_process"}},
+            model="openai/gpt-5.4",
+        ),
+    )
+
+    researcher = build_researcher_spec(parent)
+
+    assert researcher.executor.config.get("harness") == "codex"
+    assert "os_env" not in researcher.executor.config
+    # The explicit top-level os_env (which registers sys_os_shell) is intact.
+    assert researcher.os_env is not None
 
 
 def test_web_fetch_is_sync_in_sessions_native_mode() -> None:

--- a/tests/tools/builtins/test_web_fetch.py
+++ b/tests/tools/builtins/test_web_fetch.py
@@ -26,10 +26,14 @@ def _make_parent_spec(
 
     :param model: The LLM model string.
     :param executor_type: Executor type override, or ``None``
-        for default (llm).
+        for default (omnigent executor on the claude-sdk harness).
     :returns: An AgentSpec suitable for constructing WebFetchTool.
     """
-    executor = ExecutorSpec()
+    # A real bootable ``type="omnigent"`` agent always carries a harness in
+    # ``executor.config`` — without one ``harness_kind`` is the unspawnable
+    # literal "omnigent". Default the helper to a real harness so fixtures build
+    # bootable parents (and ``build_researcher_spec`` does not fail loud).
+    executor = ExecutorSpec(config={"harness": "claude-sdk"})
     if executor_type is not None:
         executor = ExecutorSpec(type=executor_type)
     return AgentSpec(
@@ -129,6 +133,7 @@ def test_researcher_inherits_parent_sandbox_egress() -> None:
         spec_version=1,
         name="test-parent",
         llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
         os_env=OSEnvSpec(type="caller_process", sandbox=sandbox),
     )
 
@@ -273,7 +278,11 @@ def testbuild_researcher_spec_copies_llm() -> None:
         model="groq/llama-4-scout",
         connection={"api_key": "test-key"},
     )
-    parent = AgentSpec(spec_version=1, llm=llm)
+    parent = AgentSpec(
+        spec_version=1,
+        llm=llm,
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+    )
     researcher = build_researcher_spec(parent)
     # Same LLM config object (reference copy, not deep copy —
     # the researcher doesn't modify it).
@@ -282,10 +291,47 @@ def testbuild_researcher_spec_copies_llm() -> None:
 
 
 def testbuild_researcher_spec_default_executor() -> None:
-    """Researcher should use default executor (omnigent)."""
+    """Researcher inherits the parent's omnigent executor type AND harness."""
     parent = _make_parent_spec()
     researcher = build_researcher_spec(parent)
     assert researcher.executor.type == "omnigent"
+    # The harness carries from the parent so the child is bootable (not the
+    # unspawnable literal "omnigent").
+    assert researcher.executor.harness_kind == "claude-sdk"
+
+
+def test_researcher_build_fails_loud_when_parent_has_no_harness() -> None:
+    """
+    A parent with ``ExecutorSpec(type="omnigent", config={})`` (no harness)
+    must NOT silently produce an unbootable child whose
+    ``harness_kind == "omnigent"`` — it must fail loud at build time.
+
+    The child ``__web_researcher`` session is created without a per-session
+    ``harness_override``, so the runner resolves its harness solely from this
+    spec. A child carrying the literal ``"omnigent"`` would crash the runner
+    with ``unknown harness 'omnigent'`` (the original Layer-1 failure). The
+    resolved harness (e.g. an API ``harness_override`` on a spec with no
+    ``executor.config["harness"]``) is not visible at this call site, so
+    ``build_researcher_spec`` raises a clear, parent-naming error instead.
+    """
+    import pytest
+
+    from omnigent.errors import ErrorCode, OmnigentError
+
+    parent = AgentSpec(
+        spec_version=1,
+        name="no-harness-leg",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(type="omnigent", config={}),
+    )
+
+    with pytest.raises(OmnigentError) as exc_info:
+        build_researcher_spec(parent)
+
+    # Actionable: names the offending parent leg and the missing harness.
+    assert exc_info.value.code == ErrorCode.INVALID_INPUT
+    assert "no-harness-leg" in str(exc_info.value)
+    assert "harness" in str(exc_info.value).lower()
 
 
 def test_researcher_inherits_parent_harness_auth_and_model() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

`web_fetch` does not fetch directly — it dispatches a synthetic `__web_researcher`
sub-agent that runs `curl` via `sys_os_shell`. `build_researcher_spec`
(`omnigent/tools/builtins/web_fetch.py`) built that child as a bare
`ExecutorSpec(max_iterations=5)`, copying only the parent's `llm` and **dropping
the parent's executor harness, `auth`, `model`, and `connection`**. With
`executor.type` defaulting to `"omnigent"` and an empty `config`, every fetch broke:

- **Layer 1 (active):** `executor.harness_kind` resolved to the literal
  `"omnigent"`, so the runner aborted every researcher spawn with
  `RuntimeError: unknown harness 'omnigent'` — *before any model routing*, so
  `web_fetch` failed on **all** harness legs.
- **Layer 2 (latent):** with the parent harness/auth gone, a gateway model such
  as `z-ai/glm-5.2` fell through to the in-process native router
  (`Unknown provider 'z-ai'`), and the codex/claude legs failed on missing
  credentials.

PR #817 reconstructs the researcher on a resolve-miss but calls the same
`build_researcher_spec`, so the bug persisted.

**The fix:** the `__web_researcher` child now inherits the parent leg's executor
— harness (`config`), `auth`, `model`, `connection`, `type`, and `profile`
(`max_iterations` still capped low; `os_env` still derived from the parent
sandbox) — so the researcher runs on the **same harness** as its parent and
routes through the **same provider**. `os_env` carried inside `executor.config`
is an inline-sub-spec translation artifact superseded by the explicit `os_env`,
so it is dropped. The change is contained to `build_researcher_spec`.

ELI5: a coordinator on (say) the pi harness asks `web_fetch` to read a page.
`web_fetch` quietly hires a little helper agent to run `curl`. The helper was
being hired with no harness and no login, so it couldn't even start. Now the
helper is hired onto the same harness and login as its boss, so it starts, runs
`curl`, and hands the page back.

```
parent agent (harness=H, auth=A, model=M)
        │  calls web_fetch
        ▼
__web_researcher child
  before: ExecutorSpec(max_iterations=5)            → type=omnigent, no harness/auth
          → "unknown harness 'omnigent'" (L1) / native router "Unknown provider" (L2)
  after:  inherits harness=H, auth=A, model=M, connection
          → boots on H, sys_os_shell → curl → page content
```

## Test Plan

Gates (run with `uv` in a fresh `uv sync --extra all --extra dev` worktree off `main`):

- `uv run ruff check .` → pass; `uv run ruff format --check .` → pass (1626 files).
- `uv run pre-commit run --files omnigent/tools/builtins/web_fetch.py tests/tools/builtins/test_web_fetch.py` → pass.
- `uv run mypy omnigent/tools/builtins/web_fetch.py` → clean.
- `uv run pytest tests/tools/ tests/runtime/ tests/spec/ -n 8 --dist loadfile` → 2080 passed
  (the new regression tests in `tests/tools/builtins/test_web_fetch.py` pass; the
  5 pre-existing `tests/tools/test_manager.py` failures reproduce identically on
  unmodified `main` and are unrelated to this change).

New regression tests assert the reconstructed `__web_researcher` spec carries the
parent's harness + `auth` + `model` (and is **not** the bare
`type=="omnigent"`/no-harness spec via `harness_kind != "omnigent"`), and that the
inline `executor.config` `os_env` is dropped.

Live verification (branch-runtime harness — branch code run as a separate
host/runner against a running server, server not promoted):

- **claude-sdk leg — full end-to-end:** an agent granted `web_fetch` was asked to
  fetch `https://example.com`. The `__web_researcher` sub-agent booted, ran
  `sys_os_shell: curl -sL "https://example.com"`, and returned the page content;
  the parent quoted *“This domain is for use in documentation examples without
  needing permission.”* The runner log shows **zero** `unknown harness 'omnigent'`
  and **zero** `Unknown provider`.
- **pi / OpenRouter leg (`z-ai/glm-5.2`) — routing verified:** the pi harness
  booted and routed `z-ai/glm-5.2` to the OpenRouter gateway with **zero**
  `unknown harness 'omnigent'` and **zero** `Unknown provider 'z-ai'` — the exact
  Layer-1 + Layer-2 signatures this fix targets. (Full researcher boot on this leg
  was gated only by an OpenRouter account credit limit — an `HTTP 402` from the
  gateway — independent of this change.)
- **Contrast (before the fix):** the prior runner log shows the researcher
  child-session create aborting with
  `RuntimeError: unknown harness 'omnigent'; registered names: [...]` followed by
  `tool callback fired with no active turn context (tool=web_fetch)`.

## Demo

N/A (non-visual). Key live excerpts:

Before (unmodified spawn — researcher child create):
```
WARNING:omnigent.runner.app:harness spawn failed: unknown harness 'omnigent'; registered names: ['antigravity', ..., 'pi', 'pi-native', 'qwen', ...]
RuntimeError: unknown harness 'omnigent'; ...
... tool callback fired with no active turn context (tool=web_fetch); returning error
```

After (claude-sdk leg — `__web_researcher` child transcript):
```
[MSG user]  Query: https://example.com  /  Start with this URL: https://example.com
[CALL] sys_os_shell: {"command": "curl -sL \"https://example.com\" | head -60"}
[MSG assistant] **Example Domain** ... Body: "This domain is for use in documentation examples
                without needing permission. Avoid use in operations."
```

After (pi / OpenRouter leg — routing, no Layer-1/Layer-2 errors):
```
INFO:omnigent.runner.app:pi gateway routing: gateway=true ... model=z-ai/glm-5.2
# runner log: 0 occurrences of "unknown harness 'omnigent'", 0 of "Unknown provider 'z-ai'"
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the branch code as a separate host/runner against a live
server and drove an agent with the `web_fetch` builtin on two harness legs. On the
claude-sdk leg the `__web_researcher` sub-agent booted, executed `curl` via
`sys_os_shell`, and returned the fetched page content end-to-end; on the
pi/OpenRouter (`z-ai/glm-5.2`) leg the harness booted and routed to the gateway
with neither `unknown harness 'omnigent'` nor `Unknown provider 'z-ai'`. Unit
regression tests lock the reconstructed spec's inherited harness/auth/model so the
two-layer regression cannot silently return.
