### PR TITLE
test(e2e-ui): prebuild codex-parity sidecar once, run goal-mode test per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
         shell: bash
         env:
           PYTHONFAULTHANDLER: "1"
+          # Reuse the binary from the "Build parity sidecar" step above so the
+          # fixture doesn't re-invoke cargo build during collection.
+          CODEX_PARITY_SIDECAR_BIN: ${{ github.workspace }}/.tmp-codex-parity-target/debug/codex-parity-sidecar
         run: |
           mkdir -p artifacts
           env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -88,12 +88,57 @@ jobs:
           NUM_SHARDS: "3"
         run: bash .github/scripts/ci/e2e-shard-matrix.sh
 
+  # Build the Codex-parity sidecar ONCE and publish the binary. The
+  # mocked_native_codex_goal_session fixture needs it, but compiling it pulls
+  # openai/codex's core_test_support (~1100 crates). Done lazily inside pytest
+  # it lands ~4min (warm) to ~7min (cold) on whichever single shard collects
+  # test_codex_goal_mode, lopsiding that shard against the 20min cap. Building
+  # here once and handing every shard the ~10MB binary (via the artifact +
+  # CODEX_PARITY_SIDECAR_BIN below) keeps the sidecar cost off the shard
+  # critical path entirely. Skips on draft PRs (empty matrix -> no shards).
+  build-sidecar:
+    name: build codex-parity sidecar
+    needs: setup
+    if: needs.setup.outputs.matrix != '{"include":[]}'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      # Pin the toolchain for a stable cache fingerprint, key on the sidecar
+      # Cargo.lock. A warm hit reuses every dep and only relinks the workspace
+      # crate (~40s); a cold miss is the full ~7min compile (rare -- the lock
+      # is near-static). Same key as ci.yml's codex-parity job, so they share.
+      - name: Cache Rust build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
+        with:
+          path: .tmp-codex-parity-target
+          key: codex-parity-sidecar-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock') }}
+      - name: Build parity sidecar
+        run: |
+          cargo build \
+            --manifest-path tests/codex_parity/sidecar/Cargo.toml \
+            --target-dir .tmp-codex-parity-target
+      - name: Upload sidecar binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: codex-parity-sidecar
+          path: .tmp-codex-parity-target/debug/codex-parity-sidecar
+          if-no-files-found: error
+          retention-days: 1
+
   e2e-ui:
     name: E2E UI Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
     # Draft PRs resolve to an EMPTY matrix in `setup`, so no shard runs for
     # them. Fork PRs DO run (mock LLM, no secrets) -- same as ci.yml.
     # `ready_for_review` re-fires when a draft is converted.
-    needs: setup
+    needs: [setup, build-sidecar]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -143,23 +188,19 @@ jobs:
           sudo apt-get install -y bubblewrap tmux
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      # Rust toolchain + target cache for the Codex parity sidecar. The
-      # mocked_native_codex_goal_session fixture builds tests/codex_parity/
-      # sidecar via `cargo build` (it pulls openai/codex's core_test_support
-      # crate, a multi-minute cold compile). Without this cache the build runs
-      # from scratch on whichever shard collects test_codex_goal_mode, adding
-      # ~9min to that shard. Mirrors ci.yml's codex-parity job: pin the
-      # toolchain for a stable cache fingerprint, key on the sidecar Cargo.lock.
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      # Fetch the prebuilt Codex-parity sidecar from the build-sidecar job
+      # instead of compiling it here: no per-shard Rust toolchain or cargo
+      # build. The mocked_native_codex_goal_session fixture uses this binary
+      # via CODEX_PARITY_SIDECAR_BIN (set on the pytest step below).
+      - name: Download codex-parity sidecar binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          toolchain: stable
-
-      - name: Cache Rust build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v4
-        with:
-          path: .tmp-codex-parity-target
-          key: codex-parity-sidecar-${{ runner.os }}-${{ hashFiles('tests/codex_parity/sidecar/Cargo.lock') }}
+          name: codex-parity-sidecar
+          path: .tmp-codex-parity-target/debug
+      - name: Make sidecar binary executable
+        # upload-artifact does not preserve the +x bit; restore it so the
+        # fixture can exec the binary.
+        run: chmod +x .tmp-codex-parity-target/debug/codex-parity-sidecar
 
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -230,6 +271,10 @@ jobs:
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
+          # Prebuilt sidecar from build-sidecar; the codex goal-mode fixture
+          # uses this instead of running cargo build. Absolute path: the
+          # fixture runs with cwd at the repo root but be explicit.
+          CODEX_PARITY_SIDECAR_BIN: ${{ github.workspace }}/.tmp-codex-parity-target/debug/codex-parity-sidecar
         run: |
           # Always exclude @visual: the UI diff snapshot runs in its own
           # pinned-runner gate (ui-snapshot.yml) so its baseline matches the

--- a/tests/codex_parity/sidecar_harness.py
+++ b/tests/codex_parity/sidecar_harness.py
@@ -16,6 +16,12 @@ ROOT = Path(__file__).resolve().parents[2]
 SIDECAR_MANIFEST = ROOT / "tests" / "codex_parity" / "sidecar" / "Cargo.toml"
 SIDECAR_TARGET_DIR = ROOT / ".tmp-codex-parity-target"
 
+# When set to an existing executable, use that prebuilt sidecar binary and skip
+# the (multi-minute, ~1100-crate) ``cargo build`` entirely. CI builds the
+# sidecar once in a dedicated job and points every consumer at the downloaded
+# artifact via this env var; see .github/workflows/e2e-ui.yml.
+PREBUILT_SIDECAR_ENV = "CODEX_PARITY_SIDECAR_BIN"
+
 
 class CodexResponsesSidecar:
     """Running mock Responses server backed by Codex's Rust test helpers."""
