### PR TITLE
iOS: add fastlane App Store screenshot pipeline

### DIFF
--- a/web/ios/.gitignore
+++ b/web/ios/.gitignore
@@ -17,6 +17,7 @@ fastlane/.env
 # fastlane run output
 fastlane/report.xml
 fastlane/Preview.html
+fastlane/screenshots/
 fastlane/test_output/
 
 # Auto-generated lane docs (regenerated on every fastlane run; see RELEASE.md)

--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -22,13 +22,23 @@
 		B10000000000000000000011 /* ChatTerminalBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* ChatTerminalBar.swift */; };
 		B1000000000000000000000D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000D /* Assets.xcassets */; };
 		B1000000000000000000000E /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000E /* AppIcon.icon */; };
+		B10000000000000000000012 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000012 /* PrivacyInfo.xcprivacy */; };
 		B20000000000000000000001 /* ServerURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ServerURLTests.swift */; };
 		B20000000000000000000002 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* SettingsStoreTests.swift */; };
 		B20000000000000000000003 /* WorkspaceURLExpanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */; };
+		B40000000000000000000001 /* OmnigentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000001 /* OmnigentUITests.swift */; };
+		B40000000000000000000002 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000002 /* SnapshotHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		E00000000000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A00000000000000000000005 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A00000000000000000000006;
+			remoteInfo = Omnigent;
+		};
+		E00000000000000000000003 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A00000000000000000000005 /* Project object */;
 			proxyType = 1;
@@ -55,9 +65,13 @@
 		A1000000000000000000000E /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = AppIcon.icon; path = "../platform-assets/AppIcon.icon"; sourceTree = "<group>"; };
 		A1000000000000000000000F /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
 		A10000000000000000000010 /* Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Release.plist"; sourceTree = "<group>"; };
+		A10000000000000000000012 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A20000000000000000000001 /* ServerURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerURLTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000002 /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceURLExpanderTests.swift; sourceTree = "<group>"; };
+		A30000000000000000000003 /* OmnigentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A40000000000000000000001 /* OmnigentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentUITests.swift; sourceTree = "<group>"; };
+		A40000000000000000000002 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		A30000000000000000000001 /* Omnigent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Omnigent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A30000000000000000000002 /* OmnigentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmnigentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -77,6 +91,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C00000000000000000000008 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -85,6 +106,7 @@
 			children = (
 				A00000000000000000000003 /* Omnigent */,
 				A00000000000000000000004 /* OmnigentTests */,
+				A00000000000000000000009 /* OmnigentUITests */,
 				A00000000000000000000008 /* Platform Assets */,
 				A00000000000000000000002 /* Products */,
 			);
@@ -95,6 +117,7 @@
 			children = (
 				A30000000000000000000001 /* Omnigent.app */,
 				A30000000000000000000002 /* OmnigentTests.xctest */,
+				A30000000000000000000003 /* OmnigentUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -116,6 +139,7 @@
 				A1000000000000000000000C /* URL+Omnigent.swift */,
 				A10000000000000000000011 /* ChatTerminalBar.swift */,
 				A1000000000000000000000D /* Assets.xcassets */,
+				A10000000000000000000012 /* PrivacyInfo.xcprivacy */,
 				A1000000000000000000000F /* Info-Debug.plist */,
 				A10000000000000000000010 /* Info-Release.plist */,
 			);
@@ -130,6 +154,15 @@
 				A20000000000000000000003 /* WorkspaceURLExpanderTests.swift */,
 			);
 			path = OmnigentTests;
+			sourceTree = "<group>";
+		};
+		A00000000000000000000009 /* OmnigentUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A40000000000000000000001 /* OmnigentUITests.swift */,
+				A40000000000000000000002 /* SnapshotHelper.swift */,
+			);
+			path = OmnigentUITests;
 			sourceTree = "<group>";
 		};
 		A00000000000000000000008 /* Platform Assets */ = {
@@ -178,6 +211,24 @@
 			productReference = A30000000000000000000002 /* OmnigentTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		A0000000000000000000000A /* OmnigentUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D40000000000000000000001 /* Build configuration list for PBXNativeTarget "OmnigentUITests" */;
+			buildPhases = (
+				C00000000000000000000007 /* Sources */,
+				C00000000000000000000008 /* Frameworks */,
+				C00000000000000000000009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E00000000000000000000004 /* PBXTargetDependency */,
+			);
+			name = OmnigentUITests;
+			productName = OmnigentUITests;
+			productReference = A30000000000000000000003 /* OmnigentUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -192,6 +243,10 @@
 						CreatedOnToolsVersion = 16.0;
 					};
 					A00000000000000000000007 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = A00000000000000000000006;
+					};
+					A0000000000000000000000A = {
 						CreatedOnToolsVersion = 16.0;
 						TestTargetID = A00000000000000000000006;
 					};
@@ -212,6 +267,7 @@
 			targets = (
 				A00000000000000000000006 /* Omnigent */,
 				A00000000000000000000007 /* OmnigentTests */,
+				A0000000000000000000000A /* OmnigentUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -223,10 +279,18 @@
 			files = (
 				B1000000000000000000000D /* Assets.xcassets in Resources */,
 				B1000000000000000000000E /* AppIcon.icon in Resources */,
+				B10000000000000000000012 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C00000000000000000000006 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C00000000000000000000009 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -266,6 +330,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C00000000000000000000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B40000000000000000000001 /* OmnigentUITests.swift in Sources */,
+				B40000000000000000000002 /* SnapshotHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -273,6 +346,11 @@
 			isa = PBXTargetDependency;
 			target = A00000000000000000000006 /* Omnigent */;
 			targetProxy = E00000000000000000000001 /* PBXContainerItemProxy */;
+		};
+		E00000000000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A00000000000000000000006 /* Omnigent */;
+			targetProxy = E00000000000000000000003 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -396,6 +474,7 @@
 		D10000000000000000000002 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_DISPLAY_NAME = Omnigent;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -419,13 +498,14 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
 		D10000000000000000000003 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_DISPLAY_NAME = Omnigent;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -449,7 +529,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -472,7 +552,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Omnigent.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Omnigent";
 			};
 			name = Debug;
