### PR TITLE
fix(runner): align ws-tunnel protocol keepalive to the 90s app-level budget (#1116)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2975,6 +2975,8 @@ def server(
 
     from omnigent.runner.transports.ws_tunnel.limits import (
         RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+        TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+        TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
     )
     from omnigent.server.app import create_app
     from omnigent.server.auth import create_auth_provider
@@ -3225,6 +3227,11 @@ def server(
             port=port,
             log_config=_server_uvicorn_log_config(),
             ws_max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+            # Server side of the runner/host tunnels' protocol keepalive, aligned
+            # to the 90 s app-level budget instead of uvicorn's 20 s default that
+            # drops a busy-but-healthy tunnel with 1011 — issue #1116.
+            ws_ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+            ws_ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
             timeout_graceful_shutdown=_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
         )
     finally:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3234,12 +3234,16 @@ def server(
             # uvicorn's ws_ping_* is server-global (no per-route override), so this
             # 30 s/90 s budget also applies to the app's other WebSocket routes —
             # /v1/sessions/updates (browser stream) and .../terminals/{id}/attach.
-            # Deliberate and acceptable: those sockets carry their own app-level
-            # session.heartbeat / terminal traffic, so the only effect is that a
-            # dead browser/terminal socket with no app traffic is reaped at worst
-            # ~120 s (30 s interval + 90 s timeout) instead of ~40 s — a slightly
-            # later half-open cleanup, not a correctness change. The tunnels are
-            # the sockets that actually need the looser budget (issue #1116).
+            # Deliberate and acceptable: for an IDLE such socket the protocol
+            # PING/PONG is the only half-open detector (the sessions-updates
+            # heartbeat is a server->client send, and an idle terminal has no
+            # traffic), so widening it means a dead idle browser/terminal socket is
+            # reaped at worst ~120 s (30 s interval + 90 s timeout) instead of
+            # ~40 s — a slightly later half-open cleanup (e.g. the out-of-process
+            # terminal-attach proxy holds its runner socket + tmux child ~80 s
+            # longer), bounded and eventually reaped, not a leak or correctness
+            # change. The tunnels are the sockets that actually need the looser
+            # budget (issue #1116).
             ws_ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
             ws_ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
             timeout_graceful_shutdown=_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S,

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3230,6 +3230,16 @@ def server(
             # Server side of the runner/host tunnels' protocol keepalive, aligned
             # to the 90 s app-level budget instead of uvicorn's 20 s default that
             # drops a busy-but-healthy tunnel with 1011 — issue #1116.
+            #
+            # uvicorn's ws_ping_* is server-global (no per-route override), so this
+            # 30 s/90 s budget also applies to the app's other WebSocket routes —
+            # /v1/sessions/updates (browser stream) and .../terminals/{id}/attach.
+            # Deliberate and acceptable: those sockets carry their own app-level
+            # session.heartbeat / terminal traffic, so the only effect is that a
+            # dead browser/terminal socket with no app traffic is reaped at worst
+            # ~120 s (30 s interval + 90 s timeout) instead of ~40 s — a slightly
+            # later half-open cleanup, not a correctness change. The tunnels are
+            # the sockets that actually need the looser budget (issue #1116).
             ws_ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
             ws_ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
             timeout_graceful_shutdown=_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_S,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -69,6 +69,10 @@ from omnigent.runner.transports.ws_tunnel.frames import (
     decode_frame,
     encode_frame,
 )
+from omnigent.runner.transports.ws_tunnel.limits import (
+    TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+    TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+)
 from omnigent.version import VERSION
 
 _logger = logging.getLogger(__name__)
@@ -1386,6 +1390,12 @@ class HostProcess:
                 url,
                 additional_headers=headers,
                 max_size=100 * 1024 * 1024,
+                # Align the host->server tunnel's protocol keepalive to the same
+                # 90 s app-level budget as the runner tunnel (not the 20 s library
+                # default that drops a busy-but-healthy tunnel with 1011 — #1116).
+                # Symmetric with serve.py's runner-side connect().
+                ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+                ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
             )
             ws = await ws_cm.__aenter__()
         except (InvalidURI, InvalidStatus) as exc:

--- a/omnigent/runner/transports/ws_tunnel/limits.py
+++ b/omnigent/runner/transports/ws_tunnel/limits.py
@@ -1,5 +1,25 @@
-"""Size limits shared by the runner WebSocket tunnel endpoints."""
+"""Size limits and keepalive budget shared by the runner WebSocket tunnel endpoints."""
 
 from __future__ import annotations
 
 RUNNER_TUNNEL_MAX_MESSAGE_BYTES = 100 * 1024 * 1024
+
+# Protocol-level WebSocket keepalive budget for the runner<->server tunnel —
+# the websockets library's own PING/PONG (set on the runner's ``connect`` and the
+# server's uvicorn). This is DISTINCT from, and a backstop to, the app-level
+# liveness loop the server runs (``_ping_loop``: ``PING_INTERVAL_S=30`` x
+# ``PING_MISS_THRESHOLD=3`` = 90 s before a peer is declared dead).
+#
+# It MUST NOT be tighter than that 90 s app-level budget. Left unset, the library
+# default is 20 s/20 s — 4.5x stricter — so a *healthy* tunnel is dropped with
+# ``1011 keepalive ping timeout`` the instant its event loop is stalled for ~20 s
+# (a synchronous/CPU-bound dispatch), pre-empting the deliberate 90 s policy and
+# triggering reconnect churn + relay-subscribe timeouts. See issue #1116.
+#
+# A PING every 30 s keeps the connection warm and is the runner's ONLY detector
+# of a silently-dead server (the app-level ``_ping_loop`` only runs server->client),
+# while the 90 s PONG timeout tolerates loop stalls up to the same window the
+# app-level loop already allows. ``test_limits.py`` asserts the >= invariant so a
+# future tightening below the app-level budget fails CI.
+TUNNEL_KEEPALIVE_PING_INTERVAL_S = 30.0
+TUNNEL_KEEPALIVE_PING_TIMEOUT_S = 90.0

--- a/omnigent/runner/transports/ws_tunnel/limits.py
+++ b/omnigent/runner/transports/ws_tunnel/limits.py
@@ -19,7 +19,10 @@ RUNNER_TUNNEL_MAX_MESSAGE_BYTES = 100 * 1024 * 1024
 # A PING every 30 s keeps the connection warm and is the runner's ONLY detector
 # of a silently-dead server (the app-level ``_ping_loop`` only runs server->client),
 # while the 90 s PONG timeout tolerates loop stalls up to the same window the
-# app-level loop already allows. ``test_limits.py`` asserts the >= invariant so a
-# future tightening below the app-level budget fails CI.
+# app-level loop already allows. A peer that dies right after a successful PONG is
+# detected at worst ~120 s later (30 s interval before the next PING + 90 s waiting
+# for its PONG) — the deliberate tradeoff for not false-dropping a busy-but-healthy
+# tunnel. ``test_limits.py`` asserts the >= invariant so a future tightening below
+# the app-level budget fails CI.
 TUNNEL_KEEPALIVE_PING_INTERVAL_S = 30.0
 TUNNEL_KEEPALIVE_PING_TIMEOUT_S = 90.0

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -45,7 +45,11 @@ from omnigent.runner.transports.ws_tunnel.frames import (
     encode_body,
     encode_frame,
 )
-from omnigent.runner.transports.ws_tunnel.limits import RUNNER_TUNNEL_MAX_MESSAGE_BYTES
+from omnigent.runner.transports.ws_tunnel.limits import (
+    RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+    TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+    TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -545,6 +549,11 @@ async def _serve_tunnel_once(
         additional_headers=headers,
         close_timeout=_RUNNER_TUNNEL_CLOSE_TIMEOUT_S,
         max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+        # Protocol keepalive aligned to the server's 90 s app-level budget (not the
+        # 20 s library default that drops a busy-but-healthy tunnel — issue #1116).
+        # Also the runner's only liveness probe for a silently-dead server.
+        ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+        ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
     ) as ws:
         await _send_hello(ws.send, runner_version)
         _logger.info("runner %s connected to %s", runner_id, tunnel_url)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -63,7 +63,11 @@ from omnigent.runner.identity import (
     RUNNER_WORKSPACE_ENV_VAR,
     token_bound_runner_id,
 )
-from omnigent.runner.transports.ws_tunnel.limits import RUNNER_TUNNEL_MAX_MESSAGE_BYTES
+from omnigent.runner.transports.ws_tunnel.limits import (
+    RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+    TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+    TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1212,6 +1216,10 @@ def test_server_command_reads_tunnel_token_and_does_not_spawn_runner(
     assert result.exit_code == 0, result.output
     assert captured.get("uvicorn_called") is True
     assert captured["uvicorn_kwargs"]["ws_max_size"] == RUNNER_TUNNEL_MAX_MESSAGE_BYTES
+    # Tunnel protocol keepalive aligned to the 90s app-level budget, not uvicorn's
+    # 20s default that drops a busy-but-healthy tunnel with 1011 (issue #1116).
+    assert captured["uvicorn_kwargs"]["ws_ping_interval"] == TUNNEL_KEEPALIVE_PING_INTERVAL_S
+    assert captured["uvicorn_kwargs"]["ws_ping_timeout"] == TUNNEL_KEEPALIVE_PING_TIMEOUT_S
     assert (
         captured["uvicorn_kwargs"]["log_config"]["formatters"]["access"]["()"]
         == "omnigent.server.performance_metrics.RequestDurationAccessFormatter"

--- a/tests/runner/transports/ws_tunnel/test_limits.py
+++ b/tests/runner/transports/ws_tunnel/test_limits.py
@@ -1,8 +1,12 @@
-"""Tests for the WS tunnel size limits constants."""
+"""Tests for the WS tunnel size limits + keepalive budget constants."""
 
 from __future__ import annotations
 
-from omnigent.runner.transports.ws_tunnel.limits import RUNNER_TUNNEL_MAX_MESSAGE_BYTES
+from omnigent.runner.transports.ws_tunnel.limits import (
+    RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+    TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+    TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+)
 
 
 def test_max_message_bytes_is_100mb() -> None:
@@ -14,3 +18,33 @@ def test_max_message_bytes_is_positive_int() -> None:
     """The constant is a positive integer, not a float or zero."""
     assert isinstance(RUNNER_TUNNEL_MAX_MESSAGE_BYTES, int)
     assert RUNNER_TUNNEL_MAX_MESSAGE_BYTES > 0
+
+
+def test_keepalive_constants_are_positive_floats() -> None:
+    """Ping interval/timeout are positive floats (passed straight to websockets/uvicorn)."""
+    assert isinstance(TUNNEL_KEEPALIVE_PING_INTERVAL_S, float)
+    assert isinstance(TUNNEL_KEEPALIVE_PING_TIMEOUT_S, float)
+    assert TUNNEL_KEEPALIVE_PING_INTERVAL_S > 0
+    assert TUNNEL_KEEPALIVE_PING_TIMEOUT_S > 0
+
+
+def test_keepalive_not_stricter_than_app_level_budget() -> None:
+    """The protocol keepalive MUST NOT pre-empt the app-level liveness budget (#1116).
+
+    The server's app-level ``_ping_loop`` declares a peer dead after
+    ``PING_INTERVAL_S * PING_MISS_THRESHOLD`` seconds of silence. If the
+    websockets/uvicorn protocol keepalive timeout is tighter than that, it drops a
+    healthy-but-busy tunnel (event loop stalled) with ``1011`` before the
+    deliberate app-level policy ever applies — the regression this guards. Checked
+    against BOTH tunnels, which share the same budget.
+    """
+    from omnigent.server.routes import host_tunnel, runner_tunnel
+
+    for module in (runner_tunnel, host_tunnel):
+        app_level_dead_after_s = module.PING_INTERVAL_S * module.PING_MISS_THRESHOLD
+        assert app_level_dead_after_s <= TUNNEL_KEEPALIVE_PING_TIMEOUT_S, (
+            f"protocol ping_timeout ({TUNNEL_KEEPALIVE_PING_TIMEOUT_S}s) is stricter "
+            f"than {module.__name__}'s {app_level_dead_after_s}s app-level budget; it "
+            "would drop a busy-but-healthy tunnel with 1011 before the app-level "
+            "keepalive fires (issue #1116)."
+        )

--- a/tests/runner/transports/ws_tunnel/test_limits.py
+++ b/tests/runner/transports/ws_tunnel/test_limits.py
@@ -3,10 +3,10 @@
 Scope note (#1116): these guard the shared constants and the tunnel-vs-app-level
 invariant. They do NOT assert anything about the server-global reach of uvicorn's
 ``ws_ping_*`` — that setting applies the same 30 s/90 s budget to every WebSocket
-route (session-updates, terminal-attach), which is deliberate: those sockets carry
-their own app-level heartbeat traffic, so the only effect is a slightly later
-half-open-socket reap (~120 s vs ~40 s), not a correctness change. See the comment
-on ``uvicorn.run`` in ``omnigent/cli.py``.
+route (session-updates, terminal-attach), which is deliberate: for an idle such
+socket the protocol PING/PONG is the only half-open detector, so the only effect is
+a slightly later half-open-socket reap (~120 s vs ~40 s), bounded and not a
+correctness change. See the comment on ``uvicorn.run`` in ``omnigent/cli.py``.
 """
 
 from __future__ import annotations

--- a/tests/runner/transports/ws_tunnel/test_limits.py
+++ b/tests/runner/transports/ws_tunnel/test_limits.py
@@ -1,4 +1,13 @@
-"""Tests for the WS tunnel size limits + keepalive budget constants."""
+"""Tests for the WS tunnel size limits + keepalive budget constants.
+
+Scope note (#1116): these guard the shared constants and the tunnel-vs-app-level
+invariant. They do NOT assert anything about the server-global reach of uvicorn's
+``ws_ping_*`` — that setting applies the same 30 s/90 s budget to every WebSocket
+route (session-updates, terminal-attach), which is deliberate: those sockets carry
+their own app-level heartbeat traffic, so the only effect is a slightly later
+half-open-socket reap (~120 s vs ~40 s), not a correctness change. See the comment
+on ``uvicorn.run`` in ``omnigent/cli.py``.
+"""
 
 from __future__ import annotations
 

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -568,6 +568,8 @@ async def test_serve_tunnel_once_sends_bearer_header(
         },
         "close_timeout": serve_module._RUNNER_TUNNEL_CLOSE_TIMEOUT_S,
         "max_size": serve_module.RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+        "ping_interval": serve_module.TUNNEL_KEEPALIVE_PING_INTERVAL_S,
+        "ping_timeout": serve_module.TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
     }
     assert isinstance(captured["sent"], str)
 

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -466,11 +466,15 @@ async def test_serve_tunnel_once_sends_bearer_header(
         :param additional_headers: Optional handshake headers.
         :param close_timeout: WebSocket close-handshake timeout.
         :param max_size: Maximum inbound WebSocket message size.
+        :param ping_interval: Protocol keepalive ping interval (seconds).
+        :param ping_timeout: Protocol keepalive PONG timeout (seconds).
         """
 
         additional_headers: dict[str, str] | None
         close_timeout: float
         max_size: int
+        ping_interval: float
+        ping_timeout: float
 
     captured: dict[str, str | _ConnectKwargs] = {}
 


### PR DESCRIPTION
## Problem (#1116)

The runner↔server WebSocket tunnel is repeatedly dropped with `1011 keepalive ping timeout`, which cascades into `Timed out waiting for runner stream relay to subscribe` (`RUNNER_UNAVAILABLE`), reasonless "failed" sessions, and 503 storms.

## Root cause

The tunnel's **protocol-level** keepalive (the `websockets` library's own PING/PONG, and uvicorn's on the server side) was left at the library default of **20s ping-interval / 20s ping-timeout on both ends** — the runner's `websockets.connect()` set no ping params, and the server's `uvicorn.run()` set no `ws_ping_*`.

That default is **4.5× stricter** than the deliberate **app-level** liveness budget the server already runs (`_ping_loop`: `PING_INTERVAL_S=30` × `PING_MISS_THRESHOLD=3` = **90s** before a peer is declared dead). The protocol keepalive runs on each side's single event loop, so the moment a *healthy* runner's loop is stalled for ~20s — a synchronous / CPU-bound dispatch that doesn't yield — it can't emit a PONG, and the peer closes the tunnel with `1011`. The intended 90s policy never gets to apply.

I reproduced the mechanism directly against `websockets` 14.2 (separate event loops, as in prod): an inline loop block > the ping window → `1011 keepalive ping timeout`; the identical work offloaded to a thread (loop stays free) → stays connected; and the same block survives once the timeout is widened past it.

## Fix

Set `ping_interval=30s` / `ping_timeout=90s` on both ends, from shared constants in `ws_tunnel/limits.py`, so the protocol keepalive is **no tighter than the app-level budget**. A loop stall up to 90s (the system's own "is it dead?" line) no longer drops a live tunnel, while a genuinely dead peer is still detected. The same uvicorn config covers **both** the runner and host tunnel server endpoints.

## Implications considered

- **Widen, not disable.** The runner has *no* outbound liveness ping (the app-level `_ping_loop` runs server→client only), so the protocol ping is the runner's **only** detector of a silently-dead server. Disabling it would blind the runner to a dead server; widening preserves detection (worst case ~120s — a 30s interval before the next PING + 90s waiting for its PONG — vs ~20s before, which is fine: planned restarts signal explicitly via 1001/1012).
- **Server-global scope (uvicorn `ws_ping_*`).** uvicorn has no per-route ping override, so the server-side 30s/90s also applies to the app's other WebSocket routes — `/v1/sessions/updates` (browser stream) and `.../terminals/{id}/attach`. Deliberate and acceptable: those sockets carry their own app-level `session.heartbeat` / terminal traffic, so the only effect is that a *dead* browser/terminal socket with no app traffic is reaped at worst ~120s instead of ~40s — a slightly later half-open cleanup, not a correctness change. The runner-side `connect()` change is correctly tunnel-scoped (it's on the tunnel's own socket). Documented at the `uvicorn.run` call site.
- **No new idle-drop risk.** The app-level 30s ping already keeps the connection warm through any proxy/ingress, independent of the protocol ping.
- **`ws.latency` is unused** anywhere, and pings are excluded from the idle-runner-shutdown activity signal — neither is affected.
- **Side benefit:** every tunnel drop cancels all in-flight dispatches, so fewer spurious drops means less cancelled work and less reconnect / relay-resubscribe churn.

## Scope / follow-ups

This is the **surgical mitigation**. The deeper fix — keeping >Ns blocking work off the event loop so a *tight*, responsive keepalive is safe again — is tracked separately, as is widening the 5s relay-subscribe timeout (`_ensure_runner_relay_ready`) for added resilience during reconnects.

## Testing

- `test_limits.py`: invariant guard — protocol `ping_timeout` ≥ app-level budget for **both** tunnels, so any future tightening below 90s fails CI.
- `test_serve.py`: the runner's `connect()` passes the aligned ping params.
- `test_cli.py`: the server's uvicorn launch sets `ws_ping_interval` / `ws_ping_timeout`.
- Full `ws_tunnel` suite (158) + the cli server test pass; ruff clean.

This pull request and its description were written by Isaac.
