### PR TITLE
fix(web): keep settings sidebar put on Members/Policies sub-pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,27 +1,23 @@
 import { lazy, Suspense } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import { ChatPage } from "@/pages/ChatPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { AppShell } from "@/shell/AppShell";
 
-// Lazy-load the three accounts pages so the bundle a header / OIDC
+// Lazy-load the accounts pages so the bundle a header / OIDC
 // deploy ships (where accounts is off) doesn't include them in the
 // main entry chunk. They're separate chunks that only download
-// when the user actually navigates to /login, /register, /members
-// — which never happens in non-accounts deploys because the route
-// table below doesn't register them.
+// when the user actually navigates to /login or /register — which
+// never happens in non-accounts deploys because the route table
+// below doesn't register them. (Members / Policies are lazy-loaded
+// too, but inside SettingsPage now that they're settings
+// sub-categories rather than standalone routes.)
 const LoginPage = lazy(() => import("@/pages/LoginPage").then((m) => ({ default: m.LoginPage })));
 const RegisterPage = lazy(() =>
   import("@/pages/RegisterPage").then((m) => ({ default: m.RegisterPage })),
 );
-const MembersPage = lazy(() =>
-  import("@/pages/MembersPage").then((m) => ({ default: m.MembersPage })),
-);
 const SetupPage = lazy(() => import("@/pages/SetupPage").then((m) => ({ default: m.SetupPage })));
-const PoliciesPage = lazy(() =>
-  import("@/pages/PoliciesPage").then((m) => ({ default: m.PoliciesPage })),
-);
 const ApprovePage = lazy(() =>
   import("@/pages/ApprovePage").then((m) => ({ default: m.ApprovePage })),
 );
