### PR TITLE
docs(agents): add code comment guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,15 @@ filename). Keep every section and checkbox row so reviewers can skim them.
 Generate the description from the actual diff and this session's context — lead
 with the motivation, then the change. Don't pass a `--body` that skips these
 sections.
+
+## Code comments
+
+Keep comments short and focused on the code, not on the change history.
+
+- **Keep them brief** — prefer one or two lines. Avoid comments longer than
+  three lines; if you need more, the code likely needs refactoring or a doc
+  string, not a wall of inline commentary.
+- **Describe the scenario, not the PR** — explain *what* the code handles or
+  *why* it exists, in terms a future reader needs. Don't reference PR numbers,
+  issue numbers, or ticket IDs (e.g. `#1646`, `fixes JIRA-123`); the scenario
+  should be clear without chasing external links.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a **Code comments** section to `AGENTS.md` so agents keep inline comments short and scenario-focused.
- Guidance: prefer one or two lines and avoid comments longer than three lines; describe *what/why* the code exists rather than referencing PR/issue/ticket numbers.

## Test Plan

Docs-only change. Verified the new section renders correctly in `AGENTS.md`; no code paths affected.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change to agent guidance; no automated test coverage is applicable.

This pull request and its description were written by Isaac.