### PR TITLE
feat(routing): use live runner model catalog; judge picks harness + model

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -86,6 +86,12 @@ prompt: |
   turn runs on; it does NOT constrain how many sub-agents you spawn, which
   workers, or which models they get. Those choices stay entirely yours.
 
+  Before any fan-out, call `sys_advise_models` if it is available (the tool
+  appears in your tool list when intelligent routing is configured). Pass the
+  full list of tasks you are about to dispatch — one entry per planned
+  `sys_session_send` — and use each recommendation's `model` as the
+  `args.model` for that dispatch.
+
   Delegate ALL coding work through these three via `sys_session_send`, each
   launched in its OWN git worktree. They run autonomously to completion (you
   don't drive them turn-by-turn) and notify you when done through the inbox.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -17441,6 +17441,36 @@ def create_runner_app(
             content={"skills": [{"name": s.name, "description": s.description} for s in skills]},
         )
 
+    @app.get("/v1/sessions/{session_id}/models")
+    async def get_session_models(session_id: str) -> JSONResponse:
+        """
+        Return the per-worker model catalog for a session.
+
+        The Omnigent server calls this before routing a turn so the
+        intelligent model router can use live, provider-resolved model
+        lists instead of the static fallback table.
+
+        :param session_id: Session/conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :returns: JSON ``{"workers": {<name>: {source, verified, models,
+            note}, ...}}`` shaped like the ``sys_list_models`` payload.
+            ``"self"`` is the calling session's own harness.  Returns an
+            empty workers dict when no spec resolver is configured.
+        """
+        spec = await _resolve_session_agent_spec(session_id)
+        if spec is None:
+            return JSONResponse(status_code=200, content={"workers": {}})
+        from omnigent.model_catalog import catalog_for_spec
+
+        try:
+            catalog = await asyncio.to_thread(catalog_for_spec, spec)
+        except Exception:
+            _logger.exception(
+                "get_session_models: catalog_for_spec failed for session=%s", session_id
+            )
+            return JSONResponse(status_code=200, content={"workers": {}})
+        return JSONResponse(status_code=200, content={"workers": catalog})
+
     @app.get("/v1/sessions/{session_id}/codex-model-options")
     async def get_session_codex_model_options(session_id: str) -> JSONResponse:
         """

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8658,7 +8658,12 @@ async def _forward_event_to_runner(
         _harness = _resolve_harness(conv)
         _user_text = _extract_user_text_for_routing(body)
         if _user_text:
-            _routed_model, _verdict = await route_turn(_harness, _user_text)
+            _routed_model, _verdict = await route_turn(
+                _harness,
+                _user_text,
+                session_id=session_id,
+                runner_client=runner_client,
+            )
             if _routed_model is not None:
                 effective_runner_override = _routed_model
                 # Persist as the session's model_override so all
@@ -8878,7 +8883,13 @@ async def _dispatch_session_event_to_runner(
             _harness = _resolve_harness(conv)
             _user_text = _extract_user_text_for_routing(body)
             if _user_text:
-                _routed_model, _verdict = await route_turn(_harness, _user_text)
+                _native_runner_client = await _get_runner_client(session_id, runner_router)
+                _routed_model, _verdict = await route_turn(
+                    _harness,
+                    _user_text,
+                    session_id=session_id,
+                    runner_client=_native_runner_client,
+                )
                 if _routed_model is not None:
                     try:
                         await asyncio.to_thread(
@@ -12831,6 +12842,9 @@ async def _handle_advise_models_mcp(
     conv: Any,
     arguments: dict[str, Any],
     agent_store: Any,
+    *,
+    session_id: str | None = None,
+    runner_router: Any = None,
 ) -> Response:
     """
     Server-side handler for ``sys_advise_models`` MCP tool calls.