@@ -132,8 +128,19 @@ function App({ basename }: AppProps = {}) {
           <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
           {info.accounts_enabled && (
             <>
-              <Route path={`${prefix}/members`} element={<MembersPage />} />
-              <Route path={`${prefix}/policies`} element={<PoliciesPage />} />
+              {/* Members / Policies are now settings sub-categories
+                  (/settings/members, /settings/policies) so entering them
+                  keeps the settings sidebar nav instead of dropping back to
+                  the conversation list. Redirect the old standalone paths so
+                  existing bookmarks / links still land in the right place. */}
+              <Route
+                path={`${prefix}/members`}
+                element={<Navigate to={`${prefix}/settings/members`} replace />}
+              />
+              <Route
+                path={`${prefix}/policies`}
+                element={<Navigate to={`${prefix}/settings/policies`} replace />}
+              />
             </>
           )}
           <Route path={basename ? `${prefix}/*` : "*"} element={<NotFoundPage />} />

--- a/web/src/hooks/useMe.ts
+++ b/web/src/hooks/useMe.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { type CurrentAccount, getMe } from "@/lib/accountsApi";
+
+// Shared cache key for the current account (GET /auth/me). Both the settings
+// sidebar nav (to admin-gate the Members / Policies sub-categories) and the
+// Settings page sections read it, so keying them off one query avoids a
+// duplicate probe per mount.
+const QUERY_KEY = ["auth-me"];
+
+/**
+ * Fetch the current account (accounts auth only). `enabled` gates the request
+ * so non-accounts deploys — where `/auth/me` isn't meaningful — never fire it.
+ * Returns `null` when unauthenticated. Cached briefly so admin gating is
+ * instant across the sidebar + page without re-probing on every navigation.
+ */
+export function useMe(enabled = true) {
+  return useQuery<CurrentAccount | null>({
+    queryKey: QUERY_KEY,
+    queryFn: getMe,
+    enabled,
+    staleTime: 30_000,
+  });
+}

--- a/web/src/hooks/useMe.ts
+++ b/web/src/hooks/useMe.ts
@@ -1,17 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
 import { type CurrentAccount, getMe } from "@/lib/accountsApi";
 
-// Shared cache key for the current account (GET /auth/me). Both the settings
-// sidebar nav (to admin-gate the Members / Policies sub-categories) and the
-// Settings page sections read it, so keying them off one query avoids a
-// duplicate probe per mount.
+// Shared cache key for the current account (GET /auth/me). Consumers that read
+// through this hook share one query, so admin gating is instant and re-mounts
+// don't re-probe within the stale window. The settings sidebar nav uses it to
+// admin-gate the Members / Policies sub-categories.
+//
+// NOTE: the MembersPage / PoliciesPage still probe via a direct getMe() call
+// (their own loading / login-bounce state machine predates this hook), so they
+// don't yet share this cache — deduping those is a possible follow-up.
 const QUERY_KEY = ["auth-me"];
 
 /**
  * Fetch the current account (accounts auth only). `enabled` gates the request
  * so non-accounts deploys — where `/auth/me` isn't meaningful — never fire it.
  * Returns `null` when unauthenticated. Cached briefly so admin gating is
- * instant across the sidebar + page without re-probing on every navigation.
+ * instant across consumers of this hook without re-probing on every navigation.
  */
 export function useMe(enabled = true) {
   return useQuery<CurrentAccount | null>({

--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -1,5 +1,6 @@
 /**
- * Admin members management page (``/members``).
+ * Admin members management page (``/settings/members``; the legacy
+ * ``/members`` path redirects here). Rendered as a Settings sub-category.
  *
  * Lists every account on the server and lets admins:
  *

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -1,5 +1,6 @@
 /**
- * Admin default-policies management page (``/policies``).
+ * Admin default-policies management page (``/settings/policies``; the legacy
+ * ``/policies`` path redirects here). Rendered as a Settings sub-category.
  *
  * Lists every global default policy and lets admins add, toggle,
  * and remove them. The add-policy dialog reuses the same registry-

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -39,6 +39,15 @@ vi.mock("@/hooks/useConversations", () => ({
   useArchiveConversation: () => ({ mutate: mocks.archiveMutate, isPending: false }),
   useStopAndDeleteConversation: () => ({ mutate: mocks.deleteMutate, isPending: false }),
 }));
+// The admin management surfaces are lazy-loaded and own heavy data layers of
+// their own; stub them so these tests only assert SettingsPage's section
+// routing (that /settings/members and /settings/policies render the right one).
+vi.mock("@/pages/MembersPage", () => ({
+  MembersPage: () => <div>members-page-stub</div>,
+}));
+vi.mock("@/pages/PoliciesPage", () => ({
+  PoliciesPage: () => <div>policies-page-stub</div>,
+}));
 
 import { SettingsPage } from "./SettingsPage";
 
@@ -107,6 +116,37 @@ describe("SettingsPage", () => {
     mocks.accountsEnabled = false;
     renderPage("/settings/account");
     expect(screen.queryByText("alice")).toBeNull();
+  });
+
+  it("renders the Members section at /settings/members when accounts is on", async () => {
+    renderPage("/settings/members");
+    expect(await screen.findByText("members-page-stub")).toBeInTheDocument();
+    expect(screen.queryByText("policies-page-stub")).toBeNull();
+  });
+
+  it("renders the Policies section at /settings/policies when accounts is on", async () => {
+    renderPage("/settings/policies");
+    expect(await screen.findByText("policies-page-stub")).toBeInTheDocument();
+    expect(screen.queryByText("members-page-stub")).toBeNull();
+  });
+
+  it("does not render the admin sections when accounts is off", () => {
+    mocks.accountsEnabled = false;
+    renderPage("/settings/members");
+    // Falls through to the section switch, which renders nothing for an
+    // unknown-when-accounts-off section.
+    expect(screen.queryByText("members-page-stub")).toBeNull();
+  });
+
+  it("no longer links to Members / Policies from the Account section", async () => {
+    // They moved to the sidebar nav (Admin group); the Account section — even
+    // for an admin — must not re-link to them, or we'd be back to navigating
+    // away from /settings.
+    mocks.me = { id: "alice", is_admin: true };
+    renderPage("/settings/account");
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+    expect(screen.queryByRole("link", { name: /Members/ })).toBeNull();
+    expect(screen.queryByRole("link", { name: /Policies/ })).toBeNull();
   });
 
   it("lists archived sessions and unarchives on click", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -13,25 +13,27 @@
  *   home of the theme control that used to sit in the sidebar header.
  * - **Keyboard shortcuts** — the full shortcuts reference, shown inline.
  * - **Account** — only when the accounts auth provider is active. Absorbs
- *   the old sidebar AccountMenu: signed-in identity, admin-only Members /
- *   Policies links, change password, and sign out.
+ *   the old sidebar AccountMenu: signed-in identity, change password, and
+ *   sign out.
+ * - **Members** / **Policies** — admin-only, accounts deploys. Server-wide
+ *   management surfaces rendered as settings sub-categories (previously
+ *   standalone `/members` and `/policies` pages linked from Account) so
+ *   entering them stays inside settings — the sidebar keeps the section nav
+ *   instead of snapping back to the conversation list.
  * - **Archived sessions** — archived sessions, moved out of the sidebar
  *   list. Not clickable; each row reveals Delete / Unarchive on hover.
  */
 
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import {
   ArchiveRestoreIcon,
   KeyRoundIcon,
   LogOutIcon,
-  ShieldCheckIcon,
   Trash2Icon,
   UserCogIcon,
-  UsersIcon,
 } from "lucide-react";
 import { LaptopMinimalIcon, MoonIcon, SunIcon } from "lucide-react";
 import { useTheme } from "next-themes";
-import { Link } from "@/lib/routing";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -60,6 +62,17 @@ import { useIsEmbedded } from "@/lib/embedded";
 import { type CliStatus, getCliStatus, isElectronShell, resetCliPath } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 
+// Admin-only management surfaces, rendered as the Members / Policies settings
+// sub-categories. Lazy-loaded so non-accounts deploys (where these sections
+// never appear) don't pull them into the settings chunk — mirrors the
+// route-level lazy loading these had when they were standalone pages.
+const MembersPage = lazy(() =>
+  import("@/pages/MembersPage").then((m) => ({ default: m.MembersPage })),
+);
+const PoliciesPage = lazy(() =>
+  import("@/pages/PoliciesPage").then((m) => ({ default: m.PoliciesPage })),
+);
+
 /**
  * Settings content panel. The section nav lives in the sidebar card
  * (SettingsSidebarBody); this renders only the selected section into the
@@ -71,6 +84,18 @@ export function SettingsPage() {
   const info = useServerInfo();
   const accountsEnabled = info !== "loading" && info.accounts_enabled;
   const { section } = useSettingsRoute();
+
+  // Members / Policies are admin-only management surfaces that own their full
+  // layout (their own PageScroll + admin gating), so they render directly —
+  // NOT inside the shared section PageScroll below, which would nest two
+  // scroll containers. Both self-gate to admins server-side and client-side.
+  if (accountsEnabled && (section === "members" || section === "policies")) {
+    return (
+      <Suspense fallback={null}>
+        {section === "members" ? <MembersPage /> : <PoliciesPage />}
+      </Suspense>
+    );
+  }
 
   return (
     <PageScroll contentClassName="px-8" extraBottom="2.5rem">
@@ -324,20 +349,10 @@ function AccountSection() {
           </div>
         </div>
 
-        {me.is_admin && (
-          <div className="flex flex-col gap-1">
-            <Button asChild variant="ghost" className="w-full justify-start gap-2">
-              <Link to="/members">
-                <UsersIcon className="size-4" /> Members
-              </Link>
-            </Button>
-            <Button asChild variant="ghost" className="w-full justify-start gap-2">
-              <Link to="/policies">
-                <ShieldCheckIcon className="size-4" /> Policies
-              </Link>
-            </Button>
-          </div>
-        )}
+        {/* Members / Policies used to live here as links to standalone pages.
+            They're now first-class settings sub-categories in the sidebar nav
+            (Admin group), so entering them keeps the settings surface put
+            instead of navigating away from /settings. */}
 
         <div className="flex flex-col gap-1">
           <Button

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -5,18 +5,25 @@
 // on a plain tap (no onNavClick) so mobile lands back on the conversation list
 // instead of the homepage. Section links still close it.
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
-const mocks = vi.hoisted(() => ({ accountsEnabled: false }));
+const mocks = vi.hoisted(() => ({
+  accountsEnabled: false,
+  me: null as { id: string; is_admin: boolean } | null,
+}));
 
 vi.mock("@/lib/CapabilitiesContext", () => ({
   useServerInfo: () => ({ accounts_enabled: mocks.accountsEnabled }),
 }));
+vi.mock("@/hooks/useMe", () => ({
+  useMe: () => ({ data: mocks.me }),
+}));
 
-import { SettingsSidebarBody, settingsNavGroups } from "./settingsNav";
+import { SettingsSidebarBody, settingsNavGroups, useSettingsRoute } from "./settingsNav";
 
 function renderBody(opts: { onNavClick?: () => void; onClose?: () => void } = {}) {
   const onNavClick = opts.onNavClick ?? vi.fn();
@@ -33,6 +40,7 @@ function renderBody(opts: { onNavClick?: () => void; onClose?: () => void } = {}
 
 beforeEach(() => {
   mocks.accountsEnabled = false;
+  mocks.me = null;
 });
 afterEach(cleanup);
 
@@ -68,6 +76,20 @@ describe("settingsNavGroups", () => {
     expect(ids(false)).not.toContain("cli");
     expect(ids(true)).toContain("cli");
   });
+
+  it("includes the Admin group (Members / Policies) only for admins on accounts deploys", () => {
+    const ids = (accountsEnabled: boolean, isAdmin: boolean) =>
+      settingsNavGroups(accountsEnabled, false, isAdmin)
+        .flatMap((g) => g.items)
+        .map((i) => i.id);
+    // Non-admin, or non-accounts deploy → no Members / Policies.
+    expect(ids(true, false)).not.toContain("members");
+    expect(ids(false, true)).not.toContain("members");
+    // Admin on an accounts deploy → both appear, grouped under "Admin".
+    const adminGroups = settingsNavGroups(true, false, true);
+    const admin = adminGroups.find((g) => g.title === "Admin");
+    expect(admin?.items.map((i) => i.id)).toEqual(["members", "policies"]);
+  });
 });
 
 describe("SettingsSidebarBody", () => {
@@ -92,5 +114,74 @@ describe("SettingsSidebarBody", () => {
     const { onNavClick } = renderBody();
     fireEvent.click(screen.getByTestId("settings-nav-appearance"));
     expect(onNavClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders Members / Policies sub-categories for an admin, linking under /settings", () => {
+    mocks.accountsEnabled = true;
+    mocks.me = { id: "admin", is_admin: true };
+    renderBody();
+    const members = screen.getByTestId("settings-nav-members");
+    const policies = screen.getByTestId("settings-nav-policies");
+    expect(members).toHaveAttribute("href", "/settings/members");
+    expect(policies).toHaveAttribute("href", "/settings/policies");
+  });
+
+  it("hides the admin sub-categories for a non-admin", () => {
+    mocks.accountsEnabled = true;
+    mocks.me = { id: "bob", is_admin: false };
+    renderBody();
+    expect(screen.queryByTestId("settings-nav-members")).toBeNull();
+    expect(screen.queryByTestId("settings-nav-policies")).toBeNull();
+  });
+});
+
+describe("useSettingsRoute", () => {
+  function routeHook(path: string) {
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+    );
+    return renderHook(() => useSettingsRoute(), { wrapper: w }).result.current;
+  }
+
+  it("treats /settings/members and /settings/policies as in-settings sections", () => {
+    // The core of the fix: Members / Policies now live UNDER /settings, so the
+    // sidebar's `inSettings` gate stays true and the settings nav stays put —
+    // the old standalone /members and /policies fell through to inSettings:false
+    // (see the bare-path case below), which snapped the sidebar back to the
+    // conversation list.
+    expect(routeHook("/settings/members")).toEqual({ inSettings: true, section: "members" });
+    expect(routeHook("/settings/policies")).toEqual({ inSettings: true, section: "policies" });
+  });
+
+  it("reports NOT in settings for the legacy standalone /members and /policies paths", () => {
+    // These paths only exist as redirects now; if one is ever hit directly it
+    // must NOT read as in-settings (that was the bug's mechanism).
+    expect(routeHook("/members").inSettings).toBe(false);
+    expect(routeHook("/policies").inSettings).toBe(false);
+  });
+
+  it("keeps recognizing the other settings sections and their bare-path default", () => {
+    expect(routeHook("/settings/appearance")).toEqual({
+      inSettings: true,
+      section: "appearance",
+    });
+    // Bare /settings: in-settings, defaulting to Appearance when accounts is off.
+    expect(routeHook("/settings")).toEqual({ inSettings: true, section: "appearance" });
+    // A non-settings route is out of settings.
+    expect(routeHook("/inbox").inSettings).toBe(false);
+  });
+
+  it("defaults bare /settings to Account when accounts auth is enabled", () => {
+    mocks.accountsEnabled = true;
+    expect(routeHook("/settings")).toEqual({ inSettings: true, section: "account" });
+  });
+
+  it("matches the settings segment under an embed basename", () => {
+    // Basename-agnostic: the sidebar rebases links behind the app's back in the
+    // embed, so detection keys off the `settings` segment wherever it lands.
+    expect(routeHook("/ml/omnigent-embed/settings/members")).toEqual({
+      inSettings: true,
+      section: "members",
+    });
   });
 });

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -143,14 +143,25 @@ describe("useSettingsRoute", () => {
     return renderHook(() => useSettingsRoute(), { wrapper: w }).result.current;
   }
 
-  it("treats /settings/members and /settings/policies as in-settings sections", () => {
+  it("treats /settings/members and /settings/policies as in-settings sections on an accounts deploy", () => {
     // The core of the fix: Members / Policies now live UNDER /settings, so the
     // sidebar's `inSettings` gate stays true and the settings nav stays put —
     // the old standalone /members and /policies fell through to inSettings:false
     // (see the bare-path case below), which snapped the sidebar back to the
     // conversation list.
+    mocks.accountsEnabled = true;
     expect(routeHook("/settings/members")).toEqual({ inSettings: true, section: "members" });
     expect(routeHook("/settings/policies")).toEqual({ inSettings: true, section: "policies" });
+  });
+
+  it("falls back from the accounts-only admin sections when accounts is off", () => {
+    // Members / Policies aren't real destinations off an accounts deploy — the
+    // sidebar never shows them and the page would render an empty panel. Only
+    // reachable by typing the URL, but resolve to the default section (still
+    // in-settings) instead of a dead admin section.
+    mocks.accountsEnabled = false;
+    expect(routeHook("/settings/members")).toEqual({ inSettings: true, section: "appearance" });
+    expect(routeHook("/settings/policies")).toEqual({ inSettings: true, section: "appearance" });
   });
 
   it("reports NOT in settings for the legacy standalone /members and /policies paths", () => {
@@ -179,6 +190,7 @@ describe("useSettingsRoute", () => {
   it("matches the settings segment under an embed basename", () => {
     // Basename-agnostic: the sidebar rebases links behind the app's back in the
     // embed, so detection keys off the `settings` segment wherever it lands.
+    mocks.accountsEnabled = true;
     expect(routeHook("/ml/omnigent-embed/settings/members")).toEqual({
       inSettings: true,
       section: "members",

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -12,22 +12,34 @@ import {
   KeyboardIcon,
   PaletteIcon,
   PanelRightOpenIcon,
+  ShieldCheckIcon,
   TerminalIcon,
   UserCogIcon,
+  UsersIcon,
 } from "lucide-react";
 import { Link, useLocation } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
+import { useMe } from "@/hooks/useMe";
 import { isElectronShell } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 
-export type SettingsSectionId = "appearance" | "shortcuts" | "account" | "archived" | "cli";
+export type SettingsSectionId =
+  | "appearance"
+  | "shortcuts"
+  | "account"
+  | "members"
+  | "policies"
+  | "archived"
+  | "cli";
 
 const SECTION_IDS: readonly SettingsSectionId[] = [
   "appearance",
   "shortcuts",
   "account",
+  "members",
+  "policies",
   "archived",
   "cli",
 ];
@@ -47,11 +59,13 @@ interface SettingsNavGroup {
 
 /**
  * Nav groups for the current deploy. The Account section is auth-gated; the
- * Desktop group (Local CLI) appears only in the Electron shell.
+ * Admin group (Members / Policies) appears only for admins on accounts
+ * deploys; the Desktop group (Local CLI) appears only in the Electron shell.
  */
 export function settingsNavGroups(
   accountsEnabled: boolean,
   isDesktop: boolean,
+  isAdmin = false,
 ): SettingsNavGroup[] {
   const general: SettingsNavItem[] = [
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
@@ -71,13 +85,24 @@ export function settingsNavGroups(
       items: [{ id: "cli", label: "Local CLI", icon: TerminalIcon }],
     });
   }
-  groups.push(
-    { title: "General", items: general },
-    {
-      title: "Archived",
-      items: [{ id: "archived", label: "Archived sessions", icon: ArchiveIcon }],
-    },
-  );
+  groups.push({ title: "General", items: general });
+  // Admin: server-wide management, admin-only. Nested here as sub-categories
+  // (rather than links out of the Account section) so entering them stays
+  // inside /settings — the sidebar keeps the settings nav instead of snapping
+  // back to the conversation list.
+  if (accountsEnabled && isAdmin) {
+    groups.push({
+      title: "Admin",
+      items: [
+        { id: "members", label: "Members", icon: UsersIcon },
+        { id: "policies", label: "Policies", icon: ShieldCheckIcon },
+      ],
+    });
+  }
+  groups.push({
+    title: "Archived",
+    items: [{ id: "archived", label: "Archived sessions", icon: ArchiveIcon }],
+  });
   return groups;
 }
 
@@ -118,8 +143,11 @@ export function SettingsSidebarBody({
 }) {
   const info = useServerInfo();
   const accountsEnabled = info !== "loading" && info.accounts_enabled;
+  // Admin gating for the Members / Policies sub-categories. Only probed on
+  // accounts deploys; non-admins (and non-accounts deploys) never see them.
+  const { data: me } = useMe(accountsEnabled);
   const { section } = useSettingsRoute();
-  const groups = settingsNavGroups(accountsEnabled, isElectronShell());
+  const groups = settingsNavGroups(accountsEnabled, isElectronShell(), me?.is_admin ?? false);
 
   return (
     <>

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -123,9 +123,15 @@ export function useSettingsRoute(): { inSettings: boolean; section: SettingsSect
   const idx = segments.lastIndexOf("settings");
   if (idx === -1) return { inSettings: false, section: defaultSection };
   const next = segments[idx + 1];
-  const section = (SECTION_IDS as readonly string[]).includes(next)
-    ? (next as SettingsSectionId)
-    : defaultSection;
+  // Members / Policies are accounts-only sections. Off an accounts deploy
+  // they aren't real destinations — fall back to the default section rather
+  // than resolving to an admin section the page would render as an empty
+  // panel (only reachable by manually typing the URL, but keep it clean).
+  const accountsOnlySections = new Set<string>(["members", "policies"]);
+  const isValidSection =
+    (SECTION_IDS as readonly string[]).includes(next) &&
+    (accountsEnabled || !accountsOnlySections.has(next));
+  const section = isValidSection ? (next as SettingsSectionId) : defaultSection;
   return { inSettings: true, section };
 }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Clicking **Members** or **Policies** from the settings Account page navigated to the standalone `/members` and `/policies` routes, which live *outside* the settings surface. `useSettingsRoute()` then reported `inSettings: false`, so the sidebar swapped its section nav back to the conversation list and re-highlighted "New session" — the sidebar appeared to jump back to sessions.
- **Redesign**: Members and Policies are now settings **sub-categories**. They resolve under `/settings/members` and `/settings/policies` (so `inSettings` stays true and the sidebar keeps the settings nav), and they appear as first-class nav items in an admin-only **Admin** group in the settings sidebar.
- The legacy `/members` and `/policies` paths now redirect to their new `/settings/*` homes, so existing bookmarks/links still work.

### What changed

- `settingsNav.tsx`: added `members`/`policies` section ids; `settingsNavGroups()` gains an `isAdmin` flag and emits the admin-only "Admin" group; `SettingsSidebarBody` reads admin status via a new shared `useMe()` hook (accounts deploys only).
- `SettingsPage.tsx`: renders the (lazy-loaded) `MembersPage`/`PoliciesPage` for those sections and drops the now-redundant Account-section links.
- `App.tsx`: replaced the standalone `/members` and `/policies` routes with `<Navigate replace>` redirects.
- `useMe.ts` (new): shared react-query cache for `GET /auth/me` so the sidebar and page share admin status without duplicate probes.

## Test Plan

- `npm test` — full suite: **3395 pass** (9 new tests added), 1 skipped, 3 expected-fail.
- `npm run build` — `tsc -b && vite build` succeeds.
- `npm run lint` / prettier — clean on all touched files.
- New tests:
  - `useSettingsRoute` recognizes `/settings/members` and `/settings/policies` as in-settings (the core fix), reports the legacy `/members` / `/policies` as not-in-settings, and matches under an embed basename.
  - `settingsNavGroups` emits the Admin group only for admins on accounts deploys.
  - `SettingsSidebarBody` renders/hides the Members/Policies sub-categories by admin status and links them under `/settings`.
  - `SettingsPage` renders the right admin section per URL and no longer links to Members/Policies from Account.

## Demo

https://github.com/user-attachments/assets/27b644b4-9b82-4cce-99c8-4ae26cfe831e


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the full vitest suite and a production `vite build` locally; both green. The navigation fix is covered by new `useSettingsRoute` unit tests asserting `/settings/members` and `/settings/policies` are treated as in-settings (previously the standalone paths were not, which caused the sidebar to reset). A screen recording of the end-to-end click-through will be attached to the Demo section.

This pull request and its description were written by Isaac.
