### PR TITLE
fix(examples): sandbox Sentinel by default; frame read_only_os as best-effort guardrail

### DIFF
--- a/examples/sentinel/agents/reviewer/config.yaml
+++ b/examples/sentinel/agents/reviewer/config.yaml
@@ -16,10 +16,11 @@ executor:
     harness: codex
 
 # Filesystem access so the reviewer can verify claims against the real files.
-# `sandbox: type: none` runs unsandboxed in the caller's repo. The bundled
-# `sys_os_write` / `sys_os_edit` tools are denied by the `read_only_os` policy
-# below, so the reviewer can read to fact-check but never edits the code or the
-# draft.
+# `sandbox: type: none` runs unsandboxed in the caller's repo (zero setup,
+# cross-platform). `read_only_os` below denies the file-write/edit tools as a
+# BEST-EFFORT guardrail -- it does not gate shell, so it is not a hard boundary.
+# For untrusted code, sandbox it (`sandbox.type: linux_bwrap` /
+# `darwin_seatbelt`) so cwd is read-only. See the orchestrator config.
 os_env:
   type: caller_process
   cwd: .
@@ -27,7 +28,7 @@ os_env:
     type: none
 
 # Same guardrails the rest of the bundle uses: blast_radius bounds shell, and
-# read_only_os denies every file-mutating tool so the reviewer can never edit.
+# read_only_os denies the file-write/edit tools (best-effort; shell not gated).
 guardrails:
   policies:
     blast_radius:

--- a/examples/sentinel/agents/reviewer/config.yaml
+++ b/examples/sentinel/agents/reviewer/config.yaml
@@ -16,16 +16,15 @@ executor:
     harness: codex
 
 # Filesystem access so the reviewer can verify claims against the real files.
-# `sandbox: type: none` runs unsandboxed in the caller's repo (zero setup,
-# cross-platform). `read_only_os` below denies the file-write/edit tools as a
-# BEST-EFFORT guardrail -- it does not gate shell, so it is not a hard boundary.
-# For untrusted code, sandbox it (`sandbox.type: linux_bwrap` /
-# `darwin_seatbelt`) so cwd is read-only. See the orchestrator config.
+# Sandboxed by default: omitting `sandbox.type` auto-selects the platform
+# backend (`linux_bwrap` / `darwin_seatbelt`), binding cwd read-only so shell
+# writes are contained. Linux needs `bwrap` installed (fails loud with a hint if
+# missing); macOS uses the built-in sandbox-exec. See the orchestrator config.
+# `read_only_os` below is defense-in-depth (refuses the file-write tools early);
+# add `sandbox: {type: none}` only for code you fully trust.
 os_env:
   type: caller_process
   cwd: .
-  sandbox:
-    type: none
 
 # Same guardrails the rest of the bundle uses: blast_radius bounds shell, and
 # read_only_os denies the file-write/edit tools (best-effort; shell not gated).

--- a/examples/sentinel/agents/scanner/config.yaml
+++ b/examples/sentinel/agents/scanner/config.yaml
@@ -14,10 +14,11 @@ executor:
     harness: claude-sdk
 
 # Filesystem access so the scanner can read files, grep, and inspect git
-# history. `sandbox: type: none` runs unsandboxed in the caller's repo. The
-# `sys_os_write` / `sys_os_edit` tools come bundled with `os_env`; the
-# `read_only_os` policy below denies them, so read-only is enforced by policy
-# rather than left to the prompt.
+# history. `sandbox: type: none` runs unsandboxed in the caller's repo (zero
+# setup, cross-platform). `read_only_os` below denies the file-write/edit tools
+# as a BEST-EFFORT guardrail -- it does not gate shell, so it is not a hard
+# boundary. For untrusted code, sandbox it (`sandbox.type: linux_bwrap` /
+# `darwin_seatbelt`) so cwd is read-only. See the orchestrator config.
 os_env:
   type: caller_process
   cwd: .
