### PR TITLE
feat(changelog): free-text changelog entries tagged by Type of change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -69,19 +69,19 @@ test coverage is not needed for this change.
 ## Changelog
 
 <!--
-If this PR has a user-facing change worth announcing, write one or more lines
-below in the user's voice, each prefixed with a category. Otherwise leave it
-as `skip`.
+One line, in the user's voice, describing the user-facing change. The category
+is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
+as "[UI] <your line>"), so don't repeat it here — just describe the change. The
+PR link is added for you.
 
-Lower the bar than docs: DO include small features and UX changes (moved/renamed
-buttons, new flags, copy tweaks). DO skip pure-internal churn (CI, refactors,
-test-only changes, dependency bumps with no user impact).
+Lower the bar than docs: DO keep this for small features and UX changes
+(moved/renamed buttons, new flags, copy tweaks).
 
-Categories: Added | Changed | Fixed | Deprecated | Removed | Security
-Format:     <Category>: <one-line description>   (the PR link is added for you)
-Example:    Added: `omnigent run --watch` reruns an agent when files change
+DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
+test-only changes, dependency bumps with no user impact) — it will simply be
+left out of the changelog. A Breaking change must always keep this section.
 
-A `skip` here is fine for chores — but a Breaking change must always be announced.
+Example:  `omnigent run --watch` reruns an agent when files change
 -->
 
-skip
+<Add a line to describe the change, else delete this section>

--- a/.github/scripts/changelog/generate.py
+++ b/.github/scripts/changelog/generate.py
@@ -26,14 +26,20 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Reuse the exact section + changelog parsing the merge gate uses.
+# Reuse the exact section + checkbox parsing the merge gate uses.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "pr-template"))
 from _md import (
-    CHANGELOG_CATEGORIES,
-    is_changelog_skip,
-    parse_changelog_entries,
+    TYPE_TAGS,
+    changelog_description,
+    checked_labels,
     section_text,
+    type_tag,
 )
+
+# The "Type of change" checkbox labels, in the order they appear in the template
+# (mirrors validate.TYPE_LABELS). Kept here so the harvester needn't import the
+# gate module; TYPE_TAGS in _md.py is the source of truth for which map to a tag.
+TYPE_LABELS = tuple(TYPE_TAGS)
 
 _FINAL_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 # A squash-merge subject ends with "(#1234)"; capture the last such reference.
@@ -99,88 +105,78 @@ class HarvestResult:
     def __init__(self, pr: int, title: str = "") -> None:
         self.pr = pr
         self.title = title
-        self.entries: list[tuple[str, str]] = []  # (category, text)
-        self.status = "skip"  # skip | included | no-section | unparseable
+        self.description = ""  # first-line, free-text changelog description
+        self.type_tags: list[str] = []  # checked Type-of-change labels
+        self.status = "omitted"  # included | omitted
 
 
 def harvest_pr(pr: int, body: str | None, title: str = "") -> HarvestResult:
     result = HarvestResult(pr, title)
     if body is None:
-        result.status = "no-section"
         return result
-    if "changelog" not in _headings(body):
-        result.status = "no-section"
-        return result
-    raw = section_text(body, "Changelog")
-    if is_changelog_skip(raw):
-        result.status = "skip"
-        return result
-    entries, malformed = parse_changelog_entries(raw)
-    result.entries = entries
-    result.status = "included" if entries else ("unparseable" if malformed else "skip")
+    result.description = changelog_description(section_text(body, "Changelog"))
+    result.type_tags = sorted(checked_labels(section_text(body, "Type of change"), TYPE_LABELS))
+    # A PR is in the changelog iff its author wrote a description line; the tag
+    # comes from the Type-of-change boxes but never puts a PR in on its own.
+    if result.description:
+        result.status = "included"
     return result
 
 
-def _headings(body: str) -> set[str]:
-    return {m.group(1).strip().lower() for m in re.finditer(r"(?im)^\s*##\s+(.+?)\s*$", body)}
+def _bullet(result: HarvestResult) -> str:
+    """One CHANGELOG.md bullet: ``- [Tag] description (#NNNN)`` (tag optional)."""
+    tag = type_tag(set(result.type_tags))
+    prefix = f"{tag} " if tag else ""
+    return f"- {prefix}{result.description} (#{result.pr})"
 
 
 def render_section(tag: str, date: str, results: list[HarvestResult]) -> str:
-    """Render the Keep-a-Changelog block for one version."""
-    by_category: dict[str, list[tuple[int, str]]] = {c: [] for c in CHANGELOG_CATEGORIES}
-    for result in results:
-        for category, text in result.entries:
-            by_category[category].append((result.pr, text))
+    """Render the changelog block for one version — a flat, PR-sorted list.
 
+    Each documented PR is one bullet prefixed with the bracket tag derived from
+    its Type-of-change checkboxes. PRs with no description are omitted entirely.
+    """
+    included = sorted((r for r in results if r.status == "included"), key=lambda r: r.pr)
     lines = [f"## [{tag}] — {date}", ""]