@@ -496,8 +576,54 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Omnigent.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Omnigent";
+			};
+			name = Release;
+		};
+		D40000000000000000000002 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = Omnigent;
+			};
+			name = Debug;
+		};
+		D40000000000000000000003 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = Omnigent;
 			};
 			name = Release;
 		};
@@ -527,6 +653,15 @@
 			buildConfigurations = (
 				D20000000000000000000002 /* Debug */,
 				D20000000000000000000003 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D40000000000000000000001 /* Build configuration list for PBXNativeTarget "OmnigentUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D40000000000000000000002 /* Debug */,
+				D40000000000000000000003 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/web/ios/Omnigent.xcodeproj/xcshareddata/xcschemes/Omnigent.xcscheme
+++ b/web/ios/Omnigent.xcodeproj/xcshareddata/xcschemes/Omnigent.xcscheme
@@ -39,7 +39,27 @@
                ReferencedContainer = "container:Omnigent.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A0000000000000000000000A"
+               BuildableName = "OmnigentUITests.xctest"
+               BlueprintName = "OmnigentUITests"
+               ReferencedContainer = "container:Omnigent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A00000000000000000000006"
+            BuildableName = "Omnigent.app"
+            BlueprintName = "Omnigent"
+            ReferencedContainer = "container:Omnigent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/web/ios/Omnigent/AppRootView.swift
+++ b/web/ios/Omnigent/AppRootView.swift
@@ -37,6 +37,7 @@ struct AppRootView: View {
       }
     }
     .task {
+      guard shouldAutoOpenSavedServer else { return }
       if case .setup(nil, nil) = mode,
         let saved = settings.serverURL,
         let url = URL(string: saved)
@@ -49,5 +50,15 @@ struct AppRootView: View {
   private enum Mode: Equatable {
     case setup(prefill: String?, error: String?)
     case web(URL)
+  }
+
+  private var shouldAutoOpenSavedServer: Bool {
+    #if DEBUG
+      let processInfo = ProcessInfo.processInfo
+      return processInfo.environment["OMNIGENT_SCREENSHOT_APP_URL"] == nil
+        && !processInfo.arguments.contains("-FASTLANE_SNAPSHOT")
+    #else
+      true
+    #endif
   }
 }

--- a/web/ios/Omnigent/ConnectView.swift
+++ b/web/ios/Omnigent/ConnectView.swift
@@ -46,6 +46,7 @@ struct ConnectView: View {
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
             .keyboardType(.URL)
+            .accessibilityIdentifier("server-url-field")
             .font(.system(size: 14))
             .padding(.horizontal, 12)
             .frame(height: 38)
@@ -70,6 +71,7 @@ struct ConnectView: View {
           }
         }
         .buttonStyle(PrimaryButtonStyle(background: primary, foreground: primaryForeground))
+        .accessibilityIdentifier("connect-button")
         .padding(.top, 16)
         .disabled(isConnecting)
         // Fires the moment connect() flips isConnecting, so the tap is

--- a/web/ios/Omnigent/Info-Debug.plist
+++ b/web/ios/Omnigent/Info-Debug.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Omnigent</string>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -38,13 +38,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/web/ios/Omnigent/Info-Release.plist
+++ b/web/ios/Omnigent/Info-Release.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Omnigent</string>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -33,13 +33,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/web/ios/Omnigent/NativeNotificationManager.swift
+++ b/web/ios/Omnigent/NativeNotificationManager.swift
@@ -22,7 +22,7 @@ final class NativeNotificationManager: NSObject, UNUserNotificationCenterDelegat
 
   func setBadgeCount(_ count: Int) {
     Task {
-      await requestAuthorizationIfNeeded()
+      _ = await requestAuthorizationIfNeeded()
       do {
         try await center.setBadgeCount(max(0, count))
       } catch {
@@ -81,6 +81,10 @@ final class NativeNotificationManager: NSObject, UNUserNotificationCenterDelegat
   }
 
   private func requestAuthorizationIfNeeded() async -> Bool {
+    #if DEBUG
+      guard !ProcessInfo.processInfo.isOmnigentScreenshotRun else { return false }
+    #endif
+
     let settings = await center.notificationSettings()
     switch settings.authorizationStatus {
     case .authorized, .provisional, .ephemeral:
@@ -98,3 +102,12 @@ final class NativeNotificationManager: NSObject, UNUserNotificationCenterDelegat
     }
   }
 }
+
+#if DEBUG
+  extension ProcessInfo {
+    fileprivate var isOmnigentScreenshotRun: Bool {
+      environment["OMNIGENT_SCREENSHOT_APP_URL"] != nil
+        || arguments.contains("-FASTLANE_SNAPSHOT")
+    }
+  }
+#endif

--- a/web/ios/Omnigent/PrivacyInfo.xcprivacy
+++ b/web/ios/Omnigent/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/web/ios/Omnigent/SettingsStore.swift
+++ b/web/ios/Omnigent/SettingsStore.swift
@@ -15,7 +15,14 @@ final class SettingsStore: ObservableObject {
 
   init(defaults: UserDefaults = .standard) {
     self.defaults = defaults
-    serverURL = defaults.string(forKey: Keys.serverURL)
+    #if DEBUG
+      serverURL =
+        ProcessInfo.processInfo.omnigentArgumentValue(after: "--omnigent-server-url")
+        ?? ProcessInfo.processInfo.environment["OMNIGENT_SCREENSHOT_APP_URL"]
+        ?? defaults.string(forKey: Keys.serverURL)
+    #else
+      serverURL = defaults.string(forKey: Keys.serverURL)
+    #endif
     recentServers = defaults.stringArray(forKey: Keys.recentServers) ?? []
   }
 
@@ -50,3 +57,16 @@ final class SettingsStore: ObservableObject {
     static let allowedProtocols = "omnigent.allowedProtocols"
   }
 }
+
+#if DEBUG
+  extension ProcessInfo {
+    fileprivate func omnigentArgumentValue(after argumentName: String) -> String? {
+      guard let index = arguments.firstIndex(of: argumentName) else { return nil }
+      let valueIndex = arguments.index(after: index)
+      guard arguments.indices.contains(valueIndex) else { return nil }
+
+      let value = arguments[valueIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+      return value.isEmpty ? nil : value
+    }
+  }
+#endif

--- a/web/ios/OmnigentUITests/OmnigentUITests.swift
+++ b/web/ios/OmnigentUITests/OmnigentUITests.swift
@@ -1,0 +1,151 @@
+import XCTest
+
+@MainActor
+final class OmnigentUITests: XCTestCase {
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  func testLocalServerSnapshot() throws {
+    let app = XCUIApplication(bundleIdentifier: "ai.omnigent.ios")
+    setupSnapshot(app)
+    let serverURL = try XCTUnwrap(
+      ScreenshotConfiguration.serverURL(from: app),
+      "Pass --omnigent-server-url or OMNIGENT_SCREENSHOT_APP_URL for screenshot tests."
+    )
+    app.launchArguments += [
+      "--omnigent-server-url",
+      serverURL,
+    ]
+    NSLog("Omnigent screenshot server URL: \(serverURL)")
+    app.launchEnvironment["OMNIGENT_SCREENSHOT_APP_URL"] = serverURL
+    app.launch()
+
+    XCTAssertTrue(
+      app.staticTexts["Server URL"].waitForExistence(timeout: 15),
+      "Expected Omnigent to show the server selection screen before connecting."
+    )
+    snapshot("01-home", timeWaitingForIdle: 2)
+
+    connectFromSetupIfNeeded(app, serverURL: serverURL)
+    XCTAssertTrue(
+      app.webViews.firstMatch.waitForExistence(timeout: 90),
+      "Expected Omnigent to connect to \(serverURL) before taking screenshots."
+    )
+
+    snapshot("02-connected", timeWaitingForIdle: 5)
+  }
+
+  private func connectFromSetupIfNeeded(_ app: XCUIApplication, serverURL: String) {
+    let setupLabel = app.staticTexts["Server URL"]
+    guard setupLabel.waitForExistence(timeout: 5) else { return }
+
+    let textField = app.textFields["server-url-field"]
+    if textField.waitForExistence(timeout: 2),
+      (textField.value as? String)?.contains(serverURL) != true
+    {
+      textField.tap()
+      textField.press(forDuration: 0.8)
+      if app.menuItems["Select All"].waitForExistence(timeout: 1) {
+        app.menuItems["Select All"].tap()
+      }
+      textField.typeText(serverURL)
+    }
+
+    let connectButton = app.buttons["connect-button"]
+    guard connectButton.waitForExistence(timeout: 2), connectButton.isEnabled else { return }
+    connectButton.tap()
+
+    let setupDismissed = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: setupLabel
+    )
+    _ = XCTWaiter.wait(for: [setupDismissed], timeout: 20)
+  }
+}
+
+private enum ScreenshotConfiguration {
+  static func serverURL(from app: XCUIApplication) -> String? {
+    ProcessInfo.processInfo.environment["OMNIGENT_SCREENSHOT_APP_URL"]?.nonEmpty
+      ?? app.launchArguments.omnigentServerURL
+      ?? fastlaneLaunchArguments().omnigentServerURL
+  }
+
+  private static func fastlaneLaunchArguments() -> [String] {
+    guard let cacheDirectory else { return [] }
+
+    let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+    guard let contents = try? String(contentsOf: path, encoding: .utf8) else {
+      return []
+    }
+    return contents.omnigentShellTokens
+  }
+
+  private static var cacheDirectory: URL? {
+    let cachePath = "Library/Caches/tools.fastlane"
+    #if os(OSX)
+      return URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(cachePath)
+    #elseif arch(i386) || arch(x86_64) || arch(arm64)
+      guard let simulatorHostHome = ProcessInfo.processInfo.environment["SIMULATOR_HOST_HOME"]
+      else {
+        return nil
+      }
+      return URL(fileURLWithPath: simulatorHostHome).appendingPathComponent(cachePath)
+    #else
+      return nil
+    #endif
+  }
+}
+
+extension [String] {
+  fileprivate var omnigentServerURL: String? {
+    omnigentArgumentValue(after: "--omnigent-server-url")
+      ?? compactMap { argument -> String? in
+        guard argument.hasPrefix("--omnigent-server-url=") else { return nil }
+        return String(argument.dropFirst("--omnigent-server-url=".count)).nonEmpty
+      }.first
+      ?? firstWebURL
+  }
+
+  fileprivate var firstWebURL: String? {
+    first { argument in
+      argument.hasPrefix("http://") || argument.hasPrefix("https://")
+    }
+  }
+
+  fileprivate func omnigentArgumentValue(after argumentName: String) -> String? {
+    guard let index = firstIndex(of: argumentName) else { return nil }
+    let valueIndex = self.index(after: index)
+    guard indices.contains(valueIndex) else { return nil }
+
+    let value = self[valueIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
+  }
+}
+
+extension String {
+  fileprivate var nonEmpty: String? {
+    let value = trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
+  }
+
+  fileprivate var omnigentShellTokens: [String] {
+    guard
+      let regex = try? NSRegularExpression(pattern: "(\\\".+?\\\"|'[^']+?'|\\S+)", options: [])
+    else {
+      return split(whereSeparator: \.isWhitespace).map(String.init)
+    }
+
+    let range = NSRange(location: 0, length: (self as NSString).length)
+    return regex.matches(in: self, options: [], range: range).map { match in
+      let token = (self as NSString).substring(with: match.range)
+      if token.count >= 2,
+        (token.hasPrefix("\"") && token.hasSuffix("\""))
+          || (token.hasPrefix("'") && token.hasSuffix("'"))
+      {
+        return String(token.dropFirst().dropLast())
+      }
+      return token
+    }
+  }
+}

--- a/web/ios/OmnigentUITests/SnapshotHelper.swift
+++ b/web/ios/OmnigentUITests/SnapshotHelper.swift
@@ -1,0 +1,326 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//
+
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
+import Foundation
+import XCTest
+
+@MainActor
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+  Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+@MainActor
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+  if waitForLoadingIndicator {
+    Snapshot.snapshot(name)
+  } else {
+    Snapshot.snapshot(name, timeWaitingForIdle: 0)
+  }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+@MainActor
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+  Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+  case cannotFindSimulatorHomeDirectory
+  case cannotRunOnPhysicalDevice
+
+  var debugDescription: String {
+    switch self {
+    case .cannotFindSimulatorHomeDirectory:
+      return
+        "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+    case .cannotRunOnPhysicalDevice:
+      return "Can't use Snapshot on a physical device."
+    }
+  }
+}
+
+@objcMembers
+@MainActor
+open class Snapshot: NSObject {
+  static var app: XCUIApplication?
+  static var waitForAnimations = true
+  static var cacheDirectory: URL?
+  static var screenshotsDirectory: URL? {
+    return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+  }
+  static var deviceLanguage = ""
+  static var currentLocale = ""
+
+  open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+
+    Snapshot.app = app
+    Snapshot.waitForAnimations = waitForAnimations
+
+    do {
+      let cacheDir = try getCacheDirectory()
+      Snapshot.cacheDirectory = cacheDir
+      setLanguage(app)
+      setLocale(app)
+      setLaunchArguments(app)
+    } catch let error {
+      NSLog(error.localizedDescription)
+    }
+  }
+
+  class func setLanguage(_ app: XCUIApplication) {
+    guard let cacheDirectory = self.cacheDirectory else {
+      NSLog("CacheDirectory is not set - probably running on a physical device?")
+      return
+    }
+
+    let path = cacheDirectory.appendingPathComponent("language.txt")
+
+    do {
+      let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+      deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(
+        in: trimCharacterSet)
+      app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+    } catch {
+      NSLog("Couldn't detect/set language...")
+    }
+  }
+
+  class func setLocale(_ app: XCUIApplication) {
+    guard let cacheDirectory = self.cacheDirectory else {
+      NSLog("CacheDirectory is not set - probably running on a physical device?")
+      return
+    }
+
+    let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+    do {
+      let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+      currentLocale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(
+        in: trimCharacterSet)
+    } catch {
+      NSLog("Couldn't detect/set locale...")
+    }
+
+    if currentLocale.isEmpty && !deviceLanguage.isEmpty {
+      currentLocale = Locale(identifier: deviceLanguage).identifier
+    }
+
+    if !currentLocale.isEmpty {
+      app.launchArguments += ["-AppleLocale", "\"\(currentLocale)\""]
+    }
+  }
+
+  class func setLaunchArguments(_ app: XCUIApplication) {
+    guard let cacheDirectory = self.cacheDirectory else {
+      NSLog("CacheDirectory is not set - probably running on a physical device?")
+      return
+    }
+
+    let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+    app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+    do {
+      let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+      let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+      let matches = regex.matches(
+        in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count)
+      )
+      let results = matches.map { result -> String in
+        (launchArguments as NSString).substring(with: result.range)
+      }
+      app.launchArguments += results
+    } catch {
+      NSLog("Couldn't detect/set launch_arguments...")
+    }
+  }
+
+  open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    if timeout > 0 {
+      waitForLoadingIndicatorToDisappear(within: timeout)
+    }
+
+    // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+    NSLog("snapshot: \(name)")
+
+    if Snapshot.waitForAnimations {
+      sleep(1)  // Waiting for the animation to be finished (kind of)
+    }
+
+    #if os(OSX)
+      guard let app = self.app else {
+        NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        return
+      }
+
+      app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+    #else
+
+      guard self.app != nil else {
+        NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        return
+      }
+
+      let screenshot = XCUIScreen.main.screenshot()
+      #if os(iOS) && !targetEnvironment(macCatalyst)
+        let image =
+          XCUIDevice.shared.orientation.isLandscape
+          ? fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+      #else
+        let image = screenshot.image
+      #endif
+
+      guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"],
+        let screenshotsDir = screenshotsDirectory
+      else { return }
+
+      do {
+        // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
+        let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+        let range = NSRange(location: 0, length: simulator.count)
+        simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+        let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+        #if swift(<5.0)
+          try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+        #else
+          try image.pngData()?.write(to: path, options: .atomic)
+        #endif
+      } catch let error {
+        NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+        NSLog(error.localizedDescription)
+      }
+    #endif
+  }
+
+  class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+    #if os(watchOS)
+      return image
+    #else
+      if #available(iOS 10.0, *) {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = image.scale
+        let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+        return renderer.image { context in
+          image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+        }
+      } else {
+        return image
+      }
+    #endif
+  }
+
+  class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+    #if os(tvOS)
+      return
+    #endif
+
+    guard let app = self.app else {
+      NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+      return
+    }
+
+    let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators
+      .element
+    let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+    _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+  }
+
+  class func getCacheDirectory() throws -> URL {
+    let cachePath = "Library/Caches/tools.fastlane"
+    // on OSX config is stored in /Users/<username>/Library
+    // and on iOS/tvOS/WatchOS it's in simulator's home dir
+    #if os(OSX)
+      let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+      return homeDir.appendingPathComponent(cachePath)
+    #elseif arch(i386) || arch(x86_64) || arch(arm64)
+      guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+        throw SnapshotError.cannotFindSimulatorHomeDirectory
+      }
+      let homeDir = URL(fileURLWithPath: simulatorHostHome)
+      return homeDir.appendingPathComponent(cachePath)
+    #else
+      throw SnapshotError.cannotRunOnPhysicalDevice
+    #endif
+  }
+}
+
+extension XCUIElementAttributes {
+  fileprivate var isNetworkLoadingIndicator: Bool {
+    if hasAllowListedIdentifier { return false }
+
+    let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+    let hasNewLoadingIndicatorSize =
+      frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+    return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+  }
+
+  fileprivate var hasAllowListedIdentifier: Bool {
+    let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+    return allowListedIdentifiers.contains(identifier)
+  }
+
+  fileprivate func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+    if elementType == .statusBar { return true }
+    guard frame.origin == .zero else { return false }
+
+    let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+    let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+    return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+  }
+}
+
+extension XCUIElementQuery {
+  fileprivate var networkLoadingIndicators: XCUIElementQuery {
+    let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+      guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+      return element.isNetworkLoadingIndicator
+    }
+
+    return self.containing(isNetworkLoadingIndicator)
+  }
+
+  @MainActor
+  fileprivate var deviceStatusBars: XCUIElementQuery {
+    guard let app = Snapshot.app else {
+      fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+    }
+
+    let deviceWidth = app.windows.firstMatch.frame.width
+
+    let isStatusBar = NSPredicate { (evaluatedObject, _) in
+      guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+      return element.isStatusBar(deviceWidth)
+    }
+
+    return self.containing(isStatusBar)
+  }
+}
+
+extension CGFloat {
+  fileprivate func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+    return numberA...numberB ~= self
+  }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.30]

