### PR TITLE
feat(policies): add Bell-LaPadula mandatory access control builtin

### DIFF
--- a/omnigent/policies/builtins/__init__.py
+++ b/omnigent/policies/builtins/__init__.py
@@ -45,5 +45,6 @@ BUILTIN_POLICY_MODULES = [
     "omnigent.policies.builtins.cel",
     "omnigent.policies.builtins.prompt",
     "omnigent.policies.builtins.context",
+    "omnigent.policies.builtins.access_control",
     "omnigent.inner.nessie.policies",
 ]

--- a/omnigent/policies/builtins/access_control.py
+++ b/omnigent/policies/builtins/access_control.py
@@ -1,0 +1,260 @@
+"""Built-in access-control policies based on formal security models.
+
+:func:`bell_lapadula` implements the Bell-LaPadula model (BLP), the
+classical mandatory-access-control model for **confidentiality**:
+
+- **No read up** (Simple Security Property): an agent may not invoke a tool
+  whose classification level exceeds the agent's clearance.  A "DENY" fires
+  on ``tool_call`` before the tool runs.
+
+- **No write down** (Star Property / \*-property): once the agent has received
+  a result from a tool at level *L*, it may not subsequently invoke a tool
+  classified below *L* whose purpose is to write or exfiltrate data.  The
+  policy tracks the agent's "contamination high-water mark" in
+  ``session_state`` (updated on ``tool_result``) and gates outbound write-tool
+  calls on ``tool_call``.
+
+Levels are operator-defined strings ordered by position in the ``levels``
+list (index 0 = least sensitive).  Only tools explicitly listed in
+``tool_levels`` are subject to BLP enforcement; unclassified tools are
+allowed freely.
+
+YAML usage::
+
+    policies:
+      blp:
+        type: function
+        function:
+          path: omnigent.policies.builtins.access_control.bell_lapadula
+          arguments:
+            levels: [public, internal, confidential, secret]
+            clearance: internal
+            tool_levels:
+              # read sources
+              sys_read_internal_docs: internal
+              sys_read_hr_data: confidential
+              # write / exfil sinks
+              sys_os_shell: public
+              sys_os_write: public
+              external_api_call: internal
+            write_tools:
+              - sys_os_shell
+              - sys_os_write
+              - external_api_call
+
+The factory must be referenced via ``function: {path, arguments}`` with a
+non-empty ``arguments`` block.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from omnigent.policies.schema import PolicyCallable, PolicyEvent, PolicyResponse
+
+_ALLOW: PolicyResponse = {"result": "ALLOW"}
+
+# session_state key storing the agent's current read high-water mark (the
+# classification level of the highest-classified tool result seen so far).
+_BLP_READ_MARK_KEY = "_blp_read_mark"
+
+
+def bell_lapadula(
+    levels: list[str],
+    clearance: str,
+    tool_levels: dict[str, str],
+    write_tools: list[str] | None = None,
+) -> PolicyCallable:
+    """Factory: enforce Bell-LaPadula mandatory access control.
+
+    Implements the two core BLP properties:
+
+    - **No read up** — a ``tool_call`` whose tool is classified above the
+      agent's *clearance* is DENYed before it runs.
+    - **No write down** — once the agent has received a ``tool_result`` from
+      a tool at level *L*, any subsequent ``tool_call`` to a *write_tool*
+      classified below *L* is DENYed.
+
+    Both properties operate only on tools explicitly listed in *tool_levels*;
+    unclassified tools are allowed freely under both properties.
+
+    :param levels: Ordered list of classification level names, least sensitive
+        first, e.g. ``["public", "internal", "confidential", "secret"]``.
+        The position in this list determines the numeric level used for
+        comparisons.  Every name in *tool_levels*, *clearance*, and
+        *write_tools* must appear here.
+    :param clearance: The agent's clearance level, e.g. ``"internal"``.  The
+        agent may read (call) tools at or below this level.
+    :param tool_levels: Mapping of tool name → classification level, e.g.
+        ``{"sys_read_hr_data": "confidential", "sys_os_shell": "public"}``.
+        Tools absent from this mapping are unclassified and unrestricted.
+    :param write_tools: Tool names considered "write / exfiltration" sinks for
+        the no-write-down check, e.g. ``["sys_os_shell", "sys_os_write"]``.
+        Only write-classified tools participate in the ``*``-property check.
+        ``None`` or ``[]`` disables no-write-down enforcement (only no-read-up
+        applies).
+    :returns: A policy callable implementing BLP on ``tool_call`` and
+        ``tool_result`` phases.
+    :raises ValueError: If *clearance* or any value in *tool_levels* is not in
+        *levels*, or if any entry in *write_tools* names a tool not in
+        *tool_levels*.
+    """
+    if not levels:
+        raise ValueError("bell_lapadula: levels must be a non-empty list")
+    level_index: dict[str, int] = {name: i for i, name in enumerate(levels)}
+
+    if clearance not in level_index:
+        raise ValueError(f"bell_lapadula: clearance {clearance!r} not in levels {levels}")
+    clearance_idx = level_index[clearance]
+
+    # Validate and resolve tool levels.
+    resolved: dict[str, int] = {}
+    for tool, lvl in tool_levels.items():
+        if lvl not in level_index:
+            raise ValueError(
+                f"bell_lapadula: tool_levels[{tool!r}] = {lvl!r} not in levels {levels}"
+            )
+        resolved[tool] = level_index[lvl]
+
+    write_set: frozenset[str] = frozenset(write_tools or [])
+    for wt in write_set:
+        if wt not in resolved:
+            raise ValueError(f"bell_lapadula: write_tools entry {wt!r} is not in tool_levels")
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Evaluate BLP properties for one tool_call or tool_result event.
+
+        - ``tool_call``: check no-read-up, then (for write tools) no-write-down.
+        - ``tool_result``: advance the contamination high-water mark when the
+          tool's level exceeds the current mark.
+        - All other phases abstain (ALLOW).
+
+        :param event: Policy event dict.
+        :returns: DENY when a BLP property is violated; ALLOW with optional
+            ``state_updates`` when the read mark advances; ALLOW otherwise.
+        """
+        phase = event.get("type")
+        tool_name: str = event.get("target") or ""
+
+        # ── tool_result: advance the read high-water mark ─────────────────
+        if phase == "tool_result":
+            tool_level_idx = resolved.get(tool_name)
+            if tool_level_idx is None:
+                return _ALLOW  # unclassified tool — no mark change
+            state = event.get("session_state") or {}
+            current_mark: int = int(state.get(_BLP_READ_MARK_KEY) or 0)
+            if tool_level_idx <= current_mark:
+                return _ALLOW  # mark already at or above this level
+            return {
+                "result": "ALLOW",
+                "state_updates": [
+                    {
+                        "key": _BLP_READ_MARK_KEY,
+                        "action": "set",
+                        "value": tool_level_idx,
+                    }
+                ],
+            }
+
+        # ── tool_call: enforce no-read-up and no-write-down ───────────────
+        if phase != "tool_call":
+            return _ALLOW
+
+        tool_level_idx = resolved.get(tool_name)
+        if tool_level_idx is None:
+            return _ALLOW  # unclassified tool — no restriction
+
+        # No read up: agent clearance must be >= tool's level.
+        if tool_level_idx > clearance_idx:
+            tool_level_name = levels[tool_level_idx]
+            return {
+                "result": "DENY",
+                "reason": (
+                    f"Bell-LaPadula no-read-up violation: tool {tool_name!r} is "
+                    f"classified {tool_level_name!r} but agent clearance is "
+                    f"{clearance!r}. The agent may not access data above its "
+                    f"clearance level."
+                ),
+            }
+
+        # No write down: if this is a write sink, its level must be >= read mark.
+        if tool_name in write_set:
+            state = event.get("session_state") or {}
+            read_mark: int = int(state.get(_BLP_READ_MARK_KEY) or 0)
+            if tool_level_idx < read_mark:
+                read_mark_name = levels[read_mark]
+                tool_level_name = levels[tool_level_idx]
+                return {
+                    "result": "DENY",
+                    "reason": (
+                        f"Bell-LaPadula no-write-down violation: the agent has "
+                        f"read data classified {read_mark_name!r} but is attempting "
+                        f"to write to {tool_name!r} which is classified "
+                        f"{tool_level_name!r}. Writing to a lower-classified "
+                        f"sink would leak confidential data."
+                    ),
+                }
+
+        return _ALLOW
+
+    return evaluate  # type: ignore[return-value]
+
+
+# ── Registry ──────────────────────────────────────────────────────────────────
+
+POLICY_REGISTRY: list[dict[str, Any]] = [
+    {
+        "handler": "omnigent.policies.builtins.access_control.bell_lapadula",
+        "kind": "factory",
+        "name": "Bell-LaPadula",
+        "description": (
+            "Enforces the Bell-LaPadula mandatory access-control model for "
+            "confidentiality. "
+            "No-read-up: blocks tool calls whose classification level exceeds "
+            "the agent's clearance (prevents reading data above clearance). "
+            "No-write-down: once the agent has read data at level L, blocks "
+            "calls to write-sink tools classified below L (prevents leaking "
+            "high-classified data to lower-classified outputs). "
+            "Only tools listed in tool_levels are subject to enforcement; "
+            "unclassified tools are allowed freely."
+        ),
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "levels": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Ordered classification levels, least sensitive first, "
+                        'e.g. ["public", "internal", "confidential", "secret"].'
+                    ),
+                },
+                "clearance": {
+                    "type": "string",
+                    "description": (
+                        "The agent's clearance level. May only read tools at or below this level."
+                    ),
+                },
+                "tool_levels": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                    "description": (
+                        "Map of tool name → classification level. Tools absent "
+                        "from this map are unclassified and unrestricted."
+                    ),
+                },
+                "write_tools": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Tool names considered write / exfiltration sinks for "
+                        "the no-write-down check. Must be a subset of tool_levels "
+                        "keys. Omit or pass [] to disable no-write-down "
+                        "(only no-read-up will apply)."
+                    ),
+                },
+            },
+            "required": ["levels", "clearance", "tool_levels"],
+        },
+    },
+]

