### PR TITLE
fix(e2e): restore mock tool-call config in test_repl_tool_call_refusal_blocks_tool

### DIFF
--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -857,7 +857,23 @@ def test_repl_tool_call_refusal_blocks_tool(
     than feeding a denial marker to the LLM and letting it continue.
     The tool must never execute: its raw output must not appear in the
     terminal or reach the mock LLM as a function_call_output.
+
+    The mock LLM is scripted to emit the ``echo`` ``function_call`` so
+    the TOOL_CALL ASK fires. (The follow-up text is never reached: the
+    turn aborts on decline before any second LLM call.)
     """
+    _configure_mock_tool_then_text(
+        mock_llm_server_url,
+        [
+            {
+                "call_id": "tc2",
+                "name": "echo",
+                "arguments": json.dumps({"message": "testing456"}),
+            }
+        ],
+        "tool-call-refuse-followup-marker",
+        match="testing456",
+    )
     child = pexpect.spawn(
         ap_cli,
         ["run", str(_TOOL_GATE_DIR)],


### PR DESCRIPTION
## Problem

`tests/e2e/test_repl_approval_e2e.py::test_repl_tool_call_refusal_blocks_tool` is failing on `main` (e.g. the scheduled run https://github.com/omnigent-ai/omnigent/actions/runs/28586422203 — `1 failed, 73 passed` on shard 0/4) with:

```
pexpect.exceptions.TIMEOUT: Timeout exceeded.
...
>           child.expect("approval required", timeout=45)
```

## Root cause

The rewrite of this test in #1839 ("abort agent turn on explicit elicitation decline") dropped the `_configure_mock_tool_then_text(...)` setup that scripts the mock LLM to emit the `echo` `function_call`. Without it, sending `"testing456"` produces no tool call, so the TOOL_CALL ASK banner never fires and `child.expect("approval required", timeout=45)` times out on every run.

This is a deterministic failure, not a flake. The test's final pre-merge E2E run was `skipped` by the merge queue, so the config-less version never ran green before it landed, and the scheduled `main` run has failed on it since. The sibling `test_repl_tool_call_approval_allows_tool_to_run` still has its config call, which is why only this one fails.

## Fix

Re-add the tool-call scripting before `pexpect.spawn`. The follow-up text is never reached (the turn aborts on decline before any second LLM call), so only the `function_call` scripting is needed; the rest of the post-#1839 body (decline -> abort -> assert no tool output) is unchanged.

## Verification

Ran locally against the mock:
- `test_repl_tool_call_refusal_blocks_tool`: 3/3 green
- sibling `test_repl_tool_call_approval_allows_tool_to_run`: green

Pre-commit (ruff format + check) passes.