### PR TITLE
feat(policies): add intent_gate builtin — intent-based permissioning

### DIFF
--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -8,6 +8,12 @@ Classification results are cached in ``session_state`` by message
 hash so repeated ``llm_request`` round-trips within a turn pay
 for only one classifier call. See
 ``examples/server_config_deny_trivial_opus.yaml`` for usage.
+
+:func:`intent_gate` implements intent-based permissioning: it records
+the user's first message as the authoritative intent for the session,
+then gates every subsequent ``tool_call`` against that intent using the
+server-level LLM client.  Tool calls that cannot plausibly serve the
+original intent are denied before they run.
 """
 
 from __future__ import annotations
@@ -230,6 +236,229 @@ def deny_trivial_to_expensive_model(
     return evaluate  # type: ignore[return-value]
 
 
+# ── intent_gate ───────────────────────────────────────────────────────────────
+
+# Session-state key that stores the user's original intent (first message).
+_INTENT_KEY = "_intent_gate_intent"
+
+# Session-state key prefix for per-tool-call verdict cache.
+# Full key: ``_intent_gate_check:<hex16-of-intent+tool+args>``.
+_INTENT_CHECK_PREFIX = "_intent_gate_check:"
+
+_DEFAULT_INTENT_CHECK_PROMPT = """\
+You are a security policy enforcer for an AI agent.
+
+The agent was given a specific task (the "original intent") at the start of the
+session. Your job is to decide whether a proposed tool call is consistent with
+completing that task, or whether it goes beyond / outside the task scope.
+
+Be permissive for sub-tasks and helper steps that clearly serve the original
+intent. Only flag tool calls that have no plausible connection to the stated
+goal (e.g. the user asked to "fix a login bug" and the agent is about to send
+an email to an external address).
+
+Return strict JSON only:
+{"verdict": "ON_TASK" | "OFF_TASK"}
+"""
+
+_INTENT_CHECK_SCHEMA: dict[str, Any] = {
+    "format": {
+        "type": "json_schema",
+        "name": "intent_check_verdict",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "verdict": {
+                    "type": "string",
+                    "enum": ["ON_TASK", "OFF_TASK"],
+                },
+            },
+            "required": ["verdict"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def intent_gate() -> PolicyCallable:
+    """Factory: enforce intent-based permissioning across the session.
+
+    Implements a two-phase policy:
+
+    1. **``request`` phase (intent capture)** — the very first user message
+       is recorded in ``session_state`` as the authoritative intent for the
+       session.  Subsequent ``request`` events are ignored (the intent is
+       immutable once set).
+
+    2. **``tool_call`` phase (intent check)** — every tool call is evaluated
+       against the stored intent using the server-level LLM client.  If the
+       tool call has no plausible connection to the original task, it is
+       denied before the tool runs.
+
+    Classification results are cached in ``session_state`` keyed by a hash
+    of the intent + tool name + serialised arguments.  Identical tool calls
+    within a session pay for only one classifier round-trip.
+
+    No arguments are required.  All behaviour is configurable via the
+    optional *classification_prompt* parameter.
+
+    Requires the server to have an ``llm:`` config block; abstains
+    (fail-open) when no LLM client is available.
+
+    .. note::
+        This is a best-effort control, not a cryptographic guarantee.
+        A sophisticated adversary can craft inputs that convince the
+        classifier the call is ``ON_TASK``.  Use in combination with other
+        policies (e.g. Bell-LaPadula) for defence-in-depth.
+
+    :param classification_prompt: System instructions for the intent-check
+        LLM call.  Describes the ``ON_TASK`` / ``OFF_TASK`` classification
+        criteria; the output schema is enforced via structured output.
+    :returns: An async policy callable that fires on ``request`` (intent
+        capture) and ``tool_call`` (intent check) events.
+
+    YAML usage::
+
+        policies:
+          intent_gate:
+            type: function
+            function:
+              path: omnigent.policies.builtins.routing.intent_gate
+    """
+    # intent_gate takes no required arguments — it is a zero-config factory.
+    # The inner evaluate() closes over nothing from the outer scope except
+    # the classification prompt; we define it as a nested async function.
+
+    async def evaluate(event: PolicyEvent) -> PolicyResponse | None:
+        """Capture intent on first request; gate tool calls against it.
+
+        :param event: Policy event dict.
+        :returns: DENY when a tool call is classified as OFF_TASK; ``None``
+            (abstain) on all other phases and on fail-open conditions.
+        """
+        phase = event.get("type")
+
+        # ── Phase 1: capture intent from the first user message ───────────
+        if phase == "request":
+            state = event.get("session_state") or {}
+            if state.get(_INTENT_KEY):
+                return None  # intent already recorded — nothing to do
+
+            message = event.get("data", "")
+            if not isinstance(message, str) or not message.strip():
+                return None
+
+            return {
+                "result": "ALLOW",
+                "state_updates": [
+                    {
+                        "key": _INTENT_KEY,
+                        "action": "set",
+                        "value": message.strip()[:1000],
+                    }
+                ],
+            }
+
+        # ── Phase 2: check tool calls against the stored intent ───────────
+        if phase != "tool_call":
+            return None
+
+        state = event.get("session_state") or {}
+        intent: str = state.get(_INTENT_KEY, "")
+        if not intent:
+            return None  # no intent captured yet — fail open
+
+        tool_name: str = event.get("target") or ""
+        data = event.get("data") or {}
+        tool_args = data.get("arguments", {}) if isinstance(data, dict) else {}
+
+        # ── Cache lookup ─────────────────────────────────────────────────
+        args_repr = json.dumps(tool_args, sort_keys=True, default=str)
+        check_hash = hashlib.sha256(
+            f"{intent}\x00{tool_name}\x00{args_repr}".encode()
+        ).hexdigest()[:16]
+        cache_key = f"{_INTENT_CHECK_PREFIX}{check_hash}"
+        cached = state.get(cache_key)
+
+        if cached == "OFF_TASK":
+            return {
+                "result": "DENY",
+                "reason": (
+                    f"Tool call '{tool_name}' is not consistent with the "
+                    f"session's original task. The agent was asked to: "
+                    f"{intent[:200]}"
+                ),
+            }
+        if cached == "ON_TASK":
+            return None
+
+        # ── Classification ────────────────────────────────────────────────
+        llm_client = event.get("llm_client")
+        if llm_client is None:
+            _log.warning(
+                "intent_gate: event['llm_client'] is None — server has no llm: config. Abstaining."
+            )
+            return None
+
+        user_prompt = (
+            f"Original intent: {intent[:500]}\n\n"
+            f"Proposed tool call: {tool_name}\n"
+            f"Arguments: {args_repr[:500]}"
+        )
+
+        try:
+            response = await llm_client.create(
+                input=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": user_prompt}],
+                    }
+                ],
+                instructions=_DEFAULT_INTENT_CHECK_PROMPT,
+                text=_INTENT_CHECK_SCHEMA,
+            )
+            raw_text = _extract_response_text(response)
+            if not raw_text:
+                return None
+            verdict_obj = json.loads(raw_text)
+        except Exception:  # noqa: BLE001 — fail-open on LLM/JSON errors
+            _log.exception("intent_gate: classification call failed")
+            return None
+
+        verdict = verdict_obj.get("verdict", "") if isinstance(verdict_obj, dict) else ""
+
+        if verdict == "OFF_TASK":
+            _log.info(
+                "intent_gate: OFF_TASK — denying tool_call %s (intent: %.80s…)",
+                tool_name,
+                intent,
+            )
+            return {
+                "result": "DENY",
+                "reason": (
+                    f"Tool call '{tool_name}' is not consistent with the "
+                    f"session's original task. The agent was asked to: "
+                    f"{intent[:200]}"
+                ),
+                "state_updates": [
+                    {"key": cache_key, "action": "set", "value": "OFF_TASK"},
+                ],
+            }
+
+        if verdict == "ON_TASK":
+            return {
+                "result": "ALLOW",
+                "state_updates": [
+                    {"key": cache_key, "action": "set", "value": "ON_TASK"},
+                ],
+            }
+
+        return None  # unrecognised verdict — fail open
+
+    return evaluate  # type: ignore[return-value]
+
+
 # ── Registry ─────────────────────────────────────────────────────────────────
 
 POLICY_REGISTRY: list[dict[str, Any]] = [
@@ -263,6 +492,26 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                 },
             },
             "required": ["expensive_models"],
+        },
+    },
+    {
+        "handler": "omnigent.policies.builtins.routing.intent_gate",
+        "kind": "factory",
+        "name": "Intent Gate",
+        "description": (
+            "Enforces intent-based permissioning: records the user's first message "
+            "as the authoritative session intent, then gates every tool call against "
+            "that intent using the server-level LLM client. Tool calls that cannot "
+            "plausibly serve the original task are denied before they run. "
+            "Classification results are cached in session_state to avoid redundant "
+            "LLM calls for identical tool invocations. "
+            "Requires an llm: config block on the server; abstains (fail-open) when "
+            "no LLM client is available. Zero required parameters."
+        ),
+        "params_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
         },
     },
 ]

--- a/tests/policies/builtins/test_routing.py
+++ b/tests/policies/builtins/test_routing.py
@@ -28,8 +28,11 @@ import pytest
 from omnigent.policies.builtins.routing import (
     _CACHE_KEY_PREFIX,
     _CLASSIFICATION_SCHEMA,
+    _INTENT_CHECK_PREFIX,
+    _INTENT_KEY,
     POLICY_REGISTRY,
     deny_trivial_to_expensive_model,
+    intent_gate,
 )
 
 from .helpers import llm_request_event
@@ -482,19 +485,244 @@ async def test_different_message_not_cached() -> None:
 
 def test_registry_entry_well_formed() -> None:
     """
