### PR TITLE
feat(harnesses): declarative capability model + matrix (Phase 0 pt.2)

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -1,7 +1,10 @@
 # Modular, self-describing harnesses — design + migration plan
 
-**Status:** proposal for review (no code yet)
-**Author:** drafted with Claude Code
+**Status:** Phase 0 implemented in `omnigent/harnesses/` (registry + capability model,
+landing as stacked PRs); Phases 1-7 pending. Structural claims below re-verified against
+`main` — the frontend has since moved `ap-web/` -> `web/` (reflected here); the per-harness
+if-chains in `runner/app.py` (36), `resume_dispatch.py` (10), `cli.py` `_manage_*` (9) and
+`server/app.py` `_ensure_default_*` (11) all still stand.
 **Goal:** Adding or editing one coding-agent harness should touch ONLY that harness's
 own files, and each harness should explicitly declare which features it supports.
 
@@ -29,11 +32,11 @@ rounds; #1204 re-collided with kimi). The touch points, classified by **shape**:
 | `omnigent/server/app.py` | `_ensure_default_X_agent()` fn + call in `_ensure_default_agents()` | **imperative fn + call** |
 | `omnigent/cli.py` | setup-menu sentinel + row block + dispatch branch + `_manage_X_harness()` fn + `omnigent X` launch | **imperative** |
 | `omnigent/server/routes/sessions.py` | `if harness == X` launch-arg / subagent-label branch | **imperative if-chain** |
-| `ap-web/src/lib/nativeCodingAgents.ts` | spec-array entry + alias-map row | declarative array (mirror of BE) |
-| `ap-web/src/lib/agentGrouping.ts` | `BUILTIN_AGENTS` member + `AGENT_DISPLAY_ORDER` row | declarative (two lists must align) |
-| `ap-web/src/shell/SubagentsPanel.tsx` | icon `if`-branch ×2 | imperative switch |
-| `ap-web/src/shell/sidebarNav.ts` | `ConversationIconKind` union member | declarative type |
-| tests: `test_resume_dispatch.py`, `test_sessions_native_messages.py`, `test_run_harness_without_agent_e2e.py` (exclusion set), ap-web `.test.ts` | per-harness cases / exclusions | mixed |
+| `web/src/lib/nativeCodingAgents.ts` | spec-array entry + alias-map row | declarative array (mirror of BE) |
+| `web/src/lib/agentGrouping.ts` | `BUILTIN_AGENTS` member + `AGENT_DISPLAY_ORDER` row | declarative (two lists must align) |
+| `web/src/shell/SubagentsPanel.tsx` | icon `if`-branch ×2 | imperative switch |
+| `web/src/shell/sidebarNav.ts` | `ConversationIconKind` union member | declarative type |
+| tests: `test_resume_dispatch.py`, `test_sessions_native_messages.py`, `test_run_harness_without_agent_e2e.py` (exclusion set), web `.test.ts` | per-harness cases / exclusions | mixed |
 | `docs/AGENT_YAML_SPEC.md` | harness in the example list | declarative comment |
 
 Two distinct sub-problems fall out:
@@ -49,9 +52,13 @@ Two distinct sub-problems fall out:
 Whether a harness supports a feature is implicit — encoded in (a) membership of ad-hoc
 frozensets (`NATIVE_HARNESSES`, `_SDK_MODEL_OVERRIDE_HARNESSES`, the two status-suppression
 sets in `runner/app.py`), and (b) **presence/absence of a module** (e.g.
-`codex_native_elicitation.py` exists; kiro has no elicitation code at all;
-`*_native_hook.py` exists for claude/codex/kimi/goose/hermes but not pi/cursor/kiro/qwen).
-There is no single place that answers "what can kiro-native do?".
+`codex_native_elicitation.py` exists; `*_native_hook.py` exists for
+claude/codex/kimi/goose/hermes; `*_native_permissions.py` exists for
+cursor/goose/hermes/kiro/opencode/qwen). There is no single place that answers "what can
+this harness do?" — and the scatter actively misleads: an early read of this code assumed
+"kiro-native has no elicitation", but the evidence (`kiro_native_permissions.py`: "TUI ACP
+recorder -> web elicitation") shows it surfaces approval cards via APPROVAL_MIRROR. A
+declared, code-backed capability set removes exactly this guesswork.
 
 ---
 
@@ -179,46 +186,35 @@ The spawn_env builders already share a uniform signature
   axes agree (e.g. a descriptor claiming `WARM_REATTACH` must back a harness whose executor
   implements the reattach path).
 
-Then `kiro-native` literally declares `elicitation=NONE`, and code that needs elicitation
-queries `d.capabilities.elicitation` instead of probing for a module's existence.
+Then a harness literally declares its elicitation mechanism (e.g. `pi-native` →
+`elicitation=NONE`, `kiro-native` → `APPROVAL_MIRROR`, `codex-native` → `JSONRPC`), and code
+that needs elicitation queries `d.capabilities.elicitation` instead of probing for a
+module's existence.
 
 ---
 
 ## 4. Capability inventory (the real axes, from code)
 
-Modeled from the conditionals/sets/modules found in the audit. `?` = present in code but
-value not yet pinned down (resolve during migration).
+The exhaustive, evidence-backed harness × capability values now live **in code** as the
+single source of truth: `omnigent/harnesses/capabilities.py` (declarations) rendered by
+`omnigent/harnesses/matrix.py` (run `python -m omnigent.harnesses.matrix`). This supersedes
+the hand-maintained draft table that used to live here — every value there had been verified
+against the implementing module and several early assumptions were corrected (notably
+`kiro-native`, which is `APPROVAL_MIRROR`, not "no elicitation").
 
-| harness | mode | elicitation | resume | model_ovr | family | effort | permission | web_bridge | subagents | auth |
-|---|---|---|---|---|---|---|---|---|---|---|
-| claude-native | NATIVE_TUI | HOOK | WARM | ✓ | CLAUDE | ANTHROPIC | flag+hook | terminal | ✓ | omni-cred |
-| codex-native | NATIVE_SERVER | JSONRPC | WARM+cold | ✓ | GPT | OPENAI | flag+hook | app_server | ✓ | omni-cred |
-| pi-native | NATIVE_TUI | NONE | WARM | ✓ | MULTI | ? | ? | terminal | ✗ | session-cfg |
-| cursor-native | NATIVE_TUI | APPROVAL_MIRROR | WARM | ✓ | ? | ? | approval-card | terminal | ✗ | ? |
-| kiro-native | NATIVE_TUI | **NONE** | WARM | ✓ | ? | ? | ? | terminal | ✗ | own-auth |
-| opencode-native | NATIVE_SERVER | SSE_PERMISSION | WARM | ✓ | ? | ? | approval-card | app_server_sse | ✓ | omni-cred |
-| antigravity-native | NATIVE_TUI(RPC) | RPC | WARM | ✓ | GEMINI | GEMINI | ? | rpc | ✗ | own-auth |
-| goose-native | NATIVE_TUI | NONE | WARM | ✓ | ? | ? | hook | terminal | ✗ | own-auth |
-| qwen-native | NATIVE_TUI | NONE | WARM | ✓ | ? | ? | ? | terminal | ✗ | ? |
-| kimi-native | NATIVE_TUI | NONE | WARM | ✓ | ? | ? | hook | terminal | ✗ | session-cfg |
-| hermes-native | NATIVE_TUI | NONE | WARM | ✓ | ? | ? | hook | terminal | ✗ | own-auth |
-| claude-sdk | SDK | NONE | COLD | ✓ | CLAUDE | ANTHROPIC | server-policy | none | n/a | omni-cred |
-| codex | SDK | NONE | COLD | ✓ | GPT | OPENAI | server-policy | none | n/a | omni-cred |
-| openai-agents | SDK | NONE | COLD | ✓ | GPT/MULTI | OPENAI | server-policy | none | n/a | omni-cred |
-| pi | SDK | NONE | COLD | ✓ | MULTI | ? | server-policy | none | n/a | omni-cred |
-| cursor | SDK(ACP) | NONE | COLD | ✓ | ? | ? | server-policy | none | n/a | omni-cred |
-| antigravity | SDK | NONE | COLD | ✓ | GEMINI | GEMINI | server-policy | none | n/a | own-auth |
-| goose | ACP_HEADLESS | (card) | COLD | ✓ | ? | ? | approval-card | none | n/a | own-auth |
-| qwen | ACP_HEADLESS | NONE | COLD | ✓ | ? | ? | server-policy | none | n/a | ? |
-| kimi | SDK | NONE | COLD | ✓ | ? | ? | server-policy | none | n/a | session-cfg |
-| hermes | SUBPROC | NONE | COLD | **✗** | ? | ? | server-policy | none | n/a | own-auth |
-| copilot | SDK | NONE | COLD | ✓ | ? | ? | server-policy | none | n/a | own-auth(GH) |
+The modeled axes are: `integration_mode` (SDK_IN_PROCESS / CLI_SUBPROCESS / ACP_SUBPROCESS /
+NATIVE_TUI / NATIVE_SERVER), `elicitation` (NONE / HOOK / JSONRPC / APPROVAL_MIRROR /
+SSE_PERMISSION), `resume` (WARM_REATTACH / COLD_ONLY), `effort` (NONE / ANTHROPIC / OPENAI /
+GEMINI / COPILOT), `model_family` (CLAUDE / GPT / GEMINI / MULTI), `auth`
+(OMNIGENT_CREDENTIAL / OWN_AUTH / SESSION_SCOPED_CONFIG), and `subagents`. Two axes are
+*derivable* and asserted against their source in tests (`model_family` from
+`model_override`'s family sets; `subagents` from `NativeCodingAgent.subagent_wrapper_label`);
+the rest are declared with an inline evidence comment.
 
-Additional axes the code also branches on (fold into capabilities or a sub-struct):
-status-suppression policy (full vs idle-only), terminal auto-create, history-synthesis at
-cold resume, app-server lifecycle ownership, session-scoped credential synthesis. Most are
-*derivable* from `integration_mode` + `web_bridge` rather than independent flags — worth
-collapsing so the descriptor stays small.
+Additional axes the code also branches on but that are *derivable* from the above (so they
+stay out of the descriptor to keep it small): status-suppression policy (full vs idle-only),
+terminal auto-create, history-synthesis at cold resume, app-server lifecycle ownership,
+session-scoped credential synthesis.
 
 ---
 

--- a/omnigent/harnesses/__init__.py
+++ b/omnigent/harnesses/__init__.py
@@ -17,6 +17,16 @@ phases invert ownership so those constants derive from the registry instead.
 
 from __future__ import annotations
 
+from omnigent.harnesses.capabilities import (
+    AuthModel,
+    EffortFamily,
+    Elicitation,
+    HarnessCapabilities,
+    IntegrationMode,
+    ModelFamily,
+    Resume,
+)
+from omnigent.harnesses.matrix import render_matrix
 from omnigent.harnesses.registry import (
     REGISTRY,
     all_descriptors,
@@ -26,7 +36,15 @@ from omnigent.harnesses.types import HarnessDescriptor
 
 __all__ = [
     "REGISTRY",
+    "AuthModel",
+    "EffortFamily",
+    "Elicitation",
+    "HarnessCapabilities",
     "HarnessDescriptor",
+    "IntegrationMode",
+    "ModelFamily",
+    "Resume",
     "all_descriptors",
     "get",
+    "render_matrix",
 ]

--- a/omnigent/harnesses/capabilities.py
+++ b/omnigent/harnesses/capabilities.py
@@ -1,0 +1,328 @@
+"""Declarative capability model for coding-agent harnesses.
+
+This is the single place that answers "what can harness X do?" — the data that
+was previously implicit, scattered across ``if harness == "x"`` branches and the
+presence/absence of companion modules (``codex_native_elicitation.py``,
+``*_native_hook.py``, ``*_native_permissions.py``, ...).
+
+Each value here is backed by the code that implements it; where a value is
+*derivable* from an existing constant (``model_family`` from
+``model_override``'s family sets, ``subagents`` from ``NativeCodingAgent``'s
+``subagent_wrapper_label``) the accompanying test asserts the declaration
+matches that source, so the table cannot silently drift. The remaining axes
+(``integration_mode``, ``elicitation``, ``resume``, ``effort``, ``auth``) are
+declared from the module-level evidence cited inline.
+
+Aligned with the axes in the ``harness-integration-guide`` skill's feature
+matrix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class IntegrationMode(str, Enum):
+    """How the harness runs the vendor agent."""
+
+    SDK_IN_PROCESS = "sdk-in-process"  # vendor SDK inside the harness subprocess
+    CLI_SUBPROCESS = "cli-subprocess"  # drives a vendor CLI per turn
+    ACP_SUBPROCESS = "acp-subprocess"  # vendor CLI in Agent Client Protocol mode
+    NATIVE_TUI = "native-tui"  # wraps a resident vendor TUI (tmux / file-inject)
+    NATIVE_SERVER = "native-server"  # runner-owned vendor server + HTTP/SSE bridge
+
+
+class Elicitation(str, Enum):
+    """How a policy ASK / tool-approval is surfaced to the Omnigent web UI."""
+
+    NONE = "none"
+    HOOK = "hook"  # vendor PreToolUse hook posts to Omnigent
+    JSONRPC = "jsonrpc"  # app-server JSON-RPC elicitation (codex)
+    APPROVAL_MIRROR = "approval-mirror"  # poll the TUI approval pane, mirror to web
+    SSE_PERMISSION = "sse-permission"  # permission events over SSE / ACP elicit
+
+
+class Resume(str, Enum):
+    """Whether a prior conversation is reattached or rebuilt."""
+
+    WARM_REATTACH = "warm-reattach"  # reattach to a live vendor session / terminal
+    COLD_ONLY = "cold-only"  # rebuild from Omnigent transcript / history replay
+
+
+class EffortFamily(str, Enum):
+    """Which reasoning-effort value set applies (see reasoning_effort.py)."""
+
+    NONE = "none"
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    GEMINI = "gemini"
+    COPILOT = "copilot"
+
+
+class ModelFamily(str, Enum):
+    """Which model vendors the harness accepts (see model_override.py)."""
+
+    CLAUDE = "claude"
+    GPT = "gpt"
+    GEMINI = "gemini"
+    MULTI = "multi"  # accepts any validated id (no family rejection)
+
+
+class AuthModel(str, Enum):
+    """Where the harness's credentials come from."""
+
+    OMNIGENT_CREDENTIAL = "omnigent-credential"  # Omnigent gateway / provider config
+    OWN_AUTH = "own-auth"  # vendor login / API key, not Omnigent-managed
+    SESSION_SCOPED_CONFIG = "session-scoped-config"  # per-session synthesized vendor config
+
+
+@dataclass(frozen=True)
+class HarnessCapabilities:
+    """The feature set one harness supports. See module docstring."""
+
+    integration_mode: IntegrationMode
+    elicitation: Elicitation
+    resume: Resume
+    effort: EffortFamily
+    model_family: ModelFamily
+    auth: AuthModel
+    subagents: bool
+
+
+# Convenience aliases for the dense table below.
+_M = IntegrationMode
+_E = Elicitation
+_R = Resume
+_EF = EffortFamily
+_MF = ModelFamily
+_A = AuthModel
+
+
+# Per canonical harness. Every value is backed by the evidence noted in the
+# section comments; derivable values (model_family, subagents) are additionally
+# asserted against their source in tests/test_harness_registry.py.
+_CAPABILITIES: dict[str, HarnessCapabilities] = {
+    # ── Native-CLI harnesses (wrap a resident vendor TUI/server) ──────────
+    "claude-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.HOOK,
+        _R.WARM_REATTACH,
+        _EF.ANTHROPIC,
+        _MF.CLAUDE,
+        _A.OMNIGENT_CREDENTIAL,
+        subagents=True,
+    ),
+    "codex-native": HarnessCapabilities(
+        # hook deny-gate + app-server JSON-RPC elicitation; elicitation surface
+        # to the web UI is the JSON-RPC path (codex_native_elicitation.py).
+        _M.NATIVE_TUI,
+        _E.JSONRPC,
+        _R.WARM_REATTACH,
+        _EF.OPENAI,
+        _MF.GPT,
+        _A.OMNIGENT_CREDENTIAL,
+        subagents=True,
+    ),
+    "pi-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.NONE,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.SESSION_SCOPED_CONFIG,
+        subagents=False,
+    ),
+    "cursor-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.APPROVAL_MIRROR,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "kiro-native": HarnessCapabilities(
+        # kiro_native_permissions.py: "TUI ACP recorder -> web elicitation".
+        _M.NATIVE_TUI,
+        _E.APPROVAL_MIRROR,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "antigravity-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.NONE,
+        _R.WARM_REATTACH,
+        _EF.GEMINI,
+        _MF.GEMINI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "goose-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.APPROVAL_MIRROR,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "qwen-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.APPROVAL_MIRROR,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "kimi-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.HOOK,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.SESSION_SCOPED_CONFIG,
+        subagents=False,
+    ),
+    "opencode-native": HarnessCapabilities(
+        _M.NATIVE_SERVER,
+        _E.SSE_PERMISSION,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=True,
+    ),
+    "hermes-native": HarnessCapabilities(
+        _M.NATIVE_TUI,
+        _E.APPROVAL_MIRROR,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    # ── SDK / subprocess harnesses (run the vendor model directly) ────────
+    "claude-sdk": HarnessCapabilities(
+        _M.SDK_IN_PROCESS,
+        _E.NONE,
+        _R.COLD_ONLY,
+        _EF.ANTHROPIC,
+        _MF.CLAUDE,
+        _A.OMNIGENT_CREDENTIAL,
+        subagents=False,
+    ),
+    "codex": HarnessCapabilities(
+        # keeps one long-lived ``codex app-server`` per session; elicitation via
+        # app-server JSON-RPC (server/routes/_codex_elicitation.py).
+        _M.CLI_SUBPROCESS,
+        _E.JSONRPC,
+        _R.WARM_REATTACH,
+        _EF.OPENAI,
+        _MF.GPT,
+        _A.OMNIGENT_CREDENTIAL,
+        subagents=False,
+    ),
+    "pi": HarnessCapabilities(
+        _M.CLI_SUBPROCESS,
+        _E.NONE,
+        _R.COLD_ONLY,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OMNIGENT_CREDENTIAL,
+        subagents=False,
+    ),
+    "openai-agents": HarnessCapabilities(
+        _M.SDK_IN_PROCESS,
+        _E.NONE,
+        _R.COLD_ONLY,
+        _EF.OPENAI,
+        _MF.MULTI,
+        _A.OMNIGENT_CREDENTIAL,
+        subagents=False,
+    ),
+    "cursor": HarnessCapabilities(
+        _M.SDK_IN_PROCESS,
+        _E.NONE,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "antigravity": HarnessCapabilities(
+        _M.SDK_IN_PROCESS,
+        _E.NONE,
+        _R.COLD_ONLY,
+        _EF.GEMINI,
+        _MF.GEMINI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "goose": HarnessCapabilities(
+        _M.ACP_SUBPROCESS,
+        _E.SSE_PERMISSION,
+        _R.COLD_ONLY,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "qwen": HarnessCapabilities(
+        _M.ACP_SUBPROCESS,
+        _E.SSE_PERMISSION,
+        _R.COLD_ONLY,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "kimi": HarnessCapabilities(
+        _M.CLI_SUBPROCESS,
+        _E.NONE,
+        _R.WARM_REATTACH,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.SESSION_SCOPED_CONFIG,
+        subagents=False,
+    ),
+    "hermes": HarnessCapabilities(
+        _M.CLI_SUBPROCESS,
+        _E.HOOK,
+        _R.COLD_ONLY,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    "copilot": HarnessCapabilities(
+        _M.SDK_IN_PROCESS,
+        _E.NONE,
+        _R.COLD_ONLY,
+        _EF.COPILOT,
+        _MF.MULTI,
+        _A.OWN_AUTH,
+        subagents=False,
+    ),
+    # ``open-responses`` is resolved through an alternate path (no
+    # _HARNESS_MODULES entry). Conservative low-confidence defaults; refine when
+    # the harness is folded into the registry proper.
+    "open-responses": HarnessCapabilities(
+        _M.SDK_IN_PROCESS,
+        _E.NONE,
+        _R.COLD_ONLY,
+        _EF.NONE,
+        _MF.MULTI,
+        _A.OMNIGENT_CREDENTIAL,
+        subagents=False,
+    ),
+}
+
+
+def capabilities_for(name: str) -> HarnessCapabilities | None:
+    """Return the declared capabilities for a canonical harness name."""
+    return _CAPABILITIES.get(name)

--- a/omnigent/harnesses/matrix.py
+++ b/omnigent/harnesses/matrix.py
@@ -1,0 +1,61 @@
+"""Render the harness x capability matrix from the registry.
+
+The registry is the single source of truth; this module turns it into a
+human-readable table so "what does each harness support?" can be answered at a
+glance (and, later, checked into docs / surfaced via ``omni harness matrix``).
+"""
+
+from __future__ import annotations
+
+from omnigent.harnesses.registry import all_descriptors
+
+_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("Harness", ""),
+    ("Integration", "integration_mode"),
+    ("Elicitation", "elicitation"),
+    ("Resume", "resume"),
+    ("Model family", "model_family"),
+    ("Effort", "effort"),
+    ("Auth", "auth"),
+    ("Model override", ""),
+    ("Sub-agents", ""),
+)
+
+
+def _cell(descriptor: object, header: str, attr: str) -> str:
+    if header == "Harness":
+        return descriptor.name  # type: ignore[attr-defined]
+    if header == "Model override":
+        return "yes" if descriptor.supports_model_override else "no"  # type: ignore[attr-defined]
+    if header == "Sub-agents":
+        return "yes" if descriptor.capabilities.subagents else "no"  # type: ignore[attr-defined]
+    value = getattr(descriptor.capabilities, attr)  # type: ignore[attr-defined]
+    # Enum -> its str value; leave plain values untouched.
+    return getattr(value, "value", str(value))
+
+
+def render_matrix() -> str:
+    """Return the harness x capability matrix as a GitHub-flavored markdown table."""
+    headers = [header for header, _ in _COLUMNS]
+    rows: list[list[str]] = []
+    for descriptor in all_descriptors():
+        rows.append([_cell(descriptor, header, attr) for header, attr in _COLUMNS])
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    def _fmt(cells: list[str]) -> str:
+        return "| " + " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) + " |"
+
+    lines = [
+        _fmt(headers),
+        "| " + " | ".join("-" * widths[i] for i in range(len(headers))) + " |",
+    ]
+    lines.extend(_fmt(row) for row in rows)
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual inspection helper
+    print(render_matrix())

--- a/omnigent/harnesses/registry.py
+++ b/omnigent/harnesses/registry.py
@@ -9,6 +9,7 @@ those constants; the accompanying test
 from __future__ import annotations
 
 from omnigent.harness_aliases import HARNESS_ALIASES
+from omnigent.harnesses.capabilities import capabilities_for
 from omnigent.harnesses.types import HarnessDescriptor
 from omnigent.model_override import harness_supports_model_override
 from omnigent.native_coding_agents import NativeCodingAgent, native_coding_agent_for_harness
@@ -81,6 +82,13 @@ def _build_registry() -> dict[str, HarnessDescriptor]:
     for name in sorted(OMNIGENT_HARNESSES):
         native = native_coding_agent_for_harness(name)
         install_family_key = _HARNESS_NAME_TO_KEY.get(name)
+        capabilities = capabilities_for(name)
+        if capabilities is None:
+            raise ValueError(
+                f"harness {name!r} is in OMNIGENT_HARNESSES but has no entry in "
+                f"omnigent.harnesses.capabilities._CAPABILITIES — declare its "
+                f"capabilities there"
+            )
         registry[name] = HarnessDescriptor(
             name=name,
             aliases=_aliases_for(name),
@@ -89,6 +97,7 @@ def _build_registry() -> dict[str, HarnessDescriptor]:
             native=native,
             install_family_key=install_family_key,
             supports_model_override=harness_supports_model_override(name),
+            capabilities=capabilities,
         )
     return registry
 

--- a/omnigent/harnesses/types.py
+++ b/omnigent/harnesses/types.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from omnigent.harnesses.capabilities import HarnessCapabilities
 from omnigent.native_coding_agents import NativeCodingAgent
 
 
@@ -50,6 +51,8 @@ class HarnessDescriptor:
     :param supports_model_override: Whether a per-session ``/model`` override
         reaches the harness process (native CLIs via ``--model`` at launch, SDK
         harnesses via ``HARNESS_<H>_MODEL`` in the spawn env).
+    :param capabilities: The declarative feature set this harness supports —
+        the single source of truth for "what can this harness do?".
     """
 
     name: str
@@ -59,6 +62,7 @@ class HarnessDescriptor:
     native: NativeCodingAgent | None
     install_family_key: str | None
     supports_model_override: bool
+    capabilities: HarnessCapabilities
 
     @property
     def is_native(self) -> bool:

--- a/tests/test_harness_registry.py
+++ b/tests/test_harness_registry.py
@@ -11,12 +11,20 @@ loudly — which is the drift the registry exists to prevent.
 from __future__ import annotations
 
 from omnigent.harness_aliases import HARNESS_ALIASES, NATIVE_HARNESSES, is_native_harness
-from omnigent.harnesses import REGISTRY, all_descriptors, get
-from omnigent.model_override import harness_supports_model_override
+from omnigent.harnesses import REGISTRY, all_descriptors, get, render_matrix
+from omnigent.harnesses.capabilities import IntegrationMode, ModelFamily, Resume
+from omnigent.model_override import (
+    _ANTIGRAVITY_FAMILY_HARNESSES,
+    _CLAUDE_FAMILY_HARNESSES,
+    _CODEX_FAMILY_HARNESSES,
+    harness_supports_model_override,
+)
 from omnigent.native_coding_agents import NATIVE_CODING_AGENTS
 from omnigent.onboarding.harness_install import _HARNESS_NAME_TO_KEY
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 from omnigent.spec._omnigent_compat import OMNIGENT_HARNESS_ALIASES, OMNIGENT_HARNESSES
+
+_NATIVE_MODES = frozenset({IntegrationMode.NATIVE_TUI, IntegrationMode.NATIVE_SERVER})
 
 # The one canonical harness that is intentionally resolved through an alternate
 # path and has no ``_HARNESS_MODULES`` entry. Documented here so that a NEW
@@ -106,3 +114,60 @@ def test_get_is_alias_insensitive() -> None:
     assert get("native-antigravity") is get("antigravity-native")
     assert get(None) is None
     assert get("definitely-not-a-harness") is None
+
+
+# ── Capability declarations (PR 2) ────────────────────────────────────────
+
+
+def test_every_descriptor_declares_capabilities() -> None:
+    for descriptor in all_descriptors():
+        assert descriptor.capabilities is not None
+
+
+def test_integration_mode_agrees_with_native_flag() -> None:
+    # A native integration mode iff the descriptor carries native UI metadata.
+    for descriptor in all_descriptors():
+        is_native_mode = descriptor.capabilities.integration_mode in _NATIVE_MODES
+        assert is_native_mode == descriptor.is_native, descriptor.name
+
+
+def test_model_family_matches_model_override_sets() -> None:
+    # model_family is derivable from model_override's family frozensets, so the
+    # declaration must not contradict the code that actually enforces routing.
+    for descriptor in all_descriptors():
+        name = descriptor.name
+        family = descriptor.capabilities.model_family
+        if name in _CLAUDE_FAMILY_HARNESSES:
+            assert family is ModelFamily.CLAUDE, name
+        elif name in _CODEX_FAMILY_HARNESSES:
+            assert family is ModelFamily.GPT, name
+        elif name in _ANTIGRAVITY_FAMILY_HARNESSES:
+            assert family is ModelFamily.GEMINI, name
+        else:
+            assert family is ModelFamily.MULTI, name
+
+
+def test_subagents_matches_native_wrapper_label() -> None:
+    # subagents is derivable: only native agents with a subagent_wrapper_label
+    # can spawn Omnigent native sub-agents.
+    subagent_capable = {
+        agent.harness for agent in NATIVE_CODING_AGENTS if agent.subagent_wrapper_label
+    }
+    for descriptor in all_descriptors():
+        expected = descriptor.name in subagent_capable
+        assert descriptor.capabilities.subagents == expected, descriptor.name
+
+
+def test_native_harnesses_resume_warm() -> None:
+    # Every native harness reattaches to a live vendor session/terminal.
+    for descriptor in all_descriptors():
+        if descriptor.is_native:
+            assert descriptor.capabilities.resume is Resume.WARM_REATTACH, descriptor.name
+
+
+def test_matrix_renders_every_harness() -> None:
+    table = render_matrix()
+    for descriptor in all_descriptors():
+        assert descriptor.name in table
+    # Header + separator + one row per harness.
+    assert len(table.splitlines()) == len(REGISTRY) + 2


### PR DESCRIPTION
## What

Phase 0 part 2 of the modular-harness effort (see `designs/harness-modular-registry-proposal.md`). **Stacked on #1793** (`harness-registry-foundation`).

Adds `omnigent/harnesses/capabilities.py` - the single source of truth for "what can this harness do?" - and attaches a `HarnessCapabilities` record to every `HarnessDescriptor`. Also adds `matrix.py`, which renders the harness x capability table.

## Why

Today a harness's feature support is implicit: encoded in ad-hoc frozensets and the presence/absence of companion modules (`codex_native_elicitation.py`, `*_native_hook.py`, `*_native_permissions.py`). There is no single place that answers what a given harness supports, and the scatter actively misleads.

## Capability axes (aligned with the harness-integration-guide feature matrix)

`integration_mode`, `elicitation`, `resume`, `effort`, `model_family`, `auth`, `subagents`. Every value is backed by the implementing code (evidence cited inline). The two derivable axes are asserted against their source so the table cannot silently drift:
- `model_family` vs `model_override`'s family frozensets
- `subagents` vs `NativeCodingAgent.subagent_wrapper_label`

## Evidence-based, not assumption-based

Building this surfaced a wrong assumption from the design phase: `kiro-native` was assumed to have "no elicitation", but `kiro_native_permissions.py` ("TUI ACP recorder -> web elicitation") shows it surfaces approval cards via `APPROVAL_MIRROR`. The declaration reflects the verified value, and the design doc was corrected. The doc's hand-maintained capability table is replaced by a pointer to `capabilities.py` as the source of truth.

The doc was also refreshed against current `main`: the frontend rename `ap-web/` -> `web/` is now reflected, and the per-harness if-chains the later phases target were re-confirmed to still exist.

## Rendered matrix (excerpt)

```
| Harness         | Integration    | Elicitation     | Resume        | Model family | Effort    | Auth                  |
| kiro-native     | native-tui     | approval-mirror | warm-reattach | multi        | none      | own-auth              |
| codex-native    | native-tui     | jsonrpc         | warm-reattach | gpt          | openai    | omnigent-credential   |
| claude-sdk      | sdk-in-process | none            | cold-only     | claude       | anthropic | omnigent-credential   |
```

## Testing

- `pytest tests/test_harness_registry.py` - 16 passed (10 from PR1 + 6 capability tests).
- `ruff format` + `ruff check` + `pre-commit run` on changed files - all pass.
