### PR TITLE
fix(web_fetch): run __web_researcher on the parent leg's harness

### DIFF
--- a/omnigent/tools/builtins/web_fetch.py
+++ b/omnigent/tools/builtins/web_fetch.py
@@ -24,6 +24,7 @@ import logging
 # has heterogeneous values.
 from typing import Any
 
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.spec.types import (
     AgentSpec,
     ExecutorSpec,
@@ -33,6 +34,12 @@ from omnigent.spec.types import (
 from omnigent.tools.base import Tool
 
 _logger = logging.getLogger(__name__)
+
+# ``ExecutorSpec.type`` defaults to this. It is the executor *type*, never a
+# registered harness, so a spec whose ``harness_kind`` resolves to it cannot be
+# spawned — the runner aborts with ``unknown harness 'omnigent'`` (see
+# ``omnigent/runtime/harnesses/process_manager.py::_resolve_module_path``).
+_UNBOOTABLE_DEFAULT_HARNESS: str = "omnigent"
 
 # Internal sub-agent name. Double-underscore prefix prevents
 # collision with user-declared sub-agent names (which use
@@ -97,10 +104,18 @@ loop endlessly. If nothing works, say so.
 
 def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
     """
-    Build the ``__web_researcher`` AgentSpec using the parent's LLM config.
+    Build the ``__web_researcher`` AgentSpec from the parent's spec.
 
     The researcher gets:
     - The parent's ``llm`` config (model + connection + extras)
+    - The parent executor's harness (``config``), ``auth``, ``model``, and
+      ``connection`` (with ``max_iterations`` capped low) — the researcher
+      runs on the SAME harness leg as its parent and routes through the
+      parent's provider. Without this the child defaults to ``type="omnigent"``
+      with no harness, which the runner rejects as ``unknown harness
+      'omnigent'`` before any model routing (Layer 1), and even past that
+      a gateway model loses its provider and hits the native router's
+      ``Unknown provider`` (Layer 2).
     - An ``os_env`` block — registers ``sys_os_shell`` for one-shot
       bash commands (curl, python3 one-liners). The previous
       implementation used ``terminal_run``; that family was deleted
@@ -120,6 +135,13 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
 
     :param parent_spec: The parent agent's parsed spec.
     :returns: A complete AgentSpec for the web researcher sub-agent.
+    :raises OmnigentError: If the parent leg declares no bootable harness
+        (``executor.type == "omnigent"`` with no ``executor.config["harness"]``).
+        The researcher would otherwise spawn the unspawnable literal harness
+        ``"omnigent"``; failing here names the parent leg instead of surfacing
+        the cryptic runner-side ``unknown harness 'omnigent'`` crash. See the
+        guard at the end of this function for why the resolved harness is not
+        recoverable at this call site.
     """
     from omnigent.inner.datamodel import OSEnvSpec
 
@@ -136,6 +158,66 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
         sandbox=parent_os_env.sandbox if parent_os_env is not None else None,
     )
 
+    # Inherit the parent leg's executor so the researcher runs on the SAME
+    # harness with the SAME credentials and model. The prior code copied only
+    # ``llm`` and built a bare ``ExecutorSpec(max_iterations=5)`` — defaulting
+    # ``type`` to ``"omnigent"`` with an empty ``config``. Two failures:
+    #   Layer 1: ``harness_kind`` (``config["harness"] or type``) resolves to
+    #     the literal ``"omnigent"``, so the runner aborts the spawn with
+    #     ``unknown harness 'omnigent'`` before any model routing.
+    #   Layer 2: with the parent's harness/auth gone, a gateway model like
+    #     ``z-ai/glm-5.2`` falls to the in-process native router
+    #     (``Unknown provider 'z-ai'``) and codex/claude lose their credentials.
+    # Inherit the routing-relevant executor fields: ``config["harness"]``
+    # (selection; runner/app.py:8691, 18601), ``model`` (``_resolve_spec_model``;
+    # workflow.py:1115), ``auth`` (``_resolve_provider_for_build``;
+    # workflow.py:1040), and ``connection`` (executor-level endpoint/credential
+    # overrides — carried so a parent whose routing depends on it, e.g. a
+    # programmatic spec where ``llm.connection`` and ``executor.connection`` are
+    # not parser-synced, is not silently re-routed). ``type`` is the executor
+    # discriminator — keep it so the fail-loud guard below stays correct for
+    # non-"omnigent" executors.
+    #
+    # Dropped: ``context_window`` (auto-detected from the model), ``profile``
+    # (deprecated Databricks path, subsumed by ``auth``), and the ``os_env`` key
+    # inside ``config`` (an inline-sub-spec artifact superseded by the explicit
+    # ``os_env`` above) — none are routing inputs on the harness legs.
+    parent_executor = parent_spec.executor
+    child_executor_config = {
+        key: value for key, value in parent_executor.config.items() if key != "os_env"
+    }
+    child_executor = ExecutorSpec(
+        type=parent_executor.type,
+        max_iterations=5,  # one-shot: 1 fetch + 1 retry + final response
+        config=child_executor_config,
+        model=parent_executor.model,
+        connection=parent_executor.connection,
+        auth=parent_executor.auth,
+    )
+
+    # Fail loud if the inherited executor still has no bootable harness. The
+    # child session is created WITHOUT a per-session ``harness_override``
+    # (``_execute_web_fetch_tool`` passes only a prompt), so the runner resolves
+    # the child's harness SOLELY from this spec. A parent whose real harness
+    # lives only in resolved session state (e.g. an API ``harness_override`` on a
+    # spec with no ``executor.config["harness"]``) is not visible here — both
+    # call sites (``WebFetchTool.__init__`` and the ``_find_spec_by_name``
+    # resolve-miss in ``runtime/workflow.py``) hand us only the static
+    # ``AgentSpec`` — so it cannot be recovered to inherit. Fail at build time
+    # with an actionable error naming the parent, rather than emit a child that
+    # the runner later aborts with the cryptic ``unknown harness 'omnigent'``.
+    if child_executor.harness_kind == _UNBOOTABLE_DEFAULT_HARNESS:
+        raise OmnigentError(
+            f"web_fetch cannot build its {RESEARCHER_NAME} sub-agent: parent agent "
+            f"{parent_spec.name or '<unnamed>'!r} declares no bootable harness "
+            f"(executor.type={parent_executor.type!r} with no "
+            f"executor.config['harness']), so the researcher would spawn the "
+            f"unknown harness 'omnigent'. Set executor.config.harness on the parent "
+            f"(e.g. 'claude-sdk', 'codex', or 'pi') so the researcher runs on the "
+            f"parent's harness.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
     return AgentSpec(
         spec_version=1,
         name=RESEARCHER_NAME,
@@ -145,10 +227,7 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
         tools=ToolsConfig(),
         os_env=child_os_env,
         instructions=_RESEARCHER_INSTRUCTIONS,
-        # Low max_iterations to keep the sub-agent fast.
-        # 1 fetch + 1 retry = 2 tool calls max, plus the
-        # final response = ~3 iterations.
-        executor=ExecutorSpec(max_iterations=5),
+        executor=child_executor,
     )
 
 

--- a/omnigent/tools/builtins/web_fetch.py
+++ b/omnigent/tools/builtins/web_fetch.py
@@ -35,10 +35,9 @@ from omnigent.tools.base import Tool
 
 _logger = logging.getLogger(__name__)
 
-# ``ExecutorSpec.type`` defaults to this. It is the executor *type*, never a
+# ``ExecutorSpec.type`` defaults to this. It is an executor type, never a
 # registered harness, so a spec whose ``harness_kind`` resolves to it cannot be
-# spawned — the runner aborts with ``unknown harness 'omnigent'`` (see
-# ``omnigent/runtime/harnesses/process_manager.py::_resolve_module_path``).
+# spawned — the runner aborts with ``unknown harness 'omnigent'``.
 _UNBOOTABLE_DEFAULT_HARNESS: str = "omnigent"
 
 # Internal sub-agent name. Double-underscore prefix prevents
@@ -135,13 +134,8 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
 
     :param parent_spec: The parent agent's parsed spec.
     :returns: A complete AgentSpec for the web researcher sub-agent.
-    :raises OmnigentError: If the parent leg declares no bootable harness
-        (``executor.type == "omnigent"`` with no ``executor.config["harness"]``).
-        The researcher would otherwise spawn the unspawnable literal harness
-        ``"omnigent"``; failing here names the parent leg instead of surfacing
-        the cryptic runner-side ``unknown harness 'omnigent'`` crash. See the
-        guard at the end of this function for why the resolved harness is not
-        recoverable at this call site.
+    :raises OmnigentError: If the parent declares no bootable harness, so the
+        researcher would spawn the unspawnable literal harness ``"omnigent"``.
     """
     from omnigent.inner.datamodel import OSEnvSpec
 
@@ -158,30 +152,14 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
         sandbox=parent_os_env.sandbox if parent_os_env is not None else None,
     )
 
-    # Inherit the parent leg's executor so the researcher runs on the SAME
-    # harness with the SAME credentials and model. The prior code copied only
-    # ``llm`` and built a bare ``ExecutorSpec(max_iterations=5)`` — defaulting
-    # ``type`` to ``"omnigent"`` with an empty ``config``. Two failures:
-    #   Layer 1: ``harness_kind`` (``config["harness"] or type``) resolves to
-    #     the literal ``"omnigent"``, so the runner aborts the spawn with
-    #     ``unknown harness 'omnigent'`` before any model routing.
-    #   Layer 2: with the parent's harness/auth gone, a gateway model like
-    #     ``z-ai/glm-5.2`` falls to the in-process native router
-    #     (``Unknown provider 'z-ai'``) and codex/claude lose their credentials.
-    # Inherit the routing-relevant executor fields: ``config["harness"]``
-    # (selection; runner/app.py:8691, 18601), ``model`` (``_resolve_spec_model``;
-    # workflow.py:1115), ``auth`` (``_resolve_provider_for_build``;
-    # workflow.py:1040), and ``connection`` (executor-level endpoint/credential
-    # overrides — carried so a parent whose routing depends on it, e.g. a
-    # programmatic spec where ``llm.connection`` and ``executor.connection`` are
-    # not parser-synced, is not silently re-routed). ``type`` is the executor
-    # discriminator — keep it so the fail-loud guard below stays correct for
-    # non-"omnigent" executors.
-    #
-    # Dropped: ``context_window`` (auto-detected from the model), ``profile``
-    # (deprecated Databricks path, subsumed by ``auth``), and the ``os_env`` key
-    # inside ``config`` (an inline-sub-spec artifact superseded by the explicit
-    # ``os_env`` above) — none are routing inputs on the harness legs.
+    # Inherit the parent leg's routing-relevant executor fields (harness, model,
+    # auth, connection, type) so the researcher runs on the SAME harness with the
+    # SAME credentials and model. The prior code built a bare
+    # ``ExecutorSpec(max_iterations=5)``, which defaults to the unspawnable
+    # ``type="omnigent"`` harness and strips the parent's provider. Drop
+    # ``context_window`` (auto-detected), ``profile`` (deprecated, subsumed by
+    # ``auth``), and the inline ``config["os_env"]`` (superseded by ``os_env``
+    # below) — none are routing inputs.
     parent_executor = parent_spec.executor
     child_executor_config = {
         key: value for key, value in parent_executor.config.items() if key != "os_env"
@@ -196,16 +174,10 @@ def build_researcher_spec(parent_spec: AgentSpec) -> AgentSpec:
     )
 
     # Fail loud if the inherited executor still has no bootable harness. The
-    # child session is created WITHOUT a per-session ``harness_override``
-    # (``_execute_web_fetch_tool`` passes only a prompt), so the runner resolves
-    # the child's harness SOLELY from this spec. A parent whose real harness
-    # lives only in resolved session state (e.g. an API ``harness_override`` on a
-    # spec with no ``executor.config["harness"]``) is not visible here — both
-    # call sites (``WebFetchTool.__init__`` and the ``_find_spec_by_name``
-    # resolve-miss in ``runtime/workflow.py``) hand us only the static
-    # ``AgentSpec`` — so it cannot be recovered to inherit. Fail at build time
-    # with an actionable error naming the parent, rather than emit a child that
-    # the runner later aborts with the cryptic ``unknown harness 'omnigent'``.
+    # child is spawned solely from this static spec (no per-session
+    # ``harness_override`` is threaded here), so a harness that lives only in
+    # resolved session state can't be recovered — better an actionable
+    # build-time error naming the parent than a cryptic runner-side crash.
     if child_executor.harness_kind == _UNBOOTABLE_DEFAULT_HARNESS:
         raise OmnigentError(
             f"web_fetch cannot build its {RESEARCHER_NAME} sub-agent: parent agent "

--- a/tests/runtime/test_workflow_subagent_resolution.py
+++ b/tests/runtime/test_workflow_subagent_resolution.py
@@ -53,7 +53,9 @@ def _coordinator_parent(*, web_fetch: bool = True) -> AgentSpec:
         spec_version=1,
         name="concordia",
         llm=LLMConfig(model="openai/gpt-5.4"),
-        executor=ExecutorSpec(max_iterations=40),
+        # A real bootable omnigent-executor coordinator carries a harness; the
+        # researcher inherits it so the reconstructed child is spawnable.
+        executor=ExecutorSpec(max_iterations=40, config={"harness": "claude-sdk"}),
         tools=ToolsConfig(builtins=builtins),
         sub_agents=[panelist],
     )
@@ -76,7 +78,9 @@ def _nested_web_fetch_parent() -> AgentSpec:
         spec_version=1,
         name="researcher_host",
         llm=LLMConfig(model="anthropic/claude-nested-7"),
-        executor=ExecutorSpec(max_iterations=40),
+        # The web_fetch owner needs a real harness so the reconstructed
+        # researcher (built from THIS owner) is bootable.
+        executor=ExecutorSpec(max_iterations=40, config={"harness": "claude-sdk"}),
         tools=ToolsConfig(builtins=[BuiltinToolConfig(name="web_fetch")]),
     )
     return AgentSpec(

--- a/tests/tools/builtins/test_web_fetch.py
+++ b/tests/tools/builtins/test_web_fetch.py
@@ -6,6 +6,7 @@ from omnigent.spec.types import (
     AgentSpec,
     ExecutorSpec,
     LLMConfig,
+    ProviderAuth,
 )
 from omnigent.tools.builtins.web_fetch import (
     RESEARCHER_NAME,
@@ -25,10 +26,14 @@ def _make_parent_spec(
 
     :param model: The LLM model string.
     :param executor_type: Executor type override, or ``None``
-        for default (llm).
+        for default (omnigent executor on the claude-sdk harness).
     :returns: An AgentSpec suitable for constructing WebFetchTool.
     """
-    executor = ExecutorSpec()
+    # A real bootable ``type="omnigent"`` agent always carries a harness in
+    # ``executor.config`` — without one ``harness_kind`` is the unspawnable
+    # literal "omnigent". Default the helper to a real harness so fixtures build
+    # bootable parents (and ``build_researcher_spec`` does not fail loud).
+    executor = ExecutorSpec(config={"harness": "claude-sdk"})
     if executor_type is not None:
         executor = ExecutorSpec(type=executor_type)
     return AgentSpec(
@@ -128,6 +133,7 @@ def test_researcher_inherits_parent_sandbox_egress() -> None:
         spec_version=1,
         name="test-parent",
         llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
         os_env=OSEnvSpec(type="caller_process", sandbox=sandbox),
     )
 
@@ -272,7 +278,11 @@ def testbuild_researcher_spec_copies_llm() -> None:
         model="groq/llama-4-scout",
         connection={"api_key": "test-key"},
     )
-    parent = AgentSpec(spec_version=1, llm=llm)
+    parent = AgentSpec(
+        spec_version=1,
+        llm=llm,
+        executor=ExecutorSpec(config={"harness": "claude-sdk"}),
+    )
     researcher = build_researcher_spec(parent)
     # Same LLM config object (reference copy, not deep copy —
     # the researcher doesn't modify it).
@@ -281,10 +291,137 @@ def testbuild_researcher_spec_copies_llm() -> None:
 
 
 def testbuild_researcher_spec_default_executor() -> None:
-    """Researcher should use default executor (omnigent)."""
+    """Researcher inherits the parent's omnigent executor type AND harness."""
     parent = _make_parent_spec()
     researcher = build_researcher_spec(parent)
     assert researcher.executor.type == "omnigent"
+    # The harness carries from the parent so the child is bootable (not the
+    # unspawnable literal "omnigent").
+    assert researcher.executor.harness_kind == "claude-sdk"
+
+
+def test_researcher_build_fails_loud_when_parent_has_no_harness() -> None:
+    """
+    A parent with ``ExecutorSpec(type="omnigent", config={})`` (no harness)
+    must NOT silently produce an unbootable child whose
+    ``harness_kind == "omnigent"`` — it must fail loud at build time.
+
+    The child ``__web_researcher`` session is created without a per-session
+    ``harness_override``, so the runner resolves its harness solely from this
+    spec. A child carrying the literal ``"omnigent"`` would crash the runner
+    with ``unknown harness 'omnigent'`` (the original Layer-1 failure). The
+    resolved harness (e.g. an API ``harness_override`` on a spec with no
+    ``executor.config["harness"]``) is not visible at this call site, so
+    ``build_researcher_spec`` raises a clear, parent-naming error instead.
+    """
+    import pytest
+
+    from omnigent.errors import ErrorCode, OmnigentError
+
+    parent = AgentSpec(
+        spec_version=1,
+        name="no-harness-leg",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(type="omnigent", config={}),
+    )
+
+    with pytest.raises(OmnigentError) as exc_info:
+        build_researcher_spec(parent)
+
+    # Actionable: names the offending parent leg and the missing harness.
+    assert exc_info.value.code == ErrorCode.INVALID_INPUT
+    assert "no-harness-leg" in str(exc_info.value)
+    assert "harness" in str(exc_info.value).lower()
+
+
+def test_researcher_inherits_parent_harness_auth_and_model() -> None:
+    """
+    Regression: the reconstructed ``__web_researcher`` must run on the
+    PARENT LEG's harness with the parent's credentials and model.
+
+    ``build_researcher_spec`` previously copied only ``llm`` and built a
+    bare ``ExecutorSpec(max_iterations=5)``. That bare spec defaults
+    ``type`` to ``"omnigent"`` with an empty ``config``, so:
+
+    - Layer 1 (active): ``executor.harness_kind`` resolves to the literal
+      ``"omnigent"`` (no ``config["harness"]``), and the runner aborts the
+      researcher spawn with ``RuntimeError: unknown harness 'omnigent'``
+      before any model routing — every ``web_fetch`` fails on all legs.
+    - Layer 2 (latent): dropping the parent's ``auth`` and model strips the
+      researcher off the parent's provider, so a gateway model such as
+      ``z-ai/glm-5.2`` hits the native router with ``Unknown provider
+      'z-ai'`` and the codex / claude legs fail on missing credentials.
+
+    The harness spawn-env builders read ``executor.config["harness"]``
+    (harness selection), ``executor.model`` (NOT ``llm.model``), and
+    ``executor.auth`` / ``executor.connection`` (credentials + endpoint
+    overrides), so all of these must carry from the parent.
+    """
+    parent_auth = ProviderAuth(name="openrouter")
+    parent = AgentSpec(
+        spec_version=1,
+        name="pi-parent",
+        llm=LLMConfig(model="z-ai/glm-5.2"),
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "pi"},
+            model="z-ai/glm-5.2",
+            connection={"base_url": "https://openrouter.ai/api/v1"},
+            auth=parent_auth,
+        ),
+    )
+
+    researcher = build_researcher_spec(parent)
+
+    # Layer 1: the child must NOT be the bare "unknown harness 'omnigent'"
+    # spec — it carries the parent's harness selector.
+    assert researcher.executor.config.get("harness") == "pi", (
+        "Researcher dropped the parent's harness — the runner would abort "
+        f"with unknown harness {researcher.executor.harness_kind!r}."
+    )
+    assert researcher.executor.harness_kind == "pi", (
+        "harness_kind must resolve to the parent's harness, not the literal "
+        f"executor type; got {researcher.executor.harness_kind!r}."
+    )
+    assert researcher.executor.harness_kind != "omnigent"
+
+    # Layer 2: credentials + model must carry so the parent's provider routes
+    # the parent's model.
+    assert researcher.executor.auth is parent_auth, (
+        "Researcher dropped the parent's auth — the gateway model would hit "
+        "the native router (Unknown provider 'z-ai')."
+    )
+    assert researcher.executor.model == "z-ai/glm-5.2"
+    assert researcher.executor.connection == {"base_url": "https://openrouter.ai/api/v1"}
+
+    # The fast-cap is preserved.
+    assert researcher.executor.max_iterations == 5
+
+
+def test_researcher_drops_inline_os_env_from_executor_config() -> None:
+    """
+    ``executor.config["os_env"]`` is an inline-sub-spec translation artifact;
+    the researcher declares its own top-level ``os_env``. Carrying the config
+    ``os_env`` would re-introduce a stale sandbox mapping, so it is dropped
+    while every other routing key (e.g. ``harness``) is preserved.
+    """
+    parent = AgentSpec(
+        spec_version=1,
+        name="codex-parent",
+        llm=LLMConfig(model="openai/gpt-5.4"),
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex", "os_env": {"type": "caller_process"}},
+            model="openai/gpt-5.4",
+        ),
+    )
+
+    researcher = build_researcher_spec(parent)
+
+    assert researcher.executor.config.get("harness") == "codex"
+    assert "os_env" not in researcher.executor.config
+    # The explicit top-level os_env (which registers sys_os_shell) is intact.
+    assert researcher.os_env is not None
 
 
 def test_web_fetch_is_sync_in_sessions_native_mode() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `web_fetch` does not fetch directly — it dispatches a synthetic
  `__web_researcher` sub-agent that runs `curl` via `sys_os_shell`.
  `build_researcher_spec` built that child as a bare
  `ExecutorSpec(max_iterations=5)`, copying only the parent's `llm` and dropping
  the parent's executor **harness, `auth`, and `model`**.
