### PR TITLE
test(harness-bench): --transport wiring + semantic driver protocol

### DIFF
--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -63,6 +63,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_false",
         help="Force the offline (declared-only) render.",
     )
+    parser.add_argument(
+        "--transport",
+        metavar="NAME",
+        default=None,
+        help="Transport driver override (e.g. 'sdk-inproc', 'full-server'). "
+        "Wins over each profile's declared transport. Defaults to the "
+        "profile's transport.",
+    )
     fmt = parser.add_mutually_exclusive_group()
     fmt.add_argument(
         "--markdown",
@@ -114,6 +122,7 @@ def main(argv: list[str] | None = None) -> int:
             profiles,
             databricks_profile=args.profile,
             live=live,
+            transport=args.transport,
             progress=_progress if live else None,
         )
     )

--- a/tests/harness_bench/__main__.py
+++ b/tests/harness_bench/__main__.py
@@ -28,6 +28,7 @@ from tests.harness_bench.bench import run_bench
 from tests.harness_bench.manifest import OFFICIAL_PROFILES
 from tests.harness_bench.profile import BenchProfile, resolve_profile
 from tests.harness_bench.report import render_json, render_markdown, render_table
+from tests.harness_bench.transport import driver_registry
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -103,6 +104,15 @@ def main(argv: list[str] | None = None) -> int:
         profiles = _resolve_profiles(args.harness)
     except KeyError as exc:
         print(str(exc), file=sys.stderr)
+        return 2
+
+    # Validate the transport override up front so a typo is a clean CLI error
+    # (exit 2) rather than a KeyError traceback out of the async run.
+    if args.transport is not None and args.transport not in driver_registry():
+        known = ", ".join(sorted(driver_registry()))
+        print(
+            f"unknown --transport {args.transport!r}; known transports: {known}", file=sys.stderr
+        )
         return 2
 
     # Live if explicitly forced, or implied by a supplied profile.

--- a/tests/harness_bench/bench.py
+++ b/tests/harness_bench/bench.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from tests.harness_bench.driver import SdkInprocDriver
 from tests.harness_bench.probes import ALL_PROBES, CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import resolve_driver_class
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict, reconcile
 
 # A progress sink: the bench calls it with human-readable status lines as it
