### PR TITLE
feat(web): click-to-zoom images in the file viewer

### DIFF
--- a/tests/e2e_ui/files/test_image_rendering.py
+++ b/tests/e2e_ui/files/test_image_rendering.py
@@ -104,3 +104,42 @@ def test_image_file_renders_as_img(
     expect(img).to_have_attribute("src", re.compile(r"^blob:"))
     expect(file_viewer.get_by_text("Unable to render image")).to_have_count(0)
     expect(file_viewer.locator("[contenteditable='true']")).to_have_count(0)
+
+
+def test_image_click_opens_zoom_lightbox(
+    page: Page,
+    seeded_image_session: tuple[str, str, str],
+) -> None:
+    """Clicking a previewed image opens the shared full-screen zoom lightbox."""
+    base_url, session_id, _file_path = seeded_image_session
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    file_button = page.get_by_role("button", name=re.compile(rf"^{re.escape(_IMAGE_FILE_PATH)}\b"))
+    expect(file_button).to_be_visible(timeout=30_000)
+    file_button.click()
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    img = file_viewer.locator(f'img[alt="{_IMAGE_FILE_PATH}"]')
+    expect(img).to_be_visible(timeout=10_000)
+
+    # No lightbox until the user clicks the inline image.
+    expect(page.get_by_role("dialog")).to_have_count(0)
+
+    img.click()
+
+    # The Radix dialog now hosts the shared ZoomViewer with its zoom toolbar.
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible(timeout=10_000)
+    expect(dialog.get_by_role("button", name="Zoom in")).to_be_visible()
+    expect(dialog.get_by_role("button", name="Zoom out")).to_be_visible()
+
+    # The same SVG is shown in the lightbox, still via its blob URL.
+    expect(dialog.locator(f'img[alt="{_IMAGE_FILE_PATH}"]')).to_have_attribute(
+        "src", re.compile(r"^blob:")
+    )
+
+    # Escape dismisses the lightbox (Radix Dialog default).
+    page.keyboard.press("Escape")
+    expect(page.get_by_role("dialog")).to_have_count(0)

--- a/web/src/shell/CodeViewer.test.tsx
+++ b/web/src/shell/CodeViewer.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { useFileContent } from "@/hooks/useFileContent";
 import { CodeViewer } from "./CodeViewer";
+import { ImageLightboxProvider } from "@/components/ImageLightbox";
 import { HTML_PREVIEW_SANDBOX } from "./codeViewerHelpers";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -318,5 +319,36 @@ describe("CodeViewer image rendering", () => {
   it("routes by content_type over extension (image MIME on a .txt name)", async () => {
     renderImage("image/png", "data.txt");
     expect(await screen.findByAltText("data.txt")).toBeDefined();
+  });
+
+  it("opens the shared zoom lightbox when the image is clicked", async () => {
+    render(
+      <ImageLightboxProvider>
+        <CodeViewer
+          conversationId="conv_1"
+          path="assets/logo.png"
+          fileQuery={makeImageQuery("image/png")}
+          comments={[]}
+          activeSelection={null}
+          onSetActiveSelection={() => {}}
+          panelOpen={true}
+          searchOpen={false}
+          setSearchOpen={() => {}}
+          searchInputRef={noopRef}
+          viewMode="source"
+        />
+      </ImageLightboxProvider>,
+    );
+
+    const img = (await screen.findByAltText("logo.png")) as HTMLImageElement;
+    // No lightbox until the user clicks the inline image.
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(img);
+
+    // The Radix Dialog is now open with the zoom controls from the lightbox.
+    expect(await screen.findByRole("dialog")).toBeDefined();
+    expect(screen.getByLabelText("Zoom in")).toBeDefined();
+    expect(screen.getByLabelText("Zoom out")).toBeDefined();
   });
 });

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -58,6 +58,7 @@ import {
 } from "./codeViewerHelpers";
 import { renderLineTokens } from "./codeViewerRendering";
 import { TruncatedBanner } from "./TruncatedBanner";
+import { useLightbox } from "@/components/ImageLightbox";
 import { getEmbedRoot } from "@/lib/host";
 
 // Monaco is heavy (~MBs + worker); load it only when a non-markdown file is
@@ -101,6 +102,7 @@ const CHECKERBOARD_STYLE: React.CSSProperties = {
 function ImageViewer({ data, path }: { data: FileContentResponse; path: string }) {
   const [url, setUrl] = useState<string | null>(null);
   const [errored, setErrored] = useState(false);
+  const { open } = useLightbox();
 
   // Create the object URL in an effect and revoke it on cleanup so the blob is
   // released when the file changes or the viewer unmounts (avoids a leak).
@@ -134,8 +136,10 @@ function ImageViewer({ data, path }: { data: FileContentResponse; path: string }
           src={url}
           alt={filename}
           onError={() => setErrored(true)}
-          className="max-h-full max-w-full object-contain"
+          onClick={() => open({ src: url, alt: filename })}
+          className="max-h-full max-w-full cursor-zoom-in object-contain"
           style={CHECKERBOARD_STYLE}
+          title="Click to zoom"
         />
       )}
     </div>


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The file viewer rendered image files (`ImageViewer` in `web/src/shell/CodeViewer.tsx`) as a **static `<img>`**, even though the rest of the app (chat images, session images, AI-element images) already opens images in a shared full-screen lightbox with wheel / button / double-click zoom and pan.
- This wires the file viewer's image preview into that same lightbox via the existing `useLightbox()` hook, so clicking a previewed image opens it zoomable — consistent with the rest of the UI. Adds a `cursor-zoom-in` affordance and a "Click to zoom" tooltip.
- Deliberately kept the existing fit-to-container layout by calling the hook on the current `<img>` rather than swapping in `ZoomableImage` (whose `inline-flex` button wrapper has no height constraint and would break `max-h-full` fit).

No new component or dependency — this reuses the already-tested `ImageLightbox` infrastructure.

## Test Plan

- `cd web && npm test` — full suite green (3384 passed).
- `cd web && npm run build` — `tsc -b && vite build` succeeds.
- Added a vitest unit test in `CodeViewer.test.tsx`: rendering the image viewer inside `ImageLightboxProvider` and clicking the image opens the Radix dialog with the zoom controls. Existing image tests (which render outside the provider) still pass because `useLightbox()` falls back to a no-op.
- Added a Playwright e2e test in `tests/e2e_ui/files/test_image_rendering.py`: clicking a previewed image opens the full-screen lightbox (dialog + zoom in/out, blob-backed `<img>`) and Escape closes it. Ran locally: `uv run pytest tests/e2e_ui/files/test_image_rendering.py` → 2 passed.

## Demo

The file-viewer image now opens the shared full-screen zoom lightbox on click — zoom via scroll wheel / +– buttons / double-click, drag to pan, Esc or ✕ to close. Behavior is covered by the new e2e test; screen recording to follow if reviewers want one.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New vitest test covers the click → lightbox-open wiring; a new Playwright e2e test covers the full-screen lightbox open/close against a seeded image file. The underlying zoom/pan behavior is already covered by `ImageLightbox.test.tsx`. The lightbox provider is already mounted app-wide in `main.tsx` and `embed.tsx`, so the file viewer sits within its context in production.

This pull request and its description were written by Isaac.
