### PR TITLE
feat(tools): add sys_compact built-in for current-session compaction

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -63,6 +63,7 @@ from omnigent.tools.builtins.async_inbox import (
     SysCancelTaskTool,
     SysReadInboxTool,
 )
+from omnigent.tools.builtins.compact import SysCompactTool
 from omnigent.tools.builtins.download_file import DownloadFileTool
 from omnigent.tools.builtins.list_comments import ListCommentsTool
 from omnigent.tools.builtins.os_env import (
@@ -303,6 +304,7 @@ _AGENT_TOOLS = frozenset({"sys_agent_get", "sys_agent_download", "sys_agent_list
 # Priority 5l: Policy management — sys_add_policy.
 # The runner proxies the Omnigent server's session policy REST endpoint.
 _POLICY_TOOLS = frozenset({"sys_add_policy", "sys_policy_registry"})
+_SESSION_CONTROL_TOOLS = frozenset({SysCompactTool.name()})
 
 # Builtin tools the claude-native / codex-native relay advertises to the
 # real CLI, beyond the always-relayed ``sys_os_*`` family. Native harnesses
@@ -331,6 +333,7 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
     | _AGENT_TOOLS
     | _POLICY_TOOLS
     | _TERMINAL_TOOLS
+    | _SESSION_CONTROL_TOOLS
 )
 
 
@@ -467,6 +470,7 @@ _ALL_LOCAL_TOOLS = (
     | _COMMENT_TOOLS
     | _AGENT_TOOLS
     | _POLICY_TOOLS
+    | _SESSION_CONTROL_TOOLS
 )
 _PLACEHOLDER_CWDS = (None, "", ".", "./")
 
@@ -4064,6 +4068,12 @@ async def execute_tool(
                 session_inbox=session_inbox,
                 publish_event=publish_event,
             )
+        elif tool_name in _SESSION_CONTROL_TOOLS:
+            output = await _execute_session_control_tool(
+                tool_name,
+                server_client=server_client,
+                conversation_id=conversation_id,
+            )
         elif tool_name in _ASYNC_INBOX_TOOLS:
             output = await _execute_async_inbox_tool(
                 tool_name,
@@ -4196,6 +4206,46 @@ async def execute_tool(
         output = f"Error: {type(exc).__name__}: {exc}"
 
     return output
+
+
+async def _execute_session_control_tool(
+    tool_name: str,
+    *,
+    server_client: httpx.AsyncClient | None,
+    conversation_id: str | None,
+) -> str:
+    """Execute runner-dispatched current-session control tools."""
+    if tool_name != SysCompactTool.name():
+        return f"Error: {tool_name} not implemented in session control dispatch"
+    if server_client is None:
+        return "Error: sys_compact requires server_client"
+    if not conversation_id:
+        return "Error: sys_compact requires conversation_id"
+
+    try:
+        resp = await server_client.post(
+            f"/v1/sessions/{conversation_id}/events",
+            json={"type": "compact", "data": {}},
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:
+        return f"Error: sys_compact request failed: {type(exc).__name__}: {exc}"
+    if resp.status_code >= 400:
+        return f"Error: sys_compact returned {resp.status_code}: {resp.text[:200]}"
+
+    handled_by_runner = resp.status_code == 200
+    return json.dumps(
+        {
+            "status": "compact_requested",
+            "session_id": conversation_id,
+            "handled_by_runner": handled_by_runner,
+            "message": (
+                "Compaction was requested for the current session. For native "
+                "harnesses this is forwarded to the terminal; otherwise the "
+                "server may run AP-side compaction when the session is idle."
+            ),
+        }
+    )
 
 
 # Per-session leading-edge throttle for changed-files invalidation

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -35,6 +35,7 @@ from omnigent.tools.builtins.async_inbox import (
     SysCancelAsyncTool,
     SysReadInboxTool,
 )
+from omnigent.tools.builtins.compact import SysCompactTool
 from omnigent.tools.builtins.list_comments import ListCommentsTool
 from omnigent.tools.builtins.list_models import SysListModelsTool
 from omnigent.tools.builtins.load_skill import (
@@ -75,6 +76,7 @@ __all__ = [
     "SysAgentListTool",
     "SysCallAsyncTool",
     "SysCancelAsyncTool",
+    "SysCompactTool",
     "SysListModelsTool",
     "SysReadInboxTool",
     "SysSessionCloseTool",
@@ -210,6 +212,9 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     # name in the runner's tool dispatch — reserved here so user specs
     # cannot shadow it.
     "sys_advise_models": None,
+    # ``sys_compact`` is auto-registered by ToolManager and runner-dispatched
+    # through the existing session-events compact control path.
+    "sys_compact": None,
 }
 
 # Canonical set of every reserved builtin name. Derived from

--- a/omnigent/tools/builtins/compact.py
+++ b/omnigent/tools/builtins/compact.py
@@ -1,0 +1,42 @@
+"""Session compaction builtin tool schema."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from omnigent.tools.base import Tool
+
+
+class SysCompactTool(Tool):
+    """Request compaction for the current session."""
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"sys_compact"``."""
+        return "sys_compact"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Human-readable description for the LLM."""
+        return (
+            "Request context compaction for the current session. Use after "
+            "dispatching child work or when the conversation contains stale "
+            "routing detail. This preserves conversation history and asks the "
+            "active harness/server compaction path to summarize; it does not "
+            "delete selected messages."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """:returns: OpenAI function-format schema for ``sys_compact``."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+        }

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -27,6 +27,7 @@ from omnigent.tools.builtins import (
     SysAgentListTool,
     SysCallAsyncTool,
     SysCancelAsyncTool,
+    SysCompactTool,
     SysListModelsTool,
     SysReadInboxTool,
     SysSessionCloseTool,
@@ -182,6 +183,11 @@ class ToolManager:
         # Policy tool is always auto-registered so agents can add
         # inline CEL policies at runtime without spec changes.
         self._register_policy_tools()
+        self._register_session_control_tools()
+
+    def _register_session_control_tools(self) -> None:
+        """Auto-register current-session control tools."""
+        self._tools[SysCompactTool.name()] = SysCompactTool()
 
     def _register_policy_tools(self) -> None:
         """

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -140,6 +140,9 @@ def test_builtin_names_size_matches_registry() -> None:
                 # is enabled (RuntimeCaps.routing_client is set).
                 "sys_list_models",
                 "sys_advise_models",
+                # sys_compact: auto-registered by ToolManager and
+                # runner-dispatched to the session-events compact path.
+                "sys_compact",
             }
         )
         == BUILTIN_NAMES

--- a/tests/tools/test_compact_tool.py
+++ b/tests/tools/test_compact_tool.py
@@ -1,0 +1,77 @@
+"""Tests for the sys_compact builtin."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.spec.types import AgentSpec
+from omnigent.tools import ToolManager
+from omnigent.tools.builtins.compact import SysCompactTool
+from omnigent.runner.tool_dispatch import _execute_session_control_tool, should_dispatch_locally
+
+
+def test_sys_compact_is_registered_and_runner_dispatched() -> None:
+    """ToolManager exposes sys_compact and the runner owns dispatch."""
+    schemas = {s["function"]["name"]: s["function"] for s in ToolManager(AgentSpec(spec_version=1)).get_tool_schemas()}
+
+    assert SysCompactTool.name() in schemas
+    assert schemas[SysCompactTool.name()]["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+    assert should_dispatch_locally(SysCompactTool.name()) is True
+
+
+@pytest.mark.asyncio
+async def test_sys_compact_posts_current_session_compact_event() -> None:
+    """The runner wrapper reuses the existing session-events compact path."""
+    seen: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "body": json.loads(request.content.decode()),
+            }
+        )
+        return httpx.Response(200, json={"queued": False})
+
+    async with httpx.AsyncClient(
+        base_url="http://testserver",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        result = await _execute_session_control_tool(
+            SysCompactTool.name(),
+            server_client=client,
+            conversation_id="conv_parent",
+        )
+
+    payload = json.loads(result)
+    assert payload["status"] == "compact_requested"
+    assert payload["session_id"] == "conv_parent"
+    assert payload["handled_by_runner"] is True
+    assert seen == [
+        {
+            "method": "POST",
+            "path": "/v1/sessions/conv_parent/events",
+            "body": {"type": "compact", "data": {}},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sys_compact_reports_missing_conversation_id() -> None:
+    """The control wrapper fails closed when no current session is bound."""
+    result = await _execute_session_control_tool(
+        SysCompactTool.name(),
+        server_client=httpx.AsyncClient(base_url="http://testserver"),
+        conversation_id=None,
+    )
+
+    assert result == "Error: sys_compact requires conversation_id"

--- a/tests/tools/test_compact_tool.py
+++ b/tests/tools/test_compact_tool.py
@@ -8,15 +8,18 @@ from typing import Any
 import httpx
 import pytest
 
+from omnigent.runner.tool_dispatch import _execute_session_control_tool, should_dispatch_locally
 from omnigent.spec.types import AgentSpec
 from omnigent.tools import ToolManager
 from omnigent.tools.builtins.compact import SysCompactTool
-from omnigent.runner.tool_dispatch import _execute_session_control_tool, should_dispatch_locally
 
 
 def test_sys_compact_is_registered_and_runner_dispatched() -> None:
     """ToolManager exposes sys_compact and the runner owns dispatch."""
-    schemas = {s["function"]["name"]: s["function"] for s in ToolManager(AgentSpec(spec_version=1)).get_tool_schemas()}
+    schemas = {
+        s["function"]["name"]: s["function"]
+        for s in ToolManager(AgentSpec(spec_version=1)).get_tool_schemas()
+    }
 
     assert SysCompactTool.name() in schemas
     assert schemas[SysCompactTool.name()]["parameters"] == {

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -70,6 +70,8 @@ _ALWAYS_PRESENT_TOOLS: frozenset[str] = frozenset(
         # browse the registry and add policies at runtime.
         "sys_add_policy",
         "sys_policy_registry",
+        # Current-session control tools are always available.
+        "sys_compact",
     }
 )
 


### PR DESCRIPTION
> **Status:** Rebased onto latest `main` (2026-07-08) — no conflicts, mergeable. All code CI passes; only the required *Maintainer Approval* check is pending review.

## Problem

A parent orchestrator has no built-in way to request compaction of its **own** session. Compaction is only reachable as a session-control event (`POST /v1/sessions/{id}/events` with `type="compact"`) — it is not exposed to agents as a tool. Long-running orchestrators that fan out subtasks accumulate context and cannot self-compact between dispatch rounds.

## Change

Add a minimal `sys_compact` built-in:

- **`SysCompactTool`** (`omnigent/tools/builtins/compact.py`): auto-registered by `ToolManager` and reserved in the built-in registry so user specs cannot shadow it.
- **Runner dispatch** (`omnigent/runner/tool_dispatch.py`): dispatched locally as a thin `POST` to the existing session-events compact path (`type="compact"`, `data={}`).

It preserves existing semantics:
- Native harnesses handle compaction in their terminal context.
- Non-native / AP-side compaction remains subject to the server's existing idle/busy constraints.
- **No message deletion or selective history mutation** is added — it only requests the same compaction the session-events path already performs.

## Tests

- `tests/tools/test_compact_tool.py` — behavior, including the missing-`conversation_id` error path.
- `tests/tools/test_manager.py` — asserts `sys_compact` is reserved/registered.
- `tests/tools/test_compact_tool.py` + `tests/tools/test_manager.py` → **43 passed**.

## Scope

Additive: one new built-in tool + its runner dispatch + reservation. No changes to compaction semantics, message retention, or authority — it exposes an existing capability to the agent tool surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
