### PR TITLE
feat(editors): VS Code extension release + publishing workflows

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -1,0 +1,102 @@
+# Build the VS Code extension and attach a SHA256-verified `.vsix` to a DRAFT
+# GitHub release. Triggered manually (workflow_dispatch), typically after a
+# "Release (vscode): vX.Y.Z" PR (from vscode-release-pr.yml) has merged. The
+# release version comes from `editors/vscode/package.json` — never typed by
+# hand here — so the tag and the packaged version can't diverge. A human
+# reviews the draft and clicks publish.
+#
+# This produces the ARTIFACT ONLY — it does NOT publish to the VS Code
+# Marketplace or Open VSX. That runs from the central secure-release repo
+# (databricks/secure-public-registry-releases-eng), on hardened runners, where
+# a workflow downloads this `.vsix`, verifies its `.sha256`, scans it, and
+# publishes. Keeping the two halves separate is deliberate: this job only
+# builds and uploads; the secured half holds the marketplace tokens and scan
+# gate.
+#
+# The release/tag is named `vscode-v<version>`, a dedicated namespace kept
+# separate from the Python release tags (`v[0-9]*`) consumed by
+# github-release.yml.
+name: VS Code Extension Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch/tag/SHA to build from (default: the merged release commit on the default branch)."
+        required: false
+        type: string
+
+# Least privilege: creating a release + tag requires `contents: write`.
+permissions:
+  contents: write
+
+defaults:
+  run:
+    working-directory: editors/vscode
+
+jobs:
+  build-and-release:
+    # Inert in forks / mirrors — only the canonical repo cuts releases.
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Install, build, and package
+        run: |
+          npm ci
+          npm run build
+          npm run package
+
+      - name: Resolve version and tag from package.json
+        id: meta
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=vscode-v$version" >> "$GITHUB_OUTPUT"
+          # Target the commit we actually built (inputs.ref may differ from the
+          # dispatch ref, so $GITHUB_SHA is not necessarily the built commit).
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Building vscode-v$version" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Compute SHA256 checksum
+        run: |
+          vsix=$(ls omnigent-vscode-*.vsix)
+          sha256sum "$vsix" > "$vsix.sha256"
+          echo "Built $vsix" | tee -a "$GITHUB_STEP_SUMMARY"
+          cat "$vsix.sha256" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish draft GitHub release with the .vsix + checksum
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          # rc / dev / alpha / beta versions are flagged as pre-releases.
+          pre=""
+          case "$TAG" in
+            *rc*|*dev*|*a[0-9]*|*b[0-9]*) pre="--prerelease" ;;
+          esac
+          # Rerun-safe: upload assets to an existing release, else create a draft
+          # one (which creates the vscode-v<version> tag on the built commit).
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" omnigent-vscode-*.vsix omnigent-vscode-*.vsix.sha256 \
+              --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            # $pre word-splits to nothing when empty; only ever "" or "--prerelease".
+            gh release create "$TAG" omnigent-vscode-*.vsix omnigent-vscode-*.vsix.sha256 \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --target "${{ steps.meta.outputs.sha }}" \
+              --title "VS Code extension $TAG" \
+              --notes "Omnigent VS Code extension \`$TAG\`. Marketplace / Open VSX publishing runs from the secure-release repo, which downloads and SHA256-verifies the attached \`.vsix\`." \
+              $pre
+          fi
+          echo "Drafted release $TAG with the .vsix + .sha256 — review and publish it from the Releases page." \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -78,25 +78,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          # rc / dev / alpha / beta versions are flagged as pre-releases.
-          pre=""
-          case "$TAG" in
-            *rc*|*dev*|*a[0-9]*|*b[0-9]*) pre="--prerelease" ;;
-          esac
           # Rerun-safe: upload assets to an existing release, else create a draft
           # one (which creates the vscode-v<version> tag on the built commit).
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release upload "$TAG" omnigent-vscode-*.vsix omnigent-vscode-*.vsix.sha256 \
               --repo "$GITHUB_REPOSITORY" --clobber
           else
-            # $pre word-splits to nothing when empty; only ever "" or "--prerelease".
             gh release create "$TAG" omnigent-vscode-*.vsix omnigent-vscode-*.vsix.sha256 \
               --repo "$GITHUB_REPOSITORY" \
               --draft \
               --target "${{ steps.meta.outputs.sha }}" \
               --title "VS Code extension $TAG" \
