### PR TITLE
feat(providers): per-tier model overrides on the databricks provider kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,37 @@ the OpenAI-compatible `…/api/v1`.
 
 </details>
 
+<details>
+<summary>Databricks model endpoints (pin serving endpoints or UC model services)</summary>
+
+A **Databricks** credential resolves its models from the workspace (via
+ucode state) by default. To pin specific endpoints, give the provider entry
+an optional `models:` map in `~/.omnigent/config.yaml`:
+
+```yaml
+providers:
+  databricks:
+    kind: databricks
+    profile: my-workspace
+    models:                                   # optional — omit to keep the workspace defaults
+      default: main.agents.my-opus-endpoint   # session launch model (Claude Code, claude-sdk, pi)
+      opus: main.agents.my-opus-endpoint      # Claude Code's Opus alias
+      sonnet: main.agents.my-sonnet-endpoint  # Claude Code's Sonnet alias
+      haiku: databricks-claude-haiku-4-5      # Claude Code's fast/background alias
+```
+
+Values are model serving endpoint names or Unity Catalog model service FQNs
+(`catalog.schema.name`) that answer the gateway's Anthropic surface — Claude
+models only. Each tier resolves as: this map → the workspace's ucode state →
+the built-in default, so unset tiers keep the workspace behavior and removing
+the map restores it entirely. Claude Code's `[1m]` long-context suffix passes
+through verbatim (e.g. `main.agents.my-opus-endpoint[1m]`), so a pinned
+endpoint can run with the 1M-token context window where the workspace's
+gateway supports it — except for the `pi` harness, which speaks the API
+directly and gets the suffix stripped at spawn.
+
+</details>
+
 ### 4. Deploy a server (and use it from your phone📱)
 
 Run Omnigent on a server with a stable URL

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1386,7 +1386,9 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
     The profile remains the explicit workspace selector. If no
     profile is selected, or the profile has no matching ucode state,
     the native wrapper leaves Claude Code's normal provider
-    configuration alone.
+    configuration alone. A ``models:`` map on the profile's ``kind:
+    databricks`` provider entry overrides the ucode-cached models
+    per tier (config > ucode > hardcoded default).
 
     :param profile: Databricks CLI profile name, e.g.
         ``"<your-profile>"``.
@@ -1402,6 +1404,7 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
         DATABRICKS_CLAUDE_DEFAULT_MODEL,
         get_workspace_url_for_profile,
     )
+    from omnigent.onboarding.provider_config import databricks_provider_models
     from omnigent.onboarding.ucode_state import read_ucode_state
 
     workspace_url = get_workspace_url_for_profile(profile)
@@ -1444,9 +1447,12 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
     # gateway model ID so that the /model picker natively shows gateway model
     # names.  Without this Claude Code normalises the picked model to a
     # canonical Anthropic name (e.g. "claude-opus-4-7[1m]") that the
-    # Databricks gateway rejects.
+    # Databricks gateway rejects.  Per-tier ``models:`` overrides from the
+    # provider config outrank the ucode-cached models; ucode fills the tiers
+    # the config leaves unset.
+    model_overrides = databricks_provider_models(profile)
     for tier, env_var in _UCODE_CLAUDE_TIER_TO_ENV.items():
-        model_id = workspace_state.claude_models.get(tier)
+        model_id = model_overrides.get(tier) or workspace_state.claude_models.get(tier)
         if model_id:
             env[env_var] = model_id
     # When ucode caches no model, default it so Claude Code doesn't fall back
@@ -1454,7 +1460,9 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
     return ClaudeNativeUcodeConfig(
         env=env,
         api_key_helper=agent_state.auth_command,
-        model=agent_state.model or DATABRICKS_CLAUDE_DEFAULT_MODEL,
+        model=(
+            model_overrides.get("default") or agent_state.model or DATABRICKS_CLAUDE_DEFAULT_MODEL
+        ),
     )
 
 

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -308,6 +308,15 @@ class ProviderEntry:
         ``None`` otherwise.
     :param profile: For ``kind="databricks"`` only: the Databricks profile
         name from ``~/.databrickscfg``, e.g. ``"oss"``. ``None`` otherwise.
+    :param models: For ``kind="databricks"`` only: optional tier→model map
+        with the same shape as :attr:`FamilyConfig.models`, e.g.
+        ``{"opus": "main.agents.my-opus-endpoint", "default":
+        "databricks-claude-opus-4-8"}``. Tier keys mirror ucode's
+        ``claude_models`` tiers (``fable`` / ``opus`` / ``sonnet`` /
+        ``haiku``) plus ``default``. Entries override the ucode-cached
+        models at every Databricks model-resolution point (see
+        :func:`databricks_provider_models`); absent tiers keep the ucode
+        → hardcoded-default behavior. Empty otherwise.
     :param model_provider: For ``kind="cli-config"`` only: the custom
         provider id in the CLI's config file that the launch pins, i.e. the
         ``X`` in ``[model_providers.X]``, e.g. ``"Databricks"``. ``None``
@@ -336,6 +345,7 @@ class ProviderEntry:
     model_provider: str | None = None
     display_name: str | None = None
     default_families: frozenset[str] = frozenset()
+    models: dict[str, str] = field(default_factory=dict)
 
     @property
     def default(self) -> bool:
@@ -863,10 +873,16 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
         # gemini: the antigravity harness drives Gemini via the dedicated google
         # SDK + GEMINI_API_KEY, not an OpenAI-compatible gateway, so a databricks
         # profile cannot serve (or default) the Gemini surface.