@@ -138,6 +138,7 @@ async def run_harness(
     probes: list[CapabilityProbe] | None = None,
     databricks_profile: str | None = None,
     live: bool = True,
+    transport: str | None = None,
     progress: Progress | None = None,
 ) -> HarnessReport:
     """Run every applicable probe against one harness.
@@ -149,6 +150,8 @@ async def run_harness(
     :param live: When ``False``, produce a declared-only report (every
         cell ``SKIPPED`` with an "offline" note) without spawning
         anything — used for a fast ``--list``/dry render.
+    :param transport: ``--transport`` override; wins over the profile's
+        declared transport when set (see :func:`resolve_driver_class`).
     :param progress: Optional status sink called with human-readable lines
         as the harness spawns and each probe runs. ``None`` stays silent.
     :returns: The :class:`HarnessReport`.
@@ -158,7 +161,8 @@ async def run_harness(
     if not live:
         return _uniform_report(profile, probes, ProbeResult.skipped("offline (declared shown)"))
 
-    unavailable = SdkInprocDriver.unavailable(profile, databricks_profile=databricks_profile)
+    driver_cls = resolve_driver_class(profile, override=transport)
+    unavailable = driver_cls.unavailable(profile, databricks_profile=databricks_profile)
     if unavailable is not None:
         _emit(progress, f"[{profile.harness}] skipped: {unavailable}")
         return _uniform_report(
@@ -168,11 +172,11 @@ async def run_harness(
     assert databricks_profile is not None  # guaranteed by the unavailable() check
     _emit(
         progress,
-        f"[{profile.harness}] launching wrap subprocess "
-        f"(transport={profile.transport}, model={profile.model}); first turn may take ~10-30s...",
+        f"[{profile.harness}] provisioning {driver_cls.transport} transport "
+        f"(model={profile.model}); first turn may take ~10-30s...",
     )
     cells: list[CellResult] = []
-    async with SdkInprocDriver(profile, databricks_profile=databricks_profile) as driver:
+    async with driver_cls(profile, databricks_profile=databricks_profile) as driver:
         prereq_skip: str | None = None
         for probe in probes:
             if not _applicable(probe, profile):
@@ -207,6 +211,7 @@ async def run_bench(
     probes: list[CapabilityProbe] | None = None,
     databricks_profile: str | None = None,
     live: bool = True,
+    transport: str | None = None,
     progress: Progress | None = None,
 ) -> BenchMatrix:
     """Run the bench across *profiles*, sequentially, into a :class:`BenchMatrix`."""
@@ -216,6 +221,7 @@ async def run_bench(
             probes=probes,
             databricks_profile=databricks_profile,
             live=live,
+            transport=transport,
             progress=progress,
         )
         for p in profiles

--- a/tests/harness_bench/driver.py
+++ b/tests/harness_bench/driver.py
@@ -42,6 +42,33 @@ PHASE_TOOL_CALL = "PHASE_TOOL_CALL"
 
 _CONV_ID = "conv_bench"
 
+# Wrap-transport turn shapes for the semantic driver methods. The wrap path
+# provokes a tool call with a request-level function tool (unlike full-server,
+# which uses a builtin); prompts are long enough that a streaming harness
+# emits many deltas and an interrupted turn has visibly less output.
+_STREAM_PROMPT = (
+    "Count from 1 to 30 in words, one number per line, and add a short note after each."
+)
+_LONG_PROMPT = (
+    "Write a very detailed 600-word essay about the history of computing, in full paragraphs."
+)
+_BENCH_TOOL_NAME = "bench_tool"
+_BENCH_DENY_REASON = "bench-policy-deny"
+_BENCH_TOOL_SPEC = [
+    {
+        "type": "function",
+        "function": {
+            "name": _BENCH_TOOL_NAME,
+            "description": "A bench probe tool. Call it when asked.",
+            "parameters": {
+                "type": "object",
+                "properties": {"arg": {"type": "string"}},
+                "required": ["arg"],
+            },
+        },
+    }
+]
+
 # Substrings in a turn error that mean the *environment* is the problem
 # (auth, entitlement, gateway, connectivity) rather than a real capability
 # gap. Turns that fail this way are reported SKIPPED, never UNSUPPORTED, so
@@ -291,6 +318,45 @@ class SdkInprocDriver:
         except (asyncio.TimeoutError, httpx.ReadTimeout):
             result.timed_out = True
         return result
+
+    # ── semantic driver protocol ─────────────────────────────
+    # The probe-facing surface (see tests/harness_bench/transport.py). Each
+    # method wraps run_turn with the wrap-transport mechanism for one
+    # capability dimension, so probes stay transport-agnostic.
+
+    async def run_basic_turn(self, marker: str) -> TurnResult:
+        return await self.run_turn(
+            f"Reply with exactly the literal string {marker} and nothing else."
+        )
+
+    async def run_streaming_turn(self) -> TurnResult:
+        return await self.run_turn(_STREAM_PROMPT)
+
+    async def run_tool_turn(self, *, deny: bool) -> TurnResult:
+        """Provoke a tool call via a request-level function tool.
+
+        With *deny*, answer the tool-call policy evaluation DENY (and post no
+        tool result, since a blocked call never runs); otherwise auto-answer
+        the call so the turn completes.
+        """
+        if deny:
+            return await self.run_turn(
+                f"Call the {_BENCH_TOOL_NAME} tool with arg='go'. It is required.",
+                tools=_BENCH_TOOL_SPEC,
+                deny_phases=frozenset({PHASE_TOOL_CALL}),
+                policy_reason=_BENCH_DENY_REASON,
+                timeout=150.0,
+            )
+        return await self.run_turn(
+            f"You must call the {_BENCH_TOOL_NAME} tool with arg='go', "
+            "then reply with the tool's output verbatim.",
+            tools=_BENCH_TOOL_SPEC,
+            auto_tool_output="bench-tool-ok",
+            timeout=150.0,
+        )
+
+    async def run_interrupt_turn(self) -> TurnResult:
+        return await self.run_turn(_LONG_PROMPT, interrupt_on_first_delta=True, timeout=120.0)
 
     async def _drive(
         self,

--- a/tests/harness_bench/full_server_driver.py
+++ b/tests/harness_bench/full_server_driver.py
@@ -28,6 +28,7 @@ bench's probes run through this driver, not just its gated tests.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import signal
@@ -195,6 +196,31 @@ class FullServerDriver:
         import shutil
 
         shutil.rmtree(self._tmp, ignore_errors=True)
+
+    # ── async driver protocol ────────────────────────────────
+    # This driver's provisioning and turns are synchronous (subprocess spawn,
+    # blocking snapshot polls, a threaded SSE reader). Bridge to the bench's
+    # async Driver protocol by running the blocking work in a worker thread so
+    # the event loop is never blocked.
+
+    async def __aenter__(self) -> FullServerDriver:
+        return await asyncio.to_thread(self.__enter__)
+
+    async def __aexit__(self, *exc: object) -> None:
+        await asyncio.to_thread(self.__exit__, *exc)
+
+    async def run_basic_turn(self, marker: str) -> TurnResult:
+        prompt = f"Reply with exactly the literal string {marker} and nothing else."
+        return await asyncio.to_thread(self.run_turn, prompt)
+
+    async def run_streaming_turn(self) -> TurnResult:
+        return await asyncio.to_thread(self.streaming_probe_turn)
+
+    async def run_tool_turn(self, *, deny: bool) -> TurnResult:
+        return await asyncio.to_thread(lambda: self.tool_probe_turn(deny=deny))
+
+    async def run_interrupt_turn(self) -> TurnResult:
+        return await asyncio.to_thread(self.interrupt_probe_turn)
 
     # ── spawn ────────────────────────────────────────────────
 

--- a/tests/harness_bench/probes/base.py
+++ b/tests/harness_bench/probes/base.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 import abc
 
-from tests.harness_bench.driver import SdkInprocDriver
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult
 
 
@@ -36,7 +36,7 @@ class CapabilityProbe(abc.ABC):
     applies_to: Applicability = Applicability.BOTH
 
     @abc.abstractmethod
-    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
         """Exercise the dimension and return the observed verdict.
 
         :param driver: A live driver already bound to *profile*'s harness.

