### PR TITLE
fix(runner): open UI-created shells in the session workspace

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -16269,7 +16269,22 @@ def create_runner_app(
             declared_terminal = terminals_map.get(terminal_name)
 
         if declared_terminal is not None:
-            env_spec = declared_terminal
+            # Resolve a placeholder cwd (``.``/``./``/unset) to the session
+            # workspace before launch — same as the synthesised branch and
+            # the sys_terminal_launch tool. Otherwise the placeholder reaches
+            # the inner builder and lands the shell in the runner's process
+            # cwd. Baked into the spec, not cwd_override (which is gated by
+            # allow_cwd_override).
+            from omnigent.tools.builtins.sys_terminal import (
+                _materialize_terminal_spec_for_launch,
+                _synthesize_parent_os_env,
+            )
+
+            default_root = resource_registry.compute_default_env_root(session_id, agent_spec)
+            env_spec = _materialize_terminal_spec_for_launch(declared_terminal, default_root)
+            # Covers terminals whose os_env inherits: the inner builder
+            # falls back to this parent, whose cwd would else be the placeholder.
+            agent_os_env = _synthesize_parent_os_env(agent_os_env, default_root)
             # Body's ``spec.cwd`` becomes a cwd_override (still
             # subject to the spec's allow_cwd_override gate and
             # the launch-time containment check).

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -1174,6 +1174,85 @@ async def test_create_terminal_uses_declared_terminal_spec_over_body(
 
 
 @pytest.mark.asyncio
+async def test_create_terminal_resolves_declared_placeholder_cwd_to_workspace(
+    tmp_path: Path,
+) -> None:
+    """A UI-created shell whose declared spec has a placeholder cwd
+    (``.``) launches in the session workspace, not the runner's
+    process cwd (the dir ``omni host`` ran in).
+
+    The declared-terminal branch previously passed ``cwd: .`` through
+    unresolved, so ``create_terminal_instance`` fell back to
+    ``Path(".").resolve()`` — the host launch dir. The resolved
+    workspace must be baked into the launched spec (never via
+    ``cwd_override``, which the stub asserts stays ``None``).
+    """
+    from omnigent.inner.datamodel import (
+        AgentDef,
+        OSEnvSandboxSpec,
+        OSEnvSpec,
+        TerminalEnvSpec,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    # Declared shell owns its os_env with the placeholder cwd — the
+    # real ``examples/polly`` ``shell`` terminal shape.
+    declared_shell = TerminalEnvSpec(
+        command="bash",
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=".",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+    agent = AgentDef(
+        name="polly-like",
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=".",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+        terminals={"shell": declared_shell},
+    )
+
+    async def _session_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "conv_test", "agent_id": "agent_polly"})
+
+    async def _resolver(agent_id: str, session_id: str) -> AgentDef:
+        return agent
+
+    server_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_session_handler),
+        base_url="http://server",
+    )
+    resource_registry = _CapturingResourceRegistry(tmp_path, runner_workspace=workspace)
+    app = create_runner_app(
+        resource_registry=resource_registry,
+        server_client=server_client,
+        spec_resolver=_resolver,
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with (
+        server_client,
+        httpx.AsyncClient(transport=transport, base_url="http://runner") as c,
+    ):
+        resp = await c.post(
+            "/v1/sessions/conv_test/resources/terminals",
+            json={"terminal": "shell", "session_key": "u-abc123"},
+        )
+
+    assert resp.status_code == 200
+    launch = resource_registry.launches[0]
+    # Placeholder resolved to the workspace, not "." (the process cwd).
+    assert isinstance(launch.os_env, OSEnvSpec)
+    assert launch.os_env.cwd == str(workspace)
+    # The original declared spec is untouched (shared across launches).
+    assert isinstance(declared_shell.os_env, OSEnvSpec)
+    assert declared_shell.os_env.cwd == "."
+
+
+@pytest.mark.asyncio
 async def test_create_terminal_publishes_bridge_tmux_target(
     client: httpx.AsyncClient,
     tmp_path: Path,


### PR DESCRIPTION
## What

Shells created from the web UI now open in the session's working
directory instead of the directory `omni host` was launched in.

Fixes **OMNI-1007**. Also fixes **OMNI-977** (new shell in managed
lakebox should open in the configured workspace).

## Why it happened

A "new shell" from the UI POSTs `{terminal, session_key}` to
`/v1/sessions/{id}/resources/terminals`. The server gates the terminal
name against the agent spec's `terminals:` block, so UI shells are
always **declared** terminals.

The runner's declared-terminal branch (`runner/app.py`) passed the
declared spec through verbatim. For the common placeholder
(`os_env.cwd: "."` — e.g. the `examples/polly` `shell` terminal),
`create_terminal_instance` then did `Path(".").resolve()`, which
resolves against the **runner's process cwd** — the directory
`omni host` was launched in. So new shells opened there.

The two sibling paths already resolved the cwd correctly:
- the **synthesised** branch (undeclared names, e.g. `omnigent claude`)
  calls `compute_default_env_root`;
- the **LLM `sys_terminal_launch` tool** materialises the resolved cwd
  into the spec via `_materialize_terminal_spec_for_launch` /
  `_synthesize_parent_os_env`.

Only the declared-terminal REST branch was missing the step.

## The fix

Resolve the placeholder against `compute_default_env_root` and bake it
into the spec before launch, reusing the exact helpers the tool path
already uses. Notes:
- The resolved cwd goes into the **spec**, not `cwd_override` —
  `cwd_override` is gated by `allow_cwd_override` and would reject
  terminals that don't opt in.
- Explicit absolute cwds in the spec are left untouched (operator config
  wins).
- OMNI-977 falls out for free: `compute_default_env_root` returns
  `OMNIGENT_RUNNER_WORKSPACE` when the managed host sets it.

## Test

Adds `test_create_terminal_resolves_declared_placeholder_cwd_to_workspace`
— posts a declared terminal with `cwd: "."` and asserts the launched
spec's cwd is the workspace (not `"."`), and that the shared declared
spec is not mutated. The existing
`test_create_terminal_uses_declared_terminal_spec_over_body` (explicit
cwd / `inherit`) still passes, proving explicit config is untouched.

This pull request and its description were written by Isaac.