-    any_entries = False
-    for category in CHANGELOG_CATEGORIES:
-        items = sorted(by_category[category])
-        if not items:
-            continue
-        any_entries = True
-        lines.append(f"### {category}")
-        for pr, text in items:
-            lines.append(f"- {text} (#{pr})")
-        lines.append("")
-    if not any_entries:
+    if included:
+        lines.extend(_bullet(r) for r in included)
+    else:
         lines.append("_No user-facing changes._")
-        lines.append("")
+    lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
 
-# Two-section draft for the GitHub Release body: the six Keep-a-Changelog
-# categories collapse into the two buckets the release coordinator curates by
-# hand (see RELEASING.md / the release-notes-drafter agent). This is the
-# deterministic scaffold — the AI drafter refines it, and it is also the
-# fallback when the LLM is unavailable.
+# Two-section draft for the GitHub Release body: the Type-of-change tags collapse
+# into the two buckets the release coordinator curates by hand (see RELEASING.md /
+# the release-notes-drafter agent). This is the deterministic scaffold — the AI
+# drafter refines it, and it is also the fallback when the LLM is unavailable.
+# Values are "Type of change" checkbox labels (see _md.TYPE_TAGS).
 DRAFT_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("Major new features", ("Added", "Changed")),
-    ("Bug fixes & hardening", ("Fixed", "Security", "Removed", "Deprecated")),
+    ("Major new features", ("Feature", "UI / frontend change")),
+    ("Bug fixes & hardening", ("Bug fix", "Breaking change")),
 )
 
 
 def render_draft_notes(results: list[HarvestResult], repo: str) -> str:
     """Render the two-section curated-draft scaffold for the GitHub Release body.
 
-    Groups the harvested one-liners into "Major new features" and "Bug fixes &
-    hardening", sorted by PR number, and appends the CHANGELOG.md link. Empty
-    sections keep their heading with a placeholder so the coordinator sees what
-    to fill in.
+    Groups documented PRs into "Major new features" and "Bug fixes & hardening"
+    by their Type-of-change labels, sorted by PR number, and appends the
+    CHANGELOG.md link. Empty sections keep their heading with a placeholder so
+    the coordinator sees what to fill in.
     """
-    by_category: dict[str, list[tuple[int, str]]] = {c: [] for c in CHANGELOG_CATEGORIES}
-    for result in results:
-        for category, text in result.entries:
-            by_category[category].append((result.pr, text))
+    included = [r for r in results if r.status == "included"]
 
     lines: list[str] = []
-    for heading, categories in DRAFT_SECTIONS:
+    for heading, labels in DRAFT_SECTIONS:
         lines.append(f"## {heading}")
         lines.append("")
-        items = sorted({item for cat in categories for item in by_category[cat]})
-        if items:
-            for pr, text in items:
-                lines.append(f"- {text} (#{pr})")
+        bucket = sorted(
+            (r for r in included if any(label in r.type_tags for label in labels)),
+            key=lambda r: r.pr,
+        )
+        if bucket:
+            lines.extend(f"- {r.description} (#{r.pr})" for r in bucket)
         else:
             lines.append("<!-- no entries harvested for this section — add highlights -->")
         lines.append("")
@@ -192,15 +188,18 @@ def render_draft_notes(results: list[HarvestResult], repo: str) -> str:
 def render_pr_list(results: list[HarvestResult]) -> str:
     """Render the PR material fed to the release-notes-drafter agent.
 
-    One line per PR: number, title, and the author-written changelog entries
-    (if any). Titles come from the squash-commit subjects, so even PRs that
-    predate the `## Changelog` field still give the agent something to theme on.
+    One line per PR: number, title, and — when the author documented it — the
+    type tag and description. Titles come from the squash-commit subjects, so
+    even PRs that predate the `## Changelog` field give the agent something to
+    theme on.
     """
     lines: list[str] = []
     for result in sorted(results, key=lambda r: r.pr):
         lines.append(f"#{result.pr}: {result.title or '(no title)'}")
-        for category, text in result.entries:
-            lines.append(f"    - [{category}] {text}")
+        if result.description:
+            tag = type_tag(set(result.type_tags))
+            prefix = f"{tag} " if tag else ""
+            lines.append(f"    - {prefix}{result.description}")
     return "\n".join(lines) + "\n"
 
 
@@ -338,27 +337,21 @@ def main() -> int:
     if args.pr_list_out:
         Path(args.pr_list_out).write_text(render_pr_list(results))
 
-    # Surface gaps so a maintainer can backfill (non-fatal).
+    # Summarize what landed (non-fatal). PRs without a description line are simply
+    # omitted from the changelog by design — no per-PR gap warnings.
     included = [r.pr for r in results if r.status == "included"]
-    skipped = [r.pr for r in results if r.status == "skip"]
-    missing = [r.pr for r in results if r.status == "no-section"]
-    unparseable = [r.pr for r in results if r.status == "unparseable"]
     print(f"Range: {prev or '(start)'}..{args.tag}")
