### PR TITLE
feat(harnesses): route remaining native forwarders through the shared retry helper

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -21,6 +21,7 @@ from omnigent._native_post_delivery import (
     append_dead_letter,
     post_external_session_status,
     post_may_have_been_delivered,
+    post_session_event_with_retry,
 )
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
@@ -221,6 +222,9 @@ _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 _SUBAGENT_META_GLOB = "agent-*.meta.json"
 _DEFAULT_POLL_INTERVAL_S = 0.25
 _POST_TIMEOUT_S = 10.0
+_POST_MAX_ATTEMPTS = 3
+_POST_RETRY_DELAY_SECONDS = 0.1
+_POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 _MAX_SEEN_SOURCE_IDS = 2000
 _CURSOR_FINGERPRINT_BYTES = 256
 _FORK_COMMAND_NAMES = frozenset({"/branch", "/fork"})
@@ -253,6 +257,11 @@ _HOOK_EVENT_TO_STATUS: dict[str, str] = {
 }
 
 _logger = logging.getLogger(__name__)
+
+
+async def _sleep(seconds: float) -> None:
+    """Stubbable indirection for the per-POST retry backoff."""
+    await asyncio.sleep(seconds)
 
 
 @dataclass
@@ -1811,19 +1820,19 @@ async def _forward_session_cost(
         model = status_state.get("model")
         if isinstance(model, str) and model:
             payload["model"] = model
-    try:
-        await _post_external_session_usage(
-            client,
-            session_id=session_id,
-            usage=payload,
-        )
-    except httpx.HTTPError as exc:
+    response = await _post_external_session_usage(
+        client,
+        session_id=session_id,
+        usage=payload,
+    )
+    if response is None or response.status_code >= 400:
+        # The post did not land (transport exhaustion or a non-2xx response);
+        # leave the cost dedupe behind so the next poll re-posts it.
         _logger.warning(
             "Failed to forward Claude session cost; session=%s bridge_dir=%s http_status=%s",
             session_id,
             bridge_dir,
-            _http_status_for_log(exc),
-            exc_info=True,
+            response.status_code if response is not None else None,
         )
         return
     if "cumulative_cost_usd" in payload:
@@ -2619,21 +2628,11 @@ async def _forward_available_status_events(
             # the rest of the hook stream.
             compaction_status = _compaction_status_for_record(record)
             if compaction_status is not None:
-                try:
-                    await _post_external_compaction_status(
-                        client,
-                        session_id=session_id,
-                        status=compaction_status,
-                    )
-                except httpx.HTTPError:
-                    _logger.warning(
-                        "Failed to forward Claude compaction status; "
-                        "session=%s event_cursor=%s status=%s",
-                        session_id,
-                        record.event_cursor,
-                        compaction_status,
-                        exc_info=True,
-                    )
+                await _post_external_compaction_status(
+                    client,
+                    session_id=session_id,
+                    status=compaction_status,
+                )
                 # Persist a compaction item so session resume knows
                 # the compaction boundary. Without this, rebuilding
                 # the transcript from the conversation DB loads the
@@ -2699,19 +2698,11 @@ async def _forward_available_status_events(
                     for tid in task_order
                 ]
             if todos_to_post is not None:
-                try:
-                    await _post_external_session_todos(
-                        client,
-                        session_id=session_id,
-                        todos=todos_to_post,
-                    )
-                except httpx.HTTPError:
-                    _logger.warning(
-                        "Failed to forward Claude todos from hook; session=%s event_cursor=%s",
-                        session_id,
-                        record.event_cursor,
-                        exc_info=True,
-                    )
+                await _post_external_session_todos(
+                    client,
+                    session_id=session_id,
+                    todos=todos_to_post,
+                )
             durable = next_durable
             await _write_hook_state_async(bridge_dir, durable)
             continue
@@ -3090,26 +3081,27 @@ async def _forward_available_items(
         resolved_context_window is not None and resolved_context_window != dedupe.context_window
     )
     if usage_changed or window_changed:
-        try:
-            await _post_external_session_usage(
-                client,
-                session_id=session_id,
-                usage=posted_usage,
-                context_window=resolved_context_window,
-            )
-            if usage_changed:
-                dedupe.usage = posted_usage
-            if window_changed:
-                dedupe.context_window = resolved_context_window
-        except httpx.HTTPError as exc:
+        response = await _post_external_session_usage(
+            client,
+            session_id=session_id,
+            usage=posted_usage,
+            context_window=resolved_context_window,
+        )
+        if response is None or response.status_code >= 400:
+            # The post did not land; leave the usage/context-window dedupe
+            # behind so the next poll re-posts the current snapshot.
             _logger.warning(
                 "Failed to forward Claude transcript usage; session=%s bridge_dir=%s "
                 "http_status=%s",
                 session_id,
                 bridge_dir,
-                _http_status_for_log(exc),
-                exc_info=True,
+                response.status_code if response is not None else None,
             )
+        else:
+            if usage_changed:
+                dedupe.usage = posted_usage
+            if window_changed:
+                dedupe.context_window = resolved_context_window
     # Mirror a TUI-side `/model` switch to the web picker. The transcript
     # records the resolved concrete id (e.g. "claude-opus-4-8"); collapse
     # it to the picker's tier alias. This transcript-derived observation
@@ -3347,66 +3339,60 @@ async def _post_clear_supersession(
         # state, but if that ever collapses to the new id, posting here
         # would dump the "you were cleared" banner onto the active chat.
         return
-    try:
-        status_resp = await client.post(
-            f"/v1/sessions/{url_component(old_session_id)}/events",
-            json={
-                "type": "external_session_status",
-                "data": {"status": "idle"},
-            },
-        )
-        status_resp.raise_for_status()
-    except httpx.HTTPError:
-        _logger.warning(
-            "Failed to post /clear supersession idle status; old_session=%s new_session=%s",
-            old_session_id,
-            new_session_id,
-            exc_info=True,
-        )
+    await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{url_component(old_session_id)}/events",
+        payload={
+            "type": "external_session_status",
+            "data": {"status": "idle"},
+        },
+        event_type="external_session_status",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
+    )
     notice = (
         "This conversation was ended by `/clear`. "
         f"Continue in [the new chat](/c/{new_session_id}). "
         "You can also send a message here to resume this conversation."
     )
-    try:
-        item_resp = await client.post(
-            f"/v1/sessions/{url_component(old_session_id)}/events",
-            json={
-                "type": "external_conversation_item",
-                "data": {
-                    "item_type": "message",
-                    "item_data": {
-                        "role": "assistant",
-                        "agent": agent_name,
-                        "content": [{"type": "output_text", "text": notice}],
-                    },
+    await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{url_component(old_session_id)}/events",
+        payload={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "message",
+                "item_data": {
+                    "role": "assistant",
+                    "agent": agent_name,
+                    "content": [{"type": "output_text", "text": notice}],
                 },
             },
-        )
-        item_resp.raise_for_status()
-    except httpx.HTTPError:
-        _logger.warning(
-            "Failed to post /clear supersession notice; old_session=%s new_session=%s",
-            old_session_id,
-            new_session_id,
-            exc_info=True,
-        )
-    try:
-        event_resp = await client.post(
-            f"/v1/sessions/{url_component(old_session_id)}/events",
-            json={
-                "type": "external_session_superseded",
-                "data": {"target_conversation_id": new_session_id},
-            },
-        )
-        event_resp.raise_for_status()
-    except httpx.HTTPError:
-        _logger.warning(
-            "Failed to post /clear supersession redirect event; old_session=%s new_session=%s",
-            old_session_id,
-            new_session_id,
-            exc_info=True,
-        )
+        },
+        event_type="external_conversation_item",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
+    )
+    await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{url_component(old_session_id)}/events",
+        payload={
+            "type": "external_session_superseded",
+            "data": {"target_conversation_id": new_session_id},
+        },
+        event_type="external_session_superseded",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
+    )
 
 
 async def _post_external_conversation_item(
@@ -3576,7 +3562,7 @@ async def _post_external_session_usage(
     session_id: str,
     usage: Mapping[str, float | str] | None,
     context_window: int | None = None,
-) -> None:
+) -> httpx.Response | None:
     """
     Post one ``external_session_usage`` event to the Sessions API.
 
@@ -3598,12 +3584,18 @@ async def _post_external_session_usage(
     if context_window is not None:
         payload["context_window"] = context_window
     if not payload:
-        return
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "external_session_usage", "data": payload},
+        return None
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={"type": "external_session_usage", "data": payload},
+        event_type="external_session_usage",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 def _model_alias_for(model: str | None) -> str | None:
@@ -3638,7 +3630,7 @@ async def _post_external_model_change(
     *,
     session_id: str,
     model: str,
-) -> None:
+) -> httpx.Response | None:
     """
     Post one ``external_model_change`` event to the Sessions API.
 
@@ -3651,11 +3643,17 @@ async def _post_external_model_change(
     :param model: Tier alias the session is now on, e.g. ``"opus"``.
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "external_model_change", "data": {"model": model}},
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={"type": "external_model_change", "data": {"model": model}},
+        event_type="external_model_change",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def _post_model_change_if_new(
@@ -3697,21 +3695,20 @@ async def _post_model_change_if_new(
         # posting so it can't clobber a pending silent model handoff.
         dedupe.posted_model = dedupe.observed_model
         return
-    try:
-        await _post_external_model_change(
-            client,
-            session_id=session_id,
-            model=dedupe.observed_model,
-        )
-        dedupe.posted_model = dedupe.observed_model
-    except httpx.HTTPError:
+    response = await _post_external_model_change(
+        client,
+        session_id=session_id,
+        model=dedupe.observed_model,
+    )
+    if response is None or response.status_code >= 400:
         # Leave posted_model behind observed_model so the next poll retries.
         _logger.warning(
             "Failed to mirror model change to Omnigent session=%s; model pill / "
             "cost-budget gate may lag until the next poll",
             session_id,
-            exc_info=True,
         )
+        return
+    dedupe.posted_model = dedupe.observed_model
 
 
 async def _forward_model_from_status(
@@ -3760,7 +3757,7 @@ async def _post_external_compaction_status(
     *,
     session_id: str,
     status: str,
-) -> None:
+) -> httpx.Response | None:
     """
     Post one ``external_compaction_status`` event to the Sessions API.
 
@@ -3780,14 +3777,20 @@ async def _post_external_compaction_status(
     :returns: None.
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={
             "type": "external_compaction_status",
             "data": {"status": status},
         },
+        event_type="external_compaction_status",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def _persist_native_compaction_item(
@@ -3795,7 +3798,7 @@ async def _persist_native_compaction_item(
     *,
     session_id: str,
     bridge_dir: Path,
-) -> None:
+) -> httpx.Response | None:
     """
     Persist a compaction boundary item to the conversation store.
 
@@ -3854,14 +3857,20 @@ async def _persist_native_compaction_item(
     if compacted_messages is not None:
         event_data["compacted_messages"] = compacted_messages
 
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={
             "type": "compaction",
             "data": event_data,
         },
+        event_type="compaction",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def _patch_external_session_id(
@@ -3984,7 +3993,7 @@ async def _post_external_session_todos(
     *,
     session_id: str,
     todos: list[dict[str, Any]],
-) -> None:
+) -> httpx.Response | None:
     """
     Post one ``external_session_todos`` event to the Sessions API.
 
@@ -3996,11 +4005,17 @@ async def _post_external_session_todos(
     :returns: None.
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "external_session_todos", "data": {"todos": todos}},
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={"type": "external_session_todos", "data": {"todos": todos}},
+        event_type="external_session_todos",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 def _is_permanent_http_error(exc: httpx.HTTPError) -> bool:

--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -48,7 +48,10 @@ from pathlib import Path
 import httpx
 
 from omnigent import cursor_native_status
-from omnigent._native_post_delivery import post_may_have_been_delivered
+from omnigent._native_post_delivery import (
+    post_may_have_been_delivered,
+    post_session_event_with_retry,
+)
 from omnigent.cursor_native_bridge import FORK_HISTORY_CLOSE_TAG, FORK_HISTORY_OPEN_TAG
 
 _logger = logging.getLogger(__name__)
@@ -58,6 +61,9 @@ _logger = logging.getLogger(__name__)
 #: latency; ~0.7s keeps the chat view feeling live.
 _DEFAULT_POLL_INTERVAL_S = 0.7
 _POST_TIMEOUT_S = 30.0
+_POST_MAX_ATTEMPTS = 3
+_POST_RETRY_DELAY_SECONDS = 0.1
+_POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 
 #: Max length of a mirrored item's ``response_id``. The server stores it in
 #: ``conversation_items.response_id``, a ``VARCHAR(64)`` (see
@@ -604,19 +610,25 @@ async def _post_model_change_if_new(
         state.observed = model
     if state.observed is None or state.observed == state.posted:
         return
-    try:
-        resp = await client.post(
-            f"/v1/sessions/{session_id}/events",
-            json={"type": "external_model_change", "data": {"model": state.observed}},
-        )
-        resp.raise_for_status()
-        state.posted = state.observed
-    except httpx.HTTPError:
+    response = await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={"type": "external_model_change", "data": {"model": state.observed}},
+        event_type="external_model_change",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
+    )
+    if response is None or response.status_code >= 400:
         # Leave posted behind observed so the next poll retries.
         _logger.warning(
             "Failed to mirror cursor model change to session=%s; web picker may lag",
             session_id,
         )
+        return
+    state.posted = state.observed
 
 
 def _read_new_items(store_path: Path, last_rowid: int, agent_name: str) -> list[_MirrorItem]:
@@ -772,7 +784,7 @@ async def _post_conversation_item(
 
 async def _post_external_compaction_status(
     client: httpx.AsyncClient, *, session_id: str, status: str
-) -> None:
+) -> httpx.Response | None:
     """POST one ``external_compaction_status`` event to the Sessions API.
 
     The server republishes this as the ``response.compaction.completed`` SSE the
@@ -786,16 +798,21 @@ async def _post_external_compaction_status(
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
     :param status: Compaction status value, e.g. ``"completed"``.
-    :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={
             "type": "external_compaction_status",
             "data": {"status": status},
         },
+        event_type="external_compaction_status",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def _persist_native_compaction_item(
@@ -858,11 +875,17 @@ async def _persist_native_compaction_item(
     if compacted_messages:
         compaction_data["compacted_messages"] = compacted_messages
 
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "compaction", "data": compaction_data},
+    await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={"type": "compaction", "data": compaction_data},
+        event_type="compaction",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def forward_cursor_store_to_session(
@@ -1020,19 +1043,9 @@ async def forward_cursor_store_to_session(
                                 # which retries connection loss forever. Matches
                                 # the claude forwarder's best-effort posture and
                                 # never desyncs the mirror, so it is acceptable.
-                                try:
-                                    await _post_external_compaction_status(
-                                        client, session_id=session_id, status="completed"
-                                    )
-                                except httpx.HTTPError:
-                                    _logger.warning(
-                                        "cursor forwarder could not post "
-                                        "compaction-completed; the web UI spinner "
-                                        "may linger; session=%s rowid=%s",
-                                        session_id,
-                                        item.rowid,
-                                        exc_info=True,
-                                    )
+                                await _post_external_compaction_status(
+                                    client, session_id=session_id, status="completed"
+                                )
                                 try:
                                     await _persist_native_compaction_item(
                                         client,
@@ -1192,6 +1205,11 @@ async def forward_cursor_store_to_session(
 def _supervisor_monotonic() -> float:
     """Indirection so tests can stub the supervisor's clock."""
     return time.monotonic()
+
+
+async def _sleep(seconds: float) -> None:
+    """Stubbable indirection for the per-POST retry backoff."""
+    await asyncio.sleep(seconds)
 
 
 async def _supervisor_sleep(seconds: float) -> None:

--- a/omnigent/goose_native_forwarder.py
+++ b/omnigent/goose_native_forwarder.py
@@ -37,6 +37,8 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_session_event_with_retry
+
 _logger = logging.getLogger(__name__)
 
 #: Seconds between store polls. Goose flushes a ``messages`` row per agentic
@@ -46,6 +48,9 @@ _logger = logging.getLogger(__name__)
 #: rather than lagging a beat behind each one. 0.4s balances liveness vs. load.
 _DEFAULT_POLL_INTERVAL_S = 0.4
 _POST_TIMEOUT_S = 30.0
+_POST_MAX_ATTEMPTS = 3
+_POST_RETRY_DELAY_SECONDS = 0.1
+_POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 
 # Supervisor backoff (mirrors cursor_native_forwarder.supervise_cursor_forwarder).
 _SUPERVISOR_INITIAL_BACKOFF_S = 1.0
@@ -300,11 +305,12 @@ def _read_new_items(
 
 async def _post_conversation_item(
     client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
-) -> None:
+) -> httpx.Response | None:
     """POST one mirrored item as an ``external_conversation_item`` event."""
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={
             "type": "external_conversation_item",
             "data": {
                 "item_type": item.item_type,
@@ -312,8 +318,13 @@ async def _post_conversation_item(
                 "response_id": item.response_id,
             },
         },
+        event_type="external_conversation_item",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def forward_goose_store_to_session(
@@ -374,7 +385,11 @@ async def forward_goose_store_to_session(
                     )
                     for item in items:
                         if item.item_type:
-                            await _post_conversation_item(client, session_id=session_id, item=item)
+                            response = await _post_conversation_item(
+                                client, session_id=session_id, item=item
+                            )
+                            if response is None or response.status_code >= 400:
+                                break
                         last_id = item.msg_id
                         _write_state(
                             bridge_dir,
@@ -394,6 +409,11 @@ async def forward_goose_store_to_session(
 def _supervisor_monotonic() -> float:
     """Indirection so tests can stub the supervisor's clock."""
     return time.monotonic()
+
+
+async def _sleep(seconds: float) -> None:
+    """Stubbable indirection for the per-POST retry backoff."""
+    await asyncio.sleep(seconds)
 
 
 async def _supervisor_sleep(seconds: float) -> None:

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -52,6 +52,7 @@ from pathlib import Path
 import httpx
 
 from omnigent import hermes_native_status
+from omnigent._native_post_delivery import post_session_event_with_retry
 
 _logger = logging.getLogger(__name__)
 
@@ -61,6 +62,9 @@ _logger = logging.getLogger(__name__)
 #: 0.4s balances liveness vs. load.
 _DEFAULT_POLL_INTERVAL_S = 0.4
 _POST_TIMEOUT_S = 30.0
+_POST_MAX_ATTEMPTS = 3
+_POST_RETRY_DELAY_SECONDS = 0.1
+_POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 
 # Supervisor backoff (mirrors goose_native_forwarder.supervise_goose_forwarder).
 _SUPERVISOR_INITIAL_BACKOFF_S = 1.0
@@ -172,20 +176,19 @@ class _HermesUsageTracker:
             self._model = await asyncio.to_thread(_read_model_from_hermes_config, self._bridge_dir)
         if not self._model or self._model == self._posted_model:
             return
-        try:
-            resp = await self._client.post(
-                f"/v1/sessions/{self._session_id}/events",
-                json={
-                    "type": "external_session_usage",
-                    "data": {"model": self._model},
-                },
-            )
-            if resp.status_code < 400:
-                self._posted_model = self._model
-            else:
-                _logger.warning("hermes usage tracker POST failed: status=%s", resp.status_code)
-        except httpx.HTTPError:
-            _logger.debug("hermes usage tracker POST failed", exc_info=True)
+        response = await post_session_event_with_retry(
+            client=self._client,
+            url=f"/v1/sessions/{self._session_id}/events",
+            payload={"type": "external_session_usage", "data": {"model": self._model}},
+            event_type="external_session_usage",
+            max_attempts=_POST_MAX_ATTEMPTS,
+            retry_status_codes=_POST_RETRY_STATUS_CODES,
+            sleep=_sleep,
+            retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+            logger_name=__name__,
+        )
+        if response is not None and response.status_code < 400:
+            self._posted_model = self._model
 
 
 def _hermes_home() -> Path:
@@ -647,11 +650,12 @@ async def _post_external_session_status(
 
 async def _post_conversation_item(
     client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
-) -> None:
+) -> httpx.Response | None:
     """POST one mirrored item as an ``external_conversation_item`` event."""
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={
             "type": "external_conversation_item",
             "data": {
                 "item_type": item.item_type,
@@ -659,8 +663,13 @@ async def _post_conversation_item(
                 "response_id": item.response_id,
             },
         },
+        event_type="external_conversation_item",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 def _has_new_compaction(db_path: Path, hermes_session_id: str) -> bool:
@@ -732,11 +741,17 @@ async def _persist_hermes_compaction_item(
     if compacted_messages:
         data["compacted_messages"] = compacted_messages
 
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "compaction", "data": data},
+    await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={"type": "compaction", "data": data},
+        event_type="compaction",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def forward_hermes_store_to_session(
@@ -843,9 +858,11 @@ async def forward_hermes_store_to_session(
                         )
                         for item in items:
                             if item.item_type:
-                                await _post_conversation_item(
+                                response = await _post_conversation_item(
                                     client, session_id=session_id, item=item
                                 )
+                                if response is None or response.status_code >= 400:
+                                    break
                             last_id = item.msg_id
                             _write_state(
                                 bridge_dir,
@@ -973,6 +990,11 @@ async def forward_hermes_store_to_session(
 def _supervisor_monotonic() -> float:
     """Indirection so tests can stub the supervisor's clock."""
     return time.monotonic()
+
+
+async def _sleep(seconds: float) -> None:
+    """Stubbable indirection for the per-POST retry backoff."""
+    await asyncio.sleep(seconds)
 
 
 async def _supervisor_sleep(seconds: float) -> None:

--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -29,6 +29,7 @@ from urllib.parse import quote
 
 import httpx
 
+from omnigent._native_post_delivery import post_session_event_with_retry
 from omnigent.opencode_native_bridge import update_active_message_id, update_last_event_id
 from omnigent.opencode_native_client import OpenCodeClient, OpenCodeEvent
 from omnigent.opencode_native_permissions import (
@@ -75,10 +76,18 @@ _OPENCODE_REAUTH_HINT = (
 
 # Bound the dedupe set so a long-lived session can't grow it without limit.
 _MAX_DEDUPE_KEYS = 8192
+_POST_MAX_ATTEMPTS = 3
+_POST_RETRY_DELAY_SECONDS = 0.1
+_POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 
 # Policy verdict resolver: receives a normalized policy input and returns a
 # verdict mapping (or None when no policy is configured / reachable).
 PolicyEvaluator = Callable[[Mapping[str, Any]], Awaitable[Mapping[str, Any] | None]]
+
+
+async def _sleep(seconds: float) -> None:
+    """Stubbable indirection for the per-POST retry backoff."""
+    await asyncio.sleep(seconds)
 
 
 @dataclass
@@ -321,25 +330,27 @@ class OpenCodeNativeForwarder:
 
     async def _post_event(self, event_type: str, data: dict[str, Any]) -> httpx.Response | None:
         """
-        POST one Omnigent session event with a single retry.
+        POST one Omnigent session event with bounded transient retries.
 
         :param event_type: Omnigent event type, e.g.
             ``"external_session_status"``.
         :param data: Event data payload.
-        :returns: The HTTP response, or ``None`` on transport failure.
+        :returns: The final HTTP response, or ``None`` when all attempts raised
+            transport errors (or after an ambiguous conversation-item failure).
         """
         url = f"/v1/sessions/{quote(self._session_id, safe='')}/events"
         payload = {"type": event_type, "data": data}
-        try:
-            return await self._server.post(url, json=payload)
-        except httpx.HTTPError:
-            _logger.warning(
-                "OpenCode forwarder failed to post %s for session=%s",
-                event_type,
-                self._session_id,
-                exc_info=True,
-            )
-            return None
+        return await post_session_event_with_retry(
+            client=self._server,
+            url=url,
+            payload=payload,
+            event_type=event_type,
+            max_attempts=_POST_MAX_ATTEMPTS,
+            retry_status_codes=_POST_RETRY_STATUS_CODES,
+            sleep=_sleep,
+            retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+            logger_name=__name__,
+        )
 
     async def _post_status(self, status: str, *, extra: Mapping[str, Any] | None = None) -> None:
         """Publish a coarse session status edge."""

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -57,6 +57,7 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_session_event_with_retry
 from omnigent.qwen_native_bridge import events_file_path
 
 _logger = logging.getLogger(__name__)
@@ -65,6 +66,9 @@ _logger = logging.getLogger(__name__)
 #: sub-second cadence keeps the mirrored chat tracking the terminal step by step.
 _DEFAULT_POLL_INTERVAL_S = 0.4
 _POST_TIMEOUT_S = 30.0
+_POST_MAX_ATTEMPTS = 3
+_POST_RETRY_DELAY_SECONDS = 0.1
+_POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 
 # Supervisor backoff (mirrors goose_native_forwarder.supervise_goose_forwarder).
 _SUPERVISOR_INITIAL_BACKOFF_S = 1.0
@@ -268,11 +272,12 @@ def _read_new_events(
 
 async def _post_conversation_item(
     client: httpx.AsyncClient, *, session_id: str, item: _MirrorItem
-) -> None:
+) -> httpx.Response | None:
     """POST one mirrored item as an ``external_conversation_item`` event."""
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={
             "type": "external_conversation_item",
             "data": {
                 "item_type": item.item_type,
@@ -280,8 +285,13 @@ async def _post_conversation_item(
                 "response_id": item.response_id,
             },
         },
+        event_type="external_conversation_item",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def forward_qwen_events_to_session(
@@ -325,10 +335,16 @@ async def forward_qwen_events_to_session(
                 items, new_offset = await asyncio.to_thread(
                     _read_new_events, target, offset, seen, agent_name
                 )
+                posted_all = True
                 for item in items:
-                    await _post_conversation_item(client, session_id=session_id, item=item)
+                    response = await _post_conversation_item(
+                        client, session_id=session_id, item=item
+                    )
+                    if response is None or response.status_code >= 400:
+                        posted_all = False
+                        break
                     seen[item.uuid] = None
-                if new_offset != offset or items:
+                if posted_all and (new_offset != offset or items):
                     offset = new_offset
                     _write_state(
                         bridge_dir,
@@ -348,6 +364,11 @@ async def forward_qwen_events_to_session(
 def _supervisor_monotonic() -> float:
     """Indirection so tests can stub the supervisor's clock."""
     return time.monotonic()
+
+
+async def _sleep(seconds: float) -> None:
+    """Stubbable indirection for the per-POST retry backoff."""
+    await asyncio.sleep(seconds)
 
 
 async def _supervisor_sleep(seconds: float) -> None:
@@ -478,13 +499,19 @@ def _read_new_compaction_statuses(recording: Path, offset: int) -> tuple[list[st
 
 async def _post_external_compaction_status(
     client: httpx.AsyncClient, *, session_id: str, status: str
-) -> None:
+) -> httpx.Response | None:
     """POST one ``external_compaction_status`` event; the server republishes the SSE."""
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={"type": "external_compaction_status", "data": {"status": status}},
+    return await post_session_event_with_retry(
+        client=client,
+        url=f"/v1/sessions/{session_id}/events",
+        payload={"type": "external_compaction_status", "data": {"status": status}},
+        event_type="external_compaction_status",
+        max_attempts=_POST_MAX_ATTEMPTS,
+        retry_status_codes=_POST_RETRY_STATUS_CODES,
+        sleep=_sleep,
+        retry_delay=lambda attempt: _POST_RETRY_DELAY_SECONDS * attempt,
+        logger_name=__name__,
     )
-    resp.raise_for_status()
 
 
 async def supervise_qwen_compaction_mirror(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -684,6 +684,251 @@ async def test_post_clear_supersession_swallows_post_failure() -> None:
 
 
 @pytest.mark.asyncio
+async def test_migrated_posts_use_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Migrated Claude event posts route through the shared retry helper."""
+    calls: list[dict[str, object]] = []
+
+    async def sink(**kwargs: object) -> httpx.Response:
+        calls.append(kwargs)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+    monkeypatch.setattr(forwarder, "post_session_event_with_retry", sink, raising=False)
+    client = AsyncMock()
+    client.get.return_value = httpx.Response(
+        200,
+        json={"data": [{"id": "item_123"}]},
+        request=httpx.Request("GET", "http://t/"),
+    )
+    with patch("omnigent.claude_native_forwarder.read_claude_session_id", return_value=None):
+        await forwarder._post_external_session_usage(
+            client,
+            session_id="conv_usage",
+            usage={"input_tokens": 1},
+            context_window=200000,
+        )
+        await forwarder._post_external_model_change(
+            client,
+            session_id="conv_model",
+            model="sonnet",
+        )
+        await forwarder._post_external_compaction_status(
+            client,
+            session_id="conv_compact_status",
+            status="completed",
+        )
+        await forwarder._persist_native_compaction_item(
+            client,
+            session_id="conv_compaction",
+            bridge_dir=tmp_path,
+        )
+        await forwarder._post_external_session_todos(
+            client,
+            session_id="conv_todos",
+            todos=[{"content": "Write tests", "status": "in_progress"}],
+        )
+        await forwarder._post_clear_supersession(
+            client,
+            old_session_id="conv old",
+            new_session_id="conv_new",
+            agent_name="claude-native-ui",
+        )
+
+    event_types = [call["event_type"] for call in calls]
+    assert event_types == [
+        "external_session_usage",
+        "external_model_change",
+        "external_compaction_status",
+        "compaction",
+        "external_session_todos",
+        "external_session_status",
+        "external_conversation_item",
+        "external_session_superseded",
+    ]
+    for call in calls:
+        payload = call["payload"]
+        assert isinstance(payload, dict)
+        assert payload["type"] == call["event_type"]
+    assert calls[0]["url"] == "/v1/sessions/conv_usage/events"
+    assert calls[5]["url"] == "/v1/sessions/conv%20old/events"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "post_event"),
+    [
+        (
+            "external_session_usage",
+            lambda client: forwarder._post_external_session_usage(
+                client,
+                session_id="conv_usage",
+                usage={"input_tokens": 1},
+            ),
+        ),
+        (
+            "external_model_change",
+            lambda client: forwarder._post_external_model_change(
+                client,
+                session_id="conv_model",
+                model="sonnet",
+            ),
+        ),
+    ],
+)
+async def test_migrated_post_records_connectivity_failure_for_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+    event_type: str,
+    post_event: Callable[[object], object],
+) -> None:
+    """Exhausted migrated POST transport failures populate the watchdog signal."""
+    from omnigent import _native_forwarder_health as health
+
+    class _AlwaysConnectError:
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(forwarder, "_sleep", no_sleep, raising=False)
+    health.clear()
+    try:
+        response = await post_event(_AlwaysConnectError())
+        assert response is None
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert event_type in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()
+
+
+@pytest.mark.asyncio
+async def test_compaction_post_records_connectivity_failure_for_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The migrated compaction POST records exhausted transport failures."""
+    from omnigent import _native_forwarder_health as health
+
+    class _CompactionClient:
+        async def get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+            del params
+            return httpx.Response(
+                200,
+                json={"data": [{"id": "item_123"}]},
+                request=httpx.Request("GET", url),
+            )
+
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(forwarder, "_sleep", no_sleep, raising=False)
+    health.clear()
+    try:
+        response = await forwarder._persist_native_compaction_item(
+            _CompactionClient(),  # type: ignore[arg-type]
+            session_id="conv_compaction",
+            bridge_dir=tmp_path,
+        )
+        assert response is None
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert "compaction" in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failed_response", [503, None])
+async def test_model_change_does_not_advance_dedupe_after_helper_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_response: int | None,
+) -> None:
+    """A failed Shape-B model mirror leaves posted_model behind for retry."""
+    dedupe = forwarder._ForwardDedupeState(observed_model="opus", posted_model="opus")
+
+    async def sink(**kwargs: object) -> httpx.Response | None:
+        assert kwargs["event_type"] == "external_model_change"
+        if failed_response is None:
+            return None
+        return httpx.Response(failed_response, request=httpx.Request("POST", "http://t/"))
+
+    monkeypatch.setattr(forwarder, "post_session_event_with_retry", sink, raising=False)
+
+    await forwarder._post_model_change_if_new(
+        object(),  # type: ignore[arg-type]
+        session_id="conv_model",
+        dedupe=dedupe,
+        alias="sonnet",
+    )
+
+    assert dedupe.observed_model == "sonnet"
+    assert dedupe.posted_model == "opus"
+
+
+@pytest.mark.asyncio
+async def test_model_change_advances_dedupe_after_helper_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful Shape-B model mirror advances posted_model."""
+    dedupe = forwarder._ForwardDedupeState(observed_model="opus", posted_model="opus")
+
+    async def sink(**kwargs: object) -> httpx.Response:
+        assert kwargs["event_type"] == "external_model_change"
+        return httpx.Response(202, request=httpx.Request("POST", "http://t/"))
+
+    monkeypatch.setattr(forwarder, "post_session_event_with_retry", sink, raising=False)
+
+    await forwarder._post_model_change_if_new(
+        object(),  # type: ignore[arg-type]
+        session_id="conv_model",
+        dedupe=dedupe,
+        alias="sonnet",
+    )
+
+    assert dedupe.observed_model == "sonnet"
+    assert dedupe.posted_model == "sonnet"
+
+
+@pytest.mark.asyncio
+async def test_tracker_coupled_shared_leaves_still_raise_on_http_error() -> None:
+    """Shared tracker-coupled leaves must keep raising httpx.HTTPError."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, request=_request, json={"error": "boom"})
+
+    item = ClaudeTranscriptItem(
+        source_id="source_1",
+        item_type="message",
+        data={"role": "assistant", "content": []},
+        response_id="response_1",
+    )
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        with pytest.raises(httpx.HTTPError):
+            await forwarder._post_external_conversation_item(
+                client,
+                session_id="conv_x",
+                item=item,
+            )
+        with pytest.raises(httpx.HTTPError):
+            await forwarder.post_external_session_status(
+                client,
+                session_id="conv_x",
+                status="idle",
+            )
+
+
+@pytest.mark.asyncio
 async def test_clear_hook_consumes_hook_rotated_session_without_duplicate_fork(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3581,11 +3826,11 @@ async def test_forwarder_retries_model_post_after_transient_failure(tmp_path: Pa
     model_posts: list[dict[str, Any]] = []
 
     def _handle_request(request: httpx.Request) -> httpx.Response:
-        """Fail the FIRST external_model_change POST (503); accept the rest."""
+        """Fail the first helper retry window for external_model_change; accept the rest."""
         body = json.loads(request.content.decode("utf-8"))
         if body["type"] == "external_model_change":
             model_posts.append(body["data"])
-            if len(model_posts) == 1:
+            if len(model_posts) <= forwarder._POST_MAX_ATTEMPTS:
                 return httpx.Response(503, json={"error": "transient"})
         return httpx.Response(202, json={})
 
@@ -3613,7 +3858,7 @@ async def test_forwarder_retries_model_post_after_transient_failure(tmp_path: Pa
         with transcript_path.open("a", encoding="utf-8") as fh:
             fh.write(_assistant("a2", "claude-sonnet-4-6") + "\n")
         await _poll()
-        assert model_posts == [{"model": "sonnet"}]  # attempted once
+        assert model_posts == [{"model": "sonnet"}] * forwarder._POST_MAX_ATTEMPTS
         assert dedupe.posted_model == "opus"  # NOT advanced — POST failed
         assert dedupe.observed_model == "sonnet"  # but remembered
 
@@ -3621,7 +3866,7 @@ async def test_forwarder_retries_model_post_after_transient_failure(tmp_path: Pa
         with transcript_path.open("a", encoding="utf-8") as fh:
             fh.write(_user("u1") + "\n")
         await _poll()
-        assert model_posts == [{"model": "sonnet"}, {"model": "sonnet"}]  # retried
+        assert model_posts == [{"model": "sonnet"}] * (forwarder._POST_MAX_ATTEMPTS + 1)
         assert dedupe.posted_model == "sonnet"  # now committed
 
 
@@ -5358,6 +5603,118 @@ def _transcript_state_for(transcript_path: Path) -> forwarder.TranscriptForwardS
 
 
 @pytest.mark.asyncio
+async def test_forward_available_items_leaves_usage_dedupe_after_failed_post(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A rejected usage POST leaves dedupe behind so the next poll retries."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "already forwarded")
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        seen_source_ids=("u1:0:message",),
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+    monkeypatch.setattr(
+        forwarder,
+        "read_claude_context_state",
+        lambda _bridge: {
+            "context_window_size": 200_000,
+            "current_usage": {"input_tokens": 7, "output_tokens": 3},
+        },
+    )
+    dedupe = forwarder._ForwardDedupeState(
+        usage={"context_tokens": 1, "input_tokens": 1, "output_tokens": 0},
+        context_window=100_000,
+    )
+    posts: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        if body["type"] == "external_session_usage":
+            posts.append(body["data"])
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(202, json={})
+
+    transport = httpx.MockTransport(_handle_request)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=state,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=dedupe,
+        )
+
+    assert posts == [
+        {
+            "context_tokens": 7,
+            "input_tokens": 7,
+            "output_tokens": 3,
+            "context_window": 200_000,
+        }
+    ]
+    assert dedupe.usage == {"context_tokens": 1, "input_tokens": 1, "output_tokens": 0}
+    assert dedupe.context_window == 100_000
+
+
+@pytest.mark.asyncio
+async def test_forward_available_items_advances_usage_dedupe_after_successful_post(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A successful usage POST advances both usage and context-window dedupe."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "already forwarded")
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        seen_source_ids=("u1:0:message",),
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+    monkeypatch.setattr(
+        forwarder,
+        "read_claude_context_state",
+        lambda _bridge: {
+            "context_window_size": 200_000,
+            "current_usage": {"input_tokens": 7, "output_tokens": 3},
+        },
+    )
+    dedupe = forwarder._ForwardDedupeState(
+        usage={"context_tokens": 1, "input_tokens": 1, "output_tokens": 0},
+        context_window=100_000,
+    )
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        if body["type"] == "external_session_usage":
+            return httpx.Response(202, json={})
+        return httpx.Response(202, json={})
+
+    transport = httpx.MockTransport(_handle_request)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=state,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=dedupe,
+        )
+
+    assert dedupe.usage == {"context_tokens": 7, "input_tokens": 7, "output_tokens": 3}
+    assert dedupe.context_window == 200_000
+
+
+@pytest.mark.asyncio
 async def test_assistant_item_held_until_its_deltas_forward(tmp_path: Path) -> None:
     """
     An assistant item whose deltas haven't fully forwarded is deferred.
@@ -6080,6 +6437,55 @@ async def test_forward_session_cost_posts_status_when_no_subagents(
     assert dedupe.posted_policy_cost == pytest.approx(0.25)
 
 
+@pytest.mark.asyncio
+async def test_forward_session_cost_leaves_dedupe_after_failed_post(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A rejected cost POST leaves both cost dedupe fields behind."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    parent = tmp_path / "sess.jsonl"
+    parent.write_text("parent", encoding="utf-8")
+    monkeypatch.setattr(
+        forwarder, "read_claude_context_state", lambda _bridge: {"total_cost_usd": 0.25}
+    )
+
+    def _fail_estimate(**_kwargs: Any) -> float | None:
+        raise AssertionError("estimator must not run without sub-agents")
+
+    monkeypatch.setattr(forwarder, "_session_cost_estimate", _fail_estimate)
+    dedupe = forwarder._ForwardDedupeState()
+    posted: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if body.get("type") == "external_session_usage":
+            posted.append(body["data"])
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(202, json={})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        await forwarder._forward_session_cost(
+            client=client,
+            session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            parent_transcript_path=parent,
+            subagent_state=forwarder.SubagentForwardState(subagents={}),
+            dedupe=dedupe,
+            cost_cache={},
+        )
+
+    assert posted == [
+        {
+            "cumulative_cost_usd": pytest.approx(0.25),
+            "policy_cost_usd": pytest.approx(0.25),
+        }
+    ]
+    assert dedupe.posted_cost is None
+    assert dedupe.posted_policy_cost is None
+
+
 def test_parse_json_response_returns_value_on_valid_json() -> None:
     """
     A normal JSON body parses through ``_parse_json_response`` unchanged.
@@ -6238,8 +6644,7 @@ async def test_persist_native_compaction_item_posts_compaction_event(tmp_path: P
     get_response.raise_for_status = MagicMock()
     get_response.json.return_value = {"data": [{"id": "item_123"}]}
 
-    post_response = MagicMock()
-    post_response.raise_for_status = MagicMock()
+    post_response = httpx.Response(200, request=httpx.Request("POST", "http://t/"))
 
     client = AsyncMock()
     client.get.return_value = get_response
@@ -6299,8 +6704,7 @@ async def test_persist_native_compaction_item_empty_items_uses_fallback(tmp_path
     get_response.raise_for_status = MagicMock()
     get_response.json.return_value = {"data": []}
 
-    post_response = MagicMock()
-    post_response.raise_for_status = MagicMock()
+    post_response = httpx.Response(200, request=httpx.Request("POST", "http://t/"))
 
     client = AsyncMock()
     client.get.return_value = get_response

--- a/tests/test_cursor_native_forwarder.py
+++ b/tests/test_cursor_native_forwarder.py
@@ -420,6 +420,20 @@ class _RecordingClient:
         return httpx.Response(200, request=httpx.Request("POST", url))
 
 
+class _PostHelperSink:
+    """Capture calls to ``post_session_event_with_retry``."""
+
+    def __init__(self, responses: list[httpx.Response | None] | None = None) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._responses = list(responses or [])
+
+    async def __call__(self, **kwargs: object) -> httpx.Response | None:
+        self.calls.append(kwargs)
+        if self._responses:
+            return self._responses.pop(0)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+
 def _write_meta_model(con: sqlite3.Connection, model: str | None, *, key: str = "0") -> None:
     """Add cursor's ``meta`` table to *con* and store a hex-encoded model blob.
 
@@ -481,36 +495,45 @@ class TestReadLastUsedModel:
 
 class TestPostModelChangeIfNew:
     @pytest.mark.asyncio
-    async def test_first_observation_is_posted(self) -> None:
+    async def test_first_observation_is_posted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Unlike claude-native, cursor posts the FIRST observed model so an
         # un-pinned session shows the real cursor model instead of omnigent's
         # default ("fable") in the Web UI pill.
-        client = _RecordingClient()
+        sink = _PostHelperSink()
+        monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
         state = fwd._ModelMirrorState()
         await fwd._post_model_change_if_new(
-            client,  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
             session_id="conv_1",
             state=state,
             model="claude-sonnet-4-5",
         )
-        url, body = client.posts[0]
-        assert url == "/v1/sessions/conv_1/events"
-        assert body == {"type": "external_model_change", "data": {"model": "claude-sonnet-4-5"}}
+        assert len(sink.calls) == 1
+        assert sink.calls[0]["event_type"] == "external_model_change"
+        assert sink.calls[0]["url"] == "/v1/sessions/conv_1/events"
+        assert sink.calls[0]["payload"] == {
+            "type": "external_model_change",
+            "data": {"model": "claude-sonnet-4-5"},
+        }
         assert state.posted == "claude-sonnet-4-5"
 
     @pytest.mark.asyncio
-    async def test_switch_after_seed_posts_external_model_change(self) -> None:
-        client = _RecordingClient()
+    async def test_switch_after_seed_posts_external_model_change(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sink = _PostHelperSink()
+        monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
         state = fwd._ModelMirrorState(observed="composer-2.5", posted="composer-2.5")
         await fwd._post_model_change_if_new(
-            client,  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
             session_id="conv_1",
             state=state,
             model="gpt-5.2",
         )
-        url, body = client.posts[0]
-        assert url == "/v1/sessions/conv_1/events"
-        assert body == {"type": "external_model_change", "data": {"model": "gpt-5.2"}}
+        assert sink.calls[0]["payload"] == {
+            "type": "external_model_change",
+            "data": {"model": "gpt-5.2"},
+        }
         assert state.posted == "gpt-5.2"
 
     @pytest.mark.asyncio
@@ -539,22 +562,18 @@ class TestPostModelChangeIfNew:
         assert state.observed == "gpt-5.2"
 
     @pytest.mark.asyncio
-    async def test_failed_post_retries_next_poll(self) -> None:
-        class _FailingThenOkClient:
-            def __init__(self) -> None:
-                self.calls = 0
-
-            async def post(self, url: str, *, json: dict) -> httpx.Response:
-                self.calls += 1
-                if self.calls == 1:
-                    raise httpx.ConnectError("boom")
-                return httpx.Response(200, request=httpx.Request("POST", url))
-
-        client = _FailingThenOkClient()
+    async def test_failed_post_retries_next_poll(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sink = _PostHelperSink(
+            [
+                httpx.Response(503, request=httpx.Request("POST", "http://t/")),
+                httpx.Response(200, request=httpx.Request("POST", "http://t/")),
+            ]
+        )
+        monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
         state = fwd._ModelMirrorState(observed="composer-2.5", posted="composer-2.5")
         # First poll: switch observed, POST fails → posted stays behind observed.
         await fwd._post_model_change_if_new(
-            client,  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
             session_id="conv_1",
             state=state,
             model="gpt-5.2",
@@ -562,13 +581,37 @@ class TestPostModelChangeIfNew:
         assert state.posted == "composer-2.5" and state.observed == "gpt-5.2"
         # Next poll retries (model=None means "no fresh read") and succeeds.
         await fwd._post_model_change_if_new(
-            client,  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
             session_id="conv_1",
             state=state,
             model=None,
         )
         assert state.posted == "gpt-5.2"
-        assert client.calls == 2
+        assert len(sink.calls) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failed_response", [503, None])
+    async def test_failed_helper_response_does_not_advance_posted_model(
+        self, monkeypatch: pytest.MonkeyPatch, failed_response: int | None
+    ) -> None:
+        response = (
+            None
+            if failed_response is None
+            else httpx.Response(failed_response, request=httpx.Request("POST", "http://t/"))
+        )
+        sink = _PostHelperSink([response])
+        monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
+        state = fwd._ModelMirrorState(observed="composer-2.5", posted="composer-2.5")
+
+        await fwd._post_model_change_if_new(
+            object(),  # type: ignore[arg-type]
+            session_id="conv_1",
+            state=state,
+            model="gpt-5.2",
+        )
+
+        assert state.observed == "gpt-5.2"
+        assert state.posted == "composer-2.5"
 
 
 @pytest.mark.asyncio
@@ -589,6 +632,118 @@ async def test_post_conversation_item_shape() -> None:
         "item_data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
         "response_id": "cursor:bid",
     }
+
+
+@pytest.mark.asyncio
+async def test_post_external_compaction_status_uses_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = _PostHelperSink()
+    monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
+
+    response = await fwd._post_external_compaction_status(
+        object(),  # type: ignore[arg-type]
+        session_id="conv_1",
+        status="completed",
+    )
+
+    assert response.status_code == 200
+    assert sink.calls[0]["event_type"] == "external_compaction_status"
+    assert sink.calls[0]["url"] == "/v1/sessions/conv_1/events"
+    assert sink.calls[0]["payload"] == {
+        "type": "external_compaction_status",
+        "data": {"status": "completed"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_persist_native_compaction_item_uses_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = _PostHelperSink()
+    monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
+    client = MagicMock()
+    get_resp = MagicMock()
+    get_resp.json.return_value = {"data": [{"id": "item_789"}]}
+    get_resp.raise_for_status = MagicMock()
+    client.get = AsyncMock(return_value=get_resp)
+
+    with patch.object(fwd, "_read_blob_rows", return_value=[]):
+        await _persist_native_compaction_item(
+            client, session_id="conv_cursor", store_path=Path("/fake")
+        )
+
+    assert len(sink.calls) == 1
+    assert sink.calls[0]["event_type"] == "compaction"
+    assert sink.calls[0]["url"] == "/v1/sessions/conv_cursor/events"
+    payload = sink.calls[0]["payload"]
+    assert isinstance(payload, dict)
+    assert payload["type"] == "compaction"
+    assert payload["data"]["last_item_id"] == "item_789"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("post_func", "event_type"),
+    [
+        ("model", "external_model_change"),
+        ("status", "external_compaction_status"),
+        ("compaction", "compaction"),
+    ],
+)
+async def test_migrated_posts_record_connectivity_failure_for_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+    post_func: str,
+    event_type: str,
+) -> None:
+    from omnigent import _native_forwarder_health as health
+
+    class _AlwaysConnectError:
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    class _CompactionClient(_AlwaysConnectError):
+        async def get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+            del params
+            return httpx.Response(
+                200,
+                json={"data": [{"id": "item_789"}]},
+                request=httpx.Request("GET", url),
+            )
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(fwd, "_sleep", no_sleep, raising=False)
+    health.clear()
+    try:
+        if post_func == "model":
+            await fwd._post_model_change_if_new(
+                _AlwaysConnectError(),  # type: ignore[arg-type]
+                session_id="conv_1",
+                state=fwd._ModelMirrorState(),
+                model="gpt-5.2",
+            )
+        elif post_func == "status":
+            response = await fwd._post_external_compaction_status(
+                _AlwaysConnectError(),  # type: ignore[arg-type]
+                session_id="conv_1",
+                status="completed",
+            )
+            assert response is None
+        else:
+            await _persist_native_compaction_item(
+                _CompactionClient(),  # type: ignore[arg-type]
+                session_id="conv_1",
+                store_path=Path("/fake"),
+            )
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert event_type in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()
 
 
 def _http_status_error(status: int) -> httpx.HTTPStatusError:
@@ -641,6 +796,11 @@ async def _drive_forwarder(
     monkeypatch.setattr(fwd, "_discover_store", lambda workspace, launch_ms: store)
     monkeypatch.setattr(fwd, "_chat_claimed_by_other", lambda *a, **k: False)
     monkeypatch.setattr(fwd, "_post_conversation_item", poster)
+
+    async def _skip_patch(client: object, *, session_id: str, chat_id: str) -> None:
+        del client, session_id, chat_id
+
+    monkeypatch.setattr(fwd, "_patch_external_session_id", _skip_patch)
     task = asyncio.create_task(
         fwd.forward_cursor_store_to_session(
             base_url="http://test",
@@ -1129,7 +1289,11 @@ class TestCompactionCompletedForwarding:
         async def _fake_compaction(client: object, *, session_id: str, status: str) -> None:
             completions.append(status)
 
+        async def _skip_persist(client: object, *, session_id: str, store_path: Path) -> None:
+            del client, session_id, store_path
+
         monkeypatch.setattr(fwd, "_post_external_compaction_status", _fake_compaction)
+        monkeypatch.setattr(fwd, "_persist_native_compaction_item", _skip_persist)
 
         poster = _FakePoster(lambda item: None)
         bridge = await _drive_forwarder(
@@ -1171,10 +1335,18 @@ class TestCompactionCompletedForwarding:
         )
         writer.close()
 
-        async def _failing_compaction(client: object, *, session_id: str, status: str) -> None:
-            raise _http_status_error(500)
+        async def _failing_compaction(
+            client: object, *, session_id: str, status: str
+        ) -> httpx.Response:
+            del client, session_id, status
+            return httpx.Response(503, request=httpx.Request("POST", "http://t/"))
 
         monkeypatch.setattr(fwd, "_post_external_compaction_status", _failing_compaction)
+
+        async def _skip_persist(client: object, *, session_id: str, store_path: Path) -> None:
+            del client, session_id, store_path
+
+        monkeypatch.setattr(fwd, "_persist_native_compaction_item", _skip_persist)
 
         poster = _FakePoster(lambda item: None)
         bridge = await _drive_forwarder(
@@ -1205,8 +1377,7 @@ async def test_persist_native_compaction_item_posts_compaction_event() -> None:
     get_resp.raise_for_status = MagicMock()
     client.get = AsyncMock(return_value=get_resp)
 
-    post_resp = MagicMock()
-    post_resp.raise_for_status = MagicMock()
+    post_resp = httpx.Response(200, request=httpx.Request("POST", "http://t/"))
     client.post = AsyncMock(return_value=post_resp)
 
     fake_rows = [
@@ -1238,8 +1409,7 @@ async def test_persist_native_compaction_item_no_store_skips_messages() -> None:
     get_resp.raise_for_status = MagicMock()
     client.get = AsyncMock(return_value=get_resp)
 
-    post_resp = MagicMock()
-    post_resp.raise_for_status = MagicMock()
+    post_resp = httpx.Response(200, request=httpx.Request("POST", "http://t/"))
     client.post = AsyncMock(return_value=post_resp)
 
     with patch.object(fwd, "_read_blob_rows", side_effect=sqlite3.Error("no db")):

--- a/tests/test_goose_native_forwarder.py
+++ b/tests/test_goose_native_forwarder.py
@@ -8,9 +8,13 @@ stripping, role mapping, and the idempotent high-water cursor.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 from pathlib import Path
+
+import httpx
+import pytest
 
 from omnigent import goose_native_forwarder as f
 
@@ -110,3 +114,160 @@ def test_default_sessions_db_honors_override(monkeypatch) -> None:
     assert f.default_sessions_db() == Path("/custom/sessions.db")
     monkeypatch.delenv("GOOSE_SESSIONS_DB", raising=False)
     assert f.default_sessions_db().name == "sessions.db"
+
+
+@pytest.mark.asyncio
+async def test_post_conversation_item_uses_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    async def sink(**kwargs: object) -> httpx.Response:
+        calls.append(kwargs)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+    monkeypatch.setattr(f, "post_session_event_with_retry", sink, raising=False)
+    item = f._MirrorItem(
+        msg_id=1,
+        item_type="message",
+        item_data={"role": "assistant"},
+        response_id="goose:1",
+    )
+
+    response = await f._post_conversation_item(object(), session_id="conv goose", item=item)  # type: ignore[arg-type]
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["event_type"] == "external_conversation_item"
+    assert calls[0]["url"] == "/v1/sessions/conv goose/events"
+    payload = calls[0]["payload"]
+    assert isinstance(payload, dict)
+    assert payload["type"] == "external_conversation_item"
+
+
+@pytest.mark.asyncio
+async def test_post_conversation_item_records_connectivity_failure_for_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent import _native_forwarder_health as health
+
+    class _AlwaysConnectError:
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(f, "_sleep", no_sleep, raising=False)
+    item = f._MirrorItem(
+        msg_id=1,
+        item_type="message",
+        item_data={"role": "assistant"},
+        response_id="goose:1",
+    )
+
+    health.clear()
+    try:
+        response = await f._post_conversation_item(
+            _AlwaysConnectError(),  # type: ignore[arg-type]
+            session_id="conv_x",
+            item=item,
+        )
+        assert response is None
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert "external_conversation_item" in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failed_response", [503, None])
+async def test_forwarder_does_not_advance_cursor_past_failed_item(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failed_response: int | None,
+) -> None:
+    db = tmp_path / "sessions.db"
+    _seed_db(db)
+    bridge_dir = tmp_path / "bridge"
+    calls = 0
+
+    async def post_stub(
+        client: httpx.AsyncClient, *, session_id: str, item: f._MirrorItem
+    ) -> httpx.Response | None:
+        nonlocal calls
+        del client, session_id
+        calls += 1
+        if calls == 1:
+            return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+        assert item.msg_id == 2
+        if failed_response is None:
+            return None
+        return httpx.Response(failed_response, request=httpx.Request("POST", "http://t/"))
+
+    async def stop_after_poll(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(f, "_post_conversation_item", post_stub)
+    monkeypatch.setattr(f.asyncio, "sleep", stop_after_poll)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_goose_store_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="goose-native-ui",
+            goose_session_name="omni-1",
+            db_path=db,
+            poll_interval_s=0,
+        )
+
+    state = f._read_state(bridge_dir)
+    assert calls == 2
+    assert state.goose_session_id == "20260619_1"
+    assert state.last_id == 1
+
+
+@pytest.mark.asyncio
+async def test_forwarder_advances_cursor_after_successful_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "sessions.db"
+    _seed_db(db)
+    bridge_dir = tmp_path / "bridge"
+    posted_ids: list[int] = []
+
+    async def post_stub(
+        client: httpx.AsyncClient, *, session_id: str, item: f._MirrorItem
+    ) -> httpx.Response:
+        del client, session_id
+        posted_ids.append(item.msg_id)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+    async def stop_after_poll(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(f, "_post_conversation_item", post_stub)
+    monkeypatch.setattr(f.asyncio, "sleep", stop_after_poll)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_goose_store_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="goose-native-ui",
+            goose_session_name="omni-1",
+            db_path=db,
+            poll_interval_s=0,
+        )
+
+    state = f._read_state(bridge_dir)
+    assert posted_ids == [1, 2]
+    assert state.goose_session_id == "20260619_1"
+    assert state.last_id == 3

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -14,6 +14,7 @@ import json
 import sqlite3
 from pathlib import Path
 
+import httpx
 import pytest
 
 from omnigent import hermes_native_forwarder as f
@@ -252,19 +253,43 @@ class _FakeClient:
         return _Resp()
 
 
-async def test_post_conversation_item_posts_event(tmp_path) -> None:
-    client = _FakeClient()
+class _PostHelperSink:
+    """Capture calls to ``post_session_event_with_retry``."""
+
+    def __init__(self, responses: list[httpx.Response | None] | None = None) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._responses = list(responses or [])
+
+    async def __call__(self, **kwargs: object) -> httpx.Response | None:
+        self.calls.append(kwargs)
+        if self._responses:
+            return self._responses.pop(0)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+
+async def test_post_conversation_item_uses_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = _PostHelperSink()
+    monkeypatch.setattr(f, "post_session_event_with_retry", sink, raising=False)
     item = f._MirrorItem(
         msg_id=5,
         item_type="message",
         item_data={"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
         response_id="hermes:5",
     )
-    await f._post_conversation_item(client, session_id="conv_q", item=item)
-    url, body = client.posts[0]
-    assert url == "/v1/sessions/conv_q/events"
-    assert body["type"] == "external_conversation_item"
-    assert body["data"]["response_id"] == "hermes:5"
+    response = await f._post_conversation_item(object(), session_id="conv_q", item=item)  # type: ignore[arg-type]
+    assert response.status_code == 200
+    assert sink.calls[0]["event_type"] == "external_conversation_item"
+    assert sink.calls[0]["url"] == "/v1/sessions/conv_q/events"
+    assert sink.calls[0]["payload"] == {
+        "type": "external_conversation_item",
+        "data": {
+            "item_type": "message",
+            "item_data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+            "response_id": "hermes:5",
+        },
+    }
 
 
 async def test_forward_loop_discovers_and_mirrors_new_messages(tmp_path, monkeypatch) -> None:
@@ -277,6 +302,7 @@ async def test_forward_loop_discovers_and_mirrors_new_messages(tmp_path, monkeyp
 
     async def _fake_post(_client, *, session_id, item):
         posted.append(item)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
 
     monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
 
@@ -304,6 +330,58 @@ async def test_forward_loop_discovers_and_mirrors_new_messages(tmp_path, monkeyp
     assert roles == ["user", "assistant"]
     # High-water cursor persisted so a restart resumes without re-posting.
     assert f._read_state(tmp_path).hermes_session_id == "20260620_1"
+    assert f._read_state(tmp_path).last_id == 4
+
+
+@pytest.mark.parametrize("failed_response", [503, None])
+async def test_forward_loop_does_not_advance_cursor_past_failed_item(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failed_response: int | None,
+) -> None:
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    _seed_db(db, cwd=workspace, started_at=1000.0)
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    calls = 0
+
+    async def _fake_post(
+        _client: object, *, session_id: str, item: f._MirrorItem
+    ) -> httpx.Response | None:
+        nonlocal calls
+        del session_id
+        calls += 1
+        if calls == 1:
+            return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+        assert item.msg_id == 2
+        if failed_response is None:
+            return None
+        return httpx.Response(failed_response, request=httpx.Request("POST", "http://t/"))
+
+    monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
+
+    async def _sleep(_s: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://x",
+            headers={},
+            session_id="conv_f",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    state = f._read_state(bridge_dir)
+    assert calls == 2
+    assert state.hermes_session_id == "20260620_1"
+    assert state.last_id == 1
 
 
 async def test_forward_loop_patches_external_session_id_once(tmp_path, monkeypatch) -> None:
@@ -323,7 +401,7 @@ async def test_forward_loop_patches_external_session_id_once(tmp_path, monkeypat
     patched_calls: list[tuple[str, dict]] = []
 
     async def _fake_post(_client, *, session_id, item):
-        pass  # ignore mirrored items for this test
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
 
     monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
 
@@ -437,6 +515,7 @@ async def test_forward_loop_repins_to_child_after_compaction(tmp_path, monkeypat
 
     async def _fake_post(_client, *, session_id, item):
         posted.append(item)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
 
     monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
     monkeypatch.setattr(f, "_persist_hermes_compaction_item", lambda *a, **k: _noop())
@@ -572,15 +651,20 @@ async def test_usage_tracker_posts_model_on_first_flush(tmp_path, monkeypatch) -
 
     (hermes_home / "config.yaml").write_text(yaml.dump({"model": "claude-sonnet-4-20250514"}))
 
+    sink = _PostHelperSink()
+    monkeypatch.setattr(f, "post_session_event_with_retry", sink, raising=False)
     client = _FakeClient()
     tracker = f._HermesUsageTracker(client, "conv_usage", tmp_path)
     await tracker.flush()
 
-    assert len(client.posts) == 1
-    url, body = client.posts[0]
-    assert url == "/v1/sessions/conv_usage/events"
-    assert body["type"] == "external_session_usage"
-    assert body["data"]["model"] == "claude-sonnet-4-20250514"
+    assert len(sink.calls) == 1
+    assert sink.calls[0]["event_type"] == "external_session_usage"
+    assert sink.calls[0]["url"] == "/v1/sessions/conv_usage/events"
+    assert sink.calls[0]["payload"] == {
+        "type": "external_session_usage",
+        "data": {"model": "claude-sonnet-4-20250514"},
+    }
+    assert tracker._posted_model == "claude-sonnet-4-20250514"
 
 
 async def test_usage_tracker_deduplicates(tmp_path, monkeypatch) -> None:
@@ -591,13 +675,38 @@ async def test_usage_tracker_deduplicates(tmp_path, monkeypatch) -> None:
 
     (hermes_home / "config.yaml").write_text(yaml.dump({"model": "gpt-4o"}))
 
+    sink = _PostHelperSink()
+    monkeypatch.setattr(f, "post_session_event_with_retry", sink, raising=False)
     client = _FakeClient()
     tracker = f._HermesUsageTracker(client, "conv_dedup", tmp_path)
     await tracker.flush()
     await tracker.flush()
     await tracker.flush()
 
-    assert len(client.posts) == 1  # only the first flush posts
+    assert len(sink.calls) == 1  # only the first flush posts
+
+
+@pytest.mark.parametrize("failed_response", [503, None])
+async def test_usage_tracker_does_not_advance_posted_model_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failed_response: int | None,
+) -> None:
+    response = (
+        None
+        if failed_response is None
+        else httpx.Response(failed_response, request=httpx.Request("POST", "http://t/"))
+    )
+    sink = _PostHelperSink([response])
+    monkeypatch.setattr(f, "post_session_event_with_retry", sink, raising=False)
+    client = _FakeClient()
+    tracker = f._HermesUsageTracker(client, "conv_usage", tmp_path)
+    tracker._model = "gpt-4o"
+    tracker._posted_model = "old-model"
+
+    await tracker.flush()
+
+    assert tracker._posted_model == "old-model"
 
 
 async def test_usage_tracker_no_post_when_no_model(tmp_path) -> None:
@@ -619,6 +728,88 @@ async def test_read_model_from_hermes_config_fallback(tmp_path, monkeypatch) -> 
 
     model = f._read_model_from_hermes_config(tmp_path / "nonexistent")
     assert model == "from-user-config"
+
+
+async def test_migrated_posts_record_connectivity_failure_for_watchdog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent import _native_forwarder_health as health
+
+    class _AlwaysConnectError:
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    class _CompactionClient(_AlwaysConnectError):
+        async def get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+            del params
+            return httpx.Response(
+                200,
+                json={"data": [{"id": "item_hermes"}]},
+                request=httpx.Request("GET", url),
+            )
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(f, "_sleep", no_sleep, raising=False)
+    item = f._MirrorItem(
+        msg_id=1,
+        item_type="message",
+        item_data={"role": "user"},
+        response_id="hermes:1",
+    )
+
+    db = tmp_path / "state.db"
+    _make_compaction_db(db)
+    for call, event_type in (
+        (
+            lambda: f._post_conversation_item(
+                _AlwaysConnectError(),  # type: ignore[arg-type]
+                session_id="conv_1",
+                item=item,
+            ),
+            "external_conversation_item",
+        ),
+        (
+            lambda: f._HermesUsageTracker(
+                _AlwaysConnectError(),  # type: ignore[arg-type]
+                "conv_1",
+                tmp_path,
+            ).flush(),
+            "external_session_usage",
+        ),
+        (
+            lambda: f._persist_hermes_compaction_item(
+                _CompactionClient(),  # type: ignore[arg-type]
+                session_id="conv_1",
+                db_path=db,
+                hermes_session_id="hermes_sess",
+            ),
+            "compaction",
+        ),
+    ):
+        health.clear()
+        try:
+            if event_type == "external_session_usage":
+                tracker = f._HermesUsageTracker(
+                    _AlwaysConnectError(),  # type: ignore[arg-type]
+                    "conv_1",
+                    tmp_path,
+                )
+                tracker._model = "gpt-4o"
+                await tracker.flush()
+            else:
+                response = await call()
+                if event_type == "external_conversation_item":
+                    assert response is None
+            detail = health.recent_post_failure(60.0)
+            assert detail is not None
+            assert event_type in detail
+            assert "No route to host" in detail
+        finally:
+            health.clear()
 
 
 # --- Compaction persistence tests -------------------------------------------
@@ -679,9 +870,13 @@ def test_has_new_compaction_returns_false_when_no_compacted_rows(tmp_path: Path)
     assert f._has_new_compaction(db, "hermes_sess") is False
 
 
-async def test_persist_hermes_compaction_item_posts_with_messages(tmp_path: Path) -> None:
+async def test_persist_hermes_compaction_item_posts_with_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from unittest.mock import AsyncMock, MagicMock
 
+    sink = _PostHelperSink()
+    monkeypatch.setattr(f, "post_session_event_with_retry", sink, raising=False)
     db = tmp_path / "state.db"
     _make_compaction_db(db)
     con = sqlite3.connect(db)
@@ -700,12 +895,8 @@ async def test_persist_hermes_compaction_item_posts_with_messages(tmp_path: Path
     get_resp.raise_for_status = MagicMock()
     get_resp.json = MagicMock(return_value={"data": [{"id": "item_hermes"}]})
 
-    post_resp = MagicMock()
-    post_resp.raise_for_status = MagicMock()
-
     client = AsyncMock()
     client.get = AsyncMock(return_value=get_resp)
-    client.post = AsyncMock(return_value=post_resp)
 
     await f._persist_hermes_compaction_item(
         client,
@@ -714,9 +905,9 @@ async def test_persist_hermes_compaction_item_posts_with_messages(tmp_path: Path
         hermes_session_id="hermes_sess",
     )
 
-    client.post.assert_called_once()
-    _url, kwargs = client.post.call_args
-    body = kwargs.get("json") or client.post.call_args[1]["json"]
+    assert len(sink.calls) == 1
+    assert sink.calls[0]["event_type"] == "compaction"
+    body = sink.calls[0]["payload"]
     assert body["type"] == "compaction"
     assert body["data"]["last_item_id"] == "item_hermes"
     assert len(body["data"]["compacted_messages"]) == 2
@@ -724,9 +915,13 @@ async def test_persist_hermes_compaction_item_posts_with_messages(tmp_path: Path
     assert body["data"]["compacted_messages"][1]["role"] == "assistant"
 
 
-async def test_persist_hermes_compaction_item_empty_db(tmp_path: Path) -> None:
+async def test_persist_hermes_compaction_item_empty_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from unittest.mock import AsyncMock, MagicMock
 
+    sink = _PostHelperSink()
+    monkeypatch.setattr(f, "post_session_event_with_retry", sink, raising=False)
     db = tmp_path / "state.db"
     _make_compaction_db(db)
 
@@ -734,12 +929,8 @@ async def test_persist_hermes_compaction_item_empty_db(tmp_path: Path) -> None:
     get_resp.raise_for_status = MagicMock()
     get_resp.json = MagicMock(return_value={"data": []})
 
-    post_resp = MagicMock()
-    post_resp.raise_for_status = MagicMock()
-
     client = AsyncMock()
     client.get = AsyncMock(return_value=get_resp)
-    client.post = AsyncMock(return_value=post_resp)
 
     await f._persist_hermes_compaction_item(
         client,
@@ -748,9 +939,9 @@ async def test_persist_hermes_compaction_item_empty_db(tmp_path: Path) -> None:
         hermes_session_id="hermes_sess",
     )
 
-    client.post.assert_called_once()
-    _url, kwargs = client.post.call_args
-    body = kwargs.get("json") or client.post.call_args[1]["json"]
+    assert len(sink.calls) == 1
+    assert sink.calls[0]["event_type"] == "compaction"
+    body = sink.calls[0]["payload"]
     assert body["type"] == "compaction"
     assert body["data"]["last_item_id"].startswith("compact_boundary_")
     assert "compacted_messages" not in body["data"]

--- a/tests/test_opencode_native_forwarder.py
+++ b/tests/test_opencode_native_forwarder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
+import pytest
 
 import omnigent.opencode_native_forwarder as fwd_mod
 from omnigent.opencode_native_client import OpenCodeEvent
@@ -59,6 +60,71 @@ def _event(event_type: str, **props: Any) -> OpenCodeEvent:
 
 def _types(posts: list[tuple[str, dict[str, Any]]]) -> list[str]:
     return [body["type"] for _url, body in posts]
+
+
+class _PostHelperSink:
+    """Capture calls to ``post_session_event_with_retry``."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def __call__(self, **kwargs: object) -> httpx.Response:
+        self.calls.append(kwargs)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+
+async def test_post_event_uses_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = _PostHelperSink()
+    monkeypatch.setattr(fwd_mod, "post_session_event_with_retry", sink, raising=False)
+    server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
+    fwd = _forwarder(server, opencode)
+
+    response = await fwd._post_event("external_session_status", {"status": "running"})
+    item_response = await fwd._post_event(
+        "external_conversation_item",
+        {"item_type": "message", "item_data": {}, "response_id": "msg_1"},
+    )
+
+    assert response.status_code == 200
+    assert item_response.status_code == 200
+    assert sink.calls[0]["event_type"] == "external_session_status"
+    assert sink.calls[0]["url"] == "/v1/sessions/conv_1/events"
+    assert sink.calls[0]["payload"] == {
+        "type": "external_session_status",
+        "data": {"status": "running"},
+    }
+    assert sink.calls[1]["event_type"] == "external_conversation_item"
+    assert sink.calls[1]["payload"]["type"] == "external_conversation_item"
+
+
+async def test_post_event_records_connectivity_failure_for_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent import _native_forwarder_health as health
+
+    class _AlwaysConnectError:
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(fwd_mod, "_sleep", no_sleep, raising=False)
+    fwd = _forwarder(_AlwaysConnectError(), _FakeOpenCodeClient())  # type: ignore[arg-type]
+
+    health.clear()
+    try:
+        response = await fwd._post_event("external_session_status", {"status": "running"})
+        assert response is None
+        detail = health.recent_post_failure(60.0)
+        assert detail is not None
+        assert "external_session_status" in detail
+        assert "No route to host" in detail
+    finally:
+        health.clear()
 
 
 async def test_part_delta_is_not_forwarded() -> None:

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -457,23 +457,115 @@ class _RecordingClient:
         return httpx.Response(200, request=httpx.Request("POST", url))
 
 
-async def test_post_conversation_item_shape() -> None:
-    client = _RecordingClient()
+class _PostHelperSink:
+    """Capture calls to ``post_session_event_with_retry``."""
+
+    def __init__(self, responses: list[httpx.Response | None] | None = None) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._responses = list(responses or [])
+
+    async def __call__(self, **kwargs: object) -> httpx.Response | None:
+        self.calls.append(kwargs)
+        if self._responses:
+            return self._responses.pop(0)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+
+async def test_post_conversation_item_uses_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = _PostHelperSink()
+    monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
     item = fwd._MirrorItem(
         uuid="u1",
         item_type="message",
         item_data={"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
         response_id="qwen:u1",
     )
-    await fwd._post_conversation_item(client, session_id="conv_1", item=item)  # type: ignore[arg-type]
-    url, body = client.posts[0]
-    assert url == "/v1/sessions/conv_1/events"
-    assert body["type"] == "external_conversation_item"
-    assert body["data"] == {
-        "item_type": "message",
-        "item_data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
-        "response_id": "qwen:u1",
+    response = await fwd._post_conversation_item(object(), session_id="conv_1", item=item)  # type: ignore[arg-type]
+    assert response.status_code == 200
+    assert sink.calls[0]["event_type"] == "external_conversation_item"
+    assert sink.calls[0]["url"] == "/v1/sessions/conv_1/events"
+    assert sink.calls[0]["payload"] == {
+        "type": "external_conversation_item",
+        "data": {
+            "item_type": "message",
+            "item_data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+            "response_id": "qwen:u1",
+        },
     }
+
+
+async def test_post_external_compaction_status_uses_session_event_retry_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = _PostHelperSink()
+    monkeypatch.setattr(fwd, "post_session_event_with_retry", sink, raising=False)
+
+    response = await fwd._post_external_compaction_status(
+        object(),  # type: ignore[arg-type]
+        session_id="conv_1",
+        status="completed",
+    )
+
+    assert response.status_code == 200
+    assert sink.calls[0]["event_type"] == "external_compaction_status"
+    assert sink.calls[0]["url"] == "/v1/sessions/conv_1/events"
+    assert sink.calls[0]["payload"] == {
+        "type": "external_compaction_status",
+        "data": {"status": "completed"},
+    }
+
+
+async def test_migrated_posts_record_connectivity_failure_for_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent import _native_forwarder_health as health
+
+    class _AlwaysConnectError:
+        async def post(self, url: str, *, json: object) -> httpx.Response:
+            del json
+            raise httpx.ConnectError("No route to host", request=httpx.Request("POST", url))
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(fwd, "_sleep", no_sleep, raising=False)
+    item = fwd._MirrorItem(
+        uuid="u1",
+        item_type="message",
+        item_data={"role": "user"},
+        response_id="qwen:u1",
+    )
+
+    for call, event_type in (
+        (
+            lambda: fwd._post_conversation_item(
+                _AlwaysConnectError(),  # type: ignore[arg-type]
+                session_id="conv_1",
+                item=item,
+            ),
+            "external_conversation_item",
+        ),
+        (
+            lambda: fwd._post_external_compaction_status(
+                _AlwaysConnectError(),  # type: ignore[arg-type]
+                session_id="conv_1",
+                status="completed",
+            ),
+            "external_compaction_status",
+        ),
+    ):
+        health.clear()
+        try:
+            response = await call()
+            assert response is None
+            detail = health.recent_post_failure(60.0)
+            assert detail is not None
+            assert event_type in detail
+            assert "No route to host" in detail
+        finally:
+            health.clear()
 
 
 async def test_forward_loop_posts_new_events_and_persists(
@@ -485,8 +577,9 @@ async def test_forward_loop_posts_new_events_and_persists(
 
     posted: list[str] = []
 
-    async def _fake_post(_client: object, *, session_id: str, item: object) -> None:
+    async def _fake_post(_client: object, *, session_id: str, item: object) -> httpx.Response:
         posted.append(item.response_id)  # type: ignore[attr-defined]
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
 
     monkeypatch.setattr(fwd, "_post_conversation_item", _fake_post)
 
@@ -514,6 +607,93 @@ async def test_forward_loop_posts_new_events_and_persists(
     state = _read_state(bridge)
     assert state.offset > 0
     assert "u1" in (state.seen_uuids or [])
+
+
+@pytest.mark.parametrize("failed_response", [503, None])
+async def test_forward_loop_does_not_advance_offset_past_failed_item(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failed_response: int | None,
+) -> None:
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "one")) + _ev_bytes(_user_ev("u2", "two"))
+    )
+    calls = 0
+
+    async def _fake_post(
+        _client: object, *, session_id: str, item: fwd._MirrorItem
+    ) -> httpx.Response | None:
+        nonlocal calls
+        del session_id
+        calls += 1
+        if calls == 1:
+            return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+        assert item.uuid == "u2"
+        if failed_response is None:
+            return None
+        return httpx.Response(failed_response, request=httpx.Request("POST", "http://t/"))
+
+    async def stop_after_poll(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(fwd, "_post_conversation_item", _fake_post)
+    monkeypatch.setattr(fwd.asyncio, "sleep", stop_after_poll)
+
+    with pytest.raises(asyncio.CancelledError):
+        await fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0,
+        )
+
+    state = _read_state(bridge)
+    assert calls == 2
+    assert state.offset == 0
+    assert state.seen_uuids == []
+
+
+async def test_forward_loop_advances_offset_after_successful_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "one")) + _ev_bytes(_user_ev("u2", "two"))
+    )
+    posted: list[str] = []
+
+    async def _fake_post(
+        _client: object, *, session_id: str, item: fwd._MirrorItem
+    ) -> httpx.Response:
+        del session_id
+        posted.append(item.uuid)
+        return httpx.Response(200, request=httpx.Request("POST", "http://t/"))
+
+    async def stop_after_poll(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(fwd, "_post_conversation_item", _fake_post)
+    monkeypatch.setattr(fwd.asyncio, "sleep", stop_after_poll)
+
+    with pytest.raises(asyncio.CancelledError):
+        await fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0,
+        )
+
+    state = _read_state(bridge)
+    assert posted == ["u1", "u2"]
+    assert state.offset == events_file_path(bridge).stat().st_size
+    assert set(state.seen_uuids or []) == {"u1", "u2"}
 
 
 async def test_compaction_mirror_seeds_at_eof_and_posts_new(


### PR DESCRIPTION
## Related issue

Closes #1230

## Summary

- The idle-turn watchdog (#1119, PR #1227) surfaces the real cause when a native forwarder cannot reach the server, by recording exhausted event-POST failures in `_native_forwarder_health` via the shared `post_session_event_with_retry` path. Only codex-native and antigravity-native went through that path.
- claude, cursor, goose, qwen, hermes, and opencode each POSTed session events with bespoke `client.post(...)` + `raise_for_status` and their own (or no) retry handling, so their connectivity failures never reached the watchdog and they duplicated the retry/delivery-ambiguity logic the helper was extracted to consolidate.
- This routes the eligible session-event POSTs in those six forwarders through `post_session_event_with_retry`: they gain bounded transient retry, connectivity-failure recording, and the success-clears guard for free (completing #1119 across all native harnesses), and the duplicated retry logic is removed.

### ELI5

Each "native" forwarder is a little courier that mails the app's events to the server.
Two couriers already used a shared, reliable mailbox that retries on a hiccup and rings an alarm when the server is unreachable.
The other six couriers each had their own ad-hoc mailbox with no alarm, so when the server was down, the system blamed the wrong thing ("the model is stuck") instead of "the courier can't reach the server."
This PR moves those six couriers to the same reliable mailbox, without changing which letters they send.

### What is (and is not) migrated

```
session-event POSTs to /v1/sessions/{id}/events   --> migrated to the shared helper
  goose(1)  cursor(3)  qwen(2)  hermes(3)  opencode(1)  claude(8)

KEEP as-is (NOT migrated):
  - claude tracker-coupled shared leaves (_post_external_conversation_item,
    _post_external_session_status, _post_external_subagent_start,
    _post_external_output_text_delta) + the 5 _PostRetryTracker call sites
    (they rely on the leaf RAISING for their cross-poll backoff + dead-letter)
  - cursor _post_conversation_item (its own bounded cross-poll retry)
  - all fork/transfer, PATCH, GET, and session-creation calls
  - codex-native (already has its own helper integration)
```

### The one behavioral subtlety reviewers should know

The shared helper returns `httpx.Response | None` and never raises (the old leaves ended in `raise_for_status()`).
Call sites fall into two shapes:

- Fire-and-forget: discard the return; the helper logs + records failures internally.
- Success-gated: the caller advances a dedupe flag / message cursor ONLY on a non-`None`, sub-400 response, so a failed POST is left behind and retried on the next poll rather than silently dropped. This covers the model-change dedupe, the item cursors, and claude's usage/cost dedupe.

## Test Plan

From the repo root:

```
uv run ruff check .
uv run ruff format --check .
uv run pre-commit run --all-files
uv run --extra dev pytest \
  tests/test_claude_native_forwarder.py \
  tests/test_cursor_native_forwarder.py \
  tests/test_goose_native_forwarder.py \
  tests/test_qwen_native_forwarder.py \
  tests/test_hermes_native_forwarder.py \
  tests/test_opencode_native_forwarder.py \
  tests/test_native_post_delivery.py \
  tests/test_native_forwarder_health.py
```

Result: ruff clean, all pre-commit hooks pass, `332 passed`.

Per migrated forwarder the tests assert: (a) the helper is invoked with the correct `event_type` / url / `payload["type"]`; (b) a connectivity failure (`httpx.ConnectError`) is recorded to `_native_forwarder_health` for the watchdog; and (c) success-gated dedupe/cursors are NOT advanced when the post returns `None` or a `>=400` response (and ARE advanced on a 2xx). claude additionally keeps a guard test confirming its tracker-coupled shared leaves still raise `httpx.HTTPError`.

## Demo

N/A (non-visual backend change).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests were added for each migrated forwarder (helper-invocation, connectivity-failure-recording, and success-gated no-advance assertions), and the existing forwarder suites continue to cover unchanged behavior. The two known-breaking existing tests (bare-`MagicMock` compaction responses and claude's cross-poll model-retry premise) were updated to reflect the helper's `Response | None` contract.



