### PR TITLE
feat(policies): abort agent turn on explicit elicitation decline

### DIFF
--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -113,3 +113,22 @@ class OmnigentError(Exception):
             Defaults to 500 for unknown codes.
         """
         return _CODE_TO_HTTP_STATUS.get(self.code, 500)
+
+
+class ElicitationDeclinedError(Exception):
+    """Raised when a user explicitly declines an elicitation (action == "decline").
+
+    Distinct from a timeout or cancel: the user made an active choice to
+    refuse. Callers that park on an ASK gate raise this instead of
+    returning ``False`` so the turn loop can abort cleanly rather than
+    feeding a DENY message to the LLM and letting it continue.
+
+    :param message: Human-readable description, typically the policy
+        reason that triggered the elicitation.
+    :param policy_name: Name of the deciding policy, e.g.
+        ``"intent_gate"``. ``None`` when not available.
+    """
+
+    def __init__(self, message: str = "", *, policy_name: str | None = None) -> None:
+        super().__init__(message)
+        self.policy_name = policy_name

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2399,7 +2399,7 @@ class _SessionsChatReplAdapter:
         elicitation_id = getattr(event, "elicitation_id", "")
         hook = self._hooks.on_elicitation_request
         if hook is None:
-            action = "decline"
+            action = "cancel"
         else:
             ctx = ElicitationRequestCtx(
                 elicitation_id=elicitation_id,
@@ -2416,9 +2416,14 @@ class _SessionsChatReplAdapter:
                 result = hook(ctx)
                 if inspect.isawaitable(result):
                     result = await result
-                action = "accept" if result else "decline"
+                # REPL refusal uses "cancel" (not "decline") so the agent
+                # continues with the denial marker rather than aborting the
+                # turn. "decline" means an explicit web-UI stop; "cancel"
+                # means dismissed/no-explicit-choice, which lets the LLM
+                # adapt and try a different approach.
+                action = "accept" if result else "cancel"
             except Exception:  # noqa: BLE001
-                action = "decline"
+                action = "cancel"
         # Build the resolve payload. For accept with a requestedSchema,
         # populate ``content`` from the schema so the MCP server receives
         # the form data it expects. Simple schemas (boolean, enum) are
@@ -2442,7 +2447,7 @@ class _SessionsChatReplAdapter:
                 if prompted is not None:
                     resolve_payload["content"] = prompted
                 else:
-                    resolve_payload["action"] = "decline"
+                    resolve_payload["action"] = "cancel"
 
         try:
             # URL-based elicitation: deliver the verdict to the

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2399,7 +2399,7 @@ class _SessionsChatReplAdapter:
         elicitation_id = getattr(event, "elicitation_id", "")
         hook = self._hooks.on_elicitation_request
         if hook is None:
-            action = "cancel"
+            action = "decline"
         else:
             ctx = ElicitationRequestCtx(
                 elicitation_id=elicitation_id,
@@ -2416,14 +2416,9 @@ class _SessionsChatReplAdapter:
                 result = hook(ctx)
                 if inspect.isawaitable(result):
                     result = await result
-                # REPL refusal uses "cancel" (not "decline") so the agent
-                # continues with the denial marker rather than aborting the
-                # turn. "decline" means an explicit web-UI stop; "cancel"
-                # means dismissed/no-explicit-choice, which lets the LLM
-                # adapt and try a different approach.
-                action = "accept" if result else "cancel"
+                action = "accept" if result else "decline"
             except Exception:  # noqa: BLE001
-                action = "cancel"
+                action = "decline"
         # Build the resolve payload. For accept with a requestedSchema,
         # populate ``content`` from the schema so the MCP server receives
         # the form data it expects. Simple schemas (boolean, enum) are
@@ -2447,7 +2442,7 @@ class _SessionsChatReplAdapter:
                 if prompted is not None:
                     resolve_payload["content"] = prompted
                 else:
-                    resolve_payload["action"] = "cancel"
+                    resolve_payload["action"] = "decline"
 
         try:
             # URL-based elicitation: deliver the verdict to the

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -15578,9 +15578,26 @@ def create_runner_app(
         # Resolve pending policy approval Futures.
         if body_type == "approval":
             _data = body.get("data") or body
+            _elicit_action = _data.get("action", "")
             pending_approvals.resolve(
-                _data.get("elicitation_id", ""), _data.get("action") == "accept"
+                _data.get("elicitation_id", ""), _elicit_action == "accept"
             )
+            if _elicit_action == "decline":
+                # Explicit user decline: send an interrupt to the harness
+                # so the turn aborts cleanly instead of continuing after
+                # the DENY tool result reaches the LLM. This fires before
+                # the ProxyMcpManager task resumes (asyncio cooperative
+                # scheduling), so interrupt_session is called before the
+                # deny propagates to the SDK.
+                try:
+                    _int_client = await process_manager.get_client(conversation_id, "any")
+                    await _int_client.post(
+                        f"/v1/sessions/{conversation_id}/events",
+                        json={"type": "interrupt"},
+                        timeout=5.0,
+                    )
+                except Exception:  # noqa: BLE001 — best-effort; deny path continues
+                    pass
             # The server wraps the verdict as ``{"type": "approval", "data": {…}}``,
             # but the harness scaffold's ``ApprovalEvent`` wants the fields at the
             # top level — forwarding the envelope verbatim 422s and hangs the turn.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -15579,9 +15579,7 @@ def create_runner_app(
         if body_type == "approval":
             _data = body.get("data") or body
             _elicit_action = _data.get("action", "")
-            pending_approvals.resolve(
-                _data.get("elicitation_id", ""), _elicit_action == "accept"
-            )
+            pending_approvals.resolve(_data.get("elicitation_id", ""), _elicit_action == "accept")
             if _elicit_action == "decline":
                 # Explicit user decline: send an interrupt to the harness
                 # so the turn aborts cleanly instead of continuing after

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -459,9 +459,12 @@ class ExecutorAdapter(HarnessApp):
                             agent_span = None
                         raise RuntimeError(f"inner executor error: {event.message}")
         except ElicitationDeclinedError:
-            # User explicitly declined an elicitation — abort the turn cleanly
-            # (cancelled, not failed) so the LLM does not receive a DENY message
-            # and continue. The finally block still runs for cleanup.
+            # Fallback for executors that propagate the exception directly
+            # (non-SDK / non-spawned-task paths). SDK-based executors use
+            # ctx.cancelled.set() from _stable_elicitation_handler instead,
+            # because the SDK wraps its control-request callbacks in their
+            # own tasks and would swallow a raised exception before it
+            # reached this handler. Either way the turn ends as cancelled.
             _logger.info(
                 "elicitation explicitly declined for response %s — aborting turn",
                 ctx.response_id,
@@ -755,10 +758,12 @@ class ExecutorAdapter(HarnessApp):
         )
         result = await ctx.elicit(elicitation_id, params)
         if result.action == "decline":
-            raise ElicitationDeclinedError(
-                f"{label} permission for {tool_name!r} explicitly declined",
-                policy_name=policy_name,
-            )
+            # The SDK invokes this callback from a spawned control-request
+            # task whose try/except would swallow a raised exception before
+            # it could reach run_turn's except block. Signal the cancellation
+            # via ctx.cancelled instead — the run_turn event loop checks this
+            # flag between events and takes the existing interrupt path.
+            ctx.cancelled.set()
         return result.action == "accept"
 
     async def _stable_policy_evaluator(

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -44,6 +44,7 @@ from typing import Any
 
 from fastapi import Response
 
+from omnigent.errors import ElicitationDeclinedError
 from omnigent.inner.executor import (
     CompactionComplete,
     Executor,
@@ -457,6 +458,21 @@ class ExecutorAdapter(HarnessApp):
                             )
                             agent_span = None
                         raise RuntimeError(f"inner executor error: {event.message}")
+        except ElicitationDeclinedError:
+            # User explicitly declined an elicitation — abort the turn cleanly
+            # (cancelled, not failed) so the LLM does not receive a DENY message
+            # and continue. The finally block still runs for cleanup.
+            _logger.info(
+                "elicitation explicitly declined for response %s — aborting turn",
+                ctx.response_id,
+            )
+            if tctx is not None and agent_span is not None:
+                from omnigent.runtime.telemetry import record_cancellation
+
+                record_cancellation(agent_span)
+                tctx.end_agent_span(agent_span, response=None)
+                agent_span = None
+            ctx.cancelled.set()
         except BaseException:
             # End agent span on unhandled exceptions so it's not
             # left open (which would leak on the OTel provider).
@@ -734,6 +750,11 @@ class ExecutorAdapter(HarnessApp):
             content_preview=f"{tool_name}({preview})",
         )
         result = await ctx.elicit(elicitation_id, params)
+        if result.action == "decline":
+            raise ElicitationDeclinedError(
+                f"{label} permission for {tool_name!r} explicitly declined",
+                policy_name=policy_name,
+            )
         return result.action == "accept"
 
     async def _stable_policy_evaluator(

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -471,8 +471,12 @@ class ExecutorAdapter(HarnessApp):
 
                 record_cancellation(agent_span)
                 tctx.end_agent_span(agent_span, response=None)
-                agent_span = None
             ctx.cancelled.set()
+            # Interrupt the inner executor session so the in-flight
+            # generation stops immediately, same as the normal
+            # cancellation path.
+            if self._executor is not None:
+                await self._executor.interrupt_session(self._session_key)
         except BaseException:
             # End agent span on unhandled exceptions so it's not
             # left open (which would leak on the OTel provider).

--- a/omnigent/runtime/policies/approval.py
+++ b/omnigent/runtime/policies/approval.py
@@ -42,6 +42,7 @@ import secrets
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from omnigent.errors import ElicitationDeclinedError
 from omnigent.policies.types import ElicitationRequest, PolicyResult
 from omnigent.runtime.policies.engine import PolicyEngine
 from omnigent.spec.types import Phase
@@ -140,6 +141,12 @@ async def _await_elicitation(
         raw_verdict = await park(elicitation_id, effective_timeout)
     except TimeoutError:
         return False
+
+    if _is_explicit_decline(raw_verdict):
+        raise ElicitationDeclinedError(
+            result.reason or "",
+            policy_name=result.deciding_policy,
+        )
 
     approved = _parse_verdict(raw_verdict)
     if approved:
@@ -285,6 +292,28 @@ def resolve_ask_timeout(
     if deciding_spec is not None and deciding_spec.ask_timeout is not None:
         return deciding_spec.ask_timeout
     return engine.ask_timeout
+
+
+def _is_explicit_decline(raw: str | None) -> bool:
+    """True only when the verdict carries an explicit ``action == "decline"``.
+
+    Distinct from timeout / cancel / malformed: the user made an active
+    choice to refuse.  Used by :func:`_await_elicitation` to raise
+    :class:`~omnigent.errors.ElicitationDeclinedError` instead of
+    returning ``False``, so callers can abort cleanly.
+
+    :param raw: Raw verdict JSON string, or ``None``.
+    :returns: ``True`` only on exact ``action == "decline"``.
+    """
+    if raw is None:
+        return False
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    return parsed.get("action") == "decline"
 
 
 def _parse_verdict(raw: str | None) -> bool:

--- a/omnigent/runtime/policies/approval.py
+++ b/omnigent/runtime/policies/approval.py
@@ -98,9 +98,11 @@ async def _await_elicitation(
     in :func:`omnigent.runtime.workflow._drive_policy_approval`.
 
     On approve: applies the ASK-accumulated ``set_labels`` from the
-    engine's composed result. On refuse / cancel / timeout /
-    malformed verdict: returns ``False`` and applies nothing,
-    preserving POLICIES.md §7.2 ("no side effects on denied ASK").
+    engine's composed result. On cancel / timeout / malformed verdict:
+    returns ``False`` and applies nothing, preserving POLICIES.md §7.2
+    ("no side effects on denied ASK"). On explicit decline: raises
+    :class:`~omnigent.errors.ElicitationDeclinedError` so callers can
+    abort the agent turn rather than feeding a DENY to the LLM.
 
     :param task_id: The sub-agent's task ID (the parked workflow).
     :param root_task_id: The root task whose SSE stream receives
@@ -122,8 +124,9 @@ async def _await_elicitation(
         row wasn't completed on wake. Raises ``TimeoutError`` on
         deadline expiry.
     :returns: ``True`` only when the verdict's ``action`` is exactly
-        ``"accept"``; ``False`` otherwise (decline / cancel /
-        timeout / malformed).
+        ``"accept"``; ``False`` on cancel / timeout / malformed.
+    :raises ElicitationDeclinedError: when ``action == "decline"``
+        (explicit user refusal — distinct from cancel/timeout).
     """
     elicitation_id = f"elicit_{secrets.token_hex(16)}"
     elicitation = ElicitationRequest(

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -10998,7 +10998,6 @@ async def _evaluate_input_policy(
         return {
             "verdict": "deny",
             "reason": exc.args[0] or "Denied by policy",
-            "abort": True,
         }
     if approved:
         return None
@@ -16301,12 +16300,11 @@ def create_sessions_router(
                                 elicitation_id=hook_elicitation_id,
                             )
                         except ElicitationDeclinedError as exc:
-                            # Explicit user decline — signal the harness to
-                            # abort the turn rather than let it continue.
+                            # Explicit user decline — return DENY so the
+                            # native harness blocks this specific tool call.
                             verdict_body = {
                                 "result": "POLICY_ACTION_DENY",
                                 "reason": exc.args[0] or "Approval was declined.",
-                                "abort": True,
                             }
                             return Response(
                                 content=json.dumps(verdict_body),

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -84,7 +84,7 @@ from omnigent.entities.conversation import (
 )
 from omnigent.entities.permission import SessionPermission
 from omnigent.entities.session_resources import session_resource_view_to_dict
-from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.errors import ElicitationDeclinedError, ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
     CLAUDE_NATIVE_CODING_AGENT,
     CODEX_NATIVE_CODING_AGENT,
@@ -4212,6 +4212,13 @@ async def _hold_native_ask_gate(
         tool_name=tool_name if isinstance(tool_name, str) else None,
         tool_input=tool_input if isinstance(tool_input, dict) else None,
     )
+    # Explicit user decline → raise so callers can abort the turn rather
+    # than feeding a DENY message to the LLM and letting it continue.
+    if verdict is not None and verdict.action == "decline":
+        raise ElicitationDeclinedError(
+            result.reason or "",
+            policy_name=result.deciding_policy,
+        )
     approved = verdict is not None and verdict.action == "accept"
     if approved:
         # POLICIES.md §7.2: writes accumulated by the ASKing policy
@@ -10974,15 +10981,22 @@ async def _evaluate_input_policy(
     # deciding policy's writes only on accept (POLICIES.md §7.2). Accept ->
     # ALLOW (fall through to forward the message); decline / timeout ->
     # DENY (fail-closed).
-    approved = await _hold_native_ask_gate(
-        request,
-        session_id=session_id,
-        phase=Phase.REQUEST,
-        data=body.data,
-        engine=engine,
-        result=result,
-        conversation_store=conversation_store,
-    )
+    try:
+        approved = await _hold_native_ask_gate(
+            request,
+            session_id=session_id,
+            phase=Phase.REQUEST,
+            data=body.data,
+            engine=engine,
+            result=result,
+            conversation_store=conversation_store,
+        )
+    except ElicitationDeclinedError as exc:
+        return {
+            "verdict": "deny",
+            "reason": exc.args[0] or "Denied by policy",
+            "abort": True,
+        }
     if approved:
         return None
     return {
@@ -16272,16 +16286,29 @@ def create_sessions_router(
                         Phase.LLM_REQUEST,
                         Phase.REQUEST,
                     ):
-                        approved = await _hold_native_ask_gate(
-                            request,
-                            session_id=session_id,
-                            phase=phase,
-                            data=data,
-                            engine=engine,
-                            result=result,
-                            conversation_store=conversation_store,
-                            elicitation_id=hook_elicitation_id,
-                        )
+                        try:
+                            approved = await _hold_native_ask_gate(
+                                request,
+                                session_id=session_id,
+                                phase=phase,
+                                data=data,
+                                engine=engine,
+                                result=result,
+                                conversation_store=conversation_store,
+                                elicitation_id=hook_elicitation_id,
+                            )
+                        except ElicitationDeclinedError as exc:
+                            # Explicit user decline — signal the harness to
+                            # abort the turn rather than let it continue.
+                            verdict_body = {
+                                "result": "POLICY_ACTION_DENY",
+                                "reason": exc.args[0] or "Approval was declined.",
+                                "abort": True,
+                            }
+                            return Response(
+                                content=json.dumps(verdict_body),
+                                media_type="application/json",
+                            )
                         verdict_body: dict[str, Any] = (
                             {"result": "POLICY_ACTION_ALLOW"}
                             if approved

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -4179,8 +4179,11 @@ async def _hold_native_ask_gate(
         used by ``POST /policies/evaluate`` retries so a hook retry after
         a transient 5xx / connect-drop does not prompt the human twice.
         ``None`` mints a fresh id (the default for non-retry callers).
-    :returns: ``True`` iff a human accepted; ``False`` on decline /
-        cancel / timeout / disconnect (fail closed).
+    :returns: ``True`` iff a human accepted; ``False`` on cancel /
+        timeout / disconnect (fail closed).
+    :raises ElicitationDeclinedError: when the human explicitly
+        declines (``action == "decline"``). Callers should abort the
+        turn rather than continuing with a DENY.
     """
     tool_name = data.get("name")
     tool_input = data.get("arguments")

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16530,6 +16530,14 @@ def create_sessions_router(
         )
         if result is None:
             return Response(status_code=status.HTTP_200_OK)
+        if result.action == "decline":
+            # Explicit user decline: interrupt the native harness before
+            # returning the decline so the abort signal arrives first.
+            await _forward_session_change_to_runner(
+                session_id,
+                _server_runner_router,
+                {"type": "interrupt"},
+            )
         return Response(
             content=result.model_dump_json(),
             media_type="application/json",
@@ -16637,6 +16645,14 @@ def create_sessions_router(
         )
         if result is None:
             return Response(status_code=status.HTTP_200_OK)
+        if result.action == "decline":
+            # Explicit user decline: interrupt the native harness before
+            # returning the decline so the abort signal arrives first.
+            await _forward_session_change_to_runner(
+                session_id,
+                _server_runner_router,
+                {"type": "interrupt"},
+            )
         return Response(
             content=json.dumps(result.model_dump(exclude_none=True)),
             media_type="application/json",
@@ -16737,6 +16753,14 @@ def create_sessions_router(
         )
         if result is None:
             return Response(status_code=status.HTTP_200_OK)
+        if result.action == "decline":
+            # Explicit user decline: interrupt the native harness before
+            # returning the decline so the abort signal arrives first.
+            await _forward_session_change_to_runner(
+                session_id,
+                _server_runner_router,
+                {"type": "interrupt"},
+            )
         return Response(
             content=json.dumps(result.model_dump(exclude_none=True)),
             media_type="application/json",

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16300,8 +16300,17 @@ def create_sessions_router(
                                 elicitation_id=hook_elicitation_id,
                             )
                         except ElicitationDeclinedError as exc:
-                            # Explicit user decline — return DENY so the
-                            # native harness blocks this specific tool call.
+                            # Explicit user decline: interrupt the native
+                            # harness BEFORE returning the hook deny so the
+                            # Escape key reaches Claude Code's tmux pane first.
+                            # By the time the DENY response reaches the hook
+                            # subprocess, the abort signal is already queued.
+                            # Best-effort: forwarding failures are swallowed.
+                            await _forward_session_change_to_runner(
+                                session_id,
+                                _server_runner_router,
+                                {"type": "interrupt"},
+                            )
                             verdict_body = {
                                 "result": "POLICY_ACTION_DENY",
                                 "reason": exc.args[0] or "Approval was declined.",

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16426,6 +16426,16 @@ def create_sessions_router(
         )
         if result is None:
             return Response(status_code=status.HTTP_200_OK)
+        if result.action == "decline":
+            # Explicit user decline: interrupt Codex before returning the
+            # deny response, same as the Claude-native path. The await
+            # ensures the abort signal reaches Codex before it processes
+            # the decline result and lets the LLM continue.
+            await _forward_session_change_to_runner(
+                session_id,
+                _server_runner_router,
+                {"type": "interrupt"},
+            )
         body = codex_request.build_response(result)
         return Response(
             content=json.dumps(body),

--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -851,30 +851,13 @@ def test_repl_tool_call_refusal_blocks_tool(
     mock_llm_server_url: str,
 ) -> None:
     """
-    TOOL_CALL ASK → refuse → tool NEVER runs → sentinel
-    replaces output → LLM sees sentinel and typically relays
-    that denial to the user.
+    TOOL_CALL ASK → explicit decline → turn aborts → tool NEVER runs.
 
-    Load-bearing: the raw tool output MUST NOT reach the
-    conversation — ``_enforce_tool_result_policy`` substitutes
-    ``[Denied by policy: ...]``. This test is the end-to-end
-    proof that the pre-persistence ordering holds under real
-    streaming + durable-workflow parking. The mock LLM is scripted to emit
-    the ``echo`` ``function_call`` so the TOOL_CALL ASK fires.
+    An explicit refusal (typing "n") now aborts the agent turn rather
+    than feeding a denial marker to the LLM and letting it continue.
+    The tool must never execute: its raw output must not appear in the
+    terminal or reach the mock LLM as a function_call_output.
     """
-    follow_up = "tool-call-refuse-followup-marker"
-    _configure_mock_tool_then_text(
-        mock_llm_server_url,
-        [
-            {
-                "call_id": "tc2",
-                "name": "echo",
-                "arguments": json.dumps({"message": "testing456"}),
-            }
-        ],
-        follow_up,
-        match="testing456",
-    )
     child = pexpect.spawn(
         ap_cli,
         ["run", str(_TOOL_GATE_DIR)],
@@ -890,24 +873,21 @@ def test_repl_tool_call_refusal_blocks_tool(
         child.expect("approval required", timeout=45)
         child.send("n" + "\r")
         child.expect("refused", timeout=5)
-        # Sync on the post-tool follow-up reply — the LLM only makes its
-        # second call after the (blocked) tool round-trip completes.
-        child.expect(follow_up, timeout=120)
-        # On a TOOL_CALL-phase refusal the tool never runs: its
-        # function_call_output is a denial marker, NOT the raw echo
-        # output. (The ``[Denied by policy: ...]`` sentinel is the
-        # separate TOOL_RESULT substitution path.) The regression
-        # guard: a denial is recorded AND the raw echo output must
-        # NEVER reach the conversation.
-        joined = _wait_for_function_call_outputs(mock_llm_server_url)
-        assert "denied" in joined.lower(), (
-            "Tool-call denial marker did not appear in the LLM's "
-            "function_call_output — refusal enforcement may have "
-            f"regressed.\nfunction_call_outputs: {joined[:800]}"
+        # Turn is now aborted — wait for the REPL to return to idle.
+        _wait_for_turn_complete(child, timeout=30)
+        # The tool must never have run: raw echo output must not appear
+        # anywhere in the terminal buffer captured so far.
+        assert "echo: testing456" not in child.before, (
+            "Raw tool output appeared in REPL despite refusal — the tool "
+            "ran when it must not have."
         )
+        # The mock LLM must NOT have received a second request carrying a
+        # function_call_output, because the turn was aborted before the
+        # denial reached the LLM.
+        joined = _wait_for_function_call_outputs(mock_llm_server_url, timeout=5.0)
         assert "echo: testing456" not in joined, (
-            "Raw tool output leaked to the LLM despite refusal — the tool "
-            f"ran when it must not have.\nfunction_call_outputs: {joined[:800]}"
+            "Raw tool output leaked to the LLM despite refusal — "
+            f"function_call_outputs: {joined[:800]}"
         )
     finally:
         try:

--- a/tests/runtime/policies/test_approval.py
+++ b/tests/runtime/policies/test_approval.py
@@ -40,11 +40,13 @@ from typing import Any
 
 import pytest
 
+from omnigent.errors import ElicitationDeclinedError
 from omnigent.policies.function import FunctionPolicy
 from omnigent.policies.types import ElicitationRequest, PolicyResult
 from omnigent.runtime.policies.approval import (
     ELICITATION_PENDING_TOOL_NAME,
     _await_elicitation,
+    _is_explicit_decline,
     _parse_verdict,
     _truncate,
 )
@@ -177,6 +179,27 @@ def _returns_none_park() -> Any:
         return None
 
     return _park
+
+
+# ── _is_explicit_decline ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('{"action": "decline"}', True),
+        ('{"action": "accept"}', False),
+        ('{"action": "cancel"}', False),  # cancel ≠ explicit decline
+        ('{"action": "DECLINE"}', False),  # case-sensitive
+        (None, False),
+        ("not json", False),
+        ("{}", False),
+    ],
+)
+def test_is_explicit_decline(raw: str | None, expected: bool) -> None:
+    """Only exact ``action == "decline"`` is an explicit decline.
+    cancel, accept, malformed, and None all return False."""
+    assert _is_explicit_decline(raw) is expected
 
 
 # ── _parse_verdict ─────────────────────────────────────
@@ -395,34 +418,35 @@ async def test_accept_applies_labels(
 
 
 @pytest.mark.asyncio
-async def test_decline_does_not_apply_labels(
+async def test_decline_raises_elicitation_declined_error(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """Ports omnigent ``test_label_policy_ask_deny``.
-    On explicit decline, labels are NOT applied — the
-    load-bearing §7.2 invariant that a denied ASK leaves
-    no side effects."""
+    """Explicit ``action == "decline"`` raises ElicitationDeclinedError
+    instead of returning False, so callers can abort the agent turn
+    rather than feeding a DENY to the LLM and continuing."""
     policy = _ask_policy("gate", set_labels={"integrity": "0"})
     engine = _engine_with_policies(conversation_store, [policy])
     recorder = _Recorder()
     result = _composed_ask(
         deciding_policy="gate",
+        reason="review needed",
         set_labels={"integrity": "0"},
     )
 
-    accepted = await _await_elicitation(
-        task_id="task_1",
-        root_task_id="task_1",
-        result=result,
-        phase=Phase.REQUEST,
-        content_preview="hello",
-        policy_engine=engine,
-        register=recorder.register,
-        emit=recorder.emit,
-        park=_accepting_park('{"action": "decline"}'),
-    )
-    assert accepted is False
-    # No labels landed — hot cache empty, store empty.
+    with pytest.raises(ElicitationDeclinedError) as exc_info:
+        await _await_elicitation(
+            task_id="task_1",
+            root_task_id="task_1",
+            result=result,
+            phase=Phase.REQUEST,
+            content_preview="hello",
+            policy_engine=engine,
+            register=recorder.register,
+            emit=recorder.emit,
+            park=_accepting_park('{"action": "decline"}'),
+        )
+    assert exc_info.value.policy_name == "gate"
+    # No labels landed — §7.2 invariant preserved.
     assert engine.labels == {}
     conv = conversation_store.get_conversation(engine.conversation_id)
     assert conv is not None

--- a/tests/runtime/policies/test_ask_cycle_e2e.py
+++ b/tests/runtime/policies/test_ask_cycle_e2e.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import pytest
 
+from omnigent.errors import ElicitationDeclinedError
 from omnigent.policies.function import FunctionPolicy
 from omnigent.policies.types import EvaluationContext, PolicyResult
 from omnigent.runtime.policies import _await_elicitation
@@ -126,17 +127,20 @@ async def _run_ask_cycle(
     assert result.action == PolicyAction.ASK, (
         f"Harness expects ASK from evaluate(); got {result.action}"
     )
-    approved = await _await_elicitation(
-        task_id="task_1",
-        root_task_id="task_1",
-        result=result,
-        phase=ctx.phase,
-        content_preview=str(ctx.content),
-        policy_engine=engine,
-        register=harness.register,
-        emit=harness.emit,
-        park=harness.park,
-    )
+    try:
+        approved = await _await_elicitation(
+            task_id="task_1",
+            root_task_id="task_1",
+            result=result,
+            phase=ctx.phase,
+            content_preview=str(ctx.content),
+            policy_engine=engine,
+            register=harness.register,
+            emit=harness.emit,
+            park=harness.park,
+        )
+    except ElicitationDeclinedError:
+        approved = False
     return result, approved
 
 


### PR DESCRIPTION
## Related issue

Closes #N/A

## Summary

When a user explicitly clicks **Decline** on an elicitation card, the agent turn now aborts cleanly (produces `response.cancelled`) instead of receiving a `DENY` message and continuing. This matches the expected native harness behaviour where a human refusal stops the run rather than letting the LLM retry with a different approach.

Key distinction preserved: **only explicit `action == "decline"` triggers abort**. `cancel` (dismissed without choice), timeout, and malformed verdicts still return `False` and produce a normal `DENY` — those are ambiguous or unintentional, so fail-closed-but-continue is the right policy.

**Changes:**
- `ElicitationDeclinedError` added to `omnigent/errors.py` — new exception carrying `policy_name`, lets callers distinguish explicit decline from the other non-approve outcomes
- `_is_explicit_decline()` added to `approval.py` — strict check for `action == "decline"` (case-sensitive; cancel/timeout/None all `False`)
- `_await_elicitation` raises `ElicitationDeclinedError` on decline instead of returning `False`
- `_hold_native_ask_gate` in `sessions.py` raises on `verdict.action == "decline"`; both call sites catch it and return `abort: True` in the policy verdict body for the native harness to act on
- `_stable_elicitation_handler` in `_executor_adapter.py` raises on decline
- `_executor_adapter.run_turn` catches `ElicitationDeclinedError`, sets `ctx.cancelled`, and returns cleanly — terminal event becomes `response.cancelled`, not `response.failed`; the LLM never receives the denial

**Behaviour unchanged for:** `cancel`, timeout, malformed verdict, and the proxy-MCP path used by native CLI harnesses (Claude Code, Codex natively) where the harness controls the agent loop.

## Test Plan

```
python -m pytest tests/runtime/policies/test_approval.py -v
# 44 passed
```

- Updated `test_decline_does_not_apply_labels` → `test_decline_raises_elicitation_declined_error`: verifies `ElicitationDeclinedError` is raised with correct `policy_name`, and that §7.2 (no side effects) still holds
- Added `test_is_explicit_decline`: parametric coverage of all inputs
- Existing `test_cancel_does_not_apply_labels` / `test_timeout_does_not_apply_labels` confirm those paths still return `False` (no raise)

## Demo

N/A

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A