### PR TITLE
feat(web): add dividers between agent-info panel sections

### DIFF
--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -926,7 +926,7 @@ function McpServersSection({
   if (!showSection) return null;
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-1.5 py-3">
       <div className="flex items-center justify-between">
         <SectionLabel>Tools</SectionLabel>
         {canEdit && (
@@ -1000,7 +1000,7 @@ function SessionPoliciesSection({ sessionId }: { sessionId: string }) {
   );
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-1.5 py-3">
       <div className="flex items-center justify-between">
         <SectionLabel>Policies</SectionLabel>
         <button
@@ -1166,9 +1166,9 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
   }
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col divide-y divide-border/50">
       {displayName && (
-        <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col gap-0.5 pb-3">
           <span className="font-medium text-sm">{displayName}</span>
           {agent?.description && (
             <span className="text-xs text-muted-foreground">{agent.description}</span>
@@ -1176,7 +1176,7 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
         </div>
       )}
       {sessionId && owner && isSessionShared && (
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-1.5 py-3">
           <SectionLabel>Owner</SectionLabel>
           <span
             className="truncate font-mono text-xs text-muted-foreground"
@@ -1189,7 +1189,7 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
         </div>
       )}
       {sessionId && (
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-1.5 py-3">
           <SectionLabel>Session ID</SectionLabel>
           <div className="flex items-center gap-2">
             <code
@@ -1217,22 +1217,28 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
           </div>
         </div>
       )}
-      {sessionId && sessionCostUsd != null && (
-        <div className="flex flex-col gap-1.5">
-          <SectionLabel>Session cost</SectionLabel>
-          <span
-            className="font-mono text-xs tabular-nums text-muted-foreground"
-            data-testid="agent-info-session-cost"
-          >
-            {formatSessionCostUsd(sessionCostUsd)}
-          </span>
-        </div>
-      )}
-      {sessionId && usageByModel != null && Object.keys(usageByModel).length > 0 && (
-        <ModelUsageBreakdown usageByModel={usageByModel} />
-      )}
+      {sessionId &&
+        (sessionCostUsd != null ||
+          (usageByModel != null && Object.keys(usageByModel).length > 0)) && (
+          <div className="flex flex-col gap-2 py-3">
+            {sessionCostUsd != null && (
+              <div className="flex items-baseline justify-between gap-3">
+                <SectionLabel>Session cost</SectionLabel>
+                <span
+                  className="font-mono text-xs tabular-nums text-muted-foreground"
+                  data-testid="agent-info-session-cost"
+                >
+                  {formatSessionCostUsd(sessionCostUsd)}
+                </span>
+              </div>
+            )}
+            {usageByModel != null && Object.keys(usageByModel).length > 0 && (
+              <ModelUsageBreakdown usageByModel={usageByModel} />
+            )}
+          </div>
+        )}
       {showRestartWithModel && sessionId && (
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-1.5 py-3">
           <SectionLabel>Model</SectionLabel>
           <Button
             type="button"
@@ -1255,7 +1261,7 @@ export function AgentInfoContent({ agent, sessionId }: AgentInfoProps) {
       <McpServersSection sessionId={sessionId} servers={servers} editable={mcpEditable} />
       {sessionId && <SessionPoliciesSection sessionId={sessionId} />}
       {versionFooter && (
-        <div className="border-t border-border pt-2">
+        <div className="py-3">
           <span
             className="font-mono text-[10px] text-muted-foreground/70"
             data-testid="agent-info-versions"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replaced `gap-3` spacing in the `AgentInfoContent` popover with `divide-y divide-border/50` so each section has a visible horizontal rule between it and the next.
- Each section now has `py-3` padding so there's breathing room on both sides of the divider.
- Merged the **Session cost** and **Token usage** rows into a single section — cost appears as a labeled row above the expandable token breakdown.

## Test Plan

Open any agent (e.g. Polly) with an active session, click the info button, and confirm:
- A subtle divider line appears between every section (Session ID, Session cost / Token usage, Policies, etc.).
- Session cost and token usage collapse into one visual group.
- The version footer at the bottom still has a separator above it.

## Demo

<img width="316" height="512" alt="image" src="https://github.com/user-attachments/assets/b3e5923f-234d-4bb9-999c-bfda58abfe06" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Pure visual/layout change; no logic altered. Existing snapshot / e2e tests that assert section content still pass.

## Changelog

Agent info panel now shows a subtle divider between each section, making it easier to scan session details at a glance.