### PR TITLE
fix(qwen-native): dedup window keeps most-recent uuids, not an arbitrary set slice

### DIFF
--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -51,6 +51,7 @@ import logging
 import os
 import re
 import time
+from collections.abc import Container, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -71,6 +72,20 @@ _SUPERVISOR_MAX_BACKOFF_S = 30.0
 _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
 
 _STATE_FILE = "qwen_forwarder.json"
+
+# Dedup window: the number of most-recently-posted event uuids persisted so a
+# truncation/relaunch re-read (offset rewinds to 0) doesn't re-post them. The
+# window must keep the *most recent* uuids, so ``seen`` is an insertion-ordered
+# mapping (a ``dict`` used as an ordered set), not a ``set`` — ``list(set)`` is
+# hash-ordered, which would make the ``[-_DEDUP_WINDOW:]`` cap keep an arbitrary
+# subset and re-post recent history on a long-session relaunch.
+_DEDUP_WINDOW = 512
+
+
+def _new_seen(uuids: Iterable[str] | None = None) -> dict[str, None]:
+    """Build the insertion-ordered dedup set (``dict`` used as an ordered set)."""
+    return dict.fromkeys(uuids or [])
+
 
 # The executor injects ``[Attached: <path>]`` markers for web-UI attachments
 # before submitting; strip them from the mirrored bubble (the path is an internal
@@ -114,8 +129,10 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
     try:
         bridge_dir.mkdir(parents=True, exist_ok=True)
         tmp = bridge_dir / (_STATE_FILE + ".tmp")
-        # Cap the dedup window so the state file can't grow unbounded.
-        seen = (state.seen_uuids or [])[-512:]
+        # Cap the dedup window so the state file can't grow unbounded. The list
+        # is insertion-ordered (see _new_seen), so this keeps the most recent
+        # _DEDUP_WINDOW uuids — the ones a relaunch re-read is most likely to hit.
+        seen = (state.seen_uuids or [])[-_DEDUP_WINDOW:]
         tmp.write_text(
             json.dumps({"offset": state.offset, "seen_uuids": seen}),
             encoding="utf-8",
@@ -204,7 +221,7 @@ def _event_to_item(event: dict[str, object], agent_name: str) -> _MirrorItem | N
 
 
 def _read_new_events(
-    events_file: Path, offset: int, seen: set[str], agent_name: str
+    events_file: Path, offset: int, seen: Container[str], agent_name: str
 ) -> tuple[list[_MirrorItem], int]:
     """Read NDJSON lines past *offset*, returning new mirror items + the new offset.
 
@@ -298,7 +315,7 @@ async def forward_qwen_events_to_session(
     target = events_file or events_file_path(bridge_dir)
     persisted = _read_state(bridge_dir)
     offset = persisted.offset
-    seen: set[str] = set(persisted.seen_uuids or [])
+    seen = _new_seen(persisted.seen_uuids)
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
@@ -310,7 +327,7 @@ async def forward_qwen_events_to_session(
                 )
                 for item in items:
                     await _post_conversation_item(client, session_id=session_id, item=item)
-                    seen.add(item.uuid)
+                    seen[item.uuid] = None
                 if new_offset != offset or items:
                     offset = new_offset
                     _write_state(

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -32,9 +32,11 @@ from omnigent.qwen_native_bridge import (
     write_tmux_target,
 )
 from omnigent.qwen_native_forwarder import (
+    _DEDUP_WINDOW,
     _compaction_status_from_record,
     _event_to_item,
     _ForwardState,
+    _new_seen,
     _read_new_compaction_statuses,
     _read_new_events,
     _read_state,
@@ -322,6 +324,35 @@ def test_forward_state_caps_seen_uuids(tmp_path: Path) -> None:
     loaded = _read_state(tmp_path)
     assert len(loaded.seen_uuids or []) == 512
     assert (loaded.seen_uuids or [])[-1] == "999"  # most-recent retained
+
+
+def test_seen_dedup_window_keeps_most_recent_in_insertion_order(tmp_path: Path) -> None:
+    """The persisted dedup window retains the *most recent* uuids, in order.
+
+    Regression: ``seen`` used to be a ``set``, so the forwarder's
+    ``list(seen)`` at persist time was hash-ordered and ``_write_state``'s
+    ``[-_DEDUP_WINDOW:]`` cap kept an arbitrary subset — not the most recent.
+    On a qwen relaunch past ``_DEDUP_WINDOW`` events (offset rewinds to 0 and
+    the file is re-read from the top), recent uuids evicted from the window
+    were re-posted as duplicate bubbles. Building ``seen`` through
+    :func:`_new_seen` (an insertion-ordered ``dict``) keeps the real tail.
+
+    This exercises the forwarder's own reload/persist path — ``_new_seen`` (the
+    line-301 ``seen = _new_seen(persisted.seen_uuids)`` idiom) then
+    ``list(seen)`` — so a revert to a ``set`` fails the ordering assertion here
+    (unlike ``test_forward_state_caps_seen_uuids``, which feeds an
+    already-ordered list straight into ``_write_state`` and so never sees the
+    ordering bug).
+    """
+    uuids = [f"u{i:05d}" for i in range(_DEDUP_WINDOW * 2)]
+    seen = _new_seen(uuids)
+
+    assert _write_state(tmp_path, _ForwardState(offset=7, seen_uuids=list(seen))) is True
+
+    kept = _read_state(tmp_path).seen_uuids or []
+    # The cap must keep the most-recent _DEDUP_WINDOW uuids, in order — not an
+    # arbitrary hash-ordered subset (which a set-backed ``seen`` produced).
+    assert kept == uuids[-_DEDUP_WINDOW:]
 
 
 def test_tmux_target_round_trip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #1779

## Summary

The qwen-native forwarder dedups posted events against a `seen` set and persists `list(seen)[-512:]` as the window. Because Python `set` iteration is hash-ordered, `list(seen)` loses insertion order, so the cap kept an **arbitrary** 512 uuids rather than the **most recent** 512 the docstring promises. On a qwen TUI relaunch — which truncates/recreates the events file, rewinding the forwarder to offset 0 and re-reading from the top — `seen` is the only guard against re-posting; for sessions with >512 events, recent uuids randomly evicted from the window get re-posted as duplicate bubbles in the web conversation.

Fix: back `seen` with an insertion-ordered `dict` (an ordered set), mirroring the sibling `opencode_native_forwarder` (which already does this with `OrderedDict` + `popitem(last=False)`). `list(seen)` is now ordered, so `[-_DEDUP_WINDOW:]` keeps the real recent tail.

## Test Plan

- New regression test `test_seen_dedup_window_keeps_most_recent_in_insertion_order`: builds `seen` via the forwarder's own `_new_seen`, persists `list(seen)`, and asserts the cap keeps the most-recent `_DEDUP_WINDOW` uuids **in order**. Verified red->green — reverting `_new_seen` to a `set` fails the ordering assertion (`AssertionError: ['u00829', 'u00174', ...] == ['u00512', 'u00517', ...]`, an arbitrary hash-ordered subset); the ordered `dict` passes. (Distinct from the existing `test_forward_state_caps_seen_uuids`, which feeds an already-ordered list straight to `_write_state` and never exercised the ordering.)
- `uv run python -m pytest tests/test_qwen_native_forwarder.py` -> 35 passed. `ruff check` / `format --check` clean.

## Demo

N/A (non-visual — backend forwarder dedup logic; covered by the red->green unit test).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Backend forwarder logic, no UI surface; the red->green unit test is the verification (fails on the prior `set`, passes on the ordered `dict`).

