### PR TITLE
feat(auth): opt-in flag to skip OIDC email_verified check for enterprise IdPs

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -143,6 +143,14 @@ POSTGRES_PASSWORD=change-me-please
 # ── Optional OIDC tuning ─────────────────────────────────
 # OMNIGENT_OIDC_SESSION_TTL_HOURS=8
 # OMNIGENT_OIDC_LOGOUT_REDIRECT_URI=https://omnigent.example.com/
+#
+# Skip the email_verified claim check on id_tokens. Some IdPs (e.g.
+# Okta without custom API Access Management) omit the claim for
+# directory-provisioned users, which otherwise fails login with
+# "Could not determine user email". Only enable when the issuer is a
+# trusted enterprise directory — it makes any signed email claim the
+# user's identity. Off by default.
+# OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION=1
 
 # ── Server config file (admins, allowed domains, …) ──────
 # Non-secret settings live in a YAML config file — the same one

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -97,6 +97,10 @@ services:
       OMNIGENT_OIDC_SESSION_TTL_HOURS: "${OMNIGENT_OIDC_SESSION_TTL_HOURS:-8}"
       OMNIGENT_OIDC_ALLOWED_DOMAINS: "${OMNIGENT_OIDC_ALLOWED_DOMAINS:-}"
       OMNIGENT_OIDC_LOGOUT_REDIRECT_URI: "${OMNIGENT_OIDC_LOGOUT_REDIRECT_URI:-}"
+      # Skip the email_verified id_token check — for IdPs (e.g. Okta
+      # without API Access Management) that omit the claim for
+      # directory-provisioned users. Off unless set; see .env.example.
+      OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION: "${OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION:-}"
       # Opt-in OIDC invites (admin pre-authorizes one off-domain email).
       # Off unless set. The admin list (/data/admins) and the optional
       # allowed-domains file (/data/allowed_domains) need no env var —

--- a/omnigent/server/oidc.py
+++ b/omnigent/server/oidc.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import logging
 import os
 import secrets
 import time
@@ -19,6 +20,8 @@ from dataclasses import dataclass
 
 import httpx
 import jwt
+
+_logger = logging.getLogger(__name__)
 
 # ── PKCE helpers (RFC 7636) ──────────────────────────────────────
 
@@ -156,6 +159,10 @@ class OIDCConfig:
     :param userinfo_endpoint: Userinfo URL for providers that
         don't issue ``id_token`` (GitHub). ``None`` for standard
         OIDC providers.
+    :param skip_email_verification: When ``True``, accept the
+        ``id_token`` email claim without requiring
+        ``email_verified``. Only affects the generic-OIDC path;
+        GitHub always requires a verified primary email.
     """
 
     issuer: str
@@ -173,6 +180,7 @@ class OIDCConfig:
     jwks_uri: str | None
     userinfo_endpoint: str | None
     allow_invites: bool
+    skip_email_verification: bool = False
 
     @property
     def base_url(self) -> str:
@@ -283,6 +291,21 @@ class OIDCConfig:
 
         allow_invites = env_var_is_truthy("OMNIGENT_OIDC_ALLOW_INVITES")
 
+        # Some IdPs (e.g. Okta without custom API Access Management)
+        # omit ``email_verified`` for directory-provisioned users even
+        # though the directory is authoritative for the address. This
+        # opt-out trusts any signed email claim from the IdP — only
+        # enable it when the issuer is a trusted enterprise directory.
+        skip_email_verification = env_var_is_truthy("OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION")
+        if skip_email_verification:
+            _logger.warning(
+                "OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION is set: the "
+                "email_verified claim will not be required on OIDC "
+                "id_tokens. Any signed email claim from %s will be "
+                "trusted as the user's identity.",
+                issuer,
+            )
+
         # Determine provider type and resolve endpoints.
         is_github = issuer.rstrip("/") == _GITHUB_ISSUER
 
@@ -305,6 +328,7 @@ class OIDCConfig:
                 jwks_uri=None,
                 userinfo_endpoint=_GITHUB_USERINFO_ENDPOINT,
                 allow_invites=allow_invites,
+                skip_email_verification=skip_email_verification,
             )
 
         # Standard OIDC: fetch discovery document.
@@ -346,4 +370,5 @@ class OIDCConfig:
             jwks_uri=jwks_uri,
             userinfo_endpoint=doc.get("userinfo_endpoint"),
             allow_invites=allow_invites,
+            skip_email_verification=skip_email_verification,
         )

--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -756,6 +756,11 @@ def _resolve_oidc_email(
     allowed domain. This mirrors the GitHub path, which
     requires ``verified`` on the primary email.
 
+    ``config.skip_email_verification`` (from
+    ``OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION``) waives the gate for
+    IdPs that omit the claim for directory-managed users (e.g. Okta
+    without custom API Access Management).
+
     :param token_json: The token endpoint response JSON containing
         ``id_token``.
     :param config: The OIDC configuration with JWKS URI and
@@ -763,7 +768,7 @@ def _resolve_oidc_email(
     :returns: The user's email from the ``id_token`` when present and
         marked verified; ``None`` if the token is missing/invalid,
         the email claim is absent, or ``email_verified`` is not
-        truthy.
+        truthy (and verification is not skipped via config).
     """
     id_token = token_json.get("id_token")
     if not id_token:
@@ -789,8 +794,17 @@ def _resolve_oidc_email(
 
     # Reject unless the IdP affirmatively verified the email. A signed
     # token only proves IdP provenance, not mailbox ownership.
-    # Absent/false ``email_verified`` is a hard reject.
+    # Absent/false ``email_verified`` is a hard reject — unless the
+    # operator opted out (OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION) for
+    # IdPs like Okta that omit the claim for directory-managed users.
     if not _claim_is_verified_true(claims.get("email_verified")):
+        if config.skip_email_verification:
+            _logger.info(
+                "Accepting id_token email %r without email_verified "
+                "(OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION is set)",
+                email,
+            )
+            return email
         _logger.warning(
             "Rejecting id_token: email %r present but email_verified is not true",
             email,

--- a/tests/server/test_oidc_callback.py
+++ b/tests/server/test_oidc_callback.py
@@ -44,11 +44,14 @@ _ISSUER = "https://accounts.google.com"
 _CLIENT_ID = "cid"
 
 
-def _oidc_config() -> OIDCConfig:
+def _oidc_config(skip_email_verification: bool = False) -> OIDCConfig:
     """Build a generic-OIDC config over plain HTTP (so TestClient cookies stick).
 
     ``allowed_domains=None`` means admit-all, so the test isolates the
     ``email_verified`` gate from the domain-allowlist check.
+
+    :param skip_email_verification: Waive the ``email_verified`` gate,
+        as ``OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION`` would.
     """
     return OIDCConfig(
         issuer=_ISSUER,
@@ -66,6 +69,7 @@ def _oidc_config() -> OIDCConfig:
         jwks_uri="https://www.googleapis.com/oauth2/v3/certs",
         userinfo_endpoint=None,
         allow_invites=False,
+        skip_email_verification=skip_email_verification,
     )
 
 
@@ -108,7 +112,10 @@ class _IdpKeys:
 
 @pytest.fixture
 def callback_client(
-    tmp_path: Path, db_uri: str, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> Iterator[tuple[TestClient, _IdpKeys]]:
     """Mount the OIDC router and stub the IdP token endpoint + JWKS lookup.
 
@@ -116,13 +123,16 @@ def callback_client(
     one-element ``pending_id_token`` list captured by the monkeypatched
     ``post`` — exposed on ``app.state.pending_id_token`` so ``_do_callback``
     can set the signed token the IdP should return.
+
+    Indirect parametrization (``request.param``, default ``False``) sets
+    the config's ``skip_email_verification`` flag.
     """
     keys = _IdpKeys()
     perm_store = SqlAlchemyPermissionStore(db_uri)
     admins = tmp_path / "admins"
     admins.write_text("")
 
-    config = _oidc_config()
+    config = _oidc_config(skip_email_verification=getattr(request, "param", False))
     provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
 
     # The signed id_token the mocked token endpoint will return. Each
@@ -251,6 +261,37 @@ def test_callback_unverified_email_rejected(
     assert "Could not determine user email" in resp.json()["error"]
     # No session was minted for the spoofable email.
     assert resp.cookies.get("ap_session") is None
+
+
+@pytest.mark.parametrize("callback_client", [True], indirect=True)
+@pytest.mark.parametrize(
+    "claims",
+    [
+        pytest.param({"email": "carol@example.com"}, id="absent"),
+        pytest.param({"email": "carol@example.com", "email_verified": False}, id="false"),
+    ],
+)
+def test_callback_skip_verification_flag_admits_unverified(
+    callback_client: tuple[TestClient, _IdpKeys],
+    claims: dict[str, object],
+) -> None:
+    """With ``skip_email_verification`` on, the gate is waived.
+
+    Models Okta tiers that drop ``email_verified`` for
+    directory-provisioned users: the same absent-claim token rejected
+    by default (covered above) mints a session when the operator has
+    opted out via ``OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION``.
+    """
+    client, keys = callback_client
+    token = keys.sign_id_token(claims)
+
+    resp = _do_callback(client, token)
+
+    assert resp.status_code == 302, resp.text
+    session_cookie = resp.cookies.get("ap_session")
+    assert session_cookie is not None
+    decoded = jwt.decode(session_cookie, _TEST_SECRET, algorithms=["HS256"])
+    assert decoded["sub"] == "carol@example.com"
 
 
 @pytest.mark.parametrize("verified_value", [True, "true", "True", "TRUE"])


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Standard Okta tiers (without custom API Access Management) omit the `email_verified` claim from `id_token`s for directory-provisioned users. Omnigent's OIDC callback hard-rejects any token where the claim isn't affirmatively `true`, so SSO fails with a 400 ("Could not determine user email from IdP") for these deployments.
- Adds `OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION` (default **off**): when set, the callback accepts the signed `id_token` email claim without requiring `email_verified`. The default path is unchanged — absent/false claims are still a hard reject, preserving the account-takeover protection for IdPs that allow user-asserted emails.
- Enabling the flag logs a warning at startup and an info line per bypassed login, so the relaxed posture is visible in logs. GitHub OAuth is unaffected (it keeps requiring a verified primary email).

**ELI5:** the server normally only trusts an email if the identity provider stamps it "verified". Okta's standard tier doesn't include that stamp for company-directory users even though the directory owns the address, so login breaks. This adds an opt-in switch for operators who trust their directory to say "accept the email without the stamp".

```
id_token → signature/iss/aud valid? ──no──▶ reject
              │yes
   email_verified is true? ──yes──▶ accept
              │no
   OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION? ──yes──▶ accept (logged)
              │no
            reject (unchanged default)
```

## Test Plan

- `pytest tests/server/test_oidc_callback.py` — 12 passed. New parametrized test drives the real callback route with a genuinely RS256-signed `id_token` that omits `email_verified` (the Okta shape) and one with `email_verified: false`; with the flag on, both mint a session for the correct email. All pre-existing rejection tests still pass, proving the default is unchanged.
- `pre-commit run` clean on all touched files.

## Demo

N/A (non-visual backend change)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests cover the flag-on path (absent and false claims); the existing `test_callback_unverified_email_rejected` matrix locks the flag-off default.

## Changelog

`OMNIGENT_OIDC_SKIP_EMAIL_VERIFICATION=1` lets OIDC logins through when the IdP omits the `email_verified` claim (e.g. standard-tier Okta with directory-provisioned users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
