### PR TITLE
fix(claude-sdk): report context_tokens when a turn ends without a ResultMessage

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2518,6 +2518,30 @@ class ClaudeSDKExecutor(Executor):
             yield ExecutorError(message=terminal_error)
             return
 
+        # A turn can finish the stream without ever yielding a
+        # ``ResultMessage`` — the CLI can close the stream early, or the
+        # turn can be cut short before its final usage is reported. In
+        # that case ``turn_usage`` is None and the context-occupancy
+        # meter freezes at the previous successful turn's value, hiding
+        # real window fill exactly when a session is in trouble (#1533).
+        # We already observed the latest prompt size from ``message_start``
+        # (``last_call_usage``), so synthesize a usage dict from it and let
+        # ``TurnComplete`` carry it. ``context_tokens`` (window fill) is the
+        # meaningful field here; ``output_tokens`` is unknown on an
+        # incomplete turn, so report 0 rather than guess. The full
+        # ``ResultMessage`` path above still wins whenever it runs.
+        if turn_usage is None and last_call_usage is not None:
+            ctx_in = last_call_usage.get("input_tokens") or 0
+            ctx_cc = last_call_usage.get("cache_creation_input_tokens") or 0
+            ctx_cr = last_call_usage.get("cache_read_input_tokens") or 0
+            turn_usage = {
+                "input_tokens": ctx_in,
+                "output_tokens": 0,
+                "total_tokens": ctx_in,
+                "context_tokens": ctx_in + ctx_cc + ctx_cr,
+                "model": observed_model or model,
+            }
+
         # ── LLM_RESPONSE policy evaluation ───────────────────────
         # Evaluate after the stream completes but before TurnComplete
         # so a DENY prevents the response from being persisted.

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2957,6 +2957,119 @@ async def test_context_tokens_uses_last_call_not_cumulative_on_multi_iteration_t
 
 
 @pytest.mark.asyncio
+async def test_context_tokens_emitted_when_turn_ends_without_result_message() -> None:
+    """A turn that never reaches ``ResultMessage`` still reports ``context_tokens``.
+
+    ``context_tokens`` (context-window fill) is normally assembled in the
+    ``ResultMessage`` branch at successful completion. But a turn can end the
+    stream without a ``ResultMessage`` — the CLI can close the stream early,
+    or the turn can be cut short before its final usage is reported. Before
+    this fix the executor yielded ``TurnComplete(usage=None)`` in that case,
+    so the occupancy meter froze at the previous successful turn's value and
+    showed a misleadingly low fill exactly when a session was in trouble
+    (#1533).
+
+    The per-call prompt size is already observed mid-turn from each
+    ``message_start`` event, so when no ``ResultMessage`` arrives the executor
+    must fall back to that observed usage and still emit ``context_tokens``.
+
+    Regression guard: pre-fix ``turn.usage`` is ``None`` here because the
+    stream carries only a ``message_start`` and then stops.
+    """
+    from unittest.mock import patch
+
+    from claude_agent_sdk.types import (
+        ClaudeAgentOptions as SDKClaudeAgentOptions,
+    )
+    from claude_agent_sdk.types import ResultMessage as SDKResultMessage
+    from claude_agent_sdk.types import StreamEvent as SDKStreamEvent
+
+    from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+    class _Sentinel:
+        pass
+
+    # The turn opens one API call (carrying its prompt usage) and then the
+    # stream simply ends — no ResultMessage, mirroring an early CLI stream
+    # close or a turn cut short before final usage is reported.
+    message_start = SDKStreamEvent(
+        uuid="u1",
+        session_id="s1",
+        event={
+            "type": "message_start",
+            "message": {
+                "usage": {
+                    "input_tokens": 400,
+                    "cache_read_input_tokens": 9000,
+                    "cache_creation_input_tokens": 100,
+                }
+            },
+        },
+    )
+
+    class _FakeSDK:
+        AssistantMessage = _Sentinel
+        UserMessage = _Sentinel
+        SystemMessage = _Sentinel
+        StreamEvent = SDKStreamEvent
+        ResultMessage = SDKResultMessage
+        ClaudeAgentOptions = SDKClaudeAgentOptions
+        messages = [message_start]  # note: no ResultMessage
+
+        class ClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+
+            async def connect(self):
+                return None
+
+            async def query(self, prompt, session_id="default"):
+                return None
+
+            async def receive_response(self):
+                for message in _FakeSDK.messages:
+                    yield message
+
+            async def disconnect(self):
+                return None
+
+    executor = ClaudeSDKExecutor()
+    with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=_FakeSDK):
+        events = [
+            e
+            async for e in executor.run_turn(
+                [{"role": "user", "content": "hi"}],
+                [],
+                "",
+            )
+        ]
+
+    turn = next(e for e in events if isinstance(e, TurnComplete))
+    assert turn.usage is not None, (
+        "TurnComplete.usage is None on a turn that ended without a ResultMessage — "
+        "the observed message_start prompt usage was discarded, so the occupancy "
+        "meter freezes at the last successful turn's value (#1533)."
+    )
+
+    # context_tokens = the observed prompt = input + cache_creation + cache_read
+    # (400 + 100 + 9000), so a failed/early-ending turn still refreshes fill.
+    assert turn.usage["context_tokens"] == 9500, (
+        f"context_tokens {turn.usage.get('context_tokens')} != 9500 (400+100+9000) — "
+        "an incomplete turn must report context_tokens from the last observed "
+        "message_start prompt so the occupancy meter does not freeze."
+    )
+    # output_tokens is unknown on an incomplete turn, so it is reported as 0
+    # rather than guessed; the meaningful field here is context_tokens.
+    assert turn.usage["output_tokens"] == 0, (
+        f"output_tokens {turn.usage.get('output_tokens')} != 0 — output is unknown "
+        "on an incomplete turn and must not be fabricated."
+    )
+    assert "model" in turn.usage, (
+        "TurnComplete.usage is missing the 'model' key on the incomplete-turn path."
+    )
+
+
+@pytest.mark.asyncio
 async def test_assistant_message_model_flows_to_turn_usage() -> None:
     """The SDK's assistant-message model is forwarded in ``TurnComplete.usage``.
 


### PR DESCRIPTION
## Related issue

Related to #1533 (executor-side slice; does not fully close it, see Coverage notes).

## Summary

- `context_tokens` (context-window fill) was only assembled in the `ResultMessage` branch at successful completion, so a turn that ends the stream without a `ResultMessage` (an early CLI stream close, or a turn cut short before its final usage is reported) yielded `TurnComplete(usage=None)`. The occupancy meter then froze at the previous successful turn's value, showing a misleadingly low fill exactly when a session is in trouble.
- The latest prompt size is already observed mid-turn from each `message_start` event (`last_call_usage`). When no `ResultMessage` arrives, fall back to that observed usage and still emit `context_tokens`, so the meter keeps refreshing. The `ResultMessage` path is unchanged and still wins whenever it runs. `output_tokens` is unknown on an incomplete turn, so it is reported as `0` rather than guessed.

## Test Plan

- New regression test `test_context_tokens_emitted_when_turn_ends_without_result_message`: feeds a single `message_start` (carrying prompt usage) and then ends the stream with no `ResultMessage`, and asserts `TurnComplete.usage["context_tokens"]` equals the observed prompt (input + cache_creation + cache_read). Verified it **fails before the fix** (`turn.usage is None`) and passes after.
- `uv run pytest tests/inner/test_claude_sdk_executor.py` -> **102 passed**.
- `ruff check` / `ruff format --check` on both files: clean.

## Demo

N/A (non-visual; covered by the unit test above).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Honest scope: this covers the case where the stream ends without a `ResultMessage`, which is fully unit-testable and is fixed here. It does **not** cover the watchdog case in the issue where the turn is cancelled out from under the generator mid-stream, because that needs the observed usage to be persisted incrementally via the runner (a streamed mid-turn usage event), not just attached to the final `TurnComplete`. I asked the assignee in the issue thread which scope they want and whether to reuse an existing event channel for the incremental path; happy to extend this PR into the full streaming version on their direction. Filed as "Related to" rather than "Closes" for that reason. No secrets involved (test usage values are dummies; `_ensure_sdk` is patched, so no network call is made).
