### PR TITLE
fix(spec): preserve llm.profile through the llm/executor consolidation

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -181,6 +181,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
             model=executor.model or llm.model,
             extra=llm.extra,
             connection=executor.connection,
+            profile=llm.profile,
             request_timeout=llm.request_timeout,
             retry=llm.retry,
         )

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -1961,6 +1961,35 @@ def test_parse_llm_timeout_defaults(tmp_path: Path) -> None:
     assert spec.llm.retry.max_retries == 7
 
 
+def test_parse_llm_profile_survives_consolidation(tmp_path: Path) -> None:
+    """``llm.profile`` must survive the llm/executor consolidation rebuild.
+
+    When an ``llm:`` block is present, ``parse`` rebuilds ``LLMConfig`` to
+    keep model/connection in sync with the authoritative executor fields.
+    That rebuild used to omit ``profile``, silently dropping the credentials
+    profile. Downstream, the policy/guardrail builder resolves a Databricks
+    workspace connection from ``spec.llm.profile``
+    (``omnigent/runtime/policies/builder.py``), so losing it makes those
+    paths fall back to env/default auth instead of the declared profile.
+
+    Regression guard: pre-fix ``spec.llm.profile`` is ``None`` here.
+    """
+    config = {
+        "spec_version": 1,
+        "llm": {
+            "model": "databricks/databricks-claude-sonnet-4",
+            "profile": "my-workspace",
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert spec.llm is not None
+    assert spec.llm.profile == "my-workspace", (
+        f"spec.llm.profile is {spec.llm.profile!r}, expected 'my-workspace' — the "
+        "consolidation rebuild dropped the declared credentials profile."
+    )
+
+
 def test_parse_tools_global_timeout_and_retry(tmp_path: Path) -> None:
     """Tools block with explicit timeout and retry overrides."""
     config = {


### PR DESCRIPTION
## Related issue

Closes #1743

## Summary

- When an `llm:` block is present, `parse` (`omnigent/spec/parser.py`) rebuilds `LLMConfig` to keep model/connection in sync with the authoritative executor fields. The rebuild omitted `profile`, silently dropping a declared credentials profile from `spec.llm.profile`.
- This is not cosmetic: the policy/guardrail builder resolves a Databricks workspace connection from `spec.llm.profile` (`runtime/policies/builder.py::_resolve_server_llm_connection`), so the dropped profile makes the policy/guardrail LLM and web_fetch sub-agent fall back to env/default auth instead of the declared workspace profile.
- Carry `profile=llm.profile` through the rebuild.

## Test Plan

- New regression test `test_parse_llm_profile_survives_consolidation`: parses a spec with `llm.model` + `llm.profile` and asserts `spec.llm.profile == "my-workspace"`. Verified it **fails before the fix** (`profile is None`) and passes after.
- `uv run pytest tests/spec/test_parser.py` -> 188 passed (2 pre-existing failures on this Windows checkout, `test_parse_skill_non_utf8_raises_omnigent_error` and `test_discover_host_skills_skips_unreadable_skill_file`, are unrelated file-encoding/permission tests that also fail on a clean `main`).
- `ruff check` / `ruff format --check` clean on both files.

## Demo

N/A (non-visual; covered by the unit test).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by reproducing the drop (parse with `llm.model` + `llm.profile` yields `spec.llm.profile is None`), applying the one-line fix, and confirming the new regression test then passes and fails without the fix. No secrets involved.
