### PR TITLE
feat(server): allow overriding the web UI dir via OMNIGENT_WEB_UI_DIST

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -124,7 +124,13 @@ def _register_web_mimetypes() -> None:
 
 _register_web_mimetypes()
 
-_WEB_UI_DIST = Path(__file__).parent / "static" / "web-ui"
+# Default: the SPA bundled into the installed wheel's package data. A deploy
+# that ships the SPA outside the wheel (e.g. as loose files in the app source
+# tree, to keep the wheel under a per-file size cap) can point here instead via
+# OMNIGENT_WEB_UI_DIST, without rebuilding or repackaging.
+_WEB_UI_DIST = Path(
+    os.environ.get("OMNIGENT_WEB_UI_DIST") or (Path(__file__).parent / "static" / "web-ui")
+)
 _WEB_UI_HTML_CACHE_CONTROL = "no-cache"
 _WEB_UI_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
 _WEB_UI_STATIC_CACHE_CONTROL = "public, max-age=3600"


### PR DESCRIPTION
## Motivation

The Databricks App deploy bakes the built `web/` SPA into the `omnigent` wheel via `[tool.setuptools.package-data]`. That wheel has crept to ~10.06 MB — just over the **Databricks Apps 10 MB per-file limit** — so the deploy fails. The durable fix (in the deploy scripts) is to ship the SPA as loose files in the app source tree instead of inside the wheel, which keeps the wheel small.

For the server to find the SPA when it lives outside the installed package, it needs to resolve `_WEB_UI_DIST` from a configurable location.

## Change

One line: `_WEB_UI_DIST` now honors an optional `OMNIGENT_WEB_UI_DIST` env var, falling back to the existing `<package>/static/web-ui` path when unset.

```python
_WEB_UI_DIST = Path(
    os.environ.get("OMNIGENT_WEB_UI_DIST") or (Path(__file__).parent / "static" / "web-ui")
)
```

## Backwards compatibility

Fully backwards-compatible — this is purely additive:

- **Env var unset (all existing users: `pip install omnigent`, `omnigent serve`, the published wheel, dev checkouts):** `os.environ.get(...)` returns `None`, so `None or <default>` evaluates to the **exact same path as before**. Byte-identical behavior.
- **The `static/web-ui` `package-data` glob is unchanged**, so the published PyPI wheel still bundles the UI and the release "web-UI-in-wheel" gate still passes.
- The only other reader, `cli.py`'s `omnigent serve` "web UI not built" warning, reads the same constant and transparently inherits the override.
- No new dependency; `os` is already imported.

## Test Plan

Validated end-to-end by deploying a Databricks App that sets `OMNIGENT_WEB_UI_DIST` to a loose `web-ui/` dir shipped alongside the app source (wheel dropped 10.06 MB → 3.60 MB):
- App started successfully; in-container dependency install succeeded.
- `GET /` → HTTP 200, `text/html`, serves the SPA (`<title>Omnigent</title>` + Vite bundle) — not the JSON API fallback.
- `GET /assets/index-*.js` → HTTP 200, `text/javascript`, 3.13 MB (the real bundle, confirming the static mount, not the SPA history fallback).
- With the env var unset, `_WEB_UI_DIST` resolves to the identical pre-change path.

## Demo

N/A — server-side path resolution, no visual change (the UI it serves is unchanged).

## Type of change

- [x] Feature (additive, backwards-compatible)

## Test coverage

- [x] Manual verification completed

## Coverage notes

Verified via a real Databricks App deploy (see Test Plan). The change is a one-line env-var fallback whose unset path is identical to prior behavior.

This pull request and its description were written by Isaac.