### PR TITLE
update(web): prompt to set server as default for new terminal sessions

### DIFF
--- a/tests/e2e_ui/start_session/test_connect_host_login_hint.py
+++ b/tests/e2e_ui/start_session/test_connect_host_login_hint.py
@@ -1,0 +1,101 @@
+"""E2E: the "Connect a host" modal on the new-session landing page.
+
+Covers the optional ``omni login`` set-as-default hint that renders
+alongside the ``omni host`` command in the connect-host instructions.
+
+Uses the same route-stubbing approach as ``test_create_custom_agent.py``:
+``/v1/hosts`` and ``/v1/agents`` are faked so the landing renders without
+a real host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* in a dedicated thread with its own event loop."""
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+def _agents_body() -> str:
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_claude_e2e",
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Anthropic's coding agent",
+                    "harness": None,
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+async def _register_routes(page) -> None:
+    """Stub hosts (empty) and agents so the landing renders deterministically."""
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(
+            status=200, content_type="application/json", body=json.dumps({"hosts": []})
+        )
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+
+
+def test_connect_host_modal_shows_login_hint(seeded_session: tuple[str, str]) -> None:
+    """The connect-host modal offers the optional `omni login` command."""
+    base_url, _ = seeded_session
+    _run_in_fresh_loop(_drive_login_hint(base_url))
+
+
+async def _drive_login_hint(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open the host dropdown → "Connect a host".
+            await page.get_by_test_id("new-chat-landing-host-chip").click()
+            await page.get_by_test_id("new-chat-landing-connect-host").click()
+
+            # The modal shows the host command plus the optional login hint.
+            await expect(page.get_by_test_id("connect-host-dialog")).to_be_visible(timeout=5_000)
+            await expect(page.get_by_test_id("connect-host-command")).to_be_visible()
+            await expect(page.get_by_test_id("connect-host-login-hint")).to_be_visible()
+            await expect(page.get_by_test_id("connect-host-login-command")).to_contain_text(
+                "omni login"
+            )
+        finally:
+            await browser.close()

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -808,6 +808,15 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("connect-host-command")).toBeTruthy();
   });
 
+  it("offers the optional `omni login` set-as-default hint alongside the host command", () => {
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-connect-host"));
+    // The hint and its own copyable command sit below the `omni host` block.
+    expect(screen.getByTestId("connect-host-login-hint")).toBeTruthy();
+    expect(screen.getByTestId("connect-host-login-command").textContent).toContain("omni login");
+  });
+
   it("offers connect-host even when no hosts are online (no dead end)", () => {
     mockHosts([]);
     renderLanding();

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -344,6 +344,10 @@ export function ConnectHostInstructions({
       ) : (
         <CliCommandBlock command={`omni host --server ${serverUrl}`} testIdPrefix="connect-host" />
       )}
+      <p className="text-xs text-muted-foreground" data-testid="connect-host-login-hint">
+        Set this server as your default for new terminal sessions:
+      </p>
+      <CliCommandBlock command={`omni login ${serverUrl}`} testIdPrefix="connect-host-login" />
     </div>
   );
 }


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

N/A - Intention described in this PR

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->
When connecting host to remote server, we prompt for `omni host` connection. This does not persist the setting for new sessions from the host. To indicate this, added an additional section to suggest `omni login` to set the remote server as the default for new sessions

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

Unit test and e2e test added to ensure visible and copy function works, modelled on existing tests. Screenshots in demo section.

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

Prior to change, the prompt modal looks like this:
<img width="522" height="192" alt="Screenshot 2026-07-02 at 9 28 27 am" src="https://github.com/user-attachments/assets/5af80b93-f4ac-4b9a-8072-c9351a307660" />

After change we will additionally have this section:
<img width="515" height="276" alt="Screenshot 2026-07-02 at 9 29 34 am" src="https://github.com/user-attachments/assets/463f2c3e-75d9-4526-ace3-3acd2a8c143c" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
If this PR has a user-facing change worth announcing, write one or more lines
below in the user's voice, each prefixed with a category. Otherwise leave it
as `skip`.

Lower the bar than docs: DO include small features and UX changes (moved/renamed
buttons, new flags, copy tweaks). DO skip pure-internal churn (CI, refactors,
test-only changes, dependency bumps with no user impact).

Categories: Added | Changed | Fixed | Deprecated | Removed | Security
Format:     <Category>: <one-line description>   (the PR link is added for you)
Example:    Added: `omnigent run --watch` reruns an agent when files change

A `skip` here is fine for chores — but a Breaking change must always be announced.
-->

skip
