### PR TITLE
feat(polly): add opencode as a fourth coding sub-agent

### DIFF
--- a/examples/polly/agents/opencode/config.yaml
+++ b/examples/polly/agents/opencode/config.yaml
@@ -1,0 +1,64 @@
+spec_version: 1
+name: opencode
+description: OpenCode coding sub-agent — implements, cross-vendor reviews, or explores a scoped task in its own worktree.
+
+# Native OpenCode server harness: the runner owns `opencode serve` + an SSE
+# forwarder and injects each turn over loopback HTTP. It runs in its own
+# terminal the human can open in the UI's Subagents panel and TAKE OVER.
+# OpenCode's permission prompts surface as web approval cards (and Omnigent
+# policies apply), so risky actions are gated rather than auto-bypassed.
+executor:
+  type: omnigent
+  config:
+    harness: opencode-native
+
+prompt: |
+  You are OpenCode, a coding sub-agent dispatched by the polly
+  orchestrator for a single scoped task in a dedicated git worktree. Your task
+  prompt names its purpose — IMPLEMENT, REVIEW, or EXPLORE. Do exactly that one
+  thing; don't refactor or wander unprompted.
+
+  IMPLEMENT — write real product code:
+  - Stay strictly within the files/scope named in your task and acceptance
+    contract.
+  - Make the change, then drive it to green: run the relevant tests, lint, and
+    typecheck for the code you touched.
+  - Co-sign every commit you author: end each commit message with a blank line
+    followed by this exact trailer as its final line —
+    `Co-authored-by: omnigent <noreply@omnigent.ai>`
+  - When green, push your task branch and open a PR with `gh pr create` (clear
+    title, what changed, how you verified). Never push to a protected branch
+    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+
+  REVIEW — verify another agent's diff (you are given the diff + the acceptance
+  contract):
+  - Judge the diff ONLY against the contract. Do NOT edit code — surface issues
+    for the orchestrator to route.
+  - Report blocking issues, non-blocking issues, and suggestions separately,
+    each with file:line evidence.
+
+  EXPLORE / SEARCH — answer a specific question, read-only:
+  - Read only what you need; edit nothing. Answer with file:line evidence.
+
+  Always return a clear, structured result: for IMPLEMENT, what you changed
+  (file:line) and how you verified it; for REVIEW / EXPLORE, your findings.
+  Note anything that did not fit the task.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Implementers open their own PRs, so push / gh pr create are allowed
+# (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,
+# hard-reset to a remote ref) is still denied.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -2,7 +2,7 @@ spec_version: 1
 name: polly
 description: >-
   A coding orchestrator that breaks your goal into pieces and hands them
-  to a team of Claude Code, Codex, and Pi sub-agents to build. Polly
+  to a team of Claude Code, Codex, OpenCode, and Pi sub-agents to build. Polly
   writes no code itself — it plans and splits up the work, delegates all
   of it (investigation / implementation / review), then has a separate
   independent different-model reviewer double-check the work before
@@ -17,7 +17,7 @@ spawn: true
 
 # Orchestrator "brain": Claude Agent SDK. polly writes no code itself — it
 # delegates ALL coding work (investigation, implementation, review) to the
-# claude_code / codex / pi sub-agents, doing only non-code authoring (docs /
+# claude_code / codex / opencode / pi sub-agents, doing only non-code authoring (docs /
 # Markdown / text edits, skills) itself. No model/profile is pinned, so the
 # brain runs on whatever Claude provider is configured as the default
 # (`omnigent setup --no-internal-beta`) — an Anthropic API key, a Claude
@@ -50,19 +50,21 @@ prompt: |
   a "docs" task starts requiring code changes or real code investigation, STOP
   and delegate that part.
 
-  You have exactly THREE sub-agents. `claude_code` and `codex` are real CLI
-  coding harnesses that run in their own terminal — the human can open either
-  in the UI's Subagents panel and watch or TAKE OVER. `pi` runs headless (no
-  terminal to open):
+  You have exactly FOUR sub-agents. `claude_code`, `codex`, and `opencode` are
+  real CLI coding harnesses that run in their own terminal — the human can open
+  any of them in the UI's Subagents panel and watch or TAKE OVER. `pi` runs
+  headless (no terminal to open):
   - `claude_code` — Claude Code (`claude-native` harness).
   - `codex` — Codex (`codex-native` harness).
