### PR TITLE
fix null tools parser fields

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -363,10 +363,12 @@ def _parse_tools_config(
         return ToolsConfig()
     timeout = int(raw["timeout"]) if "timeout" in raw else 60
     retry = _parse_retry(raw.get("retry"))
-    builtins = _parse_builtin_tools(raw.get("builtins", []))
+    raw_builtins = raw.get("builtins")
+    builtins = _parse_builtin_tools([] if raw_builtins is None else raw_builtins)
+    agents = raw.get("agents")
     sandbox = _parse_sandbox_config(raw.get("sandbox"))
     return ToolsConfig(
-        agents=raw.get("agents", []),
+        agents=[] if agents is None else agents,
         builtins=builtins,
         timeout=timeout,
         retry=retry,

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -2011,6 +2011,48 @@ def test_parse_tools_global_timeout_and_retry(tmp_path: Path) -> None:
     assert spec.tools.retry.max_retries == 4
 
 
+def test_parse_tools_null_builtins_as_empty_list(tmp_path: Path) -> None:
+    """``tools.builtins: null`` matches omitted builtins."""
+    config = {"spec_version": 1, "tools": {"builtins": None}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+
+    assert spec.tools.builtins == []
+
+
+def test_parse_tools_null_agents_as_empty_list(tmp_path: Path) -> None:
+    """``tools.agents: null`` matches omitted agents."""
+    config = {"spec_version": 1, "tools": {"agents": None}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+
+    assert spec.tools.agents == []
+
+
+def test_parse_tools_valid_builtins_and_agents_unchanged(tmp_path: Path) -> None:
+    """Valid builtins and agents keep their configured values."""
+    config = {
+        "spec_version": 1,
+        "tools": {
+            "agents": ["researcher", "critic"],
+            "builtins": [
+                "web_search",
+                {"name": "web_search_cfg", "api_key": "pplx-test"},
+            ],
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+
+    assert spec.tools.agents == ["researcher", "critic"]
+    assert [builtin.name for builtin in spec.tools.builtins] == [
+        "web_search",
+        "web_search_cfg",
+    ]
+    assert spec.tools.builtins[0].config == {}
+    assert spec.tools.builtins[1].config == {"api_key": "pplx-test"}
+
+
 def test_parse_builtins_string_entries(tmp_path: Path) -> None:
     """Plain string entries in tools.builtins produce BuiltinToolConfig
     with empty config dicts."""


### PR DESCRIPTION
## Related issue

Alternative implementation for the parser bug covered by #1805.

## Summary

- Root cause: explicit YAML `null` bypassed the parser defaults for `tools.builtins` and `tools.agents`. `tools.builtins: null` reached `_parse_builtin_tools(None)` and crashed, while `tools.agents: null` stored `None` on the parsed spec.
- Fix: normalize only `None` for those two fields to `[]`, matching omitted fields without changing valid configured lists or other invalid falsey values.
- Added regression coverage for null builtins, null agents, and existing valid builtins/agents behavior.

## Test Plan

- `uv run python -m pytest tests/spec/test_parser.py -q`
- `uv run python -m pytest tests/spec -q`

## Demo

Non-UI parser behavior covered by regression tests:

```yaml
spec_version: 1
tools:
  builtins: null
  agents: null
```

Now parses as:

```python
spec.tools.builtins == []
spec.tools.agents == []
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Parser/spec unit tests cover the changed behavior and the unchanged valid builtins/agents path.

## Changelog

Fixed: Treat `tools.builtins: null` and `tools.agents: null` as empty lists in agent specs.
