### PR TITLE
fix(web): align expanded terminal card top with workspace rail

### DIFF
--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -142,7 +142,7 @@ interface ChatHeaderProps {
  * canvas shows through, and chat content dissolves before it slides
  * under the controls (the conversation viewport's ``chat-scroll-fade``
  * mask, index.css; chat reserves clearance via ``pt-20``,
- * terminal-first via ``pt-16``). Left slot: open-sidebar +
+ * terminal-first via ``pt-14``). Left slot: open-sidebar +
  * back-to-parent. Right slot: desktop action buttons (Agent info ·
  * Share · right-panel toggle), a mobile three-dot menu mirroring the
  * same actions, and a mobile FAB that opens the rail tabs as

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -112,9 +112,11 @@ export function MainTerminalView({
   );
 
   return (
-    // Outer wrapper fills the main column. `pt-16` clears the
-    // absolute-positioned AppShell header on desktop; iOS native gets a
-    // safe-area-aware override in index.css. `px-3` gives a 12px gutter on
+    // Outer wrapper fills the main column. `pt-14` clears the 56px
+    // absolute-positioned AppShell header on desktop (matching the
+    // workspace rail's `mt-14`, so the two cards' tops line up); iOS
+    // native gets a safe-area-aware override in index.css. `px-3` gives a
+    // 12px gutter on
     // the sides. The card stretches to full width and height of the
     // available area. The ConnectionIndicator pill renders just below
     // this wrapper in ChatPage's MainAgentSurface.
@@ -124,7 +126,7 @@ export function MainTerminalView({
       // Exposed for e2e assertions that an expand targeted the right
       // terminal (not just that the view opened).
       data-active-terminal={activeKey}
-      className="main-terminal-view flex min-h-0 flex-1 flex-col px-3 pt-16 pb-1.5"
+      className="main-terminal-view flex min-h-0 flex-1 flex-col px-3 pt-14 pb-1.5"
     >
       <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card p-3 shadow-sm">
         {terminals.length === 0 ? (


### PR DESCRIPTION
## Related issue

N/A

## Summary

The expanded shell/terminal card's top edge sat 8px lower than the workspace
rail's top edge, so the two panels didn't line up.

- Both panels clear the same 56px absolute-positioned chat header (`h-14`), but
  the terminal card used `pt-16` (64px) while the workspace rail uses `mt-14`
  (56px).
- Switch the terminal card wrapper to `pt-14` so its top matches the header
  height and lines up with the rail. Updated the two stale doc-comments that
  referenced `pt-16`.

## Test Plan

- Built the web UI (`npm run build`) and served it from a local dedicated
  omnigent server with a connected host.
- Opened the app, expanded a shell, and confirmed the terminal card's top edge
  now aligns with the workspace rail's tab bar (previously 8px lower).
- `npx prettier --check` and `npx oxlint` pass on both changed files.

## Demo

Before: terminal card top at 64px, rail top at 56px (8px misalignment).
After: both at 56px, tops flush. Pure CSS-class change (`pt-16` → `pt-14`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Layout-only Tailwind spacing change with no runtime logic to unit-test.
Verified manually by building the UI, expanding a shell in a live server, and
confirming the terminal card and workspace rail tops are flush.

## Changelog

Fixed: Aligned the expanded terminal card's top edge with the workspace rail.