- With `executor.type` defaulting to `"omnigent"` and an empty `config`, every
  fetch broke on **every leg**: Layer 1 — the runner aborted the researcher
  spawn with `unknown harness 'omnigent'`; Layer 2 (latent) — a gateway model
  like `z-ai/glm-5.2` hit the in-process native router (`Unknown provider
  'z-ai'`) and codex/claude lost their credentials.
- Fix: the researcher inherits the parent leg's `config["harness"]`, `model`,
  `auth`, `connection`, and `type`, so it runs on the **same** harness and
  provider as its parent. If the parent has no determinable harness, fail loud
  at build time naming the parent instead of letting the runner crash later.
  PR #817 reconstructs the researcher on a resolve-miss but calls this same
  function, so the bug persisted.

**ELI5:** An expert agent asks `web_fetch` to read a web page. `web_fetch`
quietly hires a tiny helper to run `curl`. The helper was being hired with **no
harness and no login**, so it couldn't even start (and every fetch failed before
any `curl` ran). Now the helper is hired onto the **same harness and login as
its boss**, so it starts, runs `curl`, and hands the page back. If the boss has
no usable harness, we now say so clearly up front instead of crashing cryptically.

### Flow + where it broke

```mermaid
flowchart TD
    A[expert agent calls web_fetch] --> B[build_researcher_spec builds __web_researcher child spec]
    B --> C[runner resolves child harness from the spec:<br/>config&#91;harness&#93; or type = harness_kind]
    C --> D[harness spawns; child runs curl via sys_os_shell] --> E[page content returned]

    B -. "BEFORE: bare ExecutorSpec — no harness/auth/model" .-> X1[Layer 1: harness_kind = 'omnigent'<br/>runner aborts: unknown harness 'omnigent']
    B -. "BEFORE: parent provider dropped" .-> X2[Layer 2: gateway model hits native router<br/>Unknown provider 'z-ai' / missing creds]
    B == "FIX: inherit harness + model + auth (+type)" ==> C
    B == "FIX: no determinable harness -> raise OmnigentError naming the parent" ==> G[clear build-time error, not a runner crash]
```

