### PR TITLE
feat(changelog): automated changelog generation and publishing

### DIFF
--- a/.github/agents/release-notes-drafter/config.yaml
+++ b/.github/agents/release-notes-drafter/config.yaml
@@ -1,0 +1,93 @@
+# release-notes-drafter — a tiny, single-purpose agent used by the
+# draft-release-notes.yml workflow at release-cut time.
+#
+# Given the list of PRs merged since the previous release (each PR's number,
+# title, and the user-facing one-liner its author wrote in the PR template's
+# `## Changelog` section) plus a deterministic mechanical scaffold, it synthesizes
+# the concise, curated two-section release notes we write by hand today — collapsing
+# many related PRs into a handful of themed highlights. It has NO tools and NO
+# sub-agents: it writes prose from the material it is handed, so a run is fast,
+# cheap, and can't hang. The workflow drops its output into the GitHub Release
+# DRAFT body; a human reviews and edits before publishing.
+#
+# Run headlessly:  omnigent run .github/agents/release-notes-drafter -p "<pr list>" --no-session
+#
+# Security posture (mirrors doc-classifier / doc-drafter, a STRONGER trust position
+# than polly-review):
+#   - Runs only on ALREADY-MERGED, released history (a maintainer reviewed + merged
+#     every PR it sees), and only at release-cut on the trusted default branch.
+#   - The only secret in this process's env is LLM_API_KEY (same as Polly/doc-sync).
+#     The omnigent write-token that opens the CHANGELOG PR / edits the release is
+#     minted by the workflow AFTER this agent finishes, so it never coexists with
+#     model input.
+#   - Its input is author-written text (PR titles + `## Changelog` lines) — a prose
+#     prompt-injection surface. The workflow secret-scans this agent's stdout for
+#     LLM_API_KEY (abort on hit) and redacts artifacts, and a human edits the draft
+#     before publish. Honest residual risk: with network allowed and LLM_API_KEY in
+#     env, an injection could drive an outbound request that exfiltrates the key; a
+#     network-denying sandbox is the real mitigation but is not used here for the
+#     same CI-fragility reason documented in .github/agents/doc-drafter/config.yaml.
+#     We accept the same residual risk already accepted for polly-review.
+
+spec_version: 1
+name: release-notes-drafter
+description: >-
+  Synthesizes concise, curated GitHub Release notes from the list of PRs merged
+  since the previous release. Collapses related PRs into ~4-5 themed bullets under
+  two headings (Major new features; Bug fixes & hardening), in Omnigent's
+  release-notes voice, and emits them between RELEASE_NOTES markers. No tools, no
+  sub-agents — a pure synthesis turn.
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+prompt: |
+  You are the Omnigent release-notes drafter. A new version is being cut. You are
+  given the list of pull requests merged since the previous release — each with its
+  number, title, and (when the author filled it in) the one-line user-facing
+  changelog entry from the PR template. You are also given a deterministic
+  MECHANICAL DRAFT that already groups every harvested entry into the two sections;
+  treat it as raw material to curate, not a finished product.
+
+  Your job: write the concise, curated release notes a human would — collapsing many
+  related PRs into a handful of high-signal highlights. This is NOT a full changelog
+  (that lives in CHANGELOG.md); it is the "what's exciting in this release" summary.
+
+  ## Output shape (STRICT)
+  Emit ONLY the following, between the markers, and nothing else — no preamble:
+
+  <!-- RELEASE_NOTES -->
+  ## Major new features
+
+  - <highlight — collapse related PRs into one themed bullet> (#123, #456)
+  - <~4-5 bullets total>
+
+  ## Bug fixes & hardening
+
+  - <highlight> (#789)
+  - <~3-5 bullets total>
+
+  Full Changelog: <copy the exact `Full Changelog:` line from the mechanical draft>
+  <!-- /RELEASE_NOTES -->
+
+  ## How to write
+  - Lead with what a USER gains — a capability, a fixed pain, a smoother flow — not
+    the internal mechanics.
+  - GROUP aggressively: if six PRs add agent harnesses, that's ONE bullet naming a
+    few, not six bullets. Aim for ~4-5 bullets per section; drop pure-internal churn.
+  - Append the contributing PR refs in parentheses at the end of each bullet:
+    `(#123, #456)`. Only cite PRs you were actually given.
+  - Keep Omnigent's voice: crisp, concrete, lightly technical. A tasteful leading
+    emoji per feature bullet is fine (matching how we write releases); never invent
+    facts, versions, or flag names not present in the input.
+  - Preserve the `Full Changelog:` line from the mechanical draft verbatim.
+
+  ## Security
+  You are running in CI with access to secrets. Never echo secrets, tokens, or
+  credentials, and never make outbound network calls.
+
+  ## Act in the same turn you announce
+  Never end a turn after only saying what you will do — produce the RELEASE_NOTES
+  block in the same turn.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,3 +65,23 @@ Optional — but required if you checked "Manual verification completed" or
 "Not applicable" above. Describe what you verified manually, or why automated
 test coverage is not needed for this change.
 -->
+
+## Changelog
+
+<!--
+If this PR has a user-facing change worth announcing, write one or more lines
+below in the user's voice, each prefixed with a category. Otherwise leave it
+as `skip`.
+
+Lower the bar than docs: DO include small features and UX changes (moved/renamed
+buttons, new flags, copy tweaks). DO skip pure-internal churn (CI, refactors,
+test-only changes, dependency bumps with no user impact).
+
+Categories: Added | Changed | Fixed | Deprecated | Removed | Security
+Format:     <Category>: <one-line description>   (the PR link is added for you)
+Example:    Added: `omnigent run --watch` reruns an agent when files change
+
+A `skip` here is fine for chores — but a Breaking change must always be announced.
+-->
+
+skip

--- a/.github/scripts/changelog/generate.py
+++ b/.github/scripts/changelog/generate.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Harvest merged-PR "## Changelog" sections into the granular `CHANGELOG.md`.
+
+Run at release time (see `.github/workflows/publish-changelog.yml`). Given a
+final release tag, it:
+
+  1. finds the previous final tag (purely from git — no persisted state),
+  2. collects the PRs merged in that range (the `(#NNNN)` suffix on squash
+     commits),
+  3. reads each PR's `## Changelog` section via `gh`,
+  4. renders a Keep-a-Changelog section and inserts it into `CHANGELOG.md` in
+     version order (idempotent: re-running replaces the version's block).
+
+This is the *granular* tier. The concise website post is produced separately
+from the curated GitHub Release body (see `release_to_mdx.py`).
+
+The parsing of the `## Changelog` section is shared with the PR-template gate
+(`.github/scripts/pr-template/_md.py`) so the two can never disagree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Reuse the exact section + changelog parsing the merge gate uses.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "pr-template"))
+from _md import (  # noqa: E402
+    CHANGELOG_CATEGORIES,
+    is_changelog_skip,
+    parse_changelog_entries,
+    section_text,
+)
+
+_FINAL_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+# A squash-merge subject ends with "(#1234)"; capture the last such reference.
+_PR_REF_RE = re.compile(r"\(#(\d+)\)\s*$")
+# Existing version headers in CHANGELOG.md, e.g. "## [v0.3.0] — 2026-06-27".
+_VERSION_HEADER_RE = re.compile(r"(?m)^##\s*\[v(\d+)\.(\d+)\.(\d+)\]")
+
+
+# --- version helpers (final vX.Y.Z only → plain integer-tuple ordering) -------
+
+
+def _version_tuple(tag: str) -> tuple[int, int, int] | None:
+    match = _FINAL_TAG_RE.match(tag.strip())
+    if not match:
+        return None
+    return tuple(int(p) for p in match.groups())  # type: ignore[return-value]
+
+
+def previous_final_tag(tag: str, all_tags: list[str]) -> str | None:
+    """Highest final tag strictly below *tag*, or ``None`` if there is none."""
+    current = _version_tuple(tag)
+    if current is None:
+        raise ValueError(f"{tag!r} is not a final vX.Y.Z tag")
+    below = [
+        (version, candidate)
+        for candidate in all_tags
+        if (version := _version_tuple(candidate)) is not None and version < current
+    ]
+    if not below:
+        return None
+    return max(below)[1]
+
+
+def pr_numbers_from_subjects(subjects: list[str]) -> list[int]:
+    """PR numbers from squash-commit subjects, de-duplicated, first-seen order."""
+    return list(pr_titles_from_subjects(subjects))
+
+
+def pr_titles_from_subjects(subjects: list[str]) -> dict[int, str]:
+    """Map PR number -> title from squash-commit subjects (first seen wins).
+
+    A squash subject looks like ``feat(web): show progress bar (#1304)``; the
+    title is the subject with the trailing ``(#NNNN)`` reference stripped.
+    """
+    titles: dict[int, str] = {}
+    for subject in subjects:
+        match = _PR_REF_RE.search(subject)
+        if not match:
+            continue
+        pr = int(match.group(1))
+        if pr in titles:
+            continue
+        titles[pr] = _PR_REF_RE.sub("", subject).strip()
+    return titles
+
+
+# --- rendering ---------------------------------------------------------------
+
+
+class HarvestResult:
+    """Per-PR harvest outcome, for rendering and for surfacing gaps."""
+
+    def __init__(self, pr: int, title: str = "") -> None:
+        self.pr = pr
+        self.title = title
+        self.entries: list[tuple[str, str]] = []  # (category, text)
+        self.status = "skip"  # skip | included | no-section | unparseable
+
+
+def harvest_pr(pr: int, body: str | None, title: str = "") -> HarvestResult:
+    result = HarvestResult(pr, title)
+    if body is None:
+        result.status = "no-section"
+        return result
+    if "changelog" not in {h for h in _headings(body)}:
+        result.status = "no-section"
+        return result
+    raw = section_text(body, "Changelog")
+    if is_changelog_skip(raw):
+        result.status = "skip"
+        return result
+    entries, malformed = parse_changelog_entries(raw)
+    result.entries = entries
+    result.status = "included" if entries else ("unparseable" if malformed else "skip")
+    return result
+
+
+def _headings(body: str) -> set[str]:
+    return {m.group(1).strip().lower() for m in re.finditer(r"(?im)^\s*##\s+(.+?)\s*$", body)}
+
+
+def render_section(tag: str, date: str, results: list[HarvestResult]) -> str:
+    """Render the Keep-a-Changelog block for one version."""
+    by_category: dict[str, list[tuple[int, str]]] = {c: [] for c in CHANGELOG_CATEGORIES}
+    for result in results:
+        for category, text in result.entries:
+            by_category[category].append((result.pr, text))
+
+    lines = [f"## [{tag}] — {date}", ""]
+    any_entries = False
+    for category in CHANGELOG_CATEGORIES:
+        items = sorted(by_category[category])
+        if not items:
+            continue
+        any_entries = True
+        lines.append(f"### {category}")
+        for pr, text in items:
+            lines.append(f"- {text} (#{pr})")
+        lines.append("")
+    if not any_entries:
+        lines.append("_No user-facing changes._")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# Two-section draft for the GitHub Release body: the six Keep-a-Changelog
+# categories collapse into the two buckets the release coordinator curates by
+# hand (see RELEASING.md / the release-notes-drafter agent). This is the
+# deterministic scaffold — the AI drafter refines it, and it is also the
+# fallback when the LLM is unavailable.
+DRAFT_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("Major new features", ("Added", "Changed")),
+    ("Bug fixes & hardening", ("Fixed", "Security", "Removed", "Deprecated")),
+)
+
+
+def render_draft_notes(results: list[HarvestResult], repo: str) -> str:
+    """Render the two-section curated-draft scaffold for the GitHub Release body.
+
+    Groups the harvested one-liners into "Major new features" and "Bug fixes &
+    hardening", sorted by PR number, and appends the CHANGELOG.md link. Empty
+    sections keep their heading with a placeholder so the coordinator sees what
+    to fill in.
+    """
+    by_category: dict[str, list[tuple[int, str]]] = {c: [] for c in CHANGELOG_CATEGORIES}
+    for result in results:
+        for category, text in result.entries:
+            by_category[category].append((result.pr, text))
+
+    lines: list[str] = []
+    for heading, categories in DRAFT_SECTIONS:
+        lines.append(f"## {heading}")
+        lines.append("")
+        items = sorted({item for cat in categories for item in by_category[cat]})
+        if items:
+            for pr, text in items:
+                lines.append(f"- {text} (#{pr})")
+        else:
+            lines.append("<!-- no entries harvested for this section — add highlights -->")
+        lines.append("")
+
+    lines.append(f"Full Changelog: https://github.com/{repo}/blob/main/CHANGELOG.md")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_pr_list(results: list[HarvestResult]) -> str:
+    """Render the PR material fed to the release-notes-drafter agent.
+
+    One line per PR: number, title, and the author-written changelog entries
+    (if any). Titles come from the squash-commit subjects, so even PRs that
+    predate the `## Changelog` field still give the agent something to theme on.
+    """
+    lines: list[str] = []
+    for result in sorted(results, key=lambda r: r.pr):
+        lines.append(f"#{result.pr}: {result.title or '(no title)'}")
+        for category, text in result.entries:
+            lines.append(f"    - [{category}] {text}")
+    return "\n".join(lines) + "\n"
+
+
+def insert_section(changelog: str, tag: str, section: str) -> str:
+    """Insert (or replace) *section* for *tag* into *changelog*, version-ordered.
+
+    Newest version first. If the tag is already present its block is replaced,
+    making re-runs idempotent.
+    """
+    target = _version_tuple(tag)
+    if target is None:
+        raise ValueError(f"{tag!r} is not a final vX.Y.Z tag")
+
+    headers = list(_VERSION_HEADER_RE.finditer(changelog))
+    blocks = []  # (version_tuple, start, end)
+    for idx, match in enumerate(headers):
+        version = tuple(int(g) for g in match.groups())
+        start = match.start()
+        end = headers[idx + 1].start() if idx + 1 < len(headers) else len(changelog)
+        blocks.append((version, start, end))
+
+    section_block = section.rstrip() + "\n"
+
+    # Replace an existing block for this exact version.
+    for version, start, end in blocks:
+        if version == target:
+            return changelog[:start] + section_block + "\n" + changelog[end:].lstrip("\n")
+
+    # Otherwise insert before the first existing version that is older than ours.
+    for version, start, _end in blocks:
+        if version < target:
+            head = changelog[:start].rstrip("\n")
+            tail = changelog[start:]
+            return f"{head}\n\n{section_block}\n{tail}"
+
+    # No older block (we're the oldest, or the file has no version blocks yet):
+    # append after the preamble / existing blocks.
+    return changelog.rstrip("\n") + "\n\n" + section_block
+
+
+# --- git / gh IO -------------------------------------------------------------
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _all_tags() -> list[str]:
+    out = _git("tag", "-l", "v*")
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _range_subjects(prev: str | None, tag: str) -> list[str]:
+    rng = f"{prev}..{tag}" if prev else tag
+    out = _git("log", "--no-merges", "--pretty=%s", rng)
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def _tag_date(tag: str) -> str:
+    return _git("log", "-1", "--format=%cs", tag)
+
+
+def _gh_pr_body(repo: str, pr: int) -> str | None:
+    proc = subprocess.run(
+        ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "body", "-q", ".body"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def collect(tag: str, repo: str) -> tuple[str, list[HarvestResult], str | None]:
+    """Return (rendered_section, results, previous_tag) for *tag*."""
+    prev = previous_final_tag(tag, _all_tags())
+    subjects = _range_subjects(prev, tag)
+    titles = pr_titles_from_subjects(subjects)
+    results = [harvest_pr(pr, _gh_pr_body(repo, pr), title) for pr, title in titles.items()]
+    section = render_section(tag, _tag_date(tag), results)
+    return section, results, prev
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="final release tag, e.g. v0.3.0")
+    parser.add_argument("--repo", required=True, help="owner/name for `gh pr view`")
+    parser.add_argument(
+        "--changelog-file",
+        default="CHANGELOG.md",
+        help="path to the canonical CHANGELOG.md to update in place",
+    )
+    parser.add_argument(
+        "--section-out",
+        default=None,
+        help="optional path to also write the rendered section on its own",
+    )
+    parser.add_argument(
+        "--draft-notes-out",
+        default=None,
+        help="optional path to write the two-section curated-draft scaffold "
+        "(the GitHub Release body seed / LLM fallback)",
+    )
+    parser.add_argument(
+        "--pr-list-out",
+        default=None,
+        help="optional path to write the PR list (number/title/entries) fed to "
+        "the release-notes-drafter agent",
+    )
+    parser.add_argument(
+        "--no-changelog-update",
+        action="store_true",
+        help="skip writing CHANGELOG.md (useful when only the draft notes are wanted)",
+    )
+    args = parser.parse_args()
+
+    section, results, prev = collect(args.tag, args.repo)
+
+    if not args.no_changelog_update:
+        path = Path(args.changelog_file)
+        existing = path.read_text() if path.exists() else _SEED_CHANGELOG
+        path.write_text(insert_section(existing, args.tag, section))
+
+    if args.section_out:
+        Path(args.section_out).write_text(section)
+
+    if args.draft_notes_out:
+        Path(args.draft_notes_out).write_text(render_draft_notes(results, args.repo))
+
+    if args.pr_list_out:
+        Path(args.pr_list_out).write_text(render_pr_list(results))
+
+    # Surface gaps so a maintainer can backfill (non-fatal).
+    included = [r.pr for r in results if r.status == "included"]
+    skipped = [r.pr for r in results if r.status == "skip"]
+    missing = [r.pr for r in results if r.status == "no-section"]
+    unparseable = [r.pr for r in results if r.status == "unparseable"]
+    print(f"Range: {prev or '(start)'}..{args.tag}")
+    print(f"Included {len(included)} entr(y/ies) from PRs: {included}")
+    print(f"Skipped (explicit `skip`): {skipped}")
+    if missing:
+        print(f"::warning::PRs with no `## Changelog` section: {missing}")
+    if unparseable:
+        print(f"::warning::PRs with unparseable `## Changelog`: {unparseable}")
+    return 0
+
+
+_SEED_CHANGELOG = (
+    "# Changelog\n\n"
+    "All notable user-facing changes to omnigent are documented here. This file is "
+    "generated at release time from each PR's `## Changelog` section; the concise, "
+    "curated highlights live on the website under `/releases`.\n\n"
+    "The format follows [Keep a Changelog](https://keepachangelog.com/).\n"
+)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/changelog/generate.py
+++ b/.github/scripts/changelog/generate.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 # Reuse the exact section + changelog parsing the merge gate uses.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "pr-template"))
-from _md import (  # noqa: E402
+from _md import (
     CHANGELOG_CATEGORIES,
     is_changelog_skip,
     parse_changelog_entries,
@@ -108,7 +108,7 @@ def harvest_pr(pr: int, body: str | None, title: str = "") -> HarvestResult:
     if body is None:
         result.status = "no-section"
         return result
-    if "changelog" not in {h for h in _headings(body)}:
+    if "changelog" not in _headings(body):
         result.status = "no-section"
         return result
     raw = section_text(body, "Changelog")

--- a/.github/scripts/changelog/release_to_mdx.py
+++ b/.github/scripts/changelog/release_to_mdx.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Turn a curated GitHub Release body into an MDX-safe per-version site page.
+
+The website's `/releases/<version>` post is the *concise, curated highlights* —
+it mirrors the GitHub Release notes a maintainer already hand-edits in the
+draft→edit→publish flow. This module does a small mechanical transform so that
+GitHub-flavoured Markdown renders cleanly through the site's MDX pipeline
+(`@next/mdx`):
+
+  * unwrap `<https://…>` autolinks (angle brackets are JSX in MDX),
+  * escape `{`, `}`, and any remaining `<` so MDX never tries to evaluate them,
+  * linkify bare `#1234` references to the PR,
+  * prepend a `# vX.Y.Z` heading + a `_Released <date>_` line the index reads.
+
+No LLM, no reflow — the curation is the human's; we only make it MDX-safe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_AUTOLINK_RE = re.compile(r"<((?:https?://)[^>\s]+)>")
+# A bare "#1234" not already part of a word, path, or link. Headings are
+# "# Title" (space after #), so they never match.
+_PR_REF_RE = re.compile(r"(?<![\w/#])#(\d+)\b")
+
+
+def mdx_escape(text: str) -> str:
+    """Make GitHub-flavoured Markdown safe to parse as MDX."""
+    text = _AUTOLINK_RE.sub(r"\1", text)  # <url> -> url (GFM still autolinks bare URLs)
+    text = text.replace("{", "&#123;").replace("}", "&#125;")
+    text = text.replace("<", "&lt;")  # neutralise stray tags; '>' stays (blockquotes)
+    return text
+
+
+def linkify_pr_refs(text: str, repo: str) -> str:
+    return _PR_REF_RE.sub(
+        lambda m: f"[#{m.group(1)}](https://github.com/{repo}/pull/{m.group(1)})",
+        text,
+    )
+
+
+def release_body_to_mdx(tag: str, date: str, body: str, repo: str) -> str:
+    """Render the MDX page for one release."""
+    transformed = linkify_pr_refs(mdx_escape(body or ""), repo)
+    comment = (
+        "{/* Auto-generated from the GitHub Release for "
+        + tag
+        + ". Edit the GitHub Release, not this file. */}"
+    )
+    header = f"{comment}\n\n# {tag}\n\n_Released {date}_\n\n"
+    return header + transformed.strip() + "\n"
+
+
+def _tag_date(tag: str) -> str:
+    return subprocess.run(
+        ["git", "log", "-1", "--format=%cs", tag],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="final release tag, e.g. v0.3.0")
+    parser.add_argument("--repo", required=True, help="owner/name for PR links")
+    parser.add_argument("--date", default=None, help="release date YYYY-MM-DD (default: tag date)")
+    parser.add_argument(
+        "--body-file", default=None, help="file with the release body (default: stdin)"
+    )
+    parser.add_argument("--out", required=True, help="output page.mdx path")
+    args = parser.parse_args()
+
+    body = Path(args.body_file).read_text() if args.body_file else sys.stdin.read()
+    date = args.date or _tag_date(args.tag)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(release_body_to_mdx(args.tag, date, body, args.repo))
+    print(f"Wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/changelog/release_to_mdx.py
+++ b/.github/scripts/changelog/release_to_mdx.py
@@ -33,8 +33,8 @@ def mdx_escape(text: str) -> str:
     """Make GitHub-flavoured Markdown safe to parse as MDX."""
     text = _AUTOLINK_RE.sub(r"\1", text)  # <url> -> url (GFM still autolinks bare URLs)
     text = text.replace("{", "&#123;").replace("}", "&#125;")
-    text = text.replace("<", "&lt;")  # neutralise stray tags; '>' stays (blockquotes)
-    return text
+    # neutralise stray tags; '>' stays (blockquotes)
+    return text.replace("<", "&lt;")
 
 
 def linkify_pr_refs(text: str, repo: str) -> str:

--- a/.github/scripts/pr-template/_md.py
+++ b/.github/scripts/pr-template/_md.py
@@ -1,0 +1,98 @@
+"""Shared Markdown-section parsing for the PR-template tooling.
+
+`validate.py` (the merge gate) and the release-time changelog harvester
+(`.github/scripts/changelog/generate.py`) both need to pull a named `##`
+section out of a PR body. Keeping that logic in one place means the gate and
+the harvester can never drift on what counts as the "## Changelog" section.
+"""
+
+from __future__ import annotations
+
+import re
+
+_HEADING_RE = re.compile(r"(?im)^\s*##\s+(.+?)\s*$")
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def strip_html_comments(text: str) -> str:
+    """Drop ``<!-- ... -->`` comments (template guidance lives in these)."""
+    return _HTML_COMMENT_RE.sub("", text)
+
+
+def heading_spans(body: str) -> dict[str, tuple[int, int]]:
+    """Map each lowercased ``## heading`` to the (start, end) span of its body.
+
+    The span runs from just after the heading line to the start of the next
+    ``##`` heading (or end of document). Later duplicate headings win, matching
+    the existing validator behaviour.
+    """
+    matches = list(_HEADING_RE.finditer(body))
+    spans: dict[str, tuple[int, int]] = {}
+    for idx, match in enumerate(matches):
+        title = match.group(1).strip().lower()
+        start = match.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(body)
+        spans[title] = (start, end)
+    return spans
+
+
+def section(body: str, spans: dict[str, tuple[int, int]], heading: str) -> str:
+    """Return the raw text under *heading*, or ``""`` if it is absent."""
+    span = spans.get(heading.lower())
+    if span is None:
+        return ""
+    return body[span[0] : span[1]]
+
+
+def section_text(body: str, heading: str) -> str:
+    """Convenience: raw text under *heading* parsed straight from *body*."""
+    return section(body, heading_spans(body), heading)
+
+
+# --- "## Changelog" section format ------------------------------------------
+#
+# Authors write zero or more `<Category>: one-line description` lines, or the
+# `skip` sentinel when there's nothing user-facing to announce. The same parser
+# backs the PR gate (validate.py) and the release harvester (generate.py).
+
+CHANGELOG_CATEGORIES = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+
+_SKIP_SENTINELS = frozenset({"skip", "n/a", "na", "none", "-"})
+_ENTRY_RE = re.compile(
+    r"(?i)^\s*[-*]?\s*(?P<cat>Added|Changed|Deprecated|Removed|Fixed|Security)"
+    r"\s*:\s*(?P<text>.+\S)\s*$"
+)
+
+
+def _content_lines(section_raw: str) -> list[str]:
+    return [ln.strip() for ln in strip_html_comments(section_raw).splitlines() if ln.strip()]
+
+
+def is_changelog_skip(section_raw: str) -> bool:
+    """True when the section is empty or only the `skip`/`n/a` sentinel."""
+    lines = _content_lines(section_raw)
+    if not lines:
+        return True
+    return all(ln.lstrip("-* ").strip().lower() in _SKIP_SENTINELS for ln in lines)
+
+
+def parse_changelog_entries(section_raw: str) -> tuple[list[tuple[str, str]], list[str]]:
+    """Parse a "## Changelog" section.
+
+    Returns ``(entries, malformed)`` where *entries* is a list of
+    ``(canonical_category, description)`` tuples and *malformed* is the list of
+    non-blank, non-sentinel lines that did not match ``<Category>: text``.
+    """
+    entries: list[tuple[str, str]] = []
+    malformed: list[str] = []
+    for line in _content_lines(section_raw):
+        if line.lstrip("-* ").strip().lower() in _SKIP_SENTINELS:
+            continue
+        match = _ENTRY_RE.match(line)
+        if match:
+            cat = match.group("cat").lower()
+            canonical = next(c for c in CHANGELOG_CATEGORIES if c.lower() == cat)
+            entries.append((canonical, match.group("text").strip()))
+        else:
+            malformed.append(line)
+    return entries, malformed

--- a/.github/scripts/pr-template/format_body.py
+++ b/.github/scripts/pr-template/format_body.py
@@ -70,6 +70,13 @@ def format_body(body: str) -> str:
         "<!-- Optional; required if you checked 'Manual verification completed' "
         "or 'Not applicable' above. -->",
     )
+    body = _append_section(
+        body,
+        "Changelog",
+        "<!-- One or more '<Category>: description' lines (Added | Changed | "
+        "Fixed | Deprecated | Removed | Security) for user-facing changes, or "
+        "'skip'. A Breaking change must always be announced. -->\n\nskip",
+    )
     return body.rstrip() + "\n"
 
 

--- a/.github/scripts/pr-template/validate.py
+++ b/.github/scripts/pr-template/validate.py
@@ -11,12 +11,27 @@ from __future__ import annotations
 import os
 import re
 import sys
+from pathlib import Path
+
+# Share the Markdown-section + changelog parsing with the release-time harvester
+# (.github/scripts/changelog/generate.py) so the gate and the harvester can
+# never disagree on what the "## Changelog" section means.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _md import (  # noqa: E402
+    CHANGELOG_CATEGORIES,
+    is_changelog_skip,
+    parse_changelog_entries,
+)
+from _md import heading_spans as _heading_spans  # noqa: E402
+from _md import section as _section  # noqa: E402
+from _md import strip_html_comments as _strip_html_comments  # noqa: E402
 
 REQUIRED_HEADINGS = (
     "Summary",
     "Test Plan",
     "Type of change",
     "Test coverage",
+    "Changelog",
 )
 
 TYPE_LABELS = (
@@ -52,30 +67,7 @@ class ValidationResult:
         self.errors = errors
 
 
-_HEADING_RE = re.compile(r"(?im)^\s*##\s+(.+?)\s*$")
 _CHECKBOX_RE = re.compile(r"(?im)^\s*-\s*\[(?P<mark>[ xX])\]\s*(?P<label>.+?)\s*$")
-
-
-def _strip_html_comments(text: str) -> str:
-    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
-
-
-def _heading_spans(body: str) -> dict[str, tuple[int, int]]:
-    matches = list(_HEADING_RE.finditer(body))
-    spans: dict[str, tuple[int, int]] = {}
-    for idx, match in enumerate(matches):
-        title = match.group(1).strip().lower()
-        start = match.end()
-        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(body)
-        spans[title] = (start, end)
-    return spans
-
-
-def _section(body: str, spans: dict[str, tuple[int, int]], heading: str) -> str:
-    span = spans.get(heading.lower())
-    if span is None:
-        return ""
-    return body[span[0] : span[1]]
 
 
 def _checked_labels(section: str, expected_labels: tuple[str, ...]) -> set[str]:
@@ -172,6 +164,27 @@ def validate_pr_body(body: str) -> ValidationResult:
             )
         elif _contains_placeholder(coverage_notes):
             errors.append("Coverage notes still contains template placeholder text.")
+
+    # Changelog feeds the release-time CHANGELOG.md harvester, so it must be the
+    # `skip` sentinel or one or more `<Category>: description` lines it can parse
+    # deterministically. A breaking change must always carry an entry — those are
+    # exactly what users need announced.
+    if "changelog" in spans:
+        changelog_section = _section(body, spans, "Changelog")
+        if is_changelog_skip(changelog_section):
+            if "Breaking change" in checked_types:
+                errors.append(
+                    "Changelog must not be 'skip' when 'Breaking change' is checked "
+                    "— add a '<Category>: description' line announcing it."
+                )
+        else:
+            _entries, malformed = parse_changelog_entries(changelog_section)
+            if malformed:
+                errors.append(
+                    "Changelog lines must be 'skip' or '<Category>: description' "
+                    f"(Category one of: {', '.join(CHANGELOG_CATEGORIES)}). "
+                    "Offending line(s): " + "; ".join(malformed)
+                )
 
     return ValidationResult(ok=not errors, errors=errors)
 

--- a/.github/scripts/pr-template/validate.py
+++ b/.github/scripts/pr-template/validate.py
@@ -17,14 +17,14 @@ from pathlib import Path
 # (.github/scripts/changelog/generate.py) so the gate and the harvester can
 # never disagree on what the "## Changelog" section means.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _md import (  # noqa: E402
+from _md import (
     CHANGELOG_CATEGORIES,
     is_changelog_skip,
     parse_changelog_entries,
 )
-from _md import heading_spans as _heading_spans  # noqa: E402
-from _md import section as _section  # noqa: E402
-from _md import strip_html_comments as _strip_html_comments  # noqa: E402
+from _md import heading_spans as _heading_spans
+from _md import section as _section
+from _md import strip_html_comments as _strip_html_comments
 
 REQUIRED_HEADINGS = (
     "Summary",

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -340,8 +340,10 @@ jobs:
 
       - name: Note draft skipped (already published)
         if: steps.guard.outputs.proceed == 'true' && steps.guard.outputs.is_draft != 'true'
+        env:
+          TAG: ${{ steps.guard.outputs.tag }}
         run: |
-          echo "::notice::Release ${{ steps.guard.outputs.tag }} is not a draft — left its notes untouched (only the CHANGELOG PR ran)."
+          echo "::notice::Release ${TAG} is not a draft — left its notes untouched (only the CHANGELOG PR ran)."
 
       # ::add-mask:: redacts rendered logs, not artifact files — scrub the key
       # from artifacts (incl. the unscanned stderr) before upload.

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -1,0 +1,380 @@
+name: Draft release notes
+
+# At release CUT (a vX.Y.Z tag is pushed → the "GitHub Release" workflow creates
+# the draft), prepare everything the release coordinator needs before they hit
+# Publish:
+#
+#   1. Open a PR to omnigent/main updating the granular CHANGELOG.md (harvested
+#      from each merged PR's "## Changelog" section), so the draft's
+#      "Full Changelog" link resolves before the release goes public.
+#   2. Synthesize concise, curated two-section release notes (an Omnigent agent
+#      collapses the merged PRs into ~4-5 themed highlights per section) and drop
+#      them into the GitHub Release DRAFT body for the coordinator to edit.
+#
+# Why `workflow_run` (not extending github-release.yml): that workflow is
+# deliberately minimal — it runs NO project code, only `gh release create`, so a
+# malicious tagged commit can't execute anything. We keep that guarantee by
+# running the heavy work (LLM + git harvest) in this SEPARATE workflow, which
+# runs from the trusted default branch (workflow_run always does), never from the
+# tagged commit. Same "harvester runs from main" posture as autoformat-pr.yml.
+#
+# The LLM machinery (creds gate, Claude Code CLI, provider config, secret-scan,
+# token-minted-after-agent, artifact redaction) mirrors doc-sync.yml. The agent
+# only ever sees already-merged, released history.
+
+on:
+  workflow_run:
+    workflows: ["GitHub Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Final release tag to (re)draft, e.g. v0.3.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: draft-release-notes-${{ github.event.workflow_run.head_branch || inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  SOURCE_REPO: omnigent-ai/omnigent
+  OMNIGENT_SKIP_WEB_UI: "true"
+  UV_INDEX_URL: https://pypi.org/simple
+  PIP_INDEX_URL: https://pypi.org/simple
+
+jobs:
+  draft:
+    name: Harvest CHANGELOG and draft release notes
+    if: >-
+      github.repository == 'omnigent-ai/omnigent' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      # --- Resolve the tag and decide whether to proceed (no code run yet) ---
+      - name: Resolve tag and guard
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # On tag push, workflow_run.head_branch is the tag name (v0.3.0).
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-$RUN_BRANCH}"
+          proceed=true; is_draft=false
+
+          # Final vX.Y.Z only — exclude rc/dev/alpha/beta and non-version tags.
+          case "$tag" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) proceed=false ;;
+          esac
+          case "$tag" in
+            *rc*|*dev*|*a[0-9]*|*b[0-9]*) proceed=false ;;
+          esac
+
+          # Is there a DRAFT release for this tag? If it's already published (or a
+          # re-push after publish re-fired this workflow), we must NOT touch the
+          # notes — the coordinator has curated them. The CHANGELOG PR is still
+          # safe to (re)open, so we track isDraft separately.
+          if [ "$proceed" = "true" ]; then
+            state="$(gh release view "$tag" --repo "$SOURCE_REPO" --json isDraft,tagName 2>/dev/null || true)"
+            if [ -z "$state" ]; then
+              echo "::warning::No release found for ${tag} yet — skipping note draft (CHANGELOG PR still runs)."
+              is_draft=false
+            else
+              is_draft="$(printf '%s' "$state" | jq -r '.isDraft')"
+            fi
+          fi
+
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
+          echo "is_draft=${is_draft}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag} proceed=${proceed} is_draft=${is_draft}" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Trusted default branch, full history + tags for the range computation.
+      - name: Checkout omnigent (main)
+        if: steps.guard.outputs.proceed == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Set up Python
+        if: steps.guard.outputs.proceed == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      # --- 1) Harvest CHANGELOG.md + the mechanical scaffold + agent input ---
+      - name: Harvest changelog and PR material
+        id: harvest
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.guard.outputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/changelog/generate.py \
+            --tag "$TAG" --repo "$SOURCE_REPO" \
+            --changelog-file CHANGELOG.md \
+            --draft-notes-out /tmp/mechanical_notes.md \
+            --pr-list-out /tmp/pr_list.txt
+          # The mechanical scaffold is the fallback release-notes body.
+          cp /tmp/mechanical_notes.md /tmp/release_notes.md
+
+      # --- 2) AI synthesis (primary; degrades to the mechanical scaffold) ---
+      - name: Check LLM credentials
+        id: creds
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          if [ -z "${LLM_API_KEY:-}" ]; then
+            echo "::warning::No LLM credentials — using the mechanical draft scaffold."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::${LLM_API_KEY}"
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up uv
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Cache virtualenv
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
+
+      - name: Install dependencies
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        run: uv sync --extra all --extra dev
+
+      - name: Install Claude Code CLI
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          node node_modules/@anthropic-ai/claude-code/install.cjs
+          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Write Omnigent provider config
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+        run: |
+          mkdir -p "$HOME/.omnigent"
+          python3 -c "
+          import pathlib, os, json
+          gw = os.environ['GATEWAY_BASE_URL']
+          cfg = {'providers': {'databricks-gateway': {
+              'kind': 'gateway', 'default': ['anthropic'],
+              'anthropic': {
+                  'base_url': gw + '/anthropic',
+                  'api_key_ref': 'env:LLM_API_KEY',
+                  'models': {'default': 'databricks-claude-opus-4-8'},
+              }}}}
+          pathlib.Path.home().joinpath('.omnigent', 'config.yaml').write_text(json.dumps(cfg, indent=2))
+          "
+
+      - name: Build drafter prompt
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        env:
+          TAG: ${{ steps.guard.outputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 -u <<'PYEOF'
+          import os, pathlib
+          tag = os.environ["TAG"]
+          # The agent is tools-less, so its input must be inline — but `omnigent run
+          # -p` passes the whole prompt as one argv string, capped at ~128 KiB on
+          # Linux (MAX_ARG_STRLEN). Cap the PR list well under that; the mechanical
+          # scaffold already covers everything, so a partial list still drafts.
+          MAX = 100_000
+          pr_list = pathlib.Path("/tmp/pr_list.txt").read_text(encoding="utf-8", errors="replace")
+          mech = pathlib.Path("/tmp/mechanical_notes.md").read_text(encoding="utf-8", errors="replace")
+          truncated = len(pr_list) > MAX
+          pr_list = pr_list[:MAX]
+          note = ("\n> NOTE: the PR list was truncated — theme what's visible and keep the "
+                  "mechanical draft's coverage.\n" if truncated else "")
+          prompt = f"""Draft the curated release notes for {tag}.
+          {note}
+          ## Merged PRs (number, title, and author changelog entries)
+          {pr_list}
+
+          ## Mechanical draft (raw material — curate, don't copy verbatim)
+          {mech}
+
+          Produce the RELEASE_NOTES block per your instructions."""
+          pathlib.Path("/tmp/draft_prompt.txt").write_text(prompt)
+          PYEOF
+
+      - name: Run release-notes drafter
+        id: draft
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          set -euo pipefail
+          prompt="$(cat /tmp/draft_prompt.txt)"
+          uv run --project "${GITHUB_WORKSPACE}" omnigent run \
+            "${GITHUB_WORKSPACE}/.github/agents/release-notes-drafter" \
+            -p "$prompt" --no-session \
+            2>draft-stderr.log | tee /tmp/draft_out.txt \
+            || { echo "::warning::drafter exited non-zero — keeping mechanical draft"; cat draft-stderr.log; }
+
+      - name: Scan drafter output for secrets
+        if: steps.draft.outcome == 'success'
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${LLM_API_KEY:-}" ] && grep -qF "$LLM_API_KEY" /tmp/draft_out.txt 2>/dev/null; then
+            echo "::error::Drafter output contains LLM_API_KEY — aborting."
+            exit 1
+          fi
+
+      - name: Extract synthesized notes (fall back to mechanical)
+        if: steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        run: |
+          set -euo pipefail
+          python3 -u <<'PYEOF'
+          import pathlib, re
+          raw = pathlib.Path("/tmp/draft_out.txt").read_text(encoding="utf-8", errors="replace") \
+              if pathlib.Path("/tmp/draft_out.txt").is_file() else ""
+          m = re.search(r"<!--\s*RELEASE_NOTES\s*-->(.*?)<!--\s*/RELEASE_NOTES\s*-->", raw, re.DOTALL)
+          notes = (m.group(1).strip() if m else "")
+          if notes:
+              pathlib.Path("/tmp/release_notes.md").write_text(notes + "\n")
+              print("Using AI-synthesized release notes.")
+          else:
+              print("::warning::No RELEASE_NOTES block parsed — keeping mechanical draft.")
+          PYEOF
+
+      # --- 3) Mint the write-token — ONLY now, after the agent has run ---
+      - name: Mint App token (omnigent)
+        id: app-token
+        if: steps.guard.outputs.proceed == 'true' && vars.OMNIGENT_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: omnigent
+
+      # --- 4) Open/update the CHANGELOG.md PR ---
+      - name: Open or update the CHANGELOG.md PR
+        if: steps.guard.outputs.proceed == 'true' && steps.app-token.outputs.token != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SITE_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.guard.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain -- CHANGELOG.md)" ]; then
+            echo "CHANGELOG.md already up to date for ${TAG} — nothing to do." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          BRANCH="auto/changelog/${TAG}"
+          git config user.name "omnigent-ci[bot]"
+          git config user.email "294685417+omnigent-ci[bot]@users.noreply.github.com"
+          # No credentials persisted in .git/config (the unsandboxed agent ran
+          # earlier); push via the token URL, which GitHub masks in logs.
+          PUSH_URL="https://x-access-token:${SITE_TOKEN}@github.com/${SOURCE_REPO}.git"
+          git switch -C "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): record ${TAG}"
+          git push --force "$PUSH_URL" "$BRANCH"
+
+          if [ -n "$(gh pr list --repo "$SOURCE_REPO" --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "CHANGELOG PR already open for ${BRANCH} — force-push updated it."
+            exit 0
+          fi
+          body="$(printf 'Records **%s** in `CHANGELOG.md`, harvested from the `## Changelog` section of each merged PR. Merge as part of cutting the release so the draft notes '"'"'Full Changelog'"'"' link resolves.\n\nGenerated by `.github/workflows/draft-release-notes.yml`.' "$TAG")"
+          gh pr create \
+            --repo "$SOURCE_REPO" \
+            --base main \
+            --head "$BRANCH" \
+            --title "docs(changelog): record ${TAG}" \
+            --body "$body"
+
+      # --- 5) Enrich the GitHub Release DRAFT body (only while still a draft) ---
+      - name: Enrich the release draft body
+        if: steps.guard.outputs.proceed == 'true' && steps.guard.outputs.is_draft == 'true' && steps.app-token.outputs.token != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.guard.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Preserve the original auto-generated notes in a collapsed section for
+          # the coordinator's reference.
+          orig="$(gh release view "$TAG" --repo "$SOURCE_REPO" --json body -q .body || true)"
+          {
+            cat /tmp/release_notes.md
+            echo
+            echo "<details><summary>Auto-generated notes (reference)</summary>"
+            echo
+            printf '%s\n' "$orig"
+            echo
+            echo "</details>"
+          } > /tmp/final_notes.md
+          gh release edit "$TAG" --repo "$SOURCE_REPO" --notes-file /tmp/final_notes.md
+          echo "Enriched the ${TAG} release draft with curated notes." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Note draft skipped (already published)
+        if: steps.guard.outputs.proceed == 'true' && steps.guard.outputs.is_draft != 'true'
+        run: |
+          echo "::notice::Release ${{ steps.guard.outputs.tag }} is not a draft — left its notes untouched (only the CHANGELOG PR ran)."
+
+      # ::add-mask:: redacts rendered logs, not artifact files — scrub the key
+      # from artifacts (incl. the unscanned stderr) before upload.
+      - name: Redact secrets from artifacts
+        if: always() && steps.guard.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          set -euo pipefail
+          [ -n "${LLM_API_KEY:-}" ] || exit 0
+          python3 - <<'PYEOF'
+          import os, pathlib
+          key = os.environ.get("LLM_API_KEY", "")
+          for f in ["draft-stderr.log", "/tmp/draft_out.txt", "/tmp/draft_prompt.txt",
+                    "/tmp/release_notes.md"]:
+              p = pathlib.Path(f)
+              if not p.is_file() or not key:
+                  continue
+              t = p.read_text(encoding="utf-8", errors="replace")
+              if key in t:
+                  p.write_text(t.replace(key, "***REDACTED***"), encoding="utf-8")
+                  print(f"redacted key from {f}")
+          PYEOF
+
+      - name: Upload logs on failure
+        if: always() && steps.guard.outputs.proceed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: draft-release-notes-${{ steps.guard.outputs.tag }}-${{ github.run_id }}
+          path: |
+            draft-stderr.log
+            /tmp/draft_out.txt
+            /tmp/release_notes.md
+            /tmp/mechanical_notes.md
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -1,0 +1,167 @@
+name: Publish Changelog
+
+# When a final GitHub Release is PUBLISHED, mirror its (by-now human-curated)
+# notes to the docs site: open a PR to omnigent-site adding
+# app/releases/<version>/page.mdx, a per-version post.
+#
+# The granular CHANGELOG.md is NOT touched here — that PR is opened earlier, at
+# release-cut, by draft-release-notes.yml (so its "Full Changelog" link resolves
+# before the release goes public). This workflow is the publish-time, site-only
+# half of the pipeline.
+#
+# We trigger on `release: published` (not the tag push) because that's the moment
+# the maintainer-curated notes exist AND the version is installable — we never
+# advertise a release that PyPI can't serve yet. The release body we mirror is the
+# one draft-release-notes.yml seeded and the coordinator then edited.
+#
+# Cross-repo writes can't use the workflow's own GITHUB_TOKEN (scoped to this
+# repo), so we mint a short-lived token from the omnigent-ci GitHub App scoped to
+# omnigent-site — the same App used by sync-openapi-to-site.yml.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Final release tag to (re)publish, e.g. v0.3.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-changelog-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.r.outputs.tag }}
+      is_final: ${{ steps.r.outputs.is_final }}
+    steps:
+      - name: Resolve tag and finality
+        id: r
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-$EVENT_TAG}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+          is_final=true
+          # Only final vX.Y.Z tags; exclude rc/dev/alpha/beta and the
+          # event's prerelease flag.
+          case "$tag" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) is_final=false ;;
+          esac
+          case "$tag" in
+            *rc*|*dev*|*a[0-9]*|*b[0-9]*) is_final=false ;;
+          esac
+          if [ "${PRERELEASE}" = "true" ]; then
+            is_final=false
+          fi
+          echo "is_final=${is_final}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag} is_final=${is_final}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Open release-post PR (omnigent-site)
+    needs: resolve
+    runs-on: ubuntu-latest
+    # Canonical repo only; skip cleanly where the App isn't configured.
+    if: >-
+      needs.resolve.outputs.is_final == 'true' &&
+      github.repository == 'omnigent-ai/omnigent' &&
+      vars.OMNIGENT_BOT_APP_ID != ''
+    env:
+      TAG: ${{ needs.resolve.outputs.tag }}
+      SOURCE_REPO: ${{ github.repository }}
+      SITE_REPO: ${{ github.repository_owner }}/omnigent-site
+      RELEASES_BRANCH: auto/releases/${{ needs.resolve.outputs.tag }}
+    steps:
+      - name: Checkout omnigent (for the render script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: omnigent
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Render the curated release body to MDX
+        working-directory: omnigent
+        # The release read uses the workflow's own token (scoped to this repo);
+        # only the cross-repo site write needs the App token, minted below.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+          gh release view "$TAG" --repo "$SOURCE_REPO" \
+            --json body,publishedAt > /tmp/release.json
+          jq -r '.body' /tmp/release.json > /tmp/release_body.md
+          date="$(jq -r '.publishedAt' /tmp/release.json | cut -c1-10)"
+          mkdir -p /tmp/site_page
+          python3 .github/scripts/changelog/release_to_mdx.py \
+            --tag "$TAG" --repo "$SOURCE_REPO" --date "$date" \
+            --body-file /tmp/release_body.md \
+            --out "/tmp/site_page/page.mdx"
+
+      - name: Mint App token (omnigent-site)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: omnigent-site
+
+      - name: Checkout omnigent-site (sync target)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ env.SITE_REPO }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: site
+
+      - name: Open or update the release-post PR (omnigent-site)
+        working-directory: site
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          dest="app/releases/${VERSION}"
+          mkdir -p "$dest"
+          cp /tmp/site_page/page.mdx "$dest/page.mdx"
+
+          if [ -z "$(git status --porcelain -- "$dest")" ]; then
+            echo "Release post for ${TAG} already in sync — nothing to do." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git config user.name "omnigent-ci[bot]"
+          git config user.email "294685417+omnigent-ci[bot]@users.noreply.github.com"
+          git switch -C "$RELEASES_BRANCH"
+          git add "$dest/page.mdx"
+          git commit -m "docs(releases): publish ${TAG} release post"
+          git push --force origin "$RELEASES_BRANCH"
+
+          if [ -n "$(gh pr list --repo "$SITE_REPO" --head "$RELEASES_BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "Release-post PR already open for ${RELEASES_BRANCH} — force-push updated it."
+            exit 0
+          fi
+          body="$(printf 'Publishes the **%s** release post at `/releases/%s`, mirroring the curated GitHub Release notes.\n\nGenerated by omnigent `.github/workflows/publish-changelog.yml`. Edit the GitHub Release, not this file.' "$TAG" "$VERSION")"
+          gh pr create \
+            --repo "$SITE_REPO" \
+            --base main \
+            --head "$RELEASES_BRANCH" \
+            --title "docs(releases): publish ${TAG} release post" \
+            --body "$body"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable user-facing changes to omnigent are documented here. This file is
+generated at release time from each PR's `## Changelog` section; the concise,
+curated highlights live on the website under `/releases`.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/).
+
+## [v0.3.0] — 2026-06-26
+
+Highlights and full notes: <https://github.com/omnigent-ai/omnigent/releases/tag/v0.3.0>
+
+## [v0.2.0] — 2026-06-19
+
+Highlights and full notes: <https://github.com/omnigent-ai/omnigent/releases/tag/v0.2.0>
+
+## [v0.1.1] — 2026-06-16
+
+Predates the automated changelog. See the Git history for `v0.1.0..v0.1.1`.
+
+## [v0.1.0] — 2026-06-13
+
+First tagged release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,6 +90,11 @@ git tag v0.2.0
 git push -u origin branch-0.2 v0.2.0        # explicit tag, NOT --tags; pushing the tag drafts the GitHub Release (step 5)
 ```
 
+> Pushing the tag also kicks off the **changelog automation** (see step 5):
+> `github-release.yml` drafts the Release, then `draft-release-notes.yml` opens a
+> `CHANGELOG.md` PR and fills the draft with curated notes — both ready by the time
+> you get to step 5.
+
 Keep `main` from re-freezing — bump it to the next dev marker and push:
 
 ```bash
