### PR TITLE
fix(kimi-native): tolerate torn UTF-8 wire reads; reset supervisor backoff after healthy runs

### DIFF
--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -33,6 +33,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -49,6 +50,9 @@ _DISCOVER_SKEW_MS = 10_000
 #: Supervisor backoff bounds.
 _BACKOFF_INITIAL_S = 1.0
 _BACKOFF_MAX_S = 30.0
+#: A run at least this long is "healthy": the next crash restarts the backoff
+#: ladder instead of continuing it (matches qwen/goose supervisors).
+_SUPERVISOR_HEALTHY_UPTIME_S = 60.0
 
 
 @dataclass
@@ -221,7 +225,9 @@ def _read_new_items(wire_path: Path, last_line: int) -> list[_MirrorItem]:
     """
     try:
         lines = wire_path.read_text(encoding="utf-8").splitlines()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # A poll can race kimi's buffered write mid multi-byte character;
+        # the torn tail is complete by the next poll, so retry then.
         return []
     items: list[_MirrorItem] = []
     for idx in range(last_line, len(lines)):
@@ -320,6 +326,16 @@ async def forward_kimi_wire_to_session(
             await asyncio.sleep(_POLL_INTERVAL_S)
 
 
+def _supervisor_monotonic() -> float:
+    """Indirection so tests can stub the supervisor's clock."""
+    return time.monotonic()
+
+
+async def _supervisor_sleep(seconds: float) -> None:
+    """Indirection so tests can stub the supervisor's backoff sleep."""
+    await asyncio.sleep(seconds)
+
+
 async def supervise_kimi_forwarder(
     *,
     base_url: str,
@@ -339,6 +355,7 @@ async def supervise_kimi_forwarder(
     """
     backoff = _BACKOFF_INITIAL_S
     while True:
+        run_started_at = _supervisor_monotonic()
         try:
             await forward_kimi_wire_to_session(
                 base_url=base_url,
@@ -354,7 +371,11 @@ async def supervise_kimi_forwarder(
             raise
         except Exception:
             _logger.exception("kimi forwarder crashed for session %s; restarting", session_id)
-            await asyncio.sleep(backoff)
+            if _supervisor_monotonic() - run_started_at >= _SUPERVISOR_HEALTHY_UPTIME_S:
+                # A crash after a healthy run is a fresh incident, not part
+                # of a crash loop — start the backoff ladder over.
+                backoff = _BACKOFF_INITIAL_S
+            await _supervisor_sleep(backoff)
             backoff = min(backoff * 2, _BACKOFF_MAX_S)
         else:
             return

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -8,9 +8,13 @@ by the e2e gate, not here.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
+import pytest
+
+from omnigent import kimi_native_forwarder as knf
 from omnigent.kimi_native_forwarder import (
     _discover_wire,
     _ForwardState,
@@ -114,6 +118,76 @@ class TestReadNewItems:
 
     def test_missing_file_is_empty(self, tmp_path: Path) -> None:
         assert _read_new_items(tmp_path / "nope.jsonl", 0) == []
+
+    def test_torn_utf8_tail_is_tolerated(self, tmp_path: Path) -> None:
+        wire = tmp_path / "wire.jsonl"
+        # A complete line plus the first two bytes of U+4E2D "中" — what a
+        # poll that races kimi's buffered write mid-character observes.
+        wire.write_bytes(b'{"type":"metadata"}\n\xe4\xb8')
+        assert _read_new_items(wire, 0) == []
+
+    def test_torn_tail_is_delivered_once_completed(self, tmp_path: Path) -> None:
+        wire = tmp_path / "wire.jsonl"
+        row = json.dumps(
+            {
+                "type": "context.append_loop_event",
+                "event": {
+                    "type": "content.part",
+                    "uuid": "u9",
+                    "part": {"type": "text", "text": "中文"},
+                },
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+        torn_at = row.index("文".encode()) + 2  # two of 文's three bytes
+        wire.write_bytes(row[:torn_at])
+        assert _read_new_items(wire, 0) == []
+        wire.write_bytes(row + b"\n")
+        items = _read_new_items(wire, 0)
+        assert [(i.role, i.text) for i in items] == [("assistant", "中文")]
+
+
+class TestSuperviseBackoff:
+    async def test_backoff_resets_after_healthy_uptime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crashes = iter(
+            [
+                RuntimeError("boom"),
+                RuntimeError("boom"),
+                RuntimeError("boom"),
+                asyncio.CancelledError(),
+            ]
+        )
+        # The supervisor reads the clock twice per run (start, at crash):
+        # runs 1-2 crash after 1s of uptime, run 3 after a healthy 100s.
+        clock = iter([0.0, 1.0, 10.0, 11.0, 100.0, 200.0, 300.0])
+        sleeps: list[float] = []
+
+        async def _fake_forward(**_kw: object) -> None:
+            raise next(crashes)
+
+        async def _fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(knf, "forward_kimi_wire_to_session", _fake_forward)
+        monkeypatch.setattr(knf, "_supervisor_sleep", _fake_sleep)
+        monkeypatch.setattr(knf, "_supervisor_monotonic", lambda: next(clock))
+
+        with pytest.raises(asyncio.CancelledError):
+            await knf.supervise_kimi_forwarder(
+                base_url="http://test",
+                headers={},
+                session_id="conv",
+                bridge_dir=tmp_path,
+                kimi_home=tmp_path,
+                workspace=str(tmp_path),
+                launch_epoch_ms=0,
+            )
+
+        # Two quick crashes climb the ladder (1s, 2s); the crash after a
+        # healthy run restarts it at 1s instead of continuing to 4s.
+        assert sleeps == [1.0, 2.0, 1.0]
 
 
 class TestState:


### PR DESCRIPTION
## Related issue

Closes #1827

## Summary

- `_read_new_items` read the kimi wire log guarded only by `except OSError`; a 0.25s poll racing kimi's buffered write mid multi-byte character (kimi output is largely 3-byte CJK) raised `UnicodeDecodeError` and crashed the forwarder. Treat it as a transient read: return no items and let the next poll re-read the completed line — the cursor only advances past successfully posted items, so nothing is lost or duplicated.
- `supervise_kimi_forwarder`'s backoff only ever grew (`min(backoff * 2, 30)` with no reset), so transient crashes over a session's lifetime ratcheted every mirror stall toward a permanent 30s. It now resets to the initial 1s after a healthy run of ≥60s (`_SUPERVISOR_HEALTHY_UPTIME_S`), mirroring the qwen/goose supervisors.

ELI5: the transcript scribe choked whenever it peeked at kimi's diary halfway through a Chinese character being written — and every choke permanently lengthened its recovery nap. Now it just waits for the next peek, and naps only stay long for actual crash loops.

## Test Plan

- New `TestReadNewItems::test_torn_utf8_tail_is_tolerated` and `test_torn_tail_is_delivered_once_completed` — red on `main` (`UnicodeDecodeError`), green here; the second also proves the completed line is delivered exactly once after a torn read.
- New `TestSuperviseBackoff::test_backoff_resets_after_healthy_uptime` — red on `main` (sleep ladder `[1.0, 2.0, 4.0]`), green here (`[1.0, 2.0, 1.0]`).
- `uv run --extra dev python -m pytest tests/test_kimi_native_forwarder.py` → 15 passed; `ruff check`, `ruff format --check`, and `pre-commit` clean.

## Demo

Red→green screenshot (same tests on `main` vs this branch):
<img width="1100" height="560" alt="kimi-fix-demo-red-green" src="https://github.com/user-attachments/assets/98866924-3433-4cf1-a122-036d25ac44ba" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The torn-read race is deterministic in the new unit tests (a wire file ending in 2 of a CJK character's 3 bytes); the supervisor ladder is driven through the stubbed clock/sleep seams, same as the qwen supervisor tests.

## Changelog

Fixed: kimi-native web mirror no longer freezes with ever-growing stalls when a poll catches kimi mid-write of a multi-byte character