The fix lands in `build_researcher_spec` (`omnigent/tools/builtins/web_fetch.py`);
Layer 1 and Layer 2 both broke between steps **B** and **C**.

## Reproduction

Before the fix, an expert with the `web_fetch` builtin calling it on any leg
produced, in the host-runner log, at the researcher child-session create:

```
WARNING:omnigent.runner.app:harness spawn failed: unknown harness 'omnigent'; registered names: ['antigravity', ..., 'pi', 'pi-native', 'qwen', ...]
RuntimeError: unknown harness 'omnigent'; ...
... tool callback fired with no active turn context (tool=web_fetch); returning error
```

Every `web_fetch` failed on all three legs **before any `curl` ran**. On a
gateway leg (`model=z-ai/glm-5.2`) the latent Layer-2 failure surfaces as
`Unknown provider 'z-ai'` once Layer 1 is bypassed.

## Test Plan

Gates (fresh `uv sync --extra all --extra dev` worktree off `main`):

- `uv run ruff check .` → All checks passed
- `uv run ruff format --check` (changed files) → already formatted
- `uv run pre-commit run --files <changed>` → ruff/hygiene hooks Passed
- `uv run mypy omnigent/tools/builtins/web_fetch.py` → Success: no issues
- `uv run pytest tests/tools/builtins/test_web_fetch.py tests/runtime/test_workflow_subagent_resolution.py` → 24 passed
- `uv run pytest tests/tools/ tests/runtime/ tests/spec/ -n 8 --dist loadfile` → 2081 passed (5 pre-existing `tests/tools/test_manager.py` failures reproduce identically on unmodified `main` and are unrelated)

