### PR TITLE
feat(examples): add per-session and daily cost-budget policies to scribe

### DIFF
--- a/examples/scribe/config.yaml
+++ b/examples/scribe/config.yaml
@@ -128,7 +128,29 @@ os_env:
 # everything else — including the read-only git/gh Scribe relies on — runs
 # without an ASK (`gate_pushes: false`), since a headless orchestrator can't
 # answer an approval prompt.
+#
+# Cost-budget guardrails:
+#
+#   session_cost_cap — per-session hard spending cap.
+#     A single Scribe session is blocked once it has spent $0.50.  A soft
+#     warning fires at $0.20 so the user can decide whether to continue before
+#     the cap is reached.  No expensive_models list is given: the default blocks
+#     ALL models once the cap is hit (a true hard stop, not just a downgrade
+#     gate).  Pass an explicit list such as expensive_models: ["opus", "gpt-5"]
+#     to get a downgrade gate instead — only those tiers are blocked and the
+#     session can continue on a cheaper model.
+#
+#   user_daily_cost_budget — per-user daily cap across all sessions.
+#     The session owner's total spend across ALL their sessions today is capped
+#     at $2.00.  Soft warnings at $0.50 and $1.00 prompt the user before the
+#     daily limit is exhausted.  Approvals are sticky per user+day: approving
+#     the $0.50 checkpoint here means it won't re-ask in any other session the
+#     same day.
 guardrails:
+  # How long an ASK approval card stays open before the turn is denied.
+  # 86400s = 24 hours — lets a user come back to an approval prompt later.
+  ask_timeout: 86400
+
   policies:
     blast_radius:
       type: function
@@ -137,6 +159,29 @@ guardrails:
         path: omnigent.inner.nessie.policies.blast_radius
         arguments:
           gate_pushes: false
+
+    # Per-session hard cap: block this session once it has spent $0.50.
+    session_cost_cap:
+      type: function
+      function:
+        path: omnigent.policies.builtins.cost.cost_budget
+        arguments:
+          max_cost_usd: 0.50
+          ask_thresholds_usd: [0.20]
+          # Omit expensive_models (or pass []) → hard stop for ALL models once
+          # the cap is reached.  Uncomment for a downgrade gate instead:
+          # expensive_models: ["opus", "gpt-5"]
+
+    # Per-user daily cap: block the owner's sessions once they've spent $2.00
+    # across all their sessions today.
+    user_daily_cost_cap:
+      type: function
+      function:
+        path: omnigent.policies.builtins.cost.user_daily_cost_budget
+        arguments:
+          max_cost_usd: 2.00
+          ask_thresholds_usd: [0.50, 1.00]
+          # Same expensive_models semantics as cost_budget above.
 
 tools:
   # The two sub-agents — see agents/<name>/. `researcher` explores read-only on

--- a/omnigent/resources/examples/scribe
+++ b/omnigent/resources/examples/scribe
@@ -1,0 +1,1 @@
+../../../examples/scribe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,7 +264,7 @@ include = ["omnigent*"]
 [tool.setuptools.package-data]
 "omnigent.db" = ["alembic.ini"]
 "omnigent.db.migrations" = ["script.py.mako"]
-"omnigent.resources.examples" = ["*.yaml", "*.sh", "debby/**/*", "polly/**/*"]
+"omnigent.resources.examples" = ["*.yaml", "*.sh", "debby/**/*", "polly/**/*", "scribe/**/*"]
 "omnigent.resources.pi_native" = ["*.js"]
 # include UI assets in build
 "omnigent.server" = ["static/web-ui/**/*"]

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ class _GenerateBuildInfo(build_py):
 
         root = Path(__file__).resolve().parent
         dest_root = Path(self.build_lib) / "omnigent" / "resources" / "examples"
-        for name in ("debby", "polly"):
+        for name in ("debby", "polly", "scribe"):
             src = root / "examples" / name
             if not src.is_dir():
                 continue


### PR DESCRIPTION
## Summary

Adds \`cost_budget\` and \`user_daily_cost_budget\` guardrail policies to the existing \`scribe\` example agent — the first bundled example demonstrating both spend caps so operators have a concrete config to copy.

## What's added to \`examples/scribe/config.yaml\`

- **\`session_cost_cap\`** — hard stop at \$0.50 with a \$0.20 soft warning. No \`expensive_models\` list → all models blocked (true hard stop). Commented line shows how to switch to a downgrade gate.
- **\`user_daily_cost_cap\`** — owner's total daily spend capped at \$2.00 (across all sessions) with \$0.50 and \$1.00 soft checkpoints. Approvals are sticky per user+day.
- **\`ask_timeout: 86400\`** — 24h so approval cards outlive a user stepping away.

## Packaging

- Adds \`scribe\` symlink to \`omnigent/resources/examples/\` (same pattern as \`polly\`/\`debby\`)
- Registers \`scribe/**/*\` in \`pyproject.toml\` and \`setup.py\`

## Test plan
- [ ] \`omnigent run examples/scribe\` loads and the cost policies are active
- [ ] \`pytest\` — no new tests (config-only change)