### PR TITLE
fix(antigravity): subtract cached tokens from input to stop double-billing

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -1066,7 +1066,15 @@ class AntigravityExecutor(Executor):
         total_tokens = getattr(meta, "total_token_count", None)
         cached = getattr(meta, "cached_content_token_count", None)
         if prompt_tokens is not None:
-            usage["input_tokens"] = prompt_tokens
+            # Gemini's ``prompt_token_count`` is INCLUSIVE of
+            # ``cached_content_token_count``. ``compute_llm_cost`` expects
+            # ``input_tokens`` to be the NON-cached portion and prices
+            # ``cache_read_input_tokens`` additively, so pass the non-cached
+            # remainder here — otherwise the cached tokens are billed twice
+            # (once at the full input rate, once at the cache-read rate).
+            # Mirrors the qwen executor, which maps the same Gemini usage
+            # shape. Clamp so a malformed cached > prompt never goes negative.
+            usage["input_tokens"] = max(0, prompt_tokens - (cached or 0))
         if output_tokens is not None:
             usage["output_tokens"] = output_tokens
         if total_tokens is not None:

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -352,13 +352,65 @@ async def test_streaming_maps_text_reasoning_and_usage(monkeypatch: pytest.Monke
     assert completes[0].response == "Hello world"
     # Usage maps the SDK's UsageMetadata field names onto Omnigent's keys and
     # stamps the resolved model so the scaffold can price the turn.
+    # input_tokens is the NON-cached portion: Gemini's prompt_token_count (11)
+    # is inclusive of cached_content_token_count (2), and compute_llm_cost
+    # prices cache_read_input_tokens additively, so input must be 11 - 2 = 9 to
+    # avoid double-billing the cached tokens.
     assert completes[0].usage == {
-        "input_tokens": 11,
+        "input_tokens": 9,
         "output_tokens": 7,
         "total_tokens": 18,
         "cache_read_input_tokens": 2,
         "model": "gemini-3-pro",
     }
+
+
+def test_extract_usage_subtracts_cached_to_avoid_double_billing() -> None:
+    """``input_tokens`` excludes cached tokens so cache reads aren't billed twice.
+
+    Gemini's ``prompt_token_count`` is inclusive of
+    ``cached_content_token_count``, and ``compute_llm_cost`` prices
+    ``cache_read_input_tokens`` additively while requiring ``input_tokens`` to
+    be the NON-cached portion. Passing the full prompt count as ``input_tokens``
+    while also reporting ``cache_read_input_tokens`` bills the cached tokens
+    twice — once at the full input rate, once at the cache-read rate.
+
+    Regression guard: pre-fix ``input_tokens`` was the full 1000 here.
+    """
+    meta = SimpleNamespace(
+        prompt_token_count=1000,
+        candidates_token_count=200,
+        total_token_count=1200,
+        cached_content_token_count=800,
+    )
+    usage = AntigravityExecutor._extract_usage(meta)
+    assert usage is not None
+    # 1000 prompt - 800 cached = 200 non-cached input.
+    assert usage["input_tokens"] == 200, (
+        f"input_tokens {usage['input_tokens']} != 200 — the cached portion must be "
+        "subtracted from the Gemini prompt count so compute_llm_cost does not "
+        "double-bill it against the additive cache_read bucket."
+    )
+    assert usage["cache_read_input_tokens"] == 800
+    assert usage["output_tokens"] == 200
+    assert usage["total_tokens"] == 1200
+    # input + cache_read reconstructs the original prompt count, proving the
+    # cached tokens are counted exactly once across the two buckets.
+    assert usage["input_tokens"] + usage["cache_read_input_tokens"] == 1000
+
+
+def test_extract_usage_clamps_when_cached_exceeds_prompt() -> None:
+    """A malformed cached > prompt count clamps ``input_tokens`` to 0, not negative."""
+    meta = SimpleNamespace(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        total_token_count=150,
+        cached_content_token_count=999,
+    )
+    usage = AntigravityExecutor._extract_usage(meta)
+    assert usage is not None
+    assert usage["input_tokens"] == 0
+    assert usage["cache_read_input_tokens"] == 999
 
 
 @pytest.mark.asyncio
@@ -904,11 +956,14 @@ async def test_usage_observer_notified_on_turn_complete(monkeypatch: pytest.Monk
         remove()
 
     # Exactly one notification, carrying the model and the mapped token counts
-    # from the turn's UsageMetadata (_FakeUsage: prompt=11, candidates=7, total=18).
+    # from the turn's UsageMetadata (_FakeUsage: prompt=11, candidates=7,
+    # total=18, cached=2). input_tokens is the non-cached portion (11 - 2 = 9)
+    # so cached tokens are not double-billed against the additive cache_read
+    # bucket.
     assert len(seen) == 1
     assert seen[0] == {
         "model": "gemini-3-pro",
-        "input_tokens": 11,
+        "input_tokens": 9,
         "output_tokens": 7,
         "total_tokens": 18,
     }


### PR DESCRIPTION
## Related issue

Closes #1745

## Summary

- `AntigravityExecutor._extract_usage` copied Gemini's `prompt_token_count` straight into `input_tokens` and also wrote `cached_content_token_count` into `cache_read_input_tokens`, without subtracting the cached portion.
- Gemini's `prompt_token_count` is inclusive of `cached_content_token_count`, and `compute_llm_cost` requires `input_tokens` to be the non-cached portion (it prices `cache_read_input_tokens` additively). The cached tokens were therefore billed twice: once at the full input rate, once at the cache-read rate.
- Fix: `input_tokens = max(0, prompt_token_count - cached)`, mirroring the qwen executor, which maps the same Gemini usage shape and already subtracts. The clamp guards a malformed cached > prompt.

## Test Plan

- New `test_extract_usage_subtracts_cached_to_avoid_double_billing`: with `prompt=1000, cached=800`, asserts `input_tokens == 200` and that `input_tokens + cache_read_input_tokens == 1000` (cached counted exactly once). Verified it **fails before the fix** (`input_tokens == 1000`).
- New `test_extract_usage_clamps_when_cached_exceeds_prompt`: malformed `cached > prompt` clamps `input_tokens` to `0`.
- Updated the two existing tests that had locked the pre-fix value (`input_tokens 11` -> `9` for `prompt=11, cached=2`), with comments explaining why.
- `uv run pytest tests/inner/test_antigravity_executor.py` -> **37 passed**.
- `ruff check` / `ruff format --check` clean on both files.

## Demo

No UI surface to screenshot, this is a token-accounting change, so here is the concrete before/after. For a turn with prompt_token_count=1000, candidates=200, cached=800, priced at input 2e-6, output 1e-5, cache_read 2e-7:

- Before: input_tokens=1000, cache_read=800 -> 1000*2e-6 + 200*1e-5 + 800*2e-7 = 0.00416
- After:  input_tokens=200 (1000-800), cache_read=800 -> 0.00256

The 800 cached tokens are no longer billed at the full input rate on top of the cache-read rate.


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified against the sibling pattern: `qwen_executor.py` maps the same Gemini usage shape and explicitly subtracts the cached portion (`non_cached = max(0, inputTokens - cached)`); codex and openai executors subtract too. Antigravity was the lone Gemini path that didn't, and it emits no direct `cost_usd`, so `compute_llm_cost` is its billing path. `compute_llm_cost`'s own docstring documents that `input_tokens` must be non-cached and that failing to subtract double-bills cached tokens. No secrets involved (all token counts are dummy values; the fake SDK is monkeypatched, no network call).
