### PR TITLE
fix(web): auto-expand Pinned section when a session is pinned

### DIFF
--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -828,6 +828,36 @@ describe("Sidebar default section collapse", () => {
   });
 });
 
+// Pinning a session while the Pinned section is collapsed auto-expands it, so
+// the just-pinned chat can't silently hide inside the collapsed group.
+describe("Sidebar auto-expand Pinned on pin", () => {
+  it("expands a collapsed Pinned section when a session is newly pinned", () => {
+    localStorage.setItem("omnigent:collapsed-sidebar-sections", JSON.stringify(["Pinned"]));
+    // Start with one already-pinned session (so the Pinned section renders) and
+    // one unpinned session to pin.
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pinned"]));
+    mockConversations([conv("conv_pinned", "Claude Code"), conv("conv_plain", "Claude Code")]);
+    renderSidebar();
+
+    // Collapsed to start: the header reports collapsed and the pinned row hides.
+    expect(screen.getByRole("button", { name: /Pinned/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+
+    // Pin the plain row via its quick-pin control.
+    const plainRow = screen.getByRole("link", { name: /conv_plain/ }).closest("li")!;
+    fireEvent.click(within(plainRow).getByTestId("quick-pin-conversation"));
+
+    // The Pinned section auto-expands so the freshly-pinned session is visible,
+    // and the expansion is persisted (dropped from the collapsed list).
+    expect(screen.getByRole("button", { name: /Pinned/ })).toHaveAttribute("aria-expanded", "true");
+    expect(JSON.parse(localStorage.getItem("omnigent:collapsed-sidebar-sections")!)).not.toContain(
+      "Pinned",
+    );
+  });
+});
+
 // The quick-pin affordance is hover-revealed on every row — including pinned
 // ones. A pinned row no longer keeps a persistent pin marker (the "Pinned"
 // section header already conveys the state); on hover it reveals the UNPIN

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -902,6 +902,25 @@ function ConversationList({
     });
   }, []);
 
+  // Auto-expand the Pinned section when a session is newly pinned, so a
+  // freshly-pinned chat can't hide inside a collapsed group. Only reacts to
+  // pins being *added* — unpinning or reordering leaves the collapsed
+  // preference alone.
+  const prevPinnedIds = useRef(pinnedConversationIds);
+  useEffect(() => {
+    const prev = new Set(prevPinnedIds.current);
+    const wasPinned = pinnedConversationIds.some((id) => !prev.has(id));
+    prevPinnedIds.current = pinnedConversationIds;
+    if (wasPinned) {
+      setCollapsedSections((prevCollapsed) => {
+        if (!prevCollapsed.includes("Pinned")) return prevCollapsed;
+        const next = prevCollapsed.filter((t) => t !== "Pinned");
+        writeCollapsedSidebarSections(next);
+        return next;
+      });
+    }
+  }, [pinnedConversationIds]);
+
   // When a search query appears, auto-expand all sections so results
   // in collapsed groups are visible. The user can still manually collapse
   // sections while searching. When the search is cleared, restore the


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Pinning a session while the sidebar's **Pinned** section is collapsed left the freshly-pinned chat hidden inside the collapsed group, making it look like the pin never took effect.
- The sidebar now watches `pinnedConversationIds` and, whenever an id is **newly added**, drops `"Pinned"` from the collapsed set (and persists that to localStorage) so the section auto-expands and the just-pinned session is immediately visible.
- Only reacts to a pin being *added* — unpinning or reordering leaves the user's collapse preference untouched. Mirrors the existing search-driven auto-expand pattern nearby.

## Test Plan

- Added a unit test in `web/src/shell/Sidebar.test.tsx` that starts with a collapsed Pinned section, pins a plain row via its quick-pin control, and asserts the section reports `aria-expanded="true"` and `"Pinned"` is removed from the persisted collapsed list.
- `cd web && npm test` → 3419 passed / 199 files (full suite green).
- `cd web && npm run build` → `tsc -b && vite build` succeeds.

## Demo

N/A — behavioural fix covered by an automated test (collapsed Pinned section auto-expands on pin). No visual layout change beyond the section toggling open.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the added unit test.

## Changelog

Fixed: pinning a session now auto-expands the sidebar's Pinned section so the pinned chat is immediately visible

This pull request and its description were written by Isaac.
