### PR TITLE
fix(security-triage): cap dismissed_comment at 280 chars; count failures

### DIFF
--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -370,6 +370,10 @@ jobs:
               verdict = d.get("verdict")
               conf = float(d.get("confidence", 0) or 0)
               reason = (d.get("reason") or "")[:280]
+              # GitHub caps dismissed_comment at 280 chars, and the
+              # "auto-triage: " prefix counts against that budget -- cap the
+              # whole comment or the Dependabot API rejects it (HTTP 422).
+              comment = f"auto-triage: {reason}"[:280]
               meta = valid[(kind, num)]
 
               if verdict == "serious":
@@ -388,7 +392,7 @@ jobs:
                           f"/repos/{repo}/code-scanning/alerts/{num}",
                           "-f", "state=dismissed",
                           "-f", f"dismissed_reason={CS_REASON[verdict]}",
-                          "-f", f"dismissed_comment=auto-triage: {reason}"], gh_token)
+                          "-f", f"dismissed_comment={comment}"], gh_token)
                   dismissed.append((kind, num, verdict, conf, reason,
                                     "OK" if r.returncode == 0 else f"ERR {r.stderr[:120]}"))
               else:  # dependabot — needs elevated token
@@ -408,15 +412,21 @@ jobs:
                           f"/repos/{repo}/dependabot/alerts/{num}",
                           "-f", "state=dismissed",
                           "-f", f"dismissed_reason={DEP_REASON[verdict]}",
-                          "-f", f"dismissed_comment=auto-triage: {reason}"], elevated)
+                          "-f", f"dismissed_comment={comment}"], elevated)
                   dismissed.append((kind, num, verdict, conf, reason,
                                     "OK" if r.returncode == 0 else f"ERR {r.stderr[:120]}"))
 
           # ── Run summary ──────────────────────────────────────────────────
+          # A row whose status starts with "ERR" is a failed API call, not a
+          # real dismissal -- count it separately so the headline is honest.
+          applied = [x for x in dismissed if not str(x[5]).startswith("ERR")]
+          failed = [x for x in dismissed if str(x[5]).startswith("ERR")]
+          if failed:
+              print(f"::warning::{len(failed)} dismissal(s) failed (API error) -- see run summary")
           out = ["# Security Alert Triage", "",
                  f"- Mode: {'DRY-RUN (no mutations)' if dry_run else 'APPLY'}",
                  f"- Alerts classified: {len(decisions)}",
-                 f"- Auto-dismissed: {len(dismissed)} | Escalated (serious): {len(escalated)} | Left for human: {len(skipped)}",
+                 f"- Auto-dismissed: {len(applied)} | Failed: {len(failed)} | Escalated (serious): {len(escalated)} | Left for human: {len(skipped)}",
                  ""]
           if dismissed:
               out += ["## Dismissed", "", "| kind | # | verdict | conf | status | reason |",


### PR DESCRIPTION
## Related issue

N/A (bug found operating the triage cron).

## Summary

- The security-triage APPLY run dismisses alerts by PATCHing the Dependabot / code-scanning API with `dismissed_comment=auto-triage: {reason}`. `reason` was capped at 280 chars, but the `auto-triage: ` prefix pushed the field to 293 -- over GitHub's 280-char limit on `dismissed_comment` -- so the Dependabot dismissal failed with HTTP 422 and the alert (aws-sdk-s3 #80) stayed open despite a `wont_fix` verdict.
- Cap the entire comment (prefix included) at 280 chars.
- Count failed API calls (status `ERR...`) separately from real dismissals: the headline now reads `Auto-dismissed: N | Failed: M | ...` and a `::warning` is emitted, so a failed dismissal surfaces instead of being counted as a success.

## Test Plan

- YAML parses; the embedded apply-step Python compiles.
- Verified against the 06-30 APPLY run where the 293-char comment triggered the 422. After merge, the next scheduled run (or a manual dispatch) should dismiss aws-sdk-s3 cleanly.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflow-only change (no product code). Verified by YAML parse + py_compile of the embedded script, and against the real 422 seen in the 2026-06-30 scheduled run. The triage workflow has no unit-test harness; the daily run is the integration check.
