### PR TITLE
fix(sessions): recognize custom agents on native harnesses as native

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -7011,27 +7011,69 @@ async def _reset_runner_resources_after_switch(session_id: str) -> None:
     _publish_changed_files_invalidated(session_id)
 
 
-def _is_native_terminal_session(conv: Conversation) -> bool:
+def _native_coding_agent_for_session(conv: Conversation) -> NativeCodingAgent | None:
     """
-    Return whether a session is owned by a terminal-native wrapper.
+    Resolve native terminal metadata for a session, by wrapper label OR harness.
+
+    Two independent signals identify a native session, because native message
+    handling must NOT be coupled to the terminal-first presentation labels:
+
+    * the ``omnigent.wrapper`` presentation label — set for the built-in
+      terminal-first wrapper sessions (``omnigent claude`` / ``omnigent
+      codex``); resolved directly and cheaply here (short-circuits the harness
+      load below); and
+    * the bound agent's RESOLVED harness — for a CUSTOM agent that declares a
+      native harness (e.g. a user ``polly`` orchestrator with
+      ``executor.harness: codex-native``) but is intentionally CHAT-first, so
+      it carries no wrapper label. Its runner still runs a native transcript
+      forwarder (the single writer for the conversation), so its web messages
+      must take the same native single-writer path — else the inbound user
+      message is persisted AP-side AND mirrored by the forwarder, landing
+      twice. Resolved via :func:`_resolve_harness` (honors a per-session
+      ``harness_override``), independent of the presentation labels; SDK
+      harnesses resolve to ``None``.
 
     :param conv: Conversation row for the target session.
-    :returns: ``True`` for wrappers backed by a native terminal harness.
+    :returns: The :class:`NativeCodingAgent` for the session's harness, or
+        ``None`` when it is not a native terminal harness.
     """
     wrapper = conv.labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY)
-    return native_coding_agent_for_wrapper_label(wrapper) is not None
+    native_agent = native_coding_agent_for_wrapper_label(wrapper)
+    if native_agent is not None:
+        return native_agent
+    return native_coding_agent_for_harness(_resolve_harness(conv))
+
+
+def _is_native_terminal_session(conv: Conversation) -> bool:
+    """
+    Return whether a session's turns are driven by a native terminal harness.
+
+    True for both a built-in terminal-first wrapper (``omnigent.wrapper``
+    label) and a custom chat-first agent bound to a native harness — see
+    :func:`_native_coding_agent_for_session` for why routing keys on the
+    resolved harness, not the presentation labels.
+
+    :param conv: Conversation row for the target session.
+    :returns: ``True`` when the session's harness is a native terminal harness.
+    """
+    return _native_coding_agent_for_session(conv) is not None
 
 
 def _native_terminal_runtime(conv: Conversation) -> tuple[str, str, str]:
     """
-    Return native terminal runtime strings for a wrapper session.
+    Return native terminal runtime strings for a native-harness session.
+
+    Resolves by wrapper label OR resolved harness (see
+    :func:`_native_coding_agent_for_session`), so a custom chat-first agent on
+    a native harness (no wrapper label) resolves too — otherwise it would raise
+    ``Unsupported native terminal session`` the moment its first web message
+    reached the native dispatch branch.
 
     :param conv: Conversation row for the target session.
     :returns: ``(display_name, model, harness)``.
-    :raises OmnigentError: If the wrapper label is unsupported.
+    :raises OmnigentError: If the session is not a native terminal harness.
     """