--- a/web/ios/RELEASE.md
+++ b/web/ios/RELEASE.md
@@ -25,7 +25,9 @@ follow-up).
    cp fastlane/.env.example fastlane/.env
    # edit fastlane/.env: set ASC_KEY_ID, ASC_ISSUER_ID, ASC_KEY_PATH
    ```
-   `.env` is git-ignored and is loaded automatically by fastlane.
+   `.env` is git-ignored and is loaded automatically by fastlane. The lanes
+   also accept `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, and `APPLE_API_KEY`
+   (`.p8` file path) for compatibility with local shell exports.
 
 ## Cutting a TestFlight build
 
@@ -50,18 +52,29 @@ Apple finishes processing.
   manually. Bump `MARKETING_VERSION` for both the Debug and Release
   configurations of the **Omnigent** target in Xcode (or via `fastlane
 increment_version_number`) when shipping a new user-facing version.
+- **App icon** is the shared Icon Composer source at
+  `platform-assets/AppIcon.icon`, which the iOS target includes directly for
+  Liquid Glass app icon rendering.
 
 ## App Store submission (later)
 
 ```sh
-bundle exec fastlane release
+bundle exec fastlane prod
 ```
 
-Uploads the binary without submitting for review. App Store metadata and
-screenshots are not yet wired up — add them under `fastlane/metadata` and enable
-submission in the `release` lane when ready.
+Prepares the App Store version without submitting for review. The lane reuses
+the latest uploaded TestFlight build and uploads `fastlane/metadata` plus
+`fastlane/screenshots`. Set
+`OMNIGENT_PROD_BUILD_NUMBER=4` to pin a specific processed build.
 
 ## Other commands
 
 - `bundle exec fastlane tests` — run the `OmnigentTests` unit suite.
