### PR TITLE
fix(doc-sync): resolve merged PR reliably and honor existing labels

### DIFF
--- a/.github/agents/doc-classifier/config.yaml
+++ b/.github/agents/doc-classifier/config.yaml
@@ -43,6 +43,12 @@ prompt: |
   2. **Integration update** — a harness, model provider, MCP / tool, sandbox, or
      deploy target is **added, removed, or changes how it is configured**
      (e.g. "add Kiro to the setup harness menu", "add a new sandbox provider").
+  3. **Built-in policy update** — a built-in contextual policy is **added,
+     removed, or has its configurable behavior/parameters changed**. These live
+     under `omnigent/policies/builtins/` (e.g. `context.py`, `routing.py`,
+     `safety.py`) and are a user-facing surface people configure by name, so each
+     one has a docs entry. A new file or a new policy factory there (e.g. "add
+     `detect_task_switch` builtin policy") is **always needs-doc-update**.
 
   ## Never doc-worthy (choose no-doc-update)
   - Internal bugfixes that do NOT change documented behavior
@@ -58,9 +64,10 @@ prompt: |
   no-doc-update — be conservative: only choose **needs-doc-update** when a
   user-facing surface or an integration genuinely changed. Infer the nature of the
   change from the code: a new harness/provider/tool/sandbox/deploy target, a new
-  or changed CLI flag or config key, or a changed user-facing default lean
-  needs-doc; pure internal refactors, perf, tests, CI, build, and bugfixes that
-  don't alter documented behavior lean no-doc.
+  built-in policy under `omnigent/policies/builtins/`, a new or changed CLI flag
+  or config key, or a changed user-facing default lean needs-doc; pure internal
+  refactors, perf, tests, CI, build, and bugfixes that don't alter documented
+  behavior lean no-doc.
 
   ## Security
   You are running in CI with access to secrets. Never echo secrets, tokens, or

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -64,34 +64,71 @@ jobs:
         run: |
           set -euo pipefail
           python3 -u <<'PYEOF'
-          import json, os, subprocess
+          import json, os, re, subprocess, time
           NEEDS, NO = "needs-doc-update", "no-doc-update"
           event = os.environ.get("GITHUB_EVENT_NAME", "")
           payload = json.load(open(os.environ["GITHUB_EVENT_PATH"]))
           classify = predraft = False
           pr = author = title = merger = ""
+          labels = []
 
           repo = os.environ["CODE_REPO"]
           if event == "workflow_dispatch":
               pr = os.environ.get("INPUT_PR", "").strip()
               meta = json.loads(subprocess.run(
                   ["gh", "pr", "view", pr, "--repo", repo,
-                   "--json", "author,title,mergedBy"], capture_output=True, text=True).stdout or "{}")
+                   "--json", "author,title,mergedBy,labels"], capture_output=True, text=True).stdout or "{}")
               author = (meta.get("author") or {}).get("login", "")
               merger = (meta.get("mergedBy") or {}).get("login", "")
               title = meta.get("title", "")
-              classify = True  # manual run: classify, and draft if needs-doc
+              labels = [l.get("name", "") for l in (meta.get("labels") or [])]
           elif event == "push":
               # Resolve the merged PR from the push tip — works for fork and internal
               # PRs (trusted main history, not a PR event). Single-tip assumption: a
               # normal merge is one push whose tip is the merge commit; a push carrying
               # MULTIPLE merges (merge queue / batched) only processes the tip's PR.
               sha = os.environ.get("GITHUB_SHA", "")
-              out = subprocess.run(
-                  ["gh", "api", f"repos/{repo}/commits/{sha}/pulls", "--jq",
-                   "[.[] | {number, author: (.user.login // \"\"), title, labels: [.labels[].name]}]"],
-                  capture_output=True, text=True).stdout.strip()
-              prs = json.loads(out) if out else []
+
+              # GitHub's commit→PR association index is populated asynchronously,
+              # so a query fired seconds after the merge can return [] even though
+              # the PR exists (eventual consistency — observed a ~7s lag). Retry
+              # with backoff before concluding there's no PR.
+              def query_pulls():
+                  out = subprocess.run(
+                      ["gh", "api", f"repos/{repo}/commits/{sha}/pulls", "--jq",
+                       "[.[] | {number, author: (.user.login // \"\"), title, labels: [.labels[].name]}]"],
+                      capture_output=True, text=True).stdout.strip()
+                  return json.loads(out) if out else []
+
+              prs = []
+              for delay in (0, 3, 6, 9):
+                  if delay:
+                      time.sleep(delay)
+                  prs = query_pulls()
+                  if prs:
+                      break
+
+              # Fallback: the index never caught up (or this merge strategy isn't
+              # indexed). The squash/merge commit subject embeds the PR number, so
+              # parse it from the push payload (the repo isn't checked out yet at
+              # this step) and fetch that PR directly.
+              if not prs:
+                  subject = (((payload.get("head_commit") or {}).get("message") or "")
+                             .splitlines() or [""])[0]
+                  m = (re.search(r"\(#(\d+)\)\s*$", subject)
+                       or re.search(r"^Merge pull request #(\d+)", subject))
+                  if m:
+                      num = m.group(1)
+                      meta = json.loads(subprocess.run(
+                          ["gh", "api", f"repos/{repo}/pulls/{num}", "--jq",
+                           "{number, author: (.user.login // \"\"), title, "
+                           "labels: [.labels[].name]}"],
+                          capture_output=True, text=True).stdout or "{}")
+                      if meta.get("number"):
+                          print(f"::notice::commit {sha[:8]} not in PR index yet; "
+                                f"resolved #{num} from the commit subject.")
+                          prs = [meta]
+
               if not prs:
                   print(f"::notice::commit {sha[:8]} has no associated PR (direct push?) — nothing to do.")
               else:
