### PR TITLE
chore(issues): require repro steps and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,13 +15,17 @@ body:
     id: repro-steps
     attributes:
       label: Steps to reproduce
-      description: Minimal steps to reproduce the issue.
+      description: >
+        Minimal steps to reproduce the issue. If you can't reproduce it
+        reliably (e.g. an intermittent crash or race), describe what you
+        observed and when — write "N/A — cannot reproduce reliably" and give
+        as much detail as you can.
       placeholder: |
         1. ...
         2. ...
         3. ...
     validations:
-      required: false
+      required: true
 
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions & Help
     url: https://github.com/omnigent-ai/omnigent/discussions


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make the **Steps to reproduce** field mandatory (`required: true`) on the bug report issue form.
- Set `blank_issues_enabled: false` so reporters can't bypass the structured form with a free-form blank issue.
- Together these raise the floor on bug report quality and cut low-effort / AI-slop reports. The field description keeps an escape hatch for genuinely intermittent bugs ("N/A — cannot reproduce reliably" with observed details).

## Test Plan

Validated the two `.yml` files are well-formed GitHub issue-template/config syntax. GitHub enforces `required: true` at submission time and honors `blank_issues_enabled` — both are standard, documented fields. No runtime code changed. The Discussions contact link in `config.yml` remains, so question-askers still have a non-issue path.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Config-only change to GitHub issue templates; no automated test hooks exist for issue-form YAML. Verified manually by inspecting the rendered field requirements and confirming the config fields match GitHub's documented schema.

This pull request and its description were written by Isaac.