+- `bundle exec fastlane screenshots` — build and capture App Store screenshots
+  into `fastlane/screenshots` using the `OmnigentUITests` snapshot target. The
+  lane rebuilds the web UI, starts an isolated local Omnigent server via `uv` on
+  a non-6767 port, and connects the simulator to that server automatically.
+- `bundle exec fastlane release` — upload a new binary to App Store Connect
+  without submitting it for review. Prefer `prod` after a TestFlight build is
+  already uploaded.
 - `bundle exec fastlane lanes` — list available lanes.

--- a/web/ios/fastlane/Fastfile
+++ b/web/ios/fastlane/Fastfile
@@ -1,32 +1,294 @@
+require "fileutils"
+require "net/http"
+require "socket"
+require "tmpdir"
+require "shellwords"
+
+def omnigent_available_port
+  loop do
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    server.close
+    return port unless port == 6767
+  end
+end
+
+def omnigent_start_process(label, env, command, chdir:, log_path:)
+  FileUtils.mkdir_p(File.dirname(log_path))
+  UI.message("Starting #{label} on a dedicated screenshot port")
+  pid = Process.spawn(
+    env,
+    *command,
+    chdir: chdir,
+    out: [log_path, "w"],
+    err: [:child, :out],
+    pgroup: true
+  )
+  Process.detach(pid)
+  pid
+end
+
+def omnigent_run_command(label, command, chdir:)
+  UI.message(label)
+  UI.command(command.join(" "))
+  success = system(*command, chdir: chdir)
+  UI.user_error!("#{label} failed") unless success
+end
+
+def omnigent_fetch_env(*names)
+  names.each do |name|
+    value = ENV[name]
+    return value unless value.to_s.strip.empty?
+  end
+
+  UI.user_error!("Set one of: #{names.join(", ")}")
+end
+
+def omnigent_stop_process(pid)
+  return if pid.nil?
+
+  Process.kill("TERM", -pid)
+  deadline = Time.now + 10
+  while Time.now < deadline
+    begin
+      Process.kill(0, pid)
+    rescue Errno::ESRCH
+      return
+    end
+    sleep 0.2
+  end
+  Process.kill("KILL", -pid)
+rescue Errno::ESRCH
+  nil
+end
+
+def omnigent_wait_for_http(url, timeout_seconds:, log_path:)
+  uri = URI(url)
+  deadline = Time.now + timeout_seconds
+  last_error = nil
+
+  while Time.now < deadline
+    begin
+      response = Net::HTTP.start(uri.host, uri.port, open_timeout: 2, read_timeout: 2) do |http|
+        http.get(uri.request_uri)
+      end
+      return if response.code.to_i < 500
+    rescue StandardError => e
+      last_error = e
+    end
+    sleep 1
+  end
+
+  if File.exist?(log_path)
+    UI.error("Last server log lines:\n#{File.readlines(log_path).last(80).join}")
+  end
+  UI.user_error!("Timed out waiting for #{url}: #{last_error}")
+end
+
 default_platform(:ios)
 
 # Builds are signed with the team's distribution cert via Xcode automatic
 # signing (-allowProvisioningUpdates). Upload + provisioning use an App Store
 # Connect API key supplied through env vars — see fastlane/.env.example.
 
