### PR TITLE
feat: Canvas — agent-authored artifact panel + canvas.enabled kill-switch (#2)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3197,7 +3197,9 @@ def server(
         # seam so create_app's signature stays untouched.
         extra_routers=[
             (
-                create_canvas_router(canvas_store, auth_provider, permission_store),
+                create_canvas_router(
+                    canvas_store, auth_provider, permission_store, conversation_store
+                ),
                 "/v1",
                 ["canvas"],
             ),

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3006,6 +3006,7 @@ def server(
     # with "unable to open database file".
     _ensure_sqlite_parent_dir(db_uri)
 
+    from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
     from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
 
     agent_store = SqlAlchemyAgentStore(db_uri)
@@ -3014,6 +3015,7 @@ def server(
     comment_store = SqlAlchemyCommentStore(db_uri)
     policy_store = SqlAlchemyPolicyStore(db_uri)
     permission_store = SqlAlchemyPermissionStore(db_uri)
+    canvas_store = SqlAlchemyCanvasStore(db_uri)
     artifact_store = _create_artifact_store(art_loc)
 
     # Initialize the runtime with store references so workflow code
@@ -3066,6 +3068,7 @@ def server(
         artifact_store=artifact_store,
         comment_store=comment_store,
         policy_store=policy_store,
+        canvas_store=canvas_store,
         caps=caps,
     )
 
@@ -3150,6 +3153,8 @@ def server(
 
         account_store = SqlAlchemyAccountStore(db_uri)
 
+    from omnigent.server.routes.canvas import create_canvas_router
+
     app = create_app(
         agent_store=agent_store,
         file_store=file_store,
@@ -3167,6 +3172,15 @@ def server(
         admins=config_str_list(cfg.get("admins")),
         allowed_domains=config_str_list(cfg.get("allowed_domains")),
         sandbox_config=sandbox_config,
+        # Canvas REST API (#2). Mounted via the generic extra_routers
+        # seam so create_app's signature stays untouched.
+        extra_routers=[
+            (
+                create_canvas_router(canvas_store, auth_provider, permission_store),
+                "/v1",
+                ["canvas"],
+            ),
+        ],
     )
 
     click.echo(f"Starting omnigent server on {host}:{port}")

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -73,6 +73,21 @@ def _load_config(path: str | None) -> dict[str, Any]:  # type: ignore[explicit-a
         return yaml.safe_load(f) or {}
 
 
+def _resolve_canvas_enabled(cfg: dict[str, Any]) -> bool:  # type: ignore[explicit-any]
+    """Resolve the ``canvas.enabled`` server flag (#2). Default on.
+
+    Config scalars arrive as strings from the YAML loader (``false`` / ``no``
+    stay ``str``), and ``bool("false")`` is ``True`` — so a naive ``bool()``
+    cast silently ignores ``enabled: false`` and Canvas can never be turned
+    off. Use the shared falsey-aware coercion instead: a genuine bool ``False``
+    and the quoted false-y spellings both disable Canvas; an absent
+    ``canvas`` block or ``enabled`` key keeps it on.
+    """
+    from omnigent.spec.parser import _falsey_flag
+
+    return not _falsey_flag((cfg.get("canvas") or {}).get("enabled"))
+
+
 def _server_uvicorn_log_config() -> dict[str, Any]:  # type: ignore[explicit-any]
     """
     Return Uvicorn logging config with request-duration access logs.
@@ -3054,11 +3069,17 @@ def server(
 
             routing_client = LLMRoutingClient(_policy_client)
 
+    # Canvas feature flag (#2): ``canvas.enabled`` in the server config, default
+    # on. When false, the /v1/canvas routes 404, set_canvas isn't registered,
+    # and the web client hides the Canvas tab. Falsey-aware (see helper).
+    canvas_enabled = _resolve_canvas_enabled(cfg)
+
     caps = RuntimeCaps(
         execution_timeout=int(effective_timeout),
         default_policies=parse_default_policies(cfg.get("policies")),
         llm=server_llm,
         routing_client=routing_client,
+        canvas_enabled=canvas_enabled,
     )
     init_runtime(
         conversation_store=conversation_store,

--- a/omnigent/db/__init__.py
+++ b/omnigent/db/__init__.py
@@ -3,6 +3,7 @@
 from omnigent.db.db_models import (
     Base,
     SqlAgent,
+    SqlCanvas,
     SqlConversation,
     SqlConversationItem,
     SqlFile,
@@ -13,6 +14,7 @@ from omnigent.db.db_models import (
 __all__ = [
     "Base",
     "SqlAgent",
+    "SqlCanvas",
     "SqlConversation",
     "SqlConversationItem",
     "SqlFile",

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -675,6 +675,41 @@ class SqlPolicy(Base):
     )
 
 
+class SqlCanvas(Base):
+    """
+    SQLAlchemy model for the ``canvases`` table.
+
+    One agent-authored canvas artifact per conversation (Cursor-style): the
+    ``set_canvas`` tool upserts HTML/Markdown content, and the web UI renders
+    it in a right-rail Canvas tab.
+
+    :param id: Opaque PK, e.g. ``"cnv_a1b2c3..."``.
+    :param conversation_id: FK to ``conversations.id``; UNIQUE (one canvas per
+        conversation). ``ON DELETE CASCADE`` drops it with the conversation.
+    :param title: Tab title.
+    :param content: Artifact body — HTML or Markdown source.
+    :param content_type: ``"html"`` or ``"markdown"``. Defaults to ``"html"``.
+    :param created_at: Unix epoch seconds at row creation.
+    :param updated_at: Unix epoch seconds of the last write, ``None`` if never
+        updated since creation.
+    """
+
+    __tablename__ = "canvases"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+    )
+    title: Mapped[str] = mapped_column(String(256))
+    content: Mapped[str] = mapped_column(Text)
+    content_type: Mapped[str] = mapped_column(String(16), server_default=text("'html'"))
+    created_at: Mapped[int] = mapped_column(Integer)
+    updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    __table_args__ = (UniqueConstraint("conversation_id", name="uq_canvases_conversation_id"),)
+
+
 class SqlHost(Base):
     """
     SQLAlchemy model for the ``hosts`` table.

--- a/omnigent/db/migrations/versions/b2d4f6a8c0e1_add_canvases_table.py
+++ b/omnigent/db/migrations/versions/b2d4f6a8c0e1_add_canvases_table.py
@@ -1,0 +1,48 @@
+"""add canvases table
+
+Revision ID: b2d4f6a8c0e1
+Revises: n1a2b3c4d5e6
+Create Date: 2026-06-28 01:00:00.000000
+
+Adds the ``canvases`` table: one agent-authored artifact per conversation
+(set via the ``set_canvas`` tool, rendered in the web UI's right-rail Canvas
+tab). UNIQUE on ``conversation_id`` — the tool upserts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2d4f6a8c0e1"
+down_revision: str | None = "n1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "canvases",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("conversation_id", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=256), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "content_type",
+            sa.String(length=16),
+            server_default=sa.text("'html'"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("conversation_id", name="uq_canvases_conversation_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("canvases")

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -626,6 +626,16 @@ def generate_conversation_id() -> str:
     return f"conv_{uuid.uuid4().hex}"
 
 
+def generate_canvas_id() -> str:
+    """
+    Generate a unique canvas identifier.
+
+    :returns: A string of the form ``"cnv_<32-char hex>"``,
+        e.g. ``"cnv_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"``.
+    """
+    return f"cnv_{uuid.uuid4().hex}"
+
+
 def generate_task_id() -> str:
     """
     Generate a unique task (response) identifier.

--- a/omnigent/entities/canvas.py
+++ b/omnigent/entities/canvas.py
@@ -1,0 +1,40 @@
+"""Canvas entity — the agent-authored artifact rendered in the right pane.
+
+A canvas is a single rendered artifact per conversation (Cursor-style): the
+agent sets HTML or Markdown content via the ``set_canvas`` tool, and the web
+UI renders it in a right-rail Canvas tab. One canvas per conversation; setting
+it again overwrites.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Allowed canvas content types. HTML renders in a sandboxed iframe; Markdown
+# renders via the app's markdown viewer.
+CANVAS_CONTENT_TYPES: frozenset[str] = frozenset({"html", "markdown"})
+
+
+@dataclass
+class Canvas:
+    """
+    A conversation's canvas artifact.
+
+    :param id: Opaque primary key, e.g. ``"cnv_a1b2c3..."``.
+    :param conversation_id: The conversation this canvas belongs to (unique).
+    :param title: Short human-readable title shown in the tab header.
+    :param content: The artifact body — HTML or Markdown source.
+    :param content_type: ``"html"`` or ``"markdown"`` (see
+        :data:`CANVAS_CONTENT_TYPES`).
+    :param created_at: Unix epoch seconds at row creation.
+    :param updated_at: Unix epoch seconds of the last write, or ``None`` if
+        never updated since creation.
+    """
+
+    id: str
+    conversation_id: str
+    title: str
+    content: str
+    content_type: str
+    created_at: int
+    updated_at: int | None = None

--- a/omnigent/entities/canvas.py
+++ b/omnigent/entities/canvas.py
@@ -14,6 +14,12 @@ from dataclasses import dataclass
 # renders via the app's markdown viewer.
 CANVAS_CONTENT_TYPES: frozenset[str] = frozenset({"html", "markdown"})
 
+# Upper bound on canvas content, measured as UTF-8 bytes. A canvas is a single
+# rendered artifact, not a file store — cap it so a runaway agent (or a hostile
+# caller hitting the REST endpoint) can't persist an unbounded blob per
+# conversation. 1 MB comfortably fits a rich report / interactive widget.
+MAX_CANVAS_CONTENT_BYTES: int = 1_000_000
+
 
 @dataclass
 class Canvas:

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -304,6 +304,11 @@ _AGENT_TOOLS = frozenset({"sys_agent_get", "sys_agent_download", "sys_agent_list
 # The runner proxies the Omnigent server's session policy REST endpoint.
 _POLICY_TOOLS = frozenset({"sys_add_policy", "sys_policy_registry"})
 
+# Canvas builtin (#2, #12): set_canvas. Like the comment tools, the runner has
+# no in-process CanvasStore, so it proxies to the server's REST API over
+# server_client (see _execute_canvas_tool): PUT /v1/canvas/{conversation_id}.
+_CANVAS_TOOLS = frozenset({"set_canvas"})
+
 # Builtin tools the claude-native / codex-native relay advertises to the
 # real CLI, beyond the always-relayed ``sys_os_*`` family. Native harnesses
 # ignore the harness ``tools`` list, so the relay is their ONLY tool
@@ -331,6 +336,7 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
     | _AGENT_TOOLS
     | _POLICY_TOOLS
     | _TERMINAL_TOOLS
+    | _CANVAS_TOOLS
 )
 
 
@@ -467,6 +473,7 @@ _ALL_LOCAL_TOOLS = (
     | _COMMENT_TOOLS
     | _AGENT_TOOLS
     | _POLICY_TOOLS
+    | _CANVAS_TOOLS
 )
 _PLACEHOLDER_CWDS = (None, "", ".", "./")
 
@@ -2559,6 +2566,60 @@ async def _execute_comment_tool(
         return json.dumps({"error": f"update_comment failed: {exc}"})
 
 
+async def _execute_canvas_tool(
+    tool_name: str,
+    arguments: str,
+    *,
+    conversation_id: str | None,
+    server_client: httpx.AsyncClient | None,
+) -> str:
+    """
+    Runner-local handler for the ``set_canvas`` builtin (#2, #12).
+
+    The runner has no in-process CanvasStore, so — like the comment tools —
+    ``set_canvas`` proxies to the Omnigent server's ``PUT /v1/canvas/{id}`` over
+    ``server_client``. The canvas is scoped to the current ``conversation_id``.
+
+    :param tool_name: One of :data:`_CANVAS_TOOLS`.
+    :param arguments: JSON-encoded args from the LLM.
+    :param conversation_id: Current session id, used as the default scope.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :returns: A JSON result/error string for the agent.
+    """
+    if server_client is None:
+        return json.dumps({"error": f"{tool_name} requires server access"})
+    try:
+        args: dict[str, Any] = json.loads(arguments) if arguments.strip() else {}
+    except json.JSONDecodeError:
+        return json.dumps({"error": f"{tool_name}: malformed JSON arguments"})
+
+    def _result(resp: httpx.Response) -> str:
+        if resp.status_code >= 400:
+            return json.dumps(
+                {"error": f"{tool_name} returned HTTP {resp.status_code}: {resp.text[:300]}"}
+            )
+        return json.dumps(resp.json())
+
+    scoped_conv = args.get("conversation_id") or conversation_id
+
+    try:
+        if tool_name == "set_canvas":
+            if not scoped_conv:
+                return json.dumps({"error": "set_canvas requires a session id"})
+            body = {
+                "title": args.get("title"),
+                "content": args.get("content"),
+                "content_type": args.get("content_type", "html"),
+            }
+            return _result(
+                await server_client.put(f"/v1/canvas/{scoped_conv}", json=body, timeout=30.0)
+            )
+
+        return json.dumps({"error": f"unknown canvas tool: {tool_name}"})
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"{tool_name} failed: {exc}"})
+
+
 async def _execute_policy_tool(
     tool_name: str,
     arguments: str,
@@ -4173,6 +4234,13 @@ async def execute_tool(
             )
         elif tool_name in _POLICY_TOOLS:
             output = await _execute_policy_tool(
+                tool_name,
+                arguments,
+                conversation_id=conversation_id,
+                server_client=server_client,
+            )
+        elif tool_name in _CANVAS_TOOLS:
+            output = await _execute_canvas_tool(
                 tool_name,
                 arguments,
                 conversation_id=conversation_id,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2600,7 +2600,9 @@ async def _execute_canvas_tool(
             )
         return json.dumps(resp.json())
 
-    scoped_conv = args.get("conversation_id") or conversation_id
+    # Always the ambient session — never a conversation_id from the tool args,
+    # so an agent can't write to another conversation's canvas.
+    scoped_conv = conversation_id
 
     try:
         if tool_name == "set_canvas":

--- a/omnigent/runtime/__init__.py
+++ b/omnigent/runtime/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         ConversationStore,
         FileStore,
     )
+    from omnigent.stores.canvas_store import CanvasStore
     from omnigent.stores.comment_store import CommentStore
     from omnigent.stores.policy_store import PolicyStore
     from omnigent.terminals import TerminalRegistry
@@ -37,6 +38,7 @@ def init(
     artifact_store: ArtifactStore | None = None,
     comment_store: CommentStore | None = None,
     policy_store: PolicyStore | None = None,
+    canvas_store: CanvasStore | None = None,
     caps: RuntimeCaps | None = None,
 ) -> None:
     """
@@ -72,6 +74,7 @@ def init(
         artifact_store=artifact_store,
         comment_store=comment_store,
         policy_store=policy_store,
+        canvas_store=canvas_store,
         caps=caps,
     )
 
@@ -154,6 +157,18 @@ def get_policy_store() -> PolicyStore | None:
     :returns: The PolicyStore set during :func:`init`, or ``None``.
     """
     return _globals._policy_store
+
+
+def get_canvas_store() -> CanvasStore | None:
+    """
+    Return the CanvasStore instance, or ``None`` if not configured.
+
+    Returns ``None`` (rather than raising) because canvas_store is optional —
+    the ``set_canvas`` tool surfaces a clear error when invoked without it.
+
+    :returns: The CanvasStore set during :func:`init`, or ``None``.
+    """
+    return _globals._canvas_store
 
 
 def get_agent_cache() -> AgentCache:

--- a/omnigent/runtime/_globals.py
+++ b/omnigent/runtime/_globals.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         ConversationStore,
         FileStore,
     )
+    from omnigent.stores.canvas_store import CanvasStore
     from omnigent.stores.comment_store import CommentStore
     from omnigent.stores.policy_store import PolicyStore
     from omnigent.terminals import TerminalRegistry
@@ -36,6 +37,7 @@ _file_store: FileStore | None = None
 _artifact_store: ArtifactStore | None = None
 _comment_store: CommentStore | None = None
 _policy_store: PolicyStore | None = None
+_canvas_store: CanvasStore | None = None
 _caps: RuntimeCaps = RuntimeCaps()
 
 # Server-resident tmux terminal registry. Initialized in
@@ -169,6 +171,7 @@ def init(
     artifact_store: ArtifactStore | None = None,
     comment_store: CommentStore | None = None,
     policy_store: PolicyStore | None = None,
+    canvas_store: CanvasStore | None = None,
     caps: RuntimeCaps | None = None,
 ) -> None:
     """
@@ -206,6 +209,7 @@ def init(
     global _conversation_store, _agent_store
     global _agent_cache, _file_store, _artifact_store, _caps
     global _terminal_registry, _comment_store, _policy_store
+    global _canvas_store
     _conversation_store = conversation_store
     _agent_store = agent_store
     _agent_cache = agent_cache
@@ -213,6 +217,7 @@ def init(
     _artifact_store = artifact_store
     _comment_store = comment_store
     _policy_store = policy_store
+    _canvas_store = canvas_store
     _caps = caps if caps is not None else RuntimeCaps()
     # Tmux terminal registry: server-resident, conversation-scoped
     # ``inner.terminal.TerminalInstance`` map. See

--- a/omnigent/runtime/caps.py
+++ b/omnigent/runtime/caps.py
@@ -75,3 +75,7 @@ class RuntimeCaps:
     # Managed deployments can supply a different implementation (e.g.
     # a rules engine or remote service).  ``None`` disables routing.
     routing_client: RoutingClient | None = None
+    # Global on/off for the Canvas feature (#2), from ``canvas.enabled`` in the
+    # server --config YAML (default on). When off, the ``/v1/canvas`` routes
+    # 404, ``set_canvas`` isn't registered, and the client hides the Canvas tab.
+    canvas_enabled: bool = True

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1768,8 +1768,11 @@ def create_app(
             smart_routing_enabled = _caps is not None and (
                 _caps.routing_client is not None or _caps.policy_llm_connection_factory is not None
             )
+            # Canvas (#2) is on unless the operator disabled it via config.
+            canvas_enabled = _caps is None or _caps.canvas_enabled
         except ImportError:
             smart_routing_enabled = False
+            canvas_enabled = True
         return {
             "accounts_enabled": accounts_enabled,
             "login_url": login_url,
@@ -1779,6 +1782,7 @@ def create_app(
             "sandbox_provider": sandbox_provider,
             "server_version": _server_version(),
             "smart_routing_enabled": smart_routing_enabled,
+            "canvas_enabled": canvas_enabled,
         }
 
     @app.get("/v1/me", response_model=None)  # Union return type (dict | JSONResponse)

--- a/omnigent/server/routes/canvas.py
+++ b/omnigent/server/routes/canvas.py
@@ -1,0 +1,56 @@
+"""REST route for reading a conversation's canvas.
+
+``GET /v1/canvas/{conversation_id}`` returns the canvas the agent authored via
+``set_canvas`` (or 404 if none). Read-only; the agent is the only writer (via
+the tool). Requires authentication in multi-user mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from omnigent.entities.canvas import Canvas
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes._auth_helpers import get_user_id
+from omnigent.stores.canvas_store import CanvasStore
+from omnigent.stores.permission_store import PermissionStore
+
+
+def _to_response(canvas: Canvas) -> dict[str, Any]:
+    """Serialize a :class:`Canvas` to a response dict."""
+    return {
+        "id": canvas.id,
+        "object": "canvas",
+        "conversation_id": canvas.conversation_id,
+        "title": canvas.title,
+        "content": canvas.content,
+        "content_type": canvas.content_type,
+        "created_at": canvas.created_at,
+        "updated_at": canvas.updated_at,
+    }
+
+
+def create_canvas_router(
+    store: CanvasStore,
+    auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+) -> APIRouter:
+    """Build the canvas router (mounted at ``/canvas/{conversation_id}``)."""
+    router = APIRouter()
+
+    @router.get("/canvas/{conversation_id}")
+    async def get_canvas(request: Request, conversation_id: str) -> dict[str, Any]:
+        """Return the conversation's canvas, or 404 if none is set."""
+        user_id = get_user_id(request, auth_provider)
+        if permission_store is not None and user_id is None:
+            raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+        canvas = await asyncio.to_thread(store.get_by_conversation, conversation_id)
+        if canvas is None:
+            raise OmnigentError("No canvas for this conversation", code=ErrorCode.NOT_FOUND)
+        return _to_response(canvas)
+
+    return router

--- a/omnigent/server/routes/canvas.py
+++ b/omnigent/server/routes/canvas.py
@@ -1,8 +1,11 @@
-"""REST route for reading a conversation's canvas.
+"""REST routes for a conversation's canvas.
 
-``GET /v1/canvas/{conversation_id}`` returns the canvas the agent authored via
-``set_canvas`` (or 404 if none). Read-only; the agent is the only writer (via
-the tool). Requires authentication in multi-user mode.
+``GET /v1/canvas/{conversation_id}`` returns the canvas the agent authored (or
+404 if none). ``PUT /v1/canvas/{conversation_id}`` upserts it — used by the
+runner's ``set_canvas`` tool proxy when the agent runs off-server (the runner
+has no in-process CanvasStore, so it writes via this endpoint, mirroring how
+the comment tools proxy over ``server_client``). Requires auth in multi-user
+mode.
 """
 
 from __future__ import annotations
@@ -11,13 +14,23 @@ import asyncio
 from typing import Any
 
 from fastapi import APIRouter, Request
+from pydantic import BaseModel
 
-from omnigent.entities.canvas import Canvas
+from omnigent.db.utils import generate_canvas_id
+from omnigent.entities.canvas import CANVAS_CONTENT_TYPES, Canvas
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import get_user_id
 from omnigent.stores.canvas_store import CanvasStore
 from omnigent.stores.permission_store import PermissionStore
+
+
+class UpsertCanvasBody(BaseModel):
+    """Request body for ``PUT /canvas/{conversation_id}``."""
+
+    title: str
+    content: str
+    content_type: str = "html"
 
 
 def _to_response(canvas: Canvas) -> dict[str, Any]:
@@ -51,6 +64,29 @@ def create_canvas_router(
         canvas = await asyncio.to_thread(store.get_by_conversation, conversation_id)
         if canvas is None:
             raise OmnigentError("No canvas for this conversation", code=ErrorCode.NOT_FOUND)
+        return _to_response(canvas)
+
+    @router.put("/canvas/{conversation_id}")
+    async def upsert_canvas(
+        request: Request, conversation_id: str, body: UpsertCanvasBody
+    ) -> dict[str, Any]:
+        """Create or overwrite the conversation's canvas (one per conversation)."""
+        user_id = get_user_id(request, auth_provider)
+        if permission_store is not None and user_id is None:
+            raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+        if body.content_type not in CANVAS_CONTENT_TYPES:
+            raise OmnigentError(
+                f"content_type must be one of {sorted(CANVAS_CONTENT_TYPES)}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        canvas = await asyncio.to_thread(
+            store.upsert,
+            generate_canvas_id(),
+            conversation_id,
+            body.title,
+            body.content,
+            body.content_type,
+        )
         return _to_response(canvas)
 
     return router

--- a/omnigent/server/routes/canvas.py
+++ b/omnigent/server/routes/canvas.py
@@ -17,12 +17,17 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from omnigent.db.utils import generate_canvas_id
-from omnigent.entities.canvas import CANVAS_CONTENT_TYPES, Canvas
+from omnigent.entities.canvas import (
+    CANVAS_CONTENT_TYPES,
+    MAX_CANVAS_CONTENT_BYTES,
+    Canvas,
+)
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runtime import get_caps
-from omnigent.server.auth import AuthProvider
-from omnigent.server.routes._auth_helpers import get_user_id
+from omnigent.server.auth import LEVEL_EDIT, LEVEL_READ, AuthProvider
+from omnigent.server.routes._auth_helpers import get_user_id, require_access
 from omnigent.stores.canvas_store import CanvasStore
+from omnigent.stores.conversation_store import ConversationStore
 from omnigent.stores.permission_store import PermissionStore
 
 
@@ -52,8 +57,17 @@ def create_canvas_router(
     store: CanvasStore,
     auth_provider: AuthProvider | None = None,
     permission_store: PermissionStore | None = None,
+    conversation_store: ConversationStore | None = None,
 ) -> APIRouter:
-    """Build the canvas router (mounted at ``/canvas/{conversation_id}``)."""
+    """Build the canvas router (mounted at ``/canvas/{conversation_id}``).
+
+    In multi-user mode (``permission_store`` set) the caller must have access
+    to the target conversation — a canvas is conversation-scoped data, so
+    reading or writing one requires the same permission as the conversation
+    itself (read to GET, edit to PUT). ``require_access`` returns 404 (not 403)
+    when the caller has no access at all, so it never leaks which conversation
+    ids exist. Single-user deployments (no ``permission_store``) skip the check.
+    """
     router = APIRouter()
 
     @router.get("/canvas/{conversation_id}")
@@ -62,8 +76,9 @@ def create_canvas_router(
         if not get_caps().canvas_enabled:
             raise OmnigentError("Canvas is not enabled on this server", code=ErrorCode.NOT_FOUND)
         user_id = get_user_id(request, auth_provider)
-        if permission_store is not None and user_id is None:
-            raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+        await require_access(
+            user_id, conversation_id, LEVEL_READ, permission_store, conversation_store
+        )
         canvas = await asyncio.to_thread(store.get_by_conversation, conversation_id)
         if canvas is None:
             raise OmnigentError("No canvas for this conversation", code=ErrorCode.NOT_FOUND)
@@ -77,11 +92,17 @@ def create_canvas_router(
         if not get_caps().canvas_enabled:
             raise OmnigentError("Canvas is not enabled on this server", code=ErrorCode.NOT_FOUND)
         user_id = get_user_id(request, auth_provider)
-        if permission_store is not None and user_id is None:
-            raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+        await require_access(
+            user_id, conversation_id, LEVEL_EDIT, permission_store, conversation_store
+        )
         if body.content_type not in CANVAS_CONTENT_TYPES:
             raise OmnigentError(
                 f"content_type must be one of {sorted(CANVAS_CONTENT_TYPES)}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if len(body.content.encode("utf-8")) > MAX_CANVAS_CONTENT_BYTES:
+            raise OmnigentError(
+                f"canvas content exceeds the {MAX_CANVAS_CONTENT_BYTES}-byte limit",
                 code=ErrorCode.INVALID_INPUT,
             )
         canvas = await asyncio.to_thread(

--- a/omnigent/server/routes/canvas.py
+++ b/omnigent/server/routes/canvas.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from omnigent.db.utils import generate_canvas_id
 from omnigent.entities.canvas import CANVAS_CONTENT_TYPES, Canvas
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.runtime import get_caps
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import get_user_id
 from omnigent.stores.canvas_store import CanvasStore
@@ -58,6 +59,8 @@ def create_canvas_router(
     @router.get("/canvas/{conversation_id}")
     async def get_canvas(request: Request, conversation_id: str) -> dict[str, Any]:
         """Return the conversation's canvas, or 404 if none is set."""
+        if not get_caps().canvas_enabled:
+            raise OmnigentError("Canvas is not enabled on this server", code=ErrorCode.NOT_FOUND)
         user_id = get_user_id(request, auth_provider)
         if permission_store is not None and user_id is None:
             raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
@@ -71,6 +74,8 @@ def create_canvas_router(
         request: Request, conversation_id: str, body: UpsertCanvasBody
     ) -> dict[str, Any]:
         """Create or overwrite the conversation's canvas (one per conversation)."""
+        if not get_caps().canvas_enabled:
+            raise OmnigentError("Canvas is not enabled on this server", code=ErrorCode.NOT_FOUND)
         user_id = get_user_id(request, auth_provider)
         if permission_store is not None and user_id is None:
             raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)

--- a/omnigent/stores/canvas_store/__init__.py
+++ b/omnigent/stores/canvas_store/__init__.py
@@ -1,0 +1,59 @@
+"""Canvas store — one rendered artifact per conversation.
+
+The agent writes via ``upsert`` (overwriting the conversation's canvas); the
+web UI reads via ``get_by_conversation``.
+"""
+
+from abc import ABC, abstractmethod
+
+from omnigent.entities.canvas import Canvas
+
+
+class CanvasStore(ABC):
+    """Abstract base for canvas persistence (one canvas per conversation)."""
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        :param storage_location: Backend-specific storage URI,
+            e.g. ``"sqlite:///chat.db"`` for SQLAlchemy.
+        """
+        self.storage_location = storage_location
+
+    @abstractmethod
+    def get_by_conversation(self, conversation_id: str) -> Canvas | None:
+        """
+        :param conversation_id: The owning conversation.
+        :returns: The :class:`Canvas`, or ``None`` if none is set.
+        """
+        ...
+
+    @abstractmethod
+    def upsert(
+        self,
+        canvas_id: str,
+        conversation_id: str,
+        title: str,
+        content: str,
+        content_type: str,
+    ) -> Canvas:
+        """
+        Create or overwrite the conversation's canvas.
+
+        :param canvas_id: Id to use if creating (ignored on overwrite).
+        :param conversation_id: The owning conversation (unique key).
+        :param title: Tab title.
+        :param content: HTML or Markdown source.
+        :param content_type: ``"html"`` or ``"markdown"``.
+        :returns: The stored :class:`Canvas`.
+        """
+        ...
+
+    @abstractmethod
+    def delete(self, conversation_id: str) -> bool:
+        """
+        Delete a conversation's canvas. Idempotent.
+
+        :param conversation_id: The owning conversation.
+        :returns: ``True`` if a canvas was removed; ``False`` if none existed.
+        """
+        ...

--- a/omnigent/stores/canvas_store/sqlalchemy_store.py
+++ b/omnigent/stores/canvas_store/sqlalchemy_store.py
@@ -1,0 +1,102 @@
+"""SQLAlchemy-backed canvas store."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from omnigent.db.db_models import SqlCanvas
+from omnigent.db.utils import (
+    get_or_create_engine,
+    make_managed_session_maker,
+    now_epoch,
+)
+from omnigent.entities.canvas import Canvas
+from omnigent.stores.canvas_store import CanvasStore
+
+
+def _to_entity(row: SqlCanvas) -> Canvas:
+    """Convert a :class:`SqlCanvas` ORM row to a :class:`Canvas` entity."""
+    return Canvas(
+        id=row.id,
+        conversation_id=row.conversation_id,
+        title=row.title,
+        content=row.content,
+        content_type=row.content_type,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+class SqlAlchemyCanvasStore(CanvasStore):
+    """SQLAlchemy-backed implementation of :class:`CanvasStore`."""
+
+    def __init__(self, storage_location: str) -> None:
+        """Create or reuse a SQLAlchemy engine + session factory."""
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        # immediate=True: upsert is a check-then-write, so take the SQLite
+        # write lock up front to avoid a concurrent-create race.
+        self._session = make_managed_session_maker(self._engine, immediate=True)
+
+    def get_by_conversation(self, conversation_id: str) -> Canvas | None:
+        """Return the conversation's canvas, or ``None``."""
+        with self._session() as session:
+            row = (
+                session.execute(
+                    select(SqlCanvas).where(SqlCanvas.conversation_id == conversation_id)
+                )
+                .scalars()
+                .first()
+            )
+            return _to_entity(row) if row is not None else None
+
+    def upsert(
+        self,
+        canvas_id: str,
+        conversation_id: str,
+        title: str,
+        content: str,
+        content_type: str,
+    ) -> Canvas:
+        """Create or overwrite the conversation's canvas."""
+        with self._session() as session:
+            row = (
+                session.execute(
+                    select(SqlCanvas).where(SqlCanvas.conversation_id == conversation_id)
+                )
+                .scalars()
+                .first()
+            )
+            if row is None:
+                row = SqlCanvas(
+                    id=canvas_id,
+                    conversation_id=conversation_id,
+                    title=title,
+                    content=content,
+                    content_type=content_type,
+                    created_at=now_epoch(),
+                    updated_at=None,
+                )
+                session.add(row)
+            else:
+                row.title = title
+                row.content = content
+                row.content_type = content_type
+                row.updated_at = now_epoch()
+            session.flush()
+            return _to_entity(row)
+
+    def delete(self, conversation_id: str) -> bool:
+        """Delete the conversation's canvas. Idempotent."""
+        with self._session() as session:
+            row = (
+                session.execute(
+                    select(SqlCanvas).where(SqlCanvas.conversation_id == conversation_id)
+                )
+                .scalars()
+                .first()
+            )
+            if row is None:
+                return False
+            session.delete(row)
+            return True

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -35,6 +35,7 @@ from omnigent.tools.builtins.async_inbox import (
     SysCancelAsyncTool,
     SysReadInboxTool,
 )
+from omnigent.tools.builtins.canvas import SetCanvasTool
 from omnigent.tools.builtins.list_comments import ListCommentsTool
 from omnigent.tools.builtins.list_models import SysListModelsTool
 from omnigent.tools.builtins.load_skill import (
@@ -69,6 +70,7 @@ __all__ = [
     "ListCommentsTool",
     "LoadSkillTool",
     "ReadSkillFileTool",
+    "SetCanvasTool",
     "SysAdviseModelsTool",
     "SysAgentDownloadTool",
     "SysAgentGetTool",
@@ -168,6 +170,17 @@ def _create_export_agent(config: dict[str, str]) -> Tool:
     return ExportAgentTool()
 
 
+def _create_set_canvas(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for SetCanvasTool.
+
+    :param config: Tool config (unused).
+    :returns: A SetCanvasTool instance.
+    """
+    del config
+    return SetCanvasTool()
+
+
 # Unified registry for every reserved builtin name. The value
 # is either a factory callable (for user-enablable tools) or
 # ``None`` for framework-owned names that occupy the name-space
@@ -190,6 +203,8 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     "download_file": _create_download_file,
     "search_conversations": _create_search_conversations,
     "export_agent": _create_export_agent,
+    # Canvas (#2) — agent-authored artifact rendered in the right pane.
+    "set_canvas": _create_set_canvas,
     # Framework-owned: need runtime context. ``web_fetch`` is
     # constructed by ToolManager before reaching this registry.
     # ``list_comments`` and ``update_comment`` are auto-registered by

--- a/omnigent/tools/builtins/canvas.py
+++ b/omnigent/tools/builtins/canvas.py
@@ -1,0 +1,117 @@
+"""Built-in ``set_canvas`` tool — author the conversation's canvas artifact.
+
+The agent calls ``set_canvas`` with HTML or Markdown; the content is stored
+(one canvas per conversation, overwritten on re-set) and the web UI renders it
+in a right-rail Canvas tab. Resolves the store lazily via
+:func:`omnigent.runtime.get_canvas_store`, like the other store-backed tools.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from omnigent.entities.canvas import CANVAS_CONTENT_TYPES
+from omnigent.tools.base import Tool, ToolContext
+
+_CONTENT_TYPES = sorted(CANVAS_CONTENT_TYPES)
+
+
+class SetCanvasTool(Tool):
+    """Create or overwrite the conversation's rendered canvas artifact."""
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"set_canvas"``."""
+        return "set_canvas"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Description visible to the LLM."""
+        return (
+            "Render an artifact in the user's Canvas pane: pass HTML (default) "
+            "or Markdown and a title. Use this to show a visual result — a "
+            "table, chart, diagram, formatted report, or a small interactive "
+            "HTML/JS widget. Calling it again overwrites the conversation's "
+            "canvas, so you can iterate."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """:returns: OpenAI tool schema for ``set_canvas``."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "Canvas title."},
+                        "content": {
+                            "type": "string",
+                            "description": "The artifact body (HTML or Markdown source).",
+                        },
+                        "content_type": {
+                            "type": "string",
+                            "enum": _CONTENT_TYPES,
+                            "description": "How to render content (default 'html').",
+                        },
+                        "conversation_id": {
+                            "type": "string",
+                            "description": "Target conversation (defaults to the current one).",
+                        },
+                    },
+                    "required": ["title", "content"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        """Upsert the conversation's canvas; return it as JSON."""
+        try:
+            args = json.loads(arguments) if arguments else {}
+        except json.JSONDecodeError as exc:
+            return json.dumps({"error": f"invalid arguments: {exc}"})
+
+        title = args.get("title")
+        content = args.get("content")
+        if not isinstance(title, str) or not title.strip():
+            return json.dumps({"error": "title is required"})
+        if not isinstance(content, str) or not content:
+            return json.dumps({"error": "content is required"})
+
+        content_type = args.get("content_type", "html")
+        if content_type not in CANVAS_CONTENT_TYPES:
+            return json.dumps({"error": f"content_type must be one of {_CONTENT_TYPES}"})
+
+        conversation_id = args.get("conversation_id") or ctx.conversation_id
+        if not conversation_id:
+            return json.dumps({"error": "set_canvas requires a conversation context"})
+
+        from omnigent.db.utils import generate_canvas_id
+        from omnigent.runtime import get_canvas_store
+
+        store = get_canvas_store()
+        if store is None:
+            return json.dumps({"error": "canvas store is not configured on this server"})
+
+        canvas = store.upsert(
+            generate_canvas_id(),
+            conversation_id,
+            title.strip(),
+            content,
+            content_type,
+        )
+        return json.dumps(
+            {
+                "ok": True,
+                "canvas": {
+                    "id": canvas.id,
+                    "conversation_id": canvas.conversation_id,
+                    "title": canvas.title,
+                    "content_type": canvas.content_type,
+                    "updated_at": canvas.updated_at,
+                },
+            }
+        )

--- a/omnigent/tools/builtins/canvas.py
+++ b/omnigent/tools/builtins/canvas.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from omnigent.entities.canvas import CANVAS_CONTENT_TYPES
+from omnigent.entities.canvas import CANVAS_CONTENT_TYPES, MAX_CANVAS_CONTENT_BYTES
 from omnigent.tools.base import Tool, ToolContext
 
 _CONTENT_TYPES = sorted(CANVAS_CONTENT_TYPES)
@@ -56,10 +56,6 @@ class SetCanvasTool(Tool):
                             "enum": _CONTENT_TYPES,
                             "description": "How to render content (default 'html').",
                         },
-                        "conversation_id": {
-                            "type": "string",
-                            "description": "Target conversation (defaults to the current one).",
-                        },
                     },
                     "required": ["title", "content"],
                     "additionalProperties": False,
@@ -85,7 +81,14 @@ class SetCanvasTool(Tool):
         if content_type not in CANVAS_CONTENT_TYPES:
             return json.dumps({"error": f"content_type must be one of {_CONTENT_TYPES}"})
 
-        conversation_id = args.get("conversation_id") or ctx.conversation_id
+        if len(content.encode("utf-8")) > MAX_CANVAS_CONTENT_BYTES:
+            return json.dumps(
+                {"error": f"content exceeds the {MAX_CANVAS_CONTENT_BYTES}-byte limit"}
+            )
+
+        # Always the ambient conversation — the tool can't target another
+        # conversation's canvas (an agent writes only to its own session).
+        conversation_id = ctx.conversation_id
         if not conversation_id:
             return json.dumps({"error": "set_canvas requires a conversation context"})
 

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -182,6 +182,11 @@ class ToolManager:
         # Policy tool is always auto-registered so agents can add
         # inline CEL policies at runtime without spec changes.
         self._register_policy_tools()
+        # Canvas tool (#2) is auto-registered so an agent — and the Omnigent MCP
+        # surface — can render an artifact without the spec opting in. Registered
+        # directly (like the comment tools) rather than declared in
+        # ``tools.builtins``, sidestepping the function-tool callable-recovery path.
+        self._register_canvas_tools()
 
     def _register_policy_tools(self) -> None:
         """
@@ -521,6 +526,22 @@ class ToolManager:
         """
         self._tools[ListCommentsTool.name()] = ListCommentsTool()
         self._tools[UpdateCommentTool.name()] = UpdateCommentTool()
+
+    def _register_canvas_tools(self) -> None:
+        """
+        Auto-register the ``set_canvas`` builtin (#2, #12).
+
+        Framework-owned and always available so an agent — and the Omnigent MCP
+        surface — can render a canvas artifact without the spec opting in.
+        Instantiated straight from the builtin registry (like the comment tools)
+        rather than declared in ``tools.builtins``, which avoids the
+        declared-builtin function-tool callable-recovery path. The tool returns a
+        clear error at invoke time when its backing CanvasStore isn't configured,
+        so registering it unconditionally is safe.
+        """
+        tool = get_builtin_tool("set_canvas")
+        if tool is not None:
+            self._tools["set_canvas"] = tool
 
     def _register_os_env_tools(self) -> None:
         """

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -535,10 +535,20 @@ class ToolManager:
         surface — can render a canvas artifact without the spec opting in.
         Instantiated straight from the builtin registry (like the comment tools)
         rather than declared in ``tools.builtins``, which avoids the
-        declared-builtin function-tool callable-recovery path. The tool returns a
-        clear error at invoke time when its backing CanvasStore isn't configured,
-        so registering it unconditionally is safe.
+        declared-builtin function-tool callable-recovery path.
+
+        Gated on the ``canvas.enabled`` server flag (#2): when the operator has
+        disabled Canvas we don't advertise the tool. Best-effort — if the caps
+        aren't resolvable here (e.g. a runner without server config), we register
+        anyway; the ``/v1/canvas`` route is the hard gate and 404s regardless.
         """
+        try:
+            from omnigent.runtime import get_caps
+
+            if not get_caps().canvas_enabled:
+                return
+        except Exception:
+            pass
         tool = get_builtin_tool("set_canvas")
         if tool is not None:
             self._tools["set_canvas"] = tool

--- a/tests/cli/test_canvas_flag.py
+++ b/tests/cli/test_canvas_flag.py
@@ -1,0 +1,55 @@
+"""Tests for the ``canvas.enabled`` server-config flag parsing (#2).
+
+Guards a subtle bug: the config YAML loader keeps scalars like ``false`` as
+``str``, and ``bool("false")`` is ``True`` — so a naive ``bool()`` cast can
+never turn Canvas off. :func:`_resolve_canvas_enabled` must coerce falsey
+strings (and genuine bools) correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.cli import _load_config, _resolve_canvas_enabled
+
+
+@pytest.mark.parametrize(
+    ("yaml_text", "expected"),
+    [
+        pytest.param("", True, id="empty-config-defaults-on"),
+        pytest.param("canvas:\n  enabled: false\n", False, id="bare-false"),
+        pytest.param("canvas:\n  enabled: true\n", True, id="bare-true"),
+        pytest.param('canvas:\n  enabled: "false"\n', False, id="quoted-false"),
+        pytest.param("canvas:\n  enabled: no\n", False, id="bare-no"),
+        pytest.param("canvas:\n  enabled: off\n", False, id="bare-off"),
+        pytest.param("canvas: {}\n", True, id="empty-canvas-block-defaults-on"),
+        pytest.param("other: 1\n", True, id="unrelated-config-defaults-on"),
+    ],
+)
+def test_resolve_canvas_enabled_from_loaded_config(
+    tmp_path: Path,
+    yaml_text: str,
+    expected: bool,
+) -> None:
+    """End-to-end: write YAML, load it the way ``server`` does, resolve the flag.
+
+    Exercises the loader + coercion together so a regression where the loader
+    yields a string and the coercion mis-handles it (the original ``bool()``
+    bug) is caught.
+    """
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml_text)
+    cfg = _load_config(str(cfg_path))
+    assert _resolve_canvas_enabled(cfg) is expected
+
+
+def test_resolve_canvas_enabled_direct_dict_inputs() -> None:
+    """The coercion accepts genuine bools and absent keys, not just strings."""
+    assert _resolve_canvas_enabled({}) is True
+    assert _resolve_canvas_enabled({"canvas": {"enabled": False}}) is False
+    assert _resolve_canvas_enabled({"canvas": {"enabled": True}}) is True
+    # A naive ``bool("false")`` would be True — the whole point of the helper.
+    assert _resolve_canvas_enabled({"canvas": {"enabled": "false"}}) is False
+    assert _resolve_canvas_enabled({"canvas": None}) is True

--- a/tests/e2e_ui/canvas/test_canvas_panel.py
+++ b/tests/e2e_ui/canvas/test_canvas_panel.py
@@ -1,0 +1,43 @@
+"""UI e2e: the right-rail Canvas tab renders an agent-authored canvas (#2).
+
+Seeds a canvas via ``PUT /v1/canvas/{id}`` (the same endpoint the runner's
+``set_canvas`` proxy writes through), opens the conversation, and asserts the
+Canvas tab appears and renders the title + content — covering the useCanvas
+hook, the tab gating (``showCanvasTab``), and CanvasPanel in a real browser.
+Markdown content is used so the body is directly assertable in the DOM (HTML
+renders inside a sandboxed iframe).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+
+def test_canvas_tab_renders_seeded_canvas(
+    page: Page, live_server: str, seeded_session: tuple[str, str]
+) -> None:
+    base_url, session_id = seeded_session
+    marker = uuid.uuid4().hex[:8]
+    httpx.put(
+        f"{live_server}/v1/canvas/{session_id}",
+        json={
+            "title": f"Report {marker}",
+            "content": f"canvas body {marker}",
+            "content_type": "markdown",
+        },
+        timeout=10.0,
+    ).raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+    # The Canvas tab only renders once the conversation HAS a canvas.
+    tab = page.get_by_role("tab", name="Canvas")
+    expect(tab).to_be_visible(timeout=30_000)
+    tab.click()
+    expect(page.get_by_text(f"Report {marker}")).to_be_visible(timeout=30_000)
+    expect(page.get_by_text(f"canvas body {marker}")).to_be_visible(timeout=30_000)

--- a/tests/runner/test_canvas_dispatch.py
+++ b/tests/runner/test_canvas_dispatch.py
@@ -1,0 +1,75 @@
+"""Unit tests for the runner-side canvas tool proxy (#2, #12).
+
+``_execute_canvas_tool`` maps ``set_canvas`` to ``PUT /v1/canvas/{id}`` over
+``server_client``. These drive it against an ``httpx.MockTransport`` that
+records the request, asserting method/path/body plus the guard errors — locking
+the mapping the live agent path exercises.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from omnigent.runner.tool_dispatch import _execute_canvas_tool
+
+
+def _recording_client(recorder: list[httpx.Request]) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorder.append(request)
+        return httpx.Response(200, json={"object": "canvas", "id": "cnv_1"})
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://srv")
+
+
+async def test_set_canvas_puts_to_conversation() -> None:
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    out = await _execute_canvas_tool(
+        "set_canvas",
+        json.dumps({"title": "Plan", "content": "<h1>Hi</h1>", "content_type": "html"}),
+        conversation_id="conv_1",
+        server_client=client,
+    )
+    await client.aclose()
+    assert reqs[0].method == "PUT"
+    assert reqs[0].url.path == "/v1/canvas/conv_1"
+    assert json.loads(reqs[0].content) == {
+        "title": "Plan",
+        "content": "<h1>Hi</h1>",
+        "content_type": "html",
+    }
+    assert json.loads(out) == {"object": "canvas", "id": "cnv_1"}
+
+
+async def test_set_canvas_defaults_content_type_html() -> None:
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    await _execute_canvas_tool(
+        "set_canvas",
+        json.dumps({"title": "T", "content": "# md"}),
+        conversation_id="conv_2",
+        server_client=client,
+    )
+    await client.aclose()
+    assert json.loads(reqs[0].content)["content_type"] == "html"
+
+
+async def test_guards() -> None:
+    # No server client -> clear error, no crash.
+    out = await _execute_canvas_tool("set_canvas", "{}", conversation_id="c", server_client=None)
+    assert "requires server access" in out
+
+    # No session id -> error, no request made.
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    out = await _execute_canvas_tool(
+        "set_canvas",
+        json.dumps({"title": "T", "content": "x"}),
+        conversation_id=None,
+        server_client=client,
+    )
+    await client.aclose()
+    assert "requires a session id" in out
+    assert reqs == []

--- a/tests/runner/test_canvas_dispatch.py
+++ b/tests/runner/test_canvas_dispatch.py
@@ -56,6 +56,21 @@ async def test_set_canvas_defaults_content_type_html() -> None:
     assert json.loads(reqs[0].content)["content_type"] == "html"
 
 
+async def test_set_canvas_ignores_conversation_id_arg() -> None:
+    # An agent can't retarget another conversation's canvas: a conversation_id
+    # in the tool args is ignored; the ambient session id is always used.
+    reqs: list[httpx.Request] = []
+    client = _recording_client(reqs)
+    await _execute_canvas_tool(
+        "set_canvas",
+        json.dumps({"title": "T", "content": "x", "conversation_id": "conv_OTHER"}),
+        conversation_id="conv_mine",
+        server_client=client,
+    )
+    await client.aclose()
+    assert reqs[0].url.path == "/v1/canvas/conv_mine"
+
+
 async def test_guards() -> None:
     # No server client -> clear error, no crash.
     out = await _execute_canvas_tool("set_canvas", "{}", conversation_id="c", server_client=None)

--- a/tests/runtime/test_caps.py
+++ b/tests/runtime/test_caps.py
@@ -26,6 +26,17 @@ def test_runtime_caps_custom_value() -> None:
     assert caps.execution_timeout == 3600
 
 
+def test_runtime_caps_canvas_enabled_default_true() -> None:
+    """Canvas (#2) is on by default — absence of ``canvas.enabled`` in the
+    server config is backwards-compatible (the tool, routes, and tab all work)."""
+    assert RuntimeCaps().canvas_enabled is True
+
+
+def test_runtime_caps_canvas_enabled_can_be_disabled() -> None:
+    """Operators can turn Canvas off via ``canvas: {enabled: false}``."""
+    assert RuntimeCaps(canvas_enabled=False).canvas_enabled is False
+
+
 def test_execution_config_default_values() -> None:
     """
     ExecutorSpec defaults match the values the runtime relies on.

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -390,6 +390,20 @@ async def test_info_includes_server_version(
 
 
 @pytest.mark.asyncio
+async def test_info_includes_canvas_enabled(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``GET /v1/info`` exposes ``canvas_enabled`` (#2) so the SPA can hide the
+    Canvas rail tab (and Settings can show its status) when the operator
+    disables Canvas. Default on — no caps configured in this app → ``True``.
+    """
+    resp = await client.get("/v1/info")
+    assert resp.status_code == 200
+    assert resp.json()["canvas_enabled"] is True
+
+
+@pytest.mark.asyncio
 async def test_health_bare_returns_status_ok(db_uri: str, tmp_path: Path) -> None:
     """
     ``GET /health`` with no session params still returns the bare

--- a/tests/server/test_canvas_routes.py
+++ b/tests/server/test_canvas_routes.py
@@ -1,0 +1,51 @@
+"""Tests for the GET /v1/canvas/{conversation_id} route (single-user mode)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from omnigent.errors import OmnigentError
+from omnigent.server.routes.canvas import create_canvas_router
+from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+
+@pytest.fixture()
+def ctx(db_uri: str) -> tuple[TestClient, SqlAlchemyCanvasStore, str]:
+    store = SqlAlchemyCanvasStore(db_uri)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="c").id
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(_request: Request, exc: OmnigentError) -> JSONResponse:
+        return JSONResponse(status_code=exc.http_status, content={"error": exc.code})
+
+    app.include_router(create_canvas_router(store), prefix="/v1")
+    return TestClient(app), store, conv
+
+
+def test_get_canvas_returns_content(
+    ctx: tuple[TestClient, SqlAlchemyCanvasStore, str],
+) -> None:
+    client, store, conv = ctx
+    store.upsert("cnv_1", conv, "Report", "<h1>Hi</h1>", "html")
+
+    res = client.get(f"/v1/canvas/{conv}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["object"] == "canvas"
+    assert body["title"] == "Report"
+    assert body["content"] == "<h1>Hi</h1>"
+    assert body["content_type"] == "html"
+
+
+def test_get_canvas_404_when_unset(
+    ctx: tuple[TestClient, SqlAlchemyCanvasStore, str],
+) -> None:
+    client, _, conv = ctx
+    assert client.get(f"/v1/canvas/{conv}").status_code == 404

--- a/tests/server/test_canvas_routes.py
+++ b/tests/server/test_canvas_routes.py
@@ -8,11 +8,13 @@ from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from omnigent.errors import OmnigentError
+from omnigent.server.auth import UnifiedAuthProvider
 from omnigent.server.routes.canvas import create_canvas_router
 from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
 
 
 @pytest.fixture()
@@ -73,3 +75,66 @@ def test_canvas_routes_404_when_disabled(
         json={"title": "T", "content": "<p>x</p>", "content_type": "html"},
     )
     assert put.status_code == 404
+
+
+def test_put_rejects_oversized_content(
+    ctx: tuple[TestClient, SqlAlchemyCanvasStore, str],
+) -> None:
+    from omnigent.entities.canvas import MAX_CANVAS_CONTENT_BYTES
+
+    client, _, conv = ctx
+    huge = "x" * (MAX_CANVAS_CONTENT_BYTES + 1)
+    res = client.put(f"/v1/canvas/{conv}", json={"title": "T", "content": huge})
+    assert res.status_code == 400
+
+
+def test_multi_user_requires_conversation_access(db_uri: str) -> None:
+    # A canvas is conversation-scoped data: in multi-user mode only a caller
+    # with access to the conversation may read/write it. A user with no access
+    # is 404'd on both GET and PUT, so the conversation's existence isn't leaked.
+    from omnigent.server.auth import LEVEL_OWNER
+
+    canvas_store = SqlAlchemyCanvasStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    perm = SqlAlchemyPermissionStore(db_uri)
+    conv = conv_store.create_conversation(title="c").id
+    for user in ("alice@example.com", "bob@example.com"):
+        perm.ensure_user(user)
+    perm.grant("alice@example.com", conv, LEVEL_OWNER)  # only alice has access
+    canvas_store.upsert("cnv_1", conv, "Report", "<h1>Hi</h1>", "html")
+
+    app = FastAPI()
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(_request: Request, exc: OmnigentError) -> JSONResponse:
+        return JSONResponse(status_code=exc.http_status, content={"error": exc.code})
+
+    app.include_router(
+        create_canvas_router(
+            canvas_store,
+            auth_provider=UnifiedAuthProvider(source="header", local_single_user=True),
+            permission_store=perm,
+            conversation_store=conv_store,
+        ),
+        prefix="/v1",
+    )
+    client = TestClient(app)
+    alice = {"X-Forwarded-Email": "alice@example.com"}
+    bob = {"X-Forwarded-Email": "bob@example.com"}
+
+    # Owner reads + writes.
+    assert client.get(f"/v1/canvas/{conv}", headers=alice).status_code == 200
+    assert (
+        client.put(
+            f"/v1/canvas/{conv}", json={"title": "T", "content": "<p>x</p>"}, headers=alice
+        ).status_code
+        == 200
+    )
+    # A user with no access to the conversation → 404 on both.
+    assert client.get(f"/v1/canvas/{conv}", headers=bob).status_code == 404
+    assert (
+        client.put(
+            f"/v1/canvas/{conv}", json={"title": "T", "content": "<p>x</p>"}, headers=bob
+        ).status_code
+        == 404
+    )

--- a/tests/server/test_canvas_routes.py
+++ b/tests/server/test_canvas_routes.py
@@ -49,3 +49,27 @@ def test_get_canvas_404_when_unset(
 ) -> None:
     client, _, conv = ctx
     assert client.get(f"/v1/canvas/{conv}").status_code == 404
+
+
+def test_canvas_routes_404_when_disabled(
+    ctx: tuple[TestClient, SqlAlchemyCanvasStore, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``canvas.enabled`` is off, both handlers 404 before touching the
+    store — the hard server-side gate (#2). GET 404s even though a canvas
+    exists; PUT 404s without writing."""
+    from omnigent.runtime.caps import RuntimeCaps
+
+    client, store, conv = ctx
+    store.upsert("cnv_1", conv, "Report", "<h1>Hi</h1>", "html")
+    monkeypatch.setattr(
+        "omnigent.server.routes.canvas.get_caps",
+        lambda: RuntimeCaps(canvas_enabled=False),
+    )
+
+    assert client.get(f"/v1/canvas/{conv}").status_code == 404
+    put = client.put(
+        f"/v1/canvas/{conv}",
+        json={"title": "T", "content": "<p>x</p>", "content_type": "html"},
+    )
+    assert put.status_code == 404

--- a/tests/stores/conftest.py
+++ b/tests/stores/conftest.py
@@ -8,10 +8,10 @@ import pytest
 
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
-from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
 from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
 
 

--- a/tests/stores/conftest.py
+++ b/tests/stores/conftest.py
@@ -11,6 +11,7 @@ from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
+from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
 from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
 
 
@@ -44,3 +45,11 @@ def artifact_store(tmp_path: Path) -> LocalArtifactStore:
     :returns: A LocalArtifactStore in a temp directory.
     """
     return LocalArtifactStore(str(tmp_path / "artifacts"))
+
+
+@pytest.fixture()
+def canvas_store(db_uri: str) -> SqlAlchemyCanvasStore:
+    """
+    :returns: A SqlAlchemyCanvasStore backed by the test database.
+    """
+    return SqlAlchemyCanvasStore(db_uri)

--- a/tests/stores/test_canvas_store.py
+++ b/tests/stores/test_canvas_store.py
@@ -1,0 +1,45 @@
+"""Tests for SqlAlchemyCanvasStore (one canvas per conversation)."""
+
+from __future__ import annotations
+
+from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+
+
+def test_upsert_creates_then_overwrites(
+    canvas_store: SqlAlchemyCanvasStore,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    conv = conversation_store.create_conversation(title="c").id
+    assert canvas_store.get_by_conversation(conv) is None
+
+    created = canvas_store.upsert("cnv_1", conv, "Report", "<h1>Hi</h1>", "html")
+    assert created.id == "cnv_1"
+    assert created.content_type == "html"
+    assert created.updated_at is None
+
+    # Re-upsert overwrites in place (same row), stamping updated_at.
+    updated = canvas_store.upsert("cnv_ignored", conv, "Report v2", "<h1>Bye</h1>", "markdown")
+    assert updated.id == "cnv_1"  # original id kept
+    assert updated.title == "Report v2"
+    assert updated.content == "<h1>Bye</h1>"
+    assert updated.content_type == "markdown"
+    assert updated.updated_at is not None
+
+    fetched = canvas_store.get_by_conversation(conv)
+    assert fetched is not None
+    assert fetched.id == "cnv_1"
+    assert fetched.title == "Report v2"
+
+
+def test_delete_is_idempotent(
+    canvas_store: SqlAlchemyCanvasStore,
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    conv = conversation_store.create_conversation().id
+    canvas_store.upsert("cnv_d", conv, "t", "<p>x</p>", "html")
+    assert canvas_store.delete(conv) is True
+    assert canvas_store.get_by_conversation(conv) is None
+    assert canvas_store.delete(conv) is False

--- a/tests/tools/builtins/test_canvas_tool.py
+++ b/tests/tools/builtins/test_canvas_tool.py
@@ -1,0 +1,65 @@
+"""Tests for the set_canvas builtin tool."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omnigent.stores.canvas_store.sqlalchemy_store import SqlAlchemyCanvasStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins.canvas import SetCanvasTool
+
+
+@pytest.fixture()
+def wired(db_uri: str, monkeypatch: pytest.MonkeyPatch) -> tuple[str, SqlAlchemyCanvasStore]:
+    """A real conversation id + canvas store wired into runtime.get_canvas_store."""
+    store = SqlAlchemyCanvasStore(db_uri)
+    monkeypatch.setattr("omnigent.runtime.get_canvas_store", lambda: store)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="c").id
+    return conv, store
+
+
+def test_set_canvas_upserts(wired: tuple[str, SqlAlchemyCanvasStore]) -> None:
+    conv, store = wired
+    ctx = ToolContext(task_id="t", agent_id="a", conversation_id=conv)
+
+    out = json.loads(
+        SetCanvasTool().invoke(json.dumps({"title": "Chart", "content": "<svg/>"}), ctx)
+    )
+    assert out["ok"] is True
+    assert out["canvas"]["content_type"] == "html"  # default
+
+    stored = store.get_by_conversation(conv)
+    assert stored is not None
+    assert stored.title == "Chart"
+    assert stored.content == "<svg/>"
+
+    # Re-set with markdown overwrites.
+    SetCanvasTool().invoke(
+        json.dumps({"title": "Notes", "content": "# hi", "content_type": "markdown"}), ctx
+    )
+    again = store.get_by_conversation(conv)
+    assert again is not None and again.content_type == "markdown" and again.title == "Notes"
+
+
+def test_validation_and_context(wired: tuple[str, SqlAlchemyCanvasStore]) -> None:
+    conv, _ = wired
+    with_ctx = ToolContext(task_id="t", agent_id="a", conversation_id=conv)
+    no_ctx = ToolContext(task_id="t", agent_id="a")
+
+    assert "error" in json.loads(SetCanvasTool().invoke(json.dumps({"content": "x"}), with_ctx))
+    assert "error" in json.loads(SetCanvasTool().invoke(json.dumps({"title": "t"}), with_ctx))
+    bad_type = json.loads(
+        SetCanvasTool().invoke(
+            json.dumps({"title": "t", "content": "x", "content_type": "pdf"}), with_ctx
+        )
+    )
+    assert "error" in bad_type
+    no_conv = json.loads(
+        SetCanvasTool().invoke(json.dumps({"title": "t", "content": "x"}), no_ctx)
+    )
+    assert "error" in no_conv and "conversation" in no_conv["error"]

--- a/tests/tools/builtins/test_canvas_tool.py
+++ b/tests/tools/builtins/test_canvas_tool.py
@@ -63,3 +63,31 @@ def test_validation_and_context(wired: tuple[str, SqlAlchemyCanvasStore]) -> Non
         SetCanvasTool().invoke(json.dumps({"title": "t", "content": "x"}), no_ctx)
     )
     assert "error" in no_conv and "conversation" in no_conv["error"]
+
+
+def test_set_canvas_ignores_conversation_id_arg(
+    wired: tuple[str, SqlAlchemyCanvasStore], db_uri: str
+) -> None:
+    # A conversation_id in the args is ignored — the tool writes only to the
+    # ambient (ctx) conversation, so an agent can't target another session.
+    conv, store = wired
+    other = SqlAlchemyConversationStore(db_uri).create_conversation(title="other").id
+    ctx = ToolContext(task_id="t", agent_id="a", conversation_id=conv)
+
+    SetCanvasTool().invoke(
+        json.dumps({"title": "T", "content": "x", "conversation_id": other}), ctx
+    )
+    assert store.get_by_conversation(conv) is not None  # wrote to the ctx conversation
+    assert store.get_by_conversation(other) is None  # NOT the arg-supplied one
+
+
+def test_set_canvas_rejects_oversized_content(
+    wired: tuple[str, SqlAlchemyCanvasStore],
+) -> None:
+    from omnigent.entities.canvas import MAX_CANVAS_CONTENT_BYTES
+
+    conv, _ = wired
+    ctx = ToolContext(task_id="t", agent_id="a", conversation_id=conv)
+    huge = "x" * (MAX_CANVAS_CONTENT_BYTES + 1)
+    out = json.loads(SetCanvasTool().invoke(json.dumps({"title": "T", "content": huge}), ctx))
+    assert "error" in out and "limit" in out["error"]

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -120,6 +120,7 @@ def test_builtin_names_size_matches_registry() -> None:
                 "download_file",
                 "search_conversations",
                 "export_agent",
+                "set_canvas",
                 # Framework-owned (need runtime context, not
                 # user-instantiable). Policy ASKs surface as
                 # MCP-shape elicitations on the SSE stream and

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -70,6 +70,9 @@ _ALWAYS_PRESENT_TOOLS: frozenset[str] = frozenset(
         # browse the registry and add policies at runtime.
         "sys_add_policy",
         "sys_policy_registry",
+        # Canvas builtin (#2, #12) is always auto-registered so an agent +
+        # the Omnigent MCP can render an artifact without the spec opting in.
+        "set_canvas",
     }
 )
 

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -1168,3 +1168,39 @@ def test_web_search_does_not_emit_web_search_preview_for_databricks_model() -> N
         f"databricks-gpt-5-4 — Databricks does not support this tool type "
         f"and rejects the request with HTTP 400. Got schema: {schema!r}"
     )
+
+
+# ── Canvas tool gate (#2) ─────────────────────────────
+
+
+def test_manager_skips_set_canvas_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    When ``canvas.enabled`` is off (#2), ToolManager doesn't register
+    ``set_canvas`` — non-native agents don't even see it. The ``/v1/canvas``
+    route is the hard gate; skipping registration just avoids advertising a
+    tool that would 404.
+    """
+    from omnigent.runtime.caps import RuntimeCaps
+
+    monkeypatch.setattr(
+        "omnigent.runtime.get_caps",
+        lambda: RuntimeCaps(canvas_enabled=False),
+    )
+    mgr = ToolManager(_make_spec([]))
+    assert mgr.get_tool("set_canvas") is None
+
+
+def test_manager_registers_set_canvas_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Canvas on (the default) → ``set_canvas`` is registered and callable."""
+    from omnigent.runtime.caps import RuntimeCaps
+
+    monkeypatch.setattr(
+        "omnigent.runtime.get_caps",
+        lambda: RuntimeCaps(canvas_enabled=True),
+    )
+    mgr = ToolManager(_make_spec([]))
+    assert mgr.get_tool("set_canvas") is not None

--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -108,6 +108,7 @@ const SERVER_INFO_OFFLINE_FALLBACK: ServerInfo = {
   sandbox_provider: null,
   server_version: null,
   smart_routing_enabled: false,
+  canvas_enabled: false,
 };
 
 /**

--- a/web/src/hooks/useCanvas.test.ts
+++ b/web/src/hooks/useCanvas.test.ts
@@ -1,0 +1,76 @@
+// Unit tests for the canvas hook: GET /v1/canvas/{id}, returns the canvas,
+// maps 404 → null (no canvas), throws on other non-2xx, and stays disabled
+// without a conversation id.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCanvas } from "./useCanvas";
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useCanvas", () => {
+  it("GETs /v1/canvas/{id} and returns the canvas", async () => {
+    const canvas = {
+      id: "cnv_1",
+      object: "canvas",
+      conversation_id: "conv_1",
+      title: "Report",
+      content: "<h1>Hi</h1>",
+      content_type: "html",
+      created_at: 0,
+      updated_at: null,
+    };
+    fetchMock.mockResolvedValue(mockResponse(canvas));
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useCanvas("conv_1"), { wrapper: wrapperWith(qc) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/canvas/conv_1");
+    expect(result.current.data).toEqual(canvas);
+  });
+
+  it("maps 404 to null (no canvas set)", async () => {
+    fetchMock.mockResolvedValue(mockResponse({}, { ok: false, status: 404 }));
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useCanvas("conv_1"), { wrapper: wrapperWith(qc) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("throws on a non-404 error", async () => {
+    fetchMock.mockResolvedValue(mockResponse({}, { ok: false, status: 500 }));
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useCanvas("conv_1"), { wrapper: wrapperWith(qc) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("is disabled without a conversation id", () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useCanvas(undefined), { wrapper: wrapperWith(qc) });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useCanvas.ts
+++ b/web/src/hooks/useCanvas.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCanvas, type Canvas } from "@/lib/canvasApi";
+
+/**
+ * Fetch the conversation's canvas (or null if none). Polls so a canvas the
+ * agent sets via set_canvas appears without a manual refresh.
+ */
+export function useCanvas(conversationId: string | undefined) {
+  return useQuery<Canvas | null>({
+    queryKey: ["canvas", conversationId ?? null],
+    queryFn: () => getCanvas(conversationId as string),
+    enabled: !!conversationId,
+    staleTime: 5_000,
+    refetchInterval: 10_000,
+  });
+}

--- a/web/src/lib/canvasApi.ts
+++ b/web/src/lib/canvasApi.ts
@@ -1,0 +1,30 @@
+/**
+ * Typed client for the `/v1/canvas/{conversation_id}` endpoint.
+ * Mirrors `omnigent/server/routes/canvas.py`.
+ */
+
+import { authenticatedFetch } from "./identity";
+
+/** A conversation's canvas artifact (set by the agent's set_canvas tool). */
+export interface Canvas {
+  id: string;
+  object: "canvas";
+  conversation_id: string;
+  title: string;
+  content: string;
+  content_type: "html" | "markdown";
+  created_at: number;
+  updated_at: number | null;
+}
+
+/**
+ * Fetch a conversation's canvas, or ``null`` when none is set (the endpoint
+ * 404s — modeled as "no canvas" rather than an error so the UI can simply
+ * hide the tab).
+ */
+export async function getCanvas(conversationId: string): Promise<Canvas | null> {
+  const res = await authenticatedFetch(`/v1/canvas/${encodeURIComponent(conversationId)}`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as Canvas;
+}

--- a/web/src/lib/capabilities.test.ts
+++ b/web/src/lib/capabilities.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Probe ``/v1/info`` with a mocked ``hostFetch`` and a fresh module instance so
+ * the module-level resolve-once cache doesn't bleed between cases.
+ */
+async function probeWith(payload: unknown, ok = true) {
+  vi.resetModules();
+  vi.doMock("./host", () => ({
+    hostFetch: vi.fn(async () => ({
+      ok,
+      json: async () => payload,
+    })),
+  }));
+  const mod = await import("./capabilities");
+  return mod.resolveServerInfo();
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("./host");
+});
+
+describe("resolveServerInfo — canvas_enabled (#2)", () => {
+  it("parses canvas_enabled: true", async () => {
+    const info = await probeWith({ canvas_enabled: true });
+    expect(info.canvas_enabled).toBe(true);
+  });
+
+  it("parses canvas_enabled: false", async () => {
+    const info = await probeWith({ canvas_enabled: false });
+    expect(info.canvas_enabled).toBe(false);
+  });
+
+  it("fails closed when the field is absent", async () => {
+    const info = await probeWith({ accounts_enabled: false });
+    expect(info.canvas_enabled).toBe(false);
+  });
+
+  it("fails closed on a failed probe (the _OFF sentinel)", async () => {
+    const info = await probeWith(null, false);
+    expect(info.canvas_enabled).toBe(false);
+  });
+});

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -68,6 +68,14 @@ export interface ServerInfo {
    * (``OMNIGENT_SMART_ROUTING=1`` + ``llm:`` config). Hidden by default.
    */
   smart_routing_enabled: boolean;
+  /**
+   * True when the Canvas feature (#2) is enabled on this server
+   * (``canvas.enabled`` in the server config, default on). When false the
+   * ``/v1/canvas`` routes 404, ``set_canvas`` isn't registered, and the SPA
+   * hides the Canvas rail tab. Fails closed — a failed probe (the ``_OFF``
+   * sentinel) hides the tab.
+   */
+  canvas_enabled: boolean;
 }
 
 /** Sentinel used when the probe fails — accounts is off, no login URL. */
@@ -80,6 +88,7 @@ const _OFF: ServerInfo = {
   sandbox_provider: null,
   server_version: null,
   smart_routing_enabled: false,
+  canvas_enabled: false,
 };
 
 let _cached: ServerInfo | null = null;
@@ -114,6 +123,7 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
             typeof data.sandbox_provider === "string" ? data.sandbox_provider : null,
           server_version: typeof data.server_version === "string" ? data.server_version : null,
           smart_routing_enabled: data.smart_routing_enabled === true,
+          canvas_enabled: data.canvas_enabled === true,
         };
         return _cached;
       }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -68,6 +68,7 @@ const _bootProbe: Promise<ServerInfo> = Promise.race([
           sandbox_provider: null,
           server_version: null,
           smart_routing_enabled: false,
+          canvas_enabled: false,
         }),
       1500,
     ),

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -37,6 +37,7 @@ import { useTheme } from "next-themes";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Dialog,
   DialogContent,
@@ -106,6 +107,7 @@ export function SettingsPage() {
   return (
     <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       {section === "appearance" && <AppearanceSection />}
+      {section === "appearance" && <CanvasStatusCard />}
       {section === "shortcuts" && <ShortcutsSection />}
       {section === "account" && hasAuthSession && <AccountSection />}
       {section === "archived" && <ArchivedSection />}
@@ -177,6 +179,45 @@ function AppearanceSection() {
         </div>
       )}
     </Section>
+  );
+}
+
+/**
+ * Read-only "Canvas" status card (#2). Canvas is gated by the server's
+ * ``canvas.enabled`` config, not a per-user preference (omnigent has no
+ * server-synced user prefs), so this reflects the server flag with a disabled
+ * switch rather than offering a live toggle. Rendered under Appearance as a
+ * light labeled card (no ``h1``) so the section keeps a single top-level
+ * heading. Hidden entirely while the capability probe is loading.
+ */
+function CanvasStatusCard() {
+  const info = useServerInfo();
+  if (info === "loading") return null;
+  const enabled = info.canvas_enabled;
+  return (
+    <div className="mt-10" data-testid="canvas-status">
+      <h2 className="text-sm font-semibold text-muted-foreground">Canvas</h2>
+      <div className="mt-3 flex items-center justify-between gap-4 rounded-lg border border-border p-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium">
+            {enabled ? "Canvas is enabled" : "Canvas is disabled"}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {enabled
+              ? "Agents can create a canvas artifact per conversation, shown in the workspace rail."
+              : "The Canvas tool and panel are turned off on this server."}
+          </span>
+        </div>
+        <Switch
+          checked={enabled}
+          disabled
+          aria-label="Canvas enabled (controlled by the server operator)"
+        />
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Controlled by the server operator via <code>canvas.enabled</code>.
+      </p>
+    </div>
   );
 }
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useParams, useSearchParams } from "@/lib/routing";
+import { useCanvas } from "@/hooks/useCanvas";
 import { useConversations } from "@/hooks/useConversations";
 import { useSessionAgent } from "@/hooks/useAgents";
 import { useApproveHotkey } from "@/hooks/useApproveHotkey";
@@ -127,6 +128,8 @@ export function AppShell() {
   // Read early: the conversationId scopes the per-session workspace state
   // (rail open/width/tab/open files) used throughout this component.
   const { conversationId } = useParams<{ conversationId: string }>();
+  // Canvas (#2): drives the right-rail Canvas tab; null until the agent sets one.
+  const canvasQuery = useCanvas(conversationId);
   const [fileViewerCommentsOpen, setFileViewerCommentsOpen] = useState(false);
   const [rightRailTab, setRightRailTab] = useState<RightRailTab>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
@@ -451,6 +454,8 @@ export function AppShell() {
     () =>
       ({
         files: showFilesPanel,
+        // Canvas tab appears once the agent has set a canvas for this session.
+        canvas: !!canvasQuery.data,
         // Agents tab is unconditional: the panel always lists at least
         // the main agent (its "main" row), so there's never a dead end.
         subagents: true,
@@ -468,6 +473,7 @@ export function AppShell() {
       }) as const,
     [
       showFilesPanel,
+      canvasQuery.data,
       hideTerminalsTab,
       railTerminals.length,
       agentSupportsShells,
@@ -488,7 +494,7 @@ export function AppShell() {
   // convergent even when several tabs vanish at once.
   useEffect(() => {
     if (railTabsAvailable[rightRailTab]) return;
-    const next = (["files", "subagents", "terminals", "todos"] as const).find(
+    const next = (["files", "canvas", "subagents", "terminals", "todos"] as const).find(
       (t) => railTabsAvailable[t],
     );
     if (next) setRightRailTab(next);
@@ -1171,6 +1177,7 @@ export function AppShell() {
                       rightRailTab={rightRailTab}
                       onRightRailTabChange={handleRightRailTabChange}
                       showFilesPanel={showFilesPanel}
+                      showCanvasTab={railTabsAvailable.canvas}
                       changedCount={changedCount}
                       showShellsTab={railTabsAvailable.terminals}
                       terminalsLength={railTerminals.length}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -49,6 +49,7 @@ import {
 import { cn } from "@/lib/utils";
 import { isNativeWrapper as isNativeWrapperLabel } from "@/lib/nativeCodingAgents";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
+import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { useChatStore } from "@/store/chatStore";
 import { livenessRowFromSession, useSessionLiveness } from "@/hooks/useSessionLiveness";
 import { useResizableInlinePanel } from "@/hooks/useResizableInlinePanel";
@@ -130,6 +131,10 @@ export function AppShell() {
   const { conversationId } = useParams<{ conversationId: string }>();
   // Canvas (#2): drives the right-rail Canvas tab; null until the agent sets one.
   const canvasQuery = useCanvas(conversationId);
+  // Canvas is also gated by the server's ``canvas.enabled`` flag (#2): when the
+  // operator disables Canvas, hide the tab even if a stale canvas row exists.
+  const serverInfo = useServerInfo();
+  const canvasEnabled = serverInfo !== "loading" && serverInfo.canvas_enabled;
   const [fileViewerCommentsOpen, setFileViewerCommentsOpen] = useState(false);
   const [rightRailTab, setRightRailTab] = useState<RightRailTab>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
@@ -454,8 +459,9 @@ export function AppShell() {
     () =>
       ({
         files: showFilesPanel,
-        // Canvas tab appears once the agent has set a canvas for this session.
-        canvas: !!canvasQuery.data,
+        // Canvas tab appears once the agent has set a canvas for this session,
+        // and only when the server has Canvas enabled (``canvas.enabled``).
+        canvas: canvasEnabled && !!canvasQuery.data,
         // Agents tab is unconditional: the panel always lists at least
         // the main agent (its "main" row), so there's never a dead end.
         subagents: true,
@@ -474,6 +480,7 @@ export function AppShell() {
     [
       showFilesPanel,
       canvasQuery.data,
+      canvasEnabled,
       hideTerminalsTab,
       railTerminals.length,
       agentSupportsShells,

--- a/web/src/shell/CanvasPanel.tsx
+++ b/web/src/shell/CanvasPanel.tsx
@@ -1,0 +1,50 @@
+/**
+ * Right-rail Canvas panel — renders the conversation's agent-authored canvas
+ * artifact (#2). HTML renders in a sandboxed iframe (scripts allowed, but no
+ * same-origin / parent access, so an agent's HTML/JS widget runs without
+ * touching the app); Markdown renders as preformatted source for now.
+ */
+
+import { useCanvas } from "@/hooks/useCanvas";
+
+export function CanvasPanel({ conversationId }: { conversationId: string }) {
+  const { data: canvas, isLoading, isError } = useCanvas(conversationId);
+
+  if (isLoading) {
+    return <div className="p-4 text-sm text-muted-foreground">Loading canvas…</div>;
+  }
+  if (isError) {
+    return <div className="p-4 text-sm text-destructive">Failed to load canvas.</div>;
+  }
+  if (!canvas) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        No canvas yet. The agent can render one with the <code>set_canvas</code> tool.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 border-b border-border px-3 py-1.5 text-xs font-medium text-muted-foreground">
+        {canvas.title}
+      </div>
+      {canvas.content_type === "html" ? (
+        <iframe
+          title={canvas.title}
+          srcDoc={canvas.content}
+          // allow-scripts (no allow-same-origin): the artifact's JS runs but
+          // can't reach the parent document, cookies, or storage.
+          sandbox="allow-scripts"
+          className="min-h-0 flex-1 border-0 bg-white"
+        />
+      ) : (
+        <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap p-3 text-sm">
+          {canvas.content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export default CanvasPanel;

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -612,6 +612,7 @@ function renderLanding(infoOverrides: Partial<ServerInfo> = {}, route = "/") {
     sandbox_provider: null,
     server_version: null,
     smart_routing_enabled: false,
+    canvas_enabled: false,
     ...infoOverrides,
   };
   return render(

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -40,6 +40,7 @@ function renderWorkspace(
     rightRailTab?: RightRailTab;
     selectedFilePath?: string | null;
     openFiles?: string[];
+    showCanvasTab?: boolean;
   } = {},
 ) {
   const openFileViewer = vi.fn();
@@ -53,6 +54,7 @@ function renderWorkspace(
       rightRailTab={overrides.rightRailTab ?? "files"}
       onRightRailTabChange={onRightRailTabChange}
       showFilesPanel
+      showCanvasTab={overrides.showCanvasTab ?? false}
       changedCount={0}
       showShellsTab={false}
       terminalsLength={0}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -1,7 +1,15 @@
-import { BotIcon, FileIcon, ListTodoIcon, TerminalIcon, XIcon } from "lucide-react";
+import {
+  BotIcon,
+  FileIcon,
+  LayoutTemplateIcon,
+  ListTodoIcon,
+  TerminalIcon,
+  XIcon,
+} from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CanvasPanel } from "./CanvasPanel";
 import { FilesPanel } from "./FilesPanel";
 import { FileViewer } from "./FileViewer";
 import type { ChangedSort } from "./FlatFileList";
@@ -142,6 +150,8 @@ interface WorkspacePanelProps {
   onRightRailTabChange: (next: RightRailTab) => void;
   /** Whether the Files tab is available (agent spec exposes an os_env). */
   showFilesPanel: boolean;
+  /** Whether the Canvas tab is available (the conversation has a canvas). */
+  showCanvasTab: boolean;
   /** Count of changed files, shown as the Files tab badge. */
   changedCount: number;
   /**
@@ -226,6 +236,7 @@ export function WorkspacePanel({
   rightRailTab,
   onRightRailTabChange,
   showFilesPanel,
+  showCanvasTab,
   changedCount,
   showShellsTab,
   terminalsLength,
@@ -322,6 +333,15 @@ export function WorkspacePanel({
                     {changedCount}
                   </span>
                 )}
+              </TabsTrigger>
+            )}
+            {showCanvasTab && (
+              <TabsTrigger
+                value="canvas"
+                className="h-[32px] gap-[6px] rounded-[8px] px-[12px] text-[13px] leading-5"
+              >
+                <LayoutTemplateIcon className="size-4" />
+                Canvas
               </TabsTrigger>
             )}
             <TabsTrigger
@@ -423,6 +443,8 @@ export function WorkspacePanel({
             onCommentsOpenChange={onCommentsOpenChange}
             sort={filesPanelSort}
           />
+        ) : rightRailTab === "canvas" && showCanvasTab ? (
+          <CanvasPanel conversationId={conversationId} />
         ) : rightRailTab === "subagents" && rootSessionId ? (
           <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
         ) : rightRailTab === "todos" && isClaudeNative ? (

--- a/web/src/shell/railTabs.ts
+++ b/web/src/shell/railTabs.ts
@@ -9,7 +9,7 @@
  */
 
 /** The selectable tabs in the right workspace rail, in display order. */
-export type RightRailTab = "files" | "subagents" | "terminals" | "todos";
+export type RightRailTab = "files" | "canvas" | "subagents" | "terminals" | "todos";
 
 /**
  * Count/status badge geometry shared across the rail tabs and the mobile


### PR DESCRIPTION
Closes #1789 · part of the contribution epic #1600.

## What
Canvas (#2): an **agent-authored artifact panel**. The `set_canvas` tool upserts an HTML/Markdown document (one per conversation), rendered in a right-rail **Canvas** tab. Ships with a global `canvas.enabled` kill-switch.

### Backend
- `canvases` table (migration `b2d4f6a8c0e1`, parented at the current Alembic head — single head) + `CanvasStore` + `generate_canvas_id`.
- `GET` / `PUT /v1/canvas/{conversation_id}`.
- `set_canvas` builtin, callable by real agents on both paths: the proxy `_execute_canvas_tool` (→ `PUT /v1/canvas`) and native-relay advertisement.

### Frontend
- `useCanvas` + `CanvasPanel` + the Workspace-rail Canvas tab (appears once a canvas exists).

### Global kill-switch — `canvas.enabled` (default on)
The panel renders **agent-authored HTML in a sandboxed iframe**, so this adds an operator-controlled `canvas.enabled` server-config flag (mirrors `managed_sandboxes_enabled`; omnigent has no server-synced user prefs, so it is instance-global). When off:
- `GET` / `PUT /v1/canvas` → 404 (the hard gate),
- `set_canvas` is not registered (agents do not see it),
- the SPA hides the Canvas rail tab, and
- Settings shows a read-only status card.

## Security / trust model
`<iframe sandbox="allow-scripts">` — scripts run, but **no** `allow-same-origin`, so the artifact cannot reach app cookies/origin. Markdown renders as `<pre>` (no HTML injection). `canvas.enabled` is the kill-switch for deployments that do not want agent-authored HTML at all.

## Verified
Live-tested the flag in a real server process (isolated, temp DB, random port): `canvas.enabled: false` → `/v1/info` reports `canvas_enabled:false` and `GET` / `PUT /v1/canvas` 404 ("Canvas is not enabled on this server"); default server → `canvas_enabled:true` and the tab renders a seeded canvas. Demo video below (Canvas tab rendering the artifact + the Settings status card).

Real-server testing also surfaced and fixed a config-parse bug: the config loader keeps YAML scalars like `false` as strings and `bool("false")` is truthy, so a naive cast could never disable Canvas — now coerced via the shared `_falsey_flag` helper (regression-tested with bool **and** quoted-string inputs).

## Tests
Store, tool, routes, runner dispatch; the flag: caps default, `/v1/info` field, route 404-when-disabled, ToolManager skip/register, config coercion, and a `capabilities.ts` parse test. Full backend + frontend suites green; both CI security scanners pass; single Alembic head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
