### PR TITLE
fix(host): reap orphaned harness/tool subprocesses to stop zombie pileup (#1782)

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -117,6 +117,46 @@ _LOG_TAIL_MAX_LINES = 15
 # so a crashed runner is reported within about one client poll.
 _RUNNER_WATCH_INTERVAL_S = 0.5
 
+# Cadence of the orphan-reaper sweep. The host installs itself as a child
+# subreaper (Linux — see :func:`_install_child_subreaper`), so a harness's
+# detached tool subprocess (node/npm/chromium/tmux/python) whose runner
+# parent died reparents to the host. With no reaper such an orphan lingers
+# as a ``<defunct>`` zombie; over an overnight blocked run they reached
+# ~900 zombies and OOM'd the box (#1782). A ``WNOHANG`` sweep is a cheap
+# syscall, so 2s keeps zombie lifetime short at negligible cost.
+_ORPHAN_REAP_INTERVAL_S = 2.0
+
+
+def _install_child_subreaper() -> bool:
+    """Make this process reap orphaned descendants (Linux only).
+
+    ``prctl(PR_SET_CHILD_SUBREAPER, 1)`` asks the kernel to reparent any
+    orphaned descendant — e.g. a harness's detached tool subprocess whose
+    runner parent exited — to THIS process instead of PID 1, so the host's
+    orphan reaper can ``wait()`` on it even when the host is not itself
+    PID 1 (e.g. ``omni host --server`` launched under a shell). When the
+    host already IS PID 1 (container entrypoint) orphans reparent here
+    regardless and this call is a harmless no-op.
+
+    Complements — does not replace — the per-runner ``_watch_runner``
+    reaping of the host's own direct children.
+
+    :returns: ``True`` if the subreaper bit was set; ``False`` on non-Linux
+        or if ``prctl`` is unavailable. Both are non-fatal: direct-child
+        reaping and the PID-1 case still work; only the non-PID-1 orphan
+        case degrades.
+    """
+    if sys.platform != "linux":
+        return False
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        _PR_SET_CHILD_SUBREAPER = 36
+        return libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) == 0
+    except (OSError, AttributeError):
+        return False
+
 
 def _read_log_tail(path: Path, max_bytes: int = _LOG_TAIL_MAX_BYTES) -> str:
     """Read the last portion of a runner log file for diagnostics.
@@ -575,6 +615,158 @@ class HostProcess:
         # Strong refs to per-runner watcher tasks; asyncio only keeps
         # weak refs, so an unreferenced task can be GC'd mid-flight.
         self._watcher_tasks: set[asyncio.Task[None]] = set()
+        # Strong ref to the orphan-reaper task (see :meth:`_orphan_reaper_loop`).
+        self._reaper_task: asyncio.Task[None] | None = None
+
+    def _tracked_runner_pids(self) -> set[int]:
+        """PIDs of runners this host spawned and still tracks directly.
+
+        The orphan reaper must NOT ``wait()`` these: their exit status is
+        owned by their :class:`subprocess.Popen` (read via ``poll()`` /
+        ``.returncode`` for the ``host.runner_exited`` report). Reaping one
+        out from under ``Popen`` makes ``poll()`` either spin forever
+        (``while poll() is None`` in ``_watch_runner``) or report a bogus
+        exit 0 for a crash — so the reaper skips these and lets
+        ``_watch_runner`` / ``_handle_stop`` own them.
+
+        :returns: Set of live tracked runner OS pids.
+        """
+        return {h.proc.pid for h in self._runners.values()}
+
+    async def _orphan_reaper_loop(self) -> None:
+        """Reap orphaned descendant processes reparented to this host.
+
+        A harness spawns its tool subprocesses detached
+        (``start_new_session=True`` — ``omnigent.inner._proc.spawn_kwargs``),
+        so when the runner that owns them dies, those grandchildren
+        (``node`` / ``npm`` / ``chromium`` / ``tmux`` / ``python``) are
+        orphaned and reparented to this host (it is PID 1 in a container, or
+        a child subreaper otherwise — see :func:`_install_child_subreaper`).
+        Nothing ``wait()``s them, so each becomes a permanent ``<defunct>``
+        zombie; a blocked overnight run accumulated ~900 and OOM'd the box
+        (#1782).
+
+        This loop periodically reaps any ready-to-reap child that is NOT a
+        Popen-tracked runner (:meth:`_tracked_runner_pids`), draining zombies
+        without disturbing runner exit reporting. Non-Linux (no reparenting)
+        and the "no orphans yet" case both make this a cheap no-op sweep.
+
+        :returns: None. Runs until cancelled on shutdown.
+        """
+        while True:
+            try:
+                await asyncio.sleep(_ORPHAN_REAP_INTERVAL_S)
+                self._reap_orphans_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — a reaper must never die on a stray error
+                _logger.debug("orphan reaper sweep failed", exc_info=True)
+
+    def _reap_orphans_once(self) -> int:
+        """Reap ready orphaned children without corrupting runner exits.
+
+        The hazard: the host reads each runner's exit status through its
+        :class:`subprocess.Popen` (``poll()`` / ``.returncode``) for the
+        ``host.runner_exited`` report. A blind ``waitpid(-1)`` reaper that
+        consumes a just-crashed tracked runner makes ``Popen.poll()`` report
+        a bogus exit 0 (verified) — the crash cause is lost. So the reaper
+        must drain orphans while leaving tracked runners' status intact.
+
+        Two implementations, same guarantee:
+
+        * **Linux/POSIX with** ``os.waitid`` — *peek* at the next reapable
+          child with ``WNOWAIT`` (does not consume). Reap it only if it is
+          not a tracked runner; if it is, stop the sweep and let the runner's
+          own Popen reaper (``_watch_runner``) consume it. Cleanest: a tracked
+          runner's status is never touched.
+        * **Platforms without** ``os.waitid`` **(e.g. macOS)** — ``waitpid``
+          has no peek, so reap with ``WNOHANG`` and, if the reaped pid is a
+          tracked runner, re-inject its exit status onto the ``Popen`` so
+          ``_watch_runner`` still reports the true code. Safe because
+          ``_reap_orphans_once`` runs to completion on the event loop without
+          awaiting, so it cannot interleave with ``_watch_runner`` /
+          ``_handle_stop``.
+
+        This runs only when the host is PID 1 (container) or a child
+        subreaper (:func:`_install_child_subreaper`); otherwise no orphan
+        ever reparents here and every sweep is a no-op.
+
+        :returns: Count of orphan (non-runner) processes reaped this sweep.
+        """
+        if hasattr(os, "waitid") and hasattr(os, "P_ALL"):
+            return self._reap_orphans_waitid()
+        return self._reap_orphans_waitpid()
+
+    def _reap_orphans_waitid(self) -> int:
+        """Peek-and-reap using ``os.waitid(WNOWAIT)`` (Linux/POSIX).
+
+        :returns: Count of orphan processes reaped.
+        """
+        reaped = 0
+        tracked = self._tracked_runner_pids()
+        while True:
+            try:
+                info = os.waitid(os.P_ALL, 0, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+            except (ChildProcessError, OSError):
+                break
+            if info is None:
+                break  # children exist but none ready to reap
+            pid = info.si_pid
+            if pid in tracked:
+                # Leave it for _watch_runner's Popen to reap+report. Break, not
+                # continue: WNOWAIT keeps returning the same head pid, so
+                # continuing would spin. The runner is reaped within ~0.5s and
+                # the next sweep proceeds past it.
+                break
+            try:
+                os.waitpid(pid, 0)  # consume the orphan
+                reaped += 1
+            except ChildProcessError:
+                break
+        if reaped:
+            _logger.debug("orphan reaper reaped %d process(es)", reaped)
+        return reaped
+
+    def _reap_orphans_waitpid(self) -> int:
+        """Reap with ``waitpid(WNOHANG)``, re-injecting tracked-runner status.
+
+        Fallback for platforms without ``os.waitid`` (no peek). See
+        :meth:`_reap_orphans_once` for why re-injection is race-free.
+
+        :returns: Count of orphan (non-runner) processes reaped.
+        """
+        reaped = 0
+        while True:
+            try:
+                pid, status = os.waitpid(-1, os.WNOHANG)
+            except (ChildProcessError, OSError):
+                break
+            if pid == 0:
+                break  # children exist but none ready
+            handle = self._runner_handle_for_pid(pid)
+            if handle is not None:
+                # A tracked runner — do NOT count it as an orphan. Re-inject
+                # the status so its Popen (and thus _watch_runner) reports the
+                # true exit code instead of ECHILD → bogus 0.
+                if handle.proc.returncode is None:
+                    handle.proc.returncode = os.waitstatus_to_exitcode(status)
+                continue
+            reaped += 1
+        if reaped:
+            _logger.debug("orphan reaper reaped %d process(es)", reaped)
+        return reaped
+
+    def _runner_handle_for_pid(self, pid: int) -> _RunnerHandle | None:
+        """Return the tracked runner handle owning *pid*, or ``None``.
+
+        :param pid: An OS process id observed by the reaper.
+        :returns: The matching :class:`_RunnerHandle`, or ``None`` if *pid*
+            is not a tracked runner (i.e. an orphan to reap).
+        """
+        for handle in self._runners.values():
+            if handle.proc.pid == pid:
+                return handle
+        return None
 
     def _alive_runner_ids(self) -> list[str]:
         """Return IDs of runners that are still alive.
@@ -1276,6 +1468,15 @@ class HostProcess:
 
         :returns: None. Runs until the process is terminated.
         """
+        # Reap orphaned harness/tool grandchildren that reparent here when a
+        # runner dies (this host is PID 1 in a container, or a subreaper
+        # otherwise). Without this they pile up as <defunct> zombies and can
+        # OOM the box on a long-blocked run (#1782).
+        if _install_child_subreaper():
+            _logger.debug("installed PR_SET_CHILD_SUBREAPER; host will reap orphans")
+        self._reaper_task = asyncio.create_task(
+            self._orphan_reaper_loop(), name="host-orphan-reaper"
+        )
         backoff = _RECONNECT_BASE_S
         try:
             while True:
@@ -1347,7 +1548,14 @@ class HostProcess:
         except (KeyboardInterrupt, asyncio.CancelledError):
             pass
         finally:
+            if self._reaper_task is not None:
+                self._reaper_task.cancel()
+                self._reaper_task = None
             self._cleanup_runners()
+            # Final drain: _cleanup_runners has just reaped the tracked
+            # runners via Popen, so any of their still-orphaned tool
+            # grandchildren are now reapable and no tracked pid can be stolen.
+            self._reap_orphans_once()
 
     def _cleanup_runners(self) -> None:
         """Terminate all live runners on shutdown.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -9,12 +9,13 @@ the server.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 import subprocess
 import sys
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -617,6 +618,14 @@ class HostProcess:
         self._watcher_tasks: set[asyncio.Task[None]] = set()
         # Strong ref to the orphan-reaper task (see :meth:`_orphan_reaper_loop`).
         self._reaper_task: asyncio.Task[None] | None = None
+        # Number of host-owned ``subprocess`` operations (e.g. the git worktree
+        # commands in :mod:`omnigent.host.git_worktree`) currently in flight.
+        # The orphan reaper skips its sweep while this is >0 so it never
+        # ``wait()``s a child that ``subprocess.run`` is about to reap itself —
+        # stealing it would corrupt that command's returncode to 0 (#1782).
+        # Mutated only via :meth:`_host_subprocess_op`; safe as a plain int
+        # because both the mutation and the reaper run on the event loop.
+        self._owned_subprocess_ops = 0
 
     def _tracked_runner_pids(self) -> set[int]:
         """PIDs of runners this host spawned and still tracks directly.
@@ -693,9 +702,45 @@ class HostProcess:
 
         :returns: Count of orphan (non-runner) processes reaped this sweep.
         """
+        if self._owned_subprocess_ops > 0:
+            # A host-owned subprocess (e.g. a git worktree command) is running
+            # in a worker thread. Its child is a DIRECT child of this process
+            # but NOT a tracked runner, so it is indistinguishable from an
+            # orphan to the reaper — reaping it would steal it from
+            # ``subprocess.run``'s own ``wait()`` and corrupt that command's
+            # returncode to 0 (CPython swallows the ECHILD and reports 0).
+            # Skip this sweep; a later one drains any real orphans once the op
+            # finishes. A worktree op can hold this off for up to
+            # ``_GIT_TIMEOUT_S`` (120s) per git command, so real orphans can
+            # linger that long in the rare case a runner dies mid-worktree-op —
+            # acceptable, since the leak this guards against accrues over hours,
+            # not a two-minute worst case.
+            return 0
         if hasattr(os, "waitid") and hasattr(os, "P_ALL"):
             return self._reap_orphans_waitid()
         return self._reap_orphans_waitpid()
+
+    @contextlib.contextmanager
+    def _host_subprocess_op(self) -> Iterator[None]:
+        """Mark a host-owned ``subprocess`` operation as in flight.
+
+        Wrap any host-owned :mod:`subprocess` call (or the ``to_thread`` that
+        runs it) in this so the orphan reaper pauses and cannot ``wait()`` the
+        child out from under ``subprocess``'s own reaping — see
+        :meth:`_reap_orphans_once` for why that would corrupt the command's
+        exit code (#1782).
+
+        Increment/decrement run on the event loop (the reaper does too), so a
+        plain counter needs no lock. Re-entrant and exception-safe: the
+        decrement is in a ``finally``.
+
+        :returns: A context manager; the body runs with the reaper paused.
+        """
+        self._owned_subprocess_ops += 1
+        try:
+            yield
+        finally:
+            self._owned_subprocess_ops -= 1
 
     def _reap_orphans_waitid(self) -> int:
         """Peek-and-reap using ``os.waitid(WNOWAIT)`` (Linux/POSIX).
@@ -1398,12 +1443,17 @@ class HostProcess:
             success, or ``status: "failed"`` with an error message.
         """
         try:
-            created = await asyncio.to_thread(
-                create_worktree,
-                repo_path=frame.repo_path,
-                branch_name=frame.branch_name,
-                base_branch=frame.base_branch,
-            )
+            # Pause the orphan reaper: create_worktree runs git via
+            # subprocess.run, whose children are direct children of this host
+            # but not tracked runners — the reaper must not wait() them out
+            # from under subprocess (#1782).
+            with self._host_subprocess_op():
+                created = await asyncio.to_thread(
+                    create_worktree,
+                    repo_path=frame.repo_path,
+                    branch_name=frame.branch_name,
+                    base_branch=frame.base_branch,
+                )
         except WorktreeError as exc:
             return HostCreateWorktreeResultFrame(
                 request_id=frame.request_id,
@@ -1436,12 +1486,15 @@ class HostProcess:
             ``status: "failed"`` with an error message.
         """
         try:
-            await asyncio.to_thread(
-                remove_worktree,
-                worktree_path=frame.worktree_path,
-                branch=frame.branch,
-                delete_branch=frame.delete_branch,
-            )
+            # Pause the orphan reaper while remove_worktree runs git — see
+            # _handle_create_worktree above and _reap_orphans_once (#1782).
+            with self._host_subprocess_op():
+                await asyncio.to_thread(
+                    remove_worktree,
+                    worktree_path=frame.worktree_path,
+                    branch=frame.branch,
+                    delete_branch=frame.delete_branch,
+                )
         except WorktreeError as exc:
             return HostRemoveWorktreeResultFrame(
                 request_id=frame.request_id,

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import subprocess
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -807,6 +808,94 @@ def test_cleanup_runners_terminates_all(tmp_path: Path) -> None:
         assert proc.poll() is not None, f"Runner pid={proc.pid} should be dead after cleanup"
     # Tracking dict should be empty.
     assert host._runners == {}
+
+
+def test_reap_orphans_reaps_orphaned_children(tmp_path: Path) -> None:
+    """Regression for #1782: orphaned children are reaped, not leaked.
+
+    In production the leak is a harness tool subprocess (node/chromium/tmux)
+    whose runner parent died: it is orphaned and reparented to the host
+    (PID 1 in a container, or a subreaper). Once reparented it is a *direct*
+    child of the host that nothing ``wait()``s — so it lingers as a
+    ``<defunct>`` zombie forever. This test models that end state directly by
+    forking a child the host does not track and never waits: ``os.fork`` is
+    portable (no ``PR_SET_CHILD_SUBREAPER``, which macOS lacks), and a
+    reparented orphan is indistinguishable from a plain unwaited child to the
+    reaper. ``_reap_orphans_once`` must drain it.
+    """
+    import errno
+    import os
+
+    host = _make_host_process()
+
+    # Fork a bare child (NOT a tracked runner, NOT wrapped in Popen) that
+    # exits immediately — the faithful model of an orphan reparented to us.
+    pid = os.fork()
+    if pid == 0:  # pragma: no cover — child leg never returns to pytest
+        os._exit(0)
+
+    # Let it exit and become a zombie parented to this process.
+    deadline = time.monotonic() + 5.0
+    reaped_total = 0
+    while time.monotonic() < deadline:
+        reaped_total += host._reap_orphans_once()
+        if reaped_total >= 1:
+            break
+        time.sleep(0.05)
+
+    assert reaped_total >= 1, "orphaned child was not reaped (zombie leak — #1782)"
+    # It is truly reaped: a direct waitpid now raises ECHILD (no such child).
+    with pytest.raises(OSError) as exc_info:
+        os.waitpid(pid, 0)
+    assert exc_info.value.errno == errno.ECHILD
+    # A second sweep with no orphans left is a clean no-op.
+    assert host._reap_orphans_once() == 0
+
+
+def test_reap_orphans_never_steals_tracked_runner_exit_code(tmp_path: Path) -> None:
+    """The reaper must not consume a tracked runner's exit status (#1782).
+
+    A naive ``waitpid(-1)`` reaper would reap a just-exited tracked runner
+    behind ``Popen``'s back, making ``_watch_runner``'s ``poll()`` report a
+    bogus exit 0 for a crash. ``_reap_orphans_once`` peeks with ``WNOWAIT``
+    and skips tracked pids, so the runner's real exit code survives for the
+    ``host.runner_exited`` report.
+    """
+    host = _make_host_process()
+
+    # A tracked runner that exits non-zero (a "crash").
+    runner = subprocess.Popen(["python3", "-c", "import sys; sys.exit(42)"])
+    host._runners["runner_crash"] = _RunnerHandle(
+        proc=runner, log_path=tmp_path / "runner-crash.log"
+    )
+    # Wait until the OS reports it as exited (zombie), WITHOUT Popen.wait().
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and runner.poll() is None:
+        # poll() would itself reap; instead peek via the reaper repeatedly.
+        host._reap_orphans_once()
+        time.sleep(0.05)
+
+    # The reaper ran while the crashed runner was reapable; it must NOT have
+    # stolen it. Popen must still see the true exit code.
+    assert runner.poll() == 42, "reaper corrupted the tracked runner's exit code"
+
+    runner.wait()
+
+
+def test_install_child_subreaper_is_safe_to_call() -> None:
+    """``_install_child_subreaper`` never raises and reports a bool.
+
+    ``True`` on Linux where ``prctl`` set the bit; ``False`` on non-Linux or
+    when ``prctl`` is unavailable — both are acceptable, non-fatal outcomes.
+    """
+    import sys
+
+    from omnigent.host.connect import _install_child_subreaper
+
+    result = _install_child_subreaper()
+    assert isinstance(result, bool)
+    if sys.platform != "linux":
+        assert result is False
 
 
 def test_host_spawned_runner_has_parent_pid_env(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -882,6 +882,69 @@ def test_reap_orphans_never_steals_tracked_runner_exit_code(tmp_path: Path) -> N
     runner.wait()
 
 
+def test_reaper_does_not_steal_host_owned_subprocess_exit_code(tmp_path: Path) -> None:
+    """The reaper must not reap a host-owned subprocess's child (#1782).
+
+    Regression for the Polly-flagged race: the host also spawns *direct*
+    children that are not tracked runners — the ``git`` commands in
+    :mod:`omnigent.host.git_worktree`, run via ``subprocess.run`` under
+    ``asyncio.to_thread`` from the worktree handlers. If the 2s reaper sweep
+    fires after such a git child has exited but before ``subprocess``'s own
+    ``wait()`` collects it, a blind reaper would ``waitpid`` it — and CPython
+    then swallows the resulting ``ECHILD`` and reports ``returncode == 0``,
+    silently turning a *failed* ``git worktree`` op into a success.
+
+    ``_host_subprocess_op`` pauses the reaper for exactly that window. Here a
+    ``sh -c 'exit 42'`` stands in for a failing git command: while the op is
+    marked in flight, ``_reap_orphans_once`` must be a no-op and must NOT
+    consume the child, so the owner still reads the true exit code 42.
+    """
+    host = _make_host_process()
+
+    # A host-owned subprocess (git stand-in) that FAILS with a distinctive
+    # code. NOT a tracked runner — indistinguishable from an orphan to a naive
+    # reaper.
+    proc = subprocess.Popen(["sh", "-c", "exit 42"])
+    # Let it exit so it is reapable (the dangerous window subprocess.run has
+    # between the child exiting and its internal wait()).
+    time.sleep(0.3)
+
+    with host._host_subprocess_op():
+        # Every sweep during the op must be a no-op — the reaper is paused.
+        for _ in range(5):
+            assert host._reap_orphans_once() == 0, "reaper ran during a host-owned op"
+            time.sleep(0.02)
+
+    # The owner still collects its child's TRUE exit code — not corrupted to 0.
+    assert proc.poll() == 42, "reaper stole the host-owned subprocess's exit code (#1782)"
+    proc.wait()
+
+
+def test_host_subprocess_op_guard_is_reentrant_and_balanced(tmp_path: Path) -> None:
+    """``_host_subprocess_op`` nests correctly and always rebalances (#1782).
+
+    The reaper resumes only when the counter returns to 0, and the decrement
+    must survive an exception in the guarded body (``finally``), or a raising
+    worktree op would wedge the reaper off permanently.
+    """
+    host = _make_host_process()
+    assert host._owned_subprocess_ops == 0
+
+    with host._host_subprocess_op():
+        assert host._owned_subprocess_ops == 1
+        with host._host_subprocess_op():  # re-entrant
+            assert host._owned_subprocess_ops == 2
+        assert host._owned_subprocess_ops == 1
+    assert host._owned_subprocess_ops == 0
+
+    # An exception inside the guarded body must still rebalance the counter.
+    with pytest.raises(RuntimeError):
+        with host._host_subprocess_op():
+            assert host._owned_subprocess_ops == 1
+            raise RuntimeError("worktree op blew up")
+    assert host._owned_subprocess_ops == 0, "guard leaked a ref on exception — reaper wedged"
+
+
 def test_install_child_subreaper_is_safe_to_call() -> None:
     """``_install_child_subreaper`` never raises and reports a bool.
 


### PR DESCRIPTION
## What

Fixes the **zombie-pileup half** of #1782: `omnigent host` accumulates hundreds of `<defunct>` processes when a run is blocked on an unanswered approval elicitation, eventually OOM'ing the box.

## Root cause

`omnigent host` is PID 1 in a container (the `omnigent host --server …` entrypoint; the k8s overlay wraps it in a reaper, but no other path does). When a runner dies, the harness **tool subprocesses** it spawned detached (`node`/`npm`/`chromium`/`tmux`/`python` — via `start_new_session=True` in `omnigent.inner._proc.spawn_kwargs`) are orphaned and reparented to the host. The host installed **no child reaper** and only `wait()`s the runners it tracks directly (`_watch_runner` is a `poll()`-only loop), so every orphan became a permanent zombie. The reporter measured ~900 zombies / ~2,300 PIDs / ~6 GB RSS on one overnight run; stopping the container instantly reaped them all — confirming the host was the sole source.

## Fix

- **`_install_child_subreaper()`** at host startup — `prctl(PR_SET_CHILD_SUBREAPER, 1)` so orphaned descendants reparent to the host even when it isn't PID 1 (harmless no-op when it already is, or on non-Linux).
- **A periodic orphan-reaper sweep** (`_reap_orphans_once`, every 2s) that reaps ready orphans **without disturbing tracked-runner exit accounting**:
  - Linux/POSIX: `os.waitid(…, WNOWAIT)` *peeks* at the next reapable child without consuming it; a tracked runner is left for its `Popen` reaper (`_watch_runner`) so its real exit code still reaches `host.runner_exited`.
  - Platforms without `os.waitid` (macOS/BSD): `waitpid(WNOHANG)` reaps and **re-injects** a tracked runner's status onto its `Popen`, preserving exit-code fidelity.

A blind `waitpid(-1)` reaper would steal a just-crashed runner's status and make `Popen.poll()` report a bogus exit `0` — I verified this and guard against it in `test_reap_orphans_never_steals_tracked_runner_exit_code`.

## Testing

Three new tests in `tests/host/test_connect.py` (all 66 host tests pass):
- `test_reap_orphans_reaps_orphaned_children` — an orphan is drained to `ECHILD` (regression for the leak).
- `test_reap_orphans_never_steals_tracked_runner_exit_code` — a crashed tracked runner's exit `42` survives the reaper.
- `test_install_child_subreaper_is_safe_to_call` — never raises; returns `bool`.

**Before/after verified:** with the reaper neutralized, a forked orphan becomes a `<defunct>` zombie (`reaped=0`, `ps stat=Z`); with the fix it is reaped and a second sweep is a clean no-op.

## Scope

This is the containment half (stops the box going down). The spin-loop that drives the *fast* spawning is fixed separately (companion PR). Either alone mitigates #1782; both together close it.

Relates to #1782.

This pull request and its description were written by Isaac.
