### PR TITLE
fix(harnesses): re-check idleness, atomically with the unregister, before the reaper releases an entry

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -891,12 +891,23 @@ class HarnessProcessManager:
         """
         self._in_flight_response_ids.pop(conversation_id, None)
 
-    async def release(self, conversation_id: str) -> None:
+    async def release(
+        self, conversation_id: str, *, only_if_idle_cutoff: float | None = None
+    ) -> None:
         """
         Terminate and unregister the subprocess for a conversation.
 
         Called when the conversation reaches a terminal state. No-op
         if no subprocess is registered for the id.
+
+        ``only_if_idle_cutoff`` (the idle reaper's pass cutoff) makes the
+        release conditional: the entry is torn down only if it is still
+        idle — untouched since the cutoff and with no turn in flight.
+        The check happens under the registry lock, atomically with the
+        unregister, so a turn that starts while an earlier entry in the
+        same reaper pass tears down can never be killed mid-flight
+        (mirrors ``pane_reaper``'s busy re-check immediately before
+        teardown).
 
         Note: ``_spawn_locks[conversation_id]`` is intentionally NOT
         removed here. If we removed it, a concurrent caller already
@@ -913,6 +924,19 @@ class HarnessProcessManager:
         :param conversation_id: AP-allocated conversation id.
         """
         async with self._registry_lock:
+            if only_if_idle_cutoff is not None:
+                current = self._entries.get(conversation_id)
+                if (
+                    current is None
+                    or current.last_used_at > only_if_idle_cutoff
+                    or conversation_id in self._in_flight_response_ids
+                ):
+                    _logger.info(
+                        "skipping idle reap for conversation %s: entry became "
+                        "active or was already released during the pass",
+                        conversation_id,
+                    )
+                    return
             entry = self._entries.pop(conversation_id, None)
             # NOTE: ``_spawn_locks[conversation_id]`` intentionally
             # NOT popped — see this method's docstring for the
@@ -1188,7 +1212,11 @@ class HarnessProcessManager:
                     conv_id,
                 )
                 try:
-                    await self.release(conv_id)
+                    # Teardown of earlier entries in this pass yields the
+                    # loop, so the snapshot above can be stale by the time
+                    # this entry's turn comes — release re-checks idleness
+                    # atomically with the unregister.
+                    await self.release(conv_id, only_if_idle_cutoff=cutoff)
                 except Exception:
                     # A release failure (e.g. ``client.aclose()`` on a broken
                     # transport, or ``process.wait()`` raising) must not escape

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -29,6 +29,7 @@ import shutil
 import signal
 import sys
 import tempfile
+import time
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
@@ -43,6 +44,7 @@ from omnigent.runtime.harnesses.process_manager import (
     NoLiveHarnessError,
     _pid_alive,
     _pids_holding_socket,
+    _SubprocessEntry,
 )
 
 _TEST_HARNESS_NAME = "test"
@@ -594,11 +596,11 @@ async def test_idle_reaper_survives_release_error(
         real_release = fast.release
         calls = {"n": 0}
 
-        async def flaky_release(conversation_id: str) -> None:
+        async def flaky_release(conversation_id: str, **kw: object) -> None:
             calls["n"] += 1
             if calls["n"] == 1:
                 raise RuntimeError("simulated close failure")
-            await real_release(conversation_id)
+            await real_release(conversation_id, **kw)  # type: ignore[arg-type]
 
         monkeypatch.setattr(fast, "release", flaky_release)
 
@@ -666,6 +668,100 @@ async def test_idle_reaper_skips_in_flight_turn(
         assert not socket_path.exists()
     finally:
         await fast.shutdown()
+
+
+class _FakeReapProc:
+    """Minimal process stand-in recording whether the reaper killed it."""
+
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.killed = False
+        self._done = asyncio.Event()
+
+    def send_signal(self, sig: int) -> None:
+        self.killed = True
+        self.returncode = -15
+        self._done.set()
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+        self._done.set()
+
+    async def wait(self) -> int | None:
+        await self._done.wait()
+        return self.returncode
+
+
+class _SlowCloseClient:
+    """httpx-client stand-in whose aclose() stalls, holding the reaper pass open."""
+
+    def __init__(self, delay_s: float) -> None:
+        self._delay_s = delay_s
+
+    async def aclose(self) -> None:
+        await asyncio.sleep(self._delay_s)
+
+
+class _FakeEndpoint:
+    def cleanup(self) -> None:
+        pass
+
+
+async def test_idle_reaper_spares_turn_started_during_pass(tmp_path: Path) -> None:
+    """A turn that starts while an earlier stale entry tears down is not reaped.
+
+    The reaper snapshots its stale list under the registry lock, then releases
+    each entry outside it; a single teardown can hold the pass open for seconds
+    (graceful-SIGTERM wait). A turn that starts on a later-listed conversation
+    during that window refreshes ``last_used_at`` and marks itself in flight —
+    but the snapshot has already been taken, and ``release`` used to tear the
+    entry down without re-checking, SIGTERMing the subprocess mid-turn
+    ("Harness stream connection error" seconds after messaging an idle
+    session). ``only_if_idle_cutoff`` re-checks idleness atomically with the
+    unregister, so the now-active entry is spared; the genuinely idle entry in
+    the same pass is still reaped, and the spared one is reclaimed by a later
+    pass once it goes idle again.
+    """
+    mgr = HarnessProcessManager(idle_timeout_s=0.5, reaper_interval_s=0.2, tmp_parent=tmp_path)
+    e1 = _SubprocessEntry(_FakeReapProc(), _SlowCloseClient(0.6), _FakeEndpoint(), "h")  # type: ignore[arg-type]
+    e2 = _SubprocessEntry(_FakeReapProc(), _SlowCloseClient(0.0), _FakeEndpoint(), "h")  # type: ignore[arg-type]
+    e1.last_used_at = time.monotonic() - 100.0
+    e2.last_used_at = time.monotonic() - 100.0
+    mgr._entries = {"conv1": e1, "conv2": e2}
+
+    reaper = asyncio.create_task(mgr._idle_reaper_loop())
+    try:
+        # Wait for the pass to claim conv1 and enter its slow teardown.
+        deadline = time.monotonic() + 3.0
+        while "conv1" in mgr._entries:
+            assert time.monotonic() < deadline, "reaper never started a pass"
+            await asyncio.sleep(0.01)
+
+        # While conv1 tears down, a new turn arrives for conv2: get_client
+        # refreshes last_used_at and the runner marks the response in flight.
+        e2.last_used_at = time.monotonic()
+        mgr.mark_in_flight("conv2", "resp_live")
+
+        await asyncio.sleep(1.0)
+        assert e1.process.killed, "the genuinely idle entry must still be reaped"
+        assert not e2.process.killed, (
+            "reaper SIGTERMed a subprocess whose turn started during the pass"
+        )
+        assert "conv2" in mgr._entries
+
+        # Once the turn ends and the entry goes idle again, a later pass
+        # reclaims it — sparing is a deferral, not an exemption.
+        mgr.clear_in_flight("conv2")
+        e2.last_used_at = time.monotonic() - 100.0
+        deadline = time.monotonic() + 3.0
+        while not e2.process.killed:
+            assert time.monotonic() < deadline, "spared entry never reaped later"
+            await asyncio.sleep(0.05)
+    finally:
+        reaper.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reaper
 
 
 async def test_idle_reaper_disabled_when_timeout_zero(


### PR DESCRIPTION
## Related issue

Closes #1833

## Summary

- The idle reaper snapshots its stale list under the registry lock, then releases each entry outside it; one teardown can hold the pass open for seconds (`client.aclose()` + up to 5s graceful-SIGTERM wait). A turn that starts on a later-listed conversation during that window refreshes `last_used_at` and marks itself in flight — but `release()` tore the entry down without re-checking, SIGTERMing the subprocess mid-turn.
- `release()` now takes an `only_if_idle_cutoff` keyword (passed only by the reaper): under the registry lock, **atomically with the unregister**, it skips entries touched after the pass cutoff or with a turn in flight — they are reclaimed by a later pass once genuinely idle. Mirrors the pane reaper's "busy re-check immediately before teardown". Plain `release()` callers are unchanged.

ELI5: the janitor used to write down which rooms looked empty, then walk the list unplugging them — even if someone had walked back into a room while he was busy unplugging the previous one. Now he re-checks at each door, with his hand on the tag, before pulling the plug.

The check and the unregister share one lock acquisition on purpose: a pre-check followed by a separate `release()` call still loses to a turn already queued on the lock.

## Test Plan

- New `test_idle_reaper_spares_turn_started_during_pass` — red on `main` (the subprocess whose turn started mid-pass is SIGTERMed), green here. The same test also asserts the genuinely idle entry in the pass is still reaped, and that the spared entry is reclaimed by a later pass once idle again (sparing is a deferral, not an exemption).
- Existing `test_idle_reaper_survives_release_error`'s `flaky_release` stub gains `**kw` to match the new keyword (one line).
- `uv run --extra dev python -m pytest tests/runtime/harnesses/test_process_manager.py` → 31 passed; `ruff check`, `ruff format --check`, `pre-commit` clean.

## Demo

Red→green screenshot (same test on `main` vs this branch):
<img width="2400" height="1468" alt="reaper-fix-demo-red-green" src="https://github.com/user-attachments/assets/2315b379-a925-44a9-961d-ac957d0a0181" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The race is made deterministic in the new unit test (a slow-closing fake client holds the reaper pass open while the second entry is marked active); no manual timing needed.

## Changelog

Messaging a long-idle session no longer risks the new turn being killed mid-flight by the idle reaper