+# Two distributions ship from the same target and sources. Each is a distinct
+# app record (distinct bundle ID) with its own TestFlight build counter, so both
+# can be installed side by side. The bundle ID and display name are injected as
+# xcodebuild setting overrides at archive time — nothing in the repo changes.
+#   - public:   the App Store app.
+#   - internal: a private (custom/unlisted App Store) build for Databricks.
+FLAVORS = {
+  public: {
+    bundle_id: "ai.omnigent.ios",
+    display_name: "Omnigent",
+  },
+  internal: {
+    bundle_id: "ai.omnigent.ios.internal",
+    display_name: "Omnigent (Databricks)",
+  },
+}.freeze
+
 platform :ios do
   desc "Run the OmnigentTests unit tests"
   lane :tests do
-    run_tests(scheme: "Omnigent")
+    run_tests(
+      scheme: "Omnigent",
+      configuration: "Debug",
+      destination: "platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.5",
+      skip_detect_devices: true,
+      skip_testing: ["OmnigentUITests"]
+    )
   end
 
-  desc "Build a signed Release .ipa and upload it to TestFlight"
+  desc "Generate App Store screenshots with fastlane snapshot"
+  lane :screenshots do
+    repo_root = File.expand_path("../../..", __dir__)
+    web_dir = File.join(repo_root, "web")
+    static_index = File.join(repo_root, "omnigent/server/static/web-ui/index.html")
+    unless File.executable?(File.join(web_dir, "node_modules/.bin/tsc"))
+      omnigent_run_command(
+        "Installing web UI dependencies",
+        ["npm", "--prefix", web_dir, "install", "--package-lock=false", "--no-audit", "--no-fund"],
+        chdir: repo_root
+      )
+    end
+    omnigent_run_command(
+      "Building current web UI for screenshots",
+      ["npm", "--prefix", web_dir, "run", "build"],
+      chdir: repo_root
+    )
+    UI.user_error!("Web UI build did not produce #{static_index}") unless File.file?(static_index)
+
+    port = ENV.fetch("OMNIGENT_SCREENSHOT_SERVER_PORT", omnigent_available_port.to_s)
+    UI.user_error!("OMNIGENT_SCREENSHOT_SERVER_PORT must not be 6767") if port.to_s == "6767"
+
+    screenshot_root = File.join(Dir.tmpdir, "omnigent-ios-screenshots-#{port}")
+    data_dir = File.join(screenshot_root, "data")
+    home_dir = File.join(screenshot_root, "home")
+    log_dir = File.join(screenshot_root, "logs")
+    server_log = File.join(log_dir, "omnigent-server.log")
+    server_url = "http://127.0.0.1:#{port}"
+    agent_path = File.join(repo_root, "examples/kimi_hello.yaml")
+    snapshot_cache = File.expand_path("~/Library/Caches/tools.fastlane/screenshots")
+
+    FileUtils.mkdir_p([data_dir, home_dir, log_dir])
+    command = [
+      "uv",
+      "run",
+      "--frozen",
+      "--no-sync",
+      "--project",
+      repo_root,
+      "omnigent",
+      "server",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      port.to_s,
+      "--database-uri",
+      "sqlite:///#{File.join(data_dir, "chat.db")}",
+      "--artifact-location",
+      File.join(data_dir, "artifacts"),
+      "--no-open",
+    ]
+    command += ["--agent", agent_path] if File.file?(agent_path)
+
+    server_pid = nil
+    begin
+      server_pid = omnigent_start_process(
+        "Omnigent server",
+        {
+          "HOME" => home_dir,
+          "OMNIGENT_DATA_DIR" => data_dir,
+          "OMNIGENT_NO_UPDATE_CHECK" => "1",
+        },
+        command,
+        chdir: repo_root,
+        log_path: server_log
+      )
+      omnigent_wait_for_http("#{server_url}/", timeout_seconds: 60, log_path: server_log)
+      FileUtils.rm_rf(snapshot_cache)
+      ENV["OMNIGENT_SCREENSHOT_APP_URL"] = server_url
+      capture_ios_screenshots(
+        only_testing: ["OmnigentUITests/OmnigentUITests/testLocalServerSnapshot"],
+        launch_arguments: ["--omnigent-server-url #{server_url}"],
+        test_target_name: "Omnigent",
+        result_bundle: true,
+        number_of_retries: 0,
+        stop_after_first_error: true,
+        xcodebuild_formatter: ""
+      )
+    ensure
+      omnigent_stop_process(server_pid)
+    end
+  end
+
+  desc "Build the public app and upload it to TestFlight"
   lane :beta do