-    print(f"Included {len(included)} entr(y/ies) from PRs: {included}")
-    print(f"Skipped (explicit `skip`): {skipped}")
-    if missing:
-        print(f"::warning::PRs with no `## Changelog` section: {missing}")
-    if unparseable:
-        print(f"::warning::PRs with unparseable `## Changelog`: {unparseable}")
+    print(f"Documented {len(included)} of {len(results)} PR(s) in the changelog: {included}")
+    print(f"Omitted (no changelog description): {len(results) - len(included)} PR(s).")
     return 0
 
 
 _SEED_CHANGELOG = (
     "# Changelog\n\n"
     "All notable user-facing changes to omnigent are documented here. This file is "
-    "generated at release time from each PR's `## Changelog` section; the concise, "
-    "curated highlights live on the website under `/releases`.\n\n"
-    "The format follows [Keep a Changelog](https://keepachangelog.com/).\n"
+    "generated at release time from each PR's `## Changelog` section, tagged by the "
+    "PR's \"Type of change\" (e.g. `[UI]`); the concise, curated highlights live on "
+    "the website under `/releases`.\n"
 )
 
 

--- a/.github/scripts/changelog/generate.py
+++ b/.github/scripts/changelog/generate.py
@@ -350,7 +350,7 @@ _SEED_CHANGELOG = (
     "# Changelog\n\n"
     "All notable user-facing changes to omnigent are documented here. This file is "
     "generated at release time from each PR's `## Changelog` section, tagged by the "
-    "PR's \"Type of change\" (e.g. `[UI]`); the concise, curated highlights live on "
+    "PR's `Type of change` (e.g. `[UI]`); the concise, curated highlights live on "
     "the website under `/releases`.\n"
 )
 

--- a/.github/scripts/pr-template/_md.py
+++ b/.github/scripts/pr-template/_md.py
@@ -12,6 +12,7 @@ import re
 
 _HEADING_RE = re.compile(r"(?im)^\s*##\s+(.+?)\s*$")
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_CHECKBOX_RE = re.compile(r"(?im)^\s*-\s*\[(?P<mark>[ xX])\]\s*(?P<label>.+?)\s*$")
 
 
 def strip_html_comments(text: str) -> str:
@@ -49,50 +50,70 @@ def section_text(body: str, heading: str) -> str:
     return section(body, heading_spans(body), heading)
 
 
+# --- checkbox parsing (shared by the gate and the harvester) ----------------
+
+
+def checked_labels(section_raw: str, expected_labels: tuple[str, ...]) -> set[str]:
+    """Return the canonical labels whose checkbox is ticked in *section_raw*."""
+    expected_by_lower = {label.lower(): label for label in expected_labels}
+    checked: set[str] = set()
+    for match in _CHECKBOX_RE.finditer(section_raw):
+        label = match.group("label").strip()
+        canonical = expected_by_lower.get(label.lower())
+        if canonical and match.group("mark").lower() == "x":
+            checked.add(canonical)
+    return checked
+
+
 # --- "## Changelog" section format ------------------------------------------
 #
-# Authors write zero or more `<Category>: one-line description` lines, or the
-# `skip` sentinel when there's nothing user-facing to announce. The same parser
-# backs the PR gate (validate.py) and the release harvester (generate.py).
+# The section holds a free-text, user-voice one-liner describing the change (the
+# author may hard-wrap it — we take the first line). The category/tag is NOT
+# written here; it is derived from the "Type of change" checkboxes via TYPE_TAGS.
+# The section is optional: an author deletes it (or leaves the `<…>` placeholder)
+# when the change isn't noteworthy, and the PR is then omitted from the changelog.
+# The same parser backs the PR gate (validate.py) and the harvester (generate.py).
 
-CHANGELOG_CATEGORIES = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+# "Type of change" checkbox label -> bracket tag rendered in CHANGELOG.md.
+TYPE_TAGS: dict[str, str] = {
+    "UI / frontend change": "UI",
+    "Bug fix": "Bug fix",
+    "Feature": "Feature",
+    "Docs": "Docs",
+    "Refactor / chore": "Chore",
+    "Test / CI": "Test/CI",
+    "Breaking change": "Breaking",
+}
 
