### PR TITLE
feat(telemetry): add OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION opt-out

### DIFF
--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -399,10 +399,17 @@ def _instrument_httpx() -> None:
     runner reverse-tunnel (whose transport forwards request headers
     verbatim), and the native-harness policy HTTP hook.
 
+    Disabled when ``OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION=false``.
+    Set this to suppress internal API call spans (server↔runner↔harness
+    requests) from appearing in the trace backend alongside agent spans.
+
     Idempotent: ``HTTPXClientInstrumentor`` no-ops if already
     instrumented. Failures degrade quietly — tracing is best-effort and
     must never break request handling.
     """
+    explicit = os.environ.get("OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION")
+    if explicit is not None and explicit.strip().lower() not in ("true", "1", "yes"):
+        return
     try:
         from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 


### PR DESCRIPTION
## Summary

Adds `OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION=false` to suppress internal httpx client spans (server↔runner↔harness API calls) from appearing in the trace backend alongside agent/tool spans.

Without this, enabling `OMNIGENT_TELEMETRY_ENABLED=true` floods the MLflow traces view with internal HTTP call spans, making it hard to find agent traces.

## Test Plan

- [x] Set `OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION=false` — no httpx spans emitted
- [x] Unset (default) — httpx spans emitted as before
- [x] Pre-commit passes

## Demo

N/A — env var toggle, no UI change.

This pull request and its description were written by Isaac.