### PR TITLE
feat(changelog): order by PEP 440 and drop --generate-notes

### DIFF
--- a/.github/scripts/changelog/generate.py
+++ b/.github/scripts/changelog/generate.py
@@ -26,6 +26,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 # Reuse the exact section + checkbox parsing the merge gate uses.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "pr-template"))
 from _md import (
@@ -44,11 +46,20 @@ TYPE_LABELS = tuple(TYPE_TAGS)
 _FINAL_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 # A squash-merge subject ends with "(#1234)"; capture the last such reference.
 _PR_REF_RE = re.compile(r"\(#(\d+)\)\s*$")
-# Existing version headers in CHANGELOG.md, e.g. "## [v0.3.0] — 2026-06-27".
-_VERSION_HEADER_RE = re.compile(r"(?m)^##\s*\[v(\d+)\.(\d+)\.(\d+)\]")
+# Existing version headers in CHANGELOG.md — capture the whole bracketed tag so
+# any version shape (final, rc, dev) is found, e.g. "## [v0.4.0rc1] — 2026-…".
+_VERSION_HEADER_RE = re.compile(r"(?m)^##\s*\[([^\]]+)\]")
 
 
-# --- version helpers (final vX.Y.Z only → plain integer-tuple ordering) -------
+# --- version helpers ---------------------------------------------------------
+#
+# Two notions, deliberately distinct:
+#   * FINALITY (_version_tuple / previous_final_tag): only vX.Y.Z. Governs the
+#     default range start — a real v0.4.0 diffs against the previous *final* tag
+#     (v0.3.0), never an intervening v0.4.0rc1.
+#   * ORDERABILITY (_parse_version): any PEP 440 version, incl. dev/rc. Governs
+#     where a block sorts in CHANGELOG.md, so a manually-drafted dev/rc tag lands
+#     in the right place (and below its eventual final).
 
 
 def _version_tuple(tag: str) -> tuple[int, int, int] | None:
@@ -58,15 +69,31 @@ def _version_tuple(tag: str) -> tuple[int, int, int] | None:
     return tuple(int(p) for p in match.groups())  # type: ignore[return-value]
 
 
+def _parse_version(tag: str) -> Version | None:
+    """PEP 440 version for *tag* (leading ``v`` stripped), or ``None`` if it isn't
+    a version at all (e.g. a branch/sha). ``Version`` sorts dev < rc < final."""
+    try:
+        return Version(tag.strip().lstrip("v"))
+    except InvalidVersion:
+        return None
+
+
 def previous_final_tag(tag: str, all_tags: list[str]) -> str | None:
-    """Highest final tag strictly below *tag*, or ``None`` if there is none."""
-    current = _version_tuple(tag)
+    """Highest *final* (vX.Y.Z) tag strictly below *tag*, or ``None`` if none.
+
+    The reference *tag* may itself be any PEP 440 version (a dev/rc tag drafted
+    manually still diffs against the previous final release); only the candidates
+    are restricted to finals.
+    """
+    current = _parse_version(tag)
     if current is None:
-        raise ValueError(f"{tag!r} is not a final vX.Y.Z tag")
+        raise ValueError(f"{tag!r} is not a PEP 440 version")
     below = [
         (version, candidate)
         for candidate in all_tags
-        if (version := _version_tuple(candidate)) is not None and version < current
+        if _version_tuple(candidate) is not None
+        and (version := _parse_version(candidate)) is not None
+        and version < current
     ]
     if not below:
         return None
@@ -206,31 +233,34 @@ def render_pr_list(results: list[HarvestResult]) -> str:
 def insert_section(changelog: str, tag: str, section: str) -> str:
     """Insert (or replace) *section* for *tag* into *changelog*, version-ordered.
 
-    Newest version first. If the tag is already present its block is replaced,
-    making re-runs idempotent.
+    Newest version first, by PEP 440 — so a final ``v0.4.0`` sorts above its own
+    ``v0.4.0rc1`` / ``v0.4.0.dev0`` blocks, which in turn sort above ``v0.3.0``.
+    Re-running the same tag replaces its own block (matched by exact tag string),
+    making re-runs idempotent; distinct tags (final vs. its pre-releases) coexist.
     """
-    target = _version_tuple(tag)
+    target = _parse_version(tag)
     if target is None:
-        raise ValueError(f"{tag!r} is not a final vX.Y.Z tag")
+        raise ValueError(f"{tag!r} is not a PEP 440 version")
 
     headers = list(_VERSION_HEADER_RE.finditer(changelog))
-    blocks = []  # (version_tuple, start, end)
+    blocks = []  # (header_tag, parsed_version_or_None, start, end)
     for idx, match in enumerate(headers):
-        version = tuple(int(g) for g in match.groups())
+        header_tag = match.group(1).strip()
         start = match.start()
         end = headers[idx + 1].start() if idx + 1 < len(headers) else len(changelog)
-        blocks.append((version, start, end))
+        blocks.append((header_tag, _parse_version(header_tag), start, end))
 
     section_block = section.rstrip() + "\n"
 
-    # Replace an existing block for this exact version.
-    for version, start, end in blocks:
-        if version == target:
+    # Replace an existing block for this exact tag (idempotent re-run).
+    for header_tag, _version, start, end in blocks:
+        if header_tag == tag.strip():
             return changelog[:start] + section_block + "\n" + changelog[end:].lstrip("\n")
 
-    # Otherwise insert before the first existing version that is older than ours.
-    for version, start, _end in blocks:
-        if version < target:
+    # Otherwise insert before the first existing block that sorts below ours. An
+    # unparseable existing header is treated as oldest (sorts last).
+    for _header_tag, version, start, _end in blocks:
+        if version is None or version < target:
             head = changelog[:start].rstrip("\n")
             tail = changelog[start:]
             return f"{head}\n\n{section_block}\n{tail}"
@@ -334,18 +364,18 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    # CHANGELOG.md insertion orders blocks by version, so it needs a final
-    # vX.Y.Z tag. A non-version --tag (a preview/test ref) needs an explicit
-    # --base for the range and can only render, never insert.
-    is_version = _version_tuple(args.tag) is not None
-    if not is_version and args.base is None:
+    # CHANGELOG.md insertion orders blocks by PEP 440, so --tag must be a version
+    # (final, rc, or dev — all orderable). A non-version ref (branch/sha) can only
+    # render a preview, and needs an explicit --base for its range.
+    is_orderable = _parse_version(args.tag) is not None
+    if not is_orderable and args.base is None:
         parser.error(
-            f"--tag {args.tag!r} is not a final vX.Y.Z tag; pass --base <ref> for its range"
+            f"--tag {args.tag!r} is not a PEP 440 version; pass --base <ref> for its range"
         )
 
     section, results, prev = collect(args.tag, args.repo, base=args.base)
 
-    if is_version and not args.no_changelog_update:
+    if is_orderable and not args.no_changelog_update:
         path = Path(args.changelog_file)
         existing = path.read_text() if path.exists() else _SEED_CHANGELOG
         path.write_text(insert_section(existing, args.tag, section))

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -40,10 +40,10 @@ on:
         type: string
       dry_run:
         description: >-
-          Preview only — print the CHANGELOG section + draft notes to the run
-          summary, open no PR and edit no release. `auto` (default) previews when
-          `tag` is not a final vX.Y.Z or a base override is set, and does a real
-          run otherwise; `true`/`false` force the choice.
+          Preview only:
+          auto (default) - preview for dev/rc tags, real PR for final versions;
+          true - print the generated notes, don't open a PR;
+          false - open a real PR to CHANGELOG.md
         required: false
         type: choice
         options: [auto, "true", "false"]
@@ -167,6 +167,9 @@ jobs:
           DRY_RUN: ${{ steps.guard.outputs.dry_run }}
         run: |
           set -euo pipefail
+          # generate.py orders CHANGELOG.md by PEP 440 (packaging). This step runs
+          # bare python3 (before uv sync), so ensure packaging is importable.
+          python3 -m pip install --quiet --disable-pip-version-check packaging
           args=(--tag "$TAG" --repo "$SOURCE_REPO"
                 --draft-notes-out /tmp/mechanical_notes.md
                 --pr-list-out /tmp/pr_list.txt
@@ -382,19 +385,9 @@ jobs:
           TAG: ${{ steps.guard.outputs.tag }}
         run: |
           set -euo pipefail
-          # Preserve the original auto-generated notes in a collapsed section for
-          # the coordinator's reference.
-          orig="$(gh release view "$TAG" --repo "$SOURCE_REPO" --json body -q .body || true)"
-          {
-            cat /tmp/release_notes.md
-            echo
-            echo "<details><summary>Auto-generated notes (reference)</summary>"
-            echo
-            printf '%s\n' "$orig"
-            echo
-            echo "</details>"
-          } > /tmp/final_notes.md
-          gh release edit "$TAG" --repo "$SOURCE_REPO" --notes-file /tmp/final_notes.md
+          # github-release.yml seeds only a short placeholder body (no
+          # auto-generated notes), so replace it wholesale with the curated notes.
+          gh release edit "$TAG" --repo "$SOURCE_REPO" --notes-file /tmp/release_notes.md
           echo "Enriched the ${TAG} release draft with curated notes." \
             | tee -a "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -12,10 +12,14 @@
 #   * It uses the ephemeral `GITHUB_TOKEN` (no stored secret / PAT). The single
 #     elevated scope, `contents: write`, is the minimum GitHub requires to
 #     create a release and nothing else in the job uses it.
-#   * It attaches NO wheels. The release carries only generated notes and the
+#   * It attaches NO wheels. The release carries only a placeholder body and the
 #     source tarball GitHub auto-attaches, so PyPI (the scanned, securely
 #     published channel) stays the single source of installable artifacts.
-#   * The release is created as a DRAFT: a human verifies/edits the generated
+#   * The body is a short placeholder — the curated notes are filled in by
+#     `draft-release-notes.yml` (which fires after this on `workflow_run`). We do
+#     NOT use `--generate-notes`: we write our own notes, and for a large
+#     PR range GitHub's auto-notes overflow the 125k release-body limit.
+#   * The release is created as a DRAFT: a human verifies/edits the drafted
 #     notes and publishes it (ideally after the prod PyPI publish lands), so a
 #     bot never makes a public release on its own.
 name: GitHub Release
@@ -39,12 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      # Full history so `--generate-notes` can diff against the previous tag.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
 
-      - name: Draft release with generated notes
+      - name: Draft release with a placeholder body
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
@@ -68,8 +69,8 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --draft \
             --verify-tag \
-            --generate-notes \
+            --notes "_Release notes are being drafted automatically — check back shortly._" \
             --title "$TAG" \
             $pre
-          echo "Drafted release $TAG — review/edit the notes and publish from the Releases page." \
+          echo "Drafted release $TAG — curated notes will be filled in by draft-release-notes.yml; review and publish from the Releases page." \
             | tee -a "$GITHUB_STEP_SUMMARY"

--- a/tests/github/test_changelog_generate.py
+++ b/tests/github/test_changelog_generate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -76,12 +77,13 @@ def test_collect_without_base_uses_previous_final_tag(monkeypatch) -> None:
 # --- CLI guard rail ----------------------------------------------------------
 
 
-def test_cli_non_version_tag_without_base_errors(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(sys, "argv", ["generate.py", "--tag", "preview", "--repo", "o/o"])
+def test_cli_non_version_ref_without_base_errors(monkeypatch, capsys) -> None:
+    # A non-version ref (branch/sha) can't be ordered and has no default range.
+    monkeypatch.setattr(sys, "argv", ["generate.py", "--tag", "ci-test", "--repo", "o/o"])
     with pytest.raises(SystemExit) as exc:
         gen.main()
     assert exc.value.code != 0
-    assert "not a final vX.Y.Z" in capsys.readouterr().err
+    assert "not a PEP 440 version" in capsys.readouterr().err
 
 
 # --- pr_numbers_from_subjects ------------------------------------------------
@@ -243,6 +245,33 @@ def test_insert_is_idempotent_and_replaces() -> None:
     doc = gen.insert_section(_SEED, "v0.3.0", _section("v0.3.0", "2026-06-27", "old"))
     doc = gen.insert_section(doc, "v0.3.0", _section("v0.3.0", "2026-06-27", "new"))
     assert doc.count("[v0.3.0]") == 1
+    assert "new (#1)" in doc and "old (#1)" not in doc
+
+
+def test_insert_prerelease_orders_by_pep440_and_coexists() -> None:
+    # A dev tag lands above the previous final; the eventual final sorts above the
+    # dev; an rc sits between them. All three (final/rc/dev) coexist as blocks.
+    doc = gen.insert_section(_SEED, "v0.3.0", _section("v0.3.0", "2026-06-26", "three"))
+    doc = gen.insert_section(doc, "v0.4.0dev0", _section("v0.4.0dev0", "2026-07-02", "dev"))
+    doc = gen.insert_section(doc, "v0.4.0", _section("v0.4.0", "2026-07-10", "final"))
+    doc = gen.insert_section(doc, "v0.4.0rc1", _section("v0.4.0rc1", "2026-07-08", "rc"))
+    headers = re.findall(r"(?m)^## \[([^\]]+)\]", doc)
+    assert headers == ["v0.4.0", "v0.4.0rc1", "v0.4.0dev0", "v0.3.0"]
+
+
+def test_insert_final_and_dev_are_distinct_blocks() -> None:
+    # v0.4.0 must NOT overwrite v0.4.0dev0 (no collapse of dev → final).
+    doc = gen.insert_section(_SEED, "v0.4.0dev0", _section("v0.4.0dev0", "2026-07-02", "dev"))
+    doc = gen.insert_section(doc, "v0.4.0", _section("v0.4.0", "2026-07-10", "final"))
+    assert doc.count("[v0.4.0dev0]") == 1
+    assert re.search(r"(?m)^## \[v0\.4\.0\]", doc) is not None
+    assert "dev (#1)" in doc and "final (#1)" in doc
+
+
+def test_insert_dev_tag_idempotent() -> None:
+    doc = gen.insert_section(_SEED, "v0.4.0dev0", _section("v0.4.0dev0", "2026-07-02", "old"))
+    doc = gen.insert_section(doc, "v0.4.0dev0", _section("v0.4.0dev0", "2026-07-02", "new"))
+    assert doc.count("[v0.4.0dev0]") == 1
     assert "new (#1)" in doc and "old (#1)" not in doc
 
 


### PR DESCRIPTION
## Related issue

N/A — follow-up fixes to the changelog automation (#1763, #1826, #1832).

## Summary

Two problems surfaced from pushing a `v0.4.0dev0` tag:

1. **`github-release.yml` failed with `HTTP 422: body is too long (maximum is 125000 characters)`.** It called `gh release create --generate-notes`, which asks GitHub to enumerate every PR since the previous tag — 193 for the `v0.3.0`→HEAD range — overflowing GitHub's release-body cap. We draft our own curated notes in `draft-release-notes.yml`, so `--generate-notes` was dead weight *and* this failure mode. **Fix:** create the draft with a short placeholder body (`_Release notes are being drafted automatically…_`) that `draft-release-notes.yml` then overwrites.

2. **A manual run for a dev tag (`v0.4.0dev0 --base v0.3.0 dry_run=false`) harvested 6 PRs but reported "CHANGELOG.md already up to date".** `generate.py` gated the file write on a strict `^v\d+\.\d+\.\d+$` regex that `.dev0` fails, so it silently skipped the write. **Fix:** order `CHANGELOG.md` by **PEP 440** (`packaging.Version`) using the **full tag string** as the block header. Dev/rc tags now land in their own correctly-ordered blocks and coexist with the eventual final instead of collapsing into it:

   ```
   ## [v0.4.0]        ← final sorts above its pre-releases
   ## [v0.4.0rc1]
   ## [v0.4.0dev0]
   ## [v0.3.0]
   ```

   Re-running a tag still replaces its own block (idempotent).

`previous_final_tag` stays finals-only (a real `v0.4.0` still diffs against `v0.3.0`, never an intervening rc). **The `workflow_run` auto-trigger is unchanged and remains finals-only** — dev/rc changelog blocks are reachable **only** by manual dispatch. The harvest step installs `packaging` (it runs bare `python3` before `uv sync`), and the `dry_run` input description is trimmed to a concise `auto/true/false`.

## Test Plan

- `pytest tests/github/` — **87 pass**, incl. new `insert_section` cases: PEP 440 dev/rc/final ordering, final-and-dev coexist as distinct blocks (no collapse), dev-tag idempotent re-run; and the renamed CLI guard test (non-version *ref* without `--base` errors with "not a PEP 440 version").
- Local ordering probe: `v0.4.0 > v0.4.0rc1 > v0.4.0dev0 > v0.3.0`, idempotent, `previous_final_tag("v0.4.0dev0") == "v0.3.0"`.
- **End-to-end against real history:** `--tag v0.4.0dev0 --base v0.3.0` now writes a correctly-ordered `## [v0.4.0dev0]` block at the top of a temp `CHANGELOG.md` (6 documented PRs) instead of no-op'ing. Confirmed system `python3` lacks `packaging`, so the added `pip install` is load-bearing.
- Both workflow YAMLs parse; run-block expression-injection audit clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Script logic (PEP 440 ordering, insert/replace, guard rail) is unit-covered. The two workflow edits can't run in unit tests; verified by YAML parse + injection audit and by a local end-to-end run of the harvester against real repo history.

## Changelog

Fixed: release draft creation no longer fails on large PR ranges, and manually-drafted dev/rc tags now produce correctly-ordered CHANGELOG.md entries