-_SKIP_SENTINELS = frozenset({"skip", "n/a", "na", "none", "-"})
-_ENTRY_RE = re.compile(
-    r"(?i)^\s*[-*]?\s*(?P<cat>Added|Changed|Deprecated|Removed|Fixed|Security)"
-    r"\s*:\s*(?P<text>.+\S)\s*$"
-)
-
-
-def _content_lines(section_raw: str) -> list[str]:
-    return [ln.strip() for ln in strip_html_comments(section_raw).splitlines() if ln.strip()]
-
-
-def is_changelog_skip(section_raw: str) -> bool:
-    """True when the section is empty or only the `skip`/`n/a` sentinel."""
-    lines = _content_lines(section_raw)
-    if not lines:
-        return True
-    return all(ln.lstrip("-* ").strip().lower() in _SKIP_SENTINELS for ln in lines)
+_PLACEHOLDER_RE = re.compile(r"^\s*<.*>\s*$")
 
 
-def parse_changelog_entries(section_raw: str) -> tuple[list[tuple[str, str]], list[str]]:
-    """Parse a "## Changelog" section.
+def is_placeholder(line: str) -> bool:
+    """True when *line* is the untouched ``<…>`` template placeholder."""
+    return bool(_PLACEHOLDER_RE.match(line))
 
-    Returns ``(entries, malformed)`` where *entries* is a list of
-    ``(canonical_category, description)`` tuples and *malformed* is the list of
-    non-blank, non-sentinel lines that did not match ``<Category>: text``.
+
+def changelog_description(section_raw: str) -> str:
+    """First meaningful line of a "## Changelog" section.
+
+    Strips HTML comments, then returns the first non-blank line — unless that
+    line is the ``<…>`` placeholder (author left it untouched), in which case the
+    section counts as absent and this returns ``""``. Multi-line / wrapped bodies
+    collapse to their first line.
     """
-    entries: list[tuple[str, str]] = []
-    malformed: list[str] = []
-    for line in _content_lines(section_raw):
-        if line.lstrip("-* ").strip().lower() in _SKIP_SENTINELS:
+    for raw in strip_html_comments(section_raw).splitlines():
+        line = raw.strip()
+        if not line:
             continue
-        match = _ENTRY_RE.match(line)
-        if match:
-            cat = match.group("cat").lower()
-            canonical = next(c for c in CHANGELOG_CATEGORIES if c.lower() == cat)
-            entries.append((canonical, match.group("text").strip()))
-        else:
-            malformed.append(line)
-    return entries, malformed
+        return "" if is_placeholder(line) else line
+    return ""
+
+
+def type_tag(labels: set[str]) -> str:
+    """Render the bracket tag for the checked Type-of-change *labels*.
+
+    Joined with ` / ` in TYPE_TAGS declaration order (e.g. ``[UI / Bug fix]``).
+    Returns ``""`` when no known type is checked.
+    """
+    tags = [tag for label, tag in TYPE_TAGS.items() if label in labels]
+    return f"[{' / '.join(tags)}]" if tags else ""

--- a/.github/scripts/pr-template/format_body.py
+++ b/.github/scripts/pr-template/format_body.py
@@ -73,9 +73,10 @@ def format_body(body: str) -> str:
     body = _append_section(
         body,
         "Changelog",
-        "<!-- One or more '<Category>: description' lines (Added | Changed | "
-        "Fixed | Deprecated | Removed | Security) for user-facing changes, or "
-        "'skip'. A Breaking change must always be announced. -->\n\nskip",
+        "<!-- One line, in the user's voice, describing the user-facing change; "
+        "the category comes from the 'Type of change' boxes above. DELETE this "
+        "section if the change isn't noteworthy (a Breaking change must keep it). "
+        "-->\n\n<Add a line to describe the change, else delete this section>",
     )
     return body.rstrip() + "\n"
 

--- a/.github/scripts/pr-template/validate.py
+++ b/.github/scripts/pr-template/validate.py
@@ -17,11 +17,8 @@ from pathlib import Path
 # (.github/scripts/changelog/generate.py) so the gate and the harvester can
 # never disagree on what the "## Changelog" section means.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _md import (
-    CHANGELOG_CATEGORIES,
-    is_changelog_skip,
-    parse_changelog_entries,
-)
+from _md import changelog_description
+from _md import checked_labels as _checked_labels
 from _md import heading_spans as _heading_spans
 from _md import section as _section
 from _md import strip_html_comments as _strip_html_comments
@@ -31,7 +28,6 @@ REQUIRED_HEADINGS = (
     "Test Plan",
     "Type of change",
     "Test coverage",
-    "Changelog",
 )
 
 TYPE_LABELS = (
@@ -68,17 +64,6 @@ class ValidationResult:
 
 
 _CHECKBOX_RE = re.compile(r"(?im)^\s*-\s*\[(?P<mark>[ xX])\]\s*(?P<label>.+?)\s*$")
-
-
-def _checked_labels(section: str, expected_labels: tuple[str, ...]) -> set[str]:
-    expected_by_lower = {label.lower(): label for label in expected_labels}
-    checked: set[str] = set()
-    for match in _CHECKBOX_RE.finditer(section):
-        label = match.group("label").strip()
-        canonical = expected_by_lower.get(label.lower())
-        if canonical and match.group("mark").lower() == "x":
-            checked.add(canonical)
-    return checked
 
 
 def _missing_labels(section: str, expected_labels: tuple[str, ...]) -> list[str]:
@@ -165,26 +150,17 @@ def validate_pr_body(body: str) -> ValidationResult:
         elif _contains_placeholder(coverage_notes):
             errors.append("Coverage notes still contains template placeholder text.")
 
-    # Changelog feeds the release-time CHANGELOG.md harvester, so it must be the
-    # `skip` sentinel or one or more `<Category>: description` lines it can parse
-    # deterministically. A breaking change must always carry an entry — those are
-    # exactly what users need announced.
-    if "changelog" in spans:
-        changelog_section = _section(body, spans, "Changelog")
-        if is_changelog_skip(changelog_section):
-            if "Breaking change" in checked_types:
-                errors.append(
-                    "Changelog must not be 'skip' when 'Breaking change' is checked "
-                    "— add a '<Category>: description' line announcing it."
-                )
-        else:
-            _entries, malformed = parse_changelog_entries(changelog_section)
-            if malformed:
-                errors.append(
-                    "Changelog lines must be 'skip' or '<Category>: description' "
-                    f"(Category one of: {', '.join(CHANGELOG_CATEGORIES)}). "
-                    "Offending line(s): " + "; ".join(malformed)
-                )
+    # The Changelog section is optional — an author deletes it (or leaves the
+    # `<…>` placeholder) when the change isn't noteworthy, and the PR is simply
+    # omitted from the changelog. The one exception: a Breaking change is always
+    # noteworthy, so it must carry a real description line.
+    if "Breaking change" in checked_types:
+        changelog_section = _section(body, spans, "Changelog") if "changelog" in spans else ""
+        if not changelog_description(changelog_section):
+            errors.append(
+                "A Breaking change must describe the change in the Changelog section "
+                "(otherwise it would be omitted from the changelog)."
+            )
 
     return ValidationResult(ok=not errors, errors=errors)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
 All notable user-facing changes to omnigent are documented here. This file is
-generated at release time from each PR's `## Changelog` section; the concise,
-curated highlights live on the website under `/releases`.
-
-The format follows [Keep a Changelog](https://keepachangelog.com/).
+generated at release time from each PR's `## Changelog` section, tagged by the
+PR's "Type of change" (e.g. `[UI]`); the concise, curated highlights live on the
+website under `/releases`.
 
 ## [v0.3.0] — 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable user-facing changes to omnigent are documented here. This file is
 generated at release time from each PR's `## Changelog` section, tagged by the
-PR's "Type of change" (e.g. `[UI]`); the concise, curated highlights live on the
+PR's `Type of change` (e.g. `[UI]`); the concise, curated highlights live on the
 website under `/releases`.
 
 ## [v0.3.0] — 2026-06-26

--- a/tests/github/test_changelog_generate.py
+++ b/tests/github/test_changelog_generate.py
@@ -62,61 +62,94 @@ def test_pr_titles_strip_ref_and_dedupe() -> None:
 
 # --- harvest_pr --------------------------------------------------------------
 
+_TYPE_SECTION = {
+    "UI / frontend change": "- [x] UI / frontend change\n- [ ] Bug fix\n",
+    "Bug fix": "- [ ] UI / frontend change\n- [x] Bug fix\n",
+    "Breaking change": "- [ ] Bug fix\n- [x] Breaking change\n",
+    "none": "- [ ] Bug fix\n- [ ] Feature\n",
+}
 
-def _body(changelog: str) -> str:
-    return f"## Summary\n\nThing.\n\n## Changelog\n\n{changelog}\n"
+
+def _body(changelog: str | None, kind: str = "Bug fix") -> str:
+    type_block = _TYPE_SECTION[kind]
+    changelog_block = "" if changelog is None else f"\n## Changelog\n\n{changelog}\n"
+    return f"## Summary\n\nThing.\n\n## Type of change\n\n{type_block}{changelog_block}"
 
 
-def test_harvest_includes_entries() -> None:
-    result = gen.harvest_pr(123, _body("Added: a new flag\nFixed: a crash"))
+def test_harvest_included_with_description_and_tag() -> None:
+    body = _body("Projects workspace groups sessions", "UI / frontend change")
+    result = gen.harvest_pr(123, body)
     assert result.status == "included"
-    assert result.entries == [("Added", "a new flag"), ("Fixed", "a crash")]
+    assert result.description == "Projects workspace groups sessions"
+    assert result.type_tags == ["UI / frontend change"]
 
 
-def test_harvest_skip() -> None:
-    result = gen.harvest_pr(123, _body("skip"))
-    assert result.status == "skip"
-    assert result.entries == []
+def test_harvest_takes_first_line_of_multiline() -> None:
+    result = gen.harvest_pr(123, _body("first line of the change\n\nmore detail\nand more"))
+    assert result.status == "included"
+    assert result.description == "first line of the change"
 
 
-def test_harvest_no_section() -> None:
-    result = gen.harvest_pr(123, "## Summary\n\nNo changelog heading here.\n")
-    assert result.status == "no-section"
+def test_harvest_placeholder_is_omitted() -> None:
+    placeholder = "<Add a line to describe the change, else delete this section>"
+    result = gen.harvest_pr(123, _body(placeholder))
+    assert result.status == "omitted"
+    assert result.description == ""
+
+
+def test_harvest_deleted_section_is_omitted() -> None:
+    result = gen.harvest_pr(123, _body(None))
+    assert result.status == "omitted"
 
 
 def test_harvest_missing_body() -> None:
-    assert gen.harvest_pr(123, None).status == "no-section"
-
-
-def test_harvest_unparseable() -> None:
-    result = gen.harvest_pr(123, _body("just prose, no category"))
-    assert result.status == "unparseable"
-    assert result.entries == []
+    assert gen.harvest_pr(123, None).status == "omitted"
 
 
 # --- render_section ----------------------------------------------------------
 
 
-def _result(pr: int, entries: list[tuple[str, str]]) -> object:
+def _result(pr: int, description: str, type_tags: list[str] | None = None) -> object:
     r = gen.HarvestResult(pr)
-    r.entries = entries
-    r.status = "included"
+    r.description = description
+    r.type_tags = type_tags or []
+    r.status = "included" if description else "omitted"
     return r
 
 
-def test_render_section_groups_by_category() -> None:
+def test_render_section_flat_list_with_tags_sorted_by_pr() -> None:
     results = [
-        _result(10, [("Added", "watch flag")]),
-        _result(20, [("Fixed", "a crash")]),
-        _result(5, [("Added", "another thing")]),
+        _result(20, "a crash fix", ["Bug fix"]),
+        _result(5, "another thing", ["Feature"]),
+        _result(10, "watch flag", ["UI / frontend change"]),
     ]
     section = gen.render_section("v0.3.0", "2026-06-27", results)
     assert section.startswith("## [v0.3.0] — 2026-06-27")
-    assert "### Added" in section and "### Fixed" in section
-    # Sorted by PR number within a category.
+    # Flat list, sorted by PR number, each with its bracket tag.
     assert section.index("another thing (#5)") < section.index("watch flag (#10)")
-    # Category order follows CHANGELOG_CATEGORIES (Added before Fixed).
-    assert section.index("### Added") < section.index("### Fixed")
+    assert section.index("watch flag (#10)") < section.index("a crash fix (#20)")
+    assert "- [UI] watch flag (#10)" in section
+    assert "- [Bug fix] a crash fix (#20)" in section
+    # No category sub-headings.
+    assert "### " not in section
+
+
+def test_render_section_multiple_tags_join() -> None:
+    section = gen.render_section(
+        "v0.3.0", "2026-06-27", [_result(7, "did a thing", ["UI / frontend change", "Bug fix"])]
+    )
+    assert "- [UI / Bug fix] did a thing (#7)" in section
+
+
+def test_render_section_untagged_entry_has_no_bracket() -> None:
+    section = gen.render_section("v0.3.0", "2026-06-27", [_result(7, "did a thing", [])])
+    assert "- did a thing (#7)" in section
+
+
+def test_render_section_omits_undocumented_prs() -> None:
+    results = [_result(10, "documented", ["Bug fix"]), _result(20, "", [])]
+    section = gen.render_section("v0.3.0", "2026-06-27", results)
+    assert "(#10)" in section and "(#20)" not in section
 
 
 def test_render_section_no_entries() -> None:
@@ -160,26 +193,26 @@ def test_insert_is_idempotent_and_replaces() -> None:
 _REPO = "omnigent-ai/omnigent"
 
 
-def test_draft_notes_groups_into_two_sections() -> None:
+def test_draft_notes_groups_into_two_sections_by_type() -> None:
     results = [
-        _result(10, [("Added", "a new flag")]),
-        _result(20, [("Changed", "moved a button")]),
-        _result(30, [("Fixed", "a crash")]),
-        _result(40, [("Security", "patched an SSRF")]),
+        _result(10, "a new capability", ["Feature"]),
+        _result(20, "moved a button", ["UI / frontend change"]),
+        _result(30, "a crash fix", ["Bug fix"]),
+        _result(40, "dropped a flag", ["Breaking change"]),
     ]
     notes = gen.render_draft_notes(results, _REPO)
     assert "## Major new features" in notes
     assert "## Bug fixes & hardening" in notes
-    # Added/Changed land in features; Fixed/Security in hardening.
+    # Feature/UI land in features; Bug fix/Breaking in hardening.
     feat, hard = notes.split("## Bug fixes & hardening")
-    assert "a new flag (#10)" in feat and "moved a button (#20)" in feat
-    assert "a crash (#30)" in hard and "patched an SSRF (#40)" in hard
+    assert "a new capability (#10)" in feat and "moved a button (#20)" in feat
+    assert "a crash fix (#30)" in hard and "dropped a flag (#40)" in hard
     # Features section comes first.
     assert notes.index("## Major new features") < notes.index("## Bug fixes & hardening")
 
 
 def test_draft_notes_has_full_changelog_footer() -> None:
-    notes = gen.render_draft_notes([_result(1, [("Added", "x")])], _REPO)
+    notes = gen.render_draft_notes([_result(1, "x", ["Feature"])], _REPO)
     assert notes.rstrip().endswith(
         "Full Changelog: https://github.com/omnigent-ai/omnigent/blob/main/CHANGELOG.md"
     )
@@ -187,16 +220,16 @@ def test_draft_notes_has_full_changelog_footer() -> None:
 
 def test_draft_notes_empty_section_keeps_placeholder() -> None:
     # Only a feature entry — the hardening section should still appear with a hint.
-    notes = gen.render_draft_notes([_result(1, [("Added", "x")])], _REPO)
+    notes = gen.render_draft_notes([_result(1, "x", ["Feature"])], _REPO)
     assert "## Bug fixes & hardening" in notes
     assert "no entries harvested" in notes
 
 
 def test_draft_notes_sorted_by_pr_within_section() -> None:
     results = [
-        _result(30, [("Added", "third")]),
-        _result(10, [("Added", "first")]),
-        _result(20, [("Changed", "second")]),
+        _result(30, "third", ["Feature"]),
+        _result(10, "first", ["Feature"]),
+        _result(20, "second", ["UI / frontend change"]),
     ]
     notes = gen.render_draft_notes(results, _REPO)
     assert notes.index("first (#10)") < notes.index("second (#20)") < notes.index("third (#30)")
@@ -205,26 +238,27 @@ def test_draft_notes_sorted_by_pr_within_section() -> None:
 # --- render_pr_list (agent input) --------------------------------------------
 
 
-def _titled(pr: int, title: str, entries: list[tuple[str, str]]) -> object:
+def _titled(pr: int, title: str, description: str, type_tags: list[str] | None = None) -> object:
     r = gen.HarvestResult(pr, title)
-    r.entries = entries
-    r.status = "included" if entries else "no-section"
+    r.description = description
+    r.type_tags = type_tags or []
+    r.status = "included" if description else "omitted"
     return r
 
 
-def test_pr_list_includes_title_and_entries() -> None:
+def test_pr_list_includes_title_and_tagged_description() -> None:
     results = [
-        _titled(20, "feat(web): projects workspace", [("Added", "group sessions")]),
-        _titled(10, "chore: bump deps", []),  # no changelog entry — title only
+        _titled(20, "feat(web): projects workspace", "group sessions", ["UI / frontend change"]),
+        _titled(10, "chore: bump deps", ""),  # no changelog description — title only
     ]
     listing = gen.render_pr_list(results)
     # Sorted by PR number.
     assert listing.index("#10:") < listing.index("#20:")
     assert "#10: chore: bump deps" in listing
     assert "#20: feat(web): projects workspace" in listing
-    assert "    - [Added] group sessions" in listing
+    assert "    - [UI] group sessions" in listing
 
 
 def test_pr_list_handles_missing_title() -> None:
-    listing = gen.render_pr_list([_titled(5, "", [])])
+    listing = gen.render_pr_list([_titled(5, "", "")])
     assert "#5: (no title)" in listing

--- a/tests/github/test_pr_autoformat.py
+++ b/tests/github/test_pr_autoformat.py
@@ -37,8 +37,8 @@ def test_preserves_existing_sections_and_adds_missing_optional_context() -> None
     assert "## Changelog" in formatted
 
 
-def test_scaffolds_changelog_section_with_skip_default() -> None:
+def test_scaffolds_changelog_section_with_delete_placeholder() -> None:
     formatted = pr_autoformat.format_body("Fix the important thing.")
     assert "## Changelog" in formatted
-    # The scaffolded section defaults to the `skip` sentinel.
-    assert formatted.rstrip().endswith("skip")
+    # The scaffolded section defaults to the delete-if-not-noteworthy placeholder.
+    assert formatted.rstrip().endswith("else delete this section>")

--- a/tests/github/test_pr_template_validate.py
+++ b/tests/github/test_pr_template_validate.py
@@ -40,7 +40,7 @@ def _valid_body(
 """,
     coverage_notes: str | None = None,
     demo: str | None = None,