+  - `opencode` — OpenCode (`opencode-native` harness), a third implement /
+    review vendor for cross-vendor diversity.
   - `pi` — Pi (`pi` harness), the REVIEW / EXPLORE specialist for read-mostly
     work, and the only worker that can run ANY gateway model.
 
   Roster preflight (FIRST turn, before any dispatch). Each worker needs its own
-  CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `pi` for `pi`.
-  Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex pi || true")`. A worker is AVAILABLE
+  CLI on PATH — `claude` for `claude_code`, `codex` for `codex`, `opencode` for
+  `opencode`, `pi` for `pi`. Before delegating anything, run exactly ONE
+  `sys_os_shell("command -v claude codex opencode pi || true")`. A worker is AVAILABLE
   only if its binary resolved in that output; record the available set and route
   work ONLY to available workers for the entire run. Do this in the same first
   turn you start planning (the preflight `sys_os_shell` call counts as acting —
@@ -131,16 +133,18 @@ prompt: |
   one-line edit; there is no agent below them to route it to. A pure docs/text
   edit (no code) you make yourself per the rule above. If the human says
   "launch agents",
-  "use claude code", "use codex", or "use pi", that is a literal instruction to
-  dispatch them. `claude_code` and `codex` are the primary implementers — pick
-  per task: `claude_code` for multi-file / refactor / test-writing work,
-  `codex` for narrow, well-scoped changes. Route `review` / `explore` /
-  `search` tasks to `pi` when a third perspective or a specific model is
-  wanted.
+  "use claude code", "use codex", "use opencode", or "use pi", that is a
+  literal instruction to dispatch them. `claude_code`, `codex`, and `opencode`
+  are the primary implementers — pick per task: `claude_code` for multi-file /
+  refactor / test-writing work, `codex` for narrow, well-scoped changes,
+  `opencode` when a third implement/review vendor is wanted. Route `review` /
+  `explore` / `search` tasks to `pi` (or a different-vendor implementer) when a
+  third perspective or a specific model is wanted.
 
   Cross-vendor verification is the point: review is ALWAYS done by a DIFFERENT
-  vendor than the implementer — `claude_code`'s PR is reviewed by `codex` or
-  `pi`, `codex`'s by `claude_code` or `pi`. Give the reviewer ONLY the diff +
+  vendor than the implementer — e.g. `claude_code`'s PR is reviewed by `codex`,
+  `opencode`, or `pi`; `codex`'s by `claude_code`, `opencode`, or `pi`. Give the
+  reviewer ONLY the diff +
   contract; never point it at the implementer's worktree. Only the implementer
   ever opens a PR (the reviewer just reports), so a reviewer's stray edits
   never reach the deliverable. When a PR passes cross-review it is ready for
@@ -167,7 +171,7 @@ prompt: |
   terminal via `sys_terminal_launch` (it accepts a `cwd` override so you can run
   it inside a per-task worktree). NEVER use this terminal to launch coding
   agents / sub-agents — all delegation goes through `sys_session_send` to
-  `claude_code` / `codex` / `pi`.
+  `claude_code` / `codex` / `opencode` / `pi`.
 
   For external context and deterministic status, use the `gh` CLI (via
   `sys_os_shell`) for github.com. Reach for such tools sparingly — only to
@@ -227,9 +231,9 @@ prompt: |
     useful, cancel it instead of leaving it running while you re-dispatch. Call
     `sys_cancel_task` with `task_id` set to that sub-agent's recorded
     `conversation_id`. `claude_code` workers are hard-stopped and will wake you
-    with a cancelled inbox item; `pi` workers honor the interrupt and stop;
-    `codex` cancellation is currently best-effort, so do not assume its worker
-    is gone unless the tool result or inbox confirms it.
+    with a cancelled inbox item; `pi` and `opencode` workers honor the interrupt
+    and stop; `codex` cancellation is currently best-effort, so do not assume its
+    worker is gone unless the tool result or inbox confirms it.
   - Do not repeatedly re-prompt a dark or failing sub-agent. For coding work,
     re-dispatch a fresh implementation sub-agent in a clean worktree, or
     escalate to the human.
@@ -269,12 +273,13 @@ terminals:
         type: none
 
 tools:
-  # Coding sub-agents — see agents/<name>/. claude_code and codex are real CLI
-  # coding harnesses; pi is a headless multi-model worker. Each implements,
-  # reviews (cross-vendor), and explores.
+  # Coding sub-agents — see agents/<name>/. claude_code, codex, and opencode are
+  # real CLI coding harnesses; pi is a headless multi-model worker. Each
+  # implements, reviews (cross-vendor), and explores.
   agents:
     - claude_code
     - codex
+    - opencode
     - pi
 
 # Mechanism-layer enforcement — runner-side tool gate, no server change.

--- a/examples/polly/skills/cross-review/SKILL.md
+++ b/examples/polly/skills/cross-review/SKILL.md
@@ -16,10 +16,11 @@ anyone needs to read through.
    `sys_os_shell`. If red, re-dispatch the implementer to drive it green first;
    don't involve the reviewer yet.
 3. Dispatch a DIFFERENT-vendor sub-agent as reviewer (Claude built it →
-   `codex` or `pi`; Codex built it → `claude_code` or `pi`; Pi built it →
-   `claude_code` or `codex`). Use a task-based title such as
+   `codex`, `opencode`, or `pi`; Codex built it → `claude_code`, `opencode`, or
+   `pi`; OpenCode built it → `claude_code`, `codex`, or `pi`; Pi built it →
+   `claude_code`, `codex`, or `opencode`). Use a task-based title such as
    `review-auth-refactor`, never the raw vendor name:
-   `sys_session_send(agent="claude_code"|"codex"|"pi", title="review-<task_slug>",
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"pi", title="review-<task_slug>",
    args={purpose: "review", input: "<the diff> + <the acceptance contract>.
    Review ONLY against the contract. Report blocking / non-blocking /
    suggestions. Do not edit code."})`. Give it the diff as text — do NOT point
@@ -54,7 +55,7 @@ anyone needs to read through.
   human at the plan gate.
 - Give the reviewer ONLY the diff + contract — never the implementer's
   transcript or worktree. The cross-vendor independence is the whole point.
-- Review is a coding sub-agent (`claude_code`/`codex`/`pi`) dispatched with
+- Review is a coding sub-agent (`claude_code`/`codex`/`opencode`/`pi`) dispatched with
   `purpose: "review"` — a DIFFERENT vendor from the one that built the diff. It
   reports issues and never edits; only the implementer opens a PR, so a stray
   reviewer edit never reaches the deliverable.

--- a/examples/polly/skills/fanout/SKILL.md
+++ b/examples/polly/skills/fanout/SKILL.md
@@ -14,7 +14,7 @@ dependency).
    Record the worktree path + branch in the registry
    (`.polly/registry.json`).
 2. Dispatch one implementation sub-agent per task, scoped to its worktree:
-   `sys_session_send(agent="claude_code"|"codex", title="<task_slug>",
+   `sys_session_send(agent="claude_code"|"codex"|"opencode", title="<task_slug>",
    args={purpose: "implement", input: "<task + acceptance contract +
    worktree path>"})`. Use a short task-based title such as `auth-refactor` or
    `fix-sse-error`, never the raw vendor name. State the scope and that it must

--- a/examples/polly/skills/investigate/SKILL.md
+++ b/examples/polly/skills/investigate/SKILL.md
@@ -12,8 +12,8 @@ repository-specific technical question.
 ## Procedure
 1. Decompose the question into one or more bounded investigation tasks. Prefer
    two independent lenses for ambiguous or high-stakes questions.
-2. Dispatch each task to `claude_code`, `codex`, or `pi`:
-   `sys_session_send(agent="claude_code"|"codex"|"pi",
+2. Dispatch each task to `claude_code`, `codex`, `opencode`, or `pi`:
+   `sys_session_send(agent="claude_code"|"codex"|"opencode"|"pi",
    title="explore-<task_slug>", args={purpose: "explore", input: "<question +
    exact scope + evidence requested>"})`. Use a task-based title such as
    `explore-ci-flake`, never the raw vendor name. Use `purpose: "search"` only

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -14065,6 +14065,55 @@ def create_runner_app(
         if agent_version is not None:
             _version_cache[conv_id] = agent_version
 
+        # Cold-boot readiness gate (opencode-native turns). ``opencode serve``
+        # takes up to ~30s to boot, and a turn can only run once the terminal +
+        # bridge state are in place. That boot is normally driven by the
+        # session-init / ensure-terminal path, but a sub-agent's FIRST turn can
+        # arrive while the boot is still in flight (or before it starts): the
+        # turn then found no ready server, produced no result, and silently hung
+        # the parent orchestrator (polly). Ensure the terminal here, idempotent
+        # and under the SAME per-session lock the session-init path uses, so this
+        # turn WAITS for the boot instead of racing it (the events POST budget is
+        # ~1 day, so a one-time cold-boot wait is safe). A boot failure surfaces
+        # as a 503 turn failure -> parent inbox, never a silent hang.
+        if harness_name == "opencode-native":
+            _oc_lock = _opencode_terminal_ensure_locks.setdefault(conv_id, asyncio.Lock())
+            async with _oc_lock:
+                _oc_tr = resource_registry.terminal_registry
+                _oc_ready = (
+                    _oc_tr is not None and _oc_tr.get(conv_id, "opencode", "main") is not None
+                )
+                if not _oc_ready:
+                    _publish_terminal_pending(_publish_event, conv_id, True)
+                    try:
+                        try:
+                            _oc_spec = await _resolve_session_agent_spec(conv_id)
+                        except OmnigentError:
+                            _oc_spec = None
+                        await _auto_create_opencode_terminal(
+                            conv_id,
+                            resource_registry,
+                            _publish_event,
+                            agent_spec=_oc_spec,
+                            server_client=server_client,
+                            ensure_comment_relay=_ensure_comment_relay_started,
+                        )
+                    except Exception as exc:
+                        _logger.exception(
+                            "opencode-native cold-boot ensure failed for %s", conv_id
+                        )
+                        return JSONResponse(
+                            status_code=503,
+                            content={
+                                "error": "opencode_native_boot_failed",
+                                "detail": _client_safe_error_detail(
+                                    exc, context="opencode-native boot"
+                                ),
+                            },
+                        )
+                    finally:
+                        _publish_terminal_pending(_publish_event, conv_id, False)
+
         try:
             client = await process_manager.get_client(conv_id, harness_name, env=spawn_env)
         except RuntimeError as exc:

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1969,6 +1969,7 @@ def test_materialize_directory_bundle_with_override_keeps_nested_harness_unpinne
             {
                 "claude_code": "claude-native",
                 "codex": "codex-native",
+                "opencode": "opencode-native",
                 "pi": "pi",
             },
         ),

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -3,10 +3,10 @@
 polly is the standalone multi-agent coding orchestrator (successor to the
 deleted nessie example, whose deep structural pins were folded in here).
 Loads the bundle and asserts the distinctive wiring stays intact: the
-claude-sdk orchestrator brain, the three cross-vendor coding sub-agents
-(claude_code / codex / pi, which implement, review, and explore), the three
-spine skills, and the bounds/blast-radius guardrails. Pure spec-load — no
-LLM, no credentials.
+claude-sdk orchestrator brain, the four cross-vendor coding sub-agents
+(claude_code / codex / opencode / pi, which implement, review, and explore),
+the three spine skills, and the bounds/blast-radius guardrails. Pure spec-load
+— no LLM, no credentials.
 
 What breaks if this fails:
 - the orchestrator substrate drifts (model / harness / context window),
@@ -68,24 +68,25 @@ def test_orchestrator_executor(polly_spec: AgentSpec) -> None:
 
 def test_coding_subagents(polly_spec: AgentSpec) -> None:
     """
-    The bundle has exactly three coding sub-agents: ``claude_code`` (Claude
-    Code, claude-native) and ``codex`` (Codex, codex-native) on the native
-    terminal harnesses, plus ``pi`` (Pi, pi) as the headless multi-model
-    third worker. All implement, review, and explore. The native harnesses
-    make claude_code / codex render terminal-first (Chat / Terminal pill) so
-    the human can watch or take over.
+    The bundle has exactly four coding sub-agents: ``claude_code`` (Claude
+    Code, claude-native), ``codex`` (Codex, codex-native), and ``opencode``
+    (OpenCode, opencode-native) on the native terminal harnesses, plus ``pi``
+    (Pi, pi) as the headless multi-model worker. All implement, review, and
+    explore. The native harnesses make claude_code / codex / opencode render
+    terminal-first (Chat / Terminal pill) so the human can watch or take over.
 
-    A missing/renamed agent means no implementers, and same-vendor harnesses
+    A missing/renamed agent means fewer implementers, and same-vendor harnesses
     would break cross-vendor review — polly's differentiator.
     """
     fam = {a.name: a.executor.config.get("harness") for a in polly_spec.sub_agents}
-    assert sorted(polly_spec.tools.agents) == ["claude_code", "codex", "pi"]
+    assert sorted(polly_spec.tools.agents) == ["claude_code", "codex", "opencode", "pi"]
     assert fam["claude_code"] == "claude-native"
     assert fam["codex"] == "codex-native"
+    assert fam["opencode"] == "opencode-native"
     assert fam["pi"] == "pi"
-    # Three distinct vendors → any implementer's diff is reviewable by another.
-    assert len(set(fam.values())) == 3
-    for name in ("claude_code", "codex", "pi"):
+    # Four distinct vendors → any implementer's diff is reviewable by another.
+    assert len(set(fam.values())) == 4
+    for name in ("claude_code", "codex", "opencode", "pi"):
         prompt = (_POLLY_BUNDLE / "agents" / name / "config.yaml").read_text(encoding="utf-8")
         assert "IMPLEMENT — write real product code" in prompt
         assert "REVIEW — verify another agent's diff" in prompt
@@ -284,8 +285,9 @@ def test_investigation_skill_delegates_read_only_work() -> None:
 
     assert "Use for any read-only task: investigation, debugging, audit" in compact
     assert (
-        "Dispatch each task to `claude_code`, `codex`, or `pi`: "
-        '`sys_session_send(agent="claude_code"|"codex"|"pi", title="explore-<task_slug>", '
+        "Dispatch each task to `claude_code`, `codex`, `opencode`, or `pi`: "
+        '`sys_session_send(agent="claude_code"|"codex"|"opencode"|"pi", '
+        'title="explore-<task_slug>", '
         'args={purpose: "explore", input: "<question + exact scope + evidence requested>"})`'
     ) in compact
     # The audited skill (#3074) made task-based titles mandatory at dispatch.
@@ -355,7 +357,7 @@ def test_orchestrator_guardrails(polly_spec: AgentSpec) -> None:
 def test_subagent_guardrails(polly_spec: AgentSpec) -> None:
     """Each sub-agent carries the blast_radius gate (push/destructive)."""
     by_name = {a.name: a for a in polly_spec.sub_agents}
-    for name in ("claude_code", "codex", "pi"):
+    for name in ("claude_code", "codex", "opencode", "pi"):
         guardrails = by_name[name].guardrails
         assert guardrails is not None, name
         assert [p.name for p in guardrails.policies] == ["blast_radius"], name
@@ -388,6 +390,6 @@ def test_function_policies_have_nonempty_arguments(polly_spec: AgentSpec) -> Non
             )
             checked += 1
     # orchestrator: blast_radius + spawn_bounds + headless_subagent_purpose_guard
-    # = 3; sub-agents: blast_radius x3 (claude_code, codex, pi) = 3
-    # -> 6 total. Fewer = a policy dropped.
-    assert checked == 6, f"expected 6 function policies in the bundle, inspected {checked}"
+    # = 3; sub-agents: blast_radius x4 (claude_code, codex, opencode, pi) = 4
+    # -> 7 total. Fewer = a policy dropped.
+    assert checked == 7, f"expected 7 function policies in the bundle, inspected {checked}"

--- a/tests/server/test_builtin_bundles.py
+++ b/tests/server/test_builtin_bundles.py
@@ -104,7 +104,7 @@ def test_bundle_builder_is_reproducible(
 
 # (name, bundle source dir, sub-agents the shipped definition declares today)
 _SHIPPED_SUB_AGENT_EXAMPLES = [
-    ("polly", app._POLLY_BUNDLE_SOURCE, {"claude_code", "codex", "pi"}),
+    ("polly", app._POLLY_BUNDLE_SOURCE, {"claude_code", "codex", "opencode", "pi"}),
     ("debby", app._DEBBY_BUNDLE_SOURCE, {"claude", "gpt"}),
 ]
 

--- a/tests/test_opencode_polly_debby_worker.py
+++ b/tests/test_opencode_polly_debby_worker.py
@@ -1,12 +1,19 @@
-"""Guards that the shipped example agents ship **no** OpenCode worker.
+"""Guards the OpenCode worker's presence in the shipped example agents.
 
 Both polly and debby once declared an optional ``opencode`` sub-agent
 (``harness: opencode-native``). Shipping a sub-agent whose harness older
 clients don't recognize made every old runner/host fail to launch the agent at
-all — the version-skew incident behind omnigent-ai/omnigent#1145. Both were
-reverted to their original rosters (polly: claude_code / codex / pi; debby:
-claude / gpt), and the negative tests below guard that OpenCode does not creep
-back into either shipped spec.
+all — the version-skew incident behind omnigent-ai/omnigent#1145. That incident
+is now mitigated on the execution path: ``spec.load(...,
+prune_invalid_sub_agents=True)`` (runner ``_entry`` + server ``agent_cache``)
+gracefully DROPS a sub-agent whose harness a client doesn't recognize, so an old
+client loads polly with its remaining workers instead of failing. Combined with
+``opencode-native`` now being a recognized harness
+(``omnigent.spec._omnigent_compat.OMNIGENT_HARNESSES``), polly re-declares its
+``opencode`` worker; the positive test below guards that it stays wired.
+
+debby, however, is still deliberately opencode-free (reverted in #1295), and the
+negative test below guards that OpenCode does not creep back into that spec.
 """
 
 from __future__ import annotations
@@ -31,21 +38,17 @@ def _config(sub_agent: object) -> dict[str, object]:
     return {}
 
 
-def test_polly_does_not_declare_opencode_worker() -> None:
-    """polly stays opencode-free, so an older client can load it without skew.
+def test_polly_declares_opencode_worker() -> None:
+    """polly declares its ``opencode`` worker on the ``opencode-native`` harness.
 
-    Re-adding an ``opencode`` sub-agent (or any ``opencode-native`` harness, e.g.
-    a codex ``allowed_harnesses`` opt-in) would reintroduce the harness that
-    broke old runners on spec validation. If OpenCode is wanted back, it must
-    land with a server/runner floor that guarantees clients recognize it.
+    Safe to re-add because #1145's graceful pruning drops the worker (rather than
+    failing the whole agent) on any client too old to recognize the harness, and
+    ``opencode-native`` is a recognized harness on current clients. If this ever
+    regresses to failing old clients, prune-on-load is the contract to check.
     """
     subs = _sub_agents("polly")
-    assert "opencode" not in subs
-    config_text = (_REPO_ROOT / "examples" / "polly" / "config.yaml").read_text(encoding="utf-8")
-    assert "opencode" not in config_text.lower()
-    # No sub-agent re-introduces opencode-native via a harness override either.
-    for sub in subs.values():
-        assert "opencode-native" not in (_config(sub).get("allowed_harnesses") or [])
+    assert "opencode" in subs
+    assert _config(subs["opencode"]).get("harness") == "opencode-native"
 
 
 def test_debby_does_not_declare_opencode_head() -> None:


### PR DESCRIPTION
## What

Adds `opencode` (harness: `opencode-native`) as a fourth coding sub-agent to the polly orchestrator, alongside `claude_code`, `codex`, and `pi` — a fourth cross-vendor implement / review / explore worker that runs in its own terminal (openable and take-over-able from the Subagents panel).

## Why this is more than a config add

OpenCode was deliberately removed from polly (and debby) after the version-skew incident #1145: shipping a sub-agent whose harness older clients did not recognize made those clients fail to load the whole agent, and a guard test (`tests/test_opencode_polly_debby_worker.py`) was added to keep it out.

That incident is now resolved on the execution path: `spec.load(..., prune_invalid_sub_agents=True)` (runner `_entry` + server `agent_cache`) gracefully drops a sub-agent whose harness a client does not recognize rather than failing the parent, and `opencode-native` is a recognized harness in `OMNIGENT_HARNESSES` on current clients. Worst case for an old client is polly running without the opencode worker, not a crash. This PR flips the polly guard test to expect opencode, while leaving debby opencode-free (out of scope here).

## Cold-boot dispatch fix (runner-side)

Live-testing opencode as a headless polly worker surfaced a real bug that is NOT config: an opencode-native sub-agent's first (cold) turn could be dispatched before `opencode serve` finished booting (its readiness wait is up to ~30s). The turn path (`_stream_message_to_harness`) had no terminal-ensure for opencode, so it raced the boot — the harness found no ready server, produced no result, and silently hung the parent orchestrator. A warm re-dispatch worked because boot had completed in the background.

Fix: a readiness gate on the opencode-native turn path (before `get_client`) that ensures the terminal is booted, idempotently and under the same per-session lock the session-init path uses, so the turn WAITS for the boot instead of racing it. A boot failure now surfaces as a 503 turn failure (routed to the parent inbox) instead of a silent hang. Scoped to `harness_name == "opencode-native"` — claude/codex/pi are unchanged.

## Changes

- `examples/polly/agents/opencode/config.yaml` (new): `opencode-native` worker with the standard implement / review / explore contract and `blast_radius(gate_pushes=false)`.
- `examples/polly/config.yaml`: roster is now four; preflight checks `opencode`; `tools.agents`, routing, cancellation notes, and comments updated.
- `examples/polly/skills/{investigate,fanout,cross-review}`: opencode wired in as a full peer (implementer, reviewer rotation, explore lens).
- `omnigent/runner/app.py`: the opencode cold-boot readiness gate described above.
- `tests/test_opencode_polly_debby_worker.py`: polly guard flipped from "must be absent" to "must declare opencode"; debby's negative guard unchanged.
- `tests/e2e/omnigent/test_example_polly.py`, `tests/server/test_builtin_bundles.py`, `tests/cli/test_chat.py`: roster list, vendor count (3 to 4), policy count (6 to 7), declared bundle set, and brain-override worker-harness map updated for the fourth worker.

## Verification

- Structural / guard / bundle / cli tests updated and passing: `tests/e2e/omnigent/test_example_polly.py`, `tests/test_opencode_polly_debby_worker.py`, `tests/server/test_builtin_bundles.py` (incl. the version-skew survival test), `tests/cli/test_chat.py::test_materialize_bundle_overrides_brain_harness`.
- ruff format + check clean on all changed files.
- Live end-to-end: polly dispatches a cold `opencode` explore worker; with the readiness gate the first dispatch runs to completion and auto-wakes polly with the result (no re-dispatch). Parent-wake, headless approval (blast_radius allow/deny, never ask), and boot all confirmed against a real `opencode serve`.

## Follow-up (separate PR)

`cursor-native` and `hermes-native` are intentionally not in this PR. They need the parent-orchestrator wake plumbing (they do not emit `external_session_status: idle` today, so a headless polly dispatch would never wake polly on completion) plus the same roster/test updates. The cold-boot gate here is opencode-specific (native-server path); cursor/hermes are tmux-based and will need their own handling.

This pull request and its description were written by Claude Code.