+        models_raw = raw.get("models")
         return ProviderEntry(
             name=name,
             kind=kind,
             profile=profile_raw,
+            models=(
+                {str(k): str(v) for k, v in models_raw.items()}
+                if isinstance(models_raw, dict)
+                else {}
+            ),
             default_families=_parse_default_families(
                 name, default_raw, set(_VALID_FAMILIES) - {GEMINI_FAMILY}, pi_capable=True
             ),
@@ -953,6 +969,35 @@ def load_providers(config: dict[str, object]) -> dict[str, ProviderEntry]:
             )
         result[str(name)] = _parse_provider(str(name), raw)
     return result
+
+
+def databricks_provider_models(profile: str | None) -> dict[str, str]:
+    """Return the ``models:`` overrides of the databricks provider for *profile*.
+
+    The shared lookup behind the Databricks model-resolution points (the
+    native-claude tier pinning and the claude-sdk / pi spawn env): given
+    the profile that identifies the gateway workspace, find the ``kind:
+    databricks`` provider entry carrying it and return its tier→model map.
+    Callers apply the precedence provider ``models:`` → ucode state →
+    hardcoded default, so an absent map (no matching entry, or one without
+    ``models:``) leaves their behavior unchanged.
+
+    :param profile: Databricks profile name from ``~/.databrickscfg``,
+        e.g. ``"oss"``; ``None`` / empty returns ``{}``.
+    :returns: The entry's tier→model map, e.g. ``{"opus":
+        "main.agents.my-opus-endpoint", "default":
+        "databricks-claude-opus-4-8"}``; ``{}`` when no databricks entry
+        matches *profile* or it declares no ``models:``. When several
+        entries share a profile, the first in config order wins.
+    :raises OmnigentError: If the ``providers:`` block is malformed (same
+        as :func:`load_providers`).
+    """
+    if not profile:
+        return {}
+    for entry in load_providers(load_config()).values():
+        if entry.kind == DATABRICKS_KIND and entry.profile == profile:
+            return entry.models
+    return {}
 
 
 def harness_family(harness: str) -> str | None:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -52,6 +52,7 @@ from omnigent.onboarding.provider_config import (
     SUBSCRIPTION_KIND,
     FamilyConfig,
     ProviderEntry,
+    databricks_provider_models,
     default_provider_for_harness,
     first_available_provider,
     harness_family,
@@ -304,7 +305,10 @@ def configure_agent_harness_with_ucode(
 
     The harness-specific constants live here so callers only declare which
     agent harness they are configuring. ucode's per-agent ``agents`` entries
-    are the source of truth for gateway URLs and auth commands.
+    are the source of truth for gateway URLs and auth commands. The model
+    resolves as spec (pre-set ``env`` key) > provider-config ``models:``
+    overrides (:func:`databricks_provider_models`) > ucode state > the
+    harness's hardcoded Databricks default.
 
     :param env: Mutable spawn-env dict, modified in place.
     :param profile: The ``executor.profile`` / provider-config value,
@@ -313,13 +317,30 @@ def configure_agent_harness_with_ucode(
     """
     if not profile:
         return
+    config = _UCODE_HARNESS_CONFIGS[harness_type]
+    # Provider-config model overrides (the ``models:`` map on the ``kind:
+    # databricks`` entry) outrank ucode state: config > ucode > hardcoded
+    # default. Scoped to the Claude-gateway harnesses — the map is
+    # Claude-tier-shaped, which is exactly the harnesses that carry a
+    # Databricks Claude default model. Applied before the ucode-state
+    # checks so the override also lands on the profile-derived gateway
+    # path (no ucode state cached).
+    if config.databricks_default_model is not None and config.model_key not in env:
+        override_model = databricks_provider_models(profile).get("default")
+        if override_model:
+            if harness_type == "pi":
+                # Claude Code's ``[1m]`` long-context suffix is a client-side
+                # convention: the claude CLI strips it before calling the API,
+                # but pi passes model ids through verbatim and the gateway
+                # rejects suffixed names — strip it for pi's spawn env.
+                override_model = override_model.removesuffix("[1m]")
+            env[config.model_key] = override_model
     workspace_url = get_workspace_url_for_profile(profile)
     if workspace_url is None:
         return
     state = read_ucode_state(workspace_url)
     if state is None:
         return
-    config = _UCODE_HARNESS_CONFIGS[harness_type]
     agent_state = state.agent(config.agent_name)
     if agent_state is None:
         return

--- a/tests/e2e/test_databricks_models_override_e2e.py
+++ b/tests/e2e/test_databricks_models_override_e2e.py
@@ -1,0 +1,456 @@
+"""E2E: a ``kind: databricks`` provider's ``models:`` map pins the served model.
+
+Proves the end of the per-tier-model-override feature (see
+``feat(providers): per-tier model overrides on the databricks provider kind``)
+against a *live* Databricks workspace: a ``models: {default: <endpoint>}`` entry
+in ``~/.omnigent/config.yaml`` reaches
+:func:`omnigent.runtime.workflow.configure_agent_harness_with_ucode` at spawn
+and lands in ``HARNESS_CLAUDE_SDK_MODEL``, so the claude-sdk subprocess runs its
+turn on the overridden endpoint rather than the hardcoded Databricks default.
+
+The override target is pinned to ``databricks-claude-sonnet-4-6`` *specifically*
+because it differs from the harness's hardcoded Databricks fallback
+(:data:`omnigent.onboarding.databricks_config.DATABRICKS_CLAUDE_DEFAULT_MODEL` =
+``databricks-claude-opus-4-8``). A test that pinned the fallback value could
+pass without the override doing anything; pinning a *different* Claude tier
+(sonnet, not opus) makes the assertion fail loud if the map is ignored and the
+spawn falls back to opus.
+
+Isolation contract (why this file spawns its own server + runner):
+    The shared ``live_server`` / ``http_client`` fixtures inherit ``os.environ``
+    and do NOT redirect ``OMNIGENT_CONFIG_HOME``, so they read the developer's
+    real ``~/.omnigent/config.yaml``. This test seeds a throwaway config home
+    with the provider entry under test and spawns its OWN server and runner
+    subprocesses pointed at it. The runner is the process that builds the
+    claude-sdk spawn env (``_build_claude_sdk_spawn_env`` →
+    ``configure_agent_harness_with_provider`` → ``configure_agent_harness_with_ucode``),
+    so the runner is the one that must see the seeded ``OMNIGENT_CONFIG_HOME``.
+    The developer's real ``~/.omnigent``, ``~/.ucode/state.json``, and
+    Databricks CLI config are never written.
+
+How the served-model assertion works (which response field):
+    The claude-sdk executor reports the model the SDK actually used as
+    ``usage["model"]`` (``observed_model or model``) on every turn
+    (``omnigent/inner/claude_sdk_executor.py``). The runner accumulates that
+    into the session's per-model usage map keyed by the *raw harness-reported
+    model id* (``_model_usage_bucket`` in ``omnigent/server/routes/sessions.py``
+    — "alias normalization is intentionally deferred"), which surfaces as
+    ``usage_by_model`` on ``GET /v1/sessions/{id}`` (:class:`SessionResponse`).
+    So the served model is observable end-to-end: the ``usage_by_model`` keys
+    are the model(s) that actually ran the turn. The assertion is a
+    *discriminator*, not a brittle equality: the served model must identify the
+    Sonnet override and must NOT identify the Opus fallback. The Databricks
+    gateway may echo the requested id (``databricks-claude-sonnet-4-6``) or a
+    canonical Anthropic name (``claude-sonnet-4-…``); both satisfy
+    "contains sonnet, not opus", which is exactly the feature's contract
+    (override beat the hardcoded default).
+
+What breaks if this is wrong:
+    - The override never reaches the spawn env → the turn runs on the opus
+      fallback → ``usage_by_model`` carries an opus key → this test fails.
+    - A spec-pinned model would outrank the map (precedence is spec > provider
+      ``models:`` > ucode > default), so the agent registered here declares NO
+      model; a regression that starts stamping a default model onto no-model
+      specs would surface as a non-sonnet served model.
+
+Usage::
+
+    PROFILE=<your-databricks-profile>
+    TOKEN=$(databricks auth token --profile "$PROFILE" | jq -r .access_token)
+    env -u OPENAI_API_KEY OMNIGENT_SKIP_WEB_UI=true \\
+      uv run --no-sync pytest \\
+        tests/e2e/test_databricks_models_override_e2e.py \\
+        --llm-api-key="$TOKEN" --profile="$PROFILE" -x -q
+
+If your shell exports a workspace PAT env var, unset it first so the seeded
+profile's auth wins over ambient credentials.
+
+Skips cleanly (no-op) without ``--profile`` (mock mode has no Databricks
+gateway to route to) or when the ``claude`` CLI is not installed.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import secrets
+import signal
+import subprocess
+import tarfile
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+
+from omnigent.onboarding.databricks_config import DATABRICKS_CLAUDE_DEFAULT_MODEL
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN, token_bound_runner_id
+from tests._helpers.compat import (
+    apply_runner_env,
+    apply_server_env,
+    compat_runner_cwd,
+    compat_server_cwd,
+    runner_executable,
+    server_executable,
+)
+from tests.e2e._harness_probes import cli_unavailable_reason
+from tests.e2e.conftest import (
+    create_runner_bound_session,
+    find_free_port,
+    poll_session_until_terminal,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import HEALTH_TIMEOUT_S, POLL_INTERVAL_S
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The tier→model override under test. Pinned Sonnet on purpose: it differs from
+# the hardcoded Databricks fallback below, so the assertion can't pass by
+# accident if the override is dropped.
+_OVERRIDE_MODEL = "databricks-claude-sonnet-4-6"
+# The value the spawn would fall back to WITHOUT the override (the harness's
+# hardcoded Databricks Claude default). Asserting the served model is NOT this
+# is what proves the override actually took effect.
+_FALLBACK_MODEL = DATABRICKS_CLAUDE_DEFAULT_MODEL  # "databricks-claude-opus-4-8"
+
+
+def _register_no_model_claude_sdk_agent(
+    client: httpx.Client,
+    *,
+    name: str,
+    profile: str,
+    prompt: str,
+) -> str:
+    """Register a claude-sdk agent that declares NO model, only a profile.
+
+    Mirrors :func:`tests.e2e.conftest.register_inline_agent`'s multipart upload,
+    but deliberately omits ``executor.model`` — that helper always stamps a
+    resolved model, which (precedence spec > provider ``models:`` > ucode >
+    default) would outrank the override this test exercises. With no spec model,
+    ``_resolve_spec_model`` returns ``None``, ``HARNESS_CLAUDE_SDK_MODEL`` stays
+    unset entering ``configure_agent_harness_with_ucode``, and the provider
+    ``models: {default: …}`` map is what fills it.
+
+    :param client: HTTP client pointed at the seeded server.
+    :param name: Agent name.
+    :param profile: Databricks CLI config profile the legacy
+        ``executor.profile`` field carries; routes the spawn through the
+        synthesized databricks provider → the ucode/gateway path.
+    :param prompt: System prompt for the agent.
+    :returns: The registered agent name.
+    """
+    import json as _json
+
+    config: dict[str, Any] = {
+        "name": name,
+        "prompt": prompt,
+        # No ``model`` key: the provider ``models:`` map is the only model
+        # source, which is the code path under test.
+        "executor": {"harness": "claude-sdk", "profile": profile},
+    }
+    with io.BytesIO() as buf:
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            yaml_bytes = yaml.dump(config).encode()
+            info = tarfile.TarInfo(f"{name}.yaml")
+            info.size = len(yaml_bytes)
+            tar.addfile(info, io.BytesIO(yaml_bytes))
+        bundle = buf.getvalue()
+
+    resp = client.post(
+        "/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:500]}")
+    return name
+
+
+def _wait_for_usage_by_model(
+    client: httpx.Client,
+    session_id: str,
+    *,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Poll ``GET /v1/sessions/{id}`` until ``usage_by_model`` is populated.
+
+    Per-model usage accrues from the turn's ``response.completed`` usage, which
+    the runner may persist a beat after the turn is otherwise terminal. Poll so
+    the assertion doesn't race the write.
+
+    :param client: HTTP client pointed at the seeded server.
+    :param session_id: The runner-bound session id.
+    :param timeout: Max seconds to wait for a non-empty ``usage_by_model``.
+    :returns: The ``usage_by_model`` map, or ``{}`` if none appeared in time.
+    """
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/sessions/{session_id}")
+        resp.raise_for_status()
+        last = resp.json().get("usage_by_model") or {}
+        if last:
+            return last
+        time.sleep(POLL_INTERVAL_S)
+    return last
+
+
+@pytest.fixture
+def override_config_stack(
+    request: pytest.FixtureRequest,
+    llm_api_key: str,
+    databricks_workspace_host: str | None,
+    tmp_path: Path,
+) -> Iterator[tuple[str, str, str]]:
+    """Spawn an isolated server + runner over a seeded ``OMNIGENT_CONFIG_HOME``.
+
+    Seeds a throwaway config home whose sole ``providers:`` entry is a
+    ``kind: databricks`` provider carrying the ``models: {default: …}`` override,
+    then spawns a server and a sibling runner (bound by a shared tunnel token,
+    like ``live_server``) both pointed at that config home. The runner is where
+    the claude-sdk spawn env is built, so it must see the seeded config.
+
+    Skips (no-op) when ``--profile`` is absent — mock mode has no Databricks
+    gateway to route to — or when the ``claude`` CLI is missing/unrunnable.
+
+    :param request: pytest request — reads ``--profile``.
+    :param llm_api_key: Databricks bearer from ``--llm-api-key`` (satisfies the
+        server's startup env; the claude-sdk turn authenticates via the profile).
+    :param databricks_workspace_host: Workspace host, or ``None`` (mock mode).
+    :param tmp_path: Per-test temp dir for the config home, DB, artifacts, logs.
+    :yields: ``(base_url, runner_id, profile)``.
+    """
+    profile: str = request.config.getoption("--profile")
+    if not profile or databricks_workspace_host is None:
+        pytest.skip(
+            "databricks models-override e2e requires --profile <name> and a real "
+            "--llm-api-key (a live Databricks gateway to route the turn through); "
+            "it is a no-op in mock mode."
+        )
+    reason = cli_unavailable_reason("claude")
+    if reason is not None:
+        pytest.skip(f"claude-sdk harness requires a runnable 'claude' CLI; {reason}.")
+
+    # ── Seed the throwaway config home with the provider under test ──────
+    config_home = tmp_path / "omnigent_config_home"
+    config_home.mkdir()
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {
+                        "kind": "databricks",
+                        "profile": profile,
+                        "models": {"default": _OVERRIDE_MODEL},
+                    }
+                }
+            }
+        )
+    )
+
+    port = find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = tmp_path / "override_e2e.db"
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    server_log = tmp_path / "server.log"
+    runner_log = tmp_path / "runner.log"
+
+    binding_token = secrets.token_urlsafe(32)
+    runner_id = token_bound_runner_id(binding_token)
+
+    # Shared base env, mirroring live_server's Databricks-profile wiring.
+    base_env = {
+        **os.environ,
+        "OPENAI_API_KEY": llm_api_key,
+        "OPENAI_BASE_URL": f"{databricks_workspace_host}/serving-endpoints",
+        "DATABRICKS_CONFIG_PROFILE": profile,
+        # The isolation contract: config reads resolve here, not ~/.omnigent.
+        "OMNIGENT_CONFIG_HOME": str(config_home),
+    }
+
+    # Server-side policy classifier needs a gateway-routed llm: block (else it
+    # defaults to api.openai.com and 401s under a Databricks bearer), same as
+    # live_server does under --profile.
+    server_cfg = tmp_path / "server.yaml"
+    server_cfg.write_text(
+        yaml.safe_dump(
+            {
+                "llm": {
+                    "model": "databricks-gpt-5-4-mini",
+                    "connection": {
+                        "base_url": f"{databricks_workspace_host}/serving-endpoints",
+                        "api_key": llm_api_key,
+                    },
+                }
+            }
+        )
+    )
+
+    server_env = apply_server_env({**base_env}, _REPO_ROOT)
+    server_log_handle = open(server_log, "w")  # noqa: SIM115 — lives for the Popen lifetime
+    server_proc = subprocess.Popen(
+        [
+            server_executable(),
+            "-m",
+            "omnigent.cli",
+            "server",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{db_path}",
+            "--artifact-location",
+            str(artifact_dir),
+            "--config",
+            str(server_cfg),
+        ],
+        env={**server_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token},
+        cwd=compat_server_cwd(),
+        stdout=server_log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    runner_env = apply_runner_env(
+        {
+            **base_env,
+            "OMNIGENT_RUNNER_ID": runner_id,
+            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+            "RUNNER_SERVER_URL": base_url,
+        }
+    )
+    runner_log_handle = open(runner_log, "w")  # noqa: SIM115
+    runner_proc = subprocess.Popen(
+        [runner_executable(), "-m", "omnigent.runner._entry"],
+        env=runner_env,
+        cwd=compat_runner_cwd(),
+        stdout=runner_log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        deadline = time.monotonic() + HEALTH_TIMEOUT_S
+        while time.monotonic() < deadline:
+            try:
+                health = httpx.get(f"{base_url}/health", timeout=2)
+                status = httpx.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+                if (
+                    health.status_code == 200
+                    and status.status_code == 200
+                    and status.json().get("online") is True
+                ):
+                    break
+            except httpx.HTTPError:
+                pass
+            if server_proc.poll() is not None:
+                break
+            time.sleep(POLL_INTERVAL_S)
+        else:
+            raise RuntimeError(
+                f"server+runner didn't come online within {HEALTH_TIMEOUT_S}s.\n"
+                f"server log:\n{server_log.read_text()[-3000:]}\n"
+                f"runner log:\n{runner_log.read_text()[-3000:]}"
+            )
+        if server_proc.poll() is not None:
+            raise RuntimeError(
+                f"server exited early (code {server_proc.returncode}); "
+                f"log tail:\n{server_log.read_text()[-3000:]}"
+            )
+        yield base_url, runner_id, profile
+    finally:
+        for proc in (runner_proc, server_proc):
+            if proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+        runner_log_handle.close()
+        server_log_handle.close()
+
+
+def test_databricks_models_override_serves_pinned_endpoint(
+    override_config_stack: tuple[str, str, str],
+) -> None:
+    """A ``models: {default: …}`` map pins the live claude-sdk served model.
+
+    Registers a claude-sdk agent with NO model (only the profile), runs one
+    turn, and proves the turn ran on the Sonnet override — not the hardcoded
+    Opus fallback — via the session's ``usage_by_model`` (keyed by the raw
+    harness-reported served model). See the module docstring for the full
+    signal path and why the assertion is a sonnet/not-opus discriminator.
+
+    :param override_config_stack: ``(base_url, runner_id, profile)`` for the
+        server+runner spawned over the seeded config home.
+    """
+    base_url, runner_id, profile = override_config_stack
+
+    with httpx.Client(
+        base_url=base_url,
+        timeout=300,
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    ) as client:
+        agent_name = _register_no_model_claude_sdk_agent(
+            client,
+            name=f"dbx-models-override-{uuid.uuid4().hex[:6]}",
+            profile=profile,
+            prompt="You are a terse assistant. Follow instructions exactly.",
+        )
+        session_id = create_runner_bound_session(
+            client, agent_name=agent_name, runner_id=runner_id
+        )
+        response_id = send_user_message_to_session(
+            client,
+            session_id=session_id,
+            content="Reply with exactly: OVERRIDE-OK",
+        )
+
+        body = poll_session_until_terminal(
+            client,
+            session_id=session_id,
+            response_id=response_id,
+            timeout=300,
+        )
+        assert body["status"] == "completed", (
+            f"turn did not complete: {body.get('error', 'unknown error')}"
+        )
+
+        # A real turn ran (the reply proves the round-trip, not just a spawn).
+        text = "\n".join(
+            block.get("text", "")
+            for item in body.get("output", [])
+            if item.get("type") == "message"
+            for block in item.get("content", [])
+        )
+        assert "OVERRIDE-OK" in text, f"model did not follow the prompt; got: {text[:500]!r}"
+
+        # The served-model signal: usage_by_model is keyed by the model that
+        # actually ran the turn.
+        usage_by_model = _wait_for_usage_by_model(client, session_id)
+        assert usage_by_model, (
+            "session reported no usage_by_model; cannot confirm the served model. "
+            "The turn completed but per-model usage never surfaced — investigate "
+            "the runner usage-accumulation path before trusting this result."
+        )
+        served_models = list(usage_by_model.keys())
+
+        # The override took effect iff a Sonnet endpoint served the turn and the
+        # Opus fallback did not. Both the requested id and a canonical Anthropic
+        # name contain "sonnet"; the fallback (databricks-claude-opus-4-8)
+        # contains "opus".
+        assert any("sonnet" in m.lower() for m in served_models), (
+            f"expected the turn to run on the Sonnet override ({_OVERRIDE_MODEL!r}); "
+            f"served model(s): {served_models}. If a non-sonnet model served the "
+            f"turn, the provider models: override did not reach the spawn env."
+        )
+        assert not any("opus" in m.lower() for m in served_models), (
+            f"the turn ran on an Opus model {served_models}, i.e. the hardcoded "
+            f"fallback {_FALLBACK_MODEL!r} — the provider models: override was "
+            f"ignored (the exact regression this test guards)."
+        )

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -12,6 +12,7 @@ from omnigent.onboarding.provider_config import (
     GEMINI_FAMILY,
     OPENAI_FAMILY,
     PI_SURFACE,
+    databricks_provider_models,
     default_provider_for_harness,
     harness_family,
     load_providers,
@@ -815,3 +816,86 @@ def test_default_provider_for_pi_none_when_only_bedrock_default() -> None:
         }
     }
     assert default_provider_for_harness(config, "pi") is None
+
+
+# ── databricks kind: per-tier model overrides ────────────────────────────────
+
+
+def test_parse_databricks_models_map() -> None:
+    """A databricks entry's ``models:`` map parses onto the entry.
+
+    Failure means per-tier endpoint overrides in ``~/.omnigent/config.yaml``
+    are silently dropped at parse, and every Databricks model-resolution
+    point falls back to ucode state / the hardcoded default.
+    """
+    entry = load_providers(
+        {
+            "providers": {
+                "dbx": {
+                    "kind": "databricks",
+                    "profile": "my-ws",
+                    "models": {
+                        "default": "main.agents.opus-endpoint",
+                        "opus": "main.agents.opus-endpoint",
+                        "sonnet": "main.agents.sonnet-endpoint",
+                    },
+                }
+            }
+        }
+    )["dbx"]
+    assert entry.models == {
+        "default": "main.agents.opus-endpoint",
+        "opus": "main.agents.opus-endpoint",
+        "sonnet": "main.agents.sonnet-endpoint",
+    }
+
+
+@pytest.mark.parametrize("models_raw", [None, "not-a-map", ["a", "b"]])
+def test_parse_databricks_models_absent_or_malformed_is_empty(models_raw: object) -> None:
+    """An absent or non-mapping ``models:`` parses to an empty map.
+
+    Mirrors the lenient ``FamilyConfig.models`` handling: a malformed value
+    must not fail the whole config, and an absent key keeps the ucode-driven
+    resolution byte-for-byte unchanged.
+    """
+    raw: dict[str, object] = {"kind": "databricks", "profile": "my-ws"}
+    if models_raw is not None:
+        raw["models"] = models_raw
+    entry = load_providers({"providers": {"dbx": raw}})["dbx"]
+    assert entry.models == {}
+
+
+def test_databricks_provider_models_looks_up_by_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``databricks_provider_models`` returns the matching entry's map.
+
+    The lookup is keyed on the profile (the only databricks identity that
+    reaches the model-resolution points), skips non-databricks kinds, and
+    returns ``{}`` for a mapless entry / unknown profile / no profile — the
+    "absent map leaves behavior unchanged" contract.
+    """
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n"
+        "  gw:\n"
+        "    kind: gateway\n"
+        "    anthropic:\n"
+        "      base_url: https://gw\n"
+        "      api_key_ref: env:K\n"
+        "  dbx:\n"
+        "    kind: databricks\n"
+        "    profile: my-ws\n"
+        "    models:\n"
+        "      default: main.agents.opus-endpoint\n"
+        "  other:\n"
+        "    kind: databricks\n"
+        "    profile: other-ws\n"
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    assert databricks_provider_models("my-ws") == {"default": "main.agents.opus-endpoint"}
+    # A matching entry without a models: map — no overrides.
+    assert databricks_provider_models("other-ws") == {}
+    # No databricks entry carries this profile.
+    assert databricks_provider_models("unknown-ws") == {}
+    assert databricks_provider_models(None) == {}

--- a/tests/runtime/test_claude_sdk_spawn_env.py
+++ b/tests/runtime/test_claude_sdk_spawn_env.py
@@ -243,3 +243,127 @@ def test_ucode_state_with_model_is_not_overridden_by_default(
     env = _build_claude_sdk_spawn_env(spec, workdir=None)
 
     assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def _write_databricks_models_config(tmp_path: Path, *, models: dict[str, str]) -> None:
+    """
+    Write a ``providers:`` config with a databricks entry carrying *models*.
+
+    The autouse ``_isolate_global_config`` fixture already points
+    ``$OMNIGENT_CONFIG_HOME`` at *tmp_path*, so this exercises the real
+    config-loading path behind ``databricks_provider_models``.
+
+    :param tmp_path: The per-test config home.
+    :param models: The tier→model overrides, e.g.
+        ``{"default": "main.agents.my-opus-endpoint"}``.
+    """
+    (tmp_path / "config.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {"kind": "databricks", "profile": "oss", "models": models}
+                }
+            }
+        )
+    )
+
+
+def test_provider_models_default_beats_ucode_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    The provider entry's ``models.default`` outranks the ucode-cached model.
+
+    The user picked an explicit endpoint on the ``kind: databricks``
+    provider in ``~/.omnigent/config.yaml``; the ucode state cache must
+    not shadow it (config > ucode > hardcoded default).
+    """
+    _ucode_state_without_model(monkeypatch, model="databricks-claude-sonnet-4-6")
+    _write_databricks_models_config(tmp_path, models={"default": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.my-opus-endpoint"
+
+
+def test_provider_models_without_default_keeps_ucode_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    A ``models:`` map with no ``default`` tier leaves the ucode model alone.
+
+    Only the ``default`` tier feeds the single claude-sdk model env var;
+    a per-tier-only map (e.g. just ``opus:``) must not clobber the
+    ucode-resolved launch model.
+    """
+    _ucode_state_without_model(monkeypatch, model="databricks-claude-sonnet-4-6")
+    _write_databricks_models_config(tmp_path, models={"opus": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def test_spec_model_beats_provider_models_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    A spec-pinned model still wins over the provider ``models:`` override.
+
+    Failure means the config-level override clobbers an explicit
+    ``executor.model`` from the agent YAML — spec must stay strongest.
+    """
+    _ucode_state_without_model(monkeypatch, model=None)
+    _write_databricks_models_config(tmp_path, models={"default": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model="databricks-claude-opus-4-8", profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-opus-4-8"
+
+
+def test_provider_models_apply_without_ucode_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    The override lands even when the profile has no ucode state at all.
+
+    On the profile-derived gateway path (no ``~/.ucode/state.json`` entry)
+    ``configure_agent_harness_with_ucode`` early-returns before its ucode
+    lookups — the provider override must be applied before those checks or
+    a configured endpoint would silently fall back to the executor's
+    hardcoded Databricks default.
+    """
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.get_workspace_url_for_profile",
+        lambda profile: None,
+    )
+    _write_databricks_models_config(tmp_path, models={"default": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY"] == "true"
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.my-opus-endpoint"
+
+
+def test_provider_models_1m_suffix_kept_for_claude_sdk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The ``[1m]`` suffix passes through to the claude-sdk spawn env.
+
+    The claude-sdk harness drives the claude CLI, which understands the
+    suffix (1M-context accounting) and strips it before the API call — so
+    unlike pi, the producer must NOT strip it here.
+    """
+    _ucode_state_without_model(monkeypatch, model=None)
+    _write_databricks_models_config(
+        tmp_path, models={"default": "main.agents.my-opus-endpoint[1m]"}
+    )
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.my-opus-endpoint[1m]"

--- a/tests/runtime/test_pi_spawn_env.py
+++ b/tests/runtime/test_pi_spawn_env.py
@@ -198,3 +198,70 @@ def test_no_ucode_pi_entry_leaves_model_to_executor_default(
     assert env["HARNESS_PI_DATABRICKS_PROFILE"] == "oss"
     # No producer model — the executor's profile-path default applies.
     assert "HARNESS_PI_MODEL" not in env
+
+
+def test_provider_models_default_beats_ucode_model_for_pi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Pi parity: the databricks provider's ``models.default`` outranks ucode.
+
+    The claude-sdk and pi producers share
+    ``configure_agent_harness_with_ucode``, so the ``models:`` override on
+    the ``kind: databricks`` entry must reach ``HARNESS_PI_MODEL`` the same
+    way (config > ucode > hardcoded default).
+    """
+    import yaml as _yaml
+
+    _ucode_state_for_pi(monkeypatch, model="databricks-claude-sonnet-4-6", with_pi_entry=True)
+    (tmp_path / "config.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {
+                        "kind": "databricks",
+                        "profile": "oss",
+                        "models": {"default": "main.agents.my-opus-endpoint"},
+                    }
+                }
+            }
+        )
+    )
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_pi_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_PI_MODEL"] == "main.agents.my-opus-endpoint"
+
+
+def test_provider_models_1m_suffix_stripped_for_pi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Claude Code's ``[1m]`` suffix never reaches ``HARNESS_PI_MODEL``.
+
+    The suffix is a claude-CLI-side convention (stripped before the API
+    call); pi passes model ids through verbatim and the gateway rejects
+    suffixed names outright — so the producer must strip it for pi while
+    the claude-sdk path keeps it.
+    """
+    import yaml as _yaml
+
+    _ucode_state_for_pi(monkeypatch, model=None, with_pi_entry=True)
+    (tmp_path / "config.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {
+                        "kind": "databricks",
+                        "profile": "oss",
+                        "models": {"default": "main.agents.my-opus-endpoint[1m]"},
+                    }
+                }
+            }
+        )
+    )
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_pi_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_PI_MODEL"] == "main.agents.my-opus-endpoint"

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -907,6 +907,79 @@ def test_databricks_kind_default_routes_through_profile(
     assert "HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL" not in env
 
 
+def test_databricks_kind_default_applies_models_map(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A databricks-kind default provider's ``models:`` map reaches claude-sdk.
+
+    The provider-selected route (not just the legacy-profile route) must
+    honor the per-tier overrides: with no ucode state at all, the entry's
+    ``models.default`` still lands in ``HARNESS_CLAUDE_SDK_MODEL`` instead
+    of leaving the executor to its hardcoded Databricks default.
+    """
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "dbx": {
+                    "kind": "databricks",
+                    "default": True,
+                    "profile": "my-dbx-profile",
+                    "models": {"default": "main.agents.claude-endpoint"},
+                }
+            }
+        },
+    )
+    # No ucode state for the profile — the override alone supplies the model.
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.get_workspace_url_for_profile",
+        lambda profile: None,
+    )
+    spec = _make_spec(harness="claude-sdk")
+
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_DATABRICKS_PROFILE"] == "my-dbx-profile"
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.claude-endpoint"
+
+
+def test_databricks_models_map_does_not_touch_codex(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    The databricks ``models:`` map never feeds a codex-family harness.
+
+    The map is Claude-tier-shaped (``opus`` / ``sonnet`` / ``default``
+    endpoints), so injecting it into ``HARNESS_CODEX_MODEL`` would point
+    codex at an Anthropic-surface endpoint. The override is scoped to the
+    Claude-gateway harnesses; codex must resolve its model as before.
+    """
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "dbx": {
+                    "kind": "databricks",
+                    "default": True,
+                    "profile": "my-dbx-profile",
+                    "models": {"default": "main.agents.claude-endpoint"},
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.get_workspace_url_for_profile",
+        lambda profile: None,
+    )
+    spec = _make_spec(harness="codex")
+
+    env = _build_codex_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CODEX_DATABRICKS_PROFILE"] == "my-dbx-profile"
+    assert "HARNESS_CODEX_MODEL" not in env
+
+
 # ── Backwards-compat: no provider configured ───────────────────────────────
 
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -466,6 +466,105 @@ def test_ucode_config_for_profile_defaults_model_when_ucode_omits_it(
     assert config.model == "databricks-claude-opus-4-8"
 
 
+def test_ucode_config_for_profile_provider_models_override_tiers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Provider-config ``models:`` tiers outrank ucode ``claude_models``.
+
+    A per-tier override on the profile's ``kind: databricks`` provider
+    entry wins for its tier (opus) and for the launch default, while a
+    tier the config leaves unset (sonnet) still resolves from ucode state
+    — config > ucode > hardcoded default, per tier.
+    """
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n"
+        "  databricks:\n"
+        "    kind: databricks\n"
+        "    profile: test-profile\n"
+        "    models:\n"
+        "      default: main.agents.opus-endpoint\n"
+        "      opus: main.agents.opus-endpoint\n"
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    workspace_state = UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        claude_models={
+            "opus": "databricks-claude-opus-4-7",
+            "sonnet": "databricks-claude-sonnet-4-6",
+        },
+        agents={
+            "claude": UcodeAgentState(
+                model="databricks-claude-opus-4-7",
+                base_url="https://example.databricks.com/ai-gateway/anthropic",
+                auth_command="printf token",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: workspace_state,
+    )
+
+    config = claude_native._ucode_config_for_profile("test-profile")
+
+    assert config is not None
+    # The overridden tier and the launch default come from the provider config.
+    assert config.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "main.agents.opus-endpoint"
+    assert config.model == "main.agents.opus-endpoint"
+    # A tier the config leaves unset still resolves from ucode state.
+    assert config.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def test_ucode_config_for_profile_without_provider_models_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Regression guard: a databricks entry without ``models:`` changes nothing.
+
+    With the profile's provider entry declaring no ``models:`` map, the
+    tier env vars and the launch model must resolve exactly as before the
+    override existed (ucode ``claude_models`` + the per-agent model).
+    """
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n  databricks:\n    kind: databricks\n    profile: test-profile\n"
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    workspace_state = UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        claude_models={"opus": "databricks-claude-opus-4-7"},
+        agents={
+            "claude": UcodeAgentState(
+                model="databricks-claude-opus-4-7",
+                base_url="https://example.databricks.com/ai-gateway/anthropic",
+                auth_command="printf token",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: workspace_state,
+    )
+
+    config = claude_native._ucode_config_for_profile("test-profile")
+
+    assert config is not None
+    assert config.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "databricks-claude-opus-4-7"
+    assert config.model == "databricks-claude-opus-4-7"
+
+
 def test_ucode_config_for_profile_fails_loud_on_malformed_claude_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #1862

## Summary

- The `databricks` provider kind carries only a `profile`: models resolve from another tool's state file (`~/.ucode/state.json`, which omnigent only reads — ucode is the source of truth) or a hardcoded default. There is no omnigent-owned way to pin a custom serving endpoint (e.g. a UC-native AI Gateway `catalog.schema.name` FQN) — users must hand-edit ucode's state file.
- This adds an optional `models:` tier→model map to `kind: databricks` entries in `~/.omnigent/config.yaml`, mirroring the existing `FamilyConfig.models` shape the `gateway` kind already uses.
- Resolution precedence at every Databricks model-resolution point becomes **provider `models:` → ucode state → hardcoded default**, threaded through one shared lookup (`databricks_provider_models`, keyed on the profile): the native-claude tier pinning (`ANTHROPIC_DEFAULT_*_MODEL` + launch model) and the claude-sdk / pi spawn env (`HARNESS_*_MODEL`, including the profile-derived gateway path with no ucode state). A spec-pinned model still wins; codex-family harnesses never consume the map (it is Claude-tier-shaped); the pi producer strips Claude Code's `[1m]` long-context suffix (pi passes model ids verbatim and the gateway rejects suffixed names). An absent `models:` key leaves behavior byte-for-byte unchanged.

```yaml
providers:
  databricks:
    kind: databricks
    profile: my-workspace
    models:                                # NEW, optional
      default: main.agents.my-opus-endpoint
      opus: main.agents.my-opus-endpoint
      sonnet: main.agents.my-sonnet-endpoint
```

ELI5: today "use Databricks" always means "whatever model ucode cached". This lets you write the endpoint you actually want next to the provider entry, and omnigent prefers it — falling back to ucode, then the built-in default, exactly as before when you don't.

```
model resolution (Databricks paths)
  spec model ──► providers.<db>.models ──► ucode state.json ──► DATABRICKS_CLAUDE_DEFAULT_MODEL
   (as today)          (NEW)                 (as today)              (as today)
```

## Test Plan

- `uv run pytest tests/onboarding/test_provider_config.py tests/runtime/test_claude_sdk_spawn_env.py tests/runtime/test_pi_spawn_env.py tests/runtime/test_provider_spawn_env.py tests/test_claude_native.py` — 254 passed.
- New tests: parsing (`models:` map, absent/malformed → empty), profile-keyed lookup, precedence at each touch point (override beats ucode; partial map falls back per tier; spec model beats override; override lands without ucode state; codex untouched), and explicit regression guards that an absent key reproduces the prior behavior.
- New e2e happy path (`tests/e2e/test_databricks_models_override_e2e.py`, opt-in via `--llm-api-key` + `--profile` like the rest of the suite): spawns an isolated server + runner over a seeded `OMNIGENT_CONFIG_HOME`, registers a claude-sdk agent with no model, runs a live turn, and proves via the session's `usage_by_model` that the turn was served by the pinned Sonnet override — not the hardcoded Opus fallback. Passed live (~10s) against a real workspace, three runs.
- `ruff check` / `ruff format --check` clean; mypy error count on touched files unchanged (55 pre-existing).

## Demo

N/A (config/runtime plumbing — the interactive picker UI lands in the follow-up PR stacked on this one).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified end-to-end against a live workspace: with `models:` set on a live Databricks workspace's provider entry, `resolve_native_claude_config` resolved the launch model and `ANTHROPIC_DEFAULT_OPUS/SONNET_MODEL` to the configured UC FQNs, the Haiku tier still fell back to ucode state, `configure_agent_harness_with_ucode` set `HARNESS_CLAUDE_SDK_MODEL` to the override, and `~/.ucode/state.json` was untouched (checksum-verified).

## Changelog

Added: `kind: databricks` providers accept a per-tier `models:` map in `~/.omnigent/config.yaml` to pin custom gateway model endpoints (config > ucode state > default)

