### PR TITLE
chore(areas): pause assignment to dbczumar (OOO)

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -29,7 +29,11 @@
     "               (auto-assign-reviewer.fixture.json), so ownership changes here",
     "               do not churn them. areas.test.js validates this file (every",
     "               owner in MAINTAINER, real comp:* label, 2+ owners, path",
-    "               resolution)."
+    "               resolution).",
+    "  owners_paused - optional. Owners temporarily benched (e.g. OOO). Ignored by",
+    "               every reader -- only `owners` is used for routing -- so this is",
+    "               the 'commented out, not deleted' form: to re-activate someone,",
+    "               move their login from owners_paused back into owners."
   ],
   "areas": [
     {
@@ -93,12 +97,14 @@
       ],
       "owners": [
         "dhruv0811",
-        "dbczumar",
         "TomeHirata",
         "SabhyaC26",
         "bbqiu",
         "fanzeyi",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -110,10 +116,12 @@
       ],
       "owners": [
         "dhruv0811",
-        "dbczumar",
         "bbqiu",
         "fanzeyi",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -125,10 +133,12 @@
       ],
       "owners": [
         "dhruv0811",
-        "dbczumar",
         "bbqiu",
         "fanzeyi",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -140,12 +150,14 @@
       ],
       "owners": [
         "dhruv0811",
-        "dbczumar",
         "TomeHirata",
         "SabhyaC26",
         "bbqiu",
         "fanzeyi",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -181,10 +193,12 @@
         "omnigent/spec/"
       ],
       "owners": [
-        "dbczumar",
         "TomeHirata",
         "SabhyaC26",
         "bbqiu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -210,8 +224,10 @@
       "owners": [
         "fanzeyi",
         "dhruv0811",
-        "dbczumar",
         "bbqiu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -223,7 +239,9 @@
       ],
       "owners": [
         "SabhyaC26",
-        "fanzeyi",
+        "fanzeyi"
+      ],
+      "owners_paused": [
         "dbczumar"
       ]
     },
@@ -237,10 +255,12 @@
       "owners": [
         "bbqiu",
         "aravind-segu",
-        "dbczumar",
         "fanzeyi",
         "dhruv0811",
         "SabhyaC26"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -253,13 +273,15 @@
       "owners": [
         "bbqiu",
         "aravind-segu",
-        "dbczumar",
         "fanzeyi",
         "dhruv0811",
         "SabhyaC26",
         "serena-ruan",
         "daniellok-db",
         "TomeHirata"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -270,12 +292,14 @@
         "omnigent/terminals/"
       ],
       "owners": [
-        "dbczumar",
         "fanzeyi",
         "dhruv0811",
         "aravind-segu",
         "bbqiu",
         "SabhyaC26"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -287,12 +311,14 @@
       ],
       "owners": [
         "dhruv0811",
-        "dbczumar",
         "TomeHirata",
         "SabhyaC26",
         "bbqiu",
         "fanzeyi",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -318,7 +344,9 @@
         "dhruv0811",
         "fanzeyi",
         "serena-ruan",
-        "daniellok-db",
+        "daniellok-db"
+      ],
+      "owners_paused": [
         "dbczumar"
       ]
     },
@@ -345,8 +373,10 @@
       "owners": [
         "dhruv0811",
         "PattaraS",
-        "dbczumar",
         "SabhyaC26"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -359,11 +389,13 @@
       "owners": [
         "dhruv0811",
         "fanzeyi",
-        "dbczumar",
         "SabhyaC26",
         "TomeHirata",
         "bbqiu",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -376,12 +408,14 @@
       ],
       "owners": [
         "dhruv0811",
-        "dbczumar",
         "TomeHirata",
         "SabhyaC26",
         "bbqiu",
         "fanzeyi",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -396,12 +430,14 @@
       ],
       "owners": [
         "dhruv0811",
-        "dbczumar",
         "TomeHirata",
         "SabhyaC26",
         "bbqiu",
         "fanzeyi",
         "aravind-segu"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {
@@ -414,6 +450,9 @@
       ],
       "owners": [
         "SabhyaC26",
+        "dhruv0811"
+      ],
+      "owners_paused": [
         "dbczumar"
       ]
     },
@@ -502,8 +541,10 @@
         "dhruv0811",
         "PattaraS",
         "TomeHirata",
-        "dbczumar",
         "SabhyaC26"
+      ],
+      "owners_paused": [
+        "dbczumar"
       ]
     },
     {


### PR DESCRIPTION
dbczumar is OOO for a while — this stops the issue-triage and PR-reviewer bots from routing new work to him, without losing his ownership.

## What changed
- In `.github/areas.json`, his login moves from `owners` → a sibling **`owners_paused`** array in each of the **18 areas** he owned.
- Every reader (`auto-assign-reviewer.js`, `issue-triage.yml`, `areas.test.js`) only consults `owners`, so `owners_paused` is **inert** — he simply stops being a candidate.

## Easily revertible
This is the "commented out, not deleted" form the JSON format allows: to bring him back, move each login from `owners_paused` back into `owners`. No diff-reversal or git archaeology.

## One substitution
`harness-cursor` was `[SabhyaC26, dbczumar]`. Every area needs **2+ active owners** (enforced by `areas.test.js`), so **dhruv0811** takes the active cursor seat; dbczumar sits in `owners_paused` there like everywhere else.

## Verified
`node .github/workflows/areas.test.js` and `node .github/workflows/auto-assign-reviewer.test.js` both pass — dbczumar is active in **zero** areas, paused in 18.

This pull request and its description were written by Isaac.