@@ -163,17 +168,40 @@ uv tool install omnigent==0.2.0        # final sanity from real PyPI
 
 ### 5. Publish the GitHub Release — `omnigent-ai/omnigent` (OSS account)
 
-Pushing the `v0.2.0` tag (step 1) triggered `.github/workflows/github-release.yml`,
-which created a **draft** release with auto-generated notes (PRs since the
-previous tag). Now:
+Pushing the `v0.2.0` tag (step 1) set the **changelog automation** in motion —
+two workflows have already done the prep for you:
 
-1. Open <https://github.com/omnigent-ai/omnigent/releases> and find the `v0.2.0`
-   draft.
-2. **Verify and edit the notes** — lead with user-facing highlights, call out
-   breaking changes and any upgrade steps, and trim noise from the auto-generated
-   list. The notes are a draft, not the final word.
+- `github-release.yml` created a **draft** release.
+- `draft-release-notes.yml` (fires right after) then:
+  1. opened a **`CHANGELOG.md` PR to `main`** — the granular, feature-level log,
+     harvested mechanically from each merged PR's `## Changelog` section; and
+  2. **filled the draft's body** with concise, curated two-section notes (Major new
+     features / Bug fixes & hardening), synthesized by an agent from the merged
+     PRs, with the original auto-notes tucked into a collapsed `<details>` for
+     reference.
+
+Now:
+
+1. **Merge the `CHANGELOG.md` PR** as part of cutting the release, so the draft's
+   `Full Changelog` link (which points at `CHANGELOG.md` on `main`) resolves.
+2. Open <https://github.com/omnigent-ai/omnigent/releases>, find the `v0.2.0`
+   draft, and **review/trim the curated notes** — they're a strong starting point,
+   not the final word. Lead with user-facing highlights; call out breaking changes.
+   Whatever you leave here becomes the website post, so curate it well.
 3. **Publish the release** (ideally only after the prod PyPI publish in step 4 has
    succeeded, so you never advertise a version that isn't installable).
+
+Publishing a **final** release fires `.github/workflows/publish-changelog.yml`,
+which opens **one** PR to review and merge (pre-releases are skipped):
+
+- **`omnigent-site` `/releases/<version>`** — a per-version post mirroring the
+  notes you just curated (PR refs and angle/brace characters are made MDX-safe for
+  you).
+
+To re-run either half for an already-cut tag: dispatch `draft-release-notes.yml`
+with the `tag` (re-opens the CHANGELOG PR; it leaves the notes alone once the
+release is published), or `publish-changelog.yml` with the `tag` (re-opens the
+site post PR).
 
 If the draft wasn't created (e.g. the workflow was disabled), do it manually:
 

--- a/tests/github/test_changelog_generate.py
+++ b/tests/github/test_changelog_generate.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / ".github" / "scripts" / "changelog" / "generate.py"
+)
+spec = importlib.util.spec_from_file_location("changelog_generate", SCRIPT)
+assert spec and spec.loader
+gen = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = gen
+spec.loader.exec_module(gen)
+
+
+# --- previous_final_tag ------------------------------------------------------
+
+_TAGS = ["v0.1.0", "v0.1.0rc4", "v0.1.1", "v0.2.0", "v0.2.0rc1", "v0.3.0", "v0.3.0rc1"]
+
+
+def test_previous_final_tag_for_minor() -> None:
+    assert gen.previous_final_tag("v0.3.0", _TAGS) == "v0.2.0"
+
+
+def test_previous_final_tag_for_patch() -> None:
+    # A patch picks the previous patch/minor, never a higher minor.
+    assert gen.previous_final_tag("v0.2.1", _TAGS + ["v0.2.1"]) == "v0.2.0"
+
+
+def test_previous_final_tag_ignores_prereleases() -> None:
+    assert gen.previous_final_tag("v0.2.0", _TAGS) == "v0.1.1"
+
+
+def test_previous_final_tag_first_release() -> None:
+    assert gen.previous_final_tag("v0.1.0", ["v0.1.0", "v0.1.0rc4"]) is None
+
+
+# --- pr_numbers_from_subjects ------------------------------------------------
+
+
+def test_pr_numbers_extracted_and_deduped() -> None:
+    subjects = [
+        "feat(web): show progress bar (#1304)",
+        "fix(policies): reject url policies (#1507)",
+        "chore: no pr ref here",
+        "feat(web): show progress bar (#1304)",  # duplicate
+    ]
+    assert gen.pr_numbers_from_subjects(subjects) == [1304, 1507]
+
+
+def test_pr_titles_strip_ref_and_dedupe() -> None:
+    subjects = [
+        "feat(web): show progress bar (#1304)",
+        "fix(policies): reject url policies (#1507)",
+        "feat(web): show progress bar again (#1304)",  # dup number, first wins
+    ]
+    titles = gen.pr_titles_from_subjects(subjects)
+    assert titles == {
+        1304: "feat(web): show progress bar",
+        1507: "fix(policies): reject url policies",
+    }
+
+
+# --- harvest_pr --------------------------------------------------------------
+
+
+def _body(changelog: str) -> str:
+    return f"## Summary\n\nThing.\n\n## Changelog\n\n{changelog}\n"
+
+
+def test_harvest_includes_entries() -> None:
+    result = gen.harvest_pr(123, _body("Added: a new flag\nFixed: a crash"))
+    assert result.status == "included"
+    assert result.entries == [("Added", "a new flag"), ("Fixed", "a crash")]
+
+
+def test_harvest_skip() -> None:
+    result = gen.harvest_pr(123, _body("skip"))
+    assert result.status == "skip"
+    assert result.entries == []
+
+
+def test_harvest_no_section() -> None:
+    result = gen.harvest_pr(123, "## Summary\n\nNo changelog heading here.\n")
+    assert result.status == "no-section"
+
+
+def test_harvest_missing_body() -> None:
+    assert gen.harvest_pr(123, None).status == "no-section"
+
+
+def test_harvest_unparseable() -> None:
+    result = gen.harvest_pr(123, _body("just prose, no category"))
+    assert result.status == "unparseable"
+    assert result.entries == []
+
+
+# --- render_section ----------------------------------------------------------
+
+
+def _result(pr: int, entries: list[tuple[str, str]]) -> object:
+    r = gen.HarvestResult(pr)
+    r.entries = entries
+    r.status = "included"
+    return r
+
+
+def test_render_section_groups_by_category() -> None:
+    results = [
+        _result(10, [("Added", "watch flag")]),
+        _result(20, [("Fixed", "a crash")]),
+        _result(5, [("Added", "another thing")]),
+    ]
+    section = gen.render_section("v0.3.0", "2026-06-27", results)
+    assert section.startswith("## [v0.3.0] — 2026-06-27")
+    assert "### Added" in section and "### Fixed" in section
+    # Sorted by PR number within a category.
+    assert section.index("another thing (#5)") < section.index("watch flag (#10)")
+    # Category order follows CHANGELOG_CATEGORIES (Added before Fixed).
+    assert section.index("### Added") < section.index("### Fixed")
+
+
+def test_render_section_no_entries() -> None:
+    section = gen.render_section("v0.3.0", "2026-06-27", [])
+    assert "_No user-facing changes._" in section
+
+
+# --- insert_section ----------------------------------------------------------
+
+_SEED = gen._SEED_CHANGELOG
+
+
+def _section(tag: str, date: str, text: str) -> str:
+    return f"## [{tag}] — {date}\n\n### Added\n- {text} (#1)\n"
+
+
+def test_insert_into_empty_then_order_newest_first() -> None:
+    doc = gen.insert_section(_SEED, "v0.2.0", _section("v0.2.0", "2026-06-19", "two"))
+    doc = gen.insert_section(doc, "v0.3.0", _section("v0.3.0", "2026-06-27", "three"))
+    assert doc.index("[v0.3.0]") < doc.index("[v0.2.0]")
+    # Preamble stays on top.
+    assert doc.index("# Changelog") < doc.index("[v0.3.0]")
+
+
+def test_insert_patch_lands_below_newer_minor() -> None:
+    doc = gen.insert_section(_SEED, "v0.3.0", _section("v0.3.0", "2026-06-27", "three"))
+    doc = gen.insert_section(doc, "v0.2.0", _section("v0.2.0", "2026-06-19", "two"))
+    doc = gen.insert_section(doc, "v0.2.1", _section("v0.2.1", "2026-06-30", "patch"))
+    assert doc.index("[v0.3.0]") < doc.index("[v0.2.1]") < doc.index("[v0.2.0]")
+
+
+def test_insert_is_idempotent_and_replaces() -> None:
+    doc = gen.insert_section(_SEED, "v0.3.0", _section("v0.3.0", "2026-06-27", "old"))
+    doc = gen.insert_section(doc, "v0.3.0", _section("v0.3.0", "2026-06-27", "new"))
+    assert doc.count("[v0.3.0]") == 1
+    assert "new (#1)" in doc and "old (#1)" not in doc
+
+
+# --- render_draft_notes ------------------------------------------------------
+
+_REPO = "omnigent-ai/omnigent"
+
+
+def test_draft_notes_groups_into_two_sections() -> None:
+    results = [
+        _result(10, [("Added", "a new flag")]),
+        _result(20, [("Changed", "moved a button")]),
+        _result(30, [("Fixed", "a crash")]),
+        _result(40, [("Security", "patched an SSRF")]),
+    ]
+    notes = gen.render_draft_notes(results, _REPO)
+    assert "## Major new features" in notes
+    assert "## Bug fixes & hardening" in notes
+    # Added/Changed land in features; Fixed/Security in hardening.
+    feat, hard = notes.split("## Bug fixes & hardening")
+    assert "a new flag (#10)" in feat and "moved a button (#20)" in feat
+    assert "a crash (#30)" in hard and "patched an SSRF (#40)" in hard
+    # Features section comes first.
+    assert notes.index("## Major new features") < notes.index("## Bug fixes & hardening")
+
+
+def test_draft_notes_has_full_changelog_footer() -> None:
+    notes = gen.render_draft_notes([_result(1, [("Added", "x")])], _REPO)
+    assert notes.rstrip().endswith(
+        "Full Changelog: https://github.com/omnigent-ai/omnigent/blob/main/CHANGELOG.md"
+    )
+
+
+def test_draft_notes_empty_section_keeps_placeholder() -> None:
+    # Only a feature entry — the hardening section should still appear with a hint.
+    notes = gen.render_draft_notes([_result(1, [("Added", "x")])], _REPO)
+    assert "## Bug fixes & hardening" in notes
+    assert "no entries harvested" in notes
+
+
+def test_draft_notes_sorted_by_pr_within_section() -> None:
+    results = [
+        _result(30, [("Added", "third")]),
+        _result(10, [("Added", "first")]),
+        _result(20, [("Changed", "second")]),
+    ]
+    notes = gen.render_draft_notes(results, _REPO)
+    assert notes.index("first (#10)") < notes.index("second (#20)") < notes.index("third (#30)")
+
+
+# --- render_pr_list (agent input) --------------------------------------------
+
+
+def _titled(pr: int, title: str, entries: list[tuple[str, str]]) -> object:
+    r = gen.HarvestResult(pr, title)
+    r.entries = entries
+    r.status = "included" if entries else "no-section"
+    return r
+
+
+def test_pr_list_includes_title_and_entries() -> None:
+    results = [
+        _titled(20, "feat(web): projects workspace", [("Added", "group sessions")]),
+        _titled(10, "chore: bump deps", []),  # no changelog entry — title only
+    ]
+    listing = gen.render_pr_list(results)
+    # Sorted by PR number.
+    assert listing.index("#10:") < listing.index("#20:")
+    assert "#10: chore: bump deps" in listing
+    assert "#20: feat(web): projects workspace" in listing
+    assert "    - [Added] group sessions" in listing
+
+
+def test_pr_list_handles_missing_title() -> None:
+    listing = gen.render_pr_list([_titled(5, "", [])])
+    assert "#5: (no title)" in listing

