### PR TITLE
fix(cursor): subtract cache tokens from input to stop double-billing

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -161,6 +161,16 @@ def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
             if val is not None:
                 usage[dst] = val
                 break
+    # cursor's inputTokens is INCLUSIVE of cache read + write. compute_llm_cost
+    # expects input_tokens to be the NON-cached portion and prices the cache
+    # buckets additively, so subtract the cached tokens here — otherwise they
+    # are billed twice (once at the full input rate, once at their cache rate).
+    # Mirrors the qwen / antigravity executors. Clamp so a malformed cached >
+    # input never goes negative. total_tokens keeps the reported inclusive total.
+    cached = (usage.get("cache_read_input_tokens") or 0) + (
+        usage.get("cache_creation_input_tokens") or 0
+    )
+    usage["input_tokens"] = max(0, in_tok - cached)
     return usage
 
 

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1007,6 +1007,50 @@ def test_normalize_cursor_usage_includes_cache_fields() -> None:
     result = _normalize_cursor_usage(raw, "auto")
     assert result["cache_read_input_tokens"] == 300
     assert result["cache_creation_input_tokens"] == 50
+    # cursor's inputTokens (500) is inclusive of cache read (300) + write (50);
+    # input_tokens must be the non-cached remainder (150) so compute_llm_cost,
+    # which prices the cache buckets additively, does not double-bill them.
+    assert result["input_tokens"] == 150
+
+
+def test_normalize_cursor_usage_subtracts_cache_to_avoid_double_billing() -> None:
+    """``input_tokens`` excludes cached tokens so cache reads/writes aren't billed twice.
+
+    cursor reports ``inputTokens`` inclusive of cache read + write, but
+    ``compute_llm_cost`` requires ``input_tokens`` to be the non-cached portion
+    and prices ``cache_read_input_tokens`` / ``cache_creation_input_tokens``
+    additively. Passing the full inclusive count while also reporting the cache
+    buckets bills the cached tokens twice.
+
+    Regression guard: pre-fix ``input_tokens`` was the full 1000 here.
+    """
+    raw = {
+        "inputTokens": 1000,
+        "outputTokens": 200,
+        "totalTokens": 1200,
+        "cacheReadTokens": 700,
+        "cacheWriteTokens": 50,
+    }
+    result = _normalize_cursor_usage(raw, "auto")
+    # 1000 inclusive - 700 read - 50 write = 250 non-cached input.
+    assert result["input_tokens"] == 250, (
+        f"input_tokens {result['input_tokens']} != 250 — the cache read/write must be "
+        "subtracted from cursor's inclusive inputTokens so compute_llm_cost does not "
+        "double-bill them against the additive cache buckets."
+    )
+    assert result["cache_read_input_tokens"] == 700
+    assert result["cache_creation_input_tokens"] == 50
+    # total_tokens keeps the reported inclusive total; input + read + write
+    # reconstructs it against output, proving cached tokens are counted once.
+    assert result["input_tokens"] + 700 + 50 == 1000
+
+
+def test_normalize_cursor_usage_clamps_when_cache_exceeds_input() -> None:
+    """Malformed cache > input clamps ``input_tokens`` to 0, not negative."""
+    raw = {"inputTokens": 100, "outputTokens": 20, "cacheReadTokens": 999}
+    result = _normalize_cursor_usage(raw, "auto")
+    assert result["input_tokens"] == 0
+    assert result["cache_read_input_tokens"] == 999
 
 
 async def test_run_turn_captures_usage_from_turn_ended_update(


### PR DESCRIPTION
## Related issue

Closes #1801

## Summary

- `_normalize_cursor_usage` copied cursor's `inputTokens` straight into `input_tokens` and also mapped `cacheReadTokens`/`cacheWriteTokens` into the cache buckets, without subtracting the cached portion.
- cursor's `inputTokens` is inclusive of cache read + write (documented in `omnigent/cursor_native_usage.py`), and `compute_llm_cost` requires `input_tokens` to be the non-cached portion (it prices the cache buckets additively). The SDK path is priced via `compute_llm_cost` and emits no direct `cost_usd`, so the cached tokens were billed twice: once at the full input rate, once at their cache rate.
- Fix: subtract the mapped cache buckets from `input_tokens` (clamped at 0), mirroring the qwen and antigravity executors.

## Test Plan

- Strengthened `test_normalize_cursor_usage_includes_cache_fields` to assert the non-cached `input_tokens == 150` (was only asserting the cache fields).
- New `test_normalize_cursor_usage_subtracts_cache_to_avoid_double_billing` (`input=1000, read=700, write=50` -> `input_tokens == 250`). Verified it **fails before the fix** (`input_tokens == 1000`).
- New `test_normalize_cursor_usage_clamps_when_cache_exceeds_input` (malformed cache > input clamps to 0).
- `uv run pytest tests/inner/test_cursor_executor.py` -> 71 passed (1 pre-existing failure on this Windows checkout, `test_ensure_session_writes_hooks_json`, also fails on a clean `main` and is unrelated to this change).
- `ruff check` / `ruff format --check` clean on both files.

## Demo

No UI surface to screenshot, this is a token-accounting change. For raw usage inputTokens=1000, outputTokens=200, cacheReadTokens=700, cacheWriteTokens=50:

- Before: input_tokens=1000 (inclusive) with cache_read=700 and cache_write=50 -> the 750 cached tokens are billed at the full input rate AND again at their cache rate.
- After:  input_tokens=250 (1000-700-50), cache buckets unchanged -> each cached token billed once.


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified against the sibling pattern: qwen, codex, openai, and antigravity all subtract the cached portion before `compute_llm_cost`. The cursor SDK path was the outlier. The native cursor path (`cursor_native_usage.py`) deliberately forwards inclusive and lets the server split it, which is a different code path and is not affected by this change. No secrets involved (dummy token counts; fake SDK is monkeypatched, no network call).
