### PR TITLE
feat(setup): interactive Databricks model endpoint picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,12 @@ the OpenAI-compatible `…/api/v1`.
 <summary>Databricks model endpoints (pin serving endpoints or UC model services)</summary>
 
 A **Databricks** credential resolves its models from the workspace (via
-ucode state) by default. To pin specific endpoints, give the provider entry
-an optional `models:` map in `~/.omnigent/config.yaml`:
+ucode state) by default. `omnigent setup` can pin specific endpoints for
+you: open the Databricks credential under **Claude** or **Pi** and choose
+**Choose model endpoints** — it lists the workspace's Claude serving
+endpoints and your Unity Catalog model services per tier (free-text entry
+covers anything unlisted). The picker writes the provider entry's optional
+`models:` map in `~/.omnigent/config.yaml`, which you can also edit by hand:
 
 ```yaml
 providers:

--- a/README.md
+++ b/README.md
@@ -277,6 +277,37 @@ the OpenAI-compatible `…/api/v1`.
 
 </details>
 
+<details>
+<summary>Databricks model endpoints (pin serving endpoints or UC model services)</summary>
+
+A **Databricks** credential resolves its models from the workspace (via
+ucode state) by default. To pin specific endpoints, give the provider entry
+an optional `models:` map in `~/.omnigent/config.yaml`:
+
+```yaml
+providers:
+  databricks:
+    kind: databricks
+    profile: my-workspace
+    models:                                   # optional — omit to keep the workspace defaults
+      default: main.agents.my-opus-endpoint   # session launch model (Claude Code, claude-sdk, pi)
+      opus: main.agents.my-opus-endpoint      # Claude Code's Opus alias
+      sonnet: main.agents.my-sonnet-endpoint  # Claude Code's Sonnet alias
+      haiku: databricks-claude-haiku-4-5      # Claude Code's fast/background alias
+```
+
+Values are model serving endpoint names or Unity Catalog model service FQNs
+(`catalog.schema.name`) that answer the gateway's Anthropic surface — Claude
+models only. Each tier resolves as: this map → the workspace's ucode state →
+the built-in default, so unset tiers keep the workspace behavior and removing
+the map restores it entirely. Claude Code's `[1m]` long-context suffix passes
+through verbatim (e.g. `main.agents.my-opus-endpoint[1m]`), so a pinned
+endpoint can run with the 1M-token context window where the workspace's
+gateway supports it — except for the `pi` harness, which speaks the API
+directly and gets the suffix stripped at spawn.
+
+</details>
+
 ### 4. Deploy a server (and use it from your phone📱)
 
 Run Omnigent on a server with a stable URL

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1386,7 +1386,9 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
     The profile remains the explicit workspace selector. If no
     profile is selected, or the profile has no matching ucode state,
     the native wrapper leaves Claude Code's normal provider
-    configuration alone.
+    configuration alone. A ``models:`` map on the profile's ``kind:
+    databricks`` provider entry overrides the ucode-cached models
+    per tier (config > ucode > hardcoded default).
 
     :param profile: Databricks CLI profile name, e.g.
         ``"<your-profile>"``.
@@ -1402,6 +1404,7 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
         DATABRICKS_CLAUDE_DEFAULT_MODEL,
         get_workspace_url_for_profile,
     )
+    from omnigent.onboarding.provider_config import databricks_provider_models
     from omnigent.onboarding.ucode_state import read_ucode_state
 
     workspace_url = get_workspace_url_for_profile(profile)
@@ -1444,9 +1447,12 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
     # gateway model ID so that the /model picker natively shows gateway model
     # names.  Without this Claude Code normalises the picked model to a
     # canonical Anthropic name (e.g. "claude-opus-4-7[1m]") that the
-    # Databricks gateway rejects.
+    # Databricks gateway rejects.  Per-tier ``models:`` overrides from the
+    # provider config outrank the ucode-cached models; ucode fills the tiers
+    # the config leaves unset.
+    model_overrides = databricks_provider_models(profile)
     for tier, env_var in _UCODE_CLAUDE_TIER_TO_ENV.items():
-        model_id = workspace_state.claude_models.get(tier)
+        model_id = model_overrides.get(tier) or workspace_state.claude_models.get(tier)
         if model_id:
             env[env_var] = model_id
     # When ucode caches no model, default it so Claude Code doesn't fall back
@@ -1454,7 +1460,9 @@ def _ucode_config_for_profile(profile: str | None) -> ClaudeNativeUcodeConfig | 
     return ClaudeNativeUcodeConfig(
         env=env,
         api_key_helper=agent_state.auth_command,
-        model=agent_state.model or DATABRICKS_CLAUDE_DEFAULT_MODEL,
+        model=(
+            model_overrides.get("default") or agent_state.model or DATABRICKS_CLAUDE_DEFAULT_MODEL
+        ),
     )
 
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8976,10 +8976,33 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         # Wipe the verbose login + ucode output so the menu we return to (with a
         # "✓ Added databricks" status) renders on a clean screen.
         clear_screen()
+        # Optional per-tier model endpoint overrides (the entry's models:
+        # map). Default is the ucode-managed gateway models; the picker is
+        # for pinning specific serving endpoints / UC model services. Esc
+        # keeps the defaults — never aborts the add (the login + ucode
+        # configure above already succeeded). Skipped on the Codex page:
+        # the map's tiers feed the gateway's Anthropic surface exclusively,
+        # while codex resolves its models from ucode's ``codex_models``.
+        endpoint_models: dict[str, str] = {}
+        if family != OPENAI_FAMILY:
+            endpoint_choice = select(
+                "Model endpoints",
+                [
+                    "Use the workspace defaults (recommended)",
+                    "Choose custom model endpoints",
+                ],
+                descriptions=[
+                    "Route through the models ucode configured for this workspace.",
+                    "Pin a serving endpoint or UC model service per model tier.",
+                ],
+                clear_on_exit=True,
+            )
+            if endpoint_choice == 1:
+                endpoint_models = _pick_databricks_models(profile, {})
         # Databricks name is fixed — no prompt. The provider keys on the
         # profile; runtime resolves profile → workspace URL → ucode state.
         name = "databricks"
-        entry = build_databricks_provider_entry(profile)
+        entry = build_databricks_provider_entry(profile, models=endpoint_models)
 
     from omnigent.onboarding.configure_models import family_label
     from omnigent.onboarding.provider_config import (
@@ -9023,6 +9046,195 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         labels = " · ".join(family_label(f) for f in became_default)
         return f"✓ Added {name} — default for {labels}"
     return f"✓ Added {name}"
+
+
+# The model tiers the Databricks endpoint picker prompts for, in order:
+# (config key, human label for the menu title, what the tier drives). These
+# are the ``models:`` keys the runtime consumes — the keys are fixed schema
+# (they mirror ucode's ``claude_models`` tiers plus the FamilyConfig-style
+# ``default``), so only the labels are presentation. ``fable`` stays
+# hand-editable in ~/.omnigent/config.yaml rather than prompted.
+_DATABRICKS_MODEL_TIERS: list[tuple[str, str, str]] = [
+    (
+        "default",
+        "session launch model",
+        "What Claude / Pi sessions launch with when the agent pins no model — "
+        "the one tier every Claude-surface harness uses.",
+    ),
+    (
+        "opus",
+        "Claude Code's Opus alias",
+        "What a native Claude Code session runs when it asks for its Opus tier "
+        "(plan mode, /model, sub-agents pinning model: opus).",
+    ),
+    (
+        "sonnet",
+        "Claude Code's Sonnet alias",
+        "What a native Claude Code session runs when it asks for its Sonnet tier.",
+    ),
+    (
+        "haiku",
+        "Claude Code's Haiku alias",
+        "What a native Claude Code session runs for its fast/background Haiku "
+        "tier (lightweight helper calls).",
+    ),
+]
+
+
+def _pick_databricks_models(profile: str, current: dict[str, str]) -> dict[str, str]:
+    """Run the per-tier Databricks model-endpoint picker.
+
+    For each tier in :data:`_DATABRICKS_MODEL_TIERS` (default / opus /
+    sonnet / haiku) shows one grouped menu with two sections (every tier
+    feeds the gateway's Anthropic surface, which rejects other endpoints,
+    so both listings are Claude-scoped):
+
+    - **Databricks-hosted Claude models** — the workspace's Claude chat
+      serving endpoints the caller can query (best-effort — see
+      :func:`~omnigent.onboarding.databricks_config.list_claude_serving_endpoint_names`).
+    - **Custom endpoints (Unity Catalog)** — the caller's UC model
+      services (Beta securables, best-effort — see
+      :func:`~omnigent.onboarding.databricks_config.list_claude_model_service_fqns`),
+      plus a free-text row for FQNs the listing missed (e.g. a
+      just-created service, or when the Beta API is unavailable).
+
+    The leading keep/skip row advances to the next tier unchanged; a
+    ``Clear override`` row (shown only when the tier has one) removes it.
+    Esc backs out of the picker entirely — picks already made on earlier
+    tiers are kept.
+
+    :param profile: The ``~/.databrickscfg`` profile whose workspace is
+        listed, e.g. ``"oss"``.
+    :param current: The entry's existing tier→model map; not modified.
+    :returns: The updated tier→model map (equal to *current* when every
+        tier was skipped).
+    """
+    from omnigent.onboarding.databricks_config import (
+        claude_context_window,
+        list_claude_endpoints,
+    )
+    from omnigent.onboarding.interactive import console, prompt_text, select
+
+    def _endpoint_row(name: str) -> tuple[str, str, str]:
+        """Build a (label, description, action) endpoint row.
+
+        Displays the model family's max context window for transparency,
+        and pins 1M-capable endpoints at that window by storing the
+        ``[1m]``-suffixed id (Claude Code's long-context convention; the
+        pi producer strips it). Free-text entries stay verbatim — the
+        pin applies only to picked rows, whose family the name reveals.
+        """
+        window = claude_context_window(name)
+        if window == "1M":
+            return (
+                f"{name}  ·  1M context",
+                "Pinned at the 1M-token context window ([1m]).",
+                f"{name}[1m]",
+            )
+        if window == "200K":
+            return (f"{name}  ·  200K context", "This model family caps at 200K tokens.", name)
+        return (name, "Context window unknown from the name — stored verbatim.", name)
+
+    # The two listings take a couple of seconds (an OAuth handshake plus the
+    # permission / detail sweeps) — show progress rather than a frozen prompt.
+    with console.status("Loading this workspace's Claude model endpoints…"):
+        hosted, custom = list_claude_endpoints(profile)
+    if not hosted and not custom:
+        console.print(
+            "  [dim]Could not list this workspace's Claude endpoints — enter "
+            "endpoint names manually (e.g. a UC model service's "
+            "catalog.schema.name).[/dim]"
+        )
+    console.print(
+        "  [dim]Each tier is optional — Skip keeps the workspace default for "
+        "that tier; Esc finishes.[/dim]"
+    )
+    models = dict(current)
+    for tier, tier_label, tier_help in _DATABRICKS_MODEL_TIERS:
+        # (label, description, action) rows. ``None`` marks a section header;
+        # the ``:``-prefixed controls cannot collide with endpoint names
+        # (endpoint names and UC FQNs never contain a colon); anything else
+        # is the endpoint name the row picks.
+        keep_label = (
+            f"Keep {models[tier]}" if tier in models else "Skip — use the workspace default"
+        )
+        entries: list[tuple[str, str, str | None]] = [(keep_label, tier_help, ":skip")]
+        if tier in models:
+            entries.append(
+                (
+                    "Clear override — use the workspace default",
+                    "Remove this tier's override from ~/.omnigent/config.yaml.",
+                    ":clear",
+                )
+            )
+        if hosted:
+            entries.append(("Databricks-hosted Claude models", "", None))
+            entries.extend(_endpoint_row(name) for name in hosted)
+        entries.append(("Custom endpoints (Unity Catalog)", "", None))
+        entries.extend(_endpoint_row(name) for name in custom)
+        entries.append(
+            (
+                "Enter an endpoint name…",
+                "Type a UC model service's catalog.schema.name (e.g. one created moments ago).",
+                ":free",
+            )
+        )
+
+        idx = select(
+            f"Model endpoint · {tier} ({tier_label})",
+            [label for label, _, _ in entries],
+            descriptions=[desc for _, desc, _ in entries],
+            selectable=[action is not None for _, _, action in entries],
+            clear_on_exit=True,
+            max_visible=14,
+        )
+        if idx < 0:  # Esc — back out of the picker; earlier tier picks stay
+            break
+        action = entries[idx][2]
+        if action is None or action == ":skip":  # header rows are unreachable
+            continue
+        if action == ":clear":
+            models.pop(tier, None)
+            continue
+        if action == ":free":
+            value = prompt_text(f"{tier} endpoint name (e.g. catalog.schema.endpoint)").strip()
+            if value:
+                models[tier] = value
+            continue
+        models[tier] = action
+    return models
+
+
+def _configure_databricks_models(provider: str, entry: ProviderEntry) -> str | None:
+    """Run the endpoint picker for an existing databricks provider and persist.
+
+    Opened from the credential's level-3 menu (``Choose model endpoints``).
+    Rewrites only the entry's ``models:`` key — an emptied map drops the key
+    so the entry round-trips to its pre-override shape.
+
+    :param provider: The provider id, e.g. ``"databricks"``.
+    :param entry: The parsed entry (kind ``databricks``).
+    :returns: A status line for the level-2 menu, or ``None`` when nothing
+        changed. Side effect: writes ``~/.omnigent/config.yaml``.
+    """
+    if not entry.profile:
+        return None
+    models = _pick_databricks_models(entry.profile, dict(entry.models))
+    if models == entry.models:
+        return None
+    cfg = _load_global_config()
+    block = cfg.get("providers")
+    raw = block.get(provider) if isinstance(block, dict) else None
+    if not isinstance(block, dict) or not isinstance(raw, dict):
+        return None
+    if models:
+        raw["models"] = models
+    else:
+        raw.pop("models", None)
+    _save_global_config({"providers": block})
+    if not models:
+        return f"✓ Cleared model endpoints for {provider}"
+    return f"✓ Set model endpoints for {provider} ({', '.join(sorted(models))})"
 
 
 def _adopt_detected_providers() -> list[str]:
@@ -10445,7 +10657,9 @@ def _manage_credential(provider: str, family: str) -> str | None:
     from omnigent.onboarding.configure_models import family_label
     from omnigent.onboarding.interactive import select
     from omnigent.onboarding.provider_config import (
+        ANTHROPIC_FAMILY,
         DATABRICKS_KIND,
+        PI_SURFACE,
         SUBSCRIPTION_KIND,
         load_providers,
         surface_default_provider,
@@ -10468,6 +10682,15 @@ def _manage_credential(provider: str, family: str) -> str | None:
                 f"Make default for {family_label(family)}", action="set_default", provider=provider
             )
         )
+    # A databricks provider's models resolve from ucode state unless the
+    # entry pins per-tier endpoint overrides in its ``models:`` map — offer
+    # the picker that edits that map. Only on the Anthropic-surface pages
+    # (Claude / Pi): the map's tiers feed the gateway's Anthropic surface
+    # exclusively, while codex-family harnesses resolve their models from
+    # ucode's ``codex_models`` — offering Claude endpoints there would pin
+    # models codex cannot use.
+    if entry.kind == DATABRICKS_KIND and family in (ANTHROPIC_FAMILY, PI_SURFACE):
+        rows.append(_HarnessMenuRow("Choose model endpoints", action="models", provider=provider))
     rows.append(_HarnessMenuRow("Remove", action="remove", provider=provider))
     rows.append(_HarnessMenuRow("← Back", action="back"))
 
@@ -10479,6 +10702,8 @@ def _manage_credential(provider: str, family: str) -> str | None:
         return None
     if row.action == "set_default":
         return _set_harness_default(provider, family)
+    if row.action == "models":
+        return _configure_databricks_models(provider, entry)
     # A subscription's credential lives in the harness CLI's own auth file, not
     # our config — so removing it means signing out of that CLI (otherwise the
     # login persists and ambient detection re-adopts it on the next open).

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -669,6 +669,9 @@ def _entry_models_summary(entry: ProviderEntry) -> str:
     if entry.kind == SUBSCRIPTION_KIND:
         return f"via {entry.cli} CLI"
     if entry.kind == DATABRICKS_KIND:
+        if entry.models:
+            plural = "s" if len(entry.models) != 1 else ""
+            return f"profile: {entry.profile} · {len(entry.models)} model override{plural}"
         return f"profile: {entry.profile}"
     if entry.kind == CLI_CONFIG_KIND:
         return f"~/.{entry.cli}/config.toml: {entry.model_provider}"
@@ -927,12 +930,20 @@ def build_gateway_provider_entry(
     return body
 
 
-def build_databricks_provider_entry(profile: str) -> dict[str, object]:
+def build_databricks_provider_entry(
+    profile: str, models: dict[str, str] | None = None
+) -> dict[str, object]:
     """Build a ``kind: databricks`` provider entry body.
 
     :param profile: The Databricks profile name from
         ``~/.databrickscfg``, e.g. ``"oss"``.
+    :param models: Optional tier→model overrides from the endpoint picker,
+        e.g. ``{"default": "main.agents.my-opus-endpoint"}``. ``None`` /
+        empty omits the ``models:`` key (ucode-driven resolution).
     :returns: A provider entry body, e.g.
         ``{"kind": "databricks", "profile": "oss"}``.
     """
-    return {"kind": DATABRICKS_KIND, "profile": profile}
+    entry: dict[str, object] = {"kind": DATABRICKS_KIND, "profile": profile}
+    if models:
+        entry["models"] = dict(models)
+    return entry

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -6,7 +6,11 @@ import configparser
 import importlib.util
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from databricks.sdk import WorkspaceClient
 
 _logger = logging.getLogger(__name__)
 
@@ -83,6 +87,302 @@ def databricks_sdk_installed() -> bool:
 # endpoint name — the gateway rejects Anthropic-direct ids like the CLI's
 # own ``opus[1m]`` default.
 DATABRICKS_CLAUDE_DEFAULT_MODEL = "databricks-claude-opus-4-8"
+
+
+# Max context window per Claude model family, matched as substrings against
+# endpoint / UC-service names (most specific first, so plain "sonnet-4" only
+# catches names the 4-6/4-5 rows did not). Sources: the Anthropic model
+# catalog (1M standard on Fable 5 / Opus 4.6+ / Sonnet 4.6+; 200K on Haiku
+# 4.5 and older tiers) and the Databricks FMAPI supported-models docs
+# (Opus 4.7/4.6 documented at 1M; Opus 4.5/4.1 at 200K), live-verified on a
+# workspace gateway (a >200K-token prompt is accepted on an Opus 4.8
+# endpoint with no beta header).
+_CLAUDE_CONTEXT_WINDOWS: tuple[tuple[str, str], ...] = (
+    ("fable-5", "1M"),
+    ("opus-4-8", "1M"),
+    ("opus-4-7", "1M"),
+    ("opus-4-6", "1M"),
+    ("opus-4-5", "200K"),
+    ("opus-4-1", "200K"),
+    ("sonnet-5", "1M"),
+    ("sonnet-4-6", "1M"),
+    ("sonnet-4-5", "200K"),
+    ("sonnet-4", "200K"),
+    ("haiku-4-5", "200K"),
+)
+
+
+def claude_context_window(model_name: str) -> str | None:
+    """Return the max context window for a Claude endpoint/service name.
+
+    Matches the model family as a substring of *model_name* (hosted
+    endpoint names and user-created UC FQNs both usually carry it, e.g.
+    ``databricks-claude-opus-4-8`` or ``main.agents.opus-4-8``). A name
+    that reveals no known family returns ``None`` — callers show no label
+    and must not assume a window.
+
+    :param model_name: Endpoint name or UC model service FQN.
+    :returns: ``"1M"``, ``"200K"``, or ``None`` when the family is
+        unrecognizable from the name.
+    """
+    lowered = model_name.lower()
+    for family, window in _CLAUDE_CONTEXT_WINDOWS:
+        if family in lowered:
+            return window
+    return None
+
+
+def _serves_claude_model(endpoint: dict[str, object]) -> bool:
+    """Return whether a serving endpoint serves a Claude/Anthropic model.
+
+    Endpoint metadata exposes no supported-API-types field, so the served
+    entities' model identity is the discriminator: a Databricks-hosted
+    Claude foundation model (``foundation_model`` name/display name), an
+    ``external_model`` with the ``anthropic`` provider, or a custom entity
+    whose name carries ``claude``.
+
+    :param endpoint: One ``as_dict()``-shaped serving endpoint from the
+        list/get API.
+    :returns: ``True`` when any served entity is a Claude/Anthropic model.
+    """
+    config = endpoint.get("config")
+    entities = config.get("served_entities", []) if isinstance(config, dict) else []
+    for entity in entities:
+        if not isinstance(entity, dict):
+            continue
+        foundation = entity.get("foundation_model")
+        foundation = foundation if isinstance(foundation, dict) else {}
+        external = entity.get("external_model")
+        external = external if isinstance(external, dict) else {}
+        if str(external.get("provider", "")).lower() == "anthropic":
+            return True
+        identity = " ".join(
+            str(value)
+            for value in (
+                foundation.get("name"),
+                foundation.get("display_name"),
+                external.get("name"),
+                entity.get("entity_name"),
+            )
+            if value
+        ).lower()
+        if "claude" in identity:
+            return True
+    return False
+
+
+def list_claude_serving_endpoint_names(profile: str) -> list[str]:
+    """Return Claude-serving chat endpoints the caller can query, best-effort.
+
+    Backs the setup flow's model-endpoint picker, whose picks drive the
+    Anthropic-surface harnesses (native claude / claude-sdk / pi). The
+    workspace AI gateway rejects every other endpoint on that surface
+    ("API type 'anthropic/v1/messages' is not supported"), so the list
+    keeps only endpoints that:
+
+    - run the ``llm/v1/chat`` task (drops embeddings/completions),
+    - serve a Claude/Anthropic model (:func:`_serves_claude_model`), and
+    - the caller holds CAN_QUERY / CAN_MANAGE on. The list API alone
+      scopes to CAN_VIEW — which cannot query — so a parallel detail
+      sweep confirms each survivor's ``permission_level``.
+
+    This covers only classic serving endpoints; custom UC model services
+    (Beta securables addressed by ``catalog.schema.name``) are listed by
+    the companion :func:`list_claude_model_service_fqns`. Any wholesale
+    failure (SDK absent, auth, network) returns ``[]`` — callers degrade
+    to free-text entry rather than blocking the flow.
+
+    :param profile: ``~/.databrickscfg`` profile name, e.g. ``"oss"``.
+    :returns: Sorted endpoint names, e.g.
+        ``["databricks-claude-opus-4-8", "databricks-claude-sonnet-5"]``.
+    """
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        return _claude_serving_endpoint_names(WorkspaceClient(profile=profile))
+    except Exception as exc:  # best-effort listing — the picker degrades to free text
+        _logger.debug("Could not list serving endpoints for profile %r: %s", profile, exc)
+        return []
+
+
+def _claude_serving_endpoint_names(client: WorkspaceClient) -> list[str]:
+    """Client-taking body of :func:`list_claude_serving_endpoint_names`.
+
+    Split out so :func:`list_claude_endpoints` can run both listings on one
+    shared (already-authenticated) client. Raises on wholesale failure —
+    the public wrappers own the degrade-to-``[]`` contract.
+
+    :param client: An authenticated SDK workspace client.
+    :returns: Sorted Claude-serving chat endpoint names the caller can query.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    candidates = [
+        str(ep.name)
+        for ep in client.serving_endpoints.list()
+        if ep.name and str(ep.task or "") == "llm/v1/chat" and _serves_claude_model(ep.as_dict())
+    ]
+    if not candidates:
+        return []
+
+    def _can_query(name: str) -> bool:
+        try:
+            level = client.serving_endpoints.get(name).permission_level
+        except Exception as exc:  # dropped from the list, not fatal to the sweep
+            _logger.debug("Could not read permission level for %r: %s", name, exc)
+            return False
+        return level is not None and level.value in ("CAN_QUERY", "CAN_MANAGE")
+
+    with ThreadPoolExecutor(max_workers=min(8, len(candidates))) as pool:
+        queryable = list(pool.map(_can_query, candidates))
+    return sorted(name for name, ok in zip(candidates, queryable, strict=True) if ok)
+
+
+def _model_service_serves_claude(service: dict[str, object]) -> bool | None:
+    """Return whether a UC model service can answer the Anthropic surface.
+
+    Prefers the service's ``supported_api_types`` (authoritative — the
+    gateway names these in its rejection errors), but that field is not
+    yet populated on user-created services (observed empty on live
+    pay-per-token services that answer ``anthropic/v1/messages`` fine),
+    so fall back to the routing destinations' model identity.
+
+    :param service: One raw model-service mapping from the
+        ``unity-catalog/model-services`` API.
+    :returns: ``True``/``False`` when the payload is decisive, ``None``
+        when it carries neither populated ``supported_api_types`` nor
+        routing destinations — the *list* response omits destinations, so
+        an undecided service needs its single-get detail.
+    """
+    import json
+
+    api_types = service.get("supported_api_types")
+    if isinstance(api_types, list) and api_types:
+        return "anthropic/v1/messages" in api_types
+    config = service.get("config")
+    destinations = config.get("destinations", []) if isinstance(config, dict) else []
+    if not destinations:
+        return None
+    identity = json.dumps(destinations).lower()
+    return "claude" in identity or "anthropic" in identity
+
+
+def list_claude_model_service_fqns(profile: str) -> list[str]:
+    """Return custom UC model services that speak the Anthropic surface.
+
+    Model services are Unity Catalog securables (Beta) representing
+    governed LLM endpoints, addressed by ``catalog.schema.name`` FQN and
+    listed via ``GET /api/2.1/unity-catalog/model-services`` — visibility
+    is scoped by Unity Catalog privileges, so the caller only sees
+    services they hold grants on. Keeps Claude/Anthropic-capable services
+    (:func:`_model_service_serves_claude`; services the list payload
+    cannot decide are resolved through a parallel single-get sweep, since
+    the list response omits routing destinations) and drops the
+    ``system.ai`` schema: those built-ins mirror the workspace's hosted
+    ``databricks-*`` serving endpoints, which the picker already lists
+    separately. Any wholesale failure returns ``[]`` — callers degrade to
+    free-text entry rather than blocking the flow.
+
+    :param profile: ``~/.databrickscfg`` profile name, e.g. ``"oss"``.
+    :returns: Sorted FQNs, e.g.
+        ``["main.agents.my-opus-endpoint", "main.agents.my-sonnet-endpoint"]``.
+    """
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        return _claude_model_service_fqns(WorkspaceClient(profile=profile))
+    except Exception as exc:  # best-effort listing — the picker degrades to free text
+        _logger.debug("Could not list UC model services for profile %r: %s", profile, exc)
+        return []
+
+
+def _claude_model_service_fqns(client: WorkspaceClient) -> list[str]:
+    """Client-taking body of :func:`list_claude_model_service_fqns`.
+
+    Split out so :func:`list_claude_endpoints` can run both listings on one
+    shared (already-authenticated) client. Raises on wholesale failure —
+    the public wrappers own the degrade-to-``[]`` contract.
+
+    :param client: An authenticated SDK workspace client.
+    :returns: Sorted Claude-capable custom UC model service FQNs.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    names: list[str] = []
+    undecided: list[str] = []
+    page_token: str | None = None
+    while True:
+        path = "/api/2.1/unity-catalog/model-services"
+        if page_token:
+            path += f"?page_token={page_token}"
+        response = client.api_client.do("GET", path)
+        services = response.get("model_services", []) if isinstance(response, dict) else []
+        for service in services:
+            if not isinstance(service, dict):
+                continue
+            raw_name = str(service.get("name", ""))
+            fqn = raw_name.removeprefix("model-services/")
+            if not fqn or fqn.startswith("system.ai."):
+                continue
+            serves = _model_service_serves_claude(service)
+            if serves:
+                names.append(fqn)
+            elif serves is None:
+                undecided.append(fqn)
+        page_token = response.get("next_page_token") if isinstance(response, dict) else None
+        if not page_token:
+            break
+
+    def _detail_serves_claude(fqn: str) -> bool:
+        try:
+            detail = client.api_client.do("GET", f"/api/2.1/unity-catalog/model-services/{fqn}")
+        except Exception as exc:  # dropped from the list, not fatal to the sweep
+            _logger.debug("Could not read model service %r: %s", fqn, exc)
+            return False
+        return isinstance(detail, dict) and bool(_model_service_serves_claude(detail))
+
+    if undecided:
+        with ThreadPoolExecutor(max_workers=min(8, len(undecided))) as pool:
+            decided = list(pool.map(_detail_serves_claude, undecided))
+        names.extend(fqn for fqn, ok in zip(undecided, decided, strict=True) if ok)
+    return sorted(names)
+
+
+def list_claude_endpoints(profile: str) -> tuple[list[str], list[str]]:
+    """Return both Claude endpoint listings for *profile*, fetched in parallel.
+
+    The endpoint picker needs the hosted serving endpoints
+    (:func:`list_claude_serving_endpoint_names`) **and** the custom UC
+    model services (:func:`list_claude_model_service_fqns`); fetching them
+    through one shared client (a single OAuth handshake) in parallel
+    roughly halves the picker's load time. Each listing degrades to
+    ``[]`` independently; an unusable profile/SDK degrades both.
+
+    :param profile: ``~/.databrickscfg`` profile name, e.g. ``"oss"``.
+    :returns: ``(hosted_endpoint_names, custom_service_fqns)``.
+    """
+    from collections.abc import Callable
+
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        client = WorkspaceClient(profile=profile)
+    except Exception as exc:
+        _logger.debug("Could not build a workspace client for profile %r: %s", profile, exc)
+        return [], []
+    from concurrent.futures import ThreadPoolExecutor
+
+    def _safe(lister: Callable[[WorkspaceClient], list[str]]) -> list[str]:
+        try:
+            return lister(client)
+        except Exception as exc:
+            _logger.debug("Endpoint listing failed for profile %r: %s", profile, exc)
+            return []
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        hosted = pool.submit(_safe, _claude_serving_endpoint_names)
+        custom = pool.submit(_safe, _claude_model_service_fqns)
+        return hosted.result(), custom.result()
 
 
 def list_databricks_profiles() -> list[str]:

--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -7,7 +7,8 @@ future configure noun). The look reproduces
 
 - a bold accent header line,
 - one row per option (selected → ``❯  <label>`` in bold accent, others
-  normal weight; non-selectable sub-lines dim italic and indented beneath),
+  normal weight; non-selectable section headers dim, blank-separated
+  above the rows they label),
 - a muted footer hint line (``↑/↓ move  ·  Enter select  ·  Esc back``),
 - a raw-termios keypress loop with in-place redraw (move up, clear,
   reprint), and
@@ -110,10 +111,10 @@ def _render_menu(
     description line for the selected option (the generic analogue of the theme
     preview), and a muted footer of key hints.
 
-    Non-selectable rows (``selectable[i]`` is ``False``) render as dim italic
-    sub-lines indented beneath the preceding choice (e.g. a harness's
-    ``default: …`` summary) with a blank line after — no ``❯`` pointer, and
-    ↑/↓ skip them so the cursor only lands on real choices.
+    Non-selectable rows (``selectable[i]`` is ``False``) render as dim
+    section headers: a group label a notch left of the choice column,
+    blank-separated from the previous group — no ``❯`` pointer, and ↑/↓
+    skip them so the cursor only lands on real choices.
 
     :param title: The header shown above the options, e.g.
         ``"What kind of provider?"``.
@@ -158,34 +159,23 @@ def _render_menu(
     if win_start > 0:
         render_console.print(Text.from_markup(f"       [{MUTED}]↑ {win_start} more[/]"))
 
-    last_choice = -1  # index of the most recent selectable (group-owning) row
     for i in range(win_start, win_end):
         label = options[i]
         if not selectable[i]:
-            # Sub-line(s) under the preceding choice (a harness's default +
-            # "+N more" summary): indented, no pointer. ↑/↓ skip them. Their
-            # styling follows the cursor — the label's own emphasis (e.g. a
-            # bold-green default) shows only under the SELECTED choice; under an
-            # unselected choice the same sub-line is muted to dim so the
-            # highlight tracks where you are.
-            if last_choice == selected:
-                render_console.print(Text.from_markup(f"        {label}"))
-            else:
-                plain = Text.from_markup(label).plain  # drop the label's own color
-                render_console.print(Text(f"        {plain}", style="dim"))
-            # One blank line after the LAST sub-line of a group (next row is a
-            # real choice, or the menu ends) — so consecutive sub-lines stay
-            # together and the gap separates one choice's block from the next.
-            if i + 1 >= len(options) or selectable[i + 1]:
+            # Section header/separator: a dim group label a notch left of the
+            # choice column, blank-separated from the previous group so each
+            # section reads as its own block. ↑/↓ skip it, and its style never
+            # follows the cursor — it labels the rows below, not a choice.
+            if i > win_start:
                 render_console.print()
+            plain = Text.from_markup(label).plain  # structural: always dim
+            render_console.print(Text(f"     {plain}", style="dim"))
         elif i == selected:
             # Highlighted choice: bold accent with the ❯ pointer.
-            last_choice = i
             render_console.print(Text.from_markup(f"    [bold {ACCENT}]❯  {label}[/]"))
         else:
             # Unselected choice: normal weight (readable), aligned under the
             # pointer so the column doesn't shift as the cursor moves.
-            last_choice = i
             render_console.print(Text.from_markup(f"       {label}"))
 
     if win_end < n_options:

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -308,6 +308,15 @@ class ProviderEntry:
         ``None`` otherwise.
     :param profile: For ``kind="databricks"`` only: the Databricks profile
         name from ``~/.databrickscfg``, e.g. ``"oss"``. ``None`` otherwise.
+    :param models: For ``kind="databricks"`` only: optional tier→model map
+        with the same shape as :attr:`FamilyConfig.models`, e.g.
+        ``{"opus": "main.agents.my-opus-endpoint", "default":
+        "databricks-claude-opus-4-8"}``. Tier keys mirror ucode's
+        ``claude_models`` tiers (``fable`` / ``opus`` / ``sonnet`` /
+        ``haiku``) plus ``default``. Entries override the ucode-cached
+        models at every Databricks model-resolution point (see
+        :func:`databricks_provider_models`); absent tiers keep the ucode
+        → hardcoded-default behavior. Empty otherwise.
     :param model_provider: For ``kind="cli-config"`` only: the custom
         provider id in the CLI's config file that the launch pins, i.e. the
         ``X`` in ``[model_providers.X]``, e.g. ``"Databricks"``. ``None``
@@ -336,6 +345,7 @@ class ProviderEntry:
     model_provider: str | None = None
     display_name: str | None = None
     default_families: frozenset[str] = frozenset()
+    models: dict[str, str] = field(default_factory=dict)
 
     @property
     def default(self) -> bool:
@@ -863,10 +873,16 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
         # gemini: the antigravity harness drives Gemini via the dedicated google
         # SDK + GEMINI_API_KEY, not an OpenAI-compatible gateway, so a databricks
         # profile cannot serve (or default) the Gemini surface.
+        models_raw = raw.get("models")
         return ProviderEntry(
             name=name,
             kind=kind,
             profile=profile_raw,
+            models=(
+                {str(k): str(v) for k, v in models_raw.items()}
+                if isinstance(models_raw, dict)
+                else {}
+            ),
             default_families=_parse_default_families(
                 name, default_raw, set(_VALID_FAMILIES) - {GEMINI_FAMILY}, pi_capable=True
             ),
@@ -953,6 +969,35 @@ def load_providers(config: dict[str, object]) -> dict[str, ProviderEntry]:
             )
         result[str(name)] = _parse_provider(str(name), raw)
     return result
+
+
+def databricks_provider_models(profile: str | None) -> dict[str, str]:
+    """Return the ``models:`` overrides of the databricks provider for *profile*.
+
+    The shared lookup behind the Databricks model-resolution points (the
+    native-claude tier pinning and the claude-sdk / pi spawn env): given
+    the profile that identifies the gateway workspace, find the ``kind:
+    databricks`` provider entry carrying it and return its tier→model map.
+    Callers apply the precedence provider ``models:`` → ucode state →
+    hardcoded default, so an absent map (no matching entry, or one without
+    ``models:``) leaves their behavior unchanged.
+
+    :param profile: Databricks profile name from ``~/.databrickscfg``,
+        e.g. ``"oss"``; ``None`` / empty returns ``{}``.
+    :returns: The entry's tier→model map, e.g. ``{"opus":
+        "main.agents.my-opus-endpoint", "default":
+        "databricks-claude-opus-4-8"}``; ``{}`` when no databricks entry
+        matches *profile* or it declares no ``models:``. When several
+        entries share a profile, the first in config order wins.
+    :raises OmnigentError: If the ``providers:`` block is malformed (same
+        as :func:`load_providers`).
+    """
+    if not profile:
+        return {}
+    for entry in load_providers(load_config()).values():
+        if entry.kind == DATABRICKS_KIND and entry.profile == profile:
+            return entry.models
+    return {}
 
 
 def harness_family(harness: str) -> str | None:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -52,6 +52,7 @@ from omnigent.onboarding.provider_config import (
     SUBSCRIPTION_KIND,
     FamilyConfig,
     ProviderEntry,
+    databricks_provider_models,
     default_provider_for_harness,
     first_available_provider,
     harness_family,
@@ -304,7 +305,10 @@ def configure_agent_harness_with_ucode(
 
     The harness-specific constants live here so callers only declare which
     agent harness they are configuring. ucode's per-agent ``agents`` entries
-    are the source of truth for gateway URLs and auth commands.
+    are the source of truth for gateway URLs and auth commands. The model
+    resolves as spec (pre-set ``env`` key) > provider-config ``models:``
+    overrides (:func:`databricks_provider_models`) > ucode state > the
+    harness's hardcoded Databricks default.
 
     :param env: Mutable spawn-env dict, modified in place.
     :param profile: The ``executor.profile`` / provider-config value,
@@ -313,13 +317,30 @@ def configure_agent_harness_with_ucode(
     """
     if not profile:
         return
+    config = _UCODE_HARNESS_CONFIGS[harness_type]
+    # Provider-config model overrides (the ``models:`` map on the ``kind:
+    # databricks`` entry) outrank ucode state: config > ucode > hardcoded
+    # default. Scoped to the Claude-gateway harnesses — the map is
+    # Claude-tier-shaped, which is exactly the harnesses that carry a
+    # Databricks Claude default model. Applied before the ucode-state
+    # checks so the override also lands on the profile-derived gateway
+    # path (no ucode state cached).
+    if config.databricks_default_model is not None and config.model_key not in env:
+        override_model = databricks_provider_models(profile).get("default")
+        if override_model:
+            if harness_type == "pi":
+                # Claude Code's ``[1m]`` long-context suffix is a client-side
+                # convention: the claude CLI strips it before calling the API,
+                # but pi passes model ids through verbatim and the gateway
+                # rejects suffixed names — strip it for pi's spawn env.
+                override_model = override_model.removesuffix("[1m]")
+            env[config.model_key] = override_model
     workspace_url = get_workspace_url_for_profile(profile)
     if workspace_url is None:
         return
     state = read_ucode_state(workspace_url)
     if state is None:
         return
-    config = _UCODE_HARNESS_CONFIGS[harness_type]
     agent_state = state.agent(config.agent_name)
     if agent_state is None:
         return

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -885,9 +885,9 @@ def test_remove_databricks_cleans_ucode_wiring_without_asking(isolated_config) -
     (codex_dir / "ucode.config.toml").write_text(
         'model_provider = "ucode-databricks"\n', encoding="utf-8"
     )
-    # L1 1=Claude → L2 1=select databricks → L3 2=Remove (acts immediately)
-    # → L2 q → L1 q.
-    stdin = "\n".join(["1", "1", "2", "q", "q"]) + "\n"
+    # L1 1=Claude → L2 1=select databricks → L3 (1=Make default, 2=Choose
+    # model endpoints) 3=Remove (acts immediately) → L2 q → L1 q.
+    stdin = "\n".join(["1", "1", "3", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
     cfg = _config_yaml(isolated_config)
@@ -913,8 +913,9 @@ def test_remove_databricks_without_ucode_wiring_still_removes(isolated_config) -
     entry removal.
     """
     _write_databricks_provider(isolated_config)
-    # L1 1=Claude → L2 1=select databricks → L3 2=Remove → L2 q → L1 q.
-    stdin = "\n".join(["1", "1", "2", "q", "q"]) + "\n"
+    # L1 1=Claude → L2 1=select databricks → L3 3=Remove (after Make default
+    # and Choose model endpoints) → L2 q → L1 q.
+    stdin = "\n".join(["1", "1", "3", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
     cfg = _config_yaml(isolated_config)
@@ -1399,8 +1400,9 @@ def test_configure_harnesses_add_databricks_normalizes_url_and_persists(
 
     db = _databricks_add_menu_index()
     # L1 1=Claude → L2 1=+Add → add menu <db>=Databricks → workspace URL (no
-    # scheme + trailing slash, to exercise normalization) → L2 q=back → L1 q=exit.
-    stdin = "\n".join(["1", "1", str(db), "example.cloud.databricks.com/", "q", "q"]) + "\n"
+    # scheme + trailing slash, to exercise normalization) → endpoints
+    # 1=workspace defaults → L2 q=back → L1 q=exit.
+    stdin = "\n".join(["1", "1", str(db), "example.cloud.databricks.com/", "1", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -1493,8 +1495,10 @@ def test_configure_harnesses_add_databricks_under_codex_scopes_to_codex(
     # Databricks position within the Codex (openai) add menu, computed live.
     codex_opts = add_menu_options_for_family(OPENAI_FAMILY)
     db = next(i for i, o in enumerate(codex_opts) if o.kind == DATABRICKS_KIND) + 1
-    # L1 2=Codex → L2 1=+Add → add menu <db>=Databricks → URL → q → q.
-    stdin = "\n".join(["2", "1", str(db), "https://example.cloud.databricks.com", "q", "q"]) + "\n"
+    # L1 2=Codex → L2 1=+Add → add menu <db>=Databricks → URL → q → q. No
+    # endpoint gate on the Codex page: the models: map never feeds codex.
+    inputs = ["2", "1", str(db), "https://example.cloud.databricks.com", "q", "q"]
+    stdin = "\n".join(inputs) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -1502,6 +1506,304 @@ def test_configure_harnesses_add_databricks_under_codex_scopes_to_codex(
     cfg = _config_yaml(isolated_config)
     assert get_default_provider(cfg, "openai").name == "databricks"
     assert get_default_provider(cfg, "anthropic") is None
+
+
+# ── Databricks per-tier model endpoint picker ────────────────────────────────
+
+
+def _stub_databricks_add_boundaries(monkeypatch) -> None:
+    """Stub the databricks add branch's shell-out boundaries.
+
+    Same three stubs as the add-flow tests above (login → profile ``my-ws``,
+    ucode configure → no-op, ucode state exists → True), for tests focused on
+    the endpoint picker rather than the login/ucode wiring.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "omnigent.onboarding.setup.login_databricks_workspace",
+        lambda url, *, console=None: "my-ws",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_setup.configure_ucode_for_workspace",
+        lambda url, *, agents=None: None,
+    )
+    monkeypatch.setattr("omnigent.onboarding.ucode_setup.ucode_workspace_exists", lambda url: True)
+
+
+def test_add_databricks_with_custom_endpoints_writes_models_map(
+    isolated_config, monkeypatch
+) -> None:
+    """Choosing custom endpoints in the add flow writes the ``models:`` map.
+
+    Drives the add flow into the per-tier picker with a stubbed endpoint
+    listing: the ``default`` tier picks a listed serving endpoint, the
+    ``opus`` tier types a UC model service FQN via the free-text row, and
+    the ``sonnet`` / ``haiku`` tiers are skipped.
+    Asserts exactly those two tiers persist on the entry — the picker's
+    whole contract: it writes the ``models:`` map and nothing else.
+    """
+    _stub_databricks_add_boundaries(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        lambda profile: (["databricks-claude-opus-4-8", "databricks-claude-sonnet-4-6"], []),
+    )
+
+    db = _databricks_add_menu_index()
+    # L1 1=Claude → L2 1=+Add → <db>=Databricks → URL → endpoints 2=custom →
+    # default tier: 2=first listed endpoint (1=Skip) → opus tier: 4=free text
+    # (1=Skip, 2-3=endpoints) → FQN → sonnet tier: 1=Skip → haiku tier:
+    # 1=Skip → L2 q → L1 q.
+    stdin = (
+        "\n".join(
+            [
+                "1",
+                "1",
+                str(db),
+                "https://example.cloud.databricks.com",
+                "2",
+                "2",
+                "4",
+                "main.agents.my-opus-endpoint",
+                "1",
+                "1",
+                "q",
+                "q",
+            ]
+        )
+        + "\n"
+    )
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    # The picked 1M-family endpoint is auto-pinned with the [1m] suffix; the
+    # typed FQN stays verbatim (free text is never auto-pinned).
+    assert cfg["providers"]["databricks"] == {
+        "kind": "databricks",
+        "profile": "my-ws",
+        "models": {
+            "default": "databricks-claude-opus-4-8[1m]",
+            "opus": "main.agents.my-opus-endpoint",
+        },
+        "default": "anthropic",
+    }
+    # The entry round-trips through the parser with the overrides intact.
+    assert load_providers(cfg)["databricks"].models == {
+        "default": "databricks-claude-opus-4-8[1m]",
+        "opus": "main.agents.my-opus-endpoint",
+    }
+
+
+def test_add_databricks_default_endpoints_writes_no_models_key(
+    isolated_config, monkeypatch
+) -> None:
+    """Keeping the workspace defaults writes the pre-picker entry shape.
+
+    Regression guard: answering "Use the workspace defaults" at the add
+    flow's endpoint gate must persist an entry with NO ``models:`` key —
+    byte-for-byte what the add wrote before the picker existed — so ucode
+    state keeps driving the models.
+    """
+    _stub_databricks_add_boundaries(monkeypatch)
+
+    def _listing_must_not_run(profile: str) -> list[str]:
+        raise AssertionError("endpoint listing ran despite declining the picker")
+
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        _listing_must_not_run,
+    )
+
+    db = _databricks_add_menu_index()
+    # L1 1=Claude → L2 1=+Add → <db>=Databricks → URL → endpoints
+    # 1=workspace defaults → L2 q → L1 q.
+    stdin = "\n".join(["1", "1", str(db), "https://example.cloud.databricks.com", "1", "q", "q"])
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin + "\n")
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert cfg["providers"]["databricks"] == {
+        "kind": "databricks",
+        "profile": "my-ws",
+        "default": "anthropic",
+    }
+
+
+def test_manage_databricks_choose_endpoints_persists_models(isolated_config, monkeypatch) -> None:
+    """The credential menu's ``Choose model endpoints`` edits an existing entry.
+
+    Seeds a databricks provider, opens its level-3 menu, picks an endpoint
+    for the ``default`` tier and skips the rest (Esc via ``q``). The entry
+    must gain exactly that override while keeping its profile — and the
+    level-2 status line must confirm the write.
+    """
+    _write_databricks_provider(isolated_config)
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        lambda profile: (["databricks-claude-opus-4-8"], []),
+    )
+
+    # L1 1=Claude → L2 1=databricks → L3 2=Choose model endpoints → default
+    # tier: 2=listed endpoint (1=Skip; section headers are unnumbered) →
+    # opus: q=Esc exits the picker (sonnet never prompts) → L2 q → L1 q.
+    stdin = "\n".join(["1", "1", "2", "2", "q", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    # Picked endpoints are auto-pinned at their max context window: opus-4-8
+    # is a 1M-family model, so the stored id carries Claude Code's [1m]
+    # long-context suffix.
+    assert cfg["providers"]["databricks"] == {
+        "kind": "databricks",
+        "profile": "myws",
+        "models": {"default": "databricks-claude-opus-4-8[1m]"},
+    }
+
+
+def test_manage_databricks_clear_override_drops_models_key(isolated_config, monkeypatch) -> None:
+    """Clearing the last override removes the ``models:`` key entirely.
+
+    Seeds an entry with one ``default`` override. In the picker that tier
+    now leads with ``Keep …`` and a ``Clear override`` row — choosing the
+    latter (and skipping the other tiers) must drop the whole ``models:``
+    key so the entry round-trips to its pre-override shape.
+    """
+    config_path = os.path.join(isolated_config, "config.yaml")
+    with open(config_path, "w") as f:
+        yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {
+                        "kind": "databricks",
+                        "profile": "myws",
+                        "models": {"default": "main.agents.my-opus-endpoint"},
+                    }
+                }
+            },
+            f,
+        )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        lambda profile: (["databricks-claude-opus-4-8"], []),
+    )
+
+    # L1 1=Claude → L2 1=databricks → L3 2=Choose model endpoints → default
+    # tier: 2=Clear override (1=Keep) → opus: q=Esc exits the picker → L2 q →
+    # L1 q.
+    stdin = "\n".join(["1", "1", "2", "2", "q", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert cfg["providers"]["databricks"] == {"kind": "databricks", "profile": "myws"}
+
+
+def test_manage_databricks_pick_custom_uc_endpoint(isolated_config, monkeypatch) -> None:
+    """A Unity Catalog model service is pickable from the custom section.
+
+    The picker's second section lists the caller's Claude-capable UC model
+    services (Beta securables) so a custom endpoint no longer has to be
+    typed. Section headers are unnumbered in the fallback, so the custom
+    FQN is the third selectable row (Skip, hosted endpoint, FQN).
+    """
+    _write_databricks_provider(isolated_config)
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        lambda profile: (["databricks-claude-opus-4-8"], ["main.agents.my-opus-endpoint"]),
+    )
+
+    # L1 1=Claude → L2 1=databricks → L3 2=Choose model endpoints → default
+    # tier: 3=the UC model service (1=Skip, 2=hosted endpoint) → opus: q=Esc
+    # exits the picker → L2 q → L1 q.
+    stdin = "\n".join(["1", "1", "2", "3", "q", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert cfg["providers"]["databricks"]["models"] == {"default": "main.agents.my-opus-endpoint"}
+
+
+def test_manage_databricks_esc_exits_picker_immediately(isolated_config, monkeypatch) -> None:
+    """Esc on the first tier leaves the picker at once — no forced tier cycle.
+
+    Esc must return to the credential screen without prompting the
+    remaining tiers. The stdin carries exactly enough input for an
+    immediate exit (one Esc + the two menu-level backs); if the picker
+    still cycled through opus/sonnet, those prompts would exhaust stdin
+    and the run would abort non-zero on EOF.
+    """
+    _write_databricks_provider(isolated_config)
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        lambda profile: (["databricks-claude-opus-4-8"], []),
+    )
+
+    # L1 1=Claude → L2 1=databricks → L3 2=Choose model endpoints → default
+    # tier: q=Esc exits the picker immediately → L2 q → L1 q.
+    stdin = "\n".join(["1", "1", "2", "q", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    # Nothing changed — no models key was written.
+    cfg = _config_yaml(isolated_config)
+    assert cfg["providers"]["databricks"] == {"kind": "databricks", "profile": "myws"}
+
+
+def test_manage_databricks_200k_endpoint_not_pinned(isolated_config, monkeypatch) -> None:
+    """A 200K-family endpoint is stored without the ``[1m]`` suffix.
+
+    Auto-pinning applies only to 1M-capable model families; suffixing a
+    200K model (e.g. haiku-4-5) would make Claude Code assume a context
+    window the model does not have.
+    """
+    _write_databricks_provider(isolated_config)
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        lambda profile: (["databricks-claude-haiku-4-5"], []),
+    )
+
+    # L1 1=Claude → L2 1=databricks → L3 2=Choose model endpoints → default
+    # tier: 2=the haiku endpoint (1=Skip) → opus: q=Esc exits → L2 q → L1 q.
+    stdin = "\n".join(["1", "1", "2", "2", "q", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert cfg["providers"]["databricks"]["models"] == {"default": "databricks-claude-haiku-4-5"}
+
+
+def test_manage_databricks_codex_page_offers_no_endpoint_picker(
+    isolated_config, monkeypatch
+) -> None:
+    """The Codex page's databricks credential menu has no endpoint picker.
+
+    The ``models:`` map feeds the gateway's Anthropic surface only — codex
+    resolves its models from ucode's ``codex_models`` — so offering Claude
+    endpoints under Codex would pin models codex cannot use. The L3 menu
+    must go straight from ``Make default`` to ``Remove``: selecting row 2
+    removes the provider (it would open the picker if the row leaked in,
+    tripping the raising listing stub and failing the removal assertion).
+    """
+    _write_databricks_provider(isolated_config)
+
+    def _listing_must_not_run(profile: str) -> tuple[list[str], list[str]]:
+        raise AssertionError("the endpoint picker ran from the Codex page")
+
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_claude_endpoints",
+        _listing_must_not_run,
+    )
+
+    # L1 2=Codex → L2 1=databricks → L3 (1=Make default) 2=Remove → L2 q → L1 q.
+    stdin = "\n".join(["2", "1", "2", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    assert "Choose model endpoints" not in result.output
+    cfg = _config_yaml(isolated_config)
+    assert "databricks" not in cfg.get("providers", {})
 
 
 def test_uninstalled_harness_shows_x_and_not_installed(isolated_config, monkeypatch) -> None:
@@ -2171,8 +2473,10 @@ def test_configure_harnesses_add_databricks_under_pi_scopes_to_pi(
     # Databricks position within the Pi add menu, computed live.
     pi_opts = add_menu_options_for_family(PI_SURFACE)
     db = next(i for i, o in enumerate(pi_opts) if o.kind == DATABRICKS_KIND) + 1
-    # L1 6=Pi → L2 1=+Add → add menu <db>=Databricks → URL → q → q.
-    stdin = "\n".join(["6", "1", str(db), "https://example.cloud.databricks.com", "q", "q"]) + "\n"
+    # L1 6=Pi → L2 1=+Add → add menu <db>=Databricks → URL → endpoints
+    # 1=workspace defaults → q → q.
+    inputs = ["6", "1", str(db), "https://example.cloud.databricks.com", "1", "q", "q"]
+    stdin = "\n".join(inputs) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 

--- a/tests/e2e/test_databricks_models_override_e2e.py
+++ b/tests/e2e/test_databricks_models_override_e2e.py
@@ -1,0 +1,456 @@
+"""E2E: a ``kind: databricks`` provider's ``models:`` map pins the served model.
+
+Proves the end of the per-tier-model-override feature (see
+``feat(providers): per-tier model overrides on the databricks provider kind``)
+against a *live* Databricks workspace: a ``models: {default: <endpoint>}`` entry
+in ``~/.omnigent/config.yaml`` reaches
+:func:`omnigent.runtime.workflow.configure_agent_harness_with_ucode` at spawn
+and lands in ``HARNESS_CLAUDE_SDK_MODEL``, so the claude-sdk subprocess runs its
+turn on the overridden endpoint rather than the hardcoded Databricks default.
+
+The override target is pinned to ``databricks-claude-sonnet-4-6`` *specifically*
+because it differs from the harness's hardcoded Databricks fallback
+(:data:`omnigent.onboarding.databricks_config.DATABRICKS_CLAUDE_DEFAULT_MODEL` =
+``databricks-claude-opus-4-8``). A test that pinned the fallback value could
+pass without the override doing anything; pinning a *different* Claude tier
+(sonnet, not opus) makes the assertion fail loud if the map is ignored and the
+spawn falls back to opus.
+
+Isolation contract (why this file spawns its own server + runner):
+    The shared ``live_server`` / ``http_client`` fixtures inherit ``os.environ``
+    and do NOT redirect ``OMNIGENT_CONFIG_HOME``, so they read the developer's
+    real ``~/.omnigent/config.yaml``. This test seeds a throwaway config home
+    with the provider entry under test and spawns its OWN server and runner
+    subprocesses pointed at it. The runner is the process that builds the
+    claude-sdk spawn env (``_build_claude_sdk_spawn_env`` →
+    ``configure_agent_harness_with_provider`` → ``configure_agent_harness_with_ucode``),
+    so the runner is the one that must see the seeded ``OMNIGENT_CONFIG_HOME``.
+    The developer's real ``~/.omnigent``, ``~/.ucode/state.json``, and
+    Databricks CLI config are never written.
+
+How the served-model assertion works (which response field):
+    The claude-sdk executor reports the model the SDK actually used as
+    ``usage["model"]`` (``observed_model or model``) on every turn
+    (``omnigent/inner/claude_sdk_executor.py``). The runner accumulates that
+    into the session's per-model usage map keyed by the *raw harness-reported
+    model id* (``_model_usage_bucket`` in ``omnigent/server/routes/sessions.py``
+    — "alias normalization is intentionally deferred"), which surfaces as
+    ``usage_by_model`` on ``GET /v1/sessions/{id}`` (:class:`SessionResponse`).
+    So the served model is observable end-to-end: the ``usage_by_model`` keys
+    are the model(s) that actually ran the turn. The assertion is a
+    *discriminator*, not a brittle equality: the served model must identify the
+    Sonnet override and must NOT identify the Opus fallback. The Databricks
+    gateway may echo the requested id (``databricks-claude-sonnet-4-6``) or a
+    canonical Anthropic name (``claude-sonnet-4-…``); both satisfy
+    "contains sonnet, not opus", which is exactly the feature's contract
+    (override beat the hardcoded default).
+
+What breaks if this is wrong:
+    - The override never reaches the spawn env → the turn runs on the opus
+      fallback → ``usage_by_model`` carries an opus key → this test fails.
+    - A spec-pinned model would outrank the map (precedence is spec > provider
+      ``models:`` > ucode > default), so the agent registered here declares NO
+      model; a regression that starts stamping a default model onto no-model
+      specs would surface as a non-sonnet served model.
+
+Usage::
+
+    PROFILE=<your-databricks-profile>
+    TOKEN=$(databricks auth token --profile "$PROFILE" | jq -r .access_token)
+    env -u OPENAI_API_KEY OMNIGENT_SKIP_WEB_UI=true \\
+      uv run --no-sync pytest \\
+        tests/e2e/test_databricks_models_override_e2e.py \\
+        --llm-api-key="$TOKEN" --profile="$PROFILE" -x -q
+
+If your shell exports a workspace PAT env var, unset it first so the seeded
+profile's auth wins over ambient credentials.
+
+Skips cleanly (no-op) without ``--profile`` (mock mode has no Databricks
+gateway to route to) or when the ``claude`` CLI is not installed.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import secrets
+import signal
+import subprocess
+import tarfile
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+
+from omnigent.onboarding.databricks_config import DATABRICKS_CLAUDE_DEFAULT_MODEL
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN, token_bound_runner_id
+from tests._helpers.compat import (
+    apply_runner_env,
+    apply_server_env,
+    compat_runner_cwd,
+    compat_server_cwd,
+    runner_executable,
+    server_executable,
+)
+from tests.e2e._harness_probes import cli_unavailable_reason
+from tests.e2e.conftest import (
+    create_runner_bound_session,
+    find_free_port,
+    poll_session_until_terminal,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import HEALTH_TIMEOUT_S, POLL_INTERVAL_S
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The tier→model override under test. Pinned Sonnet on purpose: it differs from
+# the hardcoded Databricks fallback below, so the assertion can't pass by
+# accident if the override is dropped.
+_OVERRIDE_MODEL = "databricks-claude-sonnet-4-6"
+# The value the spawn would fall back to WITHOUT the override (the harness's
+# hardcoded Databricks Claude default). Asserting the served model is NOT this
+# is what proves the override actually took effect.
+_FALLBACK_MODEL = DATABRICKS_CLAUDE_DEFAULT_MODEL  # "databricks-claude-opus-4-8"
+
+
+def _register_no_model_claude_sdk_agent(
+    client: httpx.Client,
+    *,
+    name: str,
+    profile: str,
+    prompt: str,
+) -> str:
+    """Register a claude-sdk agent that declares NO model, only a profile.
+
+    Mirrors :func:`tests.e2e.conftest.register_inline_agent`'s multipart upload,
+    but deliberately omits ``executor.model`` — that helper always stamps a
+    resolved model, which (precedence spec > provider ``models:`` > ucode >
+    default) would outrank the override this test exercises. With no spec model,
+    ``_resolve_spec_model`` returns ``None``, ``HARNESS_CLAUDE_SDK_MODEL`` stays
+    unset entering ``configure_agent_harness_with_ucode``, and the provider
+    ``models: {default: …}`` map is what fills it.
+
+    :param client: HTTP client pointed at the seeded server.
+    :param name: Agent name.
+    :param profile: Databricks CLI config profile the legacy
+        ``executor.profile`` field carries; routes the spawn through the
+        synthesized databricks provider → the ucode/gateway path.
+    :param prompt: System prompt for the agent.
+    :returns: The registered agent name.
+    """
+    import json as _json
+
+    config: dict[str, Any] = {
+        "name": name,
+        "prompt": prompt,
+        # No ``model`` key: the provider ``models:`` map is the only model
+        # source, which is the code path under test.
+        "executor": {"harness": "claude-sdk", "profile": profile},
+    }
+    with io.BytesIO() as buf:
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            yaml_bytes = yaml.dump(config).encode()
+            info = tarfile.TarInfo(f"{name}.yaml")
+            info.size = len(yaml_bytes)
+            tar.addfile(info, io.BytesIO(yaml_bytes))
+        bundle = buf.getvalue()
+
+    resp = client.post(
+        "/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:500]}")
+    return name
+
+
+def _wait_for_usage_by_model(
+    client: httpx.Client,
+    session_id: str,
+    *,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Poll ``GET /v1/sessions/{id}`` until ``usage_by_model`` is populated.
+
+    Per-model usage accrues from the turn's ``response.completed`` usage, which
+    the runner may persist a beat after the turn is otherwise terminal. Poll so
+    the assertion doesn't race the write.
+
+    :param client: HTTP client pointed at the seeded server.
+    :param session_id: The runner-bound session id.
+    :param timeout: Max seconds to wait for a non-empty ``usage_by_model``.
+    :returns: The ``usage_by_model`` map, or ``{}`` if none appeared in time.
+    """
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/sessions/{session_id}")
+        resp.raise_for_status()
+        last = resp.json().get("usage_by_model") or {}
+        if last:
+            return last
+        time.sleep(POLL_INTERVAL_S)
+    return last
+
+
+@pytest.fixture
+def override_config_stack(
+    request: pytest.FixtureRequest,
+    llm_api_key: str,
+    databricks_workspace_host: str | None,
+    tmp_path: Path,
+) -> Iterator[tuple[str, str, str]]:
+    """Spawn an isolated server + runner over a seeded ``OMNIGENT_CONFIG_HOME``.
+
+    Seeds a throwaway config home whose sole ``providers:`` entry is a
+    ``kind: databricks`` provider carrying the ``models: {default: …}`` override,
+    then spawns a server and a sibling runner (bound by a shared tunnel token,
+    like ``live_server``) both pointed at that config home. The runner is where
+    the claude-sdk spawn env is built, so it must see the seeded config.
+
+    Skips (no-op) when ``--profile`` is absent — mock mode has no Databricks
+    gateway to route to — or when the ``claude`` CLI is missing/unrunnable.
+
+    :param request: pytest request — reads ``--profile``.
+    :param llm_api_key: Databricks bearer from ``--llm-api-key`` (satisfies the
+        server's startup env; the claude-sdk turn authenticates via the profile).
+    :param databricks_workspace_host: Workspace host, or ``None`` (mock mode).
+    :param tmp_path: Per-test temp dir for the config home, DB, artifacts, logs.
+    :yields: ``(base_url, runner_id, profile)``.
+    """
+    profile: str = request.config.getoption("--profile")
+    if not profile or databricks_workspace_host is None:
+        pytest.skip(
+            "databricks models-override e2e requires --profile <name> and a real "
+            "--llm-api-key (a live Databricks gateway to route the turn through); "
+            "it is a no-op in mock mode."
+        )
+    reason = cli_unavailable_reason("claude")
+    if reason is not None:
+        pytest.skip(f"claude-sdk harness requires a runnable 'claude' CLI; {reason}.")
+
+    # ── Seed the throwaway config home with the provider under test ──────
+    config_home = tmp_path / "omnigent_config_home"
+    config_home.mkdir()
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {
+                        "kind": "databricks",
+                        "profile": profile,
+                        "models": {"default": _OVERRIDE_MODEL},
+                    }
+                }
+            }
+        )
+    )
+
+    port = find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = tmp_path / "override_e2e.db"
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    server_log = tmp_path / "server.log"
+    runner_log = tmp_path / "runner.log"
+
+    binding_token = secrets.token_urlsafe(32)
+    runner_id = token_bound_runner_id(binding_token)
+
+    # Shared base env, mirroring live_server's Databricks-profile wiring.
+    base_env = {
+        **os.environ,
+        "OPENAI_API_KEY": llm_api_key,
+        "OPENAI_BASE_URL": f"{databricks_workspace_host}/serving-endpoints",
+        "DATABRICKS_CONFIG_PROFILE": profile,
+        # The isolation contract: config reads resolve here, not ~/.omnigent.
+        "OMNIGENT_CONFIG_HOME": str(config_home),
+    }
+
+    # Server-side policy classifier needs a gateway-routed llm: block (else it
+    # defaults to api.openai.com and 401s under a Databricks bearer), same as
+    # live_server does under --profile.
+    server_cfg = tmp_path / "server.yaml"
+    server_cfg.write_text(
+        yaml.safe_dump(
+            {
+                "llm": {
+                    "model": "databricks-gpt-5-4-mini",
+                    "connection": {
+                        "base_url": f"{databricks_workspace_host}/serving-endpoints",
+                        "api_key": llm_api_key,
+                    },
+                }
+            }
+        )
+    )
+
+    server_env = apply_server_env({**base_env}, _REPO_ROOT)
+    server_log_handle = open(server_log, "w")  # noqa: SIM115 — lives for the Popen lifetime
+    server_proc = subprocess.Popen(
+        [
+            server_executable(),
+            "-m",
+            "omnigent.cli",
+            "server",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{db_path}",
+            "--artifact-location",
+            str(artifact_dir),
+            "--config",
+            str(server_cfg),
+        ],
+        env={**server_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token},
+        cwd=compat_server_cwd(),
+        stdout=server_log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    runner_env = apply_runner_env(
+        {
+            **base_env,
+            "OMNIGENT_RUNNER_ID": runner_id,
+            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+            "RUNNER_SERVER_URL": base_url,
+        }
+    )
+    runner_log_handle = open(runner_log, "w")  # noqa: SIM115
+    runner_proc = subprocess.Popen(
+        [runner_executable(), "-m", "omnigent.runner._entry"],
+        env=runner_env,
+        cwd=compat_runner_cwd(),
+        stdout=runner_log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        deadline = time.monotonic() + HEALTH_TIMEOUT_S
+        while time.monotonic() < deadline:
+            try:
+                health = httpx.get(f"{base_url}/health", timeout=2)
+                status = httpx.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+                if (
+                    health.status_code == 200
+                    and status.status_code == 200
+                    and status.json().get("online") is True
+                ):
+                    break
+            except httpx.HTTPError:
+                pass
+            if server_proc.poll() is not None:
+                break
+            time.sleep(POLL_INTERVAL_S)
+        else:
+            raise RuntimeError(
+                f"server+runner didn't come online within {HEALTH_TIMEOUT_S}s.\n"
+                f"server log:\n{server_log.read_text()[-3000:]}\n"
+                f"runner log:\n{runner_log.read_text()[-3000:]}"
+            )
+        if server_proc.poll() is not None:
+            raise RuntimeError(
+                f"server exited early (code {server_proc.returncode}); "
+                f"log tail:\n{server_log.read_text()[-3000:]}"
+            )
+        yield base_url, runner_id, profile
+    finally:
+        for proc in (runner_proc, server_proc):
+            if proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+        runner_log_handle.close()
+        server_log_handle.close()
+
+
+def test_databricks_models_override_serves_pinned_endpoint(
+    override_config_stack: tuple[str, str, str],
+) -> None:
+    """A ``models: {default: …}`` map pins the live claude-sdk served model.
+
+    Registers a claude-sdk agent with NO model (only the profile), runs one
+    turn, and proves the turn ran on the Sonnet override — not the hardcoded
+    Opus fallback — via the session's ``usage_by_model`` (keyed by the raw
+    harness-reported served model). See the module docstring for the full
+    signal path and why the assertion is a sonnet/not-opus discriminator.
+
+    :param override_config_stack: ``(base_url, runner_id, profile)`` for the
+        server+runner spawned over the seeded config home.
+    """
+    base_url, runner_id, profile = override_config_stack
+
+    with httpx.Client(
+        base_url=base_url,
+        timeout=300,
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    ) as client:
+        agent_name = _register_no_model_claude_sdk_agent(
+            client,
+            name=f"dbx-models-override-{uuid.uuid4().hex[:6]}",
+            profile=profile,
+            prompt="You are a terse assistant. Follow instructions exactly.",
+        )
+        session_id = create_runner_bound_session(
+            client, agent_name=agent_name, runner_id=runner_id
+        )
+        response_id = send_user_message_to_session(
+            client,
+            session_id=session_id,
+            content="Reply with exactly: OVERRIDE-OK",
+        )
+
+        body = poll_session_until_terminal(
+            client,
+            session_id=session_id,
+            response_id=response_id,
+            timeout=300,
+        )
+        assert body["status"] == "completed", (
+            f"turn did not complete: {body.get('error', 'unknown error')}"
+        )
+
+        # A real turn ran (the reply proves the round-trip, not just a spawn).
+        text = "\n".join(
+            block.get("text", "")
+            for item in body.get("output", [])
+            if item.get("type") == "message"
+            for block in item.get("content", [])
+        )
+        assert "OVERRIDE-OK" in text, f"model did not follow the prompt; got: {text[:500]!r}"
+
+        # The served-model signal: usage_by_model is keyed by the model that
+        # actually ran the turn.
+        usage_by_model = _wait_for_usage_by_model(client, session_id)
+        assert usage_by_model, (
+            "session reported no usage_by_model; cannot confirm the served model. "
+            "The turn completed but per-model usage never surfaced — investigate "
+            "the runner usage-accumulation path before trusting this result."
+        )
+        served_models = list(usage_by_model.keys())
+
+        # The override took effect iff a Sonnet endpoint served the turn and the
+        # Opus fallback did not. Both the requested id and a canonical Anthropic
+        # name contain "sonnet"; the fallback (databricks-claude-opus-4-8)
+        # contains "opus".
+        assert any("sonnet" in m.lower() for m in served_models), (
+            f"expected the turn to run on the Sonnet override ({_OVERRIDE_MODEL!r}); "
+            f"served model(s): {served_models}. If a non-sonnet model served the "
+            f"turn, the provider models: override did not reach the spawn env."
+        )
+        assert not any("opus" in m.lower() for m in served_models), (
+            f"the turn ran on an Opus model {served_models}, i.e. the hardcoded "
+            f"fallback {_FALLBACK_MODEL!r} — the provider models: override was "
+            f"ignored (the exact regression this test guards)."
+        )

--- a/tests/onboarding/test_databricks_config.py
+++ b/tests/onboarding/test_databricks_config.py
@@ -11,6 +11,8 @@ import pytest
 from omnigent.onboarding.databricks_config import (
     databricks_sdk_installed,
     get_workspace_url_for_profile,
+    list_claude_model_service_fqns,
+    list_claude_serving_endpoint_names,
     normalize_workspace_url,
 )
 
@@ -168,3 +170,378 @@ def test_normalize_workspace_url_scheme_less_input_only_strips_trailing_slash() 
     prior ``rstrip("/")`` behavior — the wizard pre-adds ``https://`` before
     calling, so a scheme is present in practice."""
     assert normalize_workspace_url("my-ws.cloud.databricks.com/") == "my-ws.cloud.databricks.com"
+
+
+def _fake_workspace_client(endpoints: list[dict], permission_levels: dict[str, str]):
+    """Build a WorkspaceClient stand-in for the endpoint-listing tests.
+
+    :param endpoints: ``as_dict()``-shaped list items (``name`` / ``task`` /
+        ``config.served_entities``).
+    :param permission_levels: Caller's permission per endpoint name, e.g.
+        ``{"databricks-claude-opus-4-8": "CAN_QUERY"}``; a missing name makes
+        the detail ``get()`` raise (endpoint gone mid-sweep).
+    """
+
+    class _Level:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    class _ListItem:
+        def __init__(self, raw: dict) -> None:
+            self.name = raw.get("name")
+            self.task = raw.get("task")
+            self._raw = raw
+
+        def as_dict(self) -> dict:
+            return self._raw
+
+    class _Detail:
+        def __init__(self, name: str) -> None:
+            self.permission_level = _Level(permission_levels[name])
+
+    class _ServingEndpoints:
+        def list(self) -> list[_ListItem]:
+            return [_ListItem(raw) for raw in endpoints]
+
+        def get(self, name: str) -> _Detail:
+            return _Detail(name)
+
+    class _Client:
+        def __init__(self, *, profile: str) -> None:
+            assert profile == "my-ws"
+            self.serving_endpoints = _ServingEndpoints()
+
+    return _Client
+
+
+def _chat_endpoint(name: str, *, model_name: str) -> dict:
+    """One ``llm/v1/chat`` list item serving a single foundation model."""
+    return {
+        "name": name,
+        "task": "llm/v1/chat",
+        "config": {"served_entities": [{"foundation_model": {"name": model_name}}]},
+    }
+
+
+def test_list_claude_serving_endpoint_names_filters_to_queryable_claude_chat() -> None:
+    """Only Claude-serving chat endpoints with query access survive, sorted.
+
+    The picker's picks feed the gateway's Anthropic surface, which rejects
+    non-Claude endpoints ("API type 'anthropic/v1/messages' is not
+    supported") — so a GPT chat endpoint, an embeddings endpoint (even a
+    hypothetical Claude-named one), and a CAN_VIEW-only Claude endpoint
+    must all be dropped. Offering any of them would hand the user a pick
+    that fails at request time.
+    """
+    endpoints = [
+        _chat_endpoint("zeta-claude", model_name="system.ai.databricks-claude-opus-4-8"),
+        _chat_endpoint("alpha-claude", model_name="system.ai.databricks-claude-sonnet-5"),
+        _chat_endpoint("view-only-claude", model_name="system.ai.databricks-claude-haiku-4-5"),
+        _chat_endpoint("gpt-chat", model_name="system.ai.databricks-gpt-5-5"),
+        {
+            "name": "claude-embeddings",
+            "task": "llm/v1/embeddings",
+            "config": {"served_entities": [{"foundation_model": {"name": "claude-embedder"}}]},
+        },
+        {"name": None, "task": "llm/v1/chat", "config": {}},
+    ]
+    levels = {
+        "zeta-claude": "CAN_QUERY",
+        "alpha-claude": "CAN_MANAGE",
+        "view-only-claude": "CAN_VIEW",
+        "gpt-chat": "CAN_MANAGE",
+        "claude-embeddings": "CAN_MANAGE",
+    }
+    with patch("databricks.sdk.WorkspaceClient", _fake_workspace_client(endpoints, levels)):
+        assert list_claude_serving_endpoint_names("my-ws") == ["alpha-claude", "zeta-claude"]
+
+
+def test_list_claude_serving_endpoint_names_accepts_anthropic_external_model() -> None:
+    """An external-model endpoint with the ``anthropic`` provider counts as Claude.
+
+    Workspaces routing Claude through an external-model endpoint (rather
+    than a Databricks-hosted foundation model) must still be offered.
+    """
+    endpoints = [
+        {
+            "name": "my-external-anthropic",
+            "task": "llm/v1/chat",
+            "config": {
+                "served_entities": [
+                    {"external_model": {"provider": "anthropic", "name": "claude-opus-4-8"}}
+                ]
+            },
+        },
+    ]
+    levels = {"my-external-anthropic": "CAN_QUERY"}
+    with patch("databricks.sdk.WorkspaceClient", _fake_workspace_client(endpoints, levels)):
+        assert list_claude_serving_endpoint_names("my-ws") == ["my-external-anthropic"]
+
+
+def test_list_claude_serving_endpoint_names_drops_endpoint_when_detail_fails() -> None:
+    """A failing per-endpoint permission read drops that endpoint, not the list.
+
+    The detail sweep runs one ``get()`` per candidate; an endpoint deleted
+    mid-sweep (or otherwise unreadable) must be skipped while the rest of
+    the list survives.
+    """
+    endpoints = [
+        _chat_endpoint("ok-claude", model_name="system.ai.databricks-claude-opus-4-8"),
+        _chat_endpoint("gone-claude", model_name="system.ai.databricks-claude-sonnet-5"),
+    ]
+    levels = {"ok-claude": "CAN_QUERY"}  # "gone-claude" missing → get() raises KeyError
+    with patch("databricks.sdk.WorkspaceClient", _fake_workspace_client(endpoints, levels)):
+        assert list_claude_serving_endpoint_names("my-ws") == ["ok-claude"]
+
+
+def test_list_claude_serving_endpoint_names_empty_on_failure() -> None:
+    """Any wholesale listing failure degrades to an empty list, never an exception.
+
+    The picker treats ``[]`` as "offer free-text entry only" — a raising
+    helper would abort the whole add/edit flow on a network or auth
+    hiccup.
+    """
+
+    class _RaisingClient:
+        def __init__(self, *, profile: str) -> None:
+            raise RuntimeError("no auth")
+
+    with patch("databricks.sdk.WorkspaceClient", _RaisingClient):
+        assert list_claude_serving_endpoint_names("my-ws") == []
+
+
+def _fake_model_services_client(pages: list[dict], details: dict[str, dict] | None = None):
+    """Build a WorkspaceClient stand-in whose raw API serves *pages* in order.
+
+    :param pages: Raw ``unity-catalog/model-services`` list responses; each
+        after the first is served when the prior page's ``next_page_token``
+        is echoed back in the request path.
+    :param details: Single-get responses keyed by FQN (for the detail sweep
+        of services the list payload cannot decide); a missing FQN raises,
+        like a service deleted mid-sweep.
+    """
+
+    class _ApiClient:
+        def __init__(self) -> None:
+            self.pages_served = 0
+
+        def do(self, method: str, path: str) -> dict:
+            assert method == "GET"
+            tail = path.split("/model-services", 1)[1]
+            if tail.startswith("/"):
+                return (details or {})[tail[1:]]
+            self.pages_served += 1
+            return pages[self.pages_served - 1]
+
+    class _Client:
+        def __init__(self, *, profile: str) -> None:
+            assert profile == "my-ws"
+            self.api_client = _ApiClient()
+
+    return _Client
+
+
+def _model_service(fqn: str, *, api_types: list[str] | None = None, dest_model: str = "") -> dict:
+    """One raw model-service entry (``api_types=None`` omits the field)."""
+    entry: dict = {"name": f"model-services/{fqn}", "config": {}}
+    if api_types is not None:
+        entry["supported_api_types"] = api_types
+    if dest_model:
+        entry["config"] = {
+            "destinations": [{"pay_per_token_config": {"model": f"models/{dest_model}"}}]
+        }
+    return entry
+
+
+def test_list_claude_model_service_fqns_filters_and_strips() -> None:
+    """Only Claude-capable, non-system custom services survive, FQN-sorted.
+
+    ``supported_api_types`` is authoritative when populated, but live
+    user-created services report it EMPTY while answering
+    ``anthropic/v1/messages`` fine — so a Claude routing destination must
+    also qualify. ``system.ai`` services mirror the hosted serving
+    endpoints the picker already lists, so they are dropped, as are
+    GPT-routing services (the Anthropic surface rejects them).
+    """
+    pages = [
+        {
+            "model_services": [
+                # Authoritative api-types match.
+                _model_service("main.agents.zeta", api_types=["anthropic/v1/messages"]),
+                # Live shape: empty api types, Claude destination.
+                _model_service(
+                    "main.agents.alpha",
+                    api_types=[],
+                    dest_model="system.ai.databricks-claude-opus-4-8",
+                ),
+                # GPT destination — not Anthropic-surface capable.
+                _model_service(
+                    "main.agents.gpt", api_types=[], dest_model="system.ai.databricks-gpt-5-5"
+                ),
+                # Built-in mirror of the hosted endpoints — dropped.
+                _model_service("system.ai.claude-opus-4-8", api_types=["anthropic/v1/messages"]),
+                # Explicit non-Anthropic api types — dropped.
+                _model_service("main.agents.embed", api_types=["mlflow/v1/embeddings"]),
+            ]
+        }
+    ]
+    with patch("databricks.sdk.WorkspaceClient", _fake_model_services_client(pages)):
+        assert list_claude_model_service_fqns("my-ws") == [
+            "main.agents.alpha",
+            "main.agents.zeta",
+        ]
+
+
+def test_list_claude_model_service_fqns_follows_pagination() -> None:
+    """A ``next_page_token`` is followed until the listing is exhausted."""
+    pages = [
+        {
+            "model_services": [
+                _model_service("main.agents.first", api_types=["anthropic/v1/messages"])
+            ],
+            "next_page_token": "tok1",
+        },
+        {
+            "model_services": [
+                _model_service("main.agents.second", api_types=["anthropic/v1/messages"])
+            ]
+        },
+    ]
+    with patch("databricks.sdk.WorkspaceClient", _fake_model_services_client(pages)):
+        assert list_claude_model_service_fqns("my-ws") == [
+            "main.agents.first",
+            "main.agents.second",
+        ]
+
+
+def test_list_claude_model_service_fqns_detail_sweep_decides_bare_entries() -> None:
+    """List entries with no api types and no destinations use their detail.
+
+    The real list response omits routing destinations (observed live), so
+    a bare entry is undecidable from the list alone — the helper must
+    fetch its single-get detail: a Claude destination qualifies, a GPT one
+    does not, and an unreadable detail drops just that service.
+    """
+    pages = [
+        {
+            "model_services": [
+                _model_service("main.agents.opus"),
+                _model_service("main.agents.gpt"),
+                _model_service("main.agents.gone"),
+            ]
+        }
+    ]
+    details = {
+        "main.agents.opus": _model_service(
+            "main.agents.opus", api_types=[], dest_model="system.ai.databricks-claude-opus-4-8"
+        ),
+        "main.agents.gpt": _model_service(
+            "main.agents.gpt", api_types=[], dest_model="system.ai.databricks-gpt-5-5"
+        ),
+        # "main.agents.gone" missing → detail get raises (deleted mid-sweep).
+    }
+    with patch("databricks.sdk.WorkspaceClient", _fake_model_services_client(pages, details)):
+        assert list_claude_model_service_fqns("my-ws") == ["main.agents.opus"]
+
+
+def test_list_claude_model_service_fqns_empty_on_failure() -> None:
+    """A failing (e.g. pre-Beta workspace) model-services API degrades to ``[]``.
+
+    The picker then still offers the hosted section and free-text entry —
+    a raising helper would abort the whole add/edit flow.
+    """
+
+    class _RaisingClient:
+        def __init__(self, *, profile: str) -> None:
+            raise RuntimeError("ENDPOINT_NOT_FOUND")
+
+    with patch("databricks.sdk.WorkspaceClient", _RaisingClient):
+        assert list_claude_model_service_fqns("my-ws") == []
+
+
+def test_list_claude_endpoints_shares_one_client_and_degrades_independently() -> None:
+    """The combined listing serves both sections from one client.
+
+    One client (one OAuth handshake) feeds both listings in parallel; a
+    failure in one listing must not take the other down — here the
+    serving-endpoints listing raises while the UC model services still
+    return.
+    """
+
+    class _RaisingServingEndpoints:
+        def list(self) -> list:
+            raise RuntimeError("serving endpoints unavailable")
+
+    class _ApiClient:
+        def do(self, method: str, path: str) -> dict:
+            return {
+                "model_services": [
+                    {
+                        "name": "model-services/main.agents.opus",
+                        "supported_api_types": ["anthropic/v1/messages"],
+                        "config": {},
+                    }
+                ]
+            }
+
+    constructed = []
+
+    class _Client:
+        def __init__(self, *, profile: str) -> None:
+            constructed.append(profile)
+            self.serving_endpoints = _RaisingServingEndpoints()
+            self.api_client = _ApiClient()
+
+    from omnigent.onboarding.databricks_config import list_claude_endpoints
+
+    with patch("databricks.sdk.WorkspaceClient", _Client):
+        hosted, custom = list_claude_endpoints("my-ws")
+
+    assert hosted == []
+    assert custom == ["main.agents.opus"]
+    # Exactly one client was built for both listings.
+    assert constructed == ["my-ws"]
+
+
+def test_list_claude_endpoints_empty_on_client_failure() -> None:
+    """An unusable profile degrades both sections to empty lists."""
+
+    class _RaisingClient:
+        def __init__(self, *, profile: str) -> None:
+            raise RuntimeError("no such profile")
+
+    from omnigent.onboarding.databricks_config import list_claude_endpoints
+
+    with patch("databricks.sdk.WorkspaceClient", _RaisingClient):
+        assert list_claude_endpoints("my-ws") == ([], [])
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("databricks-claude-opus-4-8", "1M"),
+        ("databricks-claude-opus-4-7", "1M"),
+        ("databricks-claude-opus-4-6", "1M"),
+        ("databricks-claude-sonnet-5", "1M"),
+        ("databricks-claude-sonnet-4-6", "1M"),
+        ("main.agents.opus-4-8", "1M"),  # UC FQNs usually carry the family too
+        ("databricks-claude-opus-4-5", "200K"),
+        ("databricks-claude-opus-4-1", "200K"),
+        ("databricks-claude-sonnet-4-5", "200K"),
+        ("databricks-claude-sonnet-4", "200K"),
+        ("databricks-claude-haiku-4-5", "200K"),
+        # No family token in the name — window unknowable, no label/pin.
+        ("main.agents.my-opus-endpoint", None),
+        ("my-custom-endpoint", None),
+    ],
+)
+def test_claude_context_window_by_family(name: str, expected: str | None) -> None:
+    """Window lookup matches model families as name substrings, most specific first.
+
+    Drives the picker's context-window labels and the [1m] auto-pin: a
+    wrong row here either hides the 1M window from a capable model or —
+    worse — pins a 200K model at a window it doesn't have.
+    """
+    from omnigent.onboarding.databricks_config import claude_context_window
+
+    assert claude_context_window(name) == expected

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -12,6 +12,7 @@ from omnigent.onboarding.provider_config import (
     GEMINI_FAMILY,
     OPENAI_FAMILY,
     PI_SURFACE,
+    databricks_provider_models,
     default_provider_for_harness,
     harness_family,
     load_providers,
@@ -815,3 +816,86 @@ def test_default_provider_for_pi_none_when_only_bedrock_default() -> None:
         }
     }
     assert default_provider_for_harness(config, "pi") is None
+
+
+# ── databricks kind: per-tier model overrides ────────────────────────────────
+
+
+def test_parse_databricks_models_map() -> None:
+    """A databricks entry's ``models:`` map parses onto the entry.
+
+    Failure means per-tier endpoint overrides in ``~/.omnigent/config.yaml``
+    are silently dropped at parse, and every Databricks model-resolution
+    point falls back to ucode state / the hardcoded default.
+    """
+    entry = load_providers(
+        {
+            "providers": {
+                "dbx": {
+                    "kind": "databricks",
+                    "profile": "my-ws",
+                    "models": {
+                        "default": "main.agents.opus-endpoint",
+                        "opus": "main.agents.opus-endpoint",
+                        "sonnet": "main.agents.sonnet-endpoint",
+                    },
+                }
+            }
+        }
+    )["dbx"]
+    assert entry.models == {
+        "default": "main.agents.opus-endpoint",
+        "opus": "main.agents.opus-endpoint",
+        "sonnet": "main.agents.sonnet-endpoint",
+    }
+
+
+@pytest.mark.parametrize("models_raw", [None, "not-a-map", ["a", "b"]])
+def test_parse_databricks_models_absent_or_malformed_is_empty(models_raw: object) -> None:
+    """An absent or non-mapping ``models:`` parses to an empty map.
+
+    Mirrors the lenient ``FamilyConfig.models`` handling: a malformed value
+    must not fail the whole config, and an absent key keeps the ucode-driven
+    resolution byte-for-byte unchanged.
+    """
+    raw: dict[str, object] = {"kind": "databricks", "profile": "my-ws"}
+    if models_raw is not None:
+        raw["models"] = models_raw
+    entry = load_providers({"providers": {"dbx": raw}})["dbx"]
+    assert entry.models == {}
+
+
+def test_databricks_provider_models_looks_up_by_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``databricks_provider_models`` returns the matching entry's map.
+
+    The lookup is keyed on the profile (the only databricks identity that
+    reaches the model-resolution points), skips non-databricks kinds, and
+    returns ``{}`` for a mapless entry / unknown profile / no profile — the
+    "absent map leaves behavior unchanged" contract.
+    """
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n"
+        "  gw:\n"
+        "    kind: gateway\n"
+        "    anthropic:\n"
+        "      base_url: https://gw\n"
+        "      api_key_ref: env:K\n"
+        "  dbx:\n"
+        "    kind: databricks\n"
+        "    profile: my-ws\n"
+        "    models:\n"
+        "      default: main.agents.opus-endpoint\n"
+        "  other:\n"
+        "    kind: databricks\n"
+        "    profile: other-ws\n"
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    assert databricks_provider_models("my-ws") == {"default": "main.agents.opus-endpoint"}
+    # A matching entry without a models: map — no overrides.
+    assert databricks_provider_models("other-ws") == {}
+    # No databricks entry carries this profile.
+    assert databricks_provider_models("unknown-ws") == {}
+    assert databricks_provider_models(None) == {}

--- a/tests/runtime/test_claude_sdk_spawn_env.py
+++ b/tests/runtime/test_claude_sdk_spawn_env.py
@@ -243,3 +243,127 @@ def test_ucode_state_with_model_is_not_overridden_by_default(
     env = _build_claude_sdk_spawn_env(spec, workdir=None)
 
     assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def _write_databricks_models_config(tmp_path: Path, *, models: dict[str, str]) -> None:
+    """
+    Write a ``providers:`` config with a databricks entry carrying *models*.
+
+    The autouse ``_isolate_global_config`` fixture already points
+    ``$OMNIGENT_CONFIG_HOME`` at *tmp_path*, so this exercises the real
+    config-loading path behind ``databricks_provider_models``.
+
+    :param tmp_path: The per-test config home.
+    :param models: The tier→model overrides, e.g.
+        ``{"default": "main.agents.my-opus-endpoint"}``.
+    """
+    (tmp_path / "config.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {"kind": "databricks", "profile": "oss", "models": models}
+                }
+            }
+        )
+    )
+
+
+def test_provider_models_default_beats_ucode_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    The provider entry's ``models.default`` outranks the ucode-cached model.
+
+    The user picked an explicit endpoint on the ``kind: databricks``
+    provider in ``~/.omnigent/config.yaml``; the ucode state cache must
+    not shadow it (config > ucode > hardcoded default).
+    """
+    _ucode_state_without_model(monkeypatch, model="databricks-claude-sonnet-4-6")
+    _write_databricks_models_config(tmp_path, models={"default": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.my-opus-endpoint"
+
+
+def test_provider_models_without_default_keeps_ucode_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    A ``models:`` map with no ``default`` tier leaves the ucode model alone.
+
+    Only the ``default`` tier feeds the single claude-sdk model env var;
+    a per-tier-only map (e.g. just ``opus:``) must not clobber the
+    ucode-resolved launch model.
+    """
+    _ucode_state_without_model(monkeypatch, model="databricks-claude-sonnet-4-6")
+    _write_databricks_models_config(tmp_path, models={"opus": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def test_spec_model_beats_provider_models_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    A spec-pinned model still wins over the provider ``models:`` override.
+
+    Failure means the config-level override clobbers an explicit
+    ``executor.model`` from the agent YAML — spec must stay strongest.
+    """
+    _ucode_state_without_model(monkeypatch, model=None)
+    _write_databricks_models_config(tmp_path, models={"default": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model="databricks-claude-opus-4-8", profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-opus-4-8"
+
+
+def test_provider_models_apply_without_ucode_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    The override lands even when the profile has no ucode state at all.
+
+    On the profile-derived gateway path (no ``~/.ucode/state.json`` entry)
+    ``configure_agent_harness_with_ucode`` early-returns before its ucode
+    lookups — the provider override must be applied before those checks or
+    a configured endpoint would silently fall back to the executor's
+    hardcoded Databricks default.
+    """
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.get_workspace_url_for_profile",
+        lambda profile: None,
+    )
+    _write_databricks_models_config(tmp_path, models={"default": "main.agents.my-opus-endpoint"})
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_GATEWAY"] == "true"
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.my-opus-endpoint"
+
+
+def test_provider_models_1m_suffix_kept_for_claude_sdk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The ``[1m]`` suffix passes through to the claude-sdk spawn env.
+
+    The claude-sdk harness drives the claude CLI, which understands the
+    suffix (1M-context accounting) and strips it before the API call — so
+    unlike pi, the producer must NOT strip it here.
+    """
+    _ucode_state_without_model(monkeypatch, model=None)
+    _write_databricks_models_config(
+        tmp_path, models={"default": "main.agents.my-opus-endpoint[1m]"}
+    )
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.my-opus-endpoint[1m]"

--- a/tests/runtime/test_pi_spawn_env.py
+++ b/tests/runtime/test_pi_spawn_env.py
@@ -198,3 +198,70 @@ def test_no_ucode_pi_entry_leaves_model_to_executor_default(
     assert env["HARNESS_PI_DATABRICKS_PROFILE"] == "oss"
     # No producer model — the executor's profile-path default applies.
     assert "HARNESS_PI_MODEL" not in env
+
+
+def test_provider_models_default_beats_ucode_model_for_pi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Pi parity: the databricks provider's ``models.default`` outranks ucode.
+
+    The claude-sdk and pi producers share
+    ``configure_agent_harness_with_ucode``, so the ``models:`` override on
+    the ``kind: databricks`` entry must reach ``HARNESS_PI_MODEL`` the same
+    way (config > ucode > hardcoded default).
+    """
+    import yaml as _yaml
+
+    _ucode_state_for_pi(monkeypatch, model="databricks-claude-sonnet-4-6", with_pi_entry=True)
+    (tmp_path / "config.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {
+                        "kind": "databricks",
+                        "profile": "oss",
+                        "models": {"default": "main.agents.my-opus-endpoint"},
+                    }
+                }
+            }
+        )
+    )
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_pi_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_PI_MODEL"] == "main.agents.my-opus-endpoint"
+
+
+def test_provider_models_1m_suffix_stripped_for_pi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Claude Code's ``[1m]`` suffix never reaches ``HARNESS_PI_MODEL``.
+
+    The suffix is a claude-CLI-side convention (stripped before the API
+    call); pi passes model ids through verbatim and the gateway rejects
+    suffixed names outright — so the producer must strip it for pi while
+    the claude-sdk path keeps it.
+    """
+    import yaml as _yaml
+
+    _ucode_state_for_pi(monkeypatch, model=None, with_pi_entry=True)
+    (tmp_path / "config.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "providers": {
+                    "databricks": {
+                        "kind": "databricks",
+                        "profile": "oss",
+                        "models": {"default": "main.agents.my-opus-endpoint[1m]"},
+                    }
+                }
+            }
+        )
+    )
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_pi_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_PI_MODEL"] == "main.agents.my-opus-endpoint"

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -907,6 +907,79 @@ def test_databricks_kind_default_routes_through_profile(
     assert "HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL" not in env
 
 
+def test_databricks_kind_default_applies_models_map(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A databricks-kind default provider's ``models:`` map reaches claude-sdk.
+
+    The provider-selected route (not just the legacy-profile route) must
+    honor the per-tier overrides: with no ucode state at all, the entry's
+    ``models.default`` still lands in ``HARNESS_CLAUDE_SDK_MODEL`` instead
+    of leaving the executor to its hardcoded Databricks default.
+    """
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "dbx": {
+                    "kind": "databricks",
+                    "default": True,
+                    "profile": "my-dbx-profile",
+                    "models": {"default": "main.agents.claude-endpoint"},
+                }
+            }
+        },
+    )
+    # No ucode state for the profile — the override alone supplies the model.
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.get_workspace_url_for_profile",
+        lambda profile: None,
+    )
+    spec = _make_spec(harness="claude-sdk")
+
+    env = _build_claude_sdk_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CLAUDE_SDK_DATABRICKS_PROFILE"] == "my-dbx-profile"
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "main.agents.claude-endpoint"
+
+
+def test_databricks_models_map_does_not_touch_codex(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    The databricks ``models:`` map never feeds a codex-family harness.
+
+    The map is Claude-tier-shaped (``opus`` / ``sonnet`` / ``default``
+    endpoints), so injecting it into ``HARNESS_CODEX_MODEL`` would point
+    codex at an Anthropic-surface endpoint. The override is scoped to the
+    Claude-gateway harnesses; codex must resolve its model as before.
+    """
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "dbx": {
+                    "kind": "databricks",
+                    "default": True,
+                    "profile": "my-dbx-profile",
+                    "models": {"default": "main.agents.claude-endpoint"},
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.get_workspace_url_for_profile",
+        lambda profile: None,
+    )
+    spec = _make_spec(harness="codex")
+
+    env = _build_codex_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_CODEX_DATABRICKS_PROFILE"] == "my-dbx-profile"
+    assert "HARNESS_CODEX_MODEL" not in env
+
+
 # ── Backwards-compat: no provider configured ───────────────────────────────
 
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -466,6 +466,105 @@ def test_ucode_config_for_profile_defaults_model_when_ucode_omits_it(
     assert config.model == "databricks-claude-opus-4-8"
 
 
+def test_ucode_config_for_profile_provider_models_override_tiers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Provider-config ``models:`` tiers outrank ucode ``claude_models``.
+
+    A per-tier override on the profile's ``kind: databricks`` provider
+    entry wins for its tier (opus) and for the launch default, while a
+    tier the config leaves unset (sonnet) still resolves from ucode state
+    — config > ucode > hardcoded default, per tier.
+    """
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n"
+        "  databricks:\n"
+        "    kind: databricks\n"
+        "    profile: test-profile\n"
+        "    models:\n"
+        "      default: main.agents.opus-endpoint\n"
+        "      opus: main.agents.opus-endpoint\n"
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    workspace_state = UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        claude_models={
+            "opus": "databricks-claude-opus-4-7",
+            "sonnet": "databricks-claude-sonnet-4-6",
+        },
+        agents={
+            "claude": UcodeAgentState(
+                model="databricks-claude-opus-4-7",
+                base_url="https://example.databricks.com/ai-gateway/anthropic",
+                auth_command="printf token",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: workspace_state,
+    )
+
+    config = claude_native._ucode_config_for_profile("test-profile")
+
+    assert config is not None
+    # The overridden tier and the launch default come from the provider config.
+    assert config.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "main.agents.opus-endpoint"
+    assert config.model == "main.agents.opus-endpoint"
+    # A tier the config leaves unset still resolves from ucode state.
+    assert config.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def test_ucode_config_for_profile_without_provider_models_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Regression guard: a databricks entry without ``models:`` changes nothing.
+
+    With the profile's provider entry declaring no ``models:`` map, the
+    tier env vars and the launch model must resolve exactly as before the
+    override existed (ucode ``claude_models`` + the per-agent model).
+    """
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n  databricks:\n    kind: databricks\n    profile: test-profile\n"
+    )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    workspace_state = UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        claude_models={"opus": "databricks-claude-opus-4-7"},
+        agents={
+            "claude": UcodeAgentState(
+                model="databricks-claude-opus-4-7",
+                base_url="https://example.databricks.com/ai-gateway/anthropic",
+                auth_command="printf token",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: workspace_state,
+    )
+
+    config = claude_native._ucode_config_for_profile("test-profile")
+
+    assert config is not None
+    assert config.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "databricks-claude-opus-4-7"
+    assert config.model == "databricks-claude-opus-4-7"
+
+
 def test_ucode_config_for_profile_fails_loud_on_malformed_claude_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
> **Stacked on #1867** — this branch contains that PR's commit; review only the last commit here (`feat(setup): interactive Databricks model endpoint picker`). Will rebase once #1867 merges.

## Related issue

Closes #1863

## Summary

- Gives the databricks provider's `models:` overrides (added in the PR this stacks on) a first-class UI in `omnigent setup` — previously hand-edit-only.
- Adding a Databricks workspace ends with a light gate ("Use the workspace defaults (recommended)" / "Choose custom model endpoints"); an existing databricks credential's menu gains **Choose model endpoints**, which edits or clears the map in place. Both are scoped to the Claude/Pi pages — the map's tiers feed the gateway's Anthropic surface exclusively, while codex resolves its models from ucode's `codex_models`, so the Codex page never offers Claude endpoints.
- Both listings load through one shared SDK client in parallel behind a console spinner (the Beta model-services list call alone costs seconds server-side). Esc backs out of the picker to the credential screen; only the explicit Skip/Keep row advances tiers. `select()`'s non-selectable rows now render as real section headers (dim, blank-separated above their group) — matching the semantics its docstring already promised.
- The picker prompts per tier — default (session launch model) / opus / sonnet / haiku, each labeled with what it drives and each optional (Skip keeps the workspace default; the rare `fable` alias stays hand-editable) — with one grouped menu of two sections. Every tier feeds the gateway's Anthropic surface, which rejects other endpoints (`API type 'anthropic/v1/messages' is not supported`), so both listings are Claude-scoped:
  - **Databricks-hosted Claude models** — classic serving endpoints filtered to the `llm/v1/chat` task, Claude-serving entities (endpoint metadata exposes no supported-API-types field, so served-entity identity is the discriminator), **and** CAN_QUERY/CAN_MANAGE: the list API alone is scoped to CAN_VIEW, which cannot query, so a parallel detail sweep confirms each survivor.
  - **Custom endpoints (Unity Catalog)** — the caller's UC model services ([Beta securables](https://docs.databricks.com/aws/en/ai-gateway), `GET /api/2.1/unity-catalog/model-services`; visibility is Unity-Catalog-privilege-scoped). `supported_api_types` decides when populated; user-created services report it empty today and the list response omits routing destinations, so undecided services resolve through a parallel single-get sweep. `system.ai` built-ins (mirrors of the hosted endpoints) are dropped.
- **Harness coverage** — implemented for the harnesses the `models:` map feeds, i.e. the gateway's Anthropic surface: **native Claude Code** (launch model + the opus/sonnet/haiku tier aliases), **claude-sdk**, and **pi** (launch model via `default`). Deliberately not covered here: **codex / openai-agents / qwen** (OpenAI surface; models resolve from ucode's `codex_models` — a codex picker needs its own config surface and endpoint filtering, planned as a follow-up PR), **opencode** (routes via its own synthesized provider at `/serving-endpoints`, driven by the agent spec's profile), and harnesses with no Databricks routing in omnigent today (goose, cursor, copilot, kimi, kiro, hermes, antigravity).
- Every endpoint row shows its model family's **max context window** (1M / 200K — sourced from the Anthropic model catalog and Databricks FMAPI docs, live-verified: a >200K-token prompt is accepted on a 1M-family endpoint with no beta header). Picking a 1M-capable endpoint **auto-pins it at the max window** by storing the `[1m]`-suffixed id (Claude Code's long-context convention); 200K families and free-text entries are never suffixed.
- A free-text row remains for FQNs the listing misses (a just-created service, or a pre-Beta workspace). Esc backs out of the picker to the credential screen (earlier tier picks are kept); only the explicit Skip/Keep row advances tier-by-tier. A **Clear override** row removes an existing override. The picker writes only the `models:` map — login/ucode wiring and defaults are unchanged.

## Test Plan

- `uv run pytest tests/cli/test_configure_models.py tests/onboarding/test_databricks_config.py tests/onboarding/test_interactive.py` — 160 passed. New flow tests drive the real setup CLI through the numbered fallback: add-with-custom-endpoints writes exactly the picked map (listed endpoint + typed FQN, skipped tier absent); declining the gate persists the byte-identical pre-picker entry (regression guard); the credential-menu picker edits and clears an existing entry. New flow tests also cover picking a UC model service from the custom section, Esc exiting the picker immediately (no forced tier cycling), and the Codex page offering no endpoint picker. Unit tests cover both listings' filtering (GPT chat / embeddings / CAN_VIEW-only endpoints dropped; `anthropic`-provider external models kept; `system.ai` model services dropped; undecided UC services resolved via their detail; pagination; per-item failures drop that item only; wholesale failure → `[]`).
- Manual E2E against a live Databricks workspace (isolated `OMNIGENT_CONFIG_HOME`): the hosted listing returned exactly the 10 Claude chat endpoints (from 37 total) and the UC listing exactly the 2 user-created Claude model services (the sibling GPT-routing service excluded); verified the gateway contract live — the UC FQN endpoints answer `anthropic/v1/messages` with HTTP 200, while `databricks-gpt-5-5` is rejected with HTTP 400 naming its supported API types. Drove the picker to set `default`/`opus` → `main.agents.my-opus-endpoint` and `sonnet` → `main.agents.my-sonnet-endpoint`; config.yaml gained exactly that map; `resolve_native_claude_config` then pinned the tier env vars / launch model to those FQNs with `~/.ucode/state.json` untouched.
- `ruff check` / `ruff format --check` clean; mypy error count on touched files unchanged (22 pre-existing).

## Demo

Terminal capture of the picker (arrow-key TTY path, live workspace listing):

```
  Model endpoint · default (session launch model)

       ↑ 3 more
       databricks-claude-haiku-4-5  ·  200K context
       databricks-claude-opus-4-1  ·  200K context
       databricks-claude-opus-4-5  ·  200K context
       databricks-claude-opus-4-6  ·  1M context
       databricks-claude-opus-4-7  ·  1M context
       databricks-claude-opus-4-8  ·  1M context
       databricks-claude-sonnet-4  ·  200K context
       databricks-claude-sonnet-4-5  ·  200K context
       databricks-claude-sonnet-4-6  ·  1M context
       databricks-claude-sonnet-5  ·  1M context

     Custom endpoints (Unity Catalog)
       main.agents.my-opus-endpoint  ·  1M context
       main.agents.my-sonnet-endpoint  ·  1M context
    ❯  Enter an endpoint name…

    Type a UC model service's catalog.schema.name (e.g. one created moments ago).

  ↑/↓ move  ·  Enter select  ·  Esc back
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated flow tests cover the numbered-fallback path end-to-end (add gate, per-tier pick, free-text FQN, skip, clear). The raw-termios arrow-key rendering is shared `select()` infrastructure with its own coverage; the TTY path was verified manually against the live workspace (capture above).

## Changelog

Added: `omnigent setup` can pick custom Databricks model endpoints per tier when adding or editing a Databricks provider (lists serving endpoints; UC-native AI Gateway FQNs entered as free text)
