### PR TITLE
fix(terminal): stop leaking kitty keyboard protocol (CSI-u) into the real TTY

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -163,21 +163,26 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
     ``history-limit`` is generated per terminal because it comes from
     ``TerminalEnvSpec.scrollback``. ``mouse on`` makes the attached web
     terminal scrollable. ``focus-events on`` lets interactive programs
-    observe pane focus changes. ``extended-keys`` with CSI-u formatting
-    lets programs inside tmux receive Kitty Keyboard Protocol keys such
-    as Shift+Enter when the attached terminal supports them. Terminals
-    without that protocol ignore tmux's request, and the quiet tmux
-    options keep older tmux versions from failing launch. ``escape-time
-    0`` prevents pasted ANSI escape bytes from accumulating tmux's
-    default delay.
+    observe pane focus changes. ``escape-time 0`` prevents pasted ANSI
+    escape bytes from accumulating tmux's default delay.
+
+    ``extended-keys``/``extended-keys-format csi-u`` are deliberately
+    NOT set. Enabling them makes tmux negotiate the Kitty Keyboard
+    Protocol (CSI-u) with whatever terminal attaches to this server.
+    A native terminal attached via ``_attach_direct_tmux`` is the
+    user's real TTY, so tmux would enable progressive keyboard
+    enhancement on it and leak that mode back into the user's shell
+    when the attach ends (e.g. Ctrl+C printing ``^[[99;133u`` instead
+    of sending SIGINT). tmux defaults ``extended-keys`` to off, so
+    omitting these lines keeps the real terminal untouched. The
+    trade-off is that managed terminals no longer receive
+    disambiguated keys such as Shift+Enter.
 
     :param scrollback: Tmux history limit, e.g. ``10000``.
     :returns: Tmux commands configuring pane input and scrollback.
     """
     return [
         ["set-option", "-g", "history-limit", str(scrollback)],
-        ["set-option", "-sq", "extended-keys", "on"],
-        ["set-option", "-sq", "extended-keys-format", "csi-u"],
         ["set-option", "-g", "mouse", "on"],
         ["set-option", "-g", "focus-events", "on"],
         ["set-option", "-g", "escape-time", "0"],

--- a/sdks/ui/omnigent_ui_sdk/terminal/_host.py
+++ b/sdks/ui/omnigent_ui_sdk/terminal/_host.py
@@ -1700,16 +1700,17 @@ class TerminalHost:
 
         ticker = asyncio.create_task(_toolbar_ticker())
         try:
-            # Push Kitty Keyboard Protocol mode (flag 1 =
-            # disambiguate escape codes). Without this the terminal
-            # never knows to send CSI-u encoded sequences — e.g.
-            # Shift+Enter arrives as plain \r instead of
-            # \x1b[13;2u, so the F20 binding never fires. The
-            # push/pop model (\x1b[>Xu / \x1b[<u) restores the
-            # previous mode on exit. Terminals that don't support
-            # the protocol ignore the sequence per ECMA-48.
-            self._output.write_raw("\x1b[>1u")
-            self._output.flush()
+            # Kitty Keyboard Protocol (CSI-u progressive enhancement)
+            # is deliberately NOT enabled here. The prior code pushed
+            # ``\x1b[>1u`` so Shift+Enter arrived as ``\x1b[13;2u``,
+            # but the matching pop (``\x1b[<u``) only ran on the
+            # happy-path ``finally`` — a hard exit, SIGINT/SIGTERM/
+            # SIGHUP, or crash left the mode enabled and leaked it into
+            # the user's real terminal, so Ctrl+C at the shell prompt
+            # printed ``^[[99;133u`` instead of sending SIGINT.
+            # Never enabling it removes the leak entirely; the
+            # trade-off is losing disambiguated keys such as
+            # Shift+Enter in this TUI.
             with patch_stdout(raw=True):
                 while True:
                     try:
@@ -1817,9 +1818,9 @@ class TerminalHost:
                     self._tasks.append(task)
                     task.add_done_callback(self._on_handler_task_done)
         finally:
-            # Pop Kitty Keyboard Protocol — restore previous mode.
-            self._output.write_raw("\x1b[<u")
-            self._output.flush()
+            # Nothing to pop: the Kitty Keyboard Protocol push above
+            # was removed, so the mode is never enabled and there is
+            # no state to restore here.
             ticker.cancel()
 
     def _on_handler_task_done(self, task: asyncio.Task[None]) -> None:

--- a/tests/frontends/sdk/test_terminal_host.py
+++ b/tests/frontends/sdk/test_terminal_host.py
@@ -511,36 +511,61 @@ async def test_window_title_none_skips_title_calls(
     )
 
 
-def test_run_never_enables_kitty_keyboard_protocol() -> None:
+def test_host_never_enables_kitty_keyboard_protocol() -> None:
     """
-    The host input loop must never enable the Kitty Keyboard Protocol.
+    No code in ``_host.py`` may enable the Kitty Keyboard Protocol.
 
-    The loop used to push CSI-u progressive enhancement with
+    The input loop used to push CSI-u progressive enhancement with
     ``\\x1b[>1u`` (to get disambiguated keys like Shift+Enter) and
     pop it with ``\\x1b[<u`` in a happy-path ``finally``. Because the
     pop only ran on a clean return, any hard exit — SIGINT/SIGTERM/
     SIGHUP or a crash — left the mode enabled and leaked it into the
     user's real terminal, so Ctrl+C at the shell prompt printed
     ``^[[99;133u`` instead of sending SIGINT. The fix removes the
-    push entirely (never enabled → nothing to leak). Guard the
-    source so the enable escape cannot creep back in.
+    push entirely (never enabled → nothing to leak).
+
+    Guard against reintroduction anywhere in the module — not just
+    ``run`` — because a helper could push it too. The enable push is a
+    *string written to the terminal* that starts with ``ESC [ >`` (the
+    ``>`` private-parameter prefix, e.g. ``ESC[>1u``). We therefore
+    inspect the decoded VALUE of every string literal in the module,
+    which:
+
+    - matches the escape in any spelling (``\\x1b``, ``\\033``, or a
+      raw ESC byte), since all decode to the same bytes;
+    - ignores comments and docstrings-about-the-bug (this test and the
+      explanatory comment in ``_host.py`` mention ``\\x1b[>1u`` in prose,
+      which is not a string literal so must not trip the guard);
+    - does NOT flag the legitimate INCOMING CSI-u decoders in
+      ``_install_csi_u_sequences`` (``ESC[13u``, ``ESC[9u``,
+      ``ESC[127u`` …). Those parse sequences the terminal sends *to*
+      us and never carry the ``>`` prefix, so ``ESC [ >`` cleanly
+      separates an enable-push from decoder/parse code.
     """
+    import ast
     import inspect
 
-    source = inspect.getsource(TerminalHost.run)
+    from omnigent_ui_sdk.terminal import _host as host_module
 
-    assert "\x1b[>1u" not in source, (
-        "TerminalHost.run() writes the Kitty Keyboard Protocol push "
-        "(\\x1b[>1u). Enabling CSI-u leaks into the user's real "
-        "terminal on any non-happy-path exit — Ctrl+C then prints "
-        "^[[99;133u instead of sending SIGINT. Do not re-enable it."
-    )
-    # The literal ``\x1b[>`` prefix begins every progressive-enhancement
-    # push (``>1u``, ``>3u``, ...); block the whole family, not just >1u.
-    assert "\x1b[>" not in source, (
-        "TerminalHost.run() writes a CSI-u progressive-enhancement push "
-        "(\\x1b[>...u). Enabling any Kitty Keyboard Protocol flag leaks "
-        "into the user's real terminal on non-happy-path exits."
+    module_source = inspect.getsource(host_module)
+
+    # Real bytes (not the escaped source spelling): ESC, '[', '>'.
+    enable_push_prefix = "\x1b[>"
+
+    offenders = [
+        node.value
+        for node in ast.walk(ast.parse(module_source))
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and enable_push_prefix in node.value
+    ]
+
+    assert not offenders, (
+        "_host.py contains a string literal that enables the Kitty "
+        "Keyboard Protocol (CSI-u progressive enhancement) — it starts "
+        "with ESC[> (e.g. '\\x1b[>1u'). Writing this to the terminal "
+        "leaks the mode into the user's real shell on any non-happy-path "
+        f"exit (Ctrl+C then prints ^[[99;133u). Offending values: {offenders!r}"
     )
 
 

--- a/tests/frontends/sdk/test_terminal_host.py
+++ b/tests/frontends/sdk/test_terminal_host.py
@@ -511,6 +511,39 @@ async def test_window_title_none_skips_title_calls(
     )
 
 
+def test_run_never_enables_kitty_keyboard_protocol() -> None:
+    """
+    The host input loop must never enable the Kitty Keyboard Protocol.
+
+    The loop used to push CSI-u progressive enhancement with
+    ``\\x1b[>1u`` (to get disambiguated keys like Shift+Enter) and
+    pop it with ``\\x1b[<u`` in a happy-path ``finally``. Because the
+    pop only ran on a clean return, any hard exit — SIGINT/SIGTERM/
+    SIGHUP or a crash — left the mode enabled and leaked it into the
+    user's real terminal, so Ctrl+C at the shell prompt printed
+    ``^[[99;133u`` instead of sending SIGINT. The fix removes the
+    push entirely (never enabled → nothing to leak). Guard the
+    source so the enable escape cannot creep back in.
+    """
+    import inspect
+
+    source = inspect.getsource(TerminalHost.run)
+
+    assert "\x1b[>1u" not in source, (
+        "TerminalHost.run() writes the Kitty Keyboard Protocol push "
+        "(\\x1b[>1u). Enabling CSI-u leaks into the user's real "
+        "terminal on any non-happy-path exit — Ctrl+C then prints "
+        "^[[99;133u instead of sending SIGINT. Do not re-enable it."
+    )
+    # The literal ``\x1b[>`` prefix begins every progressive-enhancement
+    # push (``>1u``, ``>3u``, ...); block the whole family, not just >1u.
+    assert "\x1b[>" not in source, (
+        "TerminalHost.run() writes a CSI-u progressive-enhancement push "
+        "(\\x1b[>...u). Enabling any Kitty Keyboard Protocol flag leaks "
+        "into the user's real terminal on non-happy-path exits."
+    )
+
+
 def test_default_history_file_matches_legacy_omnigent_path() -> None:
     """
     With no ``history_file`` override, the host's prompt session

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -47,7 +47,7 @@ def contains_subsequence(values: list[str], expected: list[str]) -> bool:
 
     :param values: Full argv list, e.g. ``["tmux", "set-option"]``.
     :param expected: Expected contiguous argv slice, e.g.
-        ``["set-option", "-sq", "extended-keys", "on"]``.
+        ``["set-option", "-gq", "remain-on-exit", "on"]``.
     :returns: ``True`` when the expected slice appears in order.
     """
     if not expected:
@@ -430,18 +430,21 @@ async def test_launch_omits_keep_alive_options_by_default(
 
 
 @pytest.mark.asyncio
-async def test_launch_enables_csi_u_extended_keys_quietly(
+async def test_launch_does_not_enable_csi_u_extended_keys(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Managed tmux sessions request CSI-u extended-key forwarding on launch.
+    Managed tmux sessions must NOT enable CSI-u extended keys on launch.
 
-    This is the tmux-side half of Shift+Enter support for capable
-    native terminals: applications in the pane can receive
-    ``\\x1b[13;2u`` after they request Kitty Keyboard Protocol mode.
-    The ``-q`` flag is part of the assertion so older tmux versions
-    that do not know these options do not fail terminal launch.
+    Enabling ``extended-keys``/``extended-keys-format csi-u`` makes tmux
+    negotiate the Kitty Keyboard Protocol with the attached terminal.
+    A native terminal attaches its real TTY directly to this tmux
+    server, so the mode leaks back into the user's shell when the
+    attach ends — Ctrl+C then prints ``^[[99;133u`` instead of sending
+    SIGINT. tmux defaults ``extended-keys`` to off, so launch must not
+    turn it on. The trade-off is that managed terminals lose
+    disambiguated keys such as Shift+Enter.
 
     :param tmp_path: Temporary directory used for the fake tmux socket.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -487,15 +490,14 @@ async def test_launch_enables_csi_u_extended_keys_quietly(
 
     # ``launch`` should issue one flattened tmux setup command. Zero calls
     # would mean the test never captured launch; more than one call would
-    # mean the extended-key assertions below may not cover the full setup argv.
+    # mean the assertions below may not cover the full setup argv.
     assert len(captured) == 1
     cmd = captured[0]
 
-    assert contains_subsequence(cmd, ["set-option", "-sq", "extended-keys", "on"])
-    assert contains_subsequence(
-        cmd,
-        ["set-option", "-sq", "extended-keys-format", "csi-u"],
-    )
+    # Neither the option nor the CSI-u format may appear anywhere in the argv.
+    assert "extended-keys" not in cmd
+    assert "extended-keys-format" not in cmd
+    assert "csi-u" not in cmd
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Omnigent enables the **Kitty Keyboard Protocol** (CSI-u progressive enhancement) and never reliably disables it. When a native terminal (e.g. ghostty) attaches its real TTY, the mode leaks back into the user's shell — so **Ctrl+C at the shell prompt prints `^[[99;133u` instead of sending SIGINT**.

The protocol was enabled in **two** places, and the disable path was unreliable:

### Site 1 — tmux (`omnigent/inner/terminal.py`)
`_tmux_input_option_commands` set `extended-keys on` + `extended-keys-format csi-u` unconditionally on every managed tmux server. The native attach path (`_attach_direct_tmux` in `pi_native.py` / `claude_native.py` / `cursor_native.py`) hands tmux the user's **real TTY**, so tmux negotiated CSI-u directly with it. On detach the mode was left enabled and leaked into the shell.

### Site 2 — SDK TUI host (`sdks/ui/omnigent_ui_sdk/terminal/_host.py`)
`TerminalHost.run` pushed `\x1b[>1u` at the top of the input loop and popped `\x1b[<u` only in a **happy-path `finally`**. Any hard exit — SIGINT / SIGTERM / SIGHUP / crash — skipped the pop and left the mode enabled.

## Fix

- **terminal.py**: removed the two `extended-keys` / `extended-keys-format csi-u` option lines. tmux defaults `extended-keys` to *off*, so the real terminal is left untouched.
- **_host.py**: removed the `\x1b[>1u` push (and its now-orphaned `\x1b[<u` pop). The protocol is **never enabled**, so there is nothing that can leak on any exit path — the more robust choice than trying to guarantee the pop on every signal.

I grepped the whole repo for other enable sites (`extended-keys`, `csi-u`, `\x1b[>`, `[>1u`, `KeyboardEnhancement`, `kitty`, `progressive`) — these two were the only ones. The web/xterm.js attach path never touches the real TTY and is unchanged.

## Trade-off

Managed terminals and the SDK TUI lose disambiguated keys such as **Shift+Enter** (which relied on CSI-u encoding). This is intentional: the protocol must never touch the user's real terminal.

## Tests / gates

- Inverted `tests/inner/test_terminal.py` — `test_launch_does_not_enable_csi_u_extended_keys` now asserts `extended-keys` / `csi-u` are **never** emitted.
- Added `test_run_never_enables_kitty_keyboard_protocol` in `tests/frontends/sdk/test_terminal_host.py` — source guard that `TerminalHost.run` never writes the `\x1b[>` enable escape.
- `uv run pytest tests/inner tests/frontends`: **2051 passed, 37 skipped, 1 pre-existing unrelated failure** (`tests/inner/egress/test_proxy.py::test_upstream_ca_pinned_at_construction_not_reread_per_request` — fails identically on clean `main`).
- `ruff check` + `ruff format --check`: clean on all changed files.
- `pyrefly check`: no new errors introduced (identical error count with and without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)