@@ -12856,7 +12870,18 @@ async def _handle_advise_models_mcp(
         return _mcp_tool_result(rpc_id, json.dumps({"router_on": False, "recommendations": []}))
 
     from omnigent.model_catalog import spec_harness
-    from omnigent.server.smart_routing import infer_models
+    from omnigent.server.smart_routing import fetch_runner_models, infer_models
+
+    # Fetch live model catalog from the runner once; used below to populate
+    # per-agent model lists when the caller omits explicit models.
+    # Keys are worker names ("self", "claude_code", etc.) as returned by
+    # catalog_for_spec.  None when runner is unreachable — falls back to
+    # infer_models static table.
+    _runner_catalog: dict[str, list[str]] | None = None
+    if session_id is not None and runner_router is not None:
+        _runner_client = await _get_runner_client(session_id, runner_router)
+        if _runner_client is not None:
+            _runner_catalog = await fetch_runner_models(session_id, _runner_client)
 
     # Resolve the parent agent spec to look up sub-agent harnesses.
     spec: Any | None = None
@@ -12905,10 +12930,15 @@ async def _handle_advise_models_mcp(
         if not isinstance(agents_spec, list) or not agents_spec:
             continue
 
-        # Build a combined model list from all agent entries,
-        # preserving cheapest→powerful order. Map chosen model → agent.
+        # Build harness→models map for the routing client, plus two reverse
+        # maps for resolving the chosen agent after the verdict:
+        # - harness_to_agent: preferred path when the judge picks a harness
+        # - model_to_agent: fallback when harness is absent or unrecognised
+        # Insertion order is preserved; first-agent-wins dedup applies when
+        # the same model appears in multiple harness lists.
         model_to_agent: dict[str, str] = {}
-        combined_models: list[str] = []
+        harness_to_agent: dict[str, str] = {}
+        harness_models: dict[str, list[str]] = {}
         for agent_entry in agents_spec:
             if not isinstance(agent_entry, dict):
                 continue
@@ -12917,22 +12947,33 @@ async def _handle_advise_models_mcp(
             if explicit_models is not None and not isinstance(explicit_models, list):
                 explicit_models = None
             if explicit_models:
+                harness_key = agent  # use agent name as key when models are explicit
                 candidates = explicit_models
             else:
-                harness = _resolve_harness_for_worker(agent)
-                candidates = infer_models(harness) or []
-            for m in candidates:
-                if m not in model_to_agent:
-                    model_to_agent[m] = agent
-                    combined_models.append(m)
+                harness_key = _resolve_harness_for_worker(agent) or agent
+                # Prefer live runner catalog (worker name or harness key);
+                # fall back to static infer_models table.
+                candidates = (
+                    (_runner_catalog or {}).get(agent)
+                    or (_runner_catalog or {}).get(harness_key)
+                    or infer_models(harness_key)
+                    or []
+                )
+            if candidates:
+                harness_models.setdefault(harness_key, [])
+                harness_to_agent.setdefault(harness_key, agent)
+                for m in candidates:
+                    if m not in model_to_agent:
+                        model_to_agent[m] = agent
+                        harness_models[harness_key].append(m)
 
-        if not combined_models:
+        if not harness_models:
             recommendations.append(
                 {"title": title, "agent": None, "model": None, "rationale": "no candidates"}
             )
             continue
         try:
-            verdict = await routing_client.route(task_text, combined_models)
+            verdict = await routing_client.route(task_text, harness_models)
         except Exception:  # routing failures must not crash the advisor
             _logger.exception("_handle_advise_models_mcp: route failed task=%r", title)
             verdict = None
@@ -12946,7 +12987,10 @@ async def _handle_advise_models_mcp(
                 }
             )
         else:
-            chosen_agent = model_to_agent.get(verdict.model)
+            # Prefer the judge's harness pick; fall back to model ownership.
+            chosen_agent = (
+                harness_to_agent.get(verdict.harness) if verdict.harness else None
+            ) or model_to_agent.get(verdict.model)
             recommendations.append(
                 {
                     "title": title,
@@ -13410,7 +13454,14 @@ async def _handle_mcp_tools_call(
     # After policy evaluation (DENY/ASK handled above); arguments may have
     # been transformed. The advisor runs server-side where routing_client lives.
     if namespaced_name in ("sys_advise_models", "mcp__omnigent__sys_advise_models"):
-        return await _handle_advise_models_mcp(rpc_id, conv, arguments, agent_store)
+        return await _handle_advise_models_mcp(
+            rpc_id,
+            conv,
+            arguments,
+            agent_store,
+            session_id=session_id,
+            runner_router=runner_router,
+        )
 
     # ── Execute on the runner via WS tunnel ──────────────────────────
     # The runner owns stdio subprocess spawning (correct machine, cwd,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8652,6 +8652,8 @@ async def _forward_event_to_runner(
     _routing_enabled = (
         conv.cost_control_mode_override == "on" and conv.parent_conversation_id is None
     ) or _parent_routing_on
+    _routed_model: str | None = None
+    _verdict: dict[str, Any] | None = None
     if effective_runner_override is None and _routing_enabled and body.type == "message":
         from omnigent.server.smart_routing import route_turn
 
@@ -8681,14 +8683,6 @@ async def _forward_event_to_runner(
                         session_id,
                         exc_info=True,
                     )
-                # Emit the routing_decision transcript chip so the UI
-                # shows which model was picked, before the turn output.
-                await _emit_server_routing_decision(
-                    session_id,
-                    conversation_store,
-                    _routed_model,
-                    _verdict or {},
-                )
     # ────────────────────────────────────────────────────────────────
     if effective_runner_override is not None:
         runner_body["model_override"] = effective_runner_override
@@ -8709,6 +8703,16 @@ async def _forward_event_to_runner(
         # Publish input.consumed AFTER the forward succeeds —
         # the runner has the message and will start the turn.
         _publish_input_consumed(session_id, persisted_items[0])
+        # Emit the routing_decision chip AFTER input.consumed so the
+        # live SSE stream delivers the user bubble before the chip —
+        # matching the store order (user message was persisted first).
+        if _routed_model is not None and _verdict is not None:
+            await _emit_server_routing_decision(
+                session_id,
+                conversation_store,
+                _routed_model,
+                _verdict,
+            )
     except (httpx.HTTPError, ConnectionError):
         _logger.exception(
             "Forward to runner failed for session=%s; "

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8881,6 +8881,8 @@ async def _dispatch_session_event_to_runner(
         _native_routing_enabled = (
             conv.cost_control_mode_override == "on" and conv.parent_conversation_id is None
         ) or _native_parent_routing_on
+        _native_routed_model: str | None = None
+        _native_verdict: dict[str, Any] | None = None
         if conv.model_override is None and _native_routing_enabled:
             from omnigent.server.smart_routing import route_turn
 
@@ -8888,18 +8890,18 @@ async def _dispatch_session_event_to_runner(
             _user_text = _extract_user_text_for_routing(body)
             if _user_text:
                 _native_runner_client = await _get_runner_client(session_id, runner_router)
-                _routed_model, _verdict = await route_turn(
+                _native_routed_model, _native_verdict = await route_turn(
                     _harness,
                     _user_text,
                     session_id=session_id,
                     runner_client=_native_runner_client,
                 )
-                if _routed_model is not None:
+                if _native_routed_model is not None:
                     try:
                         await asyncio.to_thread(
                             conversation_store.update_conversation,
                             session_id,
-                            model_override=_routed_model,
+                            model_override=_native_routed_model,
                         )
                     except (OSError, ValueError):
                         _logger.warning(
@@ -8907,19 +8909,13 @@ async def _dispatch_session_event_to_runner(
                             session_id,
                             exc_info=True,
                         )
-                    await _emit_server_routing_decision(
-                        session_id,
-                        conversation_store,
-                        _routed_model,
-                        _verdict or {},
-                    )
                     # For claude-native: inject /model into the running
                     # terminal so the change takes effect immediately
                     # (model_override alone is only applied at spawn).
                     try:
                         await runner_client.post(
                             f"/v1/sessions/{session_id}/events",
-                            json={"type": "model_change", "model": _routed_model},
+                            json={"type": "model_change", "model": _native_routed_model},
                             timeout=5.0,
                         )
                     except httpx.HTTPError:
@@ -8943,6 +8939,16 @@ async def _dispatch_session_event_to_runner(
         finally:
             if not forwarded and pending_id is not None:
                 pending_inputs.resolve(session_id, pending_id)
+        # Emit the routing chip AFTER forwarding the message to the
+        # terminal so the live SSE stream delivers the user bubble
+        # (echoed back by the CLI) before the chip.
+        if _native_routed_model is not None and _native_verdict is not None:
+            await _emit_server_routing_decision(
+                session_id,
+                conversation_store,
+                _native_routed_model,
+                _native_verdict,
+            )
         return _SessionEventDispatchResult(item_id=None, pending_id=pending_id)
     item_id = await _forward_event_to_runner(
         session_id,

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    import httpx  # used in type annotations only; runtime import is lazy in fetch_runner_models
 
 _logger = logging.getLogger(__name__)
 
@@ -78,10 +81,14 @@ class RoutingResult:
 
     :param model: Model id to use, e.g. ``"databricks-claude-opus-4-8"``.
     :param rationale: One-sentence explanation from the judge.
+    :param harness: The harness the judge selected, e.g. ``"claude-sdk"``.
+        ``None`` when the routing client does not distinguish harnesses (e.g.
+        single-harness calls or custom implementations that omit it).
     """
 
     model: str
     rationale: str
+    harness: str | None = None
 
 
 class RoutingClient(Protocol):
@@ -90,26 +97,107 @@ class RoutingClient(Protocol):
     async def route(
         self,
         message: str,
-        available_models: list[str],
+        available_models: dict[str, list[str]],
     ) -> RoutingResult | None:
         """Pick the best model for a session's initial message.
 
         :param message: The user's first message text.
-        :param available_models: Model ids available for this harness,
-            ordered cheapest → most powerful.
+        :param available_models: Mapping of harness → model ids, each list
+            ordered cheapest → most powerful.  A single-harness call passes
+            a one-entry dict; multi-agent fan-out passes one entry per
+            harness.  Implementations that only need the flat model list can
+            call :func:`_flatten_models` to get a deduped ordered sequence.
         :returns: A :class:`RoutingResult`, or ``None`` to skip routing.
         """
         ...
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+async def fetch_runner_models(
+    session_id: str,
+    runner_client: httpx.AsyncClient,
+) -> dict[str, list[str]] | None:
+    """Fetch live model availability from the runner's ``/v1/sessions/{id}/models`` endpoint.
+
+    Converts the ``sys_list_models``-shaped catalog into the harness →
+    model-id-list format expected by :class:`RoutingClient`.  Falls back
+    to ``None`` on any HTTP/parse failure so callers can use the static
+    :func:`infer_models` table instead.
+
+    :param session_id: Session/conversation identifier.
+    :param runner_client: Async HTTP client pointed at the runner.
+    :returns: ``{harness: [model_id, ...]}`` ordered cheapest → most
+        powerful, or ``None`` when the endpoint is unavailable or the
+        response cannot be parsed.
+    """
+    import httpx as _httpx
+
+    try:
+        resp = await runner_client.get(f"/v1/sessions/{session_id}/models", timeout=5.0)
+        resp.raise_for_status()
+        payload = resp.json()
+    except (_httpx.HTTPError, ValueError, KeyError):
+        _logger.debug(
+            "fetch_runner_models: runner request failed for session=%s", session_id, exc_info=True
+        )
+        return None
+
+    workers: dict[str, Any] = payload.get("workers", {})
+    if not workers:
+        return None
+
+    result: dict[str, list[str]] = {}
+    for worker_name, row in workers.items():
+        if not isinstance(row, dict):
+            continue
+        models_raw = row.get("models", [])
+        if not isinstance(models_raw, list):
+            continue
+        ids = [m["id"] for m in models_raw if isinstance(m, dict) and isinstance(m.get("id"), str)]
+        if ids:
+            # catalog_for_spec uses the harness resolved from the spec; the
+            # worker name (e.g. "self", "claude_code") is used as the key.
+            result[worker_name] = ids
+    return result or None
+
+
+def _flatten_models(available_models: dict[str, list[str]]) -> list[str]:
+    """Return a deduped, ordered flat model list from a harness → models map.
+
+    Iterates harness entries in insertion order; within each harness the
+    model list is already cheapest → most powerful.  Duplicates (a model
+    supported by multiple harnesses) are dropped on second occurrence so
+    the first-harness ordering is preserved.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for models in available_models.values():
+        for m in models:
+            if m not in seen:
+                seen.add(m)
+                result.append(m)
+    return result
 
 
 # ── Default LLM-based implementation ───────────────────────────────────────
 
 _JUDGE_SYSTEM_TEMPLATE = """\
 You are a model router for a coding assistant. Given the user's message,
-pick the model best suited for the task.
+pick the harness and model best suited for the task.
 
-Available models (ordered fastest/cheapest to most capable/expensive):
-{model_menu}
+Available harnesses and their models (each list ordered fastest/cheapest
+to most capable/expensive):
+{harness_menu}
+
+Harness descriptions:
+- claude-sdk / claude-native: Claude Code harness; best for multi-file
+  refactors, test writing, and deep reasoning chains.
+- codex / codex-native: Codex harness; best for narrow, well-scoped
+  code changes.
+- pi: Multi-model headless harness; can run both Claude and GPT models;
+  best for read-only exploration, review, and cross-vendor verification.
 
 Model naming conventions:
 - Claude family: haiku is the fastest and most lightweight; sonnet is
@@ -117,37 +205,36 @@ Model naming conventions:
 - GPT family: nano is the most lightweight, then mini, then the base
   model; higher version numbers (e.g. gpt-5-5 vs gpt-5-4) indicate
   newer, more capable releases.
-- The list order reflects relative speed, cost, and capability for
-  this deployment — models later in the list are slower and more
-  expensive but produce higher-quality results on complex tasks.
 
 Trade-off guidance:
-- Simple tasks (greetings, quick lookups, one-line fixes) are handled
-  well by faster models with minimal quality loss.
+- Simple tasks (greetings, quick lookups, one-line fixes) → cheapest model.
 - Moderately complex tasks (single-file edits, debugging, explanation)
-  benefit from a mid-range model.
+  → mid-range model.
 - Deeply complex tasks (multi-file refactors, architecture decisions,
-  security analysis, long reasoning chains) are where the most capable
-  models make a meaningful difference.
+  security analysis, long reasoning chains) → most capable model.
 
 Return **strict JSON only**:
-{{"model": "<id>", "rationale": "<one sentence>"}}
+{{"harness": "<harness-id>", "model": "<model-id>", "rationale": "<one sentence>"}}
 """
 
 
-def _build_rubric(available_models: list[str]) -> str:
-    """Format the judge prompt with the ordered model list."""
-    lines = [f"- {m}" for m in available_models]
-    return _JUDGE_SYSTEM_TEMPLATE.format(model_menu="\n".join(lines))
+def _build_rubric(available_models: dict[str, list[str]]) -> str:
+    """Format the judge prompt with the harness → models structure."""
+    sections: list[str] = []
+    for harness, models in available_models.items():
+        model_lines = "\n".join(f"    - {m}" for m in models)
+        sections.append(f"  harness: {harness}\n{model_lines}")
+    return _JUDGE_SYSTEM_TEMPLATE.format(harness_menu="\n".join(sections))
 
 
 _VERDICT_SCHEMA: dict[str, object] = {
     "type": "object",
     "properties": {
+        "harness": {"type": "string"},
         "model": {"type": "string"},
         "rationale": {"type": "string"},
     },
-    "required": ["model", "rationale"],
+    "required": ["harness", "model", "rationale"],
     "additionalProperties": False,
 }
 
@@ -161,8 +248,9 @@ class LLMRoutingClient:
     async def route(
         self,
         message: str,
-        available_models: list[str],
+        available_models: dict[str, list[str]],
     ) -> RoutingResult | None:
+        flat = _flatten_models(available_models)
         rubric = _build_rubric(available_models)
         try:
             response = await self._llm.create(
@@ -195,18 +283,39 @@ class LLMRoutingClient:
             return None
 
         # Clamp hallucinated models to the cheapest available.
-        if model not in available_models:
-            if available_models:
+        if model not in flat:
+            if flat:
                 _logger.info(
                     "LLMRoutingClient: clamping unknown model %r to %s",
                     model,
-                    available_models[0],
+                    flat[0],
                 )
-                model = available_models[0]
+                model = flat[0]
             else:
                 return None
 
-        return RoutingResult(model=model, rationale=str(rationale))
+        # Resolve the harness: use the judge's pick only when it is both a
+        # known harness key AND actually contains the chosen model.  If
+        # either check fails, fall back to the first harness that owns the
+        # (possibly clamped) model.
+        chosen_harness = verdict.get("harness")
+        if (
+            not isinstance(chosen_harness, str)
+            or chosen_harness not in available_models
+            or model not in available_models[chosen_harness]
+        ):
+            if isinstance(chosen_harness, str) and chosen_harness in available_models:
+                _logger.info(
+                    "LLMRoutingClient: harness %r does not contain model %r; re-resolving",
+                    chosen_harness,
+                    model,
+                )
+            chosen_harness = next(
+                (h for h, models in available_models.items() if model in models),
+                None,
+            )
+
+        return RoutingResult(model=model, rationale=str(rationale), harness=chosen_harness)
 
 
 # ── Public API ──────────────────────────────────────────────────────────────
@@ -215,12 +324,17 @@ class LLMRoutingClient:
 async def route_turn(
     harness: str | None,
     user_message: str,
+    *,
+    session_id: str | None = None,
+    runner_client: httpx.AsyncClient | None = None,
 ) -> tuple[str | None, dict[str, Any] | None]:
-    """Pick the best model for a turn via :attr:`RuntimeCaps.routing_client`."""
-    models = infer_models(harness)
-    if models is None:
-        return None, None
+    """Pick the best model for a turn via :attr:`RuntimeCaps.routing_client`.
 
+    When *session_id* and *runner_client* are provided, fetches live model
+    availability from the runner's ``/v1/sessions/{id}/models`` endpoint.
+    Falls back to the static :func:`infer_models` lookup table if the runner
+    is unreachable or returns no data.
+    """
     try:
         from omnigent.runtime._globals import _caps
     except ImportError:
@@ -229,7 +343,17 @@ async def route_turn(
     if _caps is None or _caps.routing_client is None:
         return None, None
 
-    result = await _caps.routing_client.route(user_message, models)
+    # Prefer live runner catalog; fall back to static table.
+    available: dict[str, list[str]] | None = None
+    if session_id and runner_client is not None:
+        available = await fetch_runner_models(session_id, runner_client)
+    if not available:
+        models = infer_models(harness)
+        if models is None:
+            return None, None
+        available = {harness or "": models}
+
+    result = await _caps.routing_client.route(user_message, available)
     if result is None:
         return None, None
 

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -205,9 +205,12 @@ Model naming conventions — use these to judge cost and capability:
   or nano variant of any version is still cheaper than any base model.
 
 Trade-off guidance:
-- Simple tasks (greetings, quick lookups, one-line fixes) → cheapest model (nano or mini if available, else haiku).
-- Moderately complex tasks (single-file edits, debugging, explanation) → mid-range model.
-- Deeply complex tasks (multi-file refactors, architecture decisions, security analysis, long reasoning chains) → most capable model.
+- Simple tasks (greetings, quick lookups, one-line fixes) → cheapest model
+  (nano or mini if available, else haiku).
+- Moderately complex tasks (single-file edits, debugging, explanation)
+  → mid-range model.
+- Deeply complex tasks (multi-file refactors, architecture decisions,
+  security analysis, long reasoning chains) → most capable model.
 
 Return **strict JSON only**:
 {{"harness": "<harness-id>", "model": "<model-id>", "rationale": "<one sentence>"}}

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -199,10 +199,10 @@ Harness descriptions:
 Model naming conventions — use these to judge cost and capability:
 - Claude family (cheapest → most capable): haiku < sonnet < opus.
 - GPT family: a -nano or -mini suffix always means cheaper and faster
-  than the base model of the same or higher version number. Tier order:
-  *-nano < *-mini < base (no suffix), regardless of version number.
-  For example: gpt-5.4-mini is cheaper than gpt-5.4, and gpt-5.5 is
-  the most capable base model but gpt-5.4-mini beats it on cost/speed.
+  than any base model (no suffix), regardless of version number. Tier
+  order: *-nano < *-mini < base. A newer base version (e.g. X.5) is
+  more capable and expensive than an older one (e.g. X.4), but a mini
+  or nano variant of any version is still cheaper than any base model.
 
 Trade-off guidance:
 - Simple tasks (greetings, quick lookups, one-line fixes) → cheapest model (nano or mini if available, else haiku).

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -157,8 +157,6 @@ async def fetch_runner_models(
             continue
         ids = [m["id"] for m in models_raw if isinstance(m, dict) and isinstance(m.get("id"), str)]
         if ids:
-            # catalog_for_spec uses the harness resolved from the spec; the
-            # worker name (e.g. "self", "claude_code") is used as the key.
             result[worker_name] = ids
     return result or None
 
@@ -187,8 +185,7 @@ _JUDGE_SYSTEM_TEMPLATE = """\
 You are a model router for a coding assistant. Given the user's message,
 pick the harness and model best suited for the task.
 
-Available harnesses and their models (each list ordered fastest/cheapest
-to most capable/expensive):
+Available harnesses and their models:
 {harness_menu}
 
 Harness descriptions:
@@ -199,19 +196,18 @@ Harness descriptions:
 - pi: Multi-model headless harness; can run both Claude and GPT models;
   best for read-only exploration, review, and cross-vendor verification.
 
-Model naming conventions:
-- Claude family: haiku is the fastest and most lightweight; sonnet is
-  a balanced mid-range; opus is the most powerful and thorough.
-- GPT family: nano is the most lightweight, then mini, then the base
-  model; higher version numbers (e.g. gpt-5-5 vs gpt-5-4) indicate
-  newer, more capable releases.
+Model naming conventions — use these to judge cost and capability:
+- Claude family (cheapest → most capable): haiku < sonnet < opus.
+- GPT family: a -nano or -mini suffix always means cheaper and faster
+  than the base model of the same or higher version number. Tier order:
+  *-nano < *-mini < base (no suffix), regardless of version number.
+  For example: gpt-5.4-mini is cheaper than gpt-5.4, and gpt-5.5 is
+  the most capable base model but gpt-5.4-mini beats it on cost/speed.
 
 Trade-off guidance:
-- Simple tasks (greetings, quick lookups, one-line fixes) → cheapest model.
-- Moderately complex tasks (single-file edits, debugging, explanation)
-  → mid-range model.
-- Deeply complex tasks (multi-file refactors, architecture decisions,
-  security analysis, long reasoning chains) → most capable model.
+- Simple tasks (greetings, quick lookups, one-line fixes) → cheapest model (nano or mini if available, else haiku).
+- Moderately complex tasks (single-file edits, debugging, explanation) → mid-range model.
+- Deeply complex tasks (multi-file refactors, architecture decisions, security analysis, long reasoning chains) → most capable model.
 
 Return **strict JSON only**:
 {{"harness": "<harness-id>", "model": "<model-id>", "rationale": "<one sentence>"}}
@@ -252,6 +248,7 @@ class LLMRoutingClient:
     ) -> RoutingResult | None:
         flat = _flatten_models(available_models)
         rubric = _build_rubric(available_models)
+        _logger.info("LLMRoutingClient: available_models=%s", dict(available_models))
         try:
             response = await self._llm.create(
                 instructions=rubric,

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -343,10 +343,15 @@ async def route_turn(
     if _caps is None or _caps.routing_client is None:
         return None, None
 
-    # Prefer live runner catalog; fall back to static table.
+    # Prefer live runner catalog — but only the "self" worker entry.
+    # The catalog includes sub-agent workers (claude_code, pi, codex…);
+    # for brain-turn routing we only want the models this session's own
+    # harness can run, not the sub-agents' model lists.
     available: dict[str, list[str]] | None = None
     if session_id and runner_client is not None:
-        available = await fetch_runner_models(session_id, runner_client)
+        catalog = await fetch_runner_models(session_id, runner_client)
+        if catalog and "self" in catalog:
+            available = {"self": catalog["self"]}
     if not available:
         models = infer_models(harness)
         if models is None:

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,7 @@ from omnigent.server.smart_routing import (
     LLMRoutingClient,
     RoutingResult,
     _build_rubric,
+    fetch_runner_models,
     infer_models,
     route_turn,
 )
@@ -62,7 +63,9 @@ class _FakeRoutingClient:
     def __init__(self, result: RoutingResult | None) -> None:
         self._result = result
 
-    async def route(self, message: str, available_models: list[str]) -> RoutingResult | None:
+    async def route(
+        self, message: str, available_models: dict[str, list[str]]
+    ) -> RoutingResult | None:
         del message, available_models
         return self._result
 
@@ -115,13 +118,26 @@ def test_infer_models_unknown_harness() -> None:
 
 
 def test_build_rubric_includes_all_models() -> None:
-    models = ["databricks-claude-haiku-4-5", "databricks-claude-opus-4-8"]
-    rubric = _build_rubric(models)
+    available = {
+        "claude-sdk": ["databricks-claude-haiku-4-5", "databricks-claude-opus-4-8"],
+    }
+    rubric = _build_rubric(available)
     assert "databricks-claude-haiku-4-5" in rubric
     assert "databricks-claude-opus-4-8" in rubric
     assert "strict JSON" in rubric
-    # Naming conventions are explained
     assert "haiku" in rubric and "opus" in rubric
+
+
+def test_build_rubric_shows_harness_names() -> None:
+    available = {
+        "claude-sdk": ["databricks-claude-haiku-4-5"],
+        "codex": ["databricks-gpt-5-4-nano"],
+    }
+    rubric = _build_rubric(available)
+    assert "claude-sdk" in rubric
+    assert "codex" in rubric
+    assert "databricks-claude-haiku-4-5" in rubric
+    assert "databricks-gpt-5-4-nano" in rubric
 
 
 # ── LLMRoutingClient ───────────────────────────────────────────────
@@ -130,37 +146,75 @@ def test_build_rubric_includes_all_models() -> None:
 @pytest.mark.asyncio
 async def test_llm_routing_client_returns_result() -> None:
     verdict = {
+        "harness": "claude-sdk",
         "model": "databricks-claude-opus-4-8",
         "rationale": "hard refactor",
     }
     client = LLMRoutingClient(_FakeLLMClient(verdict))
     models = infer_models("claude-sdk")
     assert models is not None
-    result = await client.route("refactor auth", models)
+    result = await client.route("refactor auth", {"claude-sdk": models})
     assert result is not None
     assert result.model == "databricks-claude-opus-4-8"
     assert result.rationale == "hard refactor"
-    assert not hasattr(result, "tier")
+    assert result.harness == "claude-sdk"
+
+
+@pytest.mark.asyncio
+async def test_llm_routing_client_harness_mismatch_re_resolves() -> None:
+    """If the judge picks a harness that doesn't own the model, fall back."""
+    claude_models = infer_models("claude-sdk")
+    assert claude_models is not None
+    verdict = {
+        "harness": "codex",  # codex doesn't have claude models
+        "model": "databricks-claude-opus-4-8",
+        "rationale": "deep reasoning",
+    }
+    client = LLMRoutingClient(_FakeLLMClient(verdict))
+    result = await client.route(
+        "hard task", {"claude-sdk": claude_models, "codex": ["databricks-gpt-5-4"]}
+    )
+    assert result is not None
+    assert result.model == "databricks-claude-opus-4-8"
+    # harness re-resolved to the one that owns the model
+    assert result.harness == "claude-sdk"
+
+
+@pytest.mark.asyncio
+async def test_llm_routing_client_unknown_harness_re_resolves() -> None:
+    """If the judge returns an unrecognised harness, fall back to model ownership."""
+    models = infer_models("claude-sdk")
+    assert models is not None
+    verdict = {
+        "harness": "hallucinated-harness",
+        "model": "databricks-claude-haiku-4-5",
+        "rationale": "simple task",
+    }
+    client = LLMRoutingClient(_FakeLLMClient(verdict))
+    result = await client.route("hello", {"claude-sdk": models})
+    assert result is not None
+    assert result.model == "databricks-claude-haiku-4-5"
+    assert result.harness == "claude-sdk"
 
 
 @pytest.mark.asyncio
 async def test_llm_routing_client_clamps_hallucinated_model() -> None:
-    verdict = {"model": "hallucinated-model", "rationale": "hard"}
+    verdict = {"harness": "claude-sdk", "model": "hallucinated-model", "rationale": "hard"}
     client = LLMRoutingClient(_FakeLLMClient(verdict))
     models = infer_models("claude-sdk")
     assert models is not None
-    result = await client.route("hard task", models)
+    result = await client.route("hard task", {"claude-sdk": models})
     assert result is not None
     assert result.model == models[0]  # clamped to cheapest
 
 
 @pytest.mark.asyncio
 async def test_llm_routing_client_rejects_empty_model() -> None:
-    verdict = {"model": "", "rationale": "x"}
+    verdict = {"harness": "claude-sdk", "model": "", "rationale": "x"}
     client = LLMRoutingClient(_FakeLLMClient(verdict))
     models = infer_models("claude-sdk")
     assert models is not None
-    result = await client.route("hello", models)
+    result = await client.route("hello", {"claude-sdk": models})
     assert result is None
 
 
@@ -173,7 +227,72 @@ async def test_llm_routing_client_returns_none_on_error() -> None:
     client = LLMRoutingClient(_BrokenLLM())
     models = infer_models("claude-sdk")
     assert models is not None
-    result = await client.route("hello", models)
+    result = await client.route("hello", {"claude-sdk": models})
+    assert result is None
+
+
+# ── fetch_runner_models ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_runner_models_parses_catalog() -> None:
+    catalog_payload = {
+        "workers": {
+            "self": {
+                "source": "catalog",
+                "verified": True,
+                "models": [
+                    {"id": "databricks-claude-haiku-4-5", "family": "claude"},
+                    {"id": "databricks-claude-opus-4-8", "family": "claude"},
+                ],
+                "note": "",
+            },
+            "claude_code": {
+                "source": "catalog",
+                "verified": True,
+                "models": [
+                    {"id": "databricks-claude-haiku-4-5", "family": "claude"},
+                    {"id": "databricks-claude-sonnet-4-6", "family": "claude"},
+                ],
+                "note": "",
+            },
+        }
+    }
+    mock_response = MagicMock()
+    mock_response.json.return_value = catalog_payload
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    result = await fetch_runner_models("conv_123", mock_client)
+    assert result is not None
+    assert "databricks-claude-haiku-4-5" in result["self"]
+    assert "databricks-claude-opus-4-8" in result["self"]
+    assert "databricks-claude-sonnet-4-6" in result["claude_code"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_runner_models_returns_none_on_http_error() -> None:
+    import httpx
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=httpx.HTTPError("connection refused"))
+
+    result = await fetch_runner_models("conv_123", mock_client)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_runner_models_returns_none_on_empty_workers() -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"workers": {}}
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    result = await fetch_runner_models("conv_123", mock_client)
     assert result is None
 
 
@@ -190,6 +309,7 @@ async def test_route_turn_uses_caps_routing_client() -> None:
     expected = RoutingResult(
         model="databricks-claude-haiku-4-5",
         rationale="trivial",
+        harness="claude-sdk",
     )
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
     with patch(
@@ -218,3 +338,70 @@ async def test_route_turn_unknown_harness() -> None:
     model, _v = await route_turn("cursor", "hello")
     assert model is None
     assert _v is None
+
+
+@pytest.mark.asyncio
+async def test_route_turn_uses_runner_catalog_when_available() -> None:
+    """route_turn uses live runner catalog instead of static table when provided."""
+    expected = RoutingResult(
+        model="databricks-claude-opus-4-8",
+        rationale="complex task",
+        harness="self",
+    )
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "workers": {
+            "self": {
+                "source": "catalog",
+                "verified": True,
+                "models": [
+                    {"id": "databricks-claude-haiku-4-5"},
+                    {"id": "databricks-claude-opus-4-8"},
+                ],
+                "note": "",
+            }
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        model, _v = await route_turn(
+            "claude-sdk",
+            "complex task",
+            session_id="conv_123",
+            runner_client=mock_client,
+        )
+    assert model == "databricks-claude-opus-4-8"
+    # Runner endpoint was called
+    mock_client.get.assert_called_once()
+    call_url = mock_client.get.call_args[0][0]
+    assert "conv_123" in call_url and "models" in call_url
+
+
+@pytest.mark.asyncio
+async def test_route_turn_falls_back_to_static_when_runner_unavailable() -> None:
+    """Falls back to infer_models when runner catalog fetch fails."""
+    import httpx
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=httpx.HTTPError("runner down"))
+
+    expected = RoutingResult(
+        model="databricks-claude-haiku-4-5",
+        rationale="simple",
+        harness="claude-sdk",
+    )
+    caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        model, _v = await route_turn(
+            "claude-sdk",
+            "hello",
+            session_id="conv_123",
+            runner_client=mock_client,
+        )
+    # Still routes — fell back to static infer_models
+    assert model == "databricks-claude-haiku-4-5"


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- **Runner endpoint**: adds `GET /v1/sessions/{id}/models` that calls `catalog_for_spec` and returns the `sys_list_models`-shaped catalog so the server can fetch live, provider-resolved model availability without having the runner's credentials itself.
- **Harness-aware routing**: `RoutingClient.route` now receives `dict[str, list[str]]` (harness → models) instead of a flat list; the judge prompt includes harness names and descriptions so the LLM can pick both a model and a harness. `RoutingResult` gains a `harness` field; mismatch between the judge's harness pick and the chosen model is detected and re-resolved automatically.
- **Live catalog in route_turn**: `route_turn` accepts optional `session_id` + `runner_client` and calls `fetch_runner_models` first, falling back to the static `infer_models` lookup table when the runner is unreachable or returns nothing. Both SDK and native turn dispatch paths thread the runner client through.
- **Live catalog in sys_advise_models**: `_handle_advise_models_mcp` fetches the runner catalog once per call and prefers it per-agent over the static table, with explicit-model override still taking highest priority.
- **Polly prompt**: instruct polly to call `sys_advise_models` (if available) before any fan-out, in the same turn as the dispatches.

## Test Plan

```
python -m pytest tests/server/test_smart_routing.py -x -q
# 22 passed
pre-commit run --all
# All checks passed
```

## Demo

<img width="875" height="585" alt="image" src="https://github.com/user-attachments/assets/38a4d5f4-ff9b-42b7-98a4-eb10e6afeb7e" />

<img width="856" height="898" alt="image" src="https://github.com/user-attachments/assets/4566c8ce-a044-4613-8d29-23125b58a794" />



## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests in `tests/server/test_smart_routing.py` cover: `fetch_runner_models` (success, HTTP error, empty response), harness/model mismatch re-resolution, `route_turn` with live runner catalog, and `route_turn` falling back to static table when runner is down.