### PR TITLE
fix(runner): deliver native sub-agent completions to the parent inbox

### DIFF
--- a/omnigent/_native_post_delivery.py
+++ b/omnigent/_native_post_delivery.py
@@ -162,6 +162,44 @@ def post_may_have_been_delivered(exc: httpx.HTTPError) -> bool:
     return True
 
 
+async def post_external_session_status(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    status: str,
+    output: str | None = None,
+    background_task_count: int | None = None,
+) -> None:
+    """Post one ``external_session_status`` event to the Sessions API.
+
+    The turn-end edge native forwarders use to drive session status and, for
+    sub-agents, the parent-inbox wake. Shared by the claude-native and
+    cursor-native forwarders so the event shape stays in one place.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id.
+    :param status: Session status value, e.g. ``"idle"`` or ``"failed"``.
+    :param output: Optional text attached to ``data``. On a ``"failed"`` edge
+        the server surfaces it as ``last_task_error`` so the UI shows a detail
+        instead of a bare "failed". Ignored when falsy.
+    :param background_task_count: Background tasks (shells) still running at the
+        edge, forwarded so the UI can show "N background tasks still running".
+        ``None`` omits the field (server leaves its sticky tally untouched) — the
+        default for edges that know nothing about background shells.
+    :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
+    """
+    data: dict[str, object] = {"status": status}
+    if output:
+        data["output"] = output
+    if background_task_count is not None:
+        data["background_task_count"] = background_task_count
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+    )
+    resp.raise_for_status()
+
+
 async def post_session_event_with_retry(
     *,
     client: httpx.AsyncClient,

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -17,7 +17,11 @@ from typing import Any
 
 import httpx
 
-from omnigent._native_post_delivery import append_dead_letter, post_may_have_been_delivered
+from omnigent._native_post_delivery import (
+    append_dead_letter,
+    post_external_session_status,
+    post_may_have_been_delivered,
+)
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
     ClaudeHookRecord,
@@ -1536,7 +1540,7 @@ async def _forward_available_subagents(
             retry_key = f"subagent_status:{entry.child_conversation_id}"
             if status_retry_tracker.retry_delay_s(retry_key) is None:
                 try:
-                    await _post_external_session_status(
+                    await post_external_session_status(
                         client,
                         session_id=entry.child_conversation_id,
                         status=desired_status,
@@ -2698,7 +2702,7 @@ async def _forward_available_status_events(
         if status == "idle" and record.background_task_count > 0:
             effective_status = "waiting"
         try:
-            await _post_external_session_status(
+            await post_external_session_status(
                 client,
                 session_id=session_id,
                 status=effective_status,
@@ -3695,53 +3699,6 @@ async def _forward_model_from_status(
     )
 
 
-async def _post_external_session_status(
-    client: httpx.AsyncClient,
-    *,
-    session_id: str,
-    status: str,
-    output: str | None = None,
-    background_task_count: int | None = None,
-) -> None:
-    """
-    Post one ``external_session_status`` event to the Sessions API.
-
-    :param client: Omnigent HTTP client.
-    :param session_id: Omnigent session/conversation id.
-    :param status: Session status value, e.g. ``"idle"`` or
-        ``"failed"``.
-    :param output: Optional text attached to the event ``data``. On a
-        ``"failed"`` edge the server surfaces it as the session's failure
-        reason (``last_task_error``) so the UI renders a detail instead of
-        a bare "failed" (#1113). Ignored when falsy.
-    :param background_task_count: Number of background tasks (shells)
-        still running when the status edge fires. Forwarded to the SSE
-        stream so the web UI can display "N background tasks still
-        running" instead of a generic spinner. ``None`` (the default)
-        omits the field, which the server treats as "no information" and
-        leaves the sticky tally untouched — used by the PTY-activity
-        watcher, whose ``idle`` knows nothing about background shells. A
-        ``Stop`` hook passes its authoritative count (``0`` to clear, ``N``
-        to set), so a finished background shell clears the indicator on the
-        next turn end.
-    :returns: None.
-    :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
-    """
-    data: dict[str, Any] = {"status": status}
-    if output:
-        data["output"] = output
-    if background_task_count is not None:
-        data["background_task_count"] = background_task_count
-    resp = await client.post(
-        f"/v1/sessions/{session_id}/events",
-        json={
-            "type": "external_session_status",
-            "data": data,
-        },
-    )
-    resp.raise_for_status()
-
-
 async def _post_external_compaction_status(
     client: httpx.AsyncClient,
     *,
@@ -3943,7 +3900,7 @@ async def _post_forwarder_failed_status(
     :returns: None.
     """
     try:
-        await _post_external_session_status(
+        await post_external_session_status(
             client, session_id=session_id, status="failed", output=reason
         )
     except httpx.HTTPError:

--- a/omnigent/cursor_native_usage.py
+++ b/omnigent/cursor_native_usage.py
@@ -170,6 +170,14 @@ class _UsageAccumulator:
             self.model = model  # latest turn's model wins (mirrors a /model switch)
         return True
 
+    def seen_count(self) -> int:
+        """Distinct turns folded in so far (one per ``generation_id``).
+
+        Drives the forwarder's turn-completion wake edge: each newly-seen turn
+        posts one ``external_session_status: idle``.
+        """
+        return len(self.seen)
+
 
 def _read_usage_state(bridge_dir: Path) -> _UsageAccumulator:
     """Load the persisted accumulator, or a cold zero default."""
@@ -263,11 +271,24 @@ async def forward_cursor_usage_to_session(
     totals advanced — POSTs an ``external_session_usage`` event. The accumulator
     is persisted to ``bridge_dir`` so a supervisor restart resumes without
     re-counting. Never returns normally; cancel the task to stop it.
+
+    A newly-observed usage line means cursor-agent fired its ``stop`` hook — a
+    turn completed. On that edge we also POST ``external_session_status: idle``,
+    the only signal that reaches the parent inbox wake (the forwarder mirrors
+    only conversation items, and the PTY-activity watcher is suppressed for
+    cursor-native). Idle delivery is idempotent server-side.
     """
     import httpx
 
+    from omnigent._native_post_delivery import post_external_session_status
+
     acc = _read_usage_state(bridge_dir)
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
+    # Turns already woken this run. Seeded at 0 (not from persisted usage state):
+    # a restart re-posts one idle, which the server dedupes if already delivered
+    # — the safe direction. Seeding from persisted usage would permanently skip a
+    # wake whose idle POST crashed after the usage flush persisted.
+    idle_posted_turns = 0
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
@@ -287,6 +308,15 @@ async def forward_cursor_usage_to_session(
                     # Persist only after a successful POST so a failed flush is
                     # retried (the unseen turns stay unseen until they land).
                     await asyncio.to_thread(_write_usage_state, bridge_dir, acc)
+                # Wake the parent once per newly-seen turn, after the usage flush
+                # so the inbox read sees up-to-date cost. A failed idle is retried
+                # next poll (the counter only advances on success).
+                seen_turns = acc.seen_count()
+                if seen_turns > idle_posted_turns:
+                    await post_external_session_status(
+                        client, session_id=session_id, status="idle"
+                    )
+                    idle_posted_turns = seen_turns
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6504,6 +6504,15 @@ class _SessionSnapshot:
         ``None`` for top-level sessions. Projected from the server
         snapshot so the identity survives a runner reconnect / spec-cache
         eviction (the in-memory ``_session_sub_agent_names`` map does not).
+    :param parent_session_id: For sub-agent sessions, the parent
+        conversation's id, e.g. ``"conv_parent987"``. ``None`` for
+        top-level sessions. Lets ``_ensure_subagent_work_entry`` rebuild a lost
+        work entry when the in-memory map was wiped (reconnect / restart) or
+        never populated (a ``sys_session_create`` child).
+    :param agent_name: Human-readable bound agent name, e.g.
+        ``"cursor-native-ui"``. Used as the sub-agent label when rebuilding a
+        work entry for a child the server did not record a ``sub_agent_name``
+        for. ``None`` when unbound / the fetch failed.
     """
 
     ok: bool
@@ -6512,6 +6521,8 @@ class _SessionSnapshot:
     workspace: str | None
     agent_id: str | None
     sub_agent_name: str | None = None
+    parent_session_id: str | None = None
+    agent_name: str | None = None
 
 
 # Language constant the omnigent YAML translator stamps on callable-backed
@@ -8458,6 +8469,8 @@ def create_runner_app(
             workspace: str | None = None
             agent_id: str | None = None
             sub_agent_name: str | None = None
+            parent_session_id: str | None = None
+            agent_name: str | None = None
             try:
                 resp = await server_client.get(f"/v1/sessions/{session_id}")
                 status_code = resp.status_code
@@ -8480,6 +8493,15 @@ def create_runner_app(
                     raw_sub_agent = body.get("sub_agent_name")
                     if isinstance(raw_sub_agent, str) and raw_sub_agent:
                         sub_agent_name = raw_sub_agent
+                    # Parent linkage + agent label, so a native sub-agent's
+                    # terminal status can rebuild a lost work entry and deliver
+                    # to the parent inbox.
+                    raw_parent = body.get("parent_session_id")
+                    if isinstance(raw_parent, str) and raw_parent:
+                        parent_session_id = raw_parent
+                    raw_agent_name = body.get("agent_name")
+                    if isinstance(raw_agent_name, str) and raw_agent_name:
+                        agent_name = raw_agent_name
             except Exception:  # noqa: BLE001 — best-effort; created_at falls back to wall time
                 pass
             snapshot = _SessionSnapshot(
@@ -8489,6 +8511,8 @@ def create_runner_app(
                 workspace=workspace,
                 agent_id=agent_id,
                 sub_agent_name=sub_agent_name,
+                parent_session_id=parent_session_id,
+                agent_name=agent_name,
             )
             # Cache only a complete snapshot. A 200 with agent_id still
             # null means the agent has not bound yet; caching it would
@@ -10332,6 +10356,47 @@ def create_runner_app(
         if name:
             _session_sub_agent_names[conv_id] = name
         return name
+
+    async def _ensure_subagent_work_entry(conv_id: str) -> _SubagentWorkEntry | None:
+        """Rebuild a sub-agent's work entry from the snapshot when it is missing.
+
+        The work entry that delivers a completion to the parent inbox lives only
+        in this runner's memory. It goes missing two ways — a reconnect / restart
+        wiped ``_subagent_work_by_child`` mid-turn, or a ``sys_session_create``
+        child never registered one (the server records a ``parent_session_id``
+        but no ``sub_agent_name``) — and the terminal status is then dropped
+        without waking the parent. Recover the parent linkage from the server
+        snapshot and re-register.
+
+        Best-effort: returns ``None`` for a top-level session or an unavailable
+        snapshot, preserving the prior no-op for non-sub-agent senders.
+
+        :param conv_id: Child session id whose terminal status just arrived,
+            e.g. ``"conv_child456"``.
+        :returns: The existing or reconstructed work entry, or ``None`` when the
+            session has no recoverable parent.
+        """
+        existing = get_subagent_work(conv_id)
+        if existing is not None:
+            return existing
+        if conv_id in _drained_delivered_subagent_children:
+            # Already delivered and drained; rebuilding would discard the
+            # tombstone and re-deliver a duplicate. Leave it as a no-op.
+            return None
+        try:
+            snapshot = await _session_snapshot(conv_id)
+        except Exception:  # noqa: BLE001 — best-effort recovery
+            return None
+        parent_id = snapshot.parent_session_id
+        if not parent_id or parent_id == conv_id:
+            return None
+        agent = snapshot.sub_agent_name or snapshot.agent_name or "sub-agent"
+        return register_subagent_work(
+            parent_session_id=parent_id,
+            child_session_id=conv_id,
+            agent=agent,
+            title=snapshot.sub_agent_name or "",
+        )
 
     def _session_harness_name(conv_id: str) -> str | None:
         """
@@ -15034,6 +15099,7 @@ def create_runner_app(
             forwarded_output = data.get("output") if isinstance(data, dict) else None
             output = forwarded_output if isinstance(forwarded_output, str) else None
             delivery_ack: _SubagentDeliveryAck | None = None
+            recovered_entry: _SubagentWorkEntry | None = None
             # Keep this allowlist in sync with Omnigent server's
             # ``_EXTERNAL_SESSION_STATUS_VALUES``. These events are produced by
             # native terminal forwarders, so AP-forwarded output is the only
@@ -15046,6 +15112,11 @@ def create_runner_app(
                     latest_assistant_text=output,
                     allow_history_preview_fallback=False,
                 )
+            if status in ("idle", "failed"):
+                # Rebuild a lost / never-registered work entry from the snapshot
+                # first, so a reconnect-wiped map or a sys_session_create child
+                # still wakes the parent instead of being dropped.
+                recovered_entry = await _ensure_subagent_work_entry(conversation_id)
             if status == "idle":
                 # Native transcripts are owned by AP. If Omnigent did not forward
                 # output for this idle edge, deliver an explicit empty result
@@ -15062,9 +15133,15 @@ def create_runner_app(
                     output=output or "Error: native sub-agent turn failed",
                 )
             if delivery_ack is not None:
+                # Known sub-agent when the in-memory map names it OR the snapshot
+                # recovered a parent link — so an undelivered terminal status
+                # returns 503 (forwarder retries) instead of a silent 204.
+                is_known = (
+                    conversation_id in _session_sub_agent_names or recovered_entry is not None
+                )
                 not_confirmed = _subagent_delivery_not_confirmed_response(
                     delivery_ack,
-                    is_runner_known_subagent=conversation_id in _session_sub_agent_names,
+                    is_runner_known_subagent=is_known,
                 )
                 if not_confirmed is not None:
                     return not_confirmed

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -1,0 +1,350 @@
+"""Native sub-agent completions must reach the parent inbox.
+
+A native CLI sub-agent's completion is the forwarder's ``external_session_status:
+idle`` (or ``failed``) event POSTed to the child's ``/events``. The runner turns
+that into a ``sub_agent`` payload in the parent's async inbox (``sys_read_inbox``)
+so the orchestrator wakes instead of busy-polling ``sys_session_get_history``.
+
+Delivery is dropped whenever the runner's in-memory work entry for the child is
+missing — a reconnect / restart wiped ``_subagent_work_by_child`` mid-turn, or a
+``sys_session_create`` child never registered one (the server records a
+``parent_session_id`` but no ``sub_agent_name``). The old code then returned
+HTTP 204 and lost the completion. The fix rebuilds the entry from the server
+snapshot before delivering, and returns 503 (so the forwarder retries) when
+delivery still can't be confirmed on this runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from omnigent.runner import app as runner_app
+from omnigent.runner import create_runner_app
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+# Reuse the proven runner-turn stubs from the sessions-native suite.
+from tests.runner.helpers import NullServerClient
+from tests.runner.test_app_sessions_native import (
+    _FakeProcessManager,
+    _runner_client,
+    _ScriptedHarnessClient,
+)
+
+PARENT_SESSION_ID = "conv_parent_orchestrator"
+CHILD_SESSION_ID = "conv_child_reviewer"
+
+
+@pytest.fixture
+def _clean_subagent_registry() -> Iterator[None]:
+    """Snapshot and restore the process-wide sub-agent / inbox maps.
+
+    The sub-agent work registry and inbox queues live in module-level dicts on
+    ``omnigent.runner.app`` that otherwise leak across tests. Clear them before
+    the test and restore the originals after.
+    """
+    saved = (
+        dict(runner_app._subagent_work_by_child),
+        {k: set(v) for k, v in runner_app._subagent_work_by_parent.items()},
+        dict(runner_app._session_inboxes_ref),
+        set(runner_app._drained_delivered_subagent_children),
+    )
+    runner_app._subagent_work_by_child.clear()
+    runner_app._subagent_work_by_parent.clear()
+    runner_app._session_inboxes_ref.clear()
+    runner_app._drained_delivered_subagent_children.clear()
+    try:
+        yield
+    finally:
+        runner_app._subagent_work_by_child.clear()
+        runner_app._subagent_work_by_child.update(saved[0])
+        runner_app._subagent_work_by_parent.clear()
+        runner_app._subagent_work_by_parent.update(saved[1])
+        runner_app._session_inboxes_ref.clear()
+        runner_app._session_inboxes_ref.update(saved[2])
+        runner_app._drained_delivered_subagent_children.clear()
+        runner_app._drained_delivered_subagent_children.update(saved[3])
+
+
+class _SnapshotServerClient(NullServerClient):
+    """Server client whose ``GET /v1/sessions/{child}`` carries the sub-agent snapshot.
+
+    Mirrors ``SessionResponse`` (server routes/sessions.py): the authoritative
+    source the runner uses to rebuild a lost sub-agent work entry. The body is
+    configurable so a test can model a declared sub-agent (``sub_agent_name``
+    set), a ``sys_session_create`` child (``sub_agent_name`` null but
+    ``parent_session_id`` set + ``agent_name``), or a top-level session (no
+    parent). All other endpoints fall through to the empty-200 base.
+    """
+
+    def __init__(self, child_body: dict[str, Any]) -> None:
+        """Configure the JSON body returned for the child session GET."""
+        self._child_body = child_body
+
+    class _Resp:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self.status_code = 200
+            self._payload = payload
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    async def get(self, url: str, **kwargs: Any) -> Any:
+        del kwargs
+        if url.rstrip("/").endswith(CHILD_SESSION_ID):
+            return self._Resp(self._child_body)
+        if url.rstrip("/").endswith("/items"):
+            return self._Resp({"data": [], "has_more": False})
+        return self._Response()
+
+
+def _child_snapshot(
+    *,
+    sub_agent_name: str | None,
+    parent_session_id: str | None,
+    agent_name: str | None = "cursor-native-ui",
+) -> dict[str, Any]:
+    """Build a child ``SessionResponse``-shaped body."""
+    return {
+        "id": CHILD_SESSION_ID,
+        "agent_id": "ag_reviewer",
+        "agent_name": agent_name,
+        "sub_agent_name": sub_agent_name,
+        "parent_session_id": parent_session_id,
+        "created_at": 0,
+        "workspace": None,
+    }
+
+
+async def _post_native_idle(
+    *,
+    child_body: dict[str, Any],
+    seed_parent_inbox: bool,
+    register_work: bool,
+    output: str = "review complete: LGTM",
+) -> tuple[int, list[dict[str, Any]]]:
+    """POST a native ``external_session_status: idle`` and return (http, inbox items).
+
+    Models the forwarder reporting a finished native sub-agent turn.
+    ``register_work`` seeds the in-memory work entry (the healthy case); leaving
+    it ``False`` models a reconnect-wiped map or a ``sys_session_create`` child
+    the dispatch never registered. ``seed_parent_inbox`` controls whether the
+    parent's inbox queue is present on this runner.
+    """
+    if seed_parent_inbox:
+        runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    if register_work:
+        runner_app.register_subagent_work(
+            parent_session_id=PARENT_SESSION_ID,
+            child_session_id=CHILD_SESSION_ID,
+            agent="reviewer",
+            title="review",
+        )
+
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return AgentSpec(
+            spec_version=1,
+            name="reviewer",
+            executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+        )
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_SnapshotServerClient(child_body),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{CHILD_SESSION_ID}/events",
+            json={
+                "type": "external_session_status",
+                "data": {"status": "idle", "output": output},
+            },
+        )
+
+    inbox = runner_app._session_inboxes_ref.get(PARENT_SESSION_ID)
+    items: list[dict[str, Any]] = []
+    if inbox is not None:
+        while not inbox.empty():
+            items.append(inbox.get_nowait())
+    return resp.status_code, items
+
+
+@pytest.mark.asyncio
+async def test_native_completion_recovers_reconnect_wiped_work_entry(
+    _clean_subagent_registry: None,
+) -> None:
+    """A declared native sub-agent still delivers after its work entry was lost.
+
+    With no in-memory work entry (a reconnect wiped it mid-turn), the idle edge
+    dropped silently on the old code. The fix rebuilds the entry from the
+    snapshot's ``parent_session_id`` + ``sub_agent_name`` and delivers.
+    """
+    http, items = await _post_native_idle(
+        child_body=_child_snapshot(sub_agent_name="reviewer", parent_session_id=PARENT_SESSION_ID),
+        seed_parent_inbox=True,
+        register_work=False,
+    )
+
+    assert items, (
+        "native sub-agent reported idle but nothing was delivered to the parent "
+        "inbox: the work entry was missing (reconnect-wiped) and the idle edge "
+        f"was silently 204-acked. (http={http})"
+    )
+    payload = items[0]
+    assert payload["type"] == "sub_agent"
+    assert payload["conversation_id"] == CHILD_SESSION_ID
+    assert payload["status"] == "completed"
+    assert payload["output"] == "review complete: LGTM"
+
+
+@pytest.mark.asyncio
+async def test_sys_session_create_child_without_sub_agent_name_delivers(
+    _clean_subagent_registry: None,
+) -> None:
+    """A ``sys_session_create`` child (no ``sub_agent_name``) still wakes the parent.
+
+    The child has ``agent_name: cursor-native-ui`` but ``sub_agent_name: null``,
+    and the dispatch never registered a work entry. The fix recovers the parent
+    link from the snapshot (keying on ``parent_session_id``) and labels the work
+    with the agent name.
+    """
+    http, items = await _post_native_idle(
+        child_body=_child_snapshot(
+            sub_agent_name=None,
+            parent_session_id=PARENT_SESSION_ID,
+            agent_name="cursor-native-ui",
+        ),
+        seed_parent_inbox=True,
+        register_work=False,
+    )
+
+    assert items, (
+        f"sys_session_create child reported idle but the parent inbox stayed empty. (http={http})"
+    )
+    assert items[0]["status"] == "completed"
+    assert items[0]["agent"] == "cursor-native-ui"
+
+
+@pytest.mark.asyncio
+async def test_healthy_registered_work_entry_still_delivers(
+    _clean_subagent_registry: None,
+) -> None:
+    """Control: the normal path (work entry present) keeps delivering.
+
+    Guards against the fix regressing the common case where dispatch already
+    registered the work entry on this runner.
+    """
+    http, items = await _post_native_idle(
+        child_body=_child_snapshot(sub_agent_name="reviewer", parent_session_id=PARENT_SESSION_ID),
+        seed_parent_inbox=True,
+        register_work=True,
+    )
+
+    assert http == 204
+    assert items and items[0]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_undeliverable_native_completion_returns_503_not_silent_204(
+    _clean_subagent_registry: None,
+) -> None:
+    """A recoverable sub-agent whose parent inbox is elsewhere must 503, not 204.
+
+    When the parent inbox is not on this runner (the parent lives on a different
+    runner, or the runner restarted and lost it), delivery cannot be confirmed.
+    The handler must return 503 so the forwarder retries and server-side recovery
+    re-routes to the parent's runner — instead of a silent 204 that drops it.
+    """
+    http, items = await _post_native_idle(
+        child_body=_child_snapshot(sub_agent_name="reviewer", parent_session_id=PARENT_SESSION_ID),
+        seed_parent_inbox=False,
+        register_work=False,
+    )
+
+    assert http == 503, (
+        "an undeliverable native sub-agent completion was acked with "
+        f"http={http}; expected 503 so the forwarder retries. Items={items!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_replayed_idle_after_drain_does_not_redeliver(
+    _clean_subagent_registry: None,
+) -> None:
+    """The recovery must not re-deliver a child already delivered and drained.
+
+    Guards the snapshot-recovery arm against a duplicate: once a completion was
+    delivered and the parent drained it, the runner keeps a delivered tombstone.
+    A replayed idle whose snapshot *does* carry a ``parent_session_id`` (the
+    production shape) must NOT rebuild the work entry and re-enqueue — it stays a
+    benign already-delivered 204. (The existing suite's dedup test uses a stub
+    snapshot with no parent, so it would not catch a recovery-induced re-deliver.)
+    """
+    child_body = _child_snapshot(sub_agent_name="reviewer", parent_session_id=PARENT_SESSION_ID)
+    # First completion delivers normally.
+    http1, items1 = await _post_native_idle(
+        child_body=child_body, seed_parent_inbox=True, register_work=True
+    )
+    assert http1 == 204
+    assert len(items1) == 1  # drained by the helper
+
+    # Mark the child delivered-and-drained, exactly as sys_read_inbox does.
+    runner_app.unregister_subagent_work(CHILD_SESSION_ID, remember_drained_delivery=True)
+    assert runner_app.get_subagent_work(CHILD_SESSION_ID) is None
+
+    # Replay the idle — snapshot carries a parent, so a naive recovery would
+    # rebuild the entry and re-deliver. The tombstone guard must prevent that.
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return AgentSpec(
+            spec_version=1,
+            name="reviewer",
+            executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+        )
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_SnapshotServerClient(child_body),  # type: ignore[arg-type]
+    )
+    inbox = runner_app._session_inboxes_ref[PARENT_SESSION_ID]
+    async with _runner_client(app) as client:
+        replay = await client.post(
+            f"/v1/sessions/{CHILD_SESSION_ID}/events",
+            json={"type": "external_session_status", "data": {"status": "idle", "output": "x"}},
+        )
+
+    assert replay.status_code == 204
+    assert inbox.qsize() == 0, "replayed idle re-delivered a duplicate to the parent inbox"
+
+
+@pytest.mark.asyncio
+async def test_top_level_session_idle_is_noop(
+    _clean_subagent_registry: None,
+) -> None:
+    """A top-level session (no parent) idle edge stays a quiet 204 no-op.
+
+    Ensures the recovery arm does not mis-classify a non-sub-agent sender as a
+    sub-agent and start 503-ing or fabricating inbox deliveries.
+    """
+    http, items = await _post_native_idle(
+        child_body=_child_snapshot(sub_agent_name=None, parent_session_id=None),
+        seed_parent_inbox=True,
+        register_work=False,
+    )
+
+    assert http == 204
+    assert items == []

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -6391,41 +6391,6 @@ async def test_compaction_in_progress_does_not_persist(tmp_path: Path) -> None:
     persist_mock.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_post_external_session_status_attaches_failure_reason() -> None:
-    """A failed status carries its reason as ``output`` in the payload (#1113).
-
-    The server's ``external_session_status`` handler surfaces a failed edge's
-    ``output`` as the session's failure detail, so threading the forwarder's
-    drop reason there makes the UI render it instead of a bare "failed".
-    """
-    captured: list[dict[str, Any]] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/v1/sessions/conv_x/events":
-            captured.append(json.loads(request.content))
-            return httpx.Response(204)
-        return httpx.Response(404)
-
-    transport = httpx.MockTransport(handler)
-    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
-        await forwarder._post_external_session_status(
-            client,
-            session_id="conv_x",
-            status="failed",
-            output="transcript item item-1 rejected",
-        )
-        # No reason → no output field (e.g. a normal idle edge).
-        await forwarder._post_external_session_status(client, session_id="conv_x", status="idle")
-
-    assert captured[0]["type"] == "external_session_status"
-    assert captured[0]["data"] == {
-        "status": "failed",
-        "output": "transcript item item-1 rejected",
-    }
-    assert captured[1]["data"] == {"status": "idle"}
-
-
 def test_forward_failures_escalate_to_degraded_once() -> None:
     """
     Sustained forward failures flip the degraded latch exactly once (#1120).

--- a/tests/test_cursor_native_usage.py
+++ b/tests/test_cursor_native_usage.py
@@ -287,6 +287,20 @@ async def _run_loop_until(
             await task
 
 
+def _usage_posts(client: _CtxRecordingClient) -> list[tuple[str, dict]]:
+    """Only the ``external_session_usage`` POSTs (excludes the idle wake edges)."""
+    return [(u, b) for (u, b) in client.posts if b.get("type") == "external_session_usage"]
+
+
+def _idle_posts(client: _CtxRecordingClient) -> list[tuple[str, dict]]:
+    """Only the ``external_session_status: idle`` turn-end wake POSTs."""
+    return [
+        (u, b)
+        for (u, b) in client.posts
+        if b.get("type") == "external_session_status" and b.get("data", {}).get("status") == "idle"
+    ]
+
+
 @pytest.mark.asyncio
 class TestForwardLoop:
     async def test_posts_cumulative_usage_and_persists(
@@ -297,9 +311,9 @@ class TestForwardLoop:
         client = await _run_loop_until(
             monkeypatch,
             tmp_path,
-            lambda c: len(c.posts) >= 1 and usage._read_usage_state(tmp_path).seen == {"g1", "g2"},
+            lambda c: _usage_posts(c) and usage._read_usage_state(tmp_path).seen == {"g1", "g2"},
         )
-        url, body = client.posts[0]
+        url, body = _usage_posts(client)[0]
         assert url == "/v1/sessions/conv_1/events"
         assert body["type"] == "external_session_usage"
         assert body["data"] == {
@@ -316,23 +330,83 @@ class TestForwardLoop:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         usage.record_usage_payload(tmp_path, _TURN1)
-        client = await _run_loop_until(monkeypatch, tmp_path, lambda c: len(c.posts) >= 1)
-        # Let several more polls run; with no new turns there must be no 2nd POST.
+        client = await _run_loop_until(monkeypatch, tmp_path, _usage_posts)
+        # Let several more polls run; with no new turns there must be no 2nd
+        # usage POST and no further idle edge.
         await asyncio.sleep(0.1)
-        assert len(client.posts) == 1
+        assert len(_usage_posts(client)) == 1
+        assert len(_idle_posts(client)) == 1
 
     async def test_new_turn_triggers_followup_post(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         usage.record_usage_payload(tmp_path, _TURN1)
         client = _CtxRecordingClient()
-        # First POST covers turn 1.
-        await _run_loop_until(monkeypatch, tmp_path, lambda c: len(c.posts) >= 1, client=client)
+        # First usage POST covers turn 1.
+        await _run_loop_until(monkeypatch, tmp_path, _usage_posts, client=client)
         # Append a second turn and run again: a fresh cumulative POST must land.
         usage.record_usage_payload(tmp_path, _TURN2)
-        await _run_loop_until(monkeypatch, tmp_path, lambda c: len(c.posts) >= 2, client=client)
-        _, body = client.posts[-1]
+        await _run_loop_until(
+            monkeypatch, tmp_path, lambda c: len(_usage_posts(c)) >= 2, client=client
+        )
+        _, body = _usage_posts(client)[-1]
         assert body["data"]["cumulative_output_tokens"] == 5 + 120
+
+    async def test_completed_turn_posts_idle_wake_edge(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completed cursor turn posts external_session_status: idle.
+
+        This is the edge the runner turns into a parent-inbox wake for a cursor
+        sub-agent. Without it, a cursor child finishes with its review only in
+        its own transcript and the parent orchestrator is never woken.
+        """
+        usage.record_usage_payload(tmp_path, _TURN1)
+        client = await _run_loop_until(monkeypatch, tmp_path, _idle_posts)
+        url, body = _idle_posts(client)[0]
+        assert url == "/v1/sessions/conv_1/events"
+        assert body == {"type": "external_session_status", "data": {"status": "idle"}}
+
+    async def test_idle_posted_once_per_turn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each completed turn wakes the parent exactly once within a run."""
+        usage.record_usage_payload(tmp_path, _TURN1)
+        client = _CtxRecordingClient()
+        await _run_loop_until(monkeypatch, tmp_path, _idle_posts, client=client)
+        await asyncio.sleep(0.1)  # extra polls: turn 1 must not re-wake
+        assert len(_idle_posts(client)) == 1
+        # A second turn yields exactly one more idle edge.
+        usage.record_usage_payload(tmp_path, _TURN2)
+        await _run_loop_until(
+            monkeypatch, tmp_path, lambda c: len(_idle_posts(c)) >= 2, client=client
+        )
+        await asyncio.sleep(0.1)
+        assert len(_idle_posts(client)) == 2
+
+    async def test_restart_reposts_idle_for_dedup_not_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A restart re-posts idle (server dedupes) rather than risk skipping a wake.
+
+        The idle counter is NOT seeded from persisted usage: if it were, a wake
+        whose idle POST crashed after the usage flush persisted would be skipped
+        forever. Seeding at 0 makes a restart re-post at most one idle, which the
+        server treats as an already-delivered no-op.
+        """
+        # First run: turn 1 usage persisted.
+        usage.record_usage_payload(tmp_path, _TURN1)
+        first = _CtxRecordingClient()
+        await _run_loop_until(monkeypatch, tmp_path, _idle_posts, client=first)
+        assert usage._read_usage_state(tmp_path).seen == {"g1"}
+
+        # Fresh loop (simulated restart) over the SAME bridge dir, no new turns:
+        # idle is re-posted so a lost pre-crash wake still lands.
+        second = _CtxRecordingClient()
+        await _run_loop_until(monkeypatch, tmp_path, _idle_posts, client=second)
+        await asyncio.sleep(0.1)
+        # Exactly one re-post — the single already-seen turn, not a loop.
+        assert len(_idle_posts(second)) == 1
 
     async def test_failed_post_is_not_persisted(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -15,6 +15,7 @@ from omnigent._native_post_delivery import (
     RepostResult,
     _dead_letter_record_replayable,
     append_dead_letter,
+    post_external_session_status,
     post_may_have_been_delivered,
     replay_dead_letters,
 )
@@ -630,3 +631,38 @@ async def test_retry_loop_success_clears_a_prior_connectivity_failure() -> None:
         assert health.recent_post_failure(60.0) is None
     finally:
         health.clear()
+
+
+@pytest.mark.asyncio
+async def test_post_external_session_status_attaches_failure_reason() -> None:
+    """A failed status carries its reason as ``output``; idle omits it.
+
+    The server surfaces a failed edge's ``output`` as the session's failure
+    detail, so threading a drop reason there renders it instead of a bare
+    "failed"; a normal idle edge sends a bare status with no output field.
+    """
+    captured: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/conv_x/events":
+            captured.append(json.loads(request.content))
+            return httpx.Response(204)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        await post_external_session_status(
+            client,
+            session_id="conv_x",
+            status="failed",
+            output="transcript item item-1 rejected",
+        )
+        # No reason → no output field (e.g. a normal idle edge).
+        await post_external_session_status(client, session_id="conv_x", status="idle")
+
+    assert captured[0]["type"] == "external_session_status"
+    assert captured[0]["data"] == {
+        "status": "failed",
+        "output": "transcript item item-1 rejected",
+    }
+    assert captured[1]["data"] == {"status": "idle"}


### PR DESCRIPTION
## Related issue

Closes #848

## Summary

A native CLI sub-agent's completion only reaches the parent orchestrator's inbox (waking it) when an `external_session_status: idle` POST hits the runner, which rebuilds delivery via an in-memory work entry. Two independent gaps broke this for native sub-agents:

- **Lost work entry → silent 204 (runner).** The work entry registered at dispatch is in-memory only, so it's missing after a runner reconnect/restart, or was never registered for a `sys_session_create` child (the server records a `parent_session_id` but no `sub_agent_name`). The idle handler then found no entry and returned a silent 204, dropping the completion. The runner now rebuilds the entry from the server snapshot's parent linkage, and returns 503 (so the forwarder retries) when delivery still can't be confirmed on this runner.
- **cursor-native never posted the turn-end idle at all.** Its forwarder mirrors only conversation items, and the PTY-activity watcher is suppressed for cursor-native — so nothing triggered delivery. cursor-agent fires a `stop` hook once per completed turn (currently used for token usage); the usage forwarder now also posts `external_session_status: idle` on each newly-observed turn — the authoritative wake edge. Idle delivery is idempotent, so a restart re-posts (server dedupes) rather than risk skipping a wake.

The `external_session_status` POST helper is extracted to the shared `_native_post_delivery` module so the claude-native and cursor-native forwarders share one implementation.

Note: an audit suggests other native harnesses (qwen/goose/kimi/hermes/kiro/pi) may share cursor's missing-idle gap; that's left as a follow-up pending verification that they're used as sub-agents.

## Test Plan

- `pytest tests/runner/test_native_subagent_inbox_delivery.py` — new suite: reconnect-wiped work entry recovered, `sys_session_create` child (null `sub_agent_name`) delivered, undeliverable → 503, replayed idle after drain not re-delivered, top-level no-op.
- `pytest tests/test_cursor_native_usage.py` — new: idle posted per completed turn, once-per-turn, restart re-posts (dedup not skip); existing usage assertions updated to filter by event type.
- `pytest tests/test_native_post_delivery.py` — moved `external_session_status` shape test onto the shared helper.
- `pytest tests/test_claude_native_forwarder.py`, `tests/runner/test_app_sessions_native.py -k "external_session_status or idle or subagent or drain"` — no regressions.
- All green; `ruff format` + `ruff check` clean.
- **Manual, live:** launched polly with a cursor reviewer via `sys_session_create`; before the fix the parent parked idle with an empty `sys_read_inbox`; after, the parent receives `[System: sub-agent ... finished — result waiting in inbox]` and `sys_read_inbox` returns the review.

## Demo

Before: the sub-agent finishes the review but it's never delivered to the parent

<img width="1698" height="636" alt="image" src="https://github.com/user-attachments/assets/e271ef5c-498a-4733-832b-601e5bf1e342" />

After: the parent correctly pulls the result from sub-agent
<img width="1711" height="701" alt="image" src="https://github.com/user-attachments/assets/f42fe599-b963-42bf-8be6-b8b93a5741eb" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit suites cover both halves of the fix (work-entry recovery in the runner; cursor-native idle emission in the usage forwarder), including the failure/retry and dedup edges. Manual verification reproduced the original bug (polly + cursor sub-agent via `sys_session_create`) and confirmed the parent now wakes and collects the result. The full delivery path (server → runner → forwarder relaunch) can't be exercised in unit tests; the live polly run covers it end to end.
