### PR TITLE
feat(changelog): preview an arbitrary range from a manual dispatch

### DIFF
--- a/.github/scripts/changelog/generate.py
+++ b/.github/scripts/changelog/generate.py
@@ -275,9 +275,16 @@ def _gh_pr_body(repo: str, pr: int) -> str | None:
     return proc.stdout
 
 
-def collect(tag: str, repo: str) -> tuple[str, list[HarvestResult], str | None]:
-    """Return (rendered_section, results, previous_tag) for *tag*."""
-    prev = previous_final_tag(tag, _all_tags())
+def collect(
+    tag: str, repo: str, base: str | None = None
+) -> tuple[str, list[HarvestResult], str | None]:
+    """Return (rendered_section, results, previous_tag) for *tag*.
+
+    *base* overrides the range start: when given, the harvest range is
+    ``base..tag`` verbatim (any refs — for manual/preview runs). Otherwise the
+    start is the previous final ``vX.Y.Z`` tag, as at release time.
+    """
+    prev = base or previous_final_tag(tag, _all_tags())
     subjects = _range_subjects(prev, tag)
     titles = pr_titles_from_subjects(subjects)
     results = [harvest_pr(pr, _gh_pr_body(repo, pr), title) for pr, title in titles.items()]
@@ -290,8 +297,14 @@ def collect(tag: str, repo: str) -> tuple[str, list[HarvestResult], str | None]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--tag", required=True, help="final release tag, e.g. v0.3.0")
+    parser.add_argument("--tag", required=True, help="release tag/ref (head of the range)")
     parser.add_argument("--repo", required=True, help="owner/name for `gh pr view`")
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="override the range start (any ref); default is the previous final "
+        "vX.Y.Z tag. Required when --tag is not a final vX.Y.Z (e.g. a preview run).",
+    )
     parser.add_argument(
         "--changelog-file",
         default="CHANGELOG.md",
@@ -321,9 +334,18 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    section, results, prev = collect(args.tag, args.repo)
+    # CHANGELOG.md insertion orders blocks by version, so it needs a final
+    # vX.Y.Z tag. A non-version --tag (a preview/test ref) needs an explicit
+    # --base for the range and can only render, never insert.
+    is_version = _version_tuple(args.tag) is not None
+    if not is_version and args.base is None:
+        parser.error(
+            f"--tag {args.tag!r} is not a final vX.Y.Z tag; pass --base <ref> for its range"
+        )
 
-    if not args.no_changelog_update:
+    section, results, prev = collect(args.tag, args.repo, base=args.base)
+
+    if is_version and not args.no_changelog_update:
         path = Path(args.changelog_file)
         existing = path.read_text() if path.exists() else _SEED_CHANGELOG
         path.write_text(insert_section(existing, args.tag, section))

--- a/.github/scripts/pr-template/_md.py
+++ b/.github/scripts/pr-template/_md.py
@@ -86,6 +86,10 @@ TYPE_TAGS: dict[str, str] = {
 }
 
 _PLACEHOLDER_RE = re.compile(r"^\s*<.*>\s*$")
+# Markers meaning "nothing to announce" — the section is optional and deletable,
+# but authors (and the old template's `skip` sentinel) still write these; treat
+# them as an absent section rather than leaking them in as literal entries.
+_OMIT_MARKERS = frozenset({"skip", "n/a", "na", "none", "-"})
 
 
 def is_placeholder(line: str) -> bool:
@@ -97,15 +101,17 @@ def changelog_description(section_raw: str) -> str:
     """First meaningful line of a "## Changelog" section.
 
     Strips HTML comments, then returns the first non-blank line — unless that
-    line is the ``<…>`` placeholder (author left it untouched), in which case the
-    section counts as absent and this returns ``""``. Multi-line / wrapped bodies
-    collapse to their first line.
+    line is the ``<…>`` placeholder or an omit marker (``skip``/``n/a``/…), in
+    which case the section counts as absent and this returns ``""``. Multi-line /
+    wrapped bodies collapse to their first line.
     """
     for raw in strip_html_comments(section_raw).splitlines():
         line = raw.strip()
         if not line:
             continue
-        return "" if is_placeholder(line) else line
+        if is_placeholder(line) or line.lower() in _OMIT_MARKERS:
+            return ""
+        return line
     return ""
 
 

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -29,9 +29,25 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Final release tag to (re)draft, e.g. v0.3.0
+        description: Release tag/ref to (re)draft (head of the range), e.g. v0.3.0
         required: true
         type: string
+      base:
+        description: >-
+          Optional range-start override (tag/branch/sha). Needed when `tag` is not
+          a final vX.Y.Z. Providing it makes the run a preview unless dry_run=false.
+        required: false
+        type: string
+      dry_run:
+        description: >-
+          Preview only — print the CHANGELOG section + draft notes to the run
+          summary, open no PR and edit no release. `auto` (default) previews when
+          `tag` is not a final vX.Y.Z or a base override is set, and does a real
+          run otherwise; `true`/`false` force the choice.
+        required: false
+        type: choice
+        options: [auto, "true", "false"]
+        default: auto
 
 permissions:
   contents: read
@@ -61,28 +77,52 @@ jobs:
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
           # On tag push, workflow_run.head_branch is the tag name (v0.3.0).
           RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
           INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BASE: ${{ inputs.base }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           tag="${INPUT_TAG:-$RUN_BRANCH}"
-          proceed=true; is_draft=false
+          base="${INPUT_BASE:-}"
+          proceed=false; is_draft=false; dry_run=false
 
-          # Final vX.Y.Z only — exclude rc/dev/alpha/beta and non-version tags.
+          # Does the tag look like a final release (vX.Y.Z, not rc/dev/alpha/beta)?
+          is_version=true
           case "$tag" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
-            *) proceed=false ;;
+            *) is_version=false ;;
           esac
           case "$tag" in
