### PR TITLE
chore: drop PR/issue references from code comments

### DIFF
--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -231,7 +231,7 @@ async def post_session_event_with_retry(
                 # Surface this connectivity failure to the harness idle-turn
                 # watchdog so a stall caused by unreachable-server posts is
                 # reported with its real cause, not a generic "wedged LLM"
-                # reason (issue #1119).
+                # reason.
                 record_native_post_failure(event_type, exc)
                 return None
             await sleep(retry_delay(attempt))
@@ -239,7 +239,7 @@ async def post_session_event_with_retry(
         # Reaching here means the POST got an HTTP response (no transport
         # error), proving the server is reachable — clear any stale
         # connectivity-failure record so the watchdog can't later misattribute
-        # it to an unrelated stall (issue #1119).
+        # it to an unrelated stall.
         note_native_post_success()
         if response.status_code < 400:
             return response

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1684,7 +1684,7 @@ def codex_terminal_env(app_server: CodexNativeAppServer) -> dict[str, str]:
 # conflict (the bypass already implies ``danger-full-access``), so leaving
 # them in is harmless. We strip BOTH anyway when bypass is on — the approval
 # flag because it MUST go, the sandbox flag for hygiene so the launched arg
-# list reflects a single coherent stance. See issue #657.
+# list reflects a single coherent stance.
 _CODEX_BYPASS_SANDBOX_FLAG = "--dangerously-bypass-approvals-and-sandbox"
 # Granular approval/sandbox flags to drop when bypass is on. The "Full
 # access" / "Read only" approval presets emit the long ``--flag value`` form

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -4878,7 +4878,7 @@ def _codex_tool_call_from_item(item: dict[str, Any]) -> _CodexToolCall | None:
 # that sandbox cannot start and every command hard-fails with this raw bwrap
 # error, with no hint at how to recover. Detect the marker and append actionable
 # guidance so a top-level session degrades with direction instead of an opaque
-# failure (degrade with direction instead of crashing). The codex
+# failure. The codex
 # ``--approval-mode`` presets do NOT disable this sandbox — only the "Full
 # access" preset's ``danger-full-access`` (or a config ``sandbox_mode``) does.
 _CODEX_SANDBOX_NAMESPACE_ERROR_MARKER = "No permissions to create new namespace"

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -4878,7 +4878,7 @@ def _codex_tool_call_from_item(item: dict[str, Any]) -> _CodexToolCall | None:
 # that sandbox cannot start and every command hard-fails with this raw bwrap
 # error, with no hint at how to recover. Detect the marker and append actionable
 # guidance so a top-level session degrades with direction instead of an opaque
-# failure (issue #657; mirrors the degrade-not-crash ask in #517). The codex
+# failure (degrade with direction instead of crashing). The codex
 # ``--approval-mode`` presets do NOT disable this sandbox — only the "Full
 # access" preset's ``danger-full-access`` (or a config ``sandbox_mode``) does.
 _CODEX_SANDBOX_NAMESPACE_ERROR_MARKER = "No permissions to create new namespace"
@@ -4939,7 +4939,7 @@ def _command_execution_tool_call(call_id: str, item: dict[str, Any]) -> _CodexTo
         suffix = f"[exit code: {exit_code}]"
         output_text = f"{output_text}\n{suffix}" if output_text else suffix
     # Turn codex's opaque "sandbox can't start" bwrap failure into actionable
-    # recovery guidance (issue #657); a no-op for any other output.
+    # recovery guidance; a no-op for any other output.
     output_text = _augment_sandbox_namespace_error(output_text)
     return _CodexToolCall(call_id=call_id, name="shell", arguments=arguments, output=output_text)
 
@@ -5874,7 +5874,7 @@ async def _post_session_event_inner(
         # An HTTP response (no transport error) proves the server is reachable,
         # so clear any stale connectivity-failure record — otherwise a recovered
         # connection could have an old failure misattributed to a later,
-        # unrelated idle-watchdog stall (issue #1119).
+        # unrelated idle-watchdog stall.
         note_native_post_success()
         if _post_response_is_final(response, attempt, max_attempts):
             return _PostResult(response=response)
@@ -5928,7 +5928,7 @@ def _log_post_transport_failure(event_type: str, exc: httpx.HTTPError, max_attem
     # Surface this connectivity failure to the harness idle-turn watchdog: if
     # the turn stalls because events can't reach the server, the watchdog
     # attaches this cause to the failure reason instead of a generic
-    # "wedged LLM" message (issue #1119).
+    # "wedged LLM" message.
     record_native_post_failure(event_type, exc)
 
 

--- a/omnigent/db/migrations/versions/43fb65b29464_initial_schema_agents_files_.py
+++ b/omnigent/db/migrations/versions/43fb65b29464_initial_schema_agents_files_.py
@@ -125,7 +125,7 @@ def upgrade() -> None:
         sa.Column("agent_name", sa.String(length=256), nullable=False),
         sa.Column("background", sa.Boolean(), nullable=False),
         sa.Column("root_task_id", sa.String(length=64), nullable=True),
-        # Immediate parent task_id (distinct from
+        # Audit fix #1: immediate parent task_id (distinct from
         # root_task_id when a sub-agent creates children). The
         # PATCH async_tool_results handler signals this, so the
         # immediate calling agent's drain wakes — not the root.

--- a/omnigent/db/migrations/versions/43fb65b29464_initial_schema_agents_files_.py
+++ b/omnigent/db/migrations/versions/43fb65b29464_initial_schema_agents_files_.py
@@ -125,7 +125,7 @@ def upgrade() -> None:
         sa.Column("agent_name", sa.String(length=256), nullable=False),
         sa.Column("background", sa.Boolean(), nullable=False),
         sa.Column("root_task_id", sa.String(length=64), nullable=True),
-        # Audit fix #1: immediate parent task_id (distinct from
+        # Immediate parent task_id (distinct from
         # root_task_id when a sub-agent creates children). The
         # PATCH async_tool_results handler signals this, so the
         # immediate calling agent's drain wakes — not the root.

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -56,7 +56,7 @@ _USER_PROMPT_SUBMIT = "UserPromptSubmit"
 # Reason surfaced when a tool call is denied because its policy verdict
 # could not be obtained (server unreachable / non-2xx / empty or malformed
 # body). Mirrors the runner-side fail-closed default in
-# ``omnigent.runner.app._evaluate_policy_via_omnigent`` (PR #163).
+# ``omnigent.runner.app._evaluate_policy_via_omnigent``.
 _EVAL_UNAVAILABLE_REASON = (
     "Omnigent policy evaluation unavailable (could not reach or authenticate to the "
     "Omnigent server); failing closed for this tool call."

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -40,7 +40,7 @@ const _TRANSIENT_RETRY_MAX_BACKOFF_MS = 10_000;
 // our own _PARK_ATTEMPT_TIMEOUT_MS timer fires (the server held the
 // connection open the whole time). We use the attempt's elapsed wall-time
 // to disambiguate the two even when controller.signal.aborted has already
-// flipped true (the abort-timer-race in finding #3): only an attempt that
+// flipped true (the abort-timer race): only an attempt that
 // survived to ~the per-attempt timeout is treated as a re-attachable park;
 // anything that failed materially sooner is a genuine transport error and
 // is charged against the transient budget (→ eventually fail CLOSED).
@@ -178,7 +178,7 @@ async function evalNativePolicyHttp(config, toolName, args) {
   // resolves quickly (fail CLOSED) instead of riding the long park ceiling.
   let transientDeadline = Date.now() + _TRANSIENT_RETRY_BUDGET_MS;
   let transientBackoff = _TRANSIENT_RETRY_INITIAL_BACKOFF_MS;
-  // Bound on consecutive raw ASK rounds (see _MAX_RAW_ASK_ROUNDS / finding #2).
+  // Bound on consecutive raw ASK rounds (see _MAX_RAW_ASK_ROUNDS).
   let rawAskRounds = 0;
 
   while (true) {
@@ -211,7 +211,7 @@ async function evalNativePolicyHttp(config, toolName, args) {
       // Distinguish a LEGITIMATE long-poll re-attach from a GENUINE transport
       // error. controller.signal.aborted alone is unreliable: once our
       // per-attempt timer has fired it reads true even if a real connect
-      // reset raced the timer (finding #3). A genuine connect error throws
+      // reset raced the timer. A genuine connect error throws
       // fast — well under _PARK_ATTEMPT_TIMEOUT_MS — whereas a real long-poll
       // only aborts once the timer fires after holding the connection open
       // the whole attempt. So require BOTH aborted AND that the attempt

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -94,7 +94,7 @@ _logger = logging.getLogger(__name__)
 
 # ── session.status "waiting" backwards-compat (new runner ↔ old server) ──
 # The runner emits ``session.status: "waiting"`` when a turn ends with sub-agents
-# still running (PR #930, for the headless ``-p`` fast-exit). Servers older than
+# still running (for the headless ``-p`` fast-exit). Servers older than
 # 0.3.0 don't model "waiting" — their ``SessionResponse.status`` is
 # ``Literal["idle","running","failed"]`` — and 500 on ``GET /v1/sessions`` when
 # they try to serialize the cached value. So we resolve the server version once
@@ -8254,7 +8254,7 @@ def create_runner_app(
         :param status: New working status, ``"running"`` or ``"idle"``.
         """
         # (The native-pane reaper's status mirror is recorded centrally in
-        # _publish_event, which this routes through — see #1349.)
+        # _publish_event, which this routes through.)
         _publish_event(
             session_id,
             {"type": "session.status", "status": status},
@@ -14291,7 +14291,7 @@ def create_runner_app(
                                         # conversation while it is streaming (and
                                         # forward_cancel can resolve the harness
                                         # response id). Cleared in
-                                        # _on_proxy_stream_end. See issue #1414.
+                                        # _on_proxy_stream_end.
                                         process_manager.mark_in_flight(conv_id, _response_id)
 
                                 # Defer publish for action_required

--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -845,7 +845,7 @@ async def _run_layer2(
         if _is_summary_auth_error(exc):
             # Distinct, actionable signal: an auth/config problem (not a
             # transient blip) is silently degrading compaction to lossy
-            # truncation. Don't bury a 401 as a routine fallback (issue #1121).
+            # truncation. Don't bury a 401 as a routine fallback.
             _logger.error(
                 "Compaction Layer 2 summarisation is UNAUTHORIZED for task %s "
                 "(%s) — the summarizer's credentials are missing or invalid, so "

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -1495,7 +1495,7 @@ class HarnessApp:
                 # the idle watchdog — not the connectivity error — is what fails
                 # the turn. If such a POST failure was recorded recently, attach
                 # it so the user sees the real cause rather than a generic
-                # "wedged LLM" reason (issue #1119). The window is twice the
+                # "wedged LLM" reason. The window is twice the
                 # idle timeout: the failure that began the stall is already
                 # ~idle_timeout old when the watchdog fires, so a window equal
                 # to the stall would race past it; 2x captures it while still

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -20557,8 +20557,8 @@ async def _get_session_snapshot(
                     # compaction trigger a single source of truth — computed by
                     # one function — so they can't drift even though they run in
                     # different processes at different times. (They previously
-                    # each inlined this rule and silently fell out of step; see
-                    # PR #769 review. Sharing the function removes the manual
+                    # each inlined this rule and silently fell out of step;
+                    # sharing the function removes the manual
                     # sync.) spec.executor.context_window describes only the spec
                     # model, so an active override bypasses it — the resolver
                     # makes that decision from the spec model + override.

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -71,7 +71,7 @@ SWITCH_PREVIOUS_BUILTIN_LABEL_KEY = "omnigent.switch.previous_builtin_id"
 # so it survives reload without a schema migration. The web UI gates turning
 # this on behind a typed confirmation + a persistent red warning banner; any
 # value other than ``"1"`` (incl. absent) leaves the session in Codex's
-# normal approval/sandbox stance. See issue #657.
+# normal approval/sandbox stance.
 CODEX_NATIVE_BYPASS_SANDBOX_LABEL_KEY = "omnigent.codex_native.bypass_sandbox"
 
 # Reserved label key that stores a session's sidebar "project" membership

--- a/tests/e2e/test_child_sessions_sdk_live_e2e.py
+++ b/tests/e2e/test_child_sessions_sdk_live_e2e.py
@@ -98,5 +98,5 @@ def test_child_sessions_sdk_helpers_against_live_server(
 
     # ── subtree_busy: all children are freshly-created with no task → idle →
     # the rollup must read False ("safe to inject your turn"). This is the
-    # deterministic half of issue #444's contract.
+    # deterministic half of the subtree-busy rollup contract.
     assert out["busy"] is False, "subtree_busy should be False when no child has a task"

--- a/tests/e2e/test_host_codex_native_e2e.py
+++ b/tests/e2e/test_host_codex_native_e2e.py
@@ -1246,7 +1246,7 @@ def test_codex_native_web_model_effort_override_survives_turn(
     """
     A web model/effort pick applied mid-session does not break the turn.
 
-    Regression for #1256 / PR #1274. A model or reasoning-effort change
+    A model or reasoning-effort change
     made in the Omnigent web picker reaches the runner as
     ``ExecutorConfig.model`` / ``extra["reasoning_effort"]``, and
     ``CodexNativeExecutor.run_turn`` now applies it via a

--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -1693,11 +1693,11 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
         )
         # No interactive approval banner tunneled to the root REPL —
         # the sub-agent TOOL_CALL ASK is a non-interactive pass-through
-        # today (see #765), exactly like the sub-agent INPUT-phase ASK.
+        # today, exactly like the sub-agent INPUT-phase ASK.
         assert "approval required" not in full_turn, (
             "A sub-agent TOOL_CALL ASK banner surfaced on the root REPL — "
-            "interactive tunneled mid-flight ASK is not implemented (see "
-            "#765); the sub-agent ASK is non-interactive today.\n"
+            "interactive tunneled mid-flight ASK is not implemented; "
+            "the sub-agent ASK is non-interactive today.\n"
             f"Captured:\n{full_turn[:1500]}"
         )
     finally:

--- a/tests/e2e/test_repl_subagent_panel_events_e2e.py
+++ b/tests/e2e/test_repl_subagent_panel_events_e2e.py
@@ -174,7 +174,7 @@ def test_parent_stream_and_child_sessions_expose_subagents(
     # The SDK rollup (subtree_busy / tree_busy) an SDK driver consumes: against
     # the same real server, child_sessions_tree must list the spawned child and
     # subtree_busy must settle to False now the run is terminal — the SDK-side
-    # mirror of the data contract asserted above (issue #444).
+    # mirror of the data contract asserted above.
     async def _sdk_rollup() -> tuple[list[dict[str, Any]], bool]:
         async with httpx.AsyncClient(timeout=30.0) as ac:
             ns = SessionsNamespace(ac, live_server)

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1795,8 +1795,8 @@ def test_get_openai_client_missing_databricks_sdk_with_env_falls_through(monkeyp
     the function should log a warning and return a client configured from the
     env vars — not crash.
 
-    Regression test: a missing/invalid config must degrade to env-var
-    defaults with a warning, not crash.
+    Regression test: a missing ``databricks-sdk`` must degrade to the
+    env-var client with a warning, not crash.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :param caplog: Pytest log capture fixture.

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1767,7 +1767,7 @@ def test_get_openai_client_missing_databricks_sdk_raises_actionable_error(monkey
     available, the function must raise ``ImportError`` with install
     instructions — not crash with an opaque traceback.
 
-    Regression test for https://github.com/omnigent-ai/omnigent/issues/123.
+    Regression test: the SDK-missing path must fail loudly, not silently.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     """
@@ -1795,7 +1795,8 @@ def test_get_openai_client_missing_databricks_sdk_with_env_falls_through(monkeyp
     the function should log a warning and return a client configured from the
     env vars — not crash.
 
-    Regression test for https://github.com/omnigent-ai/omnigent/issues/123.
+    Regression test: a missing/invalid config must degrade to env-var
+    defaults with a warning, not crash.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :param caplog: Pytest log capture fixture.

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -226,7 +226,7 @@ class _FakeProcessManager:
         self.cancelled: list[str] = []
         self.get_client_calls: list[tuple[str, str, dict[str, str] | None]] = []
         # In-flight tracking the runner wires up on response.created /
-        # stream end (issue #1414). Recorded so tests can assert the
+        # stream end. Recorded so tests can assert the
         # idle reaper's guard is actually populated for a live turn.
         self.marked_in_flight: list[tuple[str, str]] = []
         self.cleared_in_flight: list[str] = []

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -1722,7 +1722,7 @@ async def test_on_shutdown_hook_called_during_lifespan_teardown(
         await mgr.shutdown()
 
 
-# ── Idle-watchdog surfaces forwarder connectivity cause (issue #1119) ──
+# ── Idle-watchdog surfaces forwarder connectivity cause ──
 #
 # The pure-module unit test for ``_native_forwarder_health`` (record / recency
 # / clear) lives in ``tests/test_native_forwarder_health.py``. This file keeps

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -1510,7 +1510,7 @@ async def test_default_window_compacts_same_fill(monkeypatch: pytest.MonkeyPatch
 
 
 # ---------------------------------------------------------------------------
-# Layer-2 auth-failure detection (issue #1121: don't bury a 401)
+# Layer-2 auth-failure detection (don't bury a 401)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/scripts/test_update_versions.py
+++ b/tests/scripts/test_update_versions.py
@@ -23,7 +23,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 # a full-suite collection (pytest's default "prepend" import mode), failing with
 # ``ImportError: cannot import name 'update_versions' from 'scripts'``. Load the
 # module by its repo-root file path instead, which is immune to the collision.
-# See https://github.com/omnigent-ai/omnigent/issues/1311.
 _UPDATE_VERSIONS_SPEC = importlib.util.spec_from_file_location(
     "_update_versions_under_test", _REPO_ROOT / "scripts" / "update_versions.py"
 )

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -146,7 +146,7 @@ class FakeProcessManager:
 
     def mark_in_flight(self, conversation_id: str, response_id: str) -> None:
         # Mirror the real manager: the runner registers the live turn on
-        # response.created so the idle reaper spares it (issue #1414).
+        # response.created so the idle reaper spares it.
         self._in_flight[conversation_id] = response_id
 
     def clear_in_flight(self, conversation_id: str) -> None:

--- a/web/src/components/AgentCard.test.tsx
+++ b/web/src/components/AgentCard.test.tsx
@@ -63,7 +63,7 @@ describe("AgentCard icon selection", () => {
     // The SDK "cursor" harness also reads as Cursor via the harness fallback.
     { name: "x", harness: "cursor", expected: "cursor" },
     // Kiro native + the bare "kiro" harness both read as the Kiro glyph
-    // (they previously borrowed Cursor's — see #1137).
+    // (they previously borrowed Cursor's).
     { name: "kiro-native-ui", harness: "kiro-native", expected: "kiro" },
     { name: "x", harness: "kiro-native", expected: "kiro" },
     { name: "x", harness: "kiro", expected: "kiro" },

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -177,7 +177,7 @@ export function ChatHeader({
       className={cn(
         // h-14 fixes the bar at 56px: 12px symmetric vertical padding around
         // the 32px controls. No own background — the app canvas shows
-        // through (a scrim can't track the canvas gradient; see #3010).
+        // through (a scrim can't track the canvas gradient).
         // Scrolled chat text can't render through the controls because the
         // conversation viewport fades its top edge instead (chat-scroll-fade
         // in index.css, applied in ChatPage).

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -196,10 +196,10 @@ describe("quick pin/unpin hover button", () => {
     expect(screen.getByTestId("pin-conversation")).toHaveClass("md:hidden");
   });
 
-  it("reveals the quick-pin button without breaking icon centering (regression for #1226)", () => {
+  it("reveals the quick-pin button without breaking icon centering", () => {
     // The Button base centers its icon with `inline-flex` + `items-center
-    // justify-center`. The desktop reveal MUST keep a flex display: PR #1226
-    // revealed it with `md:block`, which overrode `inline-flex`, made the
+    // justify-center`. The desktop reveal MUST keep a flex display: revealing
+    // it with `md:block` overrode `inline-flex`, made the
     // centering classes inert, and shoved the pin glyph to the button's
     // top-left corner (~6px off-center). Guard the display so the reveal
     // stays flex and the glyph stays centered.

--- a/web/src/shell/codeViewerHelpers.test.ts
+++ b/web/src/shell/codeViewerHelpers.test.ts
@@ -218,7 +218,7 @@ describe("indexToLine", () => {
 });
 
 // ---------------------------------------------------------------------------
-// prepareHtmlPreviewDoc — force links to open in a new tab (issue #777)
+// prepareHtmlPreviewDoc — force links to open in a new tab
 // ---------------------------------------------------------------------------
 
 describe("prepareHtmlPreviewDoc", () => {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Follow-up to the new **Code comments** guidance in `AGENTS.md`: comments should describe the *scenario*, not point at PR/issue numbers a reader has to chase.
- Strips internal PR/issue/finding references (e.g. `issue #1119`, `PR #930`, `finding #3`, and full `github.com/omnigent-ai/omnigent/issues/...` URLs) from inline comments and docstrings across production code and tests, rewording where needed so each comment still explains what the code handles and why.
- Comment-only changes — no behavior, logic, or public API touched.
- Left intact: external upstream references (`claude-code issues #...`, `coreweave/cwsandbox-client#...`) that point to third-party context a reader can't otherwise discover, and local fix enumerations (`fix #2`) that aren't issue numbers.

## Test Plan

- `python -m py_compile` on every edited Python file — all pass.
- `web/`: `npx vitest run` on the three touched test files (130 tests pass) and `npm run build` (succeeds).
- Re-ran the PR/issue-reference scan across the source tree; no internal references remain.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Comment/docstring-only change with no runtime effect. Verified by compiling all edited Python files, running the touched web unit tests plus the web build, and re-scanning the tree to confirm no internal PR/issue references remain. Existing tests continue to exercise the surrounding code.

This pull request and its description were written by Isaac.