-    changelog: str | None = "Fixed: stale polling no longer blocks the REPL handoff",
+    changelog: str | None = "Stale polling no longer blocks the REPL handoff",
 ) -> str:
     notes_section = "" if coverage_notes is None else f"\n## Coverage notes\n\n{coverage_notes}\n"
     demo_section = "" if demo is None else f"\n## Demo\n\n{demo}\n"
@@ -255,50 +255,46 @@ def test_ui_change_with_demo_passes() -> None:
     assert result.ok, result.errors
 
 
-def test_changelog_skip_is_valid() -> None:
-    result = module.validate_pr_body(_valid_body(changelog="skip"))
-    assert result.ok, result.errors
-
-
-def test_changelog_multiple_category_lines_valid() -> None:
-    body = _valid_body(
-        changelog="Added: `--watch` reruns on file changes\nFixed: REPL no longer hangs",
-    )
+def test_changelog_free_text_line_is_valid() -> None:
+    body = _valid_body(changelog="`--watch` reruns an agent when files change")
     result = module.validate_pr_body(body)
     assert result.ok, result.errors
 
 
-def test_changelog_missing_heading_rejected() -> None:
+def test_changelog_section_is_optional() -> None:
+    # A non-breaking PR may omit the Changelog section entirely.
     result = module.validate_pr_body(_valid_body(changelog=None))