-    load_asc_api_key
-    build(build_number: next_build_number)
-    upload_to_testflight(skip_waiting_for_build_processing: true)
+    beta_flavor(flavor: :public)
   end
 
-  desc "Build a signed Release .ipa and upload it to App Store Connect (no submission)"
+  desc "Build the internal (Databricks) app and upload it to TestFlight"
+  lane :beta_internal do
+    beta_flavor(flavor: :internal)
+  end
+
+  desc "Build the public app and upload it to App Store Connect (no submission)"
   lane :release do
+    release_flavor(flavor: :public)
+  end
+
+  desc "Build the internal (Databricks) app and upload it to App Store Connect (no submission)"
+  lane :release_internal do
+    release_flavor(flavor: :internal)
+  end
+
+  desc "Prepare the public App Store version using an already-uploaded build"
+  lane :prod do
+    prod_flavor(flavor: :public)
+  end
+
+  desc "Prepare the internal (Databricks) App Store version using an already-uploaded build"
+  lane :prod_internal do
+    prod_flavor(flavor: :internal)
+  end
+
+  # --- helpers ---
+
+  desc "Upload screenshots + metadata for a flavor against an already-uploaded build"
+  private_lane :prod_flavor do |options|
+    flavor = FLAVORS.fetch(options[:flavor])
+    load_asc_api_key
+    bundle_id = flavor[:bundle_id]
+    build_number = ENV["OMNIGENT_PROD_BUILD_NUMBER"] ||
+      latest_testflight_build_number(app_identifier: bundle_id, initial_build_number: 0).to_s
+    screenshots_path = File.join(Dir.tmpdir, "omnigent-ios-app-store-screenshots")
+    screenshots_locale_path = File.join(screenshots_path, "en-US")
+    screenshot_files = Dir[File.join(__dir__, "screenshots/en-US", "*.png")]
+    UI.user_error!("Generate screenshots first: bundle exec fastlane screenshots") if screenshot_files.empty?
+
+    FileUtils.rm_rf(screenshots_path)
+    FileUtils.mkdir_p(screenshots_locale_path)
+    FileUtils.cp(screenshot_files, screenshots_locale_path)
+
+    upload_to_app_store(
+      app_identifier: bundle_id,
+      app_version: ENV.fetch("OMNIGENT_PROD_APP_VERSION", "0.1.0"),
+      build_number: build_number,
+      skip_binary_upload: true,
+      skip_metadata: false,
+      screenshots_path: screenshots_path,
+      overwrite_screenshots: true,
+      submit_for_review: false,
+      automatic_release: false,
+      force: true,
+      precheck_include_in_app_purchases: false
+    )
+  end
+
+  desc "Archive a flavor and upload it to TestFlight"
+  private_lane :beta_flavor do |options|
+    flavor = FLAVORS.fetch(options[:flavor])
+    load_asc_api_key
+    build(flavor: flavor, build_number: next_build_number(bundle_id: flavor[:bundle_id]))
+    upload_to_testflight(
+      app_identifier: flavor[:bundle_id],
+      skip_waiting_for_build_processing: true
+    )
+  end
+
+  desc "Archive a flavor and upload it to App Store Connect (no submission)"
+  private_lane :release_flavor do |options|
     # NB: this uploads a fresh, uniquely-numbered binary. The more common App
     # Store flow is to *promote* an already-tested TestFlight build instead of
     # uploading a new one — if you adopt that, replace the build/upload below
     # with a submission of the chosen TestFlight build. App Store metadata and
     # screenshots are still a follow-up; this lane uploads but does not submit.