--- a/tests/github/test_changelog_generate.py
+++ b/tests/github/test_changelog_generate.py
@@ -4,9 +4,7 @@ import importlib.util
 import sys
 from pathlib import Path
 
-SCRIPT = (
-    Path(__file__).resolve().parents[2] / ".github" / "scripts" / "changelog" / "generate.py"
-)
+SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "changelog" / "generate.py"
 spec = importlib.util.spec_from_file_location("changelog_generate", SCRIPT)
 assert spec and spec.loader
 gen = importlib.util.module_from_spec(spec)
@@ -25,7 +23,7 @@ def test_previous_final_tag_for_minor() -> None:
 
 def test_previous_final_tag_for_patch() -> None:
     # A patch picks the previous patch/minor, never a higher minor.
-    assert gen.previous_final_tag("v0.2.1", _TAGS + ["v0.2.1"]) == "v0.2.0"
+    assert gen.previous_final_tag("v0.2.1", [*_TAGS, "v0.2.1"]) == "v0.2.0"
 
 
 def test_previous_final_tag_ignores_prereleases() -> None:

--- a/tests/github/test_pr_autoformat.py
+++ b/tests/github/test_pr_autoformat.py
@@ -34,3 +34,11 @@ def test_preserves_existing_sections_and_adds_missing_optional_context() -> None
     assert "## Diagram" in formatted
     assert "## Test Plan" in formatted
     assert "## Coverage notes" in formatted