-              --notes "Omnigent VS Code extension \`$TAG\`. Marketplace / Open VSX publishing runs from the secure-release repo, which downloads and SHA256-verifies the attached \`.vsix\`." \
-              $pre
+              --notes "Omnigent VS Code extension \`$TAG\`. Marketplace / Open VSX publishing runs from the secure-release repo, which downloads and SHA256-verifies the attached \`.vsix\`."
           fi
           echo "Drafted release $TAG with the .vsix + .sha256 — review and publish it from the Releases page." \
             | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vscode-release-pr.yml
+++ b/.github/workflows/vscode-release-pr.yml
@@ -51,9 +51,13 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          # Semver X.Y.Z with an optional prerelease suffix (rc1, dev0, …).
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-]?[a-z]+[0-9]*)?$ ]]; then
-            echo "::error::Version '$VERSION' is not a valid X.Y.Z[suffix]."
+          # Strict X.Y.Z only. VS Code Marketplace versions are numeric
+          # major.minor.patch — `vsce package` rejects prerelease suffixes
+          # (pre-releases use the --pre-release flag, not a version suffix), so
+          # accepting a suffix here would produce a version bump that later
+          # fails at package time.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '$VERSION' is not a valid X.Y.Z."
             exit 1
           fi
 

--- a/.github/workflows/vscode-release-pr.yml
+++ b/.github/workflows/vscode-release-pr.yml
@@ -1,0 +1,119 @@
+# Open a "Release (vscode): vX.Y.Z" PR that bumps the extension version and
+# rolls the CHANGELOG. This is step 1 of the two-step release: a human reviews
+# and merges this PR, then dispatches `vscode-extension-release.yml` to build
+# the `.vsix` and cut the draft GitHub release. Doing the version bump through a
+# reviewed PR keeps `package.json` and the tag from ever diverging (the tag is
+# derived from the merged `package.json`, never typed by hand).
+name: VS Code Extension Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Extension release version, e.g. 0.2.0 (no leading v)."
+        required: true
+        type: string
+
+# Opening a PR needs contents + pull-requests write.
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    working-directory: editors/vscode
+
+jobs:
+  release-pr:
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Only repo collaborators (write or higher) may cut a release. This is a
+      # sanity gate on top of GitHub's Actions-write dispatch permission; the
+      # real ship gate is PR review on merge and the secure repo's own checks.
+      - name: Check actor
+        # Runs before checkout, so the default editors/vscode workdir does not
+        # exist yet — run from the workspace root.
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          role=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR}/permission" --jq '.role_name')
+          if [[ "$role" != "admin" && "$role" != "maintain" && "$role" != "write" ]]; then
+            echo "::error::Actor '${GITHUB_ACTOR}' has '${role}' role, but 'write' or higher is required."
+            exit 1
+          fi
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Semver X.Y.Z with an optional prerelease suffix (rc1, dev0, …).
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-]?[a-z]+[0-9]*)?$ ]]; then
+            echo "::error::Version '$VERSION' is not a valid X.Y.Z[suffix]."
+            exit 1
+          fi
+
+      - name: Bump package.json version
+        env:
+          VERSION: ${{ inputs.version }}
+        # `npm pkg set` edits ONLY package.json (unlike `npm version`, which also
+        # rewrites package-lock.json). Keeps the release PR to package.json +
+        # CHANGELOG.md.
+        run: npm pkg set version="$VERSION"
+
+      - name: Add the CHANGELOG section
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Insert a fresh "## [<version>]" section above the newest existing
+          # version heading. Skip if that version already has a section. The
+          # reviewer fills in the bullet points on the release PR.
+          python3 - "$VERSION" <<'PY'
+          import sys, re, pathlib
+          version = sys.argv[1]
+          p = pathlib.Path("CHANGELOG.md")
+          text = p.read_text()
+          if f"## [{version}]" in text:
+              print(f"CHANGELOG already has a [{version}] section — leaving as-is.")
+              sys.exit(0)
+          m = re.search(r"^## \[", text, re.MULTILINE)
+          section = f"## [{version}]\n\n- _Describe changes here._\n\n"
+          if m:
+              text = text[:m.start()] + section + text[m.start():]
+          else:
+              text = text.rstrip("\n") + "\n\n" + section
+          p.write_text(text)
+          print(f"Added CHANGELOG section for {version}")
+          PY
+          head -20 CHANGELOG.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create the release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="release/vscode-v$VERSION"
+          git checkout -b "$BRANCH"
+          # Paths are relative to editors/vscode (the step's working dir), so
+          # only the extension's own files are ever staged.
+          git add package.json CHANGELOG.md
+          # Guard: the release PR must never touch anything outside
+          # editors/vscode (e.g. web/, lockfiles). Fail loudly if it does.
+          if git diff --cached --name-only | grep -qv '^editors/vscode/'; then
+            echo "::error::Release PR staged files outside editors/vscode:"
+            git diff --cached --name-only | grep -v '^editors/vscode/'
+            exit 1
+          fi
+          git commit -m "Release (vscode): v$VERSION"
+          git push --force-with-lease origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release (vscode): v$VERSION" \
+            --body "Bumps the Omnigent VS Code extension to \`v$VERSION\` and adds its CHANGELOG section (fill in the changes before merging). After merge, run the **VS Code Extension Release** workflow to build the \`.vsix\` and cut the draft release. See \`docs/vscode-extension-publishing.md\`."

--- a/.github/workflows/vscode-release-pr.yml
+++ b/.github/workflows/vscode-release-pr.yml
@@ -116,4 +116,4 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "Release (vscode): v$VERSION" \
-            --body "Bumps the Omnigent VS Code extension to \`v$VERSION\` and adds its CHANGELOG section (fill in the changes before merging). After merge, run the **VS Code Extension Release** workflow to build the \`.vsix\` and cut the draft release. See \`docs/vscode-extension-publishing.md\`."
+            --body "Bumps the Omnigent VS Code extension to \`v$VERSION\` and adds its CHANGELOG section (fill in the changes before merging). After merge, run the **VS Code Extension Release** workflow to build the \`.vsix\` and cut the draft release. See \`editors/vscode/PUBLISHING.md\`."

--- a/docs/vscode-extension-publishing.md
+++ b/docs/vscode-extension-publishing.md
@@ -1,0 +1,90 @@
+# Publishing the Omnigent VS Code extension
+
+The extension lives in [`editors/vscode`](../editors/vscode). It is published
+under the shared **`databricks`** VS Code Marketplace publisher (and the
+`databricks` Open VSX namespace), which means releases flow through the
+Databricks security-hardened release path — direct publishing from this repo is
+blocked by policy.
+
+The work splits into two halves:
+
+- **This repo** builds a SHA256-verified `.vsix` and attaches it to a GitHub
+release. No marketplace tokens live here.
+- **The secure-release repo**
+([`databricks/secure-public-registry-releases-eng`](https://github.com/databricks/secure-public-registry-releases-eng))
+downloads that `.vsix`, verifies the checksum, scans it (`databricks/gh-action-scan`),
+and publishes to the VS Code Marketplace and Open VSX. It holds the tokens and
+the approval gate.
+
+Two existing workflows in the secure repo are the reference:
+[`databricks-vscode.yml`](https://github.com/databricks/secure-public-registry-releases-eng/blob/main/.github/workflows/databricks-vscode.yml)
+(the extension publish flow to adapt) and
+[`omnigent.yml`](https://github.com/databricks/secure-public-registry-releases-eng/blob/main/.github/workflows/omnigent.yml)
+(omnigent's PyPI release, which already checks out `omnigent-ai/omnigent`
+cross-org). Both require SAML SSO to view.
+
+## Steps to release
+
+No tags are pushed by hand — the version flows from a reviewed PR into the
+`.vsix` and the release tag, so they can't diverge.
+
+1. **Open the release PR.** Run the **VS Code Extension Release PR** workflow
+   (`vscode-release-pr.yml`) with the target version (e.g. `0.2.0`). It bumps
+   `editors/vscode/package.json`, adds a `CHANGELOG.md` section, and opens a
+   `Release (vscode): v0.2.0` PR. Review and merge it.
+2. **Build the draft release.** Run the **VS Code Extension Release** workflow
+   (`vscode-extension-release.yml`). It reads the version from `package.json`,
+   builds the `.vsix`, attaches it and its `.sha256`, and creates a **draft**
+   `vscode-v<version>` release (a dedicated tag namespace kept separate from the
+   Python release tags `v[0-9]*`).
+3. **Publish the draft.** The workflow leaves the release as a draft: it is not
+   public and the `vscode-v<version>` git tag is not created until you publish.
+   On GitHub, open the repo's **Releases** page, find the draft, confirm the
+   attached `.vsix` + `.sha256` and the notes look right, then click **Publish
+   release**. Publishing creates the tag and makes the release downloadable by
+   the secure-repo workflow.
+4. **Publish to the marketplaces.** Dispatch `omnigent-vscode.yml` in the
+   secure-release repo (once it exists), pointing at the `vscode-v<version>`
+   tag; run with `dry-run: true` first, then publish for real.
+
+The one-time setup that makes this possible is tracked below.
+
+## Setup (one-time)
+
+
+| #   | Step                                                                                                                                                                                                                                                                                                                                           | Where                                                                                                                                                                       | Blocked on          |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| 1   | Set `"publisher": "databricks"` in `package.json`                                                                                                                                                                                                                                                                                              | `editors/vscode`                                                                                                                                                            | — (done)            |
+| 2   | Maintain `CHANGELOG.md` (strip Jira refs, keep GH issue refs)                                                                                                                                                                                                                                                                                  | `editors/vscode`                                                                                                                                                            | — (done)            |
+| 3   | Verify the build: `npm ci && npm run build && npm run package` → valid `.vsix`                                                                                                                                                                                                                                                                 | local / CI                                                                                                                                                                  | — (done)            |
+| 4   | Release-PR workflow bumps version + CHANGELOG; a manually-dispatched release workflow builds the `.vsix` and attaches it (+`.sha256`) to a draft GitHub release                                                                                                                                                                                | `.github/workflows/vscode-release-pr.yml`, `vscode-extension-release.yml`                                                                                                   | — (done)            |
+| 5   | Ask DECO to register `omnigent-vscode` under the `databricks` publisher + issue a Marketplace PAT                                                                                                                                                                                                                                              | Slack `#dev-ecosystem-discuss` ([https://databricks.slack.com/archives/C01KSAWFXG8/p1782971196701749](https://databricks.slack.com/archives/C01KSAWFXG8/p1782971196701749)) | human approval      |
+| 6   | Add an `omnigent-vscode.yml` publish workflow in the secure repo, adapting the existing [`databricks-vscode.yml`](https://github.com/databricks/secure-public-registry-releases-eng/blob/main/.github/workflows/databricks-vscode.yml) (SAML SSO required) — it already does download → scan → `vsce publish` + `ovsx publish` in one workflow | `secure-public-registry-releases-eng`                                                                                                                                       | DECO grant (step 5) |
+| 7   | Confirm `VSCE_TOKEN` + `OVSX_PAT` cover the omnigent publisher (the `databricks-vscode-marketplace` environment already holds them); register rows in `go/npp-release-status`; get sign-off in `#unblock-releases-public`                                                                                                                      | secure repo + Slack                                                                                                                                                         | steps 5–6           |
+
+
+Steps 1–4 are complete in this repo. Steps 5–7 need the DECO grant and the
+secure-repo reference workflow.
+
+## Notes for the secure-repo workflow
+
+- `databricks-vscode.yml` downloads the `.vsix` from the release with
+`gh release download -R databricks/databricks-vscode`. The omnigent variant
+must point `-R` at `omnigent-ai/omnigent` and relax the filename check (it
+hard-codes `databricks-*-${VERSION}.vsix`; ours is `omnigent-vscode-*.vsix`).
+- We author `omnigent-vscode.yml` ourselves — it's our own pipeline, not a fork
+of `databricks-vscode.yml`, so we just write it to expect our `vscode-v*`
+tags. `databricks-vscode.yml` is only a structural template; its
+`Validate tag format` step hard-codes `^release-v([0-9]+\.[0-9]+\.[0-9]+)$`,
+which is *their* convention — when copying that step, change the regex to
+match `vscode-v*`. The only thing that must agree is our two ends
+(`vscode-extension-release.yml` and `omnigent-vscode.yml`), and we control
+both.
+- Cross-org fetch from the public `omnigent-ai/omnigent` repo is already an
+accepted pattern — `omnigent.yml` checks out `omnigent-ai/omnigent` for the
+PyPI release. So reading a public omnigent release from the hardened runner is
+not a new blocker.
+- Marketplace publish binds the `databricks-vscode-marketplace` environment and
+reads `VSCE_TOKEN` / `OVSX_PAT`. A new omnigent flow either reuses that
+environment or gets its own (confirm with DECO which, per step 7).
+

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the Omnigent VS Code extension are documented here.
+
+## [0.1.0]
+
+Initial release — a minimal, iframe-only client for a locally running Omnigent
+server.
+
+- Open a running local Omnigent server in an editor-beside panel.
+- **Omnigent: Open** command, available from the editor-title bar and the
+command palette, plus an activity-bar view with an "Open Omnigent" button.
+- Automatically discovers a local server via `~/.omnigent/local_server.pid`, or
+point the extension at one with the `omnigent.serverUrl` setting. Localhost
+servers only in this build.
+

--- a/editors/vscode/PUBLISHING.md
+++ b/editors/vscode/PUBLISHING.md
@@ -52,9 +52,11 @@ No tags are pushed by hand — the version flows from a reviewed PR into the
    code --install-extension omnigent-vscode-<version>.vsix
    ```
 
-   Reload VS Code, start a local server (`omnigent server`), and check that
-   **Omnigent: Open** frames it. This catches packaging problems (missing files,
-   a broken bundle) before anything reaches the marketplaces.
+   Reload VS Code, start a local server (`omnigent server`), and run the
+   **Omnigent: Open** command — confirm it opens an editor pane showing the
+   running server's UI (not a blank pane or an error). This catches packaging
+   problems (missing files, a broken bundle) before anything reaches the
+   marketplaces.
 5. **Publish to the marketplaces.** Dispatch `omnigent-vscode.yml` in the
    secure-release repo (once it exists), pointing at the `vscode-v<version>`
    tag; run with `dry-run: true` first, then publish for real.

--- a/editors/vscode/PUBLISHING.md
+++ b/editors/vscode/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Publishing the Omnigent VS Code extension
 
-The extension lives in [`editors/vscode`](../editors/vscode). It is published
+This directory holds the Omnigent VS Code extension. It is published
 under the shared **`databricks`** VS Code Marketplace publisher (and the
 `databricks` Open VSX namespace), which means releases flow through the
 Databricks security-hardened release path — direct publishing from this repo is

--- a/editors/vscode/PUBLISHING.md
+++ b/editors/vscode/PUBLISHING.md
@@ -43,7 +43,19 @@ No tags are pushed by hand — the version flows from a reviewed PR into the
    attached `.vsix` + `.sha256` and the notes look right, then click **Publish
    release**. Publishing creates the tag and makes the release downloadable by
    the secure-repo workflow.
-4. **Publish to the marketplaces.** Dispatch `omnigent-vscode.yml` in the
+4. **Smoke-test the `.vsix` locally.** Download the `.vsix` from the published
+   release and install it into a clean VS Code, then confirm the extension
+   activates and opens a local server:
+
+   ```bash
+   gh release download vscode-v<version> --repo omnigent-ai/omnigent --pattern '*.vsix'
+   code --install-extension omnigent-vscode-<version>.vsix
+   ```
+
+   Reload VS Code, start a local server (`omnigent server`), and check that
+   **Omnigent: Open** frames it. This catches packaging problems (missing files,
+   a broken bundle) before anything reaches the marketplaces.
+5. **Publish to the marketplaces.** Dispatch `omnigent-vscode.yml` in the
    secure-release repo (once it exists), pointing at the `vscode-v<version>`
    tag; run with `dry-run: true` first, then publish for real.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Omnigent",
   "description": "Open your running local Omnigent server inside VS Code, in an editor-beside iframe.",
   "version": "0.1.0",
-  "publisher": "omnigent-ai",
+  "publisher": "databricks",
   "license": "Apache-2.0",
   "icon": "media/omnigent-icon.png",
   "repository": {


### PR DESCRIPTION
## Related issue

N/A

## Summary

Sets up the release + publishing path for the `omnigent-vscode` extension (`editors/vscode`). Because the extension publishes under the shared **`databricks`** Marketplace publisher, releases must flow through the security-hardened secure-release repo. This repo only builds a SHA256-verified `.vsix` and attaches it to a draft GitHub release; the actual `vsce`/`ovsx publish` runs from `databricks/secure-public-registry-releases-eng`.

- **`vscode-release-pr.yml`** — manually-dispatched; opens a reviewed version-bump + CHANGELOG PR (write-or-higher actor check). Uses `npm pkg set` so only `package.json` is touched, and hard-fails if anything outside `editors/vscode` is staged.
- **`vscode-extension-release.yml`** — manually-dispatched; builds the `.vsix` + `.sha256` and cuts a **draft** `vscode-v<version>` release (tag namespace kept separate from the Python `v[0-9]*` tags). Targets the actually-built commit.
- **`docs/vscode-extension-publishing.md`** — end-to-end release steps + one-time setup table (what still needs a DECO grant).
- Sets `publisher` to `databricks` and adds the extension's `CHANGELOG.md`.

## Test Plan

- `npm ci && npm run build && npm run package` in `editors/vscode` → valid `omnigent-vscode-0.1.0.vsix`.
- Validated both workflow YAMLs parse; `pre-commit run --files` clean on all changed files.
- Unit-tested the CHANGELOG-insertion Python locally (fresh section inserted above newest version heading; idempotent on re-run).

## Demo

N/A — CI workflows + docs, no runtime UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Release/publish workflows can't be meaningfully unit-tested in CI. Verified manually: the extension builds and packages cleanly, both workflows parse, and the CHANGELOG-insertion script was tested locally for the insert and idempotent-re-run cases.
