### PR TITLE
feat(web): render .ipynb notebooks as read-only previews in the file viewer

### DIFF
--- a/tests/e2e_ui/files/test_notebook_preview.py
+++ b/tests/e2e_ui/files/test_notebook_preview.py
@@ -1,0 +1,204 @@
+"""E2E: read-only .ipynb notebook preview and source toggle in the FileViewer.
+
+Counterpart to ``test_markdown_rich_rendering.py`` for notebooks: a seeded
+``.ipynb`` must open as a rendered notebook (markdown cells as HTML, code
+cells with execution counts, mime-bundle outputs) rather than raw JSON, with
+the security posture pinned — ``text/html`` outputs are never injected into
+the DOM (a hostile ``<script>`` output must not execute or mount) and fall
+back to ``text/plain`` with a note; only raster images render, as inert
+data-URIs. The source toggle must flip to the raw-JSON view and back.
+Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_NOTEBOOK_FILE_PATH = "analysis.ipynb"
+
+# 1x1 red PNG, base64 — a real decodable image for the data-URI output.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR4nGP4z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+)
+
+# nbformat-4 fixture covering the render matrix: a markdown cell, a code cell
+# with a stream output, a code cell whose execute_result carries BOTH a
+# hostile text/html payload and a text/plain fallback, a display_data image,
+# and an error output with ANSI escape codes in the traceback.
+_NOTEBOOK_CONTENT = json.dumps(
+    {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {"language_info": {"name": "python"}},
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Quarterly Analysis\n", "\n", "Exploring **Q3 data**.\n"],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "source": ["print('rows: 1523')\n"],
+                "outputs": [{"output_type": "stream", "name": "stdout", "text": ["rows: 1523\n"]}],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": 2,
+                "metadata": {},
+                "source": ["df.describe()\n"],
+                "outputs": [
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 2,
+                        "metadata": {},
+                        "data": {
+                            "text/html": [
+                                '<script id="nb-xss">window.__nb_xss = 1</script>'
+                                "<table><tr><td>injected</td></tr></table>"
+                            ],
+                            "text/plain": ["       amount\ncount  1523.0"],
+                        },
+                    }
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": 3,
+                "metadata": {},
+                "source": ["df.plot()\n"],
+                "outputs": [
+                    {
+                        "output_type": "display_data",
+                        "metadata": {},
+                        "data": {
+                            "image/png": _PNG_B64,
+                            "text/plain": ["<Figure size 640x480 with 1 Axes>"],
+                        },
+                    }
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": 4,
+                "metadata": {},
+                "source": ["1/0\n"],
+                "outputs": [
+                    {
+                        "output_type": "error",
+                        "ename": "ZeroDivisionError",
+                        "evalue": "division by zero",
+                        "traceback": ["\x1b[0;31mZeroDivisionError\x1b[0m: division by zero"],
+                    }
+                ],
+            },
+        ],
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_notebook_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed the notebook file and yield (base_url, session_id, path).
+
+    :param seeded_session: Runner-bound (base_url, session_id) pair.
+    :returns: ``(base_url, session_id, file_path)`` for the test body.
+    """
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_NOTEBOOK_FILE_PATH}"
+    )
+    resp = httpx.put(
+        file_url,
+        json={"content": _NOTEBOOK_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    yield (base_url, session_id, _NOTEBOOK_FILE_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_notebook_renders_preview_and_source_toggle(
+    page: Page,
+    seeded_notebook_session: tuple[str, str, str],
+) -> None:
+    """Notebook cells render as a preview; source toggle shows the raw JSON."""
+    base_url, session_id, _file_path = seeded_notebook_session
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    file_button = page.get_by_role(
+        "button", name=re.compile(rf"^{re.escape(_NOTEBOOK_FILE_PATH)}\b")
+    )
+    expect(file_button).to_be_visible(timeout=30_000)
+    file_button.click()
+
+    # Match the visible FileViewer instance directly (mobile + desktop both
+    # mount with the same test id; order is not guaranteed).
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    expect(
+        page.get_by_role("button", name=f"Close {_NOTEBOOK_FILE_PATH}", exact=True).first
+    ).to_be_visible()
+
+    # Preview is the default for notebooks: the markdown cell renders as
+    # semantic HTML (a heading, not "# Quarterly Analysis" verbatim).
+    heading = file_viewer.locator("h1").filter(has_text="Quarterly Analysis")
+    expect(heading).to_be_visible(timeout=10_000)
+    expect(heading).not_to_contain_text("#")
+    expect(file_viewer.locator("strong").filter(has_text="Q3 data")).to_be_visible()
+
+    # Code cells carry their source and execution counts; stream output shows.
+    expect(file_viewer.get_by_text("In [1]:", exact=False)).to_be_visible()
+    expect(file_viewer.get_by_text("rows: 1523").last).to_be_visible()
+
+    # Security: the hostile text/html output is never injected — no script or
+    # table mounts, no side effect runs, and the text/plain fallback shows
+    # with the suppression note.
+    expect(file_viewer.locator("#nb-xss")).to_have_count(0)
+    expect(file_viewer.locator("table")).to_have_count(0)
+    assert page.evaluate("() => window.__nb_xss") is None
+    expect(file_viewer.get_by_text("Rich HTML output hidden", exact=False)).to_be_visible()
+    expect(file_viewer.get_by_text("count  1523.0", exact=False)).to_be_visible()
+
+    # The image/png output renders as an inert data-URI image.
+    image = file_viewer.locator('img[src^="data:image/png;base64,"]')
+    expect(image).to_be_visible()
+
+    # The error traceback renders with its ANSI escapes consumed, not verbatim.
+    expect(file_viewer.get_by_text("division by zero", exact=False).first).to_be_visible()
+    expect(file_viewer.get_by_text("[0;31m", exact=False)).to_have_count(0)
+
+    # Source toggle: the raw notebook JSON becomes visible.
+    file_viewer.get_by_role("button", name="View source").click()
+    expect(file_viewer.get_by_text('"nbformat"', exact=False).first).to_be_visible(timeout=10_000)
+    expect(file_viewer.get_by_text('"cell_type"', exact=False).first).to_be_visible()
+
+    # Toggle back to the rendered preview.
+    file_viewer.get_by_role("button", name="View preview").click()
+    expect(file_viewer.locator("h1").filter(has_text="Quarterly Analysis")).to_be_visible(
+        timeout=10_000
+    )

--- a/web/src/shell/CodeViewer.test.tsx
+++ b/web/src/shell/CodeViewer.test.tsx
@@ -10,7 +10,11 @@ import { HTML_PREVIEW_SANDBOX } from "./codeViewerHelpers";
 vi.mock("@/hooks/usePermissions", () => ({ useCanEdit: vi.fn() }));
 // Stub Shiki so the highlighting effect never fires an async callback that
 // would mutate state after the test cleans up.
-vi.mock("@/components/ai-elements/code-block", () => ({ highlightCode: vi.fn(() => null) }));
+vi.mock("@/components/ai-elements/code-block", () => ({
+  highlightCode: vi.fn(() => null),
+  // NotebookPreview renders notebook code cells through CodeBlockContent.
+  CodeBlockContent: ({ code }: { code: string }) => <pre>{code}</pre>,
+}));
 vi.mock("./MarkdownRichTextViewer", () => ({ MarkdownRichTextViewer: () => null }));
 // Stub the lazy Monaco editor so the heavy monaco-editor bundle isn't loaded in
 // jsdom; its presence in the DOM is the signal that a file was routed to Monaco.
@@ -473,5 +477,34 @@ describe("CodeViewer image rendering", () => {
     expect(await screen.findByRole("dialog")).toBeDefined();
     expect(screen.getByLabelText("Zoom in")).toBeDefined();
     expect(screen.getByLabelText("Zoom out")).toBeDefined();
+  });
+});
+
+describe("CodeViewer .ipynb routing", () => {
+  const MINIMAL_NB = JSON.stringify({
+    nbformat: 4,
+    cells: [{ cell_type: "markdown", metadata: {}, source: ["# Notebook Title\n"] }],
+  });
+
+  it("renders the notebook preview in preview mode", () => {
+    renderViewer(MINIMAL_NB, true, "analysis.ipynb", { viewMode: "preview" });
+    expect(screen.getByRole("heading", { name: "Notebook Title" })).toBeDefined();
+    expect(screen.queryByTestId("monaco-editor-stub")).toBeNull();
+  });
+
+  it("keeps raw-JSON Monaco as the source-view escape hatch", () => {
+    renderViewer(MINIMAL_NB, true, "analysis.ipynb", { viewMode: "source" });
+    expect(screen.getByTestId("monaco-editor-stub")).toBeDefined();
+  });
+
+  it("warns about truncated notebooks instead of rendering silently-incomplete cells", () => {
+    renderViewer(MINIMAL_NB.slice(0, 40), true, "analysis.ipynb", {
+      viewMode: "preview",
+      truncated: true,
+    });
+    // Truncated JSON cannot parse — the preview shows its parse-error state…
+    expect(screen.getByText(/Cannot render notebook/)).toBeDefined();
+    // …and the shared truncation banner is stacked above it.
+    expect(screen.getByText(/truncated/i)).toBeDefined();
   });
 });

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -56,8 +56,10 @@ import {
   indexToLine,
   isBinaryPath,
   isImageFile,
+  isNotebookPath,
   lineOverlapsSelection,
 } from "./codeViewerHelpers";
+import { NotebookPreview } from "./NotebookPreview";
 import { renderLineTokens } from "./codeViewerRendering";
 import { HtmlCommentViewer } from "./HtmlCommentViewer";
 import { TruncatedBanner } from "./TruncatedBanner";
@@ -586,8 +588,12 @@ export function CodeViewer({
     );
   }
 
-  if (viewMode === "preview" && lang === "markdown") {
-    const preview = <MarkdownPreview content={content} />;
+  if (viewMode === "preview" && (lang === "markdown" || isNotebookPath(path))) {
+    const preview = isNotebookPath(path) ? (
+      <NotebookPreview content={content} />
+    ) : (
+      <MarkdownPreview content={content} />
+    );
     // A truncated preview renders incomplete content; warn the user (the editor
     // and source surfaces already do). No layout change when not truncated.
     if (!truncated) return preview;

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -87,6 +87,7 @@ import {
   type SaveStatus,
   detectLang,
   isImageFile,
+  isNotebookPath,
   openHtmlArtifactInNewTab,
 } from "./codeViewerHelpers";
 import { CommentsPanel, type ActiveSelection } from "./CommentsPanel";
@@ -600,10 +601,10 @@ function FileViewerBody({
     return () => window.removeEventListener("keydown", handler);
   }, [open, onCloseTab, searchOpen, guardDirty]);
 
-  // View mode toggle — markdown defaults to the rich-text editor, HTML to its
-  // rendered preview, and everything else to source.
+  // View mode toggle — markdown defaults to the rich-text editor, HTML and
+  // notebooks to their rendered preview, and everything else to source.
   const lang = detectLang(path);
-  const isPreviewable = lang === "markdown" || lang === "html";
+  const isPreviewable = lang === "markdown" || lang === "html" || isNotebookPath(path);
   // Images render through CodeViewer's <ImageViewer> regardless of view mode;
   // they have no source/diff representation, so diff is suppressed for them
   // (Monaco would otherwise render the base64 payload as garbage text).
@@ -616,7 +617,8 @@ function FileViewerBody({
 
   // Diff is a global toggle — turning it on/off on any file carries over as you
   // navigate to the next file. Source ↔ preview is also shared across previewable
-  // files (markdown/html), while non-previewable files always render as source.
+  // files (markdown/html/notebooks), while non-previewable files always render
+  // as source.
   // These are app-global *preferences*, persisted to localStorage so they also
   // survive a page refresh (and seed a brand-new conversation). Seed precedence:
   //   1. an explicit ?diff=1 link (shareable override, diff only),
@@ -663,8 +665,8 @@ function FileViewerBody({
     writeFileViewPreferences({ diffActive, diffLayout, previewableViewMode, hideWhitespace });
   }, [diffActive, diffLayout, previewableViewMode, hideWhitespace]);
   // Markdown supports all three previewable modes (preview / editor / source).
-  // HTML has no rich-text editor, so its "editor" preference falls back to the
-  // rendered preview; "preview" / "source" pass through for both. The shared
+  // HTML and notebooks have no rich-text editor, so their "editor" preference
+  // falls back to the rendered preview; "preview" / "source" pass through. The shared
   // preference still carries across file types — opening markdown in source
   // then switching to an HTML file keeps you in source, etc.
   const fileViewMode: "editor" | "preview" | "source" = isPreviewable
@@ -821,8 +823,9 @@ function FileViewerBody({
       icon: activeMode.icon,
       options: modeOptions,
     });
-  } else if (lang === "html" && viewMode !== "diff") {
-    // HTML has no rich-text editor — a single toggle flips preview ↔ source.
+  } else if ((lang === "html" || isNotebookPath(path)) && viewMode !== "diff") {
+    // HTML and notebooks have no rich-text editor — a single toggle flips
+    // preview ↔ source.
     toolbarActions.push({
       key: "preview",
       label: viewMode === "preview" ? "View source" : "View preview",

--- a/web/src/shell/NotebookPreview.test.tsx
+++ b/web/src/shell/NotebookPreview.test.tsx
@@ -49,6 +49,59 @@ describe("NotebookPreview — typical notebook", () => {
     expect(img).not.toBeNull();
     expect(img!.getAttribute("src")).toMatch(/^data:image\/png;base64,/);
   });
+
+  it("strips all whitespace from base64 images (CRLF-split payloads stay valid)", () => {
+    // A payload split across array lines with CRLF endings and a stray space —
+    // a data-URI containing any whitespace is rejected by the browser.
+    const nb = JSON.stringify({
+      nbformat: 4,
+      cells: [
+        {
+          cell_type: "code",
+          execution_count: 1,
+          source: [],
+          outputs: [
+            {
+              output_type: "display_data",
+              data: { "image/png": ["iVBORw0K\r\n", "GgoA AAAN\n"] },
+            },
+          ],
+        },
+      ],
+    });
+    const { container } = render(<NotebookPreview content={nb} />);
+    const src = container.querySelector("img")!.getAttribute("src")!;
+    expect(src).toBe("data:image/png;base64,iVBORw0KGgoAAAAN");
+    expect(src).not.toMatch(/\s/);
+  });
+
+  it("falls back to a note (not a broken img) for corrupt base64 images", () => {
+    // length % 4 === 1 is never valid base64 — a browser rejects the data-URI
+    // with ERR_INVALID_URL. Show the text/plain repr with a note instead.
+    const nb = JSON.stringify({
+      nbformat: 4,
+      cells: [
+        {
+          cell_type: "code",
+          execution_count: 1,
+          source: [],
+          outputs: [
+            {
+              output_type: "display_data",
+              data: {
+                "image/png": "not@valid#base64!",
+                "text/plain": "<Figure size 640x480 with 1 Axes>",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const { container } = render(<NotebookPreview content={nb} />);
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText(/could not be decoded/)).toBeInTheDocument();
+    expect(screen.getByText(/Figure size 640x480/)).toBeInTheDocument();
+  });
 });
 
 describe("NotebookPreview — edge cases", () => {
@@ -57,6 +110,10 @@ describe("NotebookPreview — edge cases", () => {
     expect(screen.getAllByText(/ZeroDivisionError/).length).toBeGreaterThan(0);
     // ansi-to-react must consume the escape sequences, not print them.
     expect(container.textContent).not.toContain("[0;31m");
+    // Long unbroken traceback runs (separator rules, paths) must scroll within
+    // the cell, not widen the layout — the output <pre> owns the overflow.
+    const tb = screen.getAllByText(/ZeroDivisionError/)[0].closest("pre");
+    expect(tb!.className).toContain("overflow-x-auto");
   });
 
   it("never executes or injects script from hostile text/html outputs", () => {
@@ -91,5 +148,19 @@ describe("NotebookPreview — invalid input", () => {
   it("rejects valid JSON that is not a notebook", () => {
     render(<NotebookPreview content='{"foo": 1}' />);
     expect(screen.getByText(/missing cells array/)).toBeInTheDocument();
+  });
+
+  it("recovers from raw control characters (unescaped ANSI) in cell output", () => {
+    // A notebook whose stream output carries a bare ESC (0x1B) and newline —
+    // strict JSON.parse rejects these, but the preview escapes and recovers.
+    const nb = `{"nbformat": 4, "cells": [
+      {"cell_type": "code", "execution_count": 1, "source": ["print(x)"],
+       "outputs": [{"output_type": "stream", "name": "stdout",
+         "text": ["\x1b[31mred\x1b[0m line one\nline two"]}]}
+    ]}`;
+    render(<NotebookPreview content={nb} />);
+    // Parse recovered (no error state) and the output text is rendered.
+    expect(screen.queryByText(/Cannot render notebook/)).toBeNull();
+    expect(screen.getByText(/line one/)).toBeInTheDocument();
   });
 });

--- a/web/src/shell/NotebookPreview.test.tsx
+++ b/web/src/shell/NotebookPreview.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NotebookPreview } from "./NotebookPreview";
+
+// Stub Shiki (same rationale as CodeViewer.test.tsx) — render code verbatim so
+// assertions can target cell source without async highlighting.
+vi.mock("@/components/ai-elements/code-block", () => ({
+  CodeBlockContent: ({ code }: { code: string }) => <pre data-testid="code-cell">{code}</pre>,
+}));
+
+import typicalRaw from "./__fixtures__/01_typical.ipynb?raw";
+import edgecasesRaw from "./__fixtures__/02_edgecases.ipynb?raw";
+import brokenRaw from "./__fixtures__/03_broken.ipynb?raw";
+
+afterEach(cleanup);
+
+describe("NotebookPreview — typical notebook", () => {
+  it("renders markdown cells as formatted markdown", () => {
+    render(<NotebookPreview content={typicalRaw} />);
+    expect(screen.getByRole("heading", { name: "Sales Analysis" })).toBeInTheDocument();
+    // **Q3 data** renders as <strong>, proving markdown is not shown raw.
+    expect(screen.getByText("Q3 data").tagName).toBe("STRONG");
+  });
+
+  it("renders code cells with source and execution counts", () => {
+    render(<NotebookPreview content={typicalRaw} />);
+    expect(screen.getAllByTestId("code-cell")[0]).toHaveTextContent("import pandas as pd");
+    expect(screen.getByText("In [1]:")).toBeInTheDocument();
+    expect(screen.getByText("In [3]:")).toBeInTheDocument();
+  });
+
+  it("renders stream output text", () => {
+    render(<NotebookPreview content={typicalRaw} />);
+    expect(screen.getByText(/rows: 1523/)).toBeInTheDocument();
+  });
+
+  it("suppresses text/html output and falls back to text/plain with a note", () => {
+    const { container } = render(<NotebookPreview content={typicalRaw} />);
+    // The DataFrame html table must NOT be injected into the DOM …
+    expect(container.querySelector("table")).toBeNull();
+    // … the plain-text repr is shown instead, with an explanatory note.
+    expect(screen.getByText(/count\s+1523\.0/)).toBeInTheDocument();
+    expect(screen.getByText(/Rich HTML output hidden/)).toBeInTheDocument();
+  });
+
+  it("renders image/png output as an inert data-URI img", () => {
+    const { container } = render(<NotebookPreview content={typicalRaw} />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toMatch(/^data:image\/png;base64,/);
+  });
+});
+
+describe("NotebookPreview — edge cases", () => {
+  it("renders error tracebacks (ANSI codes handled, not shown raw)", () => {
+    const { container } = render(<NotebookPreview content={edgecasesRaw} />);
+    expect(screen.getAllByText(/ZeroDivisionError/).length).toBeGreaterThan(0);
+    // ansi-to-react must consume the escape sequences, not print them.
+    expect(container.textContent).not.toContain("[0;31m");
+  });
+
+  it("never executes or injects script from hostile text/html outputs", () => {
+    const { container } = render(<NotebookPreview content={edgecasesRaw} />);
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("b")).toBeNull();
+    expect(screen.getByText(/Rich HTML output hidden/)).toBeInTheDocument();
+  });
+
+  it("renders stderr streams distinctly from stdout", () => {
+    render(<NotebookPreview content={edgecasesRaw} />);
+    const stderr = screen.getByText(/warning: deprecated/).closest("pre");
+    const stdout = screen.getByText("done").closest("pre");
+    expect(stderr!.className).toContain("bg-destructive");
+    expect(stdout!.className).not.toContain("bg-destructive");
+  });
+
+  it("renders raw cells verbatim and empty execution counts as In [ ]", () => {
+    render(<NotebookPreview content={edgecasesRaw} />);
+    expect(screen.getByText(/raw cell content/)).toBeInTheDocument();
+    expect(screen.getByText(/In \[ \]:/)).toBeInTheDocument();
+  });
+});
+
+describe("NotebookPreview — invalid input", () => {
+  it("shows a parse error with a pointer to the source view", () => {
+    render(<NotebookPreview content={brokenRaw} />);
+    expect(screen.getByText(/Cannot render notebook/)).toBeInTheDocument();
+    expect(screen.getByText(/source view/)).toBeInTheDocument();
+  });
+
+  it("rejects valid JSON that is not a notebook", () => {
+    render(<NotebookPreview content='{"foo": 1}' />);
+    expect(screen.getByText(/missing cells array/)).toBeInTheDocument();
+  });
+});

--- a/web/src/shell/NotebookPreview.tsx
+++ b/web/src/shell/NotebookPreview.tsx
@@ -53,12 +53,61 @@ function joinSource(src: string | string[] | undefined): string {
 // rendered directly.
 const SAFE_IMAGE_MIMES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 
+// A data-URI built from malformed base64 (wrong length, stray chars, data after
+// padding) is rejected by the browser with ERR_INVALID_URL — showing a broken
+// image with no explanation. Validate before building the URI so we can fall
+// back to a note instead. Length must be a multiple of 4 with padding only at
+// the end; length % 4 === 1 is never valid base64.
+function isValidBase64(b64: string): boolean {
+  return /^[A-Za-z0-9+/]*={0,2}$/.test(b64) && b64.length % 4 === 0;
+}
+
+// Notebooks in the wild embed raw C0 control characters (most often ANSI escape
+// sequences in traceback/output text) directly inside JSON string literals,
+// which strict JSON.parse rejects ("Bad control character in string literal").
+// Escape any control char that appears *inside* a string to its \uXXXX form,
+// leaving structural whitespace between tokens untouched.
+function escapeControlCharsInStrings(content: string): string {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+    if (!inString) {
+      out += ch;
+      if (ch === '"') inString = true;
+      continue;
+    }
+    if (escaped) {
+      out += ch;
+      escaped = false;
+    } else if (ch === "\\") {
+      out += ch;
+      escaped = true;
+    } else if (ch === '"') {
+      out += ch;
+      inString = false;
+    } else if (content.charCodeAt(i) < 0x20) {
+      out += `\\u${content.charCodeAt(i).toString(16).padStart(4, "0")}`;
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
 function parseNotebook(content: string): { notebook?: Notebook; error?: string } {
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
-  } catch (e) {
-    return { error: e instanceof Error ? e.message : String(e) };
+  } catch {
+    // Retry once with stray control characters escaped — real notebooks often
+    // contain unescaped ANSI codes in cell output that strict JSON rejects.
+    try {
+      parsed = JSON.parse(escapeControlCharsInStrings(content));
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : String(e) };
+    }
   }
   const nb = parsed as Notebook;
   if (!nb || typeof nb !== "object" || !Array.isArray(nb.cells)) {
@@ -68,8 +117,17 @@ function parseNotebook(content: string): { notebook?: Notebook; error?: string }
 }
 
 function AnsiText({ text, className }: { text: string; className?: string }) {
+  // Outputs (tracebacks especially) contain long unbroken runs — separator
+  // rules, file paths — that word-wrapping can't split. Wrap where possible
+  // (overflow-wrap) but let anything unbreakable scroll horizontally within the
+  // cell rather than pushing the whole preview wide.
   return (
-    <pre className={cn("whitespace-pre-wrap break-words font-mono text-xs p-2", className)}>
+    <pre
+      className={cn(
+        "overflow-x-auto whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-xs p-2",
+        className,
+      )}
+    >
       <Ansi>{text}</Ansi>
     </pre>
   );
@@ -93,22 +151,34 @@ function OutputView({ output }: { output: NotebookOutput }) {
   // representation.
   const data = output.data ?? {};
   const imageMime = SAFE_IMAGE_MIMES.find((m) => data[m] !== undefined);
+  let imageError: string | undefined;
   if (imageMime) {
-    const b64 = joinSource(data[imageMime]).replace(/\n/g, "");
-    return (
-      <img
-        src={`data:${imageMime};base64,${b64}`}
-        alt="notebook output"
-        className="max-w-full my-1"
-      />
-    );
+    // Strip *all* whitespace, not just newlines: base64 payloads split across
+    // JSON-array lines can carry CRLF or stray spaces, and a data-URI with any
+    // whitespace in it is rejected by the browser (renders as a broken image).
+    const b64 = joinSource(data[imageMime]).replace(/\s/g, "");
+    if (isValidBase64(b64)) {
+      return (
+        <img
+          src={`data:${imageMime};base64,${b64}`}
+          alt="notebook output"
+          className="max-w-full my-1"
+        />
+      );
+    }
+    // Corrupt payload: don't emit a broken <img> — note it and fall through to
+    // the text/plain repr below (matplotlib etc. usually include one).
+    imageError = `Image output (${imageMime}) could not be decoded.`;
   }
 
   const plain = data["text/plain"] !== undefined ? joinSource(data["text/plain"]) : undefined;
   const suppressedHtml = data["text/html"] !== undefined;
-  if (plain === undefined && !suppressedHtml) return null;
+  if (plain === undefined && !suppressedHtml && imageError === undefined) return null;
   return (
     <div>
+      {imageError && (
+        <div className="text-xs text-muted-foreground italic px-2 pt-1">{imageError}</div>
+      )}
       {suppressedHtml && (
         <div className="text-xs text-muted-foreground italic px-2 pt-1">
           Rich HTML output hidden — showing plain text.

--- a/web/src/shell/NotebookPreview.tsx
+++ b/web/src/shell/NotebookPreview.tsx
@@ -1,0 +1,180 @@
+import type { BundledLanguage } from "shiki";
+import AnsiDefault from "ansi-to-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { CodeBlockContent } from "@/components/ai-elements/code-block";
+import { cn } from "@/lib/utils";
+
+// ansi-to-react is CJS with a TS-compiled `exports.default`; depending on the
+// bundler interop (Vite dev prebundle vs vitest vs production build) the
+// default import is either the component or the whole exports object.
+const Ansi = ("default" in AnsiDefault ? AnsiDefault.default : AnsiDefault) as typeof AnsiDefault;
+
+// ---------------------------------------------------------------------------
+// NotebookPreview — read-only render of a Jupyter notebook (.ipynb, nbformat 4).
+//
+// Renders cells in order: markdown via react-markdown (same pipeline as
+// MarkdownPreview), code via the shared Shiki CodeBlockContent, and outputs
+// from each cell's mime bundle. Active content (text/html, javascript) is
+// never injected into the DOM — rich outputs fall back to their text/plain
+// representation with a note, so hostile notebooks can't run scripts here.
+// ---------------------------------------------------------------------------
+
+interface NotebookOutput {
+  output_type: string;
+  name?: string; // stream: stdout | stderr
+  text?: string | string[];
+  data?: Record<string, string | string[]>;
+  ename?: string;
+  evalue?: string;
+  traceback?: string[];
+}
+
+interface NotebookCell {
+  cell_type: string;
+  source?: string | string[];
+  execution_count?: number | null;
+  outputs?: NotebookOutput[];
+}
+
+interface Notebook {
+  nbformat?: number;
+  cells?: NotebookCell[];
+  metadata?: { language_info?: { name?: string } };
+}
+
+// nbformat stores text as a list of lines (or a single string); normalize.
+function joinSource(src: string | string[] | undefined): string {
+  if (src === undefined) return "";
+  return Array.isArray(src) ? src.join("") : src;
+}
+
+// Raster images are inert; SVG and HTML can carry scripts, so they are not
+// rendered directly.
+const SAFE_IMAGE_MIMES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+function parseNotebook(content: string): { notebook?: Notebook; error?: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) };
+  }
+  const nb = parsed as Notebook;
+  if (!nb || typeof nb !== "object" || !Array.isArray(nb.cells)) {
+    return { error: "not a notebook: missing cells array" };
+  }
+  return { notebook: nb };
+}
+
+function AnsiText({ text, className }: { text: string; className?: string }) {
+  return (
+    <pre className={cn("whitespace-pre-wrap break-words font-mono text-xs p-2", className)}>
+      <Ansi>{text}</Ansi>
+    </pre>
+  );
+}
+
+function OutputView({ output }: { output: NotebookOutput }) {
+  if (output.output_type === "stream") {
+    return (
+      <AnsiText
+        text={joinSource(output.text)}
+        className={output.name === "stderr" ? "bg-destructive/10" : undefined}
+      />
+    );
+  }
+
+  if (output.output_type === "error") {
+    return <AnsiText text={(output.traceback ?? []).join("\n")} className="bg-destructive/10" />;
+  }
+
+  // execute_result / display_data carry a mime bundle; pick the richest safe
+  // representation.
+  const data = output.data ?? {};
+  const imageMime = SAFE_IMAGE_MIMES.find((m) => data[m] !== undefined);
+  if (imageMime) {
+    const b64 = joinSource(data[imageMime]).replace(/\n/g, "");
+    return (
+      <img
+        src={`data:${imageMime};base64,${b64}`}
+        alt="notebook output"
+        className="max-w-full my-1"
+      />
+    );
+  }
+
+  const plain = data["text/plain"] !== undefined ? joinSource(data["text/plain"]) : undefined;
+  const suppressedHtml = data["text/html"] !== undefined;
+  if (plain === undefined && !suppressedHtml) return null;
+  return (
+    <div>
+      {suppressedHtml && (
+        <div className="text-xs text-muted-foreground italic px-2 pt-1">
+          Rich HTML output hidden — showing plain text.
+        </div>
+      )}
+      {plain !== undefined && <AnsiText text={plain} />}
+    </div>
+  );
+}
+
+function CodeCell({ cell, language }: { cell: NotebookCell; language: BundledLanguage }) {
+  const count = cell.execution_count;
+  return (
+    <div className="flex gap-2">
+      <div className="w-14 shrink-0 pt-1 text-right font-mono text-xs text-muted-foreground select-none">
+        In [{count ?? " "}]:
+      </div>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="rounded border bg-muted/30 text-xs">
+          <CodeBlockContent code={joinSource(cell.source)} language={language} />
+        </div>
+        {(cell.outputs ?? []).map((output, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <OutputView key={i} output={output} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function NotebookPreview({ content }: { content: string }) {
+  const { notebook, error } = parseNotebook(content);
+
+  if (error || !notebook) {
+    return (
+      <div className="p-8 text-sm">
+        <div className="text-destructive">Cannot render notebook: {error}</div>
+        <div className="mt-1 text-muted-foreground">
+          Switch to the source view to inspect the raw file.
+        </div>
+      </div>
+    );
+  }
+
+  const langName = notebook.metadata?.language_info?.name ?? "python";
+  const language = langName as BundledLanguage;
+
+  return (
+    <div className="h-full space-y-4 overflow-auto px-6 py-4">
+      {(notebook.cells ?? []).map((cell, i) => {
+        if (cell.cell_type === "markdown") {
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <div key={i} className="prose dark:prose-invert prose-sm max-w-none pl-16">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{joinSource(cell.source)}</ReactMarkdown>
+            </div>
+          );
+        }
+        if (cell.cell_type === "code") {
+          // eslint-disable-next-line react/no-array-index-key
+          return <CodeCell key={i} cell={cell} language={language} />;
+        }
+        // raw (and any unknown cell type): show the source verbatim.
+        // eslint-disable-next-line react/no-array-index-key
+        return <AnsiText key={i} text={joinSource(cell.source)} className="pl-16 opacity-70" />;
+      })}
+    </div>
+  );
+}

--- a/web/src/shell/__fixtures__/01_typical.ipynb
+++ b/web/src/shell/__fixtures__/01_typical.ipynb
@@ -1,0 +1,90 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sales Analysis\n",
+    "\n",
+    "Exploring **Q3 data** with a quick plot.\n",
+    "\n",
+    "- load\n",
+    "- clean\n",
+    "- plot\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "df = pd.read_csv('sales.csv')\n",
+    "print(f'rows: {len(df)}')\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "rows: 1523\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "source": [
+    "df.describe()\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "execution_count": 2,
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "       amount\ncount  1523.0\nmean    47.3\nstd   12.1"
+      ],
+      "text/html": [
+       "<div><table border=\"1\"><thead><tr><th></th><th>amount</th></tr></thead><tbody><tr><th>count</th><td>1523.0</td></tr><tr><th>mean</th><td>47.3</td></tr></tbody></table></div>"
+      ]
+     }
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "source": [
+    "df.plot()\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/web/src/shell/__fixtures__/02_edgecases.ipynb
+++ b/web/src/shell/__fixtures__/02_edgecases.ipynb
@@ -1,0 +1,107 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Error and unsafe outputs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "source": [
+    "1/0\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "ZeroDivisionError",
+     "evalue": "division by zero",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------\u001b[0m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;241m1\u001b[39m\u001b[38;5;241m/\u001b[39m\u001b[38;5;241m0\u001b[39m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "source": [
+    "from IPython.display import HTML\n",
+    "HTML('<script>alert(1)</script><b>bold</b>')\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "execution_count": 2,
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "<script>alert(1)</script><b>bold</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     }
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "source": [
+    "print('done')\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "warning: deprecated\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "done\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "raw cell content\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# never executed\n"
+   ],
+   "outputs": []
+  }
+ ]
+}

--- a/web/src/shell/__fixtures__/03_broken.ipynb
+++ b/web/src/shell/__fixtures__/03_broken.ipynb
@@ -1,0 +1,1 @@
+{"nbformat": 4, "cells": [{"cell_type": "cod

--- a/web/src/shell/codeViewerHelpers.test.ts
+++ b/web/src/shell/codeViewerHelpers.test.ts
@@ -6,6 +6,7 @@ import {
   indexToLine,
   isBinaryPath,
   isImageFile,
+  isNotebookPath,
   lineOverlapsSelection,
   openHtmlArtifactInNewTab,
   prepareHtmlPreviewDoc,
@@ -110,6 +111,22 @@ describe("isBinaryPath", () => {
   it("treats extension-less paths as non-binary", () => {
     expect(isBinaryPath("Dockerfile")).toBe(false);
   });
+});
+
+describe("isNotebookPath", () => {
+  it.each(["analysis.ipynb", "dir/Report.IPYNB", "a.b.ipynb"])(
+    "classifies %s as a notebook",
+    (path) => {
+      expect(isNotebookPath(path)).toBe(true);
+    },
+  );
+
+  it.each(["notes.md", "data.json", "ipynb", "nb.ipynb.bak"])(
+    "classifies %s as not a notebook",
+    (path) => {
+      expect(isNotebookPath(path)).toBe(false);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/shell/codeViewerHelpers.ts
+++ b/web/src/shell/codeViewerHelpers.ts
@@ -96,6 +96,12 @@ export function isBinaryPath(path: string): boolean {
   return BINARY_EXTENSIONS.has(ext);
 }
 
+/** Jupyter notebooks get a read-only rendered preview (with raw-JSON source as
+ * the escape hatch), so they are previewable like markdown/html. */
+export function isNotebookPath(path: string): boolean {
+  return path.toLowerCase().endsWith(".ipynb");
+}
+
 // Image formats the browser can render directly via an <img> tag. SVG is
 // included but is only ever rendered through a blob URL (never inlined into
 // the DOM), so scripts embedded in it cannot execute.


### PR DESCRIPTION
## Related issue

Closes #1634

## Summary

- Adds a read-only `.ipynb` preview to the workspace file viewer: cells render in order — markdown through the existing react-markdown/GFM pipeline, code through the shared Shiki `CodeBlockContent` with `In [n]` execution counts, and outputs from each cell's mime bundle. **Zero new dependencies.**
- Output handling is safety-first: `text/html` is never injected into the DOM — rich outputs (e.g. pandas DataFrames) fall back to their `text/plain` repr with a note; only raster image mimes render, as inert data-URIs (SVG excluded); stream/error outputs go through the same `ansi-to-react` the terminal uses, so colored tracebacks render properly.
- Notebooks join markdown/html as previewable: preview is the default view, and the raw-JSON Monaco source view stays available as the escape hatch. Invalid or truncated notebook JSON shows a parse-error state pointing at the source view (with the shared `TruncatedBanner` stacked when applicable).

ELI5: `.ipynb` files used to open as a wall of raw JSON. Now they look like a notebook — prose, highlighted code, and outputs — while staying strictly read-only and never executing anything embedded in the file.

```
FileViewer (isPreviewable += isNotebookPath)
   └─ CodeViewer viewMode dispatch
        ├─ preview  → NotebookPreview   (new; md / code / outputs per cell)
        └─ source   → Monaco raw JSON   (unchanged escape hatch)
```

## Test Plan

- `npx vitest run src/shell/` — 62 files / 1150+ tests green, including:
  - `NotebookPreview.test.tsx` (new): markdown/code/execution counts, stream output, HTML suppression + text/plain fallback, inert data-URI images, ANSI traceback consumption, hostile `<script>` output never reaching the DOM, stderr styling, raw cells, `In [ ]` for never-executed cells, broken-JSON parse error, JSON-that-is-not-a-notebook rejection.
  - `CodeViewer.test.tsx` (extended): `.ipynb` routes to the preview in preview mode, to Monaco in source mode, and truncated notebooks show the parse-error state under the truncation banner.
  - `codeViewerHelpers.test.ts` (extended): `isNotebookPath` matrix.
- Manual E2E on a live local stack (`omnigent server` + `omnigent host` + `npm run dev`): opened real notebooks in the session file viewer — see Demo. This also caught a CJS/ESM interop issue with `ansi-to-react`'s default import under the Vite dev prebundle (the default import resolves to the exports object, not the component); fixed with an interop unwrap in `NotebookPreview.tsx`. Note `terminal.tsx`'s identical bare default import has the same latent issue in dev — happy to file/fix separately.
- `npm run lint` and `npm run build` clean; `pre-commit` green.

## Demo

Typical analysis notebook — markdown, highlighted code, execution counts, stream output, a pandas DataFrame (`text/html` suppressed → `text/plain` fallback with note), and an `image/png` plot:

![notebook preview](https://raw.githubusercontent.com/sunnyadn/omnigent/pr-assets/1_preview_typical.png)

Edge cases — ANSI-colored traceback via `ansi-to-react`, a hostile `<script>` HTML output safely suppressed, stderr visually distinct from stdout:

![edge cases](https://raw.githubusercontent.com/sunnyadn/omnigent/pr-assets/2_preview_edgecases.png)

The toolbar toggle switches to the raw-JSON Monaco source view (escape hatch), same as the markdown/html previewables.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the full local stack and opened both demo notebooks plus a truncated/broken one through the real session file viewer (screenshots above); verified preview ↔ source toggling both ways and that no script from notebook outputs executes (console clean).

## Changelog

Added: `.ipynb` notebooks render as read-only previews in the workspace file viewer (raw JSON still available via the source view)
