### PR TITLE
fix(codex-native): picker readiness mirrors the launch resolver, not auth.json

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -222,8 +222,7 @@ def _codex_auth_unavailable_reason() -> str | None:
     try:
         launch = resolve_native_codex_launch(model=None)
         routes_through_provider = (
-            launch.profile is not None
-            or codex_session_meta_model_provider(launch) != "openai"
+            launch.profile is not None or codex_session_meta_model_provider(launch) != "openai"
         )
     except Exception:  # noqa: BLE001 - readiness must never raise; fail onto auth.json.
         _logger.debug("codex readiness: launch resolve failed; using auth.json", exc_info=True)

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -187,18 +187,49 @@ def _codex_auth_unavailable_reason() -> str | None:
     """
     Return why local Codex is unavailable, or ``None`` when available.
 
-    The check is synchronous, side-effect free, and local-only: it only checks
-    the ``codex`` binary and the resolved local auth source. It never runs
-    ``codex login``, shells out to a status command, or performs a network probe.
+    Readiness must ask the same question the launch resolver answers, not read a
+    credential file the launch ignores. :func:`resolve_native_codex_launch`
+    routes a Databricks-gateway / provider-configured setup through a Databricks
+    profile or a ``model_provider`` override and mints its bearer at run time
+    (``databricks auth token`` / a provider auth command) — it never reads
+    ``auth.json``. So on such a host ``auth.json`` is legitimately empty, and
+    gating on it is a false negative (the launch works). Only when the launch
+    defers to Codex's *own* login is ``auth.json`` the credential that decides
+    availability, so that is the only case gated on it. This mirrors the
+    fail-open the ``claude-sdk`` / ``openai-agents`` gateway harnesses already
+    rely on: their gateway token is a runtime mint the daemon can't observe.
+
+    The check stays synchronous, side-effect free, and local: it resolves the
+    launch (local config reads) and, only on the defer-to-login path, inspects
+    the local auth source. It never runs ``codex login``, a status command, or a
+    network probe; any resolver failure fails safe onto the ``auth.json`` check.
 
     :returns: ``"binary-missing"`` when the CLI is absent, ``"needs-auth"``
-        when the CLI exists but ``auth.json`` is missing, malformed, or carries
-        no credential, and ``None`` when a credential is configured. Token
-        *validity* (revoked/expired refresh) is not judged locally — see
-        :func:`_codex_auth_json_has_available_credential`.
+        when the launch would defer to Codex's own login but ``auth.json`` is
+        missing, malformed, or carries no credential, and ``None`` when a
+        provider will route the launch or a login credential is configured.
+        Token *validity* (revoked/expired refresh, an unreachable gateway) is
+        not judged locally — it surfaces at the first turn via the executor.
     """
     if shutil.which(_DEFAULT_CODEX_COMMAND) is None:
         return _CODEX_AUTH_UNAVAILABLE_BINARY_MISSING
+    # ponytail: resolve_native_codex_launch runs once per codex spelling
+    # (codex / codex-native / native-codex → 3×) per hello frame; on a host with
+    # NO configured provider it also runs ambient detection (a localhost ollama
+    # probe + a `claude auth status` subprocess). It's off the event loop and
+    # only bites unconfigured hosts — memoize the launch across the map build in
+    # configured_harness_map if that cost ever shows up.
+    try:
+        launch = resolve_native_codex_launch(model=None)
+        routes_through_provider = (
+            launch.profile is not None
+            or codex_session_meta_model_provider(launch) != "openai"
+        )
+    except Exception:  # noqa: BLE001 - readiness must never raise; fail onto auth.json.
+        _logger.debug("codex readiness: launch resolve failed; using auth.json", exc_info=True)
+        routes_through_provider = False
+    if routes_through_provider:
+        return None
     source = _resolve_codex_auth_source()
     if not _codex_auth_json_has_available_credential(source.auth_path):
         return _CODEX_AUTH_UNAVAILABLE_NEEDS_AUTH

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -35,9 +35,25 @@ def _write_codex_auth(path: Path, payload: object) -> None:
 
 
 def _point_codex_auth_check_at(
-    monkeypatch: pytest.MonkeyPatch, auth_path: Path, *, binary_present: bool
+    monkeypatch: pytest.MonkeyPatch,
+    auth_path: Path,
+    *,
+    binary_present: bool,
+    launch: Any | None = None,
 ) -> None:
-    """Redirect Codex availability checks away from the real machine state."""
+    """Redirect Codex availability checks away from the real machine state.
+
+    ``launch`` pins what :func:`resolve_native_codex_launch` returns; the default
+    is the defer-to-Codex-login shape (``profile=None``, ``model_provider`` not
+    set → resolves to ``"openai"``), which is exactly the case where
+    ``auth.json`` is the credential that decides availability. Provider-routed
+    tests pass an explicit launch.
+    """
+    if launch is None:
+        launch = codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[], model=None, profile=None
+        )
+    monkeypatch.setattr(codex_native, "resolve_native_codex_launch", lambda model=None: launch)
     monkeypatch.setattr(
         codex_native,
         "_resolve_codex_auth_source",
@@ -135,6 +151,53 @@ def test_codex_auth_unavailable_reason_malformed_auth_needs_auth(
     auth_path.parent.mkdir(parents=True, exist_ok=True)
     auth_path.write_text("{not json", encoding="utf-8")
 
+    assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
+
+
+def test_codex_auth_unavailable_reason_databricks_profile_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A Databricks-profile launch is available even with an EMPTY auth.json.
+
+    The reported bug: the launch mints its bearer via ``databricks auth token``
+    and never reads ``auth.json``, so gating on it is a false negative. auth.json
+    is deliberately absent here — availability must come from the launch.
+    """
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    launch = codex_native_app_server.NativeCodexLaunch(
+        config_overrides=[], model=None, profile="my-profile"
+    )
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True, launch=launch)
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_provider_override_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A launch pinning a non-openai model_provider is available sans auth.json."""
+    auth_path = tmp_path / "codex-home" / "auth.json"  # never created
+    launch = codex_native_app_server.NativeCodexLaunch(
+        config_overrides=['model_provider="omnigent_databricks"'], model=None, profile=None
+    )
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True, launch=launch)
+
+    assert codex_native._codex_auth_unavailable_reason() is None
+
+
+def test_codex_auth_unavailable_reason_resolver_failure_falls_back_to_auth_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A resolver blow-up fails safe onto the auth.json check (never raises)."""
+    auth_path = tmp_path / "codex-home" / "auth.json"
+    _point_codex_auth_check_at(monkeypatch, auth_path, binary_present=True)
+
+    def _boom(model: object = None) -> object:
+        raise RuntimeError("corrupt config")
+
+    monkeypatch.setattr(codex_native, "resolve_native_codex_launch", _boom)
+
+    # No auth.json → falls through to needs-auth rather than propagating.
     assert codex_native._codex_auth_unavailable_reason() == "needs-auth"
 
 


### PR DESCRIPTION
## Problem

On a Databricks-gateway setup the web picker shows

> Codex needs Codex authentication on `<HOST>` — run `codex login`

…but running codex works fine. Classic false negative: the readiness check and the launch path ask different questions about different files.

## Root cause

- **Picker readiness** → `_codex_auth_unavailable_reason()` only inspects `~/.codex/auth.json` for an OpenAI-family credential.
- **Actual launch** → `resolve_native_codex_launch()` routes a gateway/provider setup through a **Databricks profile** or a `model_provider` override and mints its bearer at run time (`databricks auth token` / a provider auth command). It **never reads `auth.json`**.

So on a gateway host `auth.json` is legitimately empty, readiness fires `needs-auth`, and the launch runs anyway. Codex was the only harness inspecting a stored credential file at readiness — the `claude-sdk` / `openai-agents` gateway harnesses (same Databricks gateway) fail open precisely because their token is a runtime mint the daemon can't observe.

## Fix

Make readiness ask the same question the resolver already answers: **available when the launch routes through a provider** (`profile` set, or a non-`openai` `model_provider`); fall back to the `auth.json` check only on the bare-`codex login` path where `auth.json` genuinely *is* the credential. Any resolver failure fails safe onto the `auth.json` check.

- Reuses `resolve_native_codex_launch` + `codex_session_meta_model_provider`, both already imported in the module — no new imports, no network probe.
- `_codex_auth_unavailable_reason()` is the single predicate the picker routes through, so the one guard fixes every provider-routed sibling, not just the DB-gateway path.

## Not this PR

This deliberately does **not** add a port/reachability probe. The daemon often can't reach the loopback proxy (different netns) or the remote gateway (egress-restricted), so any reachability probe is a false-negative machine — endpoint/token validity correctly surfaces at the first turn via the executor.

## Verification

- New tests: DB-profile + empty `auth.json` → available; non-`openai` provider override → available; resolver failure → falls back to `auth.json`.
- `tests/test_codex_native.py` auth-reason suite (9) + `tests/onboarding/test_harness_readiness.py` (26) green.
- Direct simulation of the reported scenario: DB profile + empty `auth.json` → available; bare login + empty `auth.json` → still `needs-auth`.

This pull request and its description were written by Isaac.