### PR TITLE
DRAFT fix(claude-native): keep policy/permission hook token fresh from the …

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1005,6 +1005,48 @@ def read_permission_hook_config(bridge_dir: Path) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def refresh_permission_hook_auth(bridge_dir: Path, authorization: str) -> bool:
+    """
+    Re-stamp the stored ``ap_auth_headers`` bearer for the native hooks.
+
+    The permission / policy command hooks read a one-shot ``ap_auth_headers``
+    snapshot from ``permission_hook.json`` (written once by
+    :func:`build_hook_settings` at launch/reattach), which dies with the ~1h
+    Databricks OAuth token lifetime. Once it lapses the hook subprocess must
+    re-mint on its own — a fragile path that fails outright when the on-disk
+    Databricks *refresh* token has itself expired, leaving every tool call to
+    fail closed. The long-lived transcript forwarder holds refresh-capable
+    auth, so it calls this on a cadence well under the 1h TTL to hand the hook
+    a live bearer, making the hook's own re-mint a rare last resort rather
+    than the primary refresh path.
+
+    Only the ``Authorization`` header is replaced; routing headers (e.g.
+    ``X-Databricks-Org-Id``) and ``ap_server_url`` are preserved. The write is
+    atomic (:func:`_write_json_file`), so a concurrent hook read never tears.
+
+    :param bridge_dir: Bridge directory path.
+    :param authorization: Full ``Authorization`` header value, e.g.
+        ``"Bearer eyJ..."``.
+    :returns: ``True`` when the snapshot was rewritten; ``False`` when there
+        is no permission-hook config to refresh or the bearer is unchanged
+        (no write performed).
+    """
+    config = _read_json_file(bridge_dir / _PERMISSION_HOOK_FILE)
+    if not isinstance(config, dict) or not config.get("ap_server_url"):
+        return False
+    raw_headers = config.get("ap_auth_headers")
+    headers = dict(raw_headers) if isinstance(raw_headers, dict) else {}
+    if headers.get("Authorization") == authorization:
+        # Token unchanged (SDK served the same cached bearer): skip the write
+        # so we don't churn the file — and its mtime — every cycle.
+        return False
+    headers["Authorization"] = authorization
+    config["ap_auth_headers"] = headers
+    config["updated_at"] = time.time()
+    _write_json_file(bridge_dir / _PERMISSION_HOOK_FILE, config)
+    return True
+
+
 def build_mcp_config(bridge_dir: Path, *, python_executable: str | None = None) -> dict[str, Any]:
     """
     Build the Claude Code MCP config for the Omnigent bridge server.

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -10,7 +10,7 @@ import logging
 import os
 import tempfile
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -36,6 +36,7 @@ from omnigent.claude_native_bridge import (
     read_transcript_items_from_offset,
     read_transcript_items_since_with_position,
     read_transcript_path,
+    refresh_permission_hook_auth,
     transcript_has_forked_from_marker,
     transcript_has_recent_local_command,
     url_component,
@@ -217,6 +218,12 @@ _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
 _SUBAGENT_META_GLOB = "agent-*.meta.json"
 _DEFAULT_POLL_INTERVAL_S = 0.25
 _POST_TIMEOUT_S = 10.0
+# Cadence for re-stamping the native hooks' ``ap_auth_headers`` bearer in
+# ``permission_hook.json``. The hooks read a one-shot snapshot that dies at the
+# ~1h Databricks OAuth TTL; well under that, the forwarder (which holds
+# refresh-capable auth) rewrites it so the hook subprocess always reads a live
+# token instead of re-minting from a possibly-lapsed on-disk refresh token.
+_HOOK_AUTH_REFRESH_INTERVAL_S = 600.0
 _MAX_SEEN_SOURCE_IDS = 2000
 _CURSOR_FINGERPRINT_BYTES = 256
 _FORK_COMMAND_NAMES = frozenset({"/branch", "/fork"})
@@ -674,6 +681,78 @@ class _PostRetryTracker:
         )
 
 
+class _HookAuthRefresher:
+    """Periodically re-stamp the native hooks' ``ap_auth_headers`` bearer.
+
+    The permission / policy command hooks authenticate with a one-shot
+    ``ap_auth_headers`` snapshot in ``permission_hook.json`` that dies at the
+    ~1h Databricks OAuth TTL. When it lapses the hook must re-mint on its own,
+    which fails outright once the on-disk Databricks *refresh* token has itself
+    expired — so every tool call fails closed while the (refresh-capable)
+    forwarder keeps working. This closes that gap: the forwarder mints a fresh
+    bearer from the same :func:`_make_auth_token_factory` its own client uses
+    and rewrites the snapshot, so the hook reads a token minted less than
+    :data:`_HOOK_AUTH_REFRESH_INTERVAL_S` ago and its own re-mint becomes a
+    rare last resort.
+
+    Best-effort throughout: a missing factory, a mint failure, or an absent
+    permission-hook config never disrupts transcript forwarding.
+    """
+
+    def __init__(self, *, bridge_dir: Path, server_url: str) -> None:
+        """
+        :param bridge_dir: Bridge directory holding ``permission_hook.json``.
+        :param server_url: Omnigent server URL — the token-factory key (the
+            same ``base_url`` the forwarder's client authenticates against).
+        """
+        self._bridge_dir = bridge_dir
+        self._server_url = server_url
+        self._factory: Callable[[], str | None] | None = None
+        self._factory_resolved = False
+        # The launch snapshot is already fresh; first refresh one interval in.
+        self._next_refresh_at = time.monotonic() + _HOOK_AUTH_REFRESH_INTERVAL_S
+
+    async def maybe_refresh(self) -> None:
+        """Re-stamp the hook bearer when the interval has elapsed.
+
+        Cheap to call every poll: returns immediately until the interval is
+        due. The token mint (which can shell out to the Databricks CLI near
+        expiry) runs off-thread so the forwarder's event loop never blocks.
+        """
+        now = time.monotonic()
+        if now < self._next_refresh_at:
+            return
+        self._next_refresh_at = now + _HOOK_AUTH_REFRESH_INTERVAL_S
+        try:
+            token = await asyncio.to_thread(self._mint_token)
+            if token:
+                refresh_permission_hook_auth(self._bridge_dir, f"Bearer {token}")
+        except Exception:  # noqa: BLE001 — never let auth refresh break forwarding
+            return
+
+    def _mint_token(self) -> str | None:
+        """Mint a fresh bearer via the shared Databricks token factory.
+
+        Resolves :func:`_make_auth_token_factory` once (lazily, off the hot
+        path) and reuses it, mirroring the runner's own auth. Returns ``None``
+        when no refresh mechanism is available or a mint transiently fails.
+        """
+        if not self._factory_resolved:
+            try:
+                from omnigent.runner._entry import _make_auth_token_factory
+
+                self._factory = _make_auth_token_factory(self._server_url)
+            except Exception:  # noqa: BLE001 — best-effort; fall back to no refresh
+                self._factory = None
+            self._factory_resolved = True
+        if self._factory is None:
+            return None
+        try:
+            return self._factory()
+        except Exception:  # noqa: BLE001 — transient SDK/refresh failure
+            return None
+
+
 async def forward_claude_transcript_to_session(
     *,
     base_url: str,
@@ -757,11 +836,17 @@ async def forward_claude_transcript_to_session(
     task_statuses: dict[str, str] = {}
     task_order: list[str] = []
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    # Keep the native hooks' ap_auth_headers bearer live from this
+    # refresh-capable loop, so the hook subprocess never has to re-mint from a
+    # possibly-lapsed on-disk Databricks refresh token. Best-effort; a no-op
+    # when no token factory resolves (e.g. local unauthenticated servers).
+    hook_auth_refresher = _HookAuthRefresher(bridge_dir=bridge_dir, server_url=base_url)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
         while True:
             try:
+                await hook_auth_refresher.maybe_refresh()
                 current_session_id = read_active_session_id(bridge_dir) or session_id
                 if hook_state is None:
                     hook_state = await _ensure_hook_state(

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -497,11 +497,7 @@ def post_evaluate_with_retry(
         try:
             with httpx.Client(headers=headers, timeout=timeout) as client:
                 resp = client.post(url, json=request_body)
-                if (
-                    reauth is not None
-                    and not reauthed
-                    and _is_login_redirect_or_unauthorized(resp)
-                ):
+                if not reauthed and _is_login_redirect_or_unauthorized(resp):
                     # The one-shot ``ap_auth_headers`` token lapsed (~1h
                     # Databricks OAuth lifetime): the Apps front door bounces
                     # an expired bearer with a 302→/oidc/ (or a 401). Re-mint
@@ -510,7 +506,7 @@ def post_evaluate_with_retry(
                     # runner's own callbacks. Without this, every tool call on a
                     # session older than the token lifetime fails CLOSED while
                     # chat (refresh-capable) keeps working.
-                    refreshed = reauth()
+                    refreshed = reauth() if reauth is not None else None
                     if refreshed:
                         headers = refreshed
                         reauthed = True
@@ -520,6 +516,22 @@ def post_evaluate_with_retry(
                             file=sys.stderr,
                         )
                         continue
+                    # No re-mint available, or the re-mint itself failed
+                    # because the Databricks OAuth *refresh* token has also
+                    # lapsed — there is nothing left to mint from. Fail closed
+                    # here with an actionable hint. (Falling through to
+                    # ``raise_for_status`` would also fail closed — a 302/401 is
+                    # caught below and returns ``None`` — but only after a terse
+                    # "Omnigent returned 302" with no next step; this names the
+                    # fix instead.)
+                    print(
+                        f"omnigent {hook_label}: Omnigent auth expired and could not "
+                        "re-mint a token (Databricks OAuth session likely lapsed) — "
+                        "run `databricks auth login` to re-authenticate. "
+                        "Failing closed for this call.",
+                        file=sys.stderr,
+                    )
+                    return None
                 resp.raise_for_status()
                 return resp
         except httpx.HTTPStatusError as exc:

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -43,6 +43,7 @@ from omnigent.claude_native_bridge import (
     read_transcript_items_since,
     read_transcript_path,
     record_hook_event,
+    refresh_permission_hook_auth,
     start_tool_relay,
     stop_hook_seen_since,
     write_tmux_target,
@@ -267,6 +268,70 @@ def test_prepare_bridge_dir_preserves_permission_hook_config(
     config = read_permission_hook_config(bridge_dir)
     assert config["ap_server_url"] == "http://127.0.0.1:8787"
     assert config["ap_auth_headers"] == {"Authorization": "Bearer xyz"}
+
+
+def test_refresh_permission_hook_auth_restamps_bearer_preserving_routing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Re-stamp only the ``Authorization`` header; keep routing + server URL.
+
+    The transcript forwarder periodically refreshes the one-shot hook token
+    (which dies at the ~1h Databricks OAuth TTL) from its own refresh-capable
+    auth. Only the bearer may change: ``ap_server_url`` and routing headers
+    like ``X-Databricks-Org-Id`` must survive, or the hook loses its workspace
+    routing and target on the next tool call.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native")
+    bridge_dir = prepare_bridge_dir("conv_abc", workspace=tmp_path)
+    augment_claude_args(
+        (),
+        bridge_dir=bridge_dir,
+        ap_server_url="http://127.0.0.1:8787",
+        ap_auth_headers={"Authorization": "Bearer stale", "X-Databricks-Org-Id": "o1"},
+    )
+    before = read_permission_hook_config(bridge_dir)["updated_at"]
+
+    changed = refresh_permission_hook_auth(bridge_dir, "Bearer fresh")
+
+    assert changed is True
+    config = read_permission_hook_config(bridge_dir)
+    assert config["ap_server_url"] == "http://127.0.0.1:8787"
+    assert config["ap_auth_headers"] == {
+        "Authorization": "Bearer fresh",
+        "X-Databricks-Org-Id": "o1",
+    }
+    assert config["updated_at"] >= before
+
+
+def test_refresh_permission_hook_auth_noops_when_unchanged_or_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Return ``False`` (no write) for an absent config or an unchanged bearer.
+
+    A bridge with no ``permission_hook.json`` yet has nothing to refresh, and
+    an unchanged token (the SDK served the same cached bearer) must not churn
+    the file — and its ``updated_at`` — every cycle.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "claude-native")
+    bridge_dir = prepare_bridge_dir("conv_abc", workspace=tmp_path)
+
+    # No permission_hook.json written yet → nothing to refresh.
+    assert refresh_permission_hook_auth(bridge_dir, "Bearer x") is False
+
+    augment_claude_args(
+        (),
+        bridge_dir=bridge_dir,
+        ap_server_url="http://127.0.0.1:8787",
+        ap_auth_headers={"Authorization": "Bearer same"},
+    )
+    # Same bearer → no rewrite.
+    assert refresh_permission_hook_auth(bridge_dir, "Bearer same") is False
 
 
 def test_prepare_bridge_dir_restricts_filesystem_permissions(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -23,8 +23,10 @@ from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
     ClaudeMessageDelta,
     ClaudeTranscriptItem,
+    augment_claude_args,
     prepare_bridge_dir,
     read_active_session_id,
+    read_permission_hook_config,
     record_hook_event,
     write_active_session_id,
 )
@@ -6699,3 +6701,75 @@ async def test_forwarder_posts_waiting_when_stop_has_background_tasks(
         "type": "external_session_status",
         "data": {"status": "waiting", "background_task_count": 1},
     }
+
+
+async def test_hook_auth_refresher_restamps_bearer_after_interval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The forwarder re-stamps the hook's ap_auth_headers bearer on its cadence.
+
+    Once the interval elapses, ``_HookAuthRefresher`` mints a fresh token via
+    the shared Databricks factory and rewrites ``permission_hook.json`` so the
+    hook subprocess reads a live bearer instead of re-minting from a possibly
+    lapsed on-disk refresh token (the failure mode that made every tool call
+    fail closed while the refresh-capable forwarder kept working).
+    """
+    bridge_dir = prepare_bridge_dir("conv_abc", workspace=tmp_path)
+    augment_claude_args(
+        (),
+        bridge_dir=bridge_dir,
+        ap_server_url="http://ap",
+        ap_auth_headers={"Authorization": "Bearer stale", "X-Databricks-Org-Id": "o1"},
+    )
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda server_url: lambda: "fresh-token",
+    )
+    refresher = forwarder._HookAuthRefresher(bridge_dir=bridge_dir, server_url="http://ap")
+
+    # Not yet due → snapshot untouched.
+    await refresher.maybe_refresh()
+    config = read_permission_hook_config(bridge_dir)
+    assert config["ap_auth_headers"]["Authorization"] == "Bearer stale"
+
+    # Interval elapsed → re-stamp only the bearer, preserving routing headers.
+    refresher._next_refresh_at = 0.0
+    await refresher.maybe_refresh()
+    config = read_permission_hook_config(bridge_dir)
+    assert config["ap_auth_headers"] == {
+        "Authorization": "Bearer fresh-token",
+        "X-Databricks-Org-Id": "o1",
+    }
+
+
+async def test_hook_auth_refresher_noop_when_no_token_factory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    No token factory (e.g. local unauthenticated server) → snapshot untouched.
+
+    The refresh is purely additive resilience: when no credential source
+    resolves, the hook keeps its launch snapshot and the forwarder never
+    rewrites the file.
+    """
+    bridge_dir = prepare_bridge_dir("conv_abc", workspace=tmp_path)
+    augment_claude_args(
+        (),
+        bridge_dir=bridge_dir,
+        ap_server_url="http://ap",
+        ap_auth_headers={"Authorization": "Bearer stale"},
+    )
+    monkeypatch.setattr(
+        "omnigent.runner._entry._make_auth_token_factory",
+        lambda server_url: None,
+    )
+    refresher = forwarder._HookAuthRefresher(bridge_dir=bridge_dir, server_url="http://ap")
+    refresher._next_refresh_at = 0.0
+
+    await refresher.maybe_refresh()
+
+    config = read_permission_hook_config(bridge_dir)
+    assert config["ap_auth_headers"]["Authorization"] == "Bearer stale"

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -487,12 +487,12 @@ def test_post_evaluate_with_retry_no_reauth_fails_on_redirect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    With no ``reauth`` callable, a login-redirect yields ``None`` (legacy).
+    With no ``reauth`` callable, a login-redirect yields ``None``.
 
-    Callers without a token source (e.g. codex/kimi today) see the same
-    behavior as before this change: ``raise_for_status`` rejects the 302 as a
-    non-retryable <500, the helper returns ``None``, and the caller fails
-    closed. Guards against the new branch altering that.
+    Callers without a token source still fail closed on an auth bounce: the
+    login-redirect branch has nothing to re-mint, so it returns ``None``
+    directly (with an actionable "run `databricks auth login`" hint on stderr)
+    rather than passing the 302 back as if it were a verdict.
     """
     seen_headers: list[dict[str, str]] = []
     redirect = httpx.Response(
@@ -516,10 +516,10 @@ def test_post_evaluate_with_retry_reauth_unavailable_fails_closed(
     """
     When re-mint yields no token, the helper returns ``None`` (caller fails closed).
 
-    Re-auth is best-effort: a ``reauth`` that returns ``None`` (no creds /
-    transient mint failure) must not loop — it falls through to
-    ``raise_for_status`` (302 → non-retryable) so the caller keeps the
-    fail-closed safety net.
+    Re-auth is best-effort: a ``reauth`` that returns ``None`` (no creds, or
+    the Databricks OAuth *refresh* token has itself lapsed so there is nothing
+    left to mint from) must not loop — the login-redirect branch fails closed
+    directly, preserving the caller's fail-closed safety net.
     """
     seen_headers: list[dict[str, str]] = []
     redirect = httpx.Response(


### PR DESCRIPTION
…forwarder

The native permission/policy command hooks authenticate with a one-shot `ap_auth_headers` bearer snapshotted into permission_hook.json at launch, which dies at the ~1h Databricks OAuth TTL. Its only recovery was the hook subprocess re-minting via `_make_auth_token_factory` — a path that fails outright once the on-disk Databricks *refresh* token has itself lapsed (or been rotated out from under it by the long-lived runner sharing the token cache), so every PreToolUse tool call fails CLOSED with an opaque "policy evaluation unavailable" while the refresh-capable transcript forwarder keeps working (its `/events` POSTs still land).

Close the gap from the side that already has healthy refresh-capable auth: the forwarder now re-stamps permission_hook.json's `ap_auth_headers` on a 10-min cadence (well under the 1h TTL) via the same token factory its own client uses, so the hook reads a bearer minted <10min ago and its own re-mint becomes a rare last resort. Only the Authorization header is replaced; routing headers (X-Databricks-Org-Id) and ap_server_url are preserved, and the write is atomic so concurrent hook reads never tear.

Also make the hook's fail-closed path actionable: when an auth bounce (302->/oidc/ or 401) cannot be re-minted, log "run `databricks auth login`" instead of a terse status line.

Co-authored-by: Isaac

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->