-    assert not result.ok
-    assert "Missing required section: ## Changelog" in result.errors
+    assert result.ok, result.errors
 
 
-def test_changelog_malformed_line_rejected() -> None:
-    body = _valid_body(changelog="this is just prose with no category prefix")
+def test_changelog_placeholder_left_in_is_allowed_for_non_breaking() -> None:
+    # Leaving the untouched placeholder is treated like deleting the section.
+    body = _valid_body(changelog="<Add a line to describe the change, else delete this section>")
+    result = module.validate_pr_body(body)
+    assert result.ok, result.errors
+
+
+def test_breaking_change_requires_a_description() -> None:
+    body = _valid_body(type_checkboxes=_BREAKING_TYPE, changelog=None)
     result = module.validate_pr_body(body)
     assert not result.ok
-    assert any(error.startswith("Changelog lines must be") for error in result.errors)
+    assert any(error.startswith("A Breaking change must describe") for error in result.errors)
 
 
-def test_changelog_unknown_category_rejected() -> None:
-    body = _valid_body(changelog="Improved: faster startup")
-    result = module.validate_pr_body(body)
-    assert not result.ok
-    assert any(error.startswith("Changelog lines must be") for error in result.errors)
-
-
-def test_breaking_change_requires_changelog_entry() -> None:
-    body = _valid_body(type_checkboxes=_BREAKING_TYPE, changelog="skip")
-    result = module.validate_pr_body(body)
-    assert not result.ok
-    assert any(error.startswith("Changelog must not be 'skip'") for error in result.errors)
-
-
-def test_breaking_change_with_entry_passes() -> None:
+def test_breaking_change_with_placeholder_is_rejected() -> None:
     body = _valid_body(
         type_checkboxes=_BREAKING_TYPE,
-        changelog="Removed: dropped the deprecated `--legacy` flag",
+        changelog="<Add a line to describe the change, else delete this section>",
+    )
+    result = module.validate_pr_body(body)
+    assert not result.ok
+    assert any(error.startswith("A Breaking change must describe") for error in result.errors)
+
+
+def test_breaking_change_with_description_passes() -> None:
+    body = _valid_body(
+        type_checkboxes=_BREAKING_TYPE,
+        changelog="Dropped the deprecated `--legacy` flag",
     )
     result = module.validate_pr_body(body)
     assert result.ok, result.errors


