### PR TITLE
docs(agents): instruct running pre-commit hook before committing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,12 @@
 Guidance for AI agents (Claude Code, Copilot, Cursor, etc.) working in this
 repository. See `CONTRIBUTING.md` for the full contributor workflow.
 
+## Committing
+
+Run the `pre-commit` hook before committing (`pre-commit run --all-files`, or
+let it run on staged files via `git commit`). Fix any issues it reports so the
+commit lands clean — CI runs the same checks.
+
 ## Pull requests
 
 When you open a pull request, fill in the repo's PR template at


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a **Committing** section to `AGENTS.md` instructing AI agents to run the
  `pre-commit` hook before committing (via `pre-commit run --all-files` or
  letting `git commit` run it on staged files).
- Notes that CI runs the same checks, so fixing hook issues locally keeps the
  commit landing clean.

## Test Plan

Docs-only change. Verified the rendered Markdown reads correctly; no code paths
affected.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change to `AGENTS.md`; no automated test coverage applicable.

This pull request and its description were written by Isaac.
