### PR TITLE
fix(runner): honor per-session workspace for the primary OS environment

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -17057,7 +17057,12 @@ def create_runner_app(
 
         agent_spec = await _require_os_env(session_id)  # also resolves spec
         await _ensure_session_registered(session_id)
-        env = resource_registry.resolve_environment(session_id, environment_id, agent_spec)
+        env = resource_registry.resolve_environment(
+            session_id,
+            environment_id,
+            agent_spec,
+            session_workspace=_session_workspace_cache.get(session_id),
+        )
         fs = CallerProcessFilesystem(env)
         entries = await fs.search_files(
             q,
@@ -17256,7 +17261,12 @@ def create_runner_app(
 
         after: str | None = None
         if not is_deleted:
-            env = resource_registry.resolve_environment(session_id, environment_id, agent_spec)
+            env = resource_registry.resolve_environment(
+                session_id,
+                environment_id,
+                agent_spec,
+                session_workspace=_session_workspace_cache.get(session_id),
+            )
             fs = CallerProcessFilesystem(env)
             content = await fs.read(relative_path, limit=None)
             after = content.data.decode(content.encoding or "utf-8", errors="replace")
@@ -17334,6 +17344,7 @@ def create_runner_app(
             session_id,
             environment_id,
             agent_spec,
+            session_workspace=_session_workspace_cache.get(session_id),
         )
         fs = CallerProcessFilesystem(env)
         body = await request.json()
@@ -17403,6 +17414,7 @@ def create_runner_app(
             session_id,
             environment_id,
             agent_spec,
+            session_workspace=_session_workspace_cache.get(session_id),
         )
         fs = CallerProcessFilesystem(env)
         # Seed the diff snapshot with the current content *before* editing.
@@ -17465,6 +17477,7 @@ def create_runner_app(
             session_id,
             environment_id,
             agent_spec,
+            session_workspace=_session_workspace_cache.get(session_id),
         )
         fs = CallerProcessFilesystem(env)
         result = await fs.delete(relative_path, recursive=recursive)
@@ -17927,6 +17940,7 @@ def create_runner_app(
             session_id,
             environment_id,
             agent_spec,
+            session_workspace=_session_workspace_cache.get(session_id),
         )
 
         fs = CallerProcessFilesystem(env)
@@ -18017,6 +18031,7 @@ def create_runner_app(
             session_id,
             environment_id,
             agent_spec,
+            session_workspace=_session_workspace_cache.get(session_id),
         )
         body = await request.json()
         command = body.get("command")

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -534,6 +534,8 @@ class SessionResourceRegistry:
         session_id: str,
         environment_id: str,
         agent_spec: Any | None = None,
+        *,
+        session_workspace: str | None = None,
     ) -> OSEnvironment:
         """Resolve an environment id to a live OSEnvironment.
 
@@ -545,11 +547,16 @@ class SessionResourceRegistry:
         :param session_id: Session/conversation identifier.
         :param environment_id: Environment resource id.
         :param agent_spec: Agent spec for primary env creation.
+        :param session_workspace: Optional per-session workspace (the
+            working directory chosen for this session). When set, the
+            primary environment uses it in preference to the runner-level
+            workspace, so the filesystem view matches the session's
+            selected directory.
         :returns: The live :class:`OSEnvironment`.
         :raises ValueError: If the environment id cannot be resolved.
         """
         if environment_id == DEFAULT_ENVIRONMENT_ID:
-            return self._resolve_primary(session_id, agent_spec)
+            return self._resolve_primary(session_id, agent_spec, session_workspace)
 
         if self._terminal_registry is not None:
             for entry in self._terminal_registry.list_for_conversation(
@@ -570,11 +577,16 @@ class SessionResourceRegistry:
         self,
         session_id: str,
         agent_spec: Any | None,
+        session_workspace: str | None = None,
     ) -> OSEnvironment:
         """Get or create the primary OSEnvironment for a session.
 
         :param session_id: Session/conversation identifier.
         :param agent_spec: Agent spec for env creation.
+        :param session_workspace: Optional per-session workspace (the
+            working directory chosen for this session, projected from the
+            session snapshot). When set, it takes precedence over the
+            runner-level workspace — see :meth:`_create_primary_env`.
         :returns: The primary :class:`OSEnvironment`.
         """
         with self._lock:
@@ -582,7 +594,7 @@ class SessionResourceRegistry:
             if cached is not None:
                 return cached
 
-            os_env = self._create_primary_env(session_id, agent_spec)
+            os_env = self._create_primary_env(session_id, agent_spec, session_workspace)
             self._primary_envs[session_id] = os_env
             return os_env
 
@@ -590,6 +602,7 @@ class SessionResourceRegistry:
         self,
         session_id: str,
         agent_spec: Any | None,
+        session_workspace: str | None = None,
     ) -> OSEnvironment:
         """Create a new primary OSEnvironment.
 
@@ -615,11 +628,27 @@ class SessionResourceRegistry:
         from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
         from omnigent.inner.os_env import create_os_environment
 
+        # A per-session workspace (the working directory chosen for this
+        # session, projected from the session snapshot) takes precedence over
+        # the runner-level workspace. This mirrors the
+        # ``session_workspace or OMNIGENT_RUNNER_WORKSPACE`` precedence already
+        # used for runner-owned native terminals, so the Files panel and the
+        # ``/resources/environments/default`` filesystem view honor the same
+        # directory the terminal harness runs in. It is used directly (no
+        # per-session isolation subdir) because the caller chose that exact
+        # folder, and its permissions are left untouched.
+        explicit_cwd: str | None = None
+        if isinstance(session_workspace, str) and session_workspace.strip():
+            explicit_cwd = str(Path(session_workspace.strip()).expanduser().resolve())
+            os.makedirs(explicit_cwd, exist_ok=True)
+
         # Prefer the CLI launch workspace so that the OS environment
         # cwd matches the filesystem-registry watch path.  Fall back
         # to the per-session temp dir for remote/cloud runners that
         # have no workspace affinity.
-        if self._runner_workspace is not None:
+        if explicit_cwd is not None:
+            default_cwd = explicit_cwd
+        elif self._runner_workspace is not None:
             if self._per_session_workspace:
                 # Isolate sessions under the shared workspace.
                 default_cwd = str(self._runner_workspace / _sanitize_session_id(session_id))
@@ -639,12 +668,14 @@ class SessionResourceRegistry:
                 raise ValueError(
                     "Agent spec has no os_env; cannot create a primary filesystem environment."
                 )
-            # Precedence per designs/SESSION_WORKSPACE_SELECTION.md:
-            # runner_workspace (env-var-driven) ALWAYS wins when set.
-            # Otherwise the spec's absolute cwd wins; otherwise we
-            # fall back to the per-session tmpdir (default_cwd).
+            # Precedence: an explicit per-session workspace wins first, then
+            # runner_workspace (env-var-driven) when set. Otherwise the spec's
+            # absolute cwd wins; otherwise we fall back to the per-session
+            # tmpdir (default_cwd). When explicit_cwd or runner_workspace is in
+            # play, default_cwd already holds the resolved directory.
             if (
-                self._runner_workspace is not None
+                explicit_cwd is not None
+                or self._runner_workspace is not None
                 or spec_os_env.cwd is None
                 or spec_os_env.cwd in (".", "./")
             ):

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -1082,3 +1082,69 @@ def test_resolve_environment_runner_workspace_overrides_absolute_spec_cwd(
     # Compare via realpath because tmp_path on macOS goes through
     # /var → /private/var symlinks.
     assert os.path.realpath(env.cwd) == os.path.realpath(workspace)
+
+
+def test_resolve_environment_session_workspace_overrides_runner_workspace(
+    tmp_path: Path,
+) -> None:
+    """
+    A per-session workspace (the working directory chosen for the session,
+    projected from the session snapshot) takes precedence over both
+    runner_workspace and the spec cwd, and is used directly without a
+    per-session isolation subdirectory.
+
+    This is what makes a new session's selected working directory become the
+    primary filesystem environment / Files-panel root, instead of the
+    runner-level workspace.
+    """
+    runner_ws = tmp_path / "runner-workspace"
+    runner_ws.mkdir()
+    selected = tmp_path / "session-picked-dir"
+    selected.mkdir()
+    reg = SessionResourceRegistry(
+        runner_workspace=runner_ws,
+        per_session_workspace=True,
+    )
+    spec = SimpleNamespace(
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=".",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        )
+    )
+
+    env = reg.resolve_environment(
+        "conv_selected",
+        DEFAULT_ENVIRONMENT_ID,
+        spec,
+        session_workspace=str(selected),
+    )
+
+    assert env is not None
+    # Used directly — not runner_ws, and not selected/<session_id>.
+    assert os.path.realpath(env.cwd) == os.path.realpath(selected)
+
+
+def test_resolve_environment_without_session_workspace_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    """Omitting session_workspace preserves the prior behavior: the primary
+    environment falls back to the (per-session-isolated) runner workspace."""
+    runner_ws = tmp_path / "runner-workspace"
+    runner_ws.mkdir()
+    reg = SessionResourceRegistry(
+        runner_workspace=runner_ws,
+        per_session_workspace=False,
+    )
+    spec = SimpleNamespace(
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=".",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        )
+    )
+
+    env = reg.resolve_environment("conv_none", DEFAULT_ENVIRONMENT_ID, spec)
+
+    assert env is not None
+    assert os.path.realpath(env.cwd) == os.path.realpath(runner_ws)


### PR DESCRIPTION
> **Status:** Rebased onto latest `main` (2026-07-08) — no conflicts, mergeable. All code CI passes; only the required *Maintainer Approval* check is pending review.

## Problem

When a new session selects a working directory, that directory (the session snapshot's `workspace`) is honored by runner-owned native terminals (codex/pi/cursor/kiro/opencode) via the `session_workspace or OMNIGENT_RUNNER_WORKSPACE` precedence. But the **primary OS environment** — which backs the Files panel and the `/resources/environments/default` filesystem endpoints — only ever used the runner-level `runner_workspace` (with per-session-id isolation) or a per-session tmpdir.

Because a spec `os_env.cwd: "."` is treated as "unset" and discarded (`resource_registry.py`), the session's chosen directory never became the primary environment's cwd. Net effect: you pick a working directory for a new session, but the Files panel / filesystem view shows the runner-level workspace (or an isolated `<runner_workspace>/<session_id>` subdir) instead of the folder you picked.

## Fix

Thread an optional `session_workspace` through:

```
resolve_environment() → _resolve_primary() → _create_primary_env()
```

When provided, `session_workspace` takes precedence over `runner_workspace` and over the spec cwd, and is used **directly** (no per-session isolation subdirectory, permissions left untouched). This mirrors the precedence already used for runner-owned native terminals, so the primary filesystem view matches the directory the harness actually runs in. Omitting `session_workspace` preserves prior behavior exactly.

The filesystem resource endpoints in `runner/app.py` pass the value that `_ensure_session_registered` already caches (`_session_workspace_cache`), so no extra server fetch is introduced.

## Precedence

`session_workspace` (per-session, explicit) → `runner_workspace` (env-driven) → absolute spec cwd → per-session tmpdir. This extends the existing `session_workspace or OMNIGENT_RUNNER_WORKSPACE` pattern (already used for terminals) to the primary environment, rather than introducing a new invariant.

## Tests

- New: an explicit `session_workspace` overrides `runner_workspace` + spec cwd and is used directly (no isolation subdir); omitting it is unchanged.
- `tests/runner/test_resource_registry.py` → 34 passed
- `tests/runner/test_environment_filesystem.py` + `tests/inner/test_os_env.py` → 70 passed

## Notes / scope

This aligns the **primary OS environment** (Files panel + filesystem APIs) with the per-session selection. Native harness terminal cwd already flows from `snapshot["workspace"]`; this closes the gap for the primary environment specifically.

## Related

- #1896 — companion fix. This PR fixes the **primary OS environment / Files panel**; #1896 fixes the **spawned harness subprocess cwd**. Together they make a session's selected working folder consistent across the file view *and* the agent's own tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