@@ -25,7 +26,7 @@ os_env:
     type: none
 
 # Same guardrails the rest of the bundle uses: blast_radius bounds shell, and
-# read_only_os denies every file-mutating tool so the scanner can never edit.
+# read_only_os denies the file-write/edit tools (best-effort; shell not gated).
 guardrails:
   policies:
     blast_radius:

--- a/examples/sentinel/agents/scanner/config.yaml
+++ b/examples/sentinel/agents/scanner/config.yaml
@@ -14,16 +14,15 @@ executor:
     harness: claude-sdk
 
 # Filesystem access so the scanner can read files, grep, and inspect git
-# history. `sandbox: type: none` runs unsandboxed in the caller's repo (zero
-# setup, cross-platform). `read_only_os` below denies the file-write/edit tools
-# as a BEST-EFFORT guardrail -- it does not gate shell, so it is not a hard
-# boundary. For untrusted code, sandbox it (`sandbox.type: linux_bwrap` /
-# `darwin_seatbelt`) so cwd is read-only. See the orchestrator config.
+# history. Sandboxed by default: omitting `sandbox.type` auto-selects the
+# platform backend (`linux_bwrap` / `darwin_seatbelt`), binding cwd read-only
+# so shell writes are contained. Linux needs `bwrap` installed (fails loud with
+# a hint if missing); macOS uses the built-in sandbox-exec. See the orchestrator
+# config. `read_only_os` below is defense-in-depth (refuses the file-write tools
+# early); add `sandbox: {type: none}` only for code you fully trust.
 os_env:
   type: caller_process
   cwd: .
-  sandbox:
-    type: none
 
 # Same guardrails the rest of the bundle uses: blast_radius bounds shell, and
 # read_only_os denies the file-write/edit tools (best-effort; shell not gated).

--- a/examples/sentinel/config.yaml
+++ b/examples/sentinel/config.yaml
@@ -124,23 +124,22 @@ cancellable: true
 # `os_env` registers the `sys_os_read` / `sys_os_write` / `sys_os_edit` /
 # `sys_os_shell` tools (filesystem access bundled with a shell).
 #
-# `sandbox: type: none` runs unsandboxed in the caller's repo, which keeps the
-# bundle zero-setup and cross-platform. The `read_only_os` policy below plus
-# the purpose guard hold Sentinel to report-only at the policy layer, but they
-# are BEST-EFFORT guardrails, NOT a containment boundary: shell stays enabled,
-# so a prompt-injected `echo > file` / `sed -i` in reviewed code is not blocked.
+# Sentinel reviews code that may be untrusted, so it is SANDBOXED BY DEFAULT:
+# omitting `sandbox.type` auto-selects the platform backend — `linux_bwrap` on
+# Linux, `darwin_seatbelt` on macOS — which binds cwd read-only, so a
+# prompt-injected shell write (`echo > file`, `sed -i`) is contained at the OS
+# level rather than only discouraged by policy. On Linux the `bwrap` binary
+# must be installed; if it is missing the run fails loud with an install hint
+# (it does NOT silently run unsandboxed). macOS uses the built-in sandbox-exec,
+# so no install is needed.
 #
-# If you point Sentinel at code you do NOT fully trust, sandbox it so cwd is
-# bound read-only and shell writes are contained at the OS level:
-#     sandbox:
-#       type: linux_bwrap      # Linux; use `darwin_seatbelt` on macOS
-# (There is no cross-platform value today, which is why the zero-setup default
-# stays `none`. See the read_only_os docstring.)
+# `read_only_os` and the purpose guard below are DEFENSE-IN-DEPTH on top of the
+# sandbox (they refuse the file-write TOOLS early); the sandbox is the actual
+# containment boundary. To run unsandboxed on code you fully trust, add
+# `sandbox: {type: none}` here — best-effort guardrails only, shell not gated.
 os_env:
   type: caller_process
   cwd: .
-  sandbox:
-    type: none
 
 # Three guardrails enforce Sentinel's contract at the policy layer, not just in
 # the prompt:

--- a/examples/sentinel/config.yaml
+++ b/examples/sentinel/config.yaml
@@ -122,11 +122,20 @@ async: true
 cancellable: true
 
 # `os_env` registers the `sys_os_read` / `sys_os_write` / `sys_os_edit` /
-# `sys_os_shell` tools (filesystem access bundled with a shell). `sandbox:
-# type: none` runs unsandboxed so it can read the repo, and keeps the bundle
-# loadable on macOS. The `sys_os_write` / `sys_os_edit` tools come bundled and
-# cannot be unregistered, so the `read_only_os` policy below is what actually
-# holds Sentinel to report-only; it never writes fixes.
+# `sys_os_shell` tools (filesystem access bundled with a shell).
+#
+# `sandbox: type: none` runs unsandboxed in the caller's repo, which keeps the
+# bundle zero-setup and cross-platform. The `read_only_os` policy below plus
+# the purpose guard hold Sentinel to report-only at the policy layer, but they
+# are BEST-EFFORT guardrails, NOT a containment boundary: shell stays enabled,
+# so a prompt-injected `echo > file` / `sed -i` in reviewed code is not blocked.
+#
+# If you point Sentinel at code you do NOT fully trust, sandbox it so cwd is
+# bound read-only and shell writes are contained at the OS level:
+#     sandbox:
+#       type: linux_bwrap      # Linux; use `darwin_seatbelt` on macOS
+# (There is no cross-platform value today, which is why the zero-setup default
+# stays `none`. See the read_only_os docstring.)
 os_env:
   type: caller_process
   cwd: .

