### PR TITLE
fix: inject model_change event for claude-native after smart routing

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8898,6 +8898,21 @@ async def _dispatch_session_event_to_runner(
                         _routed_model,
                         _verdict or {},
                     )
+                    # For claude-native: inject /model into the running
+                    # terminal so the change takes effect immediately
+                    # (model_override alone is only applied at spawn).
+                    try:
+                        await runner_client.post(
+                            f"/v1/sessions/{session_id}/events",
+                            json={"type": "model_change", "model": _routed_model},
+                            timeout=5.0,
+                        )
+                    except httpx.HTTPError:
+                        _logger.debug(
+                            "smart_routing: model_change forward failed for session=%s "
+                            "(runner may not support it yet)",
+                            session_id,
+                        )
         # ────────────────────────────────────────────────────────────
         forwarded = False
         try:


### PR DESCRIPTION
## Summary

After smart routing picks a model for a `claude-native` session, the `model_override` is persisted on the conversation row — but the running `claude` terminal doesn't see it because the model is baked in at spawn time (`--model` flag).

This sends a `model_change` event to the runner after routing, which types `/model <name>` into the tmux pane so the change takes effect immediately in the current session.

## Test plan
- Start a new `claude-native` session with smart routing on
- Verify the routing chip appears and the model actually changes in the terminal

This pull request and its description were written by Isaac.