### PR TITLE
fix(os_env): stop leaking omnigent's package root into sys_os_shell PYTHONPATH

### DIFF
--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1333,6 +1333,7 @@ def _shell_impl(
         completed = subprocess.run(
             argv,
             cwd=str(cwd),
+            env=_child_shell_env(),
             text=True,
             capture_output=True,
             timeout=timeout,
@@ -1423,6 +1424,40 @@ def _project_root() -> Path:
     # File lives at omnigent/inner/os_env.py; climb two levels to the
     # repo root that hosts `omnigent/` as a package.
     return Path(__file__).resolve().parents[2]
+
+
+def _same_path(entry: str, root: Path) -> bool:
+    """True when ``entry`` names the same directory as ``root``."""
+    try:
+        return Path(entry).resolve() == root
+    except OSError:
+        return os.path.normpath(entry) == os.path.normpath(str(root))
+
+
+def _child_shell_env() -> dict[str, str]:
+    """
+    Environment for agent shell commands, minus omnigent's own package root.
+
+    The helper prepends its project root to ``PYTHONPATH`` at spawn (see
+    ``_HelperProcessClient._start_locked``) purely so ``python -m
+    omnigent.inner.os_env`` can import omnigent. That entry has no business in
+    the commands the agent runs: under a tool install it points at omnigent's
+    ``site-packages`` and shadows the project venv's own packages on
+    ``sys.path`` (e.g. a 3.12 ``pydantic_core`` failing to load under a 3.13
+    project). Strip only omnigent's entry — any other ``PYTHONPATH`` the caller
+    set is preserved, in order.
+    """
+    env = os.environ.copy()
+    raw = env.get("PYTHONPATH")
+    if not raw:
+        return env
+    root = _project_root()
+    kept = [entry for entry in raw.split(os.pathsep) if not (entry and _same_path(entry, root))]
+    if kept:
+        env["PYTHONPATH"] = os.pathsep.join(kept)
+    else:
+        env.pop("PYTHONPATH", None)
+    return env
 
 
 def _read_config_from_fd(fd: int) -> JsonValue:

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import os
 import shutil
 import tracemalloc
 from pathlib import Path
 
-from omnigent.inner.os_env import _read_impl, _shell_impl, build_helper_env
+import pytest
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.os_env import (
+    _child_shell_env,
+    _project_root,
+    _read_impl,
+    _shell_impl,
+    build_helper_env,
+    create_os_environment,
+)
 from omnigent.inner.sandbox import SandboxPolicy
 from omnigent.runner.identity import (
     OMNIGENT_SESSION_ENV_VALUE,
@@ -294,3 +306,98 @@ def test_read_impl_nul_byte_file_classified_binary(tmp_path: Path) -> None:
 
     assert result["encoding"] == "base64"
     assert result["total_bytes"] == 10
+
+
+# ---------------------------------------------------------------------------
+# _child_shell_env — omnigent's own package root must not leak onto the
+# PYTHONPATH of agent shell commands (it would shadow the project's packages).
+# ---------------------------------------------------------------------------
+
+
+def test_child_shell_env_strips_project_root_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """omnigent's project root is removed; a project entry is preserved.
+
+    The helper prepends its project root to ``PYTHONPATH`` so it can import
+    omnigent at startup. Commands the agent runs must not inherit that entry,
+    or omnigent's ``site-packages`` shadows the project venv's own packages.
+
+    :returns: None.
+    """
+    project_entry = "/opt/venvs/proj/lib/python3.13/site-packages"
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join([str(_project_root()), project_entry]))
+
+    env = _child_shell_env()
+
+    assert env["PYTHONPATH"] == project_entry
+
+
+def test_child_shell_env_drops_var_when_only_project_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the sole entry is omnigent's root, ``PYTHONPATH`` is unset.
+
+    Leaving an empty ``PYTHONPATH`` would put the shell command's cwd on
+    ``sys.path``; dropping the var entirely avoids that surprise.
+
+    :returns: None.
+    """
+    monkeypatch.setenv("PYTHONPATH", str(_project_root()))
+
+    env = _child_shell_env()
+
+    assert "PYTHONPATH" not in env
+
+
+def test_child_shell_env_noop_without_pythonpath(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``PYTHONPATH`` in the parent env means nothing to strip.
+
+    :returns: None.
+    """
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    env = _child_shell_env()
+
+    assert "PYTHONPATH" not in env
+    assert env["PATH"] == "/usr/bin"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the real helper must not leak omnigent's package root into a
+# sys_os_shell command's PYTHONPATH. Guards the wiring in _shell_impl, not
+# just _child_shell_env in isolation.
+# ---------------------------------------------------------------------------
+
+
+def test_shell_command_does_not_see_omnigent_project_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shell command's ``PYTHONPATH`` drops omnigent's root, keeps the rest.
+
+    Spawns a real ``caller_process`` helper (``sandbox: none`` so it runs on
+    every platform) with omnigent's root pre-seeded on ``PYTHONPATH`` — the
+    same shape the helper spawn produces — and asserts the agent's command
+    sees the sibling project entry but not omnigent's, so project subprocesses
+    resolve their own packages.
+
+    :returns: None.
+    """
+    project_entry = "/opt/venvs/proj/site-packages"
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join([str(_project_root()), project_entry]))
+
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    assert os_env is not None
+    try:
+        result = asyncio.run(os_env.shell("echo PP=$PYTHONPATH"))
+    finally:
+        os_env.close()
+
+    out = result.get("stdout", "")
+    assert project_entry in out
+    assert str(_project_root()) not in out


### PR DESCRIPTION
## Related issue

Closes #1860

## Summary

- The os_env helper prepends its own project root to `PYTHONPATH` at spawn (`_HelperProcessClient._start_locked`) so `python -m omnigent.inner.os_env` can import omnigent. Because `_shell_impl` ran the agent's command via `subprocess.run(...)` with **no explicit `env=`**, that entry leaked into every `sys_os_shell` command.
- Under a `uv tool install`, `_project_root()` resolves to omnigent's own `site-packages`, which then lands ahead of the project venv's own packages on `sys.path`. Shared packages (pydantic, etc.) resolve to omnigent's copy — e.g. a 3.12 `pydantic_core` failing to load under a 3.13 project (`ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'`). Worse, `importorskip`-guarded tests turn that `ImportError` into a silent SKIP (false-green).
- Fix: strip **only** omnigent's own `_project_root()` entry from the env handed to shell commands (`_child_shell_env()`), preserving any other `PYTHONPATH` the caller set. The helper's own startup import is untouched, so uninstalled-worktree runs and the active-sandbox suite are unaffected. Scoped to the `sys_os_shell` path; harness subprocess spawns (which legitimately want omnigent's env) are not changed.

## Test Plan

- `uv run pytest tests/inner/test_os_env.py` — 14 passed. Added 3 unit tests for `_child_shell_env` (strips project root; drops the var when it was the only entry; no-op without `PYTHONPATH`) plus 1 **end-to-end wiring test** that spawns the real `caller_process` helper (`sandbox: none`, cross-platform), seeds omnigent's root on `PYTHONPATH`, and asserts a `sys_os_shell` command no longer sees it while a sibling project entry survives.
- Verified the e2e test is a real regression guard: it **fails** with the fix removed and **passes** with it restored.
- `uv run pytest tests/inner/sandbox/test_sandbox_behavior.py` — 13 passed, 13 skipped; `test_egress_e2e.py` — 10 passed, 10 skipped (the `linux_bwrap` variants skip on macOS). The active-sandbox `shell("env")` env tests still pass.
- `pre-commit run` and both security scanners (`secret-scan.py`, `exfil-scan.py`) — clean on the full PR diff.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the real os_env helper on the `caller_process` / `sandbox: none` path with omnigent's root pre-seeded on `PYTHONPATH` and confirmed the child shell command no longer sees it while an unrelated project entry survives. The new e2e test encodes exactly this and was confirmed to fail without the fix. Automated coverage additionally includes unit tests for `_child_shell_env` and the existing active-sandbox behavior/egress suites that guard the spawn/env path. Not exercisable locally: the `linux_bwrap` sandbox variants (skip on macOS) — left to CI.

## Changelog

`sys_os_shell` commands no longer inherit omnigent's own `PYTHONPATH` entry, so project subprocesses resolve their own installed packages instead of omnigent's.
