### PR TITLE
fix(claude-native): widen prompt-ready scan window for multi-line statuslines

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -127,10 +127,14 @@ _CLAUDE_PROMPT_GLYPH = "❯"
 # How many trailing non-empty lines to scan for the prompt glyph. The
 # input box sits near the bottom of the pane; scanning only the tail
 # avoids false positives from the glyph appearing in scrollback output.
-# The window has to clear the footer rendered below the box — some
-# people's statuslines run ~3 lines — so the ``❯`` row isn't the last
-# non-empty line.
-_PROMPT_SCAN_TAIL_LINES = 5
+# The window has to clear the footer rendered below the box, which on
+# real user configs is more than a few lines: a multi-line custom
+# statusline, Claude Code's own mode indicator (e.g. ``⏵⏵ auto mode
+# on``), and the box's bottom border all sit below the ``❯`` row. A
+# 4-line statusline already pushes the glyph to the 6th-from-last line,
+# so a tight window (was 5) misses it and readiness never fires. Keep
+# generous headroom.
+_PROMPT_SCAN_TAIL_LINES = 10
 _CLAUDE_READY_POLL_INTERVAL_S = 0.15
 _PASTE_SETTLE_S = 0.1  # let the TUI commit a paste before the separate submit Enter
 # How long to wait for the pasted draft to visibly land in Claude's

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4852,6 +4852,36 @@ def test_claude_prompt_rendered_sees_prompt_above_default_footer() -> None:
     assert _claude_prompt_rendered(pane) is True
 
 
+def test_claude_prompt_rendered_sees_prompt_above_multiline_statusline() -> None:
+    """
+    The scan reaches the glyph above a *multi-line* custom statusline.
+
+    A ``statusLine`` command that emits several rows (a common setup: cwd
+    on one line, model+context on another, a cost/budget line, …) renders
+    every row below the input box, in addition to the box's closing rule
+    and Claude Code's own mode-hint line. With a 3-line statusline the
+    live ``❯`` row is the 6th non-empty line from the bottom, so the old
+    5-line window fell one short and the readiness gate timed out with
+    "input prompt never rendered" even though the box was mounted — the
+    message was silently dropped. A failure here means the window
+    regressed below the footer a real user config produces.
+    """
+    pane = "\n".join(
+        [
+            "────────────────────────────────────────",  # input box top rule
+            "❯ ",  # the live prompt row (6th non-empty line from bottom)
+            "────────────────────────────────────────",  # box closing rule
+            "  ~/code/proj:main",  # custom statusline row 1 (cwd/branch)
+            "  Opus 4.8 | ctx 32k/200k (16%)",  # custom statusline row 2
+            "  $0.20/$500.00 (0% used)",  # custom statusline row 3 (budget)
+            "  ⏵⏵ auto mode on (shift+tab to cycle)",  # Claude's mode hint
+        ]
+    )
+    # ``❯`` sits 6 non-empty lines above the bottom (rule + 3 statusline
+    # rows + hint), so only a scan window of >= 6 reaches it.
+    assert _claude_prompt_rendered(pane) is True
+
+
 def _write_deltas_lines(bridge_dir: Path, lines: list[str]) -> None:
     """
     Append raw JSONL lines to the bridge deltas file.


### PR DESCRIPTION
## Summary

The Claude-native web-UI message-injection path has a readiness gate that decides whether Claude Code's input box has mounted before typing into the tmux pane. That gate misses the prompt when the user runs a **multi-line custom statusline**, so messages time out with `input prompt never rendered` and are silently dropped — even though the box is fully mounted and usable.

This widens the scan window and adds a regression test.

## Motivation / root cause

`inject_user_message` waits on `_wait_for_claude_prompt_ready`, which calls `_claude_prompt_rendered(pane)`:

```python
_PROMPT_SCAN_TAIL_LINES = 5
def _claude_prompt_rendered(pane: str) -> bool:
    non_empty = [line for line in pane.splitlines() if line.strip()]
    return any(_CLAUDE_PROMPT_GLYPH in line for line in non_empty[-_PROMPT_SCAN_TAIL_LINES:])
```

It scans only the **last 5 non-empty lines** for the `❯` glyph. The window was sized for the comment's stated assumption that *"people's statuslines run ~3 lines."* But Claude Code renders a footer **below** the input box, and with a multi-line custom `statusLine` command that footer is taller than the window:

```
❯                          ← the glyph the gate needs to see
──────────────             (1) input box bottom border
  ~/code/proj:main          (2) custom statusline row 1
  Opus 4.8 | ctx 32k/200k   (3) custom statusline row 2
  $0.20/$500.00 (0% used)   (4) custom statusline row 3 (cost/budget)
  ⏵⏵ auto mode on ...       (5) Claude Code's own mode indicator
```

That's **5 non-empty lines below `❯`**, putting the glyph at the 6th-from-last line — one past the `[-5:]` window. `_claude_prompt_rendered` returns `False` forever, the 30s gate expires, and the user sees:

> `Claude Code terminal did not become ready within 30.0s (input prompt never rendered). The message was not delivered.`

### Why it presents as flaky (first message works, later ones fail)

The `statusLine` command runs asynchronously. At cold boot, before it paints its rows (and before the budget/context line resolves), fewer lines sit below `❯`, so the glyph briefly lands within the last 5 lines and the **first** message is delivered. Once the full multi-line statusline settles, `❯` drops to the 6th-from-last line and **every subsequent send** times out. This "works once, then wedges" pattern is the classic symptom.

This is a real, common config — a statusline showing cwd/branch, model+context, and a cost/budget line is only 3 rows, and combined with Claude's mode-hint line and the box border it already overflows the window.

## Fix

- Widen `_PROMPT_SCAN_TAIL_LINES` from `5` to `10` for headroom, and update the comment to reflect the real footer composition (multi-line statusline + mode indicator + box border). Widening the readiness tail does not increase scrollback false-positive risk in practice: the live input box always sits at the very bottom of the pane, so the glyph within a 10-line tail is still the mounted box, not echoed transcript output.
- Add `test_claude_prompt_rendered_sees_prompt_above_multiline_statusline`, which reproduces a 3-line statusline (glyph at the 6th-from-last line) and asserts readiness — this fails on the old window of 5 and passes on 10.

The sibling native bridges (`kiro_native_bridge.py`, `opencode_native_app_server.py`, …) appear to share the same tail-scan heuristic; they're worth a follow-up audit but are out of scope here.

## Testing

```
uv run --with pytest python -m pytest tests/test_claude_native_bridge.py -k prompt_rendered -q
# 2 passed
```

Both the existing default-footer test and the new multi-line-statusline test pass.

## Changelog

Fixed a Claude-native readiness bug where users with a multi-line custom statusline could not send messages from the web UI — injection timed out with "input prompt never rendered" once the statusline finished painting, even though the terminal was ready.