+    flavor = FLAVORS.fetch(options[:flavor])
     load_asc_api_key
-    build(build_number: next_build_number)
+    build(flavor: flavor, build_number: next_build_number(bundle_id: flavor[:bundle_id]))
     upload_to_app_store(
+      app_identifier: flavor[:bundle_id],
       submit_for_review: false,
       skip_metadata: true,
       skip_screenshots: true,
@@ -34,16 +296,21 @@ platform :ios do
     )
   end
 
-  # --- helpers ---
-
-  desc "Archive the Release configuration into ./build"
+  desc "Archive the Release configuration into ./build for the given flavor"
   private_lane :build do |options|
     # Inject the build number as an xcodebuild setting override rather than
     # mutating tracked files. CFBundleVersion is $(CURRENT_PROJECT_VERSION) in
     # the Info.plists, so overriding CURRENT_PROJECT_VERSION here flows into the
     # archived binary — and nothing in the repo changes (no agvtool, no churn).
+    # The bundle ID and display name are overridden the same way, so each flavor
+    # comes out of the one target without a second Xcode configuration.
+    flavor = options[:flavor]
     xcargs = ["-allowProvisioningUpdates"]
     xcargs << "CURRENT_PROJECT_VERSION=#{options[:build_number]}" if options[:build_number]
