### PR TITLE
feat(providers): recognize Eden AI as an OpenAI-compatible gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ and a key. The base URL depends on which agent you point it at:
 |---|---|---|---|
 | **OpenRouter** | Claude Code | `https://openrouter.ai/api` | your OpenRouter key (`sk-or-…`) |
 | **OpenRouter** | Codex / OpenAI agents | `https://openrouter.ai/api/v1` | your OpenRouter key (`sk-or-…`) |
+| **Eden AI** | Codex / OpenAI agents | `https://api.edenai.run/v3` | your Eden AI key (`EDENAI_API_KEY`) |
 | **Ollama** (local) | Codex / OpenAI agents | `http://localhost:11434/v1` | any value (Ollama ignores it) |
 
 For Claude Code, point at OpenRouter's Anthropic-compatible endpoint

--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -55,6 +55,7 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
         "deepseek": "https://api.deepseek.com/v1",
         "xai": "https://api.x.ai/v1",
         "openrouter": "https://openrouter.ai/api/v1",
+        "edenai": "https://api.edenai.run/v3",
         "ollama": "http://localhost:11434/v1",
         "moonshot": "https://api.moonshot.cn/v1",
     }

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -27,6 +27,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "deepseek": "https://api.deepseek.com/v1",
     "xai": "https://api.x.ai/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "edenai": "https://api.edenai.run/v3",
     "ollama": "http://localhost:11434/v1",
     "moonshot": "https://api.moonshot.cn/v1",
 }

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -82,6 +82,7 @@ _ENV_KEY_FAMILY: dict[str, str | None] = {
     "anthropic": ANTHROPIC_FAMILY,
     "openai": OPENAI_FAMILY,
     "openrouter": OPENAI_FAMILY,
+    "edenai": OPENAI_FAMILY,
     "gemini": GEMINI_FAMILY,
 }
 

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -154,6 +154,7 @@ _CATALOG_PROVIDER_FAMILY: dict[str, str] = {
     # SDK directly with a GEMINI_API_KEY).
     "gemini": GEMINI_FAMILY,
     "openrouter": OPENAI_FAMILY,
+    "edenai": OPENAI_FAMILY,
     "groq": OPENAI_FAMILY,
     "deepseek": OPENAI_FAMILY,
     "xai": OPENAI_FAMILY,
@@ -244,6 +245,7 @@ _PROVIDER_DISPLAY_NAME: dict[str, str] = {
     "openai": "OpenAI",
     "anthropic": "Anthropic",
     "openrouter": "OpenRouter",
+    "edenai": "Eden AI",
     "groq": "Groq",
     "deepseek": "DeepSeek",
     "xai": "xAI",

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -189,6 +189,7 @@ class _VendorEndpoint:
 # :func:`default_base_url_for_family` (and openai keeps the Responses default).
 _KEY_PROVIDER_ENDPOINT: dict[str, _VendorEndpoint] = {
     "openrouter": _VendorEndpoint("https://openrouter.ai/api/v1", CHAT_WIRE_API),
+    "edenai": _VendorEndpoint("https://api.edenai.run/v3", CHAT_WIRE_API),
     "groq": _VendorEndpoint("https://api.groq.com/openai/v1", CHAT_WIRE_API),
     "deepseek": _VendorEndpoint("https://api.deepseek.com", CHAT_WIRE_API),
     "xai": _VendorEndpoint("https://api.x.ai/v1", CHAT_WIRE_API),
@@ -392,7 +393,13 @@ class AddOption:
 # surface, a distinct family), so it must be excluded here too — otherwise it
 # leaks into the openai-family "Other provider" catch-all, whose tail is
 # documented as "all openai-family" (see :func:`_add_option_families`).
-_PRESET_KEY_PROVIDERS: tuple[str, ...] = ("openai", "anthropic", "openrouter", "gemini")
+_PRESET_KEY_PROVIDERS: tuple[str, ...] = (
+    "openai",
+    "anthropic",
+    "openrouter",
+    "edenai",
+    "gemini",
+)
 
 
 def add_menu_options() -> list[AddOption]:
@@ -410,10 +417,10 @@ def add_menu_options() -> list[AddOption]:
         each family-scoped subset (:func:`add_menu_options_for_family`,
         which filters while preserving this order): the first-party API
         key(s) and subscription(s) lead, the cross-vendor extras
-        (Gateway, OpenRouter) follow alphabetically, and Databricks sits
-        just above the catch-all "Other provider" at the bottom. Scoped
+        (Eden AI, Gateway, OpenRouter) follow alphabetically, and Databricks
+        sits just above the catch-all "Other provider" at the bottom. Scoped
         to one family this collapses to: API key → subscription →
-        Gateway [→ OpenRouter] → Databricks [→ Other].
+        Eden AI [→ Gateway] [→ OpenRouter] → Databricks [→ Other].
     """
 
     def _opt(text: str, description: str, kind: str, **kw: object) -> AddOption:
@@ -459,7 +466,13 @@ def add_menu_options() -> list[AddOption]:
             SUBSCRIPTION_KIND,
             cli="claude",
         ),
-        # Cross-vendor extras, alphabetical (Gateway before OpenRouter).
+        # Cross-vendor extras, alphabetical (Eden AI, Gateway, OpenRouter).
+        _opt(
+            "Eden AI — API key",
+            "One key, many models with EU data residency (edenai.co).",
+            KEY_KIND,
+            provider="edenai",
+        ),
         _opt(
             "Gateway — custom base URL + key (e.g. OpenRouter)",
             "An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, OpenRouter, vLLM, …",

--- a/omnigent/onboarding/providers/__init__.py
+++ b/omnigent/onboarding/providers/__init__.py
@@ -283,6 +283,7 @@ COMMON_PROVIDERS: list[str] = [
     "groq",
     "deepseek",
     "openrouter",
+    "edenai",
     "ollama",
     "together_ai",
     "cohere",
@@ -729,6 +730,7 @@ _PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "cerebras": "Cerebras",
     "deepseek": "DeepSeek",
     "openrouter": "OpenRouter",
+    "edenai": "Eden AI",
     "ollama": "Ollama",
 }
 
@@ -759,6 +761,7 @@ PROVIDER_ENV_VARS: dict[str, str] = {
     "deepseek": "DEEPSEEK_API_KEY",
     "xai": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "edenai": "EDENAI_API_KEY",
     "togetherai": "TOGETHERAI_API_KEY",
     "cohere": "COHERE_API_KEY",
     "ai21": "AI21_API_KEY",

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -37,6 +37,13 @@ from omnigent.llms.routing import RoutedModel, infer_harness_from_model, parse_m
             ),
         ),
         (
+            "edenai/mistral/mistral-small-latest",
+            RoutedModel(
+                provider="edenai",
+                model="mistral/mistral-small-latest",
+            ),
+        ),
+        (
             "ollama/llama3",
             RoutedModel(provider="ollama", model="llama3"),
         ),

--- a/tests/onboarding/test_detected.py
+++ b/tests/onboarding/test_detected.py
@@ -95,6 +95,25 @@ def test_synthesize_env_key_openrouter_uses_vendor_endpoint_and_chat_wire() -> N
     assert openai_block["api_key_ref"] == "env:OPENROUTER_API_KEY"
 
 
+def test_synthesize_env_key_edenai_uses_vendor_endpoint_and_chat_wire() -> None:
+    """A detected Eden AI key gets Eden AI's base_url + chat wire.
+
+    Eden AI is OpenAI-compatible but is NOT api.openai.com and only speaks
+    Chat Completions. Failure (defaulting to the openai endpoint or omitting
+    the chat wire) means an ambiently-detected EDENAI_API_KEY 401s against
+    api.openai.com instead of reaching Eden AI.
+    """
+    det = DetectedProvider(
+        name="edenai", kind="key", family=OPENAI_FAMILY, source="$EDENAI_API_KEY"
+    )
+    entries = synthesize_detected_entries([det])
+    openai_block = entries["edenai"]["openai"]
+    assert openai_block["base_url"] == "https://api.edenai.run/v3"
+    # Chat wire is required — Responses would 404 against Eden AI.
+    assert openai_block["wire_api"] == "chat"
+    assert openai_block["api_key_ref"] == "env:EDENAI_API_KEY"
+
+
 def test_synthesize_env_key_openai_honors_openai_base_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/onboarding/test_providers.py
+++ b/tests/onboarding/test_providers.py
@@ -352,3 +352,18 @@ def test_unknown_provider_gets_default_api_key_mode() -> None:
     assert config.default_mode == "api_key"
     assert len(config.auth_modes) == 1
     assert config.auth_modes[0].fields[0].name == "api_key"
+
+
+def test_edenai_registered_as_openai_gateway() -> None:
+    """Eden AI is a recognized OpenAI-compatible gateway (mirrors OpenRouter)."""
+    from omnigent.llms.routing import PROVIDER_CONFIGS
+    from omnigent.onboarding.ambient import _ENV_KEY_FAMILY
+    from omnigent.onboarding.configure_models import _CATALOG_PROVIDER_FAMILY
+    from omnigent.onboarding.provider_config import OPENAI_FAMILY
+
+    assert PROVIDER_CONFIGS["edenai"] == "https://api.edenai.run/v3"
+    assert _providers_mod.PROVIDER_ENV_VARS["edenai"] == "EDENAI_API_KEY"
+    assert _providers_mod.format_provider_name("edenai") == "Eden AI"
+    assert "edenai" in _providers_mod.COMMON_PROVIDERS
+    assert _ENV_KEY_FAMILY["edenai"] == OPENAI_FAMILY
+    assert _CATALOG_PROVIDER_FAMILY["edenai"] == OPENAI_FAMILY

--- a/tests/onboarding/test_providers.py
+++ b/tests/onboarding/test_providers.py
@@ -367,3 +367,34 @@ def test_edenai_registered_as_openai_gateway() -> None:
     assert "edenai" in _providers_mod.COMMON_PROVIDERS
     assert _ENV_KEY_FAMILY["edenai"] == OPENAI_FAMILY
     assert _CATALOG_PROVIDER_FAMILY["edenai"] == OPENAI_FAMILY
+
+
+def test_edenai_key_provider_endpoint_is_not_api_openai_com() -> None:
+    """A ``key`` add for Eden AI must reach api.edenai.run, not api.openai.com.
+
+    Without a ``_KEY_PROVIDER_ENDPOINT`` entry, an ambiently-detected
+    EDENAI_API_KEY is synthesized against the openai-family default
+    (api.openai.com) and every request 401s — the exact failure mode the
+    surrounding code explicitly warns about for third-party gateways.
+    """
+    from omnigent.onboarding.configure_models import key_provider_endpoint
+
+    vendor = key_provider_endpoint("edenai")
+    assert vendor is not None
+    assert vendor.base_url == "https://api.edenai.run/v3"
+    assert vendor.wire_api == "chat"
+
+
+def test_edenai_has_an_interactive_add_path() -> None:
+    """Eden AI must be reachable via the ``configure harness`` add menu.
+
+    ``edenai`` is not in the bundled catalog JSON, so it never appears via
+    :func:`key_providers` alone — it needs a preset entry (like OpenRouter)
+    so the onboarding wizard can actually offer it, not just the routing
+    layer underneath.
+    """
+    from omnigent.onboarding.configure_models import _PRESET_KEY_PROVIDERS, add_menu_options
+
+    assert "edenai" in _PRESET_KEY_PROVIDERS
+    providers_in_menu = {opt.provider for opt in add_menu_options() if opt.provider}
+    assert "edenai" in providers_in_menu


### PR DESCRIPTION
## Related issue

N/A

## Summary

[Eden AI](https://www.edenai.co/) is an EU-based, OpenAI-compatible gateway to 100+ models (Mistral, OpenAI, Anthropic, Google, DeepSeek, Cohere, …) behind a single `EDENAI_API_KEY`. It plugs into Omnigent's existing generic `gateway` path exactly like OpenRouter — **no new adapter, no special-casing** — by registering the `edenai` name across the provider mapping tables:

- `llms/routing.py` + `llms/adapters/__init__.py`: `edenai` → `https://api.edenai.run/v3` (so `edenai/<model>` routes correctly)
- `onboarding/ambient.py` + `onboarding/configure_models.py`: `EDENAI_API_KEY` detection + `openai` family + "Eden AI" display name
- `onboarding/providers/__init__.py`: `PROVIDER_ENV_VARS`, display name, `COMMON_PROVIDERS`
- `README.md`: Eden AI row in the gateway base-URL table

Because Eden speaks the OpenAI Chat Completions surface, everything else (the `OpenAICompatibleAdapter`, `wire_api: chat`, credential injection) works unchanged.

## Test Plan

- Added `tests/onboarding/test_providers.py::test_edenai_registered_as_openai_gateway` and an `edenai/mistral/mistral-small-latest` case in `tests/llms/test_routing.py`.
- `uv run pytest tests/llms tests/onboarding/test_providers.py tests/onboarding/test_provider_config.py` — my tests pass. (One pre-existing isolation flake, `tests/llms/test_usage_observer.py::test_client_notify_records_with_active_test`, reproduces on unmodified `main` with the same command and is unrelated to this change.)
- `uv run ruff check .` — passes.
- **Manual live verification:** pointed Omnigent's `OpenAICompatibleAdapter` at `https://api.edenai.run/v3` and got valid completions for `mistral/mistral-small-latest` and `openai/gpt-4o-mini`.

## Demo

N/A (no UI change)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: a live call through Omnigent's `OpenAICompatibleAdapter` against `https://api.edenai.run/v3` returned valid Chat Completions for both a Mistral and an OpenAI model, confirming the gateway wiring end-to-end. Automated coverage asserts the routing base_url, env-var mapping, family, and display-name registration.

## Changelog

Add Eden AI as a recognized OpenAI-compatible gateway (`edenai/<model>`, `EDENAI_API_KEY`)