--- a/omnigent/inner/nessie/policies.py
+++ b/omnigent/inner/nessie/policies.py
@@ -577,15 +577,20 @@ def read_only_os(
     ),
 ) -> Callable[[_Json, _Json], _Json]:
     """
-    Factory: deny every file-mutating tool call (report-only agents).
+    Factory: deny the file-write/edit tools (best-effort report-only guardrail).
 
     DENIES ``sys_os_write`` / ``sys_os_edit`` and the Claude/Codex/Pi native
-    ``Write`` / ``Edit`` / ``MultiEdit`` aliases. Reads, searches, and shell
-    commands are left untouched — pair with :func:`blast_radius` to also bound
-    shell blast radius. Use on agents whose contract is to investigate and
-    report, never to change code (e.g. a security reviewer and its read-only
-    sub-agents): unlike prompt discipline alone, an accidental ``sys_os_edit``
-    is refused at the policy layer.
+    ``Write`` / ``Edit`` / ``MultiEdit`` aliases, so an accidental edit is
+    refused at the policy layer rather than only discouraged in prose.
+
+    NOT a containment boundary. Reads, searches, and shell are left enabled, so
+    an agent can still mutate files via the shell (``echo > f``, ``sed -i``,
+    ``tee``) — this policy does not gate that, and command parsing cannot
+    reliably catch it. For a hard guarantee (e.g. reviewing untrusted input),
+    run the agent sandboxed — ``os_env.sandbox.type: linux_bwrap`` (Linux) /
+    ``darwin_seatbelt`` (macOS) binds cwd read-only — and treat this policy as
+    defense-in-depth. Use for agents whose contract is to investigate and
+    report (a security reviewer and its read-only sub-agents).
 
     :param deny_reason: Reason text surfaced on a DENY decision.
     :returns: An evaluator ``fn(event, config)`` returning DENY for any
@@ -656,9 +661,11 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
     {
         "handler": "omnigent.inner.nessie.policies.read_only_os",
         "kind": "factory",
-        "name": "Report-Only (Deny File Writes)",
-        "description": "Denies every file-mutating tool (sys_os_write/edit, Claude/Codex "
-        "native Write/Edit/MultiEdit, and Pi native write/edit) so a report-only agent "
-        "can read and run shell but never change code",
+        "name": "Report-Only (Deny File-Write Tools)",
+        "description": "Best-effort report-only guardrail: denies the file-write/edit tools "
+        "(sys_os_write/edit, Claude/Codex native Write/Edit/MultiEdit, and Pi native "
+        "write/edit). Shell stays enabled, so shell-based writes (echo >, sed -i) are NOT "
+        "blocked -- for a hard boundary against untrusted input, sandbox the agent "
+        "(os_env.sandbox.type: linux_bwrap / darwin_seatbelt binds cwd read-only)",
     },
 ]

--- a/tests/e2e/omnigent/test_example_sentinel.py
+++ b/tests/e2e/omnigent/test_example_sentinel.py
@@ -59,8 +59,12 @@ def test_sentinel_skills_present(sentinel_spec: AgentSpec) -> None:  # DoC-4
 def test_sentinel_has_os_env(sentinel_spec: AgentSpec) -> None:  # DoC-9
     assert sentinel_spec.os_env is not None
     assert sentinel_spec.os_env.type == "caller_process"
-    assert sentinel_spec.os_env.sandbox is not None
-    assert sentinel_spec.os_env.sandbox.type == "none"
+    # Sandboxed by default: the config omits ``sandbox`` so the runtime resolves
+    # the platform backend (linux_bwrap / darwin_seatbelt, binding cwd
+    # read-only). An unset spec-level sandbox means "use the platform default",
+    # NOT unsandboxed -- ``type: none`` is the explicit opt-out, which Sentinel
+    # deliberately does not use because it reviews untrusted code.
+    assert sentinel_spec.os_env.sandbox is None
 
 
 def test_sentinel_orchestrator_guardrails(sentinel_spec: AgentSpec) -> None:  # DoC-5


### PR DESCRIPTION
## Summary

Follow-up to #1196 (same class as #1705). `read_only_os` denies the file-write/edit *tools* but not shell, so a prompt-injected `echo > f` / `sed -i` in reviewed code bypasses it. Sentinel ran **unsandboxed** (`sandbox: type: none`) and leaned on `read_only_os` as its write boundary while reviewing potentially-untrusted code -- so the "report-only" guarantee wasn't actually enforced.

Per discussion with @TomeHirata, the fix is to **sandbox Sentinel by default** and demote `read_only_os` to defense-in-depth.

## Changes

- **Sandbox by default (behavior change).** Drop `sandbox: type: none` from all three agents (orchestrator, scanner, reviewer). Omitting `sandbox.type` resolves to the platform backend at runtime -- **`linux_bwrap`** on Linux, **`darwin_seatbelt`** on macOS -- both bind cwd read-only, containing shell writes at the OS level. There is no hardcoded platform value (that would break the other OS); omission is the cross-platform "auto" path, and it **fails loud** with an install hint on Linux when `bwrap` is missing rather than silently running unsandboxed. macOS uses the built-in `sandbox-exec` (no install). `type: none` stays available as a documented opt-out for trusted code.
- **`read_only_os` reframed** (docstring + registry description): a best-effort guardrail that refuses the write *tools* early, explicitly NOT a containment boundary (shell not gated) -- the sandbox is the boundary.
- Config comments across the Sentinel bundle updated to match; `test_sentinel_has_os_env` now asserts the sandbox is unset (platform default), not the old explicit `none`.

## Note on the "cross-platform value" question

Earlier I thought no cross-platform sandbox value existed -- that was wrong. `_default_sandbox_for_platform` resolves an omitted `sandbox.type` per-OS, so *omission itself* is the auto path. That's why this drops the block rather than hardcoding `linux_bwrap` (which would hard-error on macOS).

## Validation needed before merge

Structural spec-load + policy tests pass (103), ruff clean. What I could NOT verify here (no live run): that the claude-sdk + codex harnesses spawn cleanly under bwrap/seatbelt and the reviewer can still read the read-only cwd. @TomeHirata / a live smoke on Linux + macOS would confirm the harnesses run sandboxed end-to-end.

## Type of change

- [x] Bug fix (security hardening of an example)
- [ ] Feature
- [ ] Docs

This pull request and its description were written by Isaac.
