### PR TITLE
feat(sharing): projects sharing, roles and permissions

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3007,6 +3007,7 @@ def server(
     _ensure_sqlite_parent_dir(db_uri)
 
     from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
 
     agent_store = SqlAlchemyAgentStore(db_uri)
     file_store = SqlAlchemyFileStore(db_uri)
@@ -3014,6 +3015,7 @@ def server(
     comment_store = SqlAlchemyCommentStore(db_uri)
     policy_store = SqlAlchemyPolicyStore(db_uri)
     permission_store = SqlAlchemyPermissionStore(db_uri)
+    project_store = SqlAlchemyProjectStore(db_uri)
     artifact_store = _create_artifact_store(art_loc)
 
     # Initialize the runtime with store references so workflow code
@@ -3160,6 +3162,7 @@ def server(
         agent_cache=agent_cache,
         runner_tunnel_tokens=_runner_tunnel_tokens,
         permission_store=permission_store,
+        project_store=project_store,
         auth_provider=auth_provider,
         host_store=host_store,
         account_store=account_store,

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -233,6 +233,86 @@ class SqlSessionPermission(Base):
     )
 
 
+class SqlProject(Base):
+    """
+    SQLAlchemy model for the ``projects`` table.
+
+    A project is a first-class, shareable collection of conversations.
+    Conversations reference their project via ``conversations.project_id``;
+    a project's access-control lives in ``project_permissions``, and a
+    session's effective access *inherits* from its project (so sharing a
+    project covers every chat in it, including chats filed later).
+
+    Names are unique per owner (``(created_by, name)``), so two users can
+    each own a project called ``"Client X"`` without collision.
+
+    :param id: Unique project identifier, e.g. ``"proj_e4f5a6b7..."``.
+    :param name: Human-readable project name, e.g. ``"Q3 launch"``.
+    :param created_by: The user id of the creator/owner, or ``None`` if
+        the owner's account was deleted (``ON DELETE SET NULL``).
+    :param created_at: Unix epoch seconds when the project was created.
+    :param updated_at: Unix epoch seconds of the last mutation (rename).
+    """
+
+    __tablename__ = "projects"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    name: Mapped[str] = mapped_column(String(256), nullable=False)
+    created_by: Mapped[str | None] = mapped_column(
+        String(128),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    updated_at: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("created_by", "name", name="uq_projects_owner_name"),
+        Index("ix_projects_created_by", "created_by"),
+    )
+
+
+class SqlProjectPermission(Base):
+    """
+    SQLAlchemy model for the ``project_permissions`` table.
+
+    The ACL for a project — the direct analogue of
+    :class:`SqlSessionPermission`, keyed by ``(user_id, project_id)``.
+    A session's access resolver ORs a project grant in for any session
+    whose ``project_id`` points here, which is how project sharing
+    *inherits* to the project's chats (current and future).
+
+    The ``"__public__"`` (anyone with the link) and ``"__members__"``
+    (every signed-in user) sentinel ``user_id`` values work exactly as
+    they do for sessions.
+
+    :param user_id: The grantee, e.g. ``"alice@example.com"`` or a
+        sentinel (``"__public__"`` / ``"__members__"``).
+    :param project_id: The project being shared, e.g. ``"proj_e4f5..."``.
+    :param level: Numeric permission level: ``1`` = read, ``2`` = edit,
+        ``3`` = manage, ``4`` = owner. Comparison is ``>=``.
+    """
+
+    __tablename__ = "project_permissions"
+
+    user_id: Mapped[str] = mapped_column(
+        String(128),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    project_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    level: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint("level IN (1, 2, 3, 4)", name="ck_project_permissions_level"),
+        Index("ix_project_permissions_project_id", "project_id"),
+    )
+
+
 class SqlConversation(Base):
     """
     SQLAlchemy model for the ``conversations`` table.
@@ -344,6 +424,19 @@ class SqlConversation(Base):
         ForeignKey("hosts.host_id", ondelete="SET NULL"),
         nullable=True,
     )
+    # First-class project this conversation is filed under, replacing the
+    # old ``omni_project`` label. FK to projects.id; ON DELETE SET NULL so
+    # deleting a project unfiles its chats rather than deleting them. The
+    # session access resolver inherits the project's grants for any row
+    # whose project_id is set. Like host_id (see a7b3c9d1e5f2), the
+    # migration adds this as a plain column (no DB-level FK) to avoid a
+    # batch rebuild of the large conversations table; the FK here is ORM
+    # metadata only and materializes just on fresh create_all DBs.
+    project_id: Mapped[str | None] = mapped_column(
+        String(64),
+        ForeignKey("projects.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     # Per-session reasoning-effort hint, e.g. "high". Nullable;
     # None means use the agent default.
     reasoning_effort: Mapped[str | None] = mapped_column(String(32), nullable=True)
@@ -421,6 +514,9 @@ class SqlConversation(Base):
         # Reconnect reconciliation queries conversations by host_id on
         # every host reconnect; index it to avoid a full scan.
         Index("ix_conversations_host_id", "host_id"),
+        # The listing ACL unions "sessions whose project I can access", and
+        # the sidebar filters sessions by project_id — both scan on this.
+        Index("ix_conversations_project_id", "project_id"),
         Index("ix_conversations_root_conversation_id", "root_conversation_id"),
         # Phase 4: partial unique index on (parent_conversation_id,
         # title) prevents two same-named children under the same

--- a/omnigent/db/migrations/versions/o1a2b3c4d5e6_add_projects_and_project_permissions.py
+++ b/omnigent/db/migrations/versions/o1a2b3c4d5e6_add_projects_and_project_permissions.py
@@ -1,0 +1,164 @@
+"""add projects, project_permissions, and conversations.project_id
+
+Revision ID: o1a2b3c4d5e6
+Revises: n1a2b3c4d5e6
+Create Date: 2026-07-01 00:00:00.000000
+
+Promotes "projects" from an implicit ``omni_project`` conversation label to
+a first-class, shareable entity:
+
+- ``projects`` table: id, name, owner (``created_by``), timestamps, with
+  names unique per owner.
+- ``project_permissions`` table: the project ACL, the direct analogue of
+  ``session_permissions`` keyed by ``(user_id, project_id)``. Session access
+  inherits a project's grants, so sharing a project covers every chat in it
+  (including chats filed later).
+- ``conversations.project_id``: the first-class replacement for the
+  ``omni_project`` label. Added as a plain column (no DB-level FK) mirroring
+  the ``host_id`` precedent (a7b3c9d1e5f2) to avoid a batch rebuild of the
+  large conversations table.
+
+Backfill: for each distinct ``(owner, name)`` — where ``owner`` is a
+``level >= 4`` grantee of a session carrying ``omni_project=name`` — create a
+project owned by that user, point that user's matching sessions at it, and
+seed the owner's project grant. Per-(owner, name) grouping preserves the
+per-user separation the label model had (two users' "Client X" stay
+distinct). The ``omni_project`` labels are left in place, so ``downgrade`` is
+lossless.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "o1a2b3c4d5e6"
+down_revision: str | None = "n1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PROJECT_LABEL_KEY = "omni_project"
+_LEVEL_OWNER = 4
+# Sentinel grantees are not real owners — exclude them when deriving a
+# project's owner from the session grants.
+_SENTINELS = ("__public__", "__members__")
+
+
+def upgrade() -> None:
+    """Create the project tables + column and backfill from labels."""
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("name", sa.String(256), nullable=False),
+        sa.Column(
+            "created_by",
+            sa.String(128),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.Integer, nullable=False),
+        sa.Column("updated_at", sa.Integer, nullable=False),
+        sa.UniqueConstraint("created_by", "name", name="uq_projects_owner_name"),
+    )
+    op.create_index("ix_projects_created_by", "projects", ["created_by"])
+
+    op.create_table(
+        "project_permissions",
+        sa.Column(
+            "user_id",
+            sa.String(128),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "project_id",
+            sa.String(64),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("level", sa.Integer, nullable=False),
+        sa.CheckConstraint("level IN (1, 2, 3, 4)", name="ck_project_permissions_level"),
+    )
+    op.create_index(
+        "ix_project_permissions_project_id",
+        "project_permissions",
+        ["project_id"],
+    )
+
+    op.add_column(
+        "conversations",
+        sa.Column("project_id", sa.String(64), nullable=True),
+    )
+    op.create_index("ix_conversations_project_id", "conversations", ["project_id"])
+
+    _backfill_projects_from_labels()
+
+
+def _backfill_projects_from_labels() -> None:
+    """Materialize one project per distinct ``(owner, label value)``."""
+    conn = op.get_bind()
+    now = int(time.time())
+
+    owner_names = conn.execute(
+        sa.text(
+            "SELECT DISTINCT cl.value AS name, sp.user_id AS owner "
+            "FROM conversation_labels cl "
+            "JOIN session_permissions sp ON sp.conversation_id = cl.conversation_id "
+            "WHERE cl.key = :key AND sp.level >= :owner_level "
+            "AND sp.user_id NOT IN :sentinels"
+        ).bindparams(
+            sa.bindparam("sentinels", value=_SENTINELS, expanding=True),
+        ),
+        {"key": _PROJECT_LABEL_KEY, "owner_level": _LEVEL_OWNER},
+    ).fetchall()
+
+    for name, owner in owner_names:
+        project_id = f"proj_{uuid.uuid4().hex}"
+        conn.execute(
+            sa.text(
+                "INSERT INTO projects (id, name, created_by, created_at, updated_at) "
+                "VALUES (:id, :name, :owner, :now, :now)"
+            ),
+            {"id": project_id, "name": name, "owner": owner, "now": now},
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO project_permissions (user_id, project_id, level) "
+                "VALUES (:owner, :project_id, :level)"
+            ),
+            {"owner": owner, "project_id": project_id, "level": _LEVEL_OWNER},
+        )
+        # File this owner's matching sessions under the new project.
+        conn.execute(
+            sa.text(
+                "UPDATE conversations SET project_id = :project_id WHERE id IN ("
+                "  SELECT cl.conversation_id FROM conversation_labels cl "
+                "  JOIN session_permissions sp ON sp.conversation_id = cl.conversation_id "
+                "  WHERE cl.key = :key AND cl.value = :name "
+                "  AND sp.user_id = :owner AND sp.level >= :owner_level"
+                ")"
+            ),
+            {
+                "project_id": project_id,
+                "key": _PROJECT_LABEL_KEY,
+                "name": name,
+                "owner": owner,
+                "owner_level": _LEVEL_OWNER,
+            },
+        )
+
+
+def downgrade() -> None:
+    """Drop the project column and tables (labels still hold membership)."""
+    op.drop_index("ix_conversations_project_id", table_name="conversations")
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.drop_column("project_id")
+    op.drop_index("ix_project_permissions_project_id", table_name="project_permissions")
+    op.drop_table("project_permissions")
+    op.drop_index("ix_projects_created_by", table_name="projects")
+    op.drop_table("projects")

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -626,6 +626,16 @@ def generate_conversation_id() -> str:
     return f"conv_{uuid.uuid4().hex}"
 
 
+def generate_project_id() -> str:
+    """
+    Generate a unique project identifier.
+
+    :returns: A string of the form ``"proj_<32-char hex>"``,
+        e.g. ``"proj_e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9"``.
+    """
+    return f"proj_{uuid.uuid4().hex}"
+
+
 def generate_task_id() -> str:
     """
     Generate a unique task (response) identifier.

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -25,8 +25,9 @@ from omnigent.entities.conversation import (
 )
 from omnigent.entities.file import StoredFile
 from omnigent.entities.pagination import PagedList
-from omnigent.entities.permission import ResolvedAccess, SessionPermission
+from omnigent.entities.permission import ProjectPermission, ResolvedAccess, SessionPermission
 from omnigent.entities.policy import Policy
+from omnigent.entities.project import Project
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
     SessionResourceView,
@@ -56,6 +57,8 @@ __all__ = [
     "NewConversationItem",
     "PagedList",
     "Policy",
+    "Project",
+    "ProjectPermission",
     "ReasoningData",
     "ResolvedAccess",
     "ResourceEventData",

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -64,6 +64,9 @@ class Conversation:
         retry-on-reconnect: if the server restarts before the
         runner connects, the server re-sends the launch request
         to this host.
+    :param project_id: The first-class project this session is filed
+        under, or ``None`` when unfiled. The session inherits the
+        project's access grants (share a project → its chats follow).
     :param labels: Session-scoped guardrails labels persisted
         in ``conversation_labels``. Populated by
         :meth:`ConversationStore.get_conversation` via a JOIN;
@@ -192,6 +195,7 @@ class Conversation:
     agent_id: str | None = None
     runner_id: str | None = None
     host_id: str | None = None
+    project_id: str | None = None
     labels: dict[str, str] = field(default_factory=dict)
     session_state: dict[str, Any] = field(default_factory=dict)
     session_usage: dict[str, Any] = field(default_factory=dict)

--- a/omnigent/entities/permission.py
+++ b/omnigent/entities/permission.py
@@ -22,6 +22,27 @@ class SessionPermission:
     level: int
 
 
+@dataclasses.dataclass
+class ProjectPermission:
+    """A single permission grant on a project.
+
+    The project analogue of :class:`SessionPermission`. A conversation
+    inherits its project's grants, so this is what makes "share a project"
+    cover every chat in it.
+
+    :param user_id: The grantee, e.g. ``"alice@example.com"`` or a sentinel
+        (``"__public__"`` / ``"__members__"``).
+    :param project_id: The project this grant applies to, e.g.
+        ``"proj_e4f5a6b7..."``.
+    :param level: Numeric permission level: ``1`` = read, ``2`` = edit,
+        ``3`` = manage, ``4`` = owner. Comparison is ``>=``.
+    """
+
+    user_id: str
+    project_id: str
+    level: int
+
+
 @dataclasses.dataclass(frozen=True)
 class ResolvedAccess:
     """The raw permission inputs for one ``(user, conversation)`` pair.
@@ -39,8 +60,20 @@ class ResolvedAccess:
     :param public_grant_level: The ``"__public__"`` sentinel grant level
         on the conversation (same ``1``–``4`` scale), or ``None`` if the
         session is not public.
+    :param members_grant_level: The ``"__members__"`` sentinel grant level
+        (same scale), or ``None`` if the session is not shared with all
+        members. Only populated for an authenticated user — it is ``None``
+        for an anonymous resolution, so anonymous viewers never gain access
+        through it.
+    :param project_grant_level: The caller's effective grant level on the
+        session's project (``max`` of their own, ``__members__``, and
+        ``__public__`` project grants), or ``None`` if the session has no
+        project or the caller has no project grant. This is how project
+        sharing inherits down to the project's chats.
     """
 
     is_admin: bool
     user_grant_level: int | None
     public_grant_level: int | None
+    members_grant_level: int | None = None
+    project_grant_level: int | None = None

--- a/omnigent/entities/project.py
+++ b/omnigent/entities/project.py
@@ -1,0 +1,29 @@
+"""Project entity — a first-class, shareable collection of conversations."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class Project:
+    """A first-class project.
+
+    Conversations reference their project via ``conversation.project_id``;
+    the project's ACL (``project_permissions``) is inherited by every
+    conversation filed under it, so sharing a project grants access to all
+    of its chats — including ones added after the share.
+
+    :param id: Unique project identifier, e.g. ``"proj_e4f5a6b7..."``.
+    :param name: Human-readable project name, e.g. ``"Q3 launch"``.
+    :param created_by: The owner's user id, or ``None`` if that account was
+        deleted.
+    :param created_at: Unix epoch seconds when the project was created.
+    :param updated_at: Unix epoch seconds of the last mutation (e.g. rename).
+    """
+
+    id: str
+    name: str
+    created_by: str | None
+    created_at: int
+    updated_at: int

--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -953,6 +953,7 @@ def _accumulate_usage(acc: dict[str, int], data: dict[str, Any]) -> None:  # typ
         "inputTokens": "input_tokens",
         "outputTokens": "output_tokens",
         "cacheReadTokens": "cache_read_input_tokens",
+        "cacheWriteTokens": "cache_creation_input_tokens",
     }
     for wire_key, usage_key in mapping.items():
         value = data.get(wire_key)

--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -36,9 +36,13 @@ from sqlalchemy.exc import IntegrityError
 from omnigent.db.db_models import SqlAccountToken, SqlUser
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
 from omnigent.entities import Account, AccountToken
-from omnigent.server.auth import RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC
+from omnigent.server.auth import (
+    RESERVED_USER_LOCAL,
+    RESERVED_USER_MEMBERS,
+    RESERVED_USER_PUBLIC,
+)
 
-_HIDDEN_LIST_USERS = frozenset({RESERVED_USER_PUBLIC, RESERVED_USER_LOCAL})
+_HIDDEN_LIST_USERS = frozenset({RESERVED_USER_PUBLIC, RESERVED_USER_MEMBERS, RESERVED_USER_LOCAL})
 
 
 def _to_account(row: SqlUser) -> Account:
@@ -174,11 +178,13 @@ class SqlAlchemyAccountStore:
     def list_users(self) -> list[Account]:
         """Return all users for the admin members page.
 
-        Excludes two sentinel rows that aren't actionable in
+        Excludes the sentinel rows that aren't actionable in
         accounts mode:
 
         - ``"__public__"`` — anonymous-grant sentinel, never a
           real user.
+        - ``"__members__"`` — all-signed-in-members grant sentinel,
+          likewise never a real user.
         - ``"local"`` — backfilled by the original session-permissions
           migration so pre-accounts deploys had a default owner row
           for existing conversations. In accounts mode the name is

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -60,6 +60,7 @@ from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
 from omnigent.server.routes.harnesses import create_harnesses_router
 from omnigent.server.routes.policy_registry import create_policy_registry_router
+from omnigent.server.routes.projects import create_projects_router
 from omnigent.server.routes.runner_tunnel import create_runner_tunnel_router
 from omnigent.server.routes.session_mcp_servers import create_session_mcp_servers_router
 from omnigent.server.routes.session_policies import create_session_policies_router
@@ -81,6 +82,7 @@ from omnigent.stores.conversation_store import SessionConnectivity
 from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.policy_store import PolicyStore
+from omnigent.stores.project_store import ProjectStore
 
 _logger = logging.getLogger(__name__)
 
@@ -1002,6 +1004,7 @@ def create_app(
     comment_store: CommentStore | None = None,
     policy_store: PolicyStore | None = None,
     permission_store: PermissionStore | None = None,
+    project_store: ProjectStore | None = None,
     auth_provider: AuthProvider | None = None,
     host_store: HostStore | None = None,
     account_store: Any | None = None,  # SqlAlchemyAccountStore — accounts mode only
@@ -1834,6 +1837,7 @@ def create_app(
             runner_router=runner_router,
             auth_provider=auth_provider,
             permission_store=permission_store,
+            project_store=project_store,
             agent_cache=agent_cache,
             mcp_pool=_mcp_pool,
             # Lets WS /v1/sessions/updates fold runner + host liveness into
@@ -1853,6 +1857,17 @@ def create_app(
         ),
         prefix="/v1",
         tags=["sessions"],
+    )
+    # First-class projects: CRUD + sharing (sessions inherit a project's ACL).
+    app.include_router(
+        create_projects_router(
+            project_store=project_store,
+            conversation_store=conversation_store,
+            permission_store=permission_store,
+            auth_provider=auth_provider,
+        ),
+        prefix="/v1",
+        tags=["projects"],
     )
     # Read-only built-in agent discovery (designs/BUILTIN_AGENTS.md).
     # Successor to the removed GET /api/agents list; lists only

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -44,7 +44,14 @@ _AUTH_ENABLED_ENV_DEPRECATED = "OMNIGENT_ACCOUNTS_ENABLED"
 
 RESERVED_USER_LOCAL = "local"
 RESERVED_USER_PUBLIC = "__public__"
-_RESERVED_USERS = frozenset({RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC})
+# Sentinel grantee for "everyone signed in to this Omnigent". Unlike
+# ``__public__`` (anyone with the link, including anonymous visitors), a
+# ``__members__`` grant only resolves for an *authenticated* user — but it
+# resolves for *every* authenticated user, current or future, and surfaces the
+# session in their listings (see the conversation store's ``accessible_by``
+# filter). Read-only, like ``__public__``.
+RESERVED_USER_MEMBERS = "__members__"
+_RESERVED_USERS = frozenset({RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC, RESERVED_USER_MEMBERS})
 _TRUTHY_STRINGS = ("1", "true", "yes")
 
 # Explicit single-user marker. Set by the managed local-server spawn

--- a/omnigent/server/permissions.py
+++ b/omnigent/server/permissions.py
@@ -12,6 +12,7 @@ from omnigent.entities import ResolvedAccess
 from omnigent.server.auth import LEVEL_MANAGE, LEVEL_OWNER
 from omnigent.stores.conversation_store import ConversationStore
 from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.project_store import ProjectStore
 
 
 def check_session_access(
@@ -20,6 +21,7 @@ def check_session_access(
     required_level: int,
     permission_store: PermissionStore,
     conversation_store: ConversationStore,
+    project_store: ProjectStore | None = None,
 ) -> bool:
     """Check whether *user_id* may perform an action on a session.
 
