### PR TITLE
test(harness-bench): address Polly review (policy phase scoping, guards, offline render)

### DIFF
--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -117,15 +117,17 @@ def main(argv: list[str] | None = None) -> int:
             progress=_progress if live else None,
         )
     )
+    # Offline (not live) has nothing observed, so show the declared matrix.
+    declared = not live
     if args.json:
         output = render_json(matrix)
     elif args.markdown:
-        output = render_markdown(matrix)
+        output = render_markdown(matrix, declared=declared)
     else:
         # Default: terminal table. Color only when stdout is a real TTY and
         # not suppressed, so piping to a file / pager stays plain.
         color = sys.stdout.isatty() and not args.no_color
-        output = render_table(matrix, color=color)
+        output = render_table(matrix, color=color, declared=declared)
     print(output, end="")
     # A drift is a non-zero exit so CI / scripts notice without parsing output.
     return 1 if matrix.has_drift else 0

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -16,7 +16,6 @@ transport-dependent probes as ``SKIPPED``.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import shutil
 import uuid
@@ -33,6 +32,13 @@ from tests.harness_bench.profile import BenchProfile
 # Proto-style policy verdict strings the wrap's policy_verdict event accepts.
 POLICY_ALLOW = "POLICY_ACTION_ALLOW"
 POLICY_DENY = "POLICY_ACTION_DENY"
+
+# Proto-style policy evaluation phases (see _scaffold.evaluate_policy and
+# omnigent/native_policy_hook.py). A tool call is gated at PHASE_TOOL_CALL;
+# the request/result phases fire at other points in the turn. The policy
+# probe must scope its DENY to PHASE_TOOL_CALL so a DENY on the request
+# phase cannot masquerade as a tool-call guardrail pass.
+PHASE_TOOL_CALL = "PHASE_TOOL_CALL"
 
 _CONV_ID = "conv_bench"
 
@@ -111,9 +117,12 @@ class TurnResult:
         harness forwards any.
     :param tool_calls: The ``response.tool_call`` events observed, each a
         raw event dict carrying ``call_id`` / ``name`` / ``arguments``.
-    :param policy_actions: The verdict strings this driver posted back
-        (one per ``policy_evaluation.requested``), so a probe can tell a
-        DENY was actually delivered.
+    :param policy_actions: ``(phase, action)`` pairs this driver posted back
+        (one per ``policy_evaluation.requested``), so a probe can tell which
+        verdict was delivered for which phase.
+    :param tool_call_denied: Whether a ``PHASE_TOOL_CALL`` evaluation was
+        answered DENY — the only signal that proves a tool-call guardrail
+        (not a request/result-phase DENY) was actually exercised.
     :param completed: Whether a terminal ``response.completed`` was seen.
     :param cancelled: Whether a terminal ``response.cancelled`` was seen
         (the harness honored an interrupt).
@@ -128,7 +137,8 @@ class TurnResult:
     text_delta_count: int = 0
     reasoning_delta_count: int = 0
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
-    policy_actions: list[str] = field(default_factory=list)
+    policy_actions: list[tuple[str, str]] = field(default_factory=list)
+    tool_call_denied: bool = False
     completed: bool = False
     cancelled: bool = False
     failed: bool = False
@@ -171,11 +181,18 @@ class SdkInprocDriver:
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
         """Return a skip reason if this driver cannot run *profile*, else ``None``.
 
-        Checks, in order: a supplied Databricks profile (no gateway route
-        without one), and a runnable harness CLI binary. Mirrors the e2e
-        suite's gating so the bench skips — rather than errors — in
-        environments missing creds or a vendor CLI.
+        Checks, in order: the profile's transport matches this driver, a
+        supplied Databricks profile (no gateway route without one), and a
+        runnable harness CLI binary. Mirrors the e2e suite's gating so the
+        bench skips — rather than errors — in environments missing creds or
+        a vendor CLI, or when a profile declares a transport this driver
+        does not implement (e.g. a native/community harness).
         """
+        if profile.transport != SdkInprocDriver.transport:
+            return (
+                f"transport {profile.transport!r} not supported by the "
+                f"{SdkInprocDriver.transport!r} driver"
+            )
         if not databricks_profile:
             return "no --profile / databricks profile provided; live probes need a gateway route"
         if profile.cli_binary is not None:
@@ -212,7 +229,7 @@ class SdkInprocDriver:
         prompt: str,
         *,
         tools: list[dict[str, Any]] | None = None,
-        policy_action: str = POLICY_ALLOW,
+        deny_phases: frozenset[str] = frozenset(),
         policy_reason: str | None = None,
         auto_tool_output: str | None = None,
         interrupt_on_first_delta: bool = False,
@@ -222,10 +239,14 @@ class SdkInprocDriver:
 
         Handles the three downward round-trips the wrap may need mid-turn:
 
-        - ``policy_evaluation.requested`` → posts a ``policy_verdict`` with
-          *policy_action* (set ``POLICY_DENY`` to exercise enforcement).
-        - ``response.tool_call`` → when *auto_tool_output* is set, posts a
-          ``tool_result`` so a tool-calling turn can complete.
+        - ``policy_evaluation.requested`` → posts a ``policy_verdict``,
+          answering DENY only for evaluations whose ``phase`` is in
+          *deny_phases* and ALLOW otherwise. Scoping the DENY by phase is
+          what lets the policy probe prove a *tool-call* guardrail rather
+          than accidentally denying the request phase.
+        - ``response.output_item.done`` (function_call, action_required) →
+          when *auto_tool_output* is set, posts a ``tool_result`` so a
+          tool-calling turn can complete.
         - *interrupt_on_first_delta* → posts an ``interrupt`` event the
           first time text streams, to exercise cancellation.
 
@@ -233,7 +254,9 @@ class SdkInprocDriver:
         :param tools: Optional tool specs forwarded verbatim as the wrap's
             passthrough ``tools`` field (Chat-Completions shape:
             ``[{"type": "function", "function": {...}}]``).
-        :param policy_action: Verdict posted for every policy evaluation.
+        :param deny_phases: Policy phases to answer DENY (e.g.
+            ``{PHASE_TOOL_CALL}``); all other phases are answered ALLOW.
+            Empty (default) answers ALLOW to every phase.
         :param policy_reason: Reason string sent with a DENY verdict.
         :param auto_tool_output: Stringified output auto-returned for each
             tool call; ``None`` leaves tool calls unanswered.
@@ -258,7 +281,7 @@ class SdkInprocDriver:
                 self._drive(
                     body,
                     result,
-                    policy_action,
+                    deny_phases,
                     policy_reason,
                     auto_tool_output,
                     interrupt_on_first_delta,
@@ -273,7 +296,7 @@ class SdkInprocDriver:
         self,
         body: dict[str, Any],
         result: TurnResult,
-        policy_action: str,
+        deny_phases: frozenset[str],
         policy_reason: str | None,
         auto_tool_output: str | None,
         interrupt_on_first_delta: bool,
@@ -325,15 +348,25 @@ class SdkInprocDriver:
                                     }
                                 )
                     elif etype == "policy_evaluation.requested":
+                        # Answer DENY only for phases the caller asked to deny
+                        # (e.g. PHASE_TOOL_CALL); ALLOW every other phase so a
+                        # request/result-phase evaluation cannot be mistaken
+                        # for a tool-call guardrail.
+                        phase = str(event.get("phase", ""))
+                        action = POLICY_DENY if phase in deny_phases else POLICY_ALLOW
                         verdict: dict[str, Any] = {
                             "type": "policy_verdict",
                             "evaluation_id": event["evaluation_id"],
-                            "action": policy_action,
+                            "action": action,
                         }
-                        if policy_reason is not None:
+                        if action == POLICY_DENY and policy_reason is not None:
                             verdict["reason"] = policy_reason
-                        result.policy_actions.append(policy_action)
-                        await self._post(verdict)
+                        # Record only after a successful post, so a raced /
+                        # rejected verdict is not counted as delivered.
+                        if await self._post(verdict):
+                            result.policy_actions.append((phase, action))
+                            if action == POLICY_DENY and phase == PHASE_TOOL_CALL:
+                                result.tool_call_denied = True
                     elif etype == "response.completed":
                         result.completed = True
                     elif etype == "response.cancelled":
@@ -342,16 +375,23 @@ class SdkInprocDriver:
                         result.failed = True
                         result.error = event.get("error") or event.get("response", {}).get("error")
 
