### PR TITLE
fix(codex-native): make the harness picker reflect codex startability

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ipaddress
 import json
 import logging
 import os
@@ -18,9 +19,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
+from urllib.parse import urlparse
 
 import click
 import httpx
+import tomllib
 import yaml
 
 from omnigent._native_resume_hint import echo_native_resume_hint
@@ -107,6 +110,15 @@ _UNBOUND_RUNNER_MESSAGE_FRAGMENT = "not bound to a runner"
 _CODEX_THREAD_ID_RE = re.compile(r"^[0-9a-fA-F-]+$")
 _CODEX_AUTH_UNAVAILABLE_BINARY_MISSING = "binary-missing"
 _CODEX_AUTH_UNAVAILABLE_NEEDS_AUTH = "needs-auth"
+# Reason returned when the provider the runner would actually route through has
+# a loopback ``base_url`` (a local proxy / model server, e.g. ucode's
+# ``127.0.0.1:PORT`` AI-gateway proxy) whose port is not listening. Distinct
+# from ``needs-auth`` (a credential exists; the endpoint just can't be reached).
+_CODEX_PROVIDER_UNREACHABLE = "provider-unreachable"
+# Loopback endpoints answer (or refuse) effectively instantly, so a short
+# timeout is enough to tell "listening" from "not listening" without the check
+# ever stalling the hello frame / launch gate.
+_CODEX_LOOPBACK_PROBE_TIMEOUT_SECONDS = 0.25
 
 
 @dataclass(frozen=True)
@@ -203,6 +215,169 @@ def _codex_auth_unavailable_reason() -> str | None:
     if not _codex_auth_json_has_available_credential(source.auth_path):
         return _CODEX_AUTH_UNAVAILABLE_NEEDS_AUTH
     return None