@@ -28,7 +30,10 @@ def check_session_access(
     1. Admin → allow (before conversation lookup)
     2. Conversation not found → deny
     3. Sub-agent → delegate to parent conversation
-    4. Delegate grant check to ``permission_store.check_access``
+    4. Direct session grant (``permission_store.check_access``), OR
+    5. Project grant — if the session is filed under a project and
+       *project_store* is provided, the session inherits the project's
+       ACL. This is what makes sharing a project cover every chat in it.
 
     :param user_id: The authenticated user, e.g.
         ``"alice@example.com"``. ``None`` if unauthenticated.
@@ -39,6 +44,8 @@ def check_session_access(
     :param permission_store: Store for permission lookups.
     :param conversation_store: Store for conversation lookups
         (needed for sub-agent parent delegation).
+    :param project_store: Store for project-grant inheritance. ``None``
+        disables inheritance (the pre-projects behavior).
     :returns: ``True`` if access is allowed, ``False`` otherwise.
     """
     if user_id is not None and permission_store.is_admin(user_id):
@@ -55,9 +62,21 @@ def check_session_access(
             required_level,
             permission_store,
             conversation_store,
+            project_store,
         )
 
-    return permission_store.check_access(user_id, conversation_id, required_level)
+    if permission_store.check_access(user_id, conversation_id, required_level):
+        return True
+
+    # Inherit the project's grants for a filed session.
+    if (
+        project_store is not None
+        and conv.project_id is not None
+        and project_store.check_access(user_id, conv.project_id, required_level)
+    ):
+        return True
+
+    return False
 
 
 def resolved_allows(access: ResolvedAccess, required_level: int) -> bool:
@@ -81,18 +100,23 @@ def resolved_allows(access: ResolvedAccess, required_level: int) -> bool:
         return True
     if access.public_grant_level is not None and access.public_grant_level >= required_level:
         return True
+    if access.members_grant_level is not None and access.members_grant_level >= required_level:
+        return True
+    if access.project_grant_level is not None and access.project_grant_level >= required_level:
+        return True
     return False
 
 
 def resolved_level(access: ResolvedAccess) -> int | None:
     """The effective level for UI display from a resolved-access snapshot.
 
-    The in-memory equivalent of :meth:`PermissionStore.get_permission_level`:
-    admin → ``LEVEL_OWNER``; otherwise the user's own grant, falling back to
-    the ``"__public__"`` grant, else ``None``. Note this deliberately prefers
-    the user's own grant over a (possibly higher) public grant, matching the
-    store — so it can differ from :func:`resolved_allows`, which is satisfied
-    by either.
+    The in-memory equivalent of :meth:`PermissionStore.get_permission_level`
+    extended with project inheritance: admin → ``LEVEL_OWNER``; otherwise the
+    session-level display grant (the user's own, falling back to
+    ``"__public__"`` then ``"__members__"`` — the deliberate access-vs-display
+    asymmetry), with the session's project grant max'd on top. The project
+    grant can exceed the session grant — a project manager who only reads a
+    specific chat should still see manage-level for it.
 
     :param access: The resolved-access snapshot for one ``(user, conv)``.
     :returns: Numeric level (1/2/3/4), or ``None`` when the user has no
@@ -100,9 +124,25 @@ def resolved_level(access: ResolvedAccess) -> int | None:
     """
     if access.is_admin:
         return LEVEL_OWNER
-    if access.user_grant_level is not None:
-        return access.user_grant_level
-    return access.public_grant_level
+    # Session-level display keeps the historical preference: the user's own
+    # grant first, then the ``__public__`` / ``__members__`` sentinels (the
+    # deliberate access-vs-display asymmetry — see the docstring). A project
+    # grant is then max'd on top, since it can legitimately exceed the session
+    # grant (a project manager who only reads a specific chat still manages it).
+    session_level = next(
+        (
+            lvl
+            for lvl in (
+                access.user_grant_level,
+                access.public_grant_level,
+                access.members_grant_level,
+            )
+            if lvl is not None
+        ),
+        None,
+    )
+    candidates = [lvl for lvl in (session_level, access.project_grant_level) if lvl is not None]
+    return max(candidates) if candidates else None
 
 
 def check_is_manager(

--- a/omnigent/server/routes/_auth_helpers.py
+++ b/omnigent/server/routes/_auth_helpers.py
@@ -37,6 +37,7 @@ from omnigent.server.permissions import (
 )
 from omnigent.stores import ConversationStore
 from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.project_store import ProjectStore
 
 _LEVEL_NAMES = {1: "read", 2: "edit", 3: "manage", 4: "owner"}
 
@@ -100,6 +101,7 @@ def _require_access_sync(
     required_level: int,
     permission_store: PermissionStore | None,
     conversation_store: ConversationStore,
+    project_store: ProjectStore | None = None,
 ) -> None:
     """Synchronous core of :func:`require_access`.
 
@@ -125,12 +127,17 @@ def _require_access_sync(
             code=ErrorCode.UNAUTHORIZED,
         )
     if check_session_access(
-        user_id, conversation_id, required_level, permission_store, conversation_store
+        user_id,
+        conversation_id,
+        required_level,
+        permission_store,
+        conversation_store,
+        project_store,
     ):
         return
     # Distinguish "has some access but not enough" from "no access at all".
     has_any = check_session_access(
-        user_id, conversation_id, 1, permission_store, conversation_store
+        user_id, conversation_id, 1, permission_store, conversation_store, project_store
     )
     if has_any:
         level_name = _LEVEL_NAMES.get(required_level, str(required_level))
@@ -150,6 +157,7 @@ async def require_access(
     required_level: int,
     permission_store: PermissionStore | None,
     conversation_store: ConversationStore,
+    project_store: ProjectStore | None = None,
 ) -> None:
     """Check permission, raising 403 or 404 on failure.
 
@@ -177,6 +185,7 @@ async def require_access(
         required_level,
         permission_store,
         conversation_store,
+        project_store,
     )
 
 
@@ -256,6 +265,7 @@ def _require_access_and_level_sync(
     required_level: int,
     permission_store: PermissionStore | None,
     conversation_store: ConversationStore,
+    project_store: ProjectStore | None = None,
 ) -> SessionAccess:
     """Synchronous core of :func:`require_access_and_level`.
 
@@ -310,6 +320,15 @@ def _require_access_and_level_sync(
             code=ErrorCode.NOT_FOUND,
         )
 
+    # Fold the session's project grant into the resolved access so both the
+    # decision and the displayed level inherit it (a project reader sees the
+    # chat; a project manager sees manage-level on it).
+    if project_store is not None and conv.project_id is not None:
+        project_level = project_store.get_permission_level(user_id, conv.project_id)
+        if project_level is not None:
+            access = dataclasses.replace(access, project_grant_level=project_level)
+            level = resolved_level(access)
+
     if conv.parent_conversation_id is None:
         # Top-level session: the access-governing grant lives on this same
         # conversation, so reuse the rows already fetched — no extra reads.
@@ -324,6 +343,7 @@ def _require_access_and_level_sync(
             required_level,
             permission_store,
             conversation_store,
+            project_store,
         )
     if allowed:
         return SessionAccess(level=level, conversation=conv)
@@ -334,7 +354,12 @@ def _require_access_and_level_sync(
         has_any = resolved_allows(access, 1)
     else:
         has_any = check_session_access(
-            user_id, conv.parent_conversation_id, 1, permission_store, conversation_store
+            user_id,
+            conv.parent_conversation_id,
+            1,
+            permission_store,
+            conversation_store,
+            project_store,
         )
     if has_any:
         level_name = _LEVEL_NAMES.get(required_level, str(required_level))
@@ -354,6 +379,7 @@ async def require_access_and_level(
     required_level: int,
     permission_store: PermissionStore | None,
     conversation_store: ConversationStore,
+    project_store: ProjectStore | None = None,
 ) -> SessionAccess:
     """Authorize a caller and resolve their display level in one threaded pass.
 
@@ -381,6 +407,7 @@ async def require_access_and_level(
         required_level,
         permission_store,
         conversation_store,
+        project_store,
     )
 
 

--- a/omnigent/server/routes/projects.py
+++ b/omnigent/server/routes/projects.py
@@ -1,0 +1,251 @@
+"""Routes for first-class projects: CRUD + sharing.
+
+A project is a shareable collection of conversations. Sessions filed under a
+project (``conversations.project_id``) inherit the project's ACL, so sharing a
+project grants access to every chat in it — current and future — without any
+per-session fan-out (see :func:`omnigent.server.permissions.check_session_access`).
+
+The grant surface mirrors the per-session
+``PUT/DELETE/GET /v1/sessions/{id}/permissions`` endpoints, but keyed by
+project id, and adds the ``__members__`` (all signed-in users) and
+``__public__`` (anyone with the link) sentinels — both capped at read-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, Request, Response
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import (
+    LEVEL_MANAGE,
+    LEVEL_OWNER,
+    LEVEL_READ,
+    RESERVED_USER_MEMBERS,
+    RESERVED_USER_PUBLIC,
+    AuthProvider,
+)
+from omnigent.server.routes._auth_helpers import require_user as _require_user
+from omnigent.server.schemas import (
+    GrantPermissionRequest,
+    ProjectCreateRequest,
+    ProjectMember,
+    ProjectObject,
+    ProjectPatchRequest,
+)
+from omnigent.stores.conversation_store import ConversationStore
+from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.project_store import ProjectStore
+
+_EVERYONE_SENTINELS = (RESERVED_USER_PUBLIC, RESERVED_USER_MEMBERS)
+
+
+def create_projects_router(
+    project_store: ProjectStore | None,
+    conversation_store: ConversationStore,
+    permission_store: PermissionStore | None = None,
+    auth_provider: AuthProvider | None = None,
+) -> APIRouter:
+    """Build the ``/v1/projects`` router.
+
+    :param project_store: Store for project records + grants. ``None``
+        disables the whole surface (returns 500 on use).
+    :param conversation_store: Needed to unfile a project's chats on delete.
+    :param permission_store: Used only for the admin-bypass check.
+    :param auth_provider: Auth provider for identity extraction.
+    :returns: The configured :class:`APIRouter`.
+    """
+    router = APIRouter()
+
+    def _require_store() -> ProjectStore:
+        if project_store is None:
+            raise OmnigentError("Projects not enabled", code=ErrorCode.INTERNAL_ERROR)
+        return project_store
+
+    def _is_admin(user_id: str) -> bool:
+        return permission_store is not None and permission_store.is_admin(user_id)
+
+    async def _effective_level(user_id: str, project_id: str) -> int | None:
+        """The caller's level on a project, applying the admin bypass."""
+        if _is_admin(user_id):
+            return LEVEL_OWNER
+        return await asyncio.to_thread(_require_store().get_permission_level, user_id, project_id)
+
+    async def _require_project(user_id: str, project_id: str, level: int) -> int:
+        """Authorize *user_id* at *level*, returning their effective level.
+
+        Raises 404 when the caller has no access at all (don't leak
+        existence), 403 when they have some access but not enough.
+        """
+        effective = await _effective_level(user_id, project_id)
+        if effective is None:
+            raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
+        if effective < level:
+            raise OmnigentError(
+                f"{user_id!r} needs level {level} on project {project_id!r}",
+                code=ErrorCode.FORBIDDEN,
+            )
+        return effective
+
+    async def _to_object(project, level: int) -> ProjectObject:
+        """Build a :class:`ProjectObject`, resolving the everyone-scope flags."""
+        store = _require_store()
+        members = await asyncio.to_thread(store.get, RESERVED_USER_MEMBERS, project.id)
+        public = await asyncio.to_thread(store.get, RESERVED_USER_PUBLIC, project.id)
+        return ProjectObject(
+            id=project.id,
+            name=project.name,
+            created_by=project.created_by,
+            created_at=project.created_at,
+            updated_at=project.updated_at,
+            permission_level=level,
+            members=members is not None,
+            public=public is not None,
+        )
+
+    @router.post(
+        "/projects",
+        status_code=201,
+        response_model=None,
+        responses={201: {"model": ProjectObject}},
+    )
+    async def create_project(request: Request, body: ProjectCreateRequest) -> ProjectObject:
+        """Create a project owned by the caller."""
+        user_id = _require_user(request, auth_provider)
+        store = _require_store()
+        if permission_store is not None and user_id is not None:
+            await asyncio.to_thread(permission_store.ensure_user, user_id)
+        try:
+            project = await asyncio.to_thread(store.create_project, body.name, user_id)
+        except ValueError as exc:
+            raise OmnigentError(str(exc), code=ErrorCode.INVALID_INPUT) from exc
+        return await _to_object(project, LEVEL_OWNER)
+
+    @router.get("/projects", response_model=None, responses={200: {"model": list[ProjectObject]}})
+    async def list_projects(request: Request) -> list[ProjectObject]:
+        """List every project the caller can access, with their level."""
+        user_id = _require_user(request, auth_provider)
+        store = _require_store()
+        pairs = await asyncio.to_thread(store.list_projects_for_user, user_id)
+        return [await _to_object(project, level) for project, level in pairs]
+
+    @router.get(
+        "/projects/{project_id}", response_model=None, responses={200: {"model": ProjectObject}}
+    )
+    async def get_project(request: Request, project_id: str) -> ProjectObject:
+        """Fetch a single project (read access required)."""
+        user_id = _require_user(request, auth_provider)
+        level = await _require_project(user_id, project_id, LEVEL_READ)
+        project = await asyncio.to_thread(_require_store().get_project, project_id)
+        if project is None:
+            raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
+        return await _to_object(project, level)
+
+    @router.patch(
+        "/projects/{project_id}", response_model=None, responses={200: {"model": ProjectObject}}
+    )
+    async def rename_project(
+        request: Request, project_id: str, body: ProjectPatchRequest
+    ) -> ProjectObject:
+        """Rename a project (manage access required)."""
+        user_id = _require_user(request, auth_provider)
+        level = await _require_project(user_id, project_id, LEVEL_MANAGE)
+        store = _require_store()
+        try:
+            project = await asyncio.to_thread(store.rename_project, project_id, body.name)
+        except ValueError as exc:
+            raise OmnigentError(str(exc), code=ErrorCode.INVALID_INPUT) from exc
+        if project is None:
+            raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
+        return await _to_object(project, level)
+
+    @router.delete("/projects/{project_id}", status_code=204, response_model=None)
+    async def delete_project(request: Request, project_id: str) -> Response:
+        """Delete a project (owner only); its chats survive as unfiled."""
+        user_id = _require_user(request, auth_provider)
+        await _require_project(user_id, project_id, LEVEL_OWNER)
+        store = _require_store()
+        # Unfile the chats first (project_id FK is ORM-only on migrated DBs).
+        await asyncio.to_thread(conversation_store.clear_project, project_id)
+        await asyncio.to_thread(store.delete_project, project_id)
+        return Response(status_code=204)
+
+    # ── Sharing ───────────────────────────────────────────────────
+
+    @router.put(
+        "/projects/{project_id}/permissions",
+        response_model=None,
+        responses={200: {"model": ProjectObject}},
+    )
+    async def grant_project_permission(
+        request: Request, project_id: str, body: GrantPermissionRequest
+    ) -> ProjectObject:
+        """Share a project with a user, or all members / anyone with the link."""
+        user_id = _require_user(request, auth_provider)
+        level = await _require_project(user_id, project_id, LEVEL_MANAGE)
+        store = _require_store()
+        if body.user_id == user_id:
+            raise OmnigentError("Cannot modify your own permissions", code=ErrorCode.FORBIDDEN)
+        if body.user_id in _EVERYONE_SENTINELS and body.level > LEVEL_READ:
+            raise OmnigentError(
+                "Shared-with-everyone access is limited to read-only (level 1)",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        existing = await asyncio.to_thread(store.get, body.user_id, project_id)
+        if existing is not None and existing.level == LEVEL_OWNER:
+            raise OmnigentError("Cannot modify owner permissions", code=ErrorCode.FORBIDDEN)
+        if permission_store is not None:
+            await asyncio.to_thread(permission_store.ensure_user, body.user_id)
+        await asyncio.to_thread(store.grant, body.user_id, project_id, body.level)
+        project = await asyncio.to_thread(store.get_project, project_id)
+        return await _to_object(project, level)
+
+    @router.delete(
+        "/projects/{project_id}/permissions/{target_user_id}",
+        status_code=204,
+        response_model=None,
+    )
+    async def revoke_project_permission(
+        request: Request, project_id: str, target_user_id: str
+    ) -> Response:
+        """Revoke a grantee from a project (manage access required)."""
+        user_id = _require_user(request, auth_provider)
+        await _require_project(user_id, project_id, LEVEL_MANAGE)
+        store = _require_store()
+        if target_user_id == user_id:
+            raise OmnigentError(
+                "Cannot modify your own permissions (use leave)", code=ErrorCode.FORBIDDEN
+            )
+        existing = await asyncio.to_thread(store.get, target_user_id, project_id)
+        if existing is not None and existing.level == LEVEL_OWNER:
+            raise OmnigentError("Cannot revoke owner permissions", code=ErrorCode.FORBIDDEN)
+        await asyncio.to_thread(store.revoke, target_user_id, project_id)
+        return Response(status_code=204)
+
+    @router.get(
+        "/projects/{project_id}/permissions",
+        response_model=None,
+        responses={200: {"model": list[ProjectMember]}},
+    )
+    async def list_project_permissions(request: Request, project_id: str) -> list[ProjectMember]:
+        """List a project's grantees (manage access required)."""
+        user_id = _require_user(request, auth_provider)
+        await _require_project(user_id, project_id, LEVEL_MANAGE)
+        store = _require_store()
+        grants = await asyncio.to_thread(store.list_for_project, project_id)
+        grants.sort(key=lambda g: (-g.level, g.user_id))
+        return [ProjectMember(user_id=g.user_id, level=g.level) for g in grants]
+
+    @router.delete("/projects/{project_id}/membership", status_code=204, response_model=None)
+    async def leave_project(request: Request, project_id: str) -> Response:
+        """Leave a project: drop the caller's own non-owner grant. Idempotent."""
+        user_id = _require_user(request, auth_provider)
+        store = _require_store()
+        if user_id is not None:
+            existing = await asyncio.to_thread(store.get, user_id, project_id)
+            if existing is not None and existing.level < LEVEL_OWNER:
+                await asyncio.to_thread(store.revoke, user_id, project_id)
+        return Response(status_code=204)
+
+    return router

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -152,6 +152,7 @@ from omnigent.server.auth import (
     LEVEL_MANAGE,
     LEVEL_OWNER,
     LEVEL_READ,
+    RESERVED_USER_MEMBERS,
     RESERVED_USER_PUBLIC,
     AuthProvider,
     local_single_user_enabled,
@@ -169,6 +170,9 @@ from omnigent.server.managed_hosts import (
 from omnigent.server.mcp_pool import ServerMcpPool
 from omnigent.server.permissions import check_session_access
 from omnigent.server.routes._auth_helpers import (
+    SessionAccess,
+)
+from omnigent.server.routes._auth_helpers import (
     attribution_user as _attribution_user,
 )
 from omnigent.server.routes._auth_helpers import (
@@ -181,10 +185,10 @@ from omnigent.server.routes._auth_helpers import (
     get_user_id as _get_user_id,
 )
 from omnigent.server.routes._auth_helpers import (
-    require_access as _require_access,
+    require_access as _require_access_impl,
 )
 from omnigent.server.routes._auth_helpers import (
-    require_access_and_level as _require_access_and_level,
+    require_access_and_level as _require_access_and_level_impl,
 )
 from omnigent.server.routes._auth_helpers import (
     require_user as _require_user,
@@ -278,6 +282,7 @@ from omnigent.stores.conversation_store import (
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.host_store import Host, HostStore
 from omnigent.stores.permission_store import PermissionStore
+from omnigent.stores.project_store import ProjectStore
 from omnigent.tools.client_specified import parse_client_side_tool_specs
 
 _logger = logging.getLogger(__name__)
@@ -1873,13 +1878,16 @@ def _permission_level_from_grants(
     user_id: str | None,
     grants: list[SessionPermission],
     is_admin: bool,
+    project_level: int | None = None,
 ) -> int | None:
     """
     Derive a user's permission level from a pre-fetched list of grants.
 
-    Mirrors :func:`omnigent.server.routes._auth_helpers._get_permission_level_sync`
-    but operates on grants already held in memory so callers can batch the
-    permission-store query across many sessions at once.
+    Mirrors :func:`omnigent.server.permissions.resolved_level` but operates on
+    grants already held in memory so callers can batch the permission-store
+    query across many sessions at once. The effective level is the strongest
+    of the user's own grant, the ``__public__`` / ``__members__`` sentinels,
+    and the session's inherited project grant.
 
     :param user_id: The authenticated user, or ``None`` for unauthenticated
         requests, e.g. ``"alice@example.com"``.
@@ -1888,6 +1896,9 @@ def _permission_level_from_grants(
     :param is_admin: Whether the user holds the admin flag.  Pass the result
         of a single ``permission_store.is_admin(user_id)`` call made once
         for the whole page rather than repeating it per session.
+    :param project_level: The caller's effective level on the session's
+        project (from ``project_store.get_permission_level``), or ``None``.
+        Folded in so a project member's list row shows the inherited level.
     :returns: Numeric level (1–4), or ``None`` when permissions are disabled
         or the user is unauthenticated.
     """
@@ -1895,13 +1906,19 @@ def _permission_level_from_grants(
         return None
     if is_admin:
         return LEVEL_OWNER
+    candidates: list[int] = []
     user_grant = next((g for g in grants if g.user_id == user_id), None)
     if user_grant is not None:
-        return user_grant.level
+        candidates.append(user_grant.level)
     public_grant = next((g for g in grants if g.user_id == RESERVED_USER_PUBLIC), None)
     if public_grant is not None:
-        return public_grant.level
-    return None
+        candidates.append(public_grant.level)
+    members_grant = next((g for g in grants if g.user_id == RESERVED_USER_MEMBERS), None)
+    if members_grant is not None:
+        candidates.append(members_grant.level)
+    if project_level is not None:
+        candidates.append(project_level)
+    return max(candidates) if candidates else None
 
 
 def _owner_from_grants(grants: list[SessionPermission]) -> str | None:
@@ -1918,6 +1935,32 @@ def _owner_from_grants(grants: list[SessionPermission]) -> str | None:
         :data:`LEVEL_OWNER`, or ``None`` if no such grant exists.
     """
     return next((g.user_id for g in grants if g.level >= LEVEL_OWNER), None)
+
+
+async def _project_levels_for_page(
+    convs: list[Conversation],
+    user_id: str | None,
+    project_store: ProjectStore | None,
+) -> dict[str, int]:
+    """Resolve the caller's effective level on each project across a page.
+
+    One lookup per *distinct* project id (not per session), so a filtered
+    project view or a mixed page pays only for the projects actually present.
+
+    :param convs: The conversations on the page.
+    :param user_id: The authenticated caller, or ``None``.
+    :param project_store: Project store, or ``None`` (returns ``{}``).
+    :returns: ``{project_id: level}`` for projects the caller can access.
+    """
+    if project_store is None or user_id is None:
+        return {}
+    project_ids = {c.project_id for c in convs if c.project_id is not None}
+    levels: dict[str, int] = {}
+    for pid in project_ids:
+        level = await asyncio.to_thread(project_store.get_permission_level, user_id, pid)
+        if level is not None:
+            levels[pid] = level
+    return levels
 
 
 def _session_status_from_cache(conversation_id: str) -> Literal["idle", "running", "failed"]:
@@ -2032,6 +2075,7 @@ def _build_session_list_item(
     pending_count: int,
     child_session_ids: list[str],
     comments_fingerprint: CommentsFingerprint | None,
+    project_level: int | None = None,
 ) -> SessionListItem:
     """
     Assemble one :class:`SessionListItem` from a conversation row and
@@ -2078,7 +2122,7 @@ def _build_session_list_item(
     # ``conv.agent_id`` is guaranteed non-None by the caller (sessions
     # only); assert for the type checker without a runtime branch.
     assert conv.agent_id is not None
-    level = _permission_level_from_grants(user_id, grants, user_is_admin)
+    level = _permission_level_from_grants(user_id, grants, user_is_admin, project_level)
     owner = _owner_from_grants(grants) if permissions_enabled else None
     # Per-viewer read tracking, embedded so the client hydrates the unread
     # dots straight from the list (no separate fetch). Built per-user here —
@@ -2098,6 +2142,7 @@ def _build_session_list_item(
         reasoning_effort=conv.reasoning_effort,
         permission_level=level,
         owner=owner,
+        project_id=conv.project_id,
         external_session_id=conv.external_session_id,
         pending_elicitations_count=pending_count,
         workspace=conv.workspace,
@@ -2478,6 +2523,7 @@ def _build_session_response(
         labels=labels,
         runner_id=conv.runner_id,
         host_id=conv.host_id,
+        project_id=conv.project_id,
         runner_online=runner_online,
         host_online=host_online,
         host_resumable=host_resumable,
@@ -12028,6 +12074,7 @@ async def _create_session_from_existing_agent(
     agent_cache: AgentCache | None = None,
     user_id: str | None = None,
     permission_store: PermissionStore | None = None,
+    project_store: ProjectStore | None = None,
     liveness_lookup: Callable[[list[str]], dict[str, SessionLiveness]] | None = None,
     file_store: FileStore | None = None,
     artifact_store: ArtifactStore | None = None,
@@ -12079,12 +12126,13 @@ async def _create_session_from_existing_agent(
     # session — otherwise they can execute another user's private
     # agent by guessing the raw agent id.
     if agent.session_id is not None:
-        await _require_access(
+        await _require_access_impl(
             user_id,
             agent.session_id,
             LEVEL_READ,
             permission_store,
             conversation_store,
+            project_store,
         )
 
     # Authorize parent_session_id before inheriting anything.
@@ -12093,12 +12141,13 @@ async def _create_session_from_existing_agent(
     # bindings and establish a parent-child relationship with a
     # session they don't control.
     if body.parent_session_id is not None:
-        await _require_access(
+        await _require_access_impl(
             user_id,
             body.parent_session_id,
             LEVEL_READ,
             permission_store,
             conversation_store,
+            project_store,
         )
 
     # The persisted override reaches a native CLI as a ``--model`` argv
@@ -12566,6 +12615,7 @@ async def _authorize_bundled_parent_and_inherit_runner(
     user_id: str | None,
     permission_store: PermissionStore | None,
     conversation_store: ConversationStore,
+    project_store: ProjectStore | None,
     runner_router: RunnerRouter | None,
 ) -> str | None:
     """
@@ -12592,12 +12642,13 @@ async def _authorize_bundled_parent_and_inherit_runner(
     :raises OmnigentError: 403/404 when the caller may not access the
         parent session.
     """
-    await _require_access(
+    await _require_access_impl(
         user_id,
         parent_session_id,
         LEVEL_READ,
         permission_store,
         conversation_store,
+        project_store,
     )
     parent_conv = await asyncio.to_thread(
         conversation_store.get_conversation,
@@ -13764,6 +13815,7 @@ def create_sessions_router(
     runner_router: RunnerRouter | None = None,
     auth_provider: AuthProvider | None = None,
     permission_store: PermissionStore | None = None,
+    project_store: ProjectStore | None = None,
     agent_cache: AgentCache | None = None,
     mcp_pool: ServerMcpPool | None = None,  # noqa: ARG001 — retained for API compat
     liveness_lookup: Callable[[list[str]], dict[str, SessionLiveness]] | None = None,
@@ -13829,6 +13881,42 @@ def create_sessions_router(
         ``/sessions`` endpoints.
     """
     router = APIRouter()
+
+    # Bind ``project_store`` into the access helpers once, so every route
+    # handler below gets project-grant inheritance without threading the
+    # store through each of its ~30 call sites. These shadow the module
+    # aliases within the factory scope only.
+    async def _require_access(
+        user_id: str | None,
+        conversation_id: str,
+        required_level: int,
+        permission_store: PermissionStore | None,
+        conversation_store: ConversationStore,
+    ) -> None:
+        await _require_access_impl(
+            user_id,
+            conversation_id,
+            required_level,
+            permission_store,
+            conversation_store,
+            project_store,
+        )
+
+    async def _require_access_and_level(
+        user_id: str | None,
+        conversation_id: str,
+        required_level: int,
+        permission_store: PermissionStore | None,
+        conversation_store: ConversationStore,
+    ) -> SessionAccess:
+        return await _require_access_and_level_impl(
+            user_id,
+            conversation_id,
+            required_level,
+            permission_store,
+            conversation_store,
+            project_store,
+        )
 
     # ── POST /sessions ───────────────────────────────────────────
 
@@ -13916,6 +14004,7 @@ def create_sessions_router(
             agent_cache=agent_cache,
             user_id=user_id,
             permission_store=permission_store,
+            project_store=project_store,
             liveness_lookup=liveness_lookup,
             file_store=file_store,
             artifact_store=artifact_store,
@@ -14192,6 +14281,7 @@ def create_sessions_router(
                 user_id=user_id,
                 permission_store=permission_store,
                 conversation_store=conversation_store,
+                project_store=project_store,
                 runner_router=runner_router,
             )
 
@@ -14213,35 +14303,6 @@ def create_sessions_router(
                 runner_router,
             )
         return result
-
-    # ── GET /sessions/projects ────────────────────────────────────
-    #
-    # MUST be registered before ``GET /sessions/{session_id}``: FastAPI
-    # matches routes in registration order, so a literal ``/sessions/projects``
-    # would otherwise be captured by the ``{session_id}`` path param and 404
-    # as a missing conversation.
-
-    @router.get(
-        "/sessions/projects",
-        response_model=None,
-    )
-    async def list_session_projects(
-        request: Request,
-    ) -> list[str]:
-        """
-        Return all project names for the authenticated user, ordered
-        alphabetically.
-
-        Projects are implicit: they exist while at least one session
-        has a ``conversation_labels`` row with ``key="omni_project"``.
-
-        :returns: List of project names.
-        """
-        user_id = _require_user(request, auth_provider)
-        return await asyncio.to_thread(
-            conversation_store.list_projects,
-            accessible_by=user_id,
-        )
 
     # ── PUT /sessions/{session_id}/read-state ─────────────────────
     #
@@ -14534,6 +14595,10 @@ def create_sessions_router(
         # the index's lock per row but otherwise has no DB cost.
         pending_counts = pending_elicitations.counts_for(conv_ids)
         comments_fingerprints = await _comments_fingerprints_for(conv_ids)
+        # The caller's effective level on each project on this page, so a
+        # project member's rows show the inherited level (one lookup per
+        # distinct project, not per session).
+        project_levels = await _project_levels_for_page(page.data, user_id, project_store)
         items: list[SessionListItem] = [
             _build_session_list_item(
                 conv,
@@ -14545,6 +14610,7 @@ def create_sessions_router(
                 pending_count=pending_counts.get(conv.id, 0),
                 child_session_ids=child_ids_by_parent[conv.id],
                 comments_fingerprint=comments_fingerprints.get(conv.id),
+                project_level=(project_levels.get(conv.project_id) if conv.project_id else None),
             )
             for conv in page.data
             if conv.agent_id is not None
@@ -14617,6 +14683,14 @@ def create_sessions_router(
         """
         if not watched:
             return []
+        # Load the watched conversations once (one batched store round-trip) and
+        # reuse the rows for both the access filter and the item build — a
+        # session may be accessible only through its project, so the filter
+        # needs each row's project_id.
+        watched_convs = await asyncio.to_thread(conversation_store.get_conversations, watched)
+        project_levels = await _project_levels_for_page(
+            list(watched_convs.values()), user_id, project_store
+        )
         if permission_store is not None:
             perms_by_conv = await asyncio.to_thread(permission_store.list_for_sessions, watched)
             user_is_admin = (
@@ -14627,8 +14701,12 @@ def create_sessions_router(
             accessible = [
                 cid
                 for cid in watched
-                if _permission_level_from_grants(
-                    user_id, perms_by_conv.get(cid, []), user_is_admin
+                if (conv := watched_convs.get(cid)) is not None
+                and _permission_level_from_grants(
+                    user_id,
+                    perms_by_conv.get(cid, []),
+                    user_is_admin,
+                    project_levels.get(conv.project_id) if conv.project_id else None,
                 )
                 is not None
             ]
@@ -14636,21 +14714,12 @@ def create_sessions_router(
             perms_by_conv = {}
             user_is_admin = False
             accessible = list(watched)
-        if not accessible:
-            return []
-
-        def _load_sessions(ids: list[str]) -> list[Conversation]:
-            """Bulk-load the accessible conversations that are sessions
-            (non-null ``agent_id``) in one batched store call, preserving
-            the caller's id order for deterministic output."""
-            by_id = conversation_store.get_conversations(ids)
-            return [
-                conv
-                for cid in ids
-                if (conv := by_id.get(cid)) is not None and conv.agent_id is not None
-            ]
-
-        convs = await asyncio.to_thread(_load_sessions, accessible)
+        # Sessions only (non-null agent_id), in the caller's watch order.
+        convs = [
+            conv
+            for cid in accessible
+            if (conv := watched_convs.get(cid)) is not None and conv.agent_id is not None
+        ]
         if not convs:
             return []
         unique_agent_ids = list({c.agent_id for c in convs if c.agent_id is not None})
@@ -14675,6 +14744,7 @@ def create_sessions_router(
                 pending_count=pending_counts.get(conv.id, 0),
                 child_session_ids=child_ids_by_parent[conv.id],
                 comments_fingerprint=comments_fingerprints.get(conv.id),
+                project_level=(project_levels.get(conv.project_id) if conv.project_id else None),
             )
             for conv in convs
         ]
@@ -14997,7 +15067,12 @@ def create_sessions_router(
         )
         if body.runner_id is not None and permission_store is not None:
             if not check_session_access(
-                user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
+                user_id,
+                session_id,
+                LEVEL_OWNER,
+                permission_store,
+                conversation_store,
+                project_store,
             ):
                 raise OmnigentError(
                     f"Only the session owner can attach a runner to session {session_id!r}. "
@@ -15299,6 +15374,25 @@ def create_sessions_router(
             await asyncio.to_thread(conversation_store.delete_label, session_id, PROJECT_LABEL_KEY)
         if labels_to_set:
             await asyncio.to_thread(conversation_store.set_labels, session_id, labels_to_set)
+        # File / unfile the session under a first-class project. "" unfiles
+        # (project_id -> NULL); a project id files it, but only into a project
+        # the caller can manage (so you can't attach your chat to someone
+        # else's project). The edit-level gate above already covers the session.
+        if body.project_id is not None:
+            if body.project_id == "":
+                await asyncio.to_thread(conversation_store.set_project, session_id, None)
+            else:
+                if project_store is not None and not await asyncio.to_thread(
+                    project_store.check_access, user_id, body.project_id, LEVEL_MANAGE
+                ):
+                    raise OmnigentError(
+                        f"{user_id!r} cannot file sessions into project "
+                        f"{body.project_id!r} (needs manage access)",
+                        code=ErrorCode.FORBIDDEN,
+                    )
+                await asyncio.to_thread(
+                    conversation_store.set_project, session_id, body.project_id
+                )
         if requested_codex_collaboration_mode is not None:
             _publish_collaboration_mode(
                 session_id,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1711,6 +1711,7 @@ class SessionResponse(BaseModel):
     labels: dict[str, str] = Field(default_factory=dict)
     runner_id: str | None = None
     host_id: str | None = None
+    project_id: str | None = None
     runner_online: bool | None = None
     host_online: bool | None = None
     host_resumable: bool = False
@@ -1818,6 +1819,11 @@ class UpdateSessionRequest(BaseModel):
         session from the default sidebar listing), ``False`` unarchives,
         ``None`` leaves unchanged. Owner-only (unlike ``title``, which
         needs only edit access).
+    :param project_id: File the session under a first-class project.
+        A project id sets it; the empty string ``""`` unfiles it; ``None``
+        leaves it unchanged (mirrors the removed ``omni_project`` label's
+        empty-string-clears convention). The caller must be able to manage
+        the session and (when filing) manage the target project.
     """
 
     runner_id: str | None = None
@@ -1830,6 +1836,7 @@ class UpdateSessionRequest(BaseModel):
     external_session_id: str | None = None
     terminal_launch_args: list[str] | None = None
     archived: bool | None = None
+    project_id: str | None = None
     silent: bool = False
 
     model_config = ConfigDict(extra="forbid")
@@ -2117,6 +2124,7 @@ class SessionListItem(BaseModel):
     labels: dict[str, str] = Field(default_factory=dict)
     runner_id: str | None = None
     host_id: str | None = None
+    project_id: str | None = None
     runner_online: bool | None = None
     host_online: bool | None = None
     reasoning_effort: str | None = None
@@ -2184,6 +2192,66 @@ class PermissionObject(BaseModel):
 
     user_id: str
     conversation_id: str
+    level: int
+
+
+class ProjectObject(BaseModel):
+    """
+    API representation of a first-class project.
+
+    :param id: Project id, e.g. ``"proj_e4f5a6b7..."``.
+    :param name: Human-readable name, e.g. ``"Q3 launch"``.
+    :param created_by: The owner's user id, or ``None`` if that account was
+        deleted.
+    :param created_at: Unix epoch seconds when the project was created.
+    :param updated_at: Unix epoch seconds of the last mutation.
+    :param permission_level: The requesting caller's effective level on the
+        project (1=read, 2=edit, 3=manage, 4=owner), or ``None`` when
+        permissions are disabled.
+    :param members: ``True`` when the project is shared with all signed-in
+        members (``__members__`` grant present).
+    :param public: ``True`` when the project is shared via public link
+        (``__public__`` grant present).
+    """
+
+    id: str
+    name: str
+    created_by: str | None = None
+    created_at: int
+    updated_at: int
+    permission_level: int | None = None
+    members: bool = False
+    public: bool = False
+
+
+class ProjectCreateRequest(BaseModel):
+    """Request body for ``POST /v1/projects``.
+
+    :param name: The project name, e.g. ``"Q3 launch"``.
+    """
+
+    name: str = Field(min_length=1, max_length=256)
+
+
+class ProjectPatchRequest(BaseModel):
+    """Request body for ``PATCH /v1/projects/{id}`` (rename).
+
+    :param name: The new project name.
+    """
+
+    name: str = Field(min_length=1, max_length=256)
+
+
+class ProjectMember(BaseModel):
+    """
+    One grantee on a project.
+
+    :param user_id: The grantee — a real user id, or the ``"__members__"`` /
+        ``"__public__"`` sentinel.
+    :param level: The grant level (1=read, 2=edit, 3=manage, 4=owner).
+    """
+
+    user_id: str
     level: int
 
 

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -728,6 +728,32 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def set_project(self, conversation_id: str, project_id: str | None) -> None:
+        """File a conversation under a project (or unfile it).
+
+        Sets ``conversations.project_id``. Passing ``None`` unfiles the
+        session (it returns to the sidebar's "Chats" group). The caller is
+        responsible for authorizing both the session and the project.
+
+        :param conversation_id: The session to (re)file, e.g. ``"conv_abc"``.
+        :param project_id: The target project id, or ``None`` to unfile.
+        """
+        ...
+
+    @abstractmethod
+    def clear_project(self, project_id: str) -> int:
+        """Unfile every conversation in a project (``project_id -> NULL``).
+
+        Used when deleting a project so its chats survive as unfiled. Needed
+        explicitly because the ``project_id`` FK is ORM-only on migrated DBs
+        (no DB-level ``ON DELETE SET NULL`` to rely on).
+
+        :param project_id: The project whose sessions to unfile.
+        :returns: The number of conversations updated.
+        """
+        ...
+
+    @abstractmethod
     def list_projects(
         self,
         accessible_by: str | None = None,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -102,6 +102,7 @@ def _to_conversation(
         agent_id=row.agent_id,
         runner_id=row.runner_id,
         host_id=row.host_id,
+        project_id=row.project_id,
         labels=labels if labels is not None else {},
         session_state=session_state,
         session_usage=session_usage,
@@ -1193,9 +1194,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         (4) grant outranks any read (1) / edit (2) / manage (3)
         grant, so ``ORDER BY level DESC LIMIT 1`` yields the owner
         without hardcoding the owner-level integer. The
-        ``"__public__"`` public-access sentinel is excluded, so a
-        session that only carries a public grant (and no real
-        owner) returns ``None`` rather than the sentinel.
+        ``"__public__"`` and ``"__members__"`` access sentinels are
+        excluded, so a session that only carries a public/members
+        grant (and no real owner) returns ``None`` rather than a
+        sentinel.
 
         :param conversation_id: The session to look up, e.g.
             ``"conv_abc123"``.
@@ -1204,13 +1206,17 @@ class SqlAlchemyConversationStore(ConversationStore):
             permission grants.
         """
         from omnigent.db.db_models import SqlSessionPermission
-        from omnigent.server.auth import RESERVED_USER_PUBLIC
+        from omnigent.server.auth import RESERVED_USER_MEMBERS, RESERVED_USER_PUBLIC
 
         with self._session() as session:
             return session.execute(
                 select(SqlSessionPermission.user_id)
                 .where(SqlSessionPermission.conversation_id == conversation_id)
-                .where(SqlSessionPermission.user_id != RESERVED_USER_PUBLIC)
+                .where(
+                    SqlSessionPermission.user_id.notin_(
+                        (RESERVED_USER_PUBLIC, RESERVED_USER_MEMBERS)
+                    )
+                )
                 .order_by(SqlSessionPermission.level.desc())
                 .limit(1)
             ).scalar_one_or_none()
@@ -1551,9 +1557,13 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             if accessible_by is not None:
                 from omnigent.db.db_models import SqlSessionPermission
+                from omnigent.server.auth import RESERVED_USER_MEMBERS
 
+                # A ``__members__`` grant makes the session visible to every
+                # authenticated user, so an authenticated caller's accessible
+                # set is their own grants ∪ the members-shared sessions.
                 accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.user_id == accessible_by
+                    SqlSessionPermission.user_id.in_((accessible_by, RESERVED_USER_MEMBERS))
                 )
                 stmt = stmt.where(SqlConversationLabel.conversation_id.in_(accessible_ids))
             return [row[0] for row in session.execute(stmt).all()]
@@ -1578,6 +1588,25 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlConversationLabel.key == key,
                 )
             )
+
+    def set_project(self, conversation_id: str, project_id: str | None) -> None:
+        """File/unfile a conversation under a project. See base class."""
+        with self._session() as session:
+            session.execute(
+                update(SqlConversation)
+                .where(SqlConversation.id == conversation_id)
+                .values(project_id=project_id)
+            )
+
+    def clear_project(self, project_id: str) -> int:
+        """Unfile every conversation in a project. See base class."""
+        with self._session() as session:
+            result = session.execute(
+                update(SqlConversation)
+                .where(SqlConversation.project_id == project_id)
+                .values(project_id=None)
+            )
+            return result.rowcount
 
     def list_conversations(
         self,
@@ -1680,12 +1709,29 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # because their agent_id column is NULL.
                 stmt = stmt.where(SqlConversation.agent_id == agent_id)
             if accessible_by is not None:
-                from omnigent.db.db_models import SqlSessionPermission
-
-                accessible_ids = select(SqlSessionPermission.conversation_id).where(
-                    SqlSessionPermission.user_id == accessible_by
+                from omnigent.db.db_models import (
+                    SqlProjectPermission,
+                    SqlSessionPermission,
                 )
-                stmt = stmt.where(SqlConversation.id.in_(accessible_ids))
+                from omnigent.server.auth import RESERVED_USER_MEMBERS
+
+                # A session is visible if the caller has a direct session grant
+                # OR a grant on the session's project (inheritance). The
+                # ``__members__`` sentinel folds in for both, matching the
+                # point-lookup resolver in server/permissions.py.
+                grantees = (accessible_by, RESERVED_USER_MEMBERS)
+                accessible_session_ids = select(SqlSessionPermission.conversation_id).where(
+                    SqlSessionPermission.user_id.in_(grantees)
+                )
+                accessible_project_ids = select(SqlProjectPermission.project_id).where(
+                    SqlProjectPermission.user_id.in_(grantees)
+                )
+                stmt = stmt.where(
+                    or_(
+                        SqlConversation.id.in_(accessible_session_ids),
+                        SqlConversation.project_id.in_(accessible_project_ids),
+                    )
+                )
             if search_query:
                 pattern = f"%{search_query.lower()}%"
                 title_match = func.lower(SqlConversation.title).like(pattern)
@@ -1697,24 +1743,11 @@ class SqlAlchemyConversationStore(ConversationStore):
                 stmt = stmt.where(or_(title_match, content_match))
             if project is not None:
                 if project == "":
-                    # Unfiled: sessions with no project label at all.
-                    stmt = stmt.where(
-                        SqlConversation.id.not_in(
-                            select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.key == PROJECT_LABEL_KEY
-                            )
-                        )
-                    )
+                    # Unfiled: sessions not filed under any project.
+                    stmt = stmt.where(SqlConversation.project_id.is_(None))
                 else:
-                    # Specific project: session must have this project label.
-                    stmt = stmt.where(
-                        SqlConversation.id.in_(
-                            select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.key == PROJECT_LABEL_KEY,
-                                SqlConversationLabel.value == project,
-                            )
-                        )
-                    )
+                    # Specific project, addressed by its first-class id.
+                    stmt = stmt.where(SqlConversation.project_id == project)
             if after:
                 stmt = self._apply_cursor(
                     stmt,

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -12,6 +12,7 @@ from omnigent.entities import Account, ResolvedAccess, SessionPermission
 from omnigent.server.auth import (
     LEVEL_OWNER,
     RESERVED_USER_LOCAL,
+    RESERVED_USER_MEMBERS,
     RESERVED_USER_PUBLIC,
 )
 from omnigent.stores.permission_store import PermissionStore
@@ -19,7 +20,7 @@ from omnigent.stores.permission_store import PermissionStore
 # Sentinel rows excluded from list_users() — never real, actionable
 # actors. Mirrors accounts_store._HIDDEN_LIST_USERS so the admin user
 # list is identical across auth modes.
-_HIDDEN_LIST_USERS = frozenset({RESERVED_USER_PUBLIC, RESERVED_USER_LOCAL})
+_HIDDEN_LIST_USERS = frozenset({RESERVED_USER_PUBLIC, RESERVED_USER_MEMBERS, RESERVED_USER_LOCAL})
 
 
 def _to_account(row: SqlUser) -> Account:
@@ -285,6 +286,12 @@ class SqlAlchemyPermissionStore(PermissionStore):
         if public_grant is not None and public_grant.level >= required_level:
             return True
 
+        # ``user_id is None`` already returned above, so reaching here means an
+        # authenticated user — a ``__members__`` grant resolves for them.
+        members_grant = self.get(RESERVED_USER_MEMBERS, conversation_id)
+        if members_grant is not None and members_grant.level >= required_level:
+            return True
+
         return False
 
     def get_permission_level(
@@ -303,6 +310,9 @@ class SqlAlchemyPermissionStore(PermissionStore):
         public_grant = self.get(RESERVED_USER_PUBLIC, conversation_id)
         if public_grant is not None:
             return public_grant.level
+        members_grant = self.get(RESERVED_USER_MEMBERS, conversation_id)
+        if members_grant is not None:
+            return members_grant.level
         return None
 
     def resolve_access(
@@ -329,10 +339,14 @@ class SqlAlchemyPermissionStore(PermissionStore):
             public_grant = session.get(
                 SqlSessionPermission, (RESERVED_USER_PUBLIC, conversation_id)
             )
+            members_grant = session.get(
+                SqlSessionPermission, (RESERVED_USER_MEMBERS, conversation_id)
+            )
             return ResolvedAccess(
                 is_admin=user_row is not None and user_row.is_admin,
                 user_grant_level=user_grant.level if user_grant is not None else None,
                 public_grant_level=public_grant.level if public_grant is not None else None,
+                members_grant_level=members_grant.level if members_grant is not None else None,
             )
 
     def has_any_grants(self, conversation_id: str) -> bool:

--- a/omnigent/stores/project_store/__init__.py
+++ b/omnigent/stores/project_store/__init__.py
@@ -1,0 +1,121 @@
+"""Project store — first-class projects and their access-control grants.
+
+A project is a shareable collection of conversations. This store owns both
+the project records (``projects`` table) and their ACL
+(``project_permissions`` table). The grant side mirrors
+:class:`omnigent.stores.permission_store.PermissionStore` exactly — same
+levels (1=read, 2=edit, 3=manage, 4=owner) and the same ``"__public__"`` /
+``"__members__"`` sentinels — but is keyed by ``project_id`` instead of
+``conversation_id``.
+
+A conversation *inherits* its project's grants (resolved in
+:mod:`omnigent.server.permissions`), which is what makes "share a project"
+cover every chat in it, including chats filed after the share.
+"""
+
+from abc import ABC, abstractmethod
+
+from omnigent.entities import Project, ProjectPermission
+
+
+class ProjectStore(ABC):
+    """Abstract base for project persistence + project-level grants."""
+
+    def __init__(self, storage_location: str) -> None:
+        """Initialize the project store.
+
+        :param storage_location: Backend-specific storage URI,
+            e.g. ``"sqlite:///omnigent.db"``.
+        """
+        self.storage_location = storage_location
+
+    # ── Project records ───────────────────────────────────────────
+
+    @abstractmethod
+    def create_project(self, name: str, owner: str | None) -> Project:
+        """Create a project and (when *owner* is set) its owner grant.
+
+        :param name: Human-readable name, e.g. ``"Q3 launch"``.
+        :param owner: The creator's user id, or ``None`` in single-user
+            mode. When set, an owner (level 4) grant is written.
+        :returns: The created :class:`Project`.
+        :raises ValueError: If *owner* already has a project with *name*.
+        """
+        ...
+
+    @abstractmethod
+    def get_project(self, project_id: str) -> Project | None:
+        """Look up a project by id, or ``None`` if it doesn't exist."""
+        ...
+
+    @abstractmethod
+    def rename_project(self, project_id: str, name: str) -> Project | None:
+        """Rename a project. Returns the updated project, or ``None`` if
+        missing. Raises ``ValueError`` on a per-owner name collision."""
+        ...
+
+    @abstractmethod
+    def delete_project(self, project_id: str) -> bool:
+        """Delete a project row and its grants.
+
+        The caller is responsible for unfiling the project's conversations
+        (setting ``project_id = NULL``) beforehand; on backends without the
+        DB-level FK the store cannot rely on ``ON DELETE SET NULL``.
+
+        :returns: ``True`` if a row was deleted.
+        """
+        ...
+
+    @abstractmethod
+    def list_projects_for_user(self, user_id: str | None) -> list[tuple[Project, int]]:
+        """Return every project the user can access, with their level.
+
+        Includes projects the user holds a direct grant on plus those
+        shared with all members (``"__members__"``). Ordered by name.
+
+        :param user_id: The authenticated user, or ``None``.
+        :returns: ``(project, effective_level)`` pairs.
+        """
+        ...
+
+    # ── Grants (mirror PermissionStore, keyed by project_id) ──────
+
+    @abstractmethod
+    def grant(self, user_id: str, project_id: str, level: int) -> ProjectPermission:
+        """Upsert a project grant. Caller does authorization."""
+        ...
+
+    @abstractmethod
+    def revoke(self, user_id: str, project_id: str) -> bool:
+        """Remove a project grant. Returns ``True`` if one existed."""
+        ...
+
+    @abstractmethod
+    def get(self, user_id: str, project_id: str) -> ProjectPermission | None:
+        """Look up a single grant, or ``None``."""
+        ...
+
+    @abstractmethod
+    def list_for_project(self, project_id: str) -> list[ProjectPermission]:
+        """Return all grants on a project."""
+        ...
+
+    @abstractmethod
+    def check_access(self, user_id: str | None, project_id: str, required_level: int) -> bool:
+        """Whether *user_id* has ``>= required_level`` on the project.
+
+        Considers the user's direct grant plus the ``"__public__"`` and
+        (for authenticated users) ``"__members__"`` sentinels. Does not
+        apply the admin bypass — that lives in the resolution layer.
+        """
+        ...
+
+    @abstractmethod
+    def get_permission_level(self, user_id: str | None, project_id: str) -> int | None:
+        """The caller's effective level on the project, or ``None``.
+
+        The ``max`` of the user's own grant and the applicable sentinel
+        grants — used to fold a project grant into a session's resolved
+        level. No admin bypass here.
+        """
+        ...

--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -1,0 +1,212 @@
+"""SQLAlchemy-backed project store (projects + project_permissions)."""
+
+from __future__ import annotations
+
+import time
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.db.db_models import SqlProject, SqlProjectPermission
+from omnigent.db.utils import (
+    generate_project_id,
+    get_or_create_engine,
+    make_managed_session_maker,
+)
+from omnigent.entities import Project, ProjectPermission
+from omnigent.server.auth import (
+    LEVEL_OWNER,
+    RESERVED_USER_MEMBERS,
+    RESERVED_USER_PUBLIC,
+)
+from omnigent.stores.project_store import ProjectStore
+
+
+def _to_project(row: SqlProject) -> Project:
+    return Project(
+        id=row.id,
+        name=row.name,
+        created_by=row.created_by,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _to_permission(row: SqlProjectPermission) -> ProjectPermission:
+    return ProjectPermission(user_id=row.user_id, project_id=row.project_id, level=row.level)
+
+
+class SqlAlchemyProjectStore(ProjectStore):
+    """SQLAlchemy-backed :class:`ProjectStore`.
+
+    Shares the engine/pool with the other stores via
+    :func:`get_or_create_engine`, and mirrors
+    :class:`~omnigent.stores.permission_store.sqlalchemy_store.SqlAlchemyPermissionStore`'s
+    dialect-aware upsert for grants.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        super().__init__(storage_location)
+        self._engine = get_or_create_engine(storage_location)
+        self._session = make_managed_session_maker(self._engine)
+
+    # ── Project records ───────────────────────────────────────────
+
+    def create_project(self, name: str, owner: str | None) -> Project:
+        """Create a project (+ owner grant when *owner* is set)."""
+        now = int(time.time())
+        project_id = generate_project_id()
+        with self._session() as session:
+            row = SqlProject(
+                id=project_id,
+                name=name,
+                created_by=owner,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(row)
+            try:
+                session.flush()
+            except IntegrityError as exc:
+                # (created_by, name) unique — surface a clean domain error.
+                raise ValueError(f"project {name!r} already exists for {owner!r}") from exc
+            if owner is not None:
+                session.add(
+                    SqlProjectPermission(user_id=owner, project_id=project_id, level=LEVEL_OWNER)
+                )
+                session.flush()
+            return _to_project(row)
+
+    def get_project(self, project_id: str) -> Project | None:
+        with self._session() as session:
+            row = session.get(SqlProject, project_id)
+            return _to_project(row) if row is not None else None
+
+    def rename_project(self, project_id: str, name: str) -> Project | None:
+        with self._session() as session:
+            row = session.get(SqlProject, project_id)
+            if row is None:
+                return None
+            row.name = name
+            row.updated_at = int(time.time())
+            try:
+                session.flush()
+            except IntegrityError as exc:
+                raise ValueError(
+                    f"project {name!r} already exists for {row.created_by!r}"
+                ) from exc
+            return _to_project(row)
+
+    def delete_project(self, project_id: str) -> bool:
+        with self._session() as session:
+            # Grants are also FK ON DELETE CASCADE, but drop them explicitly
+            # so the row is removed even on backends where the FK isn't
+            # enforced.
+            session.execute(
+                delete(SqlProjectPermission).where(SqlProjectPermission.project_id == project_id)
+            )
+            result = session.execute(delete(SqlProject).where(SqlProject.id == project_id))
+            return result.rowcount > 0
+
+    def list_projects_for_user(self, user_id: str | None) -> list[tuple[Project, int]]:
+        if user_id is None:
+            return []
+        with self._session() as session:
+            # The caller's own grants + the all-members sentinel. (Public
+            # projects are link-reachable but, like public sessions, do not
+            # populate a member's project list.)
+            grant_rows = (
+                session.execute(
+                    select(SqlProjectPermission).where(
+                        SqlProjectPermission.user_id.in_((user_id, RESERVED_USER_MEMBERS))
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            # Effective level per project = max across the applicable grants.
+            levels: dict[str, int] = {}
+            for g in grant_rows:
+                levels[g.project_id] = max(levels.get(g.project_id, 0), g.level)
+            if not levels:
+                return []
+            projects = (
+                session.execute(
+                    select(SqlProject)
+                    .where(SqlProject.id.in_(list(levels)))
+                    .order_by(SqlProject.name)
+                )
+                .scalars()
+                .all()
+            )
+            return [(_to_project(p), levels[p.id]) for p in projects]
+
+    # ── Grants ────────────────────────────────────────────────────
+
+    def grant(self, user_id: str, project_id: str, level: int) -> ProjectPermission:
+        with self._session() as session:
+            is_sqlite = self._engine.dialect.name == "sqlite"
+            values = {"user_id": user_id, "project_id": project_id, "level": level}
+            insert = sqlite_insert if is_sqlite else pg_insert
+            stmt = (
+                insert(SqlProjectPermission)
+                .values(**values)
+                .on_conflict_do_update(
+                    index_elements=["user_id", "project_id"],
+                    set_={"level": level},
+                )
+            )
+            session.execute(stmt)
+            session.flush()
+            return ProjectPermission(user_id=user_id, project_id=project_id, level=level)
+
+    def revoke(self, user_id: str, project_id: str) -> bool:
+        with self._session() as session:
+            result = session.execute(
+                delete(SqlProjectPermission).where(
+                    SqlProjectPermission.user_id == user_id,
+                    SqlProjectPermission.project_id == project_id,
+                )
+            )
+            return result.rowcount > 0
+
+    def get(self, user_id: str, project_id: str) -> ProjectPermission | None:
+        with self._session() as session:
+            row = session.get(SqlProjectPermission, (user_id, project_id))
+            return _to_permission(row) if row is not None else None
+
+    def list_for_project(self, project_id: str) -> list[ProjectPermission]:
+        with self._session() as session:
+            rows = (
+                session.execute(
+                    select(SqlProjectPermission).where(
+                        SqlProjectPermission.project_id == project_id
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            return [_to_permission(r) for r in rows]
+
+    def check_access(self, user_id: str | None, project_id: str, required_level: int) -> bool:
+        level = self.get_permission_level(user_id, project_id)
+        return level is not None and level >= required_level
+
+    def get_permission_level(self, user_id: str | None, project_id: str) -> int | None:
+        with self._session() as session:
+            candidates: list[str] = [RESERVED_USER_PUBLIC]
+            if user_id is not None:
+                candidates.extend((user_id, RESERVED_USER_MEMBERS))
+            rows = (
+                session.execute(
+                    select(SqlProjectPermission.level).where(
+                        SqlProjectPermission.project_id == project_id,
+                        SqlProjectPermission.user_id.in_(candidates),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            return max(rows) if rows else None

--- a/openapi.json
+++ b/openapi.json
@@ -2217,6 +2217,130 @@
         "title": "PresenceViewer",
         "type": "object"
       },
+      "ProjectCreateRequest": {
+        "description": "Request body for `POST /v1/projects`.",
+        "properties": {
+          "name": {
+            "description": "The project name, e.g. `\"Q3 launch\"`.",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ProjectCreateRequest",
+        "type": "object"
+      },
+      "ProjectMember": {
+        "description": "One grantee on a project.",
+        "properties": {
+          "level": {
+            "description": "The grant level (1=read, 2=edit, 3=manage, 4=owner).",
+            "title": "Level",
+            "type": "integer"
+          },
+          "user_id": {
+            "description": "The grantee \u2014 a real user id, or the `\"__members__\"` / `\"__public__\"` sentinel.",
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "level"
+        ],
+        "title": "ProjectMember",
+        "type": "object"
+      },
+      "ProjectObject": {
+        "description": "API representation of a first-class project.",
+        "properties": {
+          "created_at": {
+            "description": "Unix epoch seconds when the project was created.",
+            "title": "Created At",
+            "type": "integer"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The owner's user id, or `None` if that account was deleted.",
+            "title": "Created By"
+          },
+          "id": {
+            "description": "Project id, e.g. `\"proj_e4f5a6b7...\"`.",
+            "title": "Id",
+            "type": "string"
+          },
+          "members": {
+            "default": false,
+            "description": "`True` when the project is shared with all signed-in members (`__members__` grant present).",
+            "title": "Members",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Human-readable name, e.g. `\"Q3 launch\"`.",
+            "title": "Name",
+            "type": "string"
+          },
+          "permission_level": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The requesting caller's effective level on the project (1=read, 2=edit, 3=manage, 4=owner), or `None` when permissions are disabled.",
+            "title": "Permission Level"
+          },
+          "public": {
+            "default": false,
+            "description": "`True` when the project is shared via public link (`__public__` grant present).",
+            "title": "Public",
+            "type": "boolean"
+          },
+          "updated_at": {
+            "description": "Unix epoch seconds of the last mutation.",
+            "title": "Updated At",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ProjectObject",
+        "type": "object"
+      },
+      "ProjectPatchRequest": {
+        "description": "Request body for `PATCH /v1/projects/{id}` (rename).",
+        "properties": {
+          "name": {
+            "description": "The new project name.",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ProjectPatchRequest",
+        "type": "object"
+      },
       "QueuedEvent": {
         "description": "Optional event emitted between `created` and `in_progress`\nfor background tasks that are queued before they start.\n\nForeground streaming responses skip this event.",
         "properties": {
@@ -3761,6 +3885,17 @@
             "description": "The requesting user's numeric permission level on this session: `1` = read, `2` = edit, `3` = manage. `None` when permissions are disabled.",
             "title": "Permission Level"
           },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Id"
+          },
           "reasoning_effort": {
             "anyOf": [
               {
@@ -4489,6 +4624,17 @@
             ],
             "description": "The requesting user's numeric permission level on this session: `1` = read, `2` = edit, `3` = manage. `None` when permissions are disabled (single-user mode without a permission store).",
             "title": "Permission Level"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Id"
           },
           "reasoning_effort": {
             "anyOf": [
@@ -5656,6 +5802,18 @@
             ],
             "description": "Per-session LLM model override, e.g. `\"claude-opus-4-7\"`. The value is forwarded as-is to the executor at turn start; the server does not enumerate valid models. Clear aliases such as `\"default\"`, `\"off\"`, or `\"reset\"` remove the override (matching the REPL's `/model` semantics). `None` leaves unchanged.",
             "title": "Model Override"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "File the session under a first-class project. A project id sets it; the empty string `\"\"` unfiles it; `None` leaves it unchanged (mirrors the removed `omni_project` label's empty-string-clears convention). The caller must be able to manage the session and (when filing) manage the target project.",
+            "title": "Project Id"
           },
           "reasoning_effort": {
             "anyOf": [
@@ -6834,6 +6992,379 @@
         ]
       }
     },
+    "/v1/projects": {
+      "get": {
+        "description": "List every project the caller can access, with their level.",
+        "operationId": "list_projects_v1_projects_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectObject"
+                  },
+                  "title": "Response 200 List Projects V1 Projects Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Projects",
+        "tags": [
+          "projects"
+        ]
+      },
+      "post": {
+        "description": "Create a project owned by the caller.",
+        "operationId": "create_project_v1_projects_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectObject"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Project",
+        "tags": [
+          "projects"
+        ]
+      }
+    },
+    "/v1/projects/{project_id}": {
+      "delete": {
+        "description": "Delete a project (owner only); its chats survive as unfiled.",
+        "operationId": "delete_project_v1_projects__project_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Project",
+        "tags": [
+          "projects"
+        ]
+      },
+      "get": {
+        "description": "Fetch a single project (read access required).",
+        "operationId": "get_project_v1_projects__project_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectObject"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Project",
+        "tags": [
+          "projects"
+        ]
+      },
+      "patch": {
+        "description": "Rename a project (manage access required).",
+        "operationId": "rename_project_v1_projects__project_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectPatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectObject"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Rename Project",
+        "tags": [
+          "projects"
+        ]
+      }
+    },
+    "/v1/projects/{project_id}/membership": {
+      "delete": {
+        "description": "Leave a project: drop the caller's own non-owner grant. Idempotent.",
+        "operationId": "leave_project_v1_projects__project_id__membership_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Leave Project",
+        "tags": [
+          "projects"
+        ]
+      }
+    },
+    "/v1/projects/{project_id}/permissions": {
+      "get": {
+        "description": "List a project's grantees (manage access required).",
+        "operationId": "list_project_permissions_v1_projects__project_id__permissions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectMember"
+                  },
+                  "title": "Response 200 List Project Permissions V1 Projects  Project Id  Permissions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Project Permissions",
+        "tags": [
+          "projects"
+        ]
+      },
+      "put": {
+        "description": "Share a project with a user, or all members / anyone with the link.",
+        "operationId": "grant_project_permission_v1_projects__project_id__permissions_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantPermissionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectObject"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Grant Project Permission",
+        "tags": [
+          "projects"
+        ]
+      }
+    },
+    "/v1/projects/{project_id}/permissions/{target_user_id}": {
+      "delete": {
+        "description": "Revoke a grantee from a project (manage access required).",
+        "operationId": "revoke_project_permission_v1_projects__project_id__permissions__target_user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "target_user_id",
+            "required": true,
+            "schema": {
+              "title": "Target User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revoke Project Permission",
+        "tags": [
+          "projects"
+        ]
+      }
+    },
     "/v1/runners": {
       "get": {
         "description": "Return currently online runners owned by the requesting user.\n\nWhen auth is active, only runners whose tunnel was\nestablished by the same user are returned. Without auth,\nall online runners are listed (single-user / dev mode).\n\n**Returns:** A `{\"data\": [...]}` list with runner ids and advertised harnesses.",
@@ -7127,26 +7658,6 @@
           }
         },
         "summary": "Create Session",
-        "tags": [
-          "sessions"
-        ]
-      }
-    },
-    "/v1/sessions/projects": {
-      "get": {
-        "description": "Return all project names for the authenticated user, ordered\nalphabetically.\n\nProjects are implicit: they exist while at least one session\nhas a `conversation_labels` row with `key=\"omni_project\"`.\n\n**Returns:** List of project names.",
-        "operationId": "list_session_projects_v1_sessions_projects_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "List Session Projects",
         "tags": [
           "sessions"
         ]

--- a/tests/e2e_ui/collaboration/test_project_sharing.py
+++ b/tests/e2e_ui/collaboration/test_project_sharing.py
@@ -1,0 +1,169 @@
+"""UI: the first-class project Share modal and Leave flow.
+
+Projects are a first-class entity (`/v1/projects`); a chat filed under a
+project inherits the project's ACL, so sharing a project covers every chat in
+it. This drives the sidebar surfaces end to end:
+
+- `ShareProjectModal.tsx` — opened from the project folder's kebab
+  (`data-testid="share-project"`): the **Share with all members**
+  (`__members__`) and **Anyone with the link** (`__public__`) toggles, the
+  invite form, the member list, and per-member revoke — each pinned against the
+  project's `/v1/projects/{id}/permissions` REST state.
+- The folder kebab's **Leave project** item (`DELETE …/membership`).
+
+The share-modal test runs as the single headerless ``local`` owner; the leave
+test adds a second header-identified identity (mirrors `test_sharing_journey`).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable
+
+import httpx
+from playwright.sync_api import Browser, Locator, Page, expect
+
+_MEMBERS_USER = "__members__"
+_PUBLIC_USER = "__public__"
+
+
+def _wait_for(predicate: Callable[[], bool], *, timeout_s: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            if predicate():
+                return
+        except Exception as exc:  # transient httpx blip — retry until deadline
+            last_exc = exc
+        time.sleep(0.25)
+    if last_exc is not None:
+        raise last_exc
+    raise AssertionError("condition not met within timeout")
+
+
+def _create_project(base_url: str, name: str, **headers: str) -> str:
+    resp = httpx.post(
+        f"{base_url}/v1/projects", json={"name": name}, headers=headers, timeout=10.0
+    )
+    resp.raise_for_status()
+    return resp.json()["id"]
+
+
+def _file_session(base_url: str, session_id: str, project_id: str, **headers: str) -> None:
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"project_id": project_id},
+        headers=headers,
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _share(base_url: str, project_id: str, user_id: str, level: int, **headers: str) -> None:
+    resp = httpx.put(
+        f"{base_url}/v1/projects/{project_id}/permissions",
+        json={"user_id": user_id, "level": level},
+        headers=headers,
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _members(base_url: str, project_id: str, **headers: str) -> dict[str, int]:
+    resp = httpx.get(
+        f"{base_url}/v1/projects/{project_id}/permissions", headers=headers, timeout=10.0
+    )
+    resp.raise_for_status()
+    return {m["user_id"]: m["level"] for m in resp.json()}
+
+
+def _project_ids_for(base_url: str, **headers: str) -> set[str]:
+    resp = httpx.get(f"{base_url}/v1/projects", headers=headers, timeout=10.0)
+    resp.raise_for_status()
+    return {p["id"] for p in resp.json()}
+
+
+def _section(page: Page, title: str) -> Locator:
+    return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
+
+
+def _open_project_menu(page: Page, name: str) -> None:
+    header = page.get_by_role("button", name=name, exact=True)
+    expect(header).to_be_visible(timeout=30_000)
+    header.hover()
+    _section(page, name).get_by_test_id("project-actions").click()
+
+
+def test_share_project_modal_drives_server_state(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Members/public toggles, invite and revoke all drive the project ACL."""
+    base_url, session_id = seeded_session
+    name = f"ProjShare{uuid.uuid4().hex[:8]}"
+    grantee = "alice@ui.test"
+    project_id = _create_project(base_url, name)
+    _file_session(base_url, session_id, project_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    _open_project_menu(page, name)
+    page.get_by_test_id("share-project").click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog.get_by_text("Share project")).to_be_visible()
+
+    members_toggle = dialog.get_by_test_id("project-members-toggle")
+    expect(members_toggle).not_to_be_checked()
+    members_toggle.click()
+    expect(members_toggle).to_be_checked()
+    _wait_for(lambda: _members(base_url, project_id).get(_MEMBERS_USER) == 1)
+
+    public_toggle = dialog.get_by_test_id("project-public-toggle")
+    public_toggle.click()
+    expect(public_toggle).to_be_checked()
+    _wait_for(lambda: _members(base_url, project_id).get(_PUBLIC_USER) == 1)
+
+    dialog.get_by_placeholder("alice@example.com").fill(grantee)
+    dialog.get_by_role("button", name="Grant").click()
+    expect(dialog.get_by_test_id("project-member-row").filter(has_text=grantee)).to_be_visible()
+    _wait_for(lambda: _members(base_url, project_id).get(grantee) == 1)
+
+    dialog.get_by_role("button", name=f"Remove {grantee}").click()
+    expect(dialog.get_by_test_id("project-member-row").filter(has_text=grantee)).to_have_count(0)
+    _wait_for(lambda: grantee not in _members(base_url, project_id))
+
+
+def test_member_can_leave_project(
+    browser: Browser,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A member the project was shared with can leave via the folder kebab."""
+    base_url, session_id = seeded_session
+    name = f"ProjLeave{uuid.uuid4().hex[:8]}"
+    bob = f"bob-{uuid.uuid4().hex[:6]}@ui.test"
+    project_id = _create_project(base_url, name)
+    _file_session(base_url, session_id, project_id)
+    _share(base_url, project_id, bob, 1)
+    assert project_id in _project_ids_for(base_url, **{"X-Forwarded-Email": bob})
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": bob})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{base_url}/c/{session_id}")
+
+        _open_project_menu(page, name)
+        # Bob can't manage, so Share/Rename aren't offered — only Leave.
+        expect(page.get_by_test_id("share-project")).to_have_count(0)
+        page.get_by_test_id("leave-project").click()
+
+        confirm = page.get_by_role("dialog")
+        expect(confirm.get_by_text("Leave project?")).to_be_visible()
+        confirm.get_by_role("button", name="Leave project").click()
+
+        _wait_for(
+            lambda: project_id not in _project_ids_for(base_url, **{"X-Forwarded-Email": bob})
+        )
+    finally:
+        ctx.close()

--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -105,6 +105,8 @@ def test_remove_session_from_project(
 
     Moves the row into a fresh project first, then uses the kebab's
     "Remove from <project>" item and asserts the row returns to "Chats".
+    Projects are first-class, so unfiling the last chat leaves the (now
+    empty) project folder in place rather than deleting it.
     """
     base_url, session_id = seeded_session
     title = f"e2e-proj-rm-{uuid.uuid4().hex[:8]}"
@@ -133,10 +135,10 @@ def test_remove_session_from_project(
     project_row.get_by_test_id("conversation-actions").click()
     page.get_by_test_id("move-to-project").click()
     # The kebab item names the project it removes from ("Remove from <name>").
+    # Unfiling is immediate now — no confirmation (the project is first-class
+    # and survives with zero chats).
     page.get_by_role("menuitem", name=re.compile(rf"Remove from {re.escape(project)}")).click()
-    # Removal is confirmed (it may delete the implicit project) — accept it.
-    page.get_by_role("button", name="Remove from project", exact=True).click()
 
-    # Back under "Chats", and the now-empty project folder is gone.
+    # Back under "Chats"; the (now empty) project folder is still present.
     expect(_section(page, "Chats").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
-    expect(page.get_by_role("button", name=project, exact=True)).to_have_count(0)
+    expect(page.get_by_role("button", name=project, exact=True)).to_be_visible()

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -284,13 +284,17 @@ def test_event_data_reads_to_dict() -> None:
 
 def test_usage_accumulation_and_finalize() -> None:
     acc: dict[str, int] = {}
-    _accumulate_usage(acc, {"inputTokens": 10, "outputTokens": 5, "cacheReadTokens": 2})
+    _accumulate_usage(
+        acc,
+        {"inputTokens": 10, "outputTokens": 5, "cacheReadTokens": 2, "cacheWriteTokens": 7},
+    )
     _accumulate_usage(acc, {"inputTokens": 3, "outputTokens": 1})
     usage = _finalize_usage(acc)
     assert usage == {
         "input_tokens": 13,
         "output_tokens": 6,
         "cache_read_input_tokens": 2,
+        "cache_creation_input_tokens": 7,
         "total_tokens": 19,
     }
     assert _finalize_usage({}) is None
@@ -1246,11 +1250,12 @@ async def test_paragraph_break_between_pre_and_post_tool_text(
 
 
 @pytest.mark.asyncio
-async def test_run_turn_usage_accumulates_cache_read_through_events(
+async def test_run_turn_usage_accumulates_cache_read_write_through_events(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Two ASSISTANT_USAGE events (one per model call) accumulate end-to-end,
-    # including cacheReadTokens, and total_tokens excludes the cache count.
+    # including cacheReadTokens / cacheWriteTokens, and total_tokens excludes
+    # the cache counts.
     _install_fake_copilot(
         monkeypatch,
         [
@@ -1261,6 +1266,7 @@ async def test_run_turn_usage_accumulates_cache_read_through_events(
                     inputTokens=10,
                     outputTokens=2,
                     cacheReadTokens=5,
+                    cacheWriteTokens=8,
                 ),
                 _ev("ASSISTANT_USAGE", inputTokens=3, outputTokens=1, cacheReadTokens=4),
                 _ev("ASSISTANT_MESSAGE", content="ok"),
@@ -1274,6 +1280,7 @@ async def test_run_turn_usage_accumulates_cache_read_through_events(
         "input_tokens": 13,
         "output_tokens": 3,
         "cache_read_input_tokens": 9,
+        "cache_creation_input_tokens": 8,
         "total_tokens": 16,
     }
     await ex.close()

--- a/tests/server/integration/test_projects.py
+++ b/tests/server/integration/test_projects.py
@@ -1,0 +1,245 @@
+"""Integration tests for the first-class ``/v1/projects`` endpoints.
+
+Exercises the full middleware → route → store pipeline: project CRUD, sharing
+(specific user, ``__members__``, ``__public__``), leaving, and — the headline
+behaviour the old label fan-out couldn't do — a session's access **inheriting**
+from its project, including a chat filed *after* the share.
+
+Uses a header-auth app wired with a real project store; requests impersonate
+users via ``X-Forwarded-Email``.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+from tests.server.conftest import ControllableMockClient
+from tests.server.helpers import build_agent_bundle
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+def projects_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
+    """Header-auth app with a project store wired (so inheritance is live)."""
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        permission_store=SqlAlchemyPermissionStore(db_uri),
+        project_store=SqlAlchemyProjectStore(db_uri),
+        auth_provider=UnifiedAuthProvider(source="header", local_single_user=False),
+    )
+
+
+@pytest_asyncio.fixture()
+async def projects_client(
+    projects_app: FastAPI,
+    mock_llm: ControllableMockClient,
+    tmp_path: Path,
+) -> AsyncIterator[httpx.AsyncClient]:
+    from omnigent.runtime import set_harness_process_manager
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+
+    pm = HarnessProcessManager(tmp_parent=tmp_path / "harness_pm")
+    await pm.start()
+    set_harness_process_manager(pm)
+    transport = httpx.ASGITransport(app=projects_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    mock_llm.release_all()
+    set_harness_process_manager(None)
+    await pm.shutdown()
+
+
+def _h(user: str) -> dict[str, str]:
+    return {"X-Forwarded-Email": user}
+
+
+async def _create_project(client: httpx.AsyncClient, user: str, name: str) -> dict[str, Any]:
+    resp = await client.post("/v1/projects", json={"name": name}, headers=_h(user))
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_session(client: httpx.AsyncClient, user: str) -> str:
+    bundle = build_agent_bundle(name="test-agent")
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers=_h(user),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["session_id"]
+
+
+async def _file(client: httpx.AsyncClient, user: str, session_id: str, project_id: str) -> None:
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}", json={"project_id": project_id}, headers=_h(user)
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def _can_read(client: httpx.AsyncClient, user: str, session_id: str) -> bool:
+    resp = await client.get(
+        f"/v1/sessions/{session_id}?include_items=false&include_liveness=false",
+        headers=_h(user),
+    )
+    return resp.status_code == 200
+
+
+async def test_create_list_rename_delete(projects_client: httpx.AsyncClient) -> None:
+    project = await _create_project(projects_client, "alice", "Client X")
+    assert project["permission_level"] == 4
+
+    listed = await projects_client.get("/v1/projects", headers=_h("alice"))
+    assert project["id"] in {p["id"] for p in listed.json()}
+
+    renamed = await projects_client.patch(
+        f"/v1/projects/{project['id']}", json={"name": "Client Y"}, headers=_h("alice")
+    )
+    assert renamed.status_code == 200 and renamed.json()["name"] == "Client Y"
+
+    deleted = await projects_client.delete(f"/v1/projects/{project['id']}", headers=_h("alice"))
+    assert deleted.status_code == 204
+    gone = await projects_client.get(f"/v1/projects/{project['id']}", headers=_h("alice"))
+    assert gone.status_code == 404
+
+
+async def test_share_inherits_to_current_and_future_chats(
+    projects_client: httpx.AsyncClient,
+) -> None:
+    """The headline regression: a chat filed AFTER the share is still visible."""
+    project = await _create_project(projects_client, "alice", "Team")
+    first = await _create_session(projects_client, "alice")
+    await _file(projects_client, "alice", first, project["id"])
+
+    # Before sharing, bob can't read alice's chat.
+    assert await _can_read(projects_client, "bob", first) is False
+
+    # Share the project with bob (read).
+    resp = await projects_client.put(
+        f"/v1/projects/{project['id']}/permissions",
+        json={"user_id": "bob", "level": 1},
+        headers=_h("alice"),
+    )
+    assert resp.status_code == 200, resp.text
+    assert await _can_read(projects_client, "bob", first) is True
+
+    # File a NEW chat after the share — bob sees it with no extra action.
+    later = await _create_session(projects_client, "alice")
+    await _file(projects_client, "alice", later, project["id"])
+    assert await _can_read(projects_client, "bob", later) is True
+
+    # ...but read-only: bob can't archive it (owner-level action).
+    denied = await projects_client.patch(
+        f"/v1/sessions/{later}", json={"archived": True}, headers=_h("bob")
+    )
+    assert denied.status_code == 403
+
+
+async def test_members_scope_visible_to_any_user(projects_client: httpx.AsyncClient) -> None:
+    project = await _create_project(projects_client, "alice", "AllHands")
+    session = await _create_session(projects_client, "alice")
+    await _file(projects_client, "alice", session, project["id"])
+
+    assert await _can_read(projects_client, "carol", session) is False
+    await projects_client.put(
+        f"/v1/projects/{project['id']}/permissions",
+        json={"user_id": "__members__", "level": 1},
+        headers=_h("alice"),
+    )
+    # carol — never invited — now sees it, and the project appears in her list.
+    assert await _can_read(projects_client, "carol", session) is True
+    carol_projects = await projects_client.get("/v1/projects", headers=_h("carol"))
+    assert project["id"] in {p["id"] for p in carol_projects.json()}
+
+
+async def test_everyone_scopes_capped_read_only(projects_client: httpx.AsyncClient) -> None:
+    project = await _create_project(projects_client, "alice", "Cap")
+    for sentinel in ("__members__", "__public__"):
+        resp = await projects_client.put(
+            f"/v1/projects/{project['id']}/permissions",
+            json={"user_id": sentinel, "level": 2},
+            headers=_h("alice"),
+        )
+        assert resp.status_code == 400, f"{sentinel}: {resp.text}"
+
+
+async def test_members_list_and_leave(projects_client: httpx.AsyncClient) -> None:
+    project = await _create_project(projects_client, "alice", "Team")
+    await projects_client.put(
+        f"/v1/projects/{project['id']}/permissions",
+        json={"user_id": "bob", "level": 1},
+        headers=_h("alice"),
+    )
+    members = await projects_client.get(
+        f"/v1/projects/{project['id']}/permissions", headers=_h("alice")
+    )
+    by_user = {m["user_id"]: m["level"] for m in members.json()}
+    assert by_user == {"alice": 4, "bob": 1}
+
+    # Bob sees the project, then leaves — it drops off his list.
+    before = await projects_client.get("/v1/projects", headers=_h("bob"))
+    assert project["id"] in {p["id"] for p in before.json()}
+    left = await projects_client.delete(
+        f"/v1/projects/{project['id']}/membership", headers=_h("bob")
+    )
+    assert left.status_code == 204
+    after = await projects_client.get("/v1/projects", headers=_h("bob"))
+    assert project["id"] not in {p["id"] for p in after.json()}
+
+
+async def test_delete_unfiles_chats_rather_than_deleting_them(
+    projects_client: httpx.AsyncClient,
+) -> None:
+    project = await _create_project(projects_client, "alice", "Temp")
+    session = await _create_session(projects_client, "alice")
+    await _file(projects_client, "alice", session, project["id"])
+
+    await projects_client.delete(f"/v1/projects/{project['id']}", headers=_h("alice"))
+
+    # The chat survives, now unfiled (project_id cleared), still owned by alice.
+    snap = await projects_client.get(
+        f"/v1/sessions/{session}?include_items=false&include_liveness=false",
+        headers=_h("alice"),
+    )
+    assert snap.status_code == 200
+    assert snap.json()["project_id"] is None
+
+
+async def test_non_manager_cannot_file_into_others_project(
+    projects_client: httpx.AsyncClient,
+) -> None:
+    """Filing a session into a project you don't manage is refused."""
+    project = await _create_project(projects_client, "alice", "Private")
+    bobs_session = await _create_session(projects_client, "bob")
+    resp = await projects_client.patch(
+        f"/v1/sessions/{bobs_session}",
+        json={"project_id": project["id"]},
+        headers=_h("bob"),
+    )
+    assert resp.status_code == 403

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -137,40 +137,14 @@ async def test_patch_session_not_found(client: httpx.AsyncClient) -> None:
     assert resp.status_code == 404
 
 
-# ── GET /v1/sessions/projects ────────────────────────────────────────
-
-
-async def test_list_projects_empty(client: httpx.AsyncClient) -> None:
-    """No project labels anywhere → empty project list."""
-    resp = await client.get("/v1/sessions/projects")
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
-async def test_list_projects_returns_names_sorted(
-    client: httpx.AsyncClient,
-    db_uri: str,
-) -> None:
-    """Projects surface as a sorted list of names."""
-    conv_store = SqlAlchemyConversationStore(db_uri)
-    a = conv_store.create_conversation()
-    b = conv_store.create_conversation()
-    conv_store.set_labels(a.id, {"omni_project": "Sprint 42"})
-    conv_store.set_labels(b.id, {"omni_project": "Customer X"})
-
-    resp = await client.get("/v1/sessions/projects")
-    assert resp.status_code == 200
-    assert resp.json() == ["Customer X", "Sprint 42"]
-
-
-# ── GET /v1/sessions?project= (filter) ───────────────────────────────
+# ── GET /v1/sessions?project=<id> (first-class project filter) ───────
 
 
 async def test_list_sessions_filtered_by_project(
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """``?project=X`` returns only sessions in that project."""
+    """``?project=<id>`` returns only sessions filed under that project."""
     agent_store = SqlAlchemyAgentStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     # GET /v1/sessions filters has_agent_id=True, so bind the conversations to
@@ -179,9 +153,9 @@ async def test_list_sessions_filtered_by_project(
     agent_store.create(agent_id, name="project-agent", bundle_location="test:///bundle")
     filed = conv_store.create_conversation(agent_id=agent_id)
     conv_store.create_conversation(agent_id=agent_id)  # unfiled
-    conv_store.set_labels(filed.id, {"omni_project": "X"})
+    conv_store.set_project(filed.id, "proj_x")
 
-    resp = await client.get("/v1/sessions?project=X")
+    resp = await client.get("/v1/sessions?project=proj_x")
     assert resp.status_code == 200
     ids = [s["id"] for s in resp.json()["data"]]
     assert ids == [filed.id]
@@ -191,14 +165,14 @@ async def test_list_sessions_empty_project_returns_unfiled(
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """``?project=`` (empty) returns only sessions with no project label."""
+    """``?project=`` (empty) returns only sessions not filed under any project."""
     agent_store = SqlAlchemyAgentStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     agent_id = generate_agent_id()
     agent_store.create(agent_id, name="project-agent", bundle_location="test:///bundle")
     filed = conv_store.create_conversation(agent_id=agent_id)
     unfiled = conv_store.create_conversation(agent_id=agent_id)
-    conv_store.set_labels(filed.id, {"omni_project": "X"})
+    conv_store.set_project(filed.id, "proj_x")
 
     resp = await client.get("/v1/sessions?project=")
     assert resp.status_code == 200

--- a/tests/server/test_permissions.py
+++ b/tests/server/test_permissions.py
@@ -919,3 +919,26 @@ def test_resolved_level_none_when_no_access() -> None:
     access = ResolvedAccess(is_admin=False, user_grant_level=None, public_grant_level=None)
     assert resolved_level(access) is None
     assert resolved_allows(access, LEVEL_READ) is False
+
+
+def test_resolved_allows_via_project_grant() -> None:
+    """A project grant satisfies access even with no session-level grant."""
+    access = ResolvedAccess(
+        is_admin=False,
+        user_grant_level=None,
+        public_grant_level=None,
+        project_grant_level=LEVEL_READ,
+    )
+    assert resolved_allows(access, LEVEL_READ) is True
+    assert resolved_allows(access, LEVEL_EDIT) is False
+
+
+def test_resolved_level_project_grant_can_exceed_session_grant() -> None:
+    """A project manager who only reads a chat still sees manage-level for it."""
+    access = ResolvedAccess(
+        is_admin=False,
+        user_grant_level=LEVEL_READ,
+        public_grant_level=None,
+        project_grant_level=LEVEL_MANAGE,
+    )
+    assert resolved_level(access) == LEVEL_MANAGE

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4413,25 +4413,25 @@ def test_delete_label_is_noop_when_absent(
 def test_list_conversations_filters_by_project(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """``project="X"`` returns only sessions carrying that exact project label."""
+    """``project="<id>"`` returns only sessions filed under that project id."""
     filed = conversation_store.create_conversation()
     other = conversation_store.create_conversation()
     conversation_store.create_conversation()  # unfiled
 
-    conversation_store.set_labels(filed.id, {"omni_project": "X"})
-    conversation_store.set_labels(other.id, {"omni_project": "Y"})
+    conversation_store.set_project(filed.id, "proj_x")
+    conversation_store.set_project(other.id, "proj_y")
 
-    ids = {c.id for c in conversation_store.list_conversations(project="X").data}
+    ids = {c.id for c in conversation_store.list_conversations(project="proj_x").data}
     assert ids == {filed.id}
 
 
 def test_list_conversations_empty_project_returns_unfiled(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """``project=""`` returns only sessions with NO project label (Unfiled)."""
+    """``project=""`` returns only sessions not filed under any project (Unfiled)."""
     filed = conversation_store.create_conversation()
     unfiled = conversation_store.create_conversation()
-    conversation_store.set_labels(filed.id, {"omni_project": "X"})
+    conversation_store.set_project(filed.id, "proj_x")
 
     ids = {c.id for c in conversation_store.list_conversations(project="").data}
     assert unfiled.id in ids
@@ -4444,7 +4444,7 @@ def test_list_conversations_project_none_disables_filter(
     """``project=None`` (the default) returns filed and unfiled alike."""
     filed = conversation_store.create_conversation()
     unfiled = conversation_store.create_conversation()
-    conversation_store.set_labels(filed.id, {"omni_project": "X"})
+    conversation_store.set_project(filed.id, "proj_x")
 
     ids = {c.id for c in conversation_store.list_conversations().data}
     assert ids >= {filed.id, unfiled.id}

--- a/tests/stores/test_permission_store.py
+++ b/tests/stores/test_permission_store.py
@@ -1099,3 +1099,65 @@ def test_list_for_sessions_no_grants(store: SqlAlchemyPermissionStore, db_uri: s
     conv = _create_conversation(db_uri)
     result = store.list_for_sessions([conv])
     assert result == {conv: []}
+
+
+# ── __members__ sentinel ──────────────────────────────────────────────────────
+
+
+def test_check_access_members_grant_authenticated(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """A __members__ grant resolves for any authenticated user."""
+    from omnigent.server.auth import RESERVED_USER_MEMBERS
+
+    _ensure_user(store, "alice")
+    _ensure_user(store, RESERVED_USER_MEMBERS)
+    conv = _create_conversation(db_uri)
+    store.grant(RESERVED_USER_MEMBERS, conv, level=1)
+
+    assert store.check_access("alice", conv, required_level=1) is True
+    assert store.check_access("alice", conv, required_level=2) is False
+
+
+def test_check_access_members_grant_not_for_anonymous(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """A __members__ grant never resolves for an anonymous (None) caller."""
+    from omnigent.server.auth import RESERVED_USER_MEMBERS
+
+    _ensure_user(store, RESERVED_USER_MEMBERS)
+    conv = _create_conversation(db_uri)
+    store.grant(RESERVED_USER_MEMBERS, conv, level=1)
+
+    assert store.check_access(None, conv, required_level=1) is False
+
+
+def test_resolve_access_populates_members_grant_level(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """resolve_access surfaces the __members__ grant level separately."""
+    from omnigent.server.auth import RESERVED_USER_MEMBERS
+
+    _ensure_user(store, "alice")
+    _ensure_user(store, RESERVED_USER_MEMBERS)
+    conv = _create_conversation(db_uri)
+    store.grant(RESERVED_USER_MEMBERS, conv, level=1)
+
+    access = store.resolve_access("alice", conv)
+    assert access.user_grant_level is None
+    assert access.public_grant_level is None
+    assert access.members_grant_level == 1
+
+
+def test_get_permission_level_members_fallback(
+    store: SqlAlchemyPermissionStore, db_uri: str
+) -> None:
+    """get_permission_level falls back to the __members__ grant."""
+    from omnigent.server.auth import RESERVED_USER_MEMBERS
+
+    _ensure_user(store, "alice")
+    _ensure_user(store, RESERVED_USER_MEMBERS)
+    conv = _create_conversation(db_uri)
+    store.grant(RESERVED_USER_MEMBERS, conv, level=1)
+
+    assert store.get_permission_level("alice", conv) == 1

--- a/tests/stores/test_project_store.py
+++ b/tests/stores/test_project_store.py
@@ -1,0 +1,102 @@
+"""Tests for :class:`SqlAlchemyProjectStore`.
+
+Exercises project CRUD and the project-level ACL (grants + the
+``__members__`` / ``__public__`` sentinels) against a real SQLite database,
+mirroring :mod:`tests.stores.test_permission_store`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+
+
+@pytest.fixture()
+def stores(db_uri: str) -> tuple[SqlAlchemyProjectStore, SqlAlchemyPermissionStore]:
+    """A project store plus a permission store (the latter to satisfy the
+    ``users`` FK that both grant tables reference)."""
+    perm = SqlAlchemyPermissionStore(db_uri)
+    for user in ("alice", "bob", "carol", "__members__", "__public__"):
+        perm.ensure_user(user)
+    return SqlAlchemyProjectStore(db_uri), perm
+
+
+def test_create_project_grants_owner(stores) -> None:
+    store, _ = stores
+    project = store.create_project("Client X", "alice")
+    assert project.id.startswith("proj_")
+    assert project.name == "Client X"
+    assert project.created_by == "alice"
+    assert store.get_permission_level("alice", project.id) == 4
+
+
+def test_create_project_duplicate_name_per_owner_rejected(stores) -> None:
+    store, _ = stores
+    store.create_project("Client X", "alice")
+    with pytest.raises(ValueError):
+        store.create_project("Client X", "alice")
+    # A different owner may reuse the name.
+    other = store.create_project("Client X", "bob")
+    assert other.created_by == "bob"
+
+
+def test_rename_and_delete_project(stores) -> None:
+    store, _ = stores
+    project = store.create_project("Client X", "alice")
+    renamed = store.rename_project(project.id, "Client Y")
+    assert renamed is not None and renamed.name == "Client Y"
+    assert store.delete_project(project.id) is True
+    assert store.get_project(project.id) is None
+    # Grants are dropped with the project.
+    assert store.get_permission_level("alice", project.id) is None
+
+
+def test_grant_check_and_revoke(stores) -> None:
+    store, _ = stores
+    project = store.create_project("Client X", "alice")
+    store.grant("bob", project.id, 1)
+    assert store.check_access("bob", project.id, 1) is True
+    assert store.check_access("bob", project.id, 2) is False
+    store.revoke("bob", project.id)
+    assert store.check_access("bob", project.id, 1) is False
+
+
+def test_members_sentinel_resolves_for_any_authenticated_user(stores) -> None:
+    store, _ = stores
+    project = store.create_project("Client X", "alice")
+    store.grant("__members__", project.id, 1)
+    # carol never got a direct grant, yet the members sentinel resolves.
+    assert store.check_access("carol", project.id, 1) is True
+    # ...but not for an anonymous caller.
+    assert store.check_access(None, project.id, 1) is False
+
+
+def test_public_sentinel_resolves_for_anonymous(stores) -> None:
+    store, _ = stores
+    project = store.create_project("Client X", "alice")
+    store.grant("__public__", project.id, 1)
+    assert store.check_access(None, project.id, 1) is True
+
+
+def test_list_projects_for_user_includes_owned_and_members(stores) -> None:
+    store, _ = stores
+    owned = store.create_project("Owned", "alice")
+    shared = store.create_project("Shared", "bob")
+    store.grant("__members__", shared.id, 1)
+
+    alice_projects = {p.name: level for p, level in store.list_projects_for_user("alice")}
+    assert alice_projects["Owned"] == 4
+    # Alice sees bob's project via the members sentinel, at read.
+    assert alice_projects["Shared"] == 1
+    assert owned.id  # sanity
+
+
+def test_list_for_project_returns_all_grants(stores) -> None:
+    store, _ = stores
+    project = store.create_project("Client X", "alice")
+    store.grant("bob", project.id, 1)
+    store.grant("__members__", project.id, 1)
+    by_user = {g.user_id: g.level for g in store.list_for_project(project.id)}
+    assert by_user == {"alice": 4, "bob": 1, "__members__": 1}

--- a/web/src/components/ShareProjectModal.test.tsx
+++ b/web/src/components/ShareProjectModal.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ShareProjectModal } from "./ShareProjectModal";
+
+vi.mock("@/lib/projectsApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/projectsApi")>();
+  return {
+    ...actual,
+    listProjectMembers: vi.fn(),
+    shareProject: vi.fn(),
+    unshareProject: vi.fn(),
+  };
+});
+
+import * as api from "@/lib/projectsApi";
+const membersMock = vi.mocked(api.listProjectMembers);
+const shareMock = vi.mocked(api.shareProject);
+const unshareMock = vi.mocked(api.unshareProject);
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function renderModal() {
+  render(
+    <ShareProjectModal projectId="proj_x" projectName="Proj" open={true} onOpenChange={() => {}} />,
+    { wrapper: createWrapper() },
+  );
+}
+
+beforeEach(() => {
+  membersMock.mockReset();
+  shareMock.mockReset();
+  unshareMock.mockReset();
+  membersMock.mockResolvedValue([]);
+});
+
+afterEach(cleanup);
+
+describe("ShareProjectModal", () => {
+  it("turning on 'all members' shares the __members__ sentinel", async () => {
+    shareMock.mockResolvedValue({
+      id: "proj_x",
+      name: "Proj",
+      created_by: "alice",
+      created_at: 0,
+      updated_at: 0,
+      permission_level: 4,
+      members: true,
+      public: false,
+    });
+    renderModal();
+    const toggle = await screen.findByTestId("project-members-toggle");
+    await waitFor(() => expect(toggle).not.toBeDisabled());
+    fireEvent.click(toggle);
+    await waitFor(() => expect(shareMock).toHaveBeenCalledWith("proj_x", api.MEMBERS_USER, 1));
+  });
+
+  it("turning off the public link revokes the __public__ sentinel", async () => {
+    membersMock.mockResolvedValue([{ user_id: api.PUBLIC_USER, level: 1 }]);
+    unshareMock.mockResolvedValue(undefined);
+    renderModal();
+    const toggle = await screen.findByTestId("project-public-toggle");
+    await waitFor(() => expect(toggle).toBeChecked());
+    fireEvent.click(toggle);
+    await waitFor(() => expect(unshareMock).toHaveBeenCalledWith("proj_x", api.PUBLIC_USER));
+  });
+
+  it("inviting a user grants them at the chosen level", async () => {
+    shareMock.mockResolvedValue({
+      id: "proj_x",
+      name: "Proj",
+      created_by: "alice",
+      created_at: 0,
+      updated_at: 0,
+      permission_level: 4,
+      members: false,
+      public: false,
+    });
+    renderModal();
+    const input = await screen.findByPlaceholderText("alice@example.com");
+    fireEvent.change(input, { target: { value: "bob@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /grant/i }));
+    await waitFor(() => expect(shareMock).toHaveBeenCalledWith("proj_x", "bob@example.com", 1));
+  });
+
+  it("lists real members but not sentinels or owners", async () => {
+    membersMock.mockResolvedValue([
+      { user_id: "alice", level: 4 },
+      { user_id: api.MEMBERS_USER, level: 1 },
+      { user_id: "bob", level: 1 },
+    ]);
+    renderModal();
+    await waitFor(() => expect(screen.getByText("bob")).toBeInTheDocument());
+    expect(screen.queryByText("alice")).not.toBeInTheDocument();
+    expect(screen.queryByText(api.MEMBERS_USER)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/ShareProjectModal.tsx
+++ b/web/src/components/ShareProjectModal.tsx
@@ -1,0 +1,227 @@
+/**
+ * Share modal for a first-class project.
+ *
+ * Sharing a project grants access to every chat filed under it (chats inherit
+ * the project's ACL server-side), including chats added later. Two "everyone"
+ * scopes are offered as toggles — share with all signed-in members
+ * (`__members__`) and anyone with the link (`__public__`) — plus an invite form
+ * and the current member list. All grants target the project by id.
+ */
+
+import { type FormEvent, useState } from "react";
+import { Trash2Icon, UserPlusIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useProjectMembers, useShareProject, useUnshareProject } from "@/hooks/useProjectShare";
+import { MEMBERS_USER, PUBLIC_USER } from "@/lib/projectsApi";
+
+interface ShareProjectModalProps {
+  projectId: string;
+  projectName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const LEVEL_LABELS: Record<number, string> = { 1: "Read", 2: "Edit", 3: "Manage", 4: "Owner" };
+
+export function ShareProjectModal({
+  projectId,
+  projectName,
+  open,
+  onOpenChange,
+}: ShareProjectModalProps) {
+  const { data: members, isLoading } = useProjectMembers(open ? projectId : null);
+  const share = useShareProject(projectId);
+  const unshare = useUnshareProject(projectId);
+
+  const [newUserId, setNewUserId] = useState("");
+  const [newLevel, setNewLevel] = useState("1");
+  const [error, setError] = useState<string | null>(null);
+
+  const busy = share.isPending || unshare.isPending;
+  const rows = members ?? [];
+  const isMembers = rows.some((m) => m.user_id === MEMBERS_USER);
+  const isPublic = rows.some((m) => m.user_id === PUBLIC_USER);
+  // Real, removable grantees — the sentinels are the toggles above, and the
+  // owner can't be revoked, so neither belongs in the member list.
+  const memberRows = rows.filter(
+    (m) => m.user_id !== MEMBERS_USER && m.user_id !== PUBLIC_USER && m.level < 4,
+  );
+
+  function toggleScope(sentinel: string, on: boolean) {
+    setError(null);
+    if (on) {
+      share.mutate({ userId: sentinel, level: 1 }, { onError: (e) => setError(e.message) });
+    } else {
+      unshare.mutate(sentinel, { onError: (e) => setError(e.message) });
+    }
+  }
+
+  function handleInvite(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = newUserId.trim();
+    if (!trimmed) return;
+    setError(null);
+    share.mutate(
+      { userId: trimmed, level: parseInt(newLevel, 10) },
+      {
+        onSuccess: () => {
+          setNewUserId("");
+          setNewLevel("1");
+        },
+        onError: (e) => setError(e.message),
+      },
+    );
+  }
+
+  function handleRevoke(userId: string) {
+    setError(null);
+    unshare.mutate(userId, { onError: (e) => setError(e.message) });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" onClick={(e) => e.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>Share project</DialogTitle>
+          <DialogDescription>
+            Sharing applies to every chat in <span className="font-medium">{projectName}</span> —
+            including chats added later.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Members scope */}
+        <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+          <div>
+            <p className="text-sm font-medium">Share with all members</p>
+            <p className="text-xs text-muted-foreground">
+              Everyone signed in to this Omnigent sees this project
+            </p>
+          </div>
+          <Switch
+            checked={isMembers}
+            onCheckedChange={(c) => toggleScope(MEMBERS_USER, c)}
+            disabled={busy || isLoading}
+            data-testid="project-members-toggle"
+          />
+        </div>
+
+        {/* Public link scope */}
+        <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+          <div>
+            <p className="text-sm font-medium">Anyone with the link</p>
+            <p className="text-xs text-muted-foreground">
+              Anyone with a chat's link can view it, even without an account
+            </p>
+          </div>
+          <Switch
+            checked={isPublic}
+            onCheckedChange={(c) => toggleScope(PUBLIC_USER, c)}
+            disabled={busy || isLoading}
+            data-testid="project-public-toggle"
+          />
+        </div>
+
+        {/* Current members */}
+        {memberRows.length > 0 && (
+          <div className="max-h-40 overflow-y-auto">
+            <p className="px-1 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              People with access
+            </p>
+            {memberRows.map((m) => (
+              <div
+                key={m.user_id}
+                className="flex items-center gap-2 px-1 py-1 text-sm"
+                data-testid="project-member-row"
+              >
+                <span className="flex-1 truncate">{m.user_id}</span>
+                <span className="text-xs text-muted-foreground">
+                  {LEVEL_LABELS[m.level] ?? m.level}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Remove ${m.user_id}`}
+                  disabled={busy}
+                  onClick={() => handleRevoke(m.user_id)}
+                >
+                  <Trash2Icon className="size-3.5" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Invite a specific user */}
+        <form onSubmit={handleInvite} className="flex items-end gap-2">
+          <div className="flex-1">
+            <label
+              htmlFor="project-perm-user"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Invite by user ID
+            </label>
+            <Input
+              id="project-perm-user"
+              value={newUserId}
+              onChange={(e) => setNewUserId(e.target.value)}
+              placeholder="alice@example.com"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="project-perm-level"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Level
+            </label>
+            <Select value={newLevel} onValueChange={setNewLevel}>
+              <SelectTrigger className="mt-1 w-24" id="project-perm-level">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">Read</SelectItem>
+                <SelectItem value="2">Edit</SelectItem>
+                <SelectItem value="3">Manage</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button type="submit" size="sm" disabled={!newUserId.trim() || busy}>
+            <UserPlusIcon className="mr-1 size-3.5" />
+            Grant
+          </Button>
+        </form>
+
+        {error && (
+          <p className="text-xs text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -681,8 +681,19 @@ describe("useBulkStopSessions", () => {
 });
 
 describe("useProjects", () => {
-  it("GETs /v1/sessions/projects and returns the project list", async () => {
-    const projects = ["Customer X", "Sprint 42"];
+  it("GETs /v1/projects and returns the project list", async () => {
+    const projects = [
+      {
+        id: "proj_1",
+        name: "Customer X",
+        created_by: "me",
+        created_at: 0,
+        updated_at: 0,
+        permission_level: 4,
+        members: false,
+        public: false,
+      },
+    ];
     fetchMock.mockResolvedValueOnce(mockResponse(projects));
 
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -691,7 +702,7 @@ describe("useProjects", () => {
     const { result } = renderHook(() => useProjects(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/projects");
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/projects");
     expect(result.current.data).toEqual(projects);
   });
 
@@ -711,7 +722,7 @@ describe("useProjectSessions", () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
-    renderHook(() => useProjectSessions("Sprint 42", false), { wrapper });
+    renderHook(() => useProjectSessions("proj_sprint42", false), { wrapper });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -727,12 +738,12 @@ describe("useProjectSessions", () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
-    const { result } = renderHook(() => useProjectSessions("Sprint 42", true), { wrapper });
+    const { result } = renderHook(() => useProjectSessions("proj_sprint42", true), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain("/v1/sessions?");
-    expect(url).toContain("project=Sprint+42");
+    expect(url).toContain("project=proj_sprint42");
     expect(url).toContain("order=desc");
     expect(url).toContain("sort_by=updated_at");
     expect(url).toContain("limit=20");
@@ -759,13 +770,13 @@ describe("useMoveToProject", () => {
       createElement(QueryClientProvider, { client: queryClient }, children);
     const { result } = renderHook(() => useMoveToProject(), { wrapper });
 
-    result.current.mutate({ id: "conv_move", project: "Sprint 42" });
+    result.current.mutate({ id: "conv_move", projectId: "proj_sprint42" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_move");
     expect(init.method).toBe("PATCH");
-    expect(JSON.parse(init.body as string)).toEqual({ labels: { omni_project: "Sprint 42" } });
+    expect(JSON.parse(init.body as string)).toEqual({ project_id: "proj_sprint42" });
   });
 
   it("invalidates both the conversations and projects queries on success", async () => {
@@ -785,7 +796,7 @@ describe("useMoveToProject", () => {
       createElement(QueryClientProvider, { client: queryClient }, children);
     const { result } = renderHook(() => useMoveToProject(), { wrapper });
 
-    result.current.mutate({ id: "conv_move", project: "" });
+    result.current.mutate({ id: "conv_move", projectId: null });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Both keys must refresh: conversations so the row re-groups into its new
@@ -828,34 +839,8 @@ describe("useArchiveConversation", () => {
 });
 
 describe("useDeleteProject", () => {
-  function archivedConv(id: string) {
-    return mockResponse({
-      id,
-      object: "conversation",
-      title: id,
-      created_at: 0,
-      updated_at: 10,
-      archived: true,
-      labels: { omni_project: "Sprint 42" },
-    });
-  }
-
-  it("archives every session in the project (keeping the label) and refreshes the lists", async () => {
-    // 1st call: page of project members. Then one PATCH archive per member.
-    fetchMock
-      .mockResolvedValueOnce(
-        mockResponse({
-          data: [
-            { id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 1 },
-            { id: "conv_b", object: "conversation", title: "B", created_at: 0, updated_at: 2 },
-          ],
-          first_id: "conv_a",
-          last_id: "conv_b",
-          has_more: false,
-        }),
-      )
-      .mockResolvedValueOnce(archivedConv("conv_a"))
-      .mockResolvedValueOnce(archivedConv("conv_b"));
+  it("DELETEs /v1/projects/{id} and refreshes the lists", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { status: 204 }));
 
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -863,63 +848,14 @@ describe("useDeleteProject", () => {
       createElement(QueryClientProvider, { client: queryClient }, children);
     const { result } = renderHook(() => useDeleteProject(), { wrapper });
 
-    result.current.mutate("Sprint 42");
+    result.current.mutate("proj_sprint42");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    // The list fetch is filtered by project and includes archived members.
-    const listUrl = fetchMock.mock.calls[0][0] as string;
-    expect(listUrl).toContain("project=Sprint+42");
-    expect(listUrl).toContain("include_archived=true");
-
-    // Each member is archived via PATCH — NOT deleted, and the project label is
-    // left intact so unarchiving restores the session to its project.
-    const patches = (fetchMock.mock.calls.slice(1) as [string, RequestInit][]).map(
-      ([url, init]) => ({ url, init }),
-    );
-    expect(patches.map((p) => p.url).sort()).toEqual([
-      "/v1/sessions/conv_a",
-      "/v1/sessions/conv_b",
-    ]);
-    for (const { init } of patches) {
-      expect(init.method).toBe("PATCH");
-      expect(JSON.parse(init.body as string)).toEqual({ archived: true });
-    }
-
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/projects/proj_sprint42");
+    expect(init.method).toBe("DELETE");
+    // Chats survive as unfiled, so both lists must refresh.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["projects"] });
-  });
-
-  it("throws with succeeded/failed split when some archives fail", async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        mockResponse({
-          data: [
-            { id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 1 },
-            { id: "conv_b", object: "conversation", title: "B", created_at: 0, updated_at: 2 },
-          ],
-          first_id: "conv_a",
-          last_id: "conv_b",
-          has_more: false,
-        }),
-      )
-      .mockResolvedValueOnce(archivedConv("conv_a"))
-      .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 403 }));
-
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    const { result } = renderHook(() => useDeleteProject(), { wrapper });
-
-    result.current.mutate("Sprint 42");
-    await waitFor(() => expect(result.current.isError).toBe(true));
-
-    const err = result.current.error as unknown as {
-      failed: string[];
-      succeeded: string[];
-      total: number;
-    };
-    expect(err.failed).toEqual(["conv_b"]);
-    expect(err.succeeded).toEqual(["conv_a"]);
-    expect(err.total).toBe(2);
   });
 });

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -27,6 +27,13 @@ import {
 } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import {
+  type ProjectSummary,
+  createProject,
+  deleteProject as deleteProjectApi,
+  listProjects,
+  renameProject,
+} from "@/lib/projectsApi";
+import {
   filtersFromConversationQueryKey,
   mergeItemsIntoPages,
   removeIdsFromPages,
@@ -58,6 +65,8 @@ export interface Conversation {
   runner_id?: string | null;
   /** Host that launched the runner for this session, e.g. ``"host_a1b2"``. */
   host_id?: string | null;
+  /** First-class project the session is filed under, or ``null`` if unfiled. */
+  project_id?: string | null;
   /**
    * Absolute path the runner cd's into, e.g. ``"/Users/me/repo"``. For
    * worktree sessions this is the isolated worktree dir, not the picked
@@ -163,6 +172,7 @@ export async function fetchConversationById(id: string): Promise<Conversation | 
     owner: wire.owner ?? null,
     runner_id: wire.runner_id ?? null,
     host_id: wire.host_id ?? null,
+    project_id: wire.project_id ?? null,
     workspace: wire.workspace ?? null,
     agent_id: wire.agent_id,
     agent_name: wire.agent_name ?? null,
@@ -649,123 +659,82 @@ export function usePinnedConversationBackfill(
 
 // ── Project hooks ─────────────────────────────────────────────────────────────
 
-/**
- * The reserved `conversation_labels` key that stores a session's project
- * membership. Namespaced (`omni_*`) so it never collides with the user-facing
- * "project" term or other reserved keys, and is filtered out of generic label
- * surfaces.
- */
-export const PROJECT_LABEL_KEY = "omni_project";
-
-/** Fetch all project names from `GET /v1/sessions/projects`. */
+/** Fetch the projects the caller can access (owned + shared). */
 export function useProjects() {
-  return useQuery<string[]>({
+  return useQuery<ProjectSummary[]>({
     queryKey: ["projects"],
-    queryFn: async () => {
-      const res = await authenticatedFetch("/v1/sessions/projects");
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-      return (await res.json()) as string[];
-    },
+    queryFn: listProjects,
     staleTime: 30_000,
   });
 }
 
-async function moveConversationToProject(id: string, project: string): Promise<Conversation> {
+/** Create a project owned by the caller. */
+export function useCreateProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => createProject(name),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+}
+
+/** Rename a project. */
+export function useRenameProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ projectId, name }: { projectId: string; name: string }) =>
+      renameProject(projectId, name),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+}
+
+async function moveConversationToProject(
+  id: string,
+  projectId: string | null,
+): Promise<Conversation> {
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(id)}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    // Empty string signals "remove from project" (server deletes the label row).
-    body: JSON.stringify({ labels: { [PROJECT_LABEL_KEY]: project } }),
+    // "" clears the project (unfile); a project id files the session under it.
+    body: JSON.stringify({ project_id: projectId ?? "" }),
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as Conversation;
 }
 
 /**
- * Move a session to a project (or remove it from all projects when `project=""`).
+ * File a session under a project (or unfile it when `projectId` is null).
  *
- * Invalidates both the conversations list (so sidebar sections re-group) and
- * the projects list (so counts update). Patch-in-place is skipped here — project
- * changes affect which sidebar section a session belongs to, so a full
- * re-render of the list is correct.
+ * Invalidates the conversations list (so sidebar sections re-group), the
+ * projects list, and the per-project session lists.
  */
 export function useMoveToProject() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, project }: { id: string; project: string }) =>
-      moveConversationToProject(id, project),
+    mutationFn: ({ id, projectId }: { id: string; projectId: string | null }) =>
+      moveConversationToProject(id, projectId),
     onSuccess: (updated) => {
       markConversationSeen(updated.id, updated.updated_at);
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
-      // Moving into/out of a project changes both folders' paginated lists.
       void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
     },
   });
 }
 
-/**
- * Collect every session id filed under a project, paging through the
- * server-side `?project=` filter (archived included). Used by "Delete project"
- * so it removes ALL members, not just those in the loaded sidebar window.
- */
-async function fetchAllProjectSessionIds(project: string): Promise<string[]> {
-  const ids: string[] = [];
-  let after: string | undefined;
-  for (;;) {
-    const params = new URLSearchParams({
-      order: "desc",
-      sort_by: "updated_at",
-      limit: "100",
-      include_archived: "true",
-      project,
-    });
-    if (after) params.set("after", after);
-    // Sequential by necessity: each page's request needs the previous page's
-    // cursor (`after`), so these awaits can't be parallelized.
-    // eslint-disable-next-line no-await-in-loop
-    const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-    // eslint-disable-next-line no-await-in-loop
-    const page = (await res.json()) as ConversationsPage;
-    for (const conv of page.data) ids.push(conv.id);
-    if (!page.has_more || !page.last_id) break;
-    after = page.last_id;
-  }
-  return ids;
-}
-
-/**
- * Fetch up to `limit` session ids filed under a project (archived included),
- * server-side via the `?project=` filter. A single page — enough to answer
- * "is this session the project's last member?" reliably (unaffected by the
- * sidebar's loaded window or pin-precedence placement). Default `limit=2` is
- * the minimum that distinguishes "only this one" from "more than one".
- */
-export async function fetchProjectSessionIds(project: string, limit = 2): Promise<string[]> {
-  const params = new URLSearchParams({
-    order: "desc",
-    sort_by: "updated_at",
-    limit: String(limit),
-    include_archived: "true",
-    project,
-  });
-  const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  const page = (await res.json()) as ConversationsPage;
-  return page.data.map((conv) => conv.id);
-}
-
-/** One page of a project's (non-archived) sessions, newest-first. */
+/** One page of a project's (non-archived) sessions, newest-first, by id. */
 async function fetchProjectSessionsPage(
-  project: string,
+  projectId: string,
   after?: string,
 ): Promise<ConversationsPage> {
   const params = new URLSearchParams({
     order: "desc",
     sort_by: "updated_at",
     limit: "20",
-    project,
+    project: projectId,
   });
   if (after) params.set("after", after);
   const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
@@ -775,18 +744,15 @@ async function fetchProjectSessionsPage(
 
 /**
  * Cursor-paginated list of the sessions filed under one project, fetched
- * server-side via `?project=` so a folder shows ALL its members regardless of
- * how far the global sidebar list has been scrolled. Archived sessions are
- * excluded (they leave the active sidebar). `enabled` gates the fetch so a
- * collapsed folder costs nothing — pass the folder's expanded state.
- *
- * Same page size (20) and sort (`updated_at desc`) as the global list, so a
- * folder paginates independently with its own infinite-scroll sentinel.
+ * server-side via `?project=<id>` so a folder shows ALL its members regardless
+ * of how far the global sidebar list has been scrolled. `enabled` gates the
+ * fetch so a collapsed folder costs nothing.
  */
-export function useProjectSessions(project: string, enabled: boolean) {
+export function useProjectSessions(projectId: string, enabled: boolean) {
   return useInfiniteQuery({
-    queryKey: ["project-sessions", project],
-    queryFn: ({ pageParam }) => fetchProjectSessionsPage(project, pageParam as string | undefined),
+    queryKey: ["project-sessions", projectId],
+    queryFn: ({ pageParam }) =>
+      fetchProjectSessionsPage(projectId, pageParam as string | undefined),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? (lastPage.last_id ?? undefined) : undefined,
@@ -795,39 +761,14 @@ export function useProjectSessions(project: string, enabled: boolean) {
 }
 
 /**
- * Delete a whole project by ARCHIVING every session filed under it. The
- * sessions keep their `omni_project` label (so unarchiving restores them to
- * this project) and their history; they only leave the active sidebar. The
- * project is implicit and the server's project list excludes all-archived
- * projects, so the folder disappears once its last member is archived. Throws
- * `{ failed, succeeded, total }` if any session failed (e.g. a shared session
- * the user can't modify), leaving those sessions in place.
+ * Delete a project. Its chats are unfiled (they return to "Chats"), not
+ * archived — the server clears their `project_id` and drops the project row.
  */
 export function useDeleteProject() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (project: string) => {
-      const ids = await fetchAllProjectSessionIds(project);
-      const results = await Promise.allSettled(ids.map((id) => archiveConversation(id, true)));
-      const succeeded: string[] = [];
-      const failed: string[] = [];
-      for (let i = 0; i < results.length; i++) {
-        if (results[i].status === "fulfilled") {
-          succeeded.push(ids[i]);
-          markConversationSeen(
-            ids[i],
-            (results[i] as PromiseFulfilledResult<Conversation>).value.updated_at,
-          );
-        } else {
-          failed.push(ids[i]);
-        }
-      }
-      if (failed.length > 0) throw { failed, succeeded, total: ids.length };
-      return { succeeded, failed };
-    },
+    mutationFn: (projectId: string) => deleteProjectApi(projectId),
     onSettled: () => {
-      // Refresh regardless of partial failure so the sidebar reflects whatever
-      // was actually archived.
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
       void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });

--- a/web/src/hooks/useProjectShare.ts
+++ b/web/src/hooks/useProjectShare.ts
@@ -1,0 +1,71 @@
+/**
+ * TanStack Query hooks for project sharing + membership.
+ * Wraps the fetch functions in `lib/projectsApi.ts`, keyed by project id.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type ProjectMember,
+  leaveProject,
+  listProjectMembers,
+  shareProject,
+  unshareProject,
+} from "@/lib/projectsApi";
+
+function projectMembersKey(projectId: string) {
+  return ["projectMembers", projectId] as const;
+}
+
+/** Fetch a project's grantees (manage access required). */
+export function useProjectMembers(projectId: string | null) {
+  return useQuery({
+    queryKey: projectMembersKey(projectId ?? ""),
+    queryFn: () => listProjectMembers(projectId!),
+    enabled: !!projectId,
+  });
+}
+
+/**
+ * Invalidate everything a share/leave touches: the project's member list, the
+ * project list (its members/public flags), and the sidebar/conversation lists
+ * (a share changes which sessions a member can see).
+ */
+function useInvalidateShare(projectId: string) {
+  const qc = useQueryClient();
+  return () => {
+    void qc.invalidateQueries({ queryKey: projectMembersKey(projectId) });
+    void qc.invalidateQueries({ queryKey: ["projects"] });
+    void qc.invalidateQueries({ queryKey: ["conversations"] });
+    void qc.invalidateQueries({ queryKey: ["project-sessions"] });
+  };
+}
+
+/** Share a project with a user, or all members / anyone with the link. */
+export function useShareProject(projectId: string) {
+  const invalidate = useInvalidateShare(projectId);
+  return useMutation({
+    mutationFn: ({ userId, level }: { userId: string; level: number }) =>
+      shareProject(projectId, userId, level),
+    onSuccess: invalidate,
+  });
+}
+
+/** Revoke a grantee from a project. */
+export function useUnshareProject(projectId: string) {
+  const invalidate = useInvalidateShare(projectId);
+  return useMutation({
+    mutationFn: (userId: string) => unshareProject(projectId, userId),
+    onSuccess: invalidate,
+  });
+}
+
+/** Leave a project (the caller drops their own non-owner grant). */
+export function useLeaveProject(projectId: string) {
+  const invalidate = useInvalidateShare(projectId);
+  return useMutation({
+    mutationFn: () => leaveProject(projectId),
+    onSuccess: invalidate,
+  });
+}
+
+export type { ProjectMember };

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -1,0 +1,123 @@
+/**
+ * Typed client for the first-class `/v1/projects/*` endpoints.
+ * Mirrors `omnigent/server/routes/projects.py`.
+ *
+ * A project is a shareable collection of chats; a chat filed under a project
+ * (its `project_id`) inherits the project's ACL, so sharing a project covers
+ * every chat in it — current and future. Two "everyone" scopes exist, matching
+ * the share-modal toggles:
+ *   - {@link MEMBERS_USER} — every signed-in member.
+ *   - {@link PUBLIC_USER} — anyone with a chat's link (anonymous).
+ */
+
+import { authenticatedFetch } from "./identity";
+
+/** Sentinel grantee: every signed-in member (current + future). */
+export const MEMBERS_USER = "__members__";
+/** Sentinel grantee: anyone with the link, including logged-out visitors. */
+export const PUBLIC_USER = "__public__";
+
+/** A project plus the calling user's effective access. Mirrors `ProjectObject`. */
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  created_by: string | null;
+  created_at: number;
+  updated_at: number;
+  /** Caller's effective level: 1=read, 2=edit, 3=manage, 4=owner. */
+  permission_level: number | null;
+  /** Shared with all signed-in members. */
+  members: boolean;
+  /** Shared via public link. */
+  public: boolean;
+}
+
+/** One grantee on a project. */
+export interface ProjectMember {
+  user_id: string;
+  level: number;
+}
+
+async function readJson<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+const base = (projectId: string) => `/v1/projects/${encodeURIComponent(projectId)}`;
+
+export async function listProjects(): Promise<ProjectSummary[]> {
+  return readJson(await authenticatedFetch("/v1/projects"));
+}
+
+export async function createProject(name: string): Promise<ProjectSummary> {
+  return readJson(
+    await authenticatedFetch("/v1/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    }),
+  );
+}
+
+export async function renameProject(projectId: string, name: string): Promise<ProjectSummary> {
+  return readJson(
+    await authenticatedFetch(base(projectId), {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    }),
+  );
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+  const res = await authenticatedFetch(base(projectId), { method: "DELETE" });
+  if (!res.ok && res.status !== 204) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `${res.status} ${res.statusText}`);
+  }
+}
+
+export async function listProjectMembers(projectId: string): Promise<ProjectMember[]> {
+  return readJson(await authenticatedFetch(`${base(projectId)}/permissions`));
+}
+
+/**
+ * Share a project. Pass a sentinel ({@link MEMBERS_USER} / {@link PUBLIC_USER})
+ * at level 1 for the "everyone" scopes, or a real user id to invite one person.
+ */
+export async function shareProject(
+  projectId: string,
+  userId: string,
+  level: number,
+): Promise<ProjectSummary> {
+  return readJson(
+    await authenticatedFetch(`${base(projectId)}/permissions`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId, level }),
+    }),
+  );
+}
+
+export async function unshareProject(projectId: string, userId: string): Promise<void> {
+  const res = await authenticatedFetch(
+    `${base(projectId)}/permissions/${encodeURIComponent(userId)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok && res.status !== 204) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `${res.status} ${res.statusText}`);
+  }
+}
+
+/** Leave a project: drop the caller's own (non-owner) grant. */
+export async function leaveProject(projectId: string): Promise<void> {
+  const res = await authenticatedFetch(`${base(projectId)}/membership`, { method: "DELETE" });
+  if (!res.ok && res.status !== 204) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `${res.status} ${res.statusText}`);
+  }
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -58,7 +58,21 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({
 // the create-POST call-count / call-order assertions below).
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/hooks/useConversations")>()),
-  useProjects: () => ({ data: [] }),
+  // The chip resolves a project's display name from this list by id. Tests
+  // land with ?project=<id>, so include those ids (id == name here).
+  useProjects: () => ({
+    data: ["docs", "Sprint 42"].map((name) => ({
+      id: name,
+      name,
+      created_by: "me",
+      created_at: 0,
+      updated_at: 0,
+      permission_level: 4,
+      members: false,
+      public: false,
+    })),
+  }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 // The harness-label catalog is not under test here. Keep it synchronous so
 // create-session fetch assertions only observe the POST/PATCH calls they own.
@@ -1271,9 +1285,9 @@ describe("NewChatLandingScreen", () => {
     expect(patchUrl).toBe("/v1/sessions/conv_new");
     expect((patchInit as RequestInit).method).toBe("PATCH");
     const patchBody = JSON.parse((patchInit as RequestInit).body as string) as {
-      labels: Record<string, string>;
+      project_id: string;
     };
-    expect(patchBody.labels).toEqual({ omni_project: "docs" });
+    expect(patchBody.project_id).toEqual("docs");
 
     // The target folder fetches its own paginated list (useProjectSessions),
     // so filing the new session must invalidate it — otherwise the row only
@@ -1325,9 +1339,9 @@ describe("NewChatLandingScreen", () => {
     const [patchUrl, patchInit] = authenticatedFetchMock.mock.calls[1];
     expect(patchUrl).toBe("/v1/sessions/conv_new");
     const patchBody = JSON.parse((patchInit as RequestInit).body as string) as {
-      labels: Record<string, string>;
+      project_id: string;
     };
-    expect(patchBody.labels).toEqual({ omni_project: "Sprint 42" });
+    expect(patchBody.project_id).toEqual("Sprint 42");
   });
 
   it.each([

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -89,7 +89,7 @@ import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFile
 import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import type { Conversation } from "@/hooks/useConversations";
-import { useProjects, PROJECT_LABEL_KEY } from "@/hooks/useConversations";
+import { useCreateProject, useProjects } from "@/hooks/useConversations";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
 import { useMentionBrowser } from "@/hooks/useMentionBrowser";
 import {
@@ -714,10 +714,12 @@ function LandingProjectPicker({
   value,
   onChange,
 }: {
+  /** The selected project id, or ``""`` for "No project". */
   value: string;
-  onChange: (project: string) => void;
+  onChange: (projectId: string) => void;
 }) {
   const { data: projects = [] } = useProjects();
+  const createProject = useCreateProject();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [creatingNew, setCreatingNew] = useState(false);
@@ -729,11 +731,12 @@ function LandingProjectPicker({
   }, [creatingNew]);
 
   const filtered = search
-    ? projects.filter((name) => name.toLowerCase().includes(search.toLowerCase()))
+    ? projects.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
     : projects;
+  const selectedName = projects.find((p) => p.id === value)?.name ?? "";
 
-  function pick(project: string) {
-    onChange(project);
+  function pick(projectId: string) {
+    onChange(projectId);
     setOpen(false);
     setSearch("");
     setCreatingNew(false);
@@ -742,7 +745,7 @@ function LandingProjectPicker({
 
   function commitNew() {
     const name = newName.trim();
-    if (name) pick(name);
+    if (name) createProject.mutate(name, { onSuccess: (project) => pick(project.id) });
   }
 
   const itemClass =
@@ -760,7 +763,7 @@ function LandingProjectPicker({
           {/* Label collapses to icon-only on narrow viewports (mobile),
               matching the host/workspace/worktree chips. */}
           <span className={`hidden max-w-32 truncate sm:block ${value ? "text-foreground" : ""}`}>
-            {value || "No project"}
+            {selectedName || "No project"}
           </span>
           <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
         </button>
@@ -789,10 +792,10 @@ function LandingProjectPicker({
             <span className="flex-1 truncate">No project</span>
             {value === "" && <CheckIcon className="size-3.5 shrink-0 text-primary" />}
           </button>
-          {filtered.map((name) => (
-            <button key={name} type="button" className={itemClass} onClick={() => pick(name)}>
-              <span className="flex-1 truncate">{name}</span>
-              {value === name && <CheckIcon className="size-3.5 shrink-0 text-primary" />}
+          {filtered.map((p) => (
+            <button key={p.id} type="button" className={itemClass} onClick={() => pick(p.id)}>
+              <span className="flex-1 truncate">{p.name}</span>
+              {value === p.id && <CheckIcon className="size-3.5 shrink-0 text-primary" />}
             </button>
           ))}
           {filtered.length === 0 && !creatingNew && (
@@ -2504,16 +2507,15 @@ export function NewChatLandingScreen() {
         }
         data = (await res.json()) as { id: string };
       }
-      // File the new session under the chosen project (an implicit collection
-      // stored as a conversation_labels row). Awaited so the conversations
-      // refetch below already sees the label; non-fatal if it fails — the
-      // session is created either way, just unfiled.
+      // File the new session under the chosen first-class project. Awaited so
+      // the conversations refetch below already sees it; non-fatal if it fails
+      // — the session is created either way, just unfiled.
       if (selectedProject) {
         try {
           await authenticatedFetch(`/v1/sessions/${data.id}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ labels: { [PROJECT_LABEL_KEY]: selectedProject } }),
+            body: JSON.stringify({ project_id: selectedProject }),
           });
           void queryClient.invalidateQueries({ queryKey: ["projects"] });
           // Refetch the target project folder's own paginated list so the new

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -47,7 +47,7 @@ describe("computeShiftSelectRange", () => {
 
 const { projectsMock, conversationsRef, projectSessionsMock } = vi.hoisted(() => ({
   projectsMock: [] as string[],
-  conversationsRef: { current: [] as { id: string; labels?: Record<string, string> }[] },
+  conversationsRef: { current: [] as { id: string; project_id?: string | null }[] },
   projectSessionsMock: { current: {} as Record<string, unknown[]> },
 }));
 
@@ -62,14 +62,27 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useProjects: () => ({ data: projectsMock }),
+  useProjects: () => ({
+    data: projectsMock.map((name) => ({
+      id: name,
+      name,
+      created_by: "me",
+      created_at: 0,
+      updated_at: 0,
+      permission_level: 4,
+      members: false,
+      public: false,
+    })),
+  }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectSessions: (project: string, enabled: boolean) => {
     const override = projectSessionsMock.current[project];
     const rows = !enabled
       ? []
       : (override ??
         conversationsRef.current.filter(
-          (c) => (c.labels?.omni_project ?? null) === project && (c as any).archived !== true,
+          (c) => (c.project_id ?? null) === project && (c as any).archived !== true,
         ));
     return {
       data: enabled
@@ -88,8 +101,12 @@ vi.mock("@/hooks/useConversations", () => ({
   },
   useMoveToProject: () => ({ mutate: vi.fn() }),
   useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
-  fetchProjectSessionIds: vi.fn(() => Promise.resolve([] as string[])),
-  PROJECT_LABEL_KEY: "omni_project",
+}));
+vi.mock("@/hooks/useProjectShare", () => ({
+  useLeaveProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectMembers: () => ({ data: [], isLoading: false }),
+  useShareProject: () => ({ mutate: vi.fn(), isPending: false }),
+  useUnshareProject: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
@@ -188,8 +205,8 @@ describe("Sidebar shift-click selection", () => {
     // Set up project "Alpha" with 2 sessions, plus 3 unfiled chat sessions
     projectsMock.push("Alpha");
     const sessions = [
-      conv("p1", { labels: { omni_project: "Alpha" } }),
-      conv("p2", { labels: { omni_project: "Alpha" } }),
+      conv("p1", { project_id: "Alpha" }),
+      conv("p2", { project_id: "Alpha" }),
       conv("c1"),
       conv("c2"),
       conv("c3"),
@@ -248,17 +265,17 @@ describe("Sidebar shift-click selection", () => {
     // the global list has p1,p2 but the folder's own query returns p1,p2,p3.
     projectsMock.push("Alpha");
     const sessions = [
-      conv("p1", { labels: { omni_project: "Alpha" } }),
-      conv("p2", { labels: { omni_project: "Alpha" } }),
+      conv("p1", { project_id: "Alpha" }),
+      conv("p2", { project_id: "Alpha" }),
       conv("c1"),
     ];
     mockConversations(sessions);
     // The folder's useProjectSessions returns an extra session (p3)
     // that isn't in the global paginated window.
     projectSessionsMock.current["Alpha"] = [
-      conv("p1", { labels: { omni_project: "Alpha" } }),
-      conv("p2", { labels: { omni_project: "Alpha" } }),
-      conv("p3", { labels: { omni_project: "Alpha" } }),
+      conv("p1", { project_id: "Alpha" }),
+      conv("p2", { project_id: "Alpha" }),
+      conv("p3", { project_id: "Alpha" }),
     ];
     localStorage.setItem("omnigent:expanded-project-sections", JSON.stringify(["Alpha"]));
 

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -6,7 +6,7 @@
 // are no longer listed here — they live on the Settings page.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -15,30 +15,21 @@ import type { Conversation } from "@/hooks/useConversations";
 // Project mocks are declared via vi.hoisted so they exist before the hoisted
 // vi.mock factory runs. projectsMock is mutated per-test to drive project
 // sections; moveToProjectSpy captures kebab-menu "Change project" calls.
-const {
-  projectsMock,
-  moveToProjectSpy,
-  deleteProjectSpy,
-  fetchProjectSessionIdsMock,
-  conversationsRef,
-  projectSessionsMock,
-} = vi.hoisted(() => ({
-  projectsMock: [] as string[],
-  moveToProjectSpy: vi.fn(),
-  deleteProjectSpy: vi.fn(),
-  // Server-side "ids in this project" check that gates the remove
-  // confirmation. Defaults to "no other sessions"; tests override per case.
-  fetchProjectSessionIdsMock: vi.fn(() => Promise.resolve([] as string[])),
-  // Latest conversations handed to the global-list mock. The useProjectSessions
-  // mock derives each folder's rows from this by label, mirroring the server's
-  // ?project= filter — so tests that seed project sessions via the global list
-  // keep working without a separate per-project fixture.
-  conversationsRef: { current: [] as { id: string; labels?: Record<string, string> }[] },
-  // Per-project override: when a test sets projectSessionsMock[name], the folder
-  // serves exactly those rows instead of deriving from the global list — used to
-  // prove a folder fetches its members independently of the global window.
-  projectSessionsMock: { current: {} as Record<string, unknown[]> },
-}));
+const { projectsMock, moveToProjectSpy, deleteProjectSpy, conversationsRef, projectSessionsMock } =
+  vi.hoisted(() => ({
+    projectsMock: [] as string[],
+    moveToProjectSpy: vi.fn(),
+    deleteProjectSpy: vi.fn(),
+    // Latest conversations handed to the global-list mock. The useProjectSessions
+    // mock derives each folder's rows from this by project_id, mirroring the
+    // server's ?project= filter — so tests that seed project sessions via the
+    // global list keep working without a separate per-project fixture.
+    conversationsRef: { current: [] as { id: string; project_id?: string | null }[] },
+    // Per-project override: when a test sets projectSessionsMock[name], the folder
+    // serves exactly those rows instead of deriving from the global list — used to
+    // prove a folder fetches its members independently of the global window.
+    projectSessionsMock: { current: {} as Record<string, unknown[]> },
+  }));
 
 // Mutation hooks are only invoked on row actions; stub them. useConversations
 // is the data source under test, so it's a controllable mock.
@@ -56,17 +47,33 @@ vi.mock("@/hooks/useConversations", () => ({
   // Project feature: the sidebar reads the project list to build project
   // sections, and rows fire useMoveToProject from the kebab menu. Both must
   // be stubbed or the Sidebar throws on render.
-  useProjects: () => ({ data: projectsMock }),
-  // Each project folder fetches its own sessions (server-side ?project=). Derive
-  // them from the global-list fixture by label so existing tests keep seeding
-  // project sessions there. Single page, no pagination, in this mock.
+  // projectsMock stays a list of NAMES for convenience; the hook shape is
+  // ProjectSummary, so map each name to a summary using the name as the id
+  // (ids are opaque strings — reusing the name keeps fixtures readable).
+  useProjects: () => ({
+    data: projectsMock.map((name) => ({
+      id: name,
+      name,
+      created_by: "me",
+      created_at: 0,
+      updated_at: 0,
+      permission_level: 4,
+      members: false,
+      public: false,
+    })),
+  }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  // Each project folder fetches its own sessions (server-side ?project=<id>).
+  // Derive them from the global-list fixture by project_id (== name here) so
+  // existing tests keep seeding project sessions there.
   useProjectSessions: (project: string, enabled: boolean) => {
     const override = projectSessionsMock.current[project];
     const rows = !enabled
       ? []
       : (override ??
         conversationsRef.current.filter(
-          (c) => (c.labels?.omni_project ?? null) === project && (c as any).archived !== true,
+          (c) => (c.project_id ?? null) === project && (c as any).archived !== true,
         ));
     return {
       data: enabled
@@ -85,8 +92,13 @@ vi.mock("@/hooks/useConversations", () => ({
   },
   useMoveToProject: () => ({ mutate: moveToProjectSpy }),
   useDeleteProject: () => ({ mutate: deleteProjectSpy, isPending: false, isError: false }),
-  fetchProjectSessionIds: fetchProjectSessionIdsMock,
-  PROJECT_LABEL_KEY: "omni_project",
+}));
+// The folder kebab's Leave action pulls from useProjectShare.
+vi.mock("@/hooks/useProjectShare", () => ({
+  useLeaveProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectMembers: () => ({ data: [], isLoading: false }),
+  useShareProject: () => ({ mutate: vi.fn(), isPending: false }),
+  useUnshareProject: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 // Header / dialog children that pull their own context — stub to keep the
 // test scoped to the conversation list + funnel.
@@ -165,8 +177,6 @@ beforeEach(() => {
   projectsMock.length = 0;
   moveToProjectSpy.mockReset();
   deleteProjectSpy.mockReset();
-  fetchProjectSessionIdsMock.mockReset();
-  fetchProjectSessionIdsMock.mockResolvedValue([]);
   projectSessionsMock.current = {};
 });
 afterEach(cleanup);
@@ -486,7 +496,7 @@ describe("Sidebar project sections", () => {
     projectsMock.push("Customer X");
     mockConversations([
       conv("conv_unfiled", "Claude Code"),
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
+      conv("conv_filed", "Claude Code", { project_id: "Customer X" }),
     ]);
     renderSidebar();
 
@@ -511,8 +521,8 @@ describe("Sidebar project sections", () => {
     // until you scrolled). The folder fetches them itself via useProjectSessions.
     mockConversations([conv("conv_unfiled", "Claude Code")]);
     projectSessionsMock.current["Customer X"] = [
-      conv("conv_far_1", "Claude Code", { labels: { omni_project: "Customer X" } }),
-      conv("conv_far_2", "Claude Code", { labels: { omni_project: "Customer X" } }),
+      conv("conv_far_1", "Claude Code", { project_id: "Customer X" }),
+      conv("conv_far_2", "Claude Code", { project_id: "Customer X" }),
     ];
     renderSidebar();
 
@@ -529,9 +539,7 @@ describe("Sidebar project sections", () => {
 
   it("offers a pencil that starts a new session pre-filed under the project", () => {
     projectsMock.push("Customer X");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
-    ]);
+    mockConversations([conv("conv_filed", "Claude Code", { project_id: "Customer X" })]);
     renderSidebar();
 
     // The pencil links to the landing composer with the project pre-selected
@@ -546,9 +554,7 @@ describe("Sidebar project sections", () => {
     // true: a plain pencil tap must close the full-screen sidebar overlay,
     // otherwise the pre-filed new-session page is left hidden behind it.
     projectsMock.push("Customer X");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
-    ]);
+    mockConversations([conv("conv_filed", "Claude Code", { project_id: "Customer X" })]);
     const onClose = vi.fn();
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     render(
@@ -567,9 +573,7 @@ describe("Sidebar project sections", () => {
 
   it("starts a project folder collapsed with its rows hidden", () => {
     projectsMock.push("Customer X");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
-    ]);
+    mockConversations([conv("conv_filed", "Claude Code", { project_id: "Customer X" })]);
     renderSidebar();
 
     // The folder header is present under the (default-expanded) Projects group,
@@ -582,9 +586,7 @@ describe("Sidebar project sections", () => {
 
   it("auto-expands the project folder holding the selected session", () => {
     projectsMock.push("Customer X");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
-    ]);
+    mockConversations([conv("conv_filed", "Claude Code", { project_id: "Customer X" })]);
     // Render with the filed session active (a matched /c/:conversationId route
     // so useParams resolves), instead of the default renderSidebar() which
     // mounts at "/".
@@ -612,8 +614,8 @@ describe("Sidebar project sections", () => {
   it("moves a pinned project session out into the global Pinned section", () => {
     projectsMock.push("Customer X");
     mockConversations([
-      conv("conv_plain", "Claude Code", { labels: { omni_project: "Customer X" } }),
-      conv("conv_pinned", "Claude Code", { labels: { omni_project: "Customer X" } }),
+      conv("conv_plain", "Claude Code", { project_id: "Customer X" }),
+      conv("conv_pinned", "Claude Code", { project_id: "Customer X" }),
     ]);
     // Pin one of the filed sessions via localStorage (client-side pins).
     localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pinned"]));
@@ -634,7 +636,7 @@ describe("Sidebar project sections", () => {
   it("does not render a project section when useProjects returns nothing", () => {
     // A session with a stale project label but no matching project entry stays
     // in Chats — projects are driven by the project list, not the labels alone.
-    mockConversations([conv("conv_filed", "Claude Code", { labels: { omni_project: "Ghost" } })]);
+    mockConversations([conv("conv_filed", "Claude Code", { project_id: "Ghost" })]);
     renderSidebar();
 
     expect(screen.queryByText("Ghost")).toBeNull();
@@ -645,8 +647,8 @@ describe("Sidebar project sections", () => {
   it("expands all project folders at once and reverts to the previously-open set", () => {
     projectsMock.push("Alpha", "Beta");
     mockConversations([
-      conv("conv_a", "Claude Code", { labels: { omni_project: "Alpha" } }),
-      conv("conv_b", "Claude Code", { labels: { omni_project: "Beta" } }),
+      conv("conv_a", "Claude Code", { project_id: "Alpha" }),
+      conv("conv_b", "Claude Code", { project_id: "Beta" }),
     ]);
     renderSidebar();
 
@@ -678,8 +680,8 @@ describe("Sidebar project sections", () => {
     // state), reverting collapses everything rather than restoring a stale set.
     projectsMock.push("Alpha", "Beta");
     mockConversations([
-      conv("conv_a", "Claude Code", { labels: { omni_project: "Alpha" } }),
-      conv("conv_b", "Claude Code", { labels: { omni_project: "Beta" } }),
+      conv("conv_a", "Claude Code", { project_id: "Alpha" }),
+      conv("conv_b", "Claude Code", { project_id: "Beta" }),
     ]);
     renderSidebar();
 
@@ -717,8 +719,8 @@ describe("Sidebar project sections", () => {
     // expand-all / revert would be a no-op — the control must not show.
     projectsMock.push("Alpha", "Beta");
     mockConversations([
-      conv("conv_a", "Claude Code", { labels: { omni_project: "Alpha" } }),
-      conv("conv_b", "Claude Code", { labels: { omni_project: "Beta" } }),
+      conv("conv_a", "Claude Code", { project_id: "Alpha" }),
+      conv("conv_b", "Claude Code", { project_id: "Beta" }),
     ]);
     renderSidebar();
 
@@ -735,11 +737,9 @@ describe("Sidebar project sections", () => {
     expect(screen.getByTestId("expand-all-projects")).toBeInTheDocument();
   });
 
-  it("deletes a project (and all its sessions) from the folder kebab after confirming", async () => {
+  it("deletes a project from the folder kebab after confirming (chats are kept)", async () => {
     projectsMock.push("Customer X");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Customer X" } }),
-    ]);
+    mockConversations([conv("conv_filed", "Claude Code", { project_id: "Customer X" })]);
     renderSidebar();
 
     // Open the project folder's kebab → "Delete project".
@@ -749,9 +749,9 @@ describe("Sidebar project sections", () => {
     });
     fireEvent.click(await screen.findByTestId("delete-project"));
 
-    // The confirmation makes clear it removes every session, then fires the
-    // delete with the project name.
-    expect(screen.getByText(/all of its sessions/i)).toBeInTheDocument();
+    // The confirmation makes clear the chats survive, then fires the delete
+    // with the project id.
+    expect(screen.getByText(/chats are/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Delete project" }));
     expect(deleteProjectSpy).toHaveBeenCalledWith("Customer X", expect.anything());
   });
@@ -764,7 +764,7 @@ describe("Sidebar collapsed project marker", () => {
     projectsMock.push("Customer X");
     mockConversations([
       conv("conv_awaiting", "Claude Code", {
-        labels: { omni_project: "Customer X" },
+        project_id: "Customer X",
         pending_elicitations_count: 1,
       }),
     ]);
@@ -781,7 +781,7 @@ describe("Sidebar collapsed project marker", () => {
     projectsMock.push("Customer X");
     mockConversations([
       conv("conv_awaiting", "Claude Code", {
-        labels: { omni_project: "Customer X" },
+        project_id: "Customer X",
         pending_elicitations_count: 1,
       }),
     ]);
@@ -796,9 +796,7 @@ describe("Sidebar collapsed project marker", () => {
 
   it("shows no header marker when no filed row has one", () => {
     projectsMock.push("Customer X");
-    mockConversations([
-      conv("conv_plain", "Claude Code", { labels: { omni_project: "Customer X" } }),
-    ]);
+    mockConversations([conv("conv_plain", "Claude Code", { project_id: "Customer X" })]);
     renderSidebar();
 
     const header = screen.getByRole("button", { name: /^Customer X/ });
@@ -887,7 +885,7 @@ describe("Sidebar pin marker visibility", () => {
 });
 
 // The kebab menu's "Change project" item opens the project picker; selecting a
-// project fires useMoveToProject with the row id and chosen project name.
+// project fires useMoveToProject with the row id and chosen project id.
 describe("Sidebar move-to-project action", () => {
   it("moves a session into a project selected from the picker", async () => {
     projectsMock.push("Sprint 42");
@@ -903,19 +901,15 @@ describe("Sidebar move-to-project action", () => {
     });
     fireEvent.click(await screen.findByTestId("move-to-project"));
 
-    // projects render as menu items inside the submenu; picking one fires the
-    // mutation with id + project.
+    // projects render as menu items inside the submenu; picking one files the
+    // session by the project's id (== name in this fixture).
     fireEvent.click(await screen.findByRole("menuitem", { name: /Sprint 42/ }));
-    expect(moveToProjectSpy).toHaveBeenCalledWith({ id: "conv_move", project: "Sprint 42" });
+    expect(moveToProjectSpy).toHaveBeenCalledWith({ id: "conv_move", projectId: "Sprint 42" });
   });
 
-  it("confirms removal only when it's the project's last session", async () => {
+  it("removes a session from its project immediately (unfile, no confirmation)", async () => {
     projectsMock.push("Sprint 42");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Sprint 42" } }),
-    ]);
-    // Server reports this is the only session in the project.
-    fetchProjectSessionIdsMock.mockResolvedValue(["conv_filed"]);
+    mockConversations([conv("conv_filed", "Claude Code", { project_id: "Sprint 42" })]);
     renderSidebar();
 
     // Expand the project folder, open the filed row's kebab → Change project.
@@ -927,44 +921,10 @@ describe("Sidebar move-to-project action", () => {
     });
     fireEvent.click(await screen.findByTestId("move-to-project"));
 
-    // Last session → "Remove from <project>" opens a confirmation that says the
-    // project will be removed too; it does NOT remove immediately.
+    // "Remove from <project>" unfiles straight away (project_id -> null) — the
+    // first-class project survives with zero chats, so there's no confirmation.
     fireEvent.click(await screen.findByRole("menuitem", { name: /Remove from Sprint 42/ }));
-    expect(await screen.findByText(/the project will be removed as well/i)).toBeInTheDocument();
-    expect(moveToProjectSpy).not.toHaveBeenCalled();
-
-    // Confirming fires the removal with an empty project (server deletes the
-    // label; the implicit project vanishes with its last session).
-    fireEvent.click(screen.getByRole("button", { name: "Remove from project" }));
-    expect(moveToProjectSpy).toHaveBeenCalledWith(
-      { id: "conv_filed", project: "" },
-      expect.anything(),
-    );
-  });
-
-  it("removes without confirmation when other sessions remain in the project", async () => {
-    projectsMock.push("Sprint 42");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { omni_project: "Sprint 42" } }),
-    ]);
-    // Server reports another session is still in the project.
-    fetchProjectSessionIdsMock.mockResolvedValue(["conv_filed", "conv_other"]);
-    renderSidebar();
-
-    fireEvent.click(screen.getByRole("button", { name: "Sprint 42" }));
-    const row = screen.getByRole("link", { name: /conv_filed/ }).closest("li")!;
-    fireEvent.pointerDown(within(row).getByRole("button", { name: "Conversation actions" }), {
-      button: 0,
-      ctrlKey: false,
-    });
-    fireEvent.click(await screen.findByTestId("move-to-project"));
-    fireEvent.click(await screen.findByRole("menuitem", { name: /Remove from Sprint 42/ }));
-
-    // Not the last session → removes straight away, no confirmation dialog.
-    await waitFor(() =>
-      expect(moveToProjectSpy).toHaveBeenCalledWith({ id: "conv_filed", project: "" }),
-    );
-    expect(screen.queryByText(/the project will be removed as well/i)).toBeNull();
+    expect(moveToProjectSpy).toHaveBeenCalledWith({ id: "conv_filed", projectId: null });
   });
 });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
   InboxIcon,
   ListChecksIcon,
   Loader2Icon,
+  LogOutIcon,
   MailIcon,
   Maximize2Icon,
   Minimize2Icon,
@@ -99,18 +100,22 @@ import {
   useConversations,
   useMoveToProject,
   useDeleteProject,
-  fetchProjectSessionIds,
-  PROJECT_LABEL_KEY,
+  useCreateProject,
+  useRenameProject,
   usePinnedConversationBackfill,
   useRenameConversation,
   useStopAndDeleteConversation,
   useStopSession,
 } from "@/hooks/useConversations";
+import type { ProjectSummary } from "@/lib/projectsApi";
+import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { showToast } from "@/components/ui/toast";
 import { PermissionsModal } from "@/components/PermissionsModal";
+import { ShareProjectModal } from "@/components/ShareProjectModal";
 import { SessionStateBadge } from "@/components/SessionStateBadge";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useLeaveProject } from "@/hooks/useProjectShare";
 import { useActiveRootSessionId } from "@/hooks/useSession";
 import { useCommentInbox } from "@/hooks/useCommentInbox";
 import { sumPendingApprovals } from "@/lib/inbox";
@@ -699,7 +704,7 @@ function InfiniteScrollSentinel({
  * window) since a collapsed folder hasn't fetched yet.
  */
 function ProjectFolder({
-  name,
+  project,
   expanded,
   marker,
   onToggleCollapsed,
@@ -714,7 +719,7 @@ function ProjectFolder({
   onProjectAssigned,
   projectRenderedIdsRef,
 }: {
-  name: string;
+  project: ProjectSummary;
   expanded: boolean;
   marker: SessionState | null;
   onToggleCollapsed: () => void;
@@ -726,10 +731,11 @@ function ProjectFolder({
   selectionMode: boolean;
   selectedIds: Set<string>;
   onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
-  onProjectAssigned?: (projectName: string) => void;
+  onProjectAssigned?: (projectId: string) => void;
   projectRenderedIdsRef?: RefObject<Map<string, string[]>>;
 }) {
-  const query = useProjectSessions(name, expanded);
+  const name = project.name;
+  const query = useProjectSessions(project.id, expanded);
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
   const conversations = useMemo(() => {
     const loaded = query.data?.pages.flatMap((page) => page.data) ?? [];
@@ -747,7 +753,7 @@ function ProjectFolder({
     [expanded, conversations],
   );
   if (projectRenderedIdsRef) {
-    projectRenderedIdsRef.current.set(name, renderedIds);
+    projectRenderedIdsRef.current.set(project.id, renderedIds);
   }
 
   // While the first page loads, show a "Loading…" footer instead of the "No
@@ -759,8 +765,8 @@ function ProjectFolder({
   // `project:` prefix keeps the droppable id clear of conversation ids (the
   // draggable ids) and the ungroup sentinel.
   const { setNodeRef, isOver } = useDroppable({
-    id: `project:${name}`,
-    data: { type: "project", name },
+    id: `project:${project.id}`,
+    data: { type: "project", projectId: project.id },
   });
 
   return (
@@ -795,7 +801,7 @@ function ProjectFolder({
         onProjectAssigned={onProjectAssigned}
         emptyMessage={loadingFirstPage ? undefined : "No chats"}
         indentRows
-        headerAction={<ProjectFolderActions projectName={name} onNavigate={onRowClick} />}
+        headerAction={<ProjectFolderActions project={project} onNavigate={onRowClick} />}
         footer={
           loadingFirstPage ? (
             <p className="px-2 py-1 pl-7 text-muted-foreground text-xs">Loading…</p>
@@ -854,8 +860,8 @@ function ConversationList({
     [conversationsQuery.data],
   );
 
-  // Project names for grouping sessions by their reserved project label.
-  const { data: projectNames = [] } = useProjects();
+  // First-class projects (owned + shared), for grouping sessions by project_id.
+  const { data: projects = [] } = useProjects();
 
   // Each ProjectFolder registers its actually-rendered conversation IDs here
   // (synchronously during render) so shift-select ranges use the real rendered
@@ -899,15 +905,14 @@ function ConversationList({
     // pinned member is excluded here (it lives under Pinned instead), so
     // pinning a project's last session leaves the folder showing "No chats".
     const filedIds = new Set<string>();
-    const projectGroups: { name: string; conversations: Conversation[] }[] = projectNames.map(
-      (name) => {
+    const projectGroups: { project: ProjectSummary; conversations: Conversation[] }[] =
+      projects.map((project) => {
         const inProject = notArchived.filter(
-          (c) => c.labels?.[PROJECT_LABEL_KEY] === name && !pinnedIdSet.has(c.id),
+          (c) => c.project_id === project.id && !pinnedIdSet.has(c.id),
         );
         inProject.forEach((c) => filedIds.add(c.id));
-        return { name, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
-      },
-    );
+        return { project, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
+      });
     // NOTE: empty projects are intentionally NOT filtered out. A project comes
     // from the server project list (useProjects), so it can have zero *loaded*
     // conversations — either genuinely empty or because its chats live on an
@@ -935,7 +940,7 @@ function ConversationList({
     pinnedSet,
     pinnedConversationIds,
     activeOverride,
-    projectNames,
+    projects,
   ]);
 
   // Collapsed section titles — persisted like pins so the preference
@@ -1049,15 +1054,6 @@ function ConversationList({
     project: string | null;
     isPinned: boolean;
   } | null>(null);
-  // A drop-to-ungroup that turned out to remove the project's last session —
-  // held here to confirm (the implicit project vanishes with it), mirroring the
-  // kebab's "Remove from project" flow. `unpin` carries through whether the
-  // dragged session was also pinned (and so must be unpinned to leave Pinned).
-  const [pendingUngroup, setPendingUngroup] = useState<{
-    id: string;
-    project: string;
-    unpin: boolean;
-  } | null>(null);
   // Mouse: a small drag threshold so a plain click still navigates / opens the
   // kebab. Touch: a press-and-hold delay so scrolling the list isn't hijacked
   // into a drag. Keyboard users use the kebab menu instead (no KeyboardSensor).
@@ -1087,11 +1083,11 @@ function ConversationList({
         target,
       );
       if (action.kind === "move") {
-        moveToProject.mutate({ id: dragged.id, project: action.project });
+        moveToProject.mutate({ id: dragged.id, projectId: action.project });
         // Unpin a pinned session so it actually drops into the folder instead of
         // staying floated up in Pinned (pin outranks project membership).
         if (action.unpin) onTogglePinned(dragged.id);
-        // Open the (possibly brand-new) folder so the session is visible in it.
+        // Open the folder so the session is visible in it.
         expandProject(action.project);
         return;
       }
@@ -1103,25 +1099,10 @@ function ConversationList({
         return;
       }
       if (action.kind === "ungroup") {
-        const unpin = action.unpin;
-        // Removing a project's LAST session deletes the implicit project, so
-        // confirm that case (server-side check, accurate regardless of the
-        // loaded window); otherwise remove silently. Mirrors the kebab flow.
-        void (async () => {
-          let isLastSession = true;
-          try {
-            const ids = await fetchProjectSessionIds(action.project);
-            isLastSession = ids.every((id) => id === dragged.id);
-          } catch {
-            isLastSession = true;
-          }
-          if (isLastSession) {
-            setPendingUngroup({ id: dragged.id, project: action.project, unpin });
-          } else {
-            moveToProject.mutate({ id: dragged.id, project: "" });
-            if (unpin) onTogglePinned(dragged.id);
-          }
-        })();
+        // Unfile the session (project_id -> null). Projects are first-class now,
+        // so removing a chat never deletes the project — no confirmation needed.
+        moveToProject.mutate({ id: dragged.id, projectId: null });
+        if (action.unpin) onTogglePinned(dragged.id);
       }
     },
     [activeDrag, moveToProject, expandProject, onTogglePinned],
@@ -1157,17 +1138,17 @@ function ConversationList({
   // as a primitive so the auto-expand effect below only fires when the
   // selection (or its project) changes — not on every background list refetch,
   // which would re-open a folder the user just collapsed.
-  const activeProjectName = useMemo(() => {
+  const activeProjectId = useMemo(() => {
     if (!activeId) return null;
     const active = allConversations.find((c) => c.id === activeId);
-    return active?.labels?.[PROJECT_LABEL_KEY] ?? null;
+    return active?.project_id ?? null;
   }, [activeId, allConversations]);
   // Auto-expand the project folder holding the selected session, so navigating
   // to a filed session reveals it instead of leaving it hidden in a collapsed
   // folder. Fires on selection only; the user can still collapse it afterward.
   useEffect(() => {
-    if (activeProjectName) expandProject(activeProjectName);
-  }, [activeProjectName, expandProject]);
+    if (activeProjectId) expandProject(activeProjectId);
+  }, [activeProjectId, expandProject]);
 
   // Visible rows in render order (collapsed sections excluded) for the Cmd+↑/↓
   // session hotkey. Titles must match the <ConversationSection> props below.
@@ -1178,11 +1159,11 @@ function ConversationList({
     // expanded AND that individual project folder is expanded (folders are
     // collapsed unless explicitly opened — inverse of the fixed sections).
     const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
-    const projectVisible = (name: string, list: readonly Conversation[]) =>
-      !projectsCollapsed && expandedProjects.includes(name) ? list : [];
+    const projectVisible = (projectId: string, list: readonly Conversation[]) =>
+      !projectsCollapsed && expandedProjects.includes(projectId) ? list : [];
     return [
       ...visible("Pinned", sections.pinned),
-      ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
+      ...sections.projectGroups.flatMap((g) => projectVisible(g.project.id, g.conversations)),
       ...visible("Chats", sections.sessions),
       ...visible("Shared with me", sections.shared),
     ].map((c) => c.id);
@@ -1200,7 +1181,9 @@ function ConversationList({
       ...vis("Pinned", sections.pinned),
       ...(projCollapsed
         ? []
-        : sections.projectGroups.flatMap((g) => projectRenderedIdsRef.current.get(g.name) ?? [])),
+        : sections.projectGroups.flatMap(
+            (g) => projectRenderedIdsRef.current.get(g.project.id) ?? [],
+          )),
       ...vis("Chats", sections.sessions),
       ...vis("Shared with me", sections.shared),
     ];
@@ -1321,12 +1304,12 @@ function ConversationList({
                   // rendered, so expand-all / revert would be a no-op — show no
                   // control at all.
                   if (effectiveCollapsedSections.includes("Projects")) return null;
-                  const allNames = sections.projectGroups.map((g) => g.name);
+                  const allIds = sections.projectGroups.map((g) => g.project.id);
                   // Once every folder is open the only useful move is to undo it,
                   // so the control flips to "revert" — which restores the set open
                   // before "Expand all", or collapses everything when there's no
                   // real last state (folders opened by hand). Otherwise it expands.
-                  const allExpanded = allNames.every((n) => expandedProjects.includes(n));
+                  const allExpanded = allIds.every((n) => expandedProjects.includes(n));
                   if (allExpanded) {
                     return (
                       <Tooltip>
@@ -1360,7 +1343,7 @@ function ConversationList({
                           data-testid="expand-all-projects"
                           onClick={(e) => {
                             e.stopPropagation();
-                            expandAllProjects(allNames);
+                            expandAllProjects(allIds);
                           }}
                         >
                           <Maximize2Icon className="size-3.5" />
@@ -1373,13 +1356,13 @@ function ConversationList({
               >
                 {sections.projectGroups.map((group) => (
                   <ProjectFolder
-                    key={group.name}
-                    name={group.name}
-                    expanded={expandedProjects.includes(group.name)}
+                    key={group.project.id}
+                    project={group.project}
+                    expanded={expandedProjects.includes(group.project.id)}
                     // Best-effort marker from the globally-loaded window: a
                     // collapsed folder hasn't fetched its own sessions yet.
                     marker={projectMarkerState(group.conversations)}
-                    onToggleCollapsed={() => toggleProjectExpanded(group.name)}
+                    onToggleCollapsed={() => toggleProjectExpanded(group.project.id)}
                     pinnedConversationIds={pinnedConversationIds}
                     activeOverride={activeOverride}
                     scrollRoot={scrollContainerRef}
@@ -1457,53 +1440,6 @@ function ConversationList({
           </div>
         ) : null}
       </DragOverlay>
-      {/* Confirm a drag-to-ungroup that removes the project's last session (the
-          implicit project disappears with it). Mirrors the kebab's dialog. */}
-      <Dialog
-        open={pendingUngroup != null}
-        onOpenChange={(open) => {
-          if (!open) setPendingUngroup(null);
-        }}
-      >
-        <DialogContent onClick={(e) => e.stopPropagation()}>
-          <DialogHeader>
-            <DialogTitle>Remove from project?</DialogTitle>
-            <DialogDescription>
-              This is the only session in{" "}
-              <span className="break-all font-medium">{pendingUngroup?.project}</span>, so{" "}
-              <span className="font-medium">the project will be removed as well</span>. The session
-              itself is kept.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setPendingUngroup(null)}
-              disabled={moveToProject.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              disabled={moveToProject.isPending}
-              onClick={() => {
-                if (!pendingUngroup) return;
-                moveToProject.mutate(
-                  { id: pendingUngroup.id, project: "" },
-                  { onSuccess: () => setPendingUngroup(null) },
-                );
-                // A pinned session must also be unpinned to leave Pinned and
-                // land in the flat list.
-                if (pendingUngroup.unpin) onTogglePinned(pendingUngroup.id);
-              }}
-            >
-              Remove from project
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </DndContext>
   );
 }
@@ -1890,7 +1826,6 @@ function ConversationMenuItems({
   setIsEditing,
   setStopOpen,
   setDeleteOpen,
-  setRemoveProjectOpen,
   setMenuOpen,
   runArchive,
 }: {
@@ -1915,7 +1850,6 @@ function ConversationMenuItems({
   setIsEditing: (editing: boolean) => void;
   setStopOpen: (open: boolean) => void;
   setDeleteOpen: (open: boolean) => void;
-  setRemoveProjectOpen: (open: boolean) => void;
   // Closes the controlled kebab after a project pick; a no-op for the
   // (uncontrolled) context menu, which Radix closes on select automatically.
   setMenuOpen: (open: boolean) => void;
@@ -2005,37 +1939,18 @@ function ConversationMenuItems({
             <ProjectPickerMenu
               components={C}
               currentProject={currentProject}
-              onSelect={(project) => {
+              onSelect={(projectId) => {
                 setMenuOpen(false);
-                // Moving to another project is harmless — apply it now,
-                // and expand that (possibly new) project so the session
-                // is visible in it rather than hidden in a collapsed folder.
-                if (project !== "") {
-                  moveToProject.mutate({ id: conversation.id, project });
-                  onProjectAssigned?.(project);
+                // "" removes the session from its project (unfile). Projects are
+                // first-class, so removing a chat never deletes the project — no
+                // confirmation needed. A project id files it there (and expands
+                // that folder so it's visible).
+                if (projectId === "") {
+                  moveToProject.mutate({ id: conversation.id, projectId: null });
                   return;
                 }
-                // Removing: only confirm when this is the project's LAST
-                // session (removing it would delete the implicit project).
-                // Otherwise remove silently. The check is server-side so
-                // it's accurate regardless of the loaded window / pins.
-                void (async () => {
-                  let isLastSession = true;
-                  if (currentProject) {
-                    try {
-                      const ids = await fetchProjectSessionIds(currentProject);
-                      isLastSession = ids.every((id) => id === conversation.id);
-                    } catch {
-                      // If the check fails, fall back to confirming.
-                      isLastSession = true;
-                    }
-                  }
-                  if (isLastSession) {
-                    setRemoveProjectOpen(true);
-                  } else {
-                    moveToProject.mutate({ id: conversation.id, project: "" });
-                  }
-                })();
+                moveToProject.mutate({ id: conversation.id, projectId });
+                onProjectAssigned?.(projectId);
               }}
             />
           </C.SubContent>
@@ -2203,9 +2118,6 @@ function ConversationRow({
   const [isEditing, setIsEditing] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [stopOpen, setStopOpen] = useState(false);
-  // True while confirming "Remove from project" — implicit projects vanish when
-  // their last session leaves, so the removal is confirmed to make that explicit.
-  const [removeProjectOpen, setRemoveProjectOpen] = useState(false);
   // The kebab menu is controlled so the project submenu can close the whole
   // menu after a pick (a plain click inside the submenu wouldn't otherwise).
   const [menuOpen, setMenuOpen] = useState(false);
@@ -2234,7 +2146,7 @@ function ConversationRow({
 
   // The session's current project (reserved label), or null when unfiled —
   // drives the kebab submenu label ("Add to project" vs "Change project").
-  const currentProject = conversation.labels?.[PROJECT_LABEL_KEY] ?? null;
+  const currentProject = conversation.project_id ?? null;
 
   const label = conversationDisplayLabel(conversation);
   // Recompute unseen state the moment the last-seen map changes (e.g. the
@@ -2432,7 +2344,6 @@ function ConversationRow({
     setIsEditing,
     setStopOpen,
     setDeleteOpen,
-    setRemoveProjectOpen,
     runArchive,
   };
 
@@ -2731,42 +2642,6 @@ function ConversationRow({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <Dialog open={removeProjectOpen} onOpenChange={setRemoveProjectOpen}>
-        <DialogContent onClick={(e) => e.stopPropagation()}>
-          <DialogHeader>
-            <DialogTitle>Remove from project?</DialogTitle>
-            <DialogDescription>
-              This is the only session in{" "}
-              <span className="break-all font-medium">{currentProject}</span>, so{" "}
-              <span className="font-medium">the project will be removed as well</span>. The session
-              itself is kept.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setRemoveProjectOpen(false)}
-              disabled={moveToProject.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              disabled={moveToProject.isPending}
-              onClick={() =>
-                moveToProject.mutate(
-                  { id: conversation.id, project: "" },
-                  { onSuccess: () => setRemoveProjectOpen(false) },
-                )
-              }
-            >
-              Remove from project
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </li>
   );
 }
@@ -2866,27 +2741,27 @@ function ArchivingRow({ label }: { label: string }) {
  * lands already selected.
  */
 function ProjectFolderActions({
-  projectName,
+  project,
   onNavigate,
 }: {
-  projectName: string;
+  project: ProjectSummary;
   /** Plain-left-click nav handler — closes the mobile overlay so the
       pre-filed new-session page isn't left hidden behind the sidebar. */
   onNavigate: (e: MouseEvent<HTMLAnchorElement>) => void;
 }) {
   return (
     <div className="flex items-center">
-      <ProjectFolderMenu projectName={projectName} />
+      <ProjectFolderMenu project={project} />
       <Button
         asChild
         type="button"
         variant="ghost"
         size="icon-sm"
-        aria-label={`New session in ${projectName}`}
+        aria-label={`New session in ${project.name}`}
         data-testid="project-new-session"
       >
         <Link
-          to={`/?project=${encodeURIComponent(projectName)}`}
+          to={`/?project=${encodeURIComponent(project.id)}`}
           onClick={(e) => {
             // Keep the click off the folder's collapse toggle, then run the
             // shared nav handler (closes the sidebar overlay on mobile).
@@ -2903,16 +2778,33 @@ function ProjectFolderActions({
 
 // ── ProjectFolderMenu ─────────────────────────────────────────────────────────
 
+// Manage-or-above (or unknown level → treat as owner, matching the rest of the
+// UI's permissive-on-null stance; the backend enforces regardless).
+const canManageProject = (level: number | null) => level == null || level >= 3;
+const isProjectOwner = (level: number | null) => level == null || level >= 4;
+
 /**
- * The kebab on a project-folder header. Currently just "Delete project", which
- * removes every session filed under the project (the implicit project then
- * disappears). Confirmation is required since it deletes sessions, not just the
- * grouping.
+ * The kebab on a project-folder header. Share / Rename for managers, Leave for
+ * a non-owner member, Delete for the owner. Access is read straight off the
+ * project's `permission_level` (no extra fetch); the backend re-checks.
  */
-function ProjectFolderMenu({ projectName }: { projectName: string }) {
+function ProjectFolderMenu({ project }: { project: ProjectSummary }) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [leaveOpen, setLeaveOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [newName, setNewName] = useState(project.name);
   const deleteProject = useDeleteProject();
+  const renameProject = useRenameProject();
+  const leaveProject = useLeaveProject(project.id);
+
+  const level = project.permission_level;
+  const canManage = canManageProject(level);
+  const owner = isProjectOwner(level);
+  // A non-owner with access can leave (drops their own grant). Owners can't
+  // orphan their own project this way.
+  const canLeave = level != null && level < 4;
 
   return (
     <>
@@ -2922,7 +2814,7 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
             type="button"
             variant="ghost"
             size="icon-sm"
-            aria-label={`Project actions for ${projectName}`}
+            aria-label={`Project actions for ${project.name}`}
             data-testid="project-actions"
             // Sits on the folder header; keep its click off the collapse toggle.
             onClick={(e) => e.stopPropagation()}
@@ -2931,32 +2823,143 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
-          <DropdownMenuItem
-            data-testid="delete-project"
-            variant="destructive"
-            onSelect={() => setDeleteOpen(true)}
-          >
-            <Trash2Icon className="size-3.5" />
-            Delete project
-          </DropdownMenuItem>
+          {canManage && (
+            <DropdownMenuItem data-testid="share-project" onSelect={() => setShareOpen(true)}>
+              <ShareIcon className="size-3.5" />
+              Share project
+            </DropdownMenuItem>
+          )}
+          {canManage && (
+            <DropdownMenuItem
+              data-testid="rename-project"
+              onSelect={() => {
+                setNewName(project.name);
+                setRenameOpen(true);
+              }}
+            >
+              <PencilIcon className="size-3.5" />
+              Rename project
+            </DropdownMenuItem>
+          )}
+          {canLeave && (
+            <DropdownMenuItem data-testid="leave-project" onSelect={() => setLeaveOpen(true)}>
+              <LogOutIcon className="size-3.5" />
+              Leave project
+            </DropdownMenuItem>
+          )}
+          {owner && (
+            <DropdownMenuItem
+              data-testid="delete-project"
+              variant="destructive"
+              onSelect={() => setDeleteOpen(true)}
+            >
+              <Trash2Icon className="size-3.5" />
+              Delete project
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
+      <ShareProjectModal
+        projectId={project.id}
+        projectName={project.name}
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+      />
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>Rename project</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Project name"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && newName.trim()) {
+                renameProject.mutate(
+                  { projectId: project.id, name: newName.trim() },
+                  { onSuccess: () => setRenameOpen(false) },
+                );
+              }
+            }}
+          />
+          {renameProject.isError && (
+            <p className="text-sm text-destructive" role="alert">
+              Couldn't rename the project (the name may already be in use).
+            </p>
+          )}
+          <DialogFooter className="border-t-0 bg-transparent">
+            <Button type="button" variant="ghost" onClick={() => setRenameOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!newName.trim() || renameProject.isPending}
+              onClick={() =>
+                renameProject.mutate(
+                  { projectId: project.id, name: newName.trim() },
+                  { onSuccess: () => setRenameOpen(false) },
+                )
+              }
+            >
+              {renameProject.isPending ? "Renaming…" : "Rename"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={leaveOpen} onOpenChange={setLeaveOpen}>
+        <DialogContent onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>Leave project?</DialogTitle>
+            <DialogDescription>
+              You'll lose access to the chats in <span className="font-medium">{project.name}</span>{" "}
+              that were shared with you. The owner can re-share them later.
+            </DialogDescription>
+          </DialogHeader>
+          {leaveProject.isError && (
+            <p className="text-sm text-destructive" role="alert">
+              Couldn't leave the project. Please try again.
+            </p>
+          )}
+          <DialogFooter className="border-t-0 bg-transparent">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setLeaveOpen(false)}
+              disabled={leaveProject.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={leaveProject.isPending}
+              onClick={() => {
+                leaveProject.mutate(undefined, {
+                  onSuccess: () => {
+                    setLeaveOpen(false);
+                    setMenuOpen(false);
+                  },
+                });
+              }}
+            >
+              {leaveProject.isPending ? "Leaving…" : "Leave project"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogHeader>
             <DialogTitle>Delete project?</DialogTitle>
             <DialogDescription>
-              This archives the project{" "}
-              <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em] break-all">
-                {projectName}
-              </span>{" "}
-              and <span className="font-medium">all of its sessions</span>. Their history is kept.
-              You can find and restore them anytime from Settings.
+              This deletes the project <span className="font-medium">{project.name}</span> and
+              everyone's access to it. Its chats are <span className="font-medium">kept</span> —
+              they move back to "Chats".
             </DialogDescription>
           </DialogHeader>
           {deleteProject.isError && (
             <p className="text-sm text-destructive" role="alert">
-              Some sessions couldn't be archived (you may not own them); the rest were archived.
+              Couldn't delete the project. Please try again.
             </p>
           )}
           <DialogFooter className="border-t-0 bg-transparent">
@@ -2973,7 +2976,7 @@ function ProjectFolderMenu({ projectName }: { projectName: string }) {
               variant="destructive"
               disabled={deleteProject.isPending}
               onClick={() => {
-                deleteProject.mutate(projectName, {
+                deleteProject.mutate(project.id, {
                   onSuccess: () => {
                     setDeleteOpen(false);
                     setMenuOpen(false);
@@ -3006,10 +3009,13 @@ function ProjectPickerMenu({
   onSelect,
 }: {
   components: MenuComponents;
+  /** The session's current project id, or ``null`` when unfiled. */
   currentProject: string | null;
-  onSelect: (project: string) => void;
+  /** Called with a project id to file into, or ``""`` to unfile. */
+  onSelect: (projectId: string) => void;
 }) {
   const { data: projects = [] } = useProjects();
+  const createProject = useCreateProject();
   const [search, setSearch] = useState("");
   const [creatingNew, setCreatingNew] = useState(false);
   const [newProjectName, setNewProjectName] = useState("");
@@ -3022,14 +3028,17 @@ function ProjectPickerMenu({
   }, [creatingNew]);
 
   const filtered = search
-    ? projects.filter((name) => name.toLowerCase().includes(search.toLowerCase()))
+    ? projects.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
     : projects;
+  const currentName = projects.find((p) => p.id === currentProject)?.name ?? null;
 
   function handleNewProjectCommit() {
     const name = newProjectName.trim();
     setCreatingNew(false);
     setNewProjectName("");
-    if (name) onSelect(name);
+    if (!name) return;
+    // Create the first-class project, then file the session into it by id.
+    createProject.mutate(name, { onSuccess: (project) => onSelect(project.id) });
   }
 
   // Keep keystrokes inside the inputs from reaching the menu's typeahead /
@@ -3051,10 +3060,10 @@ function ProjectPickerMenu({
         />
       </div>
       <div className="max-h-48 overflow-y-auto">
-        {filtered.map((name) => (
-          <C.Item key={name} onSelect={() => onSelect(name)}>
-            <span className="flex-1 truncate text-left">{name}</span>
-            {currentProject === name && (
+        {filtered.map((p) => (
+          <C.Item key={p.id} onSelect={() => onSelect(p.id)}>
+            <span className="flex-1 truncate text-left">{p.name}</span>
+            {currentProject === p.id && (
               <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />
             )}
           </C.Item>
@@ -3101,7 +3110,7 @@ function ProjectPickerMenu({
           <C.Item onSelect={() => onSelect("")}>
             Remove from{" "}
             <span className="rounded bg-muted px-1 py-0.5 font-mono text-[0.95em]">
-              {currentProject}
+              {currentName ?? "project"}
             </span>
           </C.Item>
         )}

--- a/web/src/shell/sidebarNav.test.ts
+++ b/web/src/shell/sidebarNav.test.ts
@@ -382,7 +382,7 @@ describe("resolveSidebarDrop", () => {
   });
 
   it("files an unfiled session into the project it's dropped on", () => {
-    expect(resolveSidebarDrop(src(), { type: "project", name: "Sprint 42" })).toEqual({
+    expect(resolveSidebarDrop(src(), { type: "project", projectId: "Sprint 42" })).toEqual({
       kind: "move",
       project: "Sprint 42",
       unpin: false,
@@ -391,13 +391,16 @@ describe("resolveSidebarDrop", () => {
 
   it("moves a filed session into a different project", () => {
     expect(
-      resolveSidebarDrop(src({ project: "Backlog" }), { type: "project", name: "Sprint 42" }),
+      resolveSidebarDrop(src({ project: "Backlog" }), { type: "project", projectId: "Sprint 42" }),
     ).toEqual({ kind: "move", project: "Sprint 42", unpin: false });
   });
 
   it("is a no-op when dropped on its own project folder (no pointless PATCH)", () => {
     expect(
-      resolveSidebarDrop(src({ project: "Sprint 42" }), { type: "project", name: "Sprint 42" }),
+      resolveSidebarDrop(src({ project: "Sprint 42" }), {
+        type: "project",
+        projectId: "Sprint 42",
+      }),
     ).toEqual({ kind: "none" });
   });
 
@@ -433,7 +436,7 @@ describe("resolveSidebarDrop", () => {
     expect(
       resolveSidebarDrop(src({ project: "Backlog", isPinned: true }), {
         type: "project",
-        name: "Sprint 42",
+        projectId: "Sprint 42",
       }),
     ).toEqual({ kind: "move", project: "Sprint 42", unpin: true });
   });
@@ -444,7 +447,7 @@ describe("resolveSidebarDrop", () => {
     expect(
       resolveSidebarDrop(src({ project: "Sprint 42", isPinned: true }), {
         type: "project",
-        name: "Sprint 42",
+        projectId: "Sprint 42",
       }),
     ).toEqual({ kind: "move", project: "Sprint 42", unpin: true });
   });

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -177,6 +177,7 @@ export function normalizePinnedConversationIds(
     it's already pinned. */
 export interface SidebarDragSource {
   id: string;
+  /** The project id the session is filed under, or ``null`` if unfiled. */
   project: string | null;
   isPinned: boolean;
 }
@@ -187,7 +188,7 @@ export interface SidebarDragSource {
     drop that landed on nothing droppable (e.g. "Shared with me", which is
     never a target — sessions can't be filed there). */
 export type SidebarDropTarget =
-  | { type: "project"; name: string }
+  | { type: "project"; projectId: string }
   | { type: "ungroup" }
   | { type: "pin" }
   | null;
@@ -234,8 +235,8 @@ export function resolveSidebarDrop(
     // Same project, not pinned → nothing to do. Same project but pinned → the
     // session is hidden up in Pinned, so re-file it (a no-op label write) and
     // unpin so it drops into this folder.
-    if (target.name === source.project && !source.isPinned) return { kind: "none" };
-    return { kind: "move", project: target.name, unpin: source.isPinned };
+    if (target.projectId === source.project && !source.isPinned) return { kind: "none" };
+    return { kind: "move", project: target.projectId, unpin: source.isPinned };
   }
   if (target.type === "pin") {
     // Pinning an already-pinned session is a no-op; otherwise pin it (the list


### PR DESCRIPTION
## Related issue

N/A

> **Supersedes #1729** (closed). That PR shared a project by *fanning* a grant
> out across the chats that existed at share time — chats added afterward
> inherited nothing. Per the review there ("we may need to add project as a
> first-class entity"), this reworks it into a real project entity whose ACL
> the chats **inherit**, so a share covers every chat in the project, current
> and future.

## Summary

Share an entire **project** in one action, not just individual chats — and make
**projects a first-class entity** rather than an implicit `omni_project` label.
A project has its own record and ACL; a chat filed under it inherits the
project's grants, so sharing the project grants access to all of its chats
(including ones added after the share). A **Share project** entry in the sidebar
project-folder menu opens a modal with two "everyone" scopes plus an invite
form and member list.

- **Two share scopes**, surfaced as toggles in `ShareProjectModal`:
  - **Share with all members** — a `__members__` sentinel grant that resolves
    for every authenticated user (current and future) and surfaces the project
    in their sidebar. Never resolves for an anonymous caller; capped read-only.
  - **Anyone with the link** — the `__public__` sentinel (anonymous read).
- **Data model + migration**: new `projects` (id, name, owner; name unique per
  owner) and `project_permissions` (the project ACL, mirroring
  `session_permissions`) tables, plus `conversations.project_id`. An Alembic
  migration backfills a project per distinct `(owner, label value)` from
  existing `omni_project` labels and repoints conversations; the labels are
  kept so `downgrade` is lossless.
- **API** (`/v1/projects`): create / list / get / rename / delete (delete
  **unfiles** chats — they return to "Chats", not archived) + permissions /
  members / membership (leave). `PATCH /v1/sessions/{id}` accepts `project_id`.
- **Access inheritance**: a new `ProjectStore` owns project CRUD + grants; the
  session resolver (`check_session_access` / `resolve_access` /
  `resolved_allows` / `resolved_level`) ORs in the session's project grant and
  the listing ACL unions project-shared sessions — no per-session fan-out. The
  folder menu shows **Share** / **Rename** to managers, **Leave** to a non-owner
  member, **Delete** to the owner.

**ELI5:** a project is a real object with its own guest list. Add a chat to the
project and whoever the project is shared with can see it automatically — no
re-sharing per chat.

```text
share project P with bob  ──>  bob can read every chat whose project_id == P
file a new chat into P    ──>  bob can read it too (inherited, no extra step)
```

## Future work (not in this PR)

Making projects first-class turns each of these into a small, natural
follow-up — a project now has a stable id + owner + ACL to hang them off:

- **Usage & cost per project** — aggregate the per-session `session_usage`
  (tokens / cost) across a project's chats into a project total, and a small
  project dashboard. The `project_id` FK makes this a single grouped query.
- **Project-level policies** — attach guardrail policies at the project scope
  and have chats inherit them, exactly as access now inherits (same
  resolve-then-OR pattern in the session resolver).
- **Project-scoped / global agents** — agents made available (or defaulted) to
  every chat in a project, so a client project can pin its own toolset.
- **Nice-to-haves** — archive/restore a whole project, a project default
  host/workspace for new chats, and a per-project activity feed.

These are intentionally out of scope here to keep the review focused on the
entity + sharing; each can land incrementally on top.

## Test Plan

- `uv run pytest tests/stores/test_project_store.py tests/server/integration/test_projects.py tests/server/test_permissions.py tests/server/test_openapi_drift.py tests/server/routes/test_sessions_crud.py tests/server/routes/test_session_updates_ws.py tests/stores/test_conversation_store.py tests/stores/test_permission_store.py` → **309 passed**. Headline regression: `test_projects.py::test_share_inherits_to_current_and_future_chats` shares a project, then creates a **new** chat in it → the grantee sees it with no further action, and a write attempt returns 403.
- `cd web && npm run test` → **3481 passed**; `npx tsc -b` clean; `oxlint` + `prettier --check` clean on changed files.
- `tests/e2e_ui/collaboration/test_project_sharing.py` — Playwright: share-modal toggles / invite / revoke + the Leave flow (runs in CI).
- Migration: `upgrade`/`downgrade` on a fresh DB and a seeded label-project DB — backfill produces one project per `(owner, name)` (per-user separation preserved), repoints chats, seeds owner grants; downgrade is lossless.

### How to test (use cases)

Setup — run the server in multi-user (accounts) mode so real identities exist:

```
# Terminal 1 — server
OMNIGENT_AUTH_ENABLED=1 omnigent server --host 127.0.0.1 --port 6767
# Terminal 2 — register this machine as a host (lets you create chats)
omnigent host --server http://localhost:6767
# Terminal 3 — web
cd web && npm run dev   # open http://localhost:5173
```

First visit → create the admin account (the project owner, "alice"). For more
users, alice mints an invite (**Settings → Members → Invite**) and registers
"bob" / "carol" via the invite link in an incognito window. As alice, create a
few chats and file them under one project (chat row ⋯ → **Add to project →
Create new project**, e.g. `TeamShare`).

**UC1 — Share a project with specific people.** alice: folder ⋯ → **Share
project** → **Invite by user ID** `bob`, Read → Grant. bob appears in **People
with access**, and bob (incognito) sees `TeamShare` in his sidebar and opens
the chats read-only — **including any chat alice files into the project later**.

**UC2 — See who has access (owner).** The modal's **People with access** list
shows each invited user + level; the trash icon revokes them from the whole
project. Owner and the "everyone" sentinels are intentionally not listed as
removable rows.

**UC3 — Share with all members (toggle).** alice turns on **Share with all
members** → carol, never invited, now auto-sees `TeamShare` and opens chats
read-only (future users too). Off → carol loses it.

**UC4 — Public link (toggle).** alice turns on **Anyone with the link** → a
chat's `/c/<id>` link opens in a logged-out window (anonymous read). Off → the
logged-out link stops working.

**UC5 — Rename / Leave / Delete.** A manager can **Rename** the project from the
folder ⋯. A non-owner member (bob) sees **Leave project** (not Share) → leaving
drops his access and the project leaves his sidebar. The owner's **Delete
project** removes the project and everyone's access but **keeps the chats**
(they move back to "Chats").

**Guardrails:** the members/public toggles are read-only (no "edit for
everyone"); read-only members get 403 on writes; "Leave" only removes your own
grant; you can only file a session into a project you manage.

## Demo

Project Administrator

<img width="476" height="442" alt="image" src="https://github.com/user-attachments/assets/d3212b11-95b5-4243-93f6-e9e3fc2ac653" />

<img width="300" height="159" alt="image" src="https://github.com/user-attachments/assets/37658fed-5961-4754-b818-6a69c122352b" />

Project Member
<img width="290" height="162" alt="image" src="https://github.com/user-attachments/assets/3abb83bf-31bd-4dec-a952-01209a58561e" />

Omnigent user (not project member)
Note: In this case I shared the project for all Omnigent users.

<img width="297" height="170" alt="image" src="https://github.com/user-attachments/assets/8e0609c9-3f75-4e70-8103-bc5d891358f9" />

## Type of change

- [ ] Bug fix
- [X] Feature
- [X] UI / frontend change
- [X] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [X] Integration tests added / updated
- [X] E2E tests added / updated
- [X] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Store-level unit tests cover project CRUD + the ACL (grants, `__members__` /
`__public__`, read-only cap). Integration tests exercise the full
middleware→route→store pipeline including access **inheritance** (the
regression the fan-out couldn't do), members auto-visibility for a
never-invited user, leave, delete-unfiles, and the "can't file into a project
you don't manage" guard. Permission-resolution and migration behaviour are
unit-tested; the sidebar / new-chat / shift-select / e2e project tests were
reworked to the id-based model. Manual verification confirmed the cross-user