### PR TITLE
fix(ci): use static job names for e2e shards to avoid unexpanded template on skip

### DIFF
--- a/.github/scripts/ci/e2e-shard-matrix.sh
+++ b/.github/scripts/ci/e2e-shard-matrix.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Emits the e2e shard matrix as `matrix=<json>` on $GITHUB_OUTPUT, or an EMPTY
-# matrix ({"include":[]}) to skip. Empty yields zero jobs and thus NO check-runs
-# -- the point of the indirection: a job-level `if:` skip would instead leave a
-# check-run with an unexpanded `E2E Tests (shard ${{ matrix.shard_id }}/...)` name.
+# matrix ({"include":[]}) to skip. Empty yields zero jobs and thus NO check-runs.
+# Each entry carries only a human-readable `shard` label ("shard 0/N"); the job
+# uses strategy.job-index / strategy.job-total for the actual shard index so the
+# display name (e.g. "E2E Tests (shard 0/4)") stays clean even on skipped runs.
 #
 # Skips only draft PRs. These suites are mock-LLM (no secrets), so fork PRs run
 # directly, like CI.
@@ -25,7 +26,7 @@ fi
 
 inc=""
 for ((i = 0; i < NUM_SHARDS; i++)); do
-  inc+="{\"shard_id\":$i,\"num_shards\":$NUM_SHARDS},"
+  inc+="{\"shard\":\"shard $i/$NUM_SHARDS\"},"
 done
 echo "matrix={\"include\":[${inc%,}]}" >> "$GITHUB_OUTPUT"
 echo "run: $NUM_SHARDS shards (event=$EVENT_NAME)"

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -134,7 +134,7 @@ jobs:
           retention-days: 1
 
   e2e-ui:
-    name: E2E UI Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    name: E2E UI Tests
     # Draft PRs resolve to an EMPTY matrix in `setup`, so no shard runs for
     # them. Fork PRs DO run (mock LLM, no secrets) -- same as ci.yml.
     # `ready_for_review` re-fires when a draft is converted.
@@ -269,8 +269,8 @@ jobs:
           # Scheduled / manually dispatched runs are the full pass;
           # PR and push runs exclude @pytest.mark.nightly tests.
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-          SHARD_ID: ${{ matrix.shard_id }}
-          NUM_SHARDS: ${{ matrix.num_shards }}
+          SHARD_ID: ${{ strategy.job-index }}
+          NUM_SHARDS: ${{ strategy.job-total }}
           # Prebuilt sidecar from build-sidecar; the codex goal-mode fixture
           # uses this instead of running cargo build. Absolute path: the
           # fixture runs with cwd at the repo root but be explicit.
@@ -306,7 +306,7 @@ jobs:
         with:
           # Shard suffix avoids the matrix's parallel uploads colliding (v4
           # 409s on dupe names).
-          name: e2e-ui-playwright-${{ github.run_id }}-shard${{ matrix.shard_id }}
+          name: e2e-ui-playwright-${{ github.run_id }}-shard${{ strategy.job-index }}
           # `playwright-report/` is the JS-runner's HTML dir, never produced
           # by pytest-playwright -- kept for forward-compat (ignore-if-absent).
           path: |
@@ -339,7 +339,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: e2e-ui-server-logs-${{ github.run_id }}-shard${{ matrix.shard_id }}
+          name: e2e-ui-server-logs-${{ github.run_id }}-shard${{ strategy.job-index }}
           # server.log + runner.log from the live_server fixture's tmp dir,
           # plus the native bridge dirs and the Claude / Codex transcripts
           # staged above -- all needed to triage a native render-parity failure.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,7 +92,7 @@ jobs:
     # all shards concurrently so one wedged shard can't block the others.
     # -n 2 per shard => 4 x 2 = 8 concurrent gateway calls, below the
     # nightly's 429 pain point; drop -n before max-parallel if rate-limited.
-    name: E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    name: E2E Tests
     # Draft PRs resolve to an EMPTY matrix in `setup`, so no shard runs for
     # them. Fork PRs DO run (mock LLM, no secrets) -- same as ci.yml.
     needs: setup
@@ -122,7 +122,7 @@ jobs:
       - name: Run e2e suite
         uses: ./.github/actions/e2e-run
         with:
-          shard_id: ${{ matrix.shard_id }}
-          num_shards: ${{ matrix.num_shards }}
+          shard_id: ${{ strategy.job-index }}
+          num_shards: ${{ strategy.job-total }}
           parallelism: ${{ github.event.inputs.parallelism || '2' }}
           nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary

- When the `gate` job is skipped (e.g. on automerge label events), `setup` is also skipped, and GitHub renders the matrix job placeholder with the literal expression `E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})` — the template is never evaluated
- Fix: make job names static (`E2E Tests`, `E2E UI Tests`) and store only a human-readable `shard` label in the matrix (e.g. `"shard 0/4"`). GitHub auto-appends the label to disambiguate running jobs, producing the same check names as before (`E2E Tests (shard 0/4)`). Skipped placeholders now show just `E2E Tests`
- Replace `matrix.shard_id` / `matrix.num_shards` with `strategy.job-index` / `strategy.job-total` in steps and artifact names — no required.sh changes needed since check names are unchanged

## Test Plan

- [ ] Verify required check names in `merge-ready/required.sh` still match (they do — `E2E Tests (shard 0/4)` etc. are unchanged)
- [ ] Confirm this PR's own CI run shows clean job names without unexpanded template expressions

## Demo

N/A (workflow-only change)

## Type of change

- [x] Bug fix

## Test coverage

- [x] Not applicable

### Coverage notes

Workflow-only change; verified by inspecting the PR's own CI run.