-            *rc*|*dev*|*a[0-9]*|*b[0-9]*) proceed=false ;;
+            *rc*|*dev*|*a[0-9]*|*b[0-9]*) is_version=false ;;
           esac
 
-          # Is there a DRAFT release for this tag? If it's already published (or a
-          # re-push after publish re-fired this workflow), we must NOT touch the
-          # notes — the coordinator has curated them. The CHANGELOG PR is still
-          # safe to (re)open, so we track isDraft separately.
-          if [ "$proceed" = "true" ]; then
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            # Real release cut: strict — only a final version tag proceeds.
+            [ "$is_version" = "true" ] && proceed=true
+          else
+            # Manual dispatch: proceed for a final version tag OR when a base
+            # override is given (arbitrary-ref preview/real run).
+            if [ "$is_version" = "true" ] || [ -n "$base" ]; then
+              proceed=true
+            fi
+            # dry_run: `auto` previews for a non-version tag or a base override,
+            # and does a real run for a plain version tag; true/false force it.
+            case "$INPUT_DRY_RUN" in
+              true)  dry_run=true ;;
+              false) dry_run=false ;;
+              *)     if [ "$is_version" != "true" ] || [ -n "$base" ]; then dry_run=true; fi ;;
+            esac
+          fi
+
+          # For a real (non-dry) run, probe for a DRAFT release. If it's already
+          # published (or a re-push after publish re-fired this workflow), we must
+          # NOT touch the notes — the coordinator has curated them. The CHANGELOG
+          # PR is still safe to (re)open, so we track isDraft separately. Skipped
+          # in dry-run (a preview ref has no matching release).
+          if [ "$proceed" = "true" ] && [ "$dry_run" != "true" ]; then
             state="$(gh release view "$tag" --repo "$SOURCE_REPO" --json isDraft,tagName 2>/dev/null || true)"
             if [ -z "$state" ]; then
               echo "::warning::No release found for ${tag} yet — skipping note draft (CHANGELOG PR still runs)."
@@ -93,9 +133,11 @@ jobs:
           fi
 
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
           echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
           echo "is_draft=${is_draft}" >> "$GITHUB_OUTPUT"
-          echo "Resolved tag=${tag} proceed=${proceed} is_draft=${is_draft}" \
+          echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag} base=${base:-<none>} proceed=${proceed} dry_run=${dry_run} is_draft=${is_draft}" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       # Trusted default branch, full history + tags for the range computation.
@@ -121,15 +163,33 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.guard.outputs.tag }}
+          BASE: ${{ steps.guard.outputs.base }}
+          DRY_RUN: ${{ steps.guard.outputs.dry_run }}
         run: |
           set -euo pipefail