New unit tests in `tests/tools/builtins/test_web_fetch.py`: the reconstructed
spec carries the parent's harness/auth/model/connection (and is not the bare
`type=="omnigent"`/no-harness spec); the inline `executor.config` `os_env` is
dropped; a no-harness parent raises the clear error.

Fails-before / passes-after (production `web_fetch.py` reverted to this commit's
parent, the new tests run against it):

```
# BEFORE (old build_researcher_spec) - the 4 new researcher tests fail:
uv run pytest tests/tools/builtins/test_web_fetch.py -q
#   4 failed, 14 passed
#   FAILED testbuild_researcher_spec_default_executor
#   FAILED test_researcher_inherits_parent_harness_auth_and_model
#   FAILED test_researcher_drops_inline_os_env_from_executor_config
#   FAILED test_researcher_build_fails_loud_when_parent_has_no_harness
#   asserts vs the old bare spec:
#   ExecutorSpec(type='omnigent', config={}, model=None, connection=None, auth=None)

# AFTER (this commit):
uv run pytest tests/tools/builtins/test_web_fetch.py -q                  # 18 passed
uv run pytest tests/tools/builtins/test_web_fetch.py \\
  tests/runtime/test_workflow_subagent_resolution.py -q                 # 24 passed
```

Live branch-runtime validation (branch code run as a separate host/runner
against a running server; server not promoted):