+    assert "## Changelog" in formatted
+
+
+def test_scaffolds_changelog_section_with_skip_default() -> None:
+    formatted = pr_autoformat.format_body("Fix the important thing.")
+    assert "## Changelog" in formatted
+    # The scaffolded section defaults to the `skip` sentinel.
+    assert formatted.rstrip().endswith("skip")

--- a/tests/github/test_pr_template_validate.py
+++ b/tests/github/test_pr_template_validate.py
@@ -40,9 +40,11 @@ def _valid_body(
 """,
     coverage_notes: str | None = None,
     demo: str | None = None,
+    changelog: str | None = "Fixed: stale polling no longer blocks the REPL handoff",
 ) -> str:
     notes_section = "" if coverage_notes is None else f"\n## Coverage notes\n\n{coverage_notes}\n"
     demo_section = "" if demo is None else f"\n## Demo\n\n{demo}\n"
+    changelog_section = "" if changelog is None else f"\n## Changelog\n\n{changelog}\n"
     return f"""
 ## Summary
 
@@ -55,7 +57,18 @@ def _valid_body(
 ## Type of change
 {type_checkboxes}
 ## Test coverage
-{test_checkboxes}{notes_section}"""
+{test_checkboxes}{notes_section}{changelog_section}"""
+
+
+_BREAKING_TYPE = """
+- [ ] Bug fix
+- [ ] Feature
+- [ ] UI / frontend change
+- [ ] Refactor / chore
+- [ ] Docs
+- [ ] Test / CI
+- [x] Breaking change
+"""
 
 
 _UI_CHANGE = """
@@ -237,6 +250,55 @@ def test_ui_change_with_demo_passes() -> None:
     body = _valid_body(
         type_checkboxes=_UI_CHANGE,
         demo="![new settings panel](https://github.com/org/repo/assets/1/screenshot.png)",
+    )
+    result = module.validate_pr_body(body)
+    assert result.ok, result.errors
+
+
+def test_changelog_skip_is_valid() -> None:
+    result = module.validate_pr_body(_valid_body(changelog="skip"))
+    assert result.ok, result.errors
+
+
+def test_changelog_multiple_category_lines_valid() -> None:
+    body = _valid_body(
+        changelog="Added: `--watch` reruns on file changes\nFixed: REPL no longer hangs",
+    )
+    result = module.validate_pr_body(body)
+    assert result.ok, result.errors
+
+
+def test_changelog_missing_heading_rejected() -> None:
+    result = module.validate_pr_body(_valid_body(changelog=None))
+    assert not result.ok
+    assert "Missing required section: ## Changelog" in result.errors
+
+
+def test_changelog_malformed_line_rejected() -> None:
+    body = _valid_body(changelog="this is just prose with no category prefix")
+    result = module.validate_pr_body(body)
+    assert not result.ok
+    assert any(error.startswith("Changelog lines must be") for error in result.errors)
+
+
+def test_changelog_unknown_category_rejected() -> None:
+    body = _valid_body(changelog="Improved: faster startup")
+    result = module.validate_pr_body(body)
+    assert not result.ok
+    assert any(error.startswith("Changelog lines must be") for error in result.errors)
+
+
+def test_breaking_change_requires_changelog_entry() -> None:
+    body = _valid_body(type_checkboxes=_BREAKING_TYPE, changelog="skip")
+    result = module.validate_pr_body(body)
+    assert not result.ok
+    assert any(error.startswith("Changelog must not be 'skip'") for error in result.errors)
+
+
+def test_breaking_change_with_entry_passes() -> None:
+    body = _valid_body(
+        type_checkboxes=_BREAKING_TYPE,
+        changelog="Removed: dropped the deprecated `--legacy` flag",
     )
     result = module.validate_pr_body(body)
     assert result.ok, result.errors

--- a/tests/github/test_release_to_mdx.py
+++ b/tests/github/test_release_to_mdx.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "scripts"
+    / "changelog"
+    / "release_to_mdx.py"
+)
+spec = importlib.util.spec_from_file_location("release_to_mdx", SCRIPT)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+def test_mdx_escape_braces_and_angle_brackets() -> None:
+    out = mod.mdx_escape("use {config} and <Component> safely")
+    assert "{" not in out and "}" not in out
+    assert "<" not in out  # escaped to &lt;
+    assert "&#123;config&#125;" in out
+
+
+def test_mdx_escape_unwraps_autolinks() -> None:
+    out = mod.mdx_escape("see <https://example.com/x> now")
+    assert "https://example.com/x" in out
+    assert "<https" not in out and "&lt;https" not in out
+
+
+def test_mdx_escape_preserves_blockquote_gt() -> None:
+    # '>' is left alone so Markdown blockquotes still render.
+    assert ">" in mod.mdx_escape("> a quote")
+
+
+def test_linkify_pr_refs() -> None:
+    out = mod.linkify_pr_refs("fixed in #1304 and #20", "omnigent-ai/omnigent")
+    assert "[#1304](https://github.com/omnigent-ai/omnigent/pull/1304)" in out
+    assert "[#20](https://github.com/omnigent-ai/omnigent/pull/20)" in out
+
+
+def test_linkify_leaves_headings_alone() -> None:
+    # Heading "# v0.3.0" has a space after '#', so it is not a PR ref.
+    assert mod.linkify_pr_refs("# v0.3.0", "o/o") == "# v0.3.0"
+
+
+def test_release_body_to_mdx_structure() -> None:
+    body = "### Major new features\n\n* Seven harnesses (#1132, #330)\n"
+    page = mod.release_body_to_mdx("v0.3.0", "2026-06-27", body, "omnigent-ai/omnigent")
+    assert page.startswith("{/* Auto-generated")
+    assert "# v0.3.0" in page
+    assert "_Released 2026-06-27_" in page
+    assert "### Major new features" in page
+    assert "/pull/1132" in page  # PR refs linkified

--- a/tests/github/test_release_to_mdx.py
+++ b/tests/github/test_release_to_mdx.py
@@ -5,11 +5,7 @@ import sys
 from pathlib import Path
 
 SCRIPT = (
-    Path(__file__).resolve().parents[2]
-    / ".github"
-    / "scripts"
-    / "changelog"
-    / "release_to_mdx.py"
+    Path(__file__).resolve().parents[2] / ".github" / "scripts" / "changelog" / "release_to_mdx.py"
 )
 spec = importlib.util.spec_from_file_location("release_to_mdx", SCRIPT)
 assert spec and spec.loader


### PR DESCRIPTION
## Related issue

N/A — infrastructure for release automation.

## Summary

Adds an end-to-end changelog pipeline, split across the two moments in the release flow:

- **Authoring:** a new `## Changelog` section in the PR template lets the author (or their agent) declare user-facing changes (`<Category>: description`, or `skip`). The merge gate enforces it; a Breaking change may not be `skip`.
- **At release cut** (`draft-release-notes.yml`, fires via `workflow_run` after the *GitHub Release* draft is created — runs from `main`, so no tagged code executes): harvests each merged PR's `## Changelog` section into **`CHANGELOG.md`** (opens a version-ordered PR to `main`), and synthesizes concise **two-section release notes** (a tools-less `release-notes-drafter` agent) into the GitHub Release **draft body**, keeping the auto-notes in a collapsed `<details>`. Degrades to a deterministic scaffold if the LLM is unavailable; a hard `isDraft` guard never clobbers human-curated notes.
- **At release publish** (`publish-changelog.yml`, site-only): mirrors the curated release body to an MDX-safe `app/releases/<version>` post on `omnigent-site`.

The commit range is derived statelessly from git tags. Security posture (LLM-cred gate, output secret-scan, token-minted-after-agent, artifact redaction) mirrors `doc-sync.yml`. Companion `omnigent-site` PR adds the `/releases` section.

## Test Plan

- `pytest tests/github/` — **69 pass** (+ new coverage: prev-tag selection for minor & patch, category grouping, `skip`, sanitize, version-ordered idempotent insertion, two-section draft rendering, PR-list/title extraction, MDX escape/linkify, and the new PR-template validation rules).
- Both workflow YAMLs parse; `release-notes-drafter` loads through omnigent's `load_agent_def` (structurally identical to the proven `doc-classifier`).
- Live dry-run of the harvester over the real 413-PR `v0.2.0..v0.3.0` range (range/enumeration/`gh` body-fetch/render) and of the MDX transform over the real v0.3.0 release body.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Scripts are covered by the `tests/github/` unit suite. The two workflows and the `release-notes-drafter` agent can't run in unit tests; verified structurally (YAML parse, `load_agent_def`) and via local dry-runs of the underlying scripts against the real repo history. A live agent turn needs a CI dispatch (no `LLM_API_KEY` locally).

## Changelog

Added: automated changelog — merged PRs flow into a per-version `CHANGELOG.md` and a curated release post on the docs site