### PR TITLE
test(harness-bench): capability conformance suite (MVP)

### DIFF
--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -1,0 +1,66 @@
+# Harness test bench
+
+A standardized, pluggable conformance suite that probes a harness and
+reports a verdict per capability dimension, reconciling observed behavior
+against a self-declared profile to surface drift. Design and rationale:
+[`docs/harness-bench-design.md`](../../docs/harness-bench-design.md).
+
+## Run it
+
+```bash
+# List official harnesses.
+python -m tests.harness_bench --list
+
+# Offline (declared) matrix — no turns, no creds.
+python -m tests.harness_bench
+
+# Live probe one harness against a gateway profile.
+python -m tests.harness_bench --harness codex --profile my-profile
+
+# Live probe every official harness, JSON out.
+python -m tests.harness_bench --profile my-profile --json
+```
+
+A non-zero exit means a `DRIFT` cell was found (observed behavior
+disagrees with the declared matrix).
+
+## What it reports (P0 dimensions)
+
+`basic_turn`, `streaming`, `tool_calling`, `interrupt`, `policy_deny`,
+`model_override`. Verdicts map to the support-matrix glyphs
+(`✓ ~ ✗ — ?`), plus `·` skipped and `!! DRIFT`.
+
+## Layout
+
+| File | Role |
+| --- | --- |
+| `verdict.py` | `Verdict` / `Priority` / `ProbeResult` and the `reconcile` drift check |
+| `profile.py` | `BenchProfile` (per-harness self-declaration) + name resolution |
+| `manifest.py` | Official profiles, built from `tests/e2e/_harness_probes.py` |
+| `driver.py` | `SdkInprocDriver` — spawns a harness wrap, drives turns over SSE |
+| `probes/` | One module per dimension; `ALL_PROBES` is the registry |
+| `bench.py` | Orchestrator: probes × harnesses → `BenchMatrix` |
+| `report.py` | Markdown / JSON renderers |
+| `test_bench.py` | Offline conformance (always) + live layer (gated on `--profile`) |
+
+## Add a harness
+
+- **Official:** add a `BenchProfile` to `manifest.py` (base fields come
+  from `_harness_probes.HARNESS_PROBES`). No probe or driver edits.
+- **Community / out-of-repo:** ship a `BenchProfile` and select it by
+  reference: `--harness mypkg.harness:PROFILE`. No bench edits.
+
+## Add a dimension
+
+Add a `CapabilityProbe` subclass under `probes/`, list it in
+`probes/__init__.py:ALL_PROBES`, and add its declared verdict to the
+profiles. Probes are harness-agnostic — they only call the driver.
+
+## Scope
+
+Phase-1 MVP: the six P0 dimensions above, the `sdk-inproc` transport
+driver, and the four official SDK harnesses (claude-sdk, codex, pi,
+openai-agents). Phase-2 (per the design doc): native transport drivers
+(tmux / app-server / HTTP-SSE), the remaining SDK + native harnesses, and
+the P1 dimensions (steering, live-queue, resume/fork, elicitation,
+reasoning, images, cost, compaction).

--- a/tests/harness_bench/README.md
+++ b/tests/harness_bench/README.md
@@ -17,9 +17,17 @@ python -m tests.harness_bench
 # Live probe one harness against a gateway profile.
 python -m tests.harness_bench --harness codex --profile my-profile
 