-          python3 .github/scripts/changelog/generate.py \
-            --tag "$TAG" --repo "$SOURCE_REPO" \
-            --changelog-file CHANGELOG.md \
-            --draft-notes-out /tmp/mechanical_notes.md \
-            --pr-list-out /tmp/pr_list.txt
+          args=(--tag "$TAG" --repo "$SOURCE_REPO"
+                --draft-notes-out /tmp/mechanical_notes.md
+                --pr-list-out /tmp/pr_list.txt
+                --section-out /tmp/section.md)
+          [ -n "${BASE:-}" ] && args+=(--base "$BASE")
+          if [ "$DRY_RUN" = "true" ]; then
+            # Preview only — render, don't touch CHANGELOG.md.
+            args+=(--no-changelog-update)
+          else
+            args+=(--changelog-file CHANGELOG.md)
+          fi
+          python3 .github/scripts/changelog/generate.py "${args[@]}"
           # The mechanical scaffold is the fallback release-notes body.
           cp /tmp/mechanical_notes.md /tmp/release_notes.md
+
+          if [ "$DRY_RUN" = "true" ]; then
+            {
+              echo "## Preview — CHANGELOG.md section for \`${TAG}\`"
+              echo '```markdown'; cat /tmp/section.md; echo '```'
+              echo "## Preview — mechanical draft notes"
+              echo '```markdown'; cat /tmp/mechanical_notes.md; echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # --- 2) AI synthesis (primary; degrades to the mechanical scaffold) ---
       - name: Check LLM credentials
@@ -269,7 +329,7 @@ jobs:
       # --- 3) Mint the write-token — ONLY now, after the agent has run ---
       - name: Mint App token (omnigent)
         id: app-token
-        if: steps.guard.outputs.proceed == 'true' && vars.OMNIGENT_BOT_APP_ID != ''
+        if: steps.guard.outputs.proceed == 'true' && steps.guard.outputs.dry_run != 'true' && vars.OMNIGENT_BOT_APP_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
@@ -279,7 +339,7 @@ jobs:
 
       # --- 4) Open/update the CHANGELOG.md PR ---
       - name: Open or update the CHANGELOG.md PR
-        if: steps.guard.outputs.proceed == 'true' && steps.app-token.outputs.token != ''
+        if: steps.guard.outputs.proceed == 'true' && steps.guard.outputs.dry_run != 'true' && steps.app-token.outputs.token != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SITE_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -339,7 +399,7 @@ jobs:
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Note draft skipped (already published)
-        if: steps.guard.outputs.proceed == 'true' && steps.guard.outputs.is_draft != 'true'
+        if: steps.guard.outputs.proceed == 'true' && steps.guard.outputs.dry_run != 'true' && steps.guard.outputs.is_draft != 'true'
         env:
           TAG: ${{ steps.guard.outputs.tag }}
         run: |

--- a/tests/github/test_changelog_generate.py
+++ b/tests/github/test_changelog_generate.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "changelog" / "generate.py"
 spec = importlib.util.spec_from_file_location("changelog_generate", SCRIPT)
 assert spec and spec.loader
@@ -32,6 +34,54 @@ def test_previous_final_tag_ignores_prereleases() -> None:
 
 def test_previous_final_tag_first_release() -> None:
     assert gen.previous_final_tag("v0.1.0", ["v0.1.0", "v0.1.0rc4"]) is None
+
+
+def test_previous_final_tag_skips_rc_between_finals() -> None:
+    # v0.2.0, v0.3.0rc0, v0.3.0 present → previous of v0.3.0 is v0.2.0 (rc ignored).
+    assert gen.previous_final_tag("v0.3.0", ["v0.2.0", "v0.3.0rc0", "v0.3.0"]) == "v0.2.0"
+
+
+# --- collect() base override -------------------------------------------------
+
+
+def _stub_io(monkeypatch, *, subjects: list[str], all_tags: list[str], date: str = "2026-07-02"):
+    """Stub the git/gh IO so collect() runs offline; records the range args seen."""
+    seen: list[tuple[str | None, str]] = []
+
+    def fake_range_subjects(prev, tag):
+        seen.append((prev, tag))
+        return subjects
+
+    monkeypatch.setattr(gen, "_all_tags", lambda: all_tags)
+    monkeypatch.setattr(gen, "_range_subjects", fake_range_subjects)
+    monkeypatch.setattr(gen, "_tag_date", lambda tag: date)
+    monkeypatch.setattr(gen, "_gh_pr_body", lambda repo, pr: None)
+    _stub_io.seen = seen
+
+
+def test_collect_uses_base_override_as_range_start(monkeypatch) -> None:
+    _stub_io(monkeypatch, subjects=[], all_tags=["v0.3.0"])
+    gen.collect("HEAD", "o/o", base="v0.3.0")
+    # Range start is the explicit base, NOT previous_final_tag (which would raise
+    # on the non-version "HEAD").
+    assert _stub_io.seen == [("v0.3.0", "HEAD")]
+
+
+def test_collect_without_base_uses_previous_final_tag(monkeypatch) -> None:
+    _stub_io(monkeypatch, subjects=[], all_tags=["v0.2.0", "v0.3.0rc0", "v0.3.0"])
+    gen.collect("v0.3.0", "o/o")
+    assert _stub_io.seen == [("v0.2.0", "v0.3.0")]
+
+
+# --- CLI guard rail ----------------------------------------------------------
+
+
+def test_cli_non_version_tag_without_base_errors(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["generate.py", "--tag", "preview", "--repo", "o/o"])
+    with pytest.raises(SystemExit) as exc:
+        gen.main()
+    assert exc.value.code != 0
+    assert "not a final vX.Y.Z" in capsys.readouterr().err
 
 
 # --- pr_numbers_from_subjects ------------------------------------------------
@@ -100,6 +150,14 @@ def test_harvest_placeholder_is_omitted() -> None:
 def test_harvest_deleted_section_is_omitted() -> None:
     result = gen.harvest_pr(123, _body(None))
     assert result.status == "omitted"
+
+
+@pytest.mark.parametrize("marker", ["skip", "n/a", "N/A", "none", "-"])
+def test_harvest_omit_markers_are_omitted(marker: str) -> None:
+    # Leftover `skip`/`n/a` (old template sentinel) must not leak in as an entry.
+    result = gen.harvest_pr(123, _body(marker))
+    assert result.status == "omitted"
+    assert result.description == ""
 
 
 def test_harvest_missing_body() -> None:


### PR DESCRIPTION
## Related issue

N/A — follow-up to the changelog automation (#1763, #1826).

## Summary

Manual `workflow_dispatch` runs of `draft-release-notes.yml` were unusable for testing: the guard only proceeded for a final `vX.Y.Z` tag (a dispatch with `tag=ci-test` skipped every step), and `generate.py` itself requires a version tag to compute the range and order `CHANGELOG.md`.

This adds a **preview path** for manual runs:

- **`generate.py`** gains `--base <ref>` to override the range start (`base..tag`, any refs), plus a clear CLI error when `--tag` isn't a final `vX.Y.Z` and no `--base` is given. Version-only `CHANGELOG.md` insertion is skipped for a non-version tag.
- **The workflow** gains `base` and `dry_run` (`auto`|`true`|`false`) dispatch inputs. The guard proceeds for a version tag **or** a base override; `dry_run` defaults to `auto` → **preview** for a non-version tag or base override, **real run** otherwise, and is force-overridable. A dry-run renders the CHANGELOG section + draft notes to the **run summary** and skips the token mint, CHANGELOG PR, and release-body edit. The `workflow_run` (real release-cut) path is unchanged.

Also hardens `changelog_description`: bare omit markers (`skip`/`n/a`/`none`/`-`, left over from the old template sentinel) now count as an absent section instead of leaking in as a literal entry — caught while dry-running against real history, where a merged PR still said `skip`.

Usage:
```
# preview (default for a base override): prints to the run summary, no PR
gh workflow run draft-release-notes.yml -f tag=preview -f base=v0.3.0
# force a real CHANGELOG PR off an arbitrary base
gh workflow run draft-release-notes.yml -f base=v0.3.0 -f dry_run=false
```

## Test Plan

- `pytest tests/github/` — **84 pass**, incl. new cases: `--base` override drives the range; non-version tag without `--base` errors cleanly; the `v0.2.0`/`v0.3.0rc0`/`v0.3.0` → `v0.2.0` range; and omit-markers (`skip`/`n/a`/…) are dropped.
- Workflow YAML parses; run-block expression-injection audit clean.
- **Local end-to-end dry-run** over real repo history (`--tag HEAD --base <sha>`): rendered the flat `[Tag]` section, and confirmed a real merged PR that wrote `skip` is now omitted.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Script logic (range/`--base`/guard rail/omit-markers) is unit-covered. The workflow's dispatch-input/dry-run gating can't run in unit tests; verified by YAML parse + injection audit and by a local dry-run of the underlying script against real history. A full CI preview dispatch is the last check, once merged.

## Changelog

Manual runs of the changelog draft workflow can now preview an arbitrary commit range (`base..tag`) without a real version tag, printing the result to the run summary