### PR DESCRIPTION
## Related issue

N/A — follow-up refinement to the changelog automation from #1763.

## Summary

Reworks the PR `## Changelog` section based on review feedback, so authoring an entry is lower-friction:

- **No `Category:` format.** The changelog tag is derived from the **Type of change** checkboxes instead — a PR that checks *UI / frontend change* renders as `[UI] <description>`. Authors write a plain, user-voice one-liner and never restate the category.
- **Multi-line is fine.** The harvester takes the first non-blank line as the description instead of failing the gate on wrapped/paragraph text.
- **The section is optional.** Authors delete it (or leave the placeholder) when the change isn't noteworthy, and the PR is simply omitted from the changelog — no author-grouped "undocumented" bucket, which is just noise over a large range. The one hard rule kept: a **Breaking change** must carry a real description.
- Replaces the `skip` sentinel in the template with `<Add a line to describe the change, else delete this section>` and updates the guidance comment.

`CHANGELOG.md` now renders a flat, PR-sorted list of `- [Tag] description (#NNNN)`; the release-notes draft buckets Feature/UI into *Major new features* and Bug fix/Breaking into *Bug fixes & hardening*. The shared `_md.py` parser (`changelog_description` + `checked_labels` + `type_tag`/`TYPE_TAGS`) backs both the merge gate and the release harvester so they can't drift.

## Test Plan

- `pytest tests/github/` — **75 pass**, including new cases: multi-line → first-line, placeholder/blank/deleted → omitted, tag derivation (single + multiple checkboxes), flat-list `[Tag]` render, undocumented PRs omitted, and Breaking-change-requires-description.
- Live dry-run of the harvester over the real `v0.1.0..v0.1.1` range (range/enumeration/`gh` body-fetch/render) plus a synthetic end-to-end render confirming `- [UI] … (#NNNN)` output and first-line collapse.
- ruff check + format clean.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The scripts are covered by the `tests/github/` unit suite (75 passing). The two workflows that consume these scripts are unchanged by this PR; verified the harvester end-to-end via local dry-runs against real repo history.

## Changelog

PR changelog entries are now a plain one-line description tagged by the "Type of change" boxes (e.g. `[UI]`); the section is optional and deletable when a change isn't noteworthy