### PR TITLE
refactor(harnesses): invert SDK model-override set onto the registry (Phase 1)

### DIFF
--- a/omnigent/harnesses/capabilities.py
+++ b/omnigent/harnesses/capabilities.py
@@ -90,6 +90,29 @@ class HarnessCapabilities:
     subagents: bool
 
 
+# SDK/subprocess harnesses whose per-session model override lands in the spawn
+# env (``HARNESS_<H>_MODEL``) — must stay in sync with ``_HARNESS_MODEL_ENV_KEY``
+# in ``omnigent/runner/app.py``. Native harnesses always take the override via
+# ``--model`` at launch, so they are covered by their native metadata rather
+# than this set. This is the source of truth; ``model_override`` re-exports it as
+# ``_SDK_MODEL_OVERRIDE_HARNESSES`` (Phase 1 inversion — the harnesses package
+# owns the data, legacy modules derive from it).
+SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
+    {
+        "claude-sdk",
+        "codex",
+        "pi",
+        "openai-agents",
+        "cursor",
+        "antigravity",
+        "kimi",
+        "qwen",
+        "goose",
+        "copilot",
+    }
+)
+
+
 # Convenience aliases for the dense table below.
 _M = IntegrationMode
 _E = Elicitation

--- a/omnigent/harnesses/registry.py
+++ b/omnigent/harnesses/registry.py
@@ -9,9 +9,8 @@ those constants; the accompanying test
 from __future__ import annotations
 
 from omnigent.harness_aliases import HARNESS_ALIASES
-from omnigent.harnesses.capabilities import capabilities_for
+from omnigent.harnesses.capabilities import SDK_MODEL_OVERRIDE_HARNESSES, capabilities_for
 from omnigent.harnesses.types import HarnessDescriptor
-from omnigent.model_override import harness_supports_model_override
 from omnigent.native_coding_agents import NativeCodingAgent, native_coding_agent_for_harness
 from omnigent.onboarding.harness_install import _HARNESS_NAME_TO_KEY, harness_install_spec
 from omnigent.runtime.harnesses import _HARNESS_MODULES
@@ -89,6 +88,11 @@ def _build_registry() -> dict[str, HarnessDescriptor]:
                 f"omnigent.harnesses.capabilities._CAPABILITIES — declare its "
                 f"capabilities there"
             )
+        # Native CLIs take the override via --model at launch; SDK harnesses via
+        # HARNESS_<H>_MODEL in the spawn env (SDK_MODEL_OVERRIDE_HARNESSES). This
+        # is the same predicate model_override.harness_supports_model_override
+        # encodes — now sourced from the harnesses package (Phase 1 inversion).
+        supports_model_override = native is not None or name in SDK_MODEL_OVERRIDE_HARNESSES
         registry[name] = HarnessDescriptor(
             name=name,
             aliases=_aliases_for(name),
@@ -96,7 +100,7 @@ def _build_registry() -> dict[str, HarnessDescriptor]:
             harness_module=_HARNESS_MODULES.get(name),
             native=native,
             install_family_key=install_family_key,
-            supports_model_override=harness_supports_model_override(name),
+            supports_model_override=supports_model_override,
             capabilities=capabilities,
         )
     return registry

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import re
 
 from omnigent.harness_aliases import canonicalize_harness, is_native_harness
+from omnigent.harnesses.capabilities import SDK_MODEL_OVERRIDE_HARNESSES
 
 # Generous-but-safe upper bound; real ids ("databricks-claude-opus-4-8",
 # "us.anthropic.claude-sonnet-4-6") stay well under it.
@@ -25,20 +26,14 @@ _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\[\]-]*$")
 
 # SDK harnesses whose model override lands in the spawn env — must stay
 # in sync with ``_HARNESS_MODEL_ENV_KEY`` in ``omnigent/runner/app.py``.
-_SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
-    {
-        "claude-sdk",
-        "codex",
-        "pi",
-        "openai-agents",
-        "cursor",
-        "antigravity",
-        "kimi",
-        "qwen",
-        "goose",
-        "copilot",
-    }
-)
+#
+# The source of truth now lives in the harnesses package
+# (``omnigent.harnesses.capabilities.SDK_MODEL_OVERRIDE_HARNESSES``); this
+# name is kept as a thin re-export so existing callers are unchanged. Imported
+# from the leaf ``capabilities`` module (which imports nothing from omnigent),
+# so there is no import cycle. See designs/harness-modular-registry-proposal.md
+# Phase 1.
+_SDK_MODEL_OVERRIDE_HARNESSES = SDK_MODEL_OVERRIDE_HARNESSES
 
 
 def validate_model_override(value: str) -> str:

--- a/tests/test_harness_registry.py
+++ b/tests/test_harness_registry.py
@@ -165,6 +165,21 @@ def test_native_harnesses_resume_warm() -> None:
             assert descriptor.capabilities.resume is Resume.WARM_REATTACH, descriptor.name
 
 
+def test_model_override_set_is_owned_by_harnesses_package() -> None:
+    # Phase 1 inversion: the harnesses package owns the SDK-override set;
+    # model_override re-exports the same object (not a copy).
+    from omnigent.harnesses.capabilities import SDK_MODEL_OVERRIDE_HARNESSES
+    from omnigent.model_override import _SDK_MODEL_OVERRIDE_HARNESSES
+
+    assert _SDK_MODEL_OVERRIDE_HARNESSES is SDK_MODEL_OVERRIDE_HARNESSES
+    # And the registry's derived field agrees with the legacy predicate for every
+    # harness (guards the local re-derivation in registry._build_registry).
+    for descriptor in all_descriptors():
+        assert descriptor.supports_model_override == harness_supports_model_override(
+            descriptor.name
+        )
+
+
 def test_matrix_renders_every_harness() -> None:
     table = render_matrix()
     for descriptor in all_descriptors():


### PR DESCRIPTION
## What

First **Phase 1** ownership-inversion, done on the smallest, lowest-risk domain to prove the pattern before the larger inversions. **Stacked on #1795.**

The SDK model-override roster moves from `model_override._SDK_MODEL_OVERRIDE_HARNESSES` into the harnesses package (`omnigent.harnesses.capabilities.SDK_MODEL_OVERRIDE_HARNESSES`), which becomes the source of truth. `model_override` keeps the old private name as a **thin re-export**, so every existing caller is unchanged.

## Why this domain first

Picked by import-graph analysis as the cleanest starting point:
- **Private** to `model_override` (tiny blast radius).
- Keyed by **canonical names only** - no alias-subset ambiguity, so the move is exactly behavior-preserving.
- The set lands in the leaf `capabilities` module (imports nothing from omnigent), so `model_override` can import it with **no cycle**.

## The inversion

- The registry **no longer imports `model_override`**; it derives `supports_model_override` from the set + native metadata directly.
- `model_override` now imports the set from `capabilities` and re-exports it.
- Net effect: the harnesses package owns the data; the legacy module derives from it. This is the "old names become thin re-exports" pattern the design doc describes for Phase 1, applied once.

## Testing

- Verified no import cycle: `import omnigent.model_override` and `import omnigent.harnesses` both succeed.
- `pytest tests/test_harness_registry.py tests/test_model_override.py tests/test_resume_dispatch.py` - 138 passed.
- New test asserts the re-export is the *same object* and that the registry's derived field still agrees with `harness_supports_model_override` for every harness.
- `ruff` + `pre-commit` clean.