-    async def _post(self, payload: dict[str, Any]) -> None:
+    async def _post(self, payload: dict[str, Any]) -> bool:
         """POST a downward event on the wrap's events endpoint (best-effort).
 
         Downward events race the turn's terminal state (e.g. an interrupt
         landing just as the turn ends). A failed post here is benign — the
         probe reads the outcome from the stream — so the error is suppressed.
+
+        :returns: ``True`` if the post got a non-error response, else
+            ``False``. Callers that record a verdict as "delivered" gate on
+            this so a raced/rejected post is not counted.
         """
         assert self._client is not None
-        with contextlib.suppress(httpx.HTTPError):
-            await self._client.post(f"/v1/sessions/{_CONV_ID}/events", json=payload)
+        try:
+            resp = await self._client.post(f"/v1/sessions/{_CONV_ID}/events", json=payload)
+        except httpx.HTTPError:
+            return False
+        return not resp.is_error
 
 
 # Reasoning-delta event names vary across harness wraps; match the common

--- a/tests/harness_bench/probes/policy_deny.py
+++ b/tests/harness_bench/probes/policy_deny.py
@@ -1,17 +1,20 @@
-"""Policy-DENY probe — does the harness enforce a DENY verdict on a tool call?
+"""Policy-DENY probe — does the harness enforce a DENY on a *tool call*?
 