- **claude-sdk leg — full end-to-end.** An agent with `web_fetch` was asked to
  fetch `https://example.com`. The `__web_researcher` child booted and ran:
  ```
  [CALL] sys_os_shell: {"command": "curl -sL \"https://example.com\" | head -60"}
  [MSG assistant] **Example Domain** ... Body: "This domain is for use in documentation
                  examples without needing permission. Avoid use in operations."
  ```
  The post-fix runner log shows **0** occurrences of `unknown harness 'omnigent'`
  and **0** of `Unknown provider` (vs. the pre-fix log, which contained the
  `unknown harness 'omnigent'` abort for the researcher child create).
- **pi/GLM leg — routing verified, with an honest caveat.** The pi harness
  booted and routed the gateway model:
  ```
  INFO:omnigent.runner.app:pi gateway routing: gateway=true base_url=None profile=None model=z-ai/glm-5.2
  ```
  with **0** `unknown harness 'omnigent'` and **0** `Unknown provider 'z-ai'` —
  the exact Layer-1 + Layer-2 signatures this change targets. **Caveat (no
  overclaim):** the parent GLM turn returned `HTTP 402` from the OpenRouter
  gateway (account credit limit) *before* it called `web_fetch`, so there is no
  full `curl` proof on this leg. The 402 originates at OpenRouter, which only
  confirms routing reached the gateway; it is unrelated to this change.

## Demo

N/A (non-visual engine fix).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is a spec-construction fix in the runner/tools layer, covered by focused
unit tests in `tests/tools/builtins/test_web_fetch.py` (harness/auth/model/
connection inheritance, the `os_env`-from-config drop, and the fail-loud guard)
plus the existing resolve-miss tests in
`tests/runtime/test_workflow_subagent_resolution.py` (fixtures updated to use
bootable harnessed parents, since the guard now rejects a harness-less child).
No new e2e test: the end-to-end path is gateway-bound (it spawns a real harness
against a live provider), so it was validated by the live branch-runtime run
above (claude-sdk leg, full `curl` end-to-end) rather than in CI.

The live routing proof above was produced on a build that inherited all the
routing-relevant fields (harness/model/auth/connection); only the non-routing
`context_window` (auto-detected) and the deprecated `profile` (subsumed by
`auth`) were trimmed afterward and are covered by the unit gates — i.e. the live
run validated the routing behavior, not the exact final byte-for-byte diff.