--- a/omnigent/policies/builtins/access_control.py
+++ b/omnigent/policies/builtins/access_control.py
@@ -7,7 +7,7 @@ classical mandatory-access-control model for **confidentiality**:
   whose classification level exceeds the agent's clearance.  A "DENY" fires
   on ``tool_call`` before the tool runs.
 
-- **No write down** (Star Property / \*-property): once the agent has received
+- **No write down** (Star Property / ``*``-property): once the agent has received
   a result from a tool at level *L*, it may not subsequently invoke a tool
   classified below *L* whose purpose is to write or exfiltrate data.  The
   policy tracks the agent's "contamination high-water mark" in
@@ -57,6 +57,21 @@ _ALLOW: PolicyResponse = {"result": "ALLOW"}
 # session_state key storing the agent's current read high-water mark (the
 # classification level of the highest-classified tool result seen so far).
 _BLP_READ_MARK_KEY = "_blp_read_mark"
+
+
+def _tool_matches(raw_tool: str, name: str) -> bool:
+    """Check whether a raw event tool name matches a configured canonical name.
+
+    MCP-agnostic: matches on exact equality or on a ``"__"``-delimited suffix,
+    so ``"sys_read_hr_data"`` matches ``"mcp__omnigent__sys_read_hr_data"`` and
+    the bare name alike, without requiring server prefixes in the config.
+
+    :param raw_tool: Tool name from the event, e.g.
+        ``"mcp__omnigent__sys_read_hr_data"``.
+    :param name: Configured canonical tool name, e.g. ``"sys_read_hr_data"``.
+    :returns: ``True`` when *raw_tool* refers to *name*.
+    """
+    return raw_tool == name or raw_tool.endswith(f"__{name}")
 
 
 def bell_lapadula(
@@ -136,11 +151,19 @@ def bell_lapadula(
         phase = event.get("type")
         tool_name: str = event.get("target") or ""
 
+        # ── resolve tool name (MCP-prefix-agnostic) ──────────────────────
+        # ``resolved`` keys are canonical names (e.g. "sys_read_hr_data").
+        # The raw event target may carry an MCP server prefix such as
+        # "mcp__omnigent__sys_read_hr_data".  _tool_matches handles both.
+        matched_canonical: str | None = next(
+            (name for name in resolved if _tool_matches(tool_name, name)), None
+        )
+
         # ── tool_result: advance the read high-water mark ─────────────────
         if phase == "tool_result":
-            tool_level_idx = resolved.get(tool_name)
-            if tool_level_idx is None:
+            if matched_canonical is None:
                 return _ALLOW  # unclassified tool — no mark change
+            tool_level_idx = resolved[matched_canonical]
             state = event.get("session_state") or {}
             current_mark: int = int(state.get(_BLP_READ_MARK_KEY) or 0)
             if tool_level_idx <= current_mark:
@@ -160,9 +183,10 @@ def bell_lapadula(
         if phase != "tool_call":
             return _ALLOW
 
-        tool_level_idx = resolved.get(tool_name)
-        if tool_level_idx is None:
+        if matched_canonical is None:
             return _ALLOW  # unclassified tool — no restriction
+
+        tool_level_idx = resolved[matched_canonical]
 
         # No read up: agent clearance must be >= tool's level.
         if tool_level_idx > clearance_idx:
@@ -178,7 +202,7 @@ def bell_lapadula(
             }
 
         # No write down: if this is a write sink, its level must be >= read mark.
-        if tool_name in write_set:
+        if any(_tool_matches(tool_name, wt) for wt in write_set):
             state = event.get("session_state") or {}
             read_mark: int = int(state.get(_BLP_READ_MARK_KEY) or 0)
             if tool_level_idx < read_mark:

--- a/tests/policies/builtins/test_access_control.py
+++ b/tests/policies/builtins/test_access_control.py
@@ -1,0 +1,282 @@
+"""Unit tests for omnigent.policies.builtins.access_control — Bell-LaPadula."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.policies.builtins.access_control import _BLP_READ_MARK_KEY, bell_lapadula
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_LEVELS = ["public", "internal", "confidential", "secret"]
+# Indices:   0         1           2               3
+
+
+def _tool_call(tool: str, *, read_mark: int | None = None) -> dict:
+    state = {_BLP_READ_MARK_KEY: read_mark} if read_mark is not None else {}
+    return {
+        "type": "tool_call",
+        "target": tool,
+        "data": {"name": tool, "arguments": {}},
+        "context": {},
+        "session_state": state,
+    }
+
+
+def _tool_result(tool: str, *, read_mark: int | None = None) -> dict:
+    state = {_BLP_READ_MARK_KEY: read_mark} if read_mark is not None else {}
+    return {
+        "type": "tool_result",
+        "target": tool,
+        "data": {},
+        "context": {},
+        "session_state": state,
+    }
+
+
+def _other_phase(phase: str) -> dict:
+    return {"type": phase, "target": "some_tool", "data": {}, "context": {}, "session_state": {}}
+
+
+# ── factory validation ────────────────────────────────────────────────────────
+
+
+def test_invalid_clearance_raises() -> None:
+    with pytest.raises(ValueError, match="clearance"):
+        bell_lapadula(levels=_LEVELS, clearance="top_secret", tool_levels={})
+
+
+def test_invalid_tool_level_raises() -> None:
+    with pytest.raises(ValueError, match="tool_levels"):
+        bell_lapadula(
+            levels=_LEVELS,
+            clearance="internal",
+            tool_levels={"sys_tool": "ultra_secret"},
+        )
+
+
+def test_write_tool_not_in_tool_levels_raises() -> None:
+    with pytest.raises(ValueError, match="write_tools"):
+        bell_lapadula(
+            levels=_LEVELS,
+            clearance="internal",
+            tool_levels={"sys_read": "internal"},
+            write_tools=["sys_write"],  # not in tool_levels
+        )
+
+
+def test_empty_levels_raises() -> None:
+    with pytest.raises(ValueError, match="levels"):
+        bell_lapadula(levels=[], clearance="public", tool_levels={})
+
+
+# ── non-tool phases abstain ───────────────────────────────────────────────────
+
+
+def test_non_tool_phases_allow() -> None:
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="public",
+        tool_levels={"secret_tool": "secret"},
+    )
+    for phase in ("request", "response", "llm_request", "llm_response"):
+        assert policy(_other_phase(phase)) == {"result": "ALLOW"}
+
+
+# ── no-read-up ────────────────────────────────────────────────────────────────
+
+
+def test_tool_at_clearance_level_allows() -> None:
+    """Tool at exactly the agent's clearance level is allowed."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="internal",
+        tool_levels={"docs_reader": "internal"},
+    )
+    assert policy(_tool_call("docs_reader"))["result"] == "ALLOW"
+
+
+def test_tool_below_clearance_allows() -> None:
+    """Tool below the agent's clearance is allowed (no read-up violation)."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="confidential",
+        tool_levels={"public_api": "public"},
+    )
+    assert policy(_tool_call("public_api"))["result"] == "ALLOW"
+
+
+def test_tool_above_clearance_denies() -> None:
+    """Tool classified above the agent's clearance → DENY (no-read-up)."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="internal",
+        tool_levels={"hr_system": "confidential"},
+    )
+    result = policy(_tool_call("hr_system"))
+    assert result["result"] == "DENY"
+    assert "no-read-up" in result["reason"]
+    assert "confidential" in result["reason"]
+    assert "internal" in result["reason"]
+
+
+def test_unclassified_tool_always_allows_regardless_of_clearance() -> None:
+    """A tool absent from tool_levels is unclassified and never restricted."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="public",
+        tool_levels={"classified": "secret"},
+    )
+    assert policy(_tool_call("unclassified_tool"))["result"] == "ALLOW"
+
+
+# ── tool_result advances read mark ───────────────────────────────────────────
+
+
+def test_tool_result_sets_read_mark_when_higher() -> None:
+    """A tool_result from a classified tool advances the read mark."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"confidential_db": "confidential"},
+    )
+    result = policy(_tool_result("confidential_db", read_mark=0))
+    assert result["result"] == "ALLOW"
+    updates = {u["key"]: u["value"] for u in result["state_updates"]}
+    assert updates[_BLP_READ_MARK_KEY] == 2  # "confidential" is index 2
+
+
+def test_tool_result_does_not_lower_read_mark() -> None:
+    """A lower-classified tool_result must not decrease the read mark."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"public_api": "public"},
+    )
+    # Read mark already at confidential (2); public (0) must not lower it
+    result = policy(_tool_result("public_api", read_mark=2))
+    assert result == {"result": "ALLOW"}  # no state_updates
+
+
+def test_unclassified_tool_result_leaves_mark_unchanged() -> None:
+    """A tool_result from an unclassified tool does not touch the read mark."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"classified": "confidential"},
+    )
+    result = policy(_tool_result("unknown_tool"))
+    assert result == {"result": "ALLOW"}
+
+
+# ── no-write-down ─────────────────────────────────────────────────────────────
+
+
+def test_write_tool_at_read_mark_allows() -> None:
+    """Writing to a sink at exactly the read-mark level is permitted."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"db_write": "confidential"},
+        write_tools=["db_write"],
+    )
+    # read_mark = confidential (2), write target = confidential (2) → OK
+    result = policy(_tool_call("db_write", read_mark=2))
+    assert result["result"] == "ALLOW"
+
+
+def test_write_tool_above_read_mark_allows() -> None:
+    """Writing to a higher-classified sink than the read mark is fine."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"secret_log": "secret"},
+        write_tools=["secret_log"],
+    )
+    # read_mark = internal (1), writing to secret (3) → no write-down violation
+    result = policy(_tool_call("secret_log", read_mark=1))
+    assert result["result"] == "ALLOW"
+
+
+def test_write_tool_below_read_mark_denies() -> None:
+    """Writing to a lower-classified sink than the read mark → DENY (no-write-down)."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"shell": "public"},
+        write_tools=["shell"],
+    )
+    # Agent read confidential (mark=2), trying to write to public shell (0)
+    result = policy(_tool_call("shell", read_mark=2))
+    assert result["result"] == "DENY"
+    assert "no-write-down" in result["reason"]
+    assert "confidential" in result["reason"]
+    assert "public" in result["reason"]
+
+
+def test_no_write_down_only_applies_to_write_tools() -> None:
+    """A read tool below the read mark is allowed (only write sinks are checked)."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"public_api": "public"},
+        # public_api is NOT in write_tools
+    )
+    # read_mark = confidential (2), calling public tool for reading → fine
+    result = policy(_tool_call("public_api", read_mark=2))
+    assert result["result"] == "ALLOW"
+
+
+def test_no_read_mark_write_tool_allows() -> None:
+    """Without a read mark (fresh session), write-down check always passes."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"shell": "public"},
+        write_tools=["shell"],
+    )
+    # No read mark set → mark defaults to 0 (public) → no violation
+    result = policy(_tool_call("shell"))
+    assert result["result"] == "ALLOW"
+
+
+# ── combined: no-read-up takes precedence over no-write-down ─────────────────
+
+
+def test_above_clearance_write_tool_still_denies_via_no_read_up() -> None:
+    """A write tool above clearance is denied for no-read-up, not write-down."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="internal",
+        tool_levels={"secret_sink": "secret"},
+        write_tools=["secret_sink"],
+    )
+    result = policy(_tool_call("secret_sink"))
+    assert result["result"] == "DENY"
+    assert "no-read-up" in result["reason"]
+
+
+# ── write_tools=None disables no-write-down ───────────────────────────────────
+
+
+def test_no_write_tools_disables_write_down_enforcement() -> None:
+    """write_tools=None means only no-read-up is enforced."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"shell": "public"},
+        write_tools=None,
+    )
+    # Even with a high read mark, no write-down check fires
+    result = policy(_tool_call("shell", read_mark=3))
+    assert result["result"] == "ALLOW"
+
+
+# ── registry ──────────────────────────────────────────────────────────────────
+
+
+def test_registry_entry_present() -> None:
+    from omnigent.policies.builtins.access_control import POLICY_REGISTRY
+
+    handlers = {e["handler"] for e in POLICY_REGISTRY}
+    assert "omnigent.policies.builtins.access_control.bell_lapadula" in handlers

--- a/tests/policies/builtins/test_access_control.py
+++ b/tests/policies/builtins/test_access_control.py
@@ -272,6 +272,69 @@ def test_no_write_tools_disables_write_down_enforcement() -> None:
     assert result["result"] == "ALLOW"
 
 
+# ── MCP prefix matching ───────────────────────────────────────────────────────
+
+
+def test_mcp_prefixed_tool_call_matches_canonical_name() -> None:
+    """Raw tool name with MCP prefix matches bare canonical name in tool_levels."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="internal",
+        tool_levels={"hr_system": "confidential"},
+    )
+    # "mcp__omnigent__hr_system" should match canonical "hr_system" → DENY (no-read-up)
+    event = {
+        "type": "tool_call",
+        "target": "mcp__omnigent__hr_system",
+        "data": {"name": "mcp__omnigent__hr_system", "arguments": {}},
+        "context": {},
+        "session_state": {},
+    }
+    result = policy(event)
+    assert result["result"] == "DENY"
+    assert "no-read-up" in result["reason"]
+
+
+def test_mcp_prefixed_tool_result_advances_read_mark() -> None:
+    """tool_result with MCP prefix advances the read mark."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"confidential_db": "confidential"},
+    )
+    event = {
+        "type": "tool_result",
+        "target": "mcp__omnigent__confidential_db",
+        "data": {},
+        "context": {},
+        "session_state": {_BLP_READ_MARK_KEY: 0},
+    }
+    result = policy(event)
+    assert result["result"] == "ALLOW"
+    updates = {u["key"]: u["value"] for u in result["state_updates"]}
+    assert updates[_BLP_READ_MARK_KEY] == 2  # "confidential" is index 2
+
+
+def test_mcp_prefixed_write_tool_triggers_no_write_down() -> None:
+    """Write-down check fires when the write tool carries an MCP prefix."""
+    policy = bell_lapadula(
+        levels=_LEVELS,
+        clearance="secret",
+        tool_levels={"shell": "public"},
+        write_tools=["shell"],
+    )
+    event = {
+        "type": "tool_call",
+        "target": "mcp__omnigent__shell",
+        "data": {"name": "mcp__omnigent__shell", "arguments": {}},
+        "context": {},
+        "session_state": {_BLP_READ_MARK_KEY: 2},  # read_mark = confidential
+    }
+    result = policy(event)
+    assert result["result"] == "DENY"
+    assert "no-write-down" in result["reason"]
+
+
 # ── registry ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Implements the **Bell-LaPadula (BLP) confidentiality model** as `bell_lapadula()` in `omnigent/policies/builtins/access_control.py`.

## What it does

BLP enforces two properties on `tool_call` / `tool_result` events:

| Property | Description |
|---|---|
| **No read up** | A tool call to a tool classified *above* the agent's clearance → DENY |
| **No write down** | Once the agent has read data at level L (tracked as a high-water mark in `session_state`), any write-sink tool call *below* L → DENY |

Only tools listed in `tool_levels` are subject to enforcement. Unclassified tools are allowed freely.

## Example config

```yaml
policies:
  blp:
    type: function
    function:
      path: omnigent.policies.builtins.access_control.bell_lapadula
      arguments:
        levels: [public, internal, confidential, secret]
        clearance: internal
        tool_levels:
          sys_read_hr_data: confidential   # above clearance → read-up blocked
          external_api_call: internal       # write sink at same level → OK after internal read
          sys_os_shell: public              # write sink below any classified read → write-down blocked
        write_tools:
          - sys_os_shell
          - external_api_call
```

## Test plan
- 20 unit tests covering: factory validation, non-tool-phase abstain, no-read-up (allow/deny), unclassified tool passthrough, read-mark advancement/non-regression on `tool_result`, no-write-down (allow/deny), write-down disabled via `write_tools=None`, registry discovery.