@@ -107,12 +144,19 @@ jobs:
                   merger = subprocess.run(
                       ["gh", "api", f"repos/{repo}/pulls/{pr}", "--jq", ".merged_by.login // \"\""],
                       capture_output=True, text=True).stdout.strip()
-                  if NO in labels:
-                      pass                       # human set no-doc-update → skip
-                  elif NEEDS in labels:
-                      predraft = True            # human set needs-doc-update → draft
-                  else:
-                      classify = True            # unlabeled → let the classifier decide
+
+          # Label-driven decision, shared by push and manual runs. A pre-existing
+          # label is authoritative — trust it and skip the (slow, costly) classifier:
+          #   no-doc-update    → skip entirely
+          #   needs-doc-update → draft directly
+          #   unlabeled        → let the classifier decide
+          if pr:
+              if NO in labels:
+                  pass                           # already labeled no-doc → skip
+              elif NEEDS in labels:
+                  predraft = True                # already labeled needs-doc → draft
+              else:
+                  classify = True                # unlabeled → classify
 
           proceed = classify or predraft
           out = os.environ["GITHUB_OUTPUT"]


### PR DESCRIPTION
## Related issue

N/A

## Summary

The **Doc sync** workflow's `Plan` step resolves the merged PR from the push tip by querying GitHub's `commits/{sha}/pulls` association index. That index is populated **asynchronously**, so a query fired seconds after merge can return `[]` even though the PR exists. On [run 28492050401](https://github.com/omnigent-ai/omnigent/actions/runs/28492050401) the query ran ~7s after PR #1742 merged and hit that lag — the workflow logged *"commit e90d38bb has no associated PR (direct push?) — nothing to do"* and skipped classification/drafting entirely. (The same query returns #1742 fine now that the index caught up.)

This PR hardens PR resolution and tightens two related decisions:

- **Retry + fallback for PR resolution.** Retry the `commits/{sha}/pulls` query with backoff (0/3/6/9s) to ride out the indexing lag; if it's *still* empty, fall back to parsing the PR number from the merge/squash commit subject (`(#1742)` / `Merge pull request #1742`) in the push payload and fetch that PR directly. The fallback is index-independent, so it works even if the association is never indexed. A `::notice::` marks when the fallback fires.
- **Honor pre-existing labels on all paths.** The inline label check previously ran only on the `push` path; manual `workflow_dispatch` runs always classified. Moved it into a shared, label-driven decision: `no-doc-update` → skip, `needs-doc-update` → draft directly, unlabeled → classify. A human-set label now short-circuits the costly classifier turn regardless of trigger.
- **Built-in policies are doc-worthy.** Taught the `doc-classifier` that any add/remove/param-change to a built-in policy under `omnigent/policies/builtins/` is **always** `needs-doc-update` — the exact case that slipped through (`detect_task_switch`, #1742).

⚠️ Behavior change: manually re-running to *force* re-classification now requires removing the label first, since a label is treated as authoritative.

## Test Plan

- `python3 -c` parse check: workflow YAML + the embedded Plan-step Python both parse (`ast.parse`); classifier `config.yaml` parses and contains the new built-in-policy guidance.
- Unit-tested the fallback's PR-number regex against real commit subjects — `feat(...): ... (#1742)`, `Merge pull request #1742 from ...`, `fix(...): ... (#1749)` → correct number; `chore: bump deps` and a body-only `(#123)` mention → no match (no false positives).
- Verified against the failing run: the current `commits/e90d38bb.../pulls` query now returns PR #1742, confirming the diagnosis was an indexing race and not a genuinely PR-less commit.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [x] Not applicable

## Coverage notes

The changed logic lives entirely inside a GitHub Actions workflow's inline Python heredoc and an agent prompt — neither is exercised by the repo's test suite. Verified manually: YAML/Python parse checks, the PR-number regex tested against representative commit subjects, and confirmation that the previously-failing association query now resolves PR #1742. The classifier prompt change is a natural-language rule with no automated harness.

This pull request and its description were written by Isaac.
