### PR TITLE
fix(native): bound the permission-hook reattach spin-loop (#1782)

### DIFF
--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import secrets
 import sys
 import time
@@ -43,6 +44,14 @@ from omnigent.native_policy_hook import (
 # answers in the terminal). Kept in lockstep with the server-side
 # ``_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S`` and Claude Code's own
 # command-hook ``timeout`` so no single layer caps the wait early.
+#
+# NOTE: this bounds a SINGLE long-poll (a slow human), NOT the retry loop.
+# Re-POST attempts after a *failure* are bounded separately by
+# ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` — see :func:`_post_hook_with_reattach`.
+# Before #1782 the retry deadline was also one day, so a persistently
+# sick/unreachable server made the hook re-POST (each re-driving the turn and
+# respawning harness/tool subprocesses) every ≤30s for 24h — the spin-loop half
+# of the zombie pileup.
 _PERMISSION_TIMEOUT_S = 86400.0
 # First retry must land inside the server's re-park grace (proxies
 # sever idle long-polls); later retries back off.
@@ -51,6 +60,22 @@ _PERMISSION_RETRY_MAX_BACKOFF_S = 30.0
 # Fail unreachable-server connects fast into the backoff loop instead
 # of inheriting the day-long read budget.
 _PERMISSION_CONNECT_TIMEOUT_S = 30.0
+# Cap on CONSECUTIVE fast failures (5xx / transport error) before the reattach
+# loop gives up and lets the caller fail-ask. A "fast failure" is one that
+# returns well before the long read budget — i.e. the server is sick or
+# unreachable, not holding the poll for a human. This is what bounds the
+# #1782 spin: without it, a down server re-POSTs for a full day. A genuinely
+# held long-poll (slow human) is NOT a failure and never counts toward this,
+# so raising a legitimate approval prompt is unaffected. Overridable for
+# operators who front a flaky proxy and want more slack.
+_PERMISSION_MAX_CONSECUTIVE_FAILURES = max(
+    1, int(os.environ.get("OMNIGENT_HOOK_MAX_RETRIES", "8"))
+)
+# A failure that returns in less than this fraction of the read budget is
+# "fast" (server sick), so it counts toward the consecutive-failure cap. A
+# failure that took longer means the poll was actually held open — reset the
+# counter, since that is the server working as intended, not a spin.
+_PERMISSION_FAST_FAILURE_FRACTION = 0.5
 # Fail-fast budget for the synchronous ``/clear`` and ``/fork`` session
 # rotations that run inside the SessionStart hook to gate Claude's
 # welcome banner. Unlike the permission long-poll these are quick
@@ -532,8 +557,18 @@ def _post_hook_with_reattach(
     watches on a headless sub-agent. Re-POSTs with one stable
     ``_omnigent_elicitation_id`` so the server re-parks the SAME
     elicitation and can hand back a gap verdict via its pre-resolved
-    tombstone. Retries transport errors and 5xx within the
-    ``_PERMISSION_TIMEOUT_S`` budget; a 4xx is final.
+    tombstone. Retries transport errors and 5xx; a 4xx is final.
+
+    Retries are bounded by ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` *fast*
+    failures, NOT by wall-clock. A fast failure (one that returns well before
+    the read budget — server sick / unreachable) counts toward the cap; a
+    failure that only surfaced after the poll was held open for a while resets
+    the counter, because that is the server working as intended. This is the
+    #1782 fix: before it, the retry deadline was ``_PERMISSION_TIMEOUT_S`` (a
+    day), so a persistently down server re-POSTed — re-driving the turn and
+    respawning harness/tool subprocesses — every ≤30s for 24h. Bounding fast
+    failures stops the spin while leaving a slow human's single long-poll
+    (which is not a failure) completely untouched.
 
     :param url: Absolute hook endpoint URL, e.g.
         ``"http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request"``.
@@ -554,11 +589,15 @@ def _post_hook_with_reattach(
         **payload,
         "_omnigent_elicitation_id": f"elicit_claude_{secrets.token_hex(16)}",
     }
-    deadline = time.monotonic() + _PERMISSION_TIMEOUT_S
     backoff_s = _PERMISSION_RETRY_INITIAL_BACKOFF_S
     timeout = httpx.Timeout(_PERMISSION_TIMEOUT_S, connect=_PERMISSION_CONNECT_TIMEOUT_S)
+    # A failure faster than this means the server did not hold the poll — it is
+    # sick/unreachable, so the attempt counts toward the consecutive-failure cap.
+    fast_failure_threshold_s = _PERMISSION_TIMEOUT_S * _PERMISSION_FAST_FAILURE_FRACTION
     reauthed = False
+    consecutive_fast_failures = 0
     while True:
+        attempt_started = time.monotonic()
         try:
             with httpx.Client(headers=headers, timeout=timeout) as client:
                 resp = client.post(url, json=body)
@@ -599,9 +638,18 @@ def _post_hook_with_reattach(
                 f"omnigent {hook_label} hook: Omnigent request failed; retrying: {exc}",
                 file=sys.stderr,
             )
-        if time.monotonic() + backoff_s >= deadline:
+        # A poll that was held open for a while (server working, just slow) is
+        # not a spin — reset the counter. Only fast failures (server down)
+        # accumulate toward the cap that stops the #1782 re-POST storm.
+        if time.monotonic() - attempt_started >= fast_failure_threshold_s:
+            consecutive_fast_failures = 0
+        else:
+            consecutive_fast_failures += 1
+        if consecutive_fast_failures >= _PERMISSION_MAX_CONSECUTIVE_FAILURES:
             print(
-                f"omnigent {hook_label} hook: retry budget exhausted",
+                f"omnigent {hook_label} hook: giving up after "
+                f"{consecutive_fast_failures} consecutive failures "
+                "(server unreachable) — failing ask",
                 file=sys.stderr,
             )
             return None

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -60,22 +60,59 @@ _PERMISSION_RETRY_MAX_BACKOFF_S = 30.0
 # Fail unreachable-server connects fast into the backoff loop instead
 # of inheriting the day-long read budget.
 _PERMISSION_CONNECT_TIMEOUT_S = 30.0
-# Cap on CONSECUTIVE fast failures (5xx / transport error) before the reattach
-# loop gives up and lets the caller fail-ask. A "fast failure" is one that
-# returns well before the long read budget — i.e. the server is sick or
-# unreachable, not holding the poll for a human. This is what bounds the
-# #1782 spin: without it, a down server re-POSTs for a full day. A genuinely
-# held long-poll (slow human) is NOT a failure and never counts toward this,
-# so raising a legitimate approval prompt is unaffected. Overridable for
-# operators who front a flaky proxy and want more slack.
-_PERMISSION_MAX_CONSECUTIVE_FAILURES = max(
-    1, int(os.environ.get("OMNIGENT_HOOK_MAX_RETRIES", "8"))
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an int env override, ignoring a malformed value.
+
+    A non-integer value must not crash the hook subprocess at import time —
+    that would defeat the terminal-fallback design elsewhere in this file. Bad
+    input logs a diagnostic and falls back to *default*.
+
+    :param name: Environment variable name.
+    :param default: Value used when unset or unparseable.
+    :returns: The parsed int, or *default*.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        print(
+            f"omnigent hook: ignoring non-integer {name}={raw!r}; using {default}",
+            file=sys.stderr,
+        )
+        return default
+
+
+# Cap on CONSECUTIVE HARD failures before the reattach loop gives up and lets
+# the caller fail-ask. A "hard failure" is the server being sick or unreachable
+# (5xx, or a connection that never established) — i.e. the #1782 spin. It is
+# distinguished from a proxy severing a *held* poll (a connection that WAS
+# established and then dropped mid-wait), which is the re-park mechanism working
+# as intended and does NOT count — see :func:`_post_hook_with_reattach`. So a
+# legitimately-parked approval behind a severing proxy is never capped, while a
+# down server can no longer re-POST for a day. Overridable for operators who
+# want more slack against a flaky upstream.
+_PERMISSION_MAX_CONSECUTIVE_FAILURES = max(1, _env_int("OMNIGENT_HOOK_MAX_RETRIES", 8))
+# httpx errors that mean the request never reached a live server (no response
+# was ever begun). These are unambiguous hard failures — the server is down /
+# unreachable, not holding a poll. Everything else under ``httpx.HTTPError``
+# that is not a 4xx/5xx status (RemoteProtocolError, ReadError, ReadTimeout, …)
+# means the connection was established and then severed mid-poll.
+_NEVER_CONNECTED_ERRORS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+    httpx.ProxyError,
 )
-# A failure that returns in less than this fraction of the read budget is
-# "fast" (server sick), so it counts toward the consecutive-failure cap. A
-# failure that took longer means the poll was actually held open — reset the
-# counter, since that is the server working as intended, not a spin.
-_PERMISSION_FAST_FAILURE_FRACTION = 0.5
+# An established connection that drops in under this many seconds is treated as
+# a flapping/crash-looping server (a hard failure), NOT a genuinely-parked poll
+# a proxy severed. Comfortably below any real idle-proxy timeout (typically
+# 30-60s+) but above an instant accept-then-reset crash drop, so it tells a
+# legitimate long-poll sever from a tight establish-drop spin.
+_PERMISSION_HELD_POLL_FLOOR_S = 10.0
 # Fail-fast budget for the synchronous ``/clear`` and ``/fork`` session
 # rotations that run inside the SessionStart hook to gate Claude's
 # welcome banner. Unlike the permission long-poll these are quick
@@ -559,16 +596,30 @@ def _post_hook_with_reattach(
     elicitation and can hand back a gap verdict via its pre-resolved
     tombstone. Retries transport errors and 5xx; a 4xx is final.
 
-    Retries are bounded by ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` *fast*
-    failures, NOT by wall-clock. A fast failure (one that returns well before
-    the read budget — server sick / unreachable) counts toward the cap; a
-    failure that only surfaced after the poll was held open for a while resets
-    the counter, because that is the server working as intended. This is the
-    #1782 fix: before it, the retry deadline was ``_PERMISSION_TIMEOUT_S`` (a
-    day), so a persistently down server re-POSTed — re-driving the turn and
-    respawning harness/tool subprocesses — every ≤30s for 24h. Bounding fast
-    failures stops the spin while leaving a slow human's single long-poll
-    (which is not a failure) completely untouched.
+    Retries are bounded by ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` consecutive
+    *hard* failures, classified by kind — NOT by wall-clock. This is the #1782
+    fix: before it the retry deadline was ``_PERMISSION_TIMEOUT_S`` (a day), so
+    a persistently down server re-POSTed — re-driving the turn and respawning
+    harness/tool subprocesses — every ≤30s for 24h.
+
+    Failure classification:
+
+    * **Hard failure → count toward the cap.** A 5xx, or a connection that
+      never established (:data:`_NEVER_CONNECTED_ERRORS`), or an established
+      connection that dropped in under :data:`_PERMISSION_HELD_POLL_FLOOR_S`
+      (a flapping/crash-looping server). This is the spin.
+    * **Held-poll sever → reset the counter.** An established connection that
+      dropped mid-poll after being held ≥ the floor. That is a proxy severing
+      an idle long-poll — the re-park mechanism working as intended — so it
+      must NOT count, or a legitimately-parked human approval behind a
+      severing proxy would be capped after a handful of severs. Classifying by
+      *how the request failed* (established-then-severed vs never-connected),
+      not by elapsed wall-clock, is what makes "a slow human is never capped"
+      hold even when the proxy severs every 30-60s.
+
+    A hard 4xx is final (bad request won't succeed on retry). An absolute
+    :data:`_PERMISSION_TIMEOUT_S` ceiling still bounds the total wait as a
+    backstop, matching the day-long human-answer window.
 
     :param url: Absolute hook endpoint URL, e.g.
         ``"http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request"``.
@@ -591,11 +642,12 @@ def _post_hook_with_reattach(
     }
     backoff_s = _PERMISSION_RETRY_INITIAL_BACKOFF_S
     timeout = httpx.Timeout(_PERMISSION_TIMEOUT_S, connect=_PERMISSION_CONNECT_TIMEOUT_S)
-    # A failure faster than this means the server did not hold the poll — it is
-    # sick/unreachable, so the attempt counts toward the consecutive-failure cap.
-    fast_failure_threshold_s = _PERMISSION_TIMEOUT_S * _PERMISSION_FAST_FAILURE_FRACTION
+    # Absolute backstop: even a run of held-poll severs (which don't count
+    # toward the hard-failure cap) can't loop past the day-long human-answer
+    # window — matches the read budget and the server's ask_timeout.
+    deadline = time.monotonic() + _PERMISSION_TIMEOUT_S
     reauthed = False
-    consecutive_fast_failures = 0
+    consecutive_hard_failures = 0
     while True:
         attempt_started = time.monotonic()
         try:
@@ -629,33 +681,54 @@ def _post_hook_with_reattach(
                     file=sys.stderr,
                 )
                 return None
+            # 5xx: server responded but is sick — a hard failure (the spin).
+            is_hard_failure = True
             print(
                 f"omnigent {hook_label} hook: Omnigent request failed; retrying: {exc}",
                 file=sys.stderr,
             )
         except httpx.HTTPError as exc:
+            # Classify by HOW it failed, not by elapsed time (a proxy severs a
+            # legitimately-held poll in seconds-to-minutes, so wall-clock can't
+            # tell it from a down server — #1782 Polly review).
+            never_connected = isinstance(exc, _NEVER_CONNECTED_ERRORS)
+            held_s = time.monotonic() - attempt_started
+            # Hard failure iff the server was never reached, OR an established
+            # connection dropped so fast it's a flap rather than a parked poll.
+            is_hard_failure = never_connected or held_s < _PERMISSION_HELD_POLL_FLOOR_S
+            kind = (
+                "unreachable"
+                if never_connected
+                else ("flapping" if is_hard_failure else "held-poll severed")
+            )
             print(
-                f"omnigent {hook_label} hook: Omnigent request failed; retrying: {exc}",
+                f"omnigent {hook_label} hook: Omnigent request failed ({kind}); retrying: {exc}",
                 file=sys.stderr,
             )
-        # A poll that was held open for a while (server working, just slow) is
-        # not a spin — reset the counter. Only fast failures (server down)
-        # accumulate toward the cap that stops the #1782 re-POST storm.
-        if time.monotonic() - attempt_started >= fast_failure_threshold_s:
-            consecutive_fast_failures = 0
+        if is_hard_failure:
+            consecutive_hard_failures += 1
         else:
-            consecutive_fast_failures += 1
-        if consecutive_fast_failures >= _PERMISSION_MAX_CONSECUTIVE_FAILURES:
+            # A proxy severed a genuinely-held poll — the re-park mechanism
+            # working as intended. Reset so a slow human is never capped.
+            consecutive_hard_failures = 0
+        if consecutive_hard_failures >= _PERMISSION_MAX_CONSECUTIVE_FAILURES:
             print(
                 f"omnigent {hook_label} hook: giving up after "
-                f"{consecutive_fast_failures} consecutive failures "
-                "(server unreachable) — failing ask",
+                f"{consecutive_hard_failures} consecutive hard failures "
+                "(server unreachable/sick) — failing ask",
                 file=sys.stderr,
             )
             return None
         # Two-line backoff; not worth a retry lib in this dependency-light hook.
         time.sleep(backoff_s)
         backoff_s = min(backoff_s * 2, _PERMISSION_RETRY_MAX_BACKOFF_S)
+        if time.monotonic() >= deadline:
+            print(
+                f"omnigent {hook_label} hook: retry budget exhausted "
+                f"({_PERMISSION_TIMEOUT_S:.0f}s) — failing ask",
+                file=sys.stderr,
+            )
+            return None
 
 
 def _main_permission_request(argv: list[str]) -> int:

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import secrets
 import sys
@@ -100,13 +101,20 @@ def _env_float(name: str, default: float) -> float:
     if raw is None:
         return default
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError:
+        value = math.nan
+    # Reject non-finite too: ``float("inf"/"nan")`` parses without ValueError,
+    # but an ``inf`` floor would classify every sever as a held poll (disabling
+    # flap detection) and ``nan`` makes every ``held_s < floor`` comparison
+    # False — both silent footguns, so treat them as malformed.
+    if not math.isfinite(value):
         print(
-            f"omnigent hook: ignoring non-numeric {name}={raw!r}; using {default}",
+            f"omnigent hook: ignoring non-finite {name}={raw!r}; using {default}",
             file=sys.stderr,
         )
         return default
+    return value
 
 
 # Cap on CONSECUTIVE HARD failures before the reattach loop gives up and lets

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -86,6 +86,29 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _env_float(name: str, default: float) -> float:
+    """Read a float env override, ignoring a malformed value.
+
+    Float sibling of :func:`_env_int`; a bad value logs and falls back to
+    *default* rather than crashing the hook at import time.
+
+    :param name: Environment variable name.
+    :param default: Value used when unset or unparseable.
+    :returns: The parsed float, or *default*.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        print(
+            f"omnigent hook: ignoring non-numeric {name}={raw!r}; using {default}",
+            file=sys.stderr,
+        )
+        return default
+
+
 # Cap on CONSECUTIVE HARD failures before the reattach loop gives up and lets
 # the caller fail-ask. A "hard failure" is the server being sick or unreachable
 # (5xx, or a connection that never established) — i.e. the #1782 spin. It is
@@ -111,8 +134,13 @@ _NEVER_CONNECTED_ERRORS = (
 # a flapping/crash-looping server (a hard failure), NOT a genuinely-parked poll
 # a proxy severed. Comfortably below any real idle-proxy timeout (typically
 # 30-60s+) but above an instant accept-then-reset crash drop, so it tells a
-# legitimate long-poll sever from a tight establish-drop spin.
-_PERMISSION_HELD_POLL_FLOOR_S = 10.0
+# legitimate long-poll sever from a tight establish-drop spin. Operators behind
+# an unusually aggressive proxy/LB whose idle timeout is under 10s can lower
+# this via OMNIGENT_HOOK_HELD_POLL_FLOOR_S so their legitimate slow-human severs
+# stay classified as held polls (not flaps) and are never capped; the default
+# suits typical proxies. Floored at 0 (a negative would make every sever a
+# held poll, disabling flap detection).
+_PERMISSION_HELD_POLL_FLOOR_S = max(0.0, _env_float("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", 10.0))
 # Fail-fast budget for the synchronous ``/clear`` and ``/fork`` session
 # rotations that run inside the SessionStart hook to gate Claude's
 # welcome banner. Unlike the permission long-poll these are quick

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -617,9 +617,26 @@ def _post_hook_with_reattach(
       not by elapsed wall-clock, is what makes "a slow human is never capped"
       hold even when the proxy severs every 30-60s.
 
-    A hard 4xx is final (bad request won't succeed on retry). An absolute
-    :data:`_PERMISSION_TIMEOUT_S` ceiling still bounds the total wait as a
-    backstop, matching the day-long human-answer window.
+    A hard 4xx is final (bad request won't succeed on retry).
+
+    Residual limitation (by design): a *sick* backend behind a proxy/LB that
+    accepts the connection and then silently severs it after its upstream
+    timeout (>= the floor) is indistinguishable at the transport layer from a
+    proxy severing a genuinely-parked human poll — both surface as an
+    established-then-severed error after N seconds, and the server holds the
+    POST silently with no client-visible "parked" ack. So this case resets the
+    counter and is NOT caught by the consecutive-hard-failure cap; it is bounded
+    only by the absolute :data:`_PERMISSION_TIMEOUT_S` ceiling below (the same
+    day-long human-answer window). That is the tightest safe client-side bound:
+    capping it sooner would necessarily cap a real slow human on the same
+    topology. The blast radius is limited — this loop only re-POSTs over HTTP
+    from one hook process (it does not itself respawn harness/tool
+    subprocesses), and the host-side orphan reaper (#1782 Bug A) reclaims any
+    subprocesses a re-driven turn does spawn — so the worst case is one hook
+    slow-retrying for up to a day, not the original zombie pileup.
+
+    The absolute :data:`_PERMISSION_TIMEOUT_S` ceiling bounds the total wait on
+    every path, matching the day-long human-answer window.
 
     :param url: Absolute hook endpoint URL, e.g.
         ``"http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request"``.

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -2286,6 +2286,50 @@ def test_reattach_fast_flapping_connection_is_hard_failure(
     )
 
 
+def test_reattach_never_resolving_severs_are_bounded_by_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sick backend behind a holding proxy still terminates (#1782 review).
+
+    The known residual: a dead backend behind a proxy that accepts then
+    silently severs a held connection (>= the floor) is transport-
+    indistinguishable from a proxy severing a genuinely-parked human poll, so
+    every sever RESETS the consecutive-hard-failure counter and the cap is
+    never reached. This must NOT be an infinite loop — the absolute
+    ``_PERMISSION_TIMEOUT_S`` deadline has to bound it. Here every attempt is a
+    ~15s held sever that never resolves; the loop must eventually return
+    ``None`` (fail-ask) once the day-long budget elapses, not spin forever.
+    """
+    # Each attempt: an established connection held ~15s (> floor) then severed,
+    # never a success. The counter resets every time, so only the deadline can
+    # stop it. Fake clock advances 15s per attempt + 30s backoff.
+    held = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S + 5.0  # 15s: a held sever
+    client = _scripted_client(script=[("severed", held)], monkeypatch=monkeypatch)
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is None, "a never-resolving held-sever spin must fail-ask, not loop forever"
+    # It resets the counter every time (never hits the cap of 8), so it ran far
+    # more than the cap and stopped only when the ~1-day deadline elapsed.
+    assert len(client.calls) > claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES, (
+        "held severs must reset the cap; the deadline (not the cap) bounds this path"
+    )
+    # And it is genuinely bounded by the deadline. In this harness only post()
+    # advances the fake clock (by ``held``); the backoff sleep is a no-op, so
+    # the loop runs ~deadline/held times. (In production the real backoff sleep
+    # also elapses, so the real-world count is strictly lower.) Assert the
+    # count matches that ceiling — proving the deadline, not an accident, stops
+    # it — and stays comfortably below a runaway.
+    max_expected = claude_native_hook._PERMISSION_TIMEOUT_S / held + 2
+    assert len(client.calls) <= max_expected, "deadline did not bound the reset-forever path"
+
+
 def test_reattach_returns_response_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
     """A 2xx on the first try returns immediately (no regression).
 

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -2050,21 +2050,33 @@ def test_evaluate_policy_fails_closed_when_reauth_unavailable(
 # failure until a one-day wall-clock deadline. Against a persistently down
 # server that meant re-driving the turn (and respawning harness/tool
 # subprocesses) every <=30s for 24h — the spin half of the zombie pileup. The
-# fix bounds CONSECUTIVE FAST failures while leaving a legitimately-held
-# long-poll (a slow human) untouched.
+# fix bounds CONSECUTIVE HARD failures (server down/sick), classified by
+# EXCEPTION KIND + held time, while leaving a proxy-severed HELD poll (a slow
+# human waiting) untouched. The Polly review flagged that a pure wall-clock
+# threshold couldn't tell a 60s proxy-severed parked poll from a 60s connect
+# failure — hence the kind-based classification exercised below.
 
 
-def _counting_client(*, durations: list[float], monkeypatch: pytest.MonkeyPatch) -> type:
-    """Build an httpx.Client stub that fails N times with given durations.
+def _scripted_client(
+    *,
+    script: list[tuple[str, float]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> type:
+    """Build an httpx.Client stub whose POSTs fail per a scripted plan.
 
-    Each POST raises ``ConnectError`` (a fast failure unless its scripted
-    duration says otherwise) and records the call. ``durations[i]`` is how long
-    attempt ``i`` "took" — simulated by advancing a fake clock, so tests run
-    instantly. A duration past the end of the list repeats the last value.
+    Each entry is ``(kind, held_s)``: ``kind`` selects the failure raised and
+    ``held_s`` is how long that attempt "took" (advanced on a fake clock, so
+    tests run instantly). Past the end, the last entry repeats.
 
-    :param durations: Per-attempt simulated wall-clock seconds.
-    :param monkeypatch: Fixture used to install the fake clock + no-op sleep.
-    :returns: A drop-in ``httpx.Client`` class; its ``calls`` list counts POSTs.
+    ``kind`` values:
+      * ``"connect"`` — :class:`httpx.ConnectError` (server never reached: hard)
+      * ``"severed"`` — :class:`httpx.RemoteProtocolError` (established then
+        dropped: a held-poll sever iff ``held_s`` >= the floor)
+      * ``"5xx"``     — a 503 response (server sick: hard)
+
+    :param script: Per-attempt ``(kind, held_s)`` plan.
+    :param monkeypatch: Installs the fake clock + no-op sleep.
+    :returns: A drop-in ``httpx.Client`` class; ``.calls`` counts POSTs.
     """
     clock = {"t": 0.0}
     calls: list[str] = []
@@ -2072,13 +2084,13 @@ def _counting_client(*, durations: list[float], monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(claude_native_hook.time, "monotonic", lambda: clock["t"])
     monkeypatch.setattr(claude_native_hook.time, "sleep", lambda _s: None)
 
-    class _CountingClient:
+    class _ScriptedClient:
         calls: list[str] = []
 
         def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
             del headers, timeout
 
-        def __enter__(self) -> _CountingClient:
+        def __enter__(self) -> _ScriptedClient:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -2088,22 +2100,29 @@ def _counting_client(*, durations: list[float], monkeypatch: pytest.MonkeyPatch)
             del json
             i = len(calls)
             calls.append(url)
-            dur = durations[i] if i < len(durations) else durations[-1]
-            clock["t"] += dur  # advance the fake clock by this attempt's cost
-            raise httpx.ConnectError("AP unreachable", request=httpx.Request("POST", url))
+            kind, held_s = script[i] if i < len(script) else script[-1]
+            clock["t"] += held_s  # this attempt "took" held_s before failing
+            req = httpx.Request("POST", url)
+            if kind == "connect":
+                raise httpx.ConnectError("AP unreachable", request=req)
+            if kind == "severed":
+                raise httpx.RemoteProtocolError("server dropped the poll", request=req)
+            if kind == "5xx":
+                return httpx.Response(503, text="upstream down", request=req)
+            raise AssertionError(f"unknown scripted kind {kind!r}")
 
-    _CountingClient.calls = calls
-    return _CountingClient
+    _ScriptedClient.calls = calls
+    return _ScriptedClient
 
 
-def test_reattach_bounds_consecutive_fast_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_reattach_bounds_consecutive_hard_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     """A down server no longer re-POSTs for a day (#1782 spin-loop).
 
-    Every attempt fails fast (near-zero duration), so the loop must give up
-    after ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` attempts and return ``None``
-    (caller fails-ask) — not spin until the day-long budget.
+    Every attempt is an unreachable-server ``ConnectError``, so the loop must
+    give up after ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` attempts and return
+    ``None`` (caller fails-ask) — not spin until the day-long budget.
     """
-    client = _counting_client(durations=[0.0], monkeypatch=monkeypatch)
+    client = _scripted_client(script=[("connect", 0.0)], monkeypatch=monkeypatch)
     monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
 
     resp = claude_native_hook._post_hook_with_reattach(
@@ -2115,12 +2134,32 @@ def test_reattach_bounds_consecutive_fast_failures(monkeypatch: pytest.MonkeyPat
 
     assert resp is None
     assert len(client.calls) == claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES, (
-        "reattach must stop after the consecutive-fast-failure cap, not spin"
+        "reattach must stop after the consecutive-hard-failure cap, not spin"
     )
 
 
+def test_reattach_5xx_counts_as_hard_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A server stuck returning 5xx is a hard failure and is bounded (#1782).
+
+    A sick server that keeps 500-ing is the spin just as much as an
+    unreachable one, so it must hit the same cap.
+    """
+    client = _scripted_client(script=[("5xx", 0.0)], monkeypatch=monkeypatch)
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is None
+    assert len(client.calls) == claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES
+
+
 def test_reattach_cap_is_env_overridable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``OMNIGENT_HOOK_MAX_RETRIES`` tunes the fast-failure cap.
+    """``OMNIGENT_HOOK_MAX_RETRIES`` tunes the hard-failure cap.
 
     Operators fronting a flaky proxy can widen the budget. Re-import the
     module under the env override so the module-level constant is recomputed.
@@ -2130,7 +2169,7 @@ def test_reattach_cap_is_env_overridable(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("OMNIGENT_HOOK_MAX_RETRIES", "3")
     reloaded = importlib.reload(claude_native_hook)
     try:
-        client = _counting_client(durations=[0.0], monkeypatch=monkeypatch)
+        client = _scripted_client(script=[("connect", 0.0)], monkeypatch=monkeypatch)
         monkeypatch.setattr(reloaded.httpx, "Client", client)
 
         resp = reloaded._post_hook_with_reattach(
@@ -2149,21 +2188,89 @@ def test_reattach_cap_is_env_overridable(monkeypatch: pytest.MonkeyPatch) -> Non
         importlib.reload(claude_native_hook)
 
 
-def test_reattach_held_poll_does_not_count_as_spin(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A long-held poll (slow human) resets the fast-failure counter (#1782).
+def test_reattach_bad_env_max_retries_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-integer ``OMNIGENT_HOOK_MAX_RETRIES`` must not crash the hook.
 
-    If the server holds the poll open for most of the read budget and only
-    then drops it, that is not a spin — the counter must reset so a genuine
-    approval wait is never capped. Script: ``cap + 2`` *slow* attempts (each
-    held ~the full budget → each resets the counter), then fast failures that
-    finally trip the cap and end the loop. If slow attempts were wrongly
-    counted, the loop would stop at ``cap`` calls; we assert it runs further,
-    proving held polls don't spin.
+    ``int("banana")`` at import time would raise and defeat the terminal
+    fallback; the guarded parse keeps the default instead (#1782 review note).
+    """
+    import importlib
+
+    monkeypatch.setenv("OMNIGENT_HOOK_MAX_RETRIES", "banana")
+    reloaded = importlib.reload(claude_native_hook)
+    try:
+        assert reloaded._PERMISSION_MAX_CONSECUTIVE_FAILURES == 8  # default preserved
+    finally:
+        monkeypatch.delenv("OMNIGENT_HOOK_MAX_RETRIES", raising=False)
+        importlib.reload(claude_native_hook)
+
+
+def test_reattach_proxy_severed_held_poll_never_caps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A proxy severing a HELD poll must never cap a slow human (#1782 review).
+
+    This is the exact scenario Polly flagged: a legitimately-parked approval
+    behind a proxy that severs the idle long-poll every ~60s. Each sever is an
+    established-then-dropped ``RemoteProtocolError`` held past the floor — a
+    held-poll sever, NOT a hard failure — so the counter resets every time and
+    the human is never fail-asked. We script far more severs than the cap and
+    assert the loop keeps retrying, then a real 2xx (the human answers) returns.
     """
     cap = claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES
-    slow = claude_native_hook._PERMISSION_TIMEOUT_S  # held ~full budget → "not a spin"
-    durations = [slow] * (cap + 2) + [0.0] * cap  # slow polls, then fast failures
-    client = _counting_client(durations=durations, monkeypatch=monkeypatch)
+    held = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S + 50.0  # ~60s proxy idle
+    # 3x the cap in held-poll severs, then a success — if severs counted, it
+    # would have fail-asked long before reaching the success.
+    n_severs = cap * 3
+    clock = {"t": 0.0}
+    calls: list[str] = []
+    monkeypatch.setattr(claude_native_hook.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(claude_native_hook.time, "sleep", lambda _s: None)
+
+    class _SeverThenAnswerClient:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _SeverThenAnswerClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            i = len(calls)
+            calls.append(url)
+            req = httpx.Request("POST", url)
+            if i < n_severs:
+                clock["t"] += held  # poll was held for the proxy idle interval
+                raise httpx.RemoteProtocolError("proxy severed idle poll", request=req)
+            return httpx.Response(200, json={"ok": True}, request=req)
+
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", _SeverThenAnswerClient)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is not None and resp.status_code == 200, (
+        "a slow human behind a severing proxy was capped — the #1782 regression"
+    )
+    assert len(calls) == n_severs + 1  # retried through every sever, then answered
+
+
+def test_reattach_fast_flapping_connection_is_hard_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An established connection that drops instantly is a flap, not a poll.
+
+    A crash-looping server that accepts then immediately resets the connection
+    raises the same ``RemoteProtocolError`` as a real held-poll sever — but
+    held for ~0s. The held-time floor classifies it as a hard failure so this
+    tight loop is still bounded (it must not masquerade as a parked poll).
+    """
+    client = _scripted_client(script=[("severed", 0.0)], monkeypatch=monkeypatch)
     monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
 
     resp = claude_native_hook._post_hook_with_reattach(
@@ -2174,13 +2281,9 @@ def test_reattach_held_poll_does_not_count_as_spin(monkeypatch: pytest.MonkeyPat
     )
 
     assert resp is None
-    # It retried through all the slow (held) attempts without capping, only
-    # stopping once fast failures accumulated — proving slow polls don't spin.
-    assert len(client.calls) >= cap + 2, (
-        "a legitimately-held long-poll must not count toward the spin cap"
+    assert len(client.calls) == claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES, (
+        "an instant establish-drop flap must be bounded like any hard failure"
     )
-    # And it did eventually stop (didn't run away): cap+2 resets + cap fast fails.
-    assert len(client.calls) <= (cap + 2) + cap
 
 
 def test_reattach_returns_response_on_success(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -2304,14 +2304,19 @@ def test_held_poll_floor_is_env_overridable(monkeypatch: pytest.MonkeyPatch) -> 
         monkeypatch.delenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", raising=False)
         importlib.reload(claude_native_hook)
 
-    # A malformed override must not crash the hook — falls back to the default.
-    monkeypatch.setenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", "not-a-number")
-    reloaded = importlib.reload(claude_native_hook)
-    try:
-        assert reloaded._PERMISSION_HELD_POLL_FLOOR_S == 10.0
-    finally:
-        monkeypatch.delenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", raising=False)
-        importlib.reload(claude_native_hook)
+    # Malformed / non-finite overrides must not crash the hook or silently
+    # disable flap detection — each falls back to the 10s default. "inf" would
+    # make every sever a held poll; "nan" makes held_s < floor always False.
+    for bad in ("not-a-number", "inf", "nan", "-inf"):
+        monkeypatch.setenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", bad)
+        reloaded = importlib.reload(claude_native_hook)
+        try:
+            assert reloaded._PERMISSION_HELD_POLL_FLOOR_S == 10.0, (
+                f"bad floor {bad!r} not rejected"
+            )
+        finally:
+            monkeypatch.delenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", raising=False)
+            importlib.reload(claude_native_hook)
 
 
 def test_reattach_never_resolving_severs_are_bounded_by_deadline(

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -2042,3 +2042,181 @@ def test_evaluate_policy_fails_closed_when_reauth_unavailable(
         result["hookSpecificOutput"]["permissionDecisionReason"]
         == native_policy_hook._EVAL_UNAVAILABLE_REASON
     )
+
+
+# ── #1782: bound the reattach spin-loop ────────────────────────────────────
+#
+# Before the fix, ``_post_hook_with_reattach`` re-POSTed on every 5xx/transport
+# failure until a one-day wall-clock deadline. Against a persistently down
+# server that meant re-driving the turn (and respawning harness/tool
+# subprocesses) every <=30s for 24h — the spin half of the zombie pileup. The
+# fix bounds CONSECUTIVE FAST failures while leaving a legitimately-held
+# long-poll (a slow human) untouched.
+
+
+def _counting_client(*, durations: list[float], monkeypatch: pytest.MonkeyPatch) -> type:
+    """Build an httpx.Client stub that fails N times with given durations.
+
+    Each POST raises ``ConnectError`` (a fast failure unless its scripted
+    duration says otherwise) and records the call. ``durations[i]`` is how long
+    attempt ``i`` "took" — simulated by advancing a fake clock, so tests run
+    instantly. A duration past the end of the list repeats the last value.
+
+    :param durations: Per-attempt simulated wall-clock seconds.
+    :param monkeypatch: Fixture used to install the fake clock + no-op sleep.
+    :returns: A drop-in ``httpx.Client`` class; its ``calls`` list counts POSTs.
+    """
+    clock = {"t": 0.0}
+    calls: list[str] = []
+
+    monkeypatch.setattr(claude_native_hook.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(claude_native_hook.time, "sleep", lambda _s: None)
+
+    class _CountingClient:
+        calls: list[str] = []
+
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _CountingClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            i = len(calls)
+            calls.append(url)
+            dur = durations[i] if i < len(durations) else durations[-1]
+            clock["t"] += dur  # advance the fake clock by this attempt's cost
+            raise httpx.ConnectError("AP unreachable", request=httpx.Request("POST", url))
+
+    _CountingClient.calls = calls
+    return _CountingClient
+
+
+def test_reattach_bounds_consecutive_fast_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A down server no longer re-POSTs for a day (#1782 spin-loop).
+
+    Every attempt fails fast (near-zero duration), so the loop must give up
+    after ``_PERMISSION_MAX_CONSECUTIVE_FAILURES`` attempts and return ``None``
+    (caller fails-ask) — not spin until the day-long budget.
+    """
+    client = _counting_client(durations=[0.0], monkeypatch=monkeypatch)
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is None
+    assert len(client.calls) == claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES, (
+        "reattach must stop after the consecutive-fast-failure cap, not spin"
+    )
+
+
+def test_reattach_cap_is_env_overridable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OMNIGENT_HOOK_MAX_RETRIES`` tunes the fast-failure cap.
+
+    Operators fronting a flaky proxy can widen the budget. Re-import the
+    module under the env override so the module-level constant is recomputed.
+    """
+    import importlib
+
+    monkeypatch.setenv("OMNIGENT_HOOK_MAX_RETRIES", "3")
+    reloaded = importlib.reload(claude_native_hook)
+    try:
+        client = _counting_client(durations=[0.0], monkeypatch=monkeypatch)
+        monkeypatch.setattr(reloaded.httpx, "Client", client)
+
+        resp = reloaded._post_hook_with_reattach(
+            url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+            headers={},
+            payload={"hook_event_name": "PreToolUse"},
+            hook_label="permission",
+        )
+        assert resp is None
+        assert reloaded._PERMISSION_MAX_CONSECUTIVE_FAILURES == 3
+        assert len(client.calls) == 3
+    finally:
+        # Restore the module for other tests (monkeypatch unsets the env var,
+        # but the reloaded constant would persist without this).
+        monkeypatch.delenv("OMNIGENT_HOOK_MAX_RETRIES", raising=False)
+        importlib.reload(claude_native_hook)
+
+
+def test_reattach_held_poll_does_not_count_as_spin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A long-held poll (slow human) resets the fast-failure counter (#1782).
+
+    If the server holds the poll open for most of the read budget and only
+    then drops it, that is not a spin — the counter must reset so a genuine
+    approval wait is never capped. Script: ``cap + 2`` *slow* attempts (each
+    held ~the full budget → each resets the counter), then fast failures that
+    finally trip the cap and end the loop. If slow attempts were wrongly
+    counted, the loop would stop at ``cap`` calls; we assert it runs further,
+    proving held polls don't spin.
+    """
+    cap = claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES
+    slow = claude_native_hook._PERMISSION_TIMEOUT_S  # held ~full budget → "not a spin"
+    durations = [slow] * (cap + 2) + [0.0] * cap  # slow polls, then fast failures
+    client = _counting_client(durations=durations, monkeypatch=monkeypatch)
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is None
+    # It retried through all the slow (held) attempts without capping, only
+    # stopping once fast failures accumulated — proving slow polls don't spin.
+    assert len(client.calls) >= cap + 2, (
+        "a legitimately-held long-poll must not count toward the spin cap"
+    )
+    # And it did eventually stop (didn't run away): cap+2 resets + cap fast fails.
+    assert len(client.calls) <= (cap + 2) + cap
+
+
+def test_reattach_returns_response_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 2xx on the first try returns immediately (no regression).
+
+    The spin-loop bound must not perturb the happy path: one successful POST
+    returns its response without retry.
+    """
+    monkeypatch.setattr(claude_native_hook.time, "sleep", lambda _s: None)
+
+    class _OkClient:
+        calls = 0
+
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _OkClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            type(self).calls += 1
+            return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", _OkClient)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is not None
+    assert resp.status_code == 200
+    assert _OkClient.calls == 1

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -2286,6 +2286,34 @@ def test_reattach_fast_flapping_connection_is_hard_failure(
     )
 
 
+def test_held_poll_floor_is_env_overridable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OMNIGENT_HOOK_HELD_POLL_FLOOR_S`` tunes the flap-vs-held boundary.
+
+    Operators behind an aggressive proxy whose idle timeout is under the 10s
+    default can lower the floor so their legitimate slow-human severs stay
+    classified as held polls (reset), not flaps (counted) — closing the one
+    narrow human-capping edge. A malformed value falls back to the default.
+    """
+    import importlib
+
+    monkeypatch.setenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", "3.5")
+    reloaded = importlib.reload(claude_native_hook)
+    try:
+        assert reloaded._PERMISSION_HELD_POLL_FLOOR_S == 3.5
+    finally:
+        monkeypatch.delenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", raising=False)
+        importlib.reload(claude_native_hook)
+
+    # A malformed override must not crash the hook — falls back to the default.
+    monkeypatch.setenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", "not-a-number")
+    reloaded = importlib.reload(claude_native_hook)
+    try:
+        assert reloaded._PERMISSION_HELD_POLL_FLOOR_S == 10.0
+    finally:
+        monkeypatch.delenv("OMNIGENT_HOOK_HELD_POLL_FLOOR_S", raising=False)
+        importlib.reload(claude_native_hook)
+
+
 def test_reattach_never_resolving_severs_are_bounded_by_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

Fixes the **spin-loop half** of #1782: a host blocked on an unanswered approval elicitation re-POSTs the same elicitation indefinitely (repeated same-`elicitation_id` log lines interleaved with `Omnigent API failed: request error`), re-driving the turn and respawning harness/tool subprocesses on every cycle.

## Root cause

`_post_hook_with_reattach` (the native Claude permission/ask hook) re-POSTs a severed long-poll with a stable `_omnigent_elicitation_id` so the server re-attaches instead of prompting the human twice — correct. But its **retry deadline** was `_PERMISSION_TIMEOUT_S` (one day) — the same value that legitimately bounds a *single* long-poll for a slow human. So against a persistently sick/unreachable server the loop re-POSTed every ≤30s for 24h.

## Fix

Bound **consecutive *hard* failures**, classified by **exception kind** rather than wall-clock (a proxy severs a legitimately-*parked* poll in seconds-to-minutes, so elapsed time can't distinguish it from a down server — this was the flaw in the first iteration, caught in review):

- **Hard failure → counts toward the cap** (`_PERMISSION_MAX_CONSECUTIVE_FAILURES`, default **8**, `OMNIGENT_HOOK_MAX_RETRIES`): a 5xx; a connection that never established (`ConnectError`/`ConnectTimeout`/`PoolTimeout`/`ProxyError`); or an established connection dropped in under `_PERMISSION_HELD_POLL_FLOOR_S` (a flap).
- **Held-poll sever → resets the counter**: an established connection dropped after being held ≥ the floor — the re-park mechanism working as intended, so a slow human behind a severing proxy is never capped.

Plus: an absolute `_PERMISSION_TIMEOUT_S` (1-day) deadline backstop on total wait; a fault-tolerant `_env_int`/`_env_float` parse (a malformed override can't crash the hook at import); and the held-poll floor is env-tunable (`OMNIGENT_HOOK_HELD_POLL_FLOOR_S`) for operators behind a sub-10s-idle proxy.

### Known residual (documented, by design)

A *sick* backend behind a proxy that accepts then silently severs a held connection (≥ floor) is **transport-indistinguishable** from a proxy severing a real parked poll — both surface as an established-then-severed error after N seconds, and the server holds the POST with no client-visible "parked" ack. So that one topology resets the counter and is bounded only by the day-long deadline, not the cap. That is the tightest *safe* client-side bound (capping sooner would cap a real slow human on the same topology). Blast radius is small: this loop only re-POSTs over HTTP from one hook process (no subprocess respawn in the loop), and the companion host orphan-reaper (#1812) reclaims any subprocesses a re-driven turn spawns.

## Testing

9 reattach/floor tests in `tests/test_claude_native_hook.py` (49 hook tests pass, 12 codex-hook still green):
- `test_reattach_bounds_consecutive_hard_failures` — a down server stops at the cap.
- `test_reattach_5xx_counts_as_hard_failure` — a sick 5xx server is bounded.
- `test_reattach_fast_flapping_connection_is_hard_failure` — an instant establish-drop flap is bounded.
- `test_reattach_proxy_severed_held_poll_never_caps` — a proxy severing a held poll every ~60s (3× the cap) never caps; the human's eventual 2xx returns.
- `test_reattach_never_resolving_severs_are_bounded_by_deadline` — the reset-forever path still terminates via the 1-day deadline.
- `test_reattach_cap_is_env_overridable`, `test_reattach_bad_env_max_retries_falls_back`, `test_held_poll_floor_is_env_overridable`, `test_reattach_returns_response_on_success`.

**Before/after verified:** old 12h-wall-clock logic caps a proxy-severed held poll at ~8 severs (~8 min); new exception-kind logic never caps a held-poll sever while a down/sick server is bounded at 8.

## Scope

Companion to the host orphan-reaper PR (#1812). Either alone mitigates #1782; both together close it.

Relates to #1782.

This pull request and its description were written by Isaac.
