### PR TITLE
fix(smart-routing): unwrap claude-sdk MCP content-array in SmartRoutingCard

### DIFF
--- a/web/src/components/blocks/SmartRoutingCard.test.tsx
+++ b/web/src/components/blocks/SmartRoutingCard.test.tsx
@@ -73,11 +73,23 @@ describe("parseRecommendations", () => {
     expect(recs!.size).toBe(2);
   });
 
+  it("unwraps claude-sdk MCP content-array format", () => {
+    // The claude-sdk harness stores tool results as [{type:"text", text:"<json>"}]
+    // rather than raw JSON strings — parseRecommendations must unwrap the envelope.
+    const wrapped = JSON.stringify([{ type: "text", text: TWO_TASK_OUTPUT }]);
+    const recs = parseRecommendations(wrapped);
+    expect(recs).not.toBeNull();
+    expect(recs!.size).toBe(2);
+    expect(recs!.get("refactor-auth")?.model).toBe("databricks-claude-opus-4-8");
+  });
+
   it("returns null for the dispatcher's Error: strings and non-JSON", () => {
     // Every failure mode of the tool returns a plain string, not JSON —
     // null is what flips the card into its failure rendering.
     expect(parseRecommendations("Error: the intelligent model router is OFF")).toBeNull();
     expect(parseRecommendations("{}")).toBeNull();
+    // Content array with no text block → null
+    expect(parseRecommendations(JSON.stringify([{ type: "image" }]))).toBeNull();
   });
 });
 

--- a/web/src/components/blocks/SmartRoutingCard.tsx
+++ b/web/src/components/blocks/SmartRoutingCard.tsx
@@ -72,6 +72,20 @@ export function parseRecommendations(output: string): Map<string, Recommendation
   } catch {
     return null;
   }
+  // The claude-sdk harness stores tool results as MCP content arrays
+  // ([{type:"text", text:"<json>"}]) rather than raw text strings.
+  // Unwrap the first text block before parsing the recommendations object.
+  if (Array.isArray(payload)) {
+    const textBlock = payload.find(
+      (b): b is { type: string; text: string } =>
+        typeof b === "object" &&
+        b !== null &&
+        (b as Record<string, unknown>).type === "text" &&
+        typeof (b as Record<string, unknown>).text === "string",
+    );
+    if (!textBlock) return null;
+    return parseRecommendations(textBlock.text);
+  }
   if (typeof payload !== "object" || payload === null) return null;
   const raw = (payload as Record<string, unknown>).recommendations;
   if (!Array.isArray(raw)) return null;


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- The claude-sdk harness stores `sys_advise_models` tool results as a JSON content array (`[{"type":"text","text":"<json>"}]`) rather than a plain JSON string.
- `parseRecommendations` was calling `JSON.parse` on this array, seeing no `recommendations` key, and returning `null` — causing the SmartRoutingCard to render "· unavailable" even when the router produced valid recommendations.
- Fix: when the parsed value is an array, unwrap the first `type:"text"` block and recurse to parse the actual recommendations object.

## Test Plan

- Added a unit test in `SmartRoutingCard.test.tsx` that wraps a valid output in the content-array envelope and asserts `parseRecommendations` correctly extracts the recommendations.
- Added a negative test for a content array with no text block (returns `null`).
- Verified existing tests still pass.

## Demo

N/A — the fix restores correct card rendering ("· sized N tasks") in conversations where polly calls `sys_advise_models` through the claude-sdk harness.

## Type of change

- [x] Bug fix
- [x] UI / frontend change

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

The content-array wrapping is specific to the claude-sdk harness; the fix is a pure defensive parse path that degrades gracefully (returns `null`) for unexpected array shapes.

## Changelog

Fixed: SmartRoutingCard no longer shows "· unavailable" for `sys_advise_models` calls made through the claude-sdk harness