### PR TITLE
feat: browser-safe numeric session jump (#7)

### DIFF
--- a/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
+++ b/tests/e2e_ui/hotkeys/test_sidebar_hotkeys.py
@@ -1,0 +1,60 @@
+"""UI e2e: sidebar keyboard chords in a real browser (#7).
+
+Covers the two hook changes end to end:
+
+- ``usePinnedSessionHotkeys`` — in the browser, ``Ctrl/Cmd+Alt+<digit>`` jumps
+  to the Nth *pinned* session (plain ``Cmd+digit`` is the native tab switch,
+  so the browser path owns the Alt chord and matches ``e.code``).
+- ``useSidebarToggleHotkeys`` — ``Ctrl/Cmd+Alt+[`` toggles the left sidebar
+  (exercising the handler, AltGraph guard included, on a real keydown). The
+  sidebar collapses to an icon rail rather than unmounting, so the assertion
+  is on the search input's rendered width, not its visibility.
+"""
+
+from __future__ import annotations
+
+import json
+
+from playwright.sync_api import Page, expect
+
+# Mirrors PINNED_CONVERSATION_IDS_STORAGE_KEY in web/src/shell/sidebarNav.ts —
+# pins are client-side state, so the test seeds them where the app reads them.
+_PINNED_KEY = "omnigent:pinned-conversation-ids"
+
+_SEARCH_WIDTH_JS = """
+() => {
+  const el = document.querySelector('input[placeholder="Search sessions"]');
+  return el ? el.getBoundingClientRect().width : -1;
+}
+"""
+
+
+def test_numeric_chord_jumps_to_pinned_session(
+    page: Page, live_server: str, seeded_session: tuple[str, str]
+) -> None:
+    base_url, session_id = seeded_session
+    # Pin the seeded session before the app boots (pins live in localStorage).
+    page.add_init_script(
+        f"window.localStorage.setItem({_PINNED_KEY!r}, {json.dumps(json.dumps([session_id]))})"
+    )
+    page.goto(base_url)
+    # The hook reads the RENDERED Pinned section — wait for it (it only
+    # appears once the session list has loaded and the pin resolved).
+    expect(page.get_by_text("Pinned", exact=True)).to_be_visible(timeout=30_000)
+
+    page.keyboard.press("Control+Alt+Digit1")
+    page.wait_for_url(f"**/c/{session_id}", timeout=15_000)
+
+
+def test_bracket_chord_toggles_left_sidebar(page: Page, live_server: str) -> None:
+    page.goto(live_server)
+    expect(page.get_by_placeholder("Search sessions")).to_be_visible(timeout=30_000)
+    expanded_width = page.evaluate(_SEARCH_WIDTH_JS)
+    assert expanded_width > 100, f"sidebar unexpectedly narrow at start ({expanded_width}px)"
+
+    # Collapse: the rail shrinks to icon width (input stays mounted).
+    page.keyboard.press("Control+Alt+BracketLeft")
+    page.wait_for_function(f"() => ({_SEARCH_WIDTH_JS})() < 80", timeout=10_000)
+    # Expand again.
+    page.keyboard.press("Control+Alt+BracketLeft")
+    page.wait_for_function(f"() => ({_SEARCH_WIDTH_JS})() > 100", timeout=10_000)

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { KeyboardShortcutsDialog, openKeyboardShortcuts } from "./KeyboardShortcutsDialog";
 
-// The pinned-session row is desktop-only. Default to browser (false).
+// The pinned-session row shows in both shells; only its chord differs (Alt in
+// the browser). Default the mock to browser (false); flip per-test for native.
 const isNativeShell = vi.fn(() => false);
 vi.mock("@/lib/nativeBridge", () => ({
   isNativeShell: () => isNativeShell(),
@@ -55,16 +56,23 @@ describe("KeyboardShortcutsDialog", () => {
     expect(await screen.findByText("Send message")).toBeTruthy();
   });
 
-  it("hides the pinned-session shortcut in a plain browser", () => {
+  it("shows the pinned-session shortcut with the Alt chord in a plain browser", () => {
     render(<KeyboardShortcutsDialog />);
     toggleViaHotkey();
-    expect(screen.queryByText("Jump to pinned session (1–10)")).toBeNull();
+    const row = screen.getByText("Jump to pinned session (1–10)").closest("li");
+    expect(row).toBeTruthy();
+    // Browser chord adds Alt (jsdom navigator is non-mac → "Alt") + the 1…0 chip.
+    expect(within(row!).getByText("Alt")).toBeTruthy();
+    expect(within(row!).getByText("1…0")).toBeTruthy();
   });
 
-  it("shows the pinned-session shortcut in the Electron shell", () => {
+  it("shows the pinned-session shortcut without Alt in the Electron shell", () => {
     isNativeShell.mockReturnValue(true);
     render(<KeyboardShortcutsDialog />);
     toggleViaHotkey();
-    expect(screen.getByText("Jump to pinned session (1–10)")).toBeTruthy();
+    const row = screen.getByText("Jump to pinned session (1–10)").closest("li");
+    expect(row).toBeTruthy();
+    expect(within(row!).queryByText("Alt")).toBeNull();
+    expect(within(row!).getByText("1…0")).toBeTruthy();
   });
 });

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -103,20 +103,22 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   },
 ];
 
-// Desktop-only: Cmd/Ctrl+digit collides with browser tab-switching, so the
-// pinned-session hotkey ships only in the Electron shell (see
-// usePinnedSessionHotkeys). Injected into "Navigation" when running natively.
-const PINNED_SESSION_SHORTCUT: Shortcut = {
-  label: "Jump to pinned session (1–10)",
-  keys: [MOD_KEY, "1…0"],
-};
+// Numeric pinned-session jump. The chord is platform-aware (see
+// usePinnedSessionHotkeys): plain Cmd/Ctrl+digit in the Electron shell, but
+// Cmd/Ctrl+Alt+digit in a browser tab, where plain Cmd+digit is reserved for
+// native tab-switching. Shown in both, with the matching glyphs.
+function pinnedSessionShortcut(native: boolean): Shortcut {
+  return {
+    label: "Jump to pinned session (1–10)",
+    keys: native ? [MOD_KEY, "1…0"] : [MOD_KEY, ALT, "1…0"],
+  };
+}
 
-/** Shortcut groups for the current runtime — adds desktop-only rows natively. */
+/** Shortcut groups for the current runtime — the pinned-jump chord differs by shell. */
 function shortcutGroupsFor(native: boolean): ShortcutGroup[] {
-  if (!native) return SHORTCUT_GROUPS;
   return SHORTCUT_GROUPS.map((group) =>
     group.title === "Navigation"
-      ? { ...group, items: [...group.items, PINNED_SESSION_SHORTCUT] }
+      ? { ...group, items: [...group.items, pinnedSessionShortcut(native)] }
       : group,
   );
 }

--- a/web/src/hooks/usePinnedSessionHotkeys.test.tsx
+++ b/web/src/hooks/usePinnedSessionHotkeys.test.tsx
@@ -1,6 +1,7 @@
-// Cmd/Ctrl+digit jumps to the Nth pinned session: 1–9 → indices 0–8, 0 → 10th.
-// Requires Cmd/Ctrl, no Alt/Shift; fires inside text fields; out-of-range and
-// already-active are no-ops; only out-of-range leaves the native event alone.
+// Numeric pinned-session jump to the Nth pinned session: 1–9 → indices 0–8,
+// 0 → 10th. Platform-aware chord — plain Cmd/Ctrl+digit in the Electron shell,
+// Cmd/Ctrl+Alt+digit in the browser (matched on e.code there, since Alt rewrites
+// e.key). Fires inside text fields; out-of-range and already-active are no-ops.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,9 +12,9 @@ vi.mock("@/lib/routing", () => ({
   useNavigate: () => navigate,
 }));
 
-// The shortcut is desktop-only (Cmd+digit collides with browser tab-switching),
-// so the hook is gated on the Electron shell. Default the mock to "native" and
-// flip it per-test for the browser case.
+// The chord is platform-aware: plain Cmd+digit in the Electron shell, but
+// Cmd+Alt+digit in the browser (where plain Cmd+digit is the native tab-switch).
+// Default the mock to "native" and flip it per-test for the browser case.
 const isNativeShell = vi.fn(() => true);
 vi.mock("@/lib/nativeBridge", () => ({
   isNativeShell: () => isNativeShell(),
@@ -27,8 +28,9 @@ function press(
     metaKey: true,
   },
   target: HTMLElement = document.body,
+  code = "",
 ): KeyboardEvent {
-  const e = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...mods });
+  const e = new KeyboardEvent("keydown", { key, code, bubbles: true, cancelable: true, ...mods });
   target.dispatchEvent(e);
   return e;
 }
@@ -141,12 +143,36 @@ describe("usePinnedSessionHotkeys", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("is inert in a plain browser (not the Electron shell)", () => {
+  it("browser: leaves plain Cmd+digit to the native tab-switch", () => {
     isNativeShell.mockReturnValue(false);
     renderHook(() => usePinnedSessionHotkeys(ids, undefined));
-    const e = press("1");
+    const e = press("1", { metaKey: true }, document.body, "Digit1");
     expect(navigate).not.toHaveBeenCalled();
-    // Leave the browser's own Cmd+1 tab-switch alone.
+    // Plain Cmd+1 is the browser's own tab-switch — left alone.
     expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("browser: Cmd+Alt+Digit1 opens the first pinned session", () => {
+    isNativeShell.mockReturnValue(false);
+    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    // Alt rewrites e.key on macOS (⌥1 → "¡"), so the hook matches e.code.
+    const e = press("¡", { metaKey: true, altKey: true }, document.body, "Digit1");
+    expect(navigate).toHaveBeenCalledWith("/c/a");
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("browser: Ctrl+Alt+Digit3 opens the third (Windows/Linux)", () => {
+    isNativeShell.mockReturnValue(false);
+    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    press("3", { ctrlKey: true, altKey: true }, document.body, "Digit3");
+    expect(navigate).toHaveBeenCalledWith("/c/c");
+  });
+
+  it("browser: Cmd+Alt+Digit0 opens the tenth pinned session", () => {
+    isNativeShell.mockReturnValue(false);
+    const ten = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+    renderHook(() => usePinnedSessionHotkeys(ten, undefined));
+    press("º", { metaKey: true, altKey: true }, document.body, "Digit0");
+    expect(navigate).toHaveBeenCalledWith("/c/j");
   });
 });

--- a/web/src/hooks/usePinnedSessionHotkeys.test.tsx
+++ b/web/src/hooks/usePinnedSessionHotkeys.test.tsx
@@ -168,6 +168,20 @@ describe("usePinnedSessionHotkeys", () => {
     expect(navigate).toHaveBeenCalledWith("/c/c");
   });
 
+  it("browser: ignores AltGr chords (AltGr+digit composes characters on intl layouts)", () => {
+    // AltGr reports as Ctrl+Alt on Windows/Linux — typing AltGr+2 must
+    // compose the character (event untouched), not navigate to a session.
+    isNativeShell.mockReturnValue(false);
+    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    const altGraph = vi
+      .spyOn(KeyboardEvent.prototype, "getModifierState")
+      .mockImplementation((keyArg) => keyArg === "AltGraph");
+    const e = press("\u00b2", { ctrlKey: true, altKey: true }, document.body, "Digit2");
+    expect(navigate).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+    altGraph.mockRestore();
+  });
+
   it("browser: Cmd+Alt+Digit0 opens the tenth pinned session", () => {
     isNativeShell.mockReturnValue(false);
     const ten = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];

--- a/web/src/hooks/usePinnedSessionHotkeys.ts
+++ b/web/src/hooks/usePinnedSessionHotkeys.ts
@@ -3,17 +3,36 @@
 // useSessionSwitchHotkey — same once-bound, ref-backed, metaKey||ctrlKey shape.
 // Fires even in a focused text field so you can jump mid-compose. Bind ONCE.
 //
-// Desktop-only: a browser tab reserves Cmd/Ctrl+digit for tab-switching, so the
-// hook is inert outside the Electron shell (see isNativeShell). The matching
-// per-row chips and the shortcuts-dialog row are gated the same way.
+// Platform-aware chord: a browser tab reserves plain Cmd/Ctrl+digit for native
+// tab-switching, so in the browser the binding adds Alt (Cmd/Ctrl+Alt+digit) to
+// own a free chord; the Electron shell keeps the plain Cmd/Ctrl+digit it can
+// safely claim. With Alt held macOS rewrites e.key to a composed glyph
+// (⌥1 → "¡"), so the browser path matches on e.code (physical key) while the
+// native path matches on e.key. The shortcuts-dialog row mirrors the same split.
 
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@/lib/routing";
 import { isNativeShell } from "@/lib/nativeBridge";
 
-/** Index → the digit key that selects it. Single source of truth shared with
- *  the sidebar's per-row shortcut chips so the binding and label can't drift. */
+/** Index → the digit key that selects it (native path; matched against e.key).
+ *  Single source of truth shared with the shortcuts dialog so binding and label
+ *  can't drift. */
 export const PINNED_HOTKEY_DIGITS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"] as const;
+
+/** Index → the physical key code (browser path; matched against e.code, since
+ *  Alt rewrites e.key on macOS). Same order as {@link PINNED_HOTKEY_DIGITS}. */
+export const PINNED_HOTKEY_CODES = [
+  "Digit1",
+  "Digit2",
+  "Digit3",
+  "Digit4",
+  "Digit5",
+  "Digit6",
+  "Digit7",
+  "Digit8",
+  "Digit9",
+  "Digit0",
+] as const;
 
 /**
  * @param orderedPinnedIds Pinned conversation ids in sidebar render order
@@ -31,13 +50,20 @@ export function usePinnedSessionHotkeys(
 
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Desktop-only: in a browser tab Cmd/Ctrl+digit is the native
-      // tab-switch, which we must not hijack. Only the Electron shell owns it.
-      if (!isNativeShell()) return;
-      // Cmd/Ctrl, not Alt (Alt+chord is the message hotkey); Shift left alone.
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+      // Cmd/Ctrl required; Shift left to other bindings.
+      if (e.shiftKey || !(e.metaKey || e.ctrlKey)) return;
 
-      const index = PINNED_HOTKEY_DIGITS.indexOf(e.key as (typeof PINNED_HOTKEY_DIGITS)[number]);
+      let index: number;
+      if (isNativeShell()) {
+        // Desktop owns plain Cmd/Ctrl+digit (Alt+chord is the message hotkey).
+        if (e.altKey) return;
+        index = PINNED_HOTKEY_DIGITS.indexOf(e.key as (typeof PINNED_HOTKEY_DIGITS)[number]);
+      } else {
+        // Browser: plain Cmd/Ctrl+digit is the native tab-switch, so own the
+        // Cmd/Ctrl+Alt+digit chord instead. Alt rewrites e.key → match e.code.
+        if (!e.altKey) return;
+        index = PINNED_HOTKEY_CODES.indexOf(e.code as (typeof PINNED_HOTKEY_CODES)[number]);
+      }
       if (index === -1) return;
 
       const { orderedPinnedIds: ids, activeId: active } = latest.current;

--- a/web/src/hooks/usePinnedSessionHotkeys.ts
+++ b/web/src/hooks/usePinnedSessionHotkeys.ts
@@ -62,6 +62,11 @@ export function usePinnedSessionHotkeys(
         // Browser: plain Cmd/Ctrl+digit is the native tab-switch, so own the
         // Cmd/Ctrl+Alt+digit chord instead. Alt rewrites e.key → match e.code.
         if (!e.altKey) return;
+        // AltGr reports as Ctrl+Alt on Windows/Linux intl layouts — typing
+        // AltGr+digit must compose the character, not yank the user to a
+        // pinned session. Same guard (and same feature-detect, so synthetic
+        // events without the method don't throw) as useSidebarToggleHotkeys.
+        if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return;
         index = PINNED_HOTKEY_CODES.indexOf(e.code as (typeof PINNED_HOTKEY_CODES)[number]);
       }
       if (index === -1) return;

--- a/web/src/hooks/useSidebarToggleHotkeys.test.tsx
+++ b/web/src/hooks/useSidebarToggleHotkeys.test.tsx
@@ -88,6 +88,22 @@ describe("useSidebarToggleHotkeys", () => {
     altGraph.mockRestore();
   });
 
+  it("still fires when getModifierState is unavailable (no throw)", () => {
+    const { onToggleLeft } = setup();
+    const ev = new KeyboardEvent("keydown", {
+      code: "BracketLeft",
+      ctrlKey: true,
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    // Some environments / synthetic events lack getModifierState; the handler
+    // must guard the call rather than throw on every keydown.
+    Object.defineProperty(ev, "getModifierState", { value: undefined, configurable: true });
+    expect(() => document.body.dispatchEvent(ev)).not.toThrow();
+    expect(onToggleLeft).toHaveBeenCalledTimes(1);
+  });
+
   it("claims the event (preventDefault + stopPropagation)", () => {
     setup();
     const ev = new KeyboardEvent("keydown", {

--- a/web/src/hooks/useSidebarToggleHotkeys.ts
+++ b/web/src/hooks/useSidebarToggleHotkeys.ts
@@ -31,8 +31,10 @@ export function useSidebarToggleHotkeys(handlers: SidebarToggleHandlers): void {
       // reject Shift, so ⌘⌥⇧ combos stay free for future bindings.
       if (!(e.metaKey || e.ctrlKey) || !e.altKey || e.shiftKey) return;
       // AltGr often reports as Ctrl+Alt; ignore it so intl-layout typing doesn't
-      // accidentally toggle sidebars while focused in an editor/composer.
-      if (e.getModifierState("AltGraph")) return;
+      // accidentally toggle sidebars while focused in an editor/composer. Guard
+      // the call: not every environment implements getModifierState, and an
+      // unguarded call there would throw and break the whole keydown handler.
+      if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return;
       // Ignore auto-repeat: holding the chord would flap the panel open/closed.
       if (e.repeat) return;
       // Match the physical key, not the character: ⌥ turns "[" / "]" into "“" /


### PR DESCRIPTION
## Related issue

Closes #1735. Independent, single-feature PR off `main` (part of epic #1600).

## Summary

Makes the existing numeric **pinned-session jump** work in the **browser**, not just the Electron shell — by extending `usePinnedSessionHotkeys` rather than adding a parallel hook.

- **Browser:** `⌘/Ctrl+Alt+1…0` jumps to the first ten pinned sidebar sessions. `Alt` frees a chord the page can own (plain `⌘/Ctrl+digit` stays the browser's native tab-switch). Since `Alt` rewrites `e.key` on macOS (`⌥1 → "¡"`), the browser path matches on `e.code` (`Digit1…Digit0`).
- **Desktop (Electron):** unchanged — plain `⌘/Ctrl+1…0` (matched on `e.key`).
- The `⌘/Ctrl + /` Keyboard Shortcuts dialog now lists "Jump to pinned session (1–10)" in both shells, with the matching glyphs (adds `⌥`/Alt in the browser).

Consistent with the existing `⌘/Ctrl+Alt` family (message-nav `↑/↓`, sidebar toggles `[` `]`); the digit slots were unused, so no collision.

## Test Plan

- `web/`: `tsc -b` clean; `vitest` — `usePinnedSessionHotkeys` (native + new browser-chord paths) and `KeyboardShortcutsDialog` (row shown in both shells with the correct chord) — **25 passed**; prettier clean.
- Demo video attached on #1735 (⌘/Ctrl+/ dialog + live ⌘⌥1 / ⌘⌥2 jumps between two pinned sessions).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Not applicable

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
