### PR TITLE
fix(inbox): only surface comments from other people in the inbox

### DIFF
--- a/tests/e2e_ui/comments/test_comment_inbox.py
+++ b/tests/e2e_ui/comments/test_comment_inbox.py
@@ -169,3 +169,74 @@ def test_comment_surfaces_in_inbox_until_opened_in_file_browser(
     expect(page.get_by_text("Nothing waiting on you")).to_be_visible(timeout=15_000)
     expect(page.locator('[data-testid="inbox-comment"]')).to_have_count(0)
     expect(page.get_by_label("1 inbox item waiting")).to_have_count(0)
+
+
+@pytest.fixture
+def self_commented_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed a file plus one comment authored by the viewer themselves.
+
+    Unlike :func:`alice_commented_session`, the comment POST carries no
+    ``X-Forwarded-Email`` header, so the server records it as the
+    ``local`` identity — stored with ``created_by = null``, exactly like a
+    single-user deployment or a private session the viewer owns. The inbox
+    should never surface such a comment: it only lists comments an
+    identifiable *other* person left.
+
+    :param seeded_session: Base fixture providing a runner-bound
+        ``(base_url, session_id)`` pair.
+    :returns: ``(base_url, session_id, comment_id)``.
+    """
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_FILE_PATH}"
+    )
+    httpx.put(
+        file_url,
+        json={"content": _FILE_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    ).raise_for_status()
+
+    start = _FILE_CONTENT.find(_ANCHOR_TEXT)
+    assert start != -1, "fixture bug: anchor text missing from file content"
+    # No X-Forwarded-Email: the "local" owner authors the comment, so the
+    # server stores created_by = null (attribution_user drops the sentinel).
+    comment_resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/comments",
+        json={
+            "path": _FILE_PATH,
+            "body": _COMMENT_BODY,
+            "start_index": start,
+            "end_index": start + len(_ANCHOR_TEXT),
+            "anchor_content": _ANCHOR_TEXT,
+        },
+        timeout=10.0,
+    )
+    comment_resp.raise_for_status()
+    yield (base_url, session_id, comment_resp.json()["id"])
+
+
+def test_own_comment_never_surfaces_in_inbox(
+    page: Page,
+    self_commented_session: tuple[str, str, str],
+) -> None:
+    """A comment the viewer authored themselves stays out of the inbox.
+
+    The inbox is "comments other people left you". A comment stored with
+    ``created_by = null`` (single-user / private session) is your own, so
+    it must never list — even though the session reports ``comments_count
+    > 0`` and the draft is unseen. Guards the ``collectCommentInboxItems``
+    author filter against regressing to showing self-authored comments.
+    """
+    base_url, _session_id, _comment_id = self_commented_session
+
+    page.goto(f"{base_url}/inbox")
+
+    # The empty state must render and no comment card may appear, despite
+    # the session carrying an unseen draft comment. A visible card here
+    # means the author filter regressed (self / unauthored comments leak).
+    expect(page.get_by_text("Nothing waiting on you")).to_be_visible(timeout=15_000)
+    expect(page.locator('[data-testid="inbox-comment"]')).to_have_count(0)
+    expect(page.get_by_label("1 inbox item waiting")).to_have_count(0)

--- a/web/src/lib/inbox.test.ts
+++ b/web/src/lib/inbox.test.ts
@@ -188,25 +188,47 @@ describe("collectCommentInboxItems", () => {
     expect(items.map((i) => i.comment.id)).toEqual(["c_other"]);
   });
 
-  it("keeps anonymous comments and all comments for an anonymous viewer", () => {
-    // Single-user mode: created_by and the viewer id are both null —
-    // a null/null match must NOT exclude everything, or the inbox is
-    // permanently empty in single-user deployments.
+  it("excludes unauthored comments — nothing to show as someone else's", () => {
+    // A null author means single-user mode or a legacy pre-attribution
+    // comment. The inbox only surfaces comments an identifiable *other*
+    // person left, so an unauthored comment never qualifies — regardless
+    // of whether the viewer is known. This is what keeps a private /
+    // single-user session's inbox empty instead of echoing your own
+    // comments back at you.
     const anonymous = makeComment({ id: "c_anon", created_by: null });
     const fromNull = collectCommentInboxItems(
       [{ row: makeRow({ id: "conv_a" }), comments: [anonymous] }],
       new Set(),
       null,
     );
-    expect(fromNull.map((i) => i.comment.id)).toEqual(["c_anon"]);
+    expect(fromNull).toEqual([]);
 
-    // A known viewer still sees anonymous comments (they can't be hers).
     const fromKnown = collectCommentInboxItems(
       [{ row: makeRow({ id: "conv_a" }), comments: [anonymous] }],
       new Set(),
       "alice@example.com",
     );
-    expect(fromKnown.map((i) => i.comment.id)).toEqual(["c_anon"]);
+    expect(fromKnown).toEqual([]);
+  });
+
+  it("shows another user's comment on a shared session, hides your own", () => {
+    // A comment can only carry another user's `created_by` if they had
+    // access — so an other-authored comment implies the session is shared.
+    // Your own comment on the same shared session stays out of the inbox.
+    const items = collectCommentInboxItems(
+      [
+        {
+          row: makeRow({ id: "conv_shared" }),
+          comments: [
+            makeComment({ id: "c_mine", created_by: "alice@example.com" }),
+            makeComment({ id: "c_theirs", created_by: "bob@example.com" }),
+          ],
+        },
+      ],
+      new Set(),
+      "alice@example.com",
+    );
+    expect(items.map((i) => i.comment.id)).toEqual(["c_theirs"]);
   });
 
   it("sorts newest first, tie-breaking same-second comments on updated_at", () => {

--- a/web/src/lib/inbox.ts
+++ b/web/src/lib/inbox.ts
@@ -83,10 +83,17 @@ export interface CommentInboxSource {
  *
  * - Addressed comments are excluded — they were resolved before the
  *   viewer got to them, so there's nothing left to look at.
- * - The viewer's own comments are excluded when authorship is known
- *   (`viewerId` non-null and matching `created_by`); you don't need
- *   an inbox prompt for a comment you just wrote. In single-user
- *   mode both sides are null/anonymous and nothing is excluded.
+ * - Only comments an identifiable *other* person left qualify: the inbox
+ *   surfaces "comments other people left you", so a comment must have a
+ *   `created_by` that isn't the viewer. This means a private / unshared
+ *   session — where every comment is your own — contributes nothing, and
+ *   single-user deployments (all comments unauthored) show an empty inbox
+ *   rather than echoing your own comments back at you. A comment can only
+ *   carry another user's `created_by` if that user had access, so this
+ *   doubles as the "session is shared with someone" check without needing
+ *   the grant list. Unauthored comments (single-user, or legacy
+ *   pre-attribution) are dropped for the same reason — they can't be shown
+ *   as someone else's.
  */
 export function collectCommentInboxItems(
   sources: CommentInboxSource[],
@@ -98,7 +105,8 @@ export function collectCommentInboxItems(
     for (const comment of comments) {
       if (comment.status !== "draft") continue;
       if (seenIds.has(comment.id)) continue;
-      if (viewerId !== null && comment.created_by === viewerId) continue;
+      if (comment.created_by === null) continue;
+      if (comment.created_by === viewerId) continue;
       items.push({ row, comment });
     }
   }


### PR DESCRIPTION
## Related issue

N/A

## Summary

The comment side of the inbox was echoing your own comments back at you. The filter only excluded a comment when authorship was known (`viewerId` non-null **and** matching `created_by`), so:

- **Single-user deployments** — where every comment is stored with `created_by = null` (`attribution_user` maps the `"local"` sentinel to `None`) — kept showing all of your own comments.
- A **private session you own** contributed comments that were only ever your own.

This tightens the rule to what the inbox is actually for: a comment appears **only if an identifiable *other* person wrote it** (`created_by` is non-null and isn't the viewer). Because a comment can only carry another user's `created_by` if that user had access, this also implies "the session is shared with that person" — no grant-list lookup needed.

**Resulting behaviour:**

| Session state | Comments present | In inbox? |
|---|---|---|
| Single-user mode | all `created_by: null` | none |
| Private session you own, not shared | only your own | none |
| Shared with others | yours + theirs | only theirs |

ELI5: the inbox is "comments other people left you." It was mistakenly including comments you left yourself; now it only shows other people's.

## Test Plan

- `cd web && npm test` — full vitest suite green (3419 passed).
- `cd web && npm run build` — `tsc -b && vite build` clean.
- `cd web && npm run lint` — no new issues in changed files.
- Updated `web/src/lib/inbox.test.ts`:
  - unauthored comments are now excluded for both a null and a known viewer;
  - a shared session shows another user's comment while hiding your own.
- Ran Isaac Review (`/review`) on the diff — no findings.

## Demo

N/A — this is a filter-logic change with no new visual surface; the effect is an empty comment inbox in single-user/private sessions and unchanged rendering otherwise. Covered by unit tests.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The behaviour lives in the pure `collectCommentInboxItems` helper, covered directly by unit tests in `web/src/lib/inbox.test.ts` (unauthored-excluded, own-excluded, other's-shown). Manual verification: ran the full web test suite and production build locally; both green. The sidebar Inbox badge and the Inbox page both consume the same `useCommentInbox` hook, so their counts stay consistent.

## Changelog

Fixed: The inbox no longer shows comments you wrote yourself — only comments left by other people on shared sessions appear.

This pull request and its description were written by Isaac.