### PR TITLE
feat(editors): sidebar Sessions tree for the VS Code extension

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -20,5 +20,9 @@ vitest.config.ts
 # Dependencies are bundled into dist/ by esbuild — not needed in the package
 node_modules/**
 
+# Transient OMC runtime/telemetry state and prior package artifacts — never ship
+.omc/**
+*.vsix
+
 # Keep (NOT ignored): dist/** (the bundled extension), media/** (icons),
 # package.json, README.md, LICENSE

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnigent-vscode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnigent-vscode",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.14.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -40,25 +40,35 @@
       "omnigent-container": [
         {
           "type": "tree",
-          "id": "omnigent.home",
-          "name": "Omnigent"
+          "id": "omnigent.sessions",
+          "name": "Sessions"
         }
       ]
     },
-    "viewsWelcome": [
-      {
-        "view": "omnigent.home",
-        "contents": "Open the running Omnigent server UI in an editor tab.\n[Open Omnigent](command:omnigent.open)\nStart a local server with `omnigent server`, or set `omnigent.serverUrl` to a localhost URL."
-      }
-    ],
     "commands": [
       {
         "command": "omnigent.open",
         "title": "Omnigent: Open",
         "icon": "media/omnigent-icon.svg"
+      },
+      {
+        "command": "omnigent.sessions.refresh",
+        "title": "Omnigent: Refresh Sessions",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "omnigent.openSessionFromTree",
+        "title": "Omnigent: Open Session"
       }
     ],
     "menus": {
+      "view/title": [
+        {
+          "command": "omnigent.sessions.refresh",
+          "when": "view == omnigent.sessions",
+          "group": "navigation@1"
+        }
+      ],
       "editor/title": [
         {
           "command": "omnigent.open",
@@ -68,6 +78,13 @@
       "commandPalette": [
         {
           "command": "omnigent.open"
+        },
+        {
+          "command": "omnigent.sessions.refresh"
+        },
+        {
+          "command": "omnigent.openSessionFromTree",
+          "when": "false"
         }
       ]
     }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,8 +2,8 @@
   "name": "omnigent-vscode",
   "displayName": "Omnigent",
   "description": "Open your running local Omnigent server inside VS Code, in an editor-beside iframe.",
-  "version": "0.1.0",
-  "publisher": "databricks",
+  "version": "0.1.1",
+  "publisher": "omnigent-ai",
   "license": "Apache-2.0",
   "icon": "media/omnigent-icon.png",
   "repository": {

--- a/editors/vscode/src/api/client.test.ts
+++ b/editors/vscode/src/api/client.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the minimal /v1 client: pure `accumulateSessions` plus `listSessions`
+ * driven through an injected `fetchImpl` stub (no real network).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  accumulateSessions,
+  listSessions,
+  type ClientOptions,
+  type Session,
+  type SessionsPage,
+} from "./client";
+
+function session(id: string, over: Partial<Session> = {}): Session {
+  return { id, ...over };
+}
+
+function page(data: Session[], over: Partial<SessionsPage> = {}): SessionsPage {
+  return { object: "list", data, has_more: false, ...over };
+}
+
+/** A fetchImpl stub that returns the given pages in sequence as JSON 200s. */
+function pagedFetch(pages: SessionsPage[]): ClientOptions {
+  let call = 0;
+  const fetchImpl = (async () => {
+    const body = pages[Math.min(call, pages.length - 1)];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as Response;
+  }) as unknown as typeof fetch;
+  return { baseUrl: "http://127.0.0.1:6767", fetchImpl };
+}
+
+describe("accumulateSessions", () => {
+  it("concatenates a single page in order, not truncated", () => {
+    const r = accumulateSessions([page([session("a"), session("b")])], 200);
+    expect(r.sessions.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("concatenates multiple pages in order", () => {
+    const r = accumulateSessions(
+      [
+        page([session("a")], { has_more: true, last_id: "a" }),
+        page([session("b")], { has_more: false }),
+      ],
+      200,
+    );
+    expect(r.sessions.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("stops at the cap and reports truncated when has_more persists", () => {
+    const r = accumulateSessions(
+      [page([session("a"), session("b"), session("c")], { has_more: true, last_id: "c" })],
+      2,
+    );
+    expect(r.sessions.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("is NOT truncated when the cap is reached but has_more is false", () => {
+    const r = accumulateSessions([page([session("a"), session("b")], { has_more: false })], 2);
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe("listSessions", () => {
+  it("returns a single page when has_more is false", async () => {
+    const opts = pagedFetch([page([session("a"), session("b")])]);
+    const r = await listSessions(opts);
+    expect(r.ok).toBe(true);
+    expect(r.data?.sessions.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(r.data?.truncated).toBe(false);
+  });
+
+  it("follows the last_id cursor across pages while has_more is true", async () => {
+    const opts = pagedFetch([
+      page([session("a")], { has_more: true, last_id: "a" }),
+      page([session("b")], { has_more: true, last_id: "b" }),
+      page([session("c")], { has_more: false }),
+    ]);
+    const r = await listSessions(opts);
+    expect(r.data?.sessions.map((s) => s.id)).toEqual(["a", "b", "c"]);
+    expect(r.data?.truncated).toBe(false);
+  });
+
+  it("stops following the cursor once the cap is reached and reports truncated", async () => {
+    const opts = pagedFetch([
+      page([session("a"), session("b")], { has_more: true, last_id: "b" }),
+    ]);
+    const r = await listSessions(opts, 2);
+    expect(r.data?.sessions.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(r.data?.truncated).toBe(true);
+  });
+
+  it("does not loop forever on an empty page that still reports has_more", async () => {
+    // A misbehaving server: empty data but has_more:true and a cursor. Without the
+    // empty-page guard this would spin (pagedFetch repeats the last page forever).
+    const opts = pagedFetch([page([], { has_more: true, last_id: "x" })]);
+    const r = await listSessions(opts);
+    expect(r.ok).toBe(true);
+    expect(r.data?.sessions).toEqual([]);
+  });
+
+  it("does not loop forever when the cursor fails to advance", async () => {
+    // has_more:true but last_id never changes — the non-advancing-cursor guard
+    // breaks after the repeat instead of paging up to the cap.
+    const opts = pagedFetch([page([session("a")], { has_more: true, last_id: "a" })]);
+    const r = await listSessions(opts, 200);
+    expect(r.ok).toBe(true);
+    expect(r.data!.sessions.length).toBeLessThanOrEqual(2);
+  });
+
+  it("propagates a network failure as status 0 / not ok", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const r = await listSessions({ baseUrl: "http://127.0.0.1:6767", fetchImpl });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(0);
+  });
+
+  it("propagates a non-2xx status without throwing", async () => {
+    const fetchImpl = (async () =>
+      ({ ok: false, status: 500, json: async () => ({}) }) as Response) as unknown as typeof fetch;
+    const r = await listSessions({ baseUrl: "http://127.0.0.1:6767", fetchImpl });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(500);
+  });
+
+  it("parses optional fields and the archived boolean", async () => {
+    const opts = pagedFetch([
+      page([
+        session("conv_1", {
+          title: "Hello",
+          agent_name: "claude",
+          updated_at: 1000,
+          archived: true,
+        }),
+        session("conv_2"),
+      ]),
+    ]);
+    const r = await listSessions(opts);
+    const [a, b] = r.data!.sessions;
+    expect(a.title).toBe("Hello");
+    expect(a.archived).toBe(true);
+    expect(b.title).toBeUndefined();
+    expect(b.archived).toBeUndefined();
+  });
+});

--- a/editors/vscode/src/api/client.ts
+++ b/editors/vscode/src/api/client.ts
@@ -1,0 +1,172 @@
+/**
+ * Minimal HTTP client for the Omnigent /v1 REST surface (local server only).
+ *
+ * Pure payload/accumulation functions are co-located here and tested in
+ * isolation; the actual fetch calls go through the injected `fetchImpl` so
+ * tests can supply a stub.
+ *
+ * This is the LOCAL-ONLY slice: a local server needs no credentials, so there is
+ * no bearer header and no remote/Databricks handling — every request is plain.
+ *
+ * API surface used by this slice:
+ *   GET /v1/sessions   — list sessions (OpenAI-style cursor pagination)
+ */
+
+export type FetchFn = typeof fetch;
+
+export interface ClientOptions {
+  /** Server base URL (e.g. "http://127.0.0.1:6767"). */
+  baseUrl: string;
+  fetchImpl?: FetchFn;
+}
+
+export interface ApiResponse<T> {
+  ok: boolean;
+  status: number;
+  data?: T;
+  error?: string;
+}
+
+/**
+ * Low-level fetch — the central request point for all /v1 calls. `ok` mirrors
+ * `Response.ok` (2xx); a network/throw failure yields `{ ok:false, status:0 }`.
+ */
+export async function apiFetch<T>(
+  opts: ClientOptions,
+  path: string,
+  init: RequestInit = {},
+): Promise<ApiResponse<T>> {
+  const { baseUrl, fetchImpl = fetch } = opts;
+  const url = `${baseUrl.replace(/\/$/, "")}${path}`;
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    ...((init.headers as Record<string, string> | undefined) ?? {}),
+  };
+  let res: Response;
+  try {
+    res = await fetchImpl(url, { ...init, headers });
+  } catch (err) {
+    return { ok: false, status: 0, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (res.ok) {
+    try {
+      const data = (await res.json()) as T;
+      return { ok: true, status: res.status, data };
+    } catch {
+      return { ok: true, status: res.status };
+    }
+  }
+  return { ok: false, status: res.status, error: `HTTP ${res.status}` };
+}
+
+// ── Sessions ──────────────────────────────────────────────────────────────────
+
+/**
+ * A session as returned by `GET /v1/sessions` (pinned from a live capture).
+ * Timestamps are unix SECONDS; `title`/`workspace`/`git_branch` are OPTIONAL and
+ * absent on some sessions; `archived` is a BOOLEAN (not a status value).
+ */
+export interface Session {
+  id: string;
+  agent_id?: string;
+  agent_name?: string;
+  status?: string; // open string enum: "running" | "idle" | ...
+  created_at?: number; // unix SECONDS
+  updated_at?: number; // unix SECONDS
+  title?: string;
+  workspace?: string; // abs path
+  git_branch?: string;
+  archived?: boolean;
+  [key: string]: unknown;
+}
+
+/** One page of the OpenAI-style cursor-paginated `GET /v1/sessions` response. */
+export interface SessionsPage {
+  object: "list";
+  data: Session[];
+  first_id?: string | null;
+  last_id?: string | null;
+  has_more?: boolean;
+}
+
+/** Query options for a single `GET /v1/sessions` page. */
+export interface ListSessionsOptions {
+  limit?: number;
+  after?: string;
+}
+
+/**
+ * Pure: concatenate page `data` in order, stopping once `cap` sessions are reached.
+ * `truncated` is true when the final consumed page still reports `has_more` AND the
+ * accumulated total reached the cap (i.e. there is more on the server we did not fetch).
+ */
+export function accumulateSessions(
+  pages: SessionsPage[],
+  cap: number,
+): { sessions: Session[]; truncated: boolean } {
+  const sessions: Session[] = [];
+  let lastHasMore = false;
+  for (const page of pages) {
+    lastHasMore = page.has_more === true;
+    for (const s of page.data) {
+      if (sessions.length >= cap) break;
+      sessions.push(s);
+    }
+    if (sessions.length >= cap) break;
+  }
+  const truncated = lastHasMore && sessions.length >= cap;
+  return { sessions, truncated };
+}
+
+/** Fetch a single page of sessions. `limit`/`after` are omitted when undefined. */
+export async function listSessionsPage(
+  opts: ClientOptions,
+  page: ListSessionsOptions = {},
+): Promise<ApiResponse<SessionsPage>> {
+  const params = new URLSearchParams();
+  if (page.limit !== undefined) params.set("limit", String(page.limit));
+  if (page.after !== undefined) params.set("after", page.after);
+  const query = params.toString();
+  return apiFetch<SessionsPage>(opts, `/v1/sessions${query ? `?${query}` : ""}`);
+}
+
+/**
+ * List sessions, following the `after = last_id` cursor while `has_more` is true
+ * and the accumulated total is below `cap`. Non-ok responses propagate as-is
+ * (without throwing) so callers can map them to the error state.
+ */
+export async function listSessions(
+  opts: ClientOptions,
+  cap = 200,
+): Promise<ApiResponse<{ sessions: Session[]; truncated: boolean }>> {
+  const pages: SessionsPage[] = [];
+  let after: string | undefined;
+  let lastStatus = 200;
+  while (true) {
+    const res = await listSessionsPage(opts, { after });
+    if (!res.ok || !res.data) {
+      return { ok: res.ok, status: res.status, error: res.error };
+    }
+    lastStatus = res.status;
+    pages.push(res.data);
+    const total = pages.reduce((n, p) => n + p.data.length, 0);
+    const next = res.data.last_id ?? undefined;
+    // Stop on the normal signals (no more, no cursor, cap reached) plus two
+    // defensive guards against a misbehaving server that would otherwise spin
+    // this loop forever: an empty page, or a cursor that did not advance.
+    if (
+      res.data.has_more !== true ||
+      !next ||
+      total >= cap ||
+      res.data.data.length === 0 ||
+      next === after
+    ) {
+      break;
+    }
+    after = next;
+  }
+  const { sessions, truncated } = accumulateSessions(pages, cap);
+  return { ok: true, status: lastStatus, data: { sessions, truncated } };
+}

--- a/editors/vscode/src/commands/openSessionFromTree.ts
+++ b/editors/vscode/src/commands/openSessionFromTree.ts
@@ -1,0 +1,44 @@
+/**
+ * Commands wiring the Sessions tree to the editor panel.
+ *
+ * Thin VS Code adapter — the provider and the pure modules hold the logic.
+ * Local-only slice: clicking a session deep-links the editor-beside iframe to
+ * `/c/<id>`; the title-bar Refresh re-fetches the list.
+ */
+import * as vscode from "vscode";
+import type { EditorPanelController } from "../panel/EditorPanelController";
+import type { SessionsTreeProvider } from "../sessions/SessionsTreeProvider";
+
+export const OPEN_SESSION_FROM_TREE_COMMAND = "omnigent.openSessionFromTree";
+export const REFRESH_SESSIONS_COMMAND = "omnigent.sessions.refresh";
+
+/**
+ * Register the command fired when a tree item is clicked: navigate the editor
+ * panel to the session route.
+ */
+export function registerOpenSessionFromTree(
+  context: vscode.ExtensionContext,
+  controller: EditorPanelController,
+  output: vscode.OutputChannel,
+): void {
+  const cmd = vscode.commands.registerCommand(
+    OPEN_SESSION_FROM_TREE_COMMAND,
+    (id: string) => {
+      if (!id) return;
+      output.appendLine(`[omnigent] sessions: open ${id} from tree`);
+      controller.navigate(`/c/${id}`);
+    },
+  );
+  context.subscriptions.push(cmd);
+}
+
+/** Register the tree title-bar Refresh action. */
+export function registerRefreshSessions(
+  context: vscode.ExtensionContext,
+  provider: SessionsTreeProvider,
+): void {
+  const cmd = vscode.commands.registerCommand(REFRESH_SESSIONS_COMMAND, () => {
+    void provider.refresh();
+  });
+  context.subscriptions.push(cmd);
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,12 +1,12 @@
 /**
- * Omnigent VS Code extension entry point (minimal iframe-only build).
+ * Omnigent VS Code extension entry point (iframe + sessions sidebar).
  *
  * activate() wires:
  *  - Config / local-server discovery
- *  - A minimal Sessions/home tree view (so the activity-bar icon renders) whose
- *    welcome content offers an "Open Omnigent" button
+ *  - A native Sessions tree view (omnigent.sessions) listing the local server's
+ *    sessions; clicking one deep-links the editor panel to /c/<id>
  *  - EditorPanelController: the single editor-beside iframe surface
- *  - The omnigent.open command
+ *  - The omnigent.open command + the sessions refresh / open-from-tree commands
  */
 import * as vscode from "vscode";
 import { discoverLocalServer, DEFAULT_HEALTH_TIMEOUT_MS } from "./discovery";
@@ -14,26 +14,14 @@ import { resolveServerTarget } from "./config";
 import { readSettings } from "./config/vscodeSettings";
 import { EditorPanelController } from "./panel/EditorPanelController";
 import { registerOpenPanel } from "./commands/openPanel";
-
-/** Id of the minimal activity-bar view (declared in package.json contributes.views). */
-const HOME_VIEW_ID = "omnigent.home";
+import { SessionsTreeProvider, SESSIONS_VIEW_ID } from "./sessions/SessionsTreeProvider";
+import {
+  registerOpenSessionFromTree,
+  registerRefreshSessions,
+} from "./commands/openSessionFromTree";
 
 let output: vscode.OutputChannel | undefined;
 let controller: EditorPanelController | undefined;
-
-/**
- * A no-op tree provider. A `viewsContainer` only renders its activity-bar icon
- * when it has at least one registered view; this provides that view. The actual
- * call-to-action is the `viewsWelcome` "Open Omnigent" button in package.json.
- */
-class HomeTreeProvider implements vscode.TreeDataProvider<never> {
-  getTreeItem(element: never): vscode.TreeItem {
-    return element;
-  }
-  getChildren(): never[] {
-    return [];
-  }
-}
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   output = vscode.window.createOutputChannel("Omnigent");
@@ -42,14 +30,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // ── Single editor-beside iframe surface ───────────────────────────────────
   controller = new EditorPanelController(context.extensionUri, output);
+  const panelController = controller;
 
-  // ── Minimal activity-bar view (makes the container icon render) ────────────
+  // ── Sessions tree view (the activity-bar surface) ──────────────────────────
+  const sessionsProvider = new SessionsTreeProvider(
+    () => panelController.getClientOpts(),
+    output,
+  );
+  const treeView = vscode.window.createTreeView(SESSIONS_VIEW_ID, {
+    treeDataProvider: sessionsProvider,
+  });
+  context.subscriptions.push(treeView);
+  // Refresh the list whenever the tree becomes visible (cheap, no timer).
   context.subscriptions.push(
-    vscode.window.registerTreeDataProvider(HOME_VIEW_ID, new HomeTreeProvider()),
+    treeView.onDidChangeVisibility((e) => {
+      if (e.visible) void sessionsProvider.refresh();
+    }),
   );
 
-  // ── omnigent.open command ──────────────────────────────────────────────────
+  // ── Commands ───────────────────────────────────────────────────────────────
   registerOpenPanel(context, controller);
+  registerOpenSessionFromTree(context, controller, output);
+  registerRefreshSessions(context, sessionsProvider);
 
   // ── Resolve the local server at activation ────────────────────────────────
   try {
@@ -67,6 +69,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       output.appendLine(
         `[omnigent] target: ${target.baseUrl} (hostType=${target.hostType}, source=${target.source})`,
       );
+      // Now that a server target is known, populate the Sessions tree.
+      void sessionsProvider.refresh();
     } else {
       output.appendLine(
         `[omnigent] no local server (${resolution.reason}); start \`omnigent server\` or set omnigent.serverUrl to a localhost URL`,

--- a/editors/vscode/src/panel/EditorPanelController.test.ts
+++ b/editors/vscode/src/panel/EditorPanelController.test.ts
@@ -95,6 +95,33 @@ describe("EditorPanelController", () => {
     expect(fake.panel.webview.html.toLowerCase()).not.toContain("token");
   });
 
+  it("navigate() opens the panel and renders the iframe at the routed URL", () => {
+    const controller = makeController();
+    controller.setResolved(LOCAL_TARGET);
+    controller.navigate("/c/conv_42");
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(fake.panel.webview.html).toContain('src="http://127.0.0.1:6767/c/conv_42"');
+  });
+
+  it("revealing an already-navigated panel does not reset the route to /", () => {
+    const controller = makeController();
+    controller.setResolved(LOCAL_TARGET);
+    controller.navigate("/c/conv_42");
+    // A subsequent omnigent.open (ensure) must preserve the navigated route.
+    controller.ensure();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(fake.panel.webview.html).toContain('src="http://127.0.0.1:6767/c/conv_42"');
+  });
+
+  it("getClientOpts() is undefined before resolve and returns the baseUrl after", () => {
+    const controller = makeController();
+    expect(controller.getClientOpts()).toBeUndefined();
+    controller.setResolved(LOCAL_TARGET);
+    expect(controller.getClientOpts()).toEqual({ baseUrl: "http://127.0.0.1:6767" });
+  });
+
   it("dispose() disposes the panel and nulls the ref; onDidDispose does not double-clear", () => {
     const controller = makeController();
     controller.setResolved(LOCAL_TARGET);

--- a/editors/vscode/src/panel/EditorPanelController.ts
+++ b/editors/vscode/src/panel/EditorPanelController.ts
@@ -10,9 +10,12 @@
 import * as vscode from "vscode";
 import { renderInto, renderResolvingHtml } from "./host";
 import type { ServerTarget } from "../config";
+import type { ClientOptions } from "../api/client";
 
 export class EditorPanelController {
   private panel?: vscode.WebviewPanel;
+  // Empty = the app root (no trailing slash added); navigate() sets "/c/<id>".
+  private route = "";
   private resolved?: { target: ServerTarget };
 
   constructor(
@@ -60,6 +63,25 @@ export class EditorPanelController {
     this.output.appendLine("[omnigent] opened editor-beside panel");
   }
 
+  /**
+   * Navigate the editor panel to `route` (e.g. "/c/<id>"). Sole mutator of
+   * `this.route`. Ensures the panel exists, then re-renders the iframe at the
+   * routed URL. `ensure()` re-renders via `this.render`, which reads `this.route`.
+   */
+  navigate(route: string): void {
+    this.route = route;
+    this.ensure();
+  }
+
+  /**
+   * Client options for the resolved server, or undefined when nothing has
+   * resolved yet. Local-only: no token. The Sessions tree consumes this to call
+   * the /v1 API.
+   */
+  getClientOpts(): ClientOptions | undefined {
+    return this.resolved ? { baseUrl: this.resolved.target.baseUrl } : undefined;
+  }
+
   /** Whether the editor panel is currently open. */
   isOpen(): boolean {
     return this.panel !== undefined;
@@ -80,6 +102,7 @@ export class EditorPanelController {
     }
     renderInto(webview, {
       target: this.resolved.target,
+      route: this.route,
       log: (m) => this.output.appendLine(m),
     });
   }

--- a/editors/vscode/src/panel/host.ts
+++ b/editors/vscode/src/panel/host.ts
@@ -25,6 +25,8 @@ export function shouldUseIframe(target: ServerTarget): boolean {
 export interface RenderIntoOptions {
   /** Resolved (local) server target. */
   target: ServerTarget;
+  /** Optional route to deep-link within the framed app (e.g. "/c/<id>"). */
+  route?: string;
   /** Optional diagnostic logger. */
   log?: (msg: string) => void;
 }
@@ -37,9 +39,14 @@ export function renderInto(webview: vscode.Webview, opts: RenderIntoOptions): vo
     nonce,
     cspSource: webview.cspSource,
   });
-  webview.html = buildIframeHtml({ baseUrl: opts.target.baseUrl, csp, nonce });
+  webview.html = buildIframeHtml({
+    baseUrl: opts.target.baseUrl,
+    csp,
+    nonce,
+    route: opts.route,
+  });
   opts.log?.(
-    `[omnigent] iframe rendered (origin=${opts.target.origin}, nonce=${nonce.slice(0, 8)}...)`,
+    `[omnigent] iframe rendered (origin=${opts.target.origin}, route=${opts.route ?? "/"}, nonce=${nonce.slice(0, 8)}...)`,
   );
 }
 

--- a/editors/vscode/src/panel/iframeHtml.test.ts
+++ b/editors/vscode/src/panel/iframeHtml.test.ts
@@ -53,6 +53,25 @@ describe("buildIframeHtml", () => {
     expect(html).toContain("&quot;");
   });
 
+  it("appends a route to the base URL when given", () => {
+    const html = buildIframeHtml({ ...baseOpts, route: "/c/conv_123" });
+    expect(html).toContain('src="http://127.0.0.1:6767/c/conv_123"');
+  });
+
+  it("composes a trailing-slash base URL with a route without doubling the slash", () => {
+    const html = buildIframeHtml({
+      ...baseOpts,
+      baseUrl: "http://127.0.0.1:6767/",
+      route: "/c/x",
+    });
+    expect(html).toContain('src="http://127.0.0.1:6767/c/x"');
+    expect(html).not.toContain("6767//c/x");
+  });
+
+  it("renders the bare base URL when no route is given", () => {
+    expect(buildIframeHtml(baseOpts)).toContain('src="http://127.0.0.1:6767"');
+  });
+
   it("has a root div filling the pane", () => {
     expect(buildIframeHtml(baseOpts)).toContain('<div id="root">');
   });

--- a/editors/vscode/src/panel/iframeHtml.ts
+++ b/editors/vscode/src/panel/iframeHtml.ts
@@ -23,11 +23,17 @@ export interface BuildIframeHtmlOptions {
   csp: string;
   /** Nonce stamped on the inline <style>. */
   nonce: string;
+  /**
+   * Optional route to deep-link within the framed app (e.g. "/c/<id>"). Appended
+   * to the base URL to form the iframe src; defaults to the app root ("/"). The
+   * route stays same-origin, so the host CSP's origin-based frame-src is unchanged.
+   */
+  route?: string;
 }
 
 export function buildIframeHtml(opts: BuildIframeHtmlOptions): string {
-  const { baseUrl, csp, nonce } = opts;
-  const src = baseUrl.replace(/\/$/, "");
+  const { baseUrl, csp, nonce, route } = opts;
+  const src = `${baseUrl.replace(/\/$/, "")}${route ?? ""}`;
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/editors/vscode/src/sessions/SessionsTreeProvider.test.ts
+++ b/editors/vscode/src/sessions/SessionsTreeProvider.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for SessionsTreeProvider's getChildren node arrays across each state,
+ * driven through the injected getClientOpts + an injected fetchImpl stub.
+ */
+import { describe, it, expect } from "vitest";
+import * as vscode from "vscode";
+import { SessionsTreeProvider, type SessionsNode } from "./SessionsTreeProvider";
+import type { ClientOptions, Session, SessionsPage } from "../api/client";
+
+const output = { appendLine: () => {} } as unknown as vscode.OutputChannel;
+
+function pageFetch(data: Session[]): ClientOptions {
+  const body: SessionsPage = { object: "list", data, has_more: false };
+  const fetchImpl = (async () =>
+    ({ ok: true, status: 200, json: async () => body }) as Response) as unknown as typeof fetch;
+  return { baseUrl: "http://127.0.0.1:6767", fetchImpl };
+}
+
+function labels(nodes: SessionsNode[]): string[] {
+  return nodes.map((n) => (n.kind === "message" ? n.label : n.session.id));
+}
+
+describe("SessionsTreeProvider.getChildren", () => {
+  it("starts in loading before any refresh", () => {
+    const p = new SessionsTreeProvider(() => undefined, output);
+    expect(labels(p.getChildren())).toEqual(["Loading…"]);
+  });
+
+  it("shows the no-server message when client options are undefined", async () => {
+    const p = new SessionsTreeProvider(() => undefined, output);
+    await p.refresh();
+    expect(labels(p.getChildren())).toEqual(["Omnigent server unreachable"]);
+  });
+
+  it("shows an error message when the list request fails", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const p = new SessionsTreeProvider(
+      () => ({ baseUrl: "http://127.0.0.1:6767", fetchImpl }),
+      output,
+    );
+    await p.refresh();
+    expect(labels(p.getChildren())).toEqual(["Omnigent server unreachable"]);
+  });
+
+  it("shows 'No sessions' for an empty ready list", async () => {
+    const p = new SessionsTreeProvider(() => pageFetch([]), output);
+    await p.refresh();
+    expect(labels(p.getChildren())).toEqual(["No sessions"]);
+  });
+
+  it("returns session nodes sorted by updated_at desc when ready", async () => {
+    const p = new SessionsTreeProvider(
+      () =>
+        pageFetch([
+          { id: "old", updated_at: 100 },
+          { id: "new", updated_at: 200 },
+        ]),
+      output,
+    );
+    await p.refresh();
+    expect(labels(p.getChildren())).toEqual(["new", "old"]);
+  });
+
+  it("builds a TreeItem with the open-from-tree command for a session node", async () => {
+    const p = new SessionsTreeProvider(
+      () => pageFetch([{ id: "conv_1", title: "Hi", status: "running" }]),
+      output,
+    );
+    await p.refresh();
+    const [node] = p.getChildren();
+    const item = p.getTreeItem(node) as unknown as {
+      id: string;
+      command: { command: string; arguments: string[] };
+      contextValue: string;
+    };
+    expect(item.id).toBe("conv_1");
+    expect(item.command.command).toBe("omnigent.openSessionFromTree");
+    expect(item.command.arguments).toEqual(["conv_1"]);
+    expect(item.contextValue).toBe("omnigentSession");
+  });
+});

--- a/editors/vscode/src/sessions/SessionsTreeProvider.ts
+++ b/editors/vscode/src/sessions/SessionsTreeProvider.ts
@@ -1,0 +1,103 @@
+/**
+ * Thin VS Code adapter exposing the local Omnigent session list as a native
+ * TreeView. All sorting/view-model logic lives in the pure `treeItem.ts` module;
+ * this class owns only the IDE wiring and the load lifecycle.
+ *
+ * Local-only slice: no auth, so there is no `unauthorized` state; no filtering
+ * and no background polling (manual Refresh + refresh-on-visible only).
+ */
+import * as vscode from "vscode";
+import { listSessions, type ClientOptions, type Session } from "../api/client";
+import { sortSessions, toItemView } from "./treeItem";
+
+export const SESSIONS_VIEW_ID = "omnigent.sessions";
+
+/** Default ceiling for accumulated sessions (mirrors `listSessions` default). */
+const SESSIONS_CAP = 200;
+
+export type SessionsState = "loading" | "ready" | "error" | "no-server";
+
+/** A tree node: either a real session or a single non-selectable message line. */
+export type SessionsNode =
+  | { kind: "session"; session: Session }
+  | { kind: "message"; label: string };
+
+export class SessionsTreeProvider implements vscode.TreeDataProvider<SessionsNode> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<SessionsNode | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private state: SessionsState = "loading";
+  private sessions: Session[] = [];
+
+  constructor(
+    private readonly getClientOpts: () => ClientOptions | undefined,
+    private readonly output: vscode.OutputChannel,
+  ) {}
+
+  /** Re-fetch sessions, update state, and fire a tree change. */
+  async refresh(): Promise<void> {
+    const opts = this.getClientOpts();
+    if (!opts) {
+      this.apply("no-server", []);
+      return;
+    }
+
+    this.state = "loading";
+    this._onDidChangeTreeData.fire();
+
+    const res = await listSessions(opts, SESSIONS_CAP);
+    if (!res.ok || !res.data) {
+      this.output.appendLine(
+        `[omnigent] sessions: list failed (${res.status}: ${res.error ?? "unknown"})`,
+      );
+      this.apply("error", []);
+    } else {
+      this.apply("ready", res.data.sessions);
+    }
+  }
+
+  /** Commit a fetch result and fire a tree change. */
+  private apply(state: SessionsState, sessions: Session[]): void {
+    this.state = state;
+    this.sessions = sessions;
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(node: SessionsNode): vscode.TreeItem {
+    if (node.kind === "message") {
+      const item = new vscode.TreeItem(node.label, vscode.TreeItemCollapsibleState.None);
+      item.contextValue = "omnigentMessage";
+      return item;
+    }
+    const view = toItemView(node.session, Date.now());
+    const item = new vscode.TreeItem(view.label, vscode.TreeItemCollapsibleState.None);
+    item.id = view.id;
+    item.description = view.description;
+    item.tooltip = new vscode.MarkdownString(view.tooltip);
+    item.iconPath = new vscode.ThemeIcon(view.themeIconId);
+    item.contextValue = view.contextValue;
+    item.command = {
+      command: "omnigent.openSessionFromTree",
+      title: "Open Session",
+      arguments: [view.id],
+    };
+    return item;
+  }
+
+  getChildren(element?: SessionsNode): SessionsNode[] {
+    // Flat list — sessions have no children.
+    if (element) return [];
+
+    if (this.state === "loading") return [message("Loading…")];
+    if (this.state === "no-server" || this.state === "error") {
+      return [message("Omnigent server unreachable")];
+    }
+    if (this.sessions.length === 0) return [message("No sessions")];
+
+    return sortSessions(this.sessions).map((session) => ({ kind: "session", session }));
+  }
+}
+
+function message(label: string): SessionsNode {
+  return { kind: "message", label };
+}

--- a/editors/vscode/src/sessions/treeItem.test.ts
+++ b/editors/vscode/src/sessions/treeItem.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the pure Sessions view-model helpers (no VS Code host).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  deriveLabel,
+  relativeTime,
+  sortSessions,
+  statusThemeIconId,
+  toItemView,
+} from "./treeItem";
+import type { Session } from "../api/client";
+
+const NOW = 1_000_000 * 1000; // a fixed wall-clock in ms
+
+describe("deriveLabel", () => {
+  it("uses the trimmed title when present", () => {
+    expect(deriveLabel({ id: "conv_x", title: "  Hello  " })).toBe("Hello");
+  });
+
+  it("falls back to a short id tail after the underscore", () => {
+    expect(deriveLabel({ id: "conv_abcdefghij" })).toBe("Session abcdefgh");
+  });
+
+  it("handles an id with no underscore", () => {
+    expect(deriveLabel({ id: "abcdefghij" })).toBe("Session abcdefgh");
+  });
+
+  it("returns a bare label for an empty id", () => {
+    expect(deriveLabel({ id: "" })).toBe("Session");
+  });
+});
+
+describe("relativeTime", () => {
+  const now = 1000 * 1000; // nowMs
+  it("renders sub-minute as 'just now'", () => {
+    expect(relativeTime(1000 - 30, now)).toBe("just now");
+  });
+  it("renders minutes", () => {
+    expect(relativeTime(1000 - 5 * 60, now)).toBe("5m ago");
+  });
+  it("renders hours", () => {
+    expect(relativeTime(1000 - 3 * 3600, now)).toBe("3h ago");
+  });
+  it("renders days", () => {
+    expect(relativeTime(1000 - 2 * 86400, now)).toBe("2d ago");
+  });
+  it("clamps a future timestamp to 'just now'", () => {
+    expect(relativeTime(1000 + 100, now)).toBe("just now");
+  });
+});
+
+describe("statusThemeIconId", () => {
+  it("archived wins over status", () => {
+    expect(statusThemeIconId("running", true)).toBe("archive");
+  });
+  it("maps running", () => {
+    expect(statusThemeIconId("running")).toBe("play-circle");
+  });
+  it("maps idle", () => {
+    expect(statusThemeIconId("idle")).toBe("circle-outline");
+  });
+  it("maps error/failure substrings", () => {
+    expect(statusThemeIconId("error")).toBe("error");
+    expect(statusThemeIconId("failed")).toBe("error");
+  });
+  it("defaults unknown/absent to circle-outline", () => {
+    expect(statusThemeIconId(undefined)).toBe("circle-outline");
+    expect(statusThemeIconId("weird")).toBe("circle-outline");
+  });
+});
+
+describe("toItemView", () => {
+  it("composes description from agent + relative time", () => {
+    const v = toItemView({ id: "conv_1", agent_name: "claude", updated_at: 1_000_000 - 60 }, NOW);
+    expect(v.description).toBe("claude · 1m ago");
+    expect(v.contextValue).toBe("omnigentSession");
+  });
+
+  it("builds a tooltip with the present fields", () => {
+    const s: Session = {
+      id: "conv_1",
+      title: "T",
+      workspace: "/w",
+      git_branch: "main",
+      status: "running",
+      created_at: 1_000_000 - 3600,
+      updated_at: 1_000_000 - 60,
+    };
+    const v = toItemView(s, NOW);
+    expect(v.tooltip).toContain("Workspace: /w");
+    expect(v.tooltip).toContain("Branch: main");
+    expect(v.tooltip).toContain("Status: running");
+    expect(v.themeIconId).toBe("play-circle");
+  });
+
+  it("falls back to just the label when no detail fields exist", () => {
+    const v = toItemView({ id: "conv_xyz123ab" }, NOW);
+    expect(v.tooltip).toBe("Session xyz123ab");
+    expect(v.description).toBe("");
+  });
+});
+
+describe("sortSessions", () => {
+  it("orders by updated_at desc, id tiebreak, without mutating input", () => {
+    const input: Session[] = [
+      { id: "b", updated_at: 100 },
+      { id: "a", updated_at: 100 },
+      { id: "c", updated_at: 200 },
+    ];
+    const out = sortSessions(input);
+    expect(out.map((s) => s.id)).toEqual(["c", "a", "b"]);
+    expect(input.map((s) => s.id)).toEqual(["b", "a", "c"]); // original untouched
+  });
+
+  it("treats a missing updated_at as 0", () => {
+    const out = sortSessions([{ id: "a" }, { id: "b", updated_at: 5 }]);
+    expect(out.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+});

--- a/editors/vscode/src/sessions/treeItem.ts
+++ b/editors/vscode/src/sessions/treeItem.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure view-model derivation for Sessions tree items.
+ *
+ * No VS Code imports: produces a plain `SessionItemView` (theme-icon *id*,
+ * context value, tooltip text) that the thin `SessionsTreeProvider` maps onto
+ * `vscode.TreeItem`. Unit-testable in isolation.
+ */
+import type { Session } from "../api/client";
+
+export interface SessionItemView {
+  id: string;
+  label: string;
+  description: string;
+  tooltip: string;
+  themeIconId: string;
+  contextValue: string;
+}
+
+/** A readable label: the title when present, else a short fallback from the id. */
+export function deriveLabel(s: Session): string {
+  if (s.title && s.title.trim() !== "") return s.title.trim();
+  const id = s.id ?? "";
+  // Strip a "conv_" style prefix and keep a short, readable tail.
+  const tail = id.includes("_") ? id.slice(id.indexOf("_") + 1) : id;
+  const short = tail.slice(0, 8);
+  return short ? `Session ${short}` : "Session";
+}
+
+/** Render a unix-SECONDS timestamp as a coarse relative time ("just now", "3m ago"…). */
+export function relativeTime(unixSecs: number, nowMs: number): string {
+  const thenMs = unixSecs * 1000;
+  const diffSec = Math.max(0, Math.round((nowMs - thenMs) / 1000));
+  if (diffSec < 60) return "just now";
+  const min = Math.floor(diffSec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+/** Map a session status/archived flag to a VS Code ThemeIcon id. */
+export function statusThemeIconId(status?: string, archived?: boolean): string {
+  if (archived === true) return "archive";
+  const s = (status ?? "").toLowerCase();
+  if (s === "running") return "play-circle";
+  if (s === "idle") return "circle-outline";
+  if (s.includes("error") || s.includes("fail")) return "error";
+  return "circle-outline";
+}
+
+/** Build the full item view-model for a session at the given wall-clock time. */
+export function toItemView(s: Session, nowMs: number): SessionItemView {
+  const label = deriveLabel(s);
+  const parts: string[] = [];
+  if (s.agent_name) parts.push(s.agent_name);
+  if (typeof s.updated_at === "number") parts.push(relativeTime(s.updated_at, nowMs));
+  const description = parts.join(" · ");
+
+  const tipLines: string[] = [];
+  if (s.workspace) tipLines.push(`Workspace: ${s.workspace}`);
+  if (s.git_branch) tipLines.push(`Branch: ${s.git_branch}`);
+  if (s.status) tipLines.push(`Status: ${s.status}`);
+  if (typeof s.created_at === "number") {
+    tipLines.push(`Created: ${relativeTime(s.created_at, nowMs)}`);
+  }
+  if (typeof s.updated_at === "number") {
+    tipLines.push(`Updated: ${relativeTime(s.updated_at, nowMs)}`);
+  }
+  const tooltip = tipLines.length > 0 ? `${label}\n\n${tipLines.join("\n")}` : label;
+
+  return {
+    id: s.id,
+    label,
+    description,
+    tooltip,
+    themeIconId: statusThemeIconId(s.status, s.archived),
+    contextValue: "omnigentSession",
+  };
+}
+
+/** Copy and sort by `updated_at` descending, with id as a stable tiebreak. */
+export function sortSessions(list: Session[]): Session[] {
+  return [...list].sort((a, b) => {
+    const au = a.updated_at ?? 0;
+    const bu = b.updated_at ?? 0;
+    if (bu !== au) return bu - au;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}

--- a/editors/vscode/src/test/__mocks__/vscode.ts
+++ b/editors/vscode/src/test/__mocks__/vscode.ts
@@ -46,8 +46,44 @@ export const ColorThemeKind = { Light: 1, Dark: 2, HighContrast: 3, HighContrast
 export const TreeItem = class {
   label: string;
   collapsibleState: number;
+  id?: string;
+  description?: string;
+  tooltip?: unknown;
+  iconPath?: unknown;
+  contextValue?: string;
+  command?: unknown;
   constructor(label: string, collapsibleState = 0) {
     this.label = label;
     this.collapsibleState = collapsibleState;
   }
+};
+
+export const TreeItemCollapsibleState = { None: 0, Collapsed: 1, Expanded: 2 };
+
+export const ThemeIcon = class {
+  id: string;
+  constructor(id: string) {
+    this.id = id;
+  }
+};
+
+export const MarkdownString = class {
+  value: string;
+  constructor(value = "") {
+    this.value = value;
+  }
+};
+
+export const EventEmitter = class {
+  private listeners: Array<(e: unknown) => void> = [];
+  event = (listener: (e: unknown) => void) => {
+    this.listeners.push(listener);
+    return { dispose: () => {} };
+  };
+  fire = (e?: unknown) => {
+    for (const l of this.listeners) l(e);
+  };
+  dispose = () => {
+    this.listeners = [];
+  };
 };


### PR DESCRIPTION
## Related issue

Refs #1219

## Summary

- Replaces the no-op `omnigent.home` activity-bar view with a native **`omnigent.sessions` TreeView** that lists the local server's sessions (`GET /v1/sessions`, sorted by `updated_at` desc, with per-status theme icons and a relative-time / agent-name description).
- Clicking a session **deep-links the editor-beside iframe to `/c/<id>`** via a new `EditorPanelController.navigate(route)`; the route stays same-origin so the existing host CSP is unchanged and no token ever lands in the iframe URL.
- **Scope is an intentionally minimal, local-server-only slice:** no auth/token, no filters, no background polling, and no create-session — each deferred to a later slice. The list refreshes on a manual title-bar **Refresh** action and when the view becomes visible (no timer).

The `/v1` client (`api/client.ts`) follows the OpenAI-style `has_more` / `last_id` cursor with a defensive `cap` (200) and guards against a misbehaving server (empty page or non-advancing cursor) so the fetch loop can never spin. The pure view-model (`sessions/treeItem.ts`) and each provider state (loading / ready / error / no-server) are unit-tested.

## Test Plan

- `vitest` — **98 unit tests** pass (12 new for the `/v1` client incl. cursor pagination + the two anti-spin guards, 19 for the pure view-model, 6 for the provider states across all four tree states). `tsc --noEmit` clean; `esbuild` bundle + `vsce package` smoke both succeed.
- Manual: with a local Omnigent server running, launched the extension in the VS Code Extension Development Host — the Sessions view populates and sorts newest-first with status icons; clicking a session opens it in the editor-beside iframe at `/c/<id>`; the title-bar Refresh re-fetches; with no server the view shows the unreachable message.

## Demo

https://github.com/user-attachments/assets/ee4af037-014c-41e9-894d-ffe3d70c914b

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The `/v1` client, the pure view-model (label / relative-time / status-icon derivation, sort), and the provider's four states are covered by vitest unit tests (98 total). The thin VS Code API glue (tree-view registration, command wiring, editor-panel navigation) is verified manually in the Extension Development Host against a running local server, per the Test Plan above — the same split as the prior slice (#1288).

## Changelog

Added: The Omnigent sidebar now lists your running local server's sessions; click one to open it in the editor.