+
+
+# ``base_url=`` inside a generated provider ``-c`` override (key / gateway /
+# local providers bake the whole ``[model_providers.X]`` inline table into one
+# override string — see ``_provider_codex_config_overrides``). The value is a
+# TOML basic string, which is also valid JSON, so it is safe to ``json.loads``.
+_CODEX_OVERRIDE_BASE_URL_RE = re.compile(r'base_url\s*=\s*("(?:[^"\\]|\\.)*")')
+
+
+def _codex_provider_base_url(launch: Any, provider: str) -> str | None:
+    """Return the ``base_url`` the resolved codex launch routes through.
+
+    The base URL lives in one of two places depending on the provider kind:
+
+    * ``key`` / ``gateway`` / ``local`` providers bake a generated
+      ``model_providers.omnigent_provider={...base_url=...}`` inline table
+      straight into the launch's ``-c`` overrides, so it is read from there;
+    * a ``cli-config`` provider only pins ``model_provider="X"`` and leaves the
+      ``[model_providers.X]`` table (with its ``base_url``) in the user's
+      ``config.toml`` — the file :func:`_populate_codex_home_config` copies into
+      the session ``CODEX_HOME`` — so it is read from that source config.toml.
+
+    The built-in ``openai`` login and the Databricks-profile
+    ``omnigent_databricks`` provider have no locally-inspectable table (the
+    latter is generated at app-server start against a remote host), so they
+    resolve to ``None`` and are treated as "nothing local to check".
+
+    :param launch: A resolved :class:`NativeCodexLaunch`.
+    :param provider: The provider id the launch routes through, as returned by
+        :func:`codex_session_meta_model_provider`.
+    :returns: The resolved ``base_url``, or ``None`` when it cannot be
+        determined locally.
+    """
+    for override in launch.config_overrides:
+        match = _CODEX_OVERRIDE_BASE_URL_RE.search(override)
+        if match:
+            try:
+                return json.loads(match.group(1))
+            except json.JSONDecodeError:
+                return None
+    if provider in ("openai", "omnigent_databricks"):
+        return None
+    return _codex_config_toml_provider_base_url(provider)
+
+
+def _codex_config_toml_provider_base_url(provider: str) -> str | None:
+    """Return ``[model_providers.<provider>].base_url`` from the source config.toml.
+
+    Reads the same ``config.toml`` that :func:`_populate_codex_home_config`
+    copies into a session ``CODEX_HOME`` (resolved via
+    :func:`_codex_home_config_source_from_env`), so it observes exactly the
+    provider table the launched Codex process will use.
+
+    :param provider: The ``[model_providers.X]`` key to look up.
+    :returns: The table's ``base_url`` string, or ``None`` when the file is
+        missing/unparseable or the table/key is absent.
+    """
+    from omnigent.inner.codex_executor import _codex_home_config_source_from_env
+
+    config_path = _codex_home_config_source_from_env() / "config.toml"
+    try:
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    providers = data.get("model_providers")
+    if not isinstance(providers, dict):
+        return None
+    table = providers.get(provider)
+    if not isinstance(table, dict):
+        return None
+    base_url = table.get("base_url")
+    return base_url if isinstance(base_url, str) else None
+
+
+def _loopback_endpoint(base_url: str) -> tuple[str, int] | None:
+    """Return ``(host, port)`` when *base_url* is a loopback endpoint, else ``None``.
+
+    Only loopback hosts (``localhost`` / an IP whose :attr:`is_loopback` is set,
+    e.g. ``127.0.0.1`` or ``::1``) are returned — a remote host resolves to
+    ``None`` so callers never probe it (a remote reachability probe is out of
+    scope and would risk false negatives on transient network state).
+
+    :param base_url: A provider base URL, e.g.
+        ``"http://127.0.0.1:34659/ai-gateway/codex/v1"``.
+    :returns: ``(host, port)`` for a loopback endpoint (port defaulted from the
+        scheme when absent), or ``None`` when the URL is remote or unparseable.
+    """
+    try:
+        parsed = urlparse(base_url)
+    except ValueError:
+        return None
+    host = parsed.hostname
+    if not host:
+        return None
+    if host == "localhost":
+        is_loopback = True
+    else:
+        try:
+            is_loopback = ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            is_loopback = False
+    if not is_loopback:
+        return None
+    port = parsed.port if parsed.port is not None else (443 if parsed.scheme == "https" else 80)
+    return host, port
+
+
+def _loopback_port_listening(host: str, port: int) -> bool:
+    """Return whether a TCP connection to a loopback ``host:port`` succeeds.
+
+    :param host: A loopback host, e.g. ``"127.0.0.1"``.
+    :param port: TCP port to probe.
+    :returns: ``True`` when the port accepts a connection, ``False`` on any
+        connection error (refused / unreachable / times out).
+    """
+    try:
+        with socket.create_connection((host, port), timeout=_CODEX_LOOPBACK_PROBE_TIMEOUT_SECONDS):
+            return True
+    except OSError:
+        return False
+
+
+def _codex_provider_unreachable_reason() -> str | None:
+    """Return a reason when the codex provider the runner will use is unreachable.
+
+    Complements :func:`_codex_auth_unavailable_reason`: that confirms a local
+    credential *exists*; this confirms the provider the launch actually routes
+    through can be *reached*. It resolves the same launch the runner will use
+    (:func:`resolve_native_codex_launch`), reads that provider's ``base_url``,
+    and — only when the ``base_url`` is a **loopback** endpoint (a local proxy /
+    model server, e.g. ucode's ``127.0.0.1:PORT`` gateway proxy that only runs
+    during an interactive session) — checks that its port is listening.
+
+    This stays within the daemon's "gate only on what can be determined
+    reliably and locally" contract: a dead loopback port is a definite local
+    fact, so flagging it is a true negative, not the false negative the readiness
+    module warns against. Remote gateways are never probed, and any resolution
+    failure fails open (returns ``None``) so the check can never block a launch
+    that might work.
+
+    :returns: :data:`_CODEX_PROVIDER_UNREACHABLE` when the resolved provider is a
+        loopback endpoint whose port is not listening; otherwise ``None``.
+    """
+    try:
+        launch = resolve_native_codex_launch(model=None)
+        provider = codex_session_meta_model_provider(launch)
+        base_url = _codex_provider_base_url(launch, provider)
+    except Exception:  # noqa: BLE001 - readiness must never raise; fail open.
+        _logger.debug("codex provider reachability check could not resolve launch", exc_info=True)
+        return None
+    if base_url is None:
+        return None
+    endpoint = _loopback_endpoint(base_url)
+    if endpoint is None:
+        return None
+    if _loopback_port_listening(*endpoint):
+        return None
+    _logger.debug(
+        "codex provider %r base_url %r is a loopback endpoint that is not listening",
+        provider,
+        base_url,
+    )
+    return _CODEX_PROVIDER_UNREACHABLE
 
 
 def _update_startup_progress(

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -260,6 +260,17 @@ def harness_is_configured(harness: str) -> bool:
     install_key = _install_key(canonical)
     if not harness_cli_installed(install_key):
         return False
+    if canonical in {"codex", "codex-native", "native-codex"}:
+        # The codex binary is present, but the provider the runner will route
+        # through can still be unreachable — most commonly a ``base_url`` that
+        # points at a local proxy (e.g. ucode's loopback AI-gateway) not running
+        # in a headless daemon. Gate on that too (a reliably-local determination)
+        # so the launch fails fast with a clear "not configured" error instead of
+        # the codex app-server timing out ~15s in while never starting a thread.
+        from omnigent.codex_native import _codex_provider_unreachable_reason
+
+        if _codex_provider_unreachable_reason() is not None:
+            return False
     # Families that authenticate via file-based credentials (not a CLI login
     # command) require both the binary AND a stored credential. The ``agy`` CLI
     # falls into this category: it has no ``agy login`` subcommand and writes
@@ -276,9 +287,18 @@ def _harness_availability(canonical: str) -> HarnessAvailability:
         canonical in {"codex", "codex-native", "native-codex"}
         and _HARNESS_FAMILY.get(canonical) == OPENAI_FAMILY
     ):