-Offers a tool, prompts the model to call it, and — instead of allowing the
-call — answers the harness's ``policy_evaluation.requested`` with
-``POLICY_ACTION_DENY``. A harness that enforces the verdict blocks the
-call (the tool result reflects a block / the model is told it was denied)
-rather than executing it. This is the load-bearing half of the "Policies"
-column: ALLOW is exercised implicitly by every other probe; DENY is what
-must actually gate.
+Offers a tool, prompts the model to call it, and answers the harness's
+``policy_evaluation.requested`` with DENY **only for the tool-call phase**
+(``PHASE_TOOL_CALL``), allowing every other phase. A harness that enforces
+the verdict blocks the call rather than executing it.
+
+Scoping the DENY to the tool-call phase matters: the scaffold also
+evaluates the request and result phases, and answering DENY to all of them
+could terminate the turn at the request phase and look like a pass without
+a tool call ever being gated. So SUPPORTED requires both that a tool call
+was actually surfaced and that the DENY landed on ``PHASE_TOOL_CALL``.
 """
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import POLICY_DENY, SdkInprocDriver
+from tests.harness_bench.driver import PHASE_TOOL_CALL, SdkInprocDriver
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
@@ -45,55 +48,58 @@ class PolicyDenyProbe(CapabilityProbe):
         result = await driver.run_turn(
             f"Call the {_TOOL_NAME} tool with arg='go'. It is required.",
             tools=_TOOL_SPEC,
-            policy_action=POLICY_DENY,
+            deny_phases=frozenset({PHASE_TOOL_CALL}),
             policy_reason=_DENY_REASON,
             # No auto tool output: a correctly-enforced DENY means the tool
             # never runs, so there is no result to return.
             timeout=150.0,
         )
-        denied_delivered = POLICY_DENY in result.policy_actions
         detail = {
             "policy_actions": result.policy_actions,
+            "tool_call_denied": result.tool_call_denied,
             "tool_calls": [tc.get("name") for tc in result.tool_calls],
             "completed": result.completed,
         }
 
-        if not result.tool_calls and not denied_delivered:
-            # The model never tried the tool, so the DENY path was never
-            # exercised — cannot conclude anything about enforcement.
+        if not result.tool_calls:
+            # The model never tried the tool, so the tool-call DENY path was
+            # never exercised — cannot conclude anything about enforcement.
             return ProbeResult(
                 Verdict.SKIPPED,
-                note="model never attempted the tool; DENY path not exercised",
+                note="model never attempted the tool; tool-call DENY path not exercised",
                 detail=detail,
             )
-        if not denied_delivered:
-            # A tool call happened but no policy_evaluation.requested was
-            # surfaced. Policy evaluation is normally driven by the server /
-            # runner; in this wrap-direct transport some harnesses (e.g.
-            # codex) dispatch the tool without emitting an evaluation hook, so
-            # we cannot exercise DENY here. That is a transport limitation,
-            # not proof the harness ignores policy — report SKIPPED, and let
-            # the full-server transport (phase-2) assert enforcement.
+        if not result.tool_call_denied:
+            # A tool call happened but no PHASE_TOOL_CALL evaluation was
+            # surfaced to deny. Policy evaluation is normally driven by the
+            # server / runner; in this wrap-direct transport some harnesses
+            # (e.g. codex) dispatch the tool without a tool-call evaluation
+            # hook, so we cannot exercise DENY here. That is a transport
+            # limitation, not proof the harness ignores policy — report
+            # SKIPPED and let the full-server transport assert enforcement.
             return ProbeResult(
                 Verdict.SKIPPED,
-                note="no policy evaluation surfaced in the wrap-direct path (server-path concern)",
+                note=(
+                    "tool call not routed through a tool-call policy evaluation "
+                    "(wrap-direct limitation)"
+                ),
                 detail=detail,
             )
-        # A DENY verdict was requested and delivered, and the turn advanced
-        # (to completion or a clean end) without hanging on the blocked call
-        # — the harness accepted and enforced the DENY.
+        # A DENY landed on the tool-call phase and the turn advanced (to
+        # completion or a clean end) without hanging on the blocked call —
+        # the harness accepted and enforced the tool-call DENY.
         if result.completed or result.failed:
             return ProbeResult(
                 Verdict.SUPPORTED,
-                note="DENY verdict delivered and enforced; blocked call did not stall the turn",
+                note="tool-call DENY delivered and enforced; blocked call did not stall the turn",
                 detail=detail,
             )
         if result.timed_out:
             return ProbeResult(
                 Verdict.UNSUPPORTED,
-                note="turn stalled after DENY (blocked call not handled)",
+                note="turn stalled after tool-call DENY (blocked call not handled)",
                 detail=detail,
             )
         return ProbeResult(
-            Verdict.UNKNOWN, note="DENY delivered; outcome inconclusive", detail=detail
+            Verdict.UNKNOWN, note="tool-call DENY delivered; outcome inconclusive", detail=detail
         )

--- a/tests/harness_bench/report.py
+++ b/tests/harness_bench/report.py
@@ -45,19 +45,34 @@ def _colorize(text: str, verdict: Verdict, color: bool) -> str:
     return f"\x1b[{_ANSI.get(verdict, '0')}m{text}\x1b[0m"
 
 
-def _cell_glyph_for_grid(cell: CellResult) -> str:
-    """Compact glyph for a grid cell; drift shows the transition."""
+def _display_verdict(cell: CellResult | None, declared: bool) -> Verdict:
+    if cell is None:
+        return Verdict.UNKNOWN
+    return cell.declared if declared else cell.verdict
+
+
+def _cell_glyph_for_grid(cell: CellResult, declared: bool = False) -> str:
+    """Compact glyph for a grid cell; drift shows the transition.
+
+    When *declared* is set (offline mode), render the declared glyph so the
+    dry matrix shows claimed capabilities instead of a grid of skips.
+    """
+    if declared:
+        return cell.declared.glyph
     if cell.verdict is Verdict.DRIFT:
         return f"!!{cell.declared.glyph}>{cell.observed.glyph}"
     return cell.verdict.glyph
 
 
-def render_table(matrix: BenchMatrix, *, color: bool = False) -> str:
+def render_table(matrix: BenchMatrix, *, color: bool = False, declared: bool = False) -> str:
     """Render *matrix* as an aligned column grid for terminal reading.
 
     :param color: When true, colorize each glyph with ANSI (green supported,
         red drift, dim skipped, ...). The CLI passes the TTY state so piped
         output stays plain.
+    :param declared: When true (offline mode), render each cell's *declared*
+        verdict glyph instead of the observed/reconciled one, so the dry
+        matrix shows the capabilities the profile claims rather than ``·``.
     """
     titles = [p.title for p in ALL_PROBES]
     names = [p.name for p in ALL_PROBES]
@@ -70,8 +85,8 @@ def render_table(matrix: BenchMatrix, *, color: bool = False) -> str:
         by_name = {c.probe_name: c for c in r.cells}
         for n in names:
             cell = by_name.get(n)
-            glyphs[(id(r), n)] = _cell_glyph_for_grid(cell) if cell else "?"
-            verdicts[(id(r), n)] = cell.verdict if cell else Verdict.UNKNOWN
+            glyphs[(id(r), n)] = _cell_glyph_for_grid(cell, declared) if cell else "?"
+            verdicts[(id(r), n)] = _display_verdict(cell, declared)
     col_w = [
         max(len(t), *(len(glyphs[(id(r), n)]) for r in matrix.reports))
         for t, n in zip(titles, names, strict=False)
@@ -99,7 +114,8 @@ def render_table(matrix: BenchMatrix, *, color: bool = False) -> str:
         ]
         lines.append("  ".join(row))
 
-    out = ["Harness capability matrix", "", *lines, "", _legend()]
+    heading = "Harness capability matrix" + (" (declared, not observed)" if declared else "")
+    out = [heading, "", *lines, "", _legend()]
 
     drift = _drift_lines(matrix)
     if drift:
@@ -131,8 +147,12 @@ def _note_lines(matrix: BenchMatrix) -> list[str]:
     return lines
 
 
-def render_markdown(matrix: BenchMatrix) -> str:
-    """Render *matrix* as a Markdown capability grid with a legend and drift list."""
+def render_markdown(matrix: BenchMatrix, *, declared: bool = False) -> str:
+    """Render *matrix* as a Markdown capability grid with a legend and drift list.
+
+    :param declared: When true (offline mode), render declared glyphs so the
+        table shows the claimed matrix rather than a grid of skips.
+    """
     columns = [p.title for p in ALL_PROBES]
     names = [p.name for p in ALL_PROBES]
 
@@ -142,10 +162,11 @@ def render_markdown(matrix: BenchMatrix) -> str:
 
     for report in matrix.reports:
         by_name = {c.probe_name: c for c in report.cells}
-        cells = [_cell_glyph(by_name[n]) if n in by_name else "?" for n in names]
+        cells = [_cell_glyph(by_name[n], declared) if n in by_name else "?" for n in names]
         lines.append(f"| `{report.profile.harness}` | " + " | ".join(cells) + " |")
 
-    out = ["# Harness capability matrix", "", *lines, "", _legend()]
+    heading = "# Harness capability matrix" + (" (declared, not observed)" if declared else "")
+    out = [heading, "", *lines, "", _legend()]
 
     drift = _drift_lines(matrix)
     if drift:
@@ -158,8 +179,10 @@ def render_markdown(matrix: BenchMatrix) -> str:
     return "\n".join(out) + "\n"
 
 
-def _cell_glyph(cell: Any) -> str:
+def _cell_glyph(cell: Any, declared: bool = False) -> str:
     """Glyph for a cell; a drift cell shows the alarm plus what changed."""
+    if declared:
+        return cell.declared.glyph
     if cell.verdict is Verdict.DRIFT:
         return f"!! ({cell.declared.glyph}->{cell.observed.glyph})"
     return cell.verdict.glyph


### PR DESCRIPTION
Follow-up to #1768 addressing the [Polly AI review](https://github.com/omnigent-ai/omnigent/pull/1768#issuecomment-4851802009).

## Addressed

- **Security finding #2 (policy_deny false-pass across phases).** The driver denied *every* `policy_evaluation.requested` phase, so a DENY on the request phase could terminate the turn and be read as a tool-call guardrail pass without any tool call being gated. The driver now answers DENY only for phases the caller names; `policy_deny` scopes its DENY to `PHASE_TOOL_CALL` and requires both a surfaced tool call and a `PHASE_TOOL_CALL` DENY before concluding SUPPORTED. **Live-confirmed:** `openai-agents` (previously a false SUPPORTED) now correctly reports SKIPPED, because its wrap-direct path surfaces no tool-call evaluation. Real enforcement belongs to the full-server transport (phase-2).
- **Note: `unavailable()` ignored transport.** `SdkInprocDriver.unavailable()` now returns a clean skip when `profile.transport != "sdk-inproc"`, instead of force-running a native/community harness through the in-process driver.
- **Note: offline mode didn't render the declared matrix.** `--no-live` (and `--markdown`/table offline) now render the *declared* glyphs, labeled "declared, not observed", matching the README's "Offline (declared) matrix".
- **Note: best-effort POSTs recorded as delivered.** `_post` now returns success and the policy verdict is recorded only on a non-error response, so a raced/rejected `policy_verdict` is not counted as delivered.

## Not changed

- **Blocking finding #1 (tool-call event vocabulary)** was already fixed in the merged MVP (the driver handles `response.output_item.done` / `function_call` / `action_required` and `response.cancelled`); the review ran against the first PR commit, before that fix landed.

Offline suite: 17 passed, 4 skipped. ruff + pre-commit clean.