### PR TITLE
test(harness-bench): full-server interrupt/cancel

### DIFF
--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -18,10 +18,12 @@ request-level function tools are NOT used here: the SDK harnesses handle
 tools internally, so they never round-trip as a server-dispatched, policy-
 gated call — a builtin does.
 
+Interrupt/cancel is also verified: a long turn is interrupted mid-flight
+and the server's cancellation marker confirms it stopped.
+
 Follow-ups (stacked PRs): delta-level streaming via the
-``/v1/sessions/{id}/stream`` SSE subscribe, interrupt/cancel, and a
-``--transport`` selector + driver registry so the bench's probes run
-through this driver.
+``/v1/sessions/{id}/stream`` SSE subscribe, and a ``--transport`` selector
++ driver registry so the bench's probes run through this driver.
 """
 
 from __future__ import annotations
@@ -60,6 +62,13 @@ _POLL_INTERVAL_S = 0.2
 _TOOL_NAME = "list_files"
 _DENY_REASON = "bench-policy-deny"
 _TOOL_PROMPT = f"List the files using the {_TOOL_NAME} tool, then tell me how many there are."
+
+# The server persists an interrupted turn as a synthetic user message whose
+# text contains this marker (see tests/e2e/test_cancel_history.py).
+_CANCELLATION_MARKER = "interrupted"
+_LONG_PROMPT = (
+    "Write a very detailed 600-word essay about the history of computing, in full paragraphs."
+)
 
 
 def _find_free_port() -> int:
@@ -380,6 +389,50 @@ class FullServerDriver:
             result.timed_out = True
         return result
 
+    # ── interrupt probe ──────────────────────────────────────
+
+    def interrupt_probe_turn(self, *, timeout: float = 120.0) -> TurnResult:
+        """Start a long turn, interrupt it mid-flight, and report the outcome.
+
+        Posts an ``interrupt`` event once the turn is running (after a short
+        hold so some text streams first), then waits for the server's
+        cancellation marker. Sets :attr:`TurnResult.cancelled` when the
+        marker appears — the honored-interrupt signal.
+        """
+        assert self._client is not None and self._session_id is not None
+        sid = self._session_id
+        result = TurnResult()
+        body = {
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": _LONG_PROMPT}]},
+        }
+        self._client.post(f"/v1/sessions/{sid}/events", json=body).raise_for_status()
+
+        deadline = time.monotonic() + timeout
+        interrupted = False
+        while time.monotonic() < deadline:
+            snap = self._client.get(f"/v1/sessions/{sid}").json()
+            status = snap.get("status")
+            items = snap.get("items", [])
+            if status in ("running", "waiting") and not interrupted:
+                # Let a little text stream so the interrupt lands mid-turn.
+                time.sleep(1.5)
+                self._client.post(f"/v1/sessions/{sid}/events", json={"type": "interrupt"})
+                interrupted = True
+            if _has_cancellation_marker(items):
+                result.cancelled = True
+                result.text = _assistant_text(items)
+                break
+            if status == "idle" and interrupted:
+                # Settled after the interrupt; the marker lands just after.
+                result.cancelled = _has_cancellation_marker(items)
+                result.text = _assistant_text(items)
+                break
+            time.sleep(_POLL_INTERVAL_S)
+        else:
+            result.timed_out = True
+        return result
+
     # ── turn ─────────────────────────────────────────────────
 
     def run_turn(self, prompt: str, *, timeout: float = 180.0) -> TurnResult:
@@ -448,6 +501,19 @@ def _scan_tool_items(items: list[dict], result: TurnResult) -> None:
             out = str(data.get("output", ""))
             if data.get("status") == "blocked" or _DENY_REASON in out:
                 result.tool_call_denied = True
+
+
+def _has_cancellation_marker(items: list[dict]) -> bool:
+    """Whether items include the synthetic 'interrupted' user message."""
+    for raw in items:
+        data = raw.get("data", raw)
+        if (raw.get("type") == "message") and (data.get("role") == "user"):
+            if any(
+                _CANCELLATION_MARKER in (b.get("text", "") or "")
+                for b in data.get("content", []) or []
+            ):
+                return True
+    return False
 
 
 def _assistant_text(items: list[dict]) -> str:

--- a/tests/harness_bench/test_full_server.py
+++ b/tests/harness_bench/test_full_server.py
@@ -62,3 +62,16 @@ async def test_full_server_tool_call_and_policy_deny(databricks_profile: str) ->
     assert denied.tool_call_denied, (
         f"tool_call deny policy did not block the call: {denied.tool_calls} ({denied.error})"
     )
+
+
+async def test_full_server_interrupt(databricks_profile: str) -> None:
+    profile = resolve_profile("openai-agents")
+    reason = FullServerDriver.unavailable(profile, databricks_profile=databricks_profile)
+    if reason is not None:
+        pytest.skip(f"full-server unavailable: {reason}")
+
+    with FullServerDriver(profile, databricks_profile=databricks_profile) as driver:
+        result = driver.interrupt_probe_turn(timeout=120)
+
+    assert not result.timed_out, "interrupt turn never settled"
+    assert result.cancelled, "interrupt did not produce a cancellation marker"


### PR DESCRIPTION
Stacked on #1790 (full-server tool dispatch + policy). Adds interrupt/cancel to the full-server transport.

## What this adds

`FullServerDriver.interrupt_probe_turn()`:
- Posts a long-generation prompt, then posts an `interrupt` event once the turn is running (after a short hold so some text streams first).
- Confirms the server's synthetic `"interrupted"` cancellation marker appears (the same signal `tests/e2e/test_cancel_history.py` asserts).
- Sets `TurnResult.cancelled` when the marker is present.

A gated live test asserts the turn is cancelled.

## Verification

Live on `oss` (`pytest tests/harness_bench/test_full_server.py::test_full_server_interrupt --profile oss`, ~9s): interrupt returns 202, the session settles to idle, and the cancellation marker confirms the turn stopped.

Offline suite: 17 passed, 4 skipped. ruff + pre-commit clean.

## Stack / follow-ups

Stack: #1787 (foundation, merged) -> #1790 (tools + policy) -> this. Remaining full-server follow-up: delta-level streaming via the `/v1/sessions/{id}/stream` SSE subscribe, then the `--transport` selector + driver registry that runs the bench's probes through this driver.