@@ -84,7 +90,24 @@ class CodexResponsesSidecar:
 
 
 def build_sidecar_bin() -> Path:
-    """Build the Rust sidecar binary and return its path."""
+    """Return the sidecar binary path, building it from source if needed.
+
+    If ``CODEX_PARITY_SIDECAR_BIN`` names an existing file, that prebuilt
+    binary is used and ``cargo build`` is skipped -- this is how CI avoids
+    compiling the ~1100-crate tree on the test's critical path. A set-but-
+    missing path raises ``FileNotFoundError`` (a misconfigured CI artifact
+    must fail loudly, not silently skip the test). With the env unset we fall
+    back to building from source, so local runs work unchanged; callers that
+    treat a missing ``cargo`` as a skip catch the ``RuntimeError`` below.
+    """
+    prebuilt = os.environ.get(PREBUILT_SIDECAR_ENV)
+    if prebuilt:
+        binary = Path(prebuilt)
+        if not binary.is_file():
+            raise FileNotFoundError(
+                f"{PREBUILT_SIDECAR_ENV}={prebuilt!r} is set but no file exists there"
+            )
+        return binary
     if shutil.which("cargo") is None:
         raise RuntimeError("cargo is required for Codex parity sidecar")
     subprocess.run(

--- a/tests/e2e_ui/chat/test_codex_goal_mode.py
+++ b/tests/e2e_ui/chat/test_codex_goal_mode.py
@@ -36,11 +36,11 @@ def _goal_response(session_id: str, method: str, suffix: str = ""):
     return _matches
 
 
-# Boots a real native Codex CLI (like the native render-parity tests it shares
-# fixtures with), so it costs ~7.5min -- the bulk of one e2e-ui CI shard. Gated
-# to nightly to match those siblings and keep the per-PR shards balanced.
-@pytest.mark.nightly
-@pytest.mark.timeout(900)
+# Boots a real native Codex CLI and drives it via a prebuilt codex-parity
+# sidecar (CI supplies the binary through CODEX_PARITY_SIDECAR_BIN, so no
+# multi-minute cargo build runs here). timeout(300) matches the sibling
+# native-Codex render-parity tests now that the sidecar build is out of band.
+@pytest.mark.timeout(300)
 def test_codex_goal_mode_with_mocked_responses(
     page: Page,
     mocked_native_codex_goal_session: MockedCodexNativeSession,


### PR DESCRIPTION
## Goal

Bring `test_codex_goal_mode_with_mocked_responses` back to per-PR e2e-ui runs. It was gated to nightly in #1733 because it was consuming ~7.5 min -- 53% -- of one shard's runtime and lopsiding shard 2/3 toward the 20 min timeout.

## Root cause (from investigation)

The test needs a Rust "sidecar" whose `Cargo.lock` pulls openai/codex `core_test_support` (~1,100 crates). The `mocked_native_codex_goal_session` fixture built it **lazily via `cargo build` inside pytest**, so the entire compile landed on whichever single shard collected the test:

- warm cache: ~4 min on that one shard (vs ~40 s for `ci.yml`'s dedicated build step -- e2e-ui only cached `target/`, not `~/.cargo`, so it re-downloaded deps)
- cold cache (eviction / concurrent bursts): ~7 min, pushing the shard to ~14 min

The cache itself works in steady state; the problem is structural -- compiling a 1,100-crate tree on a test's critical path, on one shard, where it can't be shared.

## Fix -- build once, distribute the binary

- New **`build-sidecar` job** compiles the sidecar once and uploads the ~10 MB binary as an artifact (shares the existing Cargo.lock-keyed cache with `ci.yml`).
- The 3 shard jobs download that binary and point the fixture at it via a new **`CODEX_PARITY_SIDECAR_BIN`** env var; the fixture uses it and skips `cargo` entirely. No shard compiles Rust anymore, so the per-shard Rust toolchain + cache steps are removed.
- A set-but-missing binary path raises `FileNotFoundError` -- a broken CI artifact fails loudly instead of silently skipping the test. Env unset falls back to building from source, so local dev is unchanged.
- **Un-gate the test** (drop the `nightly` marker from #1733) so it runs per-PR again; lower its timeout 900s -> 300s to match the sibling native-Codex render-parity tests now that no build happens in-test.
- `ci.yml`'s codex-parity job already builds the sidecar in a dedicated step; wired `CODEX_PARITY_SIDECAR_BIN` there too so its fixture reuses that binary instead of re-invoking cargo during collection.

## Expected effect

Every shard runs clean (~4 min); the sidecar compile happens once in `build-sidecar` (~40 s warm, ~7 min cold, off the shard critical path). No single shard carries the build, so the skew that risked the timeout is gone.

## Safety

`build-sidecar` sits in the existing `gate -> setup -> shards` needs-chain. If it fails, the E2E UI workflow run fails and the (now-absent) shard checks block the merge gate via `evaluate-checks.sh`'s `workflow_run_outcome="other"` path -- the same handling as a `setup` failure. It is guarded by the same empty-matrix `if` as the shards, so draft PRs skip it.

## Validation done

YAML parses; `ruff format --check` + `ruff check` clean; the `build_sidecar_bin()` env logic unit-tested (prebuilt-used / set-but-missing-raises / unset-falls-back); confirmed the empty-matrix `if` string matches `e2e-shard-matrix.sh` output exactly.