+    if flavor
+      xcargs << "PRODUCT_BUNDLE_IDENTIFIER=#{flavor[:bundle_id].shellescape}"
+      xcargs << "APP_DISPLAY_NAME=#{flavor[:display_name].shellescape}"
+    end
     build_app(
       scheme: "Omnigent",
       configuration: "Release",
@@ -55,19 +322,26 @@ platform :ios do
   end
 
   desc "Next build number: one past the highest already on App Store Connect"
-  private_lane :next_build_number do
+  private_lane :next_build_number do |options|
     # TestFlight sees every build (App Store builds pass through it too), so the
     # latest TestFlight build number is a monotonic counter for the whole app.
-    # Requires the ASC API key to be loaded first.
-    latest_testflight_build_number(initial_build_number: 0) + 1
+    # Each flavor is a separate app record, so pass its bundle ID to count the
+    # right one. Requires the ASC API key to be loaded first.
+    latest_testflight_build_number(
+      app_identifier: options[:bundle_id],
+      initial_build_number: 0
+    ) + 1
   end
 
   desc "Load the App Store Connect API key from env vars into the session"
   private_lane :load_asc_api_key do
+    key_filepath = File.expand_path(omnigent_fetch_env("ASC_KEY_PATH", "APPLE_API_KEY"))
+    UI.user_error!("App Store Connect API key file not found: #{key_filepath}") unless File.file?(key_filepath)
+
     app_store_connect_api_key(
-      key_id: ENV.fetch("ASC_KEY_ID"),
-      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
-      key_filepath: ENV.fetch("ASC_KEY_PATH"),
+      key_id: omnigent_fetch_env("ASC_KEY_ID", "APPLE_API_KEY_ID"),
+      issuer_id: omnigent_fetch_env("ASC_ISSUER_ID", "APPLE_API_ISSUER"),
+      key_filepath: key_filepath,
       in_house: false
     )
   end

--- a/web/ios/fastlane/Snapfile
+++ b/web/ios/fastlane/Snapfile
@@ -1,0 +1,24 @@
+project("Omnigent.xcodeproj")
+scheme("Omnigent")
+test_target_name("Omnigent")
+only_testing(["OmnigentUITests/OmnigentUITests/testLocalServerSnapshot"])
+configuration("Debug")
+
+devices([
+  "iPhone 17 Pro Max"
+])
+
+languages([
+  "en-US"
+])
+
+output_directory("fastlane/screenshots")
+clear_previous_screenshots(true)
+reinstall_app(true)
+override_status_bar(true)
+skip_open_summary(true)
+concurrent_simulators(false)
+result_bundle(true)
+number_of_retries(0)
+stop_after_first_error(true)
+xcodebuild_formatter("")

--- a/web/ios/fastlane/metadata/copyright.txt
+++ b/web/ios/fastlane/metadata/copyright.txt
@@ -1,0 +1,1 @@
+Databricks Inc. 2026

--- a/web/ios/fastlane/metadata/en-US/description.txt
+++ b/web/ios/fastlane/metadata/en-US/description.txt
@@ -1,0 +1,12 @@
+Omnigent is the mobile companion for your Omnigent server: an open-source workspace for supervising AI agents across coding, research, automation, and other technical workflows.
+
+Connect to a server you run, sign in, and continue the same sessions you use from desktop or browser. Follow agent work from your phone, send messages, review outputs, and switch between sessions without losing context.
+
+Use Omnigent to:
+
+- Keep agent chats, sub-agents, terminals, and files in sync across devices
+- Supervise multiple agents from one interface
+- Work with custom YAML agents and shared team sessions
+- Reach self-hosted or cloud-hosted Omnigent deployments
+
+This app is a native iOS shell for the Omnigent web UI. You need access to an Omnigent server to use it. For local or private deployments, configure your server URL on the first screen and connect securely.

--- a/web/ios/fastlane/metadata/en-US/keywords.txt
+++ b/web/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,0 +1,1 @@
+AI,agents,coding,automation,terminal,workflow,collaboration,developer,orchestration,sandbox

--- a/web/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/web/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,0 +1,1 @@
+Connect your iPhone to Omnigent and keep agent sessions, chats, files, and terminals within reach wherever your server is running.

--- a/web/ios/fastlane/metadata/en-US/support_url.txt
+++ b/web/ios/fastlane/metadata/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/omnigent-ai/omnigent/issues/new/choose


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a fastlane `snapshot`-based App Store screenshot pipeline: a new `screenshots` lane rebuilds the web UI, boots an isolated local Omnigent server on a non-6767 port (own HOME/data/logs dirs), and drives the `OmnigentUITests/testLocalServerSnapshot` UI test to capture en-US screenshots into `fastlane/screenshots`.
- Add DEBUG-only launch hooks so the snapshot run is deterministic: the app reads its server URL from `--omnigent-server-url` / `OMNIGENT_SCREENSHOT_APP_URL`, skips auto-opening the saved server, and suppresses the notification authorization prompt during snapshots.
- Rename the `release` lane to `prod` — prepares the App Store version from an already-uploaded TestFlight build, reusing metadata + screenshots.
- Add `PrivacyInfo.xcprivacy` privacy manifest, App Store metadata files (copyright, support URL), accessibility identifiers on the connect form, and a shared `SnapshotHelper.swift`.
- Drop the iPad-specific `UISupportedInterfaceOrientations~ipad` keys from the Debug/Release Info.plists.

## Test Plan

- `bundle exec fastlane screenshots` — builds the web UI, starts the isolated local server, runs the snapshot UI test, and writes screenshots to `fastlane/screenshots/en-US`.
- `bundle exec fastlane tests` — `OmnigentTests` unit suite still passes with UI tests skipped.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added the `testLocalServerSnapshot` UI test that drives the connect flow against a local server and captures screenshots. Verified manually by running `bundle exec fastlane screenshots` end-to-end and confirming the en-US screenshots are produced. The DEBUG-only launch hooks are exercised by that test path and gated out of Release builds.
