### PR TITLE
Support OMNIGENT-prefixed provider credentials

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -304,12 +304,17 @@ and list it in the config. Its env vars are injected into every managed
 sandbox, and the in-sandbox host forwards the standard harness credential
 vars (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`,
 `CLAUDE_CODE_OAUTH_TOKEN`, `CODEX_ACCESS_TOKEN`, `OPENAI_API_KEY`,
-`OPENAI_BASE_URL`, `GEMINI_API_KEY`) to its runners:
+`OPENAI_BASE_URL`, `GEMINI_API_KEY`, plus their `OMNIGENT_`-prefixed
+aliases) to its runners:
 
 ```bash
 modal secret create omnigent-llm \
-  ANTHROPIC_API_KEY=sk-ant-… OPENAI_API_KEY=sk-…
+  OMNIGENT_ANTHROPIC_API_KEY=sk-ant-… OPENAI_API_KEY=sk-…
 ```
+
+Prefer `OMNIGENT_ANTHROPIC_API_KEY` for Claude Code API-key auth. Omnigent
+resolves it into Claude Code's `apiKeyHelper`, avoiding a raw
+`ANTHROPIC_API_KEY` in the Claude CLI process.
 
 ```yaml
 sandbox:

--- a/deploy/modal/README.md
+++ b/deploy/modal/README.md
@@ -312,7 +312,7 @@ credential vars to its runners:
 
 ```bash
 modal secret create omnigent-llm \
-  ANTHROPIC_API_KEY=sk-ant-… OPENAI_API_KEY=sk-…
+  OMNIGENT_ANTHROPIC_API_KEY=sk-ant-… OPENAI_API_KEY=sk-…
 ```
 
 The forwarded set covers the variables the harnesses themselves
@@ -324,7 +324,7 @@ like [OpenRouter](https://openrouter.ai) and
 
 | Variable | Enables |
 |---|---|
-| `ANTHROPIC_API_KEY` | Claude models on the Anthropic API (claude-sdk, pi, claude-code harnesses) |
+| `OMNIGENT_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY` | Claude models on the Anthropic API (claude-sdk, pi, claude-code harnesses). Prefer the `OMNIGENT_` form for Claude Code so the raw `ANTHROPIC_API_KEY` env var is not present in the CLI process. |
 | `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` | Anthropic-compatible gateways — point claude-code at a LiteLLM proxy, a Bedrock/Vertex bridge, or a corporate gateway |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-code with a Claude subscription (no API key) |
 | `OPENAI_API_KEY` | OpenAI models on the OpenAI API (codex, openai-agents harnesses) |
@@ -334,7 +334,10 @@ like [OpenRouter](https://openrouter.ai) and
 
 Common setups:
 
-- **Claude with an API key** — put `ANTHROPIC_API_KEY` in the secret.
+- **Claude with an API key** — put `OMNIGENT_ANTHROPIC_API_KEY` in the secret.
+  Omnigent resolves it into Claude Code's `apiKeyHelper`; do not also set
+  `ANTHROPIC_API_KEY` unless you are okay with Claude Code detecting the raw
+  custom key env var.
 - **Claude with a subscription** — run `claude setup-token` on your own
   machine (one-time browser auth) and store the resulting long-lived
   token as `CLAUDE_CODE_OAUTH_TOKEN`.

--- a/omnigent/env_credentials.py
+++ b/omnigent/env_credentials.py
@@ -1,0 +1,93 @@
+"""Helpers for Omnigent-prefixed credential environment variables."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+
+OMNIGENT_ENV_PREFIX = "OMNIGENT_"
+
+_ENV_REF_RE = re.compile(r"(?<!\$)\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))")
+
+
+def omnigent_prefixed_env_name(name: str) -> str:
+    """Return the Omnigent-prefixed alias for *name*.
+
+    :param name: Environment variable name, e.g. ``"ANTHROPIC_API_KEY"``.
+    :returns: ``"OMNIGENT_ANTHROPIC_API_KEY"`` unless *name* is already
+        Omnigent-prefixed.
+    """
+    return name if name.startswith(OMNIGENT_ENV_PREFIX) else f"{OMNIGENT_ENV_PREFIX}{name}"
+
+
+def env_names_with_omnigent_prefix(name: str) -> tuple[str, ...]:
+    """Return the canonical env var name plus its Omnigent-prefixed alias.
+
+    The canonical name stays first so existing deployments keep precedence
+    when both names are set.
+
+    :param name: Environment variable name, e.g. ``"OPENAI_API_KEY"``.
+    :returns: Candidate names in resolution order.
+    """
+    prefixed = omnigent_prefixed_env_name(name)
+    if prefixed == name:
+        return (name,)
+    return (name, prefixed)
+
+
+def getenv_with_omnigent_prefix(
+    name: str, environ: Mapping[str, str] | None = None
+) -> tuple[str, str] | None:
+    """Read *name*, falling back to ``OMNIGENT_<name>`` when unset.
+
+    :param name: Canonical environment variable name.
+    :param environ: Optional environment mapping; defaults to ``os.environ``.
+    :returns: ``(actual_name, value)`` for the first set candidate, or
+        ``None`` when neither exists.
+    """
+    env = os.environ if environ is None else environ
+    for candidate in env_names_with_omnigent_prefix(name):
+        value = env.get(candidate)
+        if value is not None:
+            return candidate, value
+    return None
+
+
+def getenv_nonempty_with_omnigent_prefix(
+    name: str, environ: Mapping[str, str] | None = None
+) -> tuple[str, str] | None:
+    """Read a non-empty env var with ``OMNIGENT_`` fallback.
+
+    :param name: Canonical environment variable name.
+    :param environ: Optional environment mapping; defaults to ``os.environ``.
+    :returns: ``(actual_name, value)`` for the first non-empty candidate, or
+        ``None`` when neither candidate has a non-blank value.
+    """
+    env = os.environ if environ is None else environ
+    for candidate in env_names_with_omnigent_prefix(name):
+        value = env.get(candidate)
+        if value is not None and value.strip():
+            return candidate, value
+    return None
+
+
+def expand_envvars_with_omnigent_prefix(value: str) -> str:
+    """Expand ``$VAR`` references with ``OMNIGENT_VAR`` fallback.
+
+    This mirrors ``os.path.expandvars`` for credential paths that already
+    support ``$VAR`` references, with one extra rule: if ``VAR`` is unset but
+    ``OMNIGENT_VAR`` is set, the prefixed value is used. Unresolved references
+    are left intact so the caller's existing unresolved-var check can produce
+    its normal error.
+
+    :param value: String that may contain shell-style env references.
+    :returns: Expanded string.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1) or match.group(2)
+        resolved = getenv_with_omnigent_prefix(name)
+        return resolved[1] if resolved is not None else match.group(0)
+
+    return _ENV_REF_RE.sub(_replace, value)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -22,6 +22,7 @@ import websockets.asyncio.client
 from websockets.exceptions import InvalidStatus, InvalidURI
 
 from omnigent._platform import WINDOWS_ENV_PASSTHROUGH
+from omnigent.env_credentials import env_names_with_omnigent_prefix
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
     HostCreateDirFrame,
@@ -349,7 +350,7 @@ _RUNNER_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = ("LC_", "MLFLOW_", "OTEL_", "O
 # on a server-managed sandbox: the deployment's injected provider
 # secrets) — forwarding them is the intent, not a leak. Vars absent
 # from the host env are simply not set.
-HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
+_BASE_HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
     {
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
@@ -364,6 +365,11 @@ HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
         "GIT_TOKEN",
         "GIT_USERNAME",
     }
+)
+HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
+    name
+    for canonical in _BASE_HARNESS_CREDENTIAL_ENV_VARS
+    for name in env_names_with_omnigent_prefix(canonical)
 )
 
 # Comma-separated EXTRA env var names to forward host→runner, beyond

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -35,6 +35,7 @@ from typing import Literal
 
 import tomllib
 
+from omnigent.env_credentials import getenv_nonempty_with_omnigent_prefix
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
 from omnigent.onboarding.providers import PROVIDER_ENV_VARS
 
@@ -654,15 +655,16 @@ def detect_providers() -> list[DetectedProvider]:
         # the model-selection surface yet.
         if provider not in _ENV_KEY_FAMILY:
             continue
-        value = os.environ.get(env_var)
-        if not value:
+        resolved = getenv_nonempty_with_omnigent_prefix(env_var)
+        if resolved is None:
             continue
+        actual_env_var, _value = resolved
         detected.append(
             DetectedProvider(
                 name=provider,
                 kind=KEY_KIND,
                 family=_ENV_KEY_FAMILY[provider],
-                source=f"${env_var}",
+                source=f"${actual_env_var}",
             )
         )
 

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -22,8 +22,7 @@ Two surfaces:
 
 from __future__ import annotations
 
-import os
-
+from omnigent.env_credentials import getenv_nonempty_with_omnigent_prefix
 from omnigent.onboarding.ambient import DetectedProvider, detect_providers
 from omnigent.onboarding.configure_models import (
     build_cli_config_provider_entry,
@@ -170,10 +169,13 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
             # ``api.openai.com`` and every request 401s — the credential is a
             # gateway token, not an OpenAI key. Scoped to the openai family's
             # canonical vendor (not a third-party endpoint, handled above).
-            if det.family == OPENAI_FAMILY and env_var == "OPENAI_API_KEY":
-                env_base_url = os.environ.get("OPENAI_BASE_URL")
-                if env_base_url:
-                    base_url = env_base_url
+            if det.family == OPENAI_FAMILY and env_var in (
+                "OPENAI_API_KEY",
+                "OMNIGENT_OPENAI_API_KEY",
+            ):
+                env_base_url = getenv_nonempty_with_omnigent_prefix("OPENAI_BASE_URL")
+                if env_base_url is not None:
+                    base_url = env_base_url[1]
         # No pinned model — the spec / catalog default picks it; /model then
         # shows "(no model pinned)" rather than a fabricated one.
         return build_key_provider_entry(det.family, base_url, api_key_ref, None, wire_api=wire_api)

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -48,6 +48,11 @@ import os
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
+from omnigent.env_credentials import (
+    expand_envvars_with_omnigent_prefix,
+    getenv_with_omnigent_prefix,
+    omnigent_prefixed_env_name,
+)
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.spec.parser import check_unresolved_env_vars
@@ -453,19 +458,22 @@ def resolve_secret(ref: str) -> str:
         return value
     if ref.startswith("env:"):
         var = ref[len("env:") :]
-        value = os.environ.get(var)
-        if value is None:
+        resolved = getenv_with_omnigent_prefix(var)
+        if resolved is None:
+            prefixed = omnigent_prefixed_env_name(var)
+            fallback = f" or ${prefixed}" if prefixed != var else ""
             raise OmnigentError(
                 f"Unresolved environment variable '${var}' referenced by "
-                f"'env:{var}'. Set the variable in the environment.",
+                f"'env:{var}'. Set ${var}{fallback} in the environment.",
                 code=ErrorCode.INVALID_INPUT,
             )
+        _actual_var, value = resolved
         # Strip surrounding whitespace: a key exported with a stray trailing
         # newline (e.g. ``export KEY=$(cat file)``) must not be forwarded
         # verbatim to a harness/SDK, where the padding fails auth.
         return value.strip()
     # Bare inline reference, e.g. "$ANTHROPIC_API_KEY" or a literal value.
-    expanded = os.path.expandvars(ref)
+    expanded = expand_envvars_with_omnigent_prefix(ref)
     check_unresolved_env_vars(ref, expanded)
     return expanded
 
@@ -514,7 +522,7 @@ def _expand(key: str, value: str) -> str:
     :returns: The expanded value, e.g. ``"sk-or-..."``.
     :raises OmnigentError: If a referenced variable is unset.
     """
-    expanded = os.path.expandvars(value)
+    expanded = expand_envvars_with_omnigent_prefix(value)
     check_unresolved_env_vars(key, expanded)
     return expanded
 

--- a/omnigent/onboarding/provider_selection.py
+++ b/omnigent/onboarding/provider_selection.py
@@ -7,12 +7,12 @@ select a chat-capable model. Uses Rich for polished terminal output.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 
 import click
 from rich.console import Console
 
+from omnigent.env_credentials import getenv_nonempty_with_omnigent_prefix
 from omnigent.onboarding.providers import (
     PROVIDER_ENV_VARS,
     AuthField,
@@ -86,16 +86,18 @@ def _read_credentials_from_env(provider: str) -> dict[str, str]:
     """
     env_var = PROVIDER_ENV_VARS.get(provider)
     if env_var:
-        value = os.environ.get(env_var)
-        if value:
+        resolved = getenv_nonempty_with_omnigent_prefix(env_var)
+        if resolved is not None:
+            _actual_env_var, value = resolved
             creds: dict[str, str] = {"api_key": value}
             if provider == "openai":
-                base_url = os.environ.get("OPENAI_BASE_URL")
-                if base_url:
-                    creds["base_url"] = base_url
+                base_url = getenv_nonempty_with_omnigent_prefix("OPENAI_BASE_URL")
+                if base_url is not None:
+                    creds["base_url"] = base_url[1]
             return creds
         raise click.ClickException(
-            f"Non-interactive mode requires {env_var} for provider {provider!r}."
+            f"Non-interactive mode requires {env_var} or "
+            f"OMNIGENT_{env_var} for provider {provider!r}."
         )
 
     # Complex providers — check default auth mode fields.
@@ -124,11 +126,12 @@ def _collect_env_credentials(
     for field in fields:
         if not field.required:
             continue
-        val = os.environ.get(field.name.upper())
-        if val:
-            credentials[field.name] = val
+        env_name = field.name.upper()
+        resolved = getenv_nonempty_with_omnigent_prefix(env_name)
+        if resolved is not None:
+            credentials[field.name] = resolved[1]
         else:
-            missing.append(field.name.upper())
+            missing.append(env_name)
 
     if missing:
         raise click.ClickException(

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -31,6 +31,7 @@ from omnigent.entities import (
     ConversationItem,
     NewConversationItem,
 )
+from omnigent.env_credentials import expand_envvars_with_omnigent_prefix
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.llms import Client as LLMClient
 from omnigent.onboarding.databricks_config import (
@@ -1499,12 +1500,12 @@ def _load_global_auth() -> ApiKeyAuth | DatabricksAuth | None:
         # Expand $VAR references (the config file may store the literal
         # env-var reference; expand at use-time so the secret never
         # needs to live in the YAML file itself).
-        api_key = os.path.expandvars(api_key)
+        api_key = expand_envvars_with_omnigent_prefix(api_key)
         check_unresolved_env_vars("auth.api_key", api_key)
         raw_base_url = raw_auth.get("base_url")
         base_url: str | None = None
         if raw_base_url:
-            base_url = os.path.expandvars(str(raw_base_url))
+            base_url = expand_envvars_with_omnigent_prefix(str(raw_base_url))
             check_unresolved_env_vars("auth.base_url", base_url)
         return ApiKeyAuth(api_key=api_key, base_url=base_url)
     if auth_type == "databricks":

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1163,6 +1163,30 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
     assert "ANTHROPIC_AUTH_TOKEN" not in env
 
 
+def test_build_runner_env_forwards_omnigent_prefixed_harness_credentials() -> None:
+    """Prefixed harness credential aliases forward without creating raw names."""
+    from omnigent.host.connect import HARNESS_CREDENTIAL_ENV_VARS
+
+    base = {
+        "PATH": "/usr/bin",
+        "HOME": "/root",
+        "OMNIGENT_ANTHROPIC_API_KEY": "sk-prefixed",
+    }
+
+    env = _build_runner_env(
+        base,
+        server_url="http://server",
+        runner_id="runner_abc",
+        binding_token="tok",
+        workspace="/ws",
+        parent_pid=42,
+    )
+
+    assert "OMNIGENT_ANTHROPIC_API_KEY" in HARNESS_CREDENTIAL_ENV_VARS
+    assert env["OMNIGENT_ANTHROPIC_API_KEY"] == "sk-prefixed"
+    assert "ANTHROPIC_API_KEY" not in env
+
+
 def test_build_runner_env_passthrough_extends_forwarded_set() -> None:
     """
     OMNIGENT_RUNNER_ENV_PASSTHROUGH names EXTRA vars to forward (for

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -22,9 +22,15 @@ from omnigent.onboarding.ambient import DetectedProvider, detect_providers
 # the host's own keys don't leak into the deterministic detection tests.
 _PROVIDER_ENV_VARS = [
     "ANTHROPIC_API_KEY",
+    "OMNIGENT_ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
+    "OMNIGENT_OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OMNIGENT_OPENAI_BASE_URL",
     "OPENROUTER_API_KEY",
+    "OMNIGENT_OPENROUTER_API_KEY",
     "GEMINI_API_KEY",
+    "OMNIGENT_GEMINI_API_KEY",
     "CLAUDE_CODE_USE_VERTEX",
     "ANTHROPIC_VERTEX_PROJECT_ID",
     "CLOUD_ML_REGION",
@@ -108,6 +114,24 @@ def test_env_key_detection(
     detected = detect_providers()
     # Exactly the one key we set is detected, with all fields exact.
     assert detected == [expected]
+
+
+def test_env_key_detection_accepts_omnigent_prefixed_alias(
+    clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ``OMNIGENT_``-prefixed key is detected without setting the raw name."""
+    monkeypatch.setenv("OMNIGENT_ANTHROPIC_API_KEY", "some-secret-value")
+
+    detected = detect_providers()
+
+    assert detected == [
+        DetectedProvider(
+            name="anthropic",
+            kind="key",
+            family="anthropic",
+            source="$OMNIGENT_ANTHROPIC_API_KEY",
+        )
+    ]
 
 
 def test_empty_env_key_not_detected(clean_env, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/onboarding/test_detected.py
+++ b/tests/onboarding/test_detected.py
@@ -64,6 +64,19 @@ def test_synthesize_env_key_anthropic() -> None:
     assert entries["anthropic"]["anthropic"]["base_url"] == "https://api.anthropic.com"
 
 
+def test_synthesize_env_key_preserves_omnigent_prefixed_source() -> None:
+    """A prefixed detection keeps the prefixed env ref in provider config."""
+    det = DetectedProvider(
+        name="anthropic",
+        kind="key",
+        family=ANTHROPIC_FAMILY,
+        source="$OMNIGENT_ANTHROPIC_API_KEY",
+    )
+    entries = synthesize_detected_entries([det])
+
+    assert entries["anthropic"]["anthropic"]["api_key_ref"] == ("env:OMNIGENT_ANTHROPIC_API_KEY")
+
+
 def test_synthesize_env_key_openrouter_uses_vendor_endpoint_and_chat_wire() -> None:
     """A detected OpenRouter key gets OpenRouter's base_url + chat wire.
 

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -17,6 +17,7 @@ from omnigent.onboarding.provider_config import (
     load_providers,
     provider_families,
     provider_family_for_harness,
+    resolve_secret,
     set_default_provider,
     surface_default_model,
     surface_default_provider,
@@ -93,6 +94,17 @@ def test_provider_family_for_harness_accepts_executor_type_spellings(
     same-family (anthropic) and carries history.
     """
     assert provider_family_for_harness(harness) == expected
+
+
+def test_resolve_secret_env_ref_accepts_omnigent_prefixed_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``env:ANTHROPIC_API_KEY`` falls back to ``OMNIGENT_ANTHROPIC_API_KEY``."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OMNIGENT_ANTHROPIC_API_KEY", "sk-ant-prefixed")
+
+    assert resolve_secret("env:ANTHROPIC_API_KEY") == "sk-ant-prefixed"
+    assert resolve_secret("$ANTHROPIC_API_KEY") == "sk-ant-prefixed"
 
 
 def test_default_provider_for_pi_skips_subscription_defaults() -> None:

--- a/tests/onboarding/test_provider_selection.py
+++ b/tests/onboarding/test_provider_selection.py
@@ -33,6 +33,18 @@ def test_resolve_reads_api_key_from_env(
     assert selection.credentials["api_key"] == "sk-openai-test"
 
 
+def test_resolve_reads_api_key_from_omnigent_prefixed_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-interactive provider selection accepts ``OMNIGENT_`` key aliases."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OMNIGENT_ANTHROPIC_API_KEY", "sk-prefixed")
+
+    selection = resolve_provider_from_model("anthropic/claude-sonnet-4-20250514")
+
+    assert selection.credentials["api_key"] == "sk-prefixed"
+
+
 def test_resolve_missing_env_var_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -5718,7 +5718,14 @@ def _isolated_provider_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
     monkeypatch.setenv("HOME", str(tmp_path))
-    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OMNIGENT_ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OMNIGENT_OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "OMNIGENT_OPENROUTER_API_KEY",
+    ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
     return tmp_path
@@ -6014,6 +6021,23 @@ def test_resolve_native_claude_config_ambient_key(
     assert cfg.env["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
     # Resolved from the env ref, delivered via the helper (no secret in env).
     assert cfg.api_key_helper == "printf %s sk-ant-ambient"
+
+
+def test_resolve_native_claude_config_ambient_prefixed_key(
+    _isolated_provider_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prefixed Anthropic key routes native Claude without raw env exposure."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OMNIGENT_ANTHROPIC_API_KEY", "sk-ant-prefixed")
+
+    cfg = claude_native.resolve_native_claude_config(spec=None)
+
+    assert cfg is not None
+    assert cfg.env == {
+        "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+    }
+    assert cfg.api_key_helper == "printf %s sk-ant-prefixed"
 
 
 def test_bedrock_config_auth_command_failure_returns_none() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add `OMNIGENT_`-prefixed aliases for provider credential env vars so hosted sandboxes can keep raw provider variables out of harness processes when needed.
- Resolve prefixed aliases during provider detection, provider config secret expansion, non-interactive provider selection, global API-key auth expansion, and host-to-runner credential forwarding.
- Document the Modal setup for Claude Code API-key auth with `OMNIGENT_ANTHROPIC_API_KEY`, and keep the deployment config/docs aligned with the Modal-backed sandbox setup.

ELI5: operators can store `OMNIGENT_ANTHROPIC_API_KEY` in Modal secrets, and Omnigent translates it for its own config paths without setting raw `ANTHROPIC_API_KEY` in the Claude CLI environment.

```text
Modal secret -> sandbox host env -> Omnigent resolver -> Claude Code apiKeyHelper
          `OMNIGENT_ANTHROPIC_API_KEY`           no raw `ANTHROPIC_API_KEY`
```

## Test Plan

- `UV_CACHE_DIR=/private/tmp/omnigent-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/omnigent-pycache uv run --extra dev pytest tests/onboarding/test_ambient.py tests/onboarding/test_detected.py tests/onboarding/test_provider_config.py tests/onboarding/test_provider_selection.py tests/test_claude_native.py tests/host/test_connect.py -q`
- `UV_CACHE_DIR=/private/tmp/omnigent-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/omnigent-pycache uv run --extra dev ruff check omnigent/env_credentials.py omnigent/host/connect.py omnigent/onboarding/ambient.py omnigent/onboarding/detected.py omnigent/onboarding/provider_config.py omnigent/onboarding/provider_selection.py omnigent/runtime/workflow.py tests/host/test_connect.py tests/onboarding/test_ambient.py tests/onboarding/test_detected.py tests/onboarding/test_provider_config.py tests/onboarding/test_provider_selection.py tests/test_claude_native.py`

## Demo

N/A - non-visual environment and deployment configuration change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added focused tests for prefixed credential detection, provider config resolution, non-interactive provider selection, native Claude `apiKeyHelper` wiring, and host runner env forwarding. Manual verification was the focused pytest suite and targeted ruff check listed above.