--- a/tests/harness_bench/probes/basic_turn.py
+++ b/tests/harness_bench/probes/basic_turn.py
@@ -7,9 +7,10 @@ also tells a reader whether a red row is "this harness is broken" versus
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import SdkInprocDriver, infra_failure_reason
+from tests.harness_bench.driver import infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
 
 
@@ -19,10 +20,8 @@ class BasicTurnProbe(CapabilityProbe):
     priority = Priority.P0
     applies_to = Applicability.BOTH
 
-    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
-        result = await driver.run_turn(
-            f"Reply with exactly the literal string {profile.marker} and nothing else."
-        )
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_basic_turn(profile.marker)
         if result.timed_out:
             # A timeout on the prerequisite turn is almost always a hung
             # environment, not a capability fact — do not call it UNSUPPORTED.

--- a/tests/harness_bench/probes/interrupt.py
+++ b/tests/harness_bench/probes/interrupt.py
@@ -8,16 +8,11 @@ long reply; one that honors it terminates with far less output.
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import SdkInprocDriver, infra_failure_reason
+from tests.harness_bench.driver import infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
-
-# A prompt whose natural completion is long, so an honored interrupt
-# produces visibly less output than letting it run.
-_LONG_PROMPT = (
-    "Write a detailed 400-word essay about the history of computing. Use full paragraphs."
-)
 
 
 class InterruptProbe(CapabilityProbe):
@@ -26,12 +21,8 @@ class InterruptProbe(CapabilityProbe):
     priority = Priority.P0
     applies_to = Applicability.BOTH
 
-    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
-        result = await driver.run_turn(
-            _LONG_PROMPT,
-            interrupt_on_first_delta=True,
-            timeout=120.0,
-        )
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        result = await driver.run_interrupt_turn()
         detail = {
             "chars": len(result.text),
             "completed": result.completed,
@@ -39,23 +30,25 @@ class InterruptProbe(CapabilityProbe):
             "failed": result.failed,
             "timed_out": result.timed_out,
         }