-        from omnigent.codex_native import _codex_auth_unavailable_reason
+        from omnigent.codex_native import (
+            _codex_auth_unavailable_reason,
+            _codex_provider_unreachable_reason,
+        )
 
-        return _codex_auth_unavailable_reason() or True
+        # ``_codex_auth_unavailable_reason`` confirms the binary + a local
+        # credential; ``_codex_provider_unreachable_reason`` confirms the
+        # provider the runner will actually route through is reachable (it
+        # catches a resolved provider whose ``base_url`` is a loopback proxy
+        # that is not running — the picker would otherwise report "available"
+        # for a codex that cannot start).
+        return _codex_auth_unavailable_reason() or _codex_provider_unreachable_reason() or True
     return harness_is_configured(canonical)
 
 
@@ -290,7 +310,9 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     ``claude`` alias, and ``pi``. SDK and unknown harnesses map to
     ``True`` (never gated); CLI-wrapping harnesses map to whether their
     binary is on ``PATH``. Codex entries use a structured string reason when
-    unavailable: ``"binary-missing"`` or ``"needs-auth"``.
+    unavailable: ``"binary-missing"``, ``"needs-auth"``, or
+    ``"provider-unreachable"`` (the resolved provider's ``base_url`` is a
+    loopback proxy that is not running).
 
     :returns: Mapping of harness spelling to readiness, e.g.
         ``{"claude-native": False, "codex-native": "needs-auth",

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
-from collections.abc import Callable
+import socket
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -136,6 +138,167 @@ def test_codex_auth_unavailable_reason_malformed_auth_needs_auth(
     auth_path.write_text("{not json", encoding="utf-8")
 
     assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+@contextlib.contextmanager
+def _listening_loopback_port() -> Iterator[int]:
+    """Yield the port of a loopback socket that is actively listening."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    try:
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def _closed_loopback_port() -> int:
+    """Return a loopback port that was bound then released (nothing listening)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _set_resolved_codex_launch(
+    monkeypatch: pytest.MonkeyPatch, *, config_overrides: list[str], profile: str | None = None
+) -> None:
+    """Pin the launch that ``_codex_provider_unreachable_reason`` resolves."""
+    launch = codex_native_app_server.NativeCodexLaunch(
+        config_overrides=list(config_overrides), model=None, profile=profile
+    )
+    monkeypatch.setattr(codex_native, "resolve_native_codex_launch", lambda *, model=None: launch)
+
+
+def _point_codex_config_toml_at(monkeypatch: pytest.MonkeyPatch, source_dir: Path) -> None:
+    """Redirect the config.toml source resolver used for provider base_url lookup."""
+    import omnigent.inner.codex_executor as codex_executor
+
+    monkeypatch.setattr(codex_executor, "_codex_home_config_source_from_env", lambda: source_dir)
+
+
+def _write_codex_config_toml(source_dir: Path, provider: str, base_url: str) -> None:
+    """Write a config.toml with one ``[model_providers.<provider>]`` base_url."""
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.toml").write_text(
+        f'[model_providers.{provider}]\nbase_url = "{base_url}"\n', encoding="utf-8"
+    )
+
+
+def test_codex_provider_unreachable_cli_config_loopback_down(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config provider whose loopback proxy is not listening is unreachable.
+
+    This is the ucode local-gateway case: the launch pins
+    ``model_provider="ucode-databricks"`` and that table's ``base_url`` is a
+    ``127.0.0.1:PORT`` proxy that only runs during an interactive session, so in
+    a headless daemon nothing is listening and codex could never start.
+    """
+    port = _closed_loopback_port()
+    _set_resolved_codex_launch(monkeypatch, config_overrides=['model_provider="ucode-databricks"'])
+    _point_codex_config_toml_at(monkeypatch, tmp_path)
+    _write_codex_config_toml(
+        tmp_path, "ucode-databricks", f"http://127.0.0.1:{port}/ai-gateway/codex/v1"
+    )
+
+    assert codex_native._codex_provider_unreachable_reason() == "provider-unreachable"
+
+
+def test_codex_provider_reachable_cli_config_loopback_listening(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config provider whose loopback proxy is listening is reachable."""
+    _set_resolved_codex_launch(monkeypatch, config_overrides=['model_provider="ucode-databricks"'])
+    _point_codex_config_toml_at(monkeypatch, tmp_path)
+    with _listening_loopback_port() as port:
+        _write_codex_config_toml(
+            tmp_path, "ucode-databricks", f"http://127.0.0.1:{port}/ai-gateway/codex/v1"
+        )
+
+        assert codex_native._codex_provider_unreachable_reason() is None
+
+
+def test_codex_provider_remote_base_url_never_probed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A remote gateway base_url is never probed (no false negatives on net state)."""
+    _set_resolved_codex_launch(monkeypatch, config_overrides=['model_provider="Databricks"'])
+    _point_codex_config_toml_at(monkeypatch, tmp_path)
+    _write_codex_config_toml(
+        tmp_path, "Databricks", "https://1965859176160743.ai-gateway.cloud.databricks.com/codex/v1"
+    )
+    # Guard: a remote host must short-circuit before any socket connect.
+    monkeypatch.setattr(
+        codex_native.socket,
+        "create_connection",
+        lambda *a, **k: pytest.fail("remote base_url must not be probed"),
+    )
+
+    assert codex_native._codex_provider_unreachable_reason() is None
+
+
+def test_codex_provider_loopback_base_url_from_launch_override_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key/gateway/local provider bakes base_url into the launch override.
+
+    The generated ``model_providers.omnigent_provider={...base_url=...}`` inline
+    table is read straight from the launch overrides (no config.toml), and a
+    down loopback endpoint there is flagged too (e.g. a local model server).
+    """
+    port = _closed_loopback_port()
+    override = (
+        'model_providers.omnigent_provider={name="Omnigent Provider",'
+        f'base_url="http://127.0.0.1:{port}/v1",'
+        'auth={command="sh",args=["-c","true"]},wire_api="responses"}'
+    )
+    _set_resolved_codex_launch(
+        monkeypatch, config_overrides=['model_provider="omnigent_provider"', override]
+    )
+
+    assert codex_native._codex_provider_unreachable_reason() == "provider-unreachable"
+
+
+def test_codex_provider_openai_login_default_is_reachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The built-in openai login default has no local table to probe → reachable."""
+    _set_resolved_codex_launch(monkeypatch, config_overrides=[])
+
+    assert codex_native._codex_provider_unreachable_reason() is None
+
+
+def test_codex_provider_databricks_profile_is_reachable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A Databricks-profile launch resolves to a remote, runtime-generated table."""
+    _set_resolved_codex_launch(monkeypatch, config_overrides=[], profile="DEFAULT")
+    _point_codex_config_toml_at(monkeypatch, tmp_path)  # no omnigent_databricks table present
+
+    assert codex_native._codex_provider_unreachable_reason() is None
+
+
+def test_codex_provider_missing_config_toml_fails_open(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cli-config provider with no readable config.toml fails open (no reason)."""
+    _set_resolved_codex_launch(monkeypatch, config_overrides=['model_provider="ucode-databricks"'])
+    _point_codex_config_toml_at(monkeypatch, tmp_path)  # directory exists, config.toml absent
+
+    assert codex_native._codex_provider_unreachable_reason() is None
+
+
+def test_codex_provider_resolution_error_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A launch-resolution failure fails open — the check never blocks a launch."""
+
+    def _boom(*, model: str | None = None) -> None:
+        raise RuntimeError("resolution exploded")
+
+    monkeypatch.setattr(codex_native, "resolve_native_codex_launch", _boom)
+
+    assert codex_native._codex_provider_unreachable_reason() is None
 
 
 class _FakeTerminalClient:

--- a/tests/test_harness_readiness.py
+++ b/tests/test_harness_readiness.py
@@ -74,3 +74,56 @@ def test_configured_harness_map_exposes_kiro_native(monkeypatch: pytest.MonkeyPa
     cmap = hr.configured_harness_map()
     assert cmap.get("kiro-native") is False
     assert cmap.get("native-kiro") is False
+
+
+def test_codex_availability_reports_provider_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The picker map surfaces ``provider-unreachable`` for a dead loopback proxy.
+
+    Even with the codex binary present and a credential configured, the resolved
+    provider's endpoint being unreachable must make the picker warn instead of
+    reporting codex as available.
+    """
+    import omnigent.codex_native as codex_native
+
+    monkeypatch.setattr(codex_native, "_codex_auth_unavailable_reason", lambda: None)
+    monkeypatch.setattr(
+        codex_native, "_codex_provider_unreachable_reason", lambda: "provider-unreachable"
+    )
+    cmap = hr.configured_harness_map()
+    assert cmap["codex-native"] == "provider-unreachable"
+    assert cmap["codex"] == "provider-unreachable"
+
+
+def test_codex_availability_prefers_auth_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing credential is reported before the reachability check is consulted."""
+    import omnigent.codex_native as codex_native
+
+    monkeypatch.setattr(codex_native, "_codex_auth_unavailable_reason", lambda: "needs-auth")
+    monkeypatch.setattr(
+        codex_native,
+        "_codex_provider_unreachable_reason",
+        lambda: pytest.fail("reachability must not run when auth already failed"),
+    )
+    assert hr._harness_availability("codex-native") == "needs-auth"
+
+
+def test_codex_launch_gate_rejects_unreachable_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The launch gate refuses codex when the resolved provider is unreachable."""
+    import omnigent.codex_native as codex_native
+
+    monkeypatch.setattr(hr, "harness_cli_installed", lambda _key: True)
+    monkeypatch.setattr(
+        codex_native, "_codex_provider_unreachable_reason", lambda: "provider-unreachable"
+    )
+    assert hr.harness_is_configured("codex-native") is False
+
+
+def test_codex_launch_gate_allows_reachable_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The launch gate allows codex when the binary is present and provider reachable."""
+    import omnigent.codex_native as codex_native
+
+    monkeypatch.setattr(hr, "harness_cli_installed", lambda _key: True)
+    monkeypatch.setattr(codex_native, "_codex_provider_unreachable_reason", lambda: None)
+    assert hr.harness_is_configured("codex-native") is True

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -436,9 +436,26 @@ describe("harnessUnconfiguredOnHost", () => {
     );
   });
 
-  it("ignores unknown future reason strings", () => {
-    expect(harnessUnavailableReasonOnHost("codex", hostWith({ codex: "future-reason" }))).toBe(
-      null,
+  it("surfaces the provider-unreachable codex reason", () => {
+    const testHost = hostWith({ codex: "provider-unreachable" });
+    expect(harnessUnconfiguredOnHost("codex", testHost)).toBe(true);
+    expect(harnessUnavailableReasonOnHost("codex", testHost)).toBe("provider-unreachable");
+    expect(harnessWarningBadgeText("provider-unreachable")).toBe("provider unreachable");
+    expect(harnessWarningMessageText("Codex", "laptop", "provider-unreachable")).toBe(
+      "Codex can't reach its Codex model provider on laptop — it's routed through a local gateway proxy that isn't running. Re-run omnigent setup on that machine and pick the direct Databricks AI Gateway.",
+    );
+  });
+
+  it("fails safe on unknown future codex reason strings", () => {
+    // A string value always means "unavailable" from the daemon (a bare `true`
+    // means available), so an unrecognized reason must still surface a warning —
+    // with generic copy — rather than silently read as available.
+    const testHost = hostWith({ codex: "future-reason" });
+    expect(harnessUnavailableReasonOnHost("codex", testHost)).toBe("future-reason");
+    expect(harnessUnconfiguredOnHost("codex", testHost)).toBe(true);
+    expect(harnessWarningBadgeText("future-reason")).toBe("needs setup");
+    expect(harnessWarningMessageText("Codex", "laptop", "future-reason")).toBe(
+      "Codex isn't configured on laptop — run omnigent setup on that machine.",
     );
   });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -515,19 +515,21 @@ export function harnessUnavailableReasonOnHost(
   if (!harness || !host?.configured_harnesses) return null;
   const availability = host.configured_harnesses[harness];
   if (availability === false) return isCodexHarness(harness) ? "binary-missing" : "unconfigured";
-  if (
-    isCodexHarness(harness) &&
-    (availability === "binary-missing" || availability === "needs-auth")
-  ) {
+  // For codex, any string value is a structured "unavailable" reason from the
+  // daemon (a bare `true` means available). Surface it even when this build has
+  // no specific copy for it yet — the badge/message helpers fall back to a
+  // generic "needs setup" — so a newer daemon reason (e.g. one added after this
+  // web build shipped) never silently reads as available.
+  if (isCodexHarness(harness) && typeof availability === "string") {
     return availability;
   }
-  // Unknown future reason strings fall through to no warning until the UI knows their copy.
   return null;
 }
 
 export function harnessWarningBadgeText(reason: string | null): string {
   if (reason === "binary-missing") return "binary missing";
   if (reason === "needs-auth") return "needs auth";
+  if (reason === "provider-unreachable") return "provider unreachable";
   return "needs setup";
 }
 
@@ -541,6 +543,9 @@ export function harnessWarningMessageText(
   }
   if (reason === "binary-missing") {
     return `${agentName} is missing the Codex binary on ${hostName} — run omnigent setup on that machine.`;
+  }
+  if (reason === "provider-unreachable") {
+    return `${agentName} can't reach its Codex model provider on ${hostName} — it's routed through a local gateway proxy that isn't running. Re-run omnigent setup on that machine and pick the direct Databricks AI Gateway.`;
   }
   return `${agentName} isn't configured on ${hostName} — run omnigent setup on that machine.`;
 }
@@ -563,6 +568,15 @@ function harnessWarningMessage(
       <>
         {agentName} is missing the Codex binary on {hostName} — run <code>omnigent setup</code> on
         that machine.
+      </>
+    );
+  }
+  if (reason === "provider-unreachable") {
+    return (
+      <>
+        {agentName} can&apos;t reach its Codex model provider on {hostName} — it&apos;s routed
+        through a local gateway proxy that isn&apos;t running. Re-run <code>omnigent setup</code> on
+        that machine and pick the direct Databricks AI Gateway.
       </>
     );
   }


### PR DESCRIPTION
The web agent picker showed Codex as "available" whenever the codex binary was present and auth.json held a credential — but the runner routes through resolve_native_codex_launch(), which for a cli-config provider pins model_provider="X" whose real endpoint lives in the config.toml [model_providers.X] table. Readiness inspected a different source than launch used, so a provider whose base_url is a loopback proxy that isn't running headless (e.g. ucode's 127.0.0.1:PORT gateway) still reported available, then the app-server timed out ~15s in without ever starting a thread.

Add _codex_provider_unreachable_reason(): it resolves the same launch the runner will use, reads that provider's base_url, and — only for a loopback endpoint — checks the port is listening, returning "provider-unreachable" when it isn't. Remote gateways are never probed and any resolution failure fails open, so the check stays within the readiness module's "gate only on what it can determine reliably and locally" contract (a dead loopback port is a true negative, not a false one).

Wire it into the picker map (_harness_availability) and the launch-time gate (harness_is_configured) so a dead-proxy launch fails fast with a clear error instead of a silent timeout. Render the new reason in the web picker and fail safe on unrecognized reason strings so a future daemon reason never silently reads as available.

Co-authored-by: Isaac

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
If this PR has a user-facing change worth announcing, write one or more lines
below in the user's voice, each prefixed with a category. Otherwise leave it
as `skip`.

Lower the bar than docs: DO include small features and UX changes (moved/renamed
buttons, new flags, copy tweaks). DO skip pure-internal churn (CI, refactors,
test-only changes, dependency bumps with no user impact).

Categories: Added | Changed | Fixed | Deprecated | Removed | Security
Format:     <Category>: <one-line description>   (the PR link is added for you)
Example:    Added: `omnigent run --watch` reruns an agent when files change

A `skip` here is fine for chores — but a Breaking change must always be announced.
-->

skip
