### PR TITLE
fix(policies): remove parentheses from blast_radius policy name

### DIFF
--- a/omnigent/inner/nessie/policies.py
+++ b/omnigent/inner/nessie/policies.py
@@ -625,7 +625,7 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
     {
         "handler": "omnigent.inner.nessie.policies.blast_radius",
         "kind": "factory",
-        "name": "Block Dangerous Shell Commands (force-push, rm -rf)",
+        "name": "Block Dangerous Shell Commands force-push, rm -rf",
         "description": "Classifies shell commands (sys_os_shell, Claude/Codex native Bash, "
         "and Pi native bash) as safe, risky (ASK), or catastrophic (DENY) to prevent "
         "destructive operations like force-push or rm -rf /",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Removes the surrounding parentheses from the `blast_radius` policy's display name: `Block Dangerous Shell Commands (force-push, rm -rf)` → `Block Dangerous Shell Commands force-push, rm -rf`

## Test Plan

No logic changed — display name only.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Not applicable

## Coverage notes

Display name string change only; no functional behaviour affected.