-# Live probe every official harness, JSON out.
-python -m tests.harness_bench --profile my-profile --json
+# Live probe every official harness.
+python -m tests.harness_bench --profile my-profile
 ```
+
+Output formats (mutually exclusive):
+
+- default: an aligned, ANSI-colored terminal table (color auto-disables
+  when piped or with `--no-color`), followed by a Notes section explaining
+  every non-supported cell so a `·` is never opaque.
+- `--markdown`: the GitHub-flavored table for docs / PRs.
+- `--json`: machine-readable, for diffing runs or regenerating docs.
 
 A non-zero exit means a `DRIFT` cell was found (observed behavior
 disagrees with the declared matrix).

--- a/tests/harness_bench/__init__.py
+++ b/tests/harness_bench/__init__.py
@@ -1,0 +1,39 @@
+"""Harness capability test bench.
+
+A standardized, pluggable conformance suite that probes a harness and
+reports a verdict per capability dimension (basic turn, streaming,
+tool calling, interrupt, policy DENY, model override, ...), reconciling
+observed behavior against a self-declared :class:`BenchProfile` to
+surface drift.
+
+Design: ``docs/harness-bench-design.md``.
+
+Two entry points:
+
+- ``python -m tests.harness_bench --harness <name>`` renders the matrix
+  for one harness (or all official harnesses with no ``--harness``).
+- ``tests/harness_bench/test_bench.py`` runs the offline conformance
+  layer on every PR and the live-probe layer when a ``--profile`` and
+  the harness CLI are available.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.profile import BenchProfile, resolve_profile
+from tests.harness_bench.verdict import (
+    Applicability,
+    Priority,
+    ProbeResult,
+    Verdict,
+    reconcile,
+)
+
+__all__ = [
+    "Applicability",
+    "BenchProfile",
+    "Priority",
+    "ProbeResult",
+    "Verdict",
+    "reconcile",
+    "resolve_profile",
+]

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -94,7 +94,20 @@ def main(argv: list[str] | None = None) -> int:
         print("--live requires --profile <name>", file=sys.stderr)
         return 2
 
-    matrix = asyncio.run(run_bench(profiles, databricks_profile=args.profile, live=live))
+    # Live runs make network calls that can take tens of seconds per turn.
+    # Stream progress to stderr (report goes to stdout) so the run is not
+    # silent; offline is fast enough to stay quiet.
+    def _progress(line: str) -> None:
+        print(line, file=sys.stderr, flush=True)
+
+    matrix = asyncio.run(
+        run_bench(
+            profiles,
+            databricks_profile=args.profile,
+            live=live,
+            progress=_progress if live else None,
+        )
+    )
     print(render_json(matrix) if args.json else render_markdown(matrix), end="")
     # A drift is a non-zero exit so CI / scripts notice without parsing output.
     return 1 if matrix.has_drift else 0

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -27,7 +27,7 @@ import sys
 from tests.harness_bench.bench import run_bench
 from tests.harness_bench.manifest import OFFICIAL_PROFILES
 from tests.harness_bench.profile import BenchProfile, resolve_profile
-from tests.harness_bench.report import render_json, render_markdown
+from tests.harness_bench.report import render_json, render_markdown, render_table
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -63,7 +63,16 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_false",
         help="Force the offline (declared-only) render.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown.")
+    fmt = parser.add_mutually_exclusive_group()
+    fmt.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Emit the GitHub-flavored Markdown table (for docs / PRs).",
+    )
+    fmt.add_argument("--json", action="store_true", help="Emit JSON.")
+    parser.add_argument(
+        "--no-color", action="store_true", help="Disable ANSI color in the terminal table."
+    )
     parser.add_argument("--list", action="store_true", help="List official harnesses and exit.")
     return parser.parse_args(argv)
 
@@ -108,7 +117,16 @@ def main(argv: list[str] | None = None) -> int:
             progress=_progress if live else None,
         )
     )
-    print(render_json(matrix) if args.json else render_markdown(matrix), end="")
+    if args.json:
+        output = render_json(matrix)
+    elif args.markdown:
+        output = render_markdown(matrix)
+    else:
+        # Default: terminal table. Color only when stdout is a real TTY and
+        # not suppressed, so piping to a file / pager stays plain.
+        color = sys.stdout.isatty() and not args.no_color
+        output = render_table(matrix, color=color)
+    print(output, end="")
     # A drift is a non-zero exit so CI / scripts notice without parsing output.
     return 1 if matrix.has_drift else 0
 

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -1,0 +1,104 @@
+"""CLI: render the harness capability matrix.
+
+Examples::
+
+    # List official harnesses.
+    python -m tests.harness_bench --list
+
+    # Dry (offline) render — declared matrix, no turns, no creds.
+    python -m tests.harness_bench
+
+    # Live probe one harness against a gateway profile.
+    python -m tests.harness_bench --harness codex --profile my-profile
+
+    # Live probe all official harnesses, JSON out.
+    python -m tests.harness_bench --profile my-profile --json
+
+    # A community harness that ships its own BenchProfile.
+    python -m tests.harness_bench --harness mypkg.harness:PROFILE --profile my-profile
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from tests.harness_bench.bench import run_bench
+from tests.harness_bench.manifest import OFFICIAL_PROFILES
+from tests.harness_bench.profile import BenchProfile, resolve_profile
+from tests.harness_bench.report import render_json, render_markdown
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m tests.harness_bench",
+        description="Probe a harness and report a verdict per capability dimension.",
+    )
+    parser.add_argument(
+        "--harness",
+        action="append",
+        metavar="NAME",
+        help="Harness to probe (repeatable). An official name, or a "
+        "'module:attr' / 'module.ATTR' reference to a community "
+        "BenchProfile. Defaults to every official harness.",
+    )
+    parser.add_argument(
+        "--profile",
+        metavar="NAME",
+        default=None,
+        help="Databricks gateway profile. Enables the live layer; without "
+        "it the bench renders the declared matrix offline.",
+    )
+    parser.add_argument(
+        "--live",
+        dest="live",
+        action="store_true",
+        default=None,
+        help="Force the live layer (requires --profile).",
+    )
+    parser.add_argument(
+        "--no-live",
+        dest="live",
+        action="store_false",
+        help="Force the offline (declared-only) render.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown.")
+    parser.add_argument("--list", action="store_true", help="List official harnesses and exit.")
+    return parser.parse_args(argv)
+
+
+def _resolve_profiles(names: list[str] | None) -> list[BenchProfile]:
+    if not names:
+        return list(OFFICIAL_PROFILES.values())
+    return [resolve_profile(name) for name in names]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    if args.list:
+        for name, profile in sorted(OFFICIAL_PROFILES.items()):
+            print(f"{name}\t{profile.transport}\t{profile.model}")
+        return 0
+
+    try:
+        profiles = _resolve_profiles(args.harness)
+    except KeyError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    # Live if explicitly forced, or implied by a supplied profile.
+    live = args.live if args.live is not None else bool(args.profile)
+    if live and not args.profile:
+        print("--live requires --profile <name>", file=sys.stderr)
+        return 2
+
+    matrix = asyncio.run(run_bench(profiles, databricks_profile=args.profile, live=live))
+    print(render_json(matrix) if args.json else render_markdown(matrix), end="")
+    # A drift is a non-zero exit so CI / scripts notice without parsing output.
+    return 1 if matrix.has_drift else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -8,12 +8,24 @@ subprocess and gateway load bounded.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from tests.harness_bench.driver import SdkInprocDriver
 from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict, reconcile
+
+# A progress sink: the bench calls it with human-readable status lines as it
+# spawns harnesses and runs probes. ``None`` (the default) stays silent, which
+# is what the pytest layer wants; the CLI passes a stderr writer so a live run
+# is not silent for minutes.
+Progress = Callable[[str], None]
+
+# The prerequisite probe: if it does not pass, the harness cannot be exercised
+# at all, so the remaining probes are skipped rather than run against a dead
+# turn (which would otherwise emit misleading UNSUPPORTED/DRIFT noise).
+_PREREQ_PROBE = "basic_turn"
 
 
 @dataclass(frozen=True)
@@ -115,12 +127,18 @@ def _uniform_report(
     return HarnessReport(profile=profile, cells=cells, skipped_reason=skipped_reason)
 
 
+def _emit(progress: Progress | None, message: str) -> None:
+    if progress is not None:
+        progress(message)
+
+
 async def run_harness(
     profile: BenchProfile,
     *,
     probes: list[CapabilityProbe] | None = None,
     databricks_profile: str | None = None,
     live: bool = True,
+    progress: Progress | None = None,
 ) -> HarnessReport:
     """Run every applicable probe against one harness.
 
@@ -131,6 +149,8 @@ async def run_harness(
     :param live: When ``False``, produce a declared-only report (every
         cell ``SKIPPED`` with an "offline" note) without spawning
         anything — used for a fast ``--list``/dry render.
+    :param progress: Optional status sink called with human-readable lines
+        as the harness spawns and each probe runs. ``None`` stays silent.
     :returns: The :class:`HarnessReport`.
     """
     probes = probes if probes is not None else ALL_PROBES
@@ -140,22 +160,44 @@ async def run_harness(
 
     unavailable = SdkInprocDriver.unavailable(profile, databricks_profile=databricks_profile)
     if unavailable is not None:
+        _emit(progress, f"[{profile.harness}] skipped: {unavailable}")
         return _uniform_report(
             profile, probes, ProbeResult.skipped(unavailable), skipped_reason=unavailable
         )
 
     assert databricks_profile is not None  # guaranteed by the unavailable() check
+    _emit(
+        progress,
+        f"[{profile.harness}] launching wrap subprocess "
+        f"(transport={profile.transport}, model={profile.model}); first turn may take ~10-30s...",
+    )
     cells: list[CellResult] = []
     async with SdkInprocDriver(profile, databricks_profile=databricks_profile) as driver:
+        prereq_skip: str | None = None
         for probe in probes:
             if not _applicable(probe, profile):
                 cells.append(_cell(probe, profile, ProbeResult.not_applicable()))
                 continue
-            try:
-                observed = await probe.run(driver, profile)
-            except Exception as exc:
-                observed = ProbeResult(Verdict.UNKNOWN, note=f"probe raised: {exc!r}")
-            cells.append(_cell(probe, profile, observed))
+            if prereq_skip is not None:
+                observed = ProbeResult.skipped(prereq_skip)
+                _emit(progress, f"[{profile.harness}]   {probe.title}: skipped (prerequisite)")
+            else:
+                _emit(progress, f"[{profile.harness}]   {probe.title}: running...")
+                try:
+                    observed = await probe.run(driver, profile)
+                except Exception as exc:
+                    observed = ProbeResult(Verdict.UNKNOWN, note=f"probe raised: {exc!r}")
+                _emit(
+                    progress,
+                    f"[{profile.harness}]   {probe.title}: {observed.verdict.name}"
+                    + (f" ({observed.note})" if observed.note else ""),
+                )
+            cell = _cell(probe, profile, observed)
+            cells.append(cell)
+            # If the prerequisite turn did not pass, short-circuit the rest:
+            # they would only re-hit the same failure and pollute the matrix.
+            if probe.name == _PREREQ_PROBE and cell.observed is not Verdict.SUPPORTED:
+                prereq_skip = f"prerequisite '{probe.title}' did not pass ({observed.note})"
     return HarnessReport(profile=profile, cells=cells)
 
 
@@ -165,10 +207,17 @@ async def run_bench(
     probes: list[CapabilityProbe] | None = None,
     databricks_profile: str | None = None,
     live: bool = True,
+    progress: Progress | None = None,
 ) -> BenchMatrix:
     """Run the bench across *profiles*, sequentially, into a :class:`BenchMatrix`."""
     reports = [
-        await run_harness(p, probes=probes, databricks_profile=databricks_profile, live=live)
+        await run_harness(
+            p,
+            probes=probes,
+            databricks_profile=databricks_profile,
+            live=live,
+            progress=progress,
+        )
         for p in profiles
     ]
     return BenchMatrix(reports=reports)

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -1,0 +1,174 @@
+"""The bench orchestrator: run probes across harnesses into a matrix.
+
+Sequential by design. Each harness spawns one wrap subprocess with a
+single in-flight turn per conversation, so its probes run one after
+another over a shared driver; harnesses run one at a time to keep the
+subprocess and gateway load bounded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict, reconcile
+
+
+@dataclass(frozen=True)
+class CellResult:
+    """One dimension's outcome for one harness (a matrix cell).
+
+    :param observed: The raw verdict the probe produced.
+    :param declared: The verdict the profile claims.
+    :param verdict: The reconciled verdict — equals *observed* unless the
+        two concrete facts disagree, in which case ``DRIFT``.
+    """
+
+    probe_name: str
+    title: str
+    priority: Priority
+    observed: Verdict
+    declared: Verdict
+    verdict: Verdict
+    note: str = ""
+    detail: dict = field(default_factory=dict)
+
+    @property
+    def is_drift(self) -> bool:
+        return self.verdict is Verdict.DRIFT
+
+
+@dataclass(frozen=True)
+class HarnessReport:
+    """Every cell for one harness, plus a whole-harness skip reason."""
+
+    profile: BenchProfile
+    cells: list[CellResult]
+    skipped_reason: str | None = None
+
+    @property
+    def has_drift(self) -> bool:
+        return any(c.is_drift for c in self.cells)
+
+
+@dataclass(frozen=True)
+class BenchMatrix:
+    """The full run: one :class:`HarnessReport` per harness."""
+
+    reports: list[HarnessReport]
+
+    @property
+    def has_drift(self) -> bool:
+        return any(r.has_drift for r in self.reports)
+
+
+def _is_native(profile: BenchProfile) -> bool:
+    """Whether *profile* names a native harness (drives the applicability gate)."""
+    return profile.transport not in {"sdk-inproc"}
+
+
+def _applicable(probe: CapabilityProbe, profile: BenchProfile) -> bool:
+    if probe.applies_to is Applicability.BOTH:
+        return True
+    if probe.applies_to is Applicability.NATIVE:
+        return _is_native(profile)
+    return not _is_native(profile)
+
+
+def _cell(probe: CapabilityProbe, profile: BenchProfile, observed: ProbeResult) -> CellResult:
+    declared = profile.declared_for(probe.name)
+    return CellResult(
+        probe_name=probe.name,
+        title=probe.title,
+        priority=probe.priority,
+        observed=observed.verdict,
+        declared=declared,
+        verdict=reconcile(observed.verdict, declared),
+        note=observed.note,
+        detail=observed.detail,
+    )
+
+
+def _uniform_report(
+    profile: BenchProfile,
+    probes: list[CapabilityProbe],
+    observed: ProbeResult,
+    *,
+    skipped_reason: str | None = None,
+) -> HarnessReport:
+    """A report where every applicable probe shares one *observed* result.
+
+    Used for the offline layer (all ``SKIPPED``) and for a harness the
+    driver cannot run (whole-harness skip), so the matrix still shows the
+    declared column and the skip reason per cell.
+    """
+    cells = [
+        _cell(
+            probe,
+            profile,
+            observed if _applicable(probe, profile) else ProbeResult.not_applicable(),
+        )
+        for probe in probes
+    ]
+    return HarnessReport(profile=profile, cells=cells, skipped_reason=skipped_reason)
+
+
+async def run_harness(
+    profile: BenchProfile,
+    *,
+    probes: list[CapabilityProbe] | None = None,
+    databricks_profile: str | None = None,
+    live: bool = True,
+) -> HarnessReport:
+    """Run every applicable probe against one harness.
+
+    :param profile: The harness under test.
+    :param probes: Probes to run; defaults to :data:`ALL_PROBES`.
+    :param databricks_profile: Gateway profile for live turns. Required
+        for ``live=True``; its absence skips the whole harness.
+    :param live: When ``False``, produce a declared-only report (every
+        cell ``SKIPPED`` with an "offline" note) without spawning
+        anything — used for a fast ``--list``/dry render.
+    :returns: The :class:`HarnessReport`.
+    """
+    probes = probes if probes is not None else ALL_PROBES
+
+    if not live:
+        return _uniform_report(profile, probes, ProbeResult.skipped("offline (declared shown)"))
+
+    unavailable = SdkInprocDriver.unavailable(profile, databricks_profile=databricks_profile)
+    if unavailable is not None:
+        return _uniform_report(
+            profile, probes, ProbeResult.skipped(unavailable), skipped_reason=unavailable
+        )
+
+    assert databricks_profile is not None  # guaranteed by the unavailable() check
+    cells: list[CellResult] = []
+    async with SdkInprocDriver(profile, databricks_profile=databricks_profile) as driver:
+        for probe in probes:
+            if not _applicable(probe, profile):
+                cells.append(_cell(probe, profile, ProbeResult.not_applicable()))
+                continue
+            try:
+                observed = await probe.run(driver, profile)
+            except Exception as exc:
+                observed = ProbeResult(Verdict.UNKNOWN, note=f"probe raised: {exc!r}")
+            cells.append(_cell(probe, profile, observed))
+    return HarnessReport(profile=profile, cells=cells)
+
+
+async def run_bench(
+    profiles: list[BenchProfile],
+    *,
+    probes: list[CapabilityProbe] | None = None,
+    databricks_profile: str | None = None,
+    live: bool = True,
+) -> BenchMatrix:
+    """Run the bench across *profiles*, sequentially, into a :class:`BenchMatrix`."""
+    reports = [
+        await run_harness(p, probes=probes, databricks_profile=databricks_profile, live=live)
+        for p in profiles
+    ]
+    return BenchMatrix(reports=reports)

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -82,7 +82,11 @@ def infra_failure_reason(result: TurnResult) -> str | None:
         return None
     for code in ("403", "401"):
         if code in text:
-            return f"gateway auth failed ({code} Invalid/Forbidden token); re-login the profile"
+            return (
+                f"gateway auth failed ({code} Invalid/Forbidden token); "
+                "re-login the profile, or clear a stale DATABRICKS_BEARER / "
+                "DATABRICKS_TOKEN env var that overrides profile auth"
+            )
     if "already processing" in text:
         return "session busy from a prior turn (sequencing, not a capability gap)"
     if "unexpected status" in text:

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -36,6 +36,54 @@ POLICY_DENY = "POLICY_ACTION_DENY"
 
 _CONV_ID = "conv_bench"
 
+# Substrings in a turn error that mean the *environment* is the problem
+# (auth, entitlement, gateway, connectivity) rather than a real capability
+# gap. Turns that fail this way are reported SKIPPED, never UNSUPPORTED, so
+# a bad token or an unentitled gateway route can never masquerade as
+# capability drift.
+_INFRA_ERROR_MARKERS: tuple[str, ...] = (
+    "403",
+    "401",
+    "Forbidden",
+    "Unauthorized",
+    "Invalid Token",
+    "invalid token",
+    "unexpected status",
+    "Connection",
+    "connection",
+    "Temporarily Unavailable",
+    "502",
+    "503",
+    "504",
+)
+
+
+def _error_text(error: object) -> str:
+    """Flatten a turn error (dict or str) into searchable text."""
+    if isinstance(error, dict):
+        return f"{error.get('message', '')} {error.get('code', '')}"
+    return str(error or "")
+
+
+def infra_failure_reason(result: TurnResult) -> str | None:
+    """Return a concise env-skip reason if a turn failed on infra/auth, else ``None``.
+
+    Lets probes distinguish "the gateway rejected us" (an environment
+    problem the operator must fix) from "the harness cannot do this" (a
+    capability fact). Only the latter should ever count as UNSUPPORTED.
+    """
+    if not result.failed:
+        return None
+    text = _error_text(result.error)
+    if not any(marker in text for marker in _INFRA_ERROR_MARKERS):
+        return None
+    for code in ("403", "401"):
+        if code in text:
+            return f"gateway auth failed ({code} Invalid/Forbidden token); re-login the profile"
+    if "unexpected status" in text:
+        return "gateway returned an unexpected status (environment/auth issue)"
+    return "environment/connectivity error reaching the gateway"
+
 
 @dataclass
 class TurnResult:

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -1,0 +1,295 @@
+"""Transport drivers: launch a harness and drive turns for the probes.
+
+A driver hides the transport (how a turn is started and how events come
+back) behind a small harness-agnostic surface the probes call. The only
+driver today is :class:`SdkInprocDriver`, which spawns a single harness
+wrap subprocess via :class:`HarnessProcessManager` and drives turns over
+the wrap's ``POST /v1/sessions/{conv}/events`` SSE endpoint — the same
+path exercised by ``tests/e2e/test_harness_wrap_e2e.py``.
+
+Native transports (tmux TUI, app-server, HTTP/SSE) are phase-2 drivers
+keyed by :attr:`BenchProfile.transport`; a profile on a transport with no
+driver yields :meth:`unavailable`, and the bench renders its
+transport-dependent probes as ``SKIPPED``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import shutil
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+from tests.e2e._harness_probes import cli_unavailable_reason
+from tests.harness_bench.profile import BenchProfile
+
+# Proto-style policy verdict strings the wrap's policy_verdict event accepts.
+POLICY_ALLOW = "POLICY_ACTION_ALLOW"
+POLICY_DENY = "POLICY_ACTION_DENY"
+
+_CONV_ID = "conv_bench"
+
+
+@dataclass
+class TurnResult:
+    """Everything a probe needs to inspect after one turn.
+
+    :param events: Every decoded SSE event dict, in order.
+    :param text: Concatenation of all ``response.output_text.delta``
+        payloads.
+    :param text_delta_count: Number of ``response.output_text.delta``
+        events — the streaming signal (>1 = token-level deltas, 1 = a
+        single complete blob).
+    :param reasoning_delta_count: Number of reasoning-delta events, if the
+        harness forwards any.
+    :param tool_calls: The ``response.tool_call`` events observed, each a
+        raw event dict carrying ``call_id`` / ``name`` / ``arguments``.
+    :param policy_actions: The verdict strings this driver posted back
+        (one per ``policy_evaluation.requested``), so a probe can tell a
+        DENY was actually delivered.
+    :param completed: Whether a terminal ``response.completed`` was seen.
+    :param failed: Whether a terminal ``response.failed`` was seen.
+    :param error: The error payload from ``response.failed``, if any.
+    :param timed_out: Whether the stream did not reach a terminal event
+        within the probe's timeout.
+    """
+
+    events: list[dict[str, Any]] = field(default_factory=list)
+    text: str = ""
+    text_delta_count: int = 0
+    reasoning_delta_count: int = 0
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    policy_actions: list[str] = field(default_factory=list)
+    completed: bool = False
+    failed: bool = False
+    error: Any = None
+    timed_out: bool = False
+
+    @property
+    def event_types(self) -> list[str]:
+        """The ``type`` of every event, in order."""
+        return [e.get("type", "") for e in self.events]
+
+
+class SdkInprocDriver:
+    """Drive turns through a single harness wrap subprocess.
+
+    Use as an async context manager::
+
+        async with SdkInprocDriver(profile, databricks_profile="prof") as d:
+            result = await d.run_turn("Reply with FOO.")
+
+    The context manager owns the :class:`HarnessProcessManager` lifecycle
+    and a short-pathed tmp parent (macOS ``AF_UNIX`` path limit).
+    """
+
+    transport = "sdk-inproc"
+
+    def __init__(self, profile: BenchProfile, *, databricks_profile: str) -> None:
+        self._profile = profile
+        self._databricks_profile = databricks_profile
+        self._pm: HarnessProcessManager | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._tmp_parent: Path | None = None
+
+    @staticmethod
+    def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
+        """Return a skip reason if this driver cannot run *profile*, else ``None``.
+
+        Checks, in order: a supplied Databricks profile (no gateway route
+        without one), and a runnable harness CLI binary. Mirrors the e2e
+        suite's gating so the bench skips — rather than errors — in
+        environments missing creds or a vendor CLI.
+        """
+        if not databricks_profile:
+            return "no --profile / databricks profile provided; live probes need a gateway route"
+        if profile.cli_binary is not None:
+            reason = cli_unavailable_reason(profile.cli_binary)
+            if reason is not None:
+                return reason
+        return None
+
+    async def __aenter__(self) -> SdkInprocDriver:
+        self._tmp_parent = Path("/tmp") / f"omni-bench-{uuid.uuid4().hex[:8]}"
+        self._tmp_parent.mkdir(mode=0o700)
+        self._pm = HarnessProcessManager(tmp_parent=self._tmp_parent)
+        await self._pm.start()
+        p = self._profile
+        self._client = await self._pm.get_client(
+            _CONV_ID,
+            p.harness,
+            env={
+                f"{p.env_prefix}GATEWAY": "true",
+                f"{p.env_prefix}DATABRICKS_PROFILE": self._databricks_profile,
+                f"{p.env_prefix}MODEL": p.model,
+            },
+        )
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._pm is not None:
+            await self._pm.shutdown()
+        if self._tmp_parent is not None:
+            shutil.rmtree(self._tmp_parent, ignore_errors=True)
+
+    async def run_turn(
+        self,
+        prompt: str,
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        policy_action: str = POLICY_ALLOW,
+        policy_reason: str | None = None,
+        auto_tool_output: str | None = None,
+        interrupt_on_first_delta: bool = False,
+        timeout: float = 120.0,
+    ) -> TurnResult:
+        """Start one turn and drain its event stream into a :class:`TurnResult`.
+
+        Handles the three downward round-trips the wrap may need mid-turn:
+
+        - ``policy_evaluation.requested`` → posts a ``policy_verdict`` with
+          *policy_action* (set ``POLICY_DENY`` to exercise enforcement).
+        - ``response.tool_call`` → when *auto_tool_output* is set, posts a
+          ``tool_result`` so a tool-calling turn can complete.
+        - *interrupt_on_first_delta* → posts an ``interrupt`` event the
+          first time text streams, to exercise cancellation.
+
+        :param prompt: The user text for the turn.
+        :param tools: Optional tool specs forwarded verbatim as the wrap's
+            passthrough ``tools`` field (Chat-Completions shape:
+            ``[{"type": "function", "function": {...}}]``).
+        :param policy_action: Verdict posted for every policy evaluation.
+        :param policy_reason: Reason string sent with a DENY verdict.
+        :param auto_tool_output: Stringified output auto-returned for each
+            tool call; ``None`` leaves tool calls unanswered.
+        :param interrupt_on_first_delta: Post an interrupt once text starts.
+        :param timeout: Seconds to wait for a terminal event before marking
+            the result :attr:`TurnResult.timed_out`.
+        :returns: The drained :class:`TurnResult`.
+        """
+        assert self._client is not None, "driver used outside its async context"
+        body: dict[str, Any] = {
+            "type": "message",
+            "role": "user",
+            "model": f"{self._profile.harness}-bench-agent",
+            "content": [{"type": "input_text", "text": prompt}],
+        }
+        if tools is not None:
+            body["tools"] = tools
+
+        result = TurnResult()
+        try:
+            await asyncio.wait_for(
+                self._drive(
+                    body,
+                    result,
+                    policy_action,
+                    policy_reason,
+                    auto_tool_output,
+                    interrupt_on_first_delta,
+                ),
+                timeout=timeout,
+            )
+        except (asyncio.TimeoutError, httpx.ReadTimeout):
+            result.timed_out = True
+        return result
+
+    async def _drive(
+        self,
+        body: dict[str, Any],
+        result: TurnResult,
+        policy_action: str,
+        policy_reason: str | None,
+        auto_tool_output: str | None,
+        interrupt_on_first_delta: bool,
+    ) -> None:
+        """POST the turn and consume the SSE stream into *result* in place."""
+        client = self._client
+        assert client is not None
+        interrupted = False
+        async with client.stream("POST", f"/v1/sessions/{_CONV_ID}/events", json=body) as response:
+            response.raise_for_status()
+            buffer = ""
+            async for chunk in response.aiter_text():
+                buffer += chunk
+                while "\n\n" in buffer:
+                    frame, _, buffer = buffer.partition("\n\n")
+                    event = _decode_frame(frame)
+                    if event is None:
+                        continue
+                    result.events.append(event)
+                    etype = event.get("type", "")
+
+                    if etype == "response.output_text.delta":
+                        result.text += event.get("delta", "")
+                        result.text_delta_count += 1
+                        if interrupt_on_first_delta and not interrupted:
+                            interrupted = True
+                            await self._post({"type": "interrupt"})
+                    elif etype in _REASONING_DELTA_TYPES:
+                        result.reasoning_delta_count += 1
+                    elif etype == "response.tool_call":
+                        result.tool_calls.append(event)
+                        if auto_tool_output is not None:
+                            await self._post(
+                                {
+                                    "type": "tool_result",
+                                    "call_id": event.get("call_id", ""),
+                                    "output": auto_tool_output,
+                                }
+                            )
+                    elif etype == "policy_evaluation.requested":
+                        verdict: dict[str, Any] = {
+                            "type": "policy_verdict",
+                            "evaluation_id": event["evaluation_id"],
+                            "action": policy_action,
+                        }
+                        if policy_reason is not None:
+                            verdict["reason"] = policy_reason
+                        result.policy_actions.append(policy_action)
+                        await self._post(verdict)
+                    elif etype == "response.completed":
+                        result.completed = True
+                    elif etype == "response.failed":
+                        result.failed = True
+                        result.error = event.get("error") or event.get("response", {}).get("error")
+
+    async def _post(self, payload: dict[str, Any]) -> None:
+        """POST a downward event on the wrap's events endpoint (best-effort).
+
+        Downward events race the turn's terminal state (e.g. an interrupt
+        landing just as the turn ends). A failed post here is benign — the
+        probe reads the outcome from the stream — so the error is suppressed.
+        """
+        assert self._client is not None
+        with contextlib.suppress(httpx.HTTPError):
+            await self._client.post(f"/v1/sessions/{_CONV_ID}/events", json=payload)
+
+
+# Reasoning-delta event names vary across harness wraps; match the common
+# spellings so the reasoning signal is captured without per-harness code.
+_REASONING_DELTA_TYPES: frozenset[str] = frozenset(
+    {"response.reasoning.delta", "response.reasoning_summary_text.delta"}
+)
+
+
+def _decode_frame(frame: str) -> dict[str, Any] | None:
+    """Decode one SSE frame's ``data:`` line into an event dict, or ``None``."""
+    data_line = next(
+        (line for line in frame.splitlines() if line.startswith("data:")),
+        None,
+    )
+    if data_line is None:
+        return None
+    try:
+        decoded = json.loads(data_line[len("data:") :].strip())
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, dict) else None

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -55,6 +55,9 @@ _INFRA_ERROR_MARKERS: tuple[str, ...] = (
     "502",
     "503",
     "504",
+    # Sequencing, not capability: a prior turn on the shared session had not
+    # fully settled. Reported SKIPPED so it never reads as a capability gap.
+    "already processing",
 )
 
 
@@ -80,6 +83,8 @@ def infra_failure_reason(result: TurnResult) -> str | None:
     for code in ("403", "401"):
         if code in text:
             return f"gateway auth failed ({code} Invalid/Forbidden token); re-login the profile"
+    if "already processing" in text:
+        return "session busy from a prior turn (sequencing, not a capability gap)"
     if "unexpected status" in text:
         return "gateway returned an unexpected status (environment/auth issue)"
     return "environment/connectivity error reaching the gateway"
@@ -103,6 +108,8 @@ class TurnResult:
         (one per ``policy_evaluation.requested``), so a probe can tell a
         DENY was actually delivered.
     :param completed: Whether a terminal ``response.completed`` was seen.
+    :param cancelled: Whether a terminal ``response.cancelled`` was seen
+        (the harness honored an interrupt).
     :param failed: Whether a terminal ``response.failed`` was seen.
     :param error: The error payload from ``response.failed``, if any.
     :param timed_out: Whether the stream did not reach a terminal event
@@ -116,9 +123,15 @@ class TurnResult:
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     policy_actions: list[str] = field(default_factory=list)
     completed: bool = False
+    cancelled: bool = False
     failed: bool = False
     error: Any = None
     timed_out: bool = False
+
+    @property
+    def reached_terminal(self) -> bool:
+        """Whether the stream ended on any terminal event (done/cancelled/failed)."""
+        return self.completed or self.cancelled or self.failed
 
     @property
     def event_types(self) -> list[str]:
@@ -283,16 +296,27 @@ class SdkInprocDriver:
                             await self._post({"type": "interrupt"})
                     elif etype in _REASONING_DELTA_TYPES:
                         result.reasoning_delta_count += 1
-                    elif etype == "response.tool_call":
-                        result.tool_calls.append(event)
-                        if auto_tool_output is not None:
-                            await self._post(
-                                {
-                                    "type": "tool_result",
-                                    "call_id": event.get("call_id", ""),
-                                    "output": auto_tool_output,
-                                }
-                            )
+                    elif etype == "response.output_item.done":
+                        # Server-dispatched tool calls arrive as an
+                        # output_item.done carrying a function_call item with
+                        # status "action_required" (see _scaffold.dispatch_tool).
+                        # We must answer with a tool_result or the turn parks
+                        # forever waiting on the dispatch future.
+                        item = event.get("item") or {}
+                        if (
+                            item.get("type") == "function_call"
+                            and item.get("status") == "action_required"
+                        ):
+                            call_id = item.get("call_id", "")
+                            result.tool_calls.append(item)
+                            if auto_tool_output is not None:
+                                await self._post(
+                                    {
+                                        "type": "tool_result",
+                                        "call_id": call_id,
+                                        "output": auto_tool_output,
+                                    }
+                                )
                     elif etype == "policy_evaluation.requested":
                         verdict: dict[str, Any] = {
                             "type": "policy_verdict",
@@ -305,6 +329,8 @@ class SdkInprocDriver:
                         await self._post(verdict)
                     elif etype == "response.completed":
                         result.completed = True
+                    elif etype == "response.cancelled":
+                        result.cancelled = True
                     elif etype == "response.failed":
                         result.failed = True
                         result.error = event.get("error") or event.get("response", {}).get("error")

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -82,10 +82,13 @@ def infra_failure_reason(result: TurnResult) -> str | None:
         return None
     for code in ("403", "401"):
         if code in text:
+            # Provider-neutral: any harness can hit this when its credential is
+            # expired or shadowed by an ambient env var (a stale bearer/API-key/
+            # token) that takes precedence over the configured auth source.
             return (
-                f"gateway auth failed ({code} Invalid/Forbidden token); "
-                "re-login the profile, or clear a stale DATABRICKS_BEARER / "
-                "DATABRICKS_TOKEN env var that overrides profile auth"
+                f"auth rejected ({code} Invalid/Forbidden token); the harness "
+                "credential is stale or shadowed by an ambient env var. Refresh "
+                "the harness auth source (profile, API key, or token env var)"
             )
     if "already processing" in text:
         return "session busy from a prior turn (sequencing, not a capability gap)"

--- a/tests/harness_bench/manifest.py
+++ b/tests/harness_bench/manifest.py
@@ -1,0 +1,92 @@
+"""The registry of official harness bench profiles — the spreadsheet, as data.
+
+Each entry declares the static matrix columns and the *expected* verdict
+per P0 dimension for one official SDK harness. The base fields (model,
+env_prefix, marker, cli_binary) are reused from
+``tests.e2e._harness_probes.HARNESS_PROBES`` so a harness added to the e2e
+parametrize matrix flows into the bench without a second source of truth.
+
+Declared verdicts encode the SDK support matrix. When a live probe
+observes something different, :func:`tests.harness_bench.verdict.reconcile`
+flags ``DRIFT`` — the whole point of the bench.
+
+Native harnesses and the remaining SDK harnesses (cursor, antigravity,
+kimi, qwen, goose, copilot, hermes) are phase-2: they need transport
+drivers and profile entries, tracked in the design doc.
+"""
+
+from __future__ import annotations
+
+from tests.e2e._harness_probes import HARNESS_PROBES, HarnessProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Verdict
+
+# All P0 SDK harnesses declare the same verdicts: they stream, call tools,
+# interrupt, enforce policy verdicts, and accept a model override. Drift
+# against this baseline is the signal we care about.
+_SUPPORTED = Verdict.SUPPORTED
+_P0_ALL_SUPPORTED: dict[str, Verdict] = {
+    "basic_turn": _SUPPORTED,
+    "streaming": _SUPPORTED,
+    "tool_calling": _SUPPORTED,
+    "interrupt": _SUPPORTED,
+    "policy_deny": _SUPPORTED,
+    "model_override": _SUPPORTED,
+}
+
+
+# Static matrix columns per official harness, keyed by harness name. Kept
+# beside the declared verdicts so the rendered report reproduces the
+# spreadsheet's descriptive columns, not just the ✓/✗ grid.
+_STATIC: dict[str, dict[str, str]] = {
+    "claude-sdk": {
+        "owner": "",
+        "auth": "Anthropic key / Databricks gateway",
+        "implementation": "SDK in-process",
+    },
+    "codex": {
+        "owner": "",
+        "auth": "Databricks gateway / codex auth.json",
+        "implementation": "CLI subprocess (app-server RPC)",
+    },
+    "pi": {
+        "owner": "",
+        "auth": "Databricks gateway / API keys",
+        "implementation": "CLI subprocess (JSONL RPC)",
+    },
+    "openai-agents": {
+        "owner": "",
+        "auth": "Databricks gateway / OpenAI key",
+        "implementation": "SDK in-process",
+    },
+}
+
+
+def _profile_from_probe(probe: HarnessProbe) -> BenchProfile:
+    """Build an official :class:`BenchProfile` from an e2e ``HarnessProbe``."""
+    static = _STATIC.get(probe.harness, {})
+    return BenchProfile(
+        harness=probe.harness,
+        model=probe.model,
+        env_prefix=probe.env_prefix,
+        marker=probe.marker,
+        cli_binary=probe.cli_binary,
+        transport="sdk-inproc",
+        owner=static.get("owner", ""),
+        auth=static.get("auth", ""),
+        implementation=static.get("implementation", ""),
+        declared=dict(_P0_ALL_SUPPORTED),
+    )
+
+
+# Official harnesses the bench ships with. Built from HARNESS_PROBES so the
+# two matrices never diverge; restricted to the harnesses the sdk-inproc
+# driver covers today.
+OFFICIAL_PROFILES: dict[str, BenchProfile] = {
+    probe.harness: _profile_from_probe(probe)
+    for probe in HARNESS_PROBES
+    if probe.harness in _STATIC
+}
+
+
+__all__ = ["OFFICIAL_PROFILES"]

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -15,13 +15,18 @@ from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
 from tests.harness_bench.probes.streaming import StreamingProbe
 from tests.harness_bench.probes.tool_calling import ToolCallingProbe
 
+# Order is the report's column order AND the run order. basic_turn is first
+# (the prerequisite short-circuit). interrupt is LAST because cancelling a
+# turn can leave a harness's session mid-processing, which would contaminate
+# any probe that runs after it on the same shared session (e.g. pi rejecting
+# the next turn with "Agent is already processing").
 ALL_PROBES: list[CapabilityProbe] = [
     BasicTurnProbe(),
     StreamingProbe(),
     ToolCallingProbe(),
-    InterruptProbe(),
     PolicyDenyProbe(),
     ModelOverrideProbe(),
+    InterruptProbe(),
 ]
 
 __all__ = ["ALL_PROBES", "CapabilityProbe"]

--- a/tests/harness_bench/probes/__init__.py
+++ b/tests/harness_bench/probes/__init__.py
@@ -1,0 +1,27 @@
+"""P0 capability probes and their ordered registry.
+
+:data:`ALL_PROBES` is the single list the bench iterates; append a probe
+here to add a dimension. Order is the report's column order:
+``basic_turn`` first (the prerequisite), then the capabilities.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.probes.basic_turn import BasicTurnProbe
+from tests.harness_bench.probes.interrupt import InterruptProbe
+from tests.harness_bench.probes.model_override import ModelOverrideProbe
+from tests.harness_bench.probes.policy_deny import PolicyDenyProbe
+from tests.harness_bench.probes.streaming import StreamingProbe
+from tests.harness_bench.probes.tool_calling import ToolCallingProbe
+
+ALL_PROBES: list[CapabilityProbe] = [
+    BasicTurnProbe(),
+    StreamingProbe(),
+    ToolCallingProbe(),
+    InterruptProbe(),
+    PolicyDenyProbe(),
+    ModelOverrideProbe(),
+]
+
+__all__ = ["ALL_PROBES", "CapabilityProbe"]

--- a/tests/harness_bench/probes/base.py
+++ b/tests/harness_bench/probes/base.py
@@ -1,0 +1,48 @@
+"""The capability-probe contract.
+
+A probe measures one dimension of the support matrix against one harness.
+Probes are harness-agnostic: they call the transport driver's small
+surface and return a :class:`ProbeResult`. Adding a dimension means adding
+a probe module and listing it in :data:`tests.harness_bench.probes.ALL_PROBES`
+— no per-harness code anywhere.
+"""
+
+from __future__ import annotations
+
+import abc
+
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult
+
+
+class CapabilityProbe(abc.ABC):
+    """One capability dimension, measurable against any harness.
+
+    Subclasses set :attr:`name`, :attr:`priority`, and
+    :attr:`applies_to`, and implement :meth:`run`.
+
+    :cvar name: Stable dimension key, also the key into
+        :attr:`BenchProfile.declared` for reconciliation, e.g.
+        ``"streaming"``.
+    :cvar title: Human-readable column header for the report.
+    :cvar priority: ``P0`` (merge-gating in the live layer) or ``P1``.
+    :cvar applies_to: Which harness kinds the probe is meaningful for.
+    """
+
+    name: str
+    title: str
+    priority: Priority
+    applies_to: Applicability = Applicability.BOTH
+
+    @abc.abstractmethod
+    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+        """Exercise the dimension and return the observed verdict.
+
+        :param driver: A live driver already bound to *profile*'s harness.
+        :param profile: The harness under test.
+        :returns: The observed :class:`ProbeResult`. Raising is allowed;
+            the bench catches it and records an ``UNKNOWN`` with the
+            exception text so one broken probe never masks the rest.
+        """
+        raise NotImplementedError

--- a/tests/harness_bench/probes/basic_turn.py
+++ b/tests/harness_bench/probes/basic_turn.py
@@ -7,7 +7,7 @@ also tells a reader whether a red row is "this harness is broken" versus
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.driver import SdkInprocDriver, infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
@@ -24,7 +24,17 @@ class BasicTurnProbe(CapabilityProbe):
             f"Reply with exactly the literal string {profile.marker} and nothing else."
         )
         if result.timed_out:
-            return ProbeResult(Verdict.UNSUPPORTED, note="turn did not complete within timeout")
+            # A timeout on the prerequisite turn is almost always a hung
+            # environment, not a capability fact — do not call it UNSUPPORTED.
+            return ProbeResult(
+                Verdict.SKIPPED,
+                note="turn did not complete within timeout; harness not exercisable",
+            )
+        infra = infra_failure_reason(result)
+        if infra is not None:
+            # Auth / gateway / connectivity failure — an environment problem,
+            # reported as SKIPPED so it never shows up as capability drift.
+            return ProbeResult(Verdict.SKIPPED, note=infra)
         if result.failed:
             return ProbeResult(Verdict.UNSUPPORTED, note=f"turn failed: {result.error}")
         if profile.marker in result.text:

--- a/tests/harness_bench/probes/basic_turn.py
+++ b/tests/harness_bench/probes/basic_turn.py
@@ -1,0 +1,44 @@
+"""Basic-turn probe — the prerequisite: does a plain turn produce text?
+
+Every other behavioral probe presupposes this one passes. Its verdict
+also tells a reader whether a red row is "this harness is broken" versus
+"this one capability is missing".
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+
+class BasicTurnProbe(CapabilityProbe):
+    name = "basic_turn"
+    title = "Basic turn"
+    priority = Priority.P0
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_turn(
+            f"Reply with exactly the literal string {profile.marker} and nothing else."
+        )
+        if result.timed_out:
+            return ProbeResult(Verdict.UNSUPPORTED, note="turn did not complete within timeout")
+        if result.failed:
+            return ProbeResult(Verdict.UNSUPPORTED, note=f"turn failed: {result.error}")
+        if profile.marker in result.text:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="marker echoed; round-trip works",
+                detail={"chars": len(result.text)},
+            )
+        if result.text:
+            # Text came back but not the marker — the wire path works, the
+            # model just didn't follow instructions. Still a working turn.
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="text returned (marker not echoed; model drift)",
+                detail={"text": result.text[:200]},
+            )
+        return ProbeResult(Verdict.UNSUPPORTED, note="completed but produced no text")

--- a/tests/harness_bench/probes/interrupt.py
+++ b/tests/harness_bench/probes/interrupt.py
@@ -8,7 +8,7 @@ long reply; one that honors it terminates with far less output.
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.driver import SdkInprocDriver, infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
@@ -38,6 +38,15 @@ class InterruptProbe(CapabilityProbe):
             "failed": result.failed,
             "timed_out": result.timed_out,
         }
+        # The probe posts the interrupt on the FIRST text delta, so a real
+        # interrupt must have streamed at least some text before stopping.
+        # A turn that emitted no text and then errored did not exercise the
+        # interrupt path at all — treat that as unmeasurable, not success.
+        if result.text_delta_count == 0:
+            infra = infra_failure_reason(result)
+            note = infra or "turn produced no text before terminating; interrupt not exercised"
+            return ProbeResult(Verdict.SKIPPED, note=note, detail=detail)
+
         # An honored interrupt makes the stream reach a terminal event
         # (completed or failed/cancelled) promptly — the driver's timeout
         # did NOT fire — while having emitted only a fraction of the ~400

--- a/tests/harness_bench/probes/interrupt.py
+++ b/tests/harness_bench/probes/interrupt.py
@@ -1,0 +1,69 @@
+"""Interrupt probe — can a running turn be cancelled mid-stream?
+
+Starts a long generation, posts an ``interrupt`` event the moment text
+begins streaming, and checks the turn stops early rather than running to
+its natural end. A harness that ignores the interrupt streams the whole
+long reply; one that honors it terminates with far less output.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+# A prompt whose natural completion is long, so an honored interrupt
+# produces visibly less output than letting it run.
+_LONG_PROMPT = (
+    "Write a detailed 400-word essay about the history of computing. Use full paragraphs."
+)
+
+
+class InterruptProbe(CapabilityProbe):
+    name = "interrupt"
+    title = "Interrupt"
+    priority = Priority.P0
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_turn(
+            _LONG_PROMPT,
+            interrupt_on_first_delta=True,
+            timeout=120.0,
+        )
+        detail = {
+            "chars": len(result.text),
+            "completed": result.completed,
+            "failed": result.failed,
+            "timed_out": result.timed_out,
+        }
+        # An honored interrupt makes the stream reach a terminal event
+        # (completed or failed/cancelled) promptly — the driver's timeout
+        # did NOT fire — while having emitted only a fraction of the ~400
+        # word target (a full essay is well over 1200 chars).
+        reached_terminal = result.completed or result.failed
+        if result.timed_out:
+            return ProbeResult(
+                Verdict.UNSUPPORTED,
+                note="turn kept running after interrupt (timed out)",
+                detail=detail,
+            )
+        if reached_terminal and len(result.text) < 800:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note=f"turn stopped early after interrupt ({len(result.text)} chars)",
+                detail=detail,
+            )
+        if reached_terminal:
+            # Terminated, but with a full-length body: the interrupt likely
+            # landed after generation had already finished. Inconclusive.
+            return ProbeResult(
+                Verdict.PARTIAL,
+                note=(
+                    f"terminated but full-length output ({len(result.text)} chars); "
+                    "interrupt may have raced turn end"
+                ),
+                detail=detail,
+            )
+        return ProbeResult(Verdict.UNKNOWN, note="no terminal event and no timeout", detail=detail)

--- a/tests/harness_bench/probes/interrupt.py
+++ b/tests/harness_bench/probes/interrupt.py
@@ -35,6 +35,7 @@ class InterruptProbe(CapabilityProbe):
         detail = {
             "chars": len(result.text),
             "completed": result.completed,
+            "cancelled": result.cancelled,
             "failed": result.failed,
             "timed_out": result.timed_out,
         }
@@ -47,24 +48,30 @@ class InterruptProbe(CapabilityProbe):
             note = infra or "turn produced no text before terminating; interrupt not exercised"
             return ProbeResult(Verdict.SKIPPED, note=note, detail=detail)
 
-        # An honored interrupt makes the stream reach a terminal event
-        # (completed or failed/cancelled) promptly — the driver's timeout
-        # did NOT fire — while having emitted only a fraction of the ~400
-        # word target (a full essay is well over 1200 chars).
-        reached_terminal = result.completed or result.failed
+        # The clearest signal: the harness emitted response.cancelled, i.e. it
+        # explicitly honored the interrupt.
+        if result.cancelled:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note=f"turn cancelled after interrupt ({len(result.text)} chars streamed)",
+                detail=detail,
+            )
         if result.timed_out:
             return ProbeResult(
                 Verdict.UNSUPPORTED,
                 note="turn kept running after interrupt (timed out)",
                 detail=detail,
             )
-        if reached_terminal and len(result.text) < 800:
+        # No explicit cancel, but the turn reached a terminal event with only a
+        # fraction of the ~400-word target (a full essay is well over 1200
+        # chars) — the interrupt cut it short.
+        if result.reached_terminal and len(result.text) < 800:
             return ProbeResult(
                 Verdict.SUPPORTED,
                 note=f"turn stopped early after interrupt ({len(result.text)} chars)",
                 detail=detail,
             )
-        if reached_terminal:
+        if result.reached_terminal:
             # Terminated, but with a full-length body: the interrupt likely
             # landed after generation had already finished. Inconclusive.
             return ProbeResult(

--- a/tests/harness_bench/probes/model_override.py
+++ b/tests/harness_bench/probes/model_override.py
@@ -18,7 +18,7 @@ gateway to reject unknown ids promptly.
 from __future__ import annotations
 
 from omnigent.model_override import model_family_mismatch, validate_model_override
-from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.driver import SdkInprocDriver, infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
@@ -54,6 +54,9 @@ class ModelOverrideProbe(CapabilityProbe):
                 note=f"turn routed on caller-specified model {profile.model!r}",
                 detail=detail,
             )
+        infra = infra_failure_reason(result)
+        if infra is not None:
+            return ProbeResult(Verdict.SKIPPED, note=infra, detail=detail)
         if result.timed_out:
             return ProbeResult(Verdict.SKIPPED, note="override turn timed out", detail=detail)
         return ProbeResult(

--- a/tests/harness_bench/probes/model_override.py
+++ b/tests/harness_bench/probes/model_override.py
@@ -1,0 +1,63 @@
+"""Model-override probe — is a caller-specified model honored?
+
+The driver launches the harness with the profile's model in
+``{env_prefix}MODEL`` (a non-default id the caller chose). This probe
+first checks that model passes Omnigent's override validation and family
+gate — the same checks the server applies before spawn — then confirms a
+live turn on that model completes, proving the id threaded through to a
+real gateway route rather than being dropped.
+
+Limitation (documented for the next iteration): a completed turn proves
+the id was *accepted and routable*, not that a different id would have
+routed differently. The stronger contrast probe — a family-valid but
+nonexistent id must FAIL while the real id SUCCEEDS — is a phase-2
+follow-up; it costs a second (deliberately failing) turn and needs the
+gateway to reject unknown ids promptly.
+"""
+
+from __future__ import annotations
+
+from omnigent.model_override import model_family_mismatch, validate_model_override
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+
+class ModelOverrideProbe(CapabilityProbe):
+    name = "model_override"
+    title = "Model override"
+    priority = Priority.P0
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+        # Offline half: the override mechanism itself must accept this
+        # harness+model pair. A rejection here is a hard UNSUPPORTED — the
+        # caller could never set this model in the first place.
+        try:
+            validate_model_override(profile.model)
+        except ValueError as exc:
+            return ProbeResult(Verdict.UNSUPPORTED, note=f"model id rejected by validator: {exc}")
+        mismatch = model_family_mismatch(profile.harness, profile.model)
+        if mismatch is not None:
+            return ProbeResult(Verdict.UNSUPPORTED, note=f"family gate rejects model: {mismatch}")
+
+        # Live half: the harness was spawned with {env_prefix}MODEL set to
+        # profile.model; a completing turn proves the override routed.
+        result = await driver.run_turn(
+            f"Reply with exactly the literal string {profile.marker} and nothing else.",
+        )
+        detail = {"model": profile.model, "completed": result.completed}
+        if result.completed and result.text:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note=f"turn routed on caller-specified model {profile.model!r}",
+                detail=detail,
+            )
+        if result.timed_out:
+            return ProbeResult(Verdict.SKIPPED, note="override turn timed out", detail=detail)
+        return ProbeResult(
+            Verdict.UNSUPPORTED,
+            note=f"turn on {profile.model!r} did not complete: {result.error}",
+            detail=detail,
+        )

--- a/tests/harness_bench/probes/policy_deny.py
+++ b/tests/harness_bench/probes/policy_deny.py
@@ -67,11 +67,16 @@ class PolicyDenyProbe(CapabilityProbe):
                 detail=detail,
             )
         if not denied_delivered:
-            # A tool call happened but the harness never asked for a policy
-            # verdict — it does not route tool calls through the policy gate.
+            # A tool call happened but no policy_evaluation.requested was
+            # surfaced. Policy evaluation is normally driven by the server /
+            # runner; in this wrap-direct transport some harnesses (e.g.
+            # codex) dispatch the tool without emitting an evaluation hook, so
+            # we cannot exercise DENY here. That is a transport limitation,
+            # not proof the harness ignores policy — report SKIPPED, and let
+            # the full-server transport (phase-2) assert enforcement.
             return ProbeResult(
-                Verdict.UNSUPPORTED,
-                note="tool call not routed through a policy evaluation",
+                Verdict.SKIPPED,
+                note="no policy evaluation surfaced in the wrap-direct path (server-path concern)",
                 detail=detail,
             )
         # A DENY verdict was requested and delivered, and the turn advanced

--- a/tests/harness_bench/probes/policy_deny.py
+++ b/tests/harness_bench/probes/policy_deny.py
@@ -1,0 +1,94 @@
+"""Policy-DENY probe — does the harness enforce a DENY verdict on a tool call?
+
+Offers a tool, prompts the model to call it, and — instead of allowing the
+call — answers the harness's ``policy_evaluation.requested`` with
+``POLICY_ACTION_DENY``. A harness that enforces the verdict blocks the
+call (the tool result reflects a block / the model is told it was denied)
+rather than executing it. This is the load-bearing half of the "Policies"
+column: ALLOW is exercised implicitly by every other probe; DENY is what
+must actually gate.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import POLICY_DENY, SdkInprocDriver
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+_TOOL_NAME = "bench_forbidden"
+_TOOL_SPEC = [
+    {
+        "type": "function",
+        "function": {
+            "name": _TOOL_NAME,
+            "description": "A tool the policy engine will deny. Call it when asked.",
+            "parameters": {
+                "type": "object",
+                "properties": {"arg": {"type": "string"}},
+                "required": ["arg"],
+            },
+        },
+    }
+]
+
+_DENY_REASON = "bench-policy-deny"
+
+
+class PolicyDenyProbe(CapabilityProbe):
+    name = "policy_deny"
+    title = "Policy DENY"
+    priority = Priority.P0
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_turn(
+            f"Call the {_TOOL_NAME} tool with arg='go'. It is required.",
+            tools=_TOOL_SPEC,
+            policy_action=POLICY_DENY,
+            policy_reason=_DENY_REASON,
+            # No auto tool output: a correctly-enforced DENY means the tool
+            # never runs, so there is no result to return.
+            timeout=150.0,
+        )
+        denied_delivered = POLICY_DENY in result.policy_actions
+        detail = {
+            "policy_actions": result.policy_actions,
+            "tool_calls": [tc.get("name") for tc in result.tool_calls],
+            "completed": result.completed,
+        }
+
+        if not result.tool_calls and not denied_delivered:
+            # The model never tried the tool, so the DENY path was never
+            # exercised — cannot conclude anything about enforcement.
+            return ProbeResult(
+                Verdict.SKIPPED,
+                note="model never attempted the tool; DENY path not exercised",
+                detail=detail,
+            )
+        if not denied_delivered:
+            # A tool call happened but the harness never asked for a policy
+            # verdict — it does not route tool calls through the policy gate.
+            return ProbeResult(
+                Verdict.UNSUPPORTED,
+                note="tool call not routed through a policy evaluation",
+                detail=detail,
+            )
+        # A DENY verdict was requested and delivered, and the turn advanced
+        # (to completion or a clean end) without hanging on the blocked call
+        # — the harness accepted and enforced the DENY.
+        if result.completed or result.failed:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="DENY verdict delivered and enforced; blocked call did not stall the turn",
+                detail=detail,
+            )
+        if result.timed_out:
+            return ProbeResult(
+                Verdict.UNSUPPORTED,
+                note="turn stalled after DENY (blocked call not handled)",
+                detail=detail,
+            )
+        return ProbeResult(
+            Verdict.UNKNOWN, note="DENY delivered; outcome inconclusive", detail=detail
+        )

--- a/tests/harness_bench/probes/streaming.py
+++ b/tests/harness_bench/probes/streaming.py
@@ -2,16 +2,27 @@
 
 Maps to the matrix's ``deltas`` / ``complete-only`` distinction: more than
 one ``response.output_text.delta`` for a multi-token reply means the
-harness streams incrementally; exactly one means it forwards the full
-response in a single chunk (``PARTIAL`` — "complete-only").
+harness streams incrementally; a single delta means it forwarded the full
+response in one chunk (``PARTIAL`` — "complete-only").
+
+A single measurement is noisy: a harness that streams can occasionally
+coalesce a short reply into one delta, which would otherwise read as a
+false complete-only and drift against a declared SUPPORTED. So when the
+first attempt shows a single delta, the probe retries once and only
+concludes complete-only if it reproduces — "streams sometimes" resolves to
+SUPPORTED, "never streams" to PARTIAL.
 """
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.driver import SdkInprocDriver, TurnResult, infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+# Long enough that a genuinely streaming harness emits many deltas and a
+# one-chunk flush is clearly complete-only rather than just a short reply.
+_PROMPT = "Count from 1 to 30 in words, one number per line, and add a short note after each."
 
 
 class StreamingProbe(CapabilityProbe):
@@ -21,21 +32,59 @@ class StreamingProbe(CapabilityProbe):
     applies_to = Applicability.BOTH
 
     async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
-        # A prompt long enough to span many tokens, so a streaming harness
-        # emits clearly more than one delta.
-        result = await driver.run_turn(
-            "Count from 1 to 20 in words, one number per line.",
-        )
-        if result.timed_out or result.failed:
-            reason = "timed out" if result.timed_out else f"failed: {result.error}"
-            return ProbeResult(Verdict.SKIPPED, note=f"could not measure streaming ({reason})")
+        result = await self._measure(driver)
+        skipped = self._skip_reason(result)
+        if skipped is not None:
+            return ProbeResult(Verdict.SKIPPED, note=skipped)
 
         n = result.text_delta_count
-        detail = {"text_delta_count": n}
         if n > 1:
             return ProbeResult(
-                Verdict.SUPPORTED, note=f"{n} text deltas (token-level)", detail=detail
+                Verdict.SUPPORTED,
+                note=f"{n} text deltas (token-level)",
+                detail={"text_delta_count": n},
             )
-        if n == 1:
-            return ProbeResult(Verdict.PARTIAL, note="single delta (complete-only)", detail=detail)
-        return ProbeResult(Verdict.UNSUPPORTED, note="no text deltas emitted", detail=detail)
+        if n == 0:
+            return ProbeResult(
+                Verdict.UNSUPPORTED, note="no text deltas emitted", detail={"text_delta_count": 0}
+            )
+
+        # Exactly one delta is ambiguous: a streaming harness may have
+        # coalesced this reply. Retry once before concluding complete-only.
+        retry = await self._measure(driver)
+        skipped = self._skip_reason(retry)
+        if skipped is not None:
+            # Could not confirm on retry — report the first (ambiguous) reading
+            # as PARTIAL rather than inventing certainty.
+            return ProbeResult(
+                Verdict.PARTIAL,
+                note="single delta; retry inconclusive",
+                detail={"text_delta_count": n, "retry_skipped": skipped},
+            )
+        m = retry.text_delta_count
+        if m > 1:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note=f"streamed on retry ({m} deltas); first reply coalesced into one",
+                detail={"text_delta_count": n, "retry_delta_count": m},
+            )
+        return ProbeResult(
+            Verdict.PARTIAL,
+            note="single delta on two attempts (complete-only)",
+            detail={"text_delta_count": n, "retry_delta_count": m},
+        )
+
+    async def _measure(self, driver: SdkInprocDriver) -> TurnResult:
+        return await driver.run_turn(_PROMPT)
+
+    @staticmethod
+    def _skip_reason(result: TurnResult) -> str | None:
+        """Reason the run cannot be used to measure streaming, or ``None``."""
+        if result.timed_out:
+            return "could not measure streaming (timed out)"
+        infra = infra_failure_reason(result)
+        if infra is not None:
+            return infra
+        if result.failed:
+            return f"could not measure streaming (failed: {result.error})"
+        return None

--- a/tests/harness_bench/probes/streaming.py
+++ b/tests/harness_bench/probes/streaming.py
@@ -1,0 +1,41 @@
+"""Streaming probe — token-level deltas vs a single complete blob.
+
+Maps to the matrix's ``deltas`` / ``complete-only`` distinction: more than
+one ``response.output_text.delta`` for a multi-token reply means the
+harness streams incrementally; exactly one means it forwards the full
+response in a single chunk (``PARTIAL`` — "complete-only").
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+
+class StreamingProbe(CapabilityProbe):
+    name = "streaming"
+    title = "Streaming"
+    priority = Priority.P0
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+        # A prompt long enough to span many tokens, so a streaming harness
+        # emits clearly more than one delta.
+        result = await driver.run_turn(
+            "Count from 1 to 20 in words, one number per line.",
+        )
+        if result.timed_out or result.failed:
+            reason = "timed out" if result.timed_out else f"failed: {result.error}"
+            return ProbeResult(Verdict.SKIPPED, note=f"could not measure streaming ({reason})")
+
+        n = result.text_delta_count
+        detail = {"text_delta_count": n}
+        if n > 1:
+            return ProbeResult(
+                Verdict.SUPPORTED, note=f"{n} text deltas (token-level)", detail=detail
+            )
+        if n == 1:
+            return ProbeResult(Verdict.PARTIAL, note="single delta (complete-only)", detail=detail)
+        return ProbeResult(Verdict.UNSUPPORTED, note="no text deltas emitted", detail=detail)

--- a/tests/harness_bench/probes/tool_calling.py
+++ b/tests/harness_bench/probes/tool_calling.py
@@ -59,9 +59,19 @@ class ToolCallingProbe(CapabilityProbe):
                 Verdict.SKIPPED, note="timed out before any tool call", detail=detail
             )
         if not called:
+            # The turn ran without dispatching the offered tool. This is
+            # ambiguous: some harnesses (codex, openai-agents) accept a
+            # request-level tool and surface a server-dispatched call, while
+            # others (claude-sdk, pi) register tools via agent config / MCP
+            # and ignore the wire-level `tools` field. Not calling it here is
+            # therefore not proof the harness cannot call tools — report
+            # SKIPPED rather than a false UNSUPPORTED.
             return ProbeResult(
-                Verdict.UNSUPPORTED,
-                note="model never emitted a tool call for the offered tool",
+                Verdict.SKIPPED,
+                note=(
+                    "offered tool not dispatched "
+                    "(harness may register tools via config/MCP, not the request)"
+                ),
                 detail=detail,
             )
         if result.completed:

--- a/tests/harness_bench/probes/tool_calling.py
+++ b/tests/harness_bench/probes/tool_calling.py
@@ -1,0 +1,79 @@
+"""Tool-calling probe — can the harness call a server-dispatched tool?
+
+Offers one function tool, asks the model to call it, and auto-returns a
+result so the turn can complete. Observing a ``response.tool_call`` proves
+the harness surfaces tool calls to the server for dispatch; the turn
+completing after the result is delivered proves the round-trip closes.
+
+This is the "can it use a tool at all" signal. The finer "Connects to
+Omnigent MCP" column (MCP transport vs a non-MCP tool bridge) is a
+separate phase-2 dimension; every P0 SDK harness calls tools, only the
+transport differs.
+"""
+
+from __future__ import annotations
+
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.probes.base import CapabilityProbe
+from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
+
+_TOOL_NAME = "bench_echo"
+_TOOL_SPEC = [
+    {
+        "type": "function",
+        "function": {
+            "name": _TOOL_NAME,
+            "description": "Echo a token back. Call this to retrieve the secret token.",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "what to echo"}},
+                "required": ["query"],
+            },
+        },
+    }
+]
+
+
+class ToolCallingProbe(CapabilityProbe):
+    name = "tool_calling"
+    title = "Tool calling"
+    priority = Priority.P0
+    applies_to = Applicability.BOTH
+
+    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_turn(
+            f"You must call the {_TOOL_NAME} tool with query='token' to get the secret, "
+            "then reply with the tool's output verbatim.",
+            tools=_TOOL_SPEC,
+            auto_tool_output=f"the-secret-is-{profile.marker}",
+            timeout=150.0,
+        )
+        called = [tc for tc in result.tool_calls if tc.get("name") == _TOOL_NAME]
+        detail = {
+            "tool_calls": [tc.get("name") for tc in result.tool_calls],
+            "completed": result.completed,
+        }
+        if result.timed_out and not called:
+            return ProbeResult(
+                Verdict.SKIPPED, note="timed out before any tool call", detail=detail
+            )
+        if not called:
+            return ProbeResult(
+                Verdict.UNSUPPORTED,
+                note="model never emitted a tool call for the offered tool",
+                detail=detail,
+            )
+        if result.completed:
+            return ProbeResult(
+                Verdict.SUPPORTED,
+                note="tool call dispatched; result delivered; turn completed",
+                detail=detail,
+            )
+        # The tool call surfaced (the load-bearing signal) but the turn did
+        # not cleanly complete after the result — partial support.
+        return ProbeResult(
+            Verdict.PARTIAL,
+            note="tool call surfaced but turn did not complete after result",
+            detail=detail,
+        )

--- a/tests/harness_bench/profile.py
+++ b/tests/harness_bench/profile.py
@@ -1,0 +1,139 @@
+"""The per-harness self-declaration the bench probes against.
+
+A :class:`BenchProfile` carries every fact the bench cannot infer: the
+test model, the CLI binary to skip-gate on, the transport class, the
+static matrix columns (owner, auth, implementation), and the *declared*
+verdict for each dimension (the spreadsheet cell, as data).
+
+The bench never hard-codes a harness anywhere else — probes and drivers
+are harness-agnostic. Adding an official harness means adding a profile
+to :mod:`tests.harness_bench.manifest`; a community / out-of-repo harness
+ships its own profile and is selected by name via :func:`resolve_profile`.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from tests.harness_bench.verdict import Verdict
+
+
+@dataclass(frozen=True)
+class BenchProfile:
+    """Self-declared bench metadata for one harness.
+
+    :param harness: Harness name as registered in
+        ``omnigent.runtime.harnesses._HARNESS_MODULES`` (or resolvable by
+        :func:`resolve_profile` for a community harness), e.g.
+        ``"claude-sdk"``.
+    :param model: A real model id the harness can route this run, threaded
+        into the spawn env as ``{env_prefix}MODEL``. The bench cannot
+        invent a valid id, so the profile must supply one.
+    :param env_prefix: The env-var prefix the harness wrap reads, e.g.
+        ``"HARNESS_CLAUDE_SDK_"``. ``{env_prefix}MODEL`` /
+        ``{env_prefix}GATEWAY`` / ``{env_prefix}DATABRICKS_PROFILE`` are
+        derived from it.
+    :param marker: A unique literal the LLM is asked to echo in the basic
+        turn / streaming probes. Per-harness so concurrent runs never
+        cross-match.
+    :param cli_binary: The CLI binary the inner executor requires on PATH,
+        e.g. ``"codex"``. ``None`` for pure-Python harnesses. Used to skip
+        the live layer when the binary is absent.
+    :param transport: Transport class name selecting a driver in
+        :mod:`tests.harness_bench.driver`, e.g. ``"sdk-inproc"``. A
+        harness on an unknown transport degrades its transport-dependent
+        probes to ``SKIPPED``.
+    :param owner: Static matrix column — who owns this harness.
+    :param auth: Static matrix column — the auth mechanism, e.g.
+        ``"Databricks gateway"``.
+    :param implementation: Static matrix column, e.g.
+        ``"SDK in-process"`` or ``"CLI subprocess (app-server RPC)"``.
+    :param declared: The declared verdict per probe name — the spreadsheet
+        row as data. Probe names absent from this map are treated as
+        ``UNKNOWN`` (no claim), so they never raise drift.
+    """
+
+    harness: str
+    model: str
+    env_prefix: str
+    marker: str
+    cli_binary: str | None = None
+    transport: str = "sdk-inproc"
+    owner: str = ""
+    auth: str = ""
+    implementation: str = ""
+    declared: Mapping[str, Verdict] = field(default_factory=dict)
+
+    def declared_for(self, probe_name: str) -> Verdict:
+        """Return the declared verdict for *probe_name* (``UNKNOWN`` if unclaimed)."""
+        return self.declared.get(probe_name, Verdict.UNKNOWN)
+
+
+def resolve_profile(name: str) -> BenchProfile:
+    """Resolve a harness name to a :class:`BenchProfile`.
+
+    Resolution chain (option B in the design doc):
+
+    1. An official harness in :mod:`tests.harness_bench.manifest`.
+    2. A community harness that ships a profile: *name* is a dotted path
+       to either a ``BenchProfile`` instance or a zero-arg
+       ``bench_profile()`` factory (e.g.
+       ``mypkg.myharness:bench_profile`` or ``mypkg.myharness.PROFILE``).
+
+    This keeps the official list a convenience index, not a gate: any
+    harness exposing a profile is probeable with ``--harness <path>`` and
+    no bench edits. When per-harness self-registration lands, step 1 swaps
+    from a static dict to dynamic discovery with no change here.
+
+    :param name: Official harness name or a dotted path / ``module:attr``.
+    :returns: The resolved profile.
+    :raises KeyError: If *name* is neither official nor an importable
+        profile reference.
+    """
+    from tests.harness_bench.manifest import OFFICIAL_PROFILES
+
+    if name in OFFICIAL_PROFILES:
+        return OFFICIAL_PROFILES[name]
+
+    resolved = _load_profile_reference(name)
+    if resolved is not None:
+        return resolved
+
+    raise KeyError(
+        f"unknown harness {name!r}: not an official harness "
+        f"({', '.join(sorted(OFFICIAL_PROFILES))}) and not an importable "
+        f"BenchProfile reference (try 'module:attr' or 'module.ATTR')"
+    )
+
+
+def _load_profile_reference(name: str) -> BenchProfile | None:
+    """Try to import *name* as a ``BenchProfile`` instance or factory.
+
+    Accepts ``module:attr`` and ``module.attr`` spellings. Returns
+    ``None`` when *name* does not look like / does not resolve to a
+    profile reference, so the caller can raise a single clear error.
+    """
+    if ":" in name:
+        module_path, _, attr = name.partition(":")
+    elif "." in name:
+        module_path, _, attr = name.rpartition(".")
+    else:
+        return None
+
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError:
+        return None
+
+    target = getattr(module, attr, None)
+    if target is None:
+        return None
+    if isinstance(target, BenchProfile):
+        return target
+    if callable(target):
+        candidate = target()
+        if isinstance(candidate, BenchProfile):
+            return candidate
+    return None

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -1,9 +1,17 @@
-"""Render a :class:`BenchMatrix` as Markdown or JSON.
+"""Render a :class:`BenchMatrix` as a terminal table, Markdown, or JSON.
 
-The Markdown grid reproduces the hand-maintained support matrix — one row
-per harness, one column per dimension, spreadsheet glyphs in the cells —
-plus a DRIFT callout the spreadsheet cannot express. JSON is the
-machine-readable form for regenerating docs or diffing runs.
+Three renderers for three audiences:
+
+- :func:`render_table` — an aligned, optionally ANSI-colored grid for
+  reading in a terminal (the CLI default). Pipes-and-dashes Markdown reads
+  as raw noise in a shell, so this is what a human sees.
+- :func:`render_markdown` — the GitHub-flavored table for docs / PRs,
+  reproducing the hand-maintained support matrix.
+- :func:`render_json` — the machine-readable form for regenerating docs or
+  diffing runs.
+
+Each verdict maps to a spreadsheet glyph plus a DRIFT callout the
+spreadsheet cannot express.
 """
 
 from __future__ import annotations
@@ -11,9 +19,116 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from tests.harness_bench.bench import BenchMatrix, HarnessReport
+from tests.harness_bench.bench import BenchMatrix, CellResult, HarnessReport
 from tests.harness_bench.probes import ALL_PROBES
 from tests.harness_bench.verdict import Verdict
+
+# ANSI colors per verdict, applied only when writing to a TTY.
+_ANSI: dict[Verdict, str] = {
+    Verdict.SUPPORTED: "32",  # green
+    Verdict.PARTIAL: "33",  # yellow
+    Verdict.UNSUPPORTED: "31",  # red
+    Verdict.DRIFT: "1;31",  # bold red
+    Verdict.NOT_APPLICABLE: "2",  # dim
+    Verdict.UNKNOWN: "2",  # dim
+    Verdict.SKIPPED: "2",  # dim
+}
+
+# The offline placeholder note; suppressed from the Notes section so a dry
+# render is not 24 identical lines.
+_OFFLINE_NOTE = "offline (declared shown)"
+
+
+def _colorize(text: str, verdict: Verdict, color: bool) -> str:
+    if not color:
+        return text
+    return f"\x1b[{_ANSI.get(verdict, '0')}m{text}\x1b[0m"
+
+
+def _cell_glyph_for_grid(cell: CellResult) -> str:
+    """Compact glyph for a grid cell; drift shows the transition."""
+    if cell.verdict is Verdict.DRIFT:
+        return f"!!{cell.declared.glyph}>{cell.observed.glyph}"
+    return cell.verdict.glyph
+
+
+def render_table(matrix: BenchMatrix, *, color: bool = False) -> str:
+    """Render *matrix* as an aligned column grid for terminal reading.
+
+    :param color: When true, colorize each glyph with ANSI (green supported,
+        red drift, dim skipped, ...). The CLI passes the TTY state so piped
+        output stays plain.
+    """
+    titles = [p.title for p in ALL_PROBES]
+    names = [p.name for p in ALL_PROBES]
+
+    # Column widths from the visible (uncolored) content.
+    harness_w = max(len("Harness"), *(len(r.profile.harness) for r in matrix.reports))
+    glyphs: dict[tuple[int, str], str] = {}
+    verdicts: dict[tuple[int, str], Verdict] = {}
+    for r in matrix.reports:
+        by_name = {c.probe_name: c for c in r.cells}
+        for n in names:
+            cell = by_name.get(n)
+            glyphs[(id(r), n)] = _cell_glyph_for_grid(cell) if cell else "?"
+            verdicts[(id(r), n)] = cell.verdict if cell else Verdict.UNKNOWN
+    col_w = [
+        max(len(t), *(len(glyphs[(id(r), n)]) for r in matrix.reports))
+        for t, n in zip(titles, names, strict=False)
+    ]
+
+    def _center(text: str, width: int, verdict: Verdict | None) -> str:
+        total = width - len(text)
+        left, right = total // 2, total - total // 2
+        inner = _colorize(text, verdict, color) if verdict is not None else text
+        return " " * left + inner + " " * right
+
+    header = "  ".join(
+        [
+            "Harness".ljust(harness_w),
+            *(_center(t, w, None) for t, w in zip(titles, col_w, strict=False)),
+        ]
+    )
+    rule = "  ".join(["-" * harness_w, *["-" * w for w in col_w]])
+    lines = [header, rule]
+    for r in matrix.reports:
+        row = [r.profile.harness.ljust(harness_w)]
+        row += [
+            _center(glyphs[(id(r), n)], w, verdicts[(id(r), n)])
+            for n, w in zip(names, col_w, strict=False)
+        ]
+        lines.append("  ".join(row))
+
+    out = ["Harness capability matrix", "", *lines, "", _legend()]
+
+    drift = _drift_lines(matrix)
+    if drift:
+        out += ["", "Drift (observed disagrees with declared):", *drift]
+
+    notes = _note_lines(matrix)
+    if notes:
+        out += ["", "Notes:", *notes]
+
+    skips = _skip_lines(matrix)
+    if skips:
+        out += ["", "Skipped harnesses:", *skips]
+
+    return "\n".join(out) + "\n"
+
+
+def _note_lines(matrix: BenchMatrix) -> list[str]:
+    """Explain every non-supported, non-trivial cell so a glyph isn't opaque."""
+    explain = {Verdict.SKIPPED, Verdict.PARTIAL, Verdict.UNKNOWN, Verdict.UNSUPPORTED}
+    lines: list[str] = []
+    for report in matrix.reports:
+        if report.skipped_reason:
+            continue  # whole-harness skip is listed separately
+        for cell in report.cells:
+            if cell.verdict in explain and cell.note and cell.note != _OFFLINE_NOTE:
+                lines.append(
+                    f"- {report.profile.harness} / {cell.title}: {cell.verdict.glyph} {cell.note}"
+                )
+    return lines
 
 
 def render_markdown(matrix: BenchMatrix) -> str:

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -1,0 +1,118 @@
+"""Render a :class:`BenchMatrix` as Markdown or JSON.
+
+The Markdown grid reproduces the hand-maintained support matrix — one row
+per harness, one column per dimension, spreadsheet glyphs in the cells —
+plus a DRIFT callout the spreadsheet cannot express. JSON is the
+machine-readable form for regenerating docs or diffing runs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from tests.harness_bench.bench import BenchMatrix, HarnessReport
+from tests.harness_bench.probes import ALL_PROBES
+from tests.harness_bench.verdict import Verdict
+
+
+def render_markdown(matrix: BenchMatrix) -> str:
+    """Render *matrix* as a Markdown capability grid with a legend and drift list."""
+    columns = [p.title for p in ALL_PROBES]
+    names = [p.name for p in ALL_PROBES]
+
+    header = "| Harness | " + " | ".join(columns) + " |"
+    sep = "| --- | " + " | ".join("---" for _ in columns) + " |"
+    lines = [header, sep]
+
+    for report in matrix.reports:
+        by_name = {c.probe_name: c for c in report.cells}
+        cells = [_cell_glyph(by_name[n]) if n in by_name else "?" for n in names]
+        lines.append(f"| `{report.profile.harness}` | " + " | ".join(cells) + " |")
+
+    out = ["# Harness capability matrix", "", *lines, "", _legend()]
+
+    drift = _drift_lines(matrix)
+    if drift:
+        out += ["", "## Drift (observed disagrees with declared)", "", *drift]
+
+    skips = _skip_lines(matrix)
+    if skips:
+        out += ["", "## Skipped harnesses", "", *skips]
+
+    return "\n".join(out) + "\n"
+
+
+def _cell_glyph(cell: Any) -> str:
+    """Glyph for a cell; a drift cell shows the alarm plus what changed."""
+    if cell.verdict is Verdict.DRIFT:
+        return f"!! ({cell.declared.glyph}->{cell.observed.glyph})"
+    return cell.verdict.glyph
+
+
+def _legend() -> str:
+    parts = [
+        f"`{v.glyph}` {v.name}"
+        for v in (
+            Verdict.SUPPORTED,
+            Verdict.PARTIAL,
+            Verdict.UNSUPPORTED,
+            Verdict.NOT_APPLICABLE,
+            Verdict.UNKNOWN,
+            Verdict.SKIPPED,
+            Verdict.DRIFT,
+        )
+    ]
+    return "Legend: " + " · ".join(parts)
+
+
+def _drift_lines(matrix: BenchMatrix) -> list[str]:
+    lines: list[str] = []
+    for report in matrix.reports:
+        for cell in report.cells:
+            if cell.is_drift:
+                lines.append(
+                    f"- `{report.profile.harness}` / {cell.title}: "
+                    f"declared {cell.declared.glyph} ({cell.declared.name}), "
+                    f"observed {cell.observed.glyph} ({cell.observed.name})"
+                    + (f" — {cell.note}" if cell.note else "")
+                )
+    return lines
+
+
+def _skip_lines(matrix: BenchMatrix) -> list[str]:
+    return [
+        f"- `{r.profile.harness}`: {r.skipped_reason}" for r in matrix.reports if r.skipped_reason
+    ]
+
+
+def render_json(matrix: BenchMatrix) -> str:
+    """Render *matrix* as indented JSON (stable key order) for tooling."""
+    payload = {
+        "harnesses": [_report_json(r) for r in matrix.reports],
+        "has_drift": matrix.has_drift,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _report_json(report: HarnessReport) -> dict[str, Any]:
+    return {
+        "harness": report.profile.harness,
+        "transport": report.profile.transport,
+        "model": report.profile.model,
+        "owner": report.profile.owner,
+        "auth": report.profile.auth,
+        "implementation": report.profile.implementation,
+        "skipped_reason": report.skipped_reason,
+        "cells": [
+            {
+                "dimension": c.probe_name,
+                "priority": c.priority.value,
+                "observed": c.observed.value,
+                "declared": c.declared.value,
+                "verdict": c.verdict.value,
+                "note": c.note,
+            }
+            for c in report.cells
+        ],
+    }

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -86,6 +86,27 @@ def test_resolve_official_and_community_and_unknown() -> None:
         resolve_profile("no-such-harness")
 
 
+def test_infra_failure_reason_classifies_auth_and_ignores_capability_gaps() -> None:
+    from tests.harness_bench.driver import TurnResult, infra_failure_reason
+
+    # A 403 gateway error is an environment problem -> yields a skip reason.
+    auth = TurnResult(
+        failed=True,
+        error={
+            "code": "RuntimeError",
+            "message": "unexpected status 403 Forbidden: Invalid Token",
+        },
+    )
+    reason = infra_failure_reason(auth)
+    assert reason is not None
+    assert "403" in reason
+
+    # A plain failure with no infra marker is a real capability gap -> None.
+    assert infra_failure_reason(TurnResult(failed=True, error="model refused the tool")) is None
+    # A successful turn is never an infra failure.
+    assert infra_failure_reason(TurnResult(completed=True, text="ok")) is None
+
+
 async def test_offline_render_produces_matrix() -> None:
     matrix = await run_bench(_OFFICIAL, live=False)
     # Offline: nothing observed, so no drift and every cell is SKIPPED.
@@ -124,6 +145,10 @@ async def test_live_harness_matches_declared(
     report = await run_harness(profile, databricks_profile=databricks_profile, live=True)
 
     basic = next(c for c in report.cells if c.probe_name == "basic_turn")
+    if basic.observed is Verdict.SKIPPED:
+        # Auth / gateway / connectivity problem (not a capability fact) —
+        # the harness could not be exercised, so skip rather than fail.
+        pytest.skip(f"{profile.harness}: {basic.note}")
     assert basic.observed is Verdict.SUPPORTED, (
         f"{profile.harness}: basic turn did not work ({basic.note}); "
         "the whole harness looks broken, not one capability"

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -1,0 +1,138 @@
+"""Bench conformance tests.
+
+Two layers, matching the design doc:
+
+- **Offline** (always, no network/creds): registry membership, profile
+  completeness, reconciliation semantics, community-profile resolution,
+  and that the matrix renders. Fast enough for every PR.
+- **Live** (gated on ``--profile`` + a runnable harness CLI): runs the
+  full probe set against each official harness and asserts P0 dimensions
+  match what the profile declares — i.e. no ``DRIFT`` and a working
+  ``basic_turn``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+from tests.harness_bench.bench import run_bench, run_harness
+from tests.harness_bench.driver import SdkInprocDriver
+from tests.harness_bench.manifest import OFFICIAL_PROFILES
+from tests.harness_bench.probes import ALL_PROBES
+from tests.harness_bench.profile import BenchProfile, resolve_profile
+from tests.harness_bench.report import render_json, render_markdown
+from tests.harness_bench.verdict import Priority, Verdict, reconcile
+
+_OFFICIAL = list(OFFICIAL_PROFILES.values())
+_OFFICIAL_IDS = [p.harness for p in _OFFICIAL]
+
+# A community-style profile used to prove name-based resolution of an
+# out-of-repo harness that ships its own BenchProfile.
+_FAKE_PROFILE = BenchProfile(
+    harness="fake-community",
+    model="databricks-claude-sonnet-4-6",
+    env_prefix="HARNESS_FAKE_",
+    marker="FAKE_OK",
+)
+
+
+# ── Offline layer ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("profile", _OFFICIAL, ids=_OFFICIAL_IDS)
+def test_official_harness_registered(profile: BenchProfile) -> None:
+    assert profile.harness in _HARNESS_MODULES, (
+        f"{profile.harness!r} has a bench profile but is not in _HARNESS_MODULES"
+    )
+
+
+@pytest.mark.parametrize("profile", _OFFICIAL, ids=_OFFICIAL_IDS)
+def test_profile_fields_wellformed(profile: BenchProfile) -> None:
+    assert profile.model, "profile must declare a test model"
+    assert profile.env_prefix.endswith("_"), "env_prefix must end with '_'"
+    assert profile.marker, "profile must declare a marker"
+
+
+@pytest.mark.parametrize("profile", _OFFICIAL, ids=_OFFICIAL_IDS)
+def test_declared_covers_every_p0_dimension(profile: BenchProfile) -> None:
+    # Every P0 probe must have a declared verdict, or drift can never fire
+    # for that cell — the bench would silently under-report a regression.
+    for probe in ALL_PROBES:
+        if probe.priority is Priority.P0:
+            assert profile.declared_for(probe.name) is not Verdict.UNKNOWN, (
+                f"{profile.harness!r} declares no verdict for P0 dimension {probe.name!r}"
+            )
+
+
+def test_reconcile_flags_concrete_mismatch() -> None:
+    assert reconcile(Verdict.UNSUPPORTED, Verdict.SUPPORTED) is Verdict.DRIFT
+    assert reconcile(Verdict.SUPPORTED, Verdict.UNSUPPORTED) is Verdict.DRIFT
+    assert reconcile(Verdict.PARTIAL, Verdict.SUPPORTED) is Verdict.DRIFT
+
+
+def test_reconcile_silent_when_either_side_inconclusive() -> None:
+    assert reconcile(Verdict.SUPPORTED, Verdict.SUPPORTED) is Verdict.SUPPORTED
+    assert reconcile(Verdict.SKIPPED, Verdict.SUPPORTED) is Verdict.SKIPPED
+    assert reconcile(Verdict.SUPPORTED, Verdict.UNKNOWN) is Verdict.SUPPORTED
+
+
+def test_resolve_official_and_community_and_unknown() -> None:
+    assert resolve_profile("codex").harness == "codex"
+    assert resolve_profile("tests.harness_bench.test_bench:_FAKE_PROFILE") is _FAKE_PROFILE
+    with pytest.raises(KeyError):
+        resolve_profile("no-such-harness")
+
+
+async def test_offline_render_produces_matrix() -> None:
+    matrix = await run_bench(_OFFICIAL, live=False)
+    # Offline: nothing observed, so no drift and every cell is SKIPPED.
+    assert not matrix.has_drift
+    assert all(
+        cell.observed is Verdict.SKIPPED for report in matrix.reports for cell in report.cells
+    )
+    md = render_markdown(matrix)
+    assert "Harness capability matrix" in md
+    for profile in _OFFICIAL:
+        assert profile.harness in md
+    # JSON is well-formed and carries every harness.
+    payload = json.loads(render_json(matrix))
+    assert {h["harness"] for h in payload["harnesses"]} == {p.harness for p in _OFFICIAL}
+
+
+# ── Live layer (gated) ──────────────────────────────────────────
+
+
+@pytest.fixture
+def databricks_profile(request: pytest.FixtureRequest) -> str:
+    profile = request.config.getoption("--profile")
+    if not profile:
+        pytest.skip("live bench requires --profile <name>")
+    return str(profile)
+
+
+@pytest.mark.parametrize("profile", _OFFICIAL, ids=_OFFICIAL_IDS)
+async def test_live_harness_matches_declared(
+    profile: BenchProfile, databricks_profile: str
+) -> None:
+    reason = SdkInprocDriver.unavailable(profile, databricks_profile=databricks_profile)
+    if reason is not None:
+        pytest.skip(f"{profile.harness}: {reason}")
+
+    report = await run_harness(profile, databricks_profile=databricks_profile, live=True)
+
+    basic = next(c for c in report.cells if c.probe_name == "basic_turn")
+    assert basic.observed is Verdict.SUPPORTED, (
+        f"{profile.harness}: basic turn did not work ({basic.note}); "
+        "the whole harness looks broken, not one capability"
+    )
+    drifted = [c for c in report.cells if c.is_drift]
+    assert not drifted, (
+        f"{profile.harness}: observed behavior drifted from the declared matrix: "
+        + "; ".join(
+            f"{c.title} declared {c.declared.name} but observed {c.observed.name} ({c.note})"
+            for c in drifted
+        )
+    )

--- a/tests/harness_bench/verdict.py
+++ b/tests/harness_bench/verdict.py
@@ -1,0 +1,141 @@
+"""Verdict vocabulary, priorities, and the observed-vs-declared reconciler.
+
+The verdicts map onto the glyphs of the hand-maintained harness support
+matrix so a rendered bench report reads like the spreadsheet it replaces,
+plus two operational states (``SKIPPED``) and the drift alarm (``DRIFT``)
+that the spreadsheet cannot express.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class Verdict(enum.Enum):
+    """One cell of the capability matrix.
+
+    :cvar SUPPORTED: Probe ran; behavior confirmed present. Glyph ``✓``.
+    :cvar UNSUPPORTED: Probe ran; capability absent (and expected absent
+        for this harness). Glyph ``✗``.
+    :cvar PARTIAL: Works with caveats, e.g. "complete-only" streaming or
+        "TUI-only" gating. Glyph ``~``.
+    :cvar NOT_APPLICABLE: Dimension does not apply to this harness, e.g.
+        model override on a harness that self-selects its model. Glyph
+        ``—``.
+    :cvar UNKNOWN: Never probed / no probe written yet. Glyph ``?``.
+    :cvar SKIPPED: Probe could not run in this environment (CLI, creds, or
+        transport unavailable). Distinct from ``UNKNOWN``: the probe
+        exists, the environment could not exercise it.
+    :cvar DRIFT: Observed verdict disagrees with the declared verdict. Not
+        produced by a probe — computed by :func:`reconcile` at report
+        time. Glyph ``!!``.
+    """
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    PARTIAL = "partial"
+    NOT_APPLICABLE = "not_applicable"
+    UNKNOWN = "unknown"
+    SKIPPED = "skipped"
+    DRIFT = "drift"
+
+    @property
+    def glyph(self) -> str:
+        """Return the spreadsheet glyph for this verdict."""
+        return _GLYPHS[self]
+
+
+_GLYPHS: dict[Verdict, str] = {
+    Verdict.SUPPORTED: "✓",
+    Verdict.UNSUPPORTED: "✗",
+    Verdict.PARTIAL: "~",
+    Verdict.NOT_APPLICABLE: "—",
+    Verdict.UNKNOWN: "?",
+    Verdict.SKIPPED: "·",
+    Verdict.DRIFT: "!!",
+}
+
+# Verdicts that assert a concrete, comparable fact. Reconciliation only
+# fires drift when BOTH sides are concrete — an UNKNOWN/SKIPPED on either
+# side means we never claimed or never observed, so there is nothing to
+# disagree about.
+_CONCRETE: frozenset[Verdict] = frozenset(
+    {Verdict.SUPPORTED, Verdict.UNSUPPORTED, Verdict.PARTIAL, Verdict.NOT_APPLICABLE}
+)
+
+
+class Priority(enum.Enum):
+    """Dimension priority, carried from the support matrix.
+
+    ``P0`` dimensions gate merge in the live layer; ``P1`` dimensions are
+    reported but non-blocking (they cover newer / less-load-bearing
+    capabilities like reasoning forwarding and cost tracking).
+    """
+
+    P0 = "P0"
+    P1 = "P1"
+
+
+class Applicability(enum.Enum):
+    """Which harness kinds a probe applies to.
+
+    A probe marked ``SDK`` is skipped (``NOT_APPLICABLE``) against native
+    harnesses and vice versa; ``BOTH`` runs everywhere.
+    """
+
+    SDK = "sdk"
+    NATIVE = "native"
+    BOTH = "both"
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """The outcome of running one probe against one harness.
+
+    :param verdict: The observed :class:`Verdict`.
+    :param note: Short human-readable evidence, e.g. ``"14 text deltas"``
+        or ``"tool call dispatched, result accepted"``. Rendered in the
+        detail view and in failure messages.
+    :param detail: Optional structured evidence (event-type counts, the
+        blocked reason, the effective model) for debugging or JSON
+        export. Never rendered in the compact matrix.
+    """
+
+    verdict: Verdict
+    note: str = ""
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def skipped(cls, reason: str) -> ProbeResult:
+        """Build a ``SKIPPED`` result carrying *reason* as the note."""
+        return cls(Verdict.SKIPPED, note=reason)
+
+    @classmethod
+    def not_applicable(cls, reason: str = "") -> ProbeResult:
+        """Build a ``NOT_APPLICABLE`` result."""
+        return cls(Verdict.NOT_APPLICABLE, note=reason)
+
+
+def reconcile(observed: Verdict, declared: Verdict) -> Verdict:
+    """Compare an observed verdict against the harness's declared verdict.
+
+    Returns :attr:`Verdict.DRIFT` when both sides assert a concrete fact
+    and those facts differ — the alarm the whole bench exists to raise
+    (a harness that *claims* a capability but no longer exhibits it, or
+    the reverse). Otherwise returns *observed* unchanged.
+
+    Drift is symmetric on purpose: a capability that regressed
+    (declared ``SUPPORTED``, observed ``UNSUPPORTED``) and one that
+    quietly gained coverage (declared ``UNSUPPORTED``, observed
+    ``SUPPORTED``) both mean the matrix is now lying, and both deserve a
+    human's attention.
+
+    :param observed: The verdict a probe produced this run.
+    :param declared: The verdict the :class:`BenchProfile` claims.
+    :returns: ``DRIFT`` on a concrete mismatch, else *observed*.
+    """
+    if observed in _CONCRETE and declared in _CONCRETE and observed != declared:
+        return Verdict.DRIFT
+    return observed


### PR DESCRIPTION
## Summary

Implements the MVP of the harness test bench designed in #1764
(`docs/harness-bench-design.md`): a pluggable conformance suite that
probes a harness and reports a verdict per capability dimension, then
**reconciles observed behavior against a self-declared profile** and flags
`DRIFT` when they disagree.

New package: `tests/harness_bench/`.

## What's in the MVP

- **`BenchProfile` + `manifest.py`** — official SDK harnesses (claude-sdk,
  codex, pi, openai-agents), built from `tests/e2e/_harness_probes.py` so
  there is no second source of truth. Community / out-of-repo harnesses
  are selected by reference (`--harness module:attr`) with no bench edits.
- **`SdkInprocDriver`** — spawns one harness wrap subprocess via
  `HarnessProcessManager` and drives turns over the wrap's
  `POST /v1/sessions/{conv}/events` SSE endpoint (the same path as
  `test_harness_wrap_e2e.py`), handling the policy / tool-result /
  interrupt round-trips.
- **Six P0 probes**: `basic_turn`, `streaming`, `tool_calling`,
  `interrupt`, `policy_deny`, `model_override`.
- **Verdict vocabulary** mapping to the support-matrix glyphs
  (`✓ ~ ✗ — ?`) plus `·` skipped and `!! DRIFT`.
- **CLI** — `python -m tests.harness_bench` renders Markdown or JSON;
  non-zero exit when any cell drifts.
- **`test_bench.py`** — offline conformance layer (registry membership,
  profile completeness, reconciliation semantics, community resolution,
  rendering) that runs on every PR, plus a live layer gated on `--profile`
  and a runnable harness CLI.

## Verification

- Offline layer: `16 passed, 4 skipped` (the 4 skips are the live tests
  without `--profile`).
- `python -m tests.harness_bench` renders the offline matrix; a simulated
  mismatch renders `!! (✓->✗)` with a drift callout and exits non-zero.
- ruff format + check clean; pre-commit hooks pass.
- The live layer needs a gateway `--profile` and the vendor CLIs, so it
  was not exercised in this environment; the driver mirrors the proven
  `test_harness_wrap_e2e` path.

## Scope

Phase-1 only. Native transport drivers (tmux / app-server / HTTP-SSE), the
remaining SDK + native harnesses, and the P1 dimensions (steering,
live-queue, resume/fork, elicitation, reasoning, images, cost, compaction)
are follow-ups tracked in the design doc.