### PR TITLE
fix(web): make trash icon red on archived sessions page

### DIFF
--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -524,7 +524,7 @@ function ArchivedRow({ conversation }: { conversation: Conversation }) {
           disabled={busy}
           onClick={() => setDeleteOpen(true)}
         >
-          <Trash2Icon className="size-4" />
+          <Trash2Icon className="size-4 text-destructive" />
         </Button>
         <Button
           type="button"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make the trash icon on the archived sessions page (Settings → archived
  session rows) red so it clearly reads as a destructive action.
- Uses the existing `text-destructive` design token rather than a raw color,
  matching the "Delete" button in the confirmation dialog (theme-aware in
  both light and dark mode).

## Test Plan

- Ran the web app locally and opened Settings → archived sessions; the delete
  (trash) icon on each archived row now renders in the destructive/red color.
- Single-class Tailwind change; no logic touched.

## Demo

N/A — one-line color token change; screenshot pending if reviewers want one.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Changelog

Changed: The delete icon for archived sessions is now red to signal it's a destructive action

## Coverage notes

Purely visual, single-class change (`text-destructive` added to the existing
`Trash2Icon`). Verified manually in the running web app; no automated coverage
added for a color token change.

This pull request and its description were written by Isaac.
