### PR TITLE
docs: master architecture + CUJ analysis (code + live traces)

### DIFF
--- a/designs/master-arch/CUJ-COVERAGE.md
+++ b/designs/master-arch/CUJ-COVERAGE.md
@@ -1,0 +1,954 @@
+# Omnigent CUJ Coverage — every journey in `designs/CUJ-MAP.md`, answered
+
+**Purpose.** One doc that walks **every** journey bullet listed in
+[`designs/CUJ-MAP.md`](../../designs/CUJ-MAP.md) §2.A–§2.H and gives each a concrete,
+**code + trace-grounded** answer. This supersedes/deepens
+[`designs/CUJ-ANALYSIS.md`](../../designs/CUJ-ANALYSIS.md) — the analysis file's `file:line`
+anchors had drifted by thousands of lines; the anchors below are **re-derived** from current
+`main` (worktree `…/traces`, HEAD `60d11673`) and cross-checked against the per-component
+architecture (`architecture/*.md`) and per-domain answer docs (`cuj-answers/*.md`).
+
+**Scope:** claude (sdk + native), codex (sdk + native), Polly / custom agents. Other harnesses
+out of scope. **codex / codex-native are live-blocked** (Databricks AI-gateway creds expired,
+403 — host reports `codex: needs-auth`) → covered from **code + the §4 capability matrix +
+structural analogy** to claude; labelled *(code-only, creds)* throughout.
+
+**Legend:** ✅ works / verified · ⚠️ works-but-caveat or known failure-branch · ❓ not
+confirmed this pass. **Trace evidence** cites real span names + conv ids where we drove it live
+(rig: local Jaeger `:16686`, persistent `omnigent server :7777` + host; extract via
+`scratchpad/trace_tools.py`).
+
+---
+
+## 0. Coverage table (per domain: # journeys → live-traced vs code-only)
+
+| Domain | Journeys | Live-traced | Code-only | Notes |
+|---|---:|---:|---:|---|
+| **§2.A** Session lifecycle & continuity | 11 | 6 | 5 | fork, switch, interrupt, compaction-reject, send/stream, disconnect traced live |
+| **§2.B** Harnesses & per-harness features | 6 | 2 | 4 | claude-native turn + model/runner binding traced; matrix code-verified |
+| **§2.C** Tools, MCP, shells, files, timers | 6 | 4 | 2 | `sys_*` (sys_os_shell), custom MCP, timers, shells traced; OmniBox code-only |
+| **§2.D** Policies, approvals, elicitations | 7 | 3 | 4 | ASK/DENY, TOOL_CALL gate, REQUEST gate traced live |
+| **§2.E** Web UI & clients | 13 | 3 | 10 | web has no OTel spans (opt-in, off) → mostly code; stream/presence/subagent-rail seen via server spans |
+| **§2.F** Agents, subagents, executor, routing | 10 | 3 | 7 | sub-agent spawn, executor loop, runner-binding traced; #848/affinity code-verified |
+| **§2.G** Onboarding, credentials, auth | 6 | 0 | 6 | creds never surface as spans → all code; PR #1439 verified merged |
+| **§2.H** API & message surface | 4 | 2 | 2 | events envelope + SSE families trace-confirmed; full REST catalog code (AST) |
+| **Total** | **63** | **~23 (11 distinct live CUJ traces)** | **rest** | 11 distinct live-trace CUJs cover ≥23 journey bullets |
+
+The **11 distinct live traces** (`cuj-answers/_LIVE-TRACE-FINDINGS.md`) are: fork · switch-agent ·
+interrupt · compaction(`/compact` reject) · model+runner-binding · sub-agent spawn · claude-native
+turn · disconnect/reconnect · custom MCP · timers · ASK/DENY policy. Each is reused across the
+domains its journey touches, so one trace often evidences several bullets.
+
+**Deeper docs:** each answer points to `architecture/<component>.md` and/or
+`cuj-answers/<domain>.md`. The reliability gaps (§6 of CUJ-ANALYSIS, carried forward + updated) are
+consolidated at the **bottom** of this doc.
+
+---
+
+## §2.A  Session lifecycle & continuity
+
+Server logic: `omnigent/server/routes/sessions.py` (912 KB) + `stores/conversation_store/`.
+Deeper: `cuj-answers/server-api-state-streaming.md`, `architecture/server.md`.
+
+### ✅ Create a new session (new chat / from existing agent / bundled upload)
+`POST /v1/sessions` → `create_session` (`sessions.py:13688`). **JSON** binds an existing `agent_id`;
+**multipart** (`metadata`+`bundle`) creates a session-scoped agent + conv row in one txn. Grants
+caller `LEVEL_OWNER`, `_announce_session_added` pushes to other tabs. Optional `host_id` triggers
+the host→runner launch (+ `workspace` pins the cwd).
+**⚠️ inert-until-bound:** REST `POST /v1/sessions {agent_id}` alone returns `runner_id:null`; the
+next `POST /events` → `{"error":{"code":"runner_unavailable"}}`. The web binds by passing `host_id`
+at create; `omnigent run` binds a per-run runner.
+**Trace:** `POST /v1/sessions` root span; the web/host path adds `host.stat`+`host.launch_runner`
+CONSUMER spans on `omni-host` (host-channel trace `aee57ff3…`). *(§2.H, §2.G overlap)*
+→ `cuj-answers/server-api-state-streaming.md` Q7; `_LIVE-TRACE-FINDINGS.md` "Driving model & runner binding".
+
+### ✅ Resume a session — *how much transcript loads into the runner?*
+`GET /v1/sessions/{id}` → `_get_session_snapshot` (`SessionResponse` at `:2458`): metadata +
+paginated items + `pending_elicitations` + `pending_inputs` + child sessions; `refresh_state=true`
+re-pulls the live runner. **How much loads into the runner:** on the next dispatched turn the runner
+calls `GET …/items` and `_load_history_as_input` (`runner/app.py:14842`) rebuilds input —
+**full conversation, OR (if a compaction item exists) only the slice after `last_item_id` + the
+expanded summary** (`workflow.py:2276` `_load_initial_history`). **SDK** re-drives the executor from
+this reconstructed history; **native** keys on `external_session_id` and the vendor CLI reloads its
+own store (Omnigent re-injects only if the vendor store is gone). ⚠️ runner offline → snapshot shows
+`runner_online:null`.
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q6; `runner-dispatch-mcp.md` Q2.
+
+### ✅ Fork a session — *how is the forked transcript constructed?* **[LIVE]**
+`POST /v1/sessions/{src}/fork` → `fork_session` (`:15180`, 201). `fork_conversation`
+(`sqlalchemy_store.py:2266`) **deep-copies items with fresh ids** (preserving position/response_id),
+optional `up_to_response_id` truncation, clones the agent (optional cross-family harness switch →
+resets model/effort), **drops instance-scoped labels** (bridge_id, context-token metrics), does
+**not** copy `external_session_id`/`workspace`/`git_branch`. Native target rebuilds transcript from
+the `FORK_CARRY_HISTORY` label.
+**⚠️ can't fork a sub-agent (400, `:15238`).**
+**Trace evidence** (`conv_820c6dee` → `conv_7fe12aec`): **server-side only** — new conv returns
+`runner_id=null, host_id=null` (no runner spawned for the copy); a burst of **~25 INSERT + many
+SELECT on `chat.db`** = the synchronous deep-copy; new session gets a cloned `agent_id` + label
+`omnigent.fork.source_id`. **Beyond code:** fork cost is synchronous server DB work that **scales
+with item count** (INSERT-per-item) — a latency spike, not a runner concern.
+→ `_LIVE-TRACE-FINDINGS.md` "Fork"; `server-api-state-streaming.md` Q7.
+
+### ✅ Switch agent in place (mid-session) **[LIVE]**
+`POST /v1/sessions/{id}/switch-agent` → `switch_session_agent` (`:15415`); **idle-only — 409 if
+running** (`:15481`); loads target bundle before committing (fail-closed). `switch_conversation_agent`
+(`sqlalchemy_store.py:2576`) deletes the old session-scoped agent, clones the target, repoints
+`agent_id`, resets model/effort on cross-family, **clears `external_session_id`** (`:2663`) so a
+native target cold-starts, stamps a "switch-back" label, publishes `session.agent_changed`.
+**Trace evidence** (`conv_820c6dee` → agent `debby`/`ag_3f172efb`): returns immediately, resets
+labels, **retains the runner binding** (`runner_token_c2a963…`) — the next turn reuses the same
+runner, re-initialized for the new agent (no new runner launch on switch).
+→ `_LIVE-TRACE-FINDINGS.md` "Switch-agent"; `harness-behavior.md` Q6.
+
+### ⚠️ Disconnect → reconnect (TUI / WebUI) **[LIVE]** — failure-branch
+**Contract = snapshot + live tail, NOT replay.** `_stream_live_events` (`sessions.py:11229`) yields
+only from `subscribe` forward — "no buffer, no replay … dedupe by item id" (docstring `:11240`).
+Reconnect: open `GET …/stream` first (`ready_event` heartbeat acks the tail slot `:11314`), read
+snapshot `GET …/{id}`, dedupe overlap by `ctx.itemId` (web `lib/blockStream.ts`; TUI byte-equal
+multiset). `[DONE]` sentinel on **every** exit path (`:11341` `finally`). A turn keeps running through
+a disconnect (runner-side); client just re-derives the view.
+**Trace evidence** (`conv_6bbdba9a`, SSE dropped mid-flight): reopening the stream **replays the
+identical opening frames** (snapshot-on-connect: `session.heartbeat` → `session.resource.created`
+[terminal `terminal_tui_main`] → `session.changed_files.invalidated` → `session.presence`), **NOT**
+token deltas. **Nuance:** in-flight assistant *text* IS re-seeded synchronously at slot registration
+(`pre_ready_snapshot=inflight_text.snapshot_for(id)`, `:11320`) so the cursor doesn't blank; resource
+state is full-snapshot, deltas dropped on the floor. Disconnect detection = `_poll_request_disconnect`
+(`:1183`) blocking on `request.receive()`, raced against the elicitation/hook futures.
+**⚠️ gap: runner-offline-on-message** (below) is the disconnect variant that actually strands a client.
+→ `_LIVE-TRACE-FINDINGS.md` "Disconnect / reconnect"; `server-api-state-streaming.md` Q4.
+
+### ✅ Close the page & come back later
+Server-durable; the session keeps running while the page is closed. On return, the web
+`switchTo(id)` opens `SSE …/stream` first, then `getSessionSlim` + `fetchInitialHistoryWindow`
+concurrently, merges deduped by item id (`chatStore.ts:1825-1907`). SSE pump auto-reconnects on
+transport drops (Databricks Apps ~5-min HTTP/2 cap); `reconcileOnReconnect` (`:2394`) pages backward
+to splice unseen items + recover spinner state. **Host offline →** `ReconnectSessionDialog`
+(`ChatPage.tsx:1095`): `host_offline` shows the CLI reconnect command; `local_stranded` shows
+`omnigent <run|claude> --resume`. Managed hosts read `host_asleep` (next message wakes the sandbox).
+→ `cuj-answers/web-client.md` Q5.
+
+### ✅ Close / archive / delete a session
+- **Archive** — `PATCH /v1/sessions/{id} {archived}` (`update_session` `:14795`), **owner-only**
+  (`:14823`); plain DB column, hidden from list by default. Pull-based (no WS publish).
+- **Close** (sub-agent) — no route; set by `sys_session_close` → label `omnigent.closed=="true"`
+  OR legacy title `:closed:` (`is_session_closed`, `session_lifecycle.py:70`). `post_event` rejects
+  new user input (409, `:18306`); **reads still allowed**.
+- **Delete** — `DELETE /v1/sessions/{id}` (`:19358`), **owner-only** (admins bypass); best-effort
+  runner-resource cleanup, file/artifact delete, optional `?delete_branch` worktree removal, managed-
+  host teardown. ⚠️ runner offline → orphans runner resources (falls back to local registry cleanup).
+→ `cuj-answers/server-api-state-streaming.md` Q7.
+
+### ✅ Send a message + receive a streaming response **[LIVE]**
+`POST /v1/sessions/{id}/events` → `post_event` (`:18150`, returns 202). **Invariant I1:
+persist-before-forward** — `conversation_store.append([item])` first (`:8540`), then POST to runner
+(`:8697`), then `_publish_input_consumed` carrying the persisted `item_id` (`:8704`) for client
+dedup. Streaming deltas = `response.output_text.delta`; final text flushed to a durable `message` at
+a function-call boundary or terminal `response.*`.
+**Events envelope** (verified `:18282`, `parse_item_data(type, {type,**data})`):
+`{"type":"message","data":{"role":"user","content":[{"type":"input_text","text":"…"}]}}`.
+**Trace evidence** (tool-use conv, 415 spans): `POST /events` → `policy.evaluate` → `UPDATE`+`INSERT
+chat.db` (the append) → cross-edge `POST` to `omni-runner /events`; the append precedes the runner POST
+(**I1 visible on the wire**); runner calls back `GET /items` + `GET /sessions/{id}`.
+**⚠️ deny path:** policy deny → persist sentinel, terminal `response.completed` (headless `-p`
+unblock), status→idle, **not forwarded**. **⚠️ runner offline:** fresh item with no runner+no host →
+503 `RUNNER_UNAVAILABLE` **before** persist (`:19073`); if a runner was bound but offline → persisted,
+forward fails, idle published, client bubble may sit until snapshot reconciliation.
+→ `cuj-answers/server-api-state-streaming.md` Q1; `_LIVE-TRACE-FINDINGS.md` "Driving model".
+
+### ⚠️ Compaction / context-window overflow **[LIVE]** — failure-branch
+3-layer, least→most lossy (`runtime/compaction.py:544`): **L1** surgical clear of tool-result bodies
+→ **L2** LLM summary (routed through runner `POST /v1/summarize` for the runner's creds, `:428`) →
+**L3** emergency truncate. Budget = `context_window*0.8 − system_budget`.
+**Two triggers (the "runner catches overflow → compacts" belief is only half right):**
+- **Proactive/threshold (the real auto-compaction):** in the in-process loop
+  `_call_llm_maybe_compact` (`workflow.py:2057`) at 0.8 threshold.
+- **⚠️ Reactive on harness-reported overflow does NOT auto-compact:** `_is_context_overflow_error`
+  (`runner/app.py:6736`) → `_ContextWindowOverflow` (`:14243`) → caught in `_run_turn_bg` (`:13804`)
+  which **ends the turn with an error** (resume-overflow surface, OMNI-143).
+- **Explicit `/compact`:** `compact_conversation_now` (`workflow.py:2347`, `force=True`).
+**Trace evidence** (`conv_63542a5f`, `/compact` on a **model-less** session): `POST /events
+{"type":"compact"}` → `{"error":{"code":"invalid_input","message":"Compaction requires a configured
+LLM model"}}` — **rejected pre-LLM, no compaction spans**. **Confirms #1192:** a session created
+without `--model` (subscription default) has no `model` on its row, so user `/compact` (needs an LLM
+for L2) fails validation; auto-compaction in the loop is unaffected (uses the turn's resolved model).
+[memory: compact-every-msg fixed #1082 — the broken-cursor guards in `_load_initial_history` are that
+fix. ⚠️ resume-overflow OMNI-143 still open.]
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q5; `_LIVE-TRACE-FINDINGS.md` "Compaction".
+
+### ⚠️ First-message delivery / optimistic pending input — failure-branch
+`runtime/pending_inputs.py`; the client paints a `PendingUserMessage{tempId}` **before** the POST
+(`chatStore.ts:791`) so a `session.input.consumed` racing ahead still finds it; on consumed the bubble
+is promoted to a committed block by `clearedPendingId` → FIFO head → payload. Snapshot includes
+`pending_inputs` on reconnect. **⚠️ native FIFO-desync class:** native web messages get no server
+`item_id` at dispatch (only a `pending_id`); dedup vs the mirrored-back transcript relies on client
+FIFO/stableKey + `cleared_pending_id` — the double-bubble risk lives exactly here
+(`server-api-state-streaming.md` Q2).
+→ `cuj-answers/web-client.md` Q3.
+
+### ⚠️ Local↔server transcript reconstruction & mismatch — invariant
+Server conversation history is the source of truth. **SDK:** 100% Omnigent; the client reconciles
+streaming↔durable by `ctx.itemId` (web) / byte-equal multiset (TUI). **Native:** the **vendor store
+is the source of truth**, mirrored back — mismatch risk is highest here (native FIFO-desync, above;
+plus reasoning is persisted on native but recomputed on SDK). Post-fork = fresh-id deep copy;
+post-resume = compaction-bounded slice; post-compaction = summary pair + items after `last_item_id`.
+**❓ open probe (CUJ-MAP §5):** local↔server mismatch cases *beyond* compaction/fork need a dedicated
+test (multi-replica in-memory status/pending caches, `server-api-state-streaming.md` Q3/OpenQ).
+→ `cuj-answers/tui-vs-web.md` Q1; `server-api-state-streaming.md` Q6.
+
+---
+
+## §2.B  Harnesses & per-harness features
+
+Taxonomy: **SDK** (in-process loop, Omnigent owns prompt+tools+transcript; base `inner/executor.py`)
+vs **Native** (resident vendor CLI in tmux/socket, vendor owns prompt+tools, transcript mirrored;
+base `native_server_harness.py`). Deeper: `cuj-answers/harness-behavior.md`, `architecture/harness-inner.md`.
+
+### ✅ Pick a harness at session start
+`omnigent <harness>` or `omnigent run --harness X`. Aliases `harness_aliases.py:9`
+(`claude`→`claude-sdk`); validate at `cli.py:5554`. **⚠️ native + AGENT-spec combo rejected**
+(`cli.py:5874`). Web: harness selector in NewChatDialog (localStorage per agent,
+`lib/modePreferences.ts`). Host gates the launch on `harness_is_configured(frame.harness)`
+(`host/connect.py:766`) → `HARNESS_NOT_CONFIGURED` (412) if the CLI/cred is missing.
+→ `cuj-answers/host-channel.md` (per-harness); `harness-behavior.md` §2.
+
+### ✅ Switch harness mid-session
+Via `switch-agent` (idle-only) or `fork` (optional harness switch). For **native** targets it clears
+`external_session_id` so the next turn rebuilds the vendor transcript; cross-family switches reset the
+model. claude-native/codex-native key their bridge to a `bridge_id` from session labels so
+`--resume`/fork land in the right pane/thread.
+→ `cuj-answers/harness-behavior.md` Q6.
+
+### ✅ Change model / effort — at start and mid-session (from WebUI) **[partial LIVE via native turn]**
+- **claude-sdk** — next-turn config: `cfg.model` read each turn; `client.set_model()` if changed
+  (`:1422/1910`); effort via `extra["reasoning_effort"]`→SDK `effort` (`:2011`). Applies **next** turn.
+- **codex (SDK)** — model is part of the app-session **signature**; changing it **closes the
+  app-session and re-threads** (`:2346/2301`); effort resets on the new thread (`:1450`).
+- **⚠️ claude-native** — best-effort, two writers: web `/model` → runner types `/model X` into tmux
+  (`app.py:11558`, `auto_confirm`); the `--model` flag is baked at spawn (not re-read at turn
+  boundaries); the forwarder mirrors an in-pane `/model` back to `model_override` every poll
+  (`:948`). **⚠️ `/effort none|minimal` are persist-only** — skipped because not in CLAUDE_EFFORTS
+  (`:11521`). Model change **never affects the running turn** (next turn only).
+- **codex-native** — RPC: `thread/settings/update` (`app.py:10664`, exec `:237/266`); the TUI's own
+  model/effort mirrored into the snapshot.
+Effort source of truth = `reasoning_effort.py` (`CLAUDE={low,med,high,xhigh,max}`;
+`OPENAI/CODEX={none,minimal,low,med,high,xhigh}`). Selectable at start (NewChatDialog) + `/effort`.
+**Trace:** claude-native turn (`conv_7c19d035`) shows `llm.model_name=claude-native-ui` = the *harness*
+name, **not** a real model (the CLI owns model selection).
+→ `cuj-answers/harness-behavior.md` §3; **⚠️ #1128** below.
+
+### ⚠️ Default model / provider resolution — carries **#1128**
+Chain (highest first): CLI `--model` → `OMNIGENT_MODEL` env → YAML `executor.model` →
+`~/.omnigent/config.yaml` default → per-harness fallback (`chat.py`). Ad-hoc specs →
+`_DEFAULT_AD_HOC_MODEL="databricks-gpt-5-4"` (`chat.py:99`).
+**⚠️ #1128 (billing) — VERIFIED at `claude_sdk_executor.py:1910-1912`:**
+`model = cfg.model or self._model_override`; if still None →
+`model = _DATABRICKS_CLAUDE_DEFAULT_MODEL` (= `databricks-claude-opus-4-8`, `databricks_config.py:85`)
+**only on the Databricks-profile gateway path**. Fires when Sonnet was intended but the override
+arrived None → silently bills Opus. Real fix PR #1146 (unmerged); frontend PRs #1570/#1563 do **not**
+fix it. codex has the analogous fallback at `:2334`.
+→ `cuj-answers/harness-behavior.md` §4; gaps §2.B below.
+
+### ⚠️ Propagate the user's OWN harness config into omni (`~/.claude`) (#3)
+- **claude-native** — `use_claude_config` flag (`claude_native.py:349`): default `False` = omni-managed
+  isolated HOME + MCP relay (`:400`); `True` **passes through the user's `~/.claude/` credentials,
+  settings.json, MCP servers, hooks** (`:371`). Strongest passthrough. ⚠️ user `settings.json` model
+  can conflict with omni `--model`.
+- **codex-native** — inherits `~/.codex/config.toml` + `auth.json` as baseline via the CODEX_HOME
+  source resolver (`codex_native.py:131`); omni `--model`/effort layer on top via RPC.
+- **SDK harnesses** — config via `HARNESS_*` env vars from the workflow; they do **not** pass through
+  CLI dotfiles (claude-sdk explicitly strips `ANTHROPIC_API_KEY` to preserve subscription auth,
+  `claude_sdk_harness.py:120`).
+→ `cuj-answers/harness-behavior.md` §5.
+
+### ✅ Native vs SDK behavioral differences **[LIVE — both shapes]**
+| Concern | SDK (claude-sdk, codex) | Native (claude-native, codex-native) |
+|---|---|---|
+| Agent loop | in-process `run_turn` drives vendor SDK | resident vendor CLI (tmux / JSON-RPC socket) |
+| System prompt / tools | **Omnigent** | **Vendor** (omni's are `del`'d, `claude_native_executor.py:123`) |
+| Transcript | Omnigent owns 100% | vendor store is truth, mirrored |
+| Turn output | streamed `ExecutorEvent`s | forwarder polls store → `external_*` events |
+**Trace contrast (the headline finding):** an **SDK** turn = a **deep tree** (`agent:claude-sdk` →
+`tool:sys_os_shell` → `POST /mcp` → `policy.evaluate` per tool). A **native** turn (`conv_7c19d035`)
+= the **opposite shape**: one `agent:claude-native-ui` (input.value + `llm.model_name`=harness-name,
+**no** child `llm_call`, **no** inline `tool:` spans) + one `claude_native.inject` (the inject+wait
+boundary where all vendor time hides) + N `omni-runner claude_native.forward` (the JSONL forwarder,
+each carrying `resp_claude_*`). The vendor turn is a **black box**; you observe it only via the
+forwarder's items. Native session row gains `external_session_id` (the real CLI's UUID) after the turn.
+→ `cuj-answers/harness-behavior.md` §2; `_LIVE-TRACE-FINDINGS.md` "claude-native".
+
+**Per-harness support matrix** (code-verified against each `inner/*_executor.py`; base defaults all ❌
+except `supports_tool_calling`, `executor.py:541-585`):
+
+| Harness | interrupt | queue | subagents | reasoning effort | elicitation | mid-session model |
+|---|---|---|---|---|---|---|
+| **claude-sdk** | ✅ `client.interrupt()` (`:1477`) | ✅ (`:1614`) | ✅ `sys_session_*` | ✅ {low..max} | ✅ `can_use_tool` bridge | ✅ next turn |
+| **codex** *(code-only)* | ✅ `turn/interrupt` (`:2243`) | ✅ (`:2240`) | ⚠️† `CODEX_HOME` isolation | ✅ {none..xhigh} | ❌ `approvalPolicy:"never"` (`:1427`) | ⚠️ re-threads (`:2346`) |
+| **claude-native** | ✅ bridge `Escape` (`bridge:2530`) | ✅ | ✅ `external_subagent_start` (`fwd:1115`) | ✅ `/effort` (⚠️ none/minimal skipped) | ✅ PreToolUse+PermissionRequest long-poll | ✅ `/model` inject; next turn |
+| **codex-native** *(code-only)* | ✅ `turn/interrupt` (`exec:116`) | ✅ `turn/steer` | ✅ `external_codex_subagent_start` (`fwd:6079`) | ✅ `thread/settings/update` | ✅ `codex-elicitation-request` long-poll | ✅ RPC; next turn |
+
+claude-sdk uniquely overrides `supports_tool_boundary_interrupt`→✅ (`:1617`). **Polly** has no row —
+its brain runs on claude-sdk (reads as that row); its workers are claude_code (claude-native) / codex
+(codex-native). † codex-SDK subagents = process isolation (private CODEX_HOME), not a declared mirror;
+codex-*native* subagents are real (`external_codex_subagent_start`).
+→ `cuj-answers/harness-behavior.md` §1; `CUJ-ANALYSIS.md §4`.
+
+---
+
+## §2.C  Tools, MCP, shells, files, timers
+
+Deeper: `cuj-answers/tools-mcp-shells.md`, `runner-dispatch-mcp.md`, `architecture/tools-omnibox.md`.
+
+### ✅ Use the Omnigent MCP (`sys_*` tools) (#6) **[LIVE]**
+All builtins register in `tools/manager.py` (`ToolManager.__init__:105`). Groups + gates: File/shell
+`sys_os_read/write/edit/shell` (os_env set, `:525`); Terminals `sys_terminal_*` (non-empty terminals,
+`:563`); Async/inbox `sys_call_async`/`sys_read_inbox`/`sys_cancel_async` (`async_enabled` default
+True, `:200`); Timers `sys_timer_set/cancel` (`timers:true`, `:231`); Sub-agents
+`sys_session_send/create/close/list/get_history/get_info/share` (`:427-468`); Agents `sys_agent_*`
+(`:471`); Policy `sys_add_policy`/`sys_policy_registry` (always, `:186`); Comments
+`list_comments`/`update_comment` (`:511`). Opt-in flags control **advertisement, not authority**.
+**Trace evidence** (`conv_63542a5f`, `sys_os_shell echo TRACETEST123`): OpenInference tree
+`omni-harness agent:claude-sdk` → `tool:sys_os_shell` (kind=TOOL); the MCP+policy chain =
+`policy.evaluate REQUEST/LLM_REQUEST` → `POST /mcp` → `policy.evaluate TOOL_CALL` (the gate) →
+`POST /mcp/execute` → `policy.evaluate TOOL_RESULT` → `LLM_RESPONSE`, all ALLOW.
+→ `cuj-answers/tools-mcp-shells.md` Q1.
+
+### ✅ Register & use a custom (user-defined) MCP server **[LIVE]**
+Declared in YAML `tools.mcp` → `MCPServerConfig` (`spec/types.py:~847`): `transport:"http"` (SSE) or
+`"stdio"` (subprocess); per-server tool allowlist + timeout/retry. Pooled by `RunnerMcpManager`
+(`runner/mcp_manager.py`): lazy connect, **8-entry LRU** keyed by spec hash; tools namespaced
+`{server}__{tool}` (`:139`). A custom MCP can request inline `elicitation/create` → web card
+(`:182`).
+**Trace evidence** (`conv_4d0e6cce`, stdio echo MCP): canonical tool name **`echo__echo_shout`** (the
+`{server}__{tool}` namespacing); gated by `policy.evaluate TOOL_CALL + TOOL_RESULT` (same pipeline as
+`sys_*`). **Routing is identical at the HTTP layer** (`POST /mcp` → `POST /mcp/execute`) but lands in
+a different executor: a **custom** MCP → the runner's `RunnerMcpManager` dispatches into the **stdio
+subprocess it spawned** (so its blast radius/creds are the runner's); `sys_*` → server REST /
+runner-local OSEnvironment. The only trace tell is the tool name.
+→ `cuj-answers/tools-mcp-shells.md` Q2; `_LIVE-TRACE-FINDINGS.md` "Custom MCP".
+
+### ✅ MCP routing — who routes a tool call where? **[LIVE]**
+**Two managers, chosen by mode** (`proxy_mcp_manager.py:15`): **Deployed** = `ProxyMcpManager`
+(server enforces policy at `/mcp`, delegates execution to runner); **No-server/test** =
+`RunnerMcpManager` (runner enforces via `RunnerToolPolicyGate`). The deployed loop: harness tool call
+→ runner POSTs `POST /v1/sessions/{id}/mcp` → server runs TOOL_CALL policy → **calls back**
+`POST /v1/sessions/{id}/mcp/execute` (`app.py:17829`); the **`__` separator is the routing key**
+(`:17954`): `"__" in name` → custom/user MCP → `RunnerMcpManager`; no `__` → runner-local builtin →
+`execute_tool`. Split is deliberate: **server owns policy+routing; runner owns execution** (right
+machine/cwd/env). **Native:** `sys_*` ride the in-turn relay (server-checked) so the PreToolUse hook
+**skips `mcp__omnigent__*`** to avoid double-eval (`native_policy_hook.py:209`); connector/custom MCP
+still hits the hook.
+→ `cuj-answers/runner-dispatch-mcp.md` Q3.
+
+### ✅ Use shells (#4) — *cwd? how exposed to agents?* **[LIVE]**
+Two paths: **`sys_os_shell`** (one-shot in the agent's shared `OSEnvironment`, `os_env.py:294` — all
+`sys_os_*` share one instance) and **`sys_terminal_*`** (persistent named tmux panes,
+`terminals/registry.py:160`, `remain-on-exit on`, surviving turns). **cwd precedence**
+(`_resolve_cwd`, `sys_terminal.py:752`, first match): LLM `cwd_override` → `terminal.os_env.cwd` →
+`spec.os_env.cwd` → `ctx.workspace` → *(implicit)* host/runner cwd. Orphan tmux servers reaped at
+runner startup (`terminal.py:581`); native panes reaped after 30-min idle (`pane_reaper.py`, #1349).
+**Trace evidence:** the `sys_os_shell` TOOL_RESULT carried `cwd=/Users/.../traces` (the runner
+workspace) → confirms cwd tier 4/5.
+→ `cuj-answers/tools-mcp-shells.md` Q4.
+
+### ⚠️ OmniBox / OS sandbox (filesystem + network isolation + credential injection) *(code-only)*
+**OmniBox = the OS-level sandbox**, not a web component. `OSEnvironment` modes: `caller_process`
+(none) · `fork` (workspace copy) · `sandbox`. Backends (`inner/sandbox.py:371`): `linux_bwrap`
+(namespaces + seccomp denylist + tmpfs-masked dotfiles), `darwin_seatbelt` (`sandbox-exec` SBPL,
+deny-default; **no namespaces/seccomp**), `windows_jobobject` (process containment only; **no
+FS/network isolation**). **Three layers:** (1) filesystem isolation (only granted paths visible), (2)
+**default-deny L7 egress proxy** (`inner/egress/`: DSL rules, DNS-safe host allowlist, private-IP +
+cloud-metadata block via resolve-once, MITM with per-sandbox CA), (3) **credential injection**
+(swap-on-access default — nothing credential-shaped in sandbox, proxy injects the real secret for the
+bound host; leak-guard 403 on wrong host). Real secret lives **only** in parent + proxy table, never
+in `SandboxPolicy`/argv/disk.
+**⚠️ #1542 (SECURITY):** `credential_proxy.py:190` runs parent-side `subprocess.run(shell=True)` +
+arbitrary file reads on an unenforced "trusted-spec-only" assumption. **⚠️ #517:** sandboxed
+claude-sdk **crashes on macOS** instead of degrading (part-1 no PR).
+→ `cuj-answers/tools-mcp-shells.md` Q5.
+
+### ⚠️ Timers & async background work **[LIVE]**
+`sys_timer_set` returns a `timer_id` synchronously; the firing arrives as `[System: timer X fired]`
+via the `async_work_complete` drain. **Mechanism** (`tool_dispatch.py:2345`): a runner-side
+`asyncio` task (`_session_timers`, `app.py:7626`) sleeps then **POSTs `[System: timer {id} fired]` as
+an `is_meta:true` user message** to `/events`, re-triggering the agent.
+**Trace evidence** (`conv_48ce846b`, `timers:true`, 3s timer): full firing loop end-to-end —
+`policy.evaluate tool=sys_timer_set ALLOW TOOL_CALL` (set is gated), then the firing re-injects a turn:
+`policy.evaluate content="[System: timer … fired]" REQUEST` → `agent:timer_agent input.value=[System:
+timer … fired]` (a brand-new agent turn). Net `/events` count jumps — the firing is literally a server
+POST, not an in-band callback. **⚠️ caveat CONFIRMED:** the **runner** path implements timers; the
+**sessions-native** path raises `NotImplementedError` (`timer.py:220`). Timers die with the runner (no
+persistence). Async: `sys_call_async` fire-and-forget → results drain via `async_work_complete`
+(auto each iteration OR `sys_read_inbox`, consume-once). **⚠️ `sys_cancel_task`/`sys_cancel_async` =
+NO-OP** — tasks table removed → `task_not_found` for every input (`async_inbox.py:108`).
+→ `cuj-answers/tools-mcp-shells.md` Q6; `executor-subagents-compaction-cache.md` Q4; `_LIVE-TRACE-FINDINGS.md` "Timers".
+
+---
+
+## §2.D  Policies, approvals, elicitations
+
+One engine (`runtime/policies/engine.py:43`), two surfaces (server + runner fast-path). Deeper:
+`cuj-answers/policy-enforcement.md`, `architecture/policies.md`.
+
+### ✅ Create / add a policy (session / admin-default / spec) (#2) **[partial LIVE]**
+Three sources merged at engine-build (`builder.py:309`, order session→spec→admin + hardcoded gate):
+- **Session** — `sys_add_policy` (after browsing `sys_policy_registry`) → `POST
+  /v1/sessions/{id}/policies` (`session_policies.py:148`). Handler **must be in the registry
+  allowlist** (anti-RCE, `:181`); activates immediately. **Hardcoded guard:** `ask_on_add_policy` is
+  unconditionally appended to every engine (`builder.py:315`) so an agent can never add a policy
+  without a human ASK.
+- **Admin default** — `POST /v1/policies` (`default_policies.py:129`, `_require_admin`); `session_id
+  IS NULL`; applies server-wide (appended last → "admin gets the last word").
+- **Spec-declared** — YAML `guardrails.policies:` → `source="spec"`, `id=None`, immutable.
+**Trace evidence** (`conv_c8a81cbd`): browsed `GET /v1/policy-registry`, attached built-in
+`ask_on_os_tools` via `POST …/policies {handler:"…safety.ask_on_os_tools"}` (`source:session`).
+→ `cuj-answers/policy-enforcement.md` Q1; `_LIVE-TRACE-FINDINGS.md` "ASK / DENY policy".
+
+### ✅ Update / enable-disable / remove a policy (#2)
+`PATCH /v1/sessions/{id}/policies/{pid}` (`:275`) / `PATCH /v1/policies/{pid}` (`:234`): mutate
+`name`/`handler`/`enabled` (the disable toggle); `type` immutable; PATCH re-checks the registry
+allowlist for handler changes (no back door, `:323`). `DELETE …/{pid}` idempotent. Spec policies
+can't PATCH/DELETE.
+→ `cuj-answers/policy-enforcement.md` Q1.
+
+### ✅ Get denied / get approved — the ASK flow (#2) **[LIVE]**
+Engine composes ASK with **withheld** `set_labels`+`state_updates`. Parks two ways: **server-parked**
+(REQUEST gate / native TOOL_CALL via hook / LLM_REQUEST) via `_hold_native_ask_gate` (`:4119`,
+publishes `response.elicitation_request` mode=url); **runner-parked** (SDK relay TOOL_CALL) returns
+`verdict:"pending"`+`elicitation_id`, runner parks on `_pending_approvals`. Resolve = `POST
+…/elicitations/{eid}/resolve` (`:18022`) OR `{type:"approval"}` event → both funnel into
+`_resolve_elicitation` (`:3921`): set Future → publish `response.elicitation_resolved` (badge −1) →
+forward to runner. **APPROVE** (`action=="accept"`, strict) applies withheld writes; **DENY/cancel/
+timeout/disconnect** discards them (no trace).
+**Trace evidence (first-ever ASK/DENY trace)** (`conv_c8a81cbd`, `ask_on_os_tools` → DENY): the turn
+**parked** (status stayed `running`); `pending_elicitations[0]` = `{mode:"url", phase:"tool_call",
+message:"ask_os_trace: Agent wants to call sys_os_shell('echo POLICYASKTEST'). Approve?",
+url:"/approve/conv_…/elicit_67ff3403…"}`. Resolved DENY via `POST …/elicitations/{eid}/resolve
+{"action":"decline"}` → session returned to **idle**, `pending_elicitations:0`, with a
+`function_call`+`function_call_output` (the **blocked** shell + its denial) + a final assistant
+message. Spans: `policy.evaluate tool=sys_os_shell decision=ASK TOOL_CALL` (×2: initial + re-eval
+after verdict); `policy.reason` == the elicitation message; `omni-server POST …/elicitations/{eid}/
+resolve`. **DENY (`decline`) surfaces to the model as a tool *result*, not a turn error** — the agent
+continues knowing the action was refused.
+→ `cuj-answers/policy-enforcement.md` Q4; `_LIVE-TRACE-FINDINGS.md` "ASK / DENY policy".
+
+### ✅ Enforcement: server-level vs session/runner-level **[LIVE]**
+**Server** (default+spec+admin): REQUEST/RESPONSE gates at `POST /events`; TOOL_CALL/TOOL_RESULT via
+the `/mcp` proxy (`_handle_mcp_tools_call`); LLM-phase + the elicitation registry via `POST
+/policies/evaluate`. **Runner fast-path** (`RunnerToolPolicyGate`, `runner/policy.py:109`): runs only
+function-type TOOL_CALL/TOOL_RESULT policies, decides ALLOW/DENY **locally before MCP dispatch**; ASK
+escalates to the server (dual evaluation is intentional). **Trace reality:** the observed claude-sdk
+run routed TOOL_CALL/TOOL_RESULT through the **server `/mcp` proxy** (because `sys_os_shell` is an
+Omnigent tool dispatched server-side); the runner fast-path fires for function-type spec policies
+bound to tools + connector-native tools.
+→ `cuj-answers/policy-enforcement.md` Q2.
+
+### ✅ What types of hooks capture elicitations / questions (vs policy hooks)?
+**Phases (5):** REQUEST (input gate) · TOOL_CALL (main gate) · TOOL_RESULT (post, DENY/redact only) ·
+advisory LLM_REQUEST/LLM_RESPONSE. **Elicitation/question hooks** (native): PreToolUse (→ TOOL_CALL),
+UserPromptSubmit (→ REQUEST), PermissionRequest (`/hooks/permission-request`), and vendor-specific
+`codex-elicitation-request` / `ask-user-question`. **Composition:** session→spec→admin; **first DENY
+short-circuits**; ASK accumulates (later DENY overrides); ALLOW chains `data` forward. **Fail-closed
+vs open:** `FAIL_CLOSED_PHASES = (TOOL_CALL, REQUEST)` (`types.py:61`) → DENY on outage; TOOL_RESULT/
+LLM_* → fail-OPEN. **Read-only eval (LEVEL_READ):** policies run but side-effects not persisted
+(audit "what would be denied"); read-only callers never enter the ASK gate.
+→ `cuj-answers/policy-enforcement.md` Q3, Q6.
+
+### ✅ Which hooks must a harness expose for ALL policies to work?
+| Harness | Required hooks | Verdict delivery |
+|---|---|---|
+| **claude-native** | PreToolUse (TOOL_CALL) + **UserPromptSubmit** (REQUEST — the sole native REQUEST gate) + PermissionRequest | **long-poll HTTP** (verdict in held body); server collapses policy-ASK→hard ALLOW/DENY so permissive `permission_mode` can't auto-approve |
+| **codex-native** *(code-only)* | codex PreToolUse/UserPromptSubmit-equiv (shared `native_policy_hook`) + `codex-elicitation-request` | long-poll HTTP |
+| **claude-sdk / codex / Polly** | server `type=approval` event (no command hooks) | runner `pending_approvals` Future / SDK `can_use_tool` callback |
+Shared translation layer `native_policy_hook.py` converts hook shape ↔ proto. **No keystroke
+emulation for any in-scope harness.**
+→ `cuj-answers/policy-enforcement.md` Q5; `harness-behavior.md` Q7.
+
+### ✅ How does an elicitation response get back to the harness? (keystrokes? something better?) — carries policy-token gap
+For in-scope harnesses: **long-poll HTTP hold** (claude-native/codex-native — verdict in the held
+response body) or an **`approval` event → Future** (SDK). **Not keystrokes.** (Some out-of-scope
+native harnesses use tmux keystrokes — not relevant here.)
+**⚠️ policy-token failure-branch — VERIFIED FIXED for in-scope native (PR #1439, merged commit
+`e9561916`):** the native PreToolUse/PermissionRequest hooks launch with a **one-shot bearer**
+snapshotted at launch (`claude_native_hook.py` reads it; wrapper `native_policy_hook.py`). **Old
+bug:** the Databricks Apps front door bounced the ~1h-expired bearer with a **302→/oidc/** (not a
+401), the hook couldn't get a verdict, and TOOL_CALL (a fail-closed phase) **failed CLOSED** — even
+though chat kept working. **Fix (PR #1439):** on a 302→/oidc|/.auth **or** 401 the hook **re-mints a
+fresh bearer** via `policy_hook_reauth` (`claude_native_hook.py:36-37,525-580`; wired `:657,:729`)
+and **retries once** (`post_evaluate_with_retry`, branch reached `:875`); fail-closed remains the last
+resort when no token can be minted (preserves #163/#579). **Residual (out of scope):** the OpenCode
+policy plugin snapshot (`runner/app.py:1141-1149`, `OMNIGENT_POLICY_AUTH`) still uses a one-shot token
+and **degrades fail-OPEN** after ~1h (comment: "a refreshable token file is the follow-up").
+→ `cuj-answers/credentials.md` Q4; `policy-enforcement.md` Q5; gaps §2.G below.
+
+---
+
+## §2.E  Web UI & clients
+
+React app under `web/src/` (renamed from `ap-web/` upstream); TUI/REPL under `omnigent/repl/`.
+**No `omni-web` OTel spans** (opt-in `VITE_OTEL_EXPORTER_OTLP_ENDPOINT`, inactive) → code-grounded;
+server-side spans corroborate the wire. Deeper: `cuj-answers/web-client.md`, `tui-vs-web.md`,
+`architecture/web.md`, `tui-repl.md`.
+
+### ✅ Sidebar: browse / search sessions
+`useConversations` (`hooks/useConversations.ts:216`): `useInfiniteQuery` over `GET /v1/sessions`
+(`order=desc`, `sort_by=updated_at`, `limit=20`, `search_query=` debounced ~300ms, cursor
+`getNextPageParam=last_id`). Live via **`WS /v1/sessions/updates`** (`sessionUpdatesSocket.ts`):
+client sends a **watch-set**; server pushes `snapshot`/`changed`/`removed`/`heartbeat`; 70s watchdog
+→ reconnect. HTTP fallback: 60s connected / 45s disconnected.
+→ `cuj-answers/web-client.md` Q1.
+
+### ✅ Organize sessions into projects (#7)
+`useProjects` → `GET /v1/sessions/projects`; **implicit** (exist iff ≥1 non-archived session); stored
+as reserved label `omni_project`; collapsible (localStorage); lazy `GET /sessions?project=`. Set at
+start (NewChatDialog) or kebab → Change project.
+→ `cuj-answers/web-client.md` Q1.
+
+### ✅ Pin / unpin (#7); archive / rename / delete
+Pin = localStorage `omnigent:pinned-conversation-ids` (drag-reorder; off-window pins backfilled via
+per-id GET). Grouping precedence **Archived > Pinned > Project > Recent**. Archive/rename/delete =
+`PATCH archived` / `PATCH title` / `DELETE` (`useConversations.ts:250,267,285`).
+→ `cuj-answers/web-client.md` Q1.
+
+### ✅ Check the inbox — approvals + unseen comments (#8)
+`pages/InboxPage.tsx` (`/inbox`): pending approvals (drains all session pages, filters
+`pending_elicitations_count>0`) **+** unseen file comments (`useCommentInbox`); comment clears when
+viewed. Badge = `pending_elicitations` (auto-tracked by `record_publish` on every
+`response.elicitation_request`, `pending_elicitations.py:81`) + comment fingerprint.
+→ `cuj-answers/web-client.md`; `policy-enforcement.md` Q6.
+
+### ✅ Comment on files & send comments to the agent (#9)
+`shell/CommentsPanel.tsx`, `FileViewer.tsx`, `hooks/useComments.ts`, Monaco gutter decorations.
+Select text → comment (char offsets, `POST …/comments`); open vs addressed tabs; **"Address All"** →
+`POST …/comments/send` (`useComments.ts:164`) posts comments to the agent. Authz: read=viewer,
+create=editor, edit/delete=author|owner.
+→ `cuj-answers/web-client.md` Q2.
+
+### ✅ Share a session / collaborate (#1)
+`ChatHeader.tsx` Share + `PermissionsModal.tsx` + `usePermissions.ts`. Levels **0/1/2/3 =
+none/view/edit/manage** (`PUT …/permissions`, incl. `__public__` toggle); copy share link `/c/:id`;
+requires manage(3). Live **presence avatars** (`PresenceAvatars.tsx`) — holding `…/stream` open
+registers a viewer (`presence.connect`, `_stream_live_events:11307`), tree-scoped so sub-agent viewers
+see each other.
+**Trace corroboration:** the disconnect trace (`conv_6bbdba9a`) shows `session.presence` in the
+snapshot-on-connect frames.
+→ `cuj-answers/web-client.md` Q2; `server-api-state-streaming.md` Q3.
+
+### ✅ Members admin (invite / reset password / delete user)
+`pages/MembersPage.tsx` (`/members`, admin, accounts mode): `GET /auth/users`, `POST /auth/invite`
+(single-use URL shown once), `POST /auth/users/{id}/reset`, `DELETE /auth/users/{id}` (cascades).
+Note: `GET /v1/users/search` is **not** a direct SPA call — it's a host-injected callback
+(`useUserSearch.ts:25`), inert in standalone.
+→ `cuj-answers/web-client.md` Q2.
+
+### ✅ See "working vs idle" state — and how it propagates
+**Single server funnel** `_publish_status` (`sessions.py:5343`): writes `_session_status_cache` (the
+sidebar bridge) **and** publishes a `session.status` SSE event. Status edges: SDK = runner
+`session.status` → relay → `_publish_status`; native = `external_session_status` → `_publish_status`.
+**Stickiness:** a cached `failed` is not overwritten by a trailing `idle` (`:5389`). **Client:**
+sidebar badge (awaiting>running>none) from WS frames; chat "Working…" (idle/launching/running/waiting/
+failed) from SSE `session.status`; `background_task_count` sticky. **⚠️ multi-replica:**
+`_session_status_cache` is per-process (`:837`) — a replica may read a status another replica's relay
+wrote (open question).
+→ `cuj-answers/server-api-state-streaming.md` Q3; `web-client.md` Q4.
+
+### ✅ Reconcile streaming vs durable messages into one coherent view
+The renderer walks one flat `blocks[]` from (a) durable snapshot items (each with `ctx.itemId`) and
+(b) live SSE (token/reasoning blocks are id-less; persisted items carry `ctx.itemId`), **merged by
+deduping on `ctx.itemId`** (`chatStore.ts:15`, enforced `:1455,:2460,:3004`). `blockStream.ts`
+handles the claude-sdk MCP **double-event** (inline + post-stream flush) via `seenCallIds`. A streamed
+assistant `message` gets its item id **stamped onto the existing streamed `text_done` in place**
+(match by responseId+fullText) so reconnect sees it as already rendered. **This is the durable-vs-
+streaming merge point.** (TUI equivalent: byte-equal multiset `consume_match`, not itemId — `tui-vs-web.md` Q1.)
+→ `cuj-answers/web-client.md` Q3.
+
+### ✅ Stop / interrupt a running turn **[LIVE]**
+`POST …/events {type:interrupt}` (only if running and not a child; child stop delegated to parent).
+Server adds to `_interrupt_fenced_sessions` and forwards; **interrupt fencing** drops the cancelled
+turn's trailing `response.*` output (no persist) but keeps pre-stop narration.
+**Trace evidence** (`conv_7fe7513654`, long bash turn cancelled): delivered as a control event on the
+**same events endpoint** (`{"queued":false}` = applied immediately); the `agent:claude-sdk` span
+carries **`error.type=cancelled`** (`record_cancellation`, `runtime/telemetry.py`) while
+`otel.status_code` stays OK — the unambiguous interrupt fingerprint. The in-flight `sleep 30` bash was
+abandoned mid-setup (had reached `POST /mcp` + `policy.evaluate TOOL_CALL` + `POST /mcp/execute`); an
+`omni-server GET … ERROR` at teardown = stream/tunnel close (interrupt-fencing dropping trailing
+output). **Interrupt is NOT a gap** — all in-scope harnesses support the web Stop.
+→ `_LIVE-TRACE-FINDINGS.md` "Interrupt"; `server-api-state-streaming.md` Q1 (control events).
+
+### ✅ Browse / view / edit files; terminals; subagents rail **[terminals/subagents partial LIVE]**
+**Files** — `FilesPanel.tsx` / `FileViewer.tsx` (Monaco) / `MonacoDiffViewer`; in-browser edit +
+autosave; changed-files badge (`GET …/environments/default/changes`). **Terminals** —
+`TerminalsPanel.tsx` xterm.js → `WS …/resources/terminals/{tid}/attach` → runner tmux; terminal-first
+sessions render inline. **Subagents rail** — `SubagentsPanel.tsx` / `useChildSessions.ts`; tree by
+depth; `GET …/child_sessions`; manual create via `AddAgentDialog.tsx`.
+**Trace corroboration:** disconnect trace shows `session.resource.created` for `terminal_tui_main`
+(tmux_socket/tmux_target); sub-agent trace shows `GET …/child_sessions` (×6).
+→ `cuj-answers/web-client.md` Q2; `_LIVE-TRACE-FINDINGS.md` "Disconnect", "Sub-agent spawn".
+
+### ✅ Settings (theme / shortcuts / account); Policies admin page
+Settings: theme, keyboard shortcuts, account/password (`accounts_enabled`), archived sessions.
+Policies page `pages/PoliciesPage.tsx` (`/policies`, admin): `GET /v1/policy-registry`, `GET/POST/
+PATCH /v1/policies`. Capabilities probe `GET /v1/info` gates UI (`CapabilitiesContext.tsx`). Fork/
+clone `ForkSessionDialog.tsx`; approve deep-link `pages/ApprovePage.tsx` (`/approve/:sid/:eid`,
+pre-auth via `GET /elicitations/{eid}`).
+→ `cuj-answers/web-client.md` Q2.
+
+### ✅ TUI / REPL equivalents of the above
+`omnigent/repl/_repl.py` (`run_repl`): rich streaming, slash-command menu, `@`-file completer, resume
+picker (`_resume_picker.py`), theme picker, event tape (`--debug-events`, Ctrl+E). **TUI has NO
+WebSocket usage** — its only push channel is per-session SSE `…/stream`. Slash→API: `/model`→PATCH
+`{model_override}`; `/effort`→PATCH `{reasoning_effort}`; `/compact`→POST `{type:compact}`;
+`/cancel`→POST `{type:interrupt}`; `/fork`→POST `…/fork`; `/switch` re-points the SSE stream (NOT
+`/switch-agent`). Dedup by byte-equal text (not itemId). **⚠️ TUI emits no OTel spans** —
+`telemetry.init("omni-tui")` is never called (doc-vs-code mismatch; the httpx propagation mechanism is
+in place, just uninitialized).
+→ `cuj-answers/tui-vs-web.md` Q2, Q3, Q6.
+
+---
+
+## §2.F  Agents, subagents, executor, routing
+
+Deeper: `cuj-answers/executor-subagents-compaction-cache.md`, `runner-dispatch-mcp.md`,
+`architecture/runtime-executor.md`, `runner.md`.
+
+### ✅ The executor's role in the turn loop **[LIVE]**
+An `Executor` (`inner/executor.py:518`) is the per-vendor adapter translating **Omnigent's abstract
+turn model ↔ a concrete vendor SDK**. In: `run_turn(messages, tools, system_prompt, config)`. Out:
+an async stream of `ExecutorEvent`s (`:96-261`: TextChunk, ReasoningChunk, ToolCallRequest,
+ToolCallComplete, TurnComplete, CompactionComplete, TurnCancelled, ExecutorError). Runs inside a
+**per-conversation harness subprocess** (`omni-harness`); the `ExecutorAdapter`
+(`harnesses/_executor_adapter.py:141`) lazily builds the executor, translates the request → Message
+list + ExecutorConfig, calls `run_turn`, and per event emits typed SSE.
+**Trace evidence** (`conv_63542a5f` / `conv_3a411011`): the loop is exactly the `agent:claude-sdk`
+AGENT span wrapping `run_turn()`, with `tool:` calls nested under it.
+**Nuance — no `llm_call [LLM]` span for SDK:** `start_llm_span` exists (`tracing.py:223`) but no
+`inner/*_executor.py` calls it — the adapter subsumes the LLM call in the AGENT span (verified: zero
+`llm`-named spans in Jaeger). Real nesting = agent → tool; policy is a separate `policy.evaluate`
+span; a sub-agent is a separate omni-harness-rooted trace.
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q1.
+
+### ✅ Spawn subagents **[LIVE]**
+Two declaration forms: **`AgentTool`** (by name or inline, `inner/tools.py:266`) and
+**`SelfAgentTool`** (clones parent, self-tools removed, `:298`). Runtime spawn (SDK): the LLM calls
+**`sys_session_send`** (`spawn.py:56`) → mints a child Conversation + starts a turn (or posts to an
+existing child); child inherits the caller's runner (co-location) and runs the same loop; results
+return via `async_work_complete`. Native: children minted via `external_subagent_start`.
+**Trace evidence** (`conv_387e2405`, debby orchestrator → claude + gpt children): the full mechanism
+on `omni-harness` — `tool:sys_session_send` (×2, one per child); children **created via runner→server
+`POST /v1/sessions` (×9)** each a **full session with its own `session.id`** (touched ids:
+`conv_387e2405` + `conv_9edbfd15` + `conv_3cfe960a`); `tool:sys_read_inbox` (×2, parent drains child
+results, confirms consume-once); `GET …/child_sessions` (×6); per-child `agent:<name>` spans with
+their **own** `policy.evaluate` gates. The gpt (codex) child fails on creds; the claude child answers
+— debby tolerates partial failure. **Beyond code:** a sub-agent is a first-class child Conversation
+(own session.id + own runner), **not** an in-process call; stitching a sub-agent tree across traces
+requires collecting **all** child session.ids (no single trace spans the whole tree).
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q2; `_LIVE-TRACE-FINDINGS.md` "Sub-agent spawn".
+
+### ✅ Information propagation between agents & subagents (#5)
+`pass_history:true` snapshots the parent's "self" history as the child's "parent" history;
+`pass_histories:[names]` for named snapshots (`inner/tools.py:281`). **Tool args = the child's first
+user message** (`spawn.py:281`). Results **truncated** into the `async_work_complete` payload the
+parent drains. **Siblings/cross-agent only communicate via the parent** (`sys_session_send` confined
+to direct children, `spawn.py:73`). **⚠️ lossy:** `pass_history`/`pass_histories`/`max_sessions` drop
+to defaults on the omnigent-compat translator (`spec/omnigent.py:1338`); first-class on the inner
+`AgentDef` path.
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q3.
+
+### ⚠️ Subagent depth limits — failure-branch (GAP)
+**VERIFIED display-only, NO spawn-time cap.** `_MAX_SUBAGENT_TREE_DEPTH=3` (`repl/_repl.py:201`) is
+used **only** to cap how deep the REPL sidebar *renders* the child tree (`:6266`) — never consulted at
+spawn time. `SelfAgentTool` recursion is bounded only by clone-pruning (one level of `self`); ordinary
+`AgentTool` chains can recurse **unbounded**. `AgentTool.max_sessions` (`:295`) is a per-tool
+*concurrency* cap, not depth. Real runaway-recursion risk (code comment: "add when needed").
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q2; gaps §2.F below.
+
+### ⚠️ Intelligent routing (#10)
+`server/smart_routing.py:route_turn` (`:234`): infer harness family (claude/gpt) → LLM judge
+classifies cheap/medium/expensive → picks a model from `TIER_TEMPLATES` → applied as `model_override`
+(runner gets a concrete model, not a routing config). **⚠️ native harnesses not routable** (returns
+None); judge unavailable → fail-open to spec default; hallucinated model → clamp to `tier[0]`. Also an
+LLM-classifier **policy** variant (`deny_trivial_to_expensive_model`, `policies/builtins/routing.py`).
+→ `CUJ-ANALYSIS.md §2.F`; `policy-enforcement.md` (adjacent).
+
+### ⚠️ Runner dispatch / affinity — failure-branch **[LIVE — binding]**
+`RunnerRouter.client_for_conversation` (`routing.py:89`): the conversation's `runner_id` is **hard
+affinity — no failover/rebalance**. Binding = atomic CAS `set_runner_id`
+(`UPDATE … WHERE runner_id IS NULL`, `sqlalchemy_store.py:1918`). Decision tree: not bound →
+`CONFLICT` (`:112`); bound-but-offline → `RUNNER_UNAVAILABLE` (`:231`); harness not in the runner's
+hello → `RUNNER_CAPABILITY_MISMATCH` (`:236`). **A bound runner going offline strands the session**
+until that exact runner reconnects. Hello set = `[claude-native, claude-sdk, codex, openai-agents,
+open-responses, pi]` (`serve.py:582`) — **codex-native not in the default list** (it's CLI/host-driven,
+not server-dispatched over the tunnel).
+**Trace evidence** (mechanism): `omnigent run --server :7777` creates a session **with a bound
+runner**; REST `POST /v1/sessions {agent_id}` creates one with **NO runner** (`runner_id:null`) →
+next `/events` → `runner_unavailable`. `host_id` at create is the trigger for the host→runner launch.
+→ `cuj-answers/runner-dispatch-mcp.md` Q1; `_LIVE-TRACE-FINDINGS.md` "Driving model & runner binding".
+
+### ✅ Create & store a custom agent (Polly)
+`omnigent create` or POST bundle. **Three tiers** (`runtime/agent_cache.py`): **ArtifactStore**
+(content-addressed `.tar.gz`, source of truth) → **Agent DB row**
+(id/name/bundle_location/version/session_id — session-scoped agents non-null `session_id`, template
+null) → **AgentCache** (in-mem `AgentSpec` + on-disk extract, **no TTL**, evict on delete, warm-swap
+on update via atomic `_specs[id]=` reassign, version bumps). **Security:** `${VAR}` expanded against
+server env **only** for operator template agents (`session_id is None`), never tenant/session agents
+(`:66-80`).
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q7.
+
+### ✅ How a custom agent's own subagents get initialized
+`AgentTool` references a registered agent by name or inline spec; `SelfAgentTool` clones the parent
+(self-tools removed) → both become nested `AgentSpec` (`spec/omnigent.py:1090`). Loaded with
+**`prune_invalid_sub_agents=True`** (`agent_cache.py:94`; impl `spec/__init__.py:314`): depth-first, a
+sub-agent that fails validation on an older server is dropped (WARNING) + removed from
+`tools.agents`, so version skew degrades gracefully and the parent still dispatches.
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q7.
+
+### ⚠️ Async work / inbox mechanics
+`sys_call_async` spawns a bg task → returns an `_AsyncToolHandle`; results auto-drain at the iteration
+boundary (`_drain_async_completions`, `async_inbox.py:253`) OR via `sys_read_inbox` mid-turn; topic
+`async_work_complete`; **consume-once**. **Subagent-completion delivery (runner side):**
+`_on_proxy_stream_end` (`runner/app.py:12519`) pushes the child's output to the parent's inbox
+(`_deliver_subagent_completion:7248`) + schedules a parent wake-POST. **⚠️
+`sys_cancel_task`/`sys_cancel_async` = NO-OP** — tasks table removed → `task_not_found` for all inputs
+(`async_inbox.py:108`).
+→ `cuj-answers/executor-subagents-compaction-cache.md` Q4.
+
+### ⚠️ Resume dispatch (which harness gets re-launched?) — carries native-subagent gate #848
+`resume_dispatch.py:39 run_resume` is **CLI glue for terminal-native sessions**: reads
+`labels.omnigent.wrapper` → `_dispatch_wrapper` (`:201`) maps it → the matching `run_<harness>_native`
+(`claude`→`run_claude_native`, `codex`→`run_codex_native`). **No wrapper label (= an SDK session)** →
+raises a hint to use `omnigent run --resume` (SDK sessions resume through the normal
+create→bind→dispatch path, not `resume_dispatch.py`).
+**⚠️ native-subagent-completion gate #848 — VERIFIED at `runner/app.py:12607`:**
+`elif not _is_native_harness(conv_id) and not has_buffered:` **excludes every native harness** from
+the `status="completed"` delivery — native sub-agent completions silently never reach the orchestrator
+(native turns only emit `waiting`/`idle`, `:12580`). 7-reporter cluster: #848 (root), #697, #880,
+#1449, #1113, #1589, #1410, #762; open PRs #853/#698/#1593/#1462; partial-in-`main` #1286/#1588/#1446.
+→ `cuj-answers/runner-dispatch-mcp.md` Q2; `executor-subagents-compaction-cache.md` (failure branches);
+gaps §2.F below.
+
+---
+
+## §2.G  Onboarding, credentials & auth
+
+Creds never surface as spans → **all code** (`traces` worktree, HEAD `60d11673`). Deeper:
+`cuj-answers/credentials.md`, `architecture/auth-credentials.md`.
+
+### ✅ First-run setup / provider selection
+`omnigent setup` wizard (`onboarding/wizard.py:run_wizard_and_launch:1384`), 3 skippable steps: server
+URL → LLM executor auth (API key vs Databricks profile, with detected hints) → default agent path.
+Writes `~/.omnigent/config.yaml` (`_save_global_config:1476`). **Ambient detection**
+(`onboarding/ambient.py:detect_providers:619`) scans in priority order: env API keys → Vertex → Claude
+CLI login (`~/.claude/.credentials.json` + macOS Keychain fallback) → Codex config provider → Codex CLI
+login → local Ollama. **Databricks profile aliasing** (`onboarding/setup.py:_alias_profile:190`): a
+same-host profile is aliased to the existing one (OAuth cache is host-keyed) → no redundant browser
+OAuth. Per-harness: claude→anthropic, codex→openai (`default_provider_for_harness:1126`).
+→ `cuj-answers/credentials.md` Q1.
+
+### ✅ LLM credential resolution + refresh
+Resolution precedence: spec `executor.auth` → spec `connection` → env → CLI login/profile → ambient
+(`spec/types.py:562`, `databricks_executor.py`). **Subscription harnesses** (claude-native/sdk, codex)
+deliberately **do NOT inherit a parent's Databricks profile** (would bypass subscription auth,
+`spec/omnigent.py:124`). **Refresh:** claude-sdk `_DatabricksBearerAuth.auth_flow`
+(`databricks_executor.py:367`) calls `Config.authenticate()` **every request** (SDK serves from
+in-mem cache, re-shells CLI near expiry) → **survives ~1h**. Codex gateway re-runs the `auth.command`
+shell on an **interval** (`_GATEWAY_AUTH_REFRESH_MS=900_000`=15min, `codex_executor.py:60`) + on 401.
+API-key/subscription = **static, no refresh** (vendor-managed for CLI subscription).
+**⚠️ live example:** codex Databricks gateway currently **403** (dead OAuth refresh grant) — the real
+reason codex/codex-native can't be live-traced.
+→ `cuj-answers/credentials.md` Q2, Q3a.
+
+### ⚠️ Runner ↔ server auth + refresh — carries WS-tunnel gap
+`_make_auth_token_factory` (`runner/_entry.py:271`): stored OIDC token first (`auth_tokens.json`),
+else Databricks OAuth via SDK. **HTTP callbacks** `_RunnerDatabricksAuth.auth_flow` (`:192`): fresh
+token **per request**, retry once on 401 **or** Apps 302→/oidc (`:241`), injects `X-Databricks-Org-Id`
+→ ✅ survives ~1h. **⚠️ WS tunnel** (`ws_tunnel/serve.py:230`): Bearer set **once at open** in the
+handshake `additional_headers` (`:540`), **no per-message refresh**. Mitigations make it mostly
+self-healing: re-mints on **every reconnect** (`_refresh_auth_token:284`), on handshake 401 (retry
+once, `:326`), and on routine ingress recycles (close 1001/1012/502 reset backoff + re-mint). A token
+expiry only bites if the socket stays open past expiry with no recycle and no server-side re-auth
+trigger; the next reconnect heals it.
+→ `cuj-answers/credentials.md` Q3b; `runner-dispatch-mcp.md` Q5; gaps §2.G below.
+
+### ✅ Client ↔ server auth + refresh
+`server/auth.py:resolve_auth_source:193`, `UnifiedAuthProvider:250`. Three modes: **header** (default,
+`X-Forwarded-Email`; missing → 401 unless `OMNIGENT_LOCAL_SINGLE_USER=1`); **accounts** (user/pass →
+cookie); **oidc** (auth-code+PKCE → cookie). Cookie `__Host-ap_session` (HS256 JWT, **validated every
+request** with a TTL cache keyed by HMAC digest, `:387`). CLI `omnigent login` (`cli.py:12146`) writes
+the JWT (`0600`, with `expires_at`) — **⚠️ NO background refresh**; expired → re-login. Databricks Apps
+stores a **pointer record** (no token; minted fresh) + `?o=`→`X-Databricks-Org-Id` per request.
+→ `cuj-answers/credentials.md` Q3c.
+
+### ⚠️ Token refresh in the chat path vs the policy-server path — failure-branch **[VERIFIED FIXED]**
+**Chat/active turn** — both refresh per request → survive ~1h: runner callbacks
+(`_RunnerDatabricksAuth`) + LLM executor (`_DatabricksBearerAuth`; codex interval shell). ✅
+**Policy-hook path (native) — the known bug, VERIFIED FIXED by PR #1439 (merged, commit
+`e9561916`):** old behavior = a one-shot bearer snapshotted at hook launch died at ~1h; Apps bounced
+it 302→/oidc; PreToolUse (fail-closed phase) **failed CLOSED** while chat kept working. Fix: the hook
+re-mints a fresh bearer on 302→/oidc|/.auth **or** 401 and retries once
+(`claude_native_hook.py:36-37,525-580,657,729,875`); fail-closed remains the last resort when
+unmintable. **Residual (out of scope):** OpenCode plugin snapshot (`runner/app.py:1141-1149`,
+`OMNIGENT_POLICY_AUTH`) still one-shot, degrades **fail-OPEN** after ~1h.
+→ `cuj-answers/credentials.md` Q4; `policy-enforcement.md` Q5.
+
+### ✅ Caching: what's cached, TTL, invalidation (agents, credentials)
+| What | Where | TTL | Invalidation |
+|---|---|---|---|
+| MLflow model catalog | `onboarding/providers/__init__.py:102` (`_CATALOG_TTL_SECONDS=3600`) | **1h** | TTL |
+| Provider model listing (`sys_list_models`) | `model_catalog.py:61` (`_CATALOG_TTL_S=300`) | **5min** | TTL; `clear_model_catalog_cache():250` |
+| Provider/credential resolution | — | **none** | fresh per call/spawn |
+| Agent bundle (spec + extract) | `runtime/agent_cache.py` | **none** | evict on delete; warm-swap on update |
+| Runner DBX SDK auth | `_make_auth_token_factory` closure | per-factory; SDK in-mem, re-shell near expiry | factory rebuild |
+| Client cookie → user-id | `server/auth.py:387` (HMAC-keyed) | token remaining lifetime | TTL; ⚠️ no revocation list |
+| Native session state / policy token | `bridge.json`/`policy_hook.json` | one-shot snapshot | re-created on relaunch; **re-minted on 401/302 (PR #1439)** for claude/codex native |
+→ `cuj-answers/credentials.md` Q5; `executor-subagents-compaction-cache.md` Q8.
+
+---
+
+## §2.H  API & message surface
+
+Deeper: `cuj-answers/server-api-state-streaming.md` Q5, `tui-vs-web.md` Q2, `web-client.md` Q2,
+`runner-dispatch-mcp.md` Q4/Q5, `host-channel.md`.
+
+### ✅ Full set of REST calls per component (TUI / WebUI / runner → server) **[partial LIVE]**
+**54 routes** on the sessions router (handler names verified by AST extraction). Highlights: Session
+CRUD (`POST/GET/PATCH/DELETE /v1/sessions[/{id}]`, `/fork`, `/switch-agent`, `/projects`, `/labels`,
+`/read-state`); Turn I/O (`POST …/events`, `GET …/stream`, `GET …/items`); Elicitations
+(`POST …/elicitations/{eid}/resolve`, `GET …/elicitations/{eid}`); native hooks
+(`…/policies/evaluate`, `…/hooks/permission-request`, `…/hooks/codex-elicitation-request`); Agent
+(`…/agent`, `…/agent/contents`, `…/mcp`); Resources (`…/child_sessions`, `…/resources/{environments,
+terminals,files}`); Sharing (`…/permissions`, `…/owner`); App-level (`/health`, `/api/version`,
+`/v1/me`, `/v1/info`, `/v1/users/search`). **Web** adds a large collaboration/admin surface
+(`/comments`, `/policies`, `/auth/*`, `/v1/hosts/{id}/{runners,filesystem,directories}`,
+`/v1/runners`); **TUI** calls a strict subset (no `/switch-agent`, no projects/permissions/comments/
+policies). **Runner→server** (over the WS tunnel): `/events`, `external_*`, `/policies/evaluate`,
+`GET …/items`, `GET …/agent/contents`, `POST /v1/summarize`.
+**Trace-confirmed roots** (both corpus convs): `POST /v1/sessions`, `POST …/events`, `GET …/{id}`,
+`GET …/stream`, `PATCH …/{id}`, `GET …/agent`, `GET …/items`, `GET …/agent/contents`,
+`GET /api/version`, `POST …/policies/evaluate`, `GET …/resources/terminals`, `GET …/skills`.
+→ `cuj-answers/server-api-state-streaming.md` Q5; `tui-vs-web.md` Q2; `web-client.md` Q2.
+
+### ✅ Full set of WebSocket / SSE messages per component **[partial LIVE]**
+**Client↔server WS:** `WS /v1/sessions/updates` (sidebar; C→S `watch`; S→C snapshot/changed/removed/
+heartbeat); `WS …/resources/terminals/{tid}/attach` (xterm↔tmux). **SSE:** `GET …/stream` (the live
+tail). **Ingress tunnels:** `WS /v1/runners/{id}/tunnel`, `WS /v1/hosts/{id}/tunnel` (JSON control
+frames; not HTTP; manual traceparent inject/extract). **Host↔server** carries `host.*` frames
+(`host.stat`, `host.launch_runner`, `host.list_dir`, `host.create_worktree`, …) — ephemeral control
+plane (not streamed to client, not persisted; durable side-effects = `set_runner_id`/`set_host_id` +
+`hosts` DB). **The TUI has no WebSocket usage at all.**
+**Trace evidence:** host-channel trace `aee57ff3…` — `omni-host host.stat`+`host.launch_runner` nest
+under `omni-server POST /v1/hosts/{id}/runners` (manual JSON-frame propagation verified).
+→ `cuj-answers/host-channel.md`; `server-api-state-streaming.md` Q5.
+
+### ✅ Message durability: which messages stream vs which persist (incl. reasoning)
+**DURABLE** (`_extract_persistent_item_from_sse`, `sessions.py:8930`): only
+`response.output_item.done` carrying a `message`/`function_call` (status `completed` only)/
+`function_call_output`, plus `compaction` items; also `session.resource.created/.deleted` → resource
+items and routing decisions. Text deltas are accumulated (`text_acc`) and flushed to a durable message
+only at a function-call boundary or terminal `response.*`. **TRANSIENT** (SSE-only): all `session.*`
+lifecycle/presence, the `response.*.delta` family, reasoning deltas, the Responses-API turn lifecycle,
+`response.elicitation_request/_resolved`, heartbeats. **Reasoning:** streamed as
+`response.reasoning_text.delta` (transient); **persisted on native** (vendor mirrors items),
+**recomputed/not-stored on SDK** (claude-sdk `compacted_messages` keeps only content blocks, so
+thinking is regenerated next turn).
+→ `cuj-answers/server-api-state-streaming.md` Q6; `harness-behavior.md` §8.
+
+### ✅ The *entire* set of API requests client (TUI / WebUI) → server, incl. over websocket
+Covered by the two bullets above (REST + WS/SSE). **Three SSE/WS naming families:** `response.*`
+(turn/output lifecycle, deltas, elicitations — mirrors OpenAI Responses API, 24 literals);
+`session.*` (Omnigent session/sidebar/presence lifecycle — status, input.consumed, presence, model,
+reasoning_effort, usage, agent_changed, resource.created/.deleted, child_session.updated,
+changed_files.invalidated, heartbeat, …); `external_*` (the **input** vocabulary a native forwarder
+POSTs into `/events` so the server re-publishes/persists terminal-observed activity — **not** an SSE
+output prefix). `_format_sse` = `event:<type>\ndata:<json>\n\n`; terminal nameless `data: [DONE]`.
+**Events envelope** (trace-verified): `POST /events {"type":"message","data":{"role":"user",
+"content":[{"type":"input_text","text":"…"}]}}`; control `{"type":"interrupt"}` / `{"type":"compact"}`.
+→ `cuj-answers/server-api-state-streaming.md` Q6; `web-client.md` Q2; `tui-vs-web.md` Q2.
+
+---
+
+## Reliability-gap findings (carried forward from CUJ-ANALYSIS §6, updated with what we verified)
+
+Grouped by domain. 🔴 P0 / 🟠 P1 / 🟡 P2 (from OSS triage). **VERIFIED** = re-confirmed against
+current `main` this pass. Prod is v0.3.0 (2026-06-27); the 06-29 batch is on `main` but not released.
+
+### Session lifecycle, streaming & continuity [§2.A]
+- 🔴 **Idle reaper / watchdog kills active turns; native sessions never reaped.** No writers to
+  `_in_flight_response_ids`, no `OMNIGENT_HARNESS_IDLE_TIMEOUT` knob. Issues #1414, #1349 (no PR),
+  #1528, #1119 · PRs #1420, #1529, #371, #1227.
+- 🟠 **Runner tunnel / stream-recovery defects.** #1116 (keepalive-1011 drops tunnels, no PR), #1117,
+  #1118, #1026, #1076 · PRs #1198, #1189, #1077 · in `main` #1078.
+- **(code) Runner-offline-on-message** — VERIFIED: fresh item with no runner+host → 503 pre-persist
+  (`sessions.py:19073`); bound-but-offline → persisted, forward fails, idle, client stuck until
+  snapshot reconciliation.
+- **(code) Streaming↔durable dedup hinges on `itemId`** — the native FIFO-desync class
+  (`server-api-state-streaming.md` Q2); no server item id at native dispatch.
+- **(trace) `/compact` on a model-less session errors pre-LLM** — confirms #1192 live (`conv_63542a5f`).
+  ⚠️ resume-overflow OMNI-143 (reactive overflow ends the turn, does NOT compact — `runner/app.py:13804`).
+  _Interrupt is NOT a gap: all in-scope harnesses support the web Stop (trace `error.type=cancelled`)._
+
+### Model selection [§2.B]
+- 🟠 **claude-sdk silently bills Opus when Sonnet was selected.** VERIFIED at
+  `claude_sdk_executor.py:1910-1912` (`_DATABRICKS_CLAUDE_DEFAULT_MODEL` fires on None override).
+  Issue #1128 · real fix PR #1146 · ⚠️ #1570/#1563 (frontend) do **not** fix it.
+- **(code) Native mid-session model override never affects the running turn** — next turn only (all
+  four); codex-SDK tears down the thread; claude-native `/effort none|minimal` persist-only (`:11521`).
+
+### Subagents & runner dispatch [§2.F]
+- 🔴 **Native sub-agent completions silently never reach the orchestrator.** VERIFIED gate at
+  `runner/app.py:12607` (`elif not _is_native_harness(conv_id) and not has_buffered:`). Issues #848
+  (root), #697, #880, #1449, #1113, #1589, #1410, #762 · open PRs #853, #698, #1593, #1462 ·
+  partial-in-`main` #1286, #1588, #1446.
+- **(code) No spawn-time subagent depth cap** — VERIFIED: `_MAX_SUBAGENT_TREE_DEPTH=3` is REPL-render-
+  only (`repl/_repl.py:201`); unbounded `AgentTool` recursion.
+- **(code) Hard runner affinity, no failover** — VERIFIED: `routing.py:89` never re-routes a bound
+  conversation; offline runner → `RUNNER_UNAVAILABLE` strands the session.
+- **(code) `sys_cancel_task`/`sys_cancel_async` = no-op** — VERIFIED: tasks table removed
+  (`async_inbox.py:108`), `task_not_found` for all inputs.
+
+### Onboarding, credentials & auth [§2.G]
+- 🔴 **Managed sandboxes broken under OIDC/accounts auth** (runner tunnel 403; host never boots via
+  `nohup` env-prefix). Issues #357, #1305, #1297 · PRs #1298, #360 + #1308 (overlapping tunnel-auth).
+- 🟠 **Host daemon can't reach backend behind a corporate proxy** (no `HTTP(S)_PROXY`/`NO_PROXY` in the
+  daemon allowlist). Issue #1022 · PR #1029.
+- 🟠 **First-run install: Claude CLI via `npm -g` → EACCES.** Issue #890 · PR #891. Also #904, #1023.
+- **(code) Policy-hook static token → fail-closed after ~1h** — ✅ **VERIFIED FIXED (PR #1439, merged
+  `e9561916`)** for claude-native + codex-native (re-mint on 302/401 + retry-once,
+  `claude_native_hook.py:525-580`). **Residual:** OpenCode plugin snapshot (`runner/app.py:1141-1149`)
+  still one-shot, **fail-OPEN** after ~1h (out of scope).
+- **(code) WS tunnel runner-auth: Bearer injected once at open, no per-message refresh** — VERIFIED
+  (`ws_tunnel/serve.py:540`); mitigated by reconnect/recycle re-mint (mostly self-healing).
+
+### Tools / sandbox (OmniBox) [§2.C]
+- 🟠 **`credential_proxy` trust-boundary defect (SECURITY):** parent-side `subprocess.run(shell=True)`
+  + arbitrary file reads on an unenforced "trusted-spec-only" assumption (`credential_proxy.py:190`).
+  Issue #1542 · **no PR**.
+- 🟠 **Sandboxed claude-sdk crashes on macOS instead of degrading.** Issue #517 · part-2 flag #541 in
+  `main`; part-1 auto-degrade never landed (no PR).
+- **(code) Timers unusable on sessions-native** — `NotImplementedError` (`timer.py:220`); works under
+  the local-runner topology (trace-confirmed, `conv_48ce846b`).
+
+### Policy / access control [§2.D]
+- **(code) Permission store disabled ⇒ `accessible_by=None` returns ALL sessions** — cross-user
+  data-leak risk on open/misconfigured servers; `_require_user()` must gate.
+
+### Web UI [§2.E]
+- 🟡 **CJK IME: Enter to confirm composition submits prematurely** (data-loss, no workaround). Issue
+  #433 · PR #567.
+- 🟡 **File viewer / browser gaps:** non-git Changes panel empty #725 (PR #843); browser empty after
+  reconnect #386 (PR #578); staged/unstaged filter #951 (PR #1587); mobile HTML preview/download
+  #968/#969 (no PR); fullscreen #1464 (no PR).
+
+**✅ Already fixed on `main` since v0.3.0 (not gaps):** #668 macOS 60s timeout (#1546), web_search on
+non-OpenAI (#54), markdown preview (#970), Windows (#19/#1236/#1325/#1375), install
+aarch64/Intel/gpt-deps (#308/#458/#296), **native hook token fail-closed (#1439)**.
+**🚫 Excluded as feature requests:** new harnesses, multi-account features, monolith decomposition,
+command-palette/shortcuts. **Dropped as minor:** model-less SDK `/compact` raw error (#1192 — web
+shielded by #1139, maintainer leans wont-fix; **but confirmed live-reproducible** this pass).
+**Fast wins (PRs written, unreviewed):** #1146, #1029, #891, #1198, #1189, #567.
+**No-PR gaps needing fresh code:** #1349, #1116, #517 (part-1), #1542, native-subagent #848 (open PRs
+exist but none merged), OpenCode policy-token follow-up.
+
+---
+
+*Companion docs: `architecture/*.md` (per-component), `cuj-answers/*.md` (per-domain deep dives),
+`cuj-answers/_LIVE-TRACE-FINDINGS.md` (the 11 live traces). Source-of-truth rule: running code is
+ground truth; traces validate/enrich it. Anchors re-derived on `main` HEAD `60d11673`.*

--- a/designs/master-arch/README.md
+++ b/designs/master-arch/README.md
@@ -1,0 +1,47 @@
+# Omnigent — Master Architecture & CUJ Analysis
+
+Deep, **code- and trace-grounded** map of Omnigent. Scope: **claude (sdk+native),
+codex (sdk+native), polly** (custom agents). Built from a codebase pass (`file:line`
+anchors), **live OpenTelemetry traces** (local Jaeger rig), and the existing
+`designs/CUJ-MAP.md` / `CUJ-ANALYSIS.md` / `OBSERVABILITY.md`.
+
+**Source-of-truth rule:** the running code is ground truth; traces validate/enrich it.
+(`CUJ-ANALYSIS.md` line anchors had drifted thousands of lines — re-derived here.)
+
+## Read in this order
+1. **`architecture/overall-architecture.md`** — system topology, component inventory, the
+   inter-component **channel matrix**, end-to-end request lifecycle, harness taxonomy, and
+   **§9 verified corrections + live-trace findings**. Start here.
+2. **`architecture/telemetry-tracing.md`** — how observability works **and how to read these
+   traces** (the two span layers, `session.id` grouping, why one action = many traces).
+3. **Per-component architecture** (`architecture/`):
+   `server.md` · `runner.md` · `host.md` · `harness-inner.md` · `runtime-executor.md` ·
+   `policies.md` · `web.md` · `tui-repl.md` · `auth-credentials.md` · `tools-omnibox.md`
+4. **CUJ answers** (`cuj-answers/`):
+   - **`_FOR-PASTE.md`** — answers to the Team Doc's *"How does claude code / codex / polly
+     behave when…"* questions, in the doc's order, pasteable.
+   - **`_LIVE-TRACE-FINDINGS.md`** — what the live traces revealed *beyond* the code.
+   - per-domain: `server-api-state-streaming.md` · `runner-dispatch-mcp.md` ·
+     `harness-behavior.md` · `executor-subagents-compaction-cache.md` · `host-channel.md` ·
+     `policy-enforcement.md` · `web-client.md` · `tui-vs-web.md` · `credentials.md` ·
+     `tools-mcp-shells.md`
+5. **`CUJ-COVERAGE.md`** — every journey in `designs/CUJ-MAP.md` (§2.A–§2.H), each with an
+   answer + `file:line` pointers + trace evidence.
+
+## How the traces were produced (reproducible)
+- **Native Jaeger binary** (Docker is org-locked on this Mac): UI `:16686`, OTLP gRPC `:14317`.
+- **Persistent local stack**: `omnigent server --port 7777` + a local `omnigent host` (safe —
+  per-server singleton, coexists with the remote-connected host), telemetry env → `:14317`.
+- **Drive**: `omnigent run --server http://localhost:7777 …` (SDK) or REST
+  (`POST /v1/sessions {agent_id,host_id,workspace}` then `POST /events
+  {type:message,data:{role,content:[{type:input_text,text}]}}`); control via
+  `{type:interrupt}` / `{type:compact}`; fork/switch via their endpoints.
+- **Extract**: `python3 scratchpad/trace_tools.py {recent|conv <id>|tree <traceid>}` →
+  Jaeger HTTP API, grouped by `session.id` (= conv id).
+
+## Scope & caveats
+- **codex / codex-native are live-blocked** (Databricks gateway creds; the host reports
+  `codex: needs-auth`; OSS path blocked by a `DATABRICKS_BEARER`/PATH propagation gap in the
+  runner spawn env). Covered from **code + the §4 capability matrix**, not fresh codex spans.
+- The **TUI emits no spans today** (`telemetry.init("omni-tui")` is never called) — code-based.
+- The **web UI** OTel is opt-in (`VITE_OTEL_EXPORTER_OTLP_ENDPOINT`) and was inactive — code-based.

--- a/designs/master-arch/README.md
+++ b/designs/master-arch/README.md
@@ -1,47 +1,77 @@
 # Omnigent — Master Architecture & CUJ Analysis
 
-Deep, **code- and trace-grounded** map of Omnigent. Scope: **claude (sdk+native),
-codex (sdk+native), polly** (custom agents). Built from a codebase pass (`file:line`
-anchors), **live OpenTelemetry traces** (local Jaeger rig), and the existing
-`designs/CUJ-MAP.md` / `CUJ-ANALYSIS.md` / `OBSERVABILITY.md`.
+A deep, **code- and trace-grounded** map of Omnigent. Scope: **claude (sdk+native),
+codex (sdk+native), polly**. Built from a codebase pass (`file:line` anchors) + **live
+OpenTelemetry traces** (local Jaeger). Source-of-truth = the running code; traces
+validate/enrich it. (`designs/CUJ-ANALYSIS.md`'s line anchors had drifted — re-derived here.)
 
-**Source-of-truth rule:** the running code is ground truth; traces validate/enrich it.
-(`CUJ-ANALYSIS.md` line anchors had drifted thousands of lines — re-derived here.)
+## 📑 Table of contents
 
-## Read in this order
-1. **`architecture/overall-architecture.md`** — system topology, component inventory, the
-   inter-component **channel matrix**, end-to-end request lifecycle, harness taxonomy, and
-   **§9 verified corrections + live-trace findings**. Start here.
-2. **`architecture/telemetry-tracing.md`** — how observability works **and how to read these
-   traces** (the two span layers, `session.id` grouping, why one action = many traces).
-3. **Per-component architecture** (`architecture/`):
-   `server.md` · `runner.md` · `host.md` · `harness-inner.md` · `runtime-executor.md` ·
-   `policies.md` · `web.md` · `tui-repl.md` · `auth-credentials.md` · `tools-omnibox.md`
-4. **CUJ answers** (`cuj-answers/`):
-   - **`_FOR-PASTE.md`** — answers to the Team Doc's *"How does claude code / codex / polly
-     behave when…"* questions, in the doc's order, pasteable.
-   - **`_LIVE-TRACE-FINDINGS.md`** — what the live traces revealed *beyond* the code.
-   - per-domain: `server-api-state-streaming.md` · `runner-dispatch-mcp.md` ·
-     `harness-behavior.md` · `executor-subagents-compaction-cache.md` · `host-channel.md` ·
-     `policy-enforcement.md` · `web-client.md` · `tui-vs-web.md` · `credentials.md` ·
-     `tools-mcp-shells.md`
-5. **`CUJ-COVERAGE.md`** — every journey in `designs/CUJ-MAP.md` (§2.A–§2.H), each with an
-   answer + `file:line` pointers + trace evidence.
+### Start here
+| Doc | What it covers |
+|---|---|
+| [`architecture/overall-architecture.md`](architecture/overall-architecture.md) | System topology, component inventory, **inter-component channel matrix**, end-to-end request lifecycle, harness taxonomy, and §9 verified corrections + live-trace findings. |
+| [`architecture/telemetry-tracing.md`](architecture/telemetry-tracing.md) | How observability works **and how to read these traces** (two span layers, `session.id` grouping, why one action = many traces). |
+
+### Component architecture — [`architecture/`](architecture/)
+| Doc | Covers |
+|---|---|
+| [`server.md`](architecture/server.md) | FastAPI server: `post_event` lifecycle, persist-before-forward, SSE vs durable, dedup, working-state, the full client→server route set, host/runner tunnels. |
+| [`runner.md`](architecture/runner.md) | Runner dispatch + affinity, MCP routing (`/mcp`→`/mcp/execute`), request lifecycle, runner↔server WS reverse-tunnel + auth, resume dispatch. |
+| [`host.md`](architecture/host.md) | Host daemon: JSON control-frame channel, runner launch/stop/exited, worktree/FS ops, spawn-env allowlist, host↔server auth. |
+| [`harness-inner.md`](architecture/harness-inner.md) | SDK vs native harnesses, the per-harness capability matrix (§4), model/effort changes, elicitation hooks, default-model resolution, harness switching. |
+| [`runtime-executor.md`](architecture/runtime-executor.md) | The executor turn loop, sub-agent spawning + depth, compaction (L1/L2/L3), inbox/async, agent cache, custom-agent storage. |
+| [`policies.md`](architecture/policies.md) | Policy engine, creation (session/admin/spec), server vs runner enforcement, phases, the ASK/DENY elicitation flow, required native hooks. |
+| [`web.md`](architecture/web.md) | Web UI: sidebar fetch, full client→server request/channel set, streaming↔durable reconciliation (dedup by `ctx.itemId`), working-state, reconnect. |
+| [`tui-repl.md`](architecture/tui-repl.md) | TUI/REPL: `OmnigentClient` REST+SSE, TUI vs Web differences, slash commands, resume picker, event tape. |
+| [`auth-credentials.md`](architecture/auth-credentials.md) | The three credential relationships + refresh paths, onboarding/provider selection, the native policy-hook token (PR #1439), caching TTLs. |
+| [`tools-omnibox.md`](architecture/tools-omnibox.md) | The `sys_*` MCP surface, custom MCP, shells + working-dir resolution, timers, and OmniBox (the OS sandbox: isolation + egress + credential proxy). |
+
+### CUJ answers — [`cuj-answers/`](cuj-answers/)
+| Doc | Covers |
+|---|---|
+| [`_FOR-PASTE.md`](cuj-answers/_FOR-PASTE.md) | **The 26 team-doc "how does claude / codex / polly behave when…" questions**, in order — pasteable into the Team Doc. |
+| [`_LIVE-TRACE-FINDINGS.md`](cuj-answers/_LIVE-TRACE-FINDINGS.md) | **11 CUJs traced live** — what the traces reveal beyond the code (fork, switch, interrupt, compaction, sub-agent, claude-native, disconnect, custom-MCP, timers, ASK/DENY, runner-binding). |
+| [`server-api-state-streaming.md`](cuj-answers/server-api-state-streaming.md) | Request lifecycle, dedup, working-state, streaming vs durable, the full client→server API. |
+| [`runner-dispatch-mcp.md`](cuj-answers/runner-dispatch-mcp.md) | Runner dispatch/affinity, MCP routing (custom vs `sys_*`), resume dispatch. |
+| [`harness-behavior.md`](cuj-answers/harness-behavior.md) | Per-harness features, model/effort, config propagation, default resolution, switching. |
+| [`executor-subagents-compaction-cache.md`](cuj-answers/executor-subagents-compaction-cache.md) | Executor role, sub-agents + depth, inbox, compaction, custom-agent storage, caching. |
+| [`host-channel.md`](cuj-answers/host-channel.md) | Host daemon channel + data + runner launch. |
+| [`policy-enforcement.md`](cuj-answers/policy-enforcement.md) | Policy creation + server/session enforcement + hooks + ASK/DENY. |
+| [`web-client.md`](cuj-answers/web-client.md) | Sidebar fetch, full client→server set, streaming/durable reconciliation, close-page-return. |
+| [`tui-vs-web.md`](cuj-answers/tui-vs-web.md) | TUI vs WebUI state + request-surface differences. |
+| [`credentials.md`](cuj-answers/credentials.md) | Credential resolution + the three refresh paths + caching. |
+| [`tools-mcp-shells.md`](cuj-answers/tools-mcp-shells.md) | `sys_*` surface, custom MCP, shells + cwd resolution, OmniBox, timers. |
+
+### CUJ-MAP coverage
+| Doc | Covers |
+|---|---|
+| [`CUJ-COVERAGE.md`](CUJ-COVERAGE.md) | **Every journey in `designs/CUJ-MAP.md` (§2.A–§2.H), 1:1** — 63 journeys, each with mechanism + `file:line` + ✅/⚠️ status + pointer to the deeper doc. |
+
+### Tooling
+| File | Purpose |
+|---|---|
+| [`trace_tools.py`](trace_tools.py) | Jaeger extraction helper — `python3 trace_tools.py {recent|conv <id>|tree <traceid>}`, grouped by `session.id`. |
+
+## Suggested reading order
+1. `architecture/overall-architecture.md` (the map) → 2. `architecture/telemetry-tracing.md` (how to read traces) →
+3. the component doc(s) for your area → 4. `cuj-answers/_FOR-PASTE.md` for the specific behavior questions →
+5. `CUJ-COVERAGE.md` to see any journey covered end-to-end.
 
 ## How the traces were produced (reproducible)
 - **Native Jaeger binary** (Docker is org-locked on this Mac): UI `:16686`, OTLP gRPC `:14317`.
-- **Persistent local stack**: `omnigent server --port 7777` + a local `omnigent host` (safe —
-  per-server singleton, coexists with the remote-connected host), telemetry env → `:14317`.
+- **Persistent local stack**: `omnigent server --port 7777` + a local `omnigent host` (per-server
+  singleton — coexists with a remote-connected host), telemetry env → `:14317`.
 - **Drive**: `omnigent run --server http://localhost:7777 …` (SDK) or REST
   (`POST /v1/sessions {agent_id,host_id,workspace}` then `POST /events
   {type:message,data:{role,content:[{type:input_text,text}]}}`); control via
   `{type:interrupt}` / `{type:compact}`; fork/switch via their endpoints.
-- **Extract**: `python3 scratchpad/trace_tools.py {recent|conv <id>|tree <traceid>}` →
-  Jaeger HTTP API, grouped by `session.id` (= conv id).
+- **Extract**: `python3 trace_tools.py {recent|conv <id>|tree <traceid>}` → Jaeger HTTP API,
+  grouped by `session.id` (= conversation id).
 
 ## Scope & caveats
-- **codex / codex-native are live-blocked** (Databricks gateway creds; the host reports
-  `codex: needs-auth`; OSS path blocked by a `DATABRICKS_BEARER`/PATH propagation gap in the
-  runner spawn env). Covered from **code + the §4 capability matrix**, not fresh codex spans.
+- **codex / codex-native are code-only** here (Databricks-gateway creds; the host reports
+  `codex: needs-auth`; the OSS path is blocked by a `DATABRICKS_BEARER`/PATH gap in the runner
+  spawn env). Covered from **code + the §4 capability matrix**, not fresh codex spans.
 - The **TUI emits no spans today** (`telemetry.init("omni-tui")` is never called) — code-based.
 - The **web UI** OTel is opt-in (`VITE_OTEL_EXPORTER_OTLP_ENDPOINT`) and was inactive — code-based.

--- a/designs/master-arch/architecture/auth-credentials.md
+++ b/designs/master-arch/architecture/auth-credentials.md
@@ -1,0 +1,291 @@
+# Architecture — Auth, Credentials & Onboarding
+
+> SME scope: the **three credential relationships** (LLM creds, Runner↔Server, Client↔Server),
+> their refresh paths, first-run setup/onboarding, and the native policy-hook token snapshot.
+> Source-of-truth = code (`file:line` anchors verified on branch `traces`, HEAD `60d11673`).
+> Creds are mostly NOT visible as trace spans (they're HTTP header injection / SDK shell-outs),
+> so this doc is code-grounded; trace evidence is limited to what's observable (§ Trace evidence).
+
+---
+
+## Overview
+
+Omnigent has **three independent credential relationships**, each with its **own refresh path**:
+
+1. **LLM creds** — how a harness authenticates to the model provider (Databricks AI gateway,
+   Anthropic/OpenAI API key, Claude/Codex subscription, OpenAI-compatible base_url, Ollama).
+2. **Runner ↔ Server** — how a runner subprocess authenticates its callbacks/tunnel to the
+   Omnigent server (stored OIDC token OR Databricks OAuth).
+3. **Client ↔ Server** — how a browser/TUI/CLI authenticates to the server
+   (header / accounts / oidc; cookie `__Host-ap_session`; `omnigent login`).
+
+A **fourth**, hook-specific path piggybacks on #2: the **native policy/permission hook** posts to
+`/policies/evaluate` with a token snapshot — historically the source of the "fail-closed after ~1h"
+bug, **fixed by PR #1439** (verified merged, commit `e9561916`).
+
+```
+                       ┌──────────────┐  (3) header / cookie / Bearer
+        browser/TUI ──▶│  omni-server │◀──────────────────────────── omnigent login → auth_tokens.json
+                       └──────┬───────┘
+                  (2) WS tunnel handshake Bearer (once at open) + httpx callbacks (per-request refresh)
+                              │
+                       ┌──────▼───────┐
+                       │  omni-runner │── (4) native policy hook → /policies/evaluate (snapshot+reauth)
+                       └──────┬───────┘
+                  (1) LLM creds: per-request httpx auth_flow (SDK) | shell auth_command @ interval (codex)
+                              │
+                       ┌──────▼───────────────────────┐
+                       │  model provider (DBX gateway, │
+                       │  Anthropic/OpenAI, Ollama)    │
+                       └───────────────────────────────┘
+```
+
+---
+
+## Key files (file:line)
+
+### First-run setup / onboarding
+- `omnigent/onboarding/wizard.py` — `run_wizard_and_launch()` **:1384** (3-step setup: server URL →
+  LLM auth `_prompt_global_auth()` **:498** → default agent path); writes `~/.omnigent/config.yaml`
+  via `_save_global_config()` **:1476**. `_list_databricks_profiles()` **:465** reads `~/.databrickscfg`.
+- `omnigent/onboarding/ambient.py` — `detect_providers()` **:619** (ambient CLI/key detection, priority-ordered).
+- `omnigent/onboarding/setup.py` — `_alias_profile(source, target)` **:190**; `_alias_source_for()` **:160**
+  (Databricks same-host profile aliasing to reuse OAuth cache); config path `~/.databrickscfg`
+  (or `DATABRICKS_CONFIG_FILE`) **:179**.
+- `omnigent/onboarding/provider_config.py` — `_config_path()` **:473** (`OMNIGENT_CONFIG_HOME` or
+  `~/.omnigent/config.yaml`); provider TYPES `_parse_provider()` **:748**; `default_provider_for_harness()` **:1126**.
+- `omnigent/onboarding/providers/__init__.py` — MLflow catalog TTL `_CATALOG_TTL_SECONDS = 3600` **:102**;
+  `_catalog_cache` **:103** (cachetools TTLCache, maxsize 64); `_fetch_provider_catalog()` **:134**.
+
+### (1) LLM creds + refresh
+- `omnigent/inner/databricks_executor.py` — `_DatabricksBearerAuth(httpx.Auth)` **:289**;
+  `auth_flow()` **:367** (per-request); `current_token()` **:349**; `_authenticate_headers()` **:325**
+  (calls SDK `Config.authenticate()`); `_resolve_databricks_auth()` **:384** (profile/host → auth+host);
+  static PAT fallback **:472-481**; SDK-Databricks client wired `http_client=httpx.Client(auth=auth)` **:620**;
+  static OpenAI api-key path **:608-610** (no refresh).
+- `omnigent/inner/codex_executor.py` — `_GATEWAY_AUTH_REFRESH_MS = 900_000` **:60** (15 min);
+  `_databricks_codex_auth_command()` **:730** (shell `databricks auth token --profile/--host [--force-refresh]`);
+  `_databricks_codex_config_overrides()` **:763** (TOML `auth={command=sh,...,refresh_interval_ms=...}` **:794**).
+
+### (2) Runner ↔ Server + refresh
+- `omnigent/runner/_entry.py` — `_make_auth_token_factory()` **:271** (OIDC token first → Databricks SDK);
+  `_RunnerDatabricksAuth(httpx.Auth)` **:162**, `auth_flow()` **:192** (per-request + retry on 401/302);
+  `_is_login_redirect_or_unauthorized()` **:241**; tunnel run `_run_tunnel_from_env()` **:881** (token at **:891**).
+- `omnigent/runner/transports/ws_tunnel/serve.py` — `serve_tunnel()` **:230** (reconnect loop `while True` **:283**,
+  `_refresh_auth_token()` **:284**/**:375**); `_serve_tunnel_once()` **:494**, handshake headers **:539-540**,
+  `websockets.connect(additional_headers=headers)` **:543-545**; 401 retry `_handle_refreshable_auth_failure()` **:407**.
+- `omnigent/cli_auth.py` — `load_token()` **:166** (expiry check **:183**); `store_token()` **:84**;
+  `store_databricks_auth()` **:109** (pointer record, no bearer); `load_databricks_workspace_host()` **:191**;
+  `load_databricks_org_id()` **:207**; `databricks_request_headers()` **:229**; header
+  `DATABRICKS_ORG_ID_HEADER = "X-Databricks-Org-Id"` **:226**; token file `auth_tokens.json` **:29**.
+
+### (3) Client ↔ Server
+- `omnigent/server/auth.py` — `resolve_auth_source()` **:193** (env → header/oidc/accounts);
+  `UnifiedAuthProvider` **:250**; `get_user_id()` **:333**; `_check_cookie()` **:351** (JWT HS256, TTL cache, Bearer fallback);
+  `_check_header()` **:415** (X-Forwarded-Email, strip-prefix, local fallback); `create_auth_provider()` **:461**;
+  `login_url` property **:312**.
+- `omnigent/cli.py` — `login()` **:12146** (probe `/v1/me` → accounts/oidc/databricks/header branches);
+  `_databricks_login()` **:11924**; `_accounts_login()` **:12303**; OIDC ticket poll **:12262-12297**;
+  `_CLI_LOGIN_TIMEOUT_SECONDS = 300` **:12300**.
+
+### (4) Native policy-hook token (the bug + fix)
+- `omnigent/native_policy_hook.py` (shared by codex-native + others) — `policy_hook_wrapper_script()` **:103**
+  (one-shot token bake into `_AUTH_HEADERS_ENV`); `policy_hook_reauth()` **:133** (re-mint via
+  `_make_auth_token_factory`); `_is_login_redirect_or_unauthorized()` **:171**; `post_evaluate_with_retry(..., reauth=)` **:440**,
+  re-mint-and-retry-once branch **:500-522**; `fail_closed_hook_output()` **:383**.
+- `omnigent/claude_native_hook.py` — imports `_is_login_redirect_or_unauthorized`, `fail_closed_hook_output` **:32-34**;
+  `ap_auth_headers` snapshot reads **:261,307,645,717,836**; reauth+retry in `_post_*` **:545-580**.
+- `omnigent/runner/app.py` — OpenCode policy plugin snapshot `OMNIGENT_POLICY_AUTH` **:1141-1149** (still one-shot →
+  "degrades to fail-open" comment **:1142**); many `_make_auth_token_factory()` + `_RunnerDatabricksAuth` call sites
+  for relays (**:2207,2398,2626,2764,3135,4290,5383**, etc. — all per-call fresh).
+
+---
+
+## Data flow
+
+### (1) LLM creds — Databricks SDK harness (claude-sdk path)
+```mermaid
+sequenceDiagram
+  participant Exec as SDK executor (in runner)
+  participant Auth as _DatabricksBearerAuth
+  participant SDK as databricks SDK Config
+  participant GW as Databricks serving-endpoints
+  Exec->>Auth: HTTP POST /serving-endpoints/... (httpx.Client auth=auth)
+  Auth->>SDK: Config.authenticate()  (auth_flow, every request)
+  SDK-->>Auth: {Authorization: Bearer <fresh>}  (in-mem cache; CLI re-shell ~0.5s near expiry)
+  Auth->>GW: request + Authorization
+  GW-->>Auth: 200 (or 401/403 if refresh token dead → DatabricksAuthError)
+```
+
+### (1) LLM creds — Codex gateway (codex / codex-native)
+Codex does NOT use httpx auth_flow. The Codex App Server is configured with a provider whose
+`auth = {command="sh", args=["-c", <databricks auth token ...>], refresh_interval_ms=900000}`
+(`codex_executor.py:763-798`). Codex itself re-runs the shell command on its **interval** (default
+15 min, `_GATEWAY_AUTH_REFRESH_MS`) and on 401, minting a fresh bearer. When the workspace OAuth
+refresh token is dead, `databricks auth token` returns empty → gateway returns **401/403** (this is
+the current live state of the codex Databricks gateway token — expired/403).
+
+### (2) Runner ↔ Server — two channels
+```mermaid
+flowchart TB
+  subgraph Runner
+    F[_make_auth_token_factory] --> T1[OIDC token from auth_tokens.json]
+    F --> T2[Databricks SDK OAuth host-keyed]
+  end
+  F -->|once at boot| WS[serve_tunnel: WS handshake Bearer in additional_headers]
+  F -->|per HTTP callback| HX[_RunnerDatabricksAuth.auth_flow]
+  WS -->|connection stays open ~hrs| SRV[(omni-server)]
+  WS -.->|on reconnect: _refresh_auth_token| SRV
+  HX -->|401 or 302-/oidc/ retry-once| SRV
+```
+- **HTTP callbacks** (agent-bundle GET, response lookups, file APIs, idle notify): `_RunnerDatabricksAuth.auth_flow`
+  mints fresh per request and retries once on 401 **or** Apps `302→/oidc/` (`_entry.py:226-238`). ✅ survives ~1h OAuth.
+- **WS tunnel**: Bearer is set **once** in the handshake `additional_headers` (`serve.py:540-545`). Inside the open
+  socket, frames flow with **no per-message re-auth**. The token is only refreshed when the connection drops and the
+  outer `while True` reconnect loop re-runs `_refresh_auth_token` (`serve.py:284`) + the 401-retry path (`serve.py:407`).
+
+### (3) Client ↔ Server — provider selection
+```mermaid
+flowchart TB
+  R[resolve_auth_source server/auth.py:193] --> EXP{OMNIGENT_AUTH_PROVIDER set?}
+  EXP -->|yes| USE[use that: header/oidc/accounts]
+  EXP -->|no| EN{OMNIGENT_AUTH_ENABLED truthy?}
+  EN -->|no| HDR[header default]
+  EN -->|yes + OMNIGENT_OIDC_ISSUER| OIDC[oidc]
+  EN -->|yes, no issuer| ACC[accounts]
+  HDR --> CH[_check_header: X-Forwarded-Email]
+  OIDC --> CK[_check_cookie: __Host-ap_session JWT HS256]
+  ACC --> CK
+```
+- **header** (default): reads `X-Forwarded-Email` (overridable `OMNIGENT_AUTH_HEADER`, e.g.
+  `Cf-Access-Authenticated-User-Email`); optional `OMNIGENT_AUTH_HEADER_STRIP_PREFIX` (Google IAP). Missing header →
+  401 (fail closed) **unless** `OMNIGENT_LOCAL_SINGLE_USER=1` → reserved `"local"` user.
+- **accounts**: built-in user/pass → `/auth/login` → `__Host-ap_session` cookie (HS256). SPA login at `/login`.
+- **oidc**: auth-code+PKCE against operator IdP → same cookie. Server-side `/auth/login` redirect.
+- Cookie validated every request (`_check_cookie`), with a TTL credential cache keyed by HMAC digest of the token
+  (`auth.py:387-411`); CLI clients send the JWT as `Authorization: Bearer` (fallback at `auth.py:380-383`).
+
+### (4) Native policy-hook token — chat vs policy path (PR #1439)
+```mermaid
+sequenceDiagram
+  participant Hook as native PreToolUse hook (subprocess)
+  participant Srv as omni-server /policies/evaluate
+  participant F as _make_auth_token_factory (reauth)
+  Note over Hook: launched with one-shot ap_auth_headers bearer (snapshot @ launch)
+  Hook->>Srv: POST /policies/evaluate (Bearer snapshot)
+  alt token still valid (<~1h)
+    Srv-->>Hook: verdict (allow/deny/ask) via long-poll body
+  else token expired (~1h): Apps 302→/oidc/ OR 401
+    Srv-->>Hook: 302/401
+    Hook->>F: reauth() — re-mint fresh bearer (PR #1439)
+    F-->>Hook: fresh Bearer (or None)
+    alt fresh token minted
+      Hook->>Srv: retry once with fresh Bearer
+      Srv-->>Hook: verdict
+    else no token mintable
+      Hook-->>Hook: fail CLOSED (deny) — last resort
+    end
+  end
+```
+
+---
+
+## Channels & message/event types
+
+| Relationship | Channel | Credential carried | Refresh trigger |
+|---|---|---|---|
+| LLM (SDK Databricks) | httpx → `/serving-endpoints` | `Authorization: Bearer` via `auth_flow` | every request (SDK in-mem cache) |
+| LLM (codex gateway) | Codex App Server provider `auth.command` | bearer printed by `databricks auth token` | codex `refresh_interval_ms` (15 min) + 401 |
+| LLM (api-key/subscription) | OpenAI-compatible / vendor CLI | static `api_key` / CLI-managed OAuth | none (vendor CLI self-manages subscription) |
+| Runner↔Server (HTTP) | httpx callbacks over WS tunnel | `Authorization: Bearer` + `X-Databricks-Org-Id` | per request + retry on 401/302 |
+| Runner↔Server (WS) | `websockets.connect` handshake | Bearer in `additional_headers` + `X-Databricks-Org-Id` + `Origin` sentinel | **once at open**; re-mint on reconnect only |
+| Client↔Server (browser) | cookie `__Host-ap_session` | HS256 JWT (`sub` claim) | re-login on expiry (no bg refresh) |
+| Client↔Server (CLI) | `Authorization: Bearer <jwt>` | same JWT from `auth_tokens.json` | re-login on expiry (no bg refresh) |
+| Native policy hook | HTTP POST `/policies/evaluate` | `ap_auth_headers` snapshot bearer | re-mint on 401/302 (PR #1439), then fail-closed |
+
+**Stored files:**
+- `~/.omnigent/config.yaml` — `server`, `auth` block (`{type, profile/api_key/...}`), `providers`, `default_agent`.
+- `~/.omnigent/auth_tokens.json` (`0o600`) — per-server entries: session token `{token, user_id, expires_at}`
+  OR Databricks pointer `{auth_type:"databricks", workspace_host, org_id?, user_id?}`.
+- `~/.databrickscfg` — Databricks CLI profiles (OAuth token cache is host-keyed → profile aliasing reuses it).
+- `~/.claude/.credentials.json`, `~/.codex/auth.json`, `~/.codex/config.toml` — vendor subscription/config (ambient detection).
+- `policy_hook.json` / wrapper script / `OMNIGENT_POLICY_AUTH` — one-shot hook token snapshot.
+
+---
+
+## Trace evidence
+
+Credentials are HTTP-header injection and SDK shell-outs — they do **not** surface as dedicated spans.
+What is observable in the Jaeger corpus:
+- The `omni-runner` service emits spans for agent turns/tool calls (telemetry init `_entry.py:902`,
+  `telemetry.init("omni-runner")`), which implies the runner's WS tunnel + httpx callbacks (auth-bearing) succeeded —
+  i.e. (2) authenticated. A failed runner↔server auth would manifest as the runner never registering / no spans.
+- `policy:` spans (OpenInference kind) appearing for a tool call (e.g. corpus
+  `conv_63542a5f...` echo-via-`sys_os_shell` with MCP + policy spans) indicate the policy path reached the server with a
+  valid token — i.e. (4) succeeded for SDK/runner. A native fail-closed event would NOT produce a successful policy-eval
+  span; it surfaces as the hook's stderr "fail-closed" + a denied tool call.
+- No spans are emitted for `Config.authenticate()`, `databricks auth token`, JWT decode, or cookie validation.
+  (chat.db `PRAGMA`/`SELECT`/`connect` spans are noise per the rig notes — filter them.)
+
+> Net: auth correctness is inferred from the *presence* of downstream spans (runner spans, policy spans,
+> llm_call spans), not from auth spans themselves.
+
+---
+
+## Per-harness differences
+
+| Aspect | claude-sdk | claude-native | codex | codex-native | Polly / custom |
+|---|---|---|---|---|---|
+| LLM cred mechanism | httpx `auth_flow` per request (DBX) OR api-key/subscription | vendor CLI manages (subscription) OR DBX via env | shell `auth_command` @ 15-min interval (gateway) | shell `auth_command` @ interval | inherits chosen harness (usually claude-sdk row) |
+| LLM cred refresh | per-request (SDK) ✅ | vendor-managed | interval + 401 | interval + 401 | per chosen harness |
+| Subscription-auth harness | yes (`_SUBSCRIPTION_AUTH_HARNESSES` omnigent.py:124) — won't inherit parent DBX profile | yes | yes | (not in that set) | per chosen harness |
+| own-config propagation | n/a | `use_claude_config` → user `~/.claude` creds/MCP/hooks | inherits `~/.codex/config.toml` | inherits `~/.codex/config.toml` (live config shows DBX provider `/codex/v1`) | per chosen harness |
+| policy-hook token | runner `_RunnerDatabricksAuth` (fresh per call) — no snapshot bug | one-shot snapshot + reauth (PR #1439, `claude_native_hook.py`) | runner relay (fresh per call) | one-shot snapshot + reauth (PR #1439, `native_policy_hook.py` via `codex_native_hook`) | per chosen harness |
+
+**Polly / custom agents** have no credential path of their own. They run on a chosen harness (typically claude-sdk)
+and inherit its LLM-cred + refresh behavior exactly. The agent spec's `executor.auth`
+(`ApiKeyAuth` / `DatabricksAuth` / `ProviderAuth`, `spec/types.py:562-597`) selects the credential; runner↔server and
+client↔server are unchanged.
+
+---
+
+## Failure branches & gaps
+
+- ⚠️ **WS tunnel Bearer is injected once at open, no per-message refresh** (`serve.py:540-545`). The session survives the
+  ~1h OAuth lifetime as long as the socket stays open (the connection itself isn't re-authenticated per frame).
+  Refresh happens only on reconnect (`serve.py:284`) or on a 401 that drops the socket (`serve.py:407`). [§6 open: "survives token expiry?"]
+  — In practice the long-lived WS connection is authenticated at handshake and the server doesn't re-check the bearer on
+  every inbound frame, so an in-flight expiry doesn't break a live tunnel; the risk is at reconnect if creds went bad.
+- ✅ **Native policy-hook fail-closed-after-1h bug — FIXED (PR #1439, merged `e9561916`).** Both `claude_native_hook.py`
+  and `native_policy_hook.py` (codex-native) now re-mint via `_make_auth_token_factory` on 401 **or** Apps `302→/oidc/`
+  and retry once before falling back to fail-closed. Fail-closed remains the **last resort** when no token can be minted
+  (preserves the #163/#579 guarantee). The runner-side snapshot in `runner/app.py:1141-1149` (OpenCode plugin) is a
+  **separate** path that still uses a one-shot token and "degrades to fail-open" — out of the claude/codex scope.
+- ⚠️ **Static credentials never refresh**: api-key providers (`OPENAI_API_KEY` etc., `databricks_executor.py:608-610`),
+  static Databricks PATs (`databricks_executor.py:472-481`), and the credential proxy's injected secrets
+  (`inner/credential_proxy.py` — L7 MITM swap, no refresh). Expiry = hard failure.
+- ⚠️ **Client tokens have no background refresh** (`cli_auth.py:166-188`): `load_token` returns None once `expires_at`
+  passes → user must `omnigent login` again. Browser cookie likewise expires → 401 → login redirect.
+- ⚠️ **Codex Databricks gateway token currently EXPIRED (403)** — a concrete live example of LLM-cred expiry. The shell
+  `databricks auth token` can't refresh a dead workspace OAuth grant, so the gateway 403s. This is why codex/codex-native
+  cannot be live-traced in this rig. (The local `~/.codex/config.toml` is pinned to a Databricks `/codex/v1` provider with
+  a shell auth command; `~/.codex/auth.json` carries no OpenAI subscription — so the only path is the expired DBX gateway.)
+- ⚠️ **Managed sandboxes broken under OIDC/accounts auth** (§6 🔴, issues #357/#1305/#1297): runner tunnel 403; host never
+  boots. Auth-mode-specific failure, not a refresh bug.
+- **Databricks SDK profile resolution**: explicit `profile` is fail-loud if unauthenticated (`databricks_executor.py:457-487`);
+  a profile from `DATABRICKS_CONFIG_PROFILE` env falls back to the ambient chain with a warning (`:436-451`).
+
+---
+
+## Open questions
+
+1. **WS tunnel mid-life expiry**: does the server re-validate the runner's handshake bearer on long-lived tunnels, or
+   only at handshake? Code shows handshake-only; needs a runtime check (let a tunnel cross the 1h OAuth boundary without
+   reconnecting and confirm frames still flow). [§6]
+2. **OpenCode policy plugin snapshot** (`runner/app.py:1141-1149`) still degrades to **fail-open** after ~1h — did PR #1439
+   only cover claude-native + codex-native, leaving OpenCode (out of scope) on the old behavior? (Comment at `:1142-1143`
+   says "a refreshable token file is the follow-up.")
+3. **Subscription vendor-CLI token expiry**: claude-native via `use_claude_config` relies on `~/.claude/.credentials.json` —
+   what happens mid-turn when that subscription token lapses? (Vendor-managed; not in Omnigent's refresh paths.)
+4. **Cookie TTL cache staleness**: `_check_cookie` caches the decoded user for the token's remaining lifetime
+   (`auth.py:405-411`) — a revoked-but-unexpired JWT stays valid until `exp`. Acceptable? (No revocation list.)

--- a/designs/master-arch/architecture/auth-credentials.md
+++ b/designs/master-arch/architecture/auth-credentials.md
@@ -112,7 +112,7 @@ sequenceDiagram
   participant GW as Databricks serving-endpoints
   Exec->>Auth: HTTP POST /serving-endpoints/... (httpx.Client auth=auth)
   Auth->>SDK: Config.authenticate()  (auth_flow, every request)
-  SDK-->>Auth: {Authorization: Bearer <fresh>}  (in-mem cache; CLI re-shell ~0.5s near expiry)
+  SDK-->>Auth: {Authorization: Bearer <fresh>}  (in-mem cache — CLI re-shell ~0.5s near expiry)
   Auth->>GW: request + Authorization
   GW-->>Auth: 200 (or 401/403 if refresh token dead → DatabricksAuthError)
 ```
@@ -129,14 +129,14 @@ the current live state of the codex Databricks gateway token — expired/403).
 ```mermaid
 flowchart TB
   subgraph Runner
-    F[_make_auth_token_factory] --> T1[OIDC token from auth_tokens.json]
-    F --> T2[Databricks SDK OAuth host-keyed]
+    F["_make_auth_token_factory"] --> T1["OIDC token from auth_tokens.json"]
+    F --> T2["Databricks SDK OAuth host-keyed"]
   end
-  F -->|once at boot| WS[serve_tunnel: WS handshake Bearer in additional_headers]
-  F -->|per HTTP callback| HX[_RunnerDatabricksAuth.auth_flow]
-  WS -->|connection stays open ~hrs| SRV[(omni-server)]
-  WS -.->|on reconnect: _refresh_auth_token| SRV
-  HX -->|401 or 302-/oidc/ retry-once| SRV
+  F -->|"once at boot"| WS["serve_tunnel: WS handshake Bearer in additional_headers"]
+  F -->|"per HTTP callback"| HX["_RunnerDatabricksAuth.auth_flow"]
+  WS -->|"connection stays open ~hrs"| SRV[("omni-server")]
+  WS -.->|"on reconnect: _refresh_auth_token"| SRV
+  HX -->|"401 or 302-/oidc/ retry-once"| SRV
 ```
 - **HTTP callbacks** (agent-bundle GET, response lookups, file APIs, idle notify): `_RunnerDatabricksAuth.auth_flow`
   mints fresh per request and retries once on 401 **or** Apps `302→/oidc/` (`_entry.py:226-238`). ✅ survives ~1h OAuth.
@@ -147,14 +147,14 @@ flowchart TB
 ### (3) Client ↔ Server — provider selection
 ```mermaid
 flowchart TB
-  R[resolve_auth_source server/auth.py:193] --> EXP{OMNIGENT_AUTH_PROVIDER set?}
-  EXP -->|yes| USE[use that: header/oidc/accounts]
-  EXP -->|no| EN{OMNIGENT_AUTH_ENABLED truthy?}
-  EN -->|no| HDR[header default]
-  EN -->|yes + OMNIGENT_OIDC_ISSUER| OIDC[oidc]
-  EN -->|yes, no issuer| ACC[accounts]
-  HDR --> CH[_check_header: X-Forwarded-Email]
-  OIDC --> CK[_check_cookie: __Host-ap_session JWT HS256]
+  R["resolve_auth_source server/auth.py:193"] --> EXP{"OMNIGENT_AUTH_PROVIDER set?"}
+  EXP -->|yes| USE["use that: header/oidc/accounts"]
+  EXP -->|no| EN{"OMNIGENT_AUTH_ENABLED truthy?"}
+  EN -->|no| HDR["header default"]
+  EN -->|"yes + OMNIGENT_OIDC_ISSUER"| OIDC["oidc"]
+  EN -->|"yes, no issuer"| ACC["accounts"]
+  HDR --> CH["_check_header: X-Forwarded-Email"]
+  OIDC --> CK["_check_cookie: __Host-ap_session JWT HS256"]
   ACC --> CK
 ```
 - **header** (default): reads `X-Forwarded-Email` (overridable `OMNIGENT_AUTH_HEADER`, e.g.

--- a/designs/master-arch/architecture/harness-inner.md
+++ b/designs/master-arch/architecture/harness-inner.md
@@ -152,7 +152,7 @@ sequenceDiagram
     end
     SDK-->>Exec: result + usage
     Exec-->>Adp: TurnComplete(response, usage)
-    Adp-->>Run: final item persisted; agent span closed
+    Adp-->>Run: final item persisted — agent span closed
 ```
 
 The LLM work happens **inside** `omni-harness POST /events` (the long span). Tools the model
@@ -179,14 +179,14 @@ sequenceDiagram
     alt claude-native
         Exec->>CLI: tmux load-buffer + paste-buffer + Enter (inject_user_message)
     else codex-native
-        Exec->>CLI: turn/start (or turn/steer) JSON-RPC; thread/settings/update first if model/effort pinned
+        Exec->>CLI: turn/start (or turn/steer) JSON-RPC — thread/settings/update first if model/effort pinned
     end
-    Exec-->>Adp: TurnComplete(response=None)  %% returns immediately
+    Exec-->>Adp: TurnComplete(response=None)
     Note over CLI: vendor runs the real LLM turn here (own prompt/tools/transcript)
     loop forwarder poll (decoupled trace)
         CLI-->>Fwd: JSONL transcript lines / SSE app-server events
         Fwd->>Srv: external_assistant_message / external_conversation_item / external_subagent_start
-        Fwd->>Srv: model mirror (statusLine /model → model_override); cost
+        Fwd->>Srv: model mirror (statusLine /model → model_override) — cost
     end
 ```
 
@@ -199,15 +199,15 @@ policy gating is the **separate PreToolUse HTTP hook**, not an in-turn `policies
 
 ```mermaid
 flowchart LR
-    Stop[Web Stop] --> RA[runner _handle_claude_native_interrupt]
+    Stop["Web Stop"] --> RA["runner _handle_claude_native_interrupt"]
     RA --> II["inject_interrupt → tmux send-keys Escape"]
-    Model["/model in web"] --> RM[runner _handle_claude_native_model_change]
+    Model["/model in web"] --> RM["runner _handle_claude_native_model_change"]
     RM --> SC["inject_slash_command '/model X' auto_confirm"]
-    Effort["/effort in web"] --> RE[runner _handle_claude_native_effort_change]
-    RE -->|effort in CLAUDE_EFFORTS| SE["inject_slash_command '/effort L' auto_confirm"]
-    RE -->|none/minimal| Persist[persist only → next spawn --effort]
-    InPane["in-pane /model switch"] --> Fwd[forwarder _forward_model_from_status]
-    Fwd --> MO[model_override mirrored every poll]
+    Effort["/effort in web"] --> RE["runner _handle_claude_native_effort_change"]
+    RE -->|"effort in CLAUDE_EFFORTS"| SE["inject_slash_command '/effort L' auto_confirm"]
+    RE -->|"none/minimal"| Persist["persist only → next spawn --effort"]
+    InPane["in-pane /model switch"] --> Fwd["forwarder _forward_model_from_status"]
+    Fwd --> MO["model_override mirrored every poll"]
 ```
 
 claude-native control is **not** done through the executor (it returns immediately). The web

--- a/designs/master-arch/architecture/harness-inner.md
+++ b/designs/master-arch/architecture/harness-inner.md
@@ -1,0 +1,347 @@
+# Harness / Inner Layer — Architecture (claude-sdk · claude-native · codex · codex-native · polly)
+
+> Scope: `omnigent/inner/` + the native harness modules. In scope ONLY: **claude-sdk,
+> claude-native, codex, codex-native, and polly** (a custom agent that runs its brain on
+> claude-sdk and delegates to claude-native + codex-native workers). Every mechanism is
+> anchored to `file:line` in the merged `traces` worktree. Trace evidence is from the
+> saved corpus (claude-sdk `conv_b4f2faed…`, native `conv_d0ddd6b3…`). **codex / codex-native
+> have no live trace — creds expired (403); covered from code + structural analogy.**
+
+---
+
+## 1. Overview
+
+An **Executor** is the seam that translates Omnigent's abstract turn model
+(`Message` in / `ExecutorEvent` stream out) into a concrete LLM backend or agent harness.
+There are two families, and the split explains almost every behavioral difference:
+
+- **SDK harnesses (in-process agent loop).** Omnigent owns the prompt, the tool set, and
+  the turn loop. The executor runs the vendor SDK *inside the harness subprocess*, streams
+  text/reasoning/tool events back, and Omnigent owns 100% of the transcript. In scope:
+  **claude-sdk** (`ClaudeSDKExecutor`), **codex** (`CodexExecutor`). Polly's brain runs here.
+- **Native harnesses (resident vendor CLI mirrored back).** A real vendor CLI/TUI runs
+  in a **tmux pane** (claude-native) or behind a **JSON-RPC app-server socket** (codex-native).
+  The *vendor* owns the system prompt + tool set + transcript; Omnigent only **injects the
+  latest user message** and **mirrors** the vendor's transcript back as durable items via a
+  forwarder. In scope: **claude-native** (`ClaudeNativeExecutor`), **codex-native**
+  (`CodexNativeExecutor`).
+
+The base class is `omnigent/inner/executor.py:518` (`Executor`). Capability methods all
+**default OFF** except `supports_tool_calling()` (`executor.py:544` → `True`):
+`supports_streaming` (`:541` → False), `handles_tools_internally` (`:547` → False),
+`max_context_tokens` (`:557` → None), `interrupt_session` (`:569` → False),
+`enqueue_session_message` (`:573` → False), `supports_live_message_queue` (`:577` → False),
+`supports_tool_boundary_interrupt` (`:581` → False), `supports_stepwise_internal_turns`
+(`:585` → False). Each harness overrides only what it actually supports — so reading the
+matrix means reading the *overrides*, not the base.
+
+---
+
+## 2. Key files (file:line)
+
+**Base contract**
+- `omnigent/inner/executor.py:70` — `ExecutorConfig` (`model`, `temperature`, `max_tokens`,
+  `extra` — `extra["reasoning_effort"]` / `extra["model_override"]` ride here).
+- `omnigent/inner/executor.py:96-261` — `ExecutorEvent` hierarchy: `TextChunk` (:101),
+  `ReasoningChunk` (:113), `ToolCallRequest` (:133), `TurnComplete` (:149),
+  `ToolCallComplete` (:185), `CompactionComplete` (:213), `TurnCancelled` (:236),
+  `ExecutorError` (:244).
+- `omnigent/inner/executor.py:518-596` — `Executor` ABC + capability defaults.
+- `omnigent/inner/tracing.py:104` — `TracingContext`; emits `agent:<name>` (AGENT, :130),
+  `llm_call` (LLM, :223), `tool:<name>` (TOOL, :270), `policy:<name>` (GUARDRAIL, :319).
+  Stamps `session.id` on every span (the cross-trace grouping key).
+
+**SDK executors**
+- `omnigent/inner/claude_sdk_executor.py` — `ClaudeSDKExecutor`. Caps: streaming `:1605`,
+  tool-calling `:1608`, `handles_tools_internally` `:1611`, `supports_live_message_queue`
+  `:1614`, `supports_tool_boundary_interrupt` `:1617`, `max_context_tokens` `:1620` (None).
+  `interrupt_session` `:1477` (SDK `client.interrupt()`), `enqueue_session_message` `:1509`
+  (`client.query`). Model: per-turn `:1910` (`cfg.model or self._model_override or
+  _DATABRICKS_CLAUDE_DEFAULT_MODEL`), mid-session swap `set_model()` `:1422`. Effort `:2011`
+  (`extra["reasoning_effort"]` → SDK `effort`). Reasoning emitted `:2225/:2266/:2318`.
+  Compaction `:2540` (emits `CompactionComplete` with `compacted_messages`).
+- `omnigent/inner/codex_executor.py` — `CodexExecutor`. Caps: streaming `:2231`, tool-calling
+  `:2234`, `handles_tools_internally` `:2237`, `supports_live_message_queue` `:2240`.
+  `interrupt_session` `:2243` (`turn/interrupt`), `enqueue_session_message` `:2276`.
+  Model: per-turn `:2334` (`cfg.model or self._model_override or _OPENAI_CODEX_DEFAULT_MODEL`
+  / `_DATABRICKS_CODEX_DEFAULT_MODEL`). **Model is part of the session signature `:2346`** →
+  a model change closes the app-session and starts a fresh thread. Effort `:2353`, applied via
+  `thread/settings/update` `:1464`, reset `self._applied_effort=None` on fresh thread `:1450`.
+  Approval **hardcoded `"approvalPolicy": "never"` `:1427`** (no executor elicitation).
+  Subagents = private per-conversation `CODEX_HOME` `:1186/:1202/:1230`. Reasoning `:1663`.
+
+**Native executors**
+- `omnigent/inner/claude_native_executor.py:32` — `ClaudeNativeExecutor`. Overrides ONLY
+  `supports_streaming`→False `:64` and `supports_live_message_queue`→True `:68`.
+  `run_turn` `:99` injects latest user text via `inject_user_message` (tmux) `:143` then yields
+  `TurnComplete(response=None)`. `enqueue_session_message` `:72`. **No `interrupt_session`,
+  no model/effort** — `config` is `del`'d (`:123`). Interrupt + model/effort are wired
+  *elsewhere* (bridge + runner routes + forwarder).
+- `omnigent/inner/codex_native_executor.py:37` — `CodexNativeExecutor`. `supports_streaming`
+  →False `:60`, `supports_live_message_queue`→True `:64`. **Has `interrupt_session` `:116`**
+  (`turn/interrupt` RPC). **Has model+effort** via `thread/settings/update` before `turn/start`
+  (`_model_effort_overrides` `:266`, applied `:237`). `run_turn` `:145` does
+  `turn/steer` (active turn) vs `turn/start` (idle), persists `active_turn_id`.
+- `omnigent/native_server_harness.py:45` — `NativeServerHarness` (shared base for
+  *opencode-native*, out of scope; codex-native uses its own executor). `handles_tools_internally`
+  →True `:89`, interrupt via `transport.abort` `:153`.
+
+**Native bridges / forwarders / routing**
+- `omnigent/claude_native_bridge.py` — `inject_user_message` (tmux load-buffer/paste-buffer
+  `:2465-2503`), **`inject_interrupt` `:2530` (sends `Escape` via tmux send-keys `:2556`)**,
+  `kill_session` `:2559` (hard stop), `inject_slash_command` `:2597` (types `/effort`/`/model`,
+  `auto_confirm` for TUI dialog).
+- `omnigent/claude_native_forwarder.py` — polls Claude's JSONL transcript; mirrors items,
+  cost, subagents. `_forward_model_from_status` `:948` mirrors the live statusLine `/model`
+  switch → `model_override` every poll; effort sync `:2981`; subagent glob
+  `agent-*.meta.json` `:217` → `_post_external_subagent_start` `:1115` → `external_subagent_start`
+  event `:1150`.
+- `omnigent/codex_native_forwarder.py` — subscribes to the app-server; subagent detection
+  `_thread_started_is_subagent` `:6079` (`source.subAgent.thread_spawn` `:4310`) →
+  `external_codex_subagent_start` `:130/:4304`.
+- `omnigent/runner/app.py` — control routes: `_handle_claude_native_interrupt` `:~10465`
+  → `inject_interrupt` `:10518`; `_handle_claude_native_effort_change` `:~11470` (`/effort`,
+  only if in `CLAUDE_EFFORTS` `:11521`); `_handle_claude_native_model_change` `:11558` (`/model`);
+  `_handle_codex_native_interrupt` `:10596` (`turn/interrupt`);
+  `_handle_codex_native_settings_update` `:10664` (`thread/settings/update`).
+
+**Wiring / metadata**
+- `omnigent/runtime/harnesses/__init__.py:37/41/43/46` — harness→module map
+  (claude-sdk→`claude_sdk_harness`, claude-native→`claude_native_harness`,
+  codex→`codex_harness`, codex-native→`codex_native_harness`).
+- `omnigent/runtime/harnesses/_executor_adapter.py:284` — `ExecutorConfig(model=
+  request.model_override, …)`; installs stable `_tool_executor` `:300`, `_elicitation_handler`
+  `:307`, `_policy_evaluator` `:314` on the SDK executor; run loop `:394`; interrupt routing
+  `:407` (between-events) + `:498` (`_handle_interrupt_event` → `executor.interrupt_session`).
+- `omnigent/inner/claude_sdk_harness.py:274` — builds `ClaudeSDKExecutor` from `HARNESS_*` env
+  (model, gateway, permission-mode, os_env, retry, skills, bundle).
+- `omnigent/harness_aliases.py:9` (`claude`→`claude-sdk`), `:53` (`NATIVE_HARNESSES`),
+  `:119` (`native_terminal_name`).
+- `omnigent/native_coding_agents.py:47/57` — `claude-native-ui` / `codex-native-ui` metadata
+  (wrapper labels, terminal names, subagent wrapper labels).
+- `omnigent/reasoning_effort.py:13/15` — `CLAUDE_EFFORTS={low,medium,high,xhigh,max}`,
+  `CODEX_EFFORTS={none,minimal,low,medium,high,xhigh}`.
+
+---
+
+## 3. Data flow
+
+### 3.1 SDK harness turn (claude-sdk / codex) — in-process loop
+
+```mermaid
+sequenceDiagram
+    participant Web as WebUI/TUI
+    participant Srv as omni-server
+    participant Run as omni-runner
+    participant Adp as ExecutorAdapter (omni-harness)
+    participant Exec as ClaudeSDKExecutor / CodexExecutor
+    participant SDK as vendor SDK / app-server (in-proc)
+
+    Web->>Srv: POST /sessions/{id}/events (persist-before-forward)
+    Srv->>Srv: policy.evaluate (REQUEST phase)
+    Srv->>Run: POST /events (over WS tunnel)
+    Run->>Adp: POST /v1/sessions/{conv}/events
+    Adp->>Adp: ExecutorConfig(model=model_override, extra[reasoning_effort])
+    Adp->>Exec: run_turn(messages, tools, system_prompt, config)
+    Exec->>SDK: query() — Omnigent owns prompt+tools
+    loop streaming
+        SDK-->>Exec: text / thinking / tool_use
+        Exec-->>Adp: TextChunk / ReasoningChunk / ToolCallRequest
+        Adp->>Srv: POST /policies/evaluate (TOOL_CALL gate, per tool)
+        Adp-->>Run: forward events → SSE response.* to client
+    end
+    SDK-->>Exec: result + usage
+    Exec-->>Adp: TurnComplete(response, usage)
+    Adp-->>Run: final item persisted; agent span closed
+```
+
+The LLM work happens **inside** `omni-harness POST /events` (the long span). Tools the model
+calls go back out as MCP round-trips; each is gated by a `POST /policies/evaluate` (TOOL_CALL
+phase). Reasoning is streamed live as `ReasoningChunk` and **recomputed** next turn (not
+persisted — claude-sdk excludes thinking blocks from `compacted_messages`).
+
+### 3.2 Native harness turn (claude-native / codex-native) — inject + mirror
+
+```mermaid
+sequenceDiagram
+    participant Web as WebUI/TUI
+    participant Srv as omni-server
+    participant Run as omni-runner
+    participant Adp as ExecutorAdapter (omni-harness)
+    participant Exec as ClaudeNativeExecutor / CodexNativeExecutor
+    participant CLI as vendor CLI (tmux pane / app-server socket) — NOT traced inline
+    participant Fwd as forwarder (runner)
+
+    Web->>Srv: POST /sessions/{id}/events
+    Srv->>Run: POST /events
+    Run->>Adp: POST /v1/sessions/{conv}/events
+    Adp->>Exec: run_turn(messages, …)
+    alt claude-native
+        Exec->>CLI: tmux load-buffer + paste-buffer + Enter (inject_user_message)
+    else codex-native
+        Exec->>CLI: turn/start (or turn/steer) JSON-RPC; thread/settings/update first if model/effort pinned
+    end
+    Exec-->>Adp: TurnComplete(response=None)  %% returns immediately
+    Note over CLI: vendor runs the real LLM turn here (own prompt/tools/transcript)
+    loop forwarder poll (decoupled trace)
+        CLI-->>Fwd: JSONL transcript lines / SSE app-server events
+        Fwd->>Srv: external_assistant_message / external_conversation_item / external_subagent_start
+        Fwd->>Srv: model mirror (statusLine /model → model_override); cost
+    end
+```
+
+The harness `POST /events` span is just the **injection + wait** (in the native corpus it
+ran 9594 ms while the vendor thought). The vendor's actual turn is a **separate async boundary
+not stitched into the trace** — correlated only by `session.id` (OBSERVABILITY §12). Tool
+policy gating is the **separate PreToolUse HTTP hook**, not an in-turn `policies/evaluate`.
+
+### 3.3 Native interrupt / model / effort (claude-native) — out-of-band control
+
+```mermaid
+flowchart LR
+    Stop[Web Stop] --> RA[runner _handle_claude_native_interrupt]
+    RA --> II["inject_interrupt → tmux send-keys Escape"]
+    Model["/model in web"] --> RM[runner _handle_claude_native_model_change]
+    RM --> SC["inject_slash_command '/model X' auto_confirm"]
+    Effort["/effort in web"] --> RE[runner _handle_claude_native_effort_change]
+    RE -->|effort in CLAUDE_EFFORTS| SE["inject_slash_command '/effort L' auto_confirm"]
+    RE -->|none/minimal| Persist[persist only → next spawn --effort]
+    InPane["in-pane /model switch"] --> Fwd[forwarder _forward_model_from_status]
+    Fwd --> MO[model_override mirrored every poll]
+```
+
+claude-native control is **not** done through the executor (it returns immediately). The web
+Stop and the `/model` `/effort` pickers reach **runner routes** that drive the **bridge**
+(Escape / slash-command keystrokes into tmux). The forwarder mirrors an *in-pane* switch back.
+codex-native instead routes those to **JSON-RPC** (`turn/interrupt`, `thread/settings/update`).
+
+---
+
+## 4. Channels & message/event types
+
+| Boundary | claude-sdk / codex (SDK) | claude-native | codex-native |
+|---|---|---|---|
+| Turn delivery | in-proc SDK `query()` | tmux `load-buffer`+`paste-buffer`+`Enter` | JSON-RPC `turn/start` / `turn/steer` |
+| Mid-turn steer | SDK `client.query()` (`enqueue`) | tmux `inject_user_message` | RPC `turn/steer` (expectedTurnId) |
+| Interrupt | SDK `client.interrupt()` (executor) | tmux `Escape` (bridge, via runner route) | RPC `turn/interrupt` (executor + runner route) |
+| Model change | `cfg.model` per turn → `set_model()` | `/model` slash-inject + statusLine mirror | RPC `thread/settings/update` |
+| Effort change | `extra[reasoning_effort]` → SDK `effort` | `/effort` slash-inject (CLAUDE_EFFORTS only) | RPC `thread/settings/update` (effort) |
+| Output | streamed `ExecutorEvent`s → SSE `response.*` | forwarder → `external_*` events | forwarder → `external_*` events |
+| Transcript owner | Omnigent (100%) | Claude Code `~/.claude/projects/**.jsonl` (mirrored) | Codex rollout `$CODEX_HOME/sessions/**.jsonl` (mirrored) |
+| Tool/policy gate | in-turn `POST /policies/evaluate` (TOOL_CALL) | PreToolUse + PermissionRequest HTTP hook (long-poll) | `codex-elicitation-request` hook (long-poll) |
+| Subagents | `mcp__omnigent__sys_session_*` (MCP bridge) | `subagents/agent-*.meta.json` → `external_subagent_start` | `source.subAgent.thread_spawn` → `external_codex_subagent_start` |
+
+Common executor events: `TextChunk`, `ReasoningChunk{event_type∈{reasoning_started,
+reasoning_text,reasoning_summary}}`, `ToolCallRequest`, `ToolCallComplete`, `TurnComplete{response,
+usage,continue_turn}`, `CompactionComplete{compacted_messages}`, `TurnCancelled`, `ExecutorError`.
+Native forwarder events (server-bound): `external_assistant_message`, `external_conversation_item`,
+`external_subagent_start` / `external_codex_subagent_start`, `external_model_change`, model/cost
+mirrors.
+
+---
+
+## 5. Trace evidence (concrete spans seen)
+
+**SDK turn** — trace `ecee1765…` (`conv_b4f2faed…`, claude-sdk), services
+{omni-server, omni-runner, omni-harness}:
+
+```
+omni-server  POST /v1/sessions/{session_id}/events  (26ms)
+  omni-server  policy.evaluate                       (REQUEST phase, server)
+  omni-server  POST → omni-runner POST /v1/sessions/{conv}/events
+      omni-runner GET → omni-server GET /items, GET /sessions/{id}   (history pull)
+      omni-runner POST → omni-harness POST /v1/sessions/{conv}/events  (2418ms = the LLM turn)
+      omni-runner POST → omni-server POST /v1/sessions/{id}/policies/evaluate  (×N TOOL_CALL gates)
+        omni-server  policy.evaluate
+      omni-runner POST → omni-harness POST /events  (tool result fed back, loop)
+```
+The agent/LLM/tool/`policy:` OpenInference spans (`agent:claude-sdk`, `llm_call`, `tool:*`)
+appear as **response-id-seeded single-span roots** (`f7659fd7…`, `5bc4eb32…`) — decoupled per
+OBSERVABILITY §5.2, grouped by `session.id`. The defining SDK signature is the **repeated
+in-turn `policies/evaluate` + the multi-second harness `POST /events`** carrying the loop.
+
+**Native turn** — trace `007a5174…` (`conv_d0ddd6b3…`, actually **codex-native** — its agent
+span is `agent:codex`, `agent.name=codex`, `llm.model_name=codex`), same services:
+
+```
+omni-server  POST /v1/sessions/{session_id}/events  (21ms)
+  omni-server  policy.evaluate                       (REQUEST phase only — ONE)
+  omni-server  POST → omni-runner POST /events
+      omni-runner GET → omni-server GET /items, /sessions/{id}
+      omni-runner POST → omni-harness POST /events  (9594ms = inject + WAIT for the pane/RPC)
+  omni-server  POST /events http send (×3)
+```
+Across the **entire** native conv: exactly **1 `policy.evaluate`** and **1 `agent:codex`** span,
+**zero `tool:` / `llm_call` / per-tool `policies/evaluate`**. The contrast is the proof of the
+taxonomy: the SDK loop is *inside* the traced harness turn; the native vendor turn is *outside*
+the trace (its own decoupled boundary, only `session.id`-correlated). The harness `POST /events`
+is pure injection latency, not the model thinking.
+
+> Note: the BRIEF labelled `conv_d0ddd6b3…` "claude-native," but its agent span is `agent:codex`
+> — it is a **codex-native** session. The structural SDK-vs-native contrast is identical either
+> way, and no live codex trace could be regenerated (creds 403).
+
+---
+
+## 6. Per-harness differences (summary; full matrix in cuj-answers/harness-behavior.md)
+
+- **claude-sdk** — full in-process Claude Agent SDK. Streams text+reasoning, runs its own
+  tool loop, all caps ✅. Mid-session model via `set_model()`; effort {low..max}. Bug #1128
+  lives here (`:1910` Opus-4.8 fallback when model is None on Databricks-profile gateway).
+- **codex** — in-process Codex app-server. Streams, own loop, interrupt+queue ✅. **No
+  executor elicitation** (`approvalPolicy:"never"`). **Mid-session model resets the thread**
+  (model in the session signature); effort resets at session. Subagents = `CODEX_HOME` isolation.
+- **claude-native** — resident Claude Code in tmux. Executor only injects + yields
+  `TurnComplete(None)`. Interrupt = bridge `Escape`; model/effort = slash-inject + statusLine
+  mirror; subagents = transcript `subagents/` glob → `external_subagent_start`. Strongest
+  own-config propagation: `use_claude_config` passes through `~/.claude/**`.
+- **codex-native** — resident Codex behind a JSON-RPC app-server. Executor has real
+  interrupt (`turn/interrupt`), model+effort (`thread/settings/update`). Subagents =
+  `source.subAgent.thread_spawn` → `external_codex_subagent_start`. Inherits `~/.codex/config.toml`
+  + `auth.json` (CODEX_HOME source resolver); omni `--model` overrides.
+- **polly** — a custom agent (`examples/polly/config.yaml`), `executor.config.harness:
+  claude-sdk`, no model pinned → catalog default `claude-opus-4-8`. `spawn: true` +
+  `tools.agents` give it `sys_session_create`. Writes no code; delegates to **claude_code
+  (claude-native)**, **codex (codex-native)**, **pi (out of scope)**. Brain inherits the
+  claude-sdk row exactly; it is the concrete example tying all in-scope harnesses together.
+
+---
+
+## 7. Failure branches & gaps
+
+- **Bug #1128 (CONFIRMED, claude-sdk)** — `claude_sdk_executor.py:1910-1912` falls back to
+  `_DATABRICKS_CLAUDE_DEFAULT_MODEL = "databricks-claude-opus-4-8"` (databricks_config.py:85)
+  when `cfg.model` is None on the Databricks-profile gateway → bills Opus when Sonnet was
+  intended. Frontend PRs #1570/#1563 do NOT fix it; real fix #1146.
+- **Native interrupt is NOT a gap** — claude-sdk/codex via `executor.interrupt_session()`;
+  claude-native via bridge `inject_interrupt` (Escape, runner route); codex-native via
+  `turn/interrupt`. The first analysis pass mis-marked claude-native ❌ by conflating "the
+  executor method exists" with "the web Stop works." Corrected: ✅ for all four.
+- **Native model override may not affect the *running* turn** — claude-native `/model` only
+  takes after the in-flight generation; codex-native `thread/settings/update` applies to the
+  next turn; codex (SDK) model change *closes the thread*. SDK `set_model()` is also next-turn.
+- **codex (SDK) elicitation** — base ❌ at the executor (`approvalPolicy:"never"`). codex-native
+  elicitation is ✅ (forwarder hook). Don't conflate the two codex rows.
+- **claude-native `/effort` partial** — `none`/`minimal` are *not* in `CLAUDE_EFFORTS`, so the
+  runner skips the slash-inject and only persists them (`runner/app.py:11521`) → no live effect.
+- **Native turn is invisible to inline tracing** — vendor work is a decoupled async boundary;
+  only `session.id` ties it to the request trace. Tool gating happens via the PreToolUse HTTP
+  hook (separate trace), so a native conv shows no in-turn `tool:`/`policies/evaluate` spans.
+- **CompactionComplete divergence** — claude-sdk DOES export `compacted_messages` (from the
+  SDK's `get_session_messages()`, `:2540`), contradicting the base docstring that says
+  claude-sdk "cannot export its compacted state." codex (SDK) does **not** emit
+  `CompactionComplete` at all. Native compaction is the vendor's, mirrored as a status event.
+
+---
+
+## 8. Open questions
+
+- Does claude-native's statusLine `/model` mirror ever disagree with the persisted
+  `model_override` after a *web* `/model` change races an *in-pane* one? (Two writers,
+  best-effort each poll.)
+- codex (SDK) "subagents" via `CODEX_HOME` isolation — do child Codex sessions actually
+  surface as Omnigent child sessions, or only avoid polluting the user's history? (codex-*native*
+  clearly mirrors children via `external_codex_subagent_start`; the SDK path looks like
+  isolation-only.)
+- Confirm whether codex-native effort, like codex-SDK, resets across a vendor `/clear`
+  (thread rotation) vs persists in `thread/settings/update`.

--- a/designs/master-arch/architecture/host.md
+++ b/designs/master-arch/architecture/host.md
@@ -1,0 +1,393 @@
+# Host Daemon (`omnigent host`) — Architecture
+
+> Scope: the host daemon control plane. Ground truth = code; line numbers verified
+> against the `traces` worktree on 2026-06-30. Trace evidence from local Jaeger
+> (`omni-host` + `omni-server`, the `<no-session>` control-plane traces).
+
+## 1. Overview — what the host daemon IS
+
+`omnigent host` is a **long-lived foreground daemon that registers one physical machine
+("host") with an Omnigent server** and lets the server do two things on that machine:
+
+1. **Spawn / stop runner subprocesses** (`omnigent.runner._entry`) — one runner per
+   session, with the session's workspace as cwd.
+2. **Browse + mutate the host filesystem** (stat / list_dir / create_dir /
+   create_worktree / remove_worktree) so the Web UI workspace picker and the
+   managed-sandbox/worktree session-create flows can validate and prepare a workspace
+   *before any runner exists*.
+
+Key property: the **host tunnel carries only JSON control frames — never HTTP traffic**
+(`frames.py:5-11`, `host_registry.py:9-11`). Runners that the host spawns open *their
+own* separate WS tunnels back to the server for HTTP request/response. The host daemon
+is purely a control + filesystem agent for the machine.
+
+The daemon is the **single trust boundary for the host owner's machine**: it runs as the
+user, holds the user's personal secrets, and deliberately strips almost all of them
+before spawning a runner (allowlist, §7). It owns `~` expansion (only the host knows its
+own `$HOME`; the server never expands tildes — `frames.py:208-213`).
+
+### Direction of the tunnel
+The **host dials out** to the server over WebSocket (`connect.py:1378` client connect to
+`wss://<server>/v1/hosts/{host_id}/tunnel`). This is outbound-only so a laptop behind NAT
+needs no inbound ports. Once open, the **server drives** by pushing request frames; the
+host answers with result frames.
+
+## 2. Key files (file:line)
+
+| File | Role |
+|---|---|
+| `omnigent/host/frames.py` | Frame schema: `HostFrameKind` enum (`:37-55`), 16 frame dataclasses, `encode_host_frame`/`decode_host_frame`, and `_encode_payload` (`:500-521`) which injects `traceparent` + records payload on every encode. |
+| `omnigent/host/connect.py` | The daemon: `HostProcess` (`:537`), reconnect loop `run` (`:1269`), `_connect_and_serve` (`:1367`), `_serve_frames` hello+recv loop (`:1462`), `_handle_raw_message` (consumer span, `:1513`), `_dispatch_host_frame` (`:1556`), per-frame handlers, spawn-env builder `_build_runner_env` (`:410`), allowlist `_RUNNER_ENV_ALLOWLIST` (`:203`), `HARNESS_CREDENTIAL_ENV_VARS` (`:352`), entry `run_host_process` (`:1585`). |
+| `omnigent/host/identity.py` | `HostIdentity`, `load_or_create_host_identity` (config.yaml `host:` section), `HOST_TOKEN_ENV_VAR="OMNIGENT_HOST_TOKEN"` (`:27`), `MANAGED_HOST_TOKEN_HEADER="X-Omnigent-Host-Token"` (`:36`). |
+| `omnigent/host/git_worktree.py` | `create_worktree` / `remove_worktree` / `validate_branch_name` (run in a thread off the event loop). |
+| `omnigent/server/routes/host_tunnel.py` | Server WS endpoint `/hosts/{host_id}/tunnel` (`:120`): pre-accept auth, hello validation, register, `_sender_loop`/`_receive_loop`/`_ping_loop`. |
+| `omnigent/server/host_registry.py` | `HostRegistry` (in-memory, per-replica), `HostConnection` with the `pending_*` future maps (`:197-217`), `RunnerExitReports` TTL store (`:55`). |
+| `omnigent/server/routes/hosts.py` | REST producers: `POST /hosts/{id}/runners` (`launch_runner`, `:405`), `GET /hosts/{id}/filesystem[/{path}]` (`:668,:706`), `POST /hosts/{id}/directories` (`:836`). |
+| `omnigent/server/routes/_workspace_validation.py` | `validate_workspace` → sends `host.stat` (`:101`), realpath canonicalization + agent `os_env.cwd` boundary check. |
+| `omnigent/server/routes/_host_worktree.py` | `create_worktree_on_host` / `remove_worktree_on_host` proxies. |
+| `omnigent/server/routes/sessions.py` | `POST /v1/sessions` host-launch path (`:6060,:6089`), stop-runner (`:7945`), fork/resume re-launch (`:13893`). |
+| `omnigent/runtime/telemetry.py` | `inject_trace_context` (`:689`), `extract_trace_context` (`:713`), `consume_frame_span` (`:734`), `record_message_payload` (`:176`), `init("omni-host")` (`:1072`). |
+| `omnigent/cli.py` | `omnigent host` group (`:6645`) → `run_host_process`. |
+
+## 3. Lifecycle (HELLO reconciliation)
+
+`run_host_process` (`connect.py:1585`) → `telemetry.init("omni-host")` →
+`load_or_create_host_identity` → `HostProcess.run()` reconnect loop.
+
+Per connection (`_connect_and_serve`, `:1367` → `_serve_frames`, `:1462`):
+
+1. Dial `wss://server/v1/hosts/{host_id}/tunnel` with auth headers (§8).
+2. On a clean upgrade set `_ever_connected=True`, reset `_login_redirect_streak`.
+3. Send **`host.hello`** (`:1475-1486`):
+   - `version="0.1.0"`, `frame_protocol_version=1`
+   - `name` (from config.yaml)
+   - **`runners`** = `_alive_runner_ids()` — IDs of runner subprocesses still alive
+     on this host. **This is the reconciliation key**: the server diffs it against
+     sessions in the DB to detect runners that died while the tunnel was down
+     (`frames.py:70-73`).
+   - **`configured_harnesses`** = `configured_harness_map()` computed off the event
+     loop (probes PATH via `shutil.which` + reads config.yaml). Per-harness readiness,
+     e.g. `{"claude-sdk": True, "codex": False}`. Recomputed on **every (re)connect**;
+     `None` means "unknown" (older host) and must NOT be read as "nothing configured"
+     (`frames.py:74-80`).
+4. **Flush queued runner-exit reports** that raced a disconnect (`_unreported_exits`,
+   `:1491-1493`) — so a runner that crashed while the tunnel was down is still reported
+   to the server after reconnect.
+5. Print the `✓ Connected as ...` banner.
+6. Enter `recv()` loop (60s timeout heartbeat-only).
+
+Server side (`host_tunnel.py:120-332`): authenticate **before** `accept()` →
+`accept()` → receive `host.hello` → validate `frame_protocol_version` (strict-major,
+`SUPPORTED_FRAME_PROTOCOL_MAJOR=1`; mismatch closes 4002) → `host_store.upsert_on_connect`
+(DB `hosts` table, cross-replica, carrying `configured_harnesses`) → `host_registry.register`
+(in-memory) → start sender/ping/receive tasks → fire `on_host_connect` reconcile callback
+(30s timeout). On disconnect: `deregister` + `host_store.set_offline` + `on_host_disconnect`.
+
+**Reconnect policy** (`run`, `:1269-1345`): exponential backoff (0.5s base → 10s cap, 0.5
+jitter). Explicit recycle codes (`1012`/`service restart`/`1001`/`going away`) and — on a
+**remote** server only — abrupt `no close frame`/`502` (Databricks Apps ingress recycling a
+live WS) → prompt 0.5s reconnect so no `launch_runner` frame is dropped. On **loopback**
+an abrupt drop is real (re-registration flap) → normal backoff. `HostConnectError` (fatal
+auth/authorization/version) is re-raised, not retried → process exits non-zero.
+
+**Liveness** (`host_tunnel.py:_ping_loop`, `:552`): server pings every 30s; each tick also
+writes `host_store.heartbeat` so the DB last-seen stays fresh (freshness gate keeps the
+host in the online set even if `set_offline` never ran on a hard crash). 3 missed
+intervals (~90s) → close 4003 "ping timeout". The host answers server `PingFrame`s with
+`PongFrame`s inline (`connect.py:1536-1537`).
+
+## 4. The host↔server channel — JSON control frames (NOT HTTP)
+
+One WS socket, **two multiplexed frame families**: host frames (`host.*`, decoded by
+`decode_host_frame`) and runner-tunnel keepalive frames (`ping`/`pong`, decoded by
+`decode_frame`). The receiver tries host-decode first, falls back to runner-decode
+(`connect.py:1527-1538`, `host_tunnel.py:399-431`). Wire format is **JSON text frames**.
+
+### Frame catalogue (every kind, pairing, direction)
+
+| Kind (`HostFrameKind`) | Direction | Pairs with | Purpose |
+|---|---|---|---|
+| `host.hello` | **host→server** | (none) | First frame; version, name, live `runners`, `configured_harnesses`. Reconciliation. |
+| `host.launch_runner` | **server→host** | `host.launch_runner_result` | Spawn a runner (binding_token, workspace, harness). |
+| `host.launch_runner_result` | host→server | `host.launch_runner` | `status` launched/failed, `runner_id`, `error`, `error_code`. |
+| `host.stop_runner` | **server→host** | `host.stop_runner_result` | Terminate a runner by id. |
+| `host.stop_runner_result` | host→server | `host.stop_runner` | `status` stopped/failed. |
+| `host.runner_exited` | **host→server** | (one-way, no result) | A spawned runner died unexpectedly; carries exit code + log tail. |
+| `host.stat` | **server→host** | `host.stat_result` | Stat a path (workspace / cwd-boundary validation). |
+| `host.stat_result` | host→server | `host.stat` | `exists`, `type`, `canonical_path` (realpath), `error`. |
+| `host.list_dir` | **server→host** | `host.list_dir_result` | Paginated directory listing (file browser). |
+| `host.list_dir_result` | host→server | `host.list_dir` | `entries[]`, `has_more`, `error`. |
+| `host.create_worktree` | **server→host** | `host.create_worktree_result` | git worktree for a new branch. |
+| `host.create_worktree_result` | host→server | `host.create_worktree` | `worktree_path`, `branch`, `error`. |
+| `host.remove_worktree` | **server→host** | `host.remove_worktree_result` | Remove a worktree (opt-in cleanup). |
+| `host.remove_worktree_result` | host→server | `host.remove_worktree` | `status`, `error`. |
+| `host.create_dir` | **server→host** | `host.create_dir_result` | mkdir -p for the picker. |
+| `host.create_dir_result` | host→server | `host.create_dir` | `path`, `error`. |
+| `ping`/`pong` | both | — | Keepalive (runner-tunnel frame encoding, reused). |
+
+**Direction summary**: every request originates **server→host** (server drives) EXCEPT
+`host.hello` and `host.runner_exited`, which the host pushes unsolicited. Results always
+flow host→server.
+
+### Request/result correlation
+Every request carries a `request_id` (`secrets.token_hex(8)` on the server). The server
+registers an `asyncio.Future` in the matching `HostConnection.pending_*` map keyed by
+`request_id` (e.g. `pending_launches`, `pending_stats`, `pending_list_dirs`,
+`pending_create_worktrees`, `pending_remove_worktrees`, `pending_create_dirs`,
+`pending_stops`). The `_receive_loop` (`host_tunnel.py:433-543`) matches the result back
+by `request_id` and `future.set_result(...)`. The producer awaits with a per-op timeout
+(launch `_LAUNCH_RESULT_TIMEOUT_S`, stat `_STAT_TIMEOUT_S`, worktree `_WORKTREE_TIMEOUT_S`)
+and pops the pending entry in a `finally` on every path. `host.runner_exited` is the lone
+unpaired report → `RunnerExitReports.record` + `on_runner_exited` callback.
+
+### Why partitioned from the runner tunnel
+`frames.py:13-17`: the runner tunnel has a *closed* `FrameKind` enum + exhaustive
+`decode_frame` match; adding host kinds there would force runner decoders to handle frames
+they never see. Hence a separate module and a separate `HostFrameKind` enum.
+
+## 5. Data flow — runner launch (the main CUJ)
+
+```mermaid
+sequenceDiagram
+    participant Web as Web UI / TUI
+    participant Srv as omni-server<br/>POST /v1/hosts/{id}/runners
+    participant Reg as HostRegistry<br/>(pending_* futures)
+    participant Host as omni-host daemon
+    participant Run as runner subprocess
+
+    Web->>Srv: POST /hosts/{id}/runners {session_id, workspace, git?}
+    Note over Srv: require_user → resolve_host_launch (host+session authz)
+    Srv->>Reg: send host.stat (validate_workspace)
+    Reg-->>Host: host.stat {path}
+    Host-->>Reg: host.stat_result {exists,type,canonical_path}
+    Note over Srv: workspace = realpath; enforce agent os_env.cwd boundary (W6)
+    opt body.git (fork/branch)
+        Srv->>Host: host.create_worktree {repo,branch,base}
+        Host-->>Srv: host.create_worktree_result {worktree_path,branch}
+    end
+    Note over Srv: binding_token=token_urlsafe(32); runner_id=token_bound_runner_id(token)
+    Note over Srv: atomic set_runner_id (UPDATE WHERE runner_id IS NULL) + set_host_id
+    Srv->>Reg: pending_launches[req_id]=Future
+    Reg-->>Host: host.launch_runner {req_id,binding_token,workspace,harness}
+    Note over Host: harness_is_configured(harness)? else HARNESS_NOT_CONFIGURED
+    Note over Host: workspace.is_dir()? build env (allowlist + creds)
+    Host->>Run: subprocess.Popen([py,-m,omnigent.runner._entry], env, stdin=/dev/null, stdout/err→log)
+    Host-->>Reg: host.launch_runner_result {status:launched, runner_id}
+    Reg->>Srv: Future.set_result
+    Srv-->>Web: 200 {runner_id, status:"launching"}
+    Run-->>Srv: (separate runner WS tunnel) connect with binding_token
+    Note over Host: _watch_runner polls; on unexpected death → host.runner_exited
+```
+
+The server-side `launch_runner` route (`hosts.py:405-666`) ordering is load-bearing:
+authz → workspace validation (`host.stat`) → optional worktree (`host.create_worktree`) →
+**atomic bind** (`set_runner_id` CAS closes the TOCTOU; second concurrent launch gets
+`False` → 400) → `set_host_id` (persists canonical workspace + host_id + git_branch) →
+resolve harness → send `host.launch_runner` → await result (rollback unbinds + removes
+worktree on timeout/failure).
+
+Host-side `_handle_launch` (`connect.py:744-861`):
+1. `harness_is_configured(frame.harness)` — if a harness is named and not configured,
+   refuse with `error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE` (`harness_not_configured`).
+   `harness=None` (older server / no resolvable harness) **skips the check (fail open)**.
+2. `Path(workspace).expanduser().is_dir()` — else `failed`.
+3. `runner_id = token_bound_runner_id(binding_token)`.
+4. `_build_runner_env(os.environ, ...)` (§7).
+5. `Popen([sys.executable, "-m", "omnigent.runner._entry"], env=env,
+   stdin=DEVNULL, stdout/stderr→ a `runner-*.log` mkstemp file under
+   `~/.omnigent/logs/host-runner/`)`. `/dev/null` stdin avoids the
+   "Bad file descriptor" startup death on a backgrounded daemon (`:809-816`).
+6. If `proc.poll()` already returned → ship the log tail in the failed result.
+7. Track in `self._runners`, start `_watch_runner` task, return `launched`.
+
+`_watch_runner` (`:898-926`) polls every 0.5s; an exit while the runner is still tracked
+(a `host.stop_runner` pops it *before* terminating) is "unexpected" → compose
+`_runner_exit_error` (exit code + host log path + up to 15 tail lines) and send
+`host.runner_exited`. If the tunnel is down, park in `_unreported_exits` and flush after
+the next hello. This is the **only** failure signal for a runner that crashed *before*
+connecting its own tunnel (so the runner-tunnel `on_runner_disconnect` never fires) —
+server `on_runner_exited` marks the session failed + pushes the cause to the open view.
+
+## 6. FS operations over the tunnel
+
+All five FS ops follow the same proxy pattern: REST route → owner authz → look up live
+`HostConnection` (409 if offline) → register a `pending_*` future → `encode_host_frame`
+(injects traceparent) → `host_registry.send_text` → `await` with timeout → map the host
+result to an HTTP status.
+
+- **`host.stat`** — `_workspace_validation.py:_stat_path_on_host` (`:101`). Host
+  `_handle_stat` (`connect.py:952`) expands `~`, `os.stat` (follows symlinks),
+  `os.path.realpath` → `canonical_path`. ENOENT+EACCES collapse to `exists:false`;
+  only unexpected I/O → `status:failed`. The realpath is stored on the session row so a
+  symlink can't smuggle a workspace out of the agent's `os_env.cwd` boundary
+  (`frames.py:239-243`). Used by `POST /v1/sessions` and `POST /hosts/{id}/runners`
+  workspace validation.
+- **`host.list_dir`** — `GET /hosts/{id}/filesystem[/{path}]` (`hosts.py:668,706`),
+  owner-scoped, **exposes the whole host FS to the host owner** (not session-scoped).
+  Host `_handle_list_dir` (`connect.py:1025`) `os.scandir`, classifies by target type,
+  skips per-entry I/O errors, sorts by name, paginates in-memory via `_paginate_list_dir`
+  (`:464`) with path cursors (`after`/`before`, limit capped at 1000). Backs the Web UI
+  directory picker before a runner exists.
+- **`host.create_dir`** — `POST /hosts/{id}/directories` (`hosts.py:836`). Host
+  `_handle_create_dir` (`connect.py:1122`) `os.makedirs(exist_ok=False)`; expected errors
+  (already-exists, permission, parent-is-file) return `status:ok` + descriptive `error`
+  so the route maps to 409, not 500. Web UI "new folder" in the picker.
+- **`host.create_worktree` / `host.remove_worktree`** — `_host_worktree.py`. Host runs
+  blocking git in `asyncio.to_thread` (`connect.py:1194,1233`) so the tunnel keeps
+  answering pings. Used by managed-sandbox / git-worktree session creation and the
+  fork-resume picker. Worktree creation in `launch_runner` happens **before** the atomic
+  bind so a lost CAS or failed launch can roll it back (no orphan worktree/branch).
+
+## 7. Host→runner spawn-env propagation (the allowlist)
+
+`_build_runner_env` (`connect.py:410-461`) builds the runner subprocess env. **Default-deny
+allowlist** (`_RUNNER_ENV_ALLOWLIST`, `:203-328`) — NOT `{**os.environ}` — because the host
+runs as the user and holds the user's personal secrets; a runner has no business with them
+(spec self-containment: agent creds/config come from the agent spec, `:194-202`).
+
+Inherited only:
+- **Process essentials**: PATH, PYTHONPATH, HOME, USER, LOGNAME, SHELL, TMPDIR, TZ, TERM*,
+  LANG; **TLS trust stores** (SSL_CERT_FILE/DIR, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE,
+  NODE_EXTRA_CA_CERTS) so outbound HTTPS works.
+- **Non-secret selectors that the whole CLI→daemon→server→runner chain must agree on**:
+  `OMNIGENT_CONFIG_HOME`, `OMNIGENT_DATA_DIR`, `OMNIGENT_AUTH_PROVIDER`,
+  `OMNIGENT_AUTH_ENABLED`/`OMNIGENT_ACCOUNTS_ENABLED`, `OMNIGENT_DISABLE_KEYRING`,
+  `DATABRICKS_CONFIG_PROFILE`, `DATABRICKS_CONFIG_FILE`, `KUBECONFIG`, `IS_SANDBOX`,
+  Claude/Bedrock non-secret flags (`CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_SKIP_BEDROCK_AUTH`,
+  `OMNIGENT_CLAUDE_SDK_NO_SANDBOX`, `OMNIGENT_CLAUDE_LAUNCHER`),
+  `AP_CONTEXT_WINDOW_OVERRIDE`, and **`OMNIGENT_TELEMETRY_ENABLED`** (must propagate or
+  the runner/harness export nothing).
+  `OMNIGENT_DATABASE_URI` is **deliberately excluded** (may embed a DB password — daemon-only).
+- **By prefix** (`_RUNNER_ENV_ALLOWLIST_PREFIXES`, `:332`): `LC_*`, `MLFLOW_*`, **`OTEL_*`,
+  `OMNIGENT_OTEL_*`** (so OTel/capture-content/FastAPI knobs reach runner+harness).
+- **Harness credentials** (`HARNESS_CREDENTIAL_ENV_VARS`, `:352-367`) — the *deliberate
+  exception*: ANTHROPIC_*, CLAUDE_CODE_OAUTH_TOKEN, AWS_BEARER_TOKEN_BEDROCK,
+  CODEX_ACCESS_TOKEN, OPENAI_*, GEMINI_API_KEY, GIT_TOKEN, GIT_USERNAME. These are exactly
+  the creds the host owner provisioned *so* their runners can auth — forwarding is intent,
+  not leak. Absent vars simply aren't set.
+- **Operator escape hatch**: `OMNIGENT_RUNNER_ENV_PASSTHROUGH` (`:374`) — comma-separated
+  extra var names to forward (custom gateway vars, exotic SDK knobs).
+
+Then layered on: `RUNNER_SERVER_URL`, `RUNNER_ID_ENV_VAR`, `RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR`,
+`RUNNER_WORKSPACE_ENV_VAR`, `RUNNER_PARENT_PID_ENV_VAR` (`:456-460`).
+
+**TRACEPARENT**: rides the `OTEL_*`/`OMNIGENT_OTEL_*` prefix indirectly via config, but the
+*active trace context* is NOT pushed into the spawn env. Per OBSERVABILITY §6.4 + the code:
+the spawn is a **one-way env handoff**, and a `TRACEPARENT` env var would only be added
+"only if a span is active at spawn time" — in practice `_build_runner_env` does **not** add
+`TRACEPARENT`, so **the runner roots its own trace** (launch is a daemon control action, not
+part of the user request). This is the intentional trace boundary: the host's
+`host.launch_runner` consumer span nests under the server request, but the runner that gets
+spawned starts a fresh trace stitched only by `session.id`.
+
+## 8. Host↔server auth
+
+`_build_connect_headers` (`connect.py:1409-1460`), checked **before** `accept()` on the
+server (`host_tunnel.py:134-204`):
+
+1. **Origin guard**: always sends `Origin: OMNIGENT_INTERNAL_WS_ORIGIN` so the server's
+   CSWSH origin guard allows the non-browser handshake.
+2. **Workspace routing headers**: `databricks_request_headers(server_url)` (names the
+   Databricks workspace so the tunnel routes to the workspace, not the account).
+3. **Managed-sandbox host**: if `OMNIGENT_HOST_TOKEN` is set, send it on
+   `X-Omnigent-Host-Token` and **skip user auth entirely** (a sandbox has no user creds).
+   Server resolves it via `host_store.resolve_launch_token`; it is scoped to one
+   `host_id` — presenting it for any other path fails closed (4004).
+4. **Otherwise mint a Databricks bearer** via `_make_auth_token_factory(server_url=...)`
+   (runner `_entry.py:271`): checks the stored `omnigent login` OIDC token
+   (`~/.omnigent/auth_tokens.json`) first, then ambient Databricks credentials. Refreshed
+   **every reconnect** so long-lived hosts survive token expiry. Failure to mint is
+   swallowed — the upgrade proceeds unauthenticated and the server/proxy decides.
+
+Server-side authentication (`host_tunnel.py`):
+- Managed token → must resolve and match `host_id` (else close 4004).
+- Else `auth_provider.get_user_id(ws)` → if `None` (auth on but unauthenticated) close 4004
+  (never falls back to `RESERVED_USER_LOCAL`, which is admin-equivalent under multi-user).
+- Else (no auth provider) → `RESERVED_USER_LOCAL` (explicit single-user/local).
+- **Cross-owner takeover refused before accept()** (`:177-202`): if the `host_id` is already
+  owned by a different user, refuse with HTTP 409 via the WebSocket Denial Response
+  extension. Skipped only for the single-user loopback server (`allow_host_id_reown`,
+  resolved from `OMNIGENT_LOCAL_SINGLE_USER`). This preserves the W2 host-hijack boundary.
+
+Client classification of fatal upgrade failures (`_fatal_upgrade_error`, `:635`;
+`_classify_http_status`, `:698`): 401 (bad creds), 403 (unauthorized / server predates
+host API), 409 (machine owned by another account) → `HostConnectError` (fatal, exit 1).
+408/429 and non-4xx (5xx bounce) → retry. Login-page redirects (`InvalidURI`) are fatal
+only on a host that never connected, after 3 consecutive (`_LOGIN_REDIRECT_FATAL_ATTEMPTS`).
+
+## 9. Trace evidence (concrete spans I observed)
+
+Local Jaeger, `<no-session>` control-plane traces on `omni-host` + `omni-server`
+(e.g. trace `aee57ff3da91a69081625d1804126850`, 38 spans). `trace_tools.py tree`:
+
+```
+omni-server POST /v1/hosts/{host_id}/runners  (23ms)   ← ROOT (FastAPI auto-instrument)
+  omni-server POST /v1/hosts/{host_id}/runners http receive
+  omni-server SELECT/UPDATE .../chat.db (DB spans — noise)
+  omni-host   host.stat            (0ms)   ← CONSUMER span, nested under the server request
+  omni-host   host.launch_runner   (8ms)   ← CONSUMER span, nested under the server request
+  omni-server POST /v1/hosts/{host_id}/runners http send
+```
+
+Jaeger `omni-host` operations = exactly `["host.stat", "host.launch_runner"]` (the FS-browser
+ops list_dir/create_dir/worktree share the identical code path via `consume_frame_span` but
+weren't exercised in this corpus).
+
+**How the cross-service edge is built**:
+- **Send side**: `_encode_payload` (`frames.py:500-521`) calls
+  `telemetry.record_message_payload` then `telemetry.inject_trace_context(payload)` on
+  *every* frame encode. So when the server (inside its `POST /v1/hosts/{id}/runners`
+  request span) calls `encode_host_frame(HostLaunchRunnerFrame(...))`, the JSON envelope
+  gets a `traceparent` field carrying the server's span context.
+- **Receive side**: the host's `_handle_raw_message` (`connect.py:1543-1554`) re-parses the
+  raw JSON as `carrier`, takes `kind` from it, and opens
+  `telemetry.consume_frame_span(kind, carrier)` → `extract_trace_context` →
+  `start_as_current_span(name=kind, context=parent, kind=CONSUMER)`. The span NAME is the
+  frame's `kind` string — hence the real span names `host.launch_runner` / `host.stat`.
+- The result frame the host sends back is encoded *inside* that consumer span, so its
+  `traceparent` points back into the same trace (round-trip stays linked).
+- OBSERVABILITY §6.3 notes a live `host.stat` frame span carries its full redacted body as
+  `omnigent.message.payload` (capture-content gated, capped 4096).
+
+Doc-vs-code line drift (OBSERVABILITY §6.4 cites stale lines): `_serve_frames` is actually
+`connect.py:1462` (doc says 1432), `_receive_loop` is `host_tunnel.py:369` (doc says 312),
+and the consumer span is opened in `_handle_raw_message` at `connect.py:1553` (doc says "in
+_receive_loop"). Mechanism is exactly as documented. (per doc — line numbers drifted)
+
+## 10. Failure branches & gaps
+
+- **Harness not configured** → host refuses with `error_code="harness_not_configured"`;
+  server maps to `ErrorCode.HARNESS_NOT_CONFIGURED` (HTTP 412 via `OmnigentError`),
+  `_rollback_failed_launch` unbinds session + removes any worktree.
+- **Workspace missing** → host `failed` "workspace path does not exist" → 502.
+- **Runner dies before connecting** → `host.runner_exited` (code + log tail) →
+  `runner_exit_reports.record` + `on_runner_exited` marks session failed; the
+  `GET /runners/{id}/status` endpoint (`runner_tunnel.py:244`) returns the cause via
+  `get_visible` (owner-scoped). Without this the client polls to a 60s timeout.
+- **Launch timeout** (`host.launch_runner_result` never arrives) → 504 + rollback.
+- **Host offline** at FS/launch time → 409 from the route (registry `get` returns None).
+- **Connection replaced mid-flight** (`send_text` raises `ConnectionError` when a newer
+  tunnel poisoned the queue) → 409.
+- **Version skew** → 4002 close; `configured_harnesses=None` and `harness=None` both
+  fail open by design.
+- **Gap / trust surface**: `host.list_dir` exposes the **entire host filesystem** to the
+  authenticated host owner (not session-scoped — `hosts.py:721-724`, by design per
+  SESSION_WORKSPACE_SELECTION.md). The boundary is owner authz, not path scoping.
+- **Gap**: `host.runner_exited` and exit reports are **in-memory per-replica** (TTL 600s);
+  on a multi-replica server the report and the status poll must land on the same replica
+  holding the host tunnel.
+- **Gap**: `HostRegistry.send_text` is coroutine-safe but NOT thread-safe; relies on every
+  caller running on the uvicorn event loop (`host_registry.py:303-312`).
+
+## 11. Open questions
+
+- Does any code path ever set `TRACEPARENT` in the spawn env (the "only if a span is
+  active" branch in OBSERVABILITY §6.4)? In the current `_build_runner_env` it does not —
+  so runner traces are always root + stitched by `session.id`. Confirm this is intended
+  vs. an unfinished phase-2 item.
+- `frame_protocol_version` is strict-major=1 with no negotiation; a v2 host can never talk
+  to a v1 server. Is there a planned upgrade dance, or is lockstep deploy assumed?
+- Per-harness `configured_harnesses` is advisory (recomputed each connect) but the
+  authoritative gate is the launch-time `harness_is_configured` check on the host. The
+  server still stores `configured_harnesses` in the DB — what consumes the stored copy
+  (UI hints?) vs. the live hello copy?

--- a/designs/master-arch/architecture/host.md
+++ b/designs/master-arch/architecture/host.md
@@ -160,12 +160,12 @@ sequenceDiagram
     Srv->>Reg: send host.stat (validate_workspace)
     Reg-->>Host: host.stat {path}
     Host-->>Reg: host.stat_result {exists,type,canonical_path}
-    Note over Srv: workspace = realpath; enforce agent os_env.cwd boundary (W6)
+    Note over Srv: workspace = realpath — enforce agent os_env.cwd boundary (W6)
     opt body.git (fork/branch)
         Srv->>Host: host.create_worktree {repo,branch,base}
         Host-->>Srv: host.create_worktree_result {worktree_path,branch}
     end
-    Note over Srv: binding_token=token_urlsafe(32); runner_id=token_bound_runner_id(token)
+    Note over Srv: binding_token=token_urlsafe(32) — runner_id=token_bound_runner_id(token)
     Note over Srv: atomic set_runner_id (UPDATE WHERE runner_id IS NULL) + set_host_id
     Srv->>Reg: pending_launches[req_id]=Future
     Reg-->>Host: host.launch_runner {req_id,binding_token,workspace,harness}
@@ -174,9 +174,9 @@ sequenceDiagram
     Host->>Run: subprocess.Popen([py,-m,omnigent.runner._entry], env, stdin=/dev/null, stdout/err→log)
     Host-->>Reg: host.launch_runner_result {status:launched, runner_id}
     Reg->>Srv: Future.set_result
-    Srv-->>Web: 200 {runner_id, status:"launching"}
+    Srv-->>Web: 200 {runner_id, status=launching}
     Run-->>Srv: (separate runner WS tunnel) connect with binding_token
-    Note over Host: _watch_runner polls; on unexpected death → host.runner_exited
+    Note over Host: _watch_runner polls — on unexpected death → host.runner_exited
 ```
 
 The server-side `launch_runner` route (`hosts.py:405-666`) ordering is load-bearing:

--- a/designs/master-arch/architecture/overall-architecture.md
+++ b/designs/master-arch/architecture/overall-architecture.md
@@ -43,18 +43,18 @@ stood up — see `telemetry-tracing.md §9`.)
 ```mermaid
 flowchart LR
   subgraph Clients
-    W[Web UI omni-web]
-    T[TUI/REPL omni-tui]
+    W["Web UI omni-web"]
+    T["TUI/REPL omni-tui"]
   end
-  W -- REST + SSE + WS/updates --> S
-  T -- REST + SSE --> S
-  S[(Server omni-server\nDB system-of-record)]
-  S <-- WS control frames (JSON) --> H[Host daemon omni-host]
-  H -- spawn (env) --> R[Runner omni-runner]
-  S <-- WS reverse-tunnel (HTTP verbatim) --> R
-  R -- HTTP over UDS --> X[Harness/executor omni-harness]
-  R <-. JSONL forwarder re-POST /events .-> S
-  X -. native: tmux + bridge HTTP relay .-> R
+  W -->|"REST + SSE + WS/updates"| S
+  T -->|"REST + SSE"| S
+  S[("Server omni-server<br/>DB system-of-record")]
+  S <-->|"WS control frames (JSON)"| H["Host daemon omni-host"]
+  H -->|"spawn (env)"| R["Runner omni-runner"]
+  S <-->|"WS reverse-tunnel (HTTP verbatim)"| R
+  R -->|"HTTP over UDS"| X["Harness/executor omni-harness"]
+  R -.->|"JSONL forwarder re-POST /events"| S
+  X -.->|"native: tmux + bridge HTTP relay"| R
 ```
 
 ## 4. Inter-component channels (answers "what channel between components")

--- a/designs/master-arch/architecture/overall-architecture.md
+++ b/designs/master-arch/architecture/overall-architecture.md
@@ -1,0 +1,154 @@
+# Omnigent — Overall Architecture (master doc / backbone)
+
+**Status:** backbone authored from directly-verified evidence (process survey, live
+traces, `sys_session_get_info`, code reads of telemetry/frames, CUJ-ANALYSIS). Per-component
+depth lives in the sibling docs under `architecture/` (server, runner, host, harness-inner,
+runtime-executor, policies, web, tui-repl, auth-credentials, tools-omnibox, telemetry-tracing)
+and is reconciled into this doc during synthesis.
+
+## 1. What Omnigent is
+A distributed, multi-process system for running coding/knowledge **agents** across
+pluggable **harnesses** (Claude, Codex, etc.), driven from multiple **clients** (web UI,
+TUI/REPL), with the **server** as the durable system-of-record. It is "heavily
+vibe-coded" (per OBSERVABILITY.md) — the goal of this analysis is a precise, shared
+mental map grounded in code + live traces.
+
+## 2. Components (process inventory)
+| Component | Process / location | Role |
+|---|---|---|
+| **Server** | FastAPI app (`omnigent/server/`); one per deployment | System-of-record: conversation store (DB), session lifecycle, auth, policy enforcement, SSE/WS fan-out to clients, the runner & host reverse-tunnels. |
+| **Host daemon** | `omnigent host` (`omnigent/host/`); one per machine | Registers a machine to the server; lets the server browse that machine's filesystem and **launch runners** on it. Talks JSON **control frames** over a WS tunnel. |
+| **Runner** | `omnigent.runner._entry`; **one per session** | Hosts the agent turn loop for a session on a host machine; connects back to the server over a WS **reverse-tunnel** (server makes HTTP calls "into" the runner through it). Dispatches tools, pools custom MCPs, runs the runner-side policy fast-path. |
+| **Harness / executor** | `omnigent/inner/*_executor.py` (+ native vendor CLI) | The actual model loop. **SDK harnesses** run in-process (Omnigent owns prompt/tools/transcript). **Native harnesses** drive a resident vendor CLI in a tmux pane and mirror its transcript back. |
+| **Clients** | Web UI (`web/src/`), TUI/REPL (`omnigent/repl/`) | Send messages, render streaming + durable transcript, drive controls (interrupt/approve/fork/switch). |
+| **Telemetry** | OTel in every process → Jaeger/OTLP | Cross-process tracing; see `telemetry-tracing.md`. |
+
+There is **no separate policy-server process** — policy is in-process in the server
+(`policies/engine.py` → `policy.evaluate` span) plus a runner fast-path and a native HTTP
+hook (`/policies/evaluate`). "Policy Server" in the team doc = these paths.
+
+## 3. Deployment topology (general + the observed dev setup)
+**General:** clients → **server** (state) ; server ⇄ **host daemons** (per machine) ;
+server ⇄ **runners** (per session, launched by a host) ; runner ⇄ **harness**.
+
+**Observed on this machine (the dev box for this analysis):** the server runs **remotely on
+a remote dev box**, reached at `localhost:6767` via an SSH tunnel;
+the **host daemon and per-session runners run locally** on the Mac; harnesses (e.g. the
+`claude` CLI) run locally in tmux; an **Omnigent.app** (Electron) is the desktop client.
+The conversation that produced this analysis is itself a live **claude-native** session
+(`conv_4f0c75a6…`, runner `runner_token_31e58e…`) — i.e. the analysis runs *inside* one of
+the harnesses under study. (For clean, complete, readable traces a dedicated local rig was
+stood up — see `telemetry-tracing.md §9`.)
+
+```mermaid
+flowchart LR
+  subgraph Clients
+    W[Web UI omni-web]
+    T[TUI/REPL omni-tui]
+  end
+  W -- REST + SSE + WS/updates --> S
+  T -- REST + SSE --> S
+  S[(Server omni-server\nDB system-of-record)]
+  S <-- WS control frames (JSON) --> H[Host daemon omni-host]
+  H -- spawn (env) --> R[Runner omni-runner]
+  S <-- WS reverse-tunnel (HTTP verbatim) --> R
+  R -- HTTP over UDS --> X[Harness/executor omni-harness]
+  R <-. JSONL forwarder re-POST /events .-> S
+  X -. native: tmux + bridge HTTP relay .-> R
+```
+
+## 4. Inter-component channels (answers "what channel between components")
+| Edge | Transport / channel | Carries | Trace propagation |
+|---|---|---|---|
+| Client → Server | HTTPS **REST** + **SSE** (`GET /sessions/{id}/stream`) | commands (POST /events, fork, switch, resolve elicitation), snapshot reads, streamed response events | FastAPI extract + HTTPX/browser inject (W3C headers) |
+| Client → Server | **WebSocket** `/v1/sessions/updates` (+ health) | sidebar watch-set snapshot + change/remove deltas + heartbeat | manual `traceparent` in JSON envelope |
+| Server ⇄ Runner | **WS reverse-tunnel** that forwards HTTP **verbatim** (server calls "into" runner) | forwarded user events; runner→server callbacks (/events, /items, /policies/evaluate, /mcp) | HTTP headers tunneled verbatim; cached client wrapped by `instrument_httpx_client` |
+| Server ⇄ Host | **WS control frames** (JSON, *not* HTTP) | `host.launch_runner`/`stop_runner`/`runner_exited`/`stat`/`list_dir`/`create_worktree`/… | manual `traceparent` field on frame (`consume_frame_span`) |
+| Host → Runner | one-way **spawn env** at process launch | binding_token, workspace, harness, (TRACEPARENT if a span is active) | env propagation |
+| Runner → Harness | **HTTP over Unix domain socket** | turn drive + tool results | tunneled HTTP headers / `get_traceparent_env()` |
+| Harness → Server | **JSONL forwarder** re-POSTs `/events` (decoupled from any request) | mirrored assistant/tool/transcript items | own trace, stitched by `session.id` |
+| Native harness ↔ Runner | **bridge HTTP relay** (Bearer) + **tmux** send-keys / log-poll | in-turn tool calls; interrupt (Escape); transcript mirror | separate async boundary, correlated by `session.id` |
+| Server ⇄ DB | SQLAlchemy (sqlite/psycopg) | durable conversation store | `SQLAlchemyInstrumentor` (sink) |
+
+## 5. End-to-end request lifecycle (send a message) — verified against traces
+Root span observed: `omni-server POST /v1/sessions/{session_id}/events`, propagating
+server → runner → harness (with runner→server callbacks for policy + history).
+
+1. Client `POST /v1/sessions/{id}/events`. Server **persists the user item first**
+   (persist-before-forward invariant), then forwards to the runner over the reverse-tunnel,
+   then publishes `session.input.consumed` (carries the item id for client dedup). *(verify in `server.md`)*
+2. Runner receives the forwarded event → builds config (model/harness/auth) → runs the
+   **executor turn loop** (`runtime/workflow.py`): prompt build → executor → consume
+   `ExecutorEvent`s (TextChunk/ReasoningChunk/ToolCallRequest/…/TurnComplete). *(see `runtime-executor.md`)*
+3. Tool calls: runner policy **fast-path** (ALLOW/DENY) → MCP dispatch; ASK escalates to the
+   server elicitation flow; the in-process `policy.evaluate` span + the `/policies/evaluate`
+   hook both appear. *(see `policies.md`)*
+4. Output: streamed back as SSE `response.output_text.delta` etc.; the **JSONL forwarder**
+   re-POSTs durable items into `/events` (its own trace). Final items persisted to the
+   conversation store; the client **dedupes by `itemId`** to merge streaming vs durable. *(see `web.md`)*
+
+> **One user action ⇒ many traces.** The forwarder, host control plane, and server startup
+> root their own traces; `session.id` (= conv id) is the cross-trace stitch. See
+> `telemetry-tracing.md §5`.
+
+## 6. Harness taxonomy (in scope: claude, codex, polly)
+- **SDK harnesses** (claude-sdk, codex): in-process loop, Omnigent owns prompt + tools +
+  100%-Omnigent transcript; client sees the Omnigent UI. Base `inner/executor.py`.
+- **Native harnesses** (claude-native, codex-native): drive a resident vendor CLI/TUI in a
+  tmux pane; the *vendor* owns prompt + tools; transcript lives in the vendor store +
+  mirrored back. Base `native_server_harness.py`; bridge + forwarder.
+- **Polly** = a registered **custom agent** (a coding orchestrator) that runs on a harness
+  (typically claude-sdk) and delegates to sub-agents; inherits its harness's row. (Also
+  `debby`, and any user-authored agent.) Custom agents: ArtifactStore tarball → Agent DB row
+  → AgentCache. *(see `harness-inner.md` + `runtime-executor.md`)*
+
+Per-harness capability matrix (interrupt/queue/subagents/reasoning/elicitation/mid-session
+model) is verified cell-by-cell in `harness-inner.md` (correcting `CUJ-ANALYSIS.md §4`).
+
+## 7. Cross-cutting invariants (re-checked at each CUJ node)
+Transcript consistency (streaming↔durable; local↔server; post compaction/fork/resume) ·
+credential validity for the 3 cred relationships (each its own refresh path) · dedup
+(server/runner/client) · working-state truth (one computation, all clients agree?) · caching
+freshness · policy reach (every tool path, every connection state). Detailed per the
+component + cuj-answers docs.
+
+## 8. Where to read next
+- Per component: `architecture/{server,runner,host,harness-inner,runtime-executor,policies,web,tui-repl,auth-credentials,tools-omnibox,telemetry-tracing}.md`
+- CUJ answers by domain: `cuj-answers/*.md`
+- The pasteable consolidated CUJ answers (for the team doc): `cuj-answers/_FOR-PASTE.md` (assembled in synthesis).
+
+## 9. Verified corrections, cross-cutting gaps & live-trace findings
+**Code corrections found during the deep pass (vs `CUJ-ANALYSIS.md` / `OBSERVABILITY.md`):**
+- `CUJ-ANALYSIS.md` §2.A/§2.E `file:line` anchors have **drifted by thousands of lines** in
+  the ~912 KB `sessions.py` (e.g. `post_event` is `:18150` not `:17610`; `stream_session`
+  `:19190` not `:18762`) — re-derived in `server.md`.
+- **TRACEPARENT is NOT injected into the runner spawn env** (contra OBSERVABILITY §6.4) → each
+  runner roots its **own** trace, stitched only by `session.id` (`host.md`). This is *the*
+  reason one user action fans out into ~21 traces.
+- **`telemetry.init("omni-tui")` is never called** → the TUI emits **no spans today** even
+  though `OBSERVABILITY.md` claims an `omni-tui → server → runner → harness` trace; the
+  mechanism is wired (HTTPX instrumented) but uninitialized — one-line fix (`tui-repl.md`).
+- **PR #1439 IS merged** (commit `e9561916`) → the native policy-hook "fail-closed after ~1h"
+  bug is **fixed** for claude-native + codex-native (self-heal re-mint on 401/302); the residual
+  one-shot-token path is the **OpenCode** plugin (out of scope) (`auth-credentials.md`).
+- **#1128 confirmed** at `claude_sdk_executor.py:1910` (Opus billed when model is None on the
+  Databricks gateway).
+- **Native sub-agent completions never reach the orchestrator** — gate `runner/app.py:12607`
+  `elif not _is_native_harness(...)` excludes every native harness (#848 cluster) (`runner.md`).
+- **§4 matrix sharpenings:** codex-native subagents = ✅ (real mirror; the † footnote was stale
+  for codex-native — it applies to codex-SDK only); codex-SDK elicitation = ❌ confirmed
+  (`approvalPolicy:"never"`); codex-SDK mid-session model change = thread teardown (`harness-inner.md`).
+
+**Live-trace findings** (full detail: `cuj-answers/_LIVE-TRACE-FINDINGS.md`):
+- **One action → ~21 traces**, stitched only by `session.id` (decoupled forwarder/host/startup).
+- **Fork** = synchronous server **DB deep-copy** (~25 `INSERT`), no runner; **switch-agent**
+  clones the agent but **retains the runner**; **interrupt** = **`error.type=cancelled`** on the
+  `agent:` span; **`/compact`** on a model-less session = **#1192** `invalid_input`.
+- **A session is inert until a runner is bound** — REST create without `host_id` → no runner →
+  `runner_unavailable`; `host_id` at create is the host→runner launch trigger (the "stuck
+  working" gap lives here).
+- **Sub-agent spawn** = `tool:sys_session_send` → child **full sessions** (own `session.id`) →
+  `tool:sys_read_inbox` drain → `GET /child_sessions`; no single trace spans the tree.
+- **codex** is blocked locally by a **`DATABRICKS_BEARER`/PATH propagation gap** in the runner
+  spawn env (host reports `codex: needs-auth`) — covered from code + matrix.
+

--- a/designs/master-arch/architecture/policies.md
+++ b/designs/master-arch/architecture/policies.md
@@ -99,23 +99,23 @@ There are **two enforcement surfaces**, both calling the same engine:
 
 ```mermaid
 flowchart TD
-  A[engine.evaluate ctx, read_only] --> S[open policy.evaluate span]
-  S --> P[populate ctx: trajectory, session_state, usage,<br/>subtree_usage, user_daily_cost, model, labels, llm_client]
-  P --> L{for policy in<br/>session + agent + admin + ask_on_add}
-  L --> F{_should_fire?<br/>PhaseSelector AND condition label-gate}
+  A["engine.evaluate ctx, read_only"] --> S["open policy.evaluate span"]
+  S --> P["populate ctx: trajectory, session_state, usage,<br/>subtree_usage, user_daily_cost, model, labels, llm_client"]
+  P --> L{"for policy in<br/>session + agent + admin + ask_on_add"}
+  L --> F{"_should_fire?<br/>PhaseSelector AND condition label-gate"}
   F -- no --> L
-  F -- yes --> D[_dispatch_policy<br/>safety net + action-whitelist check]
-  D --> M[filter set_labels thru whitelist<br/>merge monotonic; accumulate state_updates]
-  M --> V{action}
-  V -- DENY --> DENY[_compose_deny:<br/>apply accumulated writes unless read_only<br/>SHORT-CIRCUIT return]
-  V -- ALLOW --> CH[if data: feed forward as ctx.content]
-  V -- ASK --> AK[record ask_reason + deciding policy<br/>continue loop]
+  F -- yes --> D["_dispatch_policy<br/>safety net + action-whitelist check"]
+  D --> M["filter set_labels thru whitelist<br/>merge monotonic; accumulate state_updates"]
+  M --> V{"action"}
+  V -- DENY --> DENY["_compose_deny:<br/>apply accumulated writes unless read_only<br/>SHORT-CIRCUIT return"]
+  V -- ALLOW --> CH["if data: feed forward as ctx.content"]
+  V -- ASK --> AK["record ask_reason + deciding policy<br/>continue loop"]
   CH --> L
   AK --> L
-  L -- loop done --> R{any ASK?}
-  R -- yes --> RASK[return ASK<br/>WITHHELD set_labels + state_updates<br/>+ deciding_policies]
-  R -- no --> RAL[apply writes unless read_only<br/>return ALLOW]
-  DENY --> Z[set span policy.decision/reason/deciding]
+  L -- loop done --> R{"any ASK?"}
+  R -- yes --> RASK["return ASK<br/>WITHHELD set_labels + state_updates<br/>+ deciding_policies"]
+  R -- no --> RAL["apply writes unless read_only<br/>return ALLOW"]
+  DENY --> Z["set span policy.decision/reason/deciding"]
   RASK --> Z
   RAL --> Z
 ```
@@ -176,14 +176,14 @@ sequenceDiagram
     Web->>Eng: POST /elicitations/{eid}/resolve {action:accept}
     Eng->>Reg: _resolve_elicitation: Future.set_result (owner-checked)
     Eng->>Web: publish response.elicitation_resolved (badge -1, card flips)
-    Eng->>Run: _forward_approval_to_runner (canonical "approval" event)
+    Eng->>Run: _forward_approval_to_runner (canonical approval event)
     Eng->>Eng: on accept → apply withheld set_labels + state_updates
   else runner-parked (SDK relay TOOL_CALL): verdict=pending
     Eng->>Web: _register_policy_elicitation (publish request)
     Eng->>Eng: stash deferred writes in _pending_policy_ask_writes[eid]
     Run->>Run: park on _pending_approvals[eid] Future
     Web->>Eng: POST /elicitations/{eid}/resolve OR approval event
-    Eng->>Run: forward "approval" → Future resolves → tool proceeds/denied
+    Eng->>Run: forward approval → Future resolves → tool proceeds/denied
     Eng->>Eng: _apply_pending_policy_ask_writes (accept→apply, else→drop)
   end
 ```

--- a/designs/master-arch/architecture/policies.md
+++ b/designs/master-arch/architecture/policies.md
@@ -1,0 +1,278 @@
+# Omnigent Policies / Approvals / Elicitations — Architecture
+
+> Scope: `omnigent/policies/` (pure evaluators + registry + builtins),
+> `omnigent/runtime/policies/` (engine + composition + ASK helper + builder),
+> server policy routes, the runner fast-path gate, native policy hook,
+> pending-elicitation tracking. Code is ground truth; all claims carry
+> `file:line` and are cross-checked against trace
+> `conv_63542a5f92e24956812e19b104eac0e9` / trace
+> `cfb59197f6f92755270a4d785d3ee3e1`.
+
+---
+
+## 1. Overview
+
+The policy system is a **declarative guardrail layer** that intercepts five
+*phases* of a turn (REQUEST, TOOL_CALL, TOOL_RESULT, LLM_REQUEST, LLM_RESPONSE)
+and returns one of three verdicts: **ALLOW / ASK / DENY**. There are **two
+distinct package halves** (this split is the single most important structural
+fact):
+
+| Package | Role | Key types |
+|---|---|---|
+| `omnigent/policies/` | **Pure evaluators** — stateless, no DB, no conversation knowledge. The `Policy` ABC + `FunctionPolicy` + `PromptPolicy`; the **registry** (allowlist of builtin handlers); `builtins/` (cost, safety, google, github, risk_score, routing, cel, prompt, working_dir). | `Policy` (`policies/base.py:32`), `EvaluationContext`/`PolicyResult`/`ElicitationRequest`/`PolicyLLMClient` (`policies/types.py`) |
+| `omnigent/runtime/policies/` | **Runtime orchestration** — the per-workflow `PolicyEngine` that owns label/state/usage hot-caches + composition loop + write-through; the `build_policy_engine` factory; the `_enforce_policy` call-site wrapper; the `_await_elicitation` ASK helper. | `PolicyEngine` (`runtime/policies/engine.py:43`), `build_policy_engine` (`runtime/policies/builder.py:214`) |
+
+The **single in-process choke point** is `PolicyEngine.evaluate()`
+(`runtime/policies/engine.py:230`), which wraps `_evaluate_composed` in a
+`policy.evaluate` OTel span tagged with phase/decision/reason. Every
+enforcement site routes through it — verified in the trace: **5 distinct
+`policy.evaluate` spans, one per phase, all on `omni-server`, all in-process.**
+
+There are **two enforcement surfaces**, both calling the same engine:
+
+1. **SERVER-level** — the engine runs *inside* omni-server. Reached three ways:
+   - `POST /v1/sessions/{id}/events` → `_evaluate_input_policy` / `_evaluate_output_policy` (REQUEST/RESPONSE gates).
+   - `POST /v1/sessions/{id}/mcp` → `_handle_mcp_tools_call` (TOOL_CALL + TOOL_RESULT for `sys_*`/spec MCP tools dispatched through the server MCP proxy).
+   - `POST /v1/sessions/{id}/policies/evaluate` → `evaluate_policy` route (the generic "hook path": native PreToolUse/UserPromptSubmit hooks, runner LLM-phase proxying, connector-native SDK tools).
+2. **RUNNER-level (fast-path)** — `RunnerToolPolicyGate` (`runner/policy.py:109`)
+   runs *function-type* TOOL_CALL/TOOL_RESULT policies **locally on the runner**
+   before MCP dispatch, for ALLOW/DENY only. **ASK escalates to the server**
+   (`POST /policies/evaluate`) which owns the elicitation channel. This dual
+   evaluation is by design (`runner/policy.py:20-34`).
+
+---
+
+## 2. Key files (file:line)
+
+### Pure evaluators (`omnigent/policies/`)
+- `base.py:32` — `Policy` ABC; `evaluate(ctx, context) -> PolicyResult`; `reset_turn()` no-op default (`:73`).
+- `types.py:64` — `EvaluationContext` (phase, content, tool_name, trajectory, actor, session_state, usage, subtree_usage, user_daily_cost, model, harness, labels, llm_client).
+- `types.py:203` — `PolicyResult` (action, reason, set_labels, deciding_policies, data, state_updates); `.deciding_policy` property (`:266`).
+- `types.py:276` — `ElicitationRequest` (the internal ASK contract; mirrors MCP `elicitation/create` form shape).
+- `types.py:61` — `FAIL_CLOSED_PHASES = ("PHASE_TOOL_CALL", "PHASE_REQUEST")` — the single source of truth for which phases fail closed.
+- `types.py:331` — `PolicyLLMClient` (pre-bound server-LLM client for prompt/function policies).
+- `registry.py` — `load_registry` (`:68`), `is_registered_handler` (`:156` — the RCE allowlist), `validate_factory_params` (`:208`).
+- `builtins/__init__.py:37` — `BUILTIN_POLICY_MODULES` (the 10 modules scanned at startup).
+- `builtins/cost.py` — `cost_budget` / `user_daily_cost_budget` / `subagent_cost_budget` (registry `:884/:920/:957`). The canonical ASK + `state_updates` (soft-checkpoint) policy.
+- `builtins/safety.py` — `max_tool_calls_per_session`, `ask_on_os_tools`, `block_skills`, `enforce_sandbox`, `deny_pii_in_llm_request`, **`ask_on_add_policy`** (the hardcoded sys_add_policy gate).
+- `builtins/prompt.py` — `prompt_policy` = the **LLM-classifier** (`PromptPolicy`); `risk_score.py`, `routing.py` (`deny_trivial_to_expensive_model`), `cel.py`, `google.py`, `github.py`, `working_dir.py`.
+
+### Runtime orchestration (`omnigent/runtime/policies/`)
+- `engine.py:43` — `PolicyEngine`; `evaluate` span wrapper (`:230`); `_evaluate_composed` (`:284` — the composition loop); `_compose_deny` (`:414`); `_should_fire` (selector + condition gate, `:457`); `apply_label_writes` (`:490`); `apply_state_updates` (`:521`, with reserved-key routing to root/user-daily); `record_usage` (`:631`); the `_inject_*` context populators (`:695`+).
+- `engine.py:976` — `_dispatch_policy` (per-policy safety net); `_fail_closed` (`:1038` — classifier-only→ALLOW, ask-gate→ASK, else→DENY); `_condition_matches` (`:1237` — label gate).
+- `builder.py:214` — `build_policy_engine`; **composition order** `:309` (`session + agent + admin`, then `_ASK_ON_ADD_POLICY_SPEC` appended `:315`); sub-agent root-policy inheritance `:301-307`; cost-approval root-seeding `:332-339`.
+- `builder.py:64` — `_ASK_ON_ADD_POLICY_SPEC` (hardcoded, always-injected ASK before `sys_add_policy`).
+- `enforcement.py:20` — `_enforce_policy(engine, ctx)` (thin call-site wrapper used by the in-process workflow path).
+- `approval.py:80` — `_await_elicitation` (ASK round-trip: register → emit → park → parse verdict → apply writes on accept); `build_elicitation_request_event` (`:175`); `_parse_verdict` (`:290` — strict, only `action=="accept"` → True); `resolve_ask_timeout` (`:264`).
+
+### Server routes
+- `server/routes/session_policies.py` — per-session CRUD (`POST/GET/PATCH/DELETE /v1/sessions/{id}/policies`); registry-allowlist guard on create (`:181`) and patch (`:323`); LIST merges admin + session sources (`:236`).
+- `server/routes/default_policies.py` — server-wide CRUD (`POST/GET/PATCH/DELETE /v1/policies`); `_require_admin` (`:70`); stored with `session_id IS NULL`.
+- `server/routes/policy_registry.py` — `GET /v1/policy-registry` (browse builtins; filters `internal_only`, `:54`).
+- `server/routes/sessions.py` — the big one:
+  - `_evaluate_input_policy` (`:10801`, REQUEST, parks ASK server-side), `_evaluate_output_policy` (`:10971`, RESPONSE), `_evaluate_tool_call_policy` (`:10556`, the relay/non-native TOOL_CALL gate).
+  - `evaluate_policy` route (`:15973`, the `/policies/evaluate` hook path; proto phase map `:15946`).
+  - `_handle_mcp_tools_call` (`:13135`, the MCP-proxy TOOL_CALL+TOOL_RESULT path w/ MRTR retry).
+  - `_hold_native_ask_gate` (`:4119`, server-side ASK park used by REQUEST gate + the hook path).
+  - `_register_policy_elicitation` (`:10279`), `_publish_and_wait_for_harness_elicitation` (`:1397`), `_resolve_elicitation` (`:3921`), `_forward_approval_to_runner` (`:3880`), `claude_permission_request_hook` (`:15638`), `resolve_elicitation` route (`:18022`), `get_elicitation` route (`:18089`).
+  - `_apply_pending_policy_ask_writes` (`:10372`) + `_pending_policy_ask_writes` map (relay ASK deferred writes).
+- `server/_elicitation_registry.py` — in-process registries: `_harness_elicitation_registry` (id→Future), `_harness_elicitation_owners` (cross-user guard), `_harness_parked_elicitations`, `_harness_pre_resolved_elicitations` (tombstones for races).
+
+### Runner + hooks
+- `runner/policy.py:109` — `RunnerToolPolicyGate` (local fast-path, function-type tool policies only); `PolicyVerdict` (`:65`); `evaluate_tool_call` (`:159`), `evaluate_tool_result` (`:184`, ASK→DENY on result), `_evaluate_policies` (`:228`, DENY short-circuits / ASK records-but-continues); `format_deny_text` (`:314`).
+- `runner/app.py:6248` — `_evaluate_policy_via_omnigent` (runner proxies a harness `policy_evaluation.requested` event → `POST /policies/evaluate`; phase-aware fail-open/closed via `FAIL_CLOSED_PHASES` `:6297`).
+- `runner/app.py:18780+` — `_evaluate_tool_call_via_gate` (constructs `RunnerToolPolicyGate.from_spec`).
+- `runner/pending_approvals.py` — runner-side `_pending_approvals` Future map for the SDK approval-event path.
+- `native_policy_hook.py` — shared claude/codex hook translation: native hook shape (`PreToolUse`/`PostToolUse`/`UserPromptSubmit`) ↔ proto `EvaluationRequest`/`EvaluationResponse`; `post_evaluate_with_retry` (30s retry budget, `:37`); auth-header baking (`:78`/`:103`).
+- `claude_native_hook.py` — claude-native entrypoint; PermissionRequest long-poll (`:528`), PreToolUse `AskUserQuestion` interception (`:668`).
+- `runtime/pending_elicitations.py` — in-process sidebar index (`record_publish` `:81` auto-tracks every `response.elicitation_request` through `session_stream.publish`; `count_for`/`counts_for`/`snapshot_for`/`lookup`).
+
+### Tools
+- `tools/builtins/policy.py:18` — `SysAddPolicyTool` (`sys_add_policy` → runner → `POST /v1/sessions/{id}/policies`); `:94` — `SysPolicyRegistryTool` (`sys_policy_registry` → `GET /v1/policy-registry`). Registered in `tools/manager.py:185`.
+
+---
+
+## 3. Data flow
+
+### 3.1 In-process composition (the engine — `_evaluate_composed`, engine.py:284)
+
+```mermaid
+flowchart TD
+  A[engine.evaluate ctx, read_only] --> S[open policy.evaluate span]
+  S --> P[populate ctx: trajectory, session_state, usage,<br/>subtree_usage, user_daily_cost, model, labels, llm_client]
+  P --> L{for policy in<br/>session + agent + admin + ask_on_add}
+  L --> F{_should_fire?<br/>PhaseSelector AND condition label-gate}
+  F -- no --> L
+  F -- yes --> D[_dispatch_policy<br/>safety net + action-whitelist check]
+  D --> M[filter set_labels thru whitelist<br/>merge monotonic; accumulate state_updates]
+  M --> V{action}
+  V -- DENY --> DENY[_compose_deny:<br/>apply accumulated writes unless read_only<br/>SHORT-CIRCUIT return]
+  V -- ALLOW --> CH[if data: feed forward as ctx.content]
+  V -- ASK --> AK[record ask_reason + deciding policy<br/>continue loop]
+  CH --> L
+  AK --> L
+  L -- loop done --> R{any ASK?}
+  R -- yes --> RASK[return ASK<br/>WITHHELD set_labels + state_updates<br/>+ deciding_policies]
+  R -- no --> RAL[apply writes unless read_only<br/>return ALLOW]
+  DENY --> Z[set span policy.decision/reason/deciding]
+  RASK --> Z
+  RAL --> Z
+```
+
+Composition semantics (engine.py:358-412):
+- **DENY short-circuits** immediately (first DENY wins), applies accumulated writes from prior ALLOWs then returns.
+- **ASK accumulates** but the loop continues — a later DENY can still override an ASK.
+- **ALLOW continues**; if a policy returned `data`, it is fed forward as `ctx.content` so policies **chain** (e.g. PII-redact then cost-gate the redacted payload).
+- On final ASK: writes are **withheld** (carried in the result, applied only on approve — POLICIES.md §7.2 invariant).
+
+### 3.2 The two enforcement surfaces (the trace tells the whole story)
+
+From trace `cfb59197...` (claude-sdk, `echo TRACETEST123` via `sys_os_shell`), each `policy.evaluate` span's **parent** reveals the routing:
+
+```
+policy.evaluate REQUEST       parent = POST /v1/sessions/{id}/events        (server input gate)
+policy.evaluate LLM_REQUEST   parent = POST /v1/sessions/{id}/policies/evaluate  (hook path, runner-proxied)
+policy.evaluate LLM_RESPONSE  parent = POST /v1/sessions/{id}/policies/evaluate  (hook path, runner-proxied)
+policy.evaluate TOOL_CALL     parent = POST /v1/sessions/{id}/mcp            (MCP-proxy dispatch)
+policy.evaluate TOOL_RESULT   parent = POST /v1/sessions/{id}/mcp            (MCP-proxy dispatch)
+```
+
+```mermaid
+sequenceDiagram
+  participant H as omni-harness (claude CLI subprocess)
+  participant R as omni-runner
+  participant S as omni-server (PolicyEngine)
+  Note over S: ① REQUEST gate (web prompt)
+  S->>S: POST /events → _evaluate_input_policy → policy.evaluate(REQUEST)
+  Note over R,S: ② LLM phases (advisory, runner-proxied)
+  R->>S: POST /policies/evaluate {PHASE_LLM_REQUEST}
+  S->>S: policy.evaluate(LLM_REQUEST) → ALLOW
+  Note over R,S: ③ tool dispatch (sys_* MCP via server proxy)
+  R->>S: POST /mcp tools/call {sys_os_shell}
+  S->>S: policy.evaluate(TOOL_CALL) → ALLOW
+  S->>R: POST /mcp/execute  (runner runs the tool)
+  R-->>S: tool output
+  S->>S: policy.evaluate(TOOL_RESULT) → ALLOW
+  Note over R,S: ④ LLM_RESPONSE (advisory)
+  R->>S: POST /policies/evaluate {PHASE_LLM_RESPONSE}
+  S->>S: policy.evaluate(LLM_RESPONSE) → ALLOW
+```
+
+### 3.3 The ASK / elicitation flow (end-to-end)
+
+```mermaid
+sequenceDiagram
+  participant Eng as PolicyEngine (server)
+  participant Reg as _harness_elicitation_registry (Future)
+  participant Idx as pending_elicitations (sidebar index)
+  participant Web as Web ApprovalCard / approve page
+  participant Run as runner (_pending_approvals)
+  Eng->>Eng: _evaluate_composed → ASK (writes WITHHELD)
+  alt server-parked phases: REQUEST / TOOL_CALL(native) / LLM_REQUEST
+    Eng->>Reg: _hold_native_ask_gate → register Future(elicitation_id)
+    Eng->>Web: session_stream.publish(response.elicitation_request)
+    Note over Idx: record_publish auto-tracks → sidebar badge +1
+    Web->>Eng: POST /elicitations/{eid}/resolve {action:accept}
+    Eng->>Reg: _resolve_elicitation: Future.set_result (owner-checked)
+    Eng->>Web: publish response.elicitation_resolved (badge -1, card flips)
+    Eng->>Run: _forward_approval_to_runner (canonical "approval" event)
+    Eng->>Eng: on accept → apply withheld set_labels + state_updates
+  else runner-parked (SDK relay TOOL_CALL): verdict=pending
+    Eng->>Web: _register_policy_elicitation (publish request)
+    Eng->>Eng: stash deferred writes in _pending_policy_ask_writes[eid]
+    Run->>Run: park on _pending_approvals[eid] Future
+    Web->>Eng: POST /elicitations/{eid}/resolve OR approval event
+    Eng->>Run: forward "approval" → Future resolves → tool proceeds/denied
+    Eng->>Eng: _apply_pending_policy_ask_writes (accept→apply, else→drop)
+  end
+```
+
+Strict verdict parsing: only `action == "accept"` → approved
+(`approval.py:290` `_parse_verdict`; same in `_hold_native_ask_gate:4211`).
+Everything else (decline / cancel / malformed / timeout / disconnect)
+→ **DENY, no side effects** (POLICIES.md §7.2).
+
+---
+
+## 4. Channels & message/event types
+
+| Channel | Direction | Payload / type |
+|---|---|---|
+| `POST /v1/sessions/{id}/policies/evaluate` | runner/native-hook → server | `EvaluationRequest`: `{event:{type:PHASE_*, data}, context?, _omnigent_elicitation_id?}` → `EvaluationResponse`: `{result:POLICY_ACTION_*, reason?, data?}` |
+| `POST /v1/sessions/{id}/mcp` (`tools/call`) | runner → server | JSON-RPC; server gates TOOL_CALL→dispatch→TOOL_RESULT; ASK returns MCP `InputRequiredResult` (MRTR), retry carries `requestState`+`inputResponses` |
+| `POST /v1/sessions/{id}/events` | web/native → server | `function_call` w/ `evaluate_policy:true` (TOOL_CALL relay gate); `message` (input/output gate); `approval` (verdict delivery) |
+| SSE on session_stream | server → all clients | `response.elicitation_request` (the ASK card), `response.elicitation_resolved` (clear/flip), `response.output_text.delta` w/ `[Denied by policy: …]` sentinel |
+| `POST /v1/sessions/{id}/elicitations/{eid}/resolve` | web → server | `ElicitationResult` `{action:accept|decline|cancel, content?}` |
+| `GET /v1/sessions/{id}/elicitations/{eid}` | approve page → server | reads `pending_elicitations` index → `{status, message, phase, policy_name, content_preview}` |
+| `POST /v1/sessions/{id}/hooks/permission-request` | claude-native hook → server | Claude PermissionRequest payload; **long-poll** → `hookSpecificOutput.decision.behavior: allow|deny`, empty 200 on timeout = "defer to TUI" |
+| `approval` event (server→runner) | server → runner | `{type:"approval", data:{elicitation_id, action}}` resolves runner `_pending_approvals` Future |
+| `POST /v1/sessions/{id}/policies` | runner (`sys_add_policy`) / UI → server | `CreateSessionPolicyRequest` `{name, type, handler, factory_params}` |
+
+Proto phase maps (sessions.py:15946-15959):
+`PHASE_TOOL_CALL/TOOL_RESULT/LLM_REQUEST/LLM_RESPONSE/REQUEST` ↔ `Phase.*`;
+`PolicyAction.ALLOW/DENY/ASK` ↔ `POLICY_ACTION_ALLOW/DENY/ASK`.
+
+---
+
+## 5. Trace evidence (concrete)
+
+Corpus: `conv_63542a5f92e24956812e19b104eac0e9` (claude-sdk tool-use; 14 traces).
+Policy-bearing trace: **`cfb59197f6f92755270a4d785d3ee3e1`** (415 spans).
+
+Histogram (from `trace_tools.py conv`):
+- `omni-server policy.evaluate` ×5 (in-process choke point)
+- `omni-server POST /v1/sessions/{id}/policies/evaluate` ×2 (the hook path)
+- `omni-runner POST /v1/sessions/{id}/policies/evaluate http send` ×6 (runner→server proxy attempts)
+- cross-service edge: `omni-runner → omni-server [POST /policies/evaluate] x2`
+- cross-service edge: `omni-runner → omni-server [POST /mcp] x1`, `omni-server → omni-runner [POST /mcp/execute] x1`
+
+Per-span attributes captured on `policy.evaluate` (all `policy.decision=ALLOW`,
+`policy.read_only=False`, `session.id=conv_63542a5f…`):
+
+| `policy.phase` | `policy.tool_name` | `policy.content` (excerpt) |
+|---|---|---|
+| `REQUEST` | `''` | `"Use your shell/bash tool to run exactly: echo TRACETEST123 …"` |
+| `LLM_REQUEST` | `''` | `{messages_count:1, tools_count:20, system_prompt_preview:"You are Claude Code…", last_user_message:"… echo TRACETEST123 …"}` |
+| `TOOL_CALL` | `sys_os_shell` | `{name:"sys_os_shell", arguments:{command:"echo TRACETEST123"}}` |
+| `TOOL_RESULT` | `sys_os_shell` | `{result:"{stdout:TRACETEST123\n, exit_code:0, …}"}` |
+| `LLM_RESPONSE` | `''` | `{text_preview:"…The output was: TRACETEST123…", usage:{…}, model:"claude-opus-4-8"}` |
+
+This is the empirical proof of the phase set, the in-process choke point, and
+the dual-path routing (REQUEST via `/events`; LLM phases via `/policies/evaluate`;
+TOOL_* via `/mcp`). The trace shows **no ASK/DENY** (the default
+`databricks_coding_agent` spec has no blocking policy on `echo`), so the ASK/DENY
+branches below are code-grounded, not trace-observed.
+
+---
+
+## 6. Per-harness differences
+
+| Harness | TOOL_CALL enforcement | REQUEST gate | ASK verdict delivery | Notes |
+|---|---|---|---|---|
+| **claude-sdk** | `mcp__omnigent__*` tools gated via server `/mcp` proxy dispatch (`_handle_mcp_tools_call`); connector-native (`mcp__github__*`) gated via SDK `can_use_tool` → `_evaluate_tool_call_policy` (`claude_sdk_executor.py:1680`) → `/policies/evaluate`. Runner fast-path `RunnerToolPolicyGate` for function-type tool policies. | server `_evaluate_input_policy` at `POST /events`. | runner `_pending_approvals` Future (relay `approval` event) OR SDK elicitation handler. | Double-eval guard: `mcp__omnigent__*` skipped in the SDK callback (`:1737`) because the dispatch path already gates them. **This is the trace-observed harness.** |
+| **claude-native** | `PreToolUse` hook → `native_policy_hook` → `POST /policies/evaluate`. | `UserPromptSubmit` hook → `POST /policies/evaluate` (PHASE_REQUEST). Server-side `/events` input gate is *deduped* for native via `pending_inputs` (sessions.py:16065) to avoid double-prompt. | **`PermissionRequest` hook long-poll** (`/hooks/permission-request`, verdict in held HTTP body); for *policy* ASK the server holds the `/policies/evaluate` long-poll via `_hold_native_ask_gate` and collapses ASK→hard ALLOW/DENY so a permissive `permission_mode` can't auto-approve (sessions.py:16113-16177). | Required hooks: **PreToolUse + PermissionRequest + UserPromptSubmit**. PostToolUse is observational. |
+| **codex / codex-native** | Same `native_policy_hook` translation (codex hook posts PHASE_TOOL_CALL). codex-native ASK via `codex-elicitation-request` hook (`codex_elicitation_id`, route `codex_elicitation_request_hook` sessions.py:16214). | codex-native `UserPromptSubmit`-equivalent → `/policies/evaluate`. codex (SDK) like claude-sdk. | codex-native: elicitation hook long-poll. codex (SDK): runner approval event. | **No live trace (codex creds expired / 403).** Covered by code + structural analogy to claude. Codex hook reads live `/model` from `config.toml` and stamps `event.context.model` (engine respects it, `engine.py:749`). |
+| **polly / custom agents** | Run *on* a harness (typically claude-sdk) → inherit that harness's enforcement exactly. No policy-specific divergence. | inherited. | inherited. | Policies attached to a custom-agent spec's `guardrails:` block flow through `build_policy_engine` like any spec. |
+
+---
+
+## 7. Failure branches & gaps
+
+- **Fail-CLOSED phases** = `("PHASE_TOOL_CALL", "PHASE_REQUEST")` (`types.py:61`, enforced at `runner/app.py:6297` and the native hooks `native_policy_hook.py:60-67`). A server outage / non-2xx / malformed 200 on these phases → **DENY**. TOOL_RESULT + LLM_REQUEST + LLM_RESPONSE **fail OPEN** (advisory / side-effect already incurred).
+- **Per-policy fail-closed** (`_fail_closed`, engine.py:1038): a broken/raising policy → DENY by default; classifier-only (`action:[allow]`) → ALLOW (honor "never blocks" intent); ask-gate (`[ask]`/`[allow,ask]`) → ASK (park, never auto-allow).
+- **ASK timeout / disconnect** → DENY, withheld writes discarded. Default `ask_timeout` = one day (`_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S = 86400`); per-policy override wins (`resolve_ask_timeout`).
+- **Native policy-token expiry** (the §2.G bug, cross-cutting): the native PreToolUse hook bakes a one-shot Bearer token (`native_policy_hook.py:103`). If it expires, the `/policies/evaluate` POST 401s → hook fails closed → *every* native tool call is denied until re-mint. (Recent fix `e9561916` re-mints expired hook token on Apps OAuth bounce.)
+- **RCE allowlist** (`is_registered_handler`, registry.py:156): a `type:python` policy handler MUST be in the registry (builtins + admin `policy_modules`). Enforced on `POST/PATCH /policies` and on agent-bundle upload. Trusted local `omnigent run` skips this (still supports custom handlers).
+- **MRTR forge guard** (`_handle_mcp_tools_call:13239`): the retry path re-evaluates TOOL_CALL policy and verifies the `elicitation_id` is in the server-side `_pending_policy_ask_writes` map — a forged `requestState`/`inputResponses` can't bypass DENY.
+- **read_only eval** (LEVEL_READ): policies run but no persistence and no ASK-park (the read-only caller would otherwise mint an elicitation = a mutation). Returns the raw verdict (sessions.py:16130, engine.py:403/446).
+- **Gaps / in-memory caveats:** `_harness_elicitation_registry` + `pending_elicitations` are **in-process only** — a multi-replica omni-server deploy splits elicitation state per replica (documented limitation; needs a shared backplane). The `policy.evaluate` span captures content only when content-capture is on (redacted + capped).
+
+---
+
+## 8. Open questions
+
+1. **codex-native end-to-end** unverified by trace (creds). The `codex_elicitation_request_hook` and the `event.context.model` from `config.toml` are code-grounded but no live span evidence.
+2. **ASK / DENY span attributes** unobserved (the trace corpus only exercised ALLOW). A blocking policy would surface `policy.decision=ASK|DENY` + `policy.reason` + `policy.deciding_policies` on the span — confirmed in the span-writing code (engine.py:273-281) but not in the corpus.
+3. **Multi-replica elicitation backplane** — both the registry and the sidebar index acknowledge they'd need a shared store; the wiring point is noted but not implemented in this tree.
+4. **`condition:` label-gate + monotonic merge** under concurrent sub-agents — the engine seeds cost-approval from root and routes write-backs to root (`apply_state_updates` reserved-key routing), but cross-conversation label races (POLICIES.md Open Q #6) are mitigated by `INSERT … ON CONFLICT DO NOTHING` seeding, not fully serialized.

--- a/designs/master-arch/architecture/runner.md
+++ b/designs/master-arch/architecture/runner.md
@@ -1,0 +1,427 @@
+# Omnigent Runner — Architecture
+
+**Scope:** `omnigent/runner/` (`_entry.py`, `app.py`, `routing.py`, `mcp_manager.py`,
+`proxy_mcp_manager.py`, `policy.py`, `tool_dispatch.py`), the runner↔server reverse WS
+tunnel (`runner/transports/ws_tunnel/` + server `routes/runner_tunnel.py`) **from the
+runner side**, and the harness/executor subprocess boundary (`runtime/harnesses/process_manager.py`, UDS).
+
+> Source-of-truth: code (cited `file:line`), validated against live Jaeger traces from
+> `conv_63542a5f92e24956812e19b104eac0e9` (claude-sdk tool-use). Doc claims from
+> `designs/OBSERVABILITY.md` / `RUNNER*.md` are tagged when only doc-sourced.
+
+---
+
+## 1. Overview
+
+The **runner** is a standalone ASGI (FastAPI) process that owns *execution*: it spawns and
+supervises harness/executor subprocesses, owns custom-MCP stdio subprocesses, owns terminals
+and the OS sandbox, and runs the agent turn loop. It is **not** directly reachable over the
+network. Instead it dials *out* to the server and opens a **reverse WebSocket tunnel**; the
+server then makes ordinary HTTP requests *into* the runner by framing them over that tunnel
+(`WSTunnelTransport`). The runner is the WS **client**; the server is the WS **server**.
+
+Two distinct mechanisms route between server and runner over the **same** tunnel:
+- **server → runner** (turn dispatch, `/mcp/execute`, resource APIs): the server holds an
+  `httpx.AsyncClient` whose transport is `WSTunnelTransport` (`routing.py:255`). Each httpx
+  request becomes a `request` frame; the runner replays it through its ASGI app
+  (`serve.py:dispatch_via_asgi`).
+- **runner → server** (load transcript/spec, escalate policy ASK, `external_*` mirror,
+  `/mcp` proxy): the runner holds its own `httpx.AsyncClient` (`_entry.py:718`) pointed at
+  the real server URL, authed with `_RunnerDatabricksAuth`.
+
+The runner advertises which **harnesses** it can serve in its hello frame; the server binds a
+conversation to exactly one runner (hard affinity, no failover) and validates the runner is
+online + capable before every dispatch.
+
+### Process entrypoint (`runner/_entry.py`)
+`_run_tunnel_from_env()` (`_entry.py:881`) is the runner process main:
+1. Resolve `server_url`, build the auth-token factory (`_make_auth_token_factory`, `:271`),
+   read the binding token + parent pid.
+2. `telemetry.init("omni-runner")` (`:902`) — sets `service.name=omni-runner`; no-op unless
+   `OMNIGENT_TELEMETRY_ENABLED` + `OTEL_EXPORTER_OTLP_ENDPOINT`.
+3. `create_app(auth_token_factory=...)` (`:908`, → `create_app` `:660`) — builds the FastAPI
+   app, `HarnessProcessManager`, `RunnerMcpManager`, terminal registry, server httpx client.
+4. Drive the app lifespan (`pm.start()` + MCP prewarm + native-pane reaper).
+5. `serve_tunnel(app, …, auth_token_factory=…, on_reconnect=catch_up_scan, on_activity=…)`
+   (`:949`) — the forever-reconnecting WS tunnel client.
+6. Watchdogs: optional idle monitor (`_run_inactivity_monitor`), parent-death killer thread.
+
+---
+
+## 2. Key files (file:line)
+
+| File | Role |
+|---|---|
+| `runner/_entry.py:881` | `_run_tunnel_from_env` — process main; telemetry init, lifespan, tunnel start |
+| `runner/_entry.py:271` | `_make_auth_token_factory` — runner↔server Bearer factory (OIDC token → Databricks OAuth) |
+| `runner/_entry.py:162` | `_RunnerDatabricksAuth` — per-request httpx auth (refresh per request, retry on 401/302) |
+| `runner/_entry.py:660` | `create_app` — runner FastAPI factory; wires `server_client`, `RunnerMcpManager`, `pm` |
+| `runner/app.py:14598` | `POST /v1/sessions/{conv}/events` — **inbound forwarded user event**; per-conv FIFO ingest gate; turn dispatch |
+| `runner/app.py:9589` | `GET /v1/sessions/{conv}/stream` — SSE event stream back to server (202 fire-and-forget path) |
+| `runner/app.py:17829` | `POST /v1/sessions/{conv}/mcp/execute` — server calls back to execute a tool (after server-side policy) |
+| `runner/app.py:8654` | `POST /v1/sessions` — create session/turn on this runner |
+| `runner/routing.py:89` | `RunnerRouter.client_for_conversation` — **dispatch + hard affinity** decision |
+| `runner/routing.py:243` | `_client_for_runner` — cached tunnel httpx client; `instrument_httpx_client` on it |
+| `runner/transports/ws_tunnel/transport.py:118` | `WSTunnelTransport.handle_async_request` — server-side; headers forwarded verbatim (`:149`) |
+| `runner/transports/ws_tunnel/serve.py:230` | `serve_tunnel` — runner-side tunnel client (reconnect, auth refresh) |
+| `runner/transports/ws_tunnel/serve.py:566` | `_send_hello` — advertises harness capabilities + frame proto version |
+| `runner/transports/ws_tunnel/registry.py:242` | `TunnelRegistry.register` — "newest wins"; aborts old in-flight |
+| `runner/mcp_manager.py:150` | `RunnerMcpManager` — direct custom-MCP pool (8-entry LRU, namespaced tools) |
+| `runner/proxy_mcp_manager.py:42` | `ProxyMcpManager` — route ALL MCP through server `/mcp` (deployed mode) |
+| `runner/policy.py:109` | `RunnerToolPolicyGate` — runner fast-path ALLOW/DENY/ASK for function policies |
+| `runner/app.py:6248` | `_evaluate_policy_via_omnigent` — proxy harness `policy_evaluation.requested` → server `/policies/evaluate`, deliver `policy_verdict` back |
+| `runner/app.py:14115` | `proxy_stream` — SSE relay from harness; intercepts `action_required`, accumulates `_session_histories`, `_publish_event` |
+| `runner/app.py:12519` | `_on_proxy_stream_end` — turn finalize: pop `_active_turns`, publish `session.status` idle/failed |
+| `server/routes/runner_tunnel.py:277` | server-side tunnel WS handler — token gate, owner resolution, register |
+| `stores/conversation_store/sqlalchemy_store.py:1918` | `set_runner_id` — atomic CAS bind (`WHERE runner_id IS NULL`) |
+| `runtime/harnesses/process_manager.py` | per-conversation harness subprocess over **UDS** (`/tmp/omnigent`), per-spawn bearer |
+
+---
+
+## 3. Data flow
+
+### 3.1 Request lifecycle (one user turn, deployed mode)
+
+```mermaid
+sequenceDiagram
+    participant C as Client (TUI/Web)
+    participant S as omni-server
+    participant R as omni-runner
+    participant H as omni-harness (executor, UDS)
+    participant M as Custom MCP / sys_* tool
+
+    C->>S: POST /v1/sessions/{id}/events (message)
+    Note over S: persist-before-forward; policy.evaluate (REQUEST)
+    S->>R: POST /v1/sessions/{id}/events  (httpx over WS tunnel, stream=true)
+    Note over R: FIFO ingest gate (_ingest_now_serving); single-active-turn (I2)
+    R->>S: GET /v1/sessions/{id}/items     (load transcript)
+    R->>S: GET /v1/sessions/{id}/agent/contents  (load agent spec bundle)
+    R->>H: POST /v1/sessions/{id}/events   (executor, UDS) — SSE turn events
+    H-->>R: TextChunk / ToolCallRequest / TurnComplete (SSE)
+    Note over R: tool call detected
+    R->>S: POST /v1/sessions/{id}/mcp (tools/call)  [ProxyMcpManager]
+    Note over S: policy.evaluate (TOOL_CALL)
+    S->>R: POST /v1/sessions/{id}/mcp/execute       (server delegates execution)
+    R->>M: dispatch (RunnerMcpManager custom-MCP / execute_tool sys_*)
+    M-->>R: tool output
+    R-->>S: result (over /mcp/execute response)
+    Note over S: policy.evaluate (TOOL_RESULT)
+    S-->>R: tool result (over /mcp response)
+    R-->>H: tool result -> harness continues
+    R-->>S: response.output_text.delta / final item (SSE on the events stream)
+    S-->>C: SSE response.* / session.*
+```
+
+Every edge in this diagram is **observed in the live trace** (see §5).
+
+### 3.2 Tunnel establishment & dispatch decision
+
+```mermaid
+flowchart TD
+    A[runner _entry: serve_tunnel] -->|WS connect /v1/runners/{id}/tunnel<br/>Origin=omnigent://internal<br/>Bearer + X-Databricks-Org-Id + tunnel_token| B[server runner_tunnel.tunnel]
+    B -->|token gate + owner resolve<br/>fail-closed if unauth non-loopback| C{accept?}
+    C -->|no| X[ws.close 4004 / 4001 / 4002]
+    C -->|yes| D[recv hello frame: harnesses[], frame_proto_version]
+    D -->|strict-major check| E[registry.register newest-wins]
+    E --> F[runner online in TunnelRegistry]
+    G[server dispatch: RunnerRouter.client_for_conversation] --> H{conv.runner_id set?}
+    H -->|no| I[CONFLICT 'not bound']
+    H -->|yes| J{registry.get online?}
+    J -->|no| K[RUNNER_UNAVAILABLE]
+    J -->|yes| L{hello.harnesses ∋ harness?}
+    L -->|no| M[RUNNER_CAPABILITY_MISMATCH]
+    L -->|yes| N[RoutedRunner: cached WSTunnelTransport client]
+```
+
+---
+
+## 4. Channels & message/event types
+
+### 4.1 Runner↔server reverse WS tunnel (`ws_tunnel/`)
+- **Transport:** runner is WS client → `ws(s)://<server>/v1/runners/{runner_id}/tunnel`
+  (`serve.py:_tunnel_url`, `:894`). Tunnel max message bytes capped (`limits.py`).
+- **Frames** (`ws_tunnel/frames.py`): `hello`, `ping`/`pong`, `request`, `request.cancel`,
+  `response.head`, `response.body`, `response.end`, plus WS-attach frames `ws.open`/`ws.frame`/
+  `ws.close` (for tunneled terminal-attach websockets).
+- **HTTP-over-WS (server→runner):** `WSTunnelTransport.handle_async_request` (`transport.py:118`)
+  allocates a `req_id`, sends one `RequestFrame` (whole body inline — bodies are tiny JSON),
+  awaits `head_future`, then streams `ResponseBodyFrame`s until `ResponseEndFrame`
+  (`registry.RequestState`). **Headers forwarded verbatim** — `headers=[[k,v] for k,v in
+  request.headers.items()]` (`transport.py:149`) — this is how `traceparent` crosses (§6).
+- **ASGI replay (runner side):** `dispatch_via_asgi` (`serve.py:102`) builds an ASGI `http`
+  scope from the request frame and calls the runner's FastAPI app directly (no TCP listener);
+  `http.response.start`/`.body` map back to `response.head`/`.body`/`.end` frames.
+  Notably `receive()` never synthesizes `http.disconnect` after the body (`serve.py:149`) so
+  Starlette's `StreamingResponse` keeps proxying harness SSE chunks.
+- **Hello frame capabilities (`serve.py:577`):** advertises
+  `harnesses=[claude-native, claude-sdk, codex, openai-agents, open-responses, pi]` and
+  `envs=[os_sandbox]`, `frame_protocol_version=1`.
+
+### 4.2 Runner→server callbacks (`server_client`, `_entry.py:718`)
+Ordinary httpx to the real server URL, `auth=_RunnerDatabricksAuth`, `Origin=omnigent://internal`
+(passes the server's `require_trusted_origin` CSRF guard on multipart routes). Used for:
+- `GET /v1/sessions/{id}/items` (transcript), `GET /v1/sessions/{id}/agent/contents` (spec bundle),
+- `POST /v1/sessions/{id}/mcp` (ProxyMcpManager `tools/list` / `tools/call`),
+- `POST /v1/sessions/{id}/policies/evaluate` (runner-side ASK escalation, via `pending_approvals`),
+- `POST /v1/sessions/{id}/events` with `mcp_elicitation` (custom-MCP inline elicitation),
+- `external_*` native mirror events, `GET /api/version`, file/upload APIs.
+
+### 4.3 Runner→executor subprocess (UDS)
+`HarnessProcessManager` (`process_manager.py`): **one subprocess per conversation**, lazily
+spawned on first event, reachable over a per-conversation **Unix domain socket** under
+`/tmp/omnigent` (`_socket_path`). The runner hands callers an `httpx.AsyncClient` pointed at
+that UDS. Auth is a **per-spawn bearer token** for the harness control channel (defence-in-depth
+on top of UDS uid-isolation). Idle reaper for abandoned subprocesses + crash detection.
+
+### 4.4 Inbound event discriminated union (`app.py:14598`)
+`POST /v1/sessions/{conv}/events` body is the harness union
+(`runtime/harnesses/_scaffold.InboundEventRequest`):
+- `message` (or absent type) → turn path: FIFO ingest gate → content resolution → turn-vs-buffer
+  decision. `stream=true` ⇒ `StreamingResponse` (body IS the SSE stream); `stream=false` ⇒ 202 +
+  events flow via `GET …/stream`.
+- `interrupt` / `tool_result` / `approval` → forwarded **verbatim** to the harness as control events.
+
+---
+
+## 5. Trace evidence (live, `conv_63542a5f92e24956812e19b104eac0e9`)
+
+Trace `cfb59197f6f9…` (events/turn, 3 services) shows the full lifecycle as a single connected
+trace (filtered, db/connect spans removed):
+
+```
+omni-server POST /v1/sessions/{session_id}/events
+  omni-server policy.evaluate                                  # REQUEST phase
+  omni-server POST  ── (WS tunnel) ──>
+    omni-runner POST /v1/sessions/{conversation_id}/events     # forwarded user event
+      omni-runner GET ──> omni-server GET /v1/sessions/{id}/items        # load transcript
+      omni-runner GET ──> omni-server GET /v1/sessions/{id}/agent/contents# load spec bundle
+      omni-runner POST ──> omni-harness POST /v1/.../events     # executor over UDS (SSE)
+      omni-runner POST ──> omni-server POST /v1/.../policies/evaluate     # runner ASK escalation
+        omni-server policy.evaluate
+      omni-runner POST ──> omni-server POST /v1/.../mcp          # ProxyMcpManager tools/call
+        omni-server policy.evaluate                              # TOOL_CALL
+        omni-server POST ──> omni-runner POST /v1/.../mcp/execute # server delegates execution
+        omni-server policy.evaluate                              # TOOL_RESULT
+      omni-runner POST ──> omni-harness POST /v1/.../events      # tool result back to harness
+```
+
+**Cross-service edges (from the conv summary):**
+- `omni-server → omni-runner [POST /v1/sessions]` ×3 — turn create/dispatch over tunnel.
+- `omni-server → omni-runner [POST /v1/sessions/{id}/mcp/execute]` — server delegates tool execution.
+- `omni-server → omni-runner [GET /v1/sessions/{id}]`, `[GET …/resources/terminals]` — resource APIs over tunnel.
+- `omni-runner → omni-server [GET /v1/sessions/{id}/items]` ×4, `[GET …/agent/contents]` ×4 — transcript + spec load.
+- `omni-runner → omni-server [POST /v1/sessions/{id}/policies/evaluate]` ×2 — runner ASK escalation.
+- `omni-runner → omni-server [POST /v1/sessions/{id}/mcp]` — ProxyMcpManager.
+- `omni-runner → omni-harness [POST /v1/sessions/{conversation_id}/events]` ×4 — executor over UDS.
+- `omni-runner → omni-server [PATCH /v1/sessions/{id}]`, `[GET /api/version]`.
+
+**Tunnel itself:** the `omni-server HTTP /v1/runners/{runner_id}/tunnel websocket
+send/receive` spans (123 receive / 36 send in this conv) are the WS frames; `omni-runner GET
+/v1/sessions/{session_id}/stream http send` (67) is the runner streaming SSE chunks back.
+
+**Propagation:** the runner spans nest under the server spans in ONE trace, confirming
+`telemetry.instrument_httpx_client(client)` on the cached `WSTunnelTransport` client
+(`routing.py:264`) injects `traceparent`, FastAPI on the runner app extracts it
+(`telemetry.instrument_fastapi_app`), and the verbatim header forwarding (`transport.py:149`)
+carries it across. Without that instance-level instrumentation the global `HTTPXClientInstrumentor`
+would miss the custom transport and the runner would root a disconnected trace
+(OBSERVABILITY.md §12 "custom-transport client gap — resolved").
+
+---
+
+## 6. Channel auth & trace-context crossing
+
+### 6.1 Runner↔server tunnel handshake (`runner_tunnel.py:277`, `serve.py:494`)
+On the runner side (`_serve_tunnel_once`, `serve.py:494`) the WS upgrade carries:
+- `Origin: omnigent://internal` (first-party sentinel → passes server CSWSH/origin guard),
+- `Authorization: Bearer <token>` + `X-Databricks-Org-Id` (from `databricks_request_headers`),
+- `X-Omnigent-Runner-Tunnel-Token` binding token (`RUNNER_TUNNEL_TOKEN_HEADER`).
+
+Server side (`tunnel`, `runner_tunnel.py:277`): (1) validate tunnel token / derive expected
+runner_id (`_expected_runner_id_from_headers`); reject mismatch with close `4004` **before
+accept**; (2) resolve owner (`_resolve_tunnel_owner`) — **fail-closed** for an unauthenticated
+non-loopback peer (would otherwise register `owner=None` and bypass owner-scoped guards);
+(3) `accept()`; (4) receive hello, **strict-major** `frame_protocol_version` check (close `4002`
+on skew); (5) `registry.register(owner=…)`.
+
+### 6.2 The Bearer-once-at-open refresh model (KNOWN GAP, partially mitigated)
+**The Bearer is set once, in the WS upgrade headers** (`serve.py:540`). The long-lived WS then
+carries every server→runner `request` frame with **no per-message re-auth** — there is no place
+to re-inject a header on an already-open socket. Mitigation: `serve_tunnel` re-mints the token on
+**every reconnect** via `auth_token_factory` (`serve.py:284` `_refresh_auth_token`) and, on a
+handshake **HTTP 401**, refreshes once and retries (`serve.py:326`, `_handle_refreshable_auth_failure`).
+Routine ingress recycles (close 1001/1012, HTTP 502) reset backoff and reconnect promptly
+(`serve.py:343-353`) — which *also* re-mints. So in practice a token expiry surfaces only if the
+socket stays open *past* expiry with no recycle; the next reconnect heals it. **This is the
+runner↔server analog of the "no per-message refresh" item in CUJ-ANALYSIS §6/§2.G.**
+
+The **runner→server** direction has no such gap: `_RunnerDatabricksAuth.auth_flow`
+(`_entry.py:192`) mints a fresh token **per request** and retries once on 401 or Apps
+`302→/oidc/` (`_is_login_redirect_or_unauthorized`, `:241`). One SDK `Config` is cached for the
+factory's life so the OAuth token comes from the SDK's in-memory cache (no CLI shellout per
+request) — `_entry.py:312-360`.
+
+### 6.3 Trace context
+- **server→runner:** `instrument_httpx_client` on the per-runner cached client (`routing.py:264`)
+  injects `traceparent`; tunnel forwards headers verbatim (`transport.py:149`); runner FastAPI
+  extracts. Continuous trace (verified §5).
+- **runner→server callbacks:** covered by the process-wide `HTTPXClientInstrumentor`
+  (`telemetry._instrument_httpx`) — standard transport, no special handling.
+- **runner→executor (UDS):** standard httpx over UDS → process-wide instrumentor injects;
+  harness FastAPI extracts. Verified: `omni-harness` spans nest under `omni-runner` in the trace.
+- **Runner-app FastAPI instrumentation (the OBSERVABILITY §12 open item) is CONFIRMED:**
+  `create_runner_app` calls `telemetry.instrument_fastapi_app(app)` right after building the app
+  (`app.py:7775-7782`) — "so HTTP requests tunneled in from the server (whose headers are
+  forwarded verbatim) continue the caller's trace instead of starting a new one." The runner's
+  auth middleware exempts tunnel-originated requests (`scope client[0] == "tunnel"`) and `/health`.
+- **Seed:** root trace-id derivable from `response_id` via `trace_id_from_response_id`
+  (`telemetry.py:498`); `session.id=conv_…` tags every span as the cross-trace grouping key.
+
+---
+
+## 7. MCP routing (custom MCP vs `sys_*`) — runner's role
+
+There are **two MCP managers with the same interface**, selected by deployment mode:
+
+| Manager | When | Who enforces policy | Who holds MCP connections |
+|---|---|---|---|
+| `ProxyMcpManager` (`proxy_mcp_manager.py:42`) | **Deployed** (runner + server) | **Server** (`/mcp` → `_evaluate_tool_call_policy`) | **Server** `ServerMcpPool` + delegates exec to runner |
+| `RunnerMcpManager` (`mcp_manager.py:150`) | **No-server / test** | **Runner** (`RunnerToolPolicyGate`) | **Runner** (direct stdio/HTTP, 8-entry LRU) |
+
+### 7.1 The deployed loop (what the trace shows)
+1. Harness emits a tool call. Runner's `ProxyMcpManager.call_tool` POSTs `tools/call` to
+   server `/v1/sessions/{id}/mcp` (`proxy_mcp_manager.py:220`).
+2. Server runs **TOOL_CALL** policy, then calls **back into the runner** via
+   `POST /v1/sessions/{id}/mcp/execute` (`app.py:17829`). *The server owns policy + routing; the
+   runner owns execution* (so tools run on the right machine with the right cwd/env).
+3. **The routing key inside `/mcp/execute` is the `__` separator** (`app.py:17954`):
+   - `"__" in tool_name` → **custom MCP** → `RunnerMcpManager` (live stdio/HTTP subprocess);
+     the namespaced `{server}__{tool}` is validated against the server prefix, then stripped.
+   - **no `__`** → **runner-local builtin** (`sys_os_*`, `sys_terminal_*`) → `execute_tool`
+     (`tool_dispatch.py`) with the session's terminal registry / inbox / sandbox workspace.
+4. Server runs **TOOL_RESULT** policy on the returned output, then returns the (possibly
+   transformed/denied) result to the runner, which feeds it to the harness.
+
+**Two ASK-escalation paths exist** (don't conflate):
+- *Function-policy ASK in no-server `RunnerMcpManager` mode* — `RunnerToolPolicyGate` returns an
+  ASK verdict (`policy.py:159`); `tool_dispatch.execute_tool` escalates by POSTing
+  `evaluate_policy=True` to the server and awaiting via `pending_approvals` (`policy.py` module
+  docstring).
+- *Harness-driven ASK in deployed mode* — the harness emits a `policy_evaluation.requested` SSE
+  event inside `proxy_stream`; the runner calls `_evaluate_policy_via_omnigent` (`app.py:6248`)
+  which POSTs `/v1/sessions/{id}/policies/evaluate` and delivers the verdict back to the harness
+  as a `policy_verdict` inbound event. **This is the path the live trace shows** (the
+  `omni-runner → omni-server POST …/policies/evaluate` edges, each wrapping a server `policy.evaluate` span).
+
+### 7.2 ASK / elicitation across the proxy (MRTR)
+If the server's policy returns ASK, `/mcp` returns an `input_required` (MCP Multi-Round-Trip
+Requests) result. `ProxyMcpManager.call_tool` parks on `pending_approvals.wait_for_user_approval`
+(`proxy_mcp_manager.py:281`), then retries `tools/call` once with `inputResponses` +
+`requestState` (`:287`). For a **custom MCP server** that itself elicits, the runner surfaces
+`McpElicitationRequired` back through `/mcp/execute` (`app.py:18017`) so the server owns the
+elicitation channel; the runner replays with `call_tool_with_elicitation` on retry (`:18004`).
+
+### 7.3 `RunnerMcpManager` internals (direct / no-server mode)
+- 8-entry **LRU pool** keyed by spec hash (`compute_spec_hash` over MCP server configs + stdio
+  cwd, `mcp_manager.py:74`); lazy connect (`prewarm` / on-demand in `schemas_for`).
+- Tool names **namespaced** `{server}__{bare}` (`_mcp_tool_schema`, `:98`); per-server allowlist
+  (`spec.tools`) honoured against the bare name.
+- `_resolve_tool_route` (`:387`) strips the server prefix and validates the bare tool exists on
+  that server before dispatch.
+- Inline custom-MCP `elicitation/create` → web card via `_build_elicitation_callback` (`:182`):
+  POSTs `mcp_elicitation` to the server and parks on `pending_approvals`. Falls back to *decline*
+  when no server client is available.
+
+### 7.4 Native-harness MCP (in-turn relay vs out-of-turn serve-mcp)
+- **`sys_*` (Omnigent) tools — in-turn relay:** the native vendor CLI calls `mcp__omnigent__*`
+  tools, relayed by `ProxyMcpManager` → server `/mcp` (policy-checked centrally). Therefore the
+  native **PreToolUse policy hook explicitly SKIPS `mcp__omnigent__*`** to avoid double-evaluation
+  (`native_policy_hook.py:209,244`) — they're already gated by the relay path.
+- **Connector/custom MCP (`mcp__github__*`) — still hook-gated:** these go through the native
+  PreToolUse hook (`hook_payload_to_evaluation_request`, `:198`) → server `/policies/evaluate`.
+- **Out-of-turn workspace tools — `serve-mcp`:** the native harness launches a separate
+  `serve-mcp` MCP server the vendor discovers via its own settings.json; only the `sys_os_*`
+  surface is registered there (workspace cwd, no sandbox) — per CUJ-ANALYSIS §2.C
+  (`claude_native_bridge.py`, owned by the harness/native SME).
+
+---
+
+## 8. Per-harness differences (runner's view)
+
+The runner is largely **harness-agnostic** at the tunnel/dispatch layer — `client_for_conversation`
+only cares about the canonical harness string vs the runner's advertised `hello.harnesses`. The
+differences surface in `app.py`:
+
+- **claude-sdk / codex (SDK):** runner spawns an in-process executor subprocess; tool calls flow
+  `harness → runner → ProxyMcpManager → server /mcp → /mcp/execute → runner`. Reasoning/transcript
+  100% Omnigent. The trace corpus (`conv_63542a5f…`) is exactly this path.
+- **claude-native / codex-native:** runner spawns the vendor CLI in a tmux pane; `sys_*` via
+  in-turn relay (hook skips them), connector MCP via the PreToolUse hook → `/policies/evaluate`;
+  `external_*` mirror events forwarded over the runner→server client. `_is_native_harness(conv)`
+  gates several branches (e.g. `note_session_turn_started`, `app.py:14682`).
+- **Polly / custom agents:** run on a chosen harness (typically claude-sdk) → identical runner
+  path to that harness; the runner sees only the resolved spec + harness string.
+- **codex / codex-native:** no live trace (AI-gateway creds expired); covered structurally — same
+  dispatch/affinity/MCP-routing machinery (harness-agnostic), differing only in the spawned executor.
+
+---
+
+## 9. Failure branches & gaps
+
+| Branch | Where | Behavior |
+|---|---|---|
+| Conversation not bound to a runner | `routing.py:112` | `OmnigentError(CONFLICT)` — "resume the session to bind a registered runner" |
+| Bound runner offline | `routing.py:231` (+ `:139`, `:175`) | `RUNNER_UNAVAILABLE` |
+| Runner lacks the harness | `routing.py:236` | `RUNNER_CAPABILITY_MISMATCH` |
+| **Hard affinity, no failover** | `routing.py:89` (read-only; never picks/persists) | A bound runner going offline strands the session (CUJ-ANALYSIS §6) |
+| Runner offline at request time | `transport.py:125` | `httpx.ConnectError` (identical handling to TCP connect refused) |
+| Tunnel closes mid-request | `registry.deregister` `:299` → `_abort_session_inflight` | in-flight `head_future`/body aborted with `ConnectionError` (no hang) |
+| Newer tunnel for same runner_id | `registry.register` `:280` "newest wins" | old session's in-flight aborted, old writer retired (close 4000) |
+| Handshake: unauth non-loopback | `runner_tunnel.py:366` | close `4004` (fail-closed; no owner-less register) |
+| Frame proto skew | `runner_tunnel.py:385` | close `4002` |
+| WS auth redirect (Apps OAuth) | `serve.py:309` | fatal `RuntimeError` (retry can't help; tells user to `omnigent setup`) |
+| Tunnel Bearer expiry, socket stays open | `serve.py:540` (once-at-open) | **no per-message refresh**; healed on next reconnect/recycle (§6.2) |
+| Runner subprocess crash before bind | `process_manager._await_ready` | kills subprocess, raises `RuntimeError` |
+| ASGI app crashes before head | `serve.py:207` | synthesizes 500 + `response.end` so server awaiter doesn't hang |
+| MCP manager not configured | `app.py:17879,17957` | 503 `Runner MCP manager not configured` |
+| No spec for session | `app.py:17899,17977` | `-32000` "No spec available" |
+| Native sub-agent completions | (server-side gate `app.py:12496`, native excluded) | **🔴 silently never reach orchestrator** (CUJ-ANALYSIS §6 #848) — gate is server-side but the symptom hits native runs |
+
+### Dedup (runner side)
+The runner DOES dedup, but at three specific seams (not a global response-id cache):
+1. **Inbound message ordering** — a **per-conversation FIFO ingest gate**
+   (`_ingest_next_seq` / `_ingest_now_serving` / `_ingest_cond`, `app.py:14692`,
+   RUNNER_MESSAGE_INGEST.md Part A): each arrival takes a slot synchronously (before any await),
+   then waits its turn so content-resolution latency can't reorder messages. The
+   **single-active-turn invariant I2** (`_active_turns`, `app.py:14711`) buffers/steers mid-turn
+   messages.
+2. **History-load dedup** — when rebuilding the turn's input history the runner drops the
+   just-arrived item by `persisted_item_id` (`_load_history_as_input(drop_item_id=…)`,
+   `app.py:14842`) so the new message isn't counted twice (once from the store, once as the new
+   input).
+3. **Mid-turn injection exactly-once** — `injection.consumed` markers (`app.py:14251`,
+   RUNNER_MESSAGE_INGEST.md Part B): once the harness consumes a mid-turn injection into the live
+   turn, the buffered copy is dropped so it doesn't also drive a continuation turn. The native
+   transcript reader keeps an **in-memory seen-set** (the durable cursor was retired,
+   `app.py:4300`) and the native log accumulator uses **generation-id dedup** to make re-reading
+   idempotent (`app.py:2112`, `8236` "watcher already dedupes to edges").
+
+What the runner does **not** do: dedup *forwarded outbound* events by item-id. Durable dedup is
+the **client's** job (by `ctx.itemId`) and durable persistence is the **server's**
+(`conversation_store.append`); code comments flag "there is no server-side dedup"
+(`app.py:5844`) and a post-recovery double-persist risk (`app.py:321`). So the FIFO-desync bug
+class (CUJ-ANALYSIS §6) lives at the ingest gate + the cross-layer itemId contract.
+
+---
+
+## 10. Open questions
+- Does any deployed path still write the **one-shot `OMNIGENT_POLICY_AUTH`** snapshot for an
+  in-scope native harness (claude-native)? Confirmed it survives for the **opencode** plugin path
+  (`app.py:1141`, degrades fail-**open**), while cursor/hermes use the refreshable
+  `policy_hook_reauth` path. Needs the harness/native SME to confirm claude-native's exact wiring
+  (PR #1439 claim). → cross-ref policy/auth SME.
+- Exact semantics of `replace_runner_id` (`sqlalchemy_store.py:1951`) on **resume/fork** — who
+  calls it and whether it ever enables a soft "re-bind to a fresh runner" that would relax the
+  no-failover stance. (Resume re-binds via `PATCH /v1/sessions/{id}` per `routing.py` docstrings.)
+- Whether `on_reconnect=catch_up_scan` (`_entry.py:958`) can double-deliver after a recycle
+  (the "post-recovery persisted twice" comment, `app.py:321`).

--- a/designs/master-arch/architecture/runner.md
+++ b/designs/master-arch/architecture/runner.md
@@ -91,9 +91,9 @@ sequenceDiagram
     participant M as Custom MCP / sys_* tool
 
     C->>S: POST /v1/sessions/{id}/events (message)
-    Note over S: persist-before-forward; policy.evaluate (REQUEST)
+    Note over S: persist-before-forward — policy.evaluate (REQUEST)
     S->>R: POST /v1/sessions/{id}/events  (httpx over WS tunnel, stream=true)
-    Note over R: FIFO ingest gate (_ingest_now_serving); single-active-turn (I2)
+    Note over R: FIFO ingest gate (_ingest_now_serving) — single-active-turn (I2)
     R->>S: GET /v1/sessions/{id}/items     (load transcript)
     R->>S: GET /v1/sessions/{id}/agent/contents  (load agent spec bundle)
     R->>H: POST /v1/sessions/{id}/events   (executor, UDS) — SSE turn events
@@ -118,19 +118,19 @@ Every edge in this diagram is **observed in the live trace** (see §5).
 
 ```mermaid
 flowchart TD
-    A[runner _entry: serve_tunnel] -->|WS connect /v1/runners/{id}/tunnel<br/>Origin=omnigent://internal<br/>Bearer + X-Databricks-Org-Id + tunnel_token| B[server runner_tunnel.tunnel]
-    B -->|token gate + owner resolve<br/>fail-closed if unauth non-loopback| C{accept?}
-    C -->|no| X[ws.close 4004 / 4001 / 4002]
-    C -->|yes| D[recv hello frame: harnesses[], frame_proto_version]
-    D -->|strict-major check| E[registry.register newest-wins]
-    E --> F[runner online in TunnelRegistry]
-    G[server dispatch: RunnerRouter.client_for_conversation] --> H{conv.runner_id set?}
-    H -->|no| I[CONFLICT 'not bound']
-    H -->|yes| J{registry.get online?}
-    J -->|no| K[RUNNER_UNAVAILABLE]
-    J -->|yes| L{hello.harnesses ∋ harness?}
-    L -->|no| M[RUNNER_CAPABILITY_MISMATCH]
-    L -->|yes| N[RoutedRunner: cached WSTunnelTransport client]
+    A["runner _entry: serve_tunnel"] -->|"WS connect /v1/runners/{id}/tunnel<br/>Origin=omnigent://internal<br/>Bearer + X-Databricks-Org-Id + tunnel_token"| B["server runner_tunnel.tunnel"]
+    B -->|"token gate + owner resolve<br/>fail-closed if unauth non-loopback"| C{"accept?"}
+    C -->|no| X["ws.close 4004 / 4001 / 4002"]
+    C -->|yes| D["recv hello frame: harnesses[], frame_proto_version"]
+    D -->|"strict-major check"| E["registry.register newest-wins"]
+    E --> F["runner online in TunnelRegistry"]
+    G["server dispatch: RunnerRouter.client_for_conversation"] --> H{"conv.runner_id set?"}
+    H -->|no| I["CONFLICT 'not bound'"]
+    H -->|yes| J{"registry.get online?"}
+    J -->|no| K["RUNNER_UNAVAILABLE"]
+    J -->|yes| L{"hello.harnesses ∋ harness?"}
+    L -->|no| M["RUNNER_CAPABILITY_MISMATCH"]
+    L -->|yes| N["RoutedRunner: cached WSTunnelTransport client"]
 ```
 
 ---

--- a/designs/master-arch/architecture/runtime-executor.md
+++ b/designs/master-arch/architecture/runtime-executor.md
@@ -141,7 +141,7 @@ sequenceDiagram
     E-->>H: TextChunk / ReasoningChunk
     H-->>R: SSE response.output_text.delta / reasoning deltas
     E-->>H: ToolCallRequest (MCP/spec tool)
-    H->>H: start_tool_span (TOOL); emit observed function_call (inline)
+    H->>H: start_tool_span (TOOL) — emit observed function_call (inline)
     H-->>R: SSE response.output_item.done {function_call, status:action_required}
     R->>S: POST /v1/sessions/{id}/mcp/execute (run sys_* / spec tool)
     S-->>R: tool result  (+ policy.evaluate span on server)
@@ -153,7 +153,7 @@ sequenceDiagram
     H->>H: end_agent_span (records usage)
   end
   H-->>R: SSE response.completed
-  R->>S: persist final assistant item; relay SSE
+  R->>S: persist final assistant item — relay SSE
   S-->>C: SSE deltas + final item (deduped by ctx.itemId)
 ```
 

--- a/designs/master-arch/architecture/runtime-executor.md
+++ b/designs/master-arch/architecture/runtime-executor.md
@@ -1,0 +1,607 @@
+# Runtime — Executor turn loop & agent machinery
+
+**Scope:** `omnigent/runtime/` (workflow.py, compaction.py, pending_inputs.py,
+pending_elicitations.py, agent_cache.py, harnesses/_runner.py,
+harnesses/_executor_adapter.py, harnesses/_scaffold.py) + `omnigent/inner/`
+(executor.py event model, tools.py AgentTool/SelfAgentTool, tracing.py) +
+`omnigent/tools/builtins/` (spawn.py, async_inbox.py).
+Source-of-truth = code; every claim carries a `file:line` anchor. Trace
+evidence from the local Jaeger rig.
+
+---
+
+## 1. Overview
+
+An **Executor** is the per-vendor adapter that translates Omnigent's abstract
+turn model (a list of `Message`s + `ToolSpec`s + a system prompt → a stream of
+`ExecutorEvent`s) onto a concrete LLM/agent SDK (`inner/executor.py:518`,
+`Executor.run_turn`). It is the *narrow waist* between the framework and any
+backend: claude-sdk, codex, pi, openai-agents-sdk, antigravity, etc. each
+subclass `Executor` and emit the same event vocabulary.
+
+The **turn loop** is split across three processes, stitched by the OTel
+`session.id` grouping key:
+
+- **omni-server** — owns conversation history (source of truth); receives the
+  client `POST /events`, persists, and forwards to the runner over a WS tunnel.
+- **omni-runner** — `runner/app.py` orchestrates the turn: resolves
+  config/agent/auth, forwards the request to the per-conversation **harness
+  subprocess**, consumes the harness SSE event stream, dispatches
+  `action_required` tools back through the omni MCP, persists items, and relays
+  SSE up to the server. Hosts the agent cache.
+- **omni-harness** — a per-conversation FastAPI subprocess
+  (`harnesses/_runner.py`) hosting one `ExecutorAdapter` (`HarnessApp`) wrapping
+  one inner `Executor`. This is where `executor.run_turn()` actually runs and
+  the AGENT/TOOL trace spans originate.
+
+```
+client ──POST /v1/sessions/{id}/events──▶ omni-server ──(WS tunnel)──▶ omni-runner
+                                                                          │
+                                              POST /v1/sessions/{id}/events│ (httpx over UDS)
+                                                                          ▼
+                                                                     omni-harness
+                                                                 ExecutorAdapter.run_turn
+                                                                   └─ executor.run_turn() ──▶ vendor SDK
+```
+
+> **Naming note:** `runtime/workflow.py` is **not** the LLM loop. Despite its
+> module docstring ("the core agent loop"), ~lines 145–2050 are
+> per-harness **spawn-env builders** (provider/credential resolution → the
+> `HARNESS_*` env a harness subprocess reads) and ~2143–2540 are
+> **async-tool handles + compaction integration + history loading**. The line
+> `# ── The agent loop ──` at `workflow.py:2543` precedes only helper
+> functions; the actual event-consuming loop lives in `runner/app.py` (server-
+> dispatched tools / persist / forward) and in
+> `harnesses/_executor_adapter.py` (event translation inside the subprocess).
+> The `_HEARTBEAT_INTERVAL_S` / steering-poll / `async_work_complete` constants
+> the module *comments* (`workflow.py:94-118`, values stripped) actually live in
+> the **scaffold** (`_scaffold.py:83`) and the **builtins** (`async_inbox.py`).
+
+### 2.0 The runner-side orchestration (`runner/app.py`)
+
+The runner is the middle process that turns a forwarded user message into a
+driven harness turn (precise anchors from the runner-orchestration deep dive):
+
+- **Entrypoint:** `runner/app.py:14598` `post_session_events(conversation_id,
+  request, stream=…)` — dispatches by body discriminator (`message` → turn;
+  `interrupt`/`tool_result`/`approval` forwarded verbatim, `:14666`). A turn
+  launches `_run_turn_bg` (`:14903`); `stream=true` returns the SSE body via
+  `_stream_message_to_harness` (`:13866`).
+- **Forward to harness over UDS:** `process_manager.get_client(conv_id)`
+  (`:14779`) → an `httpx.AsyncClient` bound to the Unix socket
+  (`process_manager.py:390-401`, `AsyncHTTPTransport(uds=…)`, cosmetic base_url
+  `http://harness.local`). The turn stream opens in `proxy_stream`
+  (`app.py:14115`) via `client.stream("POST", "/v1/sessions/{conv_id}/events",
+  …, timeout=None)` (`:14150`).
+- **SSE consumption:** `proxy_stream` iterates `aiter_text()` (`:14199`), splits
+  `\n\n` frames, JSON-parses each `data:` line, switches on `event["type"]`
+  (captures `response.created`→`mark_in_flight`, builds in-memory history from
+  deltas/tool calls/results), re-publishes each frame to the session stream
+  (`_publish_event`) and yields raw bytes (`:14536-14552`).
+- **Tool dispatch (action_required):** intercepted in `proxy_stream` at
+  `:14352` (`is_action_required`); routed through a `ProxyMcpManager` which
+  enforces TOOL_CALL/TOOL_RESULT policy **server-side first**, then the runner's
+  `mcp_execute` (`POST /v1/sessions/{id}/mcp/execute`, `app.py:17829`) runs the
+  tool. The result is **POSTed back** to the harness as a `tool_result` event
+  (`tool_dispatch.py:4346`: `harness_client.post(".../events",
+  json={"type":"tool_result","call_id":…,"output":…})`) — i.e. the harness's
+  parked Future (`_scaffold.py:477`) resolves and it emits the paired
+  `function_call_output`. (So at the harness ABC it's a parked Future; on the
+  wire from the runner it's a **POST**, not an HTTP PATCH.)
+
+---
+
+## 2. Key files (file:line)
+
+| File | Role |
+|---|---|
+| `inner/executor.py:70` | `ExecutorConfig` (model / temperature / max_tokens / `extra`) — per-turn config. |
+| `inner/executor.py:96-261` | **Event hierarchy**: `ExecutorEvent` base → `TextChunk`, `ReasoningChunk`, `ToolCallRequest`, `TurnComplete`, `ToolCallComplete`, `CompactionComplete`, `TurnCancelled`, `ExecutorError`. The abstract vocabulary every vendor maps onto. |
+| `inner/executor.py:518-596` | `Executor` ABC: `run_turn` + capability predicates (`supports_streaming`, `handles_tools_internally`, `interrupt_session`, `enqueue_session_message`, `supports_live_message_queue`, `max_context_tokens`, `close_session`). Base defaults are all ❌ except `supports_tool_calling`. |
+| `inner/executor.py:292-338` | `iterate_blocking_stream` — bridges a *blocking* provider iterator (OpenAI/Anthropic sync streams) onto async via a worker thread + queue, so `run_turn` never blocks the event loop. |
+| `inner/executor.py:357-390` | `split_transient_tail` — separates framework-injected transient messages (e.g. the unread-inbox notice, `metadata.framework=true`) from durable history so cursor-advancing executors don't skip them. |
+| `harnesses/_runner.py:115-168` | `_load_harness_app` — `python -m …_runner --harness X --module M --socket S --conversation-id C [--parent-pid P]`: imports the harness module, calls `create_app()`, stashes `conversation_id`/`harness` on `app.state`, binds UDS (POSIX) / TCP-loopback (Windows). |
+| `harnesses/_runner.py:220-274` | Parent-watchdog + `prctl(PR_SET_PDEATHSIG)` + hard-exit backstop — orphaned-runner reaping. |
+| `harnesses/_runner.py:357-365` | `telemetry.init("omni-harness")` — why harness spans show `service.name=omni-harness`. |
+| `harnesses/_scaffold.py:353-714` | `TurnContext` — the per-turn handle: `emit()` (SSE out), `dispatch_tool()` (action_required round-trip), `elicit()`, `next_injection()` (steering), `cancelled` event. |
+| `harnesses/_scaffold.py:716+` | `HarnessApp` — base class: lifespan, SSE streaming of emitted events, `/v1/sessions/{id}/events` route, interrupt/PATCH/elicitation handlers. Subclass implements just `run_turn(request, ctx)`. |
+| `harnesses/_executor_adapter.py:141` | `ExecutorAdapter(HarnessApp)` — **the universal adapter** the four SDK wraps share; only the inner `Executor` differs. |
+| `harnesses/_executor_adapter.py:239-497` | `ExecutorAdapter.run_turn` — the event-translation loop (translate input → call `executor.run_turn()` → translate each `ExecutorEvent` → emit SSE; create AGENT/TOOL spans; cancellation; injection watcher). |
+| `inner/tracing.py:104-317` | `TracingContext` — `start_agent_span` (AGENT) / `start_llm_span` (LLM) / `start_tool_span` (TOOL); OpenInference `openinference.span.kind` attrs. |
+| `inner/tools.py:266-316` | `AgentTool` / `SelfAgentTool` (+ `HandoffTool`) dataclasses: `pass_history`, `pass_histories`, `max_sessions`, `os_env: inherit`. |
+| `tools/builtins/spawn.py:56` | `SysSessionSendTool` — the LLM-facing subagent dispatch (`sys_session_send`). `sys_session_create/list/get_info/get_history/share`. |
+| `tools/builtins/async_inbox.py` | `sys_call_async` / `sys_read_inbox` / `sys_cancel_async` / `sys_cancel_task`. |
+| `runtime/compaction.py:544-720` | `compact()` — the 3-layer compactor (L1 clear tool results → L2 LLM summary → L3 truncate). |
+| `runtime/agent_cache.py:16` | `AgentCache` — two-tier (in-mem spec + on-disk extract), no TTL. |
+| `runtime/pending_inputs.py` | optimistic native web-message bubbles (FIFO drain). |
+| `runtime/pending_elicitations.py` | sidebar index of outstanding elicitations. |
+
+---
+
+## 3. Data flow — one SDK turn (claude-sdk)
+
+```mermaid
+sequenceDiagram
+  participant C as client
+  participant S as omni-server
+  participant R as omni-runner (app.py)
+  participant H as omni-harness (ExecutorAdapter)
+  participant E as inner Executor (vendor SDK)
+
+  C->>S: POST /v1/sessions/{id}/events (user msg)
+  S->>S: conversation_store.append (persist-before-forward)
+  S-->>C: SSE session.input.consumed (carries item id → dedup)
+  S->>R: forward over WS tunnel (verbatim headers → trace continuity)
+  R->>R: resolve config/model/auth + agent-cache.load(spec) + build prompt
+  R->>H: POST /v1/sessions/{id}/events (httpx over UDS)
+  H->>H: ExecutorAdapter.run_turn: translate input→messages, build ExecutorConfig
+  H->>H: start_agent_span (AGENT, openinference.span.kind=AGENT)
+  H->>E: executor.run_turn(messages, tools, system_prompt, config)
+  loop ExecutorEvents
+    E-->>H: TextChunk / ReasoningChunk
+    H-->>R: SSE response.output_text.delta / reasoning deltas
+    E-->>H: ToolCallRequest (MCP/spec tool)
+    H->>H: start_tool_span (TOOL); emit observed function_call (inline)
+    H-->>R: SSE response.output_item.done {function_call, status:action_required}
+    R->>S: POST /v1/sessions/{id}/mcp/execute (run sys_* / spec tool)
+    S-->>R: tool result  (+ policy.evaluate span on server)
+    R->>H: PATCH function_call_output (call_id correlated)
+    H->>E: _stable_tool_executor returns result to the SDK
+    E-->>H: ToolCallComplete
+    H->>H: end_tool_span
+    E-->>H: TurnComplete(response, usage)
+    H->>H: end_agent_span (records usage)
+  end
+  H-->>R: SSE response.completed
+  R->>S: persist final assistant item; relay SSE
+  S-->>C: SSE deltas + final item (deduped by ctx.itemId)
+```
+
+### The adapter's event-translation contract (`_executor_adapter.py:239-497`)
+
+1. **Input translation** (`:258-285`): `request.input` → inner `Message` list;
+   every message stamped with `session_id = self._session_key` (`:271`) so the
+   inner executor caches its SDK client under the right key (the
+   mid-turn-steering-lost bug otherwise). `request.reasoning.effort` →
+   `extra["reasoning_effort"]`; `request.max_output_tokens` → `extra["max_tokens"]`;
+   `request.model_override` → `ExecutorConfig.model` (`:284`).
+2. **Stable bridges installed once** on the executor (`:300-315`): `_tool_executor`
+   (server tool round-trip), `_elicitation_handler` (permission prompts),
+   `_policy_evaluator` (LLM_REQUEST/RESPONSE phases). They read `_current_ctx`
+   at call time (rebound per turn at `:316`) — required because the SDK
+   closure-captures the bridge on turn 1.
+3. **Per-event translation** (`:394-459`): each yielded `ExecutorEvent` →
+   `_translate_event(event, ctx)` → typed SSE events. Span lifecycle:
+   `ToolCallRequest`→`start_tool_span`, `ToolCallComplete`→`end_tool_span`,
+   `TurnComplete`→`end_agent_span` (+ `record_llm_usage`),
+   `TurnCancelled`/`ExecutorError`→close span with cancellation/error.
+4. **`dispatch_tool` action_required round-trip** (`_scaffold.py:449-516`):
+   for spec/MCP tools the inner SDK can't run itself, the adapter emits a
+   `function_call` item with `status:"action_required"`, parks an
+   `asyncio.Future` keyed by `call_id`, and the runner PATCHes a
+   `function_call_output` carrying the same `call_id` to resolve it. The
+   correlated id lets the client dedupe the inline-observed render against the
+   action_required render (`_pending_mcp_call_ids` deque, `:223`).
+5. **Cancellation** (`:400-408`, `:498-522`): `ctx.cancelled` set → call
+   `executor.interrupt_session()`; the `_handle_interrupt_event` override
+   *also* drops the inner SDK client synchronously so the next turn rebuilds
+   fresh (otherwise a post-cancel stream-dump / off-by-one).
+6. **Mid-turn steering** (`_watch_injections`, `:524-600`): polls
+   `ctx.next_injection()` and forwards each to
+   `executor.enqueue_session_message()`; echoes `injection.consumed` so the
+   runner drops its buffered copy.
+
+---
+
+## 4. Channels & message/event types
+
+| Boundary | Channel | Carries |
+|---|---|---|
+| runner → harness | httpx `POST /v1/sessions/{id}/events` over **UDS** (POSIX) / TCP-loopback (Win) | `CreateResponseRequest` (input, tools, instructions, model_override, reasoning, max_output_tokens) |
+| harness → runner | SSE on that POST | `response.output_text.delta`, `response.reasoning_text.delta`/`.reasoning.started`/`.reasoning_summary`, `response.output_item.done` (function_call / function_call_output, status `action_required`→`completed`), `response.elicitation_request`/`_resolved`, `injection.consumed`, `response.compaction.in_progress`/`.completed`, `response.completed`/`.cancelled` |
+| runner → server | WS tunnel (httpx) | `POST /v1/sessions/{id}/mcp/execute` (tool dispatch), `POST /policies/evaluate`, `external_*` (native), conversation-item persist |
+| harness ABC events | `inner/executor.py` `ExecutorEvent` subtypes | the abstract vocabulary (TextChunk/ReasoningChunk/ToolCallRequest/ToolCallComplete/TurnComplete/CompactionComplete/TurnCancelled/ExecutorError) |
+
+`ExecutorConfig.extra` is the catch-all for per-vendor kwargs:
+`reasoning_effort`, `max_tokens`, `stepwise_internal_turns`, etc.
+
+---
+
+## 5. Trace evidence (concrete, from local Jaeger)
+
+**The executor turn loop = an `agent:<harness>` AGENT span on `omni-harness`,
+with tool calls nested under it.** From the saved corpus
+(`conv_63542a5f92e24956812e19b104eac0e9`, trace `f98feda729…`) and a freshly
+generated turn (`conv_3a411011…`, trace `f2e437fa9e…`):
+
+```
+omni-harness  agent:claude-sdk [AGENT]   (7855ms)
+  omni-harness  tool:sys_os_shell [TOOL]  (208ms)
+```
+
+Span attributes (content capture on):
+- `agent:claude-sdk` — `openinference.span.kind=AGENT`, `llm.model_name=claude-sdk`,
+  `session.id=conv_…`, `input.value` = the user prompt, `output.value` = the
+  final assistant text. (Created by `TracingContext.start_agent_span`,
+  `inner/tracing.py:130`, wrapping `executor.run_turn()`.)
+- `tool:sys_os_shell` — `openinference.span.kind=TOOL`, `tool.name=sys_os_shell`,
+  `input.value={"command":"echo …"}`, `output.value={"stdout":…,"exit_code":0,…}`.
+  (Created by `start_tool_span`, ended on `ToolCallComplete`.)
+
+**Finding — no `llm_call [LLM]` span for the SDK adapter path.** The
+`tracing.py` module docstring (`inner/tracing.py:26-33`) shows an *aspirational*
+nesting `agent → llm_call → tool → sub-agent → policy:`, and `start_llm_span`
+exists (`:223`). But **only the `ExecutorAdapter` creates spans**
+(`start_agent_span`/`start_tool_span` are called *only* from
+`_executor_adapter.py`; no `inner/*_executor.py` calls them). The adapter
+wraps the whole `executor.run_turn()` in **one** AGENT span and the LLM
+round-trip is subsumed inside it — there is no per-LLM-call boundary the SDK
+surfaces. Verified live: **zero** spans with "llm" in the operation name in the
+Jaeger store. So the real nesting for claude-sdk is **agent → tool**; `policy:`
+guardrail spans appear instead as a separate **`policy.evaluate`** span on
+`omni-server` (the in-process policy engine), and the sub-agent AGENT span (the
+docstring's deeper level) only materializes when a child conversation runs its
+own turn (a separate omni-harness AGENT-rooted trace).
+
+**The plumbing trace** (one user action → many traces). The big trace rooted at
+`POST /v1/sessions/{id}/events` (e.g. `b513edf00b…`, 415 spans) spans
+`omni-server + omni-runner + omni-harness` and shows the cross-service edges:
+
+```
+omni-runner -> omni-harness  [POST /v1/sessions/{conversation_id}/events]   (the run-turn forward)
+omni-server -> omni-runner   [POST /v1/sessions/{session_id}/mcp/execute]   (tool dispatch)
+omni-runner -> omni-server   [POST /v1/sessions/{session_id}/mcp]           (tool result/relay)
+omni-server -> omni-runner   [POST /v1/sessions]                            (session/runner bind)
+omni-runner -> omni-server   [GET  /v1/sessions/{id}/agent/contents]        (agent-bundle fetch)
+omni-server -> omni-runner   [POST /v1/sessions/{id}/policies/evaluate]     (policy hook)
+```
+
+(The harness spans inside this trace are all httpx-client spans — the
+OpenInference AGENT/TOOL kinds live in the *separate* harness-rooted trace
+above, because the adapter seeds its own response-id-derived root via
+`trace_context_for_response`, `_executor_adapter.py:376`.) DB
+`PRAGMA`/`SELECT`/`INSERT`/`connect` spans dominate the histogram — noise.
+
+---
+
+## 6. Per-harness differences
+
+| Harness | Executor module | Notes (turn loop / events) |
+|---|---|---|
+| **claude-sdk** | `inner/claude_sdk_executor.py` | Uses `ExecutorAdapter`. MCP tools come back prefixed `mcp__omnigent__…` → `_strip_mcp_tool_prefix` (`_executor_adapter.py:112`). Compaction internal to the CLI → `CompactionComplete.compacted_messages=None`. `pass_history` serialized into context on first turn (`claude_sdk_executor.py:2600`). interrupt/queue/subagents/reasoning all ✅. |
+| **codex** (SDK) | `inner/codex_executor.py` | Uses `ExecutorAdapter`. Subagents implicit via subprocess `CODEX_HOME` isolation (not a declared capability). SDK elicitation returns base ❌ at the executor boundary (forwarder *may* handle it). Reasoning `{none,minimal,low,med,high,xhigh}`. Mid-session model is per-turn (resets at session). |
+| **polly / custom agents** | run on a chosen harness (typically claude-sdk) | **No row of their own** — inherit the host harness's behavior. A polly agent on claude-sdk reads exactly as claude-sdk. Custom-agent storage + subagent init in §9/§10 below. |
+| claude-native / codex-native | native bridges (out of `runtime/` scope) | Do **not** use `ExecutorAdapter`; the vendor CLI owns the loop and the transcript is mirrored. Subagents via `external_subagent_start` (claude-native) / subprocess isolation (codex-native). Covered by the native-harness SME. |
+
+> **codex/codex-native: no live trace (Databricks AI-gateway creds expired →
+> 403).** Behavior above is from code + the CUJ-ANALYSIS §4 matrix + structural
+> analogy to claude (codex also routes through `ExecutorAdapter`, so the
+> agent→tool span shape is identical).
+
+---
+
+## 7. Compaction / transcript reconstruction (`runtime/compaction.py`)
+
+Three layers, least- to most-lossy, applied by `compact()`
+(`compaction.py:544`). Budget = `context_window * trigger_threshold (0.8) -
+system_token_budget` (`:615`). Recent window default 5 LLM-response groups
+(`:48`, protected by `_find_recent_boundary`, `:160`).
+
+- **Layer 1 — surgical clear** (`:624-631`): replace `function_call_output`
+  bodies outside the recent window with
+  `"[Previous tool result cleared — re-call tool if needed]"`
+  (`_clear_tool_results`, `:197`); replace image/file `data` with
+  `"[binary content removed…use file_id to retrieve]"` (`_clear_binary_content`,
+  preserves `file_id`); strip `output_text.annotations` (`_strip_output_annotations`).
+  If L1 already fits and not `force`, return (`:630`).
+- **Layer 2 — LLM summary** (`:633-692`): summarise everything before the
+  boundary into a synthetic `[user request → assistant summary]` pair
+  (`summarize_history`, `:347`). **Routed through the runner's
+  `POST /v1/summarize` when a `runner_client` is available**
+  (`_summarize_via_runner_uncached`, `:428`) so it uses the *runner's*
+  credentials, not the server's. A 401/403 is flagged distinctly
+  (`_is_summary_auth_error`, `:761`; issue #1121) rather than buried as a
+  routine L3 fallback. Publishes `response.compaction.in_progress`/`.completed`
+  SSE so the REPL/web show a spinner (`:642-687`).
+- **Layer 3 — truncate** (`:696-720`): emergency drop of oldest messages,
+  pair-aware (never orphan a function_call/function_call_output, `:322`).
+
+**Triggering — two distinct paths (the common "runner auto-compacts on
+overflow" belief is only half right):**
+- **Proactive / threshold-based (the real auto-compaction)** — runs in the
+  **in-process agent loop** (`_call_llm_maybe_compact`, `workflow.py:2057`),
+  calling `compact(force=False)` when context crosses `trigger_threshold` (0.8):
+  `compaction.py:612-631` returns early `if not force and l1_tokens <= budget`.
+  The cached `_CompactionState.context_window` is learned from the first
+  overflow (`:122`). (The OpenAI-Agents SDK harness delegates to the SDK's own
+  `run_compaction`, `openai_agents_sdk_executor.py:1137`.)
+- **Reactive on harness-reported overflow — does NOT auto-compact.** When the
+  harness reports a context overflow, `proxy_stream` detects it
+  (`_is_context_overflow_error`, `runner/app.py:6736`) and raises
+  `_ContextWindowOverflow` (`:14243`), caught in `_run_turn_bg` at `:13804` —
+  which **ends the turn with a descriptive error** (`_on_proxy_stream_end(…,
+  error={"message":"Context window exceeded…"})`), it does **not** call
+  `compact()`. The SDK executor re-raises the overflow precisely so the runner
+  surfaces it (`openai_agents_sdk_executor.py:1673`). [⚠️ this is the
+  resume-overflow gap surface — OMNI-143: a single oversized turn that the
+  proactive threshold didn't catch surfaces as an error, not a recovery.]
+- **Explicit `/compact`** — `workflow.py:compact_conversation_now` (`:2347`)
+  runs `compact(force=True, fail_on_summary_error=True)` so a summary item is
+  always persisted (invoked from `server/routes/sessions.py:10026`).
+
+**Persistence + reconstruction:**
+- `_maybe_persist_compaction_item` (`workflow.py:2473`) appends a
+  `type=compaction` item (`CompactionData{summary,last_item_id,model,
+  token_count}`), idempotent by `response_id==task_id` (crash-replay safe), and
+  **refuses to persist a broken item** (empty summary / bogus `last_item_id`)
+  that would poison the cursor.
+- On the next turn / resume, `_load_initial_history` (`workflow.py:2276`) reads
+  the **latest compaction item** and loads only items **after**
+  `last_item_id` — bounding history to O(items since last compaction), not
+  O(whole conversation). The compaction item is expanded back into the prompt
+  via `compaction_to_history_items` (`compaction.py:463`), which prefers
+  `compacted_messages` (native/OpenAI opaque compaction tokens) and falls back
+  to the synthetic summary pair. A broken/invalid compaction item is ignored
+  and the full conversation reloaded (`workflow.py:2315`).
+- **Native external_compaction_status:** native harnesses post their own
+  `external_compaction_status`; `CompactionComplete.compacted_messages` carries
+  the post-compaction transcript the harness can replay (per
+  `inner/executor.py:213-234`).
+
+---
+
+## 8. Resume — how much transcript loads into the runner
+
+- **SDK harnesses (claude-sdk / codex / polly):** the runner loads conversation
+  history via `_load_initial_history` (`workflow.py:2276`) — **the full
+  conversation, or, when a compaction item exists, only the slice after the
+  last `last_item_id`** plus the expanded summary pair. That history is
+  translated to the prompt input and passed to `executor.run_turn(messages=…)`.
+  The vendor SDK is re-driven from this reconstructed history each turn (the
+  in-process SDK client is re-seeded; it does not persist its own store).
+- **Native harnesses:** rebuild the **vendor's own external session from stored
+  Omnigent items**, not via `_load_initial_history`. Resume keys on
+  `external_session_id` from the session snapshot (Pi `app.py:728-774`, Codex
+  `:841-887`, OpenCode `:973-998`); fork clones use
+  `FORK_CARRY_HISTORY_LABEL_KEY` (`app.py:743,759,880,986`). Cold resume
+  synthesizes the vendor's local session file from committed Omnigent items when
+  it's missing (Pi `app.py:1715-1729`; OpenCode injects the transcript as a
+  preamble, `:1205,1590`). So the vendor CLI reloads its own session and
+  Omnigent re-injects only when the vendor store is gone. (Detail owned by the
+  native SME; anchors here for completeness.)
+
+---
+
+## 9. Custom-agent storage & cache (`runtime/agent_cache.py`)
+
+Three tiers (per CUJ-ANALYSIS §2.F, verified against `agent_cache.py`):
+
+1. **ArtifactStore** — content-addressed `.tar.gz` bundle bytes (source of
+   truth), keyed e.g. `ag_abc123/<contenthash>`.
+2. **Agent DB row** — `id` / `name` / `bundle_location` / `version` /
+   `session_id` (session-scoped agents have non-null `session_id`; template/
+   operator agents null).
+3. **AgentCache** — two tiers (`agent_cache.py:16`):
+   - **Tier 1 (in-memory):** parsed `AgentSpec` keyed by `agent_id` (`_specs`).
+   - **Tier 2 (disk):** extracted bundle dir at `<cache_dir>/<agent_id>/`.
+   - **No TTL.** Population on miss: download bundle → temp file → `load_spec`
+     (extract + parse + validate) → store both tiers (`load`, `:51-100`;
+     `_extract_and_cache`, `:174`).
+   - **Evict on delete:** `evict()` (`:161`) drops the in-mem spec and `rmtree`s
+     the disk dir.
+   - **Warm-swap on update:** `replace()` (`:102`) extracts the new bundle to a
+     `<agent_id>_staging` dir, atomically reassigns `_specs[agent_id]`, then
+     `rmtree`s old + renames staging into place. Concurrent readers see either
+     the old or the new spec, never an empty cache. Version bumps on update.
+   - **Security:** `expand_env=False` by default — `${VAR}` is expanded against
+     the server env **only** for operator-authored template agents
+     (`session_id is None`); never for tenant/session-scoped agents (would leak
+     server secrets into a spec-controlled MCP/LLM connection) (`:66-80`).
+   - **Version-skew tolerance:** loads with `prune_invalid_sub_agents=True`
+     (`:94,146,204`) — an older server drops sub-agents it can't validate
+     (WARNING) and the parent still dispatches.
+
+---
+
+## 10. A custom agent's own subagents
+
+Two declaration forms, both translated into nested `AgentSpec`s in
+`spec.sub_agents` at parse time (`spec/omnigent.py:1090-1120`):
+
+- **`AgentTool`** (`inner/tools.py:266`) — references a registered agent **by
+  name** OR an **inline** spec. `_agent_tool_to_sub_spec` (`spec/omnigent.py:
+  1319`) synthesizes a child `AgentSpec`, inheriting parent profile / harness /
+  os_env (`inherit` sentinel resolved at translation time) / terminals, and
+  recurses into nested tools (sub-sub-agents). The parent's
+  `ToolsConfig.agents` carries the tool name so the LLM sees it as a callable.
+- **`SelfAgentTool`** (`inner/tools.py:298`, `tools.<name>: self` shorthand) —
+  `_self_agent_tool_to_sub_spec` deep-copies the **parent's** `AgentDef` and
+  re-runs translation: same model / prompt / tools / executor / os_env. The
+  clone has all `SelfAgentTool` entries **removed** (`spec/omnigent.py:1310`) so
+  recursion can't re-enter the self branch — the recursion guard. (`SelfAgentTool`
+  is also pruned from the clone, so `self` is one-level — child cannot itself
+  re-`self`.)
+
+**`prune_invalid_sub_agents`** (`spec/__init__.py:314`): depth-first, validates
+each sub-agent subtree; a failing child is removed from `sub_agents` and its
+name removed from the parent's `tools.agents` (so the dangling reference doesn't
+fail validation). Used on the **execution** load path (agent cache) so version
+skew degrades gracefully; authoring/upload validation stays strict elsewhere.
+
+> Note: `pass_history` / `pass_histories` / `max_sessions` are **lossy on the
+> omnigent-compat translation path** (`spec/omnigent.py:1338-1341`) — they fall
+> back to omnigent defaults. They are first-class on the inner `AgentDef` path
+> (`inner/loader.py:450-519`).
+
+---
+
+## 11. Subagent spawning & inbox mechanics
+
+### Spawning (LLM-driven, SDK harnesses)
+- The LLM calls **`sys_session_send`** (`tools/builtins/spawn.py:56`): mode A —
+  `(agent, title)` **creates** a child conversation and starts a turn; mode B —
+  `session_id` posts to an **existing** direct child. Either way it provides
+  `args.input`, which becomes the **child's first user message**
+  (`spawn.py:281`). Optional `model` / `harness` / `cost_budget` apply only when
+  the send *creates* the session.
+- The child conversation's `parent_session_id` points at the **immediate
+  parent** (not the root) (`_resolve_parent_conversation_id`, `spawn.py:407`);
+  nested sub-agents form a tree. The child **inherits the caller's runner**
+  (co-location). It runs **the same turn loop** (its own omni-harness
+  ExecutorAdapter), producing its own AGENT-rooted trace.
+- **Depth limit — GAP:** `_MAX_SUBAGENT_TREE_DEPTH = 3` (`repl/_repl.py:201`) is
+  **display-only**. Its sole use is `_refresh_subagent_tree(max_depth=…)`
+  (`_repl.py:6266-6296`), which caps how deep the REPL sidebar **renders** the
+  child tree ("mirrors web's MAX_TREE_DEPTH"). There is **no spawn-time depth
+  cap** anywhere — `SelfAgentTool` self-recursion is stopped by clone-pruning,
+  but ordinary `AgentTool` chains can recurse unbounded. `AgentTool.max_sessions`
+  (`inner/tools.py:295`) is an optional per-tool *concurrency* cap, not a depth
+  cap.
+
+### Info propagation parent↔child
+- **`pass_history: true`** snapshots the parent's `"self"` history into the
+  child as `"parent"` history; **`pass_histories: [names]`** snapshots named
+  histories. Consumed by the executor on the child's first turn (serialized into
+  context, e.g. `claude_sdk_executor.py:2600`, `cursor_executor.py:223`).
+- **Tool args = child's first user message** (`spawn.py:281`).
+- **Results truncated into an inbox signal:** when the child's turn completes,
+  its output is **truncated** (per-payload cap; see `workflow.py:94-104`) and
+  packaged into the `async_work_complete` signal delivered to the parent's
+  inbox.
+- **Siblings/cross-agent only via the parent** — a child can only address its
+  own direct children or its parent (`sys_session_send` is "confined to your
+  direct children", `spawn.py:73-74,245`).
+
+### Inbox / async mechanics (`tools/builtins/async_inbox.py`)
+- **`sys_call_async(tool, args)`** (`:129`) — dispatch a **local Python tool**
+  as a background task; returns an `_AsyncToolHandle` JSON
+  (`{task_id, tool_name, status:"in_progress", message}`,
+  `workflow.py:2143`). `is_async()` always True → routes to `dispatch_async`.
+  MCP/builtin/client tools are rejected (`unknown_tool`/`unsupported_tool`); a
+  recursive `sys_call_async` target is rejected.
+- **The blocking drain runs *in the harness subprocess*, not the runner.** The
+  parent loop's heartbeat + steering-poll + auto-collect all live in the
+  scaffold/builtins: `_HEARTBEAT_INTERVAL_S=15.0` (`_scaffold.py:83`;
+  `_heartbeat_loop` emits `response.heartbeat`, `:1542`); steering via
+  `TurnContext.next_injection(timeout=…)` (`_scaffold.py:551`); auto-collect
+  `_drain_async_completions` "at the top of every loop iteration"
+  (`async_inbox.py:253`). Completions arrive on the `async_work_complete` topic
+  (`workflow.py:2160`).
+- **Drain at the iteration boundary OR mid-turn:** auto-collect drains at the
+  **top of every loop iteration** (push); the LLM can also pull mid-turn via
+  **`sys_read_inbox`** (`:240`) which returns piled-up `[System: task …]` blocks
+  inline as a `function_call_output`.
+- **Consume-once:** both paths consume payloads off the topic — the next
+  iteration's auto-collect won't re-deliver, so the LLM never sees a completion
+  twice (`:264`).
+- **Subagent-completion delivery (runner side) + the native gate.** When a
+  (sub-agent) turn ends cleanly, `_on_proxy_stream_end` (`runner/app.py:12519`)
+  delivers the child's terminal output to the **parent's inbox queue**
+  (`_deliver_subagent_completion`, `:7248`, `inbox.put_nowait({…,"type":
+  "sub_agent",…})`) and schedules a wake-POST to the parent's `/events`
+  (`_mark_subagent_terminal_and_wake`→`_schedule_subagent_wake`, `:12957`). The
+  success-delivery branch is gated at **`runner/app.py:12607`**:
+  `elif not _is_native_harness(conv_id) and not has_buffered:`. ⚠️ **Bug:** the
+  `not _is_native_harness(conv_id)` clause means **native** sub-agents skip the
+  `status="completed"` delivery entirely (they only emit `waiting`/`idle` at
+  `:12580-12594`) → a parent waiting on the drain never sees a native child's
+  result (#848 cluster). `has_buffered` (`:12565`) defers delivery when a
+  continuation turn is buffered, so the final synthesis is delivered exactly
+  once.
+- **`sys_cancel_task` / `sys_cancel_async` are NO-OPs — GAP:** the tasks table
+  was removed; `SysCancelTaskTool.invoke` returns
+  `{"error":"task_not_found", "hint":"The tasks table has been removed…"}`
+  **for every input** (`async_inbox.py:97-126`). `sys_cancel_async` subclasses
+  it with a `handle_id` alias → same no-op (`:334`). Cancellation of dispatched
+  async/subagent work is effectively broken.
+
+### Persist-before-forward & interrupt fencing (server-side)
+
+These are **server** invariants (`server/routes/sessions.py`), upstream of the
+runner — noted here because they bound what the turn loop can persist:
+- **Persist-before-forward (I1):** the inbound user message is appended to the
+  store (`conversation_store.append`, `sessions.py:8540`) **before** the runner
+  POST; the persisted id is threaded as `persisted_item_id` (`:8618`) so the
+  runner can dedup on cold-cache reload (`app.py:14848`). Assistant output is
+  persisted by `_flush_relay_text` (`sessions.py:9270`) and only **after a
+  confirmed persist** is `response.output_item.done` published with the
+  store-assigned id.
+- **Interrupt fence:** `_interrupt_fenced_sessions` (`sessions.py:931`) is set
+  on interrupt/stop (`:18442`, `:18476`); while fenced, trailing `response.*`
+  events are dropped (`:9464-9475`) — no forward, no persist — until the next
+  turn's `running` status or a terminal response lifts it. Elicitation events
+  are fence-exempt (`_FENCE_EXEMPT_EVENT_TYPES`, `:947`). The runner mirrors it
+  with `_interrupted_sessions` + `_append_cancellation_items` (`app.py:12566`,
+  `:10174`).
+
+---
+
+## 12. pending_inputs & pending_elicitations (transient recovery state)
+
+- **`pending_inputs.py`** — in-process index of un-consumed **native** web-
+  composer messages (claude-native / codex-native don't persist a web-typed
+  message at POST time; the transcript forwarder is the single durable writer).
+  `record()` before the runner forward (returns a `pending_id`),
+  `snapshot_for()` replays into the `GET /sessions/{id}` cold-load snapshot,
+  `resolve_oldest()` drains **FIFO** at the persist site (text-matching is
+  unreliable because the transcript reformats text). `_TTL_S=600s` evicts ghosts
+  from never-accepted messages. Kiro variant uses `resolve_matching_text`. The
+  FIFO-desync edge case (interleaving a TUI-typed message) self-heals.
+- **`pending_elicitations.py`** — in-process index of outstanding elicitation
+  requests, populated automatically by the `session_stream.publish` chokepoint
+  on `response.elicitation_request` and drained on `response.elicitation_resolved`
+  (or by the approval-dispatch path). Stores the **full event payload** so
+  `GET /sessions/{id}` can replay the ApprovalCard on cold load (SSE has no
+  replay buffer). `count_for`/`counts_for` back the sidebar awaiting-badge;
+  `lookup` backs the standalone approve deep-link; `project_for_peek` synthesizes
+  a `pending_elicitation` item for `sys_session_get_history` (a parked
+  elicitation never lands in the conversation store). In-memory only; dies with
+  the process (so it can't diverge into phantom rows).
+
+---
+
+## 13. Failure branches & gaps
+
+- **No spawn-time subagent depth cap** — `_MAX_SUBAGENT_TREE_DEPTH=3` is
+  display-only (`repl/_repl.py:201`). Runaway recursion risk via `AgentTool`
+  chains. [code-pass gap; CUJ-ANALYSIS §6]
+- **`sys_cancel_task`/`sys_cancel_async` no-op** — tasks table removed; returns
+  `task_not_found` for all inputs (`async_inbox.py:108`).
+- **Native sub-agent completions never reach the orchestrator** — the gate
+  `elif not _is_native_harness(conv_id) and not has_buffered:`
+  (`runner/app.py:12607`) excludes every native harness from the
+  `status="completed"` delivery branch; native turns only emit `waiting`/`idle`
+  (`:12580-12594`), so the parent's drain never wakes. #848 cluster
+  (cross-domain with native SME).
+- **Reactive overflow ≠ compaction** — a harness-reported context overflow ends
+  the turn with an error (`runner/app.py:13804`), it does **not** trigger
+  `compact()`. Only the proactive threshold path (`_call_llm_maybe_compact`,
+  `workflow.py:2057`) auto-compacts. OMNI-143 surface.
+- **`pass_history`/`pass_histories`/`max_sessions` lossy on the omnigent-compat
+  path** (`spec/omnigent.py:1338`) — silently default if the agent went through
+  that translator.
+- **No `llm_call` span** in the SDK adapter path → token-level/per-LLM-call
+  latency is not separately observable; usage is recorded only on the AGENT span
+  (`_executor_adapter.py:435`).
+- **Compaction L2 auth failure** degrades to lossy L3 truncation; surfaced as a
+  distinct ERROR log but the turn still proceeds (`compaction.py:844-865`).
+- **Interrupt mid-await:** `interrupt_session` is skipped if the turn is blocked
+  awaiting the first token / torn down via HTTP disconnect — mitigated by the
+  `_handle_interrupt_event` override dropping the client synchronously
+  (`_executor_adapter.py:498`), but a wedged executor still relies on the
+  harness hard-exit backstop (`_runner.py:171`).
+
+---
+
+## 14. Open questions
+
+- Does any in-scope executor ever call `start_llm_span` (would produce the
+  `llm_call` span the docstring promises)? Code search says **no** for
+  claude-sdk/codex; confirm for antigravity/cursor (out of scope) if the team
+  wants the deeper nesting.
+- Native-resume transcript rebuild details (`external_session_id`,
+  `FORK_CARRY_HISTORY`) live outside `runtime/` — confirm with the native SME
+  exactly how much the vendor CLI reloads vs. what Omnigent re-injects.
+- Async-task **cancellation** has no backing store at all now — is the intended
+  replacement the SDK-native KillBash / harness interrupt only, or is a tasks
+  table coming back?

--- a/designs/master-arch/architecture/server.md
+++ b/designs/master-arch/architecture/server.md
@@ -1,0 +1,341 @@
+# Omnigent Server — Architecture (SME deep-dive)
+
+**Scope:** `omnigent/server/` — the FastAPI control plane. Core is the (912 KB!)
+`routes/sessions.py`, plus `routes/runner_tunnel.py`, `routes/host_tunnel.py`,
+`routes/terminal_attach.py`, `auth.py`, the conversation store under
+`stores/conversation_store/`, the SSE formatter `_format_sse`, the `WS /v1/sessions/updates`
+stream, and `/health`.
+
+**Source-of-truth rule applied:** every mechanism below is anchored to `file:line` on
+current `main` (worktree `…/traces`). Line numbers in `designs/CUJ-ANALYSIS.md` had drifted
+by ~thousands of lines (the file grew); the anchors here were re-derived from the live code.
+Trace evidence is from local Jaeger (corpus `conv_b4f2faed…` claude-sdk new+resume,
+`conv_63542a5f…` claude-sdk tool-use).
+
+---
+
+## 1. Overview
+
+The server is the **system-of-record and the fan-out hub**. It owns the durable
+conversation store (chat.db / Postgres), terminates all client connections (REST + SSE +
+two WebSockets), and brokers every turn to a **runner** over a reverse WebSocket tunnel.
+It is deliberately **harness-agnostic**: it never talks to an LLM or a vendor CLI directly;
+it persists items, forwards events to the runner, and relays the runner's SSE stream back
+out to clients while persisting the durable subset.
+
+Three structural facts explain almost everything:
+
+1. **Persist-before-forward (invariant I1).** A client message is written to the
+   conversation store **before** it is forwarded to the runner. The store is the source of
+   truth; the runner is a recomputable cache.
+   (`_forward_event_to_runner`, `sessions.py:8495`, docstring `:8507-8513`.)
+2. **Two SSE consumers, one pub-sub.** The runner emits an SSE stream; the server's
+   `_relay_runner_stream` (`sessions.py:9371`) consumes it, **persists the durable items**,
+   and **re-publishes** every event onto an in-process pub-sub (`runtime/session_stream`).
+   Each connected client's `GET /sessions/{id}/stream` (`sessions.py:19190`) is a
+   **live-tail subscriber** of that pub-sub — *no buffer, no replay*.
+3. **Reconnect = snapshot + live tail (NOT replay).** Because the live stream has no
+   buffer, a (re)connecting client reads a **snapshot** (`GET /sessions/{id}`,
+   `sessions.py:14132`) for everything that happened before it subscribed, then dedupes the
+   overlap by **item id**.
+
+```
+            REST + SSE + WS                  reverse WS tunnel
+ ┌────────┐  ───────────────►  ┌────────────────┐  ───────────────►  ┌────────┐
+ │ client │                    │   OMNI-SERVER  │   HTTP-over-WS     │ runner │→ harness
+ │ web/TUI│  ◄───SSE/WS────────│ (control plane)│  ◄───SSE stream────│        │
+ └────────┘                    └───────┬────────┘                    └────────┘
+                                       │  asyncio.to_thread
+                                       ▼
+                              conversation store (chat.db / PG)  ← SOURCE OF TRUTH
+```
+
+---
+
+## 2. Key files (file:line)
+
+### 2.1 `routes/sessions.py` — the core (54 routes)
+
+The router factory mounts **54** routes (full table in the CUJ doc §"client→server"). Hot paths:
+
+| Mechanism | Symbol | Anchor |
+|---|---|---|
+| Submit event (the big switch) | `post_event` | `sessions.py:18150` |
+| Persist-before-forward (I1) | `_forward_event_to_runner` | `sessions.py:8495` (persist `:8540`, forward `:8697`, consumed `:8704`) |
+| Harness-aware dispatch (native bypass) | `_dispatch_session_event_to_runner` | `sessions.py:8735` |
+| Runner SSE consumer + durable persist | `_relay_runner_stream` | `sessions.py:9371` |
+| Which SSE events become DURABLE | `_extract_persistent_item_from_sse` | `sessions.py:8930` |
+| SSE wire formatter | `_format_sse` | `sessions.py:1848` |
+| Live-tail generator (+`[DONE]`) | `_stream_live_events` | `sessions.py:11229` (`[DONE]` at `:11341`) |
+| SSE endpoint | `stream_session` | `sessions.py:19190` |
+| Snapshot endpoint | `get_session` → `_get_session_snapshot` | `sessions.py:14132`, builder `SessionResponse(` at `:2458` |
+| Disconnect detector (long-poll) | `_poll_request_disconnect` | `sessions.py:1183` |
+| WS sidebar | `session_updates` | `sessions.py:14530` |
+| Status publish (single funnel) | `_publish_status` | `sessions.py:5343` |
+| input.consumed publish | `_publish_input_consumed` | `sessions.py:2537` |
+| Interrupt fence set | `_interrupt_fenced_sessions` | def `:931`, drop in relay `:9464` |
+| Status cache (sidebar bridge) | `_session_status_cache` | `:837` |
+| Create session | `create_session` | `sessions.py:13688` |
+| Fork | `fork_session` | `sessions.py:15180` |
+| Switch agent | `switch_session_agent` | `sessions.py:15415` |
+| PATCH (rename/archive/model/effort/runner) | `update_session` | `sessions.py:14795` |
+| Delete | `delete_session` | `sessions.py:19358` |
+| Native policy HTTP hook | `evaluate_policy` | `sessions.py:15973` |
+
+### 2.2 Tunnels & auth
+
+- **`routes/runner_tunnel.py`** — `WS /v1/runners/{runner_id}/tunnel` (`tunnel`, `:278`).
+  Runner dials *out* to the server; server registers it in the `TunnelRegistry` and makes
+  RPC HTTP calls *back* through the socket. Token-binding + owner resolution (`:294-371`)
+  before `accept()`. Server→runner client is built in `RunnerRouter._client_for_runner`
+  (`runner/routing.py:243`) on a custom `WSTunnelTransport` (`:256`), explicitly
+  telemetry-instrumented (`:264`) because the global httpx hook can't see the custom transport.
+- **`routes/host_tunnel.py`** — `WS /v1/hosts/{host_id}/tunnel` (`tunnel`, `:121`). JSON
+  control frames (`HostFrameKind`: launch_runner, stop_runner, fs ops…). `_receive_loop`
+  `:369`, `_sender_loop` `:356`, `_ping_loop` `:552`.
+- **`routes/terminal_attach.py`** — `WS …/terminals/{terminal_id}/attach` (`:131`). The
+  server **shuttles raw frames** browser↔runner (`_shuttle_ws_frames`, `:346`; two pumps
+  `_browser_to_runner` `:368`, `_runner_to_browser` `:386`). Authorized at `_authorize_terminal_attach` `:259`.
+- **`auth.py`** — `AuthProvider` ABC (`:237`); `UnifiedAuthProvider` (`:250`), one of
+  `header | oidc | accounts` per deploy (`OMNIGENT_AUTH_PROVIDER`). `get_user_id` (`:333`)
+  reads a trusted header (default `X-Forwarded-Email`) **or** the `__Host-ap_session` HS256
+  cookie. Loopback single-user maps missing identity to the reserved `"local"` sentinel.
+
+### 2.3 Conversation store (`stores/conversation_store/`)
+
+- `append` (`sqlalchemy_store.py:1411`) — the persist primitive. Locks the conv row
+  (`_lock_conversation`, FOR UPDATE on PG), bumps `updated_at`, allocates O(1) `position`
+  from a maintained `next_position` counter, mints a **fresh `item_id`** per item
+  (`generate_item_id`, `:1479`), stores `response_id` (turn grouping) and `created_by`,
+  status `"completed"` (items are final on append), and inserts an FTS row.
+  **No content-based dedup at the store** — dedup is by item id downstream.
+- `set_runner_id` (`sqlalchemy_store.py:1918`) — **atomic CAS**:
+  `UPDATE … WHERE id=:id AND runner_id IS NULL`. Exactly one concurrent first-dispatch wins
+  (rowcount==1); the loser re-reads to find the winner. This is the runner-binding race guard.
+- `fork_conversation` (`:2266`), `switch_conversation_agent` (`:2576`) — see CUJ doc.
+
+---
+
+## 3. Data flow — the turn lifecycle (POST /events → SSE back to client)
+
+```mermaid
+sequenceDiagram
+  participant C as Client (web/TUI)
+  participant S as omni-server (post_event)
+  participant DB as conv store (chat.db/PG)
+  participant P as policy.evaluate (in-proc)
+  participant R as omni-runner (via WS tunnel)
+  participant H as harness
+
+  Note over C: opens GET /sessions/{id}/stream FIRST (live-tail), reads snapshot
+  C->>S: POST /v1/sessions/{id}/events {type:"message", role:"user"}
+  S->>S: _require_access_and_level(LEVEL_EDIT); validate type ∈ _ALLOWED_EVENT_TYPES
+  S->>P: _evaluate_input_policy → engine.evaluate  (span: policy.evaluate)
+  alt policy DENY/ASK
+    P-->>S: deny(reason)
+    S->>DB: _persist_policy_deny_sentinel
+    S-->>C: SSE response.completed (terminal) + session.status idle
+    S-->>C: 200 {queued:false, denied:true, reason}
+  else ALLOW
+    S->>DB: conversation_store.append([user item])   ⟵ I1 PERSIST-BEFORE-FORWARD
+    S->>R: POST /v1/sessions/{id}/events {type, …, persisted_item_id, model_override}
+    R-->>S: 202 (turn started as background task)
+    S-->>C: SSE session.input.consumed {item_id}     ⟵ only after forward OK
+    S-->>C: 202 {queued:true, item_id}
+    Note over S,R: meanwhile _relay_runner_stream is tailing R's GET /stream
+    R->>H: drive harness; emit SSE
+    H-->>R: response.created / .output_text.delta* / .output_item.done / .completed
+    R-->>S: same SSE frames (over tunnel)
+    S->>S: re-publish each to session_stream (live clients)
+    S->>DB: persist DURABLE subset (output_item.done, compaction, resource_event…)
+    S-->>C: SSE response.* (live tail)
+    R-->>S: session.status idle  →  S: _publish_status(idle) + cache write
+  end
+```
+
+**Real spans seen** (`tree cfb59197f6f92755…`, the tool-use conv's POST /events trace, 415
+spans): `POST /v1/sessions/{session_id}/events` → `policy.evaluate` (child, with its own
+SELECTs) → `UPDATE`/`INSERT chat.db` (the append) → `POST` (cross-service edge
+`omni-server → omni-runner [POST /v1/sessions/{conversation_id}/events]`) → the runner then
+calls **back** `GET /v1/sessions/{id}/items` and `GET /v1/sessions/{id}` (transcript
+reconstruction). The persist (`INSERT`/`UPDATE`) precedes the runner `POST` in wall-clock
+order — I1 visible in the trace.
+
+### Forward-failure branch (runner offline / tunnel dropped)
+
+In `_forward_event_to_runner` the `httpx.post` is wrapped in try/except: on failure the
+item **stays persisted**, the server logs "runner picks up on reconnect", and publishes
+`session.status idle` (`sessions.py:8705-8711`). For a fresh item event where **no runner is
+bound at all**, `post_event` raises `RUNNER_UNAVAILABLE` (503) *before* persist
+(`sessions.py:19073`) — except the host-relaunch path, which first tries to relaunch a runner
+on the still-online host (`:18920-19006`).
+
+---
+
+## 4. Channels & event/message types
+
+### 4.1 The four client↔server transports
+
+| Transport | Route | Direction | Purpose |
+|---|---|---|---|
+| REST | 50+ paths under `/v1/sessions/…`, `/v1/me`, `/v1/info`, `/health`, `/api/version` | C→S | commands + reads |
+| SSE | `GET /v1/sessions/{id}/stream` | S→C | live tail of one session |
+| WS | `WS /v1/sessions/updates` | C↔S | sidebar (watch-set → snapshot/changed/removed/heartbeat) |
+| WS | `WS …/terminals/{tid}/attach` | C↔S→R | raw xterm shuttle to runner tmux |
+
+(Plus server-side ingress WS: `WS /v1/runners/{id}/tunnel`, `WS /v1/hosts/{id}/tunnel`.)
+
+### 4.2 SSE wire format
+
+`_format_sse` (`sessions.py:1857`): `event: <type>\ndata: <json>\n\n`. The terminal
+sentinel is a **nameless** frame `data: [DONE]\n\n` (`:11341`). Every published dict is
+validated against the `ServerStreamEvent` discriminated union
+(`_SERVER_STREAM_EVENT_ADAPTER`, `:826`) at the wire boundary — an unmodelled `type` fails
+loud rather than shipping.
+
+### 4.3 Event taxonomy — STREAM (transient) vs DURABLE
+
+The union itself is **labeled** in source (`schemas.py:3724-3782`):
+
+- **DURABLE** (persisted to conversation history): exactly **`response.output_item.done`**
+  (`OutputItemDoneEvent`) — wraps a conv-store item; the comment literally says
+  *"Persistent (POST + SSE replay) — wraps conv-store items"*. Plus `compaction` events and
+  resource lifecycle events, which the relay persists as their own conv items
+  (`_extract_persistent_item_from_sse` `:8930`; `_resource_event_item_from_sse` `:9005`).
+- **TRANSIENT (SSE-only, never persisted):** all `session.*` lifecycle
+  (`session.status`, `.input.consumed`, `.presence`, `.model`, `.reasoning_effort`,
+  `.usage`, `.agent_changed`, `.todos`, `.resource.created/.deleted`,
+  `.child_session.updated`, `.changed_files.invalidated`, `.heartbeat`, …); the delta
+  events (`response.output_text.delta`, `response.reasoning_text.delta`,
+  `response.reasoning.started`, `response.reasoning_summary_text.delta`); the
+  Responses-API turn lifecycle (`response.created/.in_progress/.completed/.failed/`
+  `.cancelled/.queued/.incomplete`); and operational signals (`response.error/.retry`,
+  `response.compaction.*`, `response.elicitation_request/_resolved`).
+
+**Naming convention:** three families —
+`response.*` (turn/output lifecycle, mirrors OpenAI Responses API),
+`session.*` (Omnigent session/sidebar/presence lifecycle), and
+`external_*` (events a *native* harness's forwarder POSTs **into** `/events` so the server
+re-publishes/persists them — input vocabulary, not output; see §4.4).
+
+### 4.4 `POST /events` input vocabulary (`_ALLOWED_EVENT_TYPES`, `sessions.py:800`)
+
+= every conversation item type (`message`, `function_call`, `function_call_output`,
+`compaction`, …) **plus** control/external types: `interrupt`, `approval`,
+`mcp_elicitation`, `compact`, `stop_session`, and the `external_*` family
+(`external_assistant_message`, `external_conversation_item`, `external_output_text_delta`,
+`external_output_reasoning_delta`, `external_session_interrupted`,
+`external_session_superseded`, `external_elicitation_resolved`, `external_session_status`,
+`external_session_usage`, `external_compaction_status`, `external_model_change`,
+`external_reasoning_effort_change`, `external_session_todos`, `external_subagent_start`,
+`external_codex_subagent_start`, `external_codex_collaboration_mode_change`). Unknown type → 400.
+
+### 4.5 WS /sessions/updates frames
+
+- C→S: `{"type":"watch","session_ids":[…]}` (full-replace watch-set; deduped, capped at
+  `_SESSION_UPDATES_MAX_WATCHED=500`).
+- S→C: `{"type":"snapshot","items":[SessionListItem…]}` (per watch), `{"type":"changed",…}`,
+  `{"type":"removed","ids":[…]}`, `{"type":"heartbeat"}`. Watched rows are **pull-based**
+  (re-read + diff every `_SESSION_UPDATES_RESCAN_INTERVAL_S=4s`); newly-accessible sessions
+  are **push-based** via `_discovery` listening on `user_session_stream`
+  (`_announce_session_added`). Trace context is injected into every frame in `_send`
+  (`:14601`) and extracted in `_reader` (`consume_frame_span("session_updates.watch")`, `:14683`).
+
+---
+
+## 5. Trace evidence (concrete spans/edges observed)
+
+From the saved corpus (local Jaeger, `service.name` ∈ {omni-server, omni-runner,
+omni-harness}); each span carries `session.id=<conv_…>`:
+
+- **Server FastAPI roots** (every client REST/SSE call is its own root span):
+  `POST /v1/sessions`, `POST /v1/sessions/{session_id}/events`,
+  `GET /v1/sessions/{session_id}`, `GET /v1/sessions/{session_id}/stream`,
+  `PATCH /v1/sessions/{session_id}`, `GET /v1/sessions/{session_id}/agent`,
+  `GET /v1/sessions/{session_id}/items`, `GET /api/version`. Confirms the route surface.
+- **`policy.evaluate`** child spans appear inline under `POST /events` (6× in the PONG conv,
+  5× in tool-use), with attributes `policy.phase` / `policy.decision` / `policy.reason` /
+  `session.id` (`engine.py:255-279`). Matches the in-process policy choke point.
+- **Cross-service edges** (server↔runner over the WS tunnel, all carried by
+  `HTTP /v1/runners/{runner_id}/tunnel websocket send|receive` spans):
+  - `omni-server → omni-runner`: `POST /v1/sessions` (session init, ×5), `POST /v1/sessions/{conversation_id}/events` (turn forward, ×2), `GET /v1/sessions/{session_id}` (×2), `GET …/resources/terminals` (×4), `GET …/skills` (×1).
+  - `omni-runner → omni-server` (the runner calling **back** during transcript rebuild /
+    policy): `GET /v1/sessions/{session_id}/items` (×6), `GET …/agent/contents` (×6),
+    `POST /v1/sessions/{session_id}/policies/evaluate` (×4 — the native policy hook),
+    `GET /v1/sessions/{session_id}` (×3), `PATCH /v1/sessions/{session_id}` (×2),
+    `GET /api/version`.
+- **DB spans** dominate counts (`SELECT`/`PRAGMA`/`UPDATE`/`INSERT chat.db`) and nest under
+  the owning request span — visible `INSERT`/`UPDATE` under `POST /events` is the I1 persist.
+  (Per the brief, treat `PRAGMA`/`connect` as noise.)
+- **Decoupled roots:** the runner's own `GET …/stream http send` spans root their own traces
+  (the SSE forwarder is request-decoupled). They're stitched to the rest only by
+  `session.id` — exactly the cross-trace grouping the OBSERVABILITY design calls out (§8).
+
+---
+
+## 6. Per-harness differences (server's view)
+
+The server is mostly harness-agnostic, but `post_event` / `_dispatch_session_event_to_runner`
+branch on **SDK vs native**:
+
+- **claude-sdk / codex (SDK):** server is the single writer. `_dispatch_…` → `_forward_event_to_runner`
+  → **persist user item, forward, publish `input.consumed`** (`sessions.py:8915-8926`). The
+  runner's SSE comes back through `_relay_runner_stream`, which persists `output_item.done`
+  as durable items. Transcript is 100% server-owned. *Live trace: yes (corpus).*
+- **claude-native / codex-native:** `_is_native_terminal_session` branch
+  (`sessions.py:8817`). Web-typed user messages are **NOT persisted server-side** — they're
+  forwarded into tmux and the **transcript forwarder becomes the single writer** (it later
+  POSTs `external_conversation_item`). Server records an optimistic `pending_inputs` entry
+  (`:8851`) replayed into the snapshot and drained on `input.consumed`
+  (`cleared_pending_id`). Control events (`interrupt`/`stop_session`/`compact`) are
+  forwarded harness-agnostically; the runner dispatches by harness (native injects into the
+  pane). Native model/effort overrides are best-effort (`external_model_change` /
+  `external_reasoning_effort_change` persist to columns + publish `session.model` /
+  `session.reasoning_effort`). Status comes via `external_session_status` →
+  `_publish_status`. *codex-native: no live trace (creds expired); covered by code +
+  CUJ-ANALYSIS §4 + analogy to claude-native (claude-native corpus exists).*
+- **polly / custom agents:** run on an SDK harness (typically claude-sdk) → identical
+  server path to claude-sdk; the only difference is the agent bundle.
+
+---
+
+## 7. Failure branches & gaps
+
+- **Runner offline on message:** item persisted, forward fails → `session.status idle`
+  published, runner picks up on reconnect (`:8705`). But if no runner ever rebinds, the
+  client's optimistic bubble can sit until a snapshot reconciliation. For a *brand-new* item
+  with no runner bound, the server 503s before persist (`:19073`) unless the host can
+  relaunch.
+- **Hard runner affinity, no failover.** A pinned runner going offline →
+  `RUNNER_UNAVAILABLE`/`CONFLICT` ("resume the session to bind a registered runner")
+  (`routing.py:110-116, 230-235`). Strands the session until reconnect.
+- **`failed` is sticky vs trailing `idle`** (`_publish_status` `:5389`) — a `failed` edge is
+  not overwritten by a follow-on `idle`; cleared only by the next `running`. Native-specific
+  guard (StopFailure → failed, then PTY-activity idle ~1s later).
+- **WS tunnel runner-auth** is established once at handshake; token-binding proves *a* token
+  but in no-allowlist mode any non-empty token derives a valid runner id — owner resolution
+  (`runner_tunnel.py:348-371`) closes the owner-less-runner cross-tenant gap.
+- **Permission store disabled ⇒ `accessible_by=None`** returns all sessions
+  (cross-user leak risk on misconfigured open servers) — CUJ-ANALYSIS §6 [§2.D].
+- **policy.evaluate span is created in the engine, not the HTTP handler.** The native HTTP
+  hook `evaluate_policy` (`sessions.py:15973`) has **no** explicit span of its own; the
+  `policy.evaluate` span comes from `engine.evaluate` (`engine.py:255`) called inside it. So
+  in a trace, the native policy hook shows as the FastAPI request span
+  `POST …/policies/evaluate` with a `policy.evaluate` child.
+
+---
+
+## 8. Open questions
+
+1. **Relay restart semantics.** `_relay_runner_stream` exits on 45 s heartbeat gap; what
+   precisely re-spawns it (`_ensure_runner_relay_ready`) and is there a window where durable
+   `output_item.done` events are missed during a relay flap? (Affects local↔server divergence.)
+2. **Dedup symmetry.** Server appends a fresh `item_id` and forwards `persisted_item_id` so
+   the runner drops its own pre-resolution copy by id (`sessions.py:8618`). On the
+   native bypass there is *no* server item id (only `pending_id`) — confirm the client's
+   FIFO/stableKey dedup is the only thing preventing a double bubble there.
+3. **`_session_status_cache` is per-process.** On a multi-replica deploy, does the sidebar's
+   `list_sessions`/`/health` read a status written by a *different* replica's relay? (Cache
+   is in-memory, `:837`.)
+4. **`refresh_state=true` snapshot** re-pulls live runner overlays — what is the full set of
+   overlays it refreshes vs. what stays in the AP-process caches?

--- a/designs/master-arch/architecture/server.md
+++ b/designs/master-arch/architecture/server.md
@@ -128,8 +128,8 @@ sequenceDiagram
   participant H as harness
 
   Note over C: opens GET /sessions/{id}/stream FIRST (live-tail), reads snapshot
-  C->>S: POST /v1/sessions/{id}/events {type:"message", role:"user"}
-  S->>S: _require_access_and_level(LEVEL_EDIT); validate type ∈ _ALLOWED_EVENT_TYPES
+  C->>S: POST /v1/sessions/{id}/events {type=message, role=user}
+  S->>S: _require_access_and_level(LEVEL_EDIT) — validate type ∈ _ALLOWED_EVENT_TYPES
   S->>P: _evaluate_input_policy → engine.evaluate  (span: policy.evaluate)
   alt policy DENY/ASK
     P-->>S: deny(reason)
@@ -143,7 +143,7 @@ sequenceDiagram
     S-->>C: SSE session.input.consumed {item_id}     ⟵ only after forward OK
     S-->>C: 202 {queued:true, item_id}
     Note over S,R: meanwhile _relay_runner_stream is tailing R's GET /stream
-    R->>H: drive harness; emit SSE
+    R->>H: drive harness — emit SSE
     H-->>R: response.created / .output_text.delta* / .output_item.done / .completed
     R-->>S: same SSE frames (over tunnel)
     S->>S: re-publish each to session_stream (live clients)

--- a/designs/master-arch/architecture/telemetry-tracing.md
+++ b/designs/master-arch/architecture/telemetry-tracing.md
@@ -1,0 +1,151 @@
+# Omnigent — Telemetry & Distributed Tracing (master doc)
+
+**Scope:** how observability works across Omnigent after PR #1617 (`feat(telemetry):
+holistic distributed tracing across all components`). This doc is both the
+architecture reference for the telemetry layer **and** the practical guide for
+reading Omnigent traces during CUJ analysis. Design source: `designs/OBSERVABILITY.md`.
+Code: `omnigent/runtime/telemetry.py`, `omnigent/inner/tracing.py`, plus per-boundary
+instrumentation sites. Empirical evidence: local Jaeger, this analysis.
+
+## 1. Overview — two complementary layers
+Omnigent emits **two** kinds of spans that share one provider:
+
+1. **Agent-plane / OpenInference spans** (`omnigent/inner/tracing.py`): semantic
+   spans for the turn loop — `agent:<name>` (AGENT), `llm_call` (LLM),
+   `tool:<name>` (TOOL), `policy:<name>` (GUARDRAIL). Built by a `TracingContext`
+   that carries an explicit span stack (not contextvars), created by the runner's
+   executor adapter for each turn. Attributes follow OpenInference
+   (`openinference.span.kind`, `input.value`, `output.value`, `llm.model_name`,
+   `gen_ai.usage.*`).
+2. **Boundary / infra spans** (`omnigent/runtime/telemetry.py` + auto-instrumentors):
+   FastAPI server spans (every HTTP route), HTTPX client spans (every outbound call),
+   SQLAlchemy DB spans (every query), and **manual** spans for the JSON-frame
+   websockets (host tunnel, session-updates) via `consume_frame_span` /
+   `inject_trace_context` / `extract_trace_context`.
+
+Both feed one global `TracerProvider` installed by `telemetry.init()`.
+
+## 2. Initialization & configuration
+`telemetry.init(service_name=...)` (`runtime/telemetry.py:1072`) runs in **every**
+process entrypoint (cli, `runner/_entry.py`, `runtime/harnesses/_runner.py`). It is
+**gated by a master opt-in** and is a complete no-op otherwise.
+
+| Env var | Effect |
+|---|---|
+| `OMNIGENT_TELEMETRY_ENABLED` | **Master switch** (off by default). Unset → `init()` returns immediately; no provider, no instrumentation, no spans. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables OTLP export + selects the collector. When set, also default-enables FastAPI instrumentation, metrics, and logs export. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) or `http/protobuf`. |
+| `OTEL_SERVICE_NAME` | Per-component identity; each entrypoint passes its own (`omni-server`/`omni-runner`/`omni-harness`/`omni-host`; clients `omni-tui`/`omni-web`). A child overrides the inherited value. |
+| `OMNIGENT_OTEL_FASTAPI_INSTRUMENTATION` | Force server/runner/harness FastAPI spans on/off (defaults on when an endpoint is set). |
+| `OMNIGENT_OTEL_CAPTURE_CONTENT` | Include (redacted, 4 KB-capped) message bodies on frame/policy spans. Off by default (PII). |
+
+What `init()` wires when enabled (`telemetry.py:1107-1141`): OTLP `BatchSpanProcessor`
++ a `_SessionIdSpanProcessor` on the `TracerProvider`; OTLP metrics + logs providers;
+process-wide `HTTPXClientInstrumentor`. FastAPI instrumentation is installed by each
+app factory via `instrument_fastapi_app()`. SQLAlchemy is instrumented per-engine at
+creation (`db/utils.py` → `instrument_sqlalchemy_engine`).
+
+## 3. The grouping key: `session.id` = conversation id
+Because agent turns root their **own** trace (see §5), spans across a conversation do
+**not** all share a trace id. The cross-trace grouping key is the **`session.id`**
+attribute = the Omnigent conversation id (`conv_…`). It is stamped generically:
+- `_SessionIdSpanProcessor.on_start` stamps every span from the active context
+  (bound via `session_scope()` / `set_session_id()`), and
+- `_fastapi_session_id_hook` parses it from the request path
+  `/sessions/((?:agy_)?conv_[0-9a-f]+)` onto each server span — which also re-attaches
+  the **decoupled JSONL forwarder** (it re-POSTs into `/events` under a fresh trace) to
+  its session.
+
+**This is the query key for CUJ analysis: filter/group traces by `session.id=<conv_…>`.**
+
+## 4. Trace-id ↔ response-id
+For request roots that own a response id (`resp_<32hex>`),
+`trace_id_from_response_id()` (`telemetry.py:498`) reuses the hex as the W3C trace id,
+and `trace_context_for_response()` injects a synthetic `traceparent` with a sentinel
+parent span id (`SENTINEL_PARENT_SPAN_ID = 0x1000000000000001`). `start_agent_span`
+detects the sentinel and exports the agent span as a true root (no `parentSpanId`).
+Net effect: **you can jump from a response id to its trace with no lookup** — strip
+`resp_` and search the trace id.
+
+## 5. Why one action produces MANY traces (key reality)
+Empirically, a single headless `claude-sdk` turn produced **21 distinct traces**
+across `omni-server/runner/harness/host`; a 2-turn conversation
+(`conv_b4f2faed…`) accumulated **26 traces / 2568 spans**. This is by design, not a bug:
+- Each **agent turn roots its own trace** (response-id-seeded), decoupled from the
+  client request that triggered it.
+- The **response path is decoupled from any request**: a separate JSONL-polling
+  forwarder tails the harness output and re-POSTs into `/events`; that POST roots a new
+  trace (it carries no inbound request context), correlated only by `session.id`.
+- **Host control-plane** frames (`host.launch_runner`, `host.stat`, …) and **server
+  startup** root their own traces with **no** `session.id` (a daemon control action is
+  not part of a user request). In the corpus these are the `<no-session>` traces
+  (76 traces / 508 spans on `omni-host`+`omni-server`).
+
+Implication for analysis (matches the team's Jun 30 standup note): **trace one single
+action at a time**, then stitch every trace with the same `session.id`. The
+`trace_tools.py conv <id>` helper does this.
+
+## 6. Cross-boundary propagation (what carries the trace across processes)
+| Boundary | Technique | Carrier |
+|---|---|---|
+| Client (TUI/web) → Server REST/SSE | FastAPI extract + HTTPX inject (auto) | HTTP headers |
+| Server → Runner (WS reverse-tunnel) | tunnel forwards HTTP headers **verbatim**; the cached per-runner client is wrapped by `instrument_httpx_client` (custom `WSTunnelTransport` is invisible to the global hook) | tunneled HTTP headers |
+| Runner → Harness/executor (UDS HTTP) | tunneled HTTP headers; `get_traceparent_env()` for subprocess env | HTTP headers / env |
+| Host daemon ↔ Server (JSON control frames) | **manual** `inject_trace_context`/`consume_frame_span` | `traceparent` field on the JSON frame |
+| Session-updates / terminal-attach WS | **manual** inject/extract into the JSON envelope | `traceparent` field |
+| Server ↔ DB | `SQLAlchemyInstrumentor` (sink) | n/a |
+
+**Verified locally:** one trace (`ecee1765…`, 324 spans) rooted at
+`omni-server POST /v1/sessions/{session_id}/events` and crossed
+**server → runner → harness**, with runner→server child calls for
+`POST /policies/evaluate` and `GET /items` — i.e. W3C context propagates across every
+synchronous boundary. The downstream native `tmux send-keys` + log-polling forwarder is
+a separate async boundary (its own trace, correlated by `session.id`).
+
+## 7. Service map (what each `service.name` emits)
+- **omni-server** — FastAPI route spans (`POST /v1/sessions/{id}/events`, `GET
+  /sessions/{id}`, `/items`, `/stream`, `/policies/evaluate`, `/mcp`), in-process
+  `policy.evaluate` spans, and the dominant DB spans (`PRAGMA`/`SELECT`/`connect`/
+  `INSERT`/`UPDATE` on `chat.db`).
+- **omni-runner** — runner ASGI route spans, server→runner forwarded events, runner→
+  server callbacks (`/policies/evaluate`, `/items`, `/mcp/execute`).
+- **omni-harness** — the executor turn loop: OpenInference `agent:`/`llm_call`/`tool:`/
+  `policy:` spans + harness→server `POST /events` (the forwarder path).
+- **omni-host** — `host.launch_runner` / `host.stat` consumer spans (manual frame spans),
+  nested under the server's `POST /v1/hosts/{id}/runners` when triggered by a request.
+- **omni-tui / omni-web** — client-rooted spans when those clients run with telemetry
+  (web SDK is opt-in via `VITE_OTEL_EXPORTER_OTLP_ENDPOINT`).
+
+## 8. Content capture & redaction
+With `OMNIGENT_OTEL_CAPTURE_CONTENT=true`, frame/policy spans carry the (redacted)
+body under `omnigent.message.payload` / `policy.content`. `_redact_payload` masks keys
+containing token/secret/password/authorization/credential/api_key and drops
+`traceparent`/`tracestate`; bodies are capped at 4096 chars. Raw HTTP/SSE bodies between
+server↔runner↔harness are intentionally **not** captured (reading them would break the
+SSE stream); full transcript content is the durable-event-log concern, not the trace layer.
+
+## 9. The local rig used for this analysis
+- **Native Jaeger binary** (Docker is blocked on this Mac by an enforced org sign-in):
+  `jaeger-all-in-one` v1.76, UI `:16686`, OTLP gRPC `:14317` (remapped off `:4317`,
+  which the SSH tunnel occupies), OTLP HTTP `:14318`.
+- **Drive a turn**: `omnigent run --harness claude-sdk -p "…"` from `<worktree>/.venv`
+  with the env from §2 → boots an ephemeral server+runner+harness in-process and exports
+  full traces. `--resume`/`--continue` for multi-turn; native/`--fork`/interrupt are
+  REPL/server-only.
+- **Extract**: `python3 scratchpad/trace_tools.py {recent|conv <id>|tree <traceid>|raw}`
+  against `http://localhost:16686`.
+- Jaeger all-in-one uses **in-memory storage** → traces are lost on restart; key convs
+  are snapshotted under `scratchpad/corpus/`.
+
+## 10. Gaps / caveats (telemetry layer)
+- **DB span noise**: `PRAGMA`/`SELECT`/`connect` on `chat.db` dominate span counts
+  (108 PRAGMA + 97 SELECT in one 324-span trace). Filter them when reading.
+- **One-action-many-traces** makes "follow one request" non-obvious; `session.id` is the
+  only reliable stitch across the decoupled forwarder/host/startup traces.
+- **Live remote setup is dark**: the running server is remote (reached via the `:6767` tunnel)
+  and its Jaeger UI (`:16686`) can't be tunneled (the SSH-tunnel manager's 32-forward cap), and
+  the live local runner had telemetry **disabled** — hence the dedicated local rig.
+- **codex / codex-native**: Databricks AI-gateway token expired (403) → no live codex
+  spans in this corpus; covered from code + the §4 capability matrix.
+- Per `OBSERVABILITY.md §12`: MLflow raw-span remote-parent patch, parent-based sampling
+  in prod, and `OMNIGENT_OTEL_CAPTURE_CONTENT` must stay off outside dev (PII).

--- a/designs/master-arch/architecture/tools-omnibox.md
+++ b/designs/master-arch/architecture/tools-omnibox.md
@@ -1,0 +1,425 @@
+# Architecture — Tools / MCP / Sandbox (OmniBox) / Shells / Timers
+
+SME scope: the **tool surface** (`sys_*` builtins + custom MCP), the **OS sandbox**
+("OmniBox"), **shells/terminals**, **timers**, **async/inbox**. Code is ground
+truth; every mechanism is `file:line`-anchored and (where possible) corroborated by
+the live trace corpus.
+
+---
+
+## Overview
+
+A turn's tool surface is assembled in two independent places:
+
+1. **`ToolManager`** (`omnigent/tools/manager.py`) — registers the **builtin tools**
+   the LLM sees (`sys_os_*`, `sys_terminal_*`, async/inbox, timers, sub-agents,
+   agents, models, policy, comments, skills, web, upload/download). It does **not**
+   register MCP tools.
+2. **`RunnerMcpManager`** (`omnigent/runner/mcp_manager.py`) — owns the lifecycle of
+   **user-declared MCP servers** (`tools.mcp` YAML), pools them (8-entry LRU), and
+   exposes their tools namespaced as `{server}__{tool}`.
+
+At dispatch time **both** kinds flow through one seam: the harness calls a tool →
+runner `ProxyMcpManager` POSTs to the **server** `/v1/sessions/{id}/mcp` (policy gate)
+→ server POSTs back to the **runner** `/v1/sessions/{id}/mcp/execute` (execution). The
+runner runs builtin/local tools via `tool_dispatch.execute_tool` and namespaced MCP
+tools via `RunnerMcpManager`. (Routing mechanics are owned by the RUNNER SME — see
+cross-reference below; this doc owns the tool **definitions** + sandbox/shell mechanics.)
+
+"OmniBox" is **not** a web component — it is the **OS-level sandbox** an
+`OSEnvironment` runs inside: filesystem isolation + a default-deny L7 egress proxy +
+secretless credential injection.
+
+---
+
+## Key files (file:line)
+
+### Tool registration (`ToolManager`)
+- `omnigent/tools/manager.py:105` — `ToolManager.__init__`; registration order.
+- `:186` `_register_policy_tools` (always) · `:200` `_register_async_inbox_tools`
+  (gated `async_enabled`, **default True**) · `:231` `_register_timer_tools`
+  (gated `timers`, **default False**) · `:266` `_register_skill_tools` ·
+  `:288` `_register_builtin_tools` · `:374` `_register_sub_agent_tools` ·
+  `:471` `_register_agent_mgmt_tools` (always) · `:490` `_register_task_lifecycle_tools`
+  (always `sys_cancel_task`) · `:511` `_register_comment_tools` (always) ·
+  `:525` `_register_os_env_tools` (gated `os_env`) · `:563` `_register_terminal_tools`
+  (gated `terminals`).
+
+### Builtin tool definitions
+- `omnigent/tools/builtins/os_env.py` — `sys_os_read/write/edit/shell`; all four wrap one
+  shared `OSEnvironment` (`build_os_env_tools` `:378`); `_OSEnvBackedTool.invoke` bridges
+  sync→async via `asyncio.run` (`:153`).
+- `omnigent/tools/builtins/sys_terminal.py` — `sys_terminal_launch/send/read/list/close`;
+  `_resolve_cwd` precedence `:752`; `_has_meaningful_cwd` `:48`.
+- `omnigent/tools/builtins/async_inbox.py` — `sys_call_async` `:129`, `sys_read_inbox` `:240`,
+  `sys_cancel_async` `:334`, `sys_cancel_task` `:37`.
+- `omnigent/tools/builtins/timer.py` — `SysTimerSetTool` `:49`, `SysTimerCancelTool` `:226`;
+  sessions-native `_schedule_timer` → `NotImplementedError` `:220`.
+- `omnigent/tools/builtins/spawn.py` — `sys_session_create/send/close/list/get_history/get_info/share`.
+- `omnigent/tools/builtins/agents.py` — `sys_agent_get/download/list`.
+- `omnigent/tools/builtins/list_models.py` — `sys_list_models`, `sys_advise_models`.
+- `omnigent/tools/builtins/policy.py` — `sys_add_policy`, `sys_policy_registry`.
+
+### Custom MCP
+- `omnigent/spec/types.py:~847` — `MCPServerConfig` (transport `http`(SSE)/`stdio`, `url`/`headers`
+  vs `command`/`args`/`env`, per-tool `timeout`/`retry`); allowlist field on the tool entry.
+- `omnigent/runner/mcp_manager.py` — `RunnerMcpManager`; `_POOL_SPEC_CAPACITY = 8` `:45`;
+  `compute_spec_hash` `:74`; `_mcp_tool_schema` namespacing `:99`; `_ensure_entry` `:457` /
+  `_touch` `:470` / `_evict_if_needed` `:476`; inline elicitation callback `:182`.
+- `omnigent/runner/proxy_mcp_manager.py:42` — `ProxyMcpManager`; `call_tool` `:178` POSTs to
+  server `/v1/sessions/{id}/mcp`.
+
+### Routing seam (cross-ref: RUNNER SME owns this)
+- `omnigent/runner/app.py:13086` — `_relay_tool_executor` (native harness in-turn relay → `ProxyMcpManager`).
+- `omnigent/runner/app.py:17829` — `POST /v1/sessions/{id}/mcp/execute` handler (runner executor; dispatches
+  both namespaced MCP and bare local tools).
+- `omnigent/runner/tool_dispatch.py:10` — `_OS_ENV_TOOLS` (sys_os_*), terminal/inbox families.
+- `omnigent/server/routes/sessions.py:1077` — `_evaluate_tool_call_policy` (the TOOL_CALL gate on `/mcp`).
+
+### OmniBox (OS sandbox)
+- `omnigent/inner/sandbox.py` — `SandboxPolicy` `:49`, `resolve_sandbox` `:371`,
+  `_default_sandbox_for_platform` `:806`, `run_launcher` (spawn-time wrap + activate) `:598`.
+- `omnigent/inner/bwrap_sandbox.py` — Linux `linux_bwrap` (namespaces + `--ro-bind-try` +
+  tmpfs dotfile mask + seccomp).
+- `omnigent/inner/seatbelt_sandbox.py` — macOS `darwin_seatbelt` (SBPL via `sandbox-exec -f`).
+- `omnigent/inner/windows_jobobject_sandbox.py` — Windows `windows_jobobject` (process-tree containment only).
+- `omnigent/inner/egress/` (package; the doc's "`inner/egress.py`") — `rules.py` (DSL + DNS-safe host),
+  `proxy.py` (MITM + private-IP/metadata block + credential rewrite), `controller.py`, `relay.py`, `ca.py`.
+- `omnigent/inner/credential_proxy.py` — `prepare_credential_proxy_runtime` `:103`,
+  `CredentialRewriteRule` `:51`, `_resolve_secret` `:156`.
+- `omnigent/inner/os_env.py` — `OSEnvironment` / `_HelperProcessClient`; `shell()` `:294`,
+  helper subprocess spawn `:547`.
+
+### Terminals (shells)
+- `omnigent/terminals/registry.py` — `TerminalRegistry.launch` `:160` (per-conversation, race-safe).
+- `omnigent/terminals/pane_reaper.py` — **idle** reaper for native panes (`_DEFAULT_IDLE_TIMEOUT_S = 30min`).
+- `omnigent/inner/terminal.py` — `TerminalInstance`; `reap_orphaned_terminals` (startup) `:581`;
+  tmux `remain-on-exit on` `:156`.
+
+---
+
+## The `sys_*` tool surface — groups + gating
+
+| Group | Tools | Registered by | Gating |
+|---|---|---|---|
+| **File/shell** | `sys_os_read`, `sys_os_write`, `sys_os_edit`, `sys_os_shell` | `_register_os_env_tools` `manager.py:525` | spec has `os_env:` (or pre-resolved `OSEnvironment` from `SessionResourceRegistry`) |
+| **Terminals** | `sys_terminal_launch/send/read/list/close` | `_register_terminal_tools` `:563` | spec has non-empty `terminals:` |
+| **Async/inbox** | `sys_call_async`, `sys_read_inbox`, `sys_cancel_async` | `_register_async_inbox_tools` `:200` | `async_enabled` (**default True**; `async: false` is the kill-switch) |
+| **Task lifecycle** | `sys_cancel_task` | `_register_task_lifecycle_tools` `:490` | **always** (any async handle's system message points at it) |
+| **Timers** | `sys_timer_set`, `sys_timer_cancel` | `_register_timer_tools` `:231` | `timers` (**default False**) ⚠️ sessions-native firing path unimplemented |
+| **Sub-agents (read)** | `sys_session_list`, `sys_session_get_history`, `sys_session_get_info` | `_register_sub_agent_tools` `:374` | **always** (any agent can read main/siblings) |
+| **Sub-agents (write)** | `sys_session_send`, `sys_session_close`, `sys_list_models`, `sys_advise_models` | `:446` | `tools.agents` (declared sub-agents) **OR** `spawn: true` |
+| **Sub-agents (create)** | `sys_session_create` | `:468` | `spawn: true` only |
+| **Sub-agents (share)** | `sys_session_share` | `:441` | own `agent_session_sharing` flag (`none`/`non-public`/`public`) |
+| **Agents** | `sys_agent_get`, `sys_agent_download`, `sys_agent_list` | `_register_agent_mgmt_tools` `:471` | **always** (auth-gated server-side) |
+| **Models** | `sys_list_models` | (also with sub-agent dispatch grant) | with dispatch grant |
+| **Policy** | `sys_add_policy`, `sys_policy_registry` | `_register_policy_tools` `:186` | **always** |
+| **Comments** | `list_comments`, `update_comment` | `_register_comment_tools` `:511` | **always** (framework-owned; cannot be spec-declared) |
+| **Skills/web/files** | `load_skill`, `read_skill_file`, `web_search`, `web_fetch`, `upload_file`, `download_file`, `list_files`, `search_conversations`, `export_agent` | `_register_skill_tools` / `_register_builtin_tools` | `load_skill` always; rest declared in `tools.builtins` |
+
+Key gating nuances:
+- **Authority vs advertisement**: the opt-ins control *advertisement*. Spawn writes are
+  child-only and `sys_session_share` is owner-authority-bounded; both are enforced at the
+  server/dispatch layer regardless (`manager.py:420`).
+- **`sys_os_*` collision guard**: registration raises `ValueError` if a `sys_os_*` name is
+  already taken (`:555`) — defensive against double-registration.
+
+---
+
+## Custom (user-defined) MCP servers
+
+**Declaration** (`tools.mcp` in agent YAML, `MCPServerConfig` `spec/types.py:~847`):
+- `transport: "http"` (default) → SSE client (`mcp.client.sse.sse_client`); fields `url`,
+  `headers`.
+- `transport: "stdio"` → local subprocess (`mcp.client.stdio.stdio_client`); fields `command`,
+  `args`, `env`. The validator rejects HTTP fields on stdio and vice-versa.
+- Per-server tool **allowlist** (bare names; checked in `_mcp_tool_schema` `:129`), plus
+  `timeout`/`retry` (inherit `tools.timeout`/`tools.retry`).
+
+**Pooling** (`RunnerMcpManager`):
+- Lazy connect; entries keyed by **spec hash** (`compute_spec_hash` over `spec.mcp_servers` +
+  stdio cwd `:74`).
+- **8-entry LRU** (`_POOL_SPEC_CAPACITY = 8` `:45`); `_touch` moves most-recent to tail
+  (`:470`); `_evict_if_needed` pops the head and closes its connections async (`:476`–`:497`).
+- Tools namespaced **`{server}__{tool}`** (double-underscore) so two servers' identically-named
+  tools never collide (`:139`).
+- **Inline elicitation**: a custom MCP server can request approval mid-call via
+  `elicitation/create`; the callback (`_build_elicitation_callback` `:182`) POSTs a
+  `mcp_elicitation` event to the Omnigent server → web approval card → resolved → swapped back.
+  When no server client is wired, elicitations are **declined** (`:218`).
+
+> Cross-ref (RUNNER SME): pool lifecycle, prewarm, `tools/list`, and the actual outbound
+> `tools/call` to each MCP server live in `runner/mcp_manager.py` and the `/mcp/execute` handler.
+> This doc owns the *declaration shape*, *namespacing*, *allowlist*, and *LRU* facts.
+
+---
+
+## MCP routing — the two modes + the unified gate
+
+```mermaid
+sequenceDiagram
+  participant H as Harness (vendor CLI / SDK)
+  participant R as Runner (omni-runner)
+  participant S as Server (omni-server)
+  participant X as Tool executor (runner-local OR custom MCP)
+
+  Note over H,R: Mode A — SDK harness (claude-sdk/codex/Polly): SDK calls MCP tool in-process
+  Note over H,R: Mode B — native harness: vendor CLI POSTs to bridge relay → _relay_tool_executor (app.py:13086)
+  H->>R: tool call (name, arguments)
+  R->>S: POST /v1/sessions/{id}/mcp   (ProxyMcpManager.call_tool)
+  S->>S: policy.evaluate phase=TOOL_CALL (sys_os_shell)  ← THE GATE
+  alt ALLOW
+    S->>R: POST /v1/sessions/{id}/mcp/execute  (app.py:17829)
+    R->>X: tool_dispatch.execute_tool (bare)  OR  RunnerMcpManager (server__tool)
+    X-->>R: result
+    R-->>S: result
+    S->>S: policy.evaluate phase=TOOL_RESULT (sys_os_shell)
+    S-->>R: result (back through /mcp)
+    R-->>H: tool result
+  else ASK
+    S->>S: publish response.elicitation_request → web ApprovalCard → resolve
+  else DENY
+    S-->>R: denied (fail-CLOSED on TOOL_CALL)
+  end
+```
+
+- **In-turn relay (native harnesses)**: the vendor CLI (Claude Code, codex) POSTs its tool
+  calls to a localhost bridge HTTP relay (Bearer-token auth); `_relay_tool_executor`
+  (`app.py:13086`) hands them to `ProxyMcpManager` so the **same server-side policy gate**
+  applies as for SDK harnesses.
+- **Out-of-turn (workspace tools)**: the native bridge launches its **own** MCP stdio server
+  via the `serve-mcp` subcommand (`claude_native_bridge.py:3095`/`_serve_mcp` `:3116`), wired
+  into Claude Code's `settings.json` `mcpServers` (`:1020`). This server exposes **only**
+  `sys_os_*` against the workspace cwd, **no sandbox** — it's how the vendor CLI reads/edits
+  files *outside* an active Omnigent turn. (Note: `serve-mcp` is the *native bridge's* argparse
+  subcommand, **not** a top-level `omnigent` CLI command — corrects CUJ-ANALYSIS §2.C wording.)
+- **The single gate**: regardless of harness, the **server** owns TOOL_CALL/TOOL_RESULT policy
+  (it's the only party that calls `_evaluate_tool_call_policy`); the **runner** owns execution
+  ("all tools run on the correct machine with the correct cwd and environment",
+  `app.py:17834`). Runner has a fast-path ALLOW/DENY before dispatch; ASK escalates to server
+  (per CUJ-ANALYSIS §2.D — `runner/policy.py`).
+
+---
+
+## Shells — two paths + cwd resolution
+
+There are **two distinct ways a shell reaches an agent**:
+
+1. **`sys_os_shell`** — a one-shot command run inside the agent's **shared `OSEnvironment`**
+   (`os_env.shell()` `os_env.py:294`). All four `sys_os_*` tools share one `OSEnvironment`
+   instance (`build_os_env_tools` os_env.py:378) so **cwd + sandbox + env stay consistent across
+   calls** within a turn. The command runs in the (possibly sandboxed) helper subprocess.
+2. **`sys_terminal_*`** — **persistent, named tmux panes** (`TerminalRegistry`,
+   `inner/terminal.py`). State survives across turns within a conversation (keyed
+   `(conversation_id, terminal_name, session_key)`). Panes use tmux `remain-on-exit on`
+   (`terminal.py:156`) so a dead pane (and its session/server) is kept for inspection rather
+   than auto-vanishing.
+
+### Working-directory resolution precedence (`_resolve_cwd`, `sys_terminal.py:752`)
+
+First match wins:
+1. **LLM `cwd_override`** (already vetted against the terminal spec's `allow_cwd_override`).
+2. **`terminal.os_env.cwd`** — the terminal spec's own cwd (skipped if `None`/`""`/`"."`/`"./"`
+   per `_has_meaningful_cwd` `:48`, or the legacy `"inherit"` string sentinel).
+3. **`spec.os_env.cwd`** — the agent's primary os_env cwd (same meaningful-cwd test).
+4. **`ctx.workspace`** — the per-task workspace Omnigent creates in `runtime/workflow.py`.
+5. *(implicit 5th)* If all four miss, `_resolve_cwd` returns **`None`** and the caller falls
+   back to the **host/runner cwd** (mirrors legacy behavior; docstring `:776`).
+
+The trace confirms tier 4/5: the `sys_os_shell` result carried
+`cwd=/Users/.../omnigent-worktrees/traces` (the runner workspace).
+
+### Orphan + idle reaping (two separate reapers)
+- **Orphan reaper** (`reap_orphaned_terminals` `terminal.py:581`): runs at **runner startup**.
+  Each instance dir records its **owner pid** at creation; the sweep kills the tmux server of
+  every instance whose owner pid is **gone** (`tmux -S <sock> kill-server`) and removes the dir.
+  Dirs without an owner-pid marker are left alone (older/foreign). Fixes the leak where a
+  SIGKILL'd runner orphans one tmux server per session.
+- **Idle pane reaper** (`pane_reaper.py`, issue #1349): a background loop that reaps a **native
+  harness pane** after a **30-minute** idle window (`_DEFAULT_IDLE_TIMEOUT_S`, env
+  `OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S`, `0` disables). "Busy" is a 3-signal check with a
+  second re-check immediately before teardown to close the select→reap race; teardown is
+  pane-scoped (only the one native pane, scoped via `NATIVE_PANE_TERMINAL_NAMES`).
+
+---
+
+## OmniBox — the OS sandbox (3 backend types × 3 isolation layers)
+
+### Backend resolution (`inner/sandbox.py`)
+`resolve_sandbox(spec, cwd)` `:371`: if `sandbox.type == "none"` → inert policy (and it errors
+if `none` tries to restrict reads/writes/network `:379`). Otherwise the platform default
+(`_default_sandbox_for_platform` `:806`) is chosen at **parse** time (not run time), then the
+backend's `.resolve()` builds a `SandboxPolicy`:
+
+| Platform default | `type_name` | Mechanism |
+|---|---|---|
+| Linux | `linux_bwrap` | bubblewrap: mount/PID/UTS/IPC namespaces (`--unshare-*`) + `--ro-bind-try` read roots + tmpfs dotfile mask + `--proc`/`--dev` + **hardened seccomp denylist** (k8s baseline + clone/ptrace/etc.) |
+| macOS | `darwin_seatbelt` | `sandbox-exec -f <profile>` SBPL: `(deny default)` baseline + selective `(allow ...)`; **no namespaces, no seccomp** (capability-level only) |
+| Windows | `windows_jobobject` | Job Object process-tree containment + resource limits; **no filesystem/network isolation** |
+| any (explicit) | `none` | no sandbox (the only opt-out) |
+
+`caller_process` / `fork` / `sandbox` are the three **`OSEnvironment` modes** (per CUJ-ANALYSIS
+§2.C: `caller_process` = no isolation/in-process; `fork` = workspace copy; `sandbox` = one of the
+backends above). Fail-loud: a host missing the chosen backend's binary errors at sandbox **build**
+time (`bwrap_sandbox.resolve` raises with an install hint), not silently unsandboxed.
+
+The launcher (`run_launcher` `:598`) does a **spawn-time wrap re-exec** for bwrap/seatbelt
+(`_SPAWN_WRAP_BACKENDS` `:41`): it re-execs itself under `bwrap`/`sandbox-exec` (via an inline
+`python -c` so the script file isn't needed inside the fresh tmpfs `/tmp` `:670`), guarded by the
+`OMNIGENT_LAUNCHER_SPAWN_WRAPPED` marker to break the loop. It strips runner-auth secrets from
+the env first (`:622`) and prunes to `spawn_env_allowlist` (`:632`) so host env can't leak in.
+
+### Layer 1 — filesystem isolation
+- **bwrap**: hermetic root; only granted paths bound `--ro-bind-try` (read) / `--bind-try`
+  (write `write_files`); cwd bound at its real absolute path; **every dotfile/dotdir in cwd is
+  tmpfs-masked** unless its basename is in `cwd_allow_hidden` (`.venv` whitelisted by default)
+  — masking is *invisibility* (the masked path doesn't exist in the view). `--clearenv`/`--setenv`
+  deliberately **avoided** (argv is world-readable via `/proc/<pid>/cmdline`); env pruning is done
+  in-process instead.
+- **seatbelt**: `$HOME` is hidden by the `(deny default)` baseline (no explicit subpath deny);
+  masking is **access-deny, not invisibility** (a masked file `stat`s but reads `EPERM`); SBPL is
+  **deny-wins** (`sandbox-exec` evaluates deny as last-match).
+
+### Layer 2 — default-deny L7 egress proxy (`inner/egress/`)
+- **Rule DSL** (`rules.py`): `METHODS host/path-glob`; default **deny** (`check_request` `:185`).
+- **DNS-safe host allowlist** (`_DNS_SAFE_HOST_RE` `:49`, `is_dns_safe_host` `:52`): rejects any
+  byte outside `[A-Za-z0-9.-]` — closes the NUL-truncation / percent-encoding / CRLF-injection
+  parser-differential smuggling class (explicitly cites the Claude Code sandbox-runtime CVE fix).
+- **Private-destination blocking** (`proxy.py`, default `block_private_destinations=True` `:201`):
+  the proxy **resolves the host once** before connecting (`_resolve_and_validate` `:914`) and
+  refuses any non-globally-routable IP — RFC1918, loopback, link-local, ULA, reserved, TEST-NET,
+  **CGNAT/100.64**, multicast, and **cloud-metadata traps** (`169.254.169.254`,
+  Azure WireServer `168.63.129.16` `_CLOUD_TRAP_NETWORKS` `:124`). Resolve-**once** defeats DNS
+  rebinding (public on first lookup, private on the second). Toggle:
+  `OSEnvSandboxSpec.egress_allow_private_destinations`.
+- **MITM**: terminates TLS with a per-sandbox CA (`ca.py`); the in-namespace relay (`relay.py`)
+  forwards over a Unix socket to the parent proxy (the only egress path, which is why
+  credential injection is safe — a tool can't open a raw socket around it).
+
+### Layer 3 — secretless credential injection (`inner/credential_proxy.py` + `egress/proxy.py`)
+Two models (default = swap-on-access, nothing credential-shaped in the sandbox):
+- **Swap-on-access (default)**: parent resolves the real secret
+  (`prepare_credential_proxy_runtime` `:103`; sources `env`/`file`/`command` `_resolve_secret`
+  `:156`) and hands the proxy a `CredentialRewriteRule` (`:51`). A tool fires its request with
+  **no `Authorization`**; the proxy injects `Authorization: <scheme> <real>` for the bound host
+  (`_rewrite_authorization` `:1084`, swap-on-access branch `:1145`).
+- **Opt-in placeholder injection** (for clients like `gh` that gate on a local token): the parent
+  mints a single-use `oa_cred_*` placeholder (`secrets.token_urlsafe(24)` `:141`) and injects
+  **only the placeholder** into the configured env var. The client sends the placeholder; the
+  proxy swaps it for the real secret (`:1129`).
+- **Leak guard**: a placeholder presented for a host it isn't bound to → **HTTP 403** (`:1135`);
+  an unknown `oa_cred_*`-shaped value → 403. A real, non-placeholder `Authorization` the client
+  set itself is **forwarded untouched** and suppresses injection (no-clobber `:1125`).
+- The real secret lives **only** in the parent + the proxy's in-memory table; it is **never** in
+  `SandboxPolicy.to_jsonable` (so it can't reach logs/dumps — `sandbox.py:151` comment), never on
+  argv, never written to disk in the sandbox.
+
+```mermaid
+flowchart LR
+  subgraph parent[Parent process - unsandboxed]
+    sec[Real secret resolved] --> tbl[Proxy in-memory rewrite table]
+  end
+  subgraph box[Sandbox - bwrap/seatbelt]
+    tool[git / curl / gh] -->|no auth header OR oa_cred_*| relay[in-ns relay]
+  end
+  relay -->|unix socket| proxy[Egress MITM proxy]
+  proxy -->|host bound? inject/swap real| up[(upstream 200)]
+  proxy -.->|wrong host / unknown oa_cred_*| f403[403]
+  tbl --- proxy
+```
+
+> Known SECURITY gap (CUJ-ANALYSIS §gaps): `_resolve_secret` runs parent-side
+> `subprocess.run(..., shell=True)` (`credential_proxy.py:190`) + arbitrary file reads on a
+> "trusted-spec-only" assumption (issue #1542, no PR).
+
+---
+
+## Timers + Async/Inbox (tool definitions; runtime owned by RUNTIME SME)
+
+- **Timers** (`timer.py`, gated `timers: true`, default False): `sys_timer_set` generates a
+  `timer_id` and returns **synchronously** (`:179`); the firing later arrives as a
+  `[System: timer X fired]` system message via the **same `async_work_complete` drain** as
+  `sys_call_async` (with `kind="timer"` so it doesn't block end-of-turn auto-collect,
+  `manager.py:170`). ⚠️ **On the sessions-native path the firing workflow is unimplemented** —
+  `_schedule_timer` raises `NotImplementedError` (`timer.py:220`) and `sys_timer_cancel` returns
+  a no-active-timer result.
+- **Async/inbox** (`async_inbox.py`, gated `async_enabled`, default True): `sys_call_async`
+  fire-and-forget dispatch; results drain via the `async_work_complete` inbox, pulled explicitly
+  by `sys_read_inbox` (`:240`) or auto-collected at the top of each loop iteration
+  (`_drain_async_completions`, RUNTIME-owned). `sys_cancel_async` is a thin alias over the
+  always-registered `sys_cancel_task`.
+
+---
+
+## Trace evidence (corpus `conv_63542a5f92e24956812e19b104eac0e9`, `sys_os_shell` of `echo TRACETEST123`)
+
+The `POST /events` trace **`cfb59197f6f9`** shows the exact MCP+policy chain (services in brackets):
+
+```
+omni-server [internal] policy.evaluate            phase=REQUEST     dec=ALLOW  ← POST /events
+omni-server [internal] policy.evaluate            phase=LLM_REQUEST dec=ALLOW  ← /policies/evaluate
+omni-server [server  ] POST /v1/sessions/{id}/mcp                             ← omni-runner:POST   (runner→server)
+omni-server [internal] policy.evaluate            phase=TOOL_CALL   dec=ALLOW tool=sys_os_shell  ← /mcp   (THE GATE)
+omni-runner [server  ] POST /v1/sessions/{id}/mcp/execute                     ← omni-server:POST  (server→runner exec)
+omni-server [internal] policy.evaluate            phase=TOOL_RESULT dec=ALLOW tool=sys_os_shell  ← /mcp
+omni-server [internal] policy.evaluate            phase=LLM_RESPONSE dec=ALLOW ← /policies/evaluate
+```
+
+Separately, trace **`f98feda729f6`** (the harness's OpenInference span tree):
+```
+omni-harness [internal] agent:claude-sdk
+omni-harness [internal]   tool:sys_os_shell   (openinference.span.kind=TOOL, tool.name=sys_os_shell)  ← agent:claude-sdk
+```
+
+Other corroborating spans seen for this conv:
+- `omni-runner GET /v1/sessions/{id}/resources/terminals` (traces `906c…`, `7c4b…`) — the runner
+  probing the **terminal registry** for the session (confirms `sys_terminal_*` registry is live).
+- `policy.evaluate` `policy.content` for TOOL_CALL =
+  `{"name":"sys_os_shell","arguments":{"command":"echo TRACETEST123"}}` and TOOL_RESULT carried
+  `cwd=/Users/.../traces` — confirming cwd-resolution tier 4/5 (runner workspace) and that the
+  result flows back through the server's policy stage.
+
+This is the gold case: the mechanism is confirmed by **both** code (`/mcp` gate +
+`/mcp/execute` exec) **and** trace (the 4 policy phases + the server↔runner edges + the
+OpenInference `tool:sys_os_shell` span).
+
+---
+
+## Per-harness differences
+
+| Harness | Tool surface delivery | Workspace (out-of-turn) tools | Sandbox notes |
+|---|---|---|---|
+| **claude-sdk** | SDK calls MCP tools in-process; `tool:` span on omni-harness; all gating via `ToolManager(spec)` | n/a (SDK is the turn) | sandboxed `OSEnvironment` when spec sets `os_env`; macOS sandboxed claude-sdk **crashes** instead of degrading (issue #517 part-1 unfixed) |
+| **claude-native** | vendor CLI → bridge relay → `_relay_tool_executor` → `ProxyMcpManager` (same gate); relay advertises only names `ToolManager(spec)` registered | `serve-mcp` MCP stdio in `settings.json`; **only `sys_os_*`**, workspace cwd, **no sandbox** (`claude_native_bridge.py:3116`) | in-turn tools still hit the server policy gate |
+| **codex** (SDK) | structurally identical to claude-sdk (no live trace — creds expired 403) | n/a | same `OSEnvironment` machinery |
+| **codex-native** | structurally analogous to claude-native (its own bridge relay; no live trace) | analogous serve-mcp workspace path | — |
+| **polly** (custom agents) | runs on a host harness (typically claude-sdk) and **inherits its tool behavior**; `ToolManager` registers from the custom agent's spec (`os_env`/`terminals`/`tools.mcp` as declared) | inherits host harness | inherits host harness sandbox |
+
+---
+
+## Failure branches & gaps
+
+- **Sandbox missing backend binary** → fail-loud at sandbox build (bwrap/seatbelt `.resolve()` raises).
+- **macOS sandboxed claude-sdk** → **crashes** rather than degrading (issue #517 part-1, no PR;
+  part-2 flag #541 landed). CUJ-ANALYSIS §gaps.
+- **Egress**: any non-globally-routable resolution → `PermissionError`/403; DNS rebinding defeated by
+  resolve-once; IPv6 literals + Unicode IDNs rejected by the DNS-safe-host allowlist (documented limit).
+- **Credential proxy**: wrong-host placeholder / unknown `oa_cred_*` → **403**; misconfigured/empty
+  source → `ValueError` at helper start. SECURITY: parent-side `shell=True` + file reads (#1542, no PR).
+- **Timers on sessions-native** → `NotImplementedError` (firing path never re-implemented on the runner).
+- **MCP pool**: 9th distinct spec evicts the LRU head and closes its connections async; a custom MCP
+  inline elicitation with no server client wired → **declined**.
+- **Terminal launch**: tmux not on PATH or pane exits before ready → `RuntimeError` (wrapped as JSON
+  error envelope by the tool); concurrent same-key launch → second-arrival wins, loser closed.
+
+---
+
+## Open questions / cross-references
+- **RUNNER SME** owns: `RunnerMcpManager` pool lifecycle/prewarm, the outbound `tools/call` to each
+  MCP server, `runner/policy.py` fast-path, the `/mcp/execute` dispatch internals.
+- **RUNTIME SME** owns: `async_work_complete` drain (`_drain_async_completions`), inbox queue
+  mechanics, the timer **firing** task (where it would live once implemented).
+- **POLICY SME** owns: `_evaluate_tool_call_policy`, elicitation registry, the fail-closed/fail-open
+  phase set. (This doc only notes the 4 policy phases seen in the trace.)
+- Confirm whether the `fork` `OSEnvironment` mode shares the same `_resolve_cwd`/egress wiring as
+  `sandbox` (it reuses `OSEnvironment` but with a workspace copy — not separately traced here).

--- a/designs/master-arch/architecture/tools-omnibox.md
+++ b/designs/master-arch/architecture/tools-omnibox.md
@@ -316,15 +316,15 @@ Two models (default = swap-on-access, nothing credential-shaped in the sandbox):
 
 ```mermaid
 flowchart LR
-  subgraph parent[Parent process - unsandboxed]
-    sec[Real secret resolved] --> tbl[Proxy in-memory rewrite table]
+  subgraph parent["Parent process — unsandboxed"]
+    sec["Real secret resolved"] --> tbl["Proxy in-memory rewrite table"]
   end
-  subgraph box[Sandbox - bwrap/seatbelt]
-    tool[git / curl / gh] -->|no auth header OR oa_cred_*| relay[in-ns relay]
+  subgraph box["Sandbox — bwrap/seatbelt"]
+    tool["git / curl / gh"] -->|"no auth header OR oa_cred_*"| relay["in-ns relay"]
   end
-  relay -->|unix socket| proxy[Egress MITM proxy]
-  proxy -->|host bound? inject/swap real| up[(upstream 200)]
-  proxy -.->|wrong host / unknown oa_cred_*| f403[403]
+  relay -->|"unix socket"| proxy["Egress MITM proxy"]
+  proxy -->|"host bound? inject/swap real"| up[("upstream 200")]
+  proxy -.->|"wrong host / unknown oa_cred_*"| f403["403"]
   tbl --- proxy
 ```
 

--- a/designs/master-arch/architecture/tui-repl.md
+++ b/designs/master-arch/architecture/tui-repl.md
@@ -1,0 +1,476 @@
+# TUI / REPL Client — Architecture
+
+> Scope: the interactive terminal client (`omnigent/repl/`) + the client transport
+> (`OmnigentClient`, the single `httpx.AsyncClient`), and how `omnigent run` (default
+> mode) wires the REPL as an HTTP client to a spawned local server.
+> **Source of truth = code.** Trace evidence is thin by design (corpus is headless;
+> see §Trace evidence). Cross-references the SERVER doc for server internals.
+
+---
+
+## 1. Overview
+
+The Omnigent TUI ("the REPL") is a `rich` / `prompt_toolkit` terminal front-end that is
+a **pure HTTP/SSE client of an Omnigent server** — it has no in-process runner or harness.
+It speaks the **same `/v1/sessions/*` REST + SSE surface the web UI uses**, but a *strict
+subset* of it (no WebSocket `/sessions/updates`, no `/switch-agent`, no projects/sharing/
+comments/policy-admin routes).
+
+Two things to keep distinct:
+
+- **`run_repl()`** (`omnigent/repl/_repl.py:2936`) — the interactive loop: rich streaming
+  renderer, slash commands, `@`-file completer, approval prompts, resume/theme pickers,
+  `--debug-events` tape.
+- **`OmnigentClient`** (`sdks/python-client/omnigent_client/_client.py:21`) — the typed
+  SDK that owns the single `httpx.AsyncClient` and exposes namespaces
+  (`sessions`, `files`, `responses`). The REPL drives **everything** through
+  `client.sessions.*`.
+
+The glue between them is **`_SessionsChatReplAdapter`** (`_repl.py:1234`): a sessions-API
+adapter that owns a persistent SSE pump and a push-based `_on_event` callback. It is
+duck-compatible with the legacy `Session` surface (`send`, `cancel`, `model`,
+`is_streaming`, `set_model_override`, `set_reasoning_effort`, …) so the REPL code is
+transport-agnostic.
+
+`omnigent run <agent>` (default, no URL) launches a **local server subprocess**, waits for
+it to come up, then opens `run_repl()` pointed at `http://127.0.0.1:<port>`
+(`omnigent/chat.py:_chat_local:2042`). So even "local" runs are client↔server over loopback
+HTTP — the REPL is never in-process with the server.
+
+---
+
+## 2. Key files (file:line)
+
+| File | What it owns |
+|---|---|
+| `omnigent/repl/_repl.py:2936` `run_repl()` | The interactive loop; rich rendering; slash dispatch; pickers wiring |
+| `omnigent/repl/_repl.py:1234` `_SessionsChatReplAdapter` | Sessions-API adapter: SSE pump, `_on_event`, `send`, control methods |
+| `omnigent/repl/_repl.py:2012` `_subscribe_session_stream` (pump body) | Persistent `GET /v1/sessions/{id}/stream` subscription + auto-reconnect |
+| `omnigent/repl/_repl.py:3230` `_render_session_event` | Push-based renderer (the `_on_event` callback); dedup/reconciliation |
+| `omnigent/repl/_repl.py:2787` `_TurnProseTracker` | Streamed-prose dedup (byte-equal multiset match) |
+| `omnigent/repl/_repl.py:8254` `handle_slash_command`; `:4508` `COMMANDS`; `:4511` `@_cmd()` | Slash-command registry + dispatch |
+| `omnigent/repl/_resume_picker.py:197` `pick_conversation` | Interactive resume picker (prompt_toolkit + line-buffered fallback) |
+| `omnigent/repl/_event_tape.py:211` `EventTape` | `--debug-events` SSE event tape (ring buffer + Ctrl+E overlay) |
+| `omnigent/repl/_theme_picker.py:288` `startup_theme_picker` | First-run dark/light theme picker |
+| `omnigent/repl/_session_log.py`, `_tmux_pane.py` | `/logs` zip dump; native tmux attach helpers |
+| `sdks/python-client/omnigent_client/_client.py:21` `OmnigentClient` | The single `httpx.AsyncClient` + namespaces |
+| `sdks/python-client/omnigent_client/_sessions.py:307` `SessionsNamespace` | The full REST surface the TUI uses |
+| `sdks/python-client/omnigent_client/_sessions.py:980` `stream()` / `:1018` `_stream_session_events` | SSE GET + parse |
+| `sdks/python-client/omnigent_client/_sse.py:86` `parse_sse_stream` | SSE framing → typed events |
+| `omnigent/chat.py:2042` `_chat_local` | `omnigent run` default-mode wiring (spawn server → REPL) |
+| `omnigent/conversation_browser.py:61` `conversation_url` / `:94` `open_conversation_url` | "open in browser" link |
+| `omnigent/runtime/telemetry.py:1072` `init` / `:392` `_instrument_httpx` | OTel init + httpx instrumentation (NB: no `omni-tui` caller) |
+
+---
+
+## 3. The single httpx client (`OmnigentClient`)
+
+`OmnigentClient.__init__` (`_client.py:57-97`) creates **one** `httpx.AsyncClient`
+(`self._http`) and hands it to all three namespaces. Notable:
+
+- **One SSE-tuned timeout for everything** (`_client.py:74-93`): `connect=30s, read=600s,
+  write=30s, pool=30s`. The 600s read timeout is deliberate — tool calls can hold the SSE
+  stream open for minutes (the public `timeout=` ctor arg is accepted-but-ignored to keep
+  back-compat).
+- **Sentinel `Origin` header** = `OMNIGENT_INTERNAL_WS_ORIGIN` (`_client.py:86`) so the
+  server's `require_trusted_origin` CSRF guard on multipart routes (session-create bundle
+  upload, file upload) lets the SDK through (the SDK is a non-browser client and sends no
+  Origin of its own). Caller headers win on conflict.
+- **`auth: httpx.Auth | None`** (`_client.py:91`): when set, runs on **every** request →
+  transparent OAuth/Databricks token refresh. For local `run`, auth is `None` (loopback);
+  for remote/workspace targets it's a `_DatabricksTokenAuth` (`chat.py:687`) or static
+  bearer headers (`chat.py:_server_headers:796`).
+
+The REPL receives a pre-built `OmnigentClient` and passes it into `_SessionsChatReplAdapter`
+(`_repl.py:3133-3149`).
+
+---
+
+## 4. The full TUI → server request surface
+
+Enumerated from `SessionsNamespace` (`_sessions.py`) and the REPL call sites. **All over the
+one `httpx.AsyncClient`; all under `/v1/`.** "consumed by REPL" = a method the REPL actually
+calls.
+
+| Method (SDK) | Wire call | Used by REPL for | file:line |
+|---|---|---|---|
+| `sessions.create` | `POST /v1/sessions` (multipart bundle) | first turn of a new session (lazy, on first `send`) | `_sessions.py:338` |
+| `sessions.post_event` | `POST /v1/sessions/{id}/events` | send user message; **interrupt**; **compact**; **approval** verdict; client-tool output | `_sessions.py:814` |
+| `sessions.get` | `GET /v1/sessions/{id}` | snapshot (metadata, status); turn-done backstop poll | `_sessions.py:793` |
+| `sessions.stream` | `GET /v1/sessions/{id}/stream` (SSE) | the live event stream (one persistent subscription) | `_sessions.py:980` |
+| `sessions.list` | `GET /v1/sessions` | resume picker, `/switch`, `/history` | `_sessions.py:394` |
+| `sessions.list_items` | `GET /v1/sessions/{id}/items` | `/history`, `/context`, log dump | `_sessions.py:648` |
+| `sessions.child_sessions[_tree]` | `GET /v1/sessions/{id}/child_sessions` | subagent ↓-selector tree | `_sessions.py:684,717` |
+| `sessions.bind_runner` / `unbind_runner` | `PATCH /v1/sessions/{id}` `{runner_id}` | bind/recover the local runner (owner path only) | `_sessions.py:450,481` |
+| `sessions.set_model_override` | `PATCH /v1/sessions/{id}` `{model_override}` | `/model` | `_sessions.py:535` |
+| `sessions.set_reasoning_effort` | `PATCH /v1/sessions/{id}` `{reasoning_effort}` | `/effort` | `_sessions.py:504` |
+| `sessions.compact` (→ post_event) | `POST .../events` `{type:compact}` | `/compact` | `_sessions.py:941` |
+| `sessions.interrupt` (→ post_event) | `POST .../events` `{type:interrupt}` | `/cancel`, Ctrl+C | `_sessions.py:959` |
+| `sessions.resolve_elicitation` | `POST /v1/sessions/{id}/elicitations/{eid}/resolve` | approval via dedicated URL (alt path) | `_sessions.py:845` |
+| `sessions.fork` | `POST /v1/sessions/{src}/fork` | `/fork` | `_sessions.py:887` |
+| `sessions.set_archived` / `set_external_session_id` | `PATCH /v1/sessions/{id}` | (available; archival/native-id) | `_sessions.py:580,613` |
+| `files.for_session(id).upload` | `POST /v1/sessions/{id}/files` (multipart) | `@`-file / `--file` attachments | `_files.py` |
+| `_fetch_agent_tools` | `GET /v1/sessions/{id}/agent` | client-tool validation; `/model` harness readout | `_client.py:303` |
+
+Plus a handful of **raw `httpx.get`** probes in `chat.py` that bypass the SDK (carry no
+`httpx.Auth`): `GET /v1/sessions/{id}` wrapper-label probe (`chat.py:1352`), `GET /v1/info`
+accounts probe (`chat.py:1597`), runner-status poll (`chat.py:1989`).
+
+**The single most important contrast with the web UI:** the TUI has **no
+`WS /v1/sessions/updates`** and **no `WS /health/subscribe`**. There is no sidebar to keep
+live, so the TUI never opens the watch-set websocket. The only live channel is the
+**one SSE stream for the *currently displayed* session**. Sub-agent state in the ↓-selector
+rides that same parent SSE stream as `session.created` / `session.child_session.updated`
+events (`_repl.py:3425 _apply_child_session_event`), not a separate subscription.
+
+Also web-only (no SDK method, mentioned only in a comment at `_sessions.py:129`):
+**`POST /v1/sessions/{id}/switch-agent`**. The TUI's `/switch` does NOT switch agent in
+place — it **re-points the SSE stream to a different existing session**
+(`_repl.py:2695 switch_session`).
+
+---
+
+## 5. Data flow
+
+### 5a. `omnigent run <agent>` → REPL (default local mode)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as omnigent run (chat.py:_chat_local)
+    participant SRV as local server subprocess
+    participant RUN as local runner subprocess
+    participant REPL as run_repl (foreground)
+    participant C as OmnigentClient (httpx)
+
+    U->>CLI: omnigent run agent.yaml
+    CLI->>CLI: load+validate spec; materialize overrides; _find_free_port
+    CLI->>SRV: _start_local_server(spec, port)  [telemetry.init("omni-server") here]
+    CLI->>CLI: _wait_for_server(port); base_url=http://127.0.0.1:port
+    CLI->>CLI: _resolve_resume_target (resume/continue/picker)
+    CLI->>C: build OmnigentClient(base_url)
+    CLI->>REPL: run_repl(client, agent_name, bundle, runner_id, …)
+    REPL->>C: sessions.stream(...) — start SSE pump (lazily, after first session id)
+    Note over REPL: enters prompt loop
+    U->>REPL: types a message
+    REPL->>C: (first send) sessions.create (POST /v1/sessions, bundle)
+    REPL->>C: PATCH runner_id (bind local runner)
+    REPL->>C: sessions.post_event (POST .../events)
+    SRV-->>RUN: dispatch turn (over WS tunnel)  [see SERVER doc]
+    SRV-->>C: SSE: session.status running, deltas, output_item.done, session.status idle
+    C-->>REPL: _on_event(event) per event → rich render
+```
+
+`_chat_local` (`chat.py:2042`) is the entry; it spawns the server (`_start_local_server`),
+waits (`_wait_for_server`), resolves the resume target, bundles the agent, then calls
+`_chat_with_server` → `run_repl`. The local **runner** is a separate subprocess the REPL
+binds via `PATCH /v1/sessions/{id} {runner_id}` and keeps alive via a 1 Hz watchdog
+(`_runner_recover_watch`, `_repl.py:1403`). On URL/remote targets (`omnigent run <url>` /
+`omnigent attach`) there is no spawned server/runner — the REPL is a pure co-drive client
+(`attach_only=True`, `_repl.py:1306`) that never PATCHes the runner binding.
+
+### 5b. One turn: SSE pump + push-based render
+
+```mermaid
+flowchart TD
+    A["sessions.stream() async-for"] --> B{event type}
+    B -->|session.status running| C["_saw_text_deltas=False; prose_tracker.reset_turn(); host.start_timer(); render ◆ header"]
+    B -->|TextDelta| D["_saw_text_deltas=True; prose_tracker.on_delta; fmt.format_text_chunk → host.output"]
+    B -->|ReasoningStarted / *Delta| E["fmt.format_reasoning_* → host.output"]
+    B -->|OutputItemDoneEvent| F{item.type}
+    F -->|function_call action_required| G["session._spawn_client_tool → POST .../events {function_call_output}"]
+    F -->|message assistant| H["dedup: if streamed → consume_match, skip; else _render_history_item"]
+    F -->|function_call / output / native| I["_render_history_item (tool panels)"]
+    B -->|session.input.consumed user| J["if _pending_local_user_sends>0: decrement+suppress; else echo user msg"]
+    B -->|ElicitationRequest| K["approval hook → inline y/n → POST .../events {approval} or resolve URL"]
+    B -->|session.status idle/waiting/failed| L["render failed err if any; host.stop_timer(); _turn_done.set()"]
+    B -->|CompactionInProgress/Completed| M["muted 'Compacting…' / 'Compaction complete.'"]
+```
+
+`send()` (`_repl.py:2102`) just POSTs the message, sets `_is_streaming=True`, increments
+`_pending_local_user_sends`, and awaits `_turn_done` (with a 1 Hz `sessions.get` snapshot
+**backstop poll** at `_repl.py:2196-2209`, because httpx's ASGI transport doesn't flush
+streaming chunks eagerly so the SSE pump may miss the terminal event). All rendering is in
+the pump's `_on_event` — there is **no per-send drain loop**; the pump runs continuously and
+also renders **autonomous/between-send turns**.
+
+---
+
+## 6. Channels & message/event types
+
+**Outbound (REST):** see §4 table. Send body shape:
+`{"type":"message","data":{"role":"user","content":[{"type":"input_text","text":…}]}}`
+with optional `model_override` field (`_repl.py:2159-2164`). Control events:
+`{"type":"interrupt","data":{}}`, `{"type":"compact","data":{}}`,
+`{"type":"approval",…}` / function-call-output events.
+
+**Inbound (one SSE stream, `GET /v1/sessions/{id}/stream`):** the server's typed
+`ServerStreamEvent` union, parsed by `_sessions.py:_parse_sse_lines` → Pydantic. The REPL
+consumes (translated to SDK-shape dataclasses by `_server_event_to_sdk_event`,
+`_repl.py:1123`):
+
+- Lifecycle: `response.created/queued/in_progress/completed/failed/incomplete/cancelled`
+- `session.status` (`running` / `idle` / `waiting` / `failed`) — **the turn-state driver**
+- `session.input.consumed` — user-echo + optimistic-bubble reconciliation
+- `response.output_text.delta` (`TextDelta`)
+- `response.reasoning.started` / `.text.delta` / `.summary.text.delta`
+- `response.output_item.done` (`function_call`, `function_call_output`, `message`,
+  native-tool items, `slash_command`)
+- `response.output_file.done`
+- `response.elicitation_request` / `elicitation_resolved`
+- `response.compaction.in_progress` / `.completed`
+- `response.client_task.cancel` (cancel a local client-tool task)
+- `session.agent_changed`, `session.created`, `session.child_session.updated`
+- `response.error`, `response.retry`
+
+**SSE framing** (`_sse.py:86-127`, `_sessions.py:1051-1089`): `event: <type>\n` then
+`data: <json>\n\n`; bare `data: [DONE]` terminates. Unknown event types / malformed
+payloads are logged + skipped (forward-compatible). The framing is parsed identically on
+both the SDK's typed-event path (`_sse.py`) and the raw envelope path (`_sessions.py`).
+
+---
+
+## 7. Streaming ↔ durable reconciliation (dedup) — **TUI differs from web**
+
+The CUJ question: *does the TUI dedupe by `itemId` like the web?* **No.**
+
+- **Web UI** (`web/src/lib/blockStream.ts`, per CUJ-ANALYSIS §2.E:258-260): persisted items
+  are **deduped by `ctx.itemId`** so a stream-delivered item doesn't double-render.
+- **TUI** dedupes by **byte-equal text matching with multiset semantics** via
+  `_TurnProseTracker` (`_repl.py:2787-2883`), **not** by item id:
+  - On each `TextDelta`: `_saw_text_deltas=True` + `prose_tracker.on_delta(delta)`
+    (`_repl.py:3446-3447`).
+  - At a content-block boundary (tool call, or the `message` item),
+    `_flush_inflight_assistant_text()` commits the in-flight segment and records its joined
+    text (`_repl.py:3171-3211`).
+  - When a `message`/assistant `output_item.done` arrives, the renderer checks
+    `_saw_text_deltas` and, if the deltas already committed (the relay persists each prose
+    segment at the tool-call boundary and re-publishes it as `output_item.done` *after*
+    `_saw_text_deltas` was reset), calls `prose_tracker.consume_match(item)` to match the
+    item's joined `output_text` against a committed segment. A match ⇒ **suppress** (it's the
+    persisted copy of prose the user already watched stream). A miss ⇒ **render** (genuinely
+    non-streamed message) (`_repl.py:3586-3596`).
+  - `_plan_output_item_render` (`_repl.py:2752`) centralizes the
+    `flush_inflight_text` vs `render_item` decision given `saw_text_deltas`.
+
+Why text-match not item-id: the streaming text deltas carry **no item id** (they're raw
+`response.output_text.delta` with just a `delta` string), so the TUI has nothing to key on
+until the durable `message` item lands — and by then the boundary has already flushed. The
+multiset (consume-on-match) guards against a turn that legitimately emits two identical
+segments (the second published item matches the second committed entry).
+
+**User-message reconciliation:** the TUI's analogue of the web's optimistic-bubble-until-
+`session.input.consumed` is the `_pending_local_user_sends` counter (`_repl.py:2171`,
+`3384-3385`): a locally-typed message is echoed immediately by the input loop, so when its
+`session.input.consumed` arrives on the stream it's **suppressed** (counter decremented).
+A message that arrives with no pending local send (e.g. a co-drive message from the web UI
+on the same session) **is** echoed. Same idea for skill `slash_command` items
+(`_pending_local_skill_slash_commands`, `_repl.py:3571`).
+
+**Tool-call dedup:** `_SessionsChatReplAdapter`/SessionsChat track
+`completed_tool_call_ids` (`sdks/.../_sessions_chat.py:982`) so a tool-call-end hook fires
+once even if the server echoes the output item; the REPL also keys live tool metadata by
+`call_id` in `_live_call_id_to_tool_metadata` (`_repl.py:3629`).
+
+---
+
+## 8. "Working" state in the TUI
+
+Driven entirely by **`session.status`** on the SSE stream (NOT by `response.created/completed`):
+
+- `status == "running"` → `host.start_timer()` (`_repl.py:3290`) + render the `◆ <agent>`
+  response-start header. The `TerminalHost` (`omnigent_ui_sdk`) shows a live spinner/elapsed
+  timer while the timer runs.
+- `status in ("idle","waiting","failed")` → `host.stop_timer()` (`_repl.py:3343`) and
+  `_turn_done.set()` (unblocks `send()`); a `failed` status with no preceding
+  `response.failed` (e.g. SETUP-phase failure) is rendered as an error line via
+  `_render_failed_status_error` (`_repl.py:2886`) so the spinner never "just vanishes."
+- The same `idle/waiting/failed` check is **duplicated in the pump itself**
+  (`_repl.py:2043-2050`) so `_turn_done` fires even when `_on_event` is not wired (headless
+  adapter use / tests).
+- `is_streaming` property (`_repl.py:1465+`) is the client-side "a turn is in flight" flag,
+  set in `send()` and read by slash commands to append "(current response unchanged)" when
+  the user changes model/effort mid-turn.
+- The **final elapsed time** ("12.3s") is rendered by the formatter's response-end block
+  (`_repl.py:659-673`).
+
+So the TUI computes working-state locally from the status events, whereas the web derives a
+sidebar badge from `status` + `pending_elicitations_count` over the WS updates stream
+(CUJ-ANALYSIS §2.E:261-262). Both bottom out on the same server `status`.
+
+---
+
+## 9. Slash commands → API mapping
+
+Registry: `@_cmd()` decorator (`_repl.py:4511`) → `COMMANDS` dict (`:4508`); dispatch
+`handle_slash_command(arg, session, client, host, fmt)` (`:8254-8293`). Input lines
+starting with `/` (and no second `/`) route here (`_repl.py:3869-3871`).
+
+| Command (aliases) | Handler | What it does | API call |
+|---|---|---|---|
+| `/help` (`/?`) | `_cmd_help` `:4525` | grouped help | — (local) |
+| `/theme` | `_cmd_theme` `:4574` | light/dark | `host.set_theme` + `update_user_config` (local, `~/.omnigent/config.yaml`) |
+| `/effort [level]` | `_cmd_effort` `:4654` | show/set reasoning effort | `session.set_reasoning_effort` → **PATCH /v1/sessions/{id}** `{reasoning_effort}` |
+| `/model [name]` | `_cmd_model` `:4974` | show/set LLM override | `session.set_model_override` → **PATCH /v1/sessions/{id}** `{model_override}` (pre-session: cached, applied on first turn) |
+| `/new` | `_cmd_new` `:5139` | new conversation, keep scrollback | re-point adapter (new session id) |
+| `/clear` | `_cmd_clear` `:5159` | clear screen + new conv | re-point adapter |
+| `/switch` | `_cmd_switch` `:5181` | pick a prior session, re-point | `sessions.list` + `switch_session` (re-points SSE) — **NOT** `/switch-agent` |
+| `/fork` | `_cmd_fork` `:5402` | fork conversation | `sessions.fork` → **POST /v1/sessions/{src}/fork** |
+| `/history` | `_cmd_history` `:5463` | show transcript | `sessions.list_items` → GET .../items |
+| `/context` | `_cmd_context` `:5870` | context-window usage tree | `sessions.list_items` + local estimate |
+| `/compact` | `_cmd_compact` `:5831` | compact context | `session.compact` → **POST .../events** `{type:compact}` |
+| `/cancel` | `_cmd_cancel` `:5934` | interrupt in-flight turn | `session.cancel` → **POST .../events** `{type:interrupt}` |
+| `/logs` | `_cmd_logs` `:6009` | zip session logs | `write_logs_zip` (local; pulls items via API) |
+| `/report` | `_cmd_report` `:6074` | open GitHub issue | `webbrowser.open` (local) |
+| `/quit` (`/exit`) | `_cmd_quit` `:6120` | exit REPL | `host.request_exit` (local) |
+| `/<skill>` (dynamic) | `register_skill_commands` `:8104`, `_make_handler` `:8157` | run a custom skill | `session.send_skill_slash_command` → **POST .../events** `{type:slash_command}` |
+
+**Resume is not a slash command** — it's a CLI flag (`--resume`/`-r` opens the picker,
+`--continue` resumes latest, `--resume <id>` resumes a specific conv) handled before the loop
+by pre-seeding `resume_conversation_id` into the adapter (`_repl.py:1283-1286`,
+`chat.py:_resolve_resume_target`). The adapter then attaches to that session on first `send`.
+
+`@`-file completion: `FileMentionCompleter` (`omnigent_ui_sdk.terminal._completer`,
+imported `_repl.py:58`, wired via `merge_completers([_SlashCommandCompleter(),
+FileMentionCompleter()])` at `_repl.py:3068`). Triggers on a `@` at position 0 or preceded
+by whitespace (so `user@host.com` does NOT trigger); lists non-hidden files under the cwd
+respecting `.gitignore` (`_completer.py:_at_mention_query`, `_list_files`). At submit time
+`@path` tokens resolve to file attachments uploaded via `files.for_session(id).upload`.
+
+---
+
+## 10. Resume picker, event tape, `--debug-events`
+
+### Resume picker (`_resume_picker.py`)
+- Entry `pick_conversation(...)` (`:197`); SDK-backed list fetchers
+  `pick_conversation_from_sdk` (`:878`, `client.sessions.list(limit=200, agent_id=…,
+  order="desc")`), `…_by_wrapper_label_from_sdk` (`:909`, native-harness filter),
+  `…_cross_agent_from_sdk` (`:949`); store-backed `pick_conversation_from_store` (`:974`,
+  reads the local conversation store directly).
+- **TTY path** = prompt_toolkit `Application` (`:447`, `FormattedTextControl`): ↑/↓ move,
+  Enter select, n/p page (10/page, `_PAGE_SIZE`), q/Esc/Ctrl-D cancel; rows show
+  **title · created_at · [workspace] · id · [runtime badge]** + a latest-message preview
+  glyph (`:642-830`). **Non-TTY fallback** = line-buffered Rich render (`:281`, `:1023`).
+- Returns the selected `conversation_id` string (or `None` on cancel). Used by
+  `chat.py:_resolve_resume_target` after the server boots.
+
+### Event tape — `--debug-events` (`_event_tape.py`)
+- `EventTape` (`:211`) = `deque[TapeEntry]` ring buffer, `maxlen=_TAPE_CAPACITY=500`
+  (`:33,235`). Lazily created only when `debug_events` (`_repl.py:3082-3085`); zero overhead
+  otherwise.
+- Each `TapeEntry` (`:115`) records the full **render pipeline journey** per event: `ts`,
+  `delta_ms`, `raw_event_type`, `sdk_translation`, `formatter_result`, `stage_reached`
+  (RAW→TRANSLATED→FORMATTED→RENDERED), `path` ("sessions"|"blockstream"), `raw_payload`
+  (JSON snapshot), `formatted_items`. The renderer instruments every branch:
+  `record_raw` → `update_translation` → `update_format` → `mark_rendered`
+  (e.g. `_repl.py:3276,3280,3305,3309`).
+- **Ctrl+E** opens the "SSE Event Tape" overlay (`_repl.py:4263`): a sidebar of events
+  (type, `+Nms`, stage icon 🟢🟡🔴) + a detail panel (pipeline stages, raw JSON,
+  counters `ev:/tx:/fmt:/out:`); gaps >1000ms flagged "⚠ GAP" (`_event_tape.py:37,445`).
+  Toolbar shows live `PipelineCounters` (`:160,195`).
+- When `--debug-events` is on, entries are also appended as **JSONL** to a debug log path
+  (shown in Ctrl+O) (`_repl.py:3079-3081`, `_maybe_log_tape_entry`).
+
+### Theme picker (`_theme_picker.py`)
+- `startup_theme_picker()` (`:288`) — first-run dark/light chooser; OSC-11 background probe
+  pre-selects (`:306`); raw termios ↑/↓/k/j loop; persists via
+  `update_user_config(theme=...)` to `~/.omnigent/config.yaml` (`:312,324,379`).
+
+---
+
+## 11. Trace evidence (and the `omni-tui` gap)
+
+The corpus (`scratchpad/corpus/*.json`) was generated by **headless `-p` runs**, which do
+**not** exercise the interactive REPL — so there are **no `omni-tui` spans** to validate
+against. Confirmed empirically: service names present across all three corpus files are
+exactly **`omni-server` (52), `omni-runner` (23), `omni-harness` (8)** — no `omni-tui`,
+`omni-host`, or `omni-web`.
+
+How a TUI turn *would* carry trace context (code path):
+
+- `OmnigentClient` builds a plain `httpx.AsyncClient` over standard transports
+  (`_client.py:89`). The process-wide `HTTPXClientInstrumentor().instrument()`
+  (`telemetry.py:392-409`) patches **all** standard-transport httpx clients to inject the
+  W3C `traceparent` header + emit a client span. So **if telemetry were initialized in the
+  REPL process**, every `client.sessions.*` call (and the SSE GET) would emit a client span
+  and propagate context to the server (whose FastAPI instrumentation continues the trace) —
+  yielding the `omni-tui → omni-server → omni-runner → omni-harness` single-trace shape the
+  design doc describes.
+- **But the code never calls `telemetry.init("omni-tui")`.** A repo-wide search shows the
+  only `telemetry.init(...)` callers are `omni-server` (`cli.py:3079`, inside the *server*
+  bootstrap), `omni-runner` (`runner/_entry.py:902`), `omni-host` (`host/connect.py:1608`),
+  `omni-harness` (`runtime/harnesses/_runner.py:363`). The `omnigent run` / `run_repl`
+  foreground process — the one that owns the TUI's httpx client — initializes **no**
+  telemetry, so today the TUI client emits **no spans** (and even if `OTEL_*` env were set
+  in that process, the service would default to `"omnigent"`, not `"omni-tui"`).
+- **`omni-tui` exists only in the design doc** (`designs/OBSERVABILITY.md:269,370,374-375`,
+  which claims a single TUI turn spans `omni-tui → omni-server → …`). **This is a
+  doc-vs-code mismatch** — there is no code that produces `omni-tui` spans. (Contrast:
+  `omni-web` *is* wired — `web/src/lib/telemetry.ts:40` defaults browser spans to
+  `omni-web`.)
+
+So: the *mechanism* (HTTPX instrumentation + `traceparent` over the loopback hop) is in
+place and would Just Work, but the **client-process telemetry init for the TUI is missing**.
+See §13 Open questions.
+
+---
+
+## 12. Per-harness differences (from the TUI's POV)
+
+The TUI is harness-agnostic for the **SDK** harnesses (claude-sdk, codex, polly-on-claude-
+sdk): `run_repl` drives the same sessions API regardless; the harness only changes what the
+server/runner do and which events come back (e.g. native harnesses persist reasoning +
+transcript; SDK harnesses recompute). `--harness` just seeds the `/model` readout's harness
+label before the first turn binds (`_repl.py:1300-1305`).
+
+**Native harnesses are NOT driven by the REPL.** A native session (claude-native, codex-
+native, cursor/kimi/etc.) is driven by the vendor TUI in a runner-owned tmux pane, and a
+forwarder mirrors that transcript into the conversation. Resuming a native conversation
+through `omnigent run --resume` would double-record (one Omnigent turn per message *and* the
+forwarder mirroring the same message), so `chat.py` **redirects** native resumes back to the
+vendor wrapper command (`_redirect_native_resume_if_needed:1029`, e.g.
+`_run_cursor_native_resume_redirect:1254`, `_run_kimi_native_resume_redirect:1294`). The
+wrapper-label probe (`chat.py:_wrapper_label_for_conversation:1332`) reads
+`labels.omnigent.wrapper` from a `GET /v1/sessions/{id}` snapshot to decide. So for native
+harnesses the "TUI" the user sees is the *vendor's* TUI (attached via `_tmux_pane.py`), not
+`run_repl`. (codex/codex-native: no live trace — creds expired.)
+
+`/effort` valid values are family-aware in the handler
+(`none/minimal/low/medium/high/xhigh/max`, `_repl.py:4626`) matching
+`omnigent/reasoning_effort.py` per-family sets.
+
+---
+
+## 13. Failure branches & gaps
+
+- **SSE auto-reconnect with backoff** (`_repl.py:2056-2100`): recoverable transport errors
+  (peer-closed mid-chunk, read timeout) → one-line INFO + reconnect (0.5s→5s backoff);
+  on reconnect it also re-recovers/re-binds the local runner. The server does **no replay**
+  on reconnect (`_sessions.py:989`), so a terminal event landing in a reconnect gap is
+  caught by the `sessions.get` backstop poll in `send()` — but a *between-send* autonomous
+  turn's missed terminal event has no such backstop (only the next stream reconnect + status
+  catch-up). 
+- **ASGI no-eager-flush** → the 1 Hz snapshot poll in `send()` (`_repl.py:2196-2209`) is the
+  load-bearing backstop for turn completion on the loopback transport.
+- **Dedup is text-equality, not id-based** → two assistant segments that are byte-identical
+  *and* one was non-streamed could in principle be mis-suppressed; the multiset consume-on-
+  match mitigates the common case but is structurally weaker than the web's `itemId` dedup.
+- **Native resume mis-route** → relies on a best-effort label probe; if the probe fails
+  (flaky server) it falls back to the normal REPL path, which would double-record a native
+  conversation (`chat.py:1357-1392` returns `None` on error → normal path).
+- **`omni-tui` telemetry not wired** (see §11) → TUI turns are invisible in Jaeger today.
+
+---
+
+## 14. Open questions
+
+1. **Is the missing `omni-tui` telemetry init intentional?** The mechanism is fully present
+   (httpx instrumentation + W3C propagation); only the `telemetry.init("omni-tui")` call in
+   the `run`/`run_repl` process is absent. Should `run_repl` (or `_chat_local`/`_chat_with_
+   server`) call `telemetry.init("omni-tui")` so the design-doc trace shape materializes?
+2. **Does the between-send (autonomous turn) path have a turn-done backstop** equivalent to
+   `send()`'s 1 Hz poll, or does it depend entirely on SSE liveness?
+3. **Should the TUI move to id-based dedup** to match the web (`ctx.itemId`), now that
+   `output_item.done` carries item ids — or is the delta stream's lack of ids the blocker?
+4. Confirm the exact `files` upload route shape (`_files.py`) — listed here as
+   `POST /v1/sessions/{id}/files` from call sites; verify against the SERVER doc.

--- a/designs/master-arch/architecture/tui-repl.md
+++ b/designs/master-arch/architecture/tui-repl.md
@@ -144,9 +144,9 @@ sequenceDiagram
     participant C as OmnigentClient (httpx)
 
     U->>CLI: omnigent run agent.yaml
-    CLI->>CLI: load+validate spec; materialize overrides; _find_free_port
-    CLI->>SRV: _start_local_server(spec, port)  [telemetry.init("omni-server") here]
-    CLI->>CLI: _wait_for_server(port); base_url=http://127.0.0.1:port
+    CLI->>CLI: load+validate spec — materialize overrides — _find_free_port
+    CLI->>SRV: _start_local_server(spec, port)  [telemetry.init(omni-server) here]
+    CLI->>CLI: _wait_for_server(port) — base_url=http://127.0.0.1:port
     CLI->>CLI: _resolve_resume_target (resume/continue/picker)
     CLI->>C: build OmnigentClient(base_url)
     CLI->>REPL: run_repl(client, agent_name, bundle, runner_id, …)

--- a/designs/master-arch/architecture/web.md
+++ b/designs/master-arch/architecture/web.md
@@ -1,0 +1,443 @@
+# Web UI Architecture (`web/src/`)
+
+> Scope: the Omnigent React/TypeScript web client. **Code is ground truth.**
+> Web telemetry is **opt-in** (`web/src/lib/telemetry.ts`, only active when
+> `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` is set), so there are **no live `omni-web`
+> spans** in the running Jaeger / saved corpus (confirmed). This is a
+> code-based analysis. Where the browser *does* trace, it injects a W3C
+> `traceparent` on every fetch/XHR so the trace begins at the user's click and
+> continues into `omni-server` (FastAPI-instrumented).
+
+---
+
+## 1. Overview
+
+The web client is a single-page React app (TanStack Query for server cache,
+Zustand for the active-chat streaming store). Two long-lived realtime channels
+plus a family of REST calls make up its entire surface:
+
+1. **`WS /v1/sessions/updates`** — the sidebar's live feed. The client sends a
+   *watch-set* (the conversation ids it's displaying); the server replies with a
+   snapshot then `changed`/`removed` deltas + heartbeats. Replaces the old 4 s
+   `GET /v1/sessions` poll (`lib/sessionUpdatesSocket.ts`,
+   `hooks/SessionUpdatesProvider.tsx`).
+2. **`SSE GET /v1/sessions/{id}/stream`** — the open chat's live-tail. One
+   stream per active conversation, owned by `store/chatStore.ts`. Carries both
+   the **task-scoped** `response.*` vocabulary and the **session-scoped**
+   `session.*` vocabulary. Holding it open also registers the user as a
+   **presence viewer**.
+3. **REST `/v1/...`** — everything else: create/list/patch/delete sessions,
+   post events (messages / interrupt / approval / stop / compact /
+   slash_command), fork, switch-agent, items pagination, projects, hosts /
+   runners, agents, policies, comments, files, terminals list, users search,
+   `/v1/info`, `/health`.
+
+The central design problem the web client solves is **reconciling the ephemeral
+streaming view with the durable persisted transcript into one coherent block
+list** — `lib/blockStream.ts` (the streaming reducer) + `store/chatStore.ts`
+(the merge), deduping by `ctx.itemId`. That merge is detailed in §4.
+
+All network egress funnels through two seams so the app runs identically
+standalone or embedded in a host (e.g. the Databricks monolith):
+`authenticatedFetch` / `hostFetch` for HTTP and `resolveWebSocketUrl` for WS
+(`lib/host.ts`, `lib/identity.ts`).
+
+---
+
+## 2. Key files (file:line)
+
+| File | Role |
+|---|---|
+| `web/src/store/chatStore.ts` (4221 lines) | Zustand store for the active session: SSE pump, send/stop/approval, streaming↔durable merge, pending bubbles, reconnect. |
+| `web/src/lib/blockStream.ts:921` `BlockStream` | The streaming **reducer** — hand-port of the Python `_stream.py`. Turns typed `StreamEvent`s into render `AnyBlock`s; dedup sets for tool calls/results; reasoning↔text closure. |
+| `web/src/lib/sse.ts:102` `parseSseStream`, `:269` `parseEvent` | SSE byte-stream → typed `StreamEvent`. Hand-port of `_sse.py`. Detects `[DONE]` sentinel vs. transport drop. |
+| `web/src/lib/sessionsApi.ts` | Typed client for `/v1/sessions/*` (create, fork, switch-agent, patch, events, items, stream, approve/resolve, stop, launchRunner). |
+| `web/src/lib/sessionUpdatesSocket.ts:73` `SessionUpdatesSocket` | Singleton transport for `WS /v1/sessions/updates`: watch-set, reconnect backoff, heartbeat watchdog. |
+| `web/src/hooks/SessionUpdatesProvider.tsx:131` | Wires WS frames into the TanStack `["conversations"]` / `["project-sessions"]` cache; derives + pushes the watch-set. |
+| `web/src/hooks/useConversations.ts` | `GET /v1/sessions` infinite query (cursor pagination 20/page, `sort_by=updated_at&order=desc`, `search_query`), plus rename/archive/delete/move-project/stop mutations; projects hooks. |
+| `web/src/hooks/useSessionState.ts:21` `getSessionState` | Derives the sidebar badge: `awaiting > running > none`. |
+| `web/src/hooks/useSessionLiveness.ts:187` | Open-session liveness truth table (online / starting / runner_asleep / host_asleep / host_offline / local_stranded / unknown) from `runner_online`+`host_online`. |
+| `web/src/hooks/useRunnerHealth.ts` / `RunnerHealthProvider.tsx` | `GET /health?session_ids=` poll (open session + fallback), folds `runner_online`/`host_online`. |
+| `web/src/lib/host.ts:136/143` `hostFetch`/`resolveWebSocketUrl` | Embed seam: HTTP + WS URL resolution (standalone vs host-injected). |
+| `web/src/lib/CapabilitiesContext.tsx` + `lib/capabilities.ts:96` `resolveServerInfo` | `GET /v1/info` probe; gates accounts/sandbox/smart-routing UI. |
+| `web/src/components/blocks/TerminalView.tsx:417/440` | Terminal-attach **WS** URL builder (`/v1/sessions/{id}/resources/terminals/{tid}/attach?read_only=`). |
+| `web/src/lib/telemetry.ts:33` `initBrowserTelemetry` | Opt-in browser OTel (WebTracerProvider + fetch/XHR instrumentation), only when `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` set. |
+
+---
+
+## 3. Channels & message/event types
+
+### 3.1 `WS /v1/sessions/updates` (sidebar live feed)
+
+Client→server: a single JSON frame whenever the watch-set changes —
+`{type:"watch", session_ids:[...]}` (`sessionUpdatesSocket.ts:242`). The id list
+is NEVER trusted for authz; the server access-checks each id against the
+connection's user (docstring `:13-17`).
+
+Server→client frames (`sessionUpdatesSocket.ts:23-27`):
+- `{type:"snapshot", items:[SessionListWireItem]}` — full state of the watch-set on connect / re-watch.
+- `{type:"changed", items:[...]}` — field deltas (status, runner_online, host_online, pending_elicitations_count, title, comments fingerprint, …).
+- `{type:"removed", ids:[...]}` — sessions left the watch-set / deleted.
+- `{type:"heartbeat"}` — keepalive every ~30 s when idle.
+
+Transport behavior:
+- Reconnect backoff 250 ms→5 s, ±50% jitter (`nextReconnectDelay`, `:50`).
+- **Heartbeat watchdog** `HEARTBEAT_WATCHDOG_MS = 70_000` (`:48`): if no frame
+  of any kind (even unparseable) arrives in 70 s (>2× heartbeat), force a
+  reconnect — guards a silently half-open socket. Any inbound message re-arms it
+  (`:249`).
+- While connected, `useConversations` suspends its HTTP poll for non-visible
+  consumers; the visible sidebar keeps a low-rate reconcile
+  (`CONNECTED_STREAM_REFETCH_INTERVAL_MS = 60_000`). While disconnected, all
+  consumers fall back to `DISCONNECTED_STREAM_REFETCH_INTERVAL_MS = 45_000`
+  (`useConversations.ts:41-42, 240-245`).
+
+The provider applies frames into the cache in place
+(`applyItemsToCache` → `mergeItemsIntoPages`), and only schedules a debounced
+`invalidateQueries(["conversations"])` (250 ms) for structural changes it can't
+reconstruct locally: a watched id missing from every page (a new session whose
+sort position is unknown), membership-affecting filter changes, or `updated_at`
+re-sort (`SessionUpdatesProvider.tsx:240-249`). Comment fingerprints
+(`count:updated_at`) drive `invalidate(["comments", id])` so the CommentsPanel
+refreshes on external mutations (`:206-217`).
+
+### 3.2 `SSE GET /v1/sessions/{id}/stream` (open chat live-tail)
+
+Opened by `openSessionStream` (`sessionsApi.ts:921`) with `Accept:
+text/event-stream`, an `AbortSignal`, and `?idle=true` when the presence-idle
+tracker says so (the stream URL is the **entire presence uplink**, so an idle
+flip mid-view arrives as a reconnect carrying the new value).
+
+Wire format parsed by `parseSseStream` (`sse.ts:102`): standard
+`event: <type>\n data: <json>\n\n`, terminated by a bare `data: [DONE]`. Uses
+`getReader()` (not `for await…of`) for iOS Safari < 17.4 compat. The parser
+distinguishes a clean server close (`sawDone=true`) from a transport drop
+(stream ended without `[DONE]`) — that decides whether `startStreamPump`
+reconnects.
+
+`parseEvent` (`sse.ts:269`) recognises two event families:
+
+**Task-scoped `response.*`** → drive the chat bubble:
+`response.created|queued|in_progress|completed|failed|incomplete|cancelled`,
+`response.output_text.delta`, `response.reasoning.started`,
+`response.reasoning_text.delta`, `response.reasoning_summary_text.delta`,
+`response.output_item.done` (→ `function_call`, `function_call_output`,
+`message`, `error`, `slash_command`, `routing_decision`, `terminal_command`,
+native-tool items), `response.output_file.done`, `response.retry`,
+`response.error`, `response.compaction.{in_progress,completed,failed}`,
+`response.client_task.cancel`, `response.heartbeat` (no-op),
+`response.elicitation_request`, `response.elicitation_resolved`,
+`response.policy_denied`.
+
+**Session-scoped `session.*`** → drive store sidecar state (not the reducer):
+`session.status` (idle/launching/running/waiting/failed + `background_task_count`),
+`session.usage` (context tokens/window, cost, per-model usage),
+`session.model`, `session.reasoning_effort`, `session.collaboration_mode`,
+`session.agent_changed`, `session.todos`, `session.terminal_pending`,
+`session.sandbox_status`, **`session.input.consumed`** (the durable promotion
+trigger — see §4), `session.interrupted`, `session.created` (sub-agent spawn),
+`session.superseded` (e.g. Claude `/clear` → follow to new conv),
+`session.resource.{created,deleted}` (terminals), `session.child_session.updated`,
+`session.changed_files.invalidated`, `session.terminal.activity`,
+`session.skills`, `session.model_options`, `session.presence` (full-state viewer
+list).
+
+The pump *taps* `session.*` for side effects (`tapSessionEvents` →
+`handleSessionEvent`, `chatStore.ts:3412`) **before** feeding the reducer; the
+reducer (`blockStream.ts`) is a pure block factory and intentionally ignores all
+`session.*` events except by listing them as no-ops (`blockStream.ts:896-908`).
+
+### 3.3 Terminal-attach WS
+
+`ws(s)://…/v1/sessions/{id}/resources/terminals/{tid}/attach[?read_only=true]`
+(`TerminalView.tsx:417,440`) — xterm.js ↔ runner tmux pane. Identity rides the
+transport (browser can't set `X-Forwarded-Email` on a WS handshake; ingress/dev
+proxy carries it). Read-only attach for viewers without write access.
+
+### 3.4 REST `/v1/...` — see the request table in `cuj-answers/web-client.md`.
+
+---
+
+## 4. Streaming ↔ durable reconciliation (the core merge)
+
+This is the headline question. The web client maintains **one flat `blocks:
+AnyBlock[]`** that the renderer walks. It is filled from two sources that must
+not double-render:
+
+- **Durable (snapshot)** — `GET /v1/sessions/{id}/items` history (paged) →
+  `itemsToBlocks(items)`. Each block carries `ctx.itemId` = the store-assigned
+  conversation item id.
+- **Streaming (SSE)** — live `response.*` events → `BlockStream.reduce` → blocks.
+  Token/reasoning blocks are **id-less** while streaming; persisted items
+  (`output_item.done` for `function_call`, `message`, etc.) carry `ctx.itemId`.
+
+**The merge point is dedup by `ctx.itemId`.** Everywhere a snapshot and the live
+pump can produce the same item, the client filters by item id so exactly one
+copy survives (`chatStore.ts:15` design comment; enforced at
+`:1455-1457` (send-path merge), `:1904-1907` (bind hydration),
+`:2460-2463` (reconnect backfill), `:2961-2966` (commit-time recheck in the
+pump's `flush`), `:3004-3008` (per-block stream→snapshot dedup in the pump)).
+
+### 4.1 `pendingUserMessages` — held until `session.input.consumed`
+
+A user message is optimistic: `send()` pushes a `PendingUserMessage`
+(`tempId="pend_<n>"`) onto `pendingUserMessages` **before** the POST so the
+bubble paints immediately and so a `session.input.consumed` that races ahead of
+the POST response still finds an entry to promote (`chatStore.ts:791-821,
+:127-144`). The renderer draws these *after* the `blocks`-derived bubbles, so
+streaming output from a prior turn appends cleanly at the tail without positional
+logic.
+
+When `session.input.consumed` arrives (`handleSessionEvent` case at
+`chatStore.ts:3724`), the pending bubble is **promoted into `blocks`** as a
+committed user block carrying the server `item_id`. Three matchers, in precision
+order:
+1. **By id** — `clearedPendingId` (the server names the drained pending-input
+   entry) → drop that exact bubble (`:3744-3770`).
+2. **FIFO head** — for an optimistic bubble whose POST hasn't returned the id to
+   adopt yet (consumed raced ahead), or a cross-client send. Per-session SSE
+   ordering makes the head correct; **no text match** because native transcripts
+   reformat text (`>` quotes, `[Attached:]` markers) (`:3772-3791`).
+3. **No pending entry** — render the event payload fresh (a TUI-typed message or
+   another client's send) (`:3793-3801`).
+
+The promoted block reuses the optimistic bubble's `tempId` as its React
+`stableKey` so the bubble **does not remount/flink** when it swaps from pending
+to committed.
+
+`is_meta` consumed events are ignored (`:3725`); `hasCommittedItem` guards
+against double-promotion (`:3742`).
+
+### 4.2 Persisted-vs-streamed text dedup (`text_done` stamping)
+
+A streamed assistant message renders id-less from `output_text.delta` chunks. The
+relay later publishes its persisted `output_item.done(message)` so the client
+learns the store id — but by then a tool call / reasoning section often closed
+the streamed text, so the reducer can't dedupe it. The pump **stamps the item id
+onto the already-streamed `text_done` in place** (matching by
+`responseId`+`fullText`, FIFO) rather than appending a second copy
+(`chatStore.ts:3027-3069`). This keeps one copy in its streamed position AND lets
+reconnect reconciliation (item-id-keyed) see the persisted item as already
+rendered.
+
+### 4.3 Native-terminal live-preview reconciliation
+
+claude-native/codex-native stream provisional previews keyed
+`live:<messageId>` (`LIVE_ITEM_PREFIX`) inserted at the position the first chunk
+arrived (`applyLiveDelta`, `chatStore.ts:2802`). When the authoritative
+`text_done` for the oldest in-flight message lands, the preview is **replaced in
+place** so committed text keeps its streamed position above any later
+tool/elicitation card (`:3071-3097`). The message id is retired so a trailing
+late chunk can't re-create the preview.
+
+### 4.4 The reducer's own dedup (within one response)
+
+`blockStream.ts` carries per-response dedup sets, cleared on each
+`response_created`/`response.in_progress`:
+- `seenCallIds` — under the **claude-sdk MCP path**, a tool call surfaces as TWO
+  `ToolCall` events sharing a `tool_use_id`-threaded callId (inline observed +
+  post-stream action_required); keep the first call line, drop the second
+  (`:511-531, :495-510`).
+- `seenResultCallIds` — keyed `${responseId}:${callId}`; every action_required
+  tool's result fires TWICE (inline from `_dispatch_action_required` + the
+  `response.completed` flush) — render once (`:559-604`).
+
+```mermaid
+flowchart TB
+  subgraph Sources
+    SNAP["GET /v1/sessions/{id}/items<br/>(durable history)"]
+    SSE["SSE /v1/sessions/{id}/stream<br/>(live response.* + session.*)"]
+    POST["send(): POST /events {message}<br/>(optimistic)"]
+  end
+
+  SNAP -->|itemsToBlocks| HYD["snapshot blocks<br/>(ctx.itemId set)"]
+  SSE -->|parseSseStream| EV["typed StreamEvent"]
+  EV -->|tapSessionEvents| SESS["handleSessionEvent<br/>(session.* sidecar state)"]
+  EV -->|BlockStream.reduce| RED["reducer blocks<br/>(token=id-less; items=ctx.itemId)"]
+  POST --> PUM["pendingUserMessages<br/>(tempId=pend_N)"]
+
+  SESS -->|session.input.consumed<br/>1.clearedPendingId 2.FIFO 3.fresh| PROMO["promote → committed user block<br/>(reuse tempId as React key)"]
+  PUM --> PROMO
+
+  HYD -->|dedup by ctx.itemId| BLOCKS[("blocks: AnyBlock[]<br/>(single coherent list)")]
+  RED -->|dedup by ctx.itemId<br/>+ text_done in-place stamp| BLOCKS
+  PROMO --> BLOCKS
+  BLOCKS --> RENDER["renderItems → chat view"]
+```
+
+---
+
+## 5. SSE pump lifecycle, reconnect & "close page and return"
+
+`startStreamPump` (`chatStore.ts:2542`) is a reconnect loop owned by `switchTo`
+(via `bindStream`). Properties:
+
+- **Server-durable sessions.** The session keeps running on the server while the
+  page is closed — nothing about closing the tab stops the turn. On
+  return/refresh the client re-binds: `switchTo(id)` → `bindStream` opens a fresh
+  SSE stream FIRST, then fetches the snapshot (`getSessionSlim` +
+  `fetchInitialHistoryWindow`) concurrently and merges deduping by item id
+  (`:1825-1907`). This is the documented reconnect contract (stream-then-snapshot,
+  dedupe by id).
+- **History window.** Bind hydrates only the most recent window
+  (`SESSION_HISTORY_PAGE_SIZE = 20`, extended back to include the previous user
+  prompt — `fetchInitialHistoryWindow`, `sessionsApi.ts:833`). Scroll-up
+  `loadMoreHistory` pages older. Keeps opening a long transcript cheap.
+- **Benign drops reconnect instantly.** Databricks Apps ingress hard-caps a
+  single HTTP/2 stream at ~5 min; a drop after a *healthy* connection leaves
+  `failedOpens=0` and reconnects with no delay. Only consecutive *failed opens*
+  back off (250 ms→5 s) (`:2559-2565`).
+- **`reconcileOnReconnect`** (`:2394`) runs on every reconnect (not the first
+  connect): drops ephemeral in-flight blocks, then pages the items backward until
+  the fetched window overlaps the pre-gap transcript (or hits start) so a gap
+  longer than one page is fully recovered; splices unseen committed items at the
+  right position; recovers `sessionStatus`/`activeResponse` so a gap-completed
+  turn doesn't strand the spinner; reconciles ApprovalCards against the
+  snapshot's `pending_elicitations`. All writes are `historyGeneration`-guarded.
+- **Give-up cases.** 401/403/404 on stream open → mark session failed, stop
+  (`:2600-2605`). `[DONE]`/`server_closed` and `switched`/`aborted` end the loop
+  without retry.
+
+### 5.1 Host offline → ReconnectSessionDialog
+
+Liveness is derived by `useSessionLiveness` (`hooks/useSessionLiveness.ts:187`)
+from the `/health` poll's `runner_online` + `host_online` (plus the WS stream's
+copies). Truth table → 7 variants. The two **unreachable** dead-ends open
+`ReconnectSessionDialog` (`ChatPage.tsx:1095-1105, :952`):
+- `host_offline` — host-bound, host tunnel down, host NOT resumable from web
+  (laptop/external host). Owner sees the CLI reconnect command; any viewer can
+  fork to continue.
+- `local_stranded` — not host-bound and runner down; restart from the user's own
+  machine; fork is the escape hatch.
+
+Resumable managed hosts instead read `host_asleep` (composer stays open; the next
+message wakes the sandbox via the server's `resume_managed_host`) or `starting`
+while a turn is waking it — **no dialog**. A fresh session within
+`STARTING_GRACE_S = 45` reads `starting` (passive "Connecting…") rather than
+flashing a banner during cold boot.
+
+---
+
+## 6. Sidebar fetching (`useConversations` + WS watch-set)
+
+`useConversations(searchQuery, includeArchived)` (`useConversations.ts:216`) is a
+TanStack `useInfiniteQuery` over `GET /v1/sessions`:
+- Params: `order=desc`, `sort_by=updated_at`, `limit=20`, optional
+  `search_query=` (server-side filter; caller debounces), optional
+  `include_archived=true` (`fetchConversationsPage`, `:178-204`).
+- Cursor: next page param = `last_id` while `has_more` (`:238-239`).
+- The query key includes `searchQuery` + `includeArchived` so toggling either
+  refetches.
+
+Live freshness comes from the WS watch-set, NOT polling (§3.1). `pushWatched`
+(`SessionUpdatesProvider.tsx:159`) collects ids from all `["conversations"]` +
+`["project-sessions"]` cache variants and **unions the open session** (so an
+off-sidebar child/sub-agent still gets streamed liveness), then
+`setWatched(ids)` (no-op when unchanged). Mutations patch the cache in place to
+dodge the server's **async search-index reindex** race: rename/delete overlay or
+splice rows rather than invalidating (an immediate refetch can serve stale/ghost
+rows from the search midtier) (`useConversations.ts:291-445`).
+
+Grouping precedence (per `CUJ-ANALYSIS §2.E`, verified by code paths):
+**Archived > Pinned > Project > Recent**. Pins are localStorage
+(`omnigent:pinned-conversation-ids`), backfilled via per-id
+`GET /v1/sessions/{id}` for pins outside the loaded window
+(`usePinnedConversationBackfill`, `:619`). Projects are **implicit** (exist iff
+≥1 non-archived session), stored as the reserved label `omni_project`
+(`PROJECT_LABEL_KEY`, `:658`), fetched via `GET /v1/sessions/projects`
+(`useProjects`, `:661`), each folder lazily paged via `?project=`
+(`useProjectSessions`, `:786`).
+
+### 6.1 Sidebar badge / "working" derivation
+
+`getSessionState` (`useSessionState.ts:21`) reads only the **row's**
+`status` + `pending_elicitations_count` (both arrive via the WS updates frames):
+priority **awaiting (count>0) > running > none**. `failed` is deliberately NOT a
+sidebar state (the chat surface is where you read what failed), and liveness is
+deliberately NOT a sidebar badge anymore (it moved to the open-session view via
+`useSessionLiveness`).
+
+The **chat surface's** "Working…" indicator is a richer, separate notion:
+`store/chatStore.ts:sessionStatus` (`idle|launching|running|waiting|failed`)
+driven by `session.status` SSE events (`handleSessionEvent` case `:3585`), where
+`waiting` = the parent loop parked on the async-work drain. The store also
+**patches the active session's sidebar row in cache** on each `session.status`
+event so the sidebar dot flips in lockstep with the chat's indicator instead of
+lagging a reconcile (`patchConversationStatusInCache`, `:3694`).
+
+---
+
+## 7. Per-harness differences (web client's view)
+
+The web client is harness-agnostic by design, but branches on a few
+session-snapshot fields:
+
+- **`isNativeTerminalSession`** (claude-native / codex-native, derived from the
+  `omnigent.wrapper` label on bind): web messages are **NOT persisted at POST
+  time** — they round-trip through the vendor TUI and reconcile via the
+  forwarder's `session.input.consumed`, which can arrive **after** a transient
+  `idle`/`failed`. So the idle-clear of `pendingUserMessages` is skipped for them
+  (`chatStore.ts:3653-3667`), and they replay queued sends from the snapshot's
+  `pending_inputs` on rebind.
+- **`nativeVendorOwnsModel`** (qwen/goose/cursor/pi/opencode): the model is
+  chosen inside the vendor TUI; the composer hides the model/effort label. claude-
+  /codex-native DO expose an Omnigent model picker and keep it.
+- **claude-native specifics**: `setModel` also injects `/model` into the tmux
+  pane (`sessionsApi.updateSession` non-silent); `session.todos` SSE drives the
+  TodoPanel; `slash_command` round-trips through tmux and pops the FIFO pending
+  bubble with no `session.input.consumed` (`handleSessionEvent` case `:3804`);
+  Stop hard-kills the tmux pane (`stopSession`).
+- **claude-sdk MCP double-event dedup** lives in the reducer (§4.4) — only the
+  MCP path emits two ToolCall/ToolResult events per call.
+- **codex / codex-native**: no live trace (creds expired per brief). The web
+  client treats codex-native like any native-terminal session; codex-native edits
+  surface `codexCommand`/`exec` elicitations and a Plan-mode toggle
+  (`codexPlanMode`).
+- **polly / custom agents**: run on a harness (typically claude-sdk) and inherit
+  its web behavior; the web client only knows them as a bound `agent_id` /
+  `agent_name` on the session.
+
+---
+
+## 8. Failure branches & gaps
+
+- **No `[DONE]` (transport drop)** → reconnect (instant if previously healthy).
+  **401/403/404 on stream** → fail session, stop pump (`:2600`). **Reader/parse
+  error** (e.g. `ERR_HTTP2_PROTOCOL_ERROR`) → treated as a drop, reconnect
+  (`:3151-3156`).
+- **Policy-denied input**: POST returns `{denied:true}` with no
+  `session.input.consumed`; the store settles local state from the POST response
+  (rolls back the optimistic bubble) instead of waiting on the stream
+  (`:898-918`). Surfaces as `response.policy_denied` / a `policy_denied` block too.
+- **WS updates half-open socket**: heartbeat watchdog (70 s) forces reconnect;
+  consumers fall back to the 45 s HTTP poll while disconnected.
+- **Background-tab throttling**: a tab can miss `elicitation_resolved`; on
+  `visibilitychange→visible` the store reconciles pending elicitations against a
+  fresh snapshot (`bindStream` `:1800-1808`).
+- **Search-index reindex race**: rename/delete patch cache in place (never
+  refetch immediately) to avoid resurrecting/stale-naming rows
+  (`useConversations.ts:291-445`).
+- **Stuck-pending bubble** (historical bug class): `switchTo` stashes only
+  *unsettled* own sends (`pend_` ids, `posted!==true`) per conversation; settled
+  sends defer to the server's `pending_inputs` replay; a content-equal twin from
+  the snapshot drops the stash copy (`:1179-1217, :1932-1960`).
+- **Known UI gaps (per `CUJ-ANALYSIS §2.E`, unverified by me)**: CJK IME Enter
+  submits prematurely (#433); non-git Changes panel empty (#725); browser empty
+  after reconnect (#386); mobile HTML preview/download (#968/#969). Tagged
+  *(per doc — unverified)*.
+
+---
+
+## 9. Open questions
+
+- Exact server-side shape of `SessionListWireItem` in WS frames vs.
+  `GET /v1/sessions` (the client assumes parity via `nullsToUndefined`) — would
+  confirm against `server/routes/sessions.py` (server SME).
+- Whether the WS updates endpoint pushes `runner_online`/`host_online` reliably
+  enough that the `/health` poll is purely a safety net, or if there are
+  scenarios where only the poll updates them (the code comments suggest the host
+  control plane doesn't push runner-reaped state, so the poll is still load-
+  bearing — `useRunnerHealth.ts:22-23`). Server SME to confirm.
+- Live `omni-web` traces are absent (telemetry opt-in). To validate the
+  click→server `traceparent` continuation one would set
+  `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` and re-run — out of scope here.

--- a/designs/master-arch/cuj-answers/_FOR-PASTE.md
+++ b/designs/master-arch/cuj-answers/_FOR-PASTE.md
@@ -1,0 +1,259 @@
+# How does claude-code / codex / polly behave when… — consolidated answers
+
+> **Provenance:** grounded in code (`file:line` on branch `traces`, HEAD `60d11673`) + live Jaeger traces from a local rig (claude-sdk + claude-native traced live; **codex/codex-native NOT traced — Databricks AI-gateway creds expired/403**, answered from code + the §4 matrix and labeled). **Source-of-truth rule: code wins over the design docs** (`CUJ-ANALYSIS.md`/`OBSERVABILITY.md` line anchors had drifted thousands of lines in the 912 KB `sessions.py`; all anchors below are re-derived). **Polly** = a custom agent whose brain runs on **claude-sdk** (workers = claude-native + codex-native); unless noted it reads exactly as the claude-sdk row. Legend: ✅ confirmed · ⚠️ caveat/gap · ❌ absent.
+
+---
+
+## 1. Disconnects (mid-turn) — client + server side
+
+**The turn keeps running; it is runner-side, not client-bound.** Client disconnect just drops the SSE socket. On the server, `_stream_live_events` (`sessions.py:11229`) has **no buffer and no replay**; its `finally` always yields `data: [DONE]\n\n` (`:11341`) so a clean close terminates cleanly. The reconnect contract is **GET snapshot + subscribe live tail, deduped by item id** (`:11240-44`). Disconnect detection: the SSE generator checks `request.is_disconnected()` per event + 15 s heartbeats; parked routes (native PreToolUse hook, elicitation long-poll) use `_poll_request_disconnect` (`:1183`) which *blocks* on `request.receive()` for `http.disconnect` and is raced against the verdict Future so a hung-up client releases the handler immediately. **Interrupt-fencing across reconnect:** `_interrupt_fenced_sessions` (`:931`) makes `_relay_runner_stream` drop a cancelled turn's trailing output (`:9464-75`) so a stopped turn never resurfaces in the durable store.
+**Live (`conv_6bbdba9a`):** reopening the stream replayed the *identical* opening frames (heartbeat → resource.created → changed_files.invalidated → presence) = snapshot-on-connect, NOT token deltas. The one exception: **in-flight assistant text** is re-seeded synchronously at slot registration via `pre_ready_snapshot` (`:11315-20`) so the cursor doesn't blank.
+**Per-harness:** identical at this layer (SDK + native). **Host-tunnel** disconnect is separate — runners keep running across a host blip; a runner that *dies* during the blip parks its `host.runner_exited` report and flushes after the next `host.hello` (`connect.py:1491-93`).
+
+---
+
+## 2. Forking a session — how the forked transcript is constructed
+
+`POST /v1/sessions/{src}/fork` (`fork_session`, `sessions.py:15180`, 201, gate LEVEL_READ). **Server-side only** — the new conv returns `runner_id=null`, `host_id=null`; **no runner/harness is spawned**. `fork_conversation` (`sqlalchemy_store.py:2266`) **deep-copies items with fresh ids**, preserving `position`/`response_id`; `up_to_response_id` truncates the copy; it **drops instance-scoped labels** (native bridge ids, context-token metrics) and does NOT copy `external_session_id`/`workspace`/`git_branch`. Optional cross-family harness switch resets model/effort. **Cannot fork a sub-agent** (400, `:15238`). New session gets a **cloned agent** (new `agent_id`) + label `omnigent.fork.source_id`.
+**Live (`conv_820c6dee → conv_7fe12aec`):** the fork showed as a burst of **~25 `INSERT` + many `SELECT` on chat.db** under the *source's* `session.id` — the synchronous deep-copy. **Fork cost scales with item count** (INSERT-per-item), visible as a latency spike, not a runner concern.
+**Per-harness:** **native** targets carry history via the `FORK_CARRY_HISTORY` label so the vendor CLI rebuilds its transcript on the next turn (`harness-inner` §6); SDK targets reconstruct from the copied items. Host involvement only if `git` body → `host.create_worktree` for a new branch before the bind CAS.
+
+---
+
+## 3. Resuming a session — incl. how much transcript loads into the runner (native vs sdk)
+
+**Two resume entrypoints by harness family.** **SDK (claude-sdk/codex/polly):** `omnigent run --resume` → normal create-session → bind-runner → dispatch. **Terminal-native (claude-native/codex-native):** `omnigent resume` is CLI glue (`resume_dispatch.py:39`) that reads `labels.omnigent.wrapper` and relaunches the matching `run_<harness>_native` (`:201`); an SDK session has no wrapper label → it errors and points you at `omnigent run --resume` (`:179`).
+**How much transcript loads into the runner:**
+- **SDK** — the runner reconstructs via `_load_initial_history` (`workflow.py:2276`): **full conversation, OR (when a compaction item exists) only the slice after the last `last_item_id` + the expanded summary pair**, then re-drives the SDK each turn with `executor.run_turn(messages=…)`. The in-process SDK keeps no store of its own, so "what loads" = the (possibly compaction-bounded) history. Visible in trace as `omni-runner → omni-server GET …/items` + the `persisted_item_id` dedup-drop.
+- **Native** — resume keys on `external_session_id` from the snapshot; the **vendor CLI reloads its own session** (the vendor store is source of truth). Omni only re-injects when the vendor store is gone — cold resume synthesizes the vendor's local session file from committed Omnigent items (Pi `app.py:1715-29`; OpenCode injects a transcript preamble). So the runner loads ~nothing extra on a warm native resume; the vendor owns it.
+
+---
+
+## 4. Credential resolution — (a) provider selection at setup, (b) refresh of LLM / runner↔server / client↔server
+
+**(a) Setup / provider selection.** `omnigent setup` wizard (`onboarding/wizard.py:1384`): 3 skippable steps — server URL, LLM auth (**API-key** vs **Databricks profile**, with detected `~/.databrickscfg` hints), default agent — written to `~/.omnigent/config.yaml` (`:1476`). **Ambient detection** (`ambient.py:619`) scans in priority: env API keys → Vertex → Claude CLI login (`~/.claude/.credentials.json` + Keychain) → Codex config provider → Codex CLI login (`~/.codex/auth.json`) → local Ollama. Provider kinds: `key`/`subscription`/`gateway`/`local`/`databricks`/`cli-config`/`bedrock`. DBX **profile aliasing** (`setup.py:190`) reuses a same-host profile's host-keyed OAuth cache (no redundant browser login). Per-harness default: claude→anthropic, codex→openai (`:1126`); subscription harnesses **don't inherit a parent's DBX profile** (`spec/omnigent.py:124`) so they keep subscription auth.
+**(b) Refresh of the three relationships:**
+| Relationship | Mechanism | Refresh | Status |
+|---|---|---|---|
+| **LLM creds** | claude-sdk: `_DatabricksBearerAuth.auth_flow` per request (`databricks_executor.py:367`); codex: provider `auth.command` shell on interval (`_GATEWAY_AUTH_REFRESH_MS=900_000`) + 401 (`codex_executor.py:763-98`) | **per request / 15-min interval** → survives ~1h OAuth | ✅ (static api-key/PAT/subscription = no refresh) |
+| **runner↔server** | HTTP callbacks: `_RunnerDatabricksAuth.auth_flow` mints **fresh per request**, retries on 401/Apps-302 (`_entry.py:192`). **WS tunnel**: Bearer set **once at handshake** (`serve.py:540`) — **⚠️ no per-message refresh**; re-minted only on reconnect/401-drop | per-request (HTTP) / handshake-only (WS) | ✅ HTTP; ⚠️ WS gap (self-heals on recycle) |
+| **client↔server** | cookie/JWT `__Host-ap_session` validated every request (`auth.py:351`, TTL cache); `omnigent login` writes JWT; DBX Apps = pointer record, token minted per use | validated per request; **⚠️ NO background refresh** — expired → re-login | ⚠️ no auto-refresh |
+
+**Policy-hook token (native)** was the famous fail-closed-after-1h bug — **FIXED by PR #1439** (merged `e9561916`): claude-native + codex-native hooks now re-mint a fresh bearer on 302→/oidc or 401 and retry once (`policy_hook_reauth`). Fail-closed only if no token can be minted. (OpenCode's snapshot still fail-OPEN — out of scope.)
+
+---
+
+## 5. Request lifecycle (POST /events → … → response back to client)
+
+`post_event` (`sessions.py:18150`, returns **202**). Order: **(1)** authz `_require_access_and_level(LEVEL_EDIT)` → **(2)** validate type ∈ `_ALLOWED_EVENT_TYPES` (`:18245`) → **(3)** closed-session guard (409 for a `sys_session_close`d sub-agent) → **(4) policy eval BEFORE persist** (`_evaluate_input_policy`, `:18321`; on exception → treat as **deny** so the session can't hang) → **(5) persist-before-forward (invariant I1)**: `conversation_store.append([item])` first (`:8540`), then POST to the runner over the reverse-tunnel (`:8697`), then publish `session.input.consumed` carrying the `item_id` (`:8704`). If a fresh item has **no runner + no host** → 503 `RUNNER_UNAVAILABLE` *before* persist (`:19068-76`).
+Runner side (`app.py:14598`): FIFO ingest gate → content resolve → single-active-turn gate (I2) → `_load_history_as_input(drop_item_id=persisted_item_id)` → dispatch to harness over UDS → `proxy_stream` relays SSE chunk-by-chunk back to the server, which persists durable items and fans out to the client's `GET …/stream`.
+**Live (`tree cfb59197…`, 415 spans):** `POST /events` → child `policy.evaluate` → `UPDATE`+`INSERT chat.db` (the append precedes the runner POST — **I1 visible on the wire**) → cross-edge to `omni-runner [POST …/events]` → runner calls back `GET …/items` + `GET …/agent/contents`.
+**Per-harness:** **native** bypasses persist at dispatch (no server item id, only a `pending_inputs` `pending_id`); the transcript forwarder is the single writer.
+
+---
+
+## 6. MCP routing — custom (user) MCPs vs the `sys_*` MCP (who routes a call where)
+
+**Server owns policy + routing; runner owns execution.** SDK loop: runner `ProxyMcpManager.call_tool` POSTs `POST …/mcp` (`proxy_mcp_manager.py:220`) → server runs TOOL_CALL policy → server POSTs back `POST …/mcp/execute` (`app.py:17829`). The split exists so tools run on the right machine/cwd/env. **The routing key is the `__` separator** (`app.py:17954`): **`{server}__{tool}`** (e.g. `github__search`) → **custom MCP** → `RunnerMcpManager` live stdio/HTTP subprocess (`:18011`); **no `__`** (e.g. `sys_os_read`) → **runner-local builtin** → `execute_tool` (`tool_dispatch.py`). Then TOOL_RESULT policy. So **both go through the same `/mcp → /mcp/execute` round-trip**; the only divergence is the dispatch fork.
+**Live custom-MCP (`conv_4d0e6cce`, `echo__echo_shout`):** identical HTTP path to `sys_*`, gated by `policy.evaluate` TOOL_CALL + TOOL_RESULT; only the tool name reveals which executor. A custom stdio server runs **in the runner process tree** (its blast radius/creds are the runner's).
+**Per-harness (native):** `mcp__omnigent__*` (`sys_*`) go through the in-turn relay (already policy-checked) so the **PreToolUse hook SKIPS them** to avoid double-eval (`native_policy_hook.py:209-11`); connector/custom MCP (`mcp__github__*`) still hit the hook → `/policies/evaluate`. Out-of-turn workspace access uses a separate `serve-mcp` exposing only `sys_os_*` (no sandbox).
+
+---
+
+## 7. Elicitation/permission hooks — which embedded, which REQUIRED for all policies, how verdicts return
+
+| Harness | Required hooks (for *all* policies to enforce) | How verdicts return |
+|---|---|---|
+| **claude-native** | **PreToolUse** (→ `/policies/evaluate` TOOL_CALL) + **UserPromptSubmit** (→ REQUEST; sole native input gate) + **PermissionRequest** (→ `/hooks/permission-request`) | **long-poll HTTP** — verdict in held response body (`hookSpecificOutput.decision.behavior: allow\|deny`); server holds the `/policies/evaluate` long-poll and collapses ASK→hard ALLOW/DENY so a permissive permission_mode can't auto-approve (`sessions.py:16113`) |
+| **codex-native** | shared `native_policy_hook` PreToolUse/UserPromptSubmit-equivs + **`codex-elicitation-request`** | **long-poll HTTP** (`sessions.py:16214`). **No live trace (creds 403).** |
+| **claude-sdk / codex(SDK) / polly** | no command hooks — SDK calls server in-process; server `type=approval` event | runner **`pending_approvals` Future**; SDK `can_use_tool` callback runs an elicitation handler for connector-native tools. codex(SDK) surfaces **none** (`approvalPolicy:"never"`, `:1427`) |
+
+**No keystroke emulation for any in-scope harness** — long-poll HTTP (native) or approval-event→Future (SDK). The single shared shape-translator is `native_policy_hook.py`. **The required input gate for native is UserPromptSubmit**, not the server `/events` gate (which is deduped for native via `pending_inputs`).
+**Live ASK/DENY (`conv_c8a81cbd`, `ask_on_os_tools`):** `policy.evaluate decision=ASK` → publish `response.elicitation_request` (mode=url, `/approve/{sid}/{eid}` capability URL) → park the tool-call (turn stays `running`) → client POSTs `ElicitationResult{action}` to the resolve URL → unblocks. The ASK prompt is baked into `policy.reason`. DENY (`decline`) surfaces to the model as a `function_call_output` denial — it does **not** error the turn. Same verdict can arrive via `{"type":"approval"}` on `/events`; both route through `_resolve_elicitation` (`:3921`). ⚠️ native PreToolUse fails CLOSED on an unmintable token (pre-#1439 bug).
+
+---
+
+## 8. Dedup — server / runner / client side
+
+**Server: no content-based dedup at the store.** `append` (`sqlalchemy_store.py:1411`) mints a fresh globally-unique `item_id`; dedup is id-based downstream, seeded by server-assigned ids. The server forwards `item_id` as `persisted_item_id` (`:8618`); `response_id` is the turn-grouping key stamped on every item (`:1483`), used to pair a `function_call` with its `function_call_output` (`tool_call_response_ids` map, `:9560-80`). **"There is no server-side dedup" — `app.py:5844`.**
+**Runner: three seams (no global response-id cache).** (1) per-conversation **FIFO ingest gate** + single-active-turn gate preserve order / prevent overlapping turns; (2) **history-load dedup** drops the just-arrived `persisted_item_id` (`app.py:14842`); (3) **mid-turn injection exactly-once** via `injection.consumed` markers (`:14251`); native reader keeps an in-memory seen-set + generation-id dedup. The runner does **not** dedup outbound by item-id.
+**Client: by `ctx.itemId`.** Web merges durable snapshot items + live SSE deduping on `ctx.itemId` (`chatStore.ts:15`, enforced `:1455/:1904-07/:2460-63/:2961-66/:3004-08`); per-response `seenCallIds`/`seenResultCallIds` in `blockStream.ts` drop the claude-sdk MCP **double-emit** (inline + post-stream flush). **TUI does NOT use itemId** — it dedups by **byte-equal text, multiset consume-on-match** (`_TurnProseTracker`, `_repl.py:2787-883`) because streaming deltas carry no id.
+⚠️ **Native FIFO/pending-input desync:** no server item id for native web messages, only `pending_id` + `cleared_pending_id` — double-bubble risk if client dedup mis-orders (CUJ-ANALYSIS §6).
+
+---
+
+## 9. TUI vs WebUI state
+
+Both consume the **same `response.*`/`session.*` SSE vocabulary** over the same `GET …/stream` + write to the same `POST …/events`; the web even hand-ports the Python `_sse.py`/`_stream.py` reducers. Differences: **(a) push planes** — web adds **`WS /v1/sessions/updates`** (sidebar watch-set: snapshot/changed/removed/heartbeat) + `/health` polling; **the TUI has no WebSocket at all** (only per-session SSE). **(b) dedup** — web by `ctx.itemId`, TUI by byte-equal-text multiset. **(c) surface** — web has sidebar/projects/sharing/comments/policies-admin/presence/files/terminals panels + `switch-agent`; the TUI has none of these (resume picker + event tape instead). **(d) durability of a sent message** — non-native: persisted at POST (synchronous `item_id`); native: NOT persisted at POST, round-trips the vendor TUI and reconciles via the forwarder's `session.input.consumed`. **(e) working state** — web shows a sidebar badge (awaiting>running) + chat indicator; TUI shows an inline spinner+timer from the *same* `session.status`. ⚠️ **TUI emits no traces today** (`telemetry.init("omni-tui")` is never called — one-line fix; mechanism is wired).
+
+---
+
+## 10. "Working" state — how computed + how it propagates
+
+**Single server funnel:** `_publish_status(session_id, status, …)` (`sessions.py:5343`), `status ∈ {idle, running, waiting, failed}` (Pydantic-validated, fails loud). It atomically (1) writes the in-memory `_session_status_cache` (`:5391`) that the **sidebar** reads, and (2) publishes a `session.status` SSE event. **Origins:** SDK — runner emits `session.status` → `_relay_runner_stream` re-publishes via `_publish_status` (`:9447-519`); native — forwarder POSTs `external_session_status` → validated → `_publish_status` (`:18667-726`); deny path publishes running→idle around the sentinel. **Stickiness invariant:** a cached `failed` is NOT overwritten by a trailing `idle` (`:5389`) — only the next `running` clears it (prevents native StopFailure→failed being erased by a ~1s-later PTY-idle).
+**Propagation:** sidebar reads the cache (WS updates frames carry `status` + `pending_elicitations_count`); the open chat reads `session.status` SSE (authoritative). Web chat adds `waiting` (parent parked on async-work drain) which the badge can't show; `background_task_count` is **sticky** so a claude-native turn with leftover shells reads "N background tasks running" (`chatStore.ts:3601-18`).
+**Live:** an interrupted turn's fingerprint = **`error.type=cancelled`** on the `agent:` span (`runtime/telemetry.py record_cancellation`) while `otel.status_code` stays OK. ⚠️ `_session_status_cache` is **per-process** → multi-replica sidebar may read another replica's status (open question). ⚠️ **A session is inert until a runner is bound** — the "runner-offline → stuck working" gap class lives exactly here.
+
+---
+
+## 11. Transcript reconstruction — compaction; local↔server mismatch; fork/resume
+
+**Compaction** (`runtime/compaction.py:544`, budget = `context_window*0.8 − system_budget`, recent window = 5 LLM groups): **L1 surgical clear** (tool-result bodies → placeholder, keep `file_id`) → **L2 LLM summary** (synthetic user+assistant pair, **routed through the runner's `POST /v1/summarize`** so the runner's creds are used) → **L3 emergency truncate** (pair-aware). **Triggering:** *proactive/threshold* in the in-process loop (`_call_llm_maybe_compact`, `workflow.py:2057`, force=False at 0.8) is the real auto-compaction; *reactive* harness-reported overflow **does NOT auto-compact** — `proxy_stream` raises `_ContextWindowOverflow` → `_run_turn_bg` **ends the turn with an error** (`runner/app.py:13804`, OMNI-143). Explicit `/compact` → `compact(force=True)`.
+**Reconstruction:** `_maybe_persist_compaction_item` appends a `type=compaction` item (idempotent by `response_id==task_id`); next turn `_load_initial_history` loads only items after `last_item_id` + the expanded summary (`compaction_to_history_items`). Broken item → ignored, full reload (fixes #1082). **Fork** = deep-copy with fresh ids (Q2). **Resume** = SDK reconstructs the (compaction-bounded) history; native rebuilds from the vendor store (Q3).
+**Streaming↔durable merge** (the local↔server reconcile): web walks one flat `blocks[]` from durable `GET …/items` + live SSE, deduped by `ctx.itemId`; a streamed id-less assistant `message` gets its item id **stamped onto the existing streamed block in place** (`chatStore.ts:3027-69`) so reconnect sees it as already-rendered.
+**Live `/compact` (`conv_63542a5f`):** on a **model-less session** it returned `invalid_input "Compaction requires a configured LLM model"` (confirms **#1192** — a no-`--model` subscription session has no model row; gated *before* any summary work). Auto-compaction in the turn loop is unaffected (uses the turn's resolved model).
+⚠️ **claude-sdk does NOT persist thinking** — `compacted_messages` keeps only content blocks (`:2554-58`); reasoning is regenerated on resume.
+
+---
+
+## 12. API routes & message formats — WS vs REST, which stream vs durable, reasoning
+
+**54 sessions-router routes** (handler names AST-verified). Key write/read: `POST /v1/sessions` (create; JSON=existing agent, multipart=bundled), `POST …/events` (the turn entrypoint; message/control/external), `GET …/stream` (SSE live tail), `GET …/items` (paginated transcript), `GET …/{id}` (snapshot/reconnect), `PATCH …/{id}` (rename/archive/model/effort/runner-rebind/labels), `POST …/fork`, `POST …/switch-agent`, `POST …/elicitations/{eid}/resolve`. **WS (client↔server):** `WS /v1/sessions/updates` (sidebar watch-set), `WS …/terminals/{tid}/attach` (xterm↔tmux). **Server-side ingress tunnels:** `WS /v1/runners/{id}/tunnel`, `WS /v1/hosts/{id}/tunnel` (the latter carries **JSON control frames, not HTTP**).
+**Events envelope:** `POST /events {"type":"message","data":{"role":"user","content":[{"type":"input_text","text":"…"}]}}`; control: `{"type":"interrupt"}`, `{"type":"compact"}`, `{"type":"approval"}`.
+**STREAM vs DURABLE:** **durable** (persisted) = only `response.output_item.done` carrying a `message`/`function_call`(status completed only)/`function_call_output`, plus `compaction` items, plus resource-lifecycle + routing-decision items (`_extract_persistent_item_from_sse`, `:8930`). **Transient (SSE-only):** all `session.*` lifecycle/presence, the `response.*.delta` family, reasoning deltas, the Responses-API turn lifecycle, elicitation events, heartbeats. Text deltas accumulate (`text_acc`) and flush to a durable message only at a function-call boundary or terminal. **Three name families:** `response.*` (turn/output, mirrors OpenAI Responses API), `session.*` (Omnigent session/sidebar/presence), `external_*` (the *input* vocabulary a native forwarder POSTs into `/events`).
+**Reasoning handling:** streamed as `response.reasoning_text.delta` (transient); **SDK recomputes/doesn't store** (claude-sdk keeps only content blocks); **native persists** (the vendor records reasoning in its store, the forwarder mirrors it). codex(SDK) emits **no** `CompactionComplete`; claude-sdk emits it *with* `compacted_messages`.
+
+---
+
+## 13. Harness-specific features — min features, model+effort at start AND mid-session, propagating user config, default resolution
+
+**Min capability matrix (code-verified, base defaults ❌ except tool-calling):**
+| | interrupt | queue | subagents | reasoning effort | elicitation | mid-session model |
+|---|---|---|---|---|---|---|
+| claude-sdk | ✅ `client.interrupt()` (`:1477`) | ✅ (`:1614`) | ✅ via `sys_session_*` | ✅ {low,med,high,xhigh,max} | ✅ SDK callback | ✅ `set_model()` next turn |
+| codex(SDK) | ✅ `turn/interrupt` (`:2243`) | ✅ (`:2240`) | ⚠️† `CODEX_HOME` isolation | ✅ {none..xhigh} | ❌ `approvalPolicy:"never"` | ⚠️ **resets thread** (model in signature) |
+| claude-native | ✅ bridge `Escape` (`bridge:2530`) | ✅ tmux inject | ✅ `subagents/*.meta.json`→`external_subagent_start` | ✅ `/effort` inject ⚠️none/minimal skipped | ✅ PreToolUse+PermissionRequest long-poll | ✅ `/model` inject + statusLine mirror; next turn |
+| codex-native | ✅ `turn/interrupt` (`exec:116`) | ✅ `turn/steer` | ✅ `thread_spawn`→`external_codex_subagent_start` | ✅ `thread/settings/update` | ✅ `codex-elicitation-request` long-poll | ✅ `thread/settings/update`; next turn |
+
+claude-sdk is the **only** in-scope harness with `supports_tool_boundary_interrupt`→✅ (`:1617`). **polly** = claude-sdk brain (reads as that row) + claude-native/codex-native workers.
+**Model+effort at start:** NewChatDialog → `request.model_override` → `ExecutorConfig`; native bakes `--model`/effort into spawn flags. **Mid-session (web UI):** claude-sdk = next-turn config; codex(SDK) = closes app-session + new thread; claude-native = keystroke `/model`/`/effort` into tmux + statusLine mirror **back** every poll (best-effort, never the running turn); codex-native = `thread/settings/update` RPC. ⚠️ claude-native `/effort none|minimal` is persist-only.
+**Propagating user's own harness config:** **claude-native `use_claude_config=True`** (`claude_native.py:349`) skips DBX/ucode auth and uses the user's own `~/.claude/` (creds, settings.json, MCP, hooks) — strongest passthrough. **codex-native** inherits `~/.codex/config.toml`+`auth.json` via a private CODEX_HOME mapping back to real home. SDK harnesses get config via `HARNESS_*` env (claude-sdk strips `ANTHROPIC_API_KEY` to keep subscription auth).
+**Default model/provider resolution chain:** CLI `--model` → `OMNIGENT_MODEL` → YAML `executor.model` → config.yaml provider default → per-harness fallback (ad-hoc = `databricks-gpt-5-4`). Per-harness fallback: claude-sdk → `databricks-claude-opus-4-8` on the DBX gateway (⚠️ **#1128** — Opus billed when Sonnet intended but override arrived None, `:1910`); codex → `databricks-gpt-5-5`/`gpt-5.4-mini`; native → the vendor CLI's own default unless `--model` set.
+
+---
+
+## 14. Client reconciliation of streaming vs durable; close page & return
+
+**Reconciliation** = one flat `blocks[]` fed by (a) durable snapshot items (`GET …/items`, each carries `ctx.itemId`) + (b) live SSE (`BlockStream.reduce`, token blocks id-less), **merged deduping on `ctx.itemId`**. Optimistic user bubble held as `PendingUserMessage{tempId}` until `session.input.consumed` promotes it (matched by `clearedPendingId` → FIFO head → fresh), reusing the tempId as React key (no remount). A streamed id-less assistant message gets its item id stamped onto the existing block in place.
+**Close page & return** = **server-durable; the turn keeps running.** On return: `switchTo` opens SSE `…/stream` **first**, then fetches slim snapshot + initial history window concurrently and merges by item id (the stream-then-snapshot contract, `chatStore.ts:1825-907`). The SSE pump auto-reconnects (instant if previously healthy; `reconcileOnReconnect` pages backward until the window overlaps and recovers `sessionStatus`/`activeResponse` so a gap-completed turn doesn't strand the spinner). **Host offline → `ReconnectSessionDialog`** (`host_offline` shows the CLI reconnect command; `local_stranded` shows `--resume`; resumable managed hosts read `host_asleep`/`starting` and wake on next message, no dialog). Background-tab nuance: on `visibilitychange→visible` the store reconciles pending elicitations against a fresh snapshot.
+**TUI** has the same durability story minus the dialog — the SSE pump reconnects, server keeps running, reconcile via `sessions.get`.
+
+---
+
+## 15. Role of the executor
+
+An **Executor** (`inner/executor.py:518`) is the per-vendor adapter translating **Omnigent's tiny abstract turn model ↔ a concrete vendor SDK**: in = `run_turn(messages, tools, system_prompt, config)`; out = an async stream of `ExecutorEvent`s (`TextChunk`, `ReasoningChunk`, `ToolCallRequest`, `ToolCallComplete`, `TurnComplete`, `CompactionComplete`, `TurnCancelled`, `ExecutorError`). Capability predicates (`supports_streaming`, `handles_tools_internally`, `interrupt_session`, …) default ❌ except `supports_tool_calling`. It runs inside a **per-conversation harness subprocess** (`omni-harness`); the **`ExecutorAdapter`** (`harnesses/_executor_adapter.py:141`) bridges: lazily constructs the executor, translates `CreateResponseRequest`→messages+config, calls `run_turn`, and per yielded event emits typed SSE; it round-trips spec/MCP tools the SDK can't run via `dispatch_tool` (parked Future keyed by `call_id`).
+**Live:** the loop **is** the `agent:<harness>` AGENT span on omni-harness wrapping `run_turn()`, with `tool:` spans nested under it. ⚠️ **No `llm_call [LLM]` span for the SDK path** — `start_llm_span` exists but no executor calls it; the adapter subsumes the LLM call into the one AGENT span (verified: zero `llm`-named spans in Jaeger). Real nesting = agent → tool; guardrails are a separate `policy.evaluate` span on omni-server; a sub-agent's AGENT span is a separate trace.
+**SDK vs native:** SDK `run_turn` = full loop+tools; **native `run_turn` injects the latest user message and yields `TurnComplete(response=None)` immediately** — the vendor CLI runs the real loop and the forwarder mirrors it back.
+
+---
+
+## 16. Subagent spawning + depth limits
+
+**Declaration:** `AgentTool` (by name or inline) or `SelfAgentTool` (`tools.<name>: self`, clones parent with self-tools removed = the self-recursion guard) → nested `AgentSpec` (`spec/omnigent.py:1090-120`). **Runtime spawn (SDK):** the LLM calls **`sys_session_send`** (`tools/builtins/spawn.py:56`) — mode A `(agent,title)` **mints a child Conversation** + starts a turn; mode B `session_id` posts to an existing direct child. The child's `parent_session_id` = the immediate parent, **inherits the caller's runner** (co-location), and **runs its own turn loop** (own omni-harness, own AGENT trace). `sys_session_send` is **confined to direct children** — no sibling channel. Results return via the `async_work_complete` inbox.
+**Depth limits — VERIFIED display-only, NO spawn-time cap.** `_MAX_SUBAGENT_TREE_DEPTH=3` (`repl/_repl.py:201`) caps only how deep the **REPL sidebar renders** the tree. No spawn-time depth check exists anywhere; ordinary `AgentTool` chains can recurse unbounded (`AgentTool.max_sessions` is a per-tool *concurrency* cap, not depth). ⚠️ **real runaway-recursion risk** (CUJ-ANALYSIS §6).
+**Live (`conv_387e2405`, debby → claude + gpt children):** trace exposed `tool:sys_session_send` (×2, one per child) → children created via runner→server `POST …/sessions` (each a **full session with its own session.id**) → `tool:sys_read_inbox` drains results → `GET …/child_sessions` (the rail API). The gpt(codex) child failed on creds; the claude child answered — debby tolerated partial failure. **No single trace spans the tree** — stitching requires collecting all child session.ids.
+**Per-harness (native):** children minted via `external_subagent_start` (claude-native, `fwd:217/1115`) / `external_codex_subagent_start` (codex-native, `fwd:6079/4304`). ⚠️ **#848** — native sub-agent completions never reach the orchestrator (gate `runner/app.py:12607` excludes native).
+
+---
+
+## 17. Inbox mechanics
+
+**`sys_call_async(tool, args)`** (`async_inbox.py:129`) dispatches a **local Python tool** as a background task (`is_async()` always True), returning an `_AsyncToolHandle` `{task_id, status:"in_progress"}`. The blocking **drain lives in the harness subprocess**, on topic **`async_work_complete`** — two consume-once paths: **auto-drain** at the top of every loop iteration (`_drain_async_completions`, delivers piled-up payloads as `[System: task …]` user messages, `:253`) and **`sys_read_inbox`** (pull, mid-turn, returns a string `function_call_output` so the LLM can fan out a second wave without waiting, `:240-308`). Both remove payloads so a completion is never seen twice. **Subagent-completion delivery** runs runner-side in `_on_proxy_stream_end` (`app.py:12519`) → `_deliver_subagent_completion` pushes the child's (truncated) output to the **parent's inbox queue** + schedules a wake-POST.
+⚠️ **`sys_cancel_task`/`sys_cancel_async` are NO-OPs** — the tasks table was removed; they return `{"error":"task_not_found"}` for every input (`:97-126`). Async/subagent cancellation is effectively broken (Bash background jobs are killed via the SDK's KillBash instead). ⚠️ native children skip the completed-delivery gate (#848).
+**Live:** the debby trace's `tool:sys_read_inbox` (×2) confirmed the consume-once drain (`async_work_complete`).
+
+---
+
+## 18. OmniBox (the OS sandbox)
+
+**OmniBox = the OS-level sandbox**, not a web component (`inner/sandbox.py:resolve_sandbox:371`). `OSEnvironment` modes: `caller_process` (no isolation) · `fork` (workspace copy) · `sandbox`. **Backends:** `linux_bwrap` (bubblewrap — mount/PID/UTS/IPC namespaces, ro-bind roots, tmpfs-masked dotfiles, hardened seccomp denylist), `darwin_seatbelt` (`sandbox-exec` SBPL `(deny default)`, no namespaces/seccomp), `windows_jobobject` (process-tree containment, no FS/net isolation), `none`. Missing backend binary → **fail-loud at build** (never silently unsandboxed). **3 isolation layers:** (1) **filesystem** — only granted paths visible, dotfiles masked; (2) **default-deny L7 egress proxy** (`inner/egress/`) — DSL allowlist (default deny), DNS-safe host regex, **private-destination block** (RFC1918/loopback/CGNAT-100.64/cloud-metadata 169.254.169.254 traps; **resolve-once defeats DNS rebinding**), MITM per-sandbox CA over a Unix socket; (3) **credential injection** (`credential_proxy.py`) — **swap-on-access default** (nothing credential-shaped in the sandbox; proxy injects the real Authorization for the bound host), opt-in `oa_cred_*` placeholder, wrong-host→403; the real secret lives only in parent+proxy, **never** serialized into `SandboxPolicy`/argv/disk.
+⚠️ **Sandboxed claude-sdk on macOS crashes** vs degrading (#517 part-1, no PR). ⚠️ `credential_proxy` parent-side `subprocess.run(shell=True)` + arbitrary file reads on a trusted-spec assumption (#1542, no PR). **Code-only — no live sandbox trace** in this rig.
+
+---
+
+## 19. Web UI sidebar fetching + the FULL set of client→server requests
+
+**Sidebar:** `useConversations` (`hooks/useConversations.ts:216`) = TanStack `useInfiniteQuery` over `GET /v1/sessions` (`order=desc, sort_by=updated_at, limit=20`, optional `search_query`/`include_archived`, cursor-paginated by `last_id`). **Live updates via `WS /v1/sessions/updates`** (replaces the old 4s poll): client sends `{type:"watch", session_ids:[…]}` (union of cached rows + open session); server pushes `snapshot`/`changed`(status, runner_online, host_online, pending_elicitations_count, title)/`removed`/`heartbeat`. Frames patch cache in place; only structural changes schedule a debounced invalidate. 70s heartbeat watchdog; HTTP fallback 60s connected / 45s disconnected. Grouping precedence: **Archived > Pinned > Project > Recent**. Badge priority **awaiting > running > none**.
+**FULL client→server set** (web): **REST sessions** — `GET/POST /v1/sessions`, `GET …/projects`, `GET/PATCH/DELETE …/{id}`, `POST …/events`, `POST …/fork`, `POST …/switch-agent`, `POST …/elicitations/{eid}/resolve`, `GET …/items`. **Sub-resources** — `…/agent`, `…/permissions`(GET/PUT/DELETE), `…/owner`, `…/comments`(GET/POST/PATCH/DELETE/send), `…/policies`(GET/POST/DELETE), `…/resources/terminals`(GET/POST), `…/resources/files`, `…/resources/environments/default[/changes|/filesystem|/search]`, `…/codex_goal`(GET/PUT/PATCH/DELETE + /status). **Fleet/hosts/caps** — `GET /v1/agents`, `GET /v1/runners`, `POST /v1/hosts/{id}/runners`, `GET /v1/hosts/{id}/filesystem`, `POST …/directories`, `GET /v1/policy-registry`, `GET/POST /v1/policies` + `PATCH …/{id}`, `GET /v1/info`, `GET /v1/me`, `GET /health?session_ids=`. **Accounts/auth** (only when enabled, bare cookie fetch): `/auth/{login,logout,me,register,setup,invite,users…}`. **WS/SSE:** `GET …/stream` (SSE chat tail), `WS /v1/sessions/updates`, `WS …/terminals/{tid}/attach`.
+Note: `GET /v1/users/search` is **not** a direct SPA call — it's a host-injected callback (inert in standalone). ⚠️ **No live `omni-web` traces** (web telemetry opt-in, inactive in rig) — code-grounded.
+
+---
+
+## 20. Policy enforcement — how created; server-level vs session/runner-level
+
+**Created from three sources, merged at engine-build** (`builder.py:309`, order **session → agent-spec → admin** + a hardcoded gate): **(a) session-level** — agent calls `sys_add_policy` (after `sys_policy_registry`) → `POST …/policies` (`session_policies.py:148`); python handlers **must be in the registry allowlist** (anti-RCE); activates immediately; `sys_add_policy` itself is unconditionally ASK-gated (`_ASK_ON_ADD_POLICY_SPEC`, `builder.py:64/315`). **(b) server/admin default** — `POST /v1/policies` (`default_policies.py:129`, `_require_admin`), `session_id IS NULL`, applies server-wide, appended last ("admin gets the last word"). **(c) spec-declared** (YAML `guardrails.policies:`) — immutable, `id=None`, can't be PATCHed/DELETEd.
+**Enforcement: one engine** (`PolicyEngine`, `engine.py:43`), **two surfaces.** **Server-level** (engine in omni-server): REQUEST/RESPONSE gates at `/events`; TOOL_CALL/TOOL_RESULT at the `/mcp` proxy; the generic `/policies/evaluate` hook (native PreToolUse + LLM-phase). **Runner-level fast-path** (`RunnerToolPolicyGate`, `runner/policy.py:109`): runs **only function-type TOOL_CALL/TOOL_RESULT** policies (label/prompt types stay server-side — they need the store/LLM the runner lacks); **ALLOW/DENY decided locally before MCP dispatch**, **ASK escalates to the server** (which owns the elicitation channel); TOOL_RESULT collapses ASK→DENY. **5 phases**: REQUEST, TOOL_CALL (main gate), TOOL_RESULT (DENY/redact only), advisory LLM_REQUEST/LLM_RESPONSE. **First DENY short-circuits**; ASK accumulates. **Fail-CLOSED phases = `("PHASE_TOOL_CALL","PHASE_REQUEST")`** (`types.py:61`) → DENY on server outage; TOOL_RESULT/LLM_* fail OPEN.
+**Live (`cfb59197…`):** **all 5 phases observed** as `policy.evaluate` spans — REQUEST + LLM_REQUEST as children of `POST /events`; TOOL_CALL + TOOL_RESULT as children of `POST /mcp`; LLM_RESPONSE at the end. The observed claude-sdk run routed TOOL_CALL/RESULT through the **server `/mcp` proxy** (because `sys_os_shell` is server-dispatched), not the runner fast-path. ⚠️ Permissions-disabled ⇒ `accessible_by=None` returns ALL sessions (cross-user leak risk). ⚠️ pending-elicitation badge is **in-process** → multi-replica splits it.
+
+---
+
+## 21. System resources — shells (+ working-dir resolution), how exposed, timers
+
+**Two shell paths:** **`sys_os_shell`** — one-shot command in the agent's **shared `OSEnvironment`** (all four `sys_os_*` share one instance so cwd/sandbox/env stay consistent, `os_env.py:378`); **`sys_terminal_*`** — **persistent named tmux panes** (`TerminalRegistry.launch`, keyed `(conversation_id, terminal_name, session_key)`, survive across turns, `remain-on-exit on`). Both gated by spec (`os_env:` / non-empty `terminals:`). MCP tools are **not** registered in the ToolManager — they're runner-owned.
+**Working-dir resolution** (`_resolve_cwd`, `sys_terminal.py:752`, first match): LLM `cwd_override` → `terminal.os_env.cwd` → `spec.os_env.cwd` → `ctx.workspace` → (implicit) host/runner cwd. The **host** resolves the runner's cwd: server sends a realpath-validated `workspace` in `host.launch_runner`; the host expands `~` (only it knows its `$HOME`) and passes `RUNNER_WORKSPACE`. Shells inherit from the runner, not the host. **Live:** the `sys_os_shell` TOOL_RESULT carried `cwd=/Users/.../traces` = the runner workspace (tier 4/5). **Reaping:** orphan reaper at runner startup (`tmux kill-server` for dead-owner-pid instances); idle native-pane reaper (30-min idle, #1349).
+**Timers** (gated `timers:true`, default False): `sys_timer_set` returns a `timer_id` synchronously; on fire it **re-injects a turn via a synthetic `is_meta` `[System: timer X fired]` POST to `/events`** — it's a per-session runner-local `asyncio.create_task`, **not** a scheduler service. **Live (`conv_48ce846b`):** confirmed the full firing loop — `policy.evaluate tool=sys_timer_set` (set is gated) then the firing's `policy.content="[System: timer … fired]"` → a brand-new `agent:` turn. Timers die with the runner (no persistence). ⚠️ **sessions-native firing path raises `NotImplementedError`** (`timer.py:220`) — timers only work under the local-runner topology.
+
+---
+
+## 22. Custom agent's subagents init
+
+A custom agent's subagents are declared as `AgentTool` (by name → a registered agent, or inline) or `SelfAgentTool` (clone of parent, self-tools removed), parsed into nested `AgentSpec` (`spec/omnigent.py:1090-120`). **Loaded with `prune_invalid_sub_agents=True`** (`agent_cache.py:94/146/204` → `spec/__init__.py:314`): depth-first, a sub-agent that fails validation on **this** (possibly older) server is dropped with a WARNING and its name removed from the parent's `tools.agents` — so version skew degrades gracefully and the parent still dispatches (authoring/upload validation stays strict elsewhere). **`AgentTool`/`SelfAgentTool` synthesis** inherits parent profile/harness/os_env/terminals and recurses into nested tools (`_agent_tool_to_sub_spec`, `:1319`). At runtime the agent spawns them via `sys_session_send` (Q16). ⚠️ `pass_history`/`pass_histories`/`max_sessions` are **lossy** (dropped to defaults) on the omnigent-compat translator path (`:1338-41`); first-class on the inner `AgentDef` path.
+
+---
+
+## 23. How custom agents are stored in the server
+
+**Three tiers** (`runtime/agent_cache.py`): **(1) ArtifactStore** — content-addressed `.tar.gz` bundle (source of truth); **(2) Agent DB row** — `id`/`name`/`bundle_location`/`version`/`session_id` (session-scoped agents have a non-null `session_id`; template/registered agents null); **(3) AgentCache** (`agent_cache.py:16`) — Tier-1 in-mem `AgentSpec` (`_specs`) + Tier-2 on-disk extract `<cache_dir>/<agent_id>/`, **no TTL**. Miss → download → `load_spec` (extract+parse+validate) → both tiers. **Evict on delete** (`:161`, drops spec + rmtree); **warm-swap on update** (`replace`, `:102`: extract to `_staging`, atomic `_specs[id]=` reassign, rmtree old + rename staging — readers never see an empty cache; version bumps). **Security:** `expand_env=False` default — `${VAR}` expanded against server env **only** for operator template agents (`session_id is None`), **never** tenant/session agents (`:66-80`). Created via `POST /v1/sessions` multipart (`metadata`+`bundle`) → session-scoped agent + conv row in one txn. **Polly/debby** = registered custom agents stored exactly this way.
+
+---
+
+## 24. Harness switching
+
+**`POST /v1/sessions/{id}/switch-agent`** (`switch_session_agent`, `sessions.py:15415`, gate LEVEL_EDIT) — **idle-only, 409 if running** (`:15481`). Loads the target bundle **before** committing (fail-closed); `switch_conversation_agent` (`sqlalchemy_store.py:2576`) deletes the old session-scoped agent, clones the target, repoints `agent_id`, resets model/effort on cross-family, and **clears `external_session_id`** (`:2663`) so a **native** target cold-starts (rebuilds its vendor transcript) next turn. Publishes `session.agent_changed`; resets runner resources in the background. **Fork** can also switch harness (optional), with native targets rebuilding from `FORK_CARRY_HISTORY`.
+**Live (`conv_820c6dee` trace_probe→debby):** switch on an idle session returned immediately, bound a **cloned** target agent (new `ag_…`), **reset labels**, and **retained the runner binding** (`runner_token_c2a963…`). **The runner survives the switch** — the next turn reuses the same runner, which re-initializes for the new agent/harness (no new runner launch). **Polly** switches *workers* (spawns claude_code/codex/pi sub-agents), not its own brain harness. ⚠️ TUI has no switch-agent (its `/switch` only re-points the SSE stream to a different session).
+
+---
+
+## 25. Caching — agent cache + credential cache (what / TTL / invalidation)
+
+| What | Where | TTL | Invalidation |
+|---|---|---|---|
+| **Agent bundle** (parsed spec + extracted dir) | `runtime/agent_cache.py:16` | **none** | explicit `evict()` on delete; `replace()` warm-swap on update (version bump) |
+| **Provider model listing** (`sys_list_models`) | `model_catalog.py:61` TTLCache(64) | **5 min** | TTL; `clear_model_catalog_cache()` after reconfigure; failures NOT cached |
+| **MLflow model catalog** (per provider) | `onboarding/providers/__init__.py:102` TTLCache(64) | **1 h** | TTL; `OMNIGENT_DISABLE_CATALOG_LOOKUP=1` |
+| **Provider/credential resolution** (auth/base-url/profile) | resolved per call | **none** | recomputed fresh each spawn |
+| **Runner DBX SDK auth** | `_make_auth_token_factory` closure (`_entry.py:322`) | SDK in-mem cache, re-shells near expiry | factory rebuilt → re-resolves |
+| **Client cookie→user-id** | `server/auth.py:387-411` (HMAC-digest key) | token's remaining lifetime | TTL expiry; ⚠️ no revocation list |
+| **Native session state / policy-hook token** | `bridge.json`/`policy_hook.json` | **one-shot snapshot** | re-created on relaunch; **re-minted on 401/302 (PR #1439)** for claude/codex native |
+| **Inner LLM client singleton** | `workflow.py:251` | process-lifetime | none |
+| **Status / usage / pending-elicitation** | server in-memory (`_session_status_cache` etc.) | process-lifetime | ⚠️ per-replica (no backplane) |
+
+**Net:** the credential cache inside `runtime/` is essentially "none" — auth resolved fresh per spawn, per-request token refresh in the executors/runner callbacks. The two real caches are the **agent cache (no TTL, event-invalidated)** and the **model-catalog caches (5 min / 1 h)**.
+
+---
+
+## 26. Components to instrument + the channels between each
+
+| Component | Process | Telemetry today |
+|---|---|---|
+| **Server** | FastAPI `omnigent/server/`, one per deployment | ✅ `omni-server` (FastAPI auto-instrument) |
+| **Host daemon** | `omnigent host`, one per machine | ✅ `omni-host` |
+| **Runner** | `omnigent.runner._entry`, one per session | ✅ `omni-runner` (cached server→runner client `instrument_httpx_client`'d) |
+| **Harness/executor** | `omnigent/inner/*_executor.py` (+ native CLI) | ✅ `omni-harness` (the `agent:`/`tool:` spans) |
+| **Web UI** | `web/src/` | ⚠️ wired (`lib/telemetry.ts:40`) but **opt-in/inactive** |
+| **TUI/REPL** | `omnigent/repl/` | ❌ **`telemetry.init("omni-tui")` never called** — emits no spans (one-line fix) |
+| **Policy "server"** | **no separate process** — in-server `policies/engine.py` + runner fast-path + native `/policies/evaluate` hook | ✅ via `policy.evaluate` spans |
+
+**Channels (what to instrument between each):** Client→Server = **HTTPS REST + SSE** (`…/stream`) — FastAPI extract + httpx/browser inject (W3C). Client→Server sidebar = **`WS /v1/sessions/updates`** — manual `traceparent` in JSON envelope. Server⇄Runner = **WS reverse-tunnel forwarding HTTP verbatim** (server calls "into" runner; `traceparent` tunneled, custom-transport client instrumented directly — verified runner spans nest under server spans). Server⇄Host = **WS control frames (JSON, not HTTP)** — manual `traceparent` field, host opens `consume_frame_span(kind)` (verified `host.launch_runner`/`host.stat` nest under `POST /v1/hosts/{id}/runners`). Host→Runner = **one-way spawn env** (⚠️ **TRACEPARENT is NOT injected** → each runner roots its own trace). Runner→Harness = **HTTP over UDS**. Harness→Server = **JSONL forwarder re-POSTs `/events`** (own trace). Native harness↔Runner = **bridge HTTP relay (Bearer) + tmux**. Server⇄DB = SQLAlchemy.
+**Critical cross-cutting fact:** **one user action ⇒ ~21 traces**, stitched only by **`session.id`** (the forwarder, host control plane, and runner spawn all root their own traces because TRACEPARENT isn't propagated into the spawn env). To instrument end-to-end you must correlate by `session.id`, not parent span.
+
+---
+
+### Summary — where answers are thin or code-only (no live trace)
+
+1. **All of codex / codex-native is code-only** (Q4, Q5, Q7, Q13) — AI-gateway creds expired (403); a `DATABRICKS_BEARER`/PATH propagation gap in the runner spawn env (host reports `codex: needs-auth`). The server/runner/MCP path is harness-agnostic so it applies structurally, but no codex span exists in the corpus.
+2. **OmniBox/sandbox (Q18)** is entirely code-grounded — no live sandbox trace in this rig; the macOS-crash (#517) and credential_proxy-RCE (#1542) gaps are unverified-at-runtime.
+3. **Web UI (Q14, Q19) and TUI (Q9) have no traces** — web telemetry is opt-in/inactive and the TUI never calls `telemetry.init` (so `omni-tui → …` in the design doc doesn't exist today); client-side reconciliation is read from source only.
+4. **Compaction (Q11)** — only the *rejection* path (#1192 model-less) was traced live; a real L1/L2/L3 compaction trace needs a model-pinned session exceeding the threshold. **Multi-replica** behavior (status cache, pending-elicitation badge — Q10/Q20/Q25) is an open question (in-process caches, no backplane confirmed).
+5. **Thinly traced but code-confirmed:** the runner↔server **WS-tunnel no-per-message-refresh** gap (Q4) and the **native PreToolUse fail-closed** path (Q7) are confirmed in code + PR #1439 history but not exercised live; native sub-agent completion (#848, Q16/Q17) is code-confirmed only.

--- a/designs/master-arch/cuj-answers/_LIVE-TRACE-FINDINGS.md
+++ b/designs/master-arch/cuj-answers/_LIVE-TRACE-FINDINGS.md
@@ -1,0 +1,210 @@
+# Live-trace findings — what the traces reveal beyond the code analysis
+
+Rig: local Jaeger `:16686`, persistent server `:7777` + host (telemetry → `:14317`).
+Query by `session.id` via `scratchpad/trace_tools.py`. claude-sdk = primary;
+codex family blocked (creds — host reports `codex: needs-auth`).
+
+## Fork — `conv_820c6dee` → `conv_7fe12aec`
+- `POST /v1/sessions/{source_id}/fork` is **server-side only**: new conv returns with
+  `runner_id=null`, `host_id=null` — no runner/harness spawned for the copy.
+- Trace (under the **source's** `session.id`, path-based tag): a burst of **~25 `INSERT`
+  + many `SELECT` on `chat.db`** = the synchronous **deep-copy of conversation items**.
+- New session gets a **cloned agent** (new `agent_id`) + label `omnigent.fork.source_id`;
+  instance-scoped labels dropped.
+- **Beyond code:** fork cost is synchronous server DB work that **scales with item count**
+  (INSERT-per-item) — visible as a latency/■span spike, not a runner concern.
+
+## Switch-agent — `conv_820c6dee` trace_probe → debby
+- `POST /v1/sessions/{id}/switch-agent {agent_id}` on an **idle** session returns
+  immediately; binds a **cloned** target agent (`ag_3f172efb`), **resets labels**, and
+  **retains the runner binding** (`runner_token_c2a963…`).
+- **Beyond code:** the runner binding survives the switch; the next turn reuses the same
+  runner, which re-initializes for the new agent/harness (no new runner launch on switch).
+
+## Interrupt — long claude-sdk bash turn cancelled mid-flight (`conv_7fe7513654`)
+- Delivered as a **control event**: `POST /v1/sessions/{id}/events {"type":"interrupt"}`
+  (same endpoint as input; returns `{"queued":false}` = applied immediately, not queued).
+- **Concrete trace signal:** the `omni-harness agent:claude-sdk` span carries
+  **`error.type=cancelled`** (the `record_cancellation` helper in `runtime/telemetry.py`)
+  while `otel.status_code` stays OK — the unambiguous "this turn was interrupted" marker.
+- The in-flight tool call was abandoned mid-setup (the turn had reached `POST /mcp` +
+  `policy.evaluate` (TOOL_CALL) + `POST /mcp/execute` for the `sleep 30` bash when cut).
+- An `omni-server GET … ERROR` shows at teardown (stream/tunnel close on interrupt —
+  consistent with interrupt-fencing dropping trailing output).
+- **Beyond code:** the trace fingerprint of an interrupted turn = `error.type=cancelled`
+  on the agent span; interrupt rides the events endpoint, not a separate control channel.
+
+## Compaction — user `/compact` on a model-less session (`conv_63542a5f`)
+- `POST /events {"type":"compact"}` → **`{"error":{"code":"invalid_input","message":
+  "Compaction requires a configured LLM model"}}`** — rejected pre-LLM; session stays idle,
+  **no compaction spans emitted**.
+- **Confirms #1192:** a session created without an explicit `--model` (subscription default)
+  has no `model` on its row, so user-initiated compaction (needs an LLM for the L2 summary)
+  fails validation. Auto-compaction in the turn loop is unaffected (it uses the turn's
+  resolved model).
+- **Beyond code:** `/compact` is gated on a session-row model *before* any summary work —
+  an early validation error, not a compaction-loop failure. (A real compaction trace needs a
+  model-pinned session + enough context to exceed the threshold.)
+
+## Driving model & runner binding (mechanism finding)
+- `omnigent run --server :7777 <agent>` creates a session **with a bound runner** (per-run,
+  tunnels to the server) — the reliable SDK driver.
+- **REST `POST /v1/sessions {agent_id}` creates a session with NO runner** (`runner_id:null`);
+  a later `POST /events` → **`{"error":{"code":"runner_unavailable","message":"No runner bound
+  for session"}}`**. The web UI binds one by passing **`host_id`** (+ workspace) at create, so
+  the server tells the host to launch a runner.
+- **Events envelope** (verified `sessions.py:18282`, `parse_item_data(type, {type, **data})`):
+  `POST /events {"type":"message","data":{"role":"user","content":[{"type":"input_text",
+  "text":"…"}]}}`. Control events: `{"type":"interrupt"}`, `{"type":"compact"}`.
+- **Beyond code:** a session is **inert until a runner is bound**; `host_id` at creation is the
+  trigger for the host→runner launch — there is no implicit auto-launch on first event (the
+  "runner-offline → stuck working" gap class lives exactly here).
+
+## Sub-agent spawn — debby (claude-sdk orchestrator) → claude + gpt children (`conv_387e2405`)
+- The trace exposes the **full spawn mechanism** on `omni-harness`:
+  - **`tool:sys_session_send`** (×2) — the spawn call, one per child.
+  - children **created** via runner→server `POST /v1/sessions` (×9) — each child is a **full
+    session with its own `session.id`** (the trace set touches 3 ids: parent `conv_387e2405`
+    + children `conv_9edbfd15`, `conv_3cfe960a`).
+  - **`tool:sys_read_inbox`** (×2) — the parent drains child results via the inbox
+    (`async_work_complete`) — confirms the consume-once inbox drain.
+  - **`GET /v1/sessions/{id}/child_sessions`** (×6) — the subagents-rail/child API.
+  - per-child `agent:<name>` spans, each with its **own** `policy.evaluate` gates.
+- The gpt child (codex) fails on creds; the claude child answers — debby tolerates partial failure.
+- **Beyond code:** confirms §2.F **live** — a sub-agent is a first-class child Conversation
+  (own session.id + own runner via the same host), spawned by `sys_session_send` and drained by
+  `sys_read_inbox`, **not** an in-process call. Stitching a sub-agent tree across traces requires
+  collecting **all** the child `session.id`s (no single trace spans the whole tree).
+
+## claude-native — host-bound session + 1 turn (`conv_7c19d035`); contrast vs SDK turn
+- Created via `POST /v1/sessions {agent_id=claude-native-ui, host_id, workspace}` → returns with a
+  **live runner** (`runner_online:true`, harness=`claude-native`); message via `POST /events` →
+  `{"queued":true,"pending_id":…}` (decoupled async boundary), polled to idle.
+- After the turn the session row gains an **`external_session_id`** (the real Claude CLI's session
+  UUID, e.g. `c1ffe8d8-…`), persisted via `UPDATE conversations SET … external_session_id=?` — proof
+  the vendor CLI ran in tmux and the JSONL forwarder bound to it.
+- **The vendor turn is opaque** — the whole turn collapses to a tiny span set rooted by the harness:
+  - **`omni-harness agent:claude-native-ui`** [AGENT] carrying `input.value=<user prompt>` and
+    **`llm.model_name=claude-native-ui`** (the *harness* name, NOT a real model — the CLI owns model
+    selection). **No** child `llm_call`, **no** inline `tool:` spans, **no** per-tool `policy.evaluate`.
+  - **`omni-harness claude_native.inject`** — the inject+wait boundary (here 338ms; on a long vendor
+    turn this is where all the time hides — a single opaque async span, not a span tree).
+  - **`omni-runner claude_native.forward`** (×2) — the JSONL forwarder, each carrying
+    `omnigent.response_id=resp_claude_…` (one per vendor message it relays back through runner→server).
+- **Gating differs from SDK:** the only `policy.evaluate` is **phase=REQUEST with an empty
+  `policy.tool_name`** (gates the inbound *message*), decision=ALLOW. There is **no** `phase=TOOL_CALL`
+  per-tool span. (Native tool gating rides the **PreToolUse HTTP hook** out-of-band — it long-polls
+  via `_poll_request_disconnect`, sessions.py:1183 — so tool decisions never appear as inline
+  `policy.evaluate` spans the way SDK's do; this simple turn used no tools so no hook fired.)
+- **Beyond code:** an SDK turn's trace is a deep tree (`agent:` → `llm_call` → `tool:` →
+  `POST /mcp` → `policy.evaluate` per tool); a **native** turn's trace is the **opposite shape** —
+  one `agent:` + one `inject` + N `forward` spans, with `llm.model_name`=harness-name and a single
+  message-level policy gate. The vendor turn is a black box bounded by `claude_native.inject`; you
+  observe it only via the forwarder's `resp_claude_*` items, not via internal LLM/tool spans.
+
+## Disconnect / reconnect — SDK turn, SSE dropped mid-flight (`conv_6bbdba9a`)
+- Opened `curl -N --max-time 4 …/stream` mid-turn; the live tail delivered, in order:
+  `session.heartbeat` → `session.resource.created` (the tmux terminal `terminal_tui_main`, with
+  `tmux_socket`/`tmux_target`) → `session.changed_files.invalidated` → `session.presence`, then the
+  socket dropped at max-time. **Reopening the stream replays the *identical* opening frames** — i.e.
+  the **snapshot-on-connect** (current resource/presence state), **not** the turn's token deltas.
+- Code confirms the contract verbatim (sessions.py:16-17 "reconnect contract is **snapshot + live
+  tail**, not replay"; 11240-44 "no buffer and no replay … clients reconcile pre-subscribe state via
+  the snapshot endpoint and dedupe by item id"). Nuance (11315-20): **in-flight assistant *text*** IS
+  re-seeded synchronously at slot registration via `pre_ready_snapshot=inflight_text.snapshot_for(id)`
+  (so a mid-turn reconnect re-renders the partial assistant message), while resource state comes from
+  the async `on_subscribed` hook — but the *event stream* is never replayed.
+- **`[DONE]` sentinel**: emitted as `yield "data: [DONE]\n\n"` in the stream generator's **`finally`**
+  (sessions.py:11341; doc 11247) so every clean exit (incl. client disconnect) terminates the SSE
+  cleanly. (My `--max-time` kill severed TCP before the flush, so curl never saw it — a graceful
+  client close does.) Idle streams stay alive on periodic **`session.heartbeat`** (11262-70).
+- **Disconnect detection / teardown**: `_poll_request_disconnect` (sessions.py:1183) blocks on
+  `request.receive()` for `http.disconnect`; it's raced (`asyncio.wait`, FIRST_COMPLETED) against the
+  verdict Future in the elicitation long-poll **and** the native PreToolUse hook, so a hung-up client
+  releases the parked handler immediately instead of waiting out the full timeout.
+- **Beyond code:** reconnect = **GET snapshot + subscribe live tail**, deduped by item id — there is
+  no server-side replay buffer. The only thing "replayed" is partial assistant *text* (so the cursor
+  doesn't blank on refresh); resources/presence are full-state snapshots, deltas are dropped on the
+  floor. A turn keeps running through a disconnect (it's runner-side); the client just re-derives view.
+
+## Custom MCP — claude-sdk agent + a stdio echo MCP (`conv_4d0e6cce`)
+- Authored a no-dep stdio MCP (`echo_mcp.py`, tool `echo_shout`) wired via agent YAML
+  `tools: {echo: {type: mcp, command: …python, args: [echo_mcp.py]}}`; ran with
+  `omnigent run echo_agent.yaml --server :7777` (local-runner topology). Agent called it and returned
+  `SHOUT: HELLO MCP`.
+- Trace: the custom tool's canonical name is **`echo__echo_shout`** — exactly the `{server}__{tool}`
+  namespacing (server label `echo` from the YAML key + bare tool `echo_shout`; see
+  `mcp_manager.py:139-141`, resolved by prefix-match at `:405-416`). It is gated by **`policy.evaluate`
+  phase=TOOL_CALL *and* TOOL_RESULT** (decision=ALLOW) — the same policy pipeline as `sys_*`.
+- **Routing is identical at the HTTP layer** but lands in a different executor: omni-server
+  `POST /v1/sessions/{id}/mcp` → omni-runner `POST /v1/sessions/{id}/mcp/execute`
+  (`http.server_name=runner`). For a **custom** MCP the runner's `RunnerMcpManager` (the
+  spec-defined branch in `tool_dispatch.py:10-15`) dispatches into the **stdio subprocess it spawned**;
+  for **`sys_*`** the runner routes to server REST/OSEnvironment branches instead (`sys_os_*` →
+  runner-local OSEnvironment; `sys_call_async`/file tools → server REST). The `/mcp → /mcp/execute`
+  pair is the runner→server→runner proxy hop (`tool_dispatch.py:113-117`).
+- **Beyond code:** custom-MCP vs `sys_*` is a **tool-dispatch-ladder** decision inside the runner,
+  not a different wire path — both show as `policy.evaluate` → `POST /mcp` → `POST /mcp/execute`. The
+  only trace tell is the **tool name**: `{server}__{tool}` (→ RunnerMcpManager stdio child) vs
+  `sys_*` (→ server/OS branches). A custom stdio server executes **in the runner process tree**, so
+  its blast radius and creds are the runner's, not the server's.
+
+## Timers — `timers: true` claude-sdk agent, `sys_timer_set` (`conv_48ce846b`)
+- Agent YAML `timers: true` (gates the tool, `tools/manager.py:168-170`, `:257`); ran
+  `omnigent run timer_agent.yaml --server :7777 -p "set a 3s timer…"`. Agent got back
+  `timer_id: timer_2ec43…`, then — same run — printed `TIMER_OBSERVED` (the firing landed before the
+  runner tore down).
+- Trace evidence (full firing loop, **end to end**):
+  - **`policy.evaluate tool=sys_timer_set decision=ALLOW phase=TOOL_CALL`** (+ TOOL_RESULT) — the set
+    is gated like any tool.
+  - the firing re-injects a turn: a `policy.evaluate` whose
+    **`policy.content = "[System: timer timer_2ec43… fired]\nnote: 'ping'"`** (REQUEST phase, gating
+    the synthetic meta-message), then **`omni-harness agent:timer_agent input.value=[System: timer …
+    fired]`** — a brand-new agent turn driven by the timer.
+  - net `POST …/events` count jumps (server/runner/harness all show extra `/events`) — the firing is
+    literally a server POST, not an in-band callback.
+- Mechanism (`tool_dispatch.py:2345-2456`): `sys_timer_set` spawns a runner-side `asyncio` task
+  (`_session_timers`, `app.py:7626`) that sleeps then **POSTs `[System: timer {id} fired]` as an
+  `is_meta:true` user message** to `/v1/sessions/{id}/events`, re-triggering the agent (`repeat`
+  loops; else one-shot). `sys_timer_cancel` cancels the task.
+- **Caveat confirmed:** the **runner** path implements timers; the **sessions-native** path raises
+  `NotImplementedError` (`tools/builtins/timer.py:14-15,:221`). So timers work under the local-runner
+  topology (what I drove) but are a no-op/error on sessions-native.
+- **Beyond code:** a timer is **not** a scheduler service — it's a per-session runner-local
+  `asyncio.create_task` that, on fire, **re-enters the agent via a synthetic `is_meta` `/events`
+  message**. The firing is indistinguishable in the trace from a user turn except the `input.value`
+  is `[System: timer … fired]`. Timers die with the runner (no persistence of the task across runner
+  restarts — the firing POST is the only durable artifact).
+
+## ASK / DENY policy — session-level `ask_on_os_tools`, resolved DENY (`conv_c8a81cbd`)
+- Browsed `GET /v1/policy-registry`, attached the built-in
+  **`POST /v1/sessions/{id}/policies {handler:"omnigent.policies.builtins.safety.ask_on_os_tools"}`**
+  (`source:session`, enabled) to a host-bound polly (claude-sdk) session; sent a `sys_os_shell`
+  trigger.
+- The turn **parked on an elicitation** (status stayed `running`). Snapshot
+  `pending_elicitations[0]` =
+  `{type:"response.elicitation_request", elicitation_id:"elicit_67ff3403…", method:"elicitation/create",
+  params:{mode:"url", phase:"tool_call", policy_name:"ask_os_trace",
+  message:"ask_os_trace: Agent wants to call sys_os_shell('echo POLICYASKTEST'). Approve?",
+  content_preview:"{\"command\": \"echo POLICYASKTEST\"}",
+  url:"/approve/conv_…/elicit_67ff3403…"}}`.
+- Resolved DENY: **`POST /v1/sessions/{id}/elicitations/{eid}/resolve {"action":"decline"}`** →
+  `{"queued":false}` (synchronous; `ElicitationResult.action` ∈ accept/decline/cancel —
+  decline = explicit DENY, `schemas.py:1019-1034`). Session returned to **idle**,
+  `pending_elicitations:0`, with a `function_call` + `function_call_output` (the **blocked** shell +
+  its denial) + a final assistant message — the agent saw the tool refused.
+- **First-ever ASK/DENY trace evidence** (we'd only traced ALLOW):
+  - **`policy.evaluate tool_name=sys_os_shell decision=ASK phase=TOOL_CALL`** (×2: initial eval + the
+    re-eval after the verdict).
+  - **`policy.reason = "ask_os_trace: Agent wants to call sys_os_shell('echo POLICYASKTEST'). Approve?"`**
+    — the ASK prompt baked into the span (== the elicitation `message`).
+  - **`omni-server POST …/elicitations/{eid}/resolve`** span carrying the full
+    `…/elicitations/elicit_67ff3403…/resolve` URL — the DENY delivery hop.
+- **Beyond code:** the ASK/DENY mechanism is **`policy.evaluate decision=ASK` → publish
+  `response.elicitation_request` (mode=url, with a `/approve/…` resolve URL) → park the tool-call
+  (turn stays `running`) → client POSTs `ElicitationResult{action}` to the resolve URL → verdict
+  unblocks the parked handler**. The resolve URL embeds the unguessable `elicit_…` id as the
+  capability (plus `LEVEL_EDIT`). DENY (`decline`) surfaces to the model as a tool *result* (a
+  `function_call_output` denial), so the agent continues the turn knowing the action was refused —
+  it does **not** error the turn. The same verdict can arrive via the generic `{"type":"approval"}`
+  event on `/events`; both route through one `_resolve_elicitation` (sessions.py:3921).

--- a/designs/master-arch/cuj-answers/credentials.md
+++ b/designs/master-arch/cuj-answers/credentials.md
@@ -1,0 +1,195 @@
+# CUJ Answers — Credentials, Auth & Onboarding (§2.G)
+
+> How claude / codex / polly behave for credential resolution, the three credential relationships +
+> their refresh paths, the chat-vs-policy token paths, and caching. Code-grounded; `file:line` on branch
+> `traces` (HEAD `60d11673`). Creds don't surface as spans — answers are from code. **PR #1439 verified
+> merged** (commit `e9561916`). **No secrets/tokens/workspace IDs printed.**
+
+---
+
+## Q1. First-run setup / provider selection (wizard + ambient detection; config.yaml; DBX profile aliasing)
+
+**The `omnigent setup` wizard** (`onboarding/wizard.py:run_wizard_and_launch` :1384) is a 3-step flow,
+each step skippable:
+1. **Server URL** — `_prompt_server_url()` (:597).
+2. **LLM executor auth** — `_prompt_global_auth()` (:498): menu of "API key" vs "Databricks". API-key path
+   prompts for the key + optional base_url; Databricks path prompts for a profile (with detected hints from
+   `_list_databricks_profiles()` :465 reading `~/.databrickscfg`). Returns `{"type":"api_key",...}` or
+   `{"type":"databricks","profile":...}`.
+3. **Default agent YAML path**.
+
+It then writes **`~/.omnigent/config.yaml`** (`_save_global_config()` :1476) with keys `server`, `auth`,
+`default_agent`. Config path is `OMNIGENT_CONFIG_HOME` or `~/.omnigent/config.yaml` (`provider_config.py:_config_path` :473).
+
+**Ambient detection** (`onboarding/ambient.py:detect_providers` :619) scans, in **priority order**:
+1. **Env API keys** (`PROVIDER_ENV_VARS`): `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, … → `kind="key"`.
+2. **Vertex AI** (`CLAUDE_CODE_USE_VERTEX` + GCP envs) → anthropic family.
+3. **Claude CLI login** — file check `~/.claude/.credentials.json`, **macOS Keychain fallback** via
+   `claude auth status` subprocess (:561, :590-599) → `kind="subscription"`.
+4. **Codex config provider** — parses `~/.codex/config.toml` (`model_provider` + self-contained auth) → `kind="cli-config"`.
+5. **Codex CLI login** — reads `~/.codex/auth.json` (OPENAI_API_KEY / tokens / PAT) → `kind="subscription"`.
+6. **Local Ollama** — TCP probe `localhost:11434` (0.25s timeout) → `kind="local"`.
+
+**Provider TYPES** (`provider_config.py:_parse_provider` :748, kinds at :113): `key`, `subscription`, `gateway`
+(OpenAI-compatible proxy), `local`, `databricks` (profile), `cli-config` (codex custom provider), `bedrock`.
+
+**Databricks profile aliasing** (`onboarding/setup.py:_alias_profile` :190; `_alias_source_for` :160): when a
+*same-host* profile already exists in `~/.databrickscfg` (compared host-only, trailing-slash-insensitive
+`_host_matches` :152), setup **aliases** the new profile to the existing one rather than triggering a fresh
+`databricks auth login`. Reason: the Databricks OAuth token cache is **host-keyed**, so two profiles on the same
+host share the cached login → no redundant browser OAuth. Atomic write via tempfile + rename (:201-210).
+
+**Per-harness**: claude-sdk/claude-native default to the **anthropic** family; codex/codex-native to **openai**
+(`default_provider_for_harness` :1126). Polly/custom agents inherit whatever harness they run on.
+
+---
+
+## Q2. Credential resolution chain (spec auth → env → CLI login → ambient)
+
+For **LLM creds**, resolution precedence (`spec/types.py:562-597`, `databricks_executor.py`):
+1. **Spec `executor.auth`** — explicit `ApiKeyAuth` (inline bearer) / `DatabricksAuth` (profile) / `ProviderAuth`
+   (named provider from `~/.omnigent/config.yaml`). Highest precedence; bypasses ambient.
+2. **Spec `executor.connection`** — per-provider `{api_key, base_url, ...}` overrides.
+3. **Env vars** — `OPENAI_API_KEY`/`OPENAI_BASE_URL` (`databricks_executor.py:608-610`), `DATABRICKS_CONFIG_PROFILE`,
+   `ANTHROPIC_API_KEY`, etc.
+4. **CLI login / profile** — `~/.databrickscfg` profile (SDK `Config(profile=...)`, `:433`); or vendor CLI subscription
+   (`~/.claude/.credentials.json`, `~/.codex/auth.json`).
+5. **Ambient** — the detection chain in Q1 (`ambient.py:619`) as a last resort.
+
+Notable rule (`databricks_executor.py:436-457`): an **explicit** profile is fail-loud if not authenticated, but a
+profile coming from the `DATABRICKS_CONFIG_PROFILE` **env var** falls back to the ambient credential chain (with a
+warning) so CI envs that inject tokens via env work. **Subscription harnesses** (`claude-native`, `claude-sdk`, `codex`
+in `_SUBSCRIPTION_AUTH_HARNESSES`, `spec/omnigent.py:124`) deliberately **do NOT inherit a parent agent's Databricks
+profile** — doing so would force Databricks routing and bypass subscription auth.
+
+---
+
+## Q3. The THREE credential relationships and their REFRESH paths
+
+### 3a. LLM creds (per provider)
+- **Databricks SDK harness (claude-sdk)** — `_DatabricksBearerAuth.auth_flow()` (`databricks_executor.py:367`) calls
+  the SDK `Config.authenticate()` on **every HTTP request** to `/serving-endpoints` (wired via
+  `http_client=httpx.Client(auth=auth)` :620). The SDK serves a cached OAuth token from memory and only re-shells
+  `databricks` CLI (~0.5s) near expiry → **survives the ~1h OAuth lifetime per request**. ✅
+- **Codex gateway (codex / codex-native)** — different mechanism: the Codex App Server is configured with a provider
+  `auth = {command="sh", args=["-c", "<databricks auth token ...>"], refresh_interval_ms=<...>}`
+  (`codex_executor.py:763-798`). Codex re-runs the shell command on its **interval** (default `_GATEWAY_AUTH_REFRESH_MS
+  = 900_000` = 15 min, :60) plus on 401. The command uses `--force-refresh` when the CLI supports it (:746-760).
+- **API-key / subscription = static** — `OPENAI_API_KEY` + `OPENAI_BASE_URL` (`:608-610`), static Databricks PAT
+  (`:472-481`): **no refresh**. Vendor subscription (claude/codex CLI) is **vendor-managed** — Omnigent doesn't refresh it.
+
+### 3b. Runner ↔ Server
+Token source: `_make_auth_token_factory()` (`runner/_entry.py:271`) — **stored OIDC token first**
+(`auth_tokens.json` via `load_token`, :377), **else Databricks OAuth** via the SDK (host-keyed when a Databricks Apps
+pointer record exists, :342-353). Two channels:
+- **HTTP callbacks** (`_RunnerDatabricksAuth.auth_flow`, :192): mints a **fresh token per request**; retries once on
+  **401 OR Apps `302→/oidc/`** (`_is_login_redirect_or_unauthorized` :241). Also injects `X-Databricks-Org-Id` routing.
+  ✅ survives ~1h.
+- **WS tunnel** (`serve_tunnel`, `ws_tunnel/serve.py:230`): Bearer is set **once at open** in the handshake
+  `additional_headers` (:540-545). **⚠️ No per-message refresh** inside the open socket. The token is re-minted only on
+  **reconnect** (`_refresh_auth_token` :284 inside the `while True` loop) or on a 401 that drops the socket
+  (`_handle_refreshable_auth_failure` :407). A live tunnel that crosses the 1h boundary keeps flowing (handshake-only auth).
+
+### 3c. Client ↔ Server
+- **Modes** (`server/auth.py:resolve_auth_source` :193, `UnifiedAuthProvider` :250):
+  - **header** (default) — `X-Forwarded-Email` (override `OMNIGENT_AUTH_HEADER`; strip-prefix for Google IAP). Missing
+    → 401 unless `OMNIGENT_LOCAL_SINGLE_USER=1` → reserved `"local"` user (`_check_header` :415).
+  - **accounts** — user/pass `/auth/login` → cookie.
+  - **oidc** — auth-code+PKCE → cookie.
+- **Cookie** `__Host-ap_session` (HS256 JWT, `sub` claim), **validated every request** (`_check_cookie` :351), with a
+  TTL cache keyed by HMAC digest of the token (:387-411). CLI clients send the same JWT as `Authorization: Bearer`
+  (fallback :380-383).
+- **`omnigent login`** (`cli.py:12146`): probes `/v1/me`, branches to accounts (user/pass) / oidc (browser + ticket
+  poll, 5-min timeout :12300) / databricks (`databricks auth login --host`) / header (no-op). Writes the JWT (with
+  `expires_at`, :12286) to `auth_tokens.json` (`0o600`). **⚠️ NO background refresh** — once expired, `load_token`
+  returns None (`cli_auth.py:183`) and the user must re-login.
+- **Databricks Apps**: `store_databricks_auth` writes a **pointer record** (no token, `cli_auth.py:109`) naming the
+  workspace host; tokens minted fresh per use. The `?o=` org selector becomes `X-Databricks-Org-Id` on every request
+  (`databricks_request_headers` :229).
+
+---
+
+## Q4. Token refresh CHAT path vs POLICY-hook path (the known bug — VERIFY)
+
+**Chat / active turn** — both refresh per request → survive the ~1h OAuth lifetime:
+- Runner callbacks: `_RunnerDatabricksAuth` (per-request + 401/302 retry).
+- LLM executor: `_DatabricksBearerAuth.auth_flow` (per request); codex via interval shell `auth_command`. ✅
+
+**Policy-hook path (native)** — this WAS the bug, **now FIXED by PR #1439** (verified merged, commit `e9561916`):
+- The native PreToolUse/PermissionRequest hooks are launched with a **one-shot `ap_auth_headers` bearer** snapshotted
+  at launch (`native_policy_hook.py:policy_hook_wrapper_script` :103; `claude_native_hook.py` reads at :261/307/645/717/836).
+- **Old behavior**: that token died with the ~1h OAuth lifetime; the Databricks Apps front door bounced the expired
+  bearer with a **`302→/oidc/`** (NOT a 401), the hook couldn't get a verdict, and the PreToolUse gate **failed CLOSED**
+  ("policy evaluation unavailable") — even though chat kept working (refresh-capable). This is the fail-CLOSED
+  TOOL_CALL phase (`FAIL_CLOSED_PHASES`).
+- **Fix (PR #1439)**: both `claude_native_hook.py` (claude-native) and `native_policy_hook.py`
+  (codex-native, via `codex_native_hook`) now, on a `302→/oidc|/.auth` redirect **or** 401, **re-mint a fresh bearer**
+  via the same `_make_auth_token_factory` the runner uses (`policy_hook_reauth` :133), preserve `X-Databricks-Org-Id`,
+  and **retry once** (`post_evaluate_with_retry(..., reauth=)` :440, branch :500-522) before falling back.
+  **Fail-closed remains the last resort** when no token can be minted (preserves #163/#579). Applies to the
+  evaluate-policy, permission-request, and ask-user-question hooks.
+- **SDK / runner harnesses (claude-sdk, codex, Polly)** were never affected — their policy/relay path uses
+  `_make_auth_token_factory()` per call (fresh).
+- **Caveat (out of scope)**: the **OpenCode** policy plugin snapshot (`runner/app.py:1141-1149`,
+  `OMNIGENT_POLICY_AUTH`) still uses a one-shot token and **degrades to fail-OPEN** after ~1h (comment :1142-1143:
+  "a refreshable token file is the follow-up"). OpenCode is outside the claude/codex scope.
+
+**Per-harness summary (policy-hook token):**
+| Harness | hook token | after ~1h |
+|---|---|---|
+| claude-sdk / codex (SDK) | runner relay, fresh per call | fine (no snapshot) |
+| claude-native | one-shot snapshot + **reauth (PR #1439)** | re-mints & retries; fail-closed only if unmintable |
+| codex-native | one-shot snapshot + **reauth (PR #1439)** | re-mints & retries; fail-closed only if unmintable |
+| Polly / custom | per chosen harness | per chosen harness |
+
+---
+
+## Q5. Caching table
+
+| What | Where | TTL | Invalidation |
+|---|---|---|---|
+| MLflow model catalog (per provider) | `onboarding/providers/__init__.py:102` `_CATALOG_TTL_SECONDS=3600` (cachetools TTLCache, maxsize 64) | **1 h** | TTL expiry; `OMNIGENT_DISABLE_CATALOG_LOOKUP=1` skips fetch |
+| Provider model listing | `model_catalog.py:61` `_CATALOG_TTL_S=300.0` (TTLCache, maxsize 64, keyed by non-secret provider identity) | **5 min** | TTL expiry; `clear_model_catalog_cache()` (:250) after reconfiguring providers; failures NOT cached |
+| Provider resolution (auth / base_url / profile) | — | **none** | resolved fresh per call |
+| Agent bundle (spec + extracted dir) | `runtime/agent_cache.py` | **none** | explicit evict on delete; warm-swap on update |
+| Runner Databricks SDK auth | `_make_auth_token_factory` closure (`_entry.py:322-323`) | resolved once per factory; SDK serves token from in-mem cache, re-shells near expiry | factory rebuilt → re-resolves |
+| Client cookie → user-id | `server/auth.py:387-411` (HMAC-digest-keyed) | token's remaining lifetime (`exp - now`) | TTL expiry; ⚠️ no revocation list |
+| Native session state / policy token | wrapper script / `policy_hook.json` / `OMNIGENT_POLICY_AUTH` | **one-shot snapshot** | re-created on relaunch; **re-minted on 401/302 (PR #1439)** for claude/codex native |
+
+---
+
+## Concrete live example: expired LLM cred (codex Databricks gateway, 403)
+
+The codex Databricks AI-gateway token is currently **expired (403)** — a real instance of **LLM-cred expiry (3a)**.
+The local `~/.codex/config.toml` pins codex to a Databricks `/codex/v1` provider whose `auth.command` shells
+`databricks auth token`; `~/.codex/auth.json` carries no OpenAI subscription. When the workspace OAuth refresh grant
+is dead, the shell command yields no token → the gateway returns **403**. This is why codex / codex-native cannot be
+live-traced in this rig. Covered from code + structural analogy to claude (no live trace — creds). The claude-sdk path
+would behave analogously if its DBX refresh token died: `Config.authenticate()` raises `DatabricksAuthError`
+(`databricks_executor.py:340-347`) and the turn fails loud with a "Run: databricks auth login" hint.
+
+---
+
+## Cross-cutting invariant check (§3 #2 — credential validity)
+
+- **LLM cred expires mid-turn**: SDK (claude-sdk) refreshes per request → transparent. Codex re-runs `auth_command`
+  on interval/401. Static api-key/PAT/subscription → hard failure. ⚠️ If the **refresh token** (not just access token)
+  is dead → `DatabricksAuthError` / gateway 403 (the codex live case).
+- **Runner↔server expires mid-turn**: HTTP callbacks self-heal (401/302 retry). WS tunnel: handshake-only, so a live
+  socket survives; risk is at reconnect.
+- **Client↔server expires mid-turn**: cookie/JWT valid until `exp`; after that → 401 → login redirect (browser) or
+  `omnigent login` (CLI). No background refresh.
+- **Policy reach across token expiry**: ✅ now holds for claude-native + codex-native (PR #1439 reauth). Still a
+  fail-open gap for OpenCode (out of scope).
+
+---
+
+## Open questions
+
+1. Does the server re-validate the runner's WS handshake bearer on a long-lived tunnel crossing the 1h boundary, or
+   only at handshake? (Code: handshake-only — needs runtime confirmation.)
+2. Subscription vendor-CLI token expiry mid-turn (claude-native `use_claude_config` → `~/.claude/.credentials.json`):
+   vendor-managed; behavior on lapse unverified.
+3. Cookie TTL cache keeps a revoked-but-unexpired JWT valid until `exp` (no revocation list) — acceptable posture?
+4. OpenCode policy snapshot still fail-OPEN after ~1h — was the PR #1439 follow-up "refreshable token file" ever landed?
+   (Out of claude/codex scope but a residual auth gap.)

--- a/designs/master-arch/cuj-answers/executor-subagents-compaction-cache.md
+++ b/designs/master-arch/cuj-answers/executor-subagents-compaction-cache.md
@@ -1,0 +1,321 @@
+# CUJ answers — Executor · Subagents · Inbox · Compaction · Resume · Custom-agent storage · Caching
+
+Domain: the **runtime turn loop & agent machinery** (`omnigent/runtime/` +
+`omnigent/inner/{executor,tools,tracing}.py` + `tools/builtins/{spawn,async_inbox}.py`).
+Companion architecture doc: `../architecture/runtime-executor.md`.
+Source = code (`file:line`); validated with the local Jaeger rig. In scope:
+claude-sdk, codex, polly. codex has **no live trace** (gateway creds 403).
+
+---
+
+## Q1. Role of the executor in the turn loop
+
+An **Executor** (`inner/executor.py:518`) is the per-vendor adapter that
+translates **Omnigent's abstract turn model ↔ a concrete vendor SDK**. The
+abstract model is deliberately tiny:
+
+- **In:** `run_turn(messages: list[Message], tools: list[ToolSpec],
+  system_prompt: str, config: ExecutorConfig)`.
+- **Out:** an async stream of `ExecutorEvent`s
+  (`inner/executor.py:96-261`): `TextChunk`, `ReasoningChunk`,
+  `ToolCallRequest`, `ToolCallComplete`, `TurnComplete`, `CompactionComplete`,
+  `TurnCancelled`, `ExecutorError`.
+
+Each vendor (claude-sdk, codex, pi, …) subclasses `Executor` and maps its SDK's
+native stream onto this vocabulary. Capability differences are declared via
+predicates (`supports_streaming`, `handles_tools_internally`,
+`supports_live_message_queue`, `interrupt_session`, `max_context_tokens`, …),
+all defaulting ❌ except `supports_tool_calling` (`:541-587`).
+
+**Where it runs:** the executor lives inside a **per-conversation harness
+subprocess** (`omni-harness`, `harnesses/_runner.py`). The
+**`ExecutorAdapter`** (`harnesses/_executor_adapter.py:141`, a `HarnessApp`
+subclass shared by all four SDK wraps) is the bridge:
+
+1. Lazily constructs the inner executor on first turn (`_ensure_executor`).
+2. Translates the incoming `CreateResponseRequest` → `Message` list +
+   `ExecutorConfig` (`:258-285`).
+3. Calls `executor.run_turn(...)` and, per yielded `ExecutorEvent`,
+   `_translate_event(...)` emits typed **SSE** events (`response.output_text.delta`,
+   reasoning deltas, `response.output_item.done` function_call/output,
+   `response.completed/.cancelled`) (`:394-459`).
+4. Round-trips spec/MCP tools the SDK can't run itself through
+   `dispatch_tool` (action_required → parked Future keyed by `call_id` →
+   runner PATCHes the matching `function_call_output`) (`_scaffold.py:449-516`).
+5. Wires stable bridges (`_tool_executor`, `_elicitation_handler`,
+   `_policy_evaluator`) and the steering watcher (`_watch_injections`).
+
+**Trace evidence (the loop as OpenInference spans):** the executor turn loop is
+exactly the `agent:<harness>` AGENT span on `omni-harness` wrapping
+`executor.run_turn()`, with tool calls nested under it. Live (corpus
+`conv_63542a5f92…` trace `f98feda7…`; fresh `conv_3a411011…` trace `f2e437fa9…`):
+
+```
+omni-harness  agent:claude-sdk [AGENT]   (7855ms)   input.value=<prompt>  output.value=<final text>  session.id=conv_…
+  omni-harness  tool:sys_os_shell [TOOL]  (208ms)    tool.name=sys_os_shell  input.value={"command":"echo …"}  output.value={"exit_code":0,…}
+```
+
+The AGENT span is created by `TracingContext.start_agent_span`
+(`inner/tracing.py:130`), the TOOL span by `start_tool_span` on `ToolCallRequest`,
+both **only from the adapter** (`_executor_adapter.py:387,413`).
+
+> **Nuance — no `llm_call [LLM]` span for the SDK path.** `tracing.py:26-33`
+> *documents* an ideal `agent → llm_call → tool → sub-agent → policy:` nesting
+> and `start_llm_span` exists (`:223`), but **no `inner/*_executor.py` calls
+> it** — the adapter wraps the whole turn in one AGENT span and the LLM call is
+> subsumed. Verified live: zero `llm`-named spans in Jaeger. Real nesting for
+> claude-sdk is **agent → tool**; guardrails appear as a separate
+> `policy.evaluate` span on `omni-server`; a sub-agent's AGENT span is a
+> separate omni-harness-rooted trace.
+
+---
+
+## Q2. How subagents are spawned (+ depth limits)
+
+**Two declaration forms** (parse-time → nested `AgentSpec` in `sub_agents`,
+`spec/omnigent.py:1090-1120`):
+- **`AgentTool`** (`inner/tools.py:266`) — a sub-agent referenced **by name**
+  (registered agent) or **inline**. `_agent_tool_to_sub_spec`
+  (`spec/omnigent.py:1319`) synthesizes the child spec, inheriting parent
+  profile/harness/os_env/terminals and recursing into nested tools.
+- **`SelfAgentTool`** (`inner/tools.py:298`; `tools.<name>: self`) — clones the
+  **parent's** spec (`_self_agent_tool_to_sub_spec`), with all `SelfAgentTool`
+  entries **removed from the clone** (`spec/omnigent.py:1310`) as the
+  self-recursion guard.
+
+**Runtime spawn (LLM-driven, SDK harnesses):** the LLM calls
+**`sys_session_send`** (`tools/builtins/spawn.py:56`):
+- mode A `(agent, title)` → **mints a child Conversation** and starts a turn;
+- mode B `session_id` → posts to an **existing direct child**.
+The child's `parent_session_id` = the **immediate parent**
+(`_resolve_parent_conversation_id`, `spawn.py:407`); it **inherits the caller's
+runner** (co-location) and **runs the same turn loop** (its own omni-harness
+ExecutorAdapter → its own AGENT-rooted trace). Results return to the parent via
+the `async_work_complete` inbox signal (Q4). For claude-**native**, children are
+minted via `external_subagent_start` instead (native SME).
+
+**Depth limits — VERIFIED display-only, NO spawn-time cap.**
+- `_MAX_SUBAGENT_TREE_DEPTH = 3` (`repl/_repl.py:201`). **Sole use:**
+  `_refresh_subagent_tree(max_depth=_MAX_SUBAGENT_TREE_DEPTH)`
+  (`_repl.py:6266-6296`) → caps how deep the **REPL sidebar renders** the child
+  tree ("mirrors web's MAX_TREE_DEPTH"). It is a **rendering cap on
+  `child_sessions_tree`**, never consulted at spawn time.
+- No spawn-time depth check exists anywhere. `SelfAgentTool` recursion is
+  bounded only by clone-pruning (one level of `self`); ordinary `AgentTool`
+  chains can recurse unbounded. `AgentTool.max_sessions` (`inner/tools.py:295`)
+  is an optional per-tool **concurrency** cap, not depth.
+- **Gap:** real runaway-recursion risk (CUJ-ANALYSIS §6, "add when needed").
+
+---
+
+## Q3. Info propagation parent↔child
+
+- **`pass_history: true`** snapshots the parent's `"self"` history into the
+  child as `"parent"` history; **`pass_histories: [names]`** snapshots named
+  histories (`inner/tools.py:281-294`). The child executor serializes that
+  passed history into its context on the **first turn**
+  (`claude_sdk_executor.py:2600`, `cursor_executor.py:223`,
+  `pi_executor.py:1233`).
+- **Tool args = the child's first user message** — `sys_session_send`'s
+  `args.input` is "treated as the first user turn in its conversation"
+  (`spawn.py:281`).
+- **Results truncated into the inbox signal** — on child turn completion the
+  output is **truncated** to a per-payload char budget (matching the `@tool`
+  path's `truncate_for_llm`, `workflow.py:94-104`) and packaged into the
+  `async_work_complete` payload the parent drains.
+- **Siblings / cross-agent only via the parent** — `sys_session_send` is
+  "confined to your direct children" (`spawn.py:73-74,245`); a child addresses
+  only its own children or its parent. No sibling channel.
+- **Lossy on the omnigent-compat translator:** `pass_history` /
+  `pass_histories` / `max_sessions` are dropped to defaults when an agent goes
+  through `spec/omnigent.py` (`:1338-1341`); first-class on the inner
+  `AgentDef` path (`inner/loader.py:450-519`).
+
+---
+
+## Q4. Inbox / async mechanics
+
+- **`sys_call_async(tool, args)`** (`tools/builtins/async_inbox.py:129`) —
+  dispatch a **local Python tool** as a background task; `is_async()` is always
+  True (`:222`) → routes to `dispatch_async`, returns an **`_AsyncToolHandle`**
+  JSON `{task_id, tool_name, status:"in_progress", message}`
+  (`workflow.py:2143`, `to_handle_json`). MCP/builtin/client tools and a
+  recursive `sys_call_async` target are rejected.
+- **Where the blocking drain lives:** in the **harness subprocess**, not the
+  runner. Heartbeat `_HEARTBEAT_INTERVAL_S=15.0` (`_scaffold.py:83`;
+  `_heartbeat_loop`→`response.heartbeat`, `:1542`); steering
+  `TurnContext.next_injection(timeout=…)` (`:551`); auto-collect
+  `_drain_async_completions` (`async_inbox.py:253`). (The `workflow.py:94-118`
+  constants are stripped doc-comments only.)
+- **Drain — two paths, both consume-once:**
+  - **Auto-drain at the iteration boundary (push):** `_drain_async_completions`
+    runs at the **top of every loop iteration**, delivering piled-up
+    `async_work_complete` payloads as `[System: task …]` user messages
+    (`async_inbox.py:253-261`).
+  - **`sys_read_inbox` (pull, mid-turn):** the LLM drains the inbox inline as a
+    `function_call_output` without waiting for the iteration boundary — used to
+    fan out a second wave based on first-wave results (`:240-308`). Like
+    auto-collect it's `is_async()=True` but returns a string, not a handle
+    (`:310-331`).
+  - **Consume-once:** both remove payloads off the topic, so the next
+    iteration's auto-collect never re-delivers — the LLM never sees a completion
+    twice (`:264-266`).
+- **Topic:** `async_work_complete` (`workflow.py:2160`) — the signal sub-agent
+  completions ride on. **Subagent-completion delivery (runner side)** runs in
+  `_on_proxy_stream_end` (`runner/app.py:12519`), pushing the child's output to
+  the **parent's inbox queue** (`_deliver_subagent_completion`, `:7248`) +
+  scheduling a parent wake-POST (`:12957`), gated at **`runner/app.py:12607`**
+  `elif not _is_native_harness(conv_id) and not has_buffered:` (⚠️ native
+  children skip this; #848).
+- **`sys_cancel_task` / `sys_cancel_async` — NO-OP (confirmed).** The tasks
+  table was removed; `SysCancelTaskTool.invoke` returns
+  `{"error":"task_not_found","hint":"The tasks table has been removed…"}`
+  **for every input** (`async_inbox.py:97-126`). `sys_cancel_async` subclasses
+  it with a `handle_id` alias → identical no-op (`:334-412`). Async/subagent
+  cancellation is effectively broken. (Per docstring, Bash background jobs are
+  killed via the SDK's KillBash instead.)
+
+---
+
+## Q5. Compaction / transcript reconstruction
+
+3-layer, least→most lossy (`runtime/compaction.py:544`, `compact()`); budget =
+`context_window*0.8 − system_token_budget` (`:615`); recent window = 5 LLM
+groups (`:48`):
+- **L1 surgical clear** (`:624-631`) — tool-result bodies →
+  `"[Previous tool result cleared…]"`; binary `data` →
+  `"[binary content removed…use file_id…]"` (keeps `file_id`); strip
+  `output_text.annotations`. Returns if L1 fits & not `force`.
+- **L2 LLM summary** (`:633-692`) — summarise pre-boundary into a synthetic
+  user+assistant pair. **Routed through the runner's `POST /v1/summarize`** when
+  a runner client exists (`_summarize_via_runner_uncached`, `:428`) so the
+  *runner's* creds are used. 401/403 flagged distinctly (issue #1121, `:761`).
+  Publishes `response.compaction.in_progress`/`.completed` SSE (spinner).
+- **L3 truncate** (`:696-720`) — emergency oldest-message drop, pair-aware
+  (`_pair_aware_drop_count`, `:322`).
+
+**Triggering — two paths (the "runner catches overflow → compacts" belief is
+only half right):**
+- **Proactive / threshold-based (the real auto-compaction):** runs in the
+  **in-process agent loop** (`_call_llm_maybe_compact`, `workflow.py:2057`) →
+  `compact(force=False)` when context crosses `trigger_threshold` 0.8
+  (`compaction.py:612-631`). `_CompactionState.context_window` learned from the
+  first overflow (`:122`). OpenAI-Agents harness delegates to its SDK's
+  `run_compaction` (`openai_agents_sdk_executor.py:1137`).
+- **Reactive on harness-reported overflow — does NOT auto-compact:**
+  `proxy_stream` detects it (`_is_context_overflow_error`, `runner/app.py:6736`)
+  → raises `_ContextWindowOverflow` (`:14243`) → caught in `_run_turn_bg`
+  (`:13804`) which **ends the turn with an error**, not a compaction. The SDK
+  executor re-raises overflow to surface it (`openai_agents_sdk_executor.py:1673`).
+  [⚠️ resume-overflow surface, OMNI-143.]
+- **Explicit `/compact`:** `compact_conversation_now` (`workflow.py:2347`) →
+  `compact(force=True, fail_on_summary_error=True)` (from `sessions.py:10026`).
+
+**Reconstruction:** `_maybe_persist_compaction_item` (`workflow.py:2473`) appends
+a `type=compaction` item (idempotent by `response_id==task_id`; refuses broken
+items). Next turn/resume, `_load_initial_history` (`workflow.py:2276`) loads only
+items **after** `last_item_id` + the expanded summary
+(`compaction_to_history_items`, `compaction.py:463`, prefers
+`compacted_messages`). **Native:** posts `external_compaction_status`;
+`CompactionComplete.compacted_messages` carries the post-compaction transcript
+to replay (`inner/executor.py:213-234`). Broken compaction item → ignored, full
+conversation reloaded (`workflow.py:2315`).
+
+[memory: compact-every-msg fixed #1082 — the broken-cursor guards in
+`_load_initial_history`/`_maybe_persist_compaction_item` are exactly that fix.
+⚠️ resume-overflow OMNI-143 — the cursor logic bounds load to O(items since last
+compaction), which is the relevant mechanism; whether overflow on resume itself
+is fully handled depends on the runner catch — verify with runner SME.]
+
+---
+
+## Q6. Resume — how much transcript loads into the runner
+
+- **SDK (claude-sdk / codex / polly):** the runner reconstructs history via
+  `_load_initial_history` (`workflow.py:2276`) — **full conversation, OR (when a
+  compaction item exists) only the slice after the last `last_item_id`** plus the
+  expanded summary pair — translates it to prompt input, and passes it to
+  `executor.run_turn(messages=…)` each turn. The SDK is re-driven from this
+  reconstructed history; the in-process SDK client does not persist its own
+  store, so "how much loads into the runner" = the (possibly compaction-bounded)
+  conversation history.
+- **Native (claude-native / codex-native and other native CLIs):** resume keys
+  on **`external_session_id`** from the session snapshot (Pi `app.py:728-774`,
+  Codex `:841-887`, OpenCode `:973-998`); fork clones seed via
+  `FORK_CARRY_HISTORY_LABEL_KEY` (`app.py:743,759,880,986`). The **vendor CLI
+  reloads its own session**; Omnigent re-injects only when the vendor store is
+  gone — cold resume synthesizes the vendor's local session file from committed
+  Omnigent items (Pi `app.py:1715-1729`; OpenCode injects the transcript as a
+  preamble, `:1205,1590`). Detail owned by native SME; anchors for completeness.
+
+---
+
+## Q7. Custom-agent storage & a custom agent's own subagents
+
+**Storage — three tiers** (`runtime/agent_cache.py`):
+1. **ArtifactStore** — content-addressed `.tar.gz` bundle (source of truth).
+2. **Agent DB row** — `id`/`name`/`bundle_location`/`version`/`session_id`
+   (session-scoped agents non-null `session_id`; template agents null).
+3. **AgentCache** (`agent_cache.py:16`) — Tier 1 in-mem `AgentSpec` (`_specs`)
+   + Tier 2 on-disk extract `<cache_dir>/<agent_id>/`. **No TTL.** Miss →
+   download → temp file → `load_spec` (extract+parse+validate) → both tiers
+   (`load`, `:51`). **Evict on delete** (`evict`, `:161`, drops spec + rmtree).
+   **Warm-swap on update** (`replace`, `:102`: extract to `_staging`, atomic
+   `_specs[id]=` reassign, rmtree old + rename staging in; readers never see an
+   empty cache; version bumps). **Security:** `expand_env=False` default —
+   `${VAR}` expanded against server env **only** for operator template agents
+   (`session_id is None`), never tenant/session agents (`:66-80`).
+
+**A custom agent's own subagents:**
+- `AgentTool` references a registered agent **by name** or an **inline** spec;
+  `SelfAgentTool` clones the parent (self-tools removed) — both → nested
+  `AgentSpec` (`spec/omnigent.py:1090-1120`).
+- Loaded with **`prune_invalid_sub_agents=True`** (`agent_cache.py:94,146,204`;
+  impl `spec/__init__.py:314`): depth-first, a sub-agent that fails validation
+  on **this** (older) server is dropped (WARNING) and its name removed from the
+  parent's `tools.agents`, so version skew degrades gracefully and the parent
+  still dispatches. Authoring/upload validation stays strict elsewhere.
+
+---
+
+## Q8. Caching — agent cache + credential cache (table)
+
+| What | Where (file:line) | TTL | Invalidation |
+|---|---|---|---|
+| **Agent bundle** (parsed spec + extracted dir) | `runtime/agent_cache.py:16` (`_specs` + `<cache_dir>/<agent_id>/`) | **none** | explicit `evict()` on delete; `replace()` warm-swap on update (version bump) |
+| **Provider model listing** (`sys_list_models` backing) | `model_catalog.py:61` `_CATALOG_TTL_S=300.0`; `TTLCache(maxsize=64)` `:203` | **5 min** | TTL expiry; `clear_model_catalog_cache()` (`:250`) |
+| **MLflow model catalog** (per provider) | `onboarding/providers/__init__.py:102` `_CATALOG_TTL_SECONDS=3600`; `TTLCache(maxsize=64)` `:103` | **1 h** | TTL expiry |
+| **Provider/credential resolution** (auth/base-url/profile) | resolved per call in `workflow._resolve_provider_for_build` (`:996`) and the per-harness spawn-env builders | **none** | recomputed fresh each spawn (nothing persisted) |
+| **Inner LLM client singleton** | `workflow.py:251` `_llm_client` | process-lifetime | none (lazy singleton; used for server-side L2 summarize fallback) |
+| **Native session state / policy-hook token** | `bridge.json` / `policy_hook.json` (native; out of `runtime/` scope) | one-shot snapshot | re-created on relaunch (→ known stale-token fail-closed bug, §2.G) |
+
+Notes: the **credential cache is essentially "none" inside `runtime/`** — LLM
+auth, base URL, profile are resolved fresh per spawn from the spec/provider
+config, and per-request token refresh lives in the executors / runner auth
+callbacks (chat-path refreshes per request; the native policy-hook snapshot is
+the one that doesn't — covered by the auth SME). The two real caches are the
+**agent cache (no TTL, event-invalidated)** and the **model-catalog caches
+(5 min / 1 h TTL)**.
+
+---
+
+## Failure branches & gaps (this domain)
+
+- **No spawn-time subagent depth cap** — `_MAX_SUBAGENT_TREE_DEPTH=3` is
+  REPL-render-only (`repl/_repl.py:201`).
+- **`sys_cancel_task`/`sys_cancel_async` no-op** — tasks table removed
+  (`async_inbox.py:108`).
+- **Native sub-agent completions never reach the orchestrator** — gate
+  `elif not _is_native_harness(conv_id) and not has_buffered:`
+  (`runner/app.py:12607`) excludes native harnesses from the `status="completed"`
+  delivery; native turns only emit `waiting`/`idle` (`:12580`). #848 cluster;
+  cross-domain w/ native SME.
+- **Reactive overflow ≠ compaction** — harness-reported overflow ends the turn
+  with an error (`runner/app.py:13804`); only the proactive threshold path
+  auto-compacts (`workflow.py:2057`). OMNI-143 surface.
+- **`pass_history`/`pass_histories`/`max_sessions` lossy** on the omnigent-compat
+  path (`spec/omnigent.py:1338`).
+- **No `llm_call` span** → per-LLM-call latency/usage not separately observable
+  (usage recorded on the AGENT span, `_executor_adapter.py:435`).
+- **Compaction L2 auth failure** silently degrades to lossy L3 (distinct ERROR
+  log, turn proceeds; `compaction.py:844`).

--- a/designs/master-arch/cuj-answers/harness-behavior.md
+++ b/designs/master-arch/cuj-answers/harness-behavior.md
@@ -1,0 +1,259 @@
+# CUJ Answers — Harness / Inner Behavior (claude-sdk · claude-native · codex · codex-native · polly)
+
+> Companion to `designs/CUJ-ANALYSIS.md` §2.B / §4 / §2.D. Every cell is **re-verified
+> cell-by-cell against the executors** in the merged `traces` worktree. Anchors are
+> `file:line`. **codex / codex-native = no live trace (creds 403)** — verified from code only.
+> Legend: ✅ confirmed in code · ⚠️ partial/caveated · ❌ confirmed absent.
+
+---
+
+## 0. Headline §4 corrections (read first)
+
+The §4 matrix is **mostly right**; the corrections below are the load-bearing ones.
+
+1. **claude-native interrupt = ✅ (was ❌ in the first pass).** It is **not** wired at the
+   executor (`claude_native_executor.py` has no `interrupt_session` override). The web Stop
+   button reaches `runner/app.py:_handle_claude_native_interrupt` → `claude_native_bridge.
+   inject_interrupt` (`:2530`) → `tmux send-keys … Escape` (`:2556`). Read the interrupt column
+   as "the product Stop interrupts the running turn," not "the executor method exists."
+   *(The current §4 already shows ✅ with the `inject_interrupt` note — keep it; this confirms it.)*
+
+2. **codex-native subagents = ✅ (matrix footnote † is stale for codex-native).** The footnote
+   says "codex subagents = implicit via subprocess CODEX_HOME isolation, not a declared
+   capability." That is true for codex **(SDK)** only. **codex-native** has a real subagent
+   *mirror*: `codex_native_forwarder.py:6079` (`_thread_started_is_subagent`) detects
+   `source.subAgent.thread_spawn` (`:4310`) and POSTs `external_codex_subagent_start`
+   (`:130/:4304`) → child Omnigent session. Promote codex-native subagents to ✅; keep the †
+   footnote scoped to codex-SDK.
+
+3. **claude-native subagents = ✅ (genuine, not just "tool surface").** The forwarder watches
+   `~/.claude/projects/<encoded>/<session>/subagents/agent-*.meta.json` (`:217`) →
+   `_post_external_subagent_start` (`:1115`) → `external_subagent_start` (`:1150`). Claude
+   Code's Task tool spawns are mirrored as child sessions. (Matrix already ✅ — confirmed.)
+
+4. **codex (SDK) elicitation = ❌ at the executor (confirmed, not just "unverified").** The
+   executor hardcodes `"approvalPolicy": "never"` (`codex_executor.py:1427`); there is no
+   `approval`/`elicitation` handling at the executor boundary. The matrix ‡ caveat is correct —
+   tighten it from "unverified" to "confirmed ❌ at the executor; codex-*native* ✅ via the hook."
+
+5. **codex (SDK) mid-session model = resets the thread (sharper than "per-turn").** Model is
+   part of the app-session **signature** (`codex_executor.py:2346-2350`); changing it **closes
+   the app-session and starts a fresh thread** (`:2301/:2304`). Effort likewise resets
+   (`self._applied_effort = None` on new thread, `:1450`). Matrix "⚠️ per-turn (resets at
+   session)" is right; the mechanism is *thread teardown*, not a soft per-turn toggle.
+
+6. **No new harness gains queue/stepwise/tool-boundary-interrupt.** All four executors leave
+   `supports_tool_boundary_interrupt()` and `supports_stepwise_internal_turns()` at the base
+   `False` — **except claude-sdk**, which overrides `supports_tool_boundary_interrupt()`→True
+   (`:1617`). Worth surfacing: it is the only in-scope harness that can apply queued input at a
+   tool boundary.
+
+---
+
+## 1. Corrected per-harness capability matrix (code-verified)
+
+> Verified against each `inner/*_executor.py` capability override (base defaults all ❌ except
+> `supports_tool_calling`, `executor.py:541-585`) + native bridge/forwarder/runner routes.
+> **interrupt** = the web Stop stops the running turn (SDK via executor; native via bridge/RPC).
+> **queue** = `supports_live_message_queue()`. **subagents** = surfaces a child session.
+> **reasoning effort** = accepts a `reasoning_effort` param (≠ merely streaming thinking).
+> **elicitation** = can surface a policy/permission prompt. **mid-session model** = model change
+> without a restart.
+
+### SDK harnesses
+
+| SDK harness | interrupt | queue | subagents | reasoning effort | elicitation | mid-session model |
+|---|---|---|---|---|---|---|
+| **claude-sdk** | ✅ executor `client.interrupt()` (`:1477`) | ✅ (`:1614`) `client.query` (`:1509`) | ✅ via `mcp__omnigent__sys_session_*` | ✅ {low,med,high,xhigh,max} (`:2011`) | ✅ SDK `can_use_tool`/elicitation bridge (`_executor_adapter:307`) | ✅ `set_model()` next turn (`:1422/:1910`) |
+| **codex** | ✅ executor `turn/interrupt` (`:2243`) | ✅ (`:2240`) `enqueue_message` (`:2276`) | ⚠️† `CODEX_HOME` isolation (`:1186/:1230`) | ✅ {none,minimal,low,med,high,xhigh} (`:2353`) | ❌ executor `approvalPolicy:"never"` (`:1427`) | ⚠️ resets thread (model in signature, `:2346`); effort resets (`:1450`) |
+
+Also for claude-sdk: `supports_tool_boundary_interrupt`→✅ (`:1617`) — unique among in-scope.
+
+### Native harnesses
+
+| Native harness | interrupt | queue | subagents | reasoning effort | elicitation | mid-session model |
+|---|---|---|---|---|---|---|
+| **claude-native** | ✅ bridge `Escape` (`bridge:2530` via `app.py:_handle_claude_native_interrupt`) | ✅ (`exec:68`) tmux inject (`:72`) | ✅ `subagents/*.meta.json`→`external_subagent_start` (`fwd:217/1115`) | ✅ `/effort` slash-inject (`app.py:~11470`) — **⚠️ none/minimal skipped** (`:11521`) | ✅ PreToolUse + PermissionRequest HTTP hook (long-poll) | ✅ `/model` slash-inject + statusLine mirror (`app.py:11558`, `fwd:948`); next turn |
+| **codex-native** | ✅ executor `turn/interrupt` (`exec:116`) + runner route (`app.py:10596`) | ✅ (`exec:64`) `turn/steer` (`:68`) | ✅ `source.subAgent.thread_spawn`→`external_codex_subagent_start` (`fwd:6079/4304`) | ✅ {openai set} via `thread/settings/update` (`exec:266/237`) | ✅ `codex-elicitation-request` hook (long-poll) | ✅ `thread/settings/update` (`exec:237`, `app.py:10664`); next turn |
+
+**polly** has no row — its **brain** runs on **claude-sdk** and reads exactly as the claude-sdk
+row. Its workers are `claude_code` (claude-native) and `codex` (codex-native), each reading as
+its own native row (`examples/polly/config.yaml`).
+
+† **codex (SDK) subagents** = private per-conversation `CODEX_HOME` (`tempfile.mkdtemp`,
+`codex_executor.py:1202`) keeps child Codex sessions out of the user's history; this is process
+isolation, not a declared subagent-mirror capability (unlike codex-*native*).
+
+**Reasoning-effort source of truth** = `omnigent/reasoning_effort.py`:
+`CLAUDE/ANTHROPIC = {low,medium,high,xhigh,max}` (`:13`),
+`OPENAI/CODEX = {none,minimal,low,medium,high,xhigh}` (`:15`). Effort is selectable at session
+start (NewChatDialog) and mid-session (`/effort <level>`).
+
+---
+
+## 2. SDK vs native taxonomy (who owns what)
+
+| Concern | SDK (claude-sdk, codex) | Native (claude-native, codex-native) |
+|---|---|---|
+| Agent loop | **In-process** inside the harness subprocess (`run_turn` drives the vendor SDK) | **Resident vendor CLI** in tmux (claude) / behind a JSON-RPC app-server socket (codex), mirrored back |
+| System prompt | **Omnigent** (`request.instructions` → `run_turn(system_prompt)`) | **Vendor** (the CLI's own settings); omni's system prompt is `del`'d (`claude_native_executor.py:123`) |
+| Tool set | **Omnigent** (`request.tools` → `run_turn(tools)`; MCP bridge) | **Vendor** owns its tools; omni tools ignored (`tools` `del`'d). `sys_*` reachable via an MCP relay the CLI discovers |
+| Transcript | **Omnigent owns 100%** (durable items from streamed events) | **Vendor store is source of truth**, mirrored: claude `~/.claude/projects/**.jsonl`; codex `$CODEX_HOME/sessions/**.jsonl` |
+| Turn output | streamed `ExecutorEvent`s (`supports_streaming=True`) | forwarder polls vendor store → `external_*` events (`supports_streaming=False`) |
+| Executor `run_turn` | full loop + tools + reasoning | inject latest user message, yield `TurnComplete(response=None)` immediately |
+| `handles_tools_internally` | True (vendor loop) | True (native server runs its own tools) |
+
+Wiring: each harness module builds an `ExecutorAdapter(executor_factory=…)`
+(`claude_native_harness.py:29`, `codex_native_harness.py:28`, `claude_sdk_harness.py:309`); the
+adapter (`_executor_adapter.py`) is the runner-facing FastAPI seam that runs the loop, emits
+spans, and routes interrupt/queue/policy.
+
+---
+
+## 3. Model + reasoning-effort changes (session start AND mid-session, from web UI)
+
+**Session start.** NewChatDialog passes model + effort (and for claude-native, permission mode).
+The runner threads them in as `request.model_override` → `ExecutorConfig(model=…,
+extra["reasoning_effort"]=…)` (`_executor_adapter.py:284`). For native harnesses the model/effort
+is also baked into the spawn flags (claude appends `--model` `claude_native.py:4118-4120`;
+effort persisted in metadata `:3845`).
+
+**Mid-session (the key divergence).**
+- **claude-sdk** — next-turn config. `cfg.model` read each turn (`:1910`); if it differs from the
+  cached client's model, `client.set_model(model)` (`:1422`). Effort via `extra["reasoning_effort"]`
+  → SDK `effort` (`:2011`). Applies on the **next** turn (not the running one).
+- **codex (SDK)** — model is part of the session **signature**; changing it **closes the
+  app-session and starts a fresh thread** (`:2346/2301/2304`). Effort applied via
+  `thread/settings/update` and **deduped per thread**, reset on a new thread (`:1450/1464`).
+- **claude-native — best-effort, two writers.** A web `/model` change → runner
+  `_handle_claude_native_model_change` (`app.py:11558`) types `/model X` into tmux via
+  `inject_slash_command(auto_confirm=True)`; the persisted `model_override` is the fallback on
+  next spawn (the `--model` flag is baked at spawn, *not* re-read at turn boundaries — see the
+  route docstring `:11565-11573`). Independently, the forwarder mirrors an **in-pane** `/model`
+  switch back to `model_override` **every poll** (`_forward_model_from_status` `:948`) so
+  model-gated policies don't lag a switch. Effort: `/effort L` slash-inject (`app.py:~11470`),
+  **but only if L ∈ CLAUDE_EFFORTS** (`:11521`) — `none`/`minimal` are persist-only.
+- **codex-native — RPC, persisted.** `_handle_codex_native_settings_update` (`app.py:10664`) →
+  `thread/settings/update`; the executor itself also applies `_model_effort_overrides` before
+  `turn/start` (`exec:266/237`). The TUI's own model/effort is mirrored into the server snapshot
+  (`model_override`/`reasoning_effort`, `app.py:10754-10759`) so a settings-update can re-send it.
+
+**Net:** SDK = next-turn config (codex actually re-threads); native = best-effort, applied on the
+**next** turn, never the running one. claude-native's mechanism is keystroke-injection + statusLine
+mirror; codex-native's is JSON-RPC.
+
+---
+
+## 4. Default model / provider resolution per harness (the chain)
+
+Resolution chain (highest precedence first), resolved once at spec materialization
+(`chat.py`): **CLI `--model`** → **`OMNIGENT_MODEL` env** (`chat.py:~123`) → **YAML
+`executor.model`** → **`~/.omnigent/config.yaml` provider default** → **per-harness fallback**.
+Ad-hoc specs with no executor block fall back to `_DEFAULT_AD_HOC_MODEL = "databricks-gpt-5-4"`
+(`chat.py:99`). The resolved model rides as `request.model_override` → `cfg.model`.
+
+Per-harness fallback when `cfg.model` is still None (inside the executor):
+- **claude-sdk** — `cfg.model or self._model_override or _DATABRICKS_CLAUDE_DEFAULT_MODEL`
+  (`:1910`); `_DATABRICKS_CLAUDE_DEFAULT_MODEL = "databricks-claude-opus-4-8"`
+  (`databricks_config.py:85`) **only** on the Databricks-profile gateway path. ⚠️ **Bug #1128**:
+  this Opus default fires when Sonnet was intended but the override arrived None.
+- **codex** — `cfg.model or self._model_override or (_DATABRICKS_CODEX_DEFAULT_MODEL if
+  databricks-profile else _OPENAI_CODEX_DEFAULT_MODEL)` (`:2334`); constants
+  `databricks-gpt-5-5` (`:106`) / `gpt-5.4-mini` (`:100`).
+- **claude-native** — the `claude` binary's own default unless omni resolved one (then `--model`);
+  `use_claude_config=True` defers entirely to `~/.claude` config.
+- **codex-native** — the Codex CLI's `~/.codex/config.toml` model/provider unless omni `--model`
+  overrides (CODEX_HOME source resolver `codex_native.py:131`).
+
+Provider/credentials: **claude-sdk/codex** resolve a gateway (Databricks AI-gateway base_url +
+`databricks auth token` command, or a generic key/base_url gateway) or the vendor's built-in API
+(`claude_sdk_harness.py` `HARNESS_CLAUDE_SDK_GATEWAY*`; `codex_executor.py:2171-2210`).
+**claude-native/codex-native** default to the vendor's own auth (`~/.claude/.credentials.json`;
+Codex `auth.json` — API-key or ChatGPT/OAuth, `codex_native.py:119-156`).
+
+---
+
+## 5. Propagating the user's OWN harness config into omni (#3)
+
+- **claude-native — `use_claude_config`** (`claude_native.py:349`). Default `False` →
+  `resolve_native_claude_config(spec=None)` provides an omni-managed isolated HOME + MCP relay
+  (`:400`). `True` → **skips Databricks/ucode auth and uses the user's own `~/.claude/`
+  configuration** (`:371-372`): credentials, `settings.json`, MCP servers, hooks. Strongest
+  passthrough of any in-scope harness. ⚠️ a user `settings.json` model can conflict with omni's
+  `--model`.
+- **codex-native — `~/.codex/config.toml` + `auth.json`** inherited as the baseline via the
+  `CODEX_HOME` source resolver (`codex_native.py:131`, `_codex_home_config_source_from_env`);
+  omni runs in a *private* CODEX_HOME that maps back to the user's real home. Auth is the user's
+  Codex `auth.json` (`:119-133`). omni `--model` / effort overrides layer on top via
+  `thread/settings/update`.
+- **SDK harnesses** receive config via `HARNESS_*` env vars from the workflow layer; they do not
+  pass through the user's CLI dotfiles (claude-sdk explicitly strips `ANTHROPIC_API_KEY` to avoid
+  bypassing subscription auth — `claude_sdk_harness.py:120-126`).
+
+---
+
+## 6. Harness switching mid-session
+
+- `POST /sessions/{id}/switch-agent` (idle-only) swaps the bound agent; for **native** targets it
+  clears `external_session_id` so the next turn **rebuilds the vendor transcript** (the native
+  bridge re-binds and re-mirrors). Cross-family switches reset the model.
+- Fork (`POST /sessions/{src}/fork`) clones the agent (optional harness switch); the native target
+  rebuilds its transcript from the `FORK_CARRY_HISTORY` label. claude-native/codex-native both key
+  their bridge to a `bridge_id` resolved from session labels, so `--resume`/fork land in the right
+  pane/thread (`app.py:_claude_native_bridge_id_for_session`, used by every claude-native route).
+- Polly switches *workers* by spawning the right sub-agent (claude_code/codex/pi), not by
+  switching its own brain harness.
+
+*(Server-side switch/fork mechanics are owned by the server SME; here the inner-layer fact is the
+`external_session_id` reset → native transcript rebuild on next turn.)*
+
+---
+
+## 7. Elicitation / permission hooks per harness (which hooks; HOW verdicts return)
+
+| Harness | hook(s) the harness must expose | how the verdict returns | NOT keystrokes? |
+|---|---|---|---|
+| **claude-sdk** | SDK `can_use_tool` callback + the adapter's `_elicitation_handler` / `_policy_evaluator` bridges (`_executor_adapter.py:307/314`) | server `type=approval` event → runner `pending_approvals` Future resolves the callback | ✅ event, no keystrokes |
+| **codex (SDK)** | none at the executor (`approvalPolicy:"never"`, `:1427`) | n/a at the executor (no elicitation surfaced) | ✅ (no prompt) |
+| **claude-native** | **PreToolUse + PermissionRequest** hooks (`native_policy_hook.py` reachable at `/policies/evaluate`) | **long-poll HTTP** — verdict carried in the held response body | ✅ long-poll, not keystrokes |
+| **codex-native** | **`codex-elicitation-request`** hook (`codex_native_elicitation.py`) | **long-poll HTTP** | ✅ long-poll |
+
+For the **in-scope** harnesses, verdicts return via a **long-poll HTTP hold** (claude-native /
+codex-native) or an **approval event** (claude-sdk SDK callback) — **no keystroke emulation**.
+(Other native harnesses out of scope use tmux-keystroke delivery; that is not how the in-scope set
+works.) ⚠️ The native PreToolUse hook's static `policy_hook.json` token can expire → the hook
+**fails CLOSED** (TOOL_CALL is a fail-closed phase) → tool calls die while chat survives
+(`runner/app.py` snapshot path; PR #1439 — verify live). This is the single most important
+elicitation-path reliability gap for native harnesses.
+
+---
+
+## 8. Reasoning: streamed vs persisted vs recomputed
+
+- **Streamed (`ReasoningChunk`)** — claude-sdk emits `reasoning_started` / `reasoning_text`
+  deltas live (`:2225/2266/2318`); codex emits `reasoning_text` from
+  `item/reasoning/textDelta` (`:1663`). The workflow maps these onto
+  `response.reasoning_text.delta` / `response.reasoning.started` SSE.
+- **Recomputed (SDK)** — claude-sdk **does not persist thinking**: `compacted_messages` keeps
+  only `content` blocks (`:2554-2558`), so reasoning is regenerated next turn / on resume.
+- **Persisted (native)** — the vendor records its own reasoning in its transcript; the forwarder
+  mirrors what the vendor exposes (claude-native mirrors reasoning items; codex-native mirrors
+  app-server reasoning items). The vendor store is the durable record, not Omnigent's stream.
+- **Compaction events**: claude-sdk emits `CompactionComplete` **with** `compacted_messages`
+  (from the SDK's `get_session_messages()`, `:2540`) — note this contradicts the base
+  `CompactionComplete` docstring claim that claude-sdk "cannot export." codex (SDK) emits **no**
+  `CompactionComplete`. Native posts an `external_compaction_status` from the vendor's own compaction.
+
+---
+
+## 9. Quick reliability-gap recap (inner-layer)
+
+- 🟠 **#1128 claude-sdk Opus billing** — `:1910` Databricks Opus-4.8 fallback on None model.
+- ⚠️ **Native model override never affects the running turn** — next turn only (all four);
+  codex-SDK actively tears down the thread.
+- ⚠️ **claude-native `/effort none|minimal`** silently persist-only (not in CLAUDE_EFFORTS).
+- ⚠️ **Native PreToolUse hook fail-closed on expired token** — chat works, tools blocked (PR #1439).
+- 🟢 **Interrupt is NOT a gap** — claude-sdk/codex executor; claude-native bridge `Escape`;
+  codex-native `turn/interrupt`.
+- 📝 **codex-native subagents are real** (`external_codex_subagent_start`) — the §4 † footnote
+  understates them; it applies to codex-SDK only.

--- a/designs/master-arch/cuj-answers/host-channel.md
+++ b/designs/master-arch/cuj-answers/host-channel.md
@@ -1,0 +1,231 @@
+# CUJ Answers — Host Daemon Channel
+
+> Domain: the `omnigent host` daemon and the host↔server tunnel. Code = ground truth
+> (`traces` worktree, verified 2026-06-30). Trace evidence from local Jaeger
+> (`omni-host`+`omni-server`). Per-harness behavior is **harness-agnostic at this layer**
+> (claude-sdk / claude-native / codex / codex-native / polly all launch the same way) —
+> the only harness-aware step is the launch-time `harness_is_configured` gate.
+
+---
+
+## Q: Components to instrument + the channels between them (Host Daemon)
+
+**Host Daemon ↔ Server** is one of the named boundaries to instrument (OBSERVABILITY §6.4).
+
+- **Channel**: a single outbound **WebSocket** `wss://<server>/v1/hosts/{host_id}/tunnel`,
+  carrying **JSON text control frames** — **NOT HTTP**. No OTel auto-instrumentor can see
+  it, so propagation is **manual** (`inject`/`extract` into the JSON envelope).
+- **Two multiplexed frame families** on the one socket: host frames (`host.*`) and
+  runner-tunnel keepalive (`ping`/`pong`). (`connect.py:1527-1538`, `host_tunnel.py:399-431`)
+- **Direction**: host dials out; server then drives (server→host requests). Only
+  `host.hello` and `host.runner_exited` flow host→server unsolicited; all results flow
+  host→server.
+- **Span boundary**: server REST request (e.g. `POST /v1/hosts/{id}/runners`, FastAPI
+  auto-instrumented) is the parent; the host opens a CONSUMER span per `HostFrameKind`
+  (`consume_frame_span`, `telemetry.py:734`). Verified live: `omni-host host.launch_runner`
+  and `omni-host host.stat` nest under `omni-server POST /v1/hosts/{host_id}/runners`.
+- **Host → Runner** is a separate, deliberately *un-traced* boundary: a one-way env handoff
+  at `subprocess.Popen`; the runner roots its own trace (stitched only by `session.id`).
+
+The other channels (for cross-reference, not my scope): Runner↔Server (runner tunnel, also
+WS frames), Web/TUI↔Server (HTTP + SSE + session-updates WS), Policy server.
+
+---
+
+## Q: API routes & message formats for the host (WS messages vs REST; streaming vs durable)
+
+**REST routes that drive the host** (server-side producers):
+
+| Route | Frame sent | Result | Consumer |
+|---|---|---|---|
+| `POST /v1/hosts/{id}/runners` (`hosts.py:405`) | `host.stat` (validation) then `host.launch_runner` | launching / 412 / 502 / 504 | fork-resume picker; binds an unbound clone |
+| `POST /v1/sessions` (`sessions.py:6060`) | `host.stat` (+ optional `host.create_worktree`) then `host.launch_runner` | session row + runner | new session create |
+| `GET /v1/hosts/{id}/filesystem[/{path}]` (`hosts.py:668,706`) | `host.list_dir` | `{object:list,data,has_more}` | Web UI directory picker |
+| `POST /v1/hosts/{id}/directories` (`hosts.py:836`) | `host.create_dir` | created path / 409 | Web UI "new folder" |
+| `GET /v1/hosts`, `GET /v1/hosts/{id}` (`hosts.py:318,368`) | (none — reads HostStore DB) | host list / status | sidebar host list, online check |
+| (session stop / delete) (`sessions.py:7945`) | `host.stop_runner` | stopped | stop a runner |
+| `GET /v1/runners/{id}/status` (`runner_tunnel.py:244`) | (none — reads RunnerExitReports) | online + error cause | client polling a never-connecting runner |
+
+**Message format**: all frames are JSON objects with a `kind` discriminator + a `request_id`
+(except hello/runner_exited) + a `traceparent` envelope key. Encode/decode in `frames.py`.
+
+**Streaming vs durable**: host control frames are **neither streamed to the client nor
+persisted in conversation history** — they are ephemeral control plane. What IS durable is
+the *side effect*: `conversation_store.set_runner_id` / `set_host_id` (workspace, host_id,
+git_branch persisted on the session row), and `host_store.upsert_on_connect` /
+`heartbeat` / `set_offline` (the `hosts` DB table). The `host.list_dir` result is returned
+synchronously in the REST response, not persisted.
+
+---
+
+## Q: Disconnects (mid-turn) — host tunnel perspective
+
+Two distinct disconnects matter here:
+
+1. **Host tunnel drops** (host↔server WS closes): the host's reconnect loop
+   (`connect.py:1269-1345`) reconnects with backoff. Runner subprocesses **keep running**
+   across a host-tunnel blip (they have their own tunnels). On reconnect the host re-sends
+   `host.hello` with the still-alive `runners` list → server reconciles. A runner that died
+   *during* the blip has its `host.runner_exited` report **parked** in `_unreported_exits`
+   and flushed right after the next hello (`:1491-1493`) — so the failure isn't lost.
+   On a remote (Apps-fronted) server, an abrupt `no close frame`/`502` is treated as an
+   ingress recycle → prompt 0.5s reconnect, specifically so a `host.launch_runner` frame in
+   flight isn't dropped ("runner did not connect").
+2. **Runner dies mid-turn**: `_watch_runner` (`:898`) detects the unexpected exit (still in
+   `self._runners`), composes exit code + log tail, sends `host.runner_exited`; server's
+   `on_runner_exited` marks the session failed + pushes the cause to the open view. This is
+   the only failure signal when a runner crashes *before* its own tunnel connects.
+
+Server liveness: 3 missed 30s pings → server closes the host 4003; the DB heartbeat
+freshness gate (`HOST_LIVENESS_TTL_S`) drops the host's sessions out of the connected set
+even if a hard crash skipped `set_offline`.
+
+---
+
+## Q: Forking a session / resuming — host involvement
+
+The host participates in fork/resume through **git worktrees** and **runner binding**:
+
+- **Fork with a new branch**: `POST /hosts/{id}/runners` (or `POST /v1/sessions`) with a
+  `git` body → server validates branch name → `host.create_worktree {repo, branch, base}`
+  → host runs `git worktree add` in a thread (`connect.py:1194`) → returns
+  `worktree_path` → server binds the runner to the **worktree path** as workspace.
+  Worktree is created **before** the atomic `set_runner_id` CAS so a lost race or failed
+  launch rolls it back via `host.remove_worktree` (no orphan worktree/branch).
+- **Resume**: re-binds a previously-unbound clone of the session to a fresh runner
+  (`set_runner_id` CAS; second concurrent launch gets 400). The host just spawns a new
+  runner for the resolved workspace. *How much transcript loads into the runner* is a
+  runner/runtime concern, not the host — the host only provides the cwd and the spawn.
+- **Cleanup**: `host.remove_worktree` (opt-in) derives the main repo from the worktree path
+  itself and optionally `git branch -D` (`frames.py:393-415`).
+
+---
+
+## Q: Credential resolution — (runner↔server) host-minted token, and host↔server refresh
+
+The host is where the **runner↔server binding credential** is minted and where the
+**host↔server bearer** is refreshed:
+
+- **Runner binding token**: server generates `binding_token = secrets.token_urlsafe(32)`,
+  derives `runner_id = token_bound_runner_id(binding_token)`, sends it in
+  `host.launch_runner`; the host injects it into the runner env
+  (`RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR`) so the runner authenticates its own tunnel back
+  to the server. One-time, per launch.
+- **Host↔server bearer refresh**: `_build_connect_headers` (`connect.py:1409`) re-mints the
+  bearer on **every reconnect** (stored `omnigent login` OIDC token first, then ambient
+  Databricks creds) — long-lived hosts survive token expiry without a restart. Managed
+  sandboxes use the static `X-Omnigent-Host-Token` injected at spawn instead.
+- **LLM creds** are NOT resolved by the host as "the host's"; they are *forwarded* from the
+  host env to the runner only for the names in `HARNESS_CREDENTIAL_ENV_VARS`
+  (`connect.py:352`) — the host owner provisions ANTHROPIC_*/OPENAI_*/etc. precisely so
+  their runners can authenticate. Everything else is stripped (allowlist).
+
+---
+
+## Q: Caching / refresh cadence (host-side)
+
+- `configured_harnesses` (PATH probe + config.yaml read) — recomputed **on every
+  (re)connect** in `host.hello`, off the event loop (`connect.py:1484`). Not a long-lived
+  cache; the authoritative gate is the per-launch `harness_is_configured`.
+- `RunnerExitReports` — in-memory TTLCache, **600s TTL**, max 1024 entries
+  (`host_registry.py:34-35`); purely a memory bound (runner ids are unique per launch).
+- Host bearer token — re-minted every reconnect (no persistent cache held by the daemon;
+  the underlying Databricks SDK may cache, `_entry.py` notes a per-call resolve).
+- Host registry / `hosts` DB table — in-memory per-replica (`HostRegistry`) + persistent
+  DB (`HostStore`); heartbeat refreshes last-seen every 30s ping tick.
+
+---
+
+## Q: Policy / permission hooks at the host layer
+
+**None.** The host daemon does no policy/elicitation work. It is a pure control + FS agent.
+Its only *authorization* checks are: pre-accept tunnel ownership (host_id owner match,
+managed-token scope) and, server-side, the per-route owner/session authz (`require_user`,
+`resolve_host_launch`, owner check on the FS endpoints). Policy enforcement and
+elicitation live in the runner/harness/policy-server layers, not here. The host's one
+harness-aware decision is refusing to spawn an unconfigured harness
+(`HARNESS_NOT_CONFIGURED`), which is a capability check, not a policy.
+
+---
+
+## Q: System resources — how runners (and thus shells) get a working dir
+
+The host resolves the **runner's cwd**: the server sends a `workspace` in
+`host.launch_runner` (already realpath-canonicalized via a prior `host.stat` and validated
+against the agent's `os_env.cwd` boundary). The host `Path(workspace).expanduser()`, checks
+`is_dir()`, and passes it as `RUNNER_WORKSPACE_ENV_VAR` + via the env. The host owns `~`
+expansion (only it knows its `$HOME`). Shells the agent later spawns inherit from the
+runner, not directly from the host. The host never opens shells itself.
+
+---
+
+## Per-harness differences (claude-sdk / claude-native / codex / codex-native / polly)
+
+At the host-channel layer there is **one launch path for all harnesses**:
+
+- The only harness-aware step is `harness_is_configured(frame.harness)` in `_handle_launch`
+  (`connect.py:766`). The server resolves the agent's canonical harness
+  (`_resolve_agent_harness`) and stamps it into `host.launch_runner.harness`; the host
+  refuses with `HARNESS_NOT_CONFIGURED` when that harness's CLI/cred is missing on the
+  machine. `harness=None` (older server / unresolvable) skips the check → fail open.
+- `configured_harnesses` in `host.hello` reports per-harness readiness using *every accepted
+  spelling* (claude-sdk, codex, etc.) so the server/UI can show which harnesses this machine
+  can run before a launch.
+- **polly** = a custom agent running on a harness (typically claude-sdk); from the host's
+  view it's just whatever canonical harness the agent resolves to — no special casing.
+- **native vs sdk** harnesses are identical to the host: both spawn the same
+  `omnigent.runner._entry`; the native-vs-SDK distinction is entirely inside the runner.
+  (A few native-specific *env vars* ride the allowlist — `OMNIGENT_CLAUDE_LAUNCHER` for
+  native-Claude launcher plugins, Bedrock flags — but the spawn mechanism is the same.)
+- **codex / codex-native**: no live trace (Databricks AI-gateway creds expired, 403).
+  By code, codex launches identically; the host would forward `CODEX_ACCESS_TOKEN` /
+  `OPENAI_*` from `HARNESS_CREDENTIAL_ENV_VARS` and gate on `harness_is_configured("codex")`.
+
+---
+
+## Trace evidence (concrete)
+
+Trace `aee57ff3da91a69081625d1804126850` (`trace_tools.py tree`), 38 spans, services
+`['omni-host','omni-server']`, `session.id=-` (control plane carries no session id by design):
+
+```
+omni-server POST /v1/hosts/{host_id}/runners   ← root, FastAPI auto-instrument
+  omni-host   host.stat            ← CONSUMER, parented via traceparent in the frame
+  omni-host   host.launch_runner   ← CONSUMER, parented via traceparent in the frame
+```
+
+- Jaeger `omni-host` operations = `["host.stat","host.launch_runner"]` exactly.
+- Edge construction: server stamps `traceparent` into the frame JSON at
+  `encode_host_frame`→`_encode_payload`→`inject_trace_context` (`frames.py:519-520`); host
+  re-parses the carrier and opens `consume_frame_span(kind, carrier)` named by the frame
+  `kind` (`connect.py:1553`). This proves the manual JSON-frame propagation works across the
+  process boundary (the central claim of OBSERVABILITY §6.4).
+- The `chat.db` PRAGMA/SELECT/UPDATE/connect spans in the tree are DB noise — filter them.
+- (per doc — line drift) OBSERVABILITY §6.4 cites `connect.py:1432` / `host_tunnel.py:312`;
+  actual: `_serve_frames` at 1462, `_receive_loop` at 369, consumer span at
+  `connect.py:1553`. Mechanism matches.
+
+---
+
+## Failure branches & gaps (channel-focused)
+
+- `HARNESS_NOT_CONFIGURED` (412), workspace-missing (502), launch-timeout (504),
+  host-offline (409), connection-replaced (409), version-skew (4002 close), cross-owner
+  (409 pre-accept). All covered above + in `architecture/host.md §10`.
+- **Exit reports are per-replica, in-memory (TTL 600s)** — on a multi-replica deploy the
+  status poll and the report must hit the same replica that holds the host tunnel.
+- `host.list_dir` exposes the **whole host FS** to the authenticated owner (not
+  session-scoped) — owner authz is the only boundary.
+- Runner spawn is **not** part of the user-request trace (no TRACEPARENT in spawn env) →
+  runner traces are root-stitched by `session.id` only; a launch→first-turn correlation
+  must be done by `session.id`, not parent span.
+
+## Open questions
+
+- Is the "TRACEPARENT in spawn env only if a span is active" branch (OBSERVABILITY §6.4)
+  actually wired? Current `_build_runner_env` does not add it. If intended, the launch→runner
+  trace gap is by design; if not, it's an unfinished phase-2 item.
+- What consumes the **stored** `configured_harnesses` (in the `hosts` DB row) vs. the live
+  hello copy — UI capability hints?
+- Multi-replica: is there sticky routing guaranteeing the runner-status poll lands on the
+  replica holding the host tunnel (so `RunnerExitReports.get_visible` finds the report)?

--- a/designs/master-arch/cuj-answers/policy-enforcement.md
+++ b/designs/master-arch/cuj-answers/policy-enforcement.md
@@ -1,0 +1,275 @@
+# CUJ Answers — Policy Enforcement, Approvals & Elicitations
+
+> Domain: policies / approvals / elicitations. Verifies & deepens
+> `designs/CUJ-ANALYSIS.md §2.D` (which was already accurate — line numbers
+> confirmed/updated below). Code is ground truth; trace
+> `cfb59197f6f92755270a4d785d3ee3e1` (in `conv_63542a5f92e24956812e19b104eac0e9`)
+> supplies live span evidence.
+
+---
+
+## Q1. How are policies CREATED?
+
+There are **three sources** of policies, merged at engine-build time
+(`builder.py:309`, run order `session + agent + admin` + a hardcoded gate):
+
+### (a) Session-level (agent-/user-added at runtime)
+- Agent calls **`sys_add_policy`** (`tools/builtins/policy.py:18`) after browsing
+  **`sys_policy_registry`** (`:94`). The runner forwards to
+  **`POST /v1/sessions/{id}/policies`** (`session_policies.py:148`).
+- Validation: for `type:python`, the handler **must be in the registry allowlist**
+  (`is_registered_handler`, session_policies.py:181 → registry.py:156) — this is
+  the anti-RCE guard (an arbitrary dotted path would be imported & called).
+  `factory_params` validated against the registry schema (`validate_factory_params`).
+- Persisted in the `policies` table with the owning `session_id`; **activates
+  immediately** (the next per-call engine build loads it via
+  `_load_session_policy_specs`, builder.py:292).
+- Failure: duplicate name → 409 (`IntegrityError`), bad params → 400.
+- **Hardcoded guard:** `sys_add_policy` itself is gated — `_ASK_ON_ADD_POLICY_SPEC`
+  (`builder.py:64`, handler `safety.ask_on_add_policy`) is **unconditionally
+  appended to every engine** (`builder.py:315`), so an agent can never add a
+  policy without a human ASK.
+
+### (b) Server / admin default
+- **`POST /v1/policies`** (`default_policies.py:129`), gated by **`_require_admin`**
+  (`:70` — 401 if unauth'd, 403 if not admin, in multi-user mode).
+- Stored in the same `policies` table with **`session_id IS NULL`**; applies
+  **server-wide to all sessions** (loaded via `RuntimeCaps.default_policies`,
+  appended last in run order → "admin gets the last word").
+- Same registry allowlist applies (admins are NOT exempt — custom handlers must
+  be added via the server `policy_modules` config).
+
+### (c) Spec-declared (immutable)
+- Agent YAML `guardrails.policies:` block → `source="spec"`. Surfaced in the LIST
+  endpoint with **`id=None`** and **cannot be PATCHed or DELETEd**
+  (session_policies.py LIST `:236`, `_spec_to_response:72`).
+
+### Update / enable-disable / remove
+- `PATCH /v1/sessions/{id}/policies/{pid}` (`:275`) and `PATCH /v1/policies/{pid}`
+  (`:234`): mutate `name`, `handler`, `enabled` (the disable toggle). `type` is
+  **immutable** (delete + recreate to change). PATCH re-checks the registry
+  allowlist for handler changes (no back door, `:323`).
+- `DELETE …/{pid}` (idempotent, returns `{deleted:true}`). LEVEL_EDIT (session)
+  / admin (default) required.
+
+---
+
+## Q2. Enforcement: SERVER-level vs SESSION/RUNNER-level
+
+There is **one engine** (`PolicyEngine`, `runtime/policies/engine.py:43`) reached
+from **two surfaces**:
+
+### SERVER-level (engine runs inside omni-server) — the default + spec + admin path
+Three entry points, all building the engine via `_build_policy_engine_from_spec`
+(sessions.py:10352 → `build_policy_engine`):
+1. **REQUEST / RESPONSE gates** — `POST /events` → `_evaluate_input_policy`
+   (sessions.py:10801) / `_evaluate_output_policy` (:10971). Trace: `policy.evaluate
+   phase=REQUEST` is a child of `POST /events`.
+2. **TOOL_CALL + TOOL_RESULT (server MCP proxy)** — `POST /mcp` `tools/call` →
+   `_handle_mcp_tools_call` (:13135). This is how `sys_*` and spec-MCP tools are
+   gated for SDK harnesses. Trace: `policy.evaluate phase=TOOL_CALL` and
+   `phase=TOOL_RESULT` are children of `POST /mcp`.
+3. **The generic hook path** — `POST /policies/evaluate` → `evaluate_policy`
+   (:15973). Used by native PreToolUse/UserPromptSubmit hooks, by the runner
+   proxying LLM-phase events, and by SDK connector-native tools. Trace:
+   `policy.evaluate phase=LLM_REQUEST` and `phase=LLM_RESPONSE` are children of
+   `POST /policies/evaluate`. The route also owns **LLM-phase gating** and the
+   **elicitation registry** (it collapses ASK→ALLOW/DENY via `_hold_native_ask_gate`).
+
+### RUNNER-level fast-path (engine runs on the runner) — `RunnerToolPolicyGate`
+- `runner/policy.py:109`. Runs **only function-type policies whose `on:` includes
+  TOOL_CALL/TOOL_RESULT** (label/prompt types stay server-side — they need the
+  ConversationStore / LLM classifier the runner lacks, `runner/policy.py:14-18`).
+- **ALLOW/DENY decided locally before MCP dispatch** (no server round-trip). DENY
+  feeds `[Denied by policy: …]` back as the tool output (`format_deny_text:314`).
+- **ASK escalates to the server**: the gate surfaces ASK to its caller
+  (`runner/tool_dispatch.execute_tool`), which POSTs `evaluate_policy=True` /
+  `POST /policies/evaluate`; the server independently re-evaluates and **owns the
+  elicitation channel**; the runner awaits via `pending_approvals`. Dual
+  evaluation is intentional (`runner/policy.py:20-34`).
+- `evaluate_tool_result` collapses **ASK→DENY** on the result phase (output
+  already exists, no clean rollback, `runner/policy.py:184-226`).
+
+**Note (trace reality):** the observed claude-sdk run routed TOOL_CALL/TOOL_RESULT
+through the **server `/mcp` proxy**, not the runner fast-path — because `sys_os_shell`
+is an Omnigent tool dispatched server-side. The runner fast-path fires for
+*function-type spec policies* bound to tools, and for connector-native tools.
+
+---
+
+## Q3. Phases, composition order, fail-closed vs fail-open
+
+### Phases (5)
+`Phase.REQUEST` (input gate, pre-LLM) · `Phase.TOOL_CALL` (the main gate) ·
+`Phase.TOOL_RESULT` (post-execution, can only DENY/redact) · advisory
+`Phase.LLM_REQUEST` / `Phase.LLM_RESPONSE`. Proto map at sessions.py:15946.
+**All five observed in the trace** (see architecture §5 table).
+
+### Composition order (`_evaluate_composed`, engine.py:284)
+- Run order: **session policies → agent-spec policies → admin defaults**, then
+  `__ask_on_add_policy` appended (builder.py:309-315). Sub-agents **inherit root
+  session policies prepended** (builder.py:301-307, child wins on name collision).
+- **First DENY short-circuits** (engine.py:370 → `_compose_deny`). ASK accumulates
+  but the loop continues (a later DENY overrides). ALLOW continues; `data` chains
+  forward (`ctx.content` replaced, engine.py:378-382) so policies transform
+  sequentially.
+- Each policy gated by `_should_fire` (engine.py:457): **PhaseSelector match**
+  (cheap) then **`condition:` label-gate** (`_condition_matches:1237` — AND across
+  keys, list = OR within key).
+
+### Fail-CLOSED vs fail-OPEN
+- **`FAIL_CLOSED_PHASES = ("PHASE_TOOL_CALL", "PHASE_REQUEST")`** (`types.py:61`),
+  the single source of truth. Used by `_evaluate_policy_via_omnigent`
+  (runner/app.py:6297) and the native hooks (native_policy_hook.py:60-67): on a
+  server outage / non-2xx / unparseable 200 these phases → **DENY**.
+- **TOOL_RESULT, LLM_REQUEST, LLM_RESPONSE fail OPEN** → ALLOW (advisory, or
+  side-effect already incurred — denying a post-execution result only blocks an
+  already-done action).
+- **Per-policy fail-closed** (`_fail_closed`, engine.py:1038): a raising/invalid
+  policy → DENY unless its declared `action` list is classifier-only (`[allow]`→
+  ALLOW) or ask-gate (`[ask]`/`[allow,ask]`→ASK).
+
+---
+
+## Q4. The ASK flow end-to-end (approve / deny / timeout)
+
+1. Engine composes **ASK**, returns it with **withheld** `set_labels` +
+   `state_updates` + `deciding_policies` (engine.py:389-402; POLICIES.md §7.2:
+   "a denied ASK leaves no trace").
+2. The enforcement site parks. **Two parking models:**
+   - **Server-parked** (REQUEST gate, native TOOL_CALL via hook, LLM_REQUEST):
+     `_hold_native_ask_gate` (sessions.py:4119) registers a Future in
+     `_harness_elicitation_registry`, publishes **`response.elicitation_request`**
+     (mode `url` → links to `/approve/{sid}/{eid}`), and blocks on
+     `_publish_and_wait_for_harness_elicitation` (:1397).
+   - **Runner-parked** (SDK relay TOOL_CALL): `_evaluate_tool_call_policy`
+     (sessions.py:10556) returns `verdict:"pending"` + `elicitation_id` +
+     `ask_timeout`; stashes deferred writes in `_pending_policy_ask_writes` (:10649);
+     the runner parks on its `_pending_approvals` Future.
+3. **Web ApprovalCard** renders from the SSE event; the sidebar badge increments
+   because **`pending_elicitations.record_publish`** auto-tracks every
+   `response.elicitation_request` flowing through `session_stream.publish`
+   (`pending_elicitations.py:81`). The standalone `/approve` page reads the prompt
+   via `GET /elicitations/{eid}` (sessions.py:18089 → `pending_elicitations.lookup`).
+4. **Resolve endpoint** — `POST /v1/sessions/{id}/elicitations/{eid}/resolve`
+   (sessions.py:18022) with `ElicitationResult {action}`. (Equivalent: the legacy
+   `type:"approval"` event on `POST /events`.) Both funnel into
+   **`_resolve_elicitation`** (sessions.py:3921) which does 3 things in order:
+   (a) **set the server-side Future** (owner-checked — only the owning session may
+   resolve, :3983); (b) publish **`response.elicitation_resolved`** (badge −1,
+   ApprovalCard flips, idempotent); (c) **forward to runner** as a canonical
+   `approval` event (`_forward_approval_to_runner:3880`) so runner-parked
+   Futures resolve.
+5. **Future resolves** → the parked gate wakes. **APPROVE** (`action=="accept"`,
+   strict — `_parse_verdict:290`): apply the withheld `set_labels` +
+   `state_updates` (`_hold_native_ask_gate:4212`, or `_await_elicitation:146`, or
+   `_apply_pending_policy_ask_writes:10372` for the relay path). **DENY / cancel /
+   malformed / timeout / disconnect**: discard withheld writes, verdict → DENY.
+6. Verdict reaches the action: native hook returns
+   `permissionDecision: allow|deny`; SDK tool proceeds or sees `[Denied by policy: …]`.
+
+`ask_timeout`: per-policy override wins over spec default (`resolve_ask_timeout:264`);
+the relay path returns it so the runner's park honors the same cap; native
+PermissionRequest caps at one day (`_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S=86400`).
+
+---
+
+## Q5. Which HOOKS each in-scope harness must expose, and HOW verdicts return
+
+**Required-hooks contract** = the hooks that must reach `/policies/evaluate` (or
+the permission webhook) for *all* policies to be enforced on that harness:
+
+| Harness | Required hooks | How verdicts return |
+|---|---|---|
+| **claude-native** | **PreToolUse** (→ `/policies/evaluate` PHASE_TOOL_CALL) + **UserPromptSubmit** (→ PHASE_REQUEST) + **PermissionRequest** (→ `/hooks/permission-request`) | **long-poll HTTP** — verdict in the held response body (`PermissionRequest` → `hookSpecificOutput.decision.behavior: allow\|deny`, sessions.py:15638/15801; empty 200 = "defer to TUI"). For *policy* ASK the server holds the `/policies/evaluate` long-poll (`_hold_native_ask_gate`) and collapses ASK→hard ALLOW/DENY so a permissive `permission_mode` can't auto-approve (sessions.py:16113). PostToolUse is observational (PHASE_TOOL_RESULT, fail-open). |
+| **codex-native** | codex `PreToolUse`/`UserPromptSubmit`-equivalents (shared `native_policy_hook`) + **`codex-elicitation-request`** hook | long-poll HTTP via the codex elicitation hook (`codex_elicitation_request_hook`, sessions.py:16214; `codex_elicitation_id`). Codex hook stamps live `/model` into `event.context.model`. **No live trace (creds 403).** |
+| **claude-sdk / codex (SDK) / polly** | server `type=approval` event (no command hooks; the SDK loop calls the server in-process) | runner **`pending_approvals` Future** for relay TOOL_CALL ASK; the SDK `can_use_tool` callback (`claude_sdk_executor.py:1680`) also runs an elicitation handler for connector-native tools. **No keystroke emulation.** |
+
+**Single shared translation layer**: `native_policy_hook.py` converts the native
+hook shape ↔ proto `EvaluationRequest`/`EvaluationResponse` for both claude & codex
+(output differs by event: PreToolUse → `permissionDecision`; UserPromptSubmit →
+top-level `decision/reason`). It carries a baked one-shot auth token
+(`policy_hook_wrapper_script:103`) — **this token expiring is the §2.G bug that
+fails every native tool call closed.**
+
+> The verdict for the in-scope harnesses returns via **long-poll HTTP**
+> (claude-native / codex-native) or an **`approval` event → Future** (SDK family).
+> No emulated keystrokes for any in-scope harness (some out-of-scope native
+> harnesses use tmux keystroke delivery; not relevant here).
+
+---
+
+## Q6. Read-only eval, label gating, pending-elicitation tracking + sidebar badge
+
+### Read-only eval (LEVEL_READ)
+- `evaluate_policy` route computes `is_read_only = level < LEVEL_EDIT`
+  (sessions.py:16005) and passes `read_only=True` to `engine.evaluate`.
+- The engine **skips all persistence** — no label writes, no state updates, on
+  both ALLOW and DENY paths (engine.py:403, 446) — but still returns `set_labels`/
+  `state_updates` so a caller can audit "what *would* have changed."
+- Read-only callers **never enter the ASK gate** (sessions.py:16130) — parking
+  mints an elicitation = a mutation; they get the raw ASK verdict instead.
+- Use case: LEVEL_READ collaborators auditing "what would be denied" without
+  side effects.
+
+### Label gating (`condition:`)
+- A policy fires only when its `condition:` block matches the conversation's label
+  hot-cache (`_should_fire:457` → `_condition_matches:1237`). AND across keys; a
+  list value is OR within the key; a missing label never matches (gate stays closed).
+- Labels are written *through* the engine: `apply_label_writes` (engine.py:490)
+  validates against `LabelDef` (`values` enum + `monotonic` direction —
+  `_filter_schema_valid:820`, `_monotonic_ok:1190`) and UPSERTs to
+  `conversation_labels` + the hot cache. Unschema'd labels set freely.
+- Monotonic merge during one evaluate keeps the most-restrictive value across
+  policies writing the same key (`_merge_monotonic_writes:1117`).
+
+### Pending-elicitation tracking + sidebar badge
+- In-process index `runtime/pending_elicitations.py` — populated automatically by
+  `record_publish` (`:81`) on every `response.elicitation_request` passing through
+  the single `session_stream.publish` chokepoint (server policy ASKs, claude
+  PermissionRequest, runner-relayed elicitations all funnel through it).
+- `count_for`/`counts_for` back the **sidebar badge** (`GET /v1/sessions`
+  `pending_elicitations_count`). `snapshot_for` **replays** outstanding prompts
+  into `GET /v1/sessions/{id}` on **cold load** (the SSE stream has no replay).
+- Decremented by `resolve` (approval-dispatch path) or by a
+  `response.elicitation_resolved` event flowing through `record_publish`.
+- Lifecycle is **tied to the parked awaiter** — when omni-server dies, both the
+  index and the Future die together, so the badge can't show phantom pending rows.
+- **Caveat:** in-process only → a multi-replica deploy splits the badge per replica
+  (documented; needs a backplane).
+
+---
+
+## Adjacent: builtin catalog (the policies users actually attach)
+
+From `BUILTIN_POLICY_MODULES` (`builtins/__init__.py:37`) + `POLICY_REGISTRY` scan:
+- **cost** (`cost.py`): `cost_budget`, `user_daily_cost_budget`, `subagent_cost_budget`
+  — the canonical **ASK + `state_updates`** soft-checkpoint pattern (ASK at each
+  `ask_thresholds_usd`, remembered per-session/user-day/subtree; DENY at
+  `max_cost_usd` while on an expensive model → prompts a `/model` downgrade).
+- **safety** (`safety.py`): `max_tool_calls_per_session`, `ask_on_os_tools`,
+  `block_skills`, `enforce_sandbox`, `deny_pii_in_llm_request`, `ask_on_add_policy`.
+- **prompt** (`prompt.py`): `prompt_policy` = the **LLM-classifier** (`PromptPolicy`,
+  uses the injected `PolicyLLMClient`).
+- **risk_score** (`risk_score.py`): `risk_score_policy`.
+- **routing** (`routing.py`): `deny_trivial_to_expensive_model` (model-cost routing).
+- **cel** (`cel.py`): `cel_policy` (declarative CEL expression gate).
+- **google/github/working_dir**: connector + working-dir guards.
+
+---
+
+## Verification of CUJ-ANALYSIS §2.D (line-number confirmation)
+
+§2.D was **accurate**. Confirmed/updated anchors:
+- `sys_add_policy` → `POST …/policies` → `session_policies.py:148` ✓ (doc said `:148`).
+- admin default → `default_policies.py:129`, `_require_admin` ✓.
+- The ASK flow / resolve endpoint: doc cited `:17611` for resolve — the actual
+  `resolve_elicitation` route is **`sessions.py:18022`** and the shared resolver is
+  **`_resolve_elicitation` :3921** (line drift; mechanism identical).
+- Required-hooks table (claude-native PreToolUse+PermissionRequest long-poll;
+  codex-native elicitation hook; SDK approval-event) ✓ — all confirmed in code.
+- Read-only eval, label gating, pending-elicitation tracking ✓.
+- One correction of emphasis: the doc's table omits **UserPromptSubmit** as a
+  required claude-native hook — it IS required (it is the *sole* REQUEST-phase gate
+  for native sessions; the server `/events` input gate is deduped for native via
+  `pending_inputs`, sessions.py:16065).

--- a/designs/master-arch/cuj-answers/runner-dispatch-mcp.md
+++ b/designs/master-arch/cuj-answers/runner-dispatch-mcp.md
@@ -1,0 +1,306 @@
+# CUJ Answers — Runner dispatch, MCP routing, request lifecycle, channel auth, dedup
+
+**Domain:** the RUNNER (`omnigent/runner/`) + runner↔server reverse WS tunnel + harness/executor
+UDS boundary. In-scope harnesses: claude (sdk + native), codex (sdk + native), Polly.
+
+> Every mechanism cited `file:line` (code = ground truth) and, where possible, backed by the live
+> trace `conv_63542a5f92e24956812e19b104eac0e9` (claude-sdk tool-use; trace `cfb59197f6f9…`).
+> codex/codex-native have **no live trace** (AI-gateway creds expired) — covered structurally;
+> the runner dispatch/affinity/MCP machinery is **harness-agnostic** so it applies identically.
+
+---
+
+## Q1. Runner dispatch & affinity (hard binding, no failover; CONFLICT / RUNNER_UNAVAILABLE / capability mismatch)
+
+**Mechanism:** `RunnerRouter.client_for_conversation(conversation_id, harness)`
+(`routing.py:89`). Dispatch is **read-only for affinity** — it never picks or persists a runner
+(docstring `routing.py:93-95`). The decision tree:
+
+```
+conv = conversation_store.get_conversation(id)
+├─ conv is None                       → OmnigentError(NOT_FOUND)
+├─ conv.runner_id is None             → OmnigentError(CONFLICT)   "not bound to a runner; resume to bind"   (routing.py:112)
+└─ conv.runner_id set → _routed_pinned_runner(runner_id, harness)  (routing.py:220)
+     ├─ registry.get(runner_id) is None        → RUNNER_UNAVAILABLE  "runner offline; resume to bind"      (routing.py:231)
+     ├─ not _runner_supports_harness(session, harness) → RUNNER_CAPABILITY_MISMATCH                          (routing.py:236)
+     └─ RoutedRunner(runner_id, client=_client_for_runner(runner_id))   # cached WSTunnelTransport client
+```
+
+- **Hard binding:** the conversation's `runner_id` is set **once** via an atomic CAS,
+  `set_runner_id` = `UPDATE … WHERE id=:id AND runner_id IS NULL` (`sqlalchemy_store.py:1918`).
+  Concurrent first-dispatches race; exactly one wins, the loser's UPDATE affects 0 rows → re-read
+  to discover the winner. Binding happens via `PATCH /v1/sessions/{id}` (server side), **not** in
+  dispatch.
+- **No failover / no rebalance:** there is no code path that re-routes a bound conversation to a
+  different online runner. A bound runner going offline → every dispatch raises
+  `RUNNER_UNAVAILABLE` until that exact runner reconnects (its `runner_id` is stable across
+  restarts — `get_stable_runner_id`, persisted). Confirmed gap in CUJ-ANALYSIS §6
+  ("Hard runner affinity, no failover — a bound runner going offline strands the session").
+- **Capability check:** `_runner_supports_harness` (`routing.py:269`) tests the canonicalized
+  harness string against the runner's advertised `hello.harnesses`. The hello set is
+  `[claude-native, claude-sdk, codex, openai-agents, open-responses, pi]` (`serve.py:582`) — note
+  **codex-native is NOT in the default hello list**, so a codex-native dispatch to a stock runner
+  would raise `RUNNER_CAPABILITY_MISMATCH` unless that runner advertises it. (Native harnesses are
+  largely CLI-driven from the host, not server-dispatched over the tunnel — see Q2/resume.)
+- **`replace_runner_id`** (`sqlalchemy_store.py:1951`) exists for **explicit re-bind** (PATCH
+  callers, or internal sub-agent rebind to the parent's current runner) — this is the only way the
+  binding changes, and it's caller-driven, not automatic failover.
+
+**Sibling routing helpers** (same affinity): `client_for_session_resources` (`:118`, terminals/
+files), `client_for_existing_conversation` (`:154`, interrupt/terminal-list — returns `None` when
+unpinned so callers fall back to in-process test behavior).
+
+---
+
+## Q2. Resume dispatch — which harness gets relaunched (`resume_dispatch.py`)
+
+`omnigent resume` is **CLI glue, not a runner-internal mechanism** (`resume_dispatch.py:39`
+`run_resume`). It answers "take me back to where I was" for **terminal-native** sessions by
+relaunching the right vendor wrapper:
+
+1. **Resolve the target:** direct id (`omnigent resume conv_…`) or the cross-agent picker
+   (`omnigent resume` with `--server`, `_pick_conversation_for_resume`, `:89`).
+2. **Read the wrapper label:** `_dispatch_by_runtime` (`:147`) GETs the conversation and reads
+   `labels.omnigent.wrapper` (remote: `_read_wrapper_label_remote` `:339`; local sqlite:
+   `_read_wrapper_label_local` `:312`).
+3. **Dispatch by runtime:** `_dispatch_wrapper` (`:201`) maps the wrapper label →
+   `native_coding_agent_for_wrapper_label` → the matching `run_<harness>_native(...)`:
+   - `claude` → `run_claude_native` (`:219`), `codex` → `run_codex_native` (`:228`),
+     `pi` → `run_pi_native`, plus cursor/kiro/goose/antigravity/qwen/kimi/hermes.
+   - **The relaunched harness is whichever native wrapper minted the session** (recorded in the
+     wrapper label at creation). The native wrapper owns its own local-server + runner lifecycle.
+4. **No wrapper label (i.e. an SDK session):** `_dispatch_wrapper` returns `False`, and
+   `run_resume` raises a `ClickException` pointing the user at `omnigent run --resume <conv>
+   <agent.yaml> [--server …]` (`:179`, `:193`). So **SDK harnesses (claude-sdk, codex, Polly) do
+   not resume via `resume_dispatch.py`** — they resume through `omnigent run --resume`, which goes
+   through the normal create-session → bind-runner → dispatch path.
+
+**How much transcript loads into the runner on resume** (runner's side): when a turn is
+dispatched after resume, the runner pulls the transcript itself — `GET /v1/sessions/{id}/items`
+and reconstructs input via `_load_history_as_input` (`app.py:14842`, with the `persisted_item_id`
+dedup drop). SDK harnesses load conversation history into the executor; native harnesses rebuild
+from stored items / `FORK_CARRY_HISTORY`. (Detail owned by harness/native SME; runner's role is
+the `GET …/items` fetch — visible in the trace as `omni-runner → omni-server GET …/items`.)
+
+---
+
+## Q3. MCP routing — custom (user) MCP vs Omnigent `sys_*`; who routes a tool call where
+
+**The single most important runner fact: there are TWO MCP managers with the same interface,
+chosen by mode** (`proxy_mcp_manager.py:15-23`):
+
+| Mode | Manager | Policy enforced by | MCP connections held by |
+|---|---|---|---|
+| **Deployed** (runner + server) | `ProxyMcpManager` | **Server** (`/mcp` → `_evaluate_tool_call_policy`) | **Server** `ServerMcpPool`, delegates **execution** to runner |
+| **No-server / test** | `RunnerMcpManager` | **Runner** (`RunnerToolPolicyGate`, `policy.py`) | **Runner** (direct stdio/HTTP, 8-entry LRU) |
+
+### The deployed routing loop (verified in the trace)
+1. Harness emits a tool call → runner `ProxyMcpManager.call_tool` POSTs `tools/call` to server
+   `POST /v1/sessions/{id}/mcp` (`proxy_mcp_manager.py:220`). **Trace:** `omni-runner →
+   omni-server [POST …/mcp]`.
+2. Server runs **TOOL_CALL** policy (`omni-server policy.evaluate` span), then calls **back into
+   the runner**: `POST /v1/sessions/{id}/mcp/execute` (`app.py:17829`). **Trace:** `omni-server →
+   omni-runner [POST …/mcp/execute]`. The split is deliberate: *server owns policy + routing;
+   runner owns execution* (tools must run on the right machine, cwd, env — `app.py:17834-17837`).
+3. **The routing key is the `__` separator** (`app.py:17954`):
+   - **`"__" in tool_name`** (e.g. `github__search`, `glean__search`) → **custom/user MCP** →
+     `RunnerMcpManager.call_tool` → live stdio/HTTP MCP subprocess (`app.py:18011`). The
+     `{server}__{tool}` name is validated against the server prefix then stripped
+     (`mcp_manager._resolve_tool_route`, `:387`).
+   - **no `__`** (e.g. `sys_os_read`, `sys_terminal_launch`) → **runner-local Omnigent builtin**
+     → `execute_tool` (`tool_dispatch.py`) with the session's terminal registry / inbox / sandbox
+     workspace (`app.py:18070`). Comment: "All MCP tools are namespaced … so any name without `__`
+     is definitively a runner-local tool" (`app.py:18046`).
+4. Server runs **TOOL_RESULT** policy on the output (second `policy.evaluate` span), returns the
+   (possibly transformed/denied) result to the runner, which feeds the harness.
+
+So **for SDK harnesses (claude-sdk/codex/Polly): both `sys_*` AND custom MCP go through the same
+server `/mcp` → `/mcp/execute` round-trip**; the only divergence is the `__`-based fork inside
+`/mcp/execute` (custom → RunnerMcpManager; `sys_*` → execute_tool).
+
+### Native harness MCP — in-turn relay vs out-of-turn serve-mcp
+- **`sys_*` (Omnigent) — in-turn relay:** the vendor CLI calls `mcp__omnigent__*` tools relayed by
+  `ProxyMcpManager` → server `/mcp` (centrally policy-checked). **Therefore the native PreToolUse
+  policy hook explicitly SKIPS `mcp__omnigent__*`** to avoid double-evaluation
+  (`native_policy_hook.py:209-211, 244`): "already policy-checked by the relay path."
+- **Connector/custom MCP (`mcp__github__*`) — hook-gated:** these still go through the native
+  PreToolUse hook → `hook_payload_to_evaluation_request` (`:198`) → server `/policies/evaluate`.
+- **Out-of-turn workspace tools — `serve-mcp`:** the native harness launches a separate `serve-mcp`
+  MCP server the vendor discovers via its own settings.json; only `sys_os_*` is registered there
+  (workspace cwd, no sandbox). The runner seeds its relay token at boot
+  (`write_relay_bridge_config`, `app.py:1054`). (Bridge details owned by harness/native SME.)
+
+### Custom-MCP elicitation (approval from a user MCP server)
+- `RunnerMcpManager._build_elicitation_callback` (`mcp_manager.py:182`): on inline
+  `elicitation/create`, POST `mcp_elicitation` to the server and park on
+  `pending_approvals.wait_for_user_approval`; decline if no server client.
+- Through the proxy, a custom MCP's `InputRequiredResult` surfaces as `McpElicitationRequired` back
+  through `/mcp/execute` (`app.py:18017`) → server owns the elicitation; retry uses
+  `call_tool_with_elicitation` with `inputResponses`/`requestState` (MRTR, `app.py:18004`).
+
+---
+
+## Q4. Request lifecycle from the runner's side (forwarded user event → executor → tool dispatch → persist/forward back)
+
+**Entry point:** `POST /v1/sessions/{conversation_id}/events` (`app.py:14598`
+`post_session_events`) — the runner receives the user event the server forwarded over the tunnel.
+Body is the harness discriminated union (`message` / `interrupt` / `tool_result` / `approval`).
+
+Step by step (`message` path, `stream=true` — what the trace shows):
+1. **FIFO ingest gate** (`app.py:14692`, RUNNER_MESSAGE_INGEST Part A): take an arrival slot
+   synchronously (read-increment `_ingest_next_seq` before any await), wait on `_ingest_cond`
+   until `_ingest_now_serving` reaches this seq → guarantees per-conversation arrival order.
+2. **Content resolution:** `_resolve_forwarded_message_content` (`app.py:14704`) hydrates content
+   blocks (e.g. fetches referenced items via `server_client`).
+3. **Single-active-turn gate (invariant I2):** if `conversation_id in _active_turns`, the message
+   is buffered or steered (parked-on-approval turns are NOT steered, `app.py:14711-14717`).
+4. **History rebuild:** `_load_history_as_input(drop_item_id=persisted_item_id)` (`app.py:14842`)
+   — loads transcript, drops the just-arrived item to avoid double-count. **Trace:** `omni-runner
+   → omni-server [GET …/items]` and `[GET …/agent/contents]` (spec bundle via `spec_resolver`).
+5. **Executor dispatch:** the runner POSTs the turn to the per-conversation harness/executor
+   subprocess over **UDS** (`process_manager`, `/tmp/omnigent` socket). **Trace:** `omni-runner →
+   omni-harness [POST …/events]`. MCP schemas are injected into the event body
+   (`_inject_mcp_schemas`, `app.py:6850`).
+6. **Stream relay (`proxy_stream`, `app.py:14115`):** the SSE body from the harness is relayed
+   chunk-by-chunk back to the server (`StreamingResponse`, `media_type="text/event-stream"`,
+   `app.py:14592`). The relay also:
+   - intercepts `action_required` events for **local tool dispatch** (the `/mcp` round-trip, Q3),
+   - intercepts `policy_evaluation.requested` → `_evaluate_policy_via_omnigent` (Q5),
+   - accumulates text / tool-calls / tool-results into `_session_histories`,
+   - `_publish_event` puts events on the per-session queue for `GET …/stream`.
+7. **Turn finalize:** `_on_proxy_stream_end` (`app.py:12519`) pops `_active_turns`, clears
+   in-flight, publishes `session.status` = idle / failed / waiting, schedules a post-turn buffer
+   check (drains any buffered messages queued during the turn).
+
+**Persist-vs-forward:** the runner **forwards** (streams) turn output; **durable persistence is
+the server's** (`conversation_store.append` on the server side, after receiving the SSE). The
+runner streams `response.output_text.delta` and final items back; the server persists. The
+`stream=false` variant returns 202 and events flow via `GET …/stream` + a background
+`_run_turn_bg` task.
+
+---
+
+## Q5. Runner↔server channel & auth — handshake, per-message vs once-at-open Bearer, header-verbatim forwarding
+
+### The handshake (runner side `serve.py:494`, server side `runner_tunnel.py:277`)
+The runner is the WS **client**. `_serve_tunnel_once` opens `ws(s)://<server>/v1/runners/
+{runner_id}/tunnel` (`serve.py:543`) with handshake headers:
+- `Origin: omnigent://internal` (first-party sentinel → clears server CSWSH/origin guard),
+- `Authorization: Bearer <token>` + `X-Databricks-Org-Id` (`databricks_request_headers`, `:540`),
+- `X-Omnigent-Runner-Tunnel-Token: <binding_token>` (`RUNNER_TUNNEL_TOKEN_HEADER`, `:542`).
+
+Server validates **before accept**: token gate / expected-runner-id (close `4004` on mismatch);
+owner resolution **fail-closed** for unauthenticated non-loopback (would otherwise register
+`owner=None` and bypass owner-scoped guards, `runner_tunnel.py:331-371`); then `accept()`, receive
+hello, **strict-major `frame_protocol_version`** check (close `4002`), `registry.register`.
+Register is **"newest wins"** (`registry.py:280`): a new tunnel for the same `runner_id` discards
+the old session and aborts its in-flight requests with `ConnectionError`.
+
+### Per-message vs once-at-open Bearer (the KNOWN GAP — and its mitigation)
+- **The Bearer is injected ONCE, in the WS upgrade headers** (`serve.py:540`). The long-lived
+  socket then carries every server→runner `request` frame with **no per-message re-auth** — there
+  is no hook to re-set a header on an open WS. This is the runner↔server "no per-message refresh"
+  item in CUJ-ANALYSIS §2.G / §6.
+- **Mitigations that make it mostly self-healing:**
+  - `serve_tunnel` re-mints the token on **every reconnect** (`_refresh_auth_token`, `serve.py:284`,
+    via `auth_token_factory`).
+  - On a handshake **HTTP 401**, refresh once and retry (`_handle_refreshable_auth_failure`,
+    `serve.py:326`); on a fatal 403, raise (`serve.py:332`).
+  - Routine ingress recycles — close `1001`/`1012`, HTTP `502` — reset backoff to the minimum and
+    reconnect promptly (`serve.py:343-353`, `_TUNNEL_RECYCLE_*`), which **also** re-mints.
+  - WS auto-redirect to an http(s) OAuth login (Apps unauthenticated) is **fatal** with a clear
+    "run `omnigent setup`" hint (`serve.py:309`, `_websocket_auth_redirect_url`).
+  - So a token expiry only bites if the socket stays open *past* expiry **with no recycle and no
+    new request that triggers a server-side re-auth**; the next reconnect heals it.
+- **The runner→server direction has NO such gap:** `_RunnerDatabricksAuth.auth_flow`
+  (`_entry.py:192`) mints a **fresh token per request** and retries once on 401 or Apps
+  `302→/oidc/` (`_is_login_redirect_or_unauthorized`, `:241`). One SDK `Config` is cached for the
+  factory's lifetime so the token comes from the SDK in-memory cache (no per-request CLI shellout,
+  `_entry.py:312-360`). `follow_redirects=False` deliberately so the auth flow *sees* the Apps
+  login 302 and can re-mint (`create_app`, `app.py`/`_entry.py:732-739`).
+
+### Header-verbatim forwarding (how trace context crosses)
+- `WSTunnelTransport.handle_async_request` (server side) forwards request headers **verbatim**:
+  `headers=[[k, v] for k, v in request.headers.items()]` (`transport.py:149`). On the runner side
+  `dispatch_via_asgi` rebuilds the ASGI scope headers from the frame (`serve.py:126`). So whatever
+  the server's httpx client injected (incl. `traceparent`) reaches the runner's FastAPI extractor
+  unchanged.
+- **The custom-transport propagation fix:** the server→runner client is built on the custom
+  `WSTunnelTransport`, invisible to the process-wide `HTTPXClientInstrumentor`. So the cached
+  per-runner client is instrumented **directly**: `telemetry.instrument_httpx_client(client)`
+  (`routing.py:264`, `telemetry.py:414`). This injects `traceparent` on the forward; combined with
+  `create_runner_app` calling `telemetry.instrument_fastapi_app(app)` (`app.py:7775`) and the
+  verbatim forwarding, the server→runner hop stays in **one connected trace**. **Verified in the
+  trace:** runner spans nest under server spans (§Trace evidence). This is exactly OBSERVABILITY.md
+  §12 "custom-transport client gap (resolved)".
+
+---
+
+## Q6. Dedup — runner side
+
+The runner dedups at **three specific seams** (no global response-id cache):
+1. **Inbound order, not duplicates:** the per-conversation FIFO ingest gate
+   (`app.py:14692`) preserves arrival order; the single-active-turn gate (`_active_turns`,
+   `app.py:14711`) buffers/steers mid-turn arrivals so they don't spawn overlapping turns.
+2. **History-load dedup:** `_load_history_as_input(drop_item_id=persisted_item_id)`
+   (`app.py:14842`) drops the just-arrived item so it isn't counted twice (store + new input).
+3. **Mid-turn injection exactly-once:** `injection.consumed` markers (`app.py:14251`,
+   RUNNER_MESSAGE_INGEST Part B) — once the harness consumes an injection into the live turn, the
+   buffered copy is dropped so it doesn't also drive a continuation turn. The native transcript
+   reader keeps an **in-memory seen-set** (durable cursor retired, `app.py:4300`); the native log
+   accumulator uses **generation-id dedup** for idempotent re-reads (`app.py:2112`; "watcher
+   already dedupes to edges", `app.py:8236`).
+
+**What the runner does NOT dedup:** *forwarded outbound* events by item-id. Durable dedup is the
+**client's** job (by `ctx.itemId`) and durable persistence is the **server's**
+(`conversation_store.append`). Code flags this: "there is no server-side dedup" (`app.py:5844`)
+and a post-recovery double-persist risk after a tunnel recovery scan (`app.py:321`,
+`on_reconnect=catch_up_scan`). **The FIFO-desync bug class** (CUJ-ANALYSIS §6, native-firstmsg-
+fifo-desync) lives at the ingest gate + the cross-layer itemId contract — not in a runner cache.
+
+---
+
+## Per-harness notes (runner's view)
+
+The runner is **harness-agnostic at the tunnel/dispatch/MCP-routing layer**. Differences:
+
+| Harness | Dispatch over tunnel | `sys_*` routing | Custom MCP routing | Live trace? |
+|---|---|---|---|---|
+| claude-sdk | yes (capability ✅) | server `/mcp` → `/mcp/execute` (no `__` → execute_tool) | server `/mcp` → `/mcp/execute` (`__` → RunnerMcpManager) | ✅ `conv_63542a5f…` |
+| codex (sdk) | yes (capability ✅) | same as claude-sdk (harness-agnostic) | same | ❌ creds expired (structural) |
+| claude-native | CLI/host-driven; relay in-turn | in-turn relay; PreToolUse hook **skips** `mcp__omnigent__*` | PreToolUse hook → `/policies/evaluate`; serve-mcp out-of-turn for `sys_os_*` | partial (native corpus `conv_d0ddd6b3…`) |
+| codex-native | CLI/host-driven | in-turn relay (analogous) | hook → `/policies/evaluate` | ❌ creds expired (structural) |
+| Polly / custom agents | runs on chosen harness (usually claude-sdk) → **inherits that row** | inherits | inherits | via claude-sdk |
+
+---
+
+## Failure-branch summary (runner dispatch + MCP)
+
+| Code | Condition | Site |
+|---|---|---|
+| `CONFLICT` | conversation not bound to a runner | `routing.py:112` |
+| `RUNNER_UNAVAILABLE` | bound runner offline | `routing.py:231` / `:139` / `:175` |
+| `RUNNER_CAPABILITY_MISMATCH` | runner's hello lacks the harness | `routing.py:236` |
+| `httpx.ConnectError` | runner offline at request time (tunnel) | `transport.py:125` |
+| in-flight `ConnectionError` | tunnel closed mid-request / replaced | `registry.deregister` / `register` "newest wins" |
+| close `4004`/`4001`/`4002` | bad token / no hello / proto skew (handshake) | `runner_tunnel.py:304/380/385` |
+| fatal `RuntimeError` | WS bounced to OAuth login (Apps unauth) | `serve.py:309` |
+| 503 "MCP manager not configured" | `mcp_manager is None` on `/mcp/execute` | `app.py:17879/17957` |
+| `-32000` "No spec available" | spec unresolved for session | `app.py:17899/17977` |
+| `-32000 input_required` / `McpElicitationRequired` | custom MCP elicits | `app.py:18017` (MRTR retry) |
+| **no failover (gap)** | bound runner offline strands session | `routing.py:89` (CUJ-ANALYSIS §6) |
+| **Bearer once-at-open (gap)** | tunnel token expiry w/o reconnect | `serve.py:540` (CUJ-ANALYSIS §2.G) |
+
+---
+
+## Open questions / things to cross-check with other SMEs
+- **Policy/auth SME:** confirm whether claude-native still uses the one-shot
+  `OMNIGENT_POLICY_AUTH` snapshot (fail-open, `app.py:1141` is the *opencode* path) or the
+  refreshable `policy_hook_reauth` path (`native_policy_hook.py:133`) — i.e. is the
+  fail-closed-after-1h bug (PR #1439) actually closed for the in-scope native harness? The
+  refreshable mechanism exists and re-mints on 401/Apps-302; the legacy snapshot survives in some
+  paths and degrades fail-**open** there.
+- **Server SME:** the server side of `/mcp` (ServerMcpPool, `_evaluate_tool_call_policy`) and the
+  PATCH-driven `set_runner_id` binding flow — the runner only consumes the binding.
+- **Harness/native SME:** transcript-into-runner volume on resume/fork, the `serve-mcp` bridge,
+  and the native sub-agent-completion gate (`app.py:12496`, native excluded — CUJ-ANALYSIS §6 #848).

--- a/designs/master-arch/cuj-answers/server-api-state-streaming.md
+++ b/designs/master-arch/cuj-answers/server-api-state-streaming.md
@@ -1,0 +1,404 @@
+# CUJ Answers — Server: API, State & Streaming
+
+Domain: the Omnigent **server** (`omnigent/server/`). Every claim is anchored to `file:line`
+on current `main` (worktree `…/traces`) and, where possible, to live Jaeger spans.
+Harness scope: claude (sdk + native), codex (sdk + native — no live trace, creds expired),
+polly (= custom agents on an SDK harness, behaves as claude-sdk).
+
+> Reading note: `designs/CUJ-ANALYSIS.md` §2.A/§2.E line numbers had drifted by thousands of
+> lines vs the live 912 KB `sessions.py`. The anchors below were re-derived from code.
+
+---
+
+## Q1. Full request lifecycle of `POST /v1/sessions/{id}/events`
+
+Handler `post_event` (`sessions.py:18150`). Returns **202**; body is a small ack dict.
+
+**Order of operations (the happy "message" path):**
+
+1. **AuthZ.** `_get_user_id` → `_require_access_and_level(LEVEL_EDIT)` (`:18228-18231`). 404 if
+   no conversation (`:18233-18239`).
+2. **Validate type.** `body.type ∈ _ALLOWED_EVENT_TYPES` else 400 (`:18245`). Item types also
+   `parse_item_data`-validated (`:18282`); client tool specs validated (`:18291`).
+3. **Closed-session guard.** A `sys_session_close`d sub-agent rejects new user input → 409
+   (`is_session_closed`, `:18306-18314`).
+4. **Policy eval (BEFORE persist/forward).** `_evaluate_input_policy` (`:18321`) for user
+   messages; output/tool-call policies for assistant/function_call. On exception → treat as
+   **deny** so the session can't hang "working forever" (`:18331-18346`).
+   - **Deny/ask path:** publish `session.status running`, `_publish_policy_deny`, persist a
+     **deny sentinel** item (`_persist_policy_deny_sentinel`, `:18354`), publish a **terminal
+     `response.completed`** so headless `-p` live-tail consumers unblock
+     (`_publish_input_deny_terminal`, `:18363`), publish `session.status idle`, return
+     `{queued:false, denied:true, reason}` (`:18347-18369`). **Not forwarded to the runner.**
+5. **Control events (NOT persisted as items):**
+   - `interrupt` (`:18439`): publish `session.interrupted`, **add to
+     `_interrupt_fenced_sessions`**, POST `{type:interrupt}` to runner (5 s); if undelivered,
+     drop the fence (else the still-running turn's output would be lost). `{queued:false}`.
+   - `stop_session` (`:18467`): **owner-only** (extra `LEVEL_OWNER` gate `:18472`); fence;
+     forward harness-agnostically (`_stop_session_via_runner`, **raises** on failure unlike
+     interrupt); if host-spawned, also stop the host runner so the tunnel drops honestly.
+     Non-sticky (next message relaunches). `{queued:false}`.
+   - `approval` (`:18519`): `_resolve_elicitation` (sets server-side Future, clears badge,
+     forwards to runner) + apply deferred policy-ask writes. `{queued:false}`.
+   - `mcp_elicitation` (`:18533`): mint `elicit_<hex>`, publish `response.elicitation_request`
+     to this stream + ancestor streams, return the id so the runner parks. `{queued:false}`.
+   - `compact` (`:18570`): forward to runner first (native injects `/compact` into tmux); only
+     if runner 204/absent does the server run its own `_run_compact_locked`. `{queued:false}`.
+   - `external_*` family (`:18617-18860`): persist or publish the terminal-observed signal
+     (assistant message / conversation item / status / model change / subagent start / …)
+     **without starting a turn**. These are the native forwarder's input vocabulary.
+6. **Item event — PERSIST-BEFORE-FORWARD (invariant I1).** Resolve a runner client
+   (`_get_runner_client`, with managed-launch rendezvous + host-relaunch grace,
+   `:18889-19006`). If a *fresh* item event has **no runner and no host** → raise
+   `RUNNER_UNAVAILABLE` (503) **before persisting** (`:19068-19076`) so the store never
+   desyncs from harness state. Otherwise `_dispatch_session_event_to_runner` (`:19137`):
+   - SDK / non-native → `_forward_event_to_runner` (`:8495`):
+     **`conversation_store.append([item])` first (`:8540`)**, resolve `file_id`s, build
+     `runner_body` (incl. `persisted_item_id`, `model_override`, `harness_override`,
+     `has_mcp_servers`), **POST to runner (`:8697`)**, then **`_publish_input_consumed`
+     (`:8704`)** carrying the persisted `item_id`. On forward failure: item stays persisted,
+     publish `session.status idle` (`:8711`).
+   - native-terminal → bypass: do **not** persist; record `pending_inputs` entry, forward into
+     tmux; the transcript forwarder is the single writer (`:8817-8914`).
+   Return `{queued:true, item_id}` (+ `pending_id` for native).
+
+**Trace evidence** (`tree cfb59197f6f92755…`, tool-use conv, POST /events root, 415 spans):
+`POST /v1/sessions/{session_id}/events` → child `policy.evaluate` → `UPDATE`+`INSERT chat.db`
+(the append) → `POST` cross-edge to `omni-runner [POST /v1/sessions/{conversation_id}/events]`.
+The append's writes precede the runner POST — **I1 visible on the wire.** The runner then
+calls back `GET /items` + `GET /sessions/{id}` (transcript rebuild).
+
+**Failure branches:** policy-deny (persist sentinel, no forward); runner-offline-mid-session
+(persist, forward fails, idle, picks up on reconnect); runner-never-bound (503 pre-persist);
+host-relaunch (the message *is* the relaunch trigger — `:18920-19006`).
+
+---
+
+## Q2. Server-side dedup (how `itemId` / `response_id` are used)
+
+**There is no content-based dedup at the server store.** `append` (`sqlalchemy_store.py:1411`)
+mints a **fresh globally-unique `item_id`** per item (`generate_item_id`, `:1479`). Dedup is
+**id-based and happens downstream** (runner + client), seeded by ids the server assigns:
+
+- **`item_id`** — the canonical durable id. The server forwards it to the runner as
+  **`persisted_item_id`** in `runner_body` (`sessions.py:8618`). On a cold runner cache the
+  runner reloads history (which includes this item in *pre-resolution* form), **drops it by
+  id**, and appends its own resolved copy — "id-based dedup, not a role/content guess"
+  (comment `:8614-8617`). `input.consumed` carries the same `item_id` so the client promotes
+  its optimistic bubble to the durable block by id.
+- **`response_id`** — the **turn-grouping** key (stored on every item, `append` `:1483`). The
+  relay assigns all items of one turn the same `response_id` from the latest
+  `response.in_progress` (`_extract_persistent_item_from_sse`, `:8948-9000`); the web UI groups
+  them into one bubble and **pairs a `function_call` with its `function_call_output`** even
+  when a later `response.in_progress` has advanced `current_response_id`
+  (`tool_call_response_ids` map, `_relay_runner_stream` `:9410, :9560-9580`).
+- **Native bypass:** no server item id at dispatch — only a `pending_inputs` `pending_id`
+  (`sessions.py:8851`). Dedup against the mirrored-back transcript copy relies on the client's
+  FIFO/stableKey + the `cleared_pending_id` on `input.consumed` (`_publish_input_consumed`
+  `:2554-2569`). This is the FIFO-desync bug class (CUJ-ANALYSIS §6).
+- **Telemetry id derivation:** a turn's `response_id` (`resp_<32hex>`) deterministically seeds
+  the **root trace id** via `trace_id_from_response_id` (telemetry.py) — so the server's
+  per-turn trace is recoverable from the response id (OBSERVABILITY §5.2).
+
+---
+
+## Q3. "working/idle" status — computed and published server-side
+
+**Single funnel:** `_publish_status(session_id, status, error?, response_id?, background_task_count?)`
+(`sessions.py:5343`). `status ∈ {idle, running, waiting, failed}` (Pydantic-validated;
+non-conforming values fail loud, `:5354-5357`). It does two things atomically:
+
+1. **Writes the in-memory `_session_status_cache`** (`:5391`; cache def `:837`) — the bridge
+   the **sidebar** reads. The snapshot/list endpoints read this cache so the sidebar badge
+   stays coherent with the SSE stream (docstring `:5359-5365`: "without this, the
+   `external_session_status` path leaves the sidebar stuck idle while chat shows Working…").
+   Also maintains `_session_background_task_count_cache` (sticky background-shell tally).
+2. **Publishes a `session.status` SSE event** (`SessionStatusEvent`, `:5406-5419`).
+
+**Where status edges originate:**
+- **SDK turn:** the **runner** emits `session.status` on its SSE stream;
+  `_relay_runner_stream` re-publishes via `_publish_status` so it gets `conversation_id` +
+  cache write (`:9447-9519`). `running` at turn start, `idle`/`failed` at end.
+- **Native:** the forwarder POSTs `external_session_status` → `post_event` validates +
+  `_publish_status` (`:18667-18726`). PTY-activity drives `running`/`idle`; StopFailure →
+  `failed`.
+- **Deny path:** `post_event` publishes `running` then `idle` around the sentinel (`:18352-18364`).
+
+**Stickiness invariant:** a cached `failed` is **not** overwritten by a trailing `idle`
+(`:5389-5390`); only the next `running` clears it (and a new turn / failure clears the bg
+tally). Prevents the native StopFailure→failed edge from being erased by the ~1 s-later
+PTY-idle.
+
+**Presence** (who's *viewing*) is separate from status. Holding `GET /sessions/{id}/stream`
+open registers the caller as a viewer (`presence.connect`, `_stream_live_events` `:11307`);
+co-viewers receive `session.presence` edges; the snapshot-on-connect includes the full viewer
+list (`stream_session` `:19322`). Scoped to the **session-tree root** so viewers of different
+sub-agents in one tree see each other. The `?idle=` query param is the viewer's tab-backgrounded
+flag; an idle flip arrives as a **reconnect** carrying the new value (no separate endpoint,
+`:19216-19219`).
+
+`/health` (`app.py:1659`) reports **liveness** (`runner_online` strict, `host_online`),
+not status — the sidebar polls it (batched `?session_ids=`) for the connection dot.
+
+---
+
+## Q4. Disconnect → reconnect contract (snapshot + live tail, NOT replay)
+
+**The live stream has no buffer.** `_stream_live_events` (`sessions.py:11229`) yields events
+"from the moment `subscribe` is invoked forward — no buffer, no replay. Events published
+before this generator subscribed are lost; clients reconcile pre-subscribe state via the
+snapshot endpoint and dedupe by item id" (docstring `:11240-11244`).
+
+**Reconnect sequence (the contract):**
+1. Client opens `GET /sessions/{id}/stream` (`stream_session`, `:19190`). The subscribe call
+   passes `ready_event={"type":"session.heartbeat"}` yielded **immediately** after the
+   subscriber slot registers (`:11314`) so the client has a concrete "I'm now tailing" ack
+   before posting a fast one-shot turn. A `pre_ready_snapshot` hook captures in-flight
+   assistant text **synchronously** at slot registration (`:11320`) so window deltas don't
+   double-render.
+2. Client reads the **snapshot** `GET /sessions/{id}` (`get_session` → `_get_session_snapshot`,
+   `SessionResponse` built at `:2458`). It carries: identity/status/`background_task_count`,
+   paginated `items` (or `[]` if `include_items=false` — the web hydrates the transcript via
+   `GET /items` in parallel), `runner_online`/`host_online` (or `None` when sourced from
+   `/health`), **`pending_elicitations`** (outstanding approval cards replayed — `:2502`,
+   incl. child-session elicitations `:2333-2345`), **`pending_inputs`** (un-consumed native
+   web messages replayed `:2511`), cost/usage, `last_task_error`, model/effort/harness.
+3. **Dedup the overlap by item id.** Events that fired *before* the snapshot are in the
+   snapshot's `items`; events *after* arrive on the live tail. The client drops the duplicate
+   by `ctx.itemId` (web `lib/blockStream.ts`, CUJ-ANALYSIS §2.E). This is the snapshot↔stream
+   merge point.
+
+**`[DONE]` on every exit path.** `_stream_live_events`'s `finally` always yields
+`data: [DONE]\n\n` (`:11341`) so well-behaved SSE consumers see a clean termination on
+disconnect, server shutdown, or normal completion. The pub-sub auto-cleans the subscriber
+slot in its own `finally`.
+
+**`_poll_request_disconnect`** (`sessions.py:1183`) is the **long-poll** disconnect detector
+used by parked routes (notably the claude-native `evaluate_policy`/permission-request hook):
+it **blocks on `request.receive()`** for `http.disconnect` rather than polling
+`is_disconnected()`, because Claude closes its HTTP request when its TUI prompt is answered
+first — without this the handler would sit out the full timeout. (Deliberately a blocking
+receive, not the poll variant, so an external `Task.cancel()` always propagates — docstring
+`:1193-1203`.) The SSE generator itself uses `request.is_disconnected()` checked on each event
+arrival (`_stream_live_events` `:11323`), backstopped by 15 s heartbeats so a half-open socket
+is noticed.
+
+**Interrupt fencing across a reconnect.** `_interrupt_fenced_sessions` (set, `:931`) is
+populated on `interrupt`/`stop_session` (`:18442, :18476`). In `_relay_runner_stream`
+(`:9464-9475`) a fenced session **drops the cancelled turn's trailing `response.*` output**
+(no forward, no persist) — but **keeps `text_acc`** so pre-stop narration the user already
+watched still persists at the terminal flush. The fence lifts on the next
+`session.status running` (a new turn) or any **terminal** `response.*`
+(`_TERMINAL_RESPONSE_EVENT_TYPES` — completed = the stop lost the race, process normally).
+This guarantees a stopped turn's output never lands in the durable store to resurface on
+reconnect.
+
+---
+
+## Q5. The FULL set of client→server requests
+
+54 routes are mounted by the sessions router (handler names verified by AST extraction).
+Grouped by purpose:
+
+### Session CRUD / lifecycle
+| Method | Path | Handler | Purpose |
+|---|---|---|---|
+| POST | `/v1/sessions` | `create_session` (`:13688`) | create (JSON=existing agent; multipart=bundled session-scoped agent) |
+| GET | `/v1/sessions` | `list_sessions` (`:14236`) | sidebar list (cursor-paginated, `?search_query`, `?project`, archived filter) |
+| GET | `/v1/sessions/projects` | `list_session_projects` (`:14061`) | implicit projects (reserved `omni_project` label) |
+| GET | `/v1/sessions/{id}` | `get_session` (`:14132`) | **snapshot** (reconnect) |
+| PATCH | `/v1/sessions/{id}` | `update_session` (`:14795`) | rename / **archive (owner)** / model_override / effort / cost-mode / runner rebind / labels |
+| DELETE | `/v1/sessions/{id}` | `delete_session` (`:19358`) | **owner-only** delete (+`?delete_branch` worktree) |
+| POST | `/v1/sessions/{src}/fork` | `fork_session` (`:15180`) | fork (deep-copy items, `up_to_response_id`, agent/harness switch) |
+| POST | `/v1/sessions/{id}/switch-agent` | `switch_session_agent` (`:15415`) | **idle-only (409)** in-place agent swap |
+| GET | `/v1/sessions/{id}/labels` | `get_session_labels` (`:14192`) | label read |
+| PUT | `/v1/sessions/{id}/read-state` | `put_read_state` (`:14089`) | per-user unread tracking |
+
+### Turn I/O
+| Method | Path | Handler | Purpose |
+|---|---|---|---|
+| POST | `/v1/sessions/{id}/events` | `post_event` (`:18150`) | **the turn entrypoint** (message/control/external) |
+| GET | `/v1/sessions/{id}/stream` | `stream_session` (`:19190`) | **SSE live tail** |
+| GET | `/v1/sessions/{id}/items` | `list_session_items` (`:16578`) | paginated transcript (web hydration; runner transcript rebuild) |
+
+### Elicitations / approvals
+| POST | `/v1/sessions/{id}/elicitations/{eid}/resolve` | `resolve_elicitation` (`:18013`) | dedicated resolve URL (also via `approval` event) |
+| GET | `/v1/sessions/{id}/elicitations/{eid}` | `get_elicitation` (`:18083`) | fetch one (pre-auth `/approve/…` deep-link) |
+
+### Native-harness hooks (runner / vendor CLI → server, over the tunnel)
+| POST | `…/policies/evaluate` | `evaluate_policy` (`:15973`) | proto policy hook (claude PreToolUse/PostToolUse) |
+| POST | `…/hooks/permission-request` | `claude_permission_request_hook` (`:15629`) | claude-native permission long-poll |
+| POST | `…/hooks/codex-elicitation-request` | `codex_elicitation_request_hook` (`:16205`) | codex-native |
+| POST | `…/hooks/antigravity-elicitation-request` | `antigravity_elicitation_request_hook` (`:16278`) | (out of scope) |
+| POST | `…/hooks/cursor-permission-request` | `cursor_permission_request_hook` (`:16371`) | (out of scope) |
+| POST | `…/hooks/native-permission-request` | `native_permission_request_hook` (`:16478`) | generic native |
+
+### Agent / contents
+| GET | `…/agent` | `get_session_agent` (`:19807`) · PUT `update_session_agent` (`:19927`) | session-scoped agent spec |
+| GET | `…/agent/contents` | `get_session_agent_contents` (`:19850`) | bundle contents (runner fetches these) |
+| POST | `…/mcp` | `mcp_proxy` (`:20040`) | MCP proxy passthrough |
+
+### Resources (terminals / files / environments / child sessions) — all proxied to the runner
+`…/child_sessions` (`:16639`), `…/resources` (`:16719`), `…/resources/environments[...]`
+(`:17034, 17053, 17672, 17707, 17753, 17778, 17810 GET/PUT/PATCH/DELETE, 17954 shell`),
+`…/resources/terminals` (`:17075 list, :17107 create, :17189 get, :17210 transfer,
+:17292 delete`), `…/resources/files` (`:17340 list, :17384 upload, :17478 meta,
+:17511 content, :17559 delete`), `…/resources/{rid}` (`:17991`).
+
+### Sharing / permissions
+`PUT …/permissions` (`grant_permission`, `:19517`), `DELETE …/permissions/{uid}`
+(`revoke_permission`, `:19579`), `GET …/owner` (`:19627`), `GET …/permissions` (`:19651`).
+
+### WebSockets (client↔server)
+- `WS /v1/sessions/updates` (`session_updates`, `:14530`) — **sidebar**. C→S `watch`; S→C
+  `snapshot`/`changed`/`removed`/`heartbeat`.
+- `WS …/resources/terminals/{tid}/attach` (`attach_terminal_by_resource_id`,
+  `terminal_attach.py:131`) — raw xterm shuttle to runner tmux.
+
+### App-level (outside the sessions router)
+`GET /health` (`app.py:1659`), `GET /api/version` (`:1727`), plus `/v1/me`, `/v1/info`
+(capabilities probe), `/v1/users/search`, accounts/oidc auth routes, policy-registry, and the
+server-side ingress tunnels `WS /v1/runners/{id}/tunnel` (`runner_tunnel.py:278`) and
+`WS /v1/hosts/{id}/tunnel` (`host_tunnel.py:121`).
+
+**Confirmed by trace** (root spans across both corpus convs): `POST /v1/sessions`,
+`POST …/events`, `GET …/{id}`, `GET …/stream`, `PATCH …/{id}`, `GET …/agent`,
+`GET …/items`, `GET …/agent/contents`, `GET /api/version`,
+`POST …/policies/evaluate`, `GET …/resources/terminals`, `GET …/skills`.
+
+---
+
+## Q6. STREAM vs DURABLE; SSE event naming
+
+**DURABLE (persisted to conversation history)** — decided by `_extract_persistent_item_from_sse`
+(`sessions.py:8930`): only **`response.output_item.done`** carrying a `message` /
+`function_call` (status `completed` only — interim statuses are skipped, `:8987`) /
+`function_call_output`, plus `compaction` items. The union literally tags this variant
+*"Persistent (POST + SSE replay) — wraps conv-store items"* (`schemas.py:3753-3754`).
+The relay also persists **resource lifecycle** events
+(`session.resource.created/.deleted` → `resource_event` conv item, `:9653`) and **routing
+decisions** (`:9681`) so a reconnecting client rediscovers them in the snapshot. Text deltas
+are accumulated (`text_acc`, `:9544`) and **flushed to a durable message** only at a
+function-call boundary (`:9586-9597`) or any terminal `response.*` (`:9618-9634`) — so the
+*streamed* deltas themselves are transient, but the *final* text is durable.
+
+**TRANSIENT (SSE-only, never persisted):** everything else — `session.*` lifecycle &
+presence, the `response.*.delta` family, reasoning events, the Responses-API turn lifecycle
+(`response.created/.in_progress/.completed/.failed/.cancelled/.queued/.incomplete`),
+`response.elicitation_request/_resolved`, `response.error/.retry`, `response.compaction.*`,
+heartbeats. (Full membership: `ServerStreamEvent` union, `schemas.py:3724-3782`, with explicit
+"Transient (SSE-only)" / "Persistent" section comments.)
+
+**Naming — three families:**
+- **`response.*`** — turn/output lifecycle, deltas, elicitations (mirrors the OpenAI Responses
+  API surface). 24 literals incl. `response.output_text.delta`, `.output_item.done`,
+  `.reasoning_text.delta`, `.completed`, `.failed`, `.cancelled`, `.elicitation_request`.
+- **`session.*`** — Omnigent session/sidebar/presence lifecycle (`session.status`,
+  `.input.consumed`, `.presence`, `.model`, `.reasoning_effort`, `.usage`, `.agent_changed`,
+  `.todos`, `.resource.created/.deleted`, `.child_session.updated`,
+  `.changed_files.invalidated`, `.heartbeat`, `.created`, `.superseded`,
+  `.terminal_pending`, `.sandbox_status`, `.skills`, `.model_options`, `.collaboration_mode`,
+  `.terminal.activity`).
+- **`external_*`** — *input* vocabulary a native forwarder POSTs into `/events`
+  (`_ALLOWED_EVENT_TYPES`, `sessions.py:800-822`) so the server re-publishes/persists
+  terminal-observed activity (assistant message, conversation item, status, model/effort
+  change, usage, compaction status, subagent start, …). **Not an SSE output prefix** — these
+  are how native turns get *into* the server.
+
+`_format_sse` (`:1857`): `event: <type>\ndata: <json>\n\n`; terminal nameless `data: [DONE]`.
+Reasoning: streamed as `response.reasoning_text.delta` (transient); persisted on native (the
+forwarder mirrors it as items), recomputed/not-stored on SDK unless the harness emits an
+`output_item.done` for it.
+
+---
+
+## Q7. Create / fork / switch-agent / archive / delete / close endpoints
+
+(Detailed branch logic from a focused read of each handler.)
+
+- **Create** — `POST /v1/sessions` (`create_session`, `:13688`). JSON binds an existing
+  `agent_id` → returns `SessionResponse`; multipart (`metadata` + `bundle`) creates a
+  session-scoped agent + conv row in one txn → `CreatedSessionResponse`. Grants caller
+  `LEVEL_OWNER` and `_announce_session_added` (push to other tabs via WS discovery). CSRF:
+  `require_json_or_multipart_content_type` + `require_trusted_origin` (`:13683-13686`).
+- **Fork** — `POST /v1/sessions/{src}/fork` (`fork_session`, `:15180`), status 201, gate
+  `LEVEL_READ`. **Cannot fork a sub-agent** (400, `:15238`). `fork_conversation`
+  (`sqlalchemy_store.py:2266`) deep-copies items with fresh ids preserving
+  `position`/`response_id`; `up_to_response_id` truncates; **drops instance-scoped labels**
+  (native bridge ids, context-token metrics) and does **not** copy
+  `external_session_id`/`workspace`/`git_branch`; optional cross-family harness switch resets
+  model/effort; native targets carry history via `FORK_CARRY_HISTORY` label. Grants owner +
+  announces.
+- **Switch agent** — `POST /v1/sessions/{id}/switch-agent` (`switch_session_agent`, `:15415`),
+  gate `LEVEL_EDIT`. **Idle-only — 409 if status `running`** (`:15481`). Loads the target
+  bundle **before** committing (fail-closed). `switch_conversation_agent`
+  (`sqlalchemy_store.py:2576`) deletes the old session-scoped agent, clones the target,
+  repoints `agent_id`, resets model/effort on cross-family, **clears `external_session_id`**
+  (`:2663`) so the new harness cold-starts next turn, and stamps a **switch-back** label.
+  Publishes `session.agent_changed`; resets runner resources in the background.
+- **Archive / unarchive** — `PATCH /v1/sessions/{id}` with `archived` (`update_session`,
+  `:14795`). **Owner-only** (`required_level=LEVEL_OWNER` when `archived` is set, `:14823`).
+  `archived` is a plain DB column (`SqlConversation.archived`), **not** a label/title marker;
+  archived rows are hidden from list by default. (Same handler does rename via `title`,
+  model/effort/cost-mode overrides, runner rebind, label edits.) Does **not** publish to WS
+  updates (pull-based); does forward best-effort model/effort to the live runner.
+- **Close** (sub-agent close) — not a dedicated route; set by `sys_session_close`. Gated by
+  `is_session_closed(labels, title)` (`session_lifecycle.py:70`): true when label
+  `omnigent.closed == "true"` **OR** the legacy title infix `:closed:`. `post_event` rejects
+  new user input on a closed session (409, `:18306`); reads still allowed.
+- **Delete** — `DELETE /v1/sessions/{id}` (`delete_session`, `:19358`), **owner-only**
+  (admins bypass). Best-effort cleanup: runner-side `DELETE …/resources` (falls back to local
+  terminal-registry cleanup if runner offline → delete still proceeds), session files +
+  artifacts, optional worktree removal (`?delete_branch=true` → `git worktree remove --force`
+  + `git branch -D` on the host), `delete_conversation`, cache evictions, and managed-host
+  teardown (terminate sandbox + delete host row + revoke launch token) for `host_type=managed`.
+  No SSE/WS publish on delete; watchers see a `removed` delta on the next 4 s tick.
+
+---
+
+## Per-harness notes (server side)
+
+| Aspect | claude-sdk / codex (SDK) | claude-native / codex-native | polly / custom |
+|---|---|---|---|
+| User msg persist | server appends (I1), single writer | **bypass** — not persisted; transcript forwarder is writer; `pending_inputs` optimistic entry | same as claude-sdk |
+| Durable output | relay persists `output_item.done` | forwarder POSTs `external_conversation_item` → server persists | same as claude-sdk |
+| Status edges | runner `session.status` → relay → `_publish_status` | `external_session_status` → `_publish_status` | same as claude-sdk |
+| Model/effort mid-session | `runner_body.model_override` next turn | best-effort: `external_model_change` persists column + `session.model` | same as claude-sdk |
+| Interrupt | runner `executor.interrupt_session()` | bridge inject Escape (claude) / `turn/interrupt` RPC (codex) | same as claude-sdk |
+| Policy | in-proc `_evaluate_input_policy` at POST /events | **also** the HTTP hook `evaluate_policy` (PreToolUse) → de-duped against in-flight web prompts (`:16065`) | same as claude-sdk |
+| Live trace in corpus | **yes** (claude-sdk) | claude-native yes; **codex-native NO (creds expired)** | (run on claude-sdk) |
+
+codex / codex-native are covered from code + CUJ-ANALYSIS §4 matrix + structural analogy to
+claude (the server path is identical except the runner-side executor); **no live trace**
+because the Databricks AI-gateway token is expired (403).
+
+---
+
+## Failure branches & gaps (server-owned)
+
+- **Runner-offline-on-message:** persist OK, forward fails → `idle` published, runner resumes
+  on reconnect; client bubble may sit until snapshot reconciliation (`:8705`).
+- **No runner ever bound (fresh item):** 503 `RUNNER_UNAVAILABLE` **before** persist
+  (`:19073`), unless host can relaunch (`:18920-19006`).
+- **Hard runner affinity / no failover** (`routing.py:110-116`) — pinned-runner-offline
+  strands the session.
+- **`failed` sticky vs trailing idle** (`_publish_status` `:5389`) — intentional, native-driven.
+- **`_session_status_cache` is per-process** (`:837`) — multi-replica sidebar may read a
+  status another replica's relay wrote (open question).
+- **Permissions disabled ⇒ `accessible_by=None` returns ALL sessions** — cross-user leak risk
+  (CUJ-ANALYSIS §6 [§2.D]).
+- **Native FIFO/pending-input desync** — server has no item id for native web messages, only
+  `pending_id`; double-bubble risk if client dedup mis-orders (CUJ-ANALYSIS §6 [§2.A]).
+- **`evaluate_policy` has no own span** — the `policy.evaluate` span is the engine's
+  (`engine.py:255`), so in a trace the native hook = `POST …/policies/evaluate` FastAPI span
+  with a `policy.evaluate` child.
+
+## Open questions
+
+1. Relay-restart window: can durable `output_item.done` events be missed during a
+   `_relay_runner_stream` heartbeat-timeout flap before `_ensure_runner_relay_ready` respawns it?
+2. Multi-replica: status/usage caches are in-memory — how is sidebar coherence maintained
+   across replicas (sticky sessions? or accepted staleness)?
+3. Native dedup: confirm `cleared_pending_id` + client FIFO is the *only* guard against a
+   double user bubble on native (no server item id exists at dispatch).
+4. `refresh_state=true` snapshot — exact set of runner overlays re-pulled vs AP-cache.

--- a/designs/master-arch/cuj-answers/tools-mcp-shells.md
+++ b/designs/master-arch/cuj-answers/tools-mcp-shells.md
@@ -1,0 +1,239 @@
+# CUJ Answers — Tools / MCP / Shells / Sandbox / Timers
+
+Domain: tool surface + custom MCP + OmniBox sandbox + shells/terminals + timers.
+Companion architecture doc: `../architecture/tools-omnibox.md`. Every claim is
+`file:line`-anchored; the `sys_os_shell` flow is also trace-confirmed.
+
+---
+
+## Q1. The Omnigent `sys_*` surface — tool groups + gating
+
+All builtins register in `omnigent/tools/manager.py` (`ToolManager.__init__` `:105`). Groups
+and their gates:
+
+| Group | Tools | Gate | Anchor |
+|---|---|---|---|
+| File/shell | `sys_os_read/write/edit/shell` | spec `os_env:` set (or pre-resolved env) | `manager.py:525` |
+| Terminals | `sys_terminal_launch/send/read/list/close` | spec non-empty `terminals:` | `manager.py:563` |
+| Async/inbox | `sys_call_async`, `sys_read_inbox`, `sys_cancel_async` | `async_enabled` (default **True**; `async:false` kills) | `manager.py:200`, `spec/types.py:1537` |
+| Task lifecycle | `sys_cancel_task` | **always** | `manager.py:490` |
+| Timers | `sys_timer_set`, `sys_timer_cancel` | `timers:true` (default **False**) | `manager.py:231` |
+| Sub-agents (read) | `sys_session_list/get_history/get_info` | **always** | `manager.py:427` |
+| Sub-agents (write) | `sys_session_send/close`, `sys_list_models`, `sys_advise_models` | `tools.agents` OR `spawn:true` | `manager.py:446` |
+| Sub-agents (create) | `sys_session_create` | `spawn:true` only | `manager.py:468` |
+| Sub-agents (share) | `sys_session_share` | `agent_session_sharing` (`none`/`non-public`/`public`) | `manager.py:441` |
+| Agents | `sys_agent_get/download/list` | **always** (auth-gated server-side) | `manager.py:471` |
+| Models | `sys_list_models` | with dispatch grant | `manager.py:457` |
+| Policy | `sys_add_policy`, `sys_policy_registry` | **always** | `manager.py:186` |
+| Comments | `list_comments`, `update_comment` | **always** (cannot be spec-declared) | `manager.py:511` |
+| Skills/web/files | `load_skill`(+`read_skill_file`), `web_search`, `web_fetch`, `upload_file`, `download_file`, `list_files`, `search_conversations`, `export_agent` | `load_skill` always; rest via `tools.builtins` | `manager.py:266`/`:288` |
+
+Important: the opt-in flags control **advertisement**, not authority — spawn writes are
+child-only and `sys_session_share` is owner-authority-bounded, both enforced at the server/dispatch
+layer regardless (`manager.py:420`). MCP tools are **not** registered here — they're runner-owned.
+
+---
+
+## Q2. Custom (user-defined) MCP servers — declaration, transport, allowlist, pooling
+
+- **Declaration**: `tools.mcp` in agent YAML → `MCPServerConfig` (`spec/types.py:~847`).
+  - `transport: "http"` (default) → SSE (`mcp.client.sse.sse_client`); `url`, `headers`.
+  - `transport: "stdio"` → subprocess (`mcp.client.stdio.stdio_client`); `command`, `args`, `env`.
+    Validator rejects HTTP fields on stdio and vice-versa.
+  - Per-server **allowlist** of bare tool names (filtered in `_mcp_tool_schema` `mcp_manager.py:129`);
+    per-tool `timeout`/`retry` (inherit `tools.timeout`/`tools.retry`).
+- **Pooling** (`RunnerMcpManager`, `runner/mcp_manager.py`): lazy connect; **8-entry LRU**
+  (`_POOL_SPEC_CAPACITY = 8` `:45`) keyed by **spec hash** (`compute_spec_hash` over
+  `spec.mcp_servers` + stdio cwd `:74`); `_touch` `:470` / `_evict_if_needed` `:476` (head pops,
+  connections closed async). Tools namespaced **`{server}__{tool}`** (`:139`) so collisions across
+  servers are impossible.
+- **Inline approval**: a custom MCP can request `elicitation/create` mid-call → `mcp_elicitation`
+  event → web approval card → resolved/declined (`_build_elicitation_callback` `:182`; declined
+  when no server client `:218`).
+
+> Cross-ref: the **RUNNER SME** owns the routing/pool-lifecycle mechanism; this answer owns the
+> *definition shape* (transport, allowlist, namespacing) + the LRU facts.
+
+---
+
+## Q3. MCP routing — who routes a call where? (custom MCP vs `sys_*`)
+
+**Both** kinds use one seam; the **server** is the policy authority, the **runner** is the executor.
+
+1. Harness emits a tool call:
+   - **SDK harnesses** (claude-sdk/codex/Polly): the SDK invokes the MCP tool in-process.
+   - **Native harnesses** (claude-native/codex-native): the vendor CLI POSTs to a localhost bridge
+     relay (Bearer auth) → `_relay_tool_executor` (`runner/app.py:13086`).
+2. Runner `ProxyMcpManager.call_tool` (`proxy_mcp_manager.py:178`) POSTs to **server**
+   `POST /v1/sessions/{id}/mcp`.
+3. Server evaluates **TOOL_CALL** policy (`_evaluate_tool_call_policy`, `server/routes/sessions.py:1077`).
+4. On ALLOW, server POSTs **runner** `POST /v1/sessions/{id}/mcp/execute` (`app.py:17829`). The
+   runner dispatches **uniformly**:
+   - **bare names** (`sys_os_*`, `sys_terminal_*`, async, etc.) → `tool_dispatch.execute_tool`
+     (`runner/tool_dispatch.py:10`) using the session's terminal registry / inbox / **runner cwd**.
+   - **namespaced `server__tool`** → `RunnerMcpManager` (live stdio/http connections).
+5. Result flows back; server evaluates **TOOL_RESULT** policy, returns up through `/mcp`.
+
+So: **custom-MCP tools and `sys_*` tools take the *same* server-gated path**; the only difference
+is the final dispatch fork inside `/mcp/execute` (RunnerMcpManager vs runner-local executor). The
+runner also has a fast-path ALLOW/DENY before dispatch; ASK escalates to the server.
+
+**Out-of-turn exception**: native bridges additionally run a separate `serve-mcp` MCP stdio server
+(in the vendor CLI's `settings.json`) exposing **only `sys_os_*`** against the workspace cwd, **no
+sandbox** (`claude_native_bridge.py:3116`) — the vendor CLI's file access *between* Omnigent turns.
+(`serve-mcp` is the native bridge's argparse subcommand, **not** a top-level `omnigent` command —
+corrects CUJ-ANALYSIS §2.C "exposed via serve-mcp subcommand".)
+
+---
+
+## Q4. Shells — creation, cwd resolution, the two paths, orphan reaping
+
+**Two ways shells reach agents:**
+1. **`sys_os_shell`** — one-shot command in the agent's **shared `OSEnvironment`**
+   (`os_env.shell()` `os_env.py:294`). All four `sys_os_*` share **one** `OSEnvironment` instance
+   so cwd/sandbox/env stay consistent across calls (`build_os_env_tools` `os_env.py:378`).
+2. **`sys_terminal_*`** — **persistent named tmux panes** (`TerminalRegistry.launch`
+   `terminals/registry.py:160`), keyed `(conversation_id, terminal_name, session_key)`, surviving
+   across turns; tmux `remain-on-exit on` keeps dead panes for inspection (`terminal.py:156`).
+
+**Working-directory resolution precedence** (`_resolve_cwd`, `sys_terminal.py:752`, first match wins):
+1. **LLM `cwd_override`** (vetted vs `allow_cwd_override`).
+2. **`terminal.os_env.cwd`** (skip if `None`/`""`/`"."`/`"./"` or the `"inherit"` sentinel).
+3. **`spec.os_env.cwd`** (same meaningful-cwd test).
+4. **`ctx.workspace`** (per-task workspace from `runtime/workflow.py`).
+5. *(implicit)* if all miss → returns `None` → caller falls back to **host/runner cwd**.
+
+Trace confirms tier 4/5: the `sys_os_shell` TOOL_RESULT carried
+`cwd=/Users/.../omnigent-worktrees/traces` (the runner workspace).
+
+**Reaping (two reapers):**
+- **Orphan reaper** (`reap_orphaned_terminals` `terminal.py:581`) at **runner startup**: each
+  instance dir records its **owner pid**; the sweep `tmux kill-server`s every instance whose owner
+  pid is gone and removes the dir (markerless dirs left alone). Fixes the one-tmux-server-per-session
+  leak from SIGKILL'd runners.
+- **Idle pane reaper** (`pane_reaper.py`, #1349): background loop reaping **native** panes after a
+  **30-min** idle window (`OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S`, `0` disables), 3-signal busy check
+  with a second pre-teardown re-check; pane-scoped teardown.
+
+---
+
+## Q5. OmniBox — the OS sandbox (3 backends × 3 isolation layers)
+
+**OmniBox = the OS-level sandbox**, not a web component. Resolution in `inner/sandbox.py`
+(`resolve_sandbox` `:371`, `_default_sandbox_for_platform` `:806`).
+
+**`OSEnvironment` modes**: `caller_process` (no isolation, in-process) · `fork` (workspace copy) ·
+`sandbox` (one of the backends below).
+
+**Sandbox backends:**
+- **`linux_bwrap`** — bubblewrap: mount/PID/UTS/IPC namespaces (`--unshare-*`), `--ro-bind-try`
+  read roots, `--proc`/`--dev`, **tmpfs-masked dotfiles** in cwd (unless `cwd_allow_hidden`;
+  `.venv` default), **hardened seccomp denylist**.
+- **`darwin_seatbelt`** — `sandbox-exec -f <profile>` SBPL, `(deny default)` baseline + selective
+  allows; **no namespaces, no seccomp** (capability-level); masking is access-deny (not invisible);
+  deny-wins.
+- **`windows_jobobject`** — Job Object process-tree containment + resource limits; **no FS/network
+  isolation**.
+- **`none`** — the only explicit opt-out.
+Fail-loud: a missing backend binary errors at sandbox **build** (not silently unsandboxed).
+
+**The 3 isolation layers:**
+1. **Filesystem isolation** — only granted paths visible (bwrap binds; seatbelt deny-default);
+   dotfiles masked.
+2. **Default-deny L7 egress proxy** (`inner/egress/`):
+   - DSL rules `METHODS host/glob`, default deny (`rules.py:185`).
+   - DNS-safe host allowlist `[A-Za-z0-9.-]` (`rules.py:49`) → kills NUL/percent/CRLF smuggling
+     (cites the Claude Code sandbox-runtime CVE class).
+   - **Private-destination block** (default on): resolve-**once** then refuse any non-global IP —
+     RFC1918/loopback/link-local/ULA/reserved/TEST-NET, **CGNAT 100.64**, multicast, and
+     **cloud-metadata traps** (`169.254.169.254`, Azure `168.63.129.16`) (`proxy.py:124`/`:914`).
+     Resolve-once defeats DNS rebinding.
+   - MITM with per-sandbox CA; in-ns relay → parent proxy over a Unix socket (the *only* egress path).
+3. **Credential injection** (`inner/credential_proxy.py` + `egress/proxy.py`):
+   - **Swap-on-access (default)**: nothing credential-shaped in the sandbox; tool sends no
+     `Authorization`, proxy injects `<scheme> <real>` for the bound host (`proxy.py:1145`).
+   - **Opt-in placeholder**: parent injects a single-use `oa_cred_*` token; client sends it; proxy
+     swaps to real (`proxy.py:1129`).
+   - **Leak guard**: wrong-host/unknown `oa_cred_*` → **403** (`proxy.py:1135`); a real client-set
+     `Authorization` is forwarded untouched (no clobber `:1125`).
+   - Real secret lives only in the parent + proxy table; **never** serialized into `SandboxPolicy`
+     (`sandbox.py:151`), argv, or sandbox disk.
+
+---
+
+## Q6. Timers + Async/Inbox (definitions)
+
+- **Timers** (gated `timers:true`, default False): `sys_timer_set` returns a `timer_id`
+  **synchronously** (`timer.py:179`); the firing later arrives as `[System: timer X fired]` via the
+  `async_work_complete` drain with `kind="timer"` (`manager.py:170`). ⚠️ **sessions-native firing
+  path is `NotImplementedError`** (`timer.py:220`); `sys_timer_cancel` returns no-active-timer.
+- **Async/inbox** (gated `async_enabled`, default True): `sys_call_async` fire-and-forget;
+  results drain via the `async_work_complete` inbox — auto-collected each loop iteration
+  (`_drain_async_completions`, RUNTIME-owned) or pulled by `sys_read_inbox` (`async_inbox.py:240`);
+  `sys_cancel_async` aliases `sys_cancel_task`. (RUNTIME SME owns the drain mechanics.)
+
+---
+
+## Trace evidence (the load-bearing case)
+
+Corpus `conv_63542a5f92e24956812e19b104eac0e9` (`sys_os_shell` running `echo TRACETEST123`):
+
+**Trace `cfb59197f6f9`** (the `POST /events` trace) — the MCP + policy chain:
+```
+omni-server policy.evaluate REQUEST      ALLOW
+omni-server policy.evaluate LLM_REQUEST  ALLOW
+omni-server POST /v1/sessions/{id}/mcp           ← omni-runner:POST          (runner → server)
+omni-server policy.evaluate TOOL_CALL    ALLOW tool=sys_os_shell  ← /mcp     (THE GATE)
+omni-runner POST /v1/sessions/{id}/mcp/execute   ← omni-server:POST          (server → runner exec)
+omni-server policy.evaluate TOOL_RESULT  ALLOW tool=sys_os_shell  ← /mcp
+omni-server policy.evaluate LLM_RESPONSE ALLOW
+```
+- TOOL_CALL `policy.content` = `{"name":"sys_os_shell","arguments":{"command":"echo TRACETEST123"}}`.
+- TOOL_RESULT `policy.content` carried `"cwd":"/Users/.../traces"` → confirms cwd tier 4/5 (runner workspace).
+
+**Trace `f98feda729f6`** (harness OpenInference tree):
+```
+omni-harness agent:claude-sdk
+omni-harness   tool:sys_os_shell  (openinference.span.kind=TOOL, tool.name=sys_os_shell)
+```
+
+**Also**: `omni-runner GET /v1/sessions/{id}/resources/terminals` (traces `906c…`/`7c4b…`) — the
+runner probing the **terminal registry** for the session (confirms `sys_terminal_*` registry is live
+even on a non-terminal turn).
+
+Mechanism confirmed by **both** code and trace: the runner→server `/mcp` gate, the four policy
+phases, the server→runner `/mcp/execute` exec, and the OpenInference `tool:sys_os_shell` span.
+
+---
+
+## Per-harness deltas (in-scope only)
+
+- **claude-sdk**: tools in-process; `tool:` span on omni-harness; all gating via `ToolManager(spec)`.
+  Sandboxed claude-sdk on macOS **crashes** vs degrading (#517 part-1, no PR).
+- **claude-native**: vendor CLI → bridge relay → same server gate; out-of-turn `serve-mcp` exposes
+  only `sys_os_*` (no sandbox).
+- **codex / codex-native**: structurally identical to claude (SDK and native respectively) —
+  **no live trace** (AI-gateway creds expired, 403).
+- **polly** (custom agents): runs on a host harness (typically claude-sdk) and **inherits its tool
+  behavior**; `ToolManager` registers from the custom agent's own spec (`os_env`/`terminals`/`tools.mcp`).
+
+---
+
+## Failure branches & gaps
+
+- macOS sandboxed claude-sdk **crashes** (#517 part-1, no PR).
+- `credential_proxy` SECURITY: parent-side `subprocess.run(shell=True)` + arbitrary file reads on a
+  trusted-spec assumption (`credential_proxy.py:190`, #1542, no PR).
+- **Timers** unusable on sessions-native (`NotImplementedError`).
+- Egress: non-global resolution → block/403; DNS rebind defeated by resolve-once; IPv6 literals +
+  Unicode IDNs rejected (documented limit).
+- MCP pool: 9th distinct spec evicts LRU head (connections closed async); inline elicitation declined
+  when no server client wired.
+- Terminal launch: tmux missing / pane exits early → `RuntimeError` (wrapped as JSON error);
+  concurrent same-key launch → second-arrival wins.
+
+## Cross-references
+- **RUNNER SME**: `RunnerMcpManager` pool/prewarm, outbound `tools/call`, `/mcp/execute` internals,
+  `runner/policy.py` fast-path.
+- **RUNTIME SME**: `async_work_complete` drain, inbox queue, timer firing task (when implemented).
+- **POLICY SME**: `_evaluate_tool_call_policy`, elicitation registry, fail-closed/open phase set.

--- a/designs/master-arch/cuj-answers/tui-vs-web.md
+++ b/designs/master-arch/cuj-answers/tui-vs-web.md
@@ -1,0 +1,251 @@
+# CUJ Answers — TUI / REPL vs Web UI
+
+> Domain: the TUI/REPL client (`omnigent/repl/`) + client transport (`OmnigentClient`).
+> Evidence is **code-based** (corpus is headless → no `omni-tui` spans; verified §6).
+> Server internals are cross-referenced, not re-derived (see SERVER doc).
+> Companion: `architecture/tui-repl.md`.
+
+---
+
+## Q1. TUI vs WebUI state: what the REPL renders, how it consumes the SSE stream, and how it reconciles streaming deltas vs durable items (does it dedupe by itemId like the web?)
+
+**What the REPL renders:** a single scrolling rich transcript for the **currently displayed
+session only** — `◆ <agent>` response headers, streamed assistant prose, reasoning blocks,
+tool-call/tool-output panels, compaction notices, inline approval (y/n) prompts, error lines,
+and a live spinner + elapsed-time "working" indicator. A `↓`-selector shows the sub-agent
+tree (built from events on the same parent stream). It is a *linear terminal* view, not the
+web's multi-panel app (no files/terminals/comments/subagents-rail panels, no sidebar).
+
+**How it consumes the SSE stream:** `_SessionsChatReplAdapter` runs **one persistent
+subscription** to `GET /v1/sessions/{id}/stream` (`_repl.py:2012-2052`,
+`client.sessions.stream`). Every event is pushed through a **single `_on_event` callback**
+(`_render_session_event`, `_repl.py:3230`) that renders directly to the terminal — there is
+**no queue/drain loop**; the pump renders both user-initiated and autonomous turns. It
+auto-reconnects with 0.5→5s backoff on transport errors (`_repl.py:2056-2100`); the server
+does no replay on reconnect (`_sessions.py:989`). `send()` is thin: POST the message, set
+`_is_streaming`, await `_turn_done` (with a 1 Hz `sessions.get` backstop poll because httpx's
+ASGI transport doesn't flush eagerly, `_repl.py:2196-2209`).
+
+**Reconciliation — does it dedupe by itemId like the web? → NO.**
+
+| | Web UI | TUI / REPL |
+|---|---|---|
+| Durable-vs-stream dedup key | **`ctx.itemId`** (`web/src/lib/blockStream.ts`, CUJ-ANALYSIS §2.E:258-260) | **byte-equal text, multiset consume-on-match** (`_TurnProseTracker`, `_repl.py:2787-2883`) |
+| Optimistic user bubble | held until `session.input.consumed` (`chatStore.send`) | `_pending_local_user_sends` counter suppresses the echoed `session.input.consumed` (`_repl.py:2171, 3384`) |
+| Tool-call dedup | by item/call id | `completed_tool_call_ids` set (`_sessions_chat.py:982`) + `_live_call_id_to_tool_metadata` keyed by `call_id` (`_repl.py:3629`) |
+
+Mechanism (TUI): each `TextDelta` sets `_saw_text_deltas=True` and feeds
+`prose_tracker.on_delta` (`_repl.py:3446`). At a content-block boundary (tool call / the
+`message` item) `_flush_inflight_assistant_text` commits the segment and records its joined
+text (`:3171-3211`). The relay persists each prose segment and **re-publishes it as
+`response.output_item.done` after `_saw_text_deltas` was already reset** — so when that
+`message`/assistant item arrives, the renderer calls `prose_tracker.consume_match(item)`:
+match (byte-equal to a committed segment) ⇒ **suppress** (already streamed); miss ⇒
+**render** (genuinely non-streamed) (`:3586-3596`). The reason it can't use itemId: the
+streaming deltas (`response.output_text.delta`) carry **only a `delta` string, no id**, so
+there is nothing to key on until the durable item lands.
+
+This is the **single durable-vs-streaming merge point** for the TUI, and it is structurally
+weaker than the web's id-based dedup (text-equality can in theory mis-match two byte-identical
+segments; the multiset consume mitigates the common case).
+
+---
+
+## Q2. The full set of TUI→server requests (REST + SSE) via OmnigentClient — and how it contrasts with the web UI's larger surface
+
+**TUI surface (all over the one `httpx.AsyncClient` in `OmnigentClient`, all `/v1/`):**
+
+- `POST /v1/sessions` (multipart bundle) — create session, lazily on first send
+  (`sessions.create`, `_sessions.py:338`).
+- `POST /v1/sessions/{id}/events` — the workhorse: user message; **interrupt**
+  (`{type:interrupt}`); **compact** (`{type:compact}`); **approval verdict**; client-tool
+  output; skill slash command (`sessions.post_event`, `:814`).
+- `GET /v1/sessions/{id}` — snapshot/status; turn-done backstop poll (`sessions.get`, `:793`).
+- `GET /v1/sessions/{id}/stream` (SSE) — the one live event stream (`sessions.stream`, `:980`).
+- `GET /v1/sessions` — resume picker, `/switch`, `/history` (`sessions.list`, `:394`).
+- `GET /v1/sessions/{id}/items` — `/history`, `/context`, log dump (`:648`).
+- `GET /v1/sessions/{id}/child_sessions` — subagent tree (`:684`).
+- `PATCH /v1/sessions/{id}` — `{runner_id}` bind/unbind; `{model_override}` (`/model`);
+  `{reasoning_effort}` (`/effort`); `{archived}` (`:450,481,504,535,580`).
+- `POST /v1/sessions/{id}/elicitations/{eid}/resolve` — approval via dedicated URL
+  (alternate to the in-band `{type:approval}` event) (`:845`).
+- `POST /v1/sessions/{src}/fork` — `/fork` (`:887`).
+- `POST /v1/sessions/{id}/files` (multipart) — `@`-file attachments (`_files.py`).
+- `GET /v1/sessions/{id}/agent` — client-tool validation + `/model` harness readout
+  (`_client.py:303`).
+- Raw (non-SDK) `httpx.get` probes: `GET /v1/sessions/{id}` (wrapper label, `chat.py:1352`),
+  `GET /v1/info` (accounts, `chat.py:1597`), runner status (`chat.py:1989`).
+
+**Contrast with the web UI (its surface is much larger):**
+
+| Capability | Web UI | TUI |
+|---|---|---|
+| **`WS /v1/sessions/updates`** (sidebar watch-set: snapshot + deltas + heartbeat) | **yes** (CUJ-ANALYSIS §2.E:242-243) | **NO** — no sidebar, no watch-set WS at all |
+| **`WS /health/subscribe`** | yes | **NO** |
+| Live session list / badges | via WS updates | only `GET /sessions` on demand (picker/`/switch`) |
+| `POST /v1/sessions/{id}/switch-agent` (switch agent in place) | yes (`SwitchAgentDialog`) | **NO** (no SDK method; `/switch` only re-points SSE to another session) |
+| Projects `GET /v1/sessions/projects` | yes | no |
+| Sharing/permissions `GET /v1/users/search`, permissions modal | yes | no |
+| Comments on files (`CommentsPanel`, `useComments`) | yes | no |
+| Policies admin `GET /policy-registry`, Policies page | yes | no |
+| Members admin, presence avatars | yes | no |
+| Capabilities probe `GET /v1/info` | yes (gates UI) | yes (only the accounts first-run probe) |
+| Files/terminals/diffs panels (Monaco, xterm) | yes | no (terminal-attach is the native-harness path, not `run_repl`) |
+| Live channel for a session | SSE `/stream` | SSE `/stream` (same) |
+
+So both clients converge on the **same SSE `/stream` + same `/sessions/{id}/events` write
+path**, but the web adds (a) a **WebSocket sidebar/health** plane and (b) a large set of
+collaboration/admin REST routes the TUI simply never calls. **The TUI has no WebSocket
+usage at all** — its only push channel is the per-session SSE stream.
+
+---
+
+## Q3. Slash commands (/model, /effort, /compact, resume) and how they map to API calls
+
+Registry `@_cmd()`→`COMMANDS` (`_repl.py:4508-4521`), dispatch `handle_slash_command`
+(`:8254`). Full table in `architecture/tui-repl.md §9`. The CUJ-relevant ones:
+
+- **`/model [name]`** (`_cmd_model`, `:4974`) → `session.set_model_override(name)` →
+  **PATCH /v1/sessions/{id}** `{model_override}` (`_sessions.py:535`). Before the session
+  exists, it's cached on the adapter (`_model_override`, `_repl.py:1370`) and attached to the
+  first turn's `post_event` payload as `model_override` (`:2163-2164`). Same semantics as the
+  web's `/model` (SlashCommandMenu) and NewChatDialog's model picker.
+- **`/effort [level]`** (`_cmd_effort`, `:4654`) → `session.set_reasoning_effort(level)` →
+  **PATCH /v1/sessions/{id}** `{reasoning_effort}` (`_sessions.py:504`). Valid set is
+  family-aware (`none/minimal/low/medium/high/xhigh/max`, `:4626`) per
+  `omnigent/reasoning_effort.py`. Mirrors the web's `/effort` + NewChatDialog effort picker.
+  (claude-native mirrors an in-pane `/effort` back to the row, per CUJ-ANALYSIS §4 — that's
+  the native path, not `run_repl`.)
+- **`/compact`** (`_cmd_compact`, `:5831`) → `session.compact()` → **POST .../events**
+  `{type:"compact","data":{}}` (`_sessions.py:941`). Server runs compaction without
+  appending a user message; the REPL renders `Compacting…` / `Compaction complete.` from the
+  `response.compaction.in_progress`/`.completed` SSE events (`_repl.py:3475-3499`).
+- **`/cancel`** (`:5934`) → `session.cancel()` → **POST .../events** `{type:"interrupt"}`
+  (`_sessions.py:959`) — bypasses the input queue server-side. Ctrl+C maps here too.
+- **`/fork`** (`:5402`) → `sessions.fork(id, title)` → **POST /v1/sessions/{src}/fork**.
+- **`/switch`** (`:5181`) → `sessions.list` + `switch_session` (re-points the SSE stream to a
+  chosen existing session, `_repl.py:2695`). **NOT** `/switch-agent` (web-only).
+- **`/<skill>`** (dynamic, `register_skill_commands` `:8104`) →
+  `session.send_skill_slash_command` → **POST .../events** `{type:"slash_command"}`; the
+  echoed `slash_command` item is suppressed via `_pending_local_skill_slash_commands`
+  (`:3571`).
+- **Local-only** (no API): `/help`, `/theme` (writes `~/.omnigent/config.yaml`), `/new`,
+  `/clear`, `/history` (GET items), `/context` (GET items + estimate), `/logs`, `/report`,
+  `/quit`.
+
+**Resume is NOT a slash command** — it's CLI flags resolved before the loop by
+`chat.py:_resolve_resume_target` and pre-seeded as `resume_conversation_id` on the adapter
+(`_repl.py:1283-1286`):
+- `--resume` / `-r` (no value) → interactive **resume picker** (`_resume_picker.py`).
+- `--continue` → resume the latest conversation for this agent (`resume_latest`).
+- `--resume <conv_id>` → attach to a specific conversation.
+The adapter attaches to that session id on the first `send` (no separate "resume" call —
+it just stops creating a new session). For native-harness conversations, `chat.py` **redirects
+the resume** to the vendor wrapper instead of `run_repl` (`_redirect_native_resume_if_needed`,
+`chat.py:1029`) to avoid double-recording.
+
+---
+
+## Q4. Resume picker + event tape + the `--debug-events` pipeline
+
+**Resume picker (`_resume_picker.py`):** `pick_conversation` (`:197`). Fetches the
+resumable list via **`client.sessions.list(limit=200, agent_id=…, order="desc")`**
+(`pick_conversation_from_sdk`, `:878`) — i.e. `GET /v1/sessions` — or from the local
+conversation store (`pick_conversation_from_store`, `:974`); a wrapper-label variant
+(`:909`) and a cross-agent variant (`:949`) exist for native/all-agent cases. TTY render =
+prompt_toolkit `Application` (`:447`): ↑/↓ move, Enter select, n/p page (10/page), q/Esc
+cancel; rows = **title · created_at · [workspace] · id · [runtime badge]** + latest-message
+preview (`:642-830`). Non-TTY → line-buffered Rich fallback (`:281`). Returns the chosen
+`conversation_id`.
+
+**Event tape + `--debug-events` (`_event_tape.py`):** `EventTape` (`:211`) =
+`deque[TapeEntry]` ring buffer (`maxlen=500`, `:33,235`), created **only** when
+`--debug-events` is passed (`_repl.py:3082-3085`) — zero overhead otherwise. Each
+`TapeEntry` (`:115`) captures the per-event **render-pipeline journey**: `ts`, `delta_ms`,
+`raw_event_type`, `sdk_translation`, `formatter_result`, `stage_reached`
+(RAW→TRANSLATED→FORMATTED→RENDERED), `path`, raw JSON payload, formatted items. The
+renderer instruments every branch (`record_raw`→`update_translation`→`update_format`→
+`mark_rendered`, e.g. `_repl.py:3276-3309`). **Ctrl+E** opens the "SSE Event Tape" overlay
+(`_repl.py:4263`): event sidebar (type, `+Nms`, 🟢🟡🔴 stage) + detail panel (stages, raw
+JSON, counters `ev:/tx:/fmt:/out:`); gaps >1000ms flagged "⚠ GAP" (`:37,445`). When enabled,
+entries also append to a **JSONL** debug log (path shown via Ctrl+O, `_repl.py:3079-3081`).
+This is the TUI's diagnostic answer to "what did the server send vs what got rendered" — the
+web has no equivalent end-to-end pipeline tape.
+
+---
+
+## Q5. How "working" state is shown in the TUI
+
+Computed **locally from `session.status`** on the SSE stream (not from `response.created/
+completed`):
+- `status == "running"` → `host.start_timer()` (`_repl.py:3290`) + render `◆ <agent>`
+  header. `TerminalHost` (from `omnigent_ui_sdk`) shows a live spinner + elapsed timer while
+  the timer runs.
+- `status in ("idle","waiting","failed")` → `host.stop_timer()` (`:3343`) +
+  `_turn_done.set()`. A `failed` with no preceding `response.failed` (SETUP-phase failure)
+  renders an error line via `_render_failed_status_error` (`:2886`) so the spinner doesn't
+  "just vanish."
+- The pump **also** sets `_turn_done` on idle/waiting/failed independently of `_on_event`
+  (`:2043-2050`) so headless adapter use still terminates.
+- `is_streaming` (`:1465+`) is the client-side in-flight flag; slash commands read it to add
+  "(current response unchanged)" when you change model/effort mid-turn.
+- Final elapsed time is rendered by the response-end formatter block (`:659-673`).
+
+**vs web:** the web derives a *sidebar badge* from `status` + `pending_elicitations_count`
+over the **WS updates** stream (CUJ-ANALYSIS §2.E:261-262; priority awaiting > running >
+none). The TUI has no badge — it shows an inline spinner/timer driven by the *same* server
+`status`, just delivered over SSE instead of the WS plane. Both bottom out on the server's
+authoritative `status`.
+
+---
+
+## Q6. How the TUI client would carry trace context (HTTPXClientInstrumentor → omni-tui spans) — and why the corpus has none
+
+**Empirical:** the corpus is from **headless `-p` runs** that never start the interactive
+REPL, so there are **no `omni-tui` spans**. Verified: service names across all corpus files
+are exactly `omni-server` (52) / `omni-runner` (23) / `omni-harness` (8) — no `omni-tui`,
+`omni-host`, or `omni-web`.
+
+**Code path that *would* produce them:** `OmnigentClient` uses a plain `httpx.AsyncClient`
+over standard transports (`_client.py:89`). The process-wide
+`HTTPXClientInstrumentor().instrument()` (`telemetry.py:392-409`) patches every standard
+httpx client to inject the W3C `traceparent` header and emit a client span. So if the REPL
+process initialized telemetry, every `client.sessions.*` REST call **and** the SSE
+`GET /stream` would emit a client span and propagate context across the loopback hop into
+the server (whose FastAPI instrumentation continues the trace) — giving the
+`omni-tui → omni-server → omni-runner → omni-harness` single trace the design doc describes.
+
+**The gap (code vs doc):** the code **never calls `telemetry.init("omni-tui")`**. The only
+`telemetry.init(...)` callers are `omni-server` (`cli.py:3079`, inside the *server*
+bootstrap, not the REPL), `omni-runner` (`runner/_entry.py:902`), `omni-host`
+(`host/connect.py:1608`), `omni-harness` (`runtime/harnesses/_runner.py:363`). The
+`omnigent run` / `run_repl` **foreground process that owns the TUI httpx client initializes
+no telemetry**, so the TUI emits **no spans today**; even with `OTEL_*` env set in that
+process, the service would default to `"omnigent"`, not `"omni-tui"`. `omni-tui` appears
+**only in `designs/OBSERVABILITY.md` (:269,370,374-375)** — a **doc-vs-code mismatch**.
+(Contrast: `omni-web` *is* really wired — `web/src/lib/telemetry.ts:40`.)
+
+**Bottom line:** the instrumentation *mechanism* (httpx `traceparent` propagation over the
+loopback hop) is in place and would Just Work; the missing piece is a one-line
+`telemetry.init("omni-tui")` in the REPL/`run` entrypoint. Until that lands, TUI turns are
+invisible in Jaeger and the design doc's `omni-tui → …` trace shape does not exist.
+
+---
+
+## Cross-cutting CUJ notes the TUI illuminates
+
+- **Disconnect mid-turn (close terminal):** the session is server-durable; the SSE pump just
+  reconnects on transport error (`_repl.py:2056`) and the server keeps running the turn (no
+  replay → reconcile via `sessions.get`). Same durability story as the web's "close page &
+  return" (CUJ-ANALYSIS §2.E:254-255), minus the web's `ReconnectSessionDialog`.
+- **Elicitation/approval round-trip:** the verdict goes back as either an in-band
+  `{type:"approval"}` event via `POST .../events` (the inline y/n prompt) **or** the
+  dedicated `POST .../elicitations/{id}/resolve` URL (`_sessions.py:845`) — both converge on
+  the same server resolver. An external resolution (web approval page) arrives as
+  `elicitation_resolved` and wakes the parked REPL future (`_repl.py:3409-3416`). No
+  emulated keystrokes — it's plain REST + an awaited future.
+- **Co-drive:** `omnigent attach` / `run <url>` sets `attach_only=True` (`_repl.py:1306`):
+  the TUI posts turns to the session's already-bound (host's) runner and never PATCHes the
+  binding — exactly the web's co-drive model. Cross-client messages (web typing on the same
+  session) show up because the TUI echoes any `session.input.consumed` with no matching
+  pending local send.

--- a/designs/master-arch/cuj-answers/web-client.md
+++ b/designs/master-arch/cuj-answers/web-client.md
@@ -1,0 +1,351 @@
+# CUJ Answers — Web Client (`web/src/`)
+
+> Code is ground truth; every claim is `file:line`-anchored. Web telemetry is
+> opt-in (`lib/telemetry.ts`) and inactive in the running rig, so there are **no
+> live `omni-web` traces** — this is a code-grounded analysis (confirmed: no
+> `omni-web` spans in the saved corpus). Companion: `architecture/web.md`.
+
+---
+
+## Q1 — How the SIDEBAR fetches items
+
+**Source list (`useConversations`, `hooks/useConversations.ts:216`)** — TanStack
+`useInfiniteQuery` over `GET /v1/sessions`:
+- Query params (`fetchConversationsPage`, `:178-204`): `order=desc`,
+  `sort_by=updated_at`, `limit=20`, optional `search_query=<q>` (server-side
+  filter; the caller debounces ~300 ms before passing it), optional
+  `include_archived=true` (only when the toggle is on).
+- Cursor pagination: `getNextPageParam = lastPage.has_more ? lastPage.last_id :
+  undefined` (`:238-239`). 20 per page. Infinite-scroll sentinel in `Sidebar.tsx`
+  (200 px pre-fetch margin) calls `fetchNextPage`.
+- `sort_by=updated_at` matches the within-group sort, keeping server pagination
+  consistent with visible order. The active chat's row is pinned in place by an
+  in-memory `ActiveChatOverride` so a send doesn't reorder it (`:16-18`).
+
+**Live updates — `WS /v1/sessions/updates`** (`lib/sessionUpdatesSocket.ts`,
+`hooks/SessionUpdatesProvider.tsx`) replace the old 4 s poll:
+- Client sends a **watch-set**: `{type:"watch", session_ids:[…]}`
+  (`sessionUpdatesSocket.ts:242`). Ids = union of all `["conversations"]` +
+  `["project-sessions"]` cache rows **plus the open session**
+  (`SessionUpdatesProvider.tsx:159-178`). No-op when unchanged.
+- Server pushes **`snapshot`** (full watch-set state), **`changed`** (field
+  deltas: status, runner_online, host_online, pending_elicitations_count, title,
+  comment fingerprint), **`removed`** (ids), **`heartbeat`** (~30 s idle)
+  (`sessionUpdatesSocket.ts:23-27`).
+- Frames patch the cache in place (`applyItemsToCache` →`mergeItemsIntoPages`);
+  only structural changes (a watched id missing from every page, membership/sort
+  changes) schedule a debounced `invalidate(["conversations"])` (250 ms)
+  (`SessionUpdatesProvider.tsx:240-249`).
+- **Heartbeat watchdog** `70_000 ms` (`:48`): no frame in 70 s → force reconnect.
+  Reconnect backoff 250 ms→5 s ±50% jitter.
+- HTTP fallback cadence: connected → `60_000 ms` low-rate reconcile for the
+  visible sidebar only (others suspend); disconnected → `45_000 ms` for all
+  (`useConversations.ts:41-42, 240-245`).
+
+**Grouping precedence** (per `CUJ-ANALYSIS §2.E`): **Archived > Pinned > Project >
+Recent**. Pins = localStorage `omnigent:pinned-conversation-ids`, off-window pins
+backfilled via per-id `GET /v1/sessions/{id}` (`usePinnedConversationBackfill`,
+`:619`). Projects implicit (≥1 non-archived session), reserved label
+`omni_project` (`:658`), listed via `GET /v1/sessions/projects` (`:661`), folders
+paged via `?project=` (`useProjectSessions`, `:786`).
+
+**Badge** (`useSessionState.ts:21`): priority **awaiting (pending_elicitations_count>0)
+> running > none**. `failed`/liveness deliberately NOT sidebar badges.
+
+---
+
+## Q2 — FULL set of client→server requests (exhaustive)
+
+> Every distinct request the SPA issues, verified in non-test source. All HTTP
+> goes through `authenticatedFetch` / `hostFetch`; all WS through
+> `resolveWebSocketUrl`. `/auth/*` use bare `fetch` (cookie-based, accounts mode).
+
+### REST — sessions core
+
+| Method | Path | File:line | Trigger |
+|---|---|---|---|
+| GET | `/v1/sessions` | `useConversations.ts:201` | Sidebar list (paginated, search, archived) |
+| GET | `/v1/sessions?project=<p>` | `useConversations.ts:727,753,771` | Project folder list / last-member check |
+| GET | `/v1/sessions/projects` | `useConversations.ts:665` | Project names |
+| GET | `/v1/sessions?limit=100[&kind=any]` | `useAgents.ts:82`, `useAvailableAgents.ts:168` | Custom/registered agents (sessions-as-agents) |
+| POST | `/v1/sessions` (JSON) | `sessionsApi.ts:419` | Create session bound to `agent_id` |
+| POST | `/v1/sessions` (multipart) | `sessionsApi.ts:455` | Create with inline agent bundle |
+| GET | `/v1/sessions/{id}` | `sessionsApi.ts:715`, `useConversations.ts:151` | Full snapshot / pinned backfill |
+| GET | `/v1/sessions/{id}?include_items=false&include_liveness=false[&refresh_state=true]` | `sessionsApi.ts:746` | Slim snapshot (bind fast path) |
+| GET | `/v1/sessions/{id}/items?limit=20&order=desc[&after=]` | `sessionsApi.ts:789` | History page (hydrate / scroll-up) |
+| PATCH | `/v1/sessions/{id}` | `sessionsApi.ts:659`, `useConversations.ts:250,267` | rename / archive / model_override / reasoning_effort / collaboration_mode / cost_control / runner_id / labels(project) |
+| DELETE | `/v1/sessions/{id}[?delete_branch=true]` | `useConversations.ts:285` | Delete session (+worktree) |
+| POST | `/v1/sessions/{id}/events` | `sessionsApi.ts:887` | message / interrupt / approval / stop_session / compact / slash_command |
+| POST | `/v1/sessions/{id}/fork` | `sessionsApi.ts:520` | Fork/clone (`up_to_response_id`, `agent_id`, `model_override`) |
+| POST | `/v1/sessions/{id}/switch-agent` | `sessionsApi.ts:546` | Switch harness/agent in place (idle only) |
+| POST | `/v1/sessions/{id}/elicitations/{eid}/resolve` | `sessionsApi.ts:972` | Approval verdict (URL-based elicitation) |
+
+### REST — sub-resources
+
+| Method | Path | File:line | Trigger |
+|---|---|---|---|
+| GET | `/v1/sessions/{id}/agent` | `useAgents.ts:134` | Session's bound agent detail |
+| GET | `/v1/sessions/{id}/permissions` | `permissionsApi.ts:96` | Share dialog: list grants |
+| GET | `/v1/sessions/{id}/owner` | `permissionsApi.ts:102` | Owner (info popover) |
+| PUT | `/v1/sessions/{id}/permissions` | `permissionsApi.ts:116` | Grant/update level (incl. `__public__` toggle) |
+| DELETE | `/v1/sessions/{id}/permissions/{userId}` | `permissionsApi.ts:131` | Revoke |
+| GET | `/v1/sessions/{id}/comments[?path=]` | `useComments.ts:47-48` | List file comments |
+| POST | `/v1/sessions/{id}/comments` | `useComments.ts:82` | Create comment |
+| PATCH | `/v1/sessions/{id}/comments/{cid}` | `useComments.ts:131` | Update (status/body) |
+| DELETE | `/v1/sessions/{id}/comments/{cid}` | `useComments.ts:111` | Delete |
+| POST | `/v1/sessions/{id}/comments/send` | `useComments.ts:164` | "Address All" → send comments to agent |
+| GET | `/v1/sessions/{id}/policies` | `usePolicies.ts:35` | Session policies |
+| POST | `/v1/sessions/{id}/policies` | `usePolicies.ts:83` | Add session policy |
+| DELETE | `/v1/sessions/{id}/policies/{pid}` | `usePolicies.ts:107` | Remove session policy |
+| GET | `/v1/sessions/{id}/resources/terminals?order=asc&limit=1000` | `useTerminals.ts:262,304` | List terminals |
+| POST | `/v1/sessions/{id}/resources/terminals` | `NewTerminalButton` | Create terminal |
+| GET | `/v1/sessions/{id}/resources/files` | `filesApi.ts:17` | File upload/list |
+| GET | `/v1/sessions/{id}/resources/environments/default` | `useWorkspaceChangedFiles.ts:596` | Env availability (Files tab gate) |
+| GET | `…/environments/default/changes` | `useWorkspaceChangedFiles.ts:166` | Changed-files list |
+| GET | `…/environments/default/filesystem[/{path}]?limit=1000&order=asc` | `useWorkspaceChangedFiles.ts:284,403,521` | Browse workspace files |
+| GET | `…/environments/default/search?…` | `useWorkspaceChangedFiles.ts:349` | Search workspace |
+| GET/PUT/PATCH/DELETE | `/v1/sessions/{id}/codex_goal` | `codexGoalApi.ts:152,178,216` | Codex goal read/set/update/clear |
+| GET | `/v1/sessions/{id}/codex_goal/status` | `codexGoalApi.ts:199` | Codex goal status |
+
+### REST — fleet / hosts / policies / capabilities
+
+| Method | Path | File:line | Trigger |
+|---|---|---|---|
+| GET | `/v1/agents[?after=]` | `useAvailableAgents.ts:120` | Built-in agent catalog (picker) |
+| GET | `/v1/runners` | `sessionsApi.ts:689` | Online runners (bind-only-online) |
+| POST | `/v1/hosts/{hostId}/runners` | `sessionsApi.ts:593` | Launch runner / fork-resume bind |
+| GET | `/v1/hosts/{hostId}/filesystem[/{path}]` | `useHostFilesystem.ts:54` | New-chat host file browser |
+| POST | `/v1/hosts/{hostId}/directories` | `useHostFilesystem.ts:203` | Create dir on host |
+| GET | `/v1/policy-registry` | `usePolicies.ts:42` | Policy types registry |
+| GET | `/v1/policies` | `useDefaultPolicies.ts:23` | Default (server-level) policies |
+| POST | `/v1/policies` | `useDefaultPolicies.ts:50` | Create default policy |
+| PATCH | `/v1/policies/{id}` | `useDefaultPolicies.ts:64` | Toggle default policy |
+| GET | `/v1/info` | `capabilities.ts:104` (via `hostFetch`) | Boot capabilities probe |
+| GET | `/v1/me` | `identity.ts:64` (via `hostFetch`) | Identity probe (header mode) |
+| GET | `/health?session_ids=<csv>` | `useRunnerHealth.ts:95` | Open-session liveness poll (~10 s) |
+
+### REST — accounts/auth (only when `accounts_enabled`, bare `fetch`, cookie)
+
+| Method | Path | File:line | Trigger |
+|---|---|---|---|
+| POST | `/auth/login` | `accountsApi.ts:63` | LoginPage |
+| POST | `/auth/logout` | `accountsApi.ts:110` | AccountMenu |
+| GET | `/auth/me` | `accountsApi.ts:131` | Accounts identity |
+| POST | `/auth/register` | `accountsApi.ts:157` | Redeem invite |
+| POST | `/auth/users/me/password` | `accountsApi.ts:210` | Self password change |
+| POST | `/auth/setup` | `accountsApi.ts:251` | First-run admin claim |
+| GET | `/auth/users` | `accountsApi.ts:367` | MembersPage (admin) |
+| POST | `/auth/invite` | `accountsApi.ts:386` | Mint single-use invite (admin) |
+| POST | `/auth/users/{id}/reset` | `accountsApi.ts:~395` | Reset password (admin) |
+| DELETE | `/auth/users/{id}` | `accountsApi.ts:418` | Delete user (admin, cascades) |
+| (GET) | `/api/version` | (`/v1/info` server_version mirror) | version footer |
+
+### WebSocket / SSE channels
+
+| Channel | Path | File:line | Notes |
+|---|---|---|---|
+| **SSE** | `GET /v1/sessions/{id}/stream[?idle=true]` | `sessionsApi.ts:921` | Open-chat live-tail; `response.*` + `session.*`; presence uplink; `[DONE]` sentinel; reconnect on drop |
+| **WS** | `/v1/sessions/updates` | `sessionUpdatesSocket.ts:66` | Sidebar live feed; watch-set ↔ snapshot/changed/removed/heartbeat |
+| **WS** | `/v1/sessions/{id}/resources/terminals/{tid}/attach[?read_only=true]` | `TerminalView.tsx:417,440` | xterm.js ↔ runner tmux; read-only for viewers |
+
+**Note on user search:** `GET /v1/users/search` is **not** a direct SPA call — the
+permissions "add user" combobox uses a host-injected `searchUsers` callback
+(`hooks/useUserSearch.ts:25,39`; `host.ts:43`) and is inert (plain text input) in
+standalone. The `/v1/users/search` route in `CUJ-ANALYSIS §2.E` is what an
+embedding host's callback hits.
+
+---
+
+## Q3 — Streaming ↔ durable reconciliation (the merge point)
+
+The renderer walks one flat `blocks: AnyBlock[]` fed from (a) durable snapshot
+items (`GET …/items` → `itemsToBlocks`, each block has `ctx.itemId`) and (b) live
+SSE (`parseSseStream` → `BlockStream.reduce`; token/reasoning blocks are id-less,
+persisted items carry `ctx.itemId`). **They are merged by deduping on
+`ctx.itemId`** so each persisted item renders once
+(`chatStore.ts:15`; enforced at `:1455,:1904-1907,:2460-2463,:2961-2966,:3004-3008`).
+
+**`lib/blockStream.ts` consuming SSE:** `BlockStream.reduce(events)` is a pure,
+stateful reducer (hand-port of Python `_stream.py`) — text/reasoning flush
+thresholds (30 chars / newline), per-response dedup sets `seenCallIds` /
+`seenResultCallIds` (cleared each `response.created`), reasoning↔text closure on
+tool calls and terminals. The claude-sdk MCP path emits each tool
+call/result **twice** (inline observed + post-stream action_required / completed
+flush); the dedup keeps one (`blockStream.ts:495-531,559-604`). It explicitly
+ignores `session.*` events (no-ops, `:896-908`) — those are tapped separately.
+
+**`pendingUserMessages` held until `session.input.consumed`:** `send()` pushes a
+`PendingUserMessage{tempId:"pend_N"}` **before** the POST (`chatStore.ts:791-821`)
+so the bubble paints instantly and a consumed event racing ahead of the POST
+still finds it. On `session.input.consumed` (`:3724`), the pending bubble is
+**promoted into `blocks`** as a committed user block carrying the server
+`item_id`, matched in precision order: (1) by `clearedPendingId`, (2) FIFO head
+(no text match — native transcripts reformat text), (3) fresh from payload. The
+promoted block **reuses the `tempId` as React key** → no remount/flink
+(`:3744-3801`). `is_meta` consumed events ignored; `hasCommittedItem` guards
+double-promotion.
+
+**Persisted items deduped by `ctx.itemId`:** in the pump, every block with a
+`ctx.itemId` is skipped if already committed or buffered (`:3004-3008`), and the
+`flush` re-checks at commit time (a snapshot merge may have inserted it while it
+sat in the buffer, `:2961-2966`). A persisted assistant `message` whose text
+already streamed id-less gets its item id **stamped onto the existing streamed
+`text_done` in place** (match by `responseId`+`fullText`, FIFO) rather than
+appended (`:3027-3069`) — keeping one copy in its streamed position AND letting
+reconnect (item-id-keyed) see it as already rendered. This is the durable-vs-
+streaming merge.
+
+---
+
+## Q4 — How "working/idle" is derived in the client
+
+Two distinct notions:
+
+**Sidebar row badge** (`useSessionState.ts:21`): from the **row's**
+`status` (`idle|running|failed`) + `pending_elicitations_count`, both delivered
+by the WS updates frames. Priority **awaiting > running > none** (`failed` not a
+sidebar state). The store also patches the active row in cache on each
+`session.status` SSE event so the dot flips in lockstep with the chat
+(`patchConversationStatusInCache`, `chatStore.ts:3694`).
+
+**Chat-surface "Working…" indicator** (`chatStore.ts:sessionStatus`,
+`idle|launching|running|waiting|failed`): driven by `session.status` SSE events
+(`handleSessionEvent` case `:3585`). Adds `waiting` (parent loop parked on the
+async-work / sub-agent drain) which the row badge can't represent. Seeded from
+the snapshot on bind so a refresh on a running session shows "Working…"
+immediately. `background_task_count` is **sticky** (a Stop-hook `0` clears it; a
+bare PTY `idle` leaves it untouched; a new turn/failure clears it) — so a
+finished-with-background-shells claude-native turn reads "N background tasks still
+running" (`:3601-3618`). The `activeResponse` sidecar tracks the per-turn
+lifecycle (streaming/completed/failed/cancelled), reconciled by `session.status`,
+`response_end`, and `session.interrupted`.
+
+Updated via the **WS updates stream** (sidebar) and the **SSE stream** (chat) —
+the chat's `session.status` events are authoritative for the open session.
+
+---
+
+## Q5 — Close-the-page-and-return behavior
+
+**Server-durable.** Closing the tab stops nothing server-side; the turn keeps
+running. On return/refresh:
+1. `switchTo(id)` → `bindStream` opens a fresh `SSE …/stream` **first**, then
+   fetches `getSessionSlim` + `fetchInitialHistoryWindow` concurrently and merges
+   deduping by item id (`chatStore.ts:1825-1907`) — the documented
+   stream-then-snapshot reconnect contract.
+2. History hydrates only the most recent window (20, extended back to the prior
+   user prompt — `fetchInitialHistoryWindow`, `sessionsApi.ts:833`); scroll-up
+   pages older.
+3. The SSE pump (`startStreamPump`, `:2542`) reconnects automatically on transport
+   drops (Databricks Apps' ~5-min HTTP/2 cap): a drop after a healthy connection
+   reconnects **instantly** (`failedOpens=0`); only consecutive failed opens back
+   off. On each reconnect (not first connect), `reconcileOnReconnect` (`:2394`)
+   pages items backward until the window overlaps the pre-gap transcript, splices
+   unseen items at the right position, recovers `sessionStatus`/`activeResponse`
+   (so a gap-completed turn doesn't strand the spinner), and reconciles
+   ApprovalCards against `pending_elicitations`.
+4. 401/403/404 on stream open → mark session failed and stop (`:2600`).
+
+**Host offline → `ReconnectSessionDialog`** (`ChatPage.tsx:1095-1105,:952`):
+liveness from `useSessionLiveness` (`hooks/useSessionLiveness.ts:187`) using
+`/health`'s `runner_online`+`host_online`. The two unreachable variants open the
+dialog:
+- `host_offline` (host-bound, host tunnel down, host NOT web-resumable):
+  shows the **CLI reconnect command** (`omnigent host --server <url>`); owner
+  reconnects from that machine, any viewer can fork.
+- `local_stranded` (not host-bound, runner down): shows
+  `omnigent <run|claude> --resume <id> --server <url>`; restart from own machine,
+  fork is the escape hatch.
+
+Resumable managed hosts instead read `host_asleep` (composer open; next message
+wakes the sandbox via server `resume_managed_host`) or `starting` while waking —
+**no dialog**. A fresh session within `STARTING_GRACE_S=45` reads `starting`
+("Connecting…") rather than flashing a banner during cold boot.
+
+Background-tab nuance: a throttled tab can miss `elicitation_resolved`; on
+`visibilitychange→visible` the store reconciles pending elicitations against a
+fresh snapshot (`bindStream` `:1800-1808`).
+
+---
+
+## Q6 — TUI vs WebUI state differences (high level)
+
+> The TUI agent owns TUI depth; this is the web client's view of the contrast.
+
+- **Transport.** Web uses HTTP SSE (`…/stream`) + WS (updates, terminal-attach)
+  through `authenticatedFetch`/`resolveWebSocketUrl`; the TUI/REPL
+  (`omnigent/repl/`) is a Python client driving the same server but renders to a
+  terminal (rich streaming, slash-command menu, resume picker, event tape). Both
+  consume the **same `response.*`/`session.*` event vocabulary** — the web client
+  even hand-ports the Python `_sse.py`/`_stream.py` reducers (`sse.ts`,
+  `blockStream.ts` headers) to stay byte-parity with the TUI/SDK client.
+- **Durability.** Web messages on **non-native** sessions are persisted at POST
+  time (synchronous `item_id` in the POST response, then `session.input.consumed`
+  promotes the optimistic bubble). On **native-terminal** sessions
+  (claude-native/codex-native), a web message is NOT persisted at POST — it
+  round-trips through the vendor TUI and reconciles via the forwarder's
+  `session.input.consumed`, which can arrive after a transient idle/failed; the
+  web client special-cases this (skip idle-clear, replay `pending_inputs` on
+  rebind — `chatStore.ts:3653-3667,:1957-1960`). A TUI session typed directly in
+  the vendor binary has no optimistic web bubble at all; the web client renders
+  those as fresh committed bubbles (consumed-event path #3).
+- **Working state.** Web derives a sidebar badge (awaiting>running) + a chat
+  indicator (idle/launching/running/waiting/failed) from `session.status` events.
+  The TUI shows its own inline spinner driven by the same status stream.
+- **Presence / collaboration.** Web has presence avatars, share/permissions,
+  comments, and a subagents rail — multi-viewer concerns that the single-user TUI
+  lacks. Presence is the SSE stream URL itself (holding `…/stream` open = a
+  viewer; `?idle=` flips presence-idle).
+- **Model/effort.** Web exposes a model/effort picker for SDK + claude-/codex-
+  native (and injects `/model` into the tmux pane for claude-native); for vendor-
+  owned-model harnesses (qwen/goose/cursor/pi/opencode) the web hides the label
+  and defers to the TUI's own picker (`nativeVendorOwnsModel`,
+  `chatStore.ts:287-296`).
+
+---
+
+## Per-harness notes (web client's branches)
+
+- **claude-sdk / polly (on claude-sdk):** standard persisted-at-POST flow; the
+  reducer's MCP double-event dedup (`blockStream.ts:495-531,559-604`) is the only
+  harness-specific path. *Live traces available in corpus
+  (`conv_b4f2…`, `conv_6354…`).*
+- **claude-native:** `isNativeTerminalSession=true`; not persisted at POST;
+  `session.todos`→TodoPanel; `slash_command` round-trips tmux and pops FIFO
+  pending with no consumed event (`:3804`); Stop hard-kills the tmux pane;
+  `setModel` injects `/model` into the pane. *Live trace `conv_d0dd…`.*
+- **codex / codex-native:** no live trace (creds expired). codex-native: web
+  treats like any native-terminal session; surfaces `codexCommand`/exec
+  elicitations + a Plan-mode toggle (`codexPlanMode`); has a `codex_goal`
+  REST surface. Structurally analogous to claude-native on the web side.
+
+---
+
+## Failure branches & gaps
+
+- No `[DONE]` → reconnect (instant if healthy); 401/403/404 → fail+stop
+  (`:2600`); reader/parse error (`ERR_HTTP2_PROTOCOL_ERROR`) → drop→reconnect
+  (`:3151`).
+- Policy-denied input: POST `{denied:true}`, no consumed event → settle from POST
+  response, roll back bubble (`:898-918`); also a `policy_denied`/`response.policy_denied`
+  block.
+- WS updates half-open socket → 70 s watchdog reconnect; 45 s HTTP fallback while
+  down.
+- Search-index reindex race: rename/delete patch cache in place, never immediate
+  refetch (`useConversations.ts:291-445`).
+- "Stuck-pending bubble" class: `switchTo` stashes only unsettled own sends
+  (`pend_`, `posted!==true`); settled sends defer to server `pending_inputs`;
+  content-equal snapshot twin drops the stash copy (`:1179-1217,:1932-1960`).
+- **Per `CUJ-ANALYSIS §2.E` (unverified by me):** CJK IME Enter submits
+  prematurely (#433); non-git Changes panel empty (#725); browser empty after
+  reconnect (#386); mobile HTML preview/download (#968/#969). *(per doc — unverified)*
+
+## Open questions
+
+- Exact wire parity of `SessionListWireItem` (WS frames) vs. `GET /v1/sessions`
+  rows (client assumes it via `nullsToUndefined`) — server SME.
+- Whether the WS updates push of `runner_online`/`host_online` makes the
+  `/health` poll redundant; code comments say the host control plane doesn't push
+  runner-reaped state, so the poll stays load-bearing (`useRunnerHealth.ts:22-23`).
+- No live `omni-web` traces (telemetry opt-in); validating click→server
+  `traceparent` continuation would need `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` set.

--- a/designs/master-arch/trace_tools.py
+++ b/designs/master-arch/trace_tools.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Omnigent trace extraction helpers (Jaeger query API at :16686).
+
+Usage:
+  python trace_tools.py services
+  python trace_tools.py recent [minutes=10]      # recent traces, grouped, with session.id
+  python trace_tools.py conv <conv_id> [minutes=60]   # all spans for a session.id, summarized
+  python trace_tools.py tree <trace_id>          # parent/child span tree for one trace
+  python trace_tools.py raw <conv_id> <outfile>  # dump all traces for a conv to a json file
+"""
+import json, sys, urllib.request, collections
+
+BASE = "http://localhost:16686"
+
+def get(path):
+    with urllib.request.urlopen(BASE + path, timeout=15) as r:
+        return json.load(r)
+
+def services():
+    return get("/api/services")["data"] or []
+
+def all_traces(minutes=60, limit=200):
+    """Return {traceID: trace} across all omni-* services."""
+    lookback = f"{minutes}m" if minutes < 60 else f"{minutes//60}h"
+    out = {}
+    for s in services():
+        if not s.lower().startswith("omni"):
+            continue
+        try:
+            d = get(f"/api/traces?service={s}&limit={limit}&lookback={lookback}")["data"]
+        except Exception:
+            d = []
+        for t in d:
+            out[t["traceID"]] = t
+    return out
+
+def _svc(t):
+    return {pid: p["serviceName"] for pid, p in t["processes"].items()}
+
+def _sids(t):
+    s = set()
+    for sp in t["spans"]:
+        for tag in sp.get("tags", []):
+            if tag["key"] == "session.id":
+                s.add(tag["value"])
+    return s
+
+def _parent(sp, spanids):
+    for r in sp.get("references", []):
+        if r["refType"] == "CHILD_OF":
+            return r["spanID"]
+    return None
+
+def cmd_recent(minutes=10):
+    traces = all_traces(int(minutes))
+    rows = []
+    for tid, t in traces.items():
+        procs = _svc(t)
+        svcset = sorted({procs.get(sp["processID"]) for sp in t["spans"]})
+        rows.append((min(sp["startTime"] for sp in t["spans"]), tid, len(t["spans"]), svcset, _sids(t)))
+    rows.sort()
+    for st, tid, n, svcset, sids in rows:
+        print(f"{tid}  spans={n:4d}  services={svcset}  session.id={sorted(sids) or '-'}")
+
+def cmd_conv(conv_id, minutes=60):
+    traces = [t for t in all_traces(int(minutes)).values() if conv_id in _sids(t)]
+    print(f"conv {conv_id}: {len(traces)} traces")
+    hist = collections.Counter()
+    edges = collections.Counter()
+    roots = []
+    for t in traces:
+        procs = _svc(t)
+        spans = {sp["spanID"]: sp for sp in t["spans"]}
+        for sp in t["spans"]:
+            hist[(procs.get(sp["processID"]), sp["operationName"])] += 1
+            p = _parent(sp, spans)
+            if p is None or p not in spans:
+                roots.append((procs.get(sp["processID"]), sp["operationName"], t["traceID"]))
+            elif procs.get(spans[p]["processID"]) != procs.get(sp["processID"]):
+                edges[(procs.get(spans[p]["processID"]), procs.get(sp["processID"]), sp["operationName"])] += 1
+    print("\n=== root spans (per trace) ===")
+    for r in roots[:40]:
+        print(f"  {r[0]:12s} {r[1]}   [{r[2][:12]}]")
+    print("\n=== span histogram (service, op): count ===")
+    for (sv, op), c in hist.most_common(60):
+        print(f"  {c:4d}  {str(sv):12s} {op}")
+    print("\n=== cross-service edges ===")
+    for (a, b, op), c in edges.most_common(30):
+        print(f"  {a} -> {b}  [{op}] x{c}")
+
+def cmd_tree(trace_id):
+    t = get(f"/api/traces/{trace_id}")["data"][0]
+    procs = _svc(t)
+    spans = {sp["spanID"]: sp for sp in t["spans"]}
+    children = collections.defaultdict(list)
+    roots = []
+    for sp in t["spans"]:
+        p = _parent(sp, spans)
+        (children[p] if (p and p in spans) else roots).append(sp)
+    for lst in children.values():
+        lst.sort(key=lambda s: s["startTime"])
+    roots.sort(key=lambda s: s["startTime"])
+    def walk(sp, depth):
+        tags = {tg["key"]: tg["value"] for tg in sp.get("tags", [])}
+        kind = tags.get("openinference.span.kind", "")
+        extra = f" [{kind}]" if kind else ""
+        print(f"{'  '*depth}{procs.get(sp['processID']):11s} {sp['operationName']}{extra} ({sp['duration']//1000}ms)")
+        for c in children.get(sp["spanID"], []):
+            walk(c, depth + 1)
+    for r in roots:
+        walk(r, 0)
+
+def cmd_raw(conv_id, outfile):
+    traces = [t for t in all_traces(180).values() if conv_id in _sids(t)]
+    with open(outfile, "w") as f:
+        json.dump(traces, f)
+    print(f"wrote {len(traces)} traces to {outfile}")
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "recent"
+    args = sys.argv[2:]
+    {"services": lambda: print(services()),
+     "recent": cmd_recent, "conv": cmd_conv, "tree": cmd_tree, "raw": cmd_raw}[cmd](*args)


### PR DESCRIPTION
## What
Adds `designs/master-arch/` — a deep, code- and trace-grounded map of Omnigent:

- **Overall architecture** (`architecture/overall-architecture.md`) — topology, the inter-component **channel matrix**, end-to-end request lifecycle, harness taxonomy, and verified corrections.
- **Per-component architecture** (10 docs) — server, runner, host, harness/inner, runtime/executor, policies, web, tui-repl, auth/credentials, tools/OmniBox — plus `telemetry-tracing.md`.
- **Answers to the CUJ questions** (`cuj-answers/_FOR-PASTE.md`) — the 26 “how does claude / codex / polly behave when…” questions, in the doc’s order.
- **CUJ-MAP coverage** (`CUJ-COVERAGE.md`) — all 63 journeys in `designs/CUJ-MAP.md` (§2.A–§2.H), each with mechanism + `file:line` + ✅/⚠️ status.
- **Live-trace findings** (`cuj-answers/_LIVE-TRACE-FINDINGS.md`) + `trace_tools.py` to reproduce extractions.

Scope: **claude (sdk+native), codex (sdk+native), polly**.

## How it was produced
A codebase pass (`file:line` anchors) **+ live OpenTelemetry traces** from a local Jaeger rig — 11 CUJs traced live (incl. fork, interrupt, disconnect/reconnect, sub-agent spawn, ASK/DENY). Source-of-truth = the running code; traces validate/enrich it. (`CUJ-ANALYSIS.md`’s `file:line` anchors had drifted thousands of lines — re-derived here.)

## Notable verified findings
- **TRACEPARENT isn’t propagated into the runner spawn env** → one user action fans out to ~21 traces, stitched only by `session.id`.
- **`telemetry.init("omni-tui")` is never called** → the TUI emits no spans today.
- **PR #1439 is merged** → native policy-hook fail-closed-after-~1h is fixed (claude/codex-native).
- **#1128** confirmed at `claude_sdk_executor.py:1910`; native sub-agent completion gate at `runner/app.py:12607` (#848 cluster).

## For reviewers
- ⚠️ **AI-generated — needs line-by-line human review** before being treated as canonical.
- **codex / codex-native are code-only** here (creds; the host reports `codex: needs-auth`) — no live codex spans.
- **Web/TUI** coverage is code-based (web OTel is opt-in/inactive; the TUI emits no spans today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
