### PR TITLE
chore: bump main to 0.5.0.dev0

### DIFF
--- a/omnigent/version.py
+++ b/omnigent/version.py
@@ -12,4 +12,4 @@ the two in sync, so releases are cut by bumping pyproject alone (via
 ``scripts/update_versions.py``).
 """
 
-VERSION = "0.3.0.dev0"
+VERSION = "0.5.0.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "omnigent"
 # Keep in sync with omnigent/version.py's VERSION constant.
-version = "0.3.0.dev0"
+version = "0.5.0.dev0"
 description = "Omnigent: declarative agent authoring and runtime framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,8 +26,8 @@ dependencies = [
     # one version, so a published `omnigent==X` must resolve the SDK wheels
     # built alongside it (release-omnigent.yml verifies these pins match the
     # release tag). Local/editable installs still resolve via tool.uv.sources.
-    "omnigent-client==0.3.0.dev0",
-    "omnigent-ui-sdk==0.3.0.dev0",
+    "omnigent-client==0.5.0.dev0",
+    "omnigent-ui-sdk==0.5.0.dev0",
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     "openai>=1.0,<3",

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-client"
-version = "0.3.0.dev0"
+version = "0.5.0.dev0"
 description = "Python client SDK for the omnigent server API"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -16,7 +16,7 @@ dependencies = [
     # editable alongside the root ``omnigent`` package. Version-locked
     # (==) so a published SDK always pairs with the server release it
     # shipped with (release-omnigent.yml verifies the pin).
-    "omnigent==0.3.0.dev0",
+    "omnigent==0.5.0.dev0",
     "httpx>=0.27",
     "pydantic>=2.0,<3",
 ]

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-ui-sdk"
-version = "0.3.0.dev0"
+version = "0.5.0.dev0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -13,7 +13,7 @@ dependencies = [
     # at one version (release-omnigent.yml verifies the pin). A `>=`
     # floor would also reject pre-releases (e.g. 0.1.0rc1 < 0.1.0 in
     # PEP 440).
-    "omnigent-client==0.3.0.dev0",
+    "omnigent-client==0.5.0.dev0",
     "rich>=13",
     "prompt_toolkit>=3",
     "pyyaml>=6.0,<7",

--- a/uv.lock
+++ b/uv.lock
@@ -2775,7 +2775,7 @@ wheels = [
 
 [[package]]
 name = "omnigent"
-version = "0.3.0.dev0"
+version = "0.5.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2977,7 +2977,7 @@ provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "verte
 
 [[package]]
 name = "omnigent-client"
-version = "0.3.0.dev0"
+version = "0.5.0.dev0"
 source = { editable = "sdks/python-client" }
 dependencies = [
     { name = "httpx" },
@@ -2994,7 +2994,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-ui-sdk"
-version = "0.3.0.dev0"
+version = "0.5.0.dev0"
 source = { editable = "sdks/ui" }
 dependencies = [
     { name = "omnigent-client" },
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "omnigent-client", specifier = "==0.3.0.dev0" },
+    { name = "omnigent-client", specifier = "==0.5.0.dev0" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=13" },


### PR DESCRIPTION
Main was never bumped after `v0.3.0` shipped (2026-06-26) — `main` still carried `0.3.0.dev0`. We're cutting `v0.4.0` now off `release/v0.4.0`, so move `main` to the next-minor dev marker `0.5.0.dev0` (matching the established minor-bump cadence: 0.2.0.dev0 → 0.3.0.dev0).

Stamped via `scripts/update_versions.py pre-release --new-version 0.5.0.dev0` (the three pyprojects + sibling `==` pins + the `omnigent/version.py` runtime constant), plus a hand-edit of the four `uv.lock` version/specifier lines (no `uv lock` — avoids leaking the internal proxy URL into the lockfile).

`update_versions.py check --expect 0.5.0.dev0` passes.

This pull request and its description were written by Isaac.
