### PR TITLE
feat(ios): add in-app info menu with website, docs, and privacy links

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B1000000000000000000000B /* OmnigentWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000B /* OmnigentWebView.swift */; };
 		B1000000000000000000000C /* URL+Omnigent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000C /* URL+Omnigent.swift */; };
 		B10000000000000000000011 /* ChatTerminalBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* ChatTerminalBar.swift */; };
+		B10000000000000000000012 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000012 /* SafariView.swift */; };
 		B1000000000000000000000D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000D /* Assets.xcassets */; };
 		B1000000000000000000000E /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000E /* AppIcon.icon */; };
 		B20000000000000000000001 /* ServerURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ServerURLTests.swift */; };
@@ -51,6 +52,7 @@
 		A1000000000000000000000B /* OmnigentWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentWebView.swift; sourceTree = "<group>"; };
 		A1000000000000000000000C /* URL+Omnigent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Omnigent.swift"; sourceTree = "<group>"; };
 		A10000000000000000000011 /* ChatTerminalBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTerminalBar.swift; sourceTree = "<group>"; };
+		A10000000000000000000012 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		A1000000000000000000000D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1000000000000000000000E /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = AppIcon.icon; path = "../platform-assets/AppIcon.icon"; sourceTree = "<group>"; };
 		A1000000000000000000000F /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				A1000000000000000000000B /* OmnigentWebView.swift */,
 				A1000000000000000000000C /* URL+Omnigent.swift */,
 				A10000000000000000000011 /* ChatTerminalBar.swift */,
+				A10000000000000000000012 /* SafariView.swift */,
 				A1000000000000000000000D /* Assets.xcassets */,
 				A1000000000000000000000F /* Info-Debug.plist */,
 				A10000000000000000000010 /* Info-Release.plist */,
@@ -253,6 +256,7 @@
 				B1000000000000000000000B /* OmnigentWebView.swift in Sources */,
 				B1000000000000000000000C /* URL+Omnigent.swift in Sources */,
 				B10000000000000000000011 /* ChatTerminalBar.swift in Sources */,
+				B10000000000000000000012 /* SafariView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/web/ios/Omnigent/ConnectView.swift
+++ b/web/ios/Omnigent/ConnectView.swift
@@ -10,6 +10,7 @@ struct ConnectView: View {
   @State private var serverURL: String
   @State private var message: String?
   @State private var isConnecting = false
+  @State private var infoLink: InfoLink?
 
   init(prefill: String?, error: String?, onConnect: @escaping (URL) -> Void) {
     self.prefill = prefill
@@ -30,7 +31,7 @@ struct ConnectView: View {
           .frame(height: 80)
           .padding(.bottom, 12)
 
-        Text("Enter the URL of the Omnigents server. The iOS app loads its web UI directly.")
+        Text("Enter the URL of the Omnigents server.")
           .font(.system(size: 14))
           .lineSpacing(2)
           .multilineTextAlignment(.center)
@@ -121,6 +122,45 @@ struct ConnectView: View {
     .padding(.horizontal, 16)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(DesignTokens.background(colorScheme))
+    .overlay(alignment: .topTrailing) {
+      infoMenu
+        .padding(.trailing, 16)
+        .padding(.top, 8)
+    }
+    .sheet(item: $infoLink) { link in
+      SafariView(url: link.url)
+        .ignoresSafeArea()
+    }
+  }
+
+  // Tucked into the top corner so the links stay out of the way but remain
+  // reachable — a tap reveals the website, docs, and privacy policy, each
+  // opened in an in-app Safari sheet rather than kicking out to the browser.
+  private var infoMenu: some View {
+    Menu {
+      Button {
+        infoLink = .website
+      } label: {
+        Label("Website", systemImage: "globe")
+      }
+      Button {
+        infoLink = .docs
+      } label: {
+        Label("Documentation", systemImage: "book")
+      }
+      Button {
+        infoLink = .privacy
+      } label: {
+        Label("Privacy Policy", systemImage: "hand.raised")
+      }
+    } label: {
+      Image(systemName: "info.circle")
+        .font(.system(size: 20))
+        .foregroundStyle(DesignTokens.mutedForeground(colorScheme))
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
+    }
+    .accessibilityLabel("About Omnigent")
   }
 
   private var primary: Color {
@@ -150,6 +190,24 @@ struct ConnectView: View {
           message = (error as? LocalizedError)?.errorDescription ?? String(describing: error)
         }
       }
+    }
+  }
+}
+
+// External links surfaced from the info menu, presented in an in-app Safari
+// sheet. Identifiable so `.sheet(item:)` can drive the presentation.
+private enum InfoLink: Identifiable {
+  case website
+  case docs
+  case privacy
+
+  var id: Int { hashValue }
+
+  var url: URL {
+    switch self {
+    case .website: URL(string: "https://omnigent.ai")!
+    case .docs: URL(string: "https://omnigent.ai/docs")!
+    case .privacy: URL(string: "https://omnigent.ai/privacy")!
     }
   }
 }

--- a/web/ios/Omnigent/SafariView.swift
+++ b/web/ios/Omnigent/SafariView.swift
@@ -1,0 +1,14 @@
+import SafariServices
+import SwiftUI
+
+// Presents a URL in an in-app Safari sheet so external links (website, docs,
+// privacy policy) open without leaving Omnigent.
+struct SafariView: UIViewControllerRepresentable {
+  let url: URL
+
+  func makeUIViewController(context: Context) -> SFSafariViewController {
+    SFSafariViewController(url: url)
+  }
+
+  func updateUIViewController(_ controller: SFSafariViewController, context: Context) {}
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a discreet info (ⓘ) button to the top-trailing corner of the iOS
  connect screen — hidden but discoverable, and always reachable since the
  connect screen is the app's entry point.
- Tapping it opens a menu with Website, Documentation, and Privacy Policy
  links (omnigent.ai, omnigent.ai/docs, omnigent.ai/privacy), satisfying the
  need for an in-app privacy policy link.
- Present each link in an in-app Safari sheet via a new `SafariView`
  (`SFSafariViewController` wrapper) so users stay inside the app rather than
  being kicked out to the system browser.
- Trim the connect screen's server-URL description to a single line.

## Test Plan

- `swift format lint` passes on the changed files.
- `xcodebuild -scheme Omnigent` builds successfully with the new source file
  wired into the project.
- Ran the app on the iPhone 17 Pro simulator and confirmed the info icon
  renders on the connect screen; verified the menu opens and links present the
  in-app Safari sheet.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually: the change is UI-only (a SwiftUI info menu and an
SFSafariViewController wrapper on the connect screen) with no automated UI
test harness in this target. Confirmed via a clean build and running the app
on the simulator that the info icon appears and the menu links open the
in-app Safari sheet.