-        # The probe posts the interrupt on the FIRST text delta, so a real
-        # interrupt must have streamed at least some text before stopping.
-        # A turn that emitted no text and then errored did not exercise the
-        # interrupt path at all — treat that as unmeasurable, not success.
-        if result.text_delta_count == 0:
-            infra = infra_failure_reason(result)
-            note = infra or "turn produced no text before terminating; interrupt not exercised"
-            return ProbeResult(Verdict.SKIPPED, note=note, detail=detail)
-
-        # The clearest signal: the harness emitted response.cancelled, i.e. it
-        # explicitly honored the interrupt.
+        # The clearest signal: the transport confirmed a cancellation (an SSE
+        # response.cancelled, or the server's cancellation marker). This is
+        # checked first because a confirmed cancel proves the interrupt was
+        # honored regardless of how the transport surfaces streamed text — the
+        # full-server driver confirms via the marker, not a delta count.
         if result.cancelled:
             return ProbeResult(
                 Verdict.SUPPORTED,
                 note=f"turn cancelled after interrupt ({len(result.text)} chars streamed)",
                 detail=detail,
             )
+
+        # No confirmed cancel. The wrap path posts the interrupt on the FIRST
+        # text delta, so a turn that emitted no text and then terminated did
+        # not exercise the interrupt at all — unmeasurable, not a failure.
+        if result.text_delta_count == 0:
+            infra = infra_failure_reason(result)
+            note = infra or "turn produced no text before terminating; interrupt not exercised"
+            return ProbeResult(Verdict.SKIPPED, note=note, detail=detail)
         if result.timed_out:
             return ProbeResult(
                 Verdict.UNSUPPORTED,

--- a/tests/harness_bench/probes/interrupt.py
+++ b/tests/harness_bench/probes/interrupt.py
@@ -45,6 +45,15 @@ class InterruptProbe(CapabilityProbe):
         # No confirmed cancel. The wrap path posts the interrupt on the FIRST
         # text delta, so a turn that emitted no text and then terminated did
         # not exercise the interrupt at all — unmeasurable, not a failure.
+        #
+        # Measurement gap: the full-server driver confirms an interrupt via the
+        # cancellation marker (handled above) and never populates
+        # text_delta_count, so a full-server harness that *ignores* an
+        # interrupt can only be caught as UNSUPPORTED via timed_out below —
+        # otherwise it settles here as SKIPPED (unmeasurable), not a negative
+        # result. Honored interrupts (the probe's goal) are measured on both
+        # transports; a full-server negative needs a delta signal on that
+        # transport to become UNSUPPORTED rather than SKIPPED.
         if result.text_delta_count == 0:
             infra = infra_failure_reason(result)
             note = infra or "turn produced no text before terminating; interrupt not exercised"

--- a/tests/harness_bench/probes/model_override.py
+++ b/tests/harness_bench/probes/model_override.py
@@ -18,9 +18,10 @@ gateway to reject unknown ids promptly.
 from __future__ import annotations
 
 from omnigent.model_override import model_family_mismatch, validate_model_override
-from tests.harness_bench.driver import SdkInprocDriver, infra_failure_reason
+from tests.harness_bench.driver import infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
 
 
@@ -30,7 +31,7 @@ class ModelOverrideProbe(CapabilityProbe):
     priority = Priority.P0
     applies_to = Applicability.BOTH
 
-    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
         # Offline half: the override mechanism itself must accept this
         # harness+model pair. A rejection here is a hard UNSUPPORTED — the
         # caller could never set this model in the first place.
@@ -44,9 +45,7 @@ class ModelOverrideProbe(CapabilityProbe):
 
         # Live half: the harness was spawned with {env_prefix}MODEL set to
         # profile.model; a completing turn proves the override routed.
-        result = await driver.run_turn(
-            f"Reply with exactly the literal string {profile.marker} and nothing else.",
-        )
+        result = await driver.run_basic_turn(profile.marker)
         detail = {"model": profile.model, "completed": result.completed}
         if result.completed and result.text:
             return ProbeResult(

--- a/tests/harness_bench/probes/policy_deny.py
+++ b/tests/harness_bench/probes/policy_deny.py
@@ -14,28 +14,10 @@ was actually surfaced and that the DENY landed on ``PHASE_TOOL_CALL``.
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import PHASE_TOOL_CALL, SdkInprocDriver
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
-
-_TOOL_NAME = "bench_forbidden"
-_TOOL_SPEC = [
-    {
-        "type": "function",
-        "function": {
-            "name": _TOOL_NAME,
-            "description": "A tool the policy engine will deny. Call it when asked.",
-            "parameters": {
-                "type": "object",
-                "properties": {"arg": {"type": "string"}},
-                "required": ["arg"],
-            },
-        },
-    }
-]
-
-_DENY_REASON = "bench-policy-deny"
 
 
 class PolicyDenyProbe(CapabilityProbe):
@@ -44,16 +26,11 @@ class PolicyDenyProbe(CapabilityProbe):
     priority = Priority.P0
     applies_to = Applicability.BOTH
 
-    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
-        result = await driver.run_turn(
-            f"Call the {_TOOL_NAME} tool with arg='go'. It is required.",
-            tools=_TOOL_SPEC,
-            deny_phases=frozenset({PHASE_TOOL_CALL}),
-            policy_reason=_DENY_REASON,
-            # No auto tool output: a correctly-enforced DENY means the tool
-            # never runs, so there is no result to return.
-            timeout=150.0,
-        )
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        # The driver owns the deny mechanism (a tool_call-phase verdict on the
+        # wrap path, a spec-baked deny policy on full-server); the probe only
+        # cares whether a surfaced tool call was actually blocked.
+        result = await driver.run_tool_turn(deny=True)
         detail = {
             "policy_actions": result.policy_actions,
             "tool_call_denied": result.tool_call_denied,

--- a/tests/harness_bench/probes/streaming.py
+++ b/tests/harness_bench/probes/streaming.py
@@ -15,14 +15,11 @@ SUPPORTED, "never streams" to PARTIAL.
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import SdkInprocDriver, TurnResult, infra_failure_reason
+from tests.harness_bench.driver import TurnResult, infra_failure_reason
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
-
-# Long enough that a genuinely streaming harness emits many deltas and a
-# one-chunk flush is clearly complete-only rather than just a short reply.
-_PROMPT = "Count from 1 to 30 in words, one number per line, and add a short note after each."
 
 
 class StreamingProbe(CapabilityProbe):
@@ -31,7 +28,7 @@ class StreamingProbe(CapabilityProbe):
     priority = Priority.P0
     applies_to = Applicability.BOTH
 
-    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
         result = await self._measure(driver)
         skipped = self._skip_reason(result)
         if skipped is not None:
@@ -74,8 +71,8 @@ class StreamingProbe(CapabilityProbe):
             detail={"text_delta_count": n, "retry_delta_count": m},
         )
 
-    async def _measure(self, driver: SdkInprocDriver) -> TurnResult:
-        return await driver.run_turn(_PROMPT)
+    async def _measure(self, driver: Driver) -> TurnResult:
+        return await driver.run_streaming_turn()
 
     @staticmethod
     def _skip_reason(result: TurnResult) -> str | None:

--- a/tests/harness_bench/probes/tool_calling.py
+++ b/tests/harness_bench/probes/tool_calling.py
@@ -13,26 +13,10 @@ transport differs.
 
 from __future__ import annotations
 
-from tests.harness_bench.driver import SdkInprocDriver
 from tests.harness_bench.probes.base import CapabilityProbe
 from tests.harness_bench.profile import BenchProfile
+from tests.harness_bench.transport import Driver
 from tests.harness_bench.verdict import Applicability, Priority, ProbeResult, Verdict
-
-_TOOL_NAME = "bench_echo"
-_TOOL_SPEC = [
-    {
-        "type": "function",
-        "function": {
-            "name": _TOOL_NAME,
-            "description": "Echo a token back. Call this to retrieve the secret token.",
-            "parameters": {
-                "type": "object",
-                "properties": {"query": {"type": "string", "description": "what to echo"}},
-                "required": ["query"],
-            },
-        },
-    }
-]
 
 
 class ToolCallingProbe(CapabilityProbe):
@@ -41,15 +25,12 @@ class ToolCallingProbe(CapabilityProbe):
     priority = Priority.P0
     applies_to = Applicability.BOTH
 
-    async def run(self, driver: SdkInprocDriver, profile: BenchProfile) -> ProbeResult:
-        result = await driver.run_turn(
-            f"You must call the {_TOOL_NAME} tool with query='token' to get the secret, "
-            "then reply with the tool's output verbatim.",
-            tools=_TOOL_SPEC,
-            auto_tool_output=f"the-secret-is-{profile.marker}",
-            timeout=150.0,
-        )
-        called = [tc for tc in result.tool_calls if tc.get("name") == _TOOL_NAME]
+    async def run(self, driver: Driver, profile: BenchProfile) -> ProbeResult:
+        # The driver owns the tool mechanism (a request-level function tool on
+        # the wrap path, a builtin on full-server); the probe only cares that
+        # *a* tool call was dispatched and the turn closed.
+        result = await driver.run_tool_turn(deny=False)
+        called = list(result.tool_calls)
         detail = {
             "tool_calls": [tc.get("name") for tc in result.tool_calls],
             "completed": result.completed,

--- a/tests/harness_bench/test_bench.py
+++ b/tests/harness_bench/test_bench.py
@@ -161,3 +161,44 @@ async def test_live_harness_matches_declared(
             for c in drifted
         )
     )
+
+
+# ── full-server async shims (offline) ───────────────────────────
+
+
+async def test_full_server_async_shims_delegate_to_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The FullServerDriver async protocol methods delegate to the sync ones.
+
+    The live gated tests exercise the sync entry points; this covers the
+    asyncio.to_thread shims (and __aenter__/__aexit__) offline so a regression
+    in the async binding is caught without a server+runner. Builds no driver
+    state — every sync method is stubbed.
+    """
+    from tests.harness_bench.driver import TurnResult
+    from tests.harness_bench.full_server_driver import FullServerDriver
+    from tests.harness_bench.profile import BenchProfile
+
+    profile = BenchProfile(harness="stub", model="m", env_prefix="HARNESS_STUB_", marker="STUB_OK")
+    driver = FullServerDriver(profile, databricks_profile="oss")
+    calls: list[str] = []
+
+    def _stub(name: str, **kw: object):
+        calls.append(f"{name}:{kw}")
+        return TurnResult(completed=True)
+
+    monkeypatch.setattr(driver, "__enter__", lambda: (calls.append("enter"), driver)[1])
+    monkeypatch.setattr(driver, "__exit__", lambda *a: calls.append("exit"))
+    monkeypatch.setattr(driver, "run_turn", lambda prompt, **kw: _stub("run_turn", prompt=prompt))
+    monkeypatch.setattr(driver, "streaming_probe_turn", lambda **kw: _stub("streaming"))
+    monkeypatch.setattr(driver, "tool_probe_turn", lambda **kw: _stub("tool", **kw))
+    monkeypatch.setattr(driver, "interrupt_probe_turn", lambda **kw: _stub("interrupt"))
+
+    async with driver as d:
+        assert d is driver
+        assert (await d.run_basic_turn("STUB_OK")).completed
+        assert (await d.run_streaming_turn()).completed
+        assert (await d.run_tool_turn(deny=True)).completed
+        assert (await d.run_interrupt_turn()).completed
+
+    assert calls[0] == "enter" and calls[-1] == "exit"
+    assert any(c.startswith("tool:") and "True" in c for c in calls)

--- a/tests/harness_bench/transport.py
+++ b/tests/harness_bench/transport.py
@@ -1,0 +1,114 @@
+"""Transport drivers: the probe-facing contract and the registry.
+
+A probe measures one capability dimension by calling a small set of
+*semantic* methods on a driver — ``run_basic_turn``, ``run_streaming_turn``,
+``run_tool_turn``, ``run_interrupt_turn`` — each returning a
+:class:`~tests.harness_bench.driver.TurnResult`. The driver owns the
+*mechanism* (how a tool call is provoked, how a deny is enforced, how deltas
+are observed); the probe owns the *interpretation* (what verdict the result
+implies). This split is what lets one probe run over transports that reach
+the same capability by different means:
+
+- ``sdk-inproc`` (:class:`~tests.harness_bench.driver.SdkInprocDriver`)
+  drives a harness wrap subprocess directly, with request-level tools and
+  verdict-posted policy.
+- ``full-server``
+  (:class:`~tests.harness_bench.full_server_driver.FullServerDriver`) drives
+  a real server+runner, with a builtin tool and a spec-baked policy.
+
+A kwargs-carrying ``run_turn`` could not bridge these: e.g. streaming is only
+observable on full-server via a separate SSE subscription, so "basic turn"
+and "streaming turn" must be *distinct* calls, not one call with a flag.
+
+Transport selection: each :class:`BenchProfile` declares a default
+``transport``; a ``--transport`` CLI override wins over it globally (see
+:func:`resolve_driver_class`).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from tests.harness_bench.driver import TurnResult
+from tests.harness_bench.profile import BenchProfile
+
+
+@runtime_checkable
+class Driver(Protocol):
+    """The probe-facing driver contract.
+
+    Implementations are async context managers: ``__aenter__`` provisions the
+    transport (spawns a wrap subprocess, or a server+runner) and binds a
+    session; ``__aexit__`` tears it down. Each ``run_*`` method drives one
+    turn and returns a :class:`TurnResult` the probes interpret.
+    """
+
+    transport: str
+
+    async def __aenter__(self) -> Driver: ...
+    async def __aexit__(self, *exc: object) -> None: ...
+
+    async def run_basic_turn(self, marker: str) -> TurnResult:
+        """Plain turn asking the model to echo *marker*. Used by basic_turn
+        and model_override."""
+        ...
+
+    async def run_streaming_turn(self) -> TurnResult:
+        """A multi-token turn; the result's ``text_delta_count`` reflects
+        whether the transport streamed token-level deltas."""
+        ...
+
+    async def run_tool_turn(self, *, deny: bool) -> TurnResult:
+        """Provoke a tool call. With *deny*, a tool-call policy DENY is in
+        force so the call should be blocked (``tool_call_denied``); otherwise
+        the call is dispatched and answered (``tool_calls`` populated)."""
+        ...
+
+    async def run_interrupt_turn(self) -> TurnResult:
+        """Start a long turn and interrupt it mid-flight; ``cancelled``
+        reflects whether the transport honored the interrupt."""
+        ...
+
+    @staticmethod
+    def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
+        """Return a skip reason if this driver cannot run *profile*, else None."""
+        ...
+
+
+def driver_registry() -> dict[str, type]:
+    """Map transport name → driver class.
+
+    Imported lazily so the transport module stays cheap to import (the
+    full-server driver pulls in server/runner spawn helpers).
+    """
+    from tests.harness_bench.driver import SdkInprocDriver
+    from tests.harness_bench.full_server_driver import FullServerDriver
+
+    return {
+        SdkInprocDriver.transport: SdkInprocDriver,
+        FullServerDriver.transport: FullServerDriver,
+    }
+
+
+def resolve_driver_class(profile: BenchProfile, *, override: str | None) -> type:
+    """Resolve the driver class for *profile*.
+
+    *override* (the ``--transport`` flag) wins over the profile's declared
+    ``transport`` when set. Raises :class:`KeyError` for an unknown transport
+    so a typo fails loud rather than silently falling back.
+
+    :param profile: The harness under test.
+    :param override: A transport name from ``--transport``, or ``None`` to use
+        the profile's declared transport.
+    :returns: The driver class to instantiate.
+    """
+    name = override or profile.transport
+    registry = driver_registry()
+    if name not in registry:
+        raise KeyError(
+            f"unknown transport {name!r}; known transports: {', '.join(sorted(registry))}"
+        )
+    return registry[name]
+
+
+__all__ = ["Driver", "driver_registry", "resolve_driver_class"]

--- a/tests/harness_bench/transport.py
+++ b/tests/harness_bench/transport.py
@@ -27,13 +27,12 @@ Transport selection: each :class:`BenchProfile` declares a default
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 from tests.harness_bench.driver import TurnResult
 from tests.harness_bench.profile import BenchProfile
 
 
-@runtime_checkable
 class Driver(Protocol):
     """The probe-facing driver contract.
 
@@ -41,38 +40,42 @@ class Driver(Protocol):
     transport (spawns a wrap subprocess, or a server+runner) and binds a
     session; ``__aexit__`` tears it down. Each ``run_*`` method drives one
     turn and returns a :class:`TurnResult` the probes interpret.
+
+    Not ``@runtime_checkable`` on purpose: drivers are selected by class from
+    :func:`driver_registry`, never by ``isinstance`` — and a runtime protocol
+    check would not cover the data/static members (``transport``,
+    ``unavailable``) anyway. The docstring-only method bodies below are the
+    Protocol stub form; the concrete drivers supply the behavior.
     """
 
     transport: str
 
-    async def __aenter__(self) -> Driver: ...
-    async def __aexit__(self, *exc: object) -> None: ...
+    async def __aenter__(self) -> Driver:
+        """Provision the transport and bind a session."""
+
+    async def __aexit__(self, *exc: object) -> None:
+        """Tear down the transport."""
 
     async def run_basic_turn(self, marker: str) -> TurnResult:
         """Plain turn asking the model to echo *marker*. Used by basic_turn
         and model_override."""
-        ...
 
     async def run_streaming_turn(self) -> TurnResult:
         """A multi-token turn; the result's ``text_delta_count`` reflects
         whether the transport streamed token-level deltas."""
-        ...
 
     async def run_tool_turn(self, *, deny: bool) -> TurnResult:
         """Provoke a tool call. With *deny*, a tool-call policy DENY is in
         force so the call should be blocked (``tool_call_denied``); otherwise
         the call is dispatched and answered (``tool_calls`` populated)."""
-        ...
 
     async def run_interrupt_turn(self) -> TurnResult:
         """Start a long turn and interrupt it mid-flight; ``cancelled``
         reflects whether the transport honored the interrupt."""
-        ...
 
     @staticmethod
     def unavailable(profile: BenchProfile, *, databricks_profile: str | None) -> str | None:
         """Return a skip reason if this driver cannot run *profile*, else None."""
-        ...
 
 
 def driver_registry() -> dict[str, type]:


### PR DESCRIPTION
The final phase-2 piece: make the bench's probes run through a **selectable transport**, so the same six P0 probes execute over either the harness-wrap path or a real server+runner.

## The seam

Introduces a `Driver` protocol (`transport.py`) with four **semantic** per-dimension methods — `run_basic_turn`, `run_streaming_turn`, `run_tool_turn(deny)`, `run_interrupt_turn` — that both drivers implement. The driver owns the *mechanism*; the probe owns the *interpretation*. This is what lets one probe span transports that reach the same capability differently:

- **sdk-inproc** (wrap): request-level function tool + verdict-posted policy DENY.
- **full-server**: builtin tool the server dispatches + a spec-baked `tool_call` deny policy + SSE subscribe for deltas.

A kwargs-carrying `run_turn` couldn't bridge these (e.g. full-server only observes streaming via a separate SSE subscription), so distinct semantic calls are required, not one call with flags.

## What changed

- `transport.py`: `Driver` protocol, `driver_registry()`, `resolve_driver_class()` — `--transport` override wins over the profile's declared transport; unknown transport fails loud.
- `SdkInprocDriver` + `FullServerDriver` both implement the four methods; full-server bridges its sync provisioning/turns to async via `asyncio.to_thread`.
- All six probes refactored to the semantic surface (no more wrap-specific `run_turn` kwargs or per-probe tool specs); `base.run()` typed against `Driver`.
- `run_harness`/`run_bench` + the CLI take `--transport`.
- Interrupt probe: check `result.cancelled` **before** the delta-count guard, so a transport that confirms cancellation via a marker (full-server) isn't falsely SKIPPED.

## Verification (live on oss)

- **sdk-inproc** (default) — matrix unchanged from before the refactor:
  - claude-sdk / pi: tool_calling + policy_deny are justified `·` (register tools via config/MCP, not the wire); codex / openai-agents: tool_calling ✓.
- **`--transport full-server`** — the same six probes, now filling the two cells the wrap path can only skip:
  ```
  claude-sdk      ✓  ✓  ✓  ✓  ✓  ✓
  pi              ✓  ✓  ✓  ✓  ✓  ✓
  openai-agents   ✓  ✓  ✓  ✓  ✓  ✓
  ```
  Real server-dispatched tools + real tool-call policy DENY enforcement, no unexpected DRIFT. (codex intermittently hits the known gateway-auth/timeout flake — prereq-skipped cleanly, not a capability result.)
- Offline suite: 17 passed, 4 skipped. ruff + pre-commit clean.

## Stack

Independent of the capability-seam work (#1865, merged) — touches drivers/probes/CLI, not `manifest.py`. This completes the full-server transport: all four behavioral dimensions (#1790 tools+policy, #1792 interrupt, #1796 streaming) are now reachable through the bench's probes via `--transport full-server`.