-    wrapper = conv.labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY)
-    native_agent = native_coding_agent_for_wrapper_label(wrapper)
+    native_agent = _native_coding_agent_for_session(conv)
     if native_agent is not None:
         return native_agent.display_name, native_agent.agent_name, native_agent.harness
     raise OmnigentError(

--- a/tests/test_sessions_native_messages.py
+++ b/tests/test_sessions_native_messages.py
@@ -185,3 +185,78 @@ def test_policy_notice_from_ensure_response(
     from omnigent.server.routes import sessions as sessions_routes
 
     assert sessions_routes._policy_notice_from_ensure_response(response) == expected
+
+
+# ── native routing is harness-driven, not presentation-driven ────────
+
+
+def test_custom_native_harness_session_without_wrapper_label_is_native(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A chat-first custom agent on a native harness is still single-writer.
+
+    A user agent that declares ``executor.harness: codex-native`` but is not a
+    built-in ``*-native-ui`` wrapper (e.g. a ``polly`` orchestrator) carries NO
+    ``omnigent.wrapper`` label — it renders chat-first on purpose. Its runner
+    still runs a native transcript forwarder, so the persist decision must
+    treat it as native via the RESOLVED harness; otherwise the inbound user
+    message is persisted AP-side AND mirrored by the forwarder (double input).
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    conv = Conversation(
+        id="conv_polly",
+        created_at=0,
+        updated_at=0,
+        root_conversation_id="conv_polly",
+        agent_id="ag_polly",
+        labels={},  # chat-first: no wrapper / ui presentation labels
+    )
+    monkeypatch.setattr(sessions_routes, "_resolve_harness", lambda _c: "codex-native")
+    assert sessions_routes._is_native_terminal_session(conv) is True
+    # The native dispatch branch resolves runtime strings from the SAME
+    # resolver, so a label-less native session no longer raises
+    # "Unsupported native terminal session".
+    display_name, _model, harness = sessions_routes._native_terminal_runtime(conv)
+    assert (display_name, harness) == ("Codex", "codex-native")
+
+
+def test_custom_sdk_harness_session_is_not_native(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An SDK-harness session keeps the normal persist-before-forward path.
+
+    SDK harnesses have no transcript forwarder, so the server's single
+    persisted copy is correct — the harness fallback must not over-fire.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    conv = Conversation(
+        id="conv_sdk",
+        created_at=0,
+        updated_at=0,
+        root_conversation_id="conv_sdk",
+        agent_id="ag_sdk",
+        labels={},
+    )
+    monkeypatch.setattr(sessions_routes, "_resolve_harness", lambda _c: "claude-sdk")
+    assert sessions_routes._is_native_terminal_session(conv) is False
+
+
+def test_wrapper_label_session_is_native_without_resolving_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrapper-label path short-circuits before the harness fallback.
+
+    Built-in terminal-first wrapper sessions are recognized by label alone, so
+    the (spec-loading) harness resolution never runs for them.
+    """
+    from omnigent.server.routes import sessions as sessions_routes
+
+    conv = _conversation_with_wrapper("codex-native-ui")
+
+    def _must_not_run(_c: object) -> str:
+        raise AssertionError("harness resolution must not run when the wrapper label matches")
+
+    monkeypatch.setattr(sessions_routes, "_resolve_harness", _must_not_run)
+    assert sessions_routes._is_native_terminal_session(conv) is True


### PR DESCRIPTION
## Related issue

Closes #1738

## Summary

A top-level session bound to a **custom agent on a native terminal harness** (e.g. a `polly` orchestrator with `executor.harness: codex-native`) carries no `omnigent.wrapper` presentation label, so `_is_native_terminal_session` returned `False`. The server then persisted the inbound user message (persist-before-forward) **and** the native transcript forwarder mirrored the rendered turn back — so **every** web/UI message was recorded twice.

- Recognize a native session by wrapper label **OR** resolved harness, via a shared `_native_coding_agent_for_session` helper used by both `_is_native_terminal_session` and `_native_terminal_runtime`.
- Such a session now takes the native single-writer path (the server skips its persist; the transcript forwarder is the sole writer) → messages recorded once.
- **No presentation label is stamped**, so the session stays chat-first — routing is decoupled from presentation. Routing `_native_terminal_runtime` through the same resolver also avoids the `Unsupported native terminal session` error a label-less native session would otherwise hit in the native dispatch branch.

ELI5: native harnesses let the terminal's transcript be the one true record of the chat. The server was told "this is a native session" only by a UI label. Custom agents on a native harness don't get that label, so the server didn't know to step back — it wrote the message too, on top of the terminal's copy. Now the server also checks the actual harness, not just the label.

## Test Plan

- Added unit tests in `tests/test_sessions_native_messages.py`:
  - a label-less native-harness session is classified native **and** `_native_terminal_runtime` resolves its runtime strings (no `Unsupported native terminal session`);
  - an SDK-harness session is **not** native (fallback doesn't over-fire);
  - a wrapper-label session short-circuits without resolving the harness.
- `uv run pytest tests/test_sessions_native_messages.py tests/test_native_coding_agents.py tests/server/integration/test_sessions_add_agent.py tests/server/integration/test_sessions_child_sessions.py tests/server/routes/test_sessions_fork.py tests/server/routes/test_sessions_cost_labels.py tests/test_claude_native.py tests/test_codex_native.py` → **423 passed, 1 xfailed**.
- Manual: ran a custom `polly` agent on `codex-native` locally — the message now appears **once** (was twice), the session stays **chat-first** (not flipped to the terminal-first wrapper), and there is no `Unsupported native terminal session` error. Built-in `omnigent claude`/`omnigent codex` wrappers (wrapper-label short-circuit) and SDK agents (resolve to non-native) are unchanged.

## Demo
Behaviour before fix
<img width="811" height="396" alt="Screenshot 2026-07-01 at 4 48 32 pm" src="https://github.com/user-attachments/assets/24d6b323-5a12-4975-acdb-92d2d91346bd" />


Behaviour after fix
<img width="811" height="367" alt="Screenshot 2026-07-01 at 4 47 27 pm" src="https://github.com/user-attachments/assets/e918809b-2220-4432-bec9-b31736fdad8e" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests lock the routing decision (native by wrapper label or resolved harness, and `_native_terminal_runtime` resolution) without a live TUI. Manual verification covered the end-to-end behaviour that unit tests can't reach: a real `codex-native` custom-agent session records one message, stays chat-first, and raises no native-runtime error; built-in wrappers and SDK agents behave as before.