### PR TITLE
test(e2e-ui): gate codex goal-mode test to nightly

### DIFF
--- a/tests/e2e_ui/chat/test_codex_goal_mode.py
+++ b/tests/e2e_ui/chat/test_codex_goal_mode.py
@@ -36,6 +36,10 @@ def _goal_response(session_id: str, method: str, suffix: str = ""):
     return _matches
 
 
+# Boots a real native Codex CLI (like the native render-parity tests it shares
+# fixtures with), so it costs ~7.5min -- the bulk of one e2e-ui CI shard. Gated
+# to nightly to match those siblings and keep the per-PR shards balanced.
+@pytest.mark.nightly
 @pytest.mark.timeout(900)
 def test_codex_goal_mode_with_mocked_responses(
     page: Page,


### PR DESCRIPTION
## Problem

E2E UI Tests have been timing out / running long more often recently. Root cause is a single test.

`tests/e2e_ui/chat/test_codex_goal_mode.py::test_codex_goal_mode_with_mocked_responses` (added in #699) costs **~7.5 min in CI -- 53% of one PR shard's entire runtime**. Under the strided-slice sharding it lands on shard 2/3, pushing that shard from ~4 min to ~14 min against the 20 min job cap while shards 0/1 stay at ~4 min. Measured across the last several PR runs, shard 2's pytest step is consistently 13-14 min vs ~4 min for its siblings (~3.8x skew).

## Why it's slow

The `mocked_native_codex_goal_session` fixture lazily runs `cargo build` for the codex-parity sidecar. The test body itself is trivial -- pytest's own slow-test report clocks it at **6.24s**; the other ~447s is all fixture setup (the cargo build).

The Rust-build cache added in #1378 reports a **cache HIT** on every run, but the sidecar recompiles anyway: a plain `actions/cache` of the cargo target dir doesn't preserve the fingerprints/mtimes cargo relies on, so its large dependency tree (openai/codex `core_test_support`) rebuilds from scratch each run. So this is not a cache-miss problem -- the cache lands, cargo just ignores it.

## Fix

Gate the test to `@pytest.mark.nightly`, matching every sibling native-Codex test (the render-parity suite it shares fixtures with is already nightly). This one escaped the gate.

It is also the **only non-nightly consumer** of the codex-parity sidecar, so nightly-gating removes the Rust toolchain build from every per-PR e2e-ui run.

## Follow-ups (not in this PR)

- The Rust toolchain + cache steps in `e2e-ui.yml` are now dead weight on per-PR runs; they could move to the nightly/dispatch path.
- If the test ever needs to run per-PR again, switch the codex-parity cache to `Swatinem/rust-cache` (or pre-build the sidecar in a dedicated step) so the warm path is actually warm. cc @serena-ruan re #1378.
- Consider duration-based shard balancing so a single heavy test can't lopside one shard.