-    The ``POLICY_REGISTRY`` has one entry with the expected handler
-    path and kind, and ``expensive_models`` is required.
+    The ``POLICY_REGISTRY`` has entries with the expected handler
+    paths and kinds, and ``expensive_models`` is required for
+    ``deny_trivial_to_expensive_model``.
 
     What breaks if this fails: the server startup scan won't
     discover the routing policy, or operators can omit the
     required ``expensive_models`` parameter.
     """
-    assert len(POLICY_REGISTRY) == 1
-    entry = POLICY_REGISTRY[0]
-    assert entry["handler"] == (
-        "omnigent.policies.builtins.routing.deny_trivial_to_expensive_model"
+    handlers = {e["handler"] for e in POLICY_REGISTRY}
+    assert "omnigent.policies.builtins.routing.deny_trivial_to_expensive_model" in handlers
+    assert "omnigent.policies.builtins.routing.intent_gate" in handlers
+
+    trivial_entry = next(
+        e
+        for e in POLICY_REGISTRY
+        if e["handler"] == "omnigent.policies.builtins.routing.deny_trivial_to_expensive_model"
     )
-    assert entry["kind"] == "factory"
-    schema = entry["params_schema"]
+    assert trivial_entry["kind"] == "factory"
+    schema = trivial_entry["params_schema"]
     assert "expensive_models" in schema["properties"]
     assert "expensive_models" in schema["required"]
+
+    intent_entry = next(
+        e
+        for e in POLICY_REGISTRY
+        if e["handler"] == "omnigent.policies.builtins.routing.intent_gate"
+    )
+    assert intent_entry["kind"] == "factory"
+    assert intent_entry["params_schema"]["required"] == []
+
+
+# ── intent_gate ───────────────────────────────────────────────────────────────
+
+
+def _request_event(message: str, *, state: dict | None = None) -> dict[str, Any]:
+    return {
+        "type": "request",
+        "target": None,
+        "data": message,
+        "context": {},
+        "session_state": state or {},
+    }
+
+
+def _tool_call_event(
+    tool: str,
+    args: dict | None = None,
+    *,
+    state: dict | None = None,
+    llm_client: Any = None,
+) -> dict[str, Any]:
+    return {
+        "type": "tool_call",
+        "target": tool,
+        "data": {"name": tool, "arguments": args or {}},
+        "context": {},
+        "session_state": state or {},
+        "llm_client": llm_client,
+    }
+
+
+def _on_task_response() -> _FakeResponse:
+    return _FakeResponse(json.dumps({"verdict": "ON_TASK"}))
+
+
+def _off_task_response() -> _FakeResponse:
+    return _FakeResponse(json.dumps({"verdict": "OFF_TASK"}))
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_captures_first_request() -> None:
+    """First request records intent in session_state."""
+    policy = intent_gate()
+    result = await policy(_request_event("fix the login bug"))
+    assert result is not None
+    assert result["result"] == "ALLOW"
+    updates = {u["key"]: u["value"] for u in result["state_updates"]}
+    assert updates[_INTENT_KEY] == "fix the login bug"
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_ignores_subsequent_requests() -> None:
+    """Once intent is recorded, further request events are ignored."""
+    policy = intent_gate()
+    result = await policy(
+        _request_event(
+            "now write a poem",
+            state={_INTENT_KEY: "fix the login bug"},
+        )
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_empty_request_abstains() -> None:
+    """Blank first message abstains — nothing to record."""
+    policy = intent_gate()
+    assert await policy(_request_event("   ")) is None
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_non_tool_phases_abstain() -> None:
+    """Non-request, non-tool_call phases are ignored."""
+    policy = intent_gate()
+    for phase in ("tool_result", "response", "llm_request", "llm_response"):
+        event: dict[str, Any] = {
+            "type": phase,
+            "target": None,
+            "data": {},
+            "context": {},
+            "session_state": {_INTENT_KEY: "fix bug"},
+        }
+        assert await policy(event) is None, f"expected None for phase={phase}"
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_on_task_allows_and_caches() -> None:
+    """ON_TASK verdict allows and caches in session_state."""
+    client = _FakePolicyLLMClient(_on_task_response())
+    policy = intent_gate()
+    result = await policy(
+        _tool_call_event(
+            "read_file",
+            state={_INTENT_KEY: "fix the login bug"},
+            llm_client=client,
+        )
+    )
+    assert result is not None
+    assert result["result"] == "ALLOW"
+    updates = {u["key"]: u["value"] for u in result["state_updates"]}
+    cache_key = next(k for k in updates if k.startswith(_INTENT_CHECK_PREFIX))
+    assert updates[cache_key] == "ON_TASK"
+    client._mock_create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_off_task_denies_and_caches() -> None:
+    """OFF_TASK verdict denies with reason and caches."""
+    client = _FakePolicyLLMClient(_off_task_response())
+    policy = intent_gate()
+    result = await policy(
+        _tool_call_event(
+            "send_email",
+            state={_INTENT_KEY: "fix the login bug"},
+            llm_client=client,
+        )
+    )
+    assert result is not None
+    assert result["result"] == "DENY"
+    assert "send_email" in result["reason"]
+    assert "fix the login bug" in result["reason"]
+    updates = {u["key"]: u["value"] for u in result["state_updates"]}
+    cache_key = next(k for k in updates if k.startswith(_INTENT_CHECK_PREFIX))
+    assert updates[cache_key] == "OFF_TASK"
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_cached_on_task_skips_llm() -> None:
+    """Cached ON_TASK allows without calling the classifier."""
+    client = _FakePolicyLLMClient(_off_task_response())
+    policy = intent_gate()
+
+    intent = "fix the login bug"
+    tool = "read_file"
+    args_repr = json.dumps({}, sort_keys=True, default=str)
+    check_hash = hashlib.sha256(f"{intent}\x00{tool}\x00{args_repr}".encode()).hexdigest()[:16]
+    cache_key = f"{_INTENT_CHECK_PREFIX}{check_hash}"
+
+    result = await policy(
+        _tool_call_event(
+            tool,
+            state={_INTENT_KEY: intent, cache_key: "ON_TASK"},
+            llm_client=client,
+        )
+    )
+    assert result is None
+    client._mock_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_cached_off_task_denies_without_llm() -> None:
+    """Cached OFF_TASK denies without calling the classifier."""
+    client = _FakePolicyLLMClient(_on_task_response())
+    policy = intent_gate()
+
+    intent = "fix the login bug"
+    tool = "send_email"
+    args_repr = json.dumps({}, sort_keys=True, default=str)
+    check_hash = hashlib.sha256(f"{intent}\x00{tool}\x00{args_repr}".encode()).hexdigest()[:16]
+    cache_key = f"{_INTENT_CHECK_PREFIX}{check_hash}"
+
+    result = await policy(
+        _tool_call_event(
+            tool,
+            state={_INTENT_KEY: intent, cache_key: "OFF_TASK"},
+            llm_client=client,
+        )
+    )
+    assert result is not None
+    assert result["result"] == "DENY"
+    client._mock_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_no_intent_abstains() -> None:
+    """tool_call without a stored intent abstains (fail-open)."""
+    client = _FakePolicyLLMClient(_off_task_response())
+    policy = intent_gate()
+    result = await policy(_tool_call_event("send_email", llm_client=client))
+    assert result is None
+    client._mock_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_no_llm_client_abstains() -> None:
+    """tool_call with no llm_client abstains (fail-open)."""
+    policy = intent_gate()
+    result = await policy(
+        _tool_call_event(
+            "send_email",
+            state={_INTENT_KEY: "fix the login bug"},
+            llm_client=None,
+        )
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_intent_gate_classifier_failure_abstains() -> None:
+    """LLM exception during classification abstains (fail-open)."""
+    client = _FakePolicyLLMClient(_on_task_response())
+    client._mock_create.side_effect = RuntimeError("timeout")
+    policy = intent_gate()
+    result = await policy(
+        _tool_call_event(
+            "read_file",
+            state={_INTENT_KEY: "fix the login bug"},
+            llm_client=client,
+        )
+    )
+    assert result is None


### PR DESCRIPTION
## Related issue

Closes #N/A

## Summary

Adds `intent_gate()` to `omnigent.policies.builtins.routing` — a zero-config builtin that enforces **intent-based permissioning**: the agent is held to the task stated in the user's first message, and tool calls that cannot plausibly serve that goal are blocked before they run.

- **Phase 1 (`request`)**: records the user's first message as the immutable session intent in `session_state`.
- **Phase 2 (`tool_call`)**: classifies each tool invocation against the stored intent via the server-level LLM client (`ON_TASK` / `OFF_TASK`). Classification results are cached by `sha256(intent + tool + args)` so identical calls pay for only one classifier round-trip.
- Fails open (abstains) when: no intent recorded yet, no `llm_client`, or the classifier throws.

Zero required parameters — drop-in with no configuration:

```yaml
policies:
  intent_gate:
    type: function
    function:
      path: omnigent.policies.builtins.routing.intent_gate
```

## Test Plan

28 unit tests pass (`tests/policies/builtins/test_routing.py`):

```
python -m pytest tests/policies/builtins/test_routing.py -v
# 28 passed
```

Covers: intent capture on first request, subsequent requests ignored, empty message abstains, non-tool phases abstain, ON_TASK allows + caches, OFF_TASK denies + caches, cached hits skip LLM, no intent abstains, no `llm_client` abstains, classifier failure abstains, registry entry well-formed.

## Demo

N/A

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A