### PR TITLE
feat(server,web): surface admin + account settings under OIDC/SSO

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1287,6 +1287,16 @@ def create_app(
     app.state.host_registry = host_registry
     app.state.host_store = host_store
     app.state.sandbox_config = sandbox_config
+    # Admin roster: the config ``admins:`` list (canonical) union'd with the
+    # runtime-editable ``<data_dir>/admins`` file. Built once here so BOTH the
+    # admin-gated auth routes AND ``/v1/me``'s is_admin computation consult the
+    # same source — otherwise an identity listed in the file but not yet
+    # promoted (``promote_if_listed`` runs at login) would be authorized by the
+    # routes yet see no admin chrome. The file portion lazily reloads on mtime
+    # change (no restart).
+    from omnigent.server.admin_list import load_admin_list
+
+    admin_list = load_admin_list(extra=frozenset(admins or ()))
     # Tracks in-flight background managed-host launches (POST
     # /v1/sessions returns before the sandbox exists) so a message
     # racing the provision can rendezvous instead of failing with
@@ -1802,10 +1812,15 @@ def create_app(
                 status_code=401,
                 content={"user_id": None, "login_url": login_url},
             )
-        is_admin = (
-            user_id is not None
-            and permission_store is not None
-            and permission_store.is_admin(user_id)
+        # Mirror the admin check the auth routes use
+        # (``permission_store.is_admin(caller) or admin_list.is_admin(caller)``)
+        # so the SPA's admin chrome never under-reports relative to what the
+        # endpoints actually authorize — e.g. for an identity added to the
+        # admin-list file who hasn't re-logged-in yet (so ``promote_if_listed``
+        # hasn't flipped the DB flag).
+        is_admin = user_id is not None and (
+            (permission_store is not None and permission_store.is_admin(user_id))
+            or admin_list.is_admin(user_id)
         )
         return {"user_id": user_id, "is_admin": is_admin}
 
@@ -2143,16 +2158,12 @@ def create_app(
     # Must be registered BEFORE the SPA static mount because the SPA's
     # HTML5-history fallback catches all unmatched extensionless paths.
     if auth_provider is not None and getattr(auth_provider, "login_url", None):
-        from omnigent.server.admin_list import load_admin_list
         from omnigent.server.auth import UnifiedAuthProvider
 
-        # Admin roster: the config ``admins:`` list (canonical) union'd
-        # with the runtime-editable ``<data_dir>/admins`` file. Consulted
-        # on each login to promote listed identities — the only admin
-        # path for OIDC, and an additive convenience for accounts. The
-        # file portion lazily reloads on mtime change (no restart).
-        admin_list = load_admin_list(extra=frozenset(admins or ()))
-
+        # ``admin_list`` is built once near app creation (see above) so the
+        # auth routes and ``/v1/me`` share one roster. Consulted on each login
+        # to promote listed identities — the only admin path for OIDC, and an
+        # additive convenience for accounts.
         if (
             isinstance(auth_provider, UnifiedAuthProvider)
             and auth_provider._source == "accounts"

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1771,21 +1771,27 @@ def create_app(
         }
 
     @app.get("/v1/me", response_model=None)  # Union return type (dict | JSONResponse)
-    async def me(request: Request) -> dict[str, str | None] | JSONResponse:
+    async def me(request: Request) -> dict[str, str | bool | None] | JSONResponse:
         """Return the current user's identity.
 
         Reads the user from the auth provider (same logic that
         session routes use). The frontend calls this on load to
         discover who it is.
 
+        Also returns ``is_admin`` — the mode-agnostic admin signal
+        (the shared ``users.is_admin`` column, set by the admin-list
+        promotion at login). The SPA gates admin chrome on it in
+        EVERY mode, including OIDC/SSO where the accounts-only
+        ``/auth/me`` endpoint does not exist.
+
         When OIDC is active and the user is unauthenticated,
         returns 401 with a ``login_url`` so the frontend knows
         where to redirect.
 
         :param request: The incoming FastAPI request.
-        :returns: ``{"user_id": "alice@example.com"}``,
-            ``{"user_id": null}`` if unauthenticated in header
-            mode, or 401 with ``login_url`` in OIDC mode.
+        :returns: ``{"user_id": "alice@example.com", "is_admin": true}``,
+            ``{"user_id": null, "is_admin": false}`` if unauthenticated
+            in header mode, or 401 with ``login_url`` in OIDC mode.
         """
         user_id: str | None = None
         if auth_provider is not None:
@@ -1796,7 +1802,12 @@ def create_app(
                 status_code=401,
                 content={"user_id": None, "login_url": login_url},
             )
-        return {"user_id": user_id}
+        is_admin = (
+            user_id is not None
+            and permission_store is not None
+            and permission_store.is_admin(user_id)
+        )
+        return {"user_id": user_id, "is_admin": is_admin}
 
     app.include_router(
         create_sessions_router(

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -553,6 +553,57 @@ def create_auth_router(
             },
         )
 
+    # ── Admin: read-only user list ────────────────────────────────
+
+    @router.get("/users")
+    async def list_users(request: Request) -> Response:
+        """List all users (admin only).
+
+        The OIDC analog of the accounts provider's ``GET /auth/users``
+        — same response shape, so the SPA's Members surface renders
+        identically. This is the read-only discovery half of the
+        admin surface: OIDC identities are owned by the IdP, so there
+        are no server-side password actions (invite/reset/delete) to
+        offer here, and the SPA hides those controls in OIDC mode.
+
+        Admin is gated on the same ``is_admin`` flag the rest of the
+        app uses (set by the admin-list promotion at login), with the
+        admin list as a direct fallback — matching the OIDC invite
+        route above.
+
+        :param request: The incoming request (carries the session cookie).
+        :returns: 200 with ``{"users": [...]}``, 401 if unauthenticated,
+            403 if not an admin, or 200 with an empty list if no
+            permission store is wired.
+        """
+        from fastapi.responses import JSONResponse
+
+        caller = auth_provider.get_user_id(request)
+        if caller is None:
+            return JSONResponse(status_code=401, content={"error": "not authenticated"})
+        is_admin = (
+            permission_store is not None and permission_store.is_admin(caller)
+        ) or admin_list.is_admin(caller)
+        if not is_admin:
+            return JSONResponse(status_code=403, content={"error": "admin only"})
+
+        users = permission_store.list_users() if permission_store is not None else []
+        return JSONResponse(
+            status_code=200,
+            content={
+                "users": [
+                    {
+                        "id": u.id,
+                        "is_admin": u.is_admin,
+                        "created_at": u.created_at,
+                        "last_login_at": u.last_login_at,
+                        "has_password": u.has_password,
+                    }
+                    for u in users
+                ]
+            },
+        )
+
     return router
 
 

--- a/omnigent/stores/permission_store/__init__.py
+++ b/omnigent/stores/permission_store/__init__.py
@@ -7,7 +7,7 @@ sentinel user ID represents public read access.
 
 from abc import ABC, abstractmethod
 
-from omnigent.entities import ResolvedAccess, SessionPermission
+from omnigent.entities import Account, ResolvedAccess, SessionPermission
 
 
 class PermissionStore(ABC):
@@ -125,6 +125,22 @@ class PermissionStore(ABC):
             ``"alice@example.com"`` or ``"local"``.
         :param is_admin: Set to ``True`` for the ``"local"`` user
             in single-user mode.
+        """
+        ...
+
+    @abstractmethod
+    def list_users(self) -> list[Account]:
+        """Return every real user row, for the admin user list.
+
+        Excludes the reserved sentinels (``"__public__"`` and
+        ``"local"``) that aren't real actors, mirroring
+        :meth:`SqlAlchemyAccountStore.list_users` so the OIDC/header
+        admin surface can reuse the accounts-mode ``Account`` shape.
+        The ``password_hash`` is never included (see :class:`Account`).
+
+        Result is unordered; callers sort for display.
+
+        :returns: List of :class:`Account` rows.
         """
         ...
 

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -8,9 +8,35 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from omnigent.db.db_models import SqlSessionPermission, SqlUser
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
-from omnigent.entities import ResolvedAccess, SessionPermission
-from omnigent.server.auth import LEVEL_OWNER, RESERVED_USER_PUBLIC
+from omnigent.entities import Account, ResolvedAccess, SessionPermission
+from omnigent.server.auth import (
+    LEVEL_OWNER,
+    RESERVED_USER_LOCAL,
+    RESERVED_USER_PUBLIC,
+)
 from omnigent.stores.permission_store import PermissionStore
+
+# Sentinel rows excluded from list_users() — never real, actionable
+# actors. Mirrors accounts_store._HIDDEN_LIST_USERS so the admin user
+# list is identical across auth modes.
+_HIDDEN_LIST_USERS = frozenset({RESERVED_USER_PUBLIC, RESERVED_USER_LOCAL})
+
+
+def _to_account(row: SqlUser) -> Account:
+    """Convert a :class:`SqlUser` ORM row to an :class:`Account` entity.
+
+    Strips ``password_hash`` — it never leaves the store via this
+    conversion (see :class:`Account`). Mirrors
+    ``accounts_store._to_account`` so both stores surface the same
+    admin user shape.
+    """
+    return Account(
+        id=row.id,
+        is_admin=row.is_admin,
+        created_at=row.created_at,
+        last_login_at=row.last_login_at,
+        has_password=row.password_hash is not None,
+    )
 
 
 def _to_entity(row: SqlSessionPermission) -> SessionPermission:
@@ -223,6 +249,12 @@ class SqlAlchemyPermissionStore(PermissionStore):
                     .on_conflict_do_nothing(index_elements=["id"])
                 )
             session.execute(stmt)
+
+    def list_users(self) -> list[Account]:
+        """List every real user row. See base class for contract."""
+        with self._session() as session:
+            rows = session.execute(select(SqlUser)).scalars().all()
+            return [_to_account(r) for r in rows if r.id not in _HIDDEN_LIST_USERS]
 
     def is_admin(self, user_id: str) -> bool:
         """Check the admin flag. See base class for contract."""

--- a/openapi.json
+++ b/openapi.json
@@ -6541,7 +6541,7 @@
     },
     "/v1/me": {
       "get": {
-        "description": "Return the current user's identity.\n\nReads the user from the auth provider (same logic that\nsession routes use). The frontend calls this on load to\ndiscover who it is.\n\nWhen OIDC is active and the user is unauthenticated,\nreturns 401 with a `login_url` so the frontend knows\nwhere to redirect.\n\n**Returns:** `{\"user_id\": \"alice@example.com\"}`, `{\"user_id\": null}` if unauthenticated in header mode, or 401 with `login_url` in OIDC mode.",
+        "description": "Return the current user's identity.\n\nReads the user from the auth provider (same logic that\nsession routes use). The frontend calls this on load to\ndiscover who it is.\n\nAlso returns `is_admin` \u2014 the mode-agnostic admin signal\n(the shared `users.is_admin` column, set by the admin-list\npromotion at login). The SPA gates admin chrome on it in\nEVERY mode, including OIDC/SSO where the accounts-only\n`/auth/me` endpoint does not exist.\n\nWhen OIDC is active and the user is unauthenticated,\nreturns 401 with a `login_url` so the frontend knows\nwhere to redirect.\n\n**Returns:** `{\"user_id\": \"alice@example.com\", \"is_admin\": true}`, `{\"user_id\": null, \"is_admin\": false}` if unauthenticated in header mode, or 401 with `login_url` in OIDC mode.",
         "operationId": "me_v1_me_get",
         "responses": {
           "200": {

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -287,6 +287,67 @@ async def test_me_header_mode_behaviors(
     assert reserved.json() == {"user_id": None, "is_admin": False}
 
 
+async def test_me_is_admin_honors_admin_list_before_db_promotion(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/v1/me`` reports is_admin for an admin-list identity not yet promoted.
+
+    The admin-gated routes (``/auth/users``, ``/auth/invite``) authorize on
+    ``permission_store.is_admin(caller) or admin_list.is_admin(caller)``. If
+    ``/v1/me`` checked only the DB flag, an identity freshly added to the
+    admin-list file (before ``promote_if_listed`` runs at their next login)
+    would be authorized by those routes yet see no admin chrome. This pins
+    ``/v1/me`` to the same fallback so the SPA never under-reports.
+
+    :param runtime_init: Fixture that initializes the runtime with a mock LLM.
+    :param db_uri: Test database URI.
+    :param tmp_path: Pytest temporary directory fixture.
+    :param monkeypatch: Pins header auth and points the admin-list file at a
+        roster containing ``alice`` — whose DB row is intentionally left
+        non-admin.
+    """
+    from omnigent.server.auth import create_auth_provider
+
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "header")
+    monkeypatch.delenv("OMNIGENT_LOCAL_SINGLE_USER", raising=False)
+    # Admin-list file lists alice; her DB row is never promoted.
+    admin_file = tmp_path / "admins"
+    admin_file.write_text("alice@example.com\n")
+    monkeypatch.setenv("OMNIGENT_ADMIN_LIST_PATH", str(admin_file))
+
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    perm_store.ensure_user("alice@example.com")  # is_admin defaults False
+    assert perm_store.is_admin("alice@example.com") is False
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    app = app_module.create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        permission_store=perm_store,
+        auth_provider=create_auth_provider(),
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/v1/me",
+            headers={"X-Forwarded-Email": "alice@example.com"},
+        )
+
+    # DB flag is still False, but the admin-list fallback flips is_admin True —
+    # matching what /auth/users would authorize for the same caller.
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": "alice@example.com", "is_admin": True}
+
+
 async def test_web_ui_serves_pwa_service_worker_and_manifest(
     runtime_init: None,
     db_uri: str,

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -276,14 +276,15 @@ async def test_me_header_mode_behaviors(
     # Missing header fails closed: /v1/me itself stays
     # 200 (it's the identity probe the frontend bootstraps from) but
     # reports no user instead of resolving to a shared "local" identity.
+    # is_admin is always present (mode-agnostic signal) and false with no user.
     assert missing.status_code == 200
-    assert missing.json() == {"user_id": None}
-    # Valid header returns the identity.
+    assert missing.json() == {"user_id": None, "is_admin": False}
+    # Valid header returns the identity; alice has no admin flag set.
     assert normal.status_code == 200
-    assert normal.json() == {"user_id": "alice@example.com"}
+    assert normal.json() == {"user_id": "alice@example.com", "is_admin": False}
     # Reserved name is rejected (returns None → route returns null).
     assert reserved.status_code == 200
-    assert reserved.json() == {"user_id": None}
+    assert reserved.json() == {"user_id": None, "is_admin": False}
 
 
 async def test_web_ui_serves_pwa_service_worker_and_manifest(

--- a/tests/server/integration/test_oidc_default_policies.py
+++ b/tests/server/integration/test_oidc_default_policies.py
@@ -1,0 +1,200 @@
+"""OIDC integration tests for the global (default) policies routes.
+
+The default-policies router (``/v1/policies``) gates purely on the
+mode-agnostic ``permission_store.is_admin`` — reads require auth, writes
+require admin — so it works under OIDC exactly as under accounts. These
+tests pin that end-to-end: a real ``create_app`` wired with an OIDC
+provider + permission store + policy store, driven by presenting an OIDC
+session JWT as a Bearer token (the same mechanism ``test_oidc_admin_users``
+uses).
+
+Unlike Members (read-only under OIDC — no password actions), Policies is
+fully functional: an OIDC admin can list, create, toggle, and delete.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.server.oidc import OIDCConfig, mint_session_cookie
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
+
+pytestmark = pytest.mark.asyncio
+
+_TEST_SECRET = bytes.fromhex("aa" * 32)
+_ADMIN = "admin@example.com"
+_MEMBER = "member@example.com"
+
+
+def _oidc_config() -> OIDCConfig:
+    """Build a minimal GitHub-flavoured OIDCConfig for testing."""
+    return OIDCConfig(
+        issuer="https://github.com",
+        client_id="cid",
+        client_secret="secret",
+        redirect_uri="http://localhost:8000/auth/callback",
+        cookie_secret=_TEST_SECRET,
+        scopes="read:user user:email",
+        session_ttl_hours=8,
+        logout_redirect_uri=None,
+        allowed_domains=None,
+        provider_type="github",
+        authorization_endpoint="https://github.com/login/oauth/authorize",
+        token_endpoint="https://github.com/login/oauth/access_token",
+        jwks_uri=None,
+        userinfo_endpoint="https://api.github.com/user",
+        allow_invites=False,
+    )
+
+
+def _bearer(user_id: str) -> dict[str, str]:
+    """Authorization header carrying an OIDC session JWT for *user_id*."""
+    token = mint_session_cookie(
+        user_id=user_id,
+        cookie_secret=_TEST_SECRET,
+        ttl_hours=8,
+        provider="oidc",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def oidc_policy_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
+    """A create_app instance with OIDC auth + permission store + policy store.
+
+    Seeds an admin and a non-admin so the tests can drive both gating
+    paths. Header/accounts routers aren't mounted (no login_url match
+    needed) — the /v1/policies router only needs auth_provider +
+    permission_store, which is exactly the OIDC wiring.
+    """
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    perm_store.ensure_user(_ADMIN, is_admin=True)
+    perm_store.ensure_user(_MEMBER)
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    auth_provider = UnifiedAuthProvider(source="oidc", oidc_config=_oidc_config())
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        policy_store=SqlAlchemyPolicyStore(db_uri),
+        permission_store=perm_store,
+        auth_provider=auth_provider,
+    )
+
+
+@pytest_asyncio.fixture()
+async def oidc_policy_client(
+    oidc_policy_app: FastAPI,
+) -> AsyncIterator[httpx.AsyncClient]:
+    """HTTP client wired to the OIDC policy-enabled app."""
+    transport = httpx.ASGITransport(app=oidc_policy_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _policy_payload(**overrides: object) -> dict:
+    """Build a valid CreateDefaultPolicyRequest payload (URL type)."""
+    base: dict = {
+        "name": "oidc_url_policy",
+        "type": "url",
+        "handler": "https://example.com/policies/eval",
+    }
+    base.update(overrides)  # type: ignore[arg-type]
+    return base
+
+
+# ── Admin: full CRUD works under OIDC ─────────────────────────────────
+
+
+async def test_oidc_admin_can_crud_default_policies(
+    oidc_policy_client: httpx.AsyncClient,
+) -> None:
+    """An OIDC admin can create, list, toggle, and delete global policies."""
+    headers = _bearer(_ADMIN)
+
+    # Create.
+    create = await oidc_policy_client.post("/v1/policies", json=_policy_payload(), headers=headers)
+    assert create.status_code == 200, create.text
+    pid = create.json()["id"]
+    assert pid.startswith("pol_")
+
+    # List — the created policy is present.
+    listing = await oidc_policy_client.get("/v1/policies", headers=headers)
+    assert listing.status_code == 200
+    assert pid in [p["id"] for p in listing.json()["data"]]
+
+    # Toggle disabled.
+    patch = await oidc_policy_client.patch(
+        f"/v1/policies/{pid}", json={"enabled": False}, headers=headers
+    )
+    assert patch.status_code == 200
+    assert patch.json()["enabled"] is False
+
+    # Delete.
+    delete = await oidc_policy_client.delete(f"/v1/policies/{pid}", headers=headers)
+    assert delete.status_code == 200
+    assert delete.json()["deleted"] is True
+
+
+# ── Auth gating ───────────────────────────────────────────────────────
+
+
+async def test_oidc_unauthenticated_cannot_read_policies(
+    oidc_policy_client: httpx.AsyncClient,
+) -> None:
+    """A request with no session is rejected (401) — reads require auth."""
+    resp = await oidc_policy_client.get("/v1/policies")
+    assert resp.status_code == 401
+
+
+async def test_oidc_non_admin_can_read_but_not_write(
+    oidc_policy_client: httpx.AsyncClient,
+) -> None:
+    """A non-admin OIDC user can list policies but cannot create them (403)."""
+    member = _bearer(_MEMBER)
+
+    # Reads are allowed for any authenticated user.
+    listing = await oidc_policy_client.get("/v1/policies", headers=member)
+    assert listing.status_code == 200
+
+    # Writes require admin — 403 for a member.
+    create = await oidc_policy_client.post("/v1/policies", json=_policy_payload(), headers=member)
+    assert create.status_code == 403
+
+
+async def test_oidc_non_admin_cannot_delete(
+    oidc_policy_client: httpx.AsyncClient,
+) -> None:
+    """A non-admin can't delete a policy an admin created (403)."""
+    pid = (
+        await oidc_policy_client.post(
+            "/v1/policies", json=_policy_payload(), headers=_bearer(_ADMIN)
+        )
+    ).json()["id"]
+
+    resp = await oidc_policy_client.delete(f"/v1/policies/{pid}", headers=_bearer(_MEMBER))
+    assert resp.status_code == 403

--- a/tests/server/integration/test_utility_endpoints.py
+++ b/tests/server/integration/test_utility_endpoints.py
@@ -84,8 +84,11 @@ async def test_info_returns_expected_fields(client: httpx.AsyncClient) -> None:
 
 
 async def test_me_returns_null_user_without_auth(client: httpx.AsyncClient) -> None:
-    """Without auth, /v1/me returns user_id null."""
+    """Without auth, /v1/me returns user_id null and is_admin false."""
     resp = await client.get("/v1/me")
     assert resp.status_code == 200
     data = resp.json()
     assert data["user_id"] is None
+    # is_admin is always present (mode-agnostic admin signal) and false
+    # for an unauthenticated / no-permission-store caller.
+    assert data["is_admin"] is False

--- a/tests/server/test_oidc_admin_users.py
+++ b/tests/server/test_oidc_admin_users.py
@@ -1,0 +1,126 @@
+"""Tests for the read-only OIDC admin user list (``GET /auth/users``).
+
+The OIDC analog of the accounts provider's ``GET /auth/users`` — same
+response shape, admin-gated, but read-only (OIDC identities are owned by
+the IdP, so there are no password-based management actions). This is the
+#1489 fix: under OIDC the SPA otherwise has no admin user surface at all.
+
+Mirrors the harness in ``test_oidc_invites.py`` (real DB + a mounted
+OIDC router on a ``TestClient``, presenting the admin's session JWT as a
+Bearer token).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omnigent.server.accounts_store import SqlAlchemyAccountStore
+from omnigent.server.admin_list import AdminList
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.server.oidc import OIDCConfig, mint_session_cookie
+from omnigent.server.routes.auth import create_auth_router
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+_TEST_SECRET = bytes.fromhex("aa" * 32)
+
+
+def _oidc_config() -> OIDCConfig:
+    """Build an OIDCConfig over plain HTTP (so TestClient cookies work)."""
+    return OIDCConfig(
+        issuer="https://accounts.google.com",
+        client_id="cid",
+        client_secret="secret",
+        redirect_uri="http://localhost:8000/auth/callback",
+        cookie_secret=_TEST_SECRET,
+        scopes="openid email profile",
+        session_ttl_hours=8,
+        logout_redirect_uri=None,
+        allowed_domains=None,
+        provider_type="oidc",
+        authorization_endpoint="https://accounts.google.com/o/oauth2/v2/auth",
+        token_endpoint="https://oauth2.googleapis.com/token",
+        jwks_uri="https://www.googleapis.com/oauth2/v3/certs",
+        userinfo_endpoint=None,
+        allow_invites=False,
+    )
+
+
+@pytest.fixture
+def oidc_users_client(tmp_path: Path, db_uri: str) -> Iterator[tuple[TestClient, str]]:
+    """OIDC router mounted on a TestClient, with two users pre-seeded.
+
+    Yields the client and the admin's session JWT. ``admin@example.com``
+    is an admin; ``member@example.com`` is a regular user. The reserved
+    ``local`` sentinel is also seeded (must be hidden from the list).
+    """
+    perm_store = SqlAlchemyPermissionStore(db_uri)
+    account_store = SqlAlchemyAccountStore(db_uri)
+    admins = tmp_path / "admins"
+    admins.write_text("")
+    admin_list = AdminList(admins)
+
+    perm_store.ensure_user("admin@example.com", is_admin=True)
+    perm_store.ensure_user("member@example.com")
+    perm_store.ensure_user("local", is_admin=True)  # reserved sentinel
+
+    config = _oidc_config()
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
+
+    app = FastAPI()
+    app.include_router(
+        create_auth_router(provider, perm_store, admin_list, account_store),
+        prefix="/auth",
+    )
+    admin_jwt = mint_session_cookie(
+        user_id="admin@example.com",
+        cookie_secret=config.cookie_secret,
+        ttl_hours=8,
+        provider="oidc",
+    )
+    with TestClient(app) as client:
+        yield client, admin_jwt
+
+
+def test_users_route_admin_lists_real_users(
+    oidc_users_client: tuple[TestClient, str],
+) -> None:
+    """An admin gets every real user with the admin flag; sentinels hidden."""
+    client, admin_jwt = oidc_users_client
+    resp = client.get("/auth/users", headers={"Authorization": f"Bearer {admin_jwt}"})
+    assert resp.status_code == 200, resp.text
+    users = {u["id"]: u for u in resp.json()["users"]}
+    # Reserved `local` sentinel is excluded; both real users are present.
+    assert set(users) == {"admin@example.com", "member@example.com"}
+    assert users["admin@example.com"]["is_admin"] is True
+    assert users["member@example.com"]["is_admin"] is False
+    # OIDC identities have no password — the shape carries has_password=False.
+    assert users["member@example.com"]["has_password"] is False
+
+
+def test_users_route_requires_auth(
+    oidc_users_client: tuple[TestClient, str],
+) -> None:
+    """An unauthenticated caller gets 401."""
+    client, _admin_jwt = oidc_users_client
+    resp = client.get("/auth/users")
+    assert resp.status_code == 401
+
+
+def test_users_route_rejects_non_admin(
+    oidc_users_client: tuple[TestClient, str],
+) -> None:
+    """A non-admin authenticated user gets 403 (can't list users)."""
+    client, _admin_jwt = oidc_users_client
+    member_jwt = mint_session_cookie(
+        user_id="member@example.com",
+        cookie_secret=_TEST_SECRET,
+        ttl_hours=8,
+        provider="oidc",
+    )
+    resp = client.get("/auth/users", headers={"Authorization": f"Bearer {member_jwt}"})
+    assert resp.status_code == 403

--- a/tests/stores/test_permission_store.py
+++ b/tests/stores/test_permission_store.py
@@ -430,6 +430,50 @@ def test_ensure_user_does_not_overwrite_admin_flag(
     )
 
 
+# ── list_users ───────────────────────────────────────────────────────────────
+
+
+def test_list_users_returns_real_users_with_admin_flag(
+    store: SqlAlchemyPermissionStore,
+) -> None:
+    """``list_users`` returns every real user with the admin flag set.
+
+    Backs the OIDC/header admin user list — the analog of the
+    accounts-mode ``account_store.list_users()``.
+    """
+    store.ensure_user("alice@test.com", is_admin=True)
+    store.ensure_user("bob@test.com")
+
+    users = {u.id: u for u in store.list_users()}
+    assert set(users) == {"alice@test.com", "bob@test.com"}
+    assert users["alice@test.com"].is_admin is True
+    assert users["bob@test.com"].is_admin is False
+    # Header/OIDC rows have no password — the Account shape must reflect that.
+    assert users["bob@test.com"].has_password is False
+
+
+def test_list_users_excludes_reserved_sentinels(
+    store: SqlAlchemyPermissionStore,
+) -> None:
+    """``list_users`` hides the ``local`` and ``__public__`` sentinels.
+
+    They aren't real, actionable actors, matching
+    ``account_store.list_users()`` so the admin list is identical
+    across auth modes.
+    """
+    store.ensure_user("local", is_admin=True)
+    store.ensure_user("__public__")
+    store.ensure_user("real@test.com")
+
+    ids = {u.id for u in store.list_users()}
+    assert ids == {"real@test.com"}
+
+
+def test_list_users_empty(store: SqlAlchemyPermissionStore) -> None:
+    """``list_users`` returns an empty list when there are no real users."""
+    assert store.list_users() == []
+
+
 # ── is_admin ─────────────────────────────────────────────────────────────────
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -126,23 +126,21 @@ function App({ basename }: AppProps = {}) {
               defaults to Appearance. */}
           <Route path={`${prefix}/settings`} element={<SettingsPage />} />
           <Route path={`${prefix}/settings/:section`} element={<SettingsPage />} />
-          {info.accounts_enabled && (
-            <>
-              {/* Members / Policies are now settings sub-categories
-                  (/settings/members, /settings/policies) so entering them
-                  keeps the settings sidebar nav instead of dropping back to
-                  the conversation list. Redirect the old standalone paths so
-                  existing bookmarks / links still land in the right place. */}
-              <Route
-                path={`${prefix}/members`}
-                element={<Navigate to={`${prefix}/settings/members`} replace />}
-              />
-              <Route
-                path={`${prefix}/policies`}
-                element={<Navigate to={`${prefix}/settings/policies`} replace />}
-              />
-            </>
-          )}
+          {/* Members / Policies are now settings sub-categories
+              (/settings/members, /settings/policies) so entering them
+              keeps the settings sidebar nav instead of dropping back to
+              the conversation list. Redirect the old standalone paths so
+              existing bookmarks / links still land in the right place.
+              Registered in every multi-user mode (accounts AND OIDC) —
+              the sections self-gate to admins. */}
+          <Route
+            path={`${prefix}/members`}
+            element={<Navigate to={`${prefix}/settings/members`} replace />}
+          />
+          <Route
+            path={`${prefix}/policies`}
+            element={<Navigate to={`${prefix}/settings/policies`} replace />}
+          />
           <Route path={basename ? `${prefix}/*` : "*"} element={<NotFoundPage />} />
         </Route>
       </Routes>

--- a/web/src/hooks/useIsAdmin.ts
+++ b/web/src/hooks/useIsAdmin.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
+
+// Mode-agnostic admin gate, sourced from the `/v1/me` identity probe
+// (the shared `users.is_admin` column). Unlike `useMe`, which reads the
+// accounts-only `/auth/me` endpoint, this works in EVERY auth mode —
+// header, accounts, AND OIDC/SSO — so admin chrome (the Members /
+// Policies settings sections) can surface under OIDC where `/auth/me`
+// doesn't exist.
+const QUERY_KEY = ["identity-is-admin"];
+
+/**
+ * Whether the current user is an admin, per `GET /v1/me`. Returns false
+ * until identity resolves. Cached briefly so gating is instant across
+ * consumers without re-probing on every navigation. Server enforces the
+ * flag on every admin route regardless — this is chrome only.
+ */
+export function useIsAdmin(): boolean {
+  const { data } = useQuery<boolean>({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      await resolveIdentity();
+      return getCurrentIsAdmin();
+    },
+    staleTime: 30_000,
+    // Seed from the already-resolved cache so first paint is correct when
+    // identity resolved during boot (the common case).
+    initialData: getCurrentIsAdmin,
+  });
+  return data;
+}

--- a/web/src/lib/identity.ts
+++ b/web/src/lib/identity.ts
@@ -23,6 +23,11 @@ import { getOmnigentHostConfig, hostFetch } from "./host";
 const RESERVED_USER_LOCAL = "local";
 
 let _currentUserId: string | null = null;
+// Admin flag from the same `/v1/me` probe. Mode-agnostic (the shared
+// `users.is_admin` column), so the SPA can gate admin chrome in EVERY
+// auth mode — including OIDC/SSO, where the accounts-only `/auth/me`
+// endpoint doesn't exist. Defaults false until the probe resolves.
+let _currentIsAdmin = false;
 let _resolved = false;
 let _resolvePromise: Promise<string | null> | null = null;
 // Cache the server-provided login URL on the first /v1/me probe so
@@ -87,8 +92,12 @@ export async function resolveIdentity(): Promise<string | null> {
         }
       }
       if (res.ok) {
-        const data = (await res.json()) as { user_id: string | null };
+        const data = (await res.json()) as {
+          user_id: string | null;
+          is_admin?: boolean;
+        };
         _currentUserId = data.user_id;
+        _currentIsAdmin = data.is_admin ?? false;
       }
     } catch {
       // Server unreachable — leave as null.
@@ -102,6 +111,15 @@ export async function resolveIdentity(): Promise<string | null> {
 /** Return the cached user ID (null before resolveIdentity completes). */
 export function getCurrentUserId(): string | null {
   return _currentUserId;
+}
+
+/**
+ * Whether the current user is an admin, per the `/v1/me` probe.
+ * Mode-agnostic — usable to gate admin chrome under header, accounts,
+ * AND OIDC. Returns false before `resolveIdentity` completes.
+ */
+export function getCurrentIsAdmin(): boolean {
+  return _currentIsAdmin;
 }
 
 /**

--- a/web/src/pages/MembersPage.test.tsx
+++ b/web/src/pages/MembersPage.test.tsx
@@ -1,9 +1,11 @@
 // Tests for the admin MembersPage (invite, password reset, delete user).
 //
 // Browser e2e is impractical (admin/accounts-gated — would need a second
-// authenticated server), so the surface is pinned here by mocking accountsApi
-// (getMe gates admin; listUsers/createInvite/resetUserPassword/deleteUser drive
-// the table + actions) and useNavigate (to observe the unauth → /login bounce).
+// authenticated server), so the surface is pinned here by mocking the
+// mode-agnostic identity probe (resolveIdentity/getCurrentIsAdmin gate admin),
+// accountsApi (listUsers/createInvite/resetUserPassword/deleteUser drive the
+// table + actions), and useServerInfo (accounts_enabled toggles the
+// manage-vs-read-only surface — the latter is the OIDC case).
 
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -11,15 +13,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MembersPage } from "./MembersPage";
 import type { AccountListEntry } from "@/lib/accountsApi";
 import * as accountsApi from "@/lib/accountsApi";
+import * as identity from "@/lib/identity";
 
-const navigateMock = vi.fn();
+const mocks = vi.hoisted(() => ({ accountsEnabled: true }));
 
-vi.mock("@/lib/routing", async (importActual) => ({
-  ...(await importActual<typeof import("@/lib/routing")>()),
-  useNavigate: () => navigateMock,
+vi.mock("@/lib/CapabilitiesContext", () => ({
+  useServerInfo: () => ({ accounts_enabled: mocks.accountsEnabled }),
+}));
+vi.mock("@/lib/identity", () => ({
+  resolveIdentity: vi.fn(),
+  getCurrentIsAdmin: vi.fn(),
 }));
 vi.mock("@/lib/accountsApi", () => ({
-  getMe: vi.fn(),
   listUsers: vi.fn(),
   createInvite: vi.fn(),
   resetUserPassword: vi.fn(),
@@ -46,12 +51,9 @@ function renderPage() {
 }
 
 beforeEach(() => {
-  vi.mocked(accountsApi.getMe).mockResolvedValue({
-    id: "admin",
-    is_admin: true,
-    created_at: null,
-    last_login_at: null,
-  });
+  mocks.accountsEnabled = true;
+  vi.mocked(identity.resolveIdentity).mockResolvedValue("admin");
+  vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(true);
   vi.mocked(accountsApi.listUsers).mockResolvedValue([]);
   vi.mocked(accountsApi.createInvite).mockResolvedValue({
     ok: true,
@@ -75,18 +77,14 @@ afterEach(() => {
 
 describe("MembersPage gating", () => {
   it("shows a loading state until the identity probe resolves", () => {
-    vi.mocked(accountsApi.getMe).mockReturnValue(new Promise(() => {})); // never resolves
+    vi.mocked(identity.resolveIdentity).mockReturnValue(new Promise(() => {})); // never resolves
     renderPage();
     expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 
   it("blocks non-admins with a permission message and never lists users", async () => {
-    vi.mocked(accountsApi.getMe).mockResolvedValue({
-      id: "alice",
-      is_admin: false,
-      created_at: null,
-      last_login_at: null,
-    });
+    vi.mocked(identity.resolveIdentity).mockResolvedValue("alice");
+    vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(false);
     renderPage();
     expect(
       await screen.findByText("You don't have permission to manage members."),
@@ -94,10 +92,14 @@ describe("MembersPage gating", () => {
     expect(accountsApi.listUsers).not.toHaveBeenCalled();
   });
 
-  it("bounces an unauthenticated visitor to /login", async () => {
-    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+  it("stays in the loading state for an unauthenticated visitor (resolveIdentity redirects)", async () => {
+    // resolveIdentity returns null AND owns the login redirect, so the page
+    // just never leaves its loading state — it must NOT list users.
+    vi.mocked(identity.resolveIdentity).mockResolvedValue(null);
     renderPage();
-    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/login", { replace: true }));
+    await waitFor(() => expect(identity.getCurrentIsAdmin).not.toHaveBeenCalled());
+    expect(accountsApi.listUsers).not.toHaveBeenCalled();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 });
 
@@ -178,5 +180,32 @@ describe("MembersPage actions", () => {
     await waitFor(() => expect(accountsApi.createInvite).toHaveBeenCalledWith(false));
     // The single-use invite URL renders in a readonly, copyable input.
     expect(await screen.findByDisplayValue(/register\?invite=tok/)).toBeInTheDocument();
+  });
+});
+
+describe("MembersPage under OIDC (read-only)", () => {
+  beforeEach(() => {
+    // OIDC: accounts disabled → no password-based management. The list still
+    // renders (admins can see who's provisioned), but every management
+    // affordance is gone.
+    mocks.accountsEnabled = false;
+  });
+
+  it("lists users but offers no management actions", async () => {
+    vi.mocked(accountsApi.listUsers).mockResolvedValue([
+      user({ id: "admin", is_admin: true }),
+      user({ id: "bob" }),
+    ]);
+    renderPage();
+
+    // The list renders with role badges.
+    const bobRow = (await screen.findByText("bob")).closest("tr")!;
+    expect(within(bobRow).getByText("Member")).toBeInTheDocument();
+
+    // No invite button, no per-row Reset/Remove, and a read-only notice.
+    expect(screen.queryByRole("button", { name: /Invite member/ })).toBeNull();
+    expect(within(bobRow).queryByRole("button", { name: /Reset/ })).toBeNull();
+    expect(within(bobRow).queryByRole("button", { name: /Remove/ })).toBeNull();
+    expect(screen.getByText(/provisioned automatically on first sign-in/)).toBeInTheDocument();
   });
 });

--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -24,7 +24,6 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { useNavigate } from "@/lib/routing";
 import { CopyIcon, KeyRoundIcon, RefreshCwIcon, Trash2Icon, UserPlusIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
@@ -44,13 +43,18 @@ import {
   type PasswordReset,
   createInvite,
   deleteUser,
-  getMe,
   listUsers,
   resetUserPassword,
 } from "@/lib/accountsApi";
+import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
+import { useServerInfo } from "@/lib/CapabilitiesContext";
 
 export function MembersPage() {
-  const navigate = useNavigate();
+  const info = useServerInfo();
+  // Password-based management (invite / reset / remove) only exists in
+  // accounts mode — OIDC identities are owned by the IdP, so under OIDC
+  // this page is a read-only user list (no action column, no modals).
+  const manageable = info !== "loading" && info.accounts_enabled;
   const [meIsAdmin, setMeIsAdmin] = useState<boolean | null>(null);
   const [meId, setMeId] = useState<string | null>(null);
   const [users, setUsers] = useState<AccountListEntry[] | null>(null);
@@ -80,21 +84,24 @@ export function MembersPage() {
 
   // Initial load: identity probe + members list. The identity probe
   // gates the UI (non-admins see "no access"); the list is what we
-  // render the table from.
+  // render the table from. Uses the mode-agnostic `/v1/me` identity
+  // (via resolveIdentity) rather than the accounts-only `/auth/me`, so
+  // the page also works under OIDC where `/auth/me` doesn't exist.
   useEffect(() => {
     void (async () => {
-      const me = await getMe();
-      if (me === null) {
-        // Not authenticated — bounce to login. Shouldn't happen
-        // because identity.ts redirects on 401, but defensive.
-        navigate("/login", { replace: true });
+      const userId = await resolveIdentity();
+      if (userId === null) {
+        // Not authenticated — resolveIdentity already redirects to the
+        // provider's login URL when one exists (OIDC/accounts). Nothing
+        // more to do; leave the loading state.
         return;
       }
-      setMeId(me.id);
-      setMeIsAdmin(me.is_admin);
-      if (me.is_admin) await refresh();
+      setMeId(userId);
+      const isAdmin = getCurrentIsAdmin();
+      setMeIsAdmin(isAdmin);
+      if (isAdmin) await refresh();
     })();
-  }, [navigate, refresh]);
+  }, [refresh]);
 
   // Pre-admin-check render: blank loading state. min-h-full so the
   // AppShell's outlet container governs height — we're a child view,
@@ -165,10 +172,22 @@ export function MembersPage() {
     <PageScroll contentClassName="px-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Members</h1>
-        <Button onClick={() => setShowCreateInvite(true)}>
-          <UserPlusIcon /> Invite member
-        </Button>
+        {/* Invite mints a password-backed account — accounts mode only.
+        Under OIDC, accounts are provisioned by the IdP on first login, so
+        there's nothing to invite here. */}
+        {manageable && (
+          <Button onClick={() => setShowCreateInvite(true)}>
+            <UserPlusIcon /> Invite member
+          </Button>
+        )}
       </div>
+
+      {!manageable && (
+        <p className="mb-4 text-sm text-muted-foreground">
+          Users are provisioned automatically on first sign-in through your identity provider. This
+          list is read-only.
+        </p>
+      )}
 
       {loadError !== null && (
         <div
@@ -187,7 +206,7 @@ export function MembersPage() {
                 <th className="px-3 py-2 font-medium">Username</th>
                 <th className="px-3 py-2 font-medium">Role</th>
                 <th className="px-3 py-2 font-medium">Last login</th>
-                <th className="px-3 py-2 text-right font-medium">Actions</th>
+                {manageable && <th className="px-3 py-2 text-right font-medium">Actions</th>}
               </tr>
             </thead>
             <tbody>
@@ -210,28 +229,30 @@ export function MembersPage() {
                   <td className="px-3 py-2 align-middle text-muted-foreground">
                     {formatEpoch(u.last_login_at)}
                   </td>
-                  <td className="px-3 py-2 text-right">
-                    <div className="flex justify-end gap-1">
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        title="Reset password"
-                        onClick={() => void onResetPassword(u.id)}
-                        disabled={pendingAction || !u.has_password}
-                      >
-                        <KeyRoundIcon /> Reset
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        title="Remove user"
-                        onClick={() => setDeleteCandidate(u.id)}
-                        disabled={pendingAction || u.id === meId}
-                      >
-                        <Trash2Icon /> Remove
-                      </Button>
-                    </div>
-                  </td>
+                  {manageable && (
+                    <td className="px-3 py-2 text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          title="Reset password"
+                          onClick={() => void onResetPassword(u.id)}
+                          disabled={pendingAction || !u.has_password}
+                        >
+                          <KeyRoundIcon /> Reset
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          title="Remove user"
+                          onClick={() => setDeleteCandidate(u.id)}
+                          disabled={pendingAction || u.id === meId}
+                        >
+                          <Trash2Icon /> Remove
+                        </Button>
+                      </div>
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/web/src/pages/PoliciesPage.test.tsx
+++ b/web/src/pages/PoliciesPage.test.tsx
@@ -2,29 +2,28 @@
 // add, delete).
 //
 // Browser e2e is impractical (admin/accounts-gated), so the surface is pinned
-// here by mocking getMe (admin gate), useNavigate (unauth bounce), and the
-// react-query policy hooks (useDefaultPolicies / usePolicyRegistry +
-// add/update/delete mutations) so no QueryClient or network is needed.
+// here by mocking the mode-agnostic identity probe (resolveIdentity /
+// getCurrentIsAdmin gate admin — works under OIDC too) and the react-query
+// policy hooks (useDefaultPolicies / usePolicyRegistry + add/update/delete
+// mutations) so no QueryClient or network is needed.
 
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PoliciesPage } from "./PoliciesPage";
-import * as accountsApi from "@/lib/accountsApi";
+import * as identity from "@/lib/identity";
 import * as defaultPolicies from "@/hooks/useDefaultPolicies";
 import * as policies from "@/hooks/usePolicies";
 
-const navigateMock = vi.fn();
 const addMutate = vi.fn();
 const updateMutate = vi.fn();
 const deleteMutate = vi.fn();
 const refetchMock = vi.fn();
 
-vi.mock("@/lib/routing", async (importActual) => ({
-  ...(await importActual<typeof import("@/lib/routing")>()),
-  useNavigate: () => navigateMock,
+vi.mock("@/lib/identity", () => ({
+  resolveIdentity: vi.fn(),
+  getCurrentIsAdmin: vi.fn(),
 }));
-vi.mock("@/lib/accountsApi", () => ({ getMe: vi.fn() }));
 vi.mock("@/hooks/useDefaultPolicies", () => ({
   useDefaultPolicies: vi.fn(),
   useAddDefaultPolicy: vi.fn(),
@@ -74,12 +73,8 @@ function renderPage() {
 }
 
 beforeEach(() => {
-  vi.mocked(accountsApi.getMe).mockResolvedValue({
-    id: "admin",
-    is_admin: true,
-    created_at: null,
-    last_login_at: null,
-  });
+  vi.mocked(identity.resolveIdentity).mockResolvedValue("admin");
+  vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(true);
   setPolicies([]);
   vi.mocked(policies.usePolicyRegistry).mockReturnValue({ data: [] } as never);
   vi.mocked(defaultPolicies.useAddDefaultPolicy).mockReturnValue(mutationStub(addMutate) as never);
@@ -98,28 +93,27 @@ afterEach(() => {
 
 describe("PoliciesPage gating", () => {
   it("shows a loading state until the identity probe resolves", () => {
-    vi.mocked(accountsApi.getMe).mockReturnValue(new Promise(() => {}));
+    vi.mocked(identity.resolveIdentity).mockReturnValue(new Promise(() => {}));
     renderPage();
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("blocks non-admins with a permission message", async () => {
-    vi.mocked(accountsApi.getMe).mockResolvedValue({
-      id: "alice",
-      is_admin: false,
-      created_at: null,
-      last_login_at: null,
-    });
+    vi.mocked(identity.resolveIdentity).mockResolvedValue("alice");
+    vi.mocked(identity.getCurrentIsAdmin).mockReturnValue(false);
     renderPage();
     expect(
       await screen.findByText("You don't have permission to manage global policies."),
     ).toBeInTheDocument();
   });
 
-  it("bounces an unauthenticated visitor to /login", async () => {
-    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+  it("stays loading for an unauthenticated visitor (resolveIdentity redirects)", async () => {
+    // resolveIdentity returns null AND owns the login redirect, so the page
+    // never resolves its admin flag — it stays in the loading state.
+    vi.mocked(identity.resolveIdentity).mockResolvedValue(null);
     renderPage();
-    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/login", { replace: true }));
+    await waitFor(() => expect(identity.getCurrentIsAdmin).not.toHaveBeenCalled());
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 });
 

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -12,7 +12,6 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { useNavigate } from "@/lib/routing";
 import { PlusIcon, RefreshCwIcon, ShieldCheckIcon, TrashIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
@@ -33,7 +32,7 @@ import {
   type DefaultPolicy,
 } from "@/hooks/useDefaultPolicies";
 import { usePolicyRegistry, type PolicyRegistryEntry } from "@/hooks/usePolicies";
-import { getMe } from "@/lib/accountsApi";
+import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { coercePolicyParams } from "@/lib/policyParams";
 
 // ---------------------------------------------------------------------------
@@ -351,7 +350,6 @@ function AddDefaultPolicyDialog({
 // ---------------------------------------------------------------------------
 
 export function PoliciesPage() {
-  const navigate = useNavigate();
   const [meIsAdmin, setMeIsAdmin] = useState<boolean | null>(null);
   const { data: policies = [], refetch } = useDefaultPolicies();
   const { data: registry = [] } = usePolicyRegistry();
@@ -369,16 +367,16 @@ export function PoliciesPage() {
     void refetch();
   }, [refetch]);
 
+  // Admin probe via the mode-agnostic `/v1/me` identity (works under OIDC
+  // too, unlike the accounts-only `/auth/me`). resolveIdentity handles the
+  // login redirect when unauthenticated, so we only set the admin flag here.
   useEffect(() => {
     void (async () => {
-      const me = await getMe();
-      if (me === null) {
-        navigate("/login", { replace: true });
-        return;
-      }
-      setMeIsAdmin(me.is_admin);
+      const userId = await resolveIdentity();
+      if (userId === null) return;
+      setMeIsAdmin(getCurrentIsAdmin());
     })();
-  }, [navigate]);
+  }, []);
 
   if (meIsAdmin === null) {
     return (

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -15,6 +15,11 @@ const mocks = vi.hoisted(() => ({
   archiveMutate: vi.fn(),
   deleteMutate: vi.fn(),
   accountsEnabled: true,
+  // login_url: non-null for any sign-in mode (accounts OR OIDC), null in
+  // header single-user mode. Gates the Account section.
+  loginUrl: "/login" as string | null,
+  // Identity from the mode-agnostic `/v1/me` probe (resolveIdentity returns
+  // the id, getCurrentIsAdmin the flag). null → unauthenticated.
   me: { id: "alice", is_admin: false } as { id: string; is_admin: boolean } | null,
   conversations: [] as Conversation[],
 }));
@@ -24,12 +29,18 @@ vi.mock("next-themes", () => ({
 }));
 vi.mock("@/lib/embedded", () => ({ useIsEmbedded: () => false }));
 vi.mock("@/lib/CapabilitiesContext", () => ({
-  useServerInfo: () => ({ accounts_enabled: mocks.accountsEnabled }),
+  useServerInfo: () => ({
+    accounts_enabled: mocks.accountsEnabled,
+    login_url: mocks.loginUrl,
+  }),
 }));
 vi.mock("@/lib/accountsApi", () => ({
-  getMe: () => Promise.resolve(mocks.me),
   logout: vi.fn(),
   changePassword: vi.fn(),
+}));
+vi.mock("@/lib/identity", () => ({
+  resolveIdentity: () => Promise.resolve(mocks.me?.id ?? null),
+  getCurrentIsAdmin: () => mocks.me?.is_admin ?? false,
 }));
 vi.mock("@/hooks/useConversations", () => ({
   useConversations: () => ({
@@ -80,6 +91,7 @@ beforeEach(() => {
   mocks.deleteMutate.mockReset();
   mocks.theme = "system";
   mocks.accountsEnabled = true;
+  mocks.loginUrl = "/login";
   mocks.me = { id: "alice", is_admin: false };
   mocks.conversations = [];
 });
@@ -95,27 +107,43 @@ describe("SettingsPage", () => {
     expect(mocks.setTheme).toHaveBeenCalledWith("dark");
   });
 
-  it("defaults bare /settings to Account when accounts is on, else Appearance", async () => {
-    // Accounts on → Account leads, so /settings lands on it.
+  it("defaults bare /settings to Account when a login session exists, else Appearance", async () => {
+    // Login session (accounts OR OIDC) → Account leads, so /settings lands on it.
     renderPage("/settings");
     await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
 
-    // Accounts off → no Account section; default falls back to Appearance.
+    // Header single-user (no login_url) → no Account section; falls back to
+    // Appearance.
     cleanup();
     mocks.accountsEnabled = false;
+    mocks.loginUrl = null;
     renderPage("/settings");
     expect(screen.getByRole("heading", { name: "Appearance" })).toBeInTheDocument();
   });
 
-  it("renders the Account section at /settings/account when auth is enabled", async () => {
+  it("renders the Account section at /settings/account for any login session", async () => {
     renderPage("/settings/account");
     await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
 
-    // With accounts off, the section renders nothing even at its URL.
+    // Header single-user (no login_url) → the section renders nothing even at
+    // its URL.
     cleanup();
     mocks.accountsEnabled = false;
+    mocks.loginUrl = null;
     renderPage("/settings/account");
     expect(screen.queryByText("alice")).toBeNull();
+  });
+
+  it("renders the Account section under OIDC (accounts off, login_url set)", async () => {
+    // #1489: an SSO user must be able to see their identity and sign out.
+    mocks.accountsEnabled = false;
+    mocks.loginUrl = "/auth/login";
+    renderPage("/settings/account");
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+    // Change password is accounts-only — hidden under OIDC.
+    expect(screen.queryByRole("button", { name: /Change password/ })).toBeNull();
+    // Sign out is still available.
+    expect(screen.getByRole("button", { name: /Sign out/ })).toBeInTheDocument();
   });
 
   it("renders the Members section at /settings/members when accounts is on", async () => {
@@ -130,12 +158,13 @@ describe("SettingsPage", () => {
     expect(screen.queryByText("members-page-stub")).toBeNull();
   });
 
-  it("does not render the admin sections when accounts is off", () => {
+  it("still renders the admin sections when accounts is off (OIDC)", async () => {
+    // #1489: Members / Policies are admin surfaces valid under OIDC too. The
+    // page itself self-gates to admins (and runs read-only under OIDC); the
+    // SettingsPage no longer withholds the section based on accounts_enabled.
     mocks.accountsEnabled = false;
     renderPage("/settings/members");
-    // Falls through to the section switch, which renders nothing for an
-    // unknown-when-accounts-off section.
-    expect(screen.queryByText("members-page-stub")).toBeNull();
+    expect(await screen.findByText("members-page-stub")).toBeInTheDocument();
   });
 
   it("no longer links to Members / Policies from the Account section", async () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -46,7 +46,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { KeyboardShortcutsList } from "@/components/KeyboardShortcutsDialog";
-import { changePassword, type CurrentAccount, getMe, logout } from "@/lib/accountsApi";
+import { changePassword, logout } from "@/lib/accountsApi";
+import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import {
   type Conversation,
@@ -82,14 +83,19 @@ const PoliciesPage = lazy(() =>
  */
 export function SettingsPage() {
   const info = useServerInfo();
-  const accountsEnabled = info !== "loading" && info.accounts_enabled;
+  // A login session exists (accounts OR OIDC) when the server advertises a
+  // login_url; gates the Account section so SSO users get it too.
+  const hasAuthSession = info !== "loading" && info.login_url !== null;
   const { section } = useSettingsRoute();
 
   // Members / Policies are admin-only management surfaces that own their full
   // layout (their own PageScroll + admin gating), so they render directly —
   // NOT inside the shared section PageScroll below, which would nest two
   // scroll containers. Both self-gate to admins server-side and client-side.
-  if (accountsEnabled && (section === "members" || section === "policies")) {
+  // Rendered in ANY multi-user mode (accounts AND OIDC), not gated on
+  // `accountsEnabled` — the nav + pages handle admin gating, and Members runs
+  // read-only under OIDC (no password actions).
+  if (section === "members" || section === "policies") {
     return (
       <Suspense fallback={null}>
         {section === "members" ? <MembersPage /> : <PoliciesPage />}
@@ -101,7 +107,7 @@ export function SettingsPage() {
     <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       {section === "appearance" && <AppearanceSection />}
       {section === "shortcuts" && <ShortcutsSection />}
-      {section === "account" && accountsEnabled && <AccountSection />}
+      {section === "account" && hasAuthSession && <AccountSection />}
       {section === "archived" && <ArchivedSection />}
       {section === "cli" && isElectronShell() && <LocalCliSection />}
     </PageScroll>
@@ -279,9 +285,14 @@ function LocalCliSection() {
 }
 
 function AccountSection() {
-  const [me, setMe] = useState<CurrentAccount | null | "unknown">("unknown");
+  const info = useServerInfo();
+  const accountsEnabled = info !== "loading" && info.accounts_enabled;
+  // Identity for display. Sourced from the mode-agnostic `/v1/me` probe so it
+  // works under OIDC too (the accounts-only `/auth/me` doesn't exist there).
+  const [me, setMe] = useState<{ id: string; is_admin: boolean } | null | "unknown">("unknown");
 
   // Change-password dialog state (lifted verbatim from the old AccountMenu).
+  // Only used in accounts mode — OIDC identities have no local password.
   const [pwOpen, setPwOpen] = useState(false);
   const [oldPw, setOldPw] = useState("");
   const [newPw, setNewPw] = useState("");
@@ -291,14 +302,27 @@ function AccountSection() {
   const [pwDone, setPwDone] = useState(false);
 
   useEffect(() => {
-    void (async () => setMe(await getMe()))();
+    void (async () => {
+      const userId = await resolveIdentity();
+      setMe(userId === null ? null : { id: userId, is_admin: getCurrentIsAdmin() });
+    })();
   }, []);
 
   const onSignOut = useCallback(async () => {
-    await logout();
-    // Hard navigation so the chat store / react-query cache reset.
-    window.location.href = "/login";
-  }, []);
+    if (accountsEnabled) {
+      // Accounts: clear the cookie via the JSON logout endpoint, then land on
+      // the SPA login form.
+      await logout();
+      // Hard navigation so the chat store / react-query cache reset.
+      window.location.href = "/login";
+      return;
+    }
+    // OIDC: logout is a server-side GET redirect at /auth/logout that clears
+    // the session cookie (and honors the IdP end-session endpoint when
+    // configured). A hard navigation lets the browser follow it and resets
+    // client caches.
+    window.location.href = "/auth/logout";
+  }, [accountsEnabled]);
 
   const resetPwForm = useCallback(() => {
     setOldPw("");
@@ -355,16 +379,20 @@ function AccountSection() {
             instead of navigating away from /settings. */}
 
         <div className="flex flex-col gap-1">
-          <Button
-            variant="ghost"
-            className="w-full justify-start gap-2"
-            onClick={() => {
-              resetPwForm();
-              setPwOpen(true);
-            }}
-          >
-            <KeyRoundIcon className="size-4" /> Change password
-          </Button>
+          {/* Change password is accounts-only — an OIDC identity's password
+              lives with the IdP, so there's nothing to change here. */}
+          {accountsEnabled && (
+            <Button
+              variant="ghost"
+              className="w-full justify-start gap-2"
+              onClick={() => {
+                resetPwForm();
+                setPwOpen(true);
+              }}
+            >
+              <KeyRoundIcon className="size-4" /> Change password
+            </Button>
+          )}
           <Button
             variant="ghost"
             className="w-full justify-start gap-2"

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -13,14 +13,23 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 const mocks = vi.hoisted(() => ({
   accountsEnabled: false,
-  me: null as { id: string; is_admin: boolean } | null,
+  // login_url: non-null for any sign-in mode (accounts OR OIDC), null in
+  // header single-user. Gates the Account section + the bare-/settings default.
+  loginUrl: null as string | null,
+  isAdmin: false,
 }));
 
 vi.mock("@/lib/CapabilitiesContext", () => ({
-  useServerInfo: () => ({ accounts_enabled: mocks.accountsEnabled }),
+  useServerInfo: () => ({
+    accounts_enabled: mocks.accountsEnabled,
+    login_url: mocks.loginUrl,
+  }),
 }));
-vi.mock("@/hooks/useMe", () => ({
-  useMe: () => ({ data: mocks.me }),
+// Admin gating is now mode-agnostic, sourced from `/v1/me` via useIsAdmin
+// (not the accounts-only `/auth/me` useMe hook), so the Admin group appears
+// under OIDC too.
+vi.mock("@/hooks/useIsAdmin", () => ({
+  useIsAdmin: () => mocks.isAdmin,
 }));
 
 import { SettingsSidebarBody, settingsNavGroups, useSettingsRoute } from "./settingsNav";
@@ -40,7 +49,8 @@ function renderBody(opts: { onNavClick?: () => void; onClose?: () => void } = {}
 
 beforeEach(() => {
   mocks.accountsEnabled = false;
-  mocks.me = null;
+  mocks.loginUrl = null;
+  mocks.isAdmin = false;
 });
 afterEach(cleanup);
 
@@ -54,18 +64,20 @@ describe("settingsNavGroups", () => {
     }
   });
 
-  it("includes Account (leading) only when accounts auth is enabled", () => {
+  it("includes Account (leading) whenever a login session exists (accounts OR OIDC)", () => {
+    // First arg is hasAuthSession (login_url != null), not accounts-specific.
+    // Header single-user (no session) → no Account section.
     expect(
       settingsNavGroups(false, false)
         .flatMap((g) => g.items)
         .map((i) => i.id),
     ).not.toContain("account");
-    const withAccounts = settingsNavGroups(true, false)
+    // Any login session → Account appears and leads its group.
+    const withAccount = settingsNavGroups(true, false)
       .flatMap((g) => g.items)
       .map((i) => i.id);
-    expect(withAccounts).toContain("account");
-    // Account leads its group — it's the most-visited section on accounts deploys.
-    expect(withAccounts[0]).toBe("account");
+    expect(withAccount).toContain("account");
+    expect(withAccount[0]).toBe("account");
   });
 
   it("includes the Local CLI section only in the desktop shell", () => {
@@ -77,18 +89,21 @@ describe("settingsNavGroups", () => {
     expect(ids(true)).toContain("cli");
   });
 
-  it("includes the Admin group (Members / Policies) only for admins on accounts deploys", () => {
+  it("includes the Admin group (Members / Policies) for any admin, in accounts OR OIDC mode", () => {
     const ids = (accountsEnabled: boolean, isAdmin: boolean) =>
       settingsNavGroups(accountsEnabled, false, isAdmin)
         .flatMap((g) => g.items)
         .map((i) => i.id);
-    // Non-admin, or non-accounts deploy → no Members / Policies.
+    // Non-admin → no Members / Policies, regardless of auth mode.
     expect(ids(true, false)).not.toContain("members");
-    expect(ids(false, true)).not.toContain("members");
+    expect(ids(false, false)).not.toContain("members");
     // Admin on an accounts deploy → both appear, grouped under "Admin".
-    const adminGroups = settingsNavGroups(true, false, true);
-    const admin = adminGroups.find((g) => g.title === "Admin");
-    expect(admin?.items.map((i) => i.id)).toEqual(["members", "policies"]);
+    const accountsAdmin = settingsNavGroups(true, false, true).find((g) => g.title === "Admin");
+    expect(accountsAdmin?.items.map((i) => i.id)).toEqual(["members", "policies"]);
+    // Admin under OIDC (accountsEnabled false) → still appears. This is the
+    // #1489 fix: OIDC previously had no admin chrome at all.
+    const oidcAdmin = settingsNavGroups(false, false, true).find((g) => g.title === "Admin");
+    expect(oidcAdmin?.items.map((i) => i.id)).toEqual(["members", "policies"]);
   });
 });
 
@@ -118,7 +133,7 @@ describe("SettingsSidebarBody", () => {
 
   it("renders Members / Policies sub-categories for an admin, linking under /settings", () => {
     mocks.accountsEnabled = true;
-    mocks.me = { id: "admin", is_admin: true };
+    mocks.isAdmin = true;
     renderBody();
     const members = screen.getByTestId("settings-nav-members");
     const policies = screen.getByTestId("settings-nav-policies");
@@ -126,9 +141,21 @@ describe("SettingsSidebarBody", () => {
     expect(policies).toHaveAttribute("href", "/settings/policies");
   });
 
+  it("renders the admin sub-categories for an admin under OIDC (accounts off)", () => {
+    // #1489: admin chrome must surface under OIDC, where accounts is off.
+    mocks.accountsEnabled = false;
+    mocks.isAdmin = true;
+    renderBody();
+    expect(screen.getByTestId("settings-nav-members")).toHaveAttribute("href", "/settings/members");
+    expect(screen.getByTestId("settings-nav-policies")).toHaveAttribute(
+      "href",
+      "/settings/policies",
+    );
+  });
+
   it("hides the admin sub-categories for a non-admin", () => {
     mocks.accountsEnabled = true;
-    mocks.me = { id: "bob", is_admin: false };
+    mocks.isAdmin = false;
     renderBody();
     expect(screen.queryByTestId("settings-nav-members")).toBeNull();
     expect(screen.queryByTestId("settings-nav-policies")).toBeNull();
@@ -154,14 +181,14 @@ describe("useSettingsRoute", () => {
     expect(routeHook("/settings/policies")).toEqual({ inSettings: true, section: "policies" });
   });
 
-  it("falls back from the accounts-only admin sections when accounts is off", () => {
-    // Members / Policies aren't real destinations off an accounts deploy — the
-    // sidebar never shows them and the page would render an empty panel. Only
-    // reachable by typing the URL, but resolve to the default section (still
-    // in-settings) instead of a dead admin section.
+  it("treats the admin sections as valid destinations even when accounts is off (OIDC)", () => {
+    // #1489: Members / Policies are admin sections valid in ANY multi-user
+    // mode (accounts AND OIDC). They no longer fall back to the default
+    // section off an accounts deploy — the nav gates them on is_admin and the
+    // pages self-gate / the server 403s.
     mocks.accountsEnabled = false;
-    expect(routeHook("/settings/members")).toEqual({ inSettings: true, section: "appearance" });
-    expect(routeHook("/settings/policies")).toEqual({ inSettings: true, section: "appearance" });
+    expect(routeHook("/settings/members")).toEqual({ inSettings: true, section: "members" });
+    expect(routeHook("/settings/policies")).toEqual({ inSettings: true, section: "policies" });
   });
 
   it("reports NOT in settings for the legacy standalone /members and /policies paths", () => {
@@ -176,14 +203,16 @@ describe("useSettingsRoute", () => {
       inSettings: true,
       section: "appearance",
     });
-    // Bare /settings: in-settings, defaulting to Appearance when accounts is off.
+    // Bare /settings: in-settings, defaulting to Appearance in header mode
+    // (no login session — loginUrl null per beforeEach).
     expect(routeHook("/settings")).toEqual({ inSettings: true, section: "appearance" });
     // A non-settings route is out of settings.
     expect(routeHook("/inbox").inSettings).toBe(false);
   });
 
-  it("defaults bare /settings to Account when accounts auth is enabled", () => {
-    mocks.accountsEnabled = true;
+  it("defaults bare /settings to Account when a login session exists", () => {
+    // login_url set (accounts OR OIDC) → Account is the landing section.
+    mocks.loginUrl = "/login";
     expect(routeHook("/settings")).toEqual({ inSettings: true, section: "account" });
   });
 

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -21,7 +21,7 @@ import { Link, useLocation } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
-import { useMe } from "@/hooks/useMe";
+import { useIsAdmin } from "@/hooks/useIsAdmin";
 import { isElectronShell } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 
@@ -58,12 +58,16 @@ interface SettingsNavGroup {
 }
 
 /**
- * Nav groups for the current deploy. The Account section is auth-gated; the
- * Admin group (Members / Policies) appears only for admins on accounts
- * deploys; the Desktop group (Local CLI) appears only in the Electron shell.
+ * Nav groups for the current deploy. The Account section appears whenever the
+ * deploy has a login session (accounts OR OIDC/SSO — i.e. a `login_url`
+ * exists), so an SSO user can see who they're signed in as and sign out; it's
+ * absent only in header single-user mode. The Admin group (Members / Policies)
+ * appears for admins in ANY multi-user mode since both accounts and OIDC share
+ * the `users.is_admin` flag and the server enforces admin on every route; the
+ * Desktop group (Local CLI) appears only in the Electron shell.
  */
 export function settingsNavGroups(
-  accountsEnabled: boolean,
+  hasAuthSession: boolean,
   isDesktop: boolean,
   isAdmin = false,
 ): SettingsNavGroup[] {
@@ -71,9 +75,9 @@ export function settingsNavGroups(
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
     { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
   ];
-  if (accountsEnabled) {
+  if (hasAuthSession) {
     // Account leads the group when present — it's the most-visited section
-    // on accounts deploys.
+    // on a deploy with sign-in.
     general.unshift({ id: "account", label: "Account", icon: UserCogIcon });
   }
   const groups: SettingsNavGroup[] = [];
@@ -89,8 +93,11 @@ export function settingsNavGroups(
   // Admin: server-wide management, admin-only. Nested here as sub-categories
   // (rather than links out of the Account section) so entering them stays
   // inside /settings — the sidebar keeps the settings nav instead of snapping
-  // back to the conversation list.
-  if (accountsEnabled && isAdmin) {
+  // back to the conversation list. Gated on `isAdmin` alone (not
+  // `accountsEnabled`) so the surface also appears under OIDC/SSO, the one
+  // mode where there's otherwise no admin chrome at all. Members runs
+  // read-only under OIDC (no password actions); Policies is identical.
+  if (isAdmin) {
     groups.push({
       title: "Admin",
       items: [
@@ -116,21 +123,21 @@ export function settingsNavGroups(
  */
 export function useSettingsRoute(): { inSettings: boolean; section: SettingsSectionId } {
   const info = useServerInfo();
-  const accountsEnabled = info !== "loading" && info.accounts_enabled;
-  const defaultSection: SettingsSectionId = accountsEnabled ? "account" : "appearance";
+  // A login session exists (accounts OR OIDC) when the server advertises a
+  // login_url; header single-user mode reports null. The Account section —
+  // and the bare-/settings default landing on it — follows that, not
+  // accounts specifically.
+  const hasAuthSession = info !== "loading" && info.login_url !== null;
+  const defaultSection: SettingsSectionId = hasAuthSession ? "account" : "appearance";
 
   const segments = useLocation().pathname.split("/").filter(Boolean);
   const idx = segments.lastIndexOf("settings");
   if (idx === -1) return { inSettings: false, section: defaultSection };
   const next = segments[idx + 1];
-  // Members / Policies are accounts-only sections. Off an accounts deploy
-  // they aren't real destinations — fall back to the default section rather
-  // than resolving to an admin section the page would render as an empty
-  // panel (only reachable by manually typing the URL, but keep it clean).
-  const accountsOnlySections = new Set<string>(["members", "policies"]);
-  const isValidSection =
-    (SECTION_IDS as readonly string[]).includes(next) &&
-    (accountsEnabled || !accountsOnlySections.has(next));
+  // Members / Policies are admin sections valid in ANY multi-user mode
+  // (accounts AND OIDC). They're gated in the nav on `is_admin` and the
+  // pages self-gate + the server 403s, so no accounts-mode carve-out here.
+  const isValidSection = (SECTION_IDS as readonly string[]).includes(next);
   const section = isValidSection ? (next as SettingsSectionId) : defaultSection;
   return { inSettings: true, section };
 }
@@ -148,12 +155,14 @@ export function SettingsSidebarBody({
   onClose: () => void;
 }) {
   const info = useServerInfo();
-  const accountsEnabled = info !== "loading" && info.accounts_enabled;
-  // Admin gating for the Members / Policies sub-categories. Only probed on
-  // accounts deploys; non-admins (and non-accounts deploys) never see them.
-  const { data: me } = useMe(accountsEnabled);
+  // Account section shows whenever there's a login session (accounts OR OIDC).
+  const hasAuthSession = info !== "loading" && info.login_url !== null;
+  // Admin gating for the Members / Policies sub-categories. Sourced from
+  // `/v1/me` (mode-agnostic) so the group appears for admins under OIDC too,
+  // not just accounts deploys. Non-admins never see it.
+  const isAdmin = useIsAdmin();
   const { section } = useSettingsRoute();
-  const groups = settingsNavGroups(accountsEnabled, isElectronShell(), me?.is_admin ?? false);
+  const groups = settingsNavGroups(hasAuthSession, isElectronShell(), isAdmin);
 
   return (
     <>


### PR DESCRIPTION
## Related issue

Part 1 of #1489 (the OIDC admin-surface gap). Parts 2 (per-user session browse) and 3 (cost attribution) are intentionally **out of scope** — see below.

## Problem

Under OIDC/SSO the SPA rendered **no admin or account chrome at all**:

- The **Members** / **Policies** / **Account** settings sections gated on `accounts_enabled`, so on an OIDC deploy (`/v1/info` reports `accounts_enabled: false`) they never mounted.
- `MembersPage` / `PoliciesPage` / the Account section probed admin via the **accounts-only `/auth/me`**, which 404s under OIDC (only `/v1/me` exists there) → bounced to a nonexistent `/login`.

So an operator running JumpCloud/Okta/Entra SSO couldn't see who has accounts, manage global policies, see their own identity, or even **sign out** (the only Sign out button lived in the hidden Account section and used the accounts-mode logout path).

The `is_admin` flag itself is already mode-agnostic (accounts and OIDC share one `users.is_admin` column) — what was missing was any UI/read API that surfaces it outside accounts mode.

## What this does

Root cause was narrow: admin/account chrome keyed on **accounts-only signals**. The fix makes them mode-agnostic, keeping everything in **Settings** (no new top-level page).

**Backend**
- `GET /v1/me` now returns `is_admin` (the shared `users.is_admin` column) — the mode-agnostic admin signal the SPA gates on in every mode.
- `PermissionStore.list_users()` (+ SQLAlchemy impl) — returns `Account` rows, excludes the reserved `local` / `__public__` sentinels (mirrors `account_store.list_users()`).
- Read-only `GET /auth/users` on the **OIDC** router — the analog of the accounts route, same response shape, admin-gated (401 unauth / 403 non-admin).

**Frontend**
- `identity.ts` parses `is_admin` from `/v1/me`; new `getCurrentIsAdmin()` + `useIsAdmin` hook.
- Settings nav + pages gate on `/v1/me` (`is_admin` / `login_url`), not `accounts_enabled`.
- **Members**: read-only under OIDC — the user list renders, but password-based management (invite / reset / remove) is hidden, since OIDC identities are owned by the IdP.
- **Policies**: fully functional under OIDC (global policies have no IdP dependency; the backend routes were already mode-agnostic).
- **Account**: shows the signed-in identity and a **mode-aware Sign out** (OIDC → server-side `GET /auth/logout` redirect; accounts → `POST /auth/logout` → `/login`). **Change password is hidden under OIDC** (no local password).

## Behavior across modes

- **Header single-user**: unchanged — no `login_url`, `local` is never admin, so no admin/account chrome.
- **Accounts**: unchanged — same Members (management) / Policies / Account sections.
- **OIDC/SSO**: the sections now mount for admins; the motivating case.

## Explicitly out of scope

This adds **no new permission level** and **does not change session-listing scope** — every user (admin or not) still lists only their own sessions. The `is_admin` bypass applies to opening a specific session by ID, not to the list query. Per-user **session browse** (#1489 part 2) and **cost attribution** (part 3) are deliberately left out — the former is a privacy step-change worth its own discussion, the latter is a cross-mode admin-reporting feature unrelated to OIDC.

## Test plan

- **Backend**: `tests/server/test_oidc_admin_users.py` (new — OIDC `/auth/users` admin-gating + sentinel hiding), `list_users` store tests, `/v1/me` `is_admin` assertion. All green.
- **Frontend**: updated `settingsNav` / `SettingsPage` / `MembersPage` / `PoliciesPage` tests for mode-agnostic gating + OIDC read-only Members + OIDC Account (identity, no change-password, sign out present). Full web suite passes (3424 tests).
- ruff / tsc / oxlint / prettier clean; no new mypy errors on touched files.

## Demo

https://github.com/user-attachments/assets/c8635a67-6620-4161-b3f5-e892101eae90




This pull request and its description were written by Isaac.