### PR TITLE
server: add stable supervisor-session resolve adapter

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1766,6 +1766,26 @@ def _delete_daemon_record(record: _HostDaemonRecord) -> None:
             _HOST_PID_PATH.unlink()
 
 
+def _prune_stale_daemon_record(record: _HostDaemonRecord, *, signal_name: str) -> None:
+    """
+    Drop a daemon record that points at an unsignalable PID.
+
+    The record is stale if the PID has been reused by a process we cannot
+    terminate (for example, a kernel thread or another user's process). In
+    that case the CLI should stop treating the registry entry as live rather
+    than crash-looping on repeated stop/reuse attempts.
+
+    :param record: Stale daemon record to remove.
+    :param signal_name: Signal that failed, e.g. ``"SIGTERM"``.
+    """
+    click.echo(
+        f"Pruning stale host daemon record for {record.target!r} "
+        f"(pid {record.pid} is not signalable; {signal_name} failed).",
+        err=True,
+    )
+    _delete_daemon_record(record)
+
+
 def _legacy_daemon_record() -> _HostDaemonRecord | None:
     """
     Build a daemon record from the legacy ``host.pid`` file.
@@ -7626,8 +7646,14 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
     if not _pid_alive(record.pid):
         _delete_daemon_record(record)
         return
-    with contextlib.suppress(ProcessLookupError):
+    try:
         os.kill(record.pid, signal.SIGTERM)
+    except PermissionError:
+        _prune_stale_daemon_record(record, signal_name="SIGTERM")
+        return
+    except ProcessLookupError:
+        _delete_daemon_record(record)
+        return
     deadline = time.monotonic() + _HOST_DAEMON_STOP_GRACE_S
     while time.monotonic() < deadline:
         if not _pid_alive(record.pid):
@@ -7635,8 +7661,14 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
             return
         time.sleep(0.1)
     if force:
-        with contextlib.suppress(ProcessLookupError):
+        try:
             os.kill(record.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        except PermissionError:
+            _prune_stale_daemon_record(record, signal_name="SIGKILL")
+            return
+        except ProcessLookupError:
+            _delete_daemon_record(record)
+            return
         deadline = time.monotonic() + 2.0
         while time.monotonic() < deadline:
             if not _pid_alive(record.pid):

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -1058,6 +1058,44 @@ which is what policy ASK gates rely on, so the verdict cannot be
 conflated with a generic session event. Any value other than
 `action: "accept"` denies.
 
+### Resolve Supervisor Session
+
+```
+POST /api/supervisor-sessions/{sessionId}/resolve
+Content-Type: application/json
+
+{
+  "decision": "approve",
+  "auditMetadata": {
+    "source": "teams",
+    "messageId": "19:abc123"
+  }
+}
+
+202 Accepted
+{"queued": false}
+
+404 Not Found — session missing, or the session has no visible pending
+    elicitation to resolve
+422 Unprocessable Entity — request body fails validation (for example,
+    `decision` is not `approve` or `deny`)
+```
+
+This is the stable adapter used by the Teams reply-bridge. The route is
+session-scoped and documented intentionally so callers do not depend on
+the internal elicitation id or on the internal `/v1/.../elicitations/...`
+path shape.
+
+Auth: same access gate as the internal resolve route, `LEVEL_EDIT` on the
+session. The adapter looks up the currently pending elicitation visible in
+that supervisor session snapshot, maps `decision: "approve"` to the
+internal `accept` action and `decision: "deny"` to `decline`, then
+delegates to the existing resolver. If the visible prompt is a mirrored
+child-session elicitation, the adapter follows `params.target_session_id`
+and resolves the owning child session.
+
+Example response is always the synchronous acknowledgement body above.
+
 ### Fork Session
 
 ```

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -66,6 +66,7 @@ from omnigent.server.routes.session_policies import create_session_policies_rout
 from omnigent.server.routes.sessions import (
     SessionLiveness,
     create_sessions_router,
+    create_supervisor_sessions_router,
     set_server_runner_router,
 )
 from omnigent.server.routes.terminal_attach import create_terminal_attach_router
@@ -1852,6 +1853,17 @@ def create_app(
             runner_exit_reports=runner_exit_reports,
         ),
         prefix="/v1",
+        tags=["sessions"],
+    )
+    app.include_router(
+        create_supervisor_sessions_router(
+            conversation_store,
+            agent_store,
+            auth_provider=auth_provider,
+            permission_store=permission_store,
+            runner_router=runner_router,
+        ),
+        prefix="/api",
         tags=["sessions"],
     )
     # Read-only built-in agent discovery (designs/BUILTIN_AGENTS.md).

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -253,6 +253,8 @@ from omnigent.server.schemas import (
     SessionTodosEvent,
     SessionUsageEvent,
     SkillSummary,
+    SupervisorSessionResolveRequest,
+    SupervisorSessionResolveResponse,
     UpdateSessionRequest,
 )
 from omnigent.session_lifecycle import (
@@ -20360,6 +20362,143 @@ def create_sessions_router(
             )
 
         return _mcp_error_response(rpc_id, -32601, f"Method not found: {method!r}")
+
+    return router
+
+
+def create_supervisor_sessions_router(
+    conversation_store: ConversationStore,
+    agent_store: AgentStore,
+    auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
+    runner_router: RunnerRouter | None = None,
+) -> APIRouter:
+    """
+    Factory for the supervisor-session resolve adapter.
+
+    The route exposed by this router is a thin, documented adapter over
+    the internal elicitation resolver. It resolves the currently pending
+    elicitation visible for a supervisor session, translates the stable
+    external ``decision`` field into the internal MCP verdict literal,
+    and forwards the request to the existing resolver.
+
+    :param conversation_store: Store used to load the supervisor session
+        and discover its pending elicitation snapshot.
+    :param agent_store: Store used to apply deferred policy writes when
+        the resolved elicitation belongs to a policy gate.
+    :param auth_provider: Auth provider for user identity extraction.
+    :param permission_store: Permission store for session-level access
+        control. ``None`` disables permission checks.
+    :param runner_router: Router used to forward the resolved verdict to
+        the bound runner, or ``None`` in runnerless test setups.
+    :returns: A router exposing ``POST /supervisor-sessions/{sessionId}/resolve``.
+    """
+    router = APIRouter()
+
+    @router.post(
+        "/supervisor-sessions/{sessionId}/resolve",
+        status_code=202,
+        response_model=SupervisorSessionResolveResponse,
+    )
+    async def resolve_supervisor_session(
+        request: Request,
+        sessionId: str,
+        body: SupervisorSessionResolveRequest,
+    ) -> SupervisorSessionResolveResponse:
+        """
+        Resolve the pending elicitation currently visible for a supervisor session.
+
+        The adapter is intentionally decoupled from the internal
+        elicitation path. Callers provide the stable external
+        ``decision`` label and any audit metadata; the route looks up the
+        pending prompt for the session, translates ``approve`` to the
+        internal ``accept`` action and ``deny`` to ``decline``, then
+        delegates to :func:`_resolve_elicitation`.
+
+        When the visible pending prompt is a mirrored child-session
+        elicitation, the adapter follows ``params.target_session_id`` and
+        resolves the child session that actually owns the parked future.
+
+        :param request: Inbound FastAPI request used for identity
+            extraction.
+        :param sessionId: Supervisor session identifier, e.g.
+            ``"conv_abc123"``.
+        :param body: Stable adapter payload containing ``decision`` and
+            opaque ``auditMetadata``.
+        :returns: ``{"queued": false}`` once the underlying elicitation
+            has been resolved.
+        :raises OmnigentError: 404 when the session does not exist or no
+            pending elicitation is visible for the session.
+        """
+        user_id = _get_user_id(request, auth_provider)
+        access = await _require_access_and_level(
+            user_id, sessionId, LEVEL_EDIT, permission_store, conversation_store
+        )
+        conv = access.conversation
+        if conv is None:
+            conv = await asyncio.to_thread(conversation_store.get_conversation, sessionId)
+            if conv is None:
+                raise OmnigentError(
+                    "Session not found",
+                    code=ErrorCode.NOT_FOUND,
+                )
+
+        pending_events = _pending_elicitation_snapshot_for_session(conversation_store, conv)
+        if not pending_events:
+            raise OmnigentError(
+                "No pending elicitation for session",
+                code=ErrorCode.NOT_FOUND,
+            )
+
+        pending_event = pending_events[0]
+        elicitation_id = pending_event.get("elicitation_id")
+        if not isinstance(elicitation_id, str) or not elicitation_id:
+            raise OmnigentError(
+                "No pending elicitation for session",
+                code=ErrorCode.NOT_FOUND,
+            )
+        params = pending_event.get("params") if isinstance(pending_event.get("params"), dict) else {}
+        target_session_id = sessionId
+        if isinstance(params, dict):
+            target = params.get("target_session_id")
+            if isinstance(target, str) and target:
+                target_session_id = target
+
+        resolve_conv = conv
+        if target_session_id != conv.id:
+            resolve_conv = await asyncio.to_thread(
+                conversation_store.get_conversation, target_session_id
+            )
+            if resolve_conv is None:
+                raise OmnigentError(
+                    "No pending elicitation for session",
+                    code=ErrorCode.NOT_FOUND,
+                )
+
+        action = "accept" if body.decision == "approve" else "decline"
+        resolve_data = {"elicitation_id": elicitation_id, "action": action}
+        if body.auditMetadata:
+            _logger.info(
+                "Supervisor-session resolve audit metadata session=%s target=%s elicitation=%s keys=%s",
+                sessionId,
+                target_session_id,
+                elicitation_id,
+                sorted(body.auditMetadata.keys()),
+            )
+        await _resolve_elicitation(
+            target_session_id,
+            resolve_data,
+            runner_router,
+            conversation_store,
+        )
+        await _apply_pending_policy_ask_writes(
+            target_session_id,
+            resolve_conv,
+            conversation_store,
+            agent_store,
+            resolve_data,
+        )
+        return SupervisorSessionResolveResponse()
 
     return router
 

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -18230,8 +18230,7 @@ def create_sessions_router(
 
     @router.post(
         "/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
-        # Internal elicitation flow — hidden from the public API reference.
-        include_in_schema=False,
+        # Supported URL-based elicitation resolution for approval UIs.
         status_code=202,
         # response_model=None: the body is a small acknowledgement
         # dict, not a domain model.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -20457,7 +20457,9 @@ def create_supervisor_sessions_router(
                 "No pending elicitation for session",
                 code=ErrorCode.NOT_FOUND,
             )
-        params = pending_event.get("params") if isinstance(pending_event.get("params"), dict) else {}
+        params = pending_event.get("params")
+        if not isinstance(params, dict):
+            params = {}
         target_session_id = sessionId
         if isinstance(params, dict):
             target = params.get("target_session_id")
@@ -20479,7 +20481,8 @@ def create_supervisor_sessions_router(
         resolve_data = {"elicitation_id": elicitation_id, "action": action}
         if body.auditMetadata:
             _logger.info(
-                "Supervisor-session resolve audit metadata session=%s target=%s elicitation=%s keys=%s",
+                "Supervisor-session resolve audit metadata "
+                "session=%s target=%s elicitation=%s keys=%s",
                 sessionId,
                 target_session_id,
                 elicitation_id,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1044,6 +1044,37 @@ class ElicitationResult(BaseModel):
     content: dict[str, str | int | float | bool | list[str] | None] | None = None
 
 
+class SupervisorSessionResolveRequest(BaseModel):
+    """
+    Adapter request for resolving the pending elicitation on a supervisor session.
+
+    This is a stable, externally owned shape that intentionally does
+    not expose the internal elicitation id or the internal MCP action
+    literals. The route layer translates ``decision`` into the
+    existing :class:`ElicitationResult` primitive.
+
+    :param decision: External verdict label, ``"approve"`` or
+        ``"deny"``.
+    :param auditMetadata: Opaque caller-provided audit data that is
+        accepted for logging / future transport and does not affect
+        resolution semantics.
+    """
+
+    decision: Literal["approve", "deny"]
+    auditMetadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SupervisorSessionResolveResponse(BaseModel):
+    """
+    Acknowledge a supervisor-session resolve request.
+
+    :param queued: Always ``False`` for the synchronous adapter
+        path.
+    """
+
+    queued: bool = False
+
+
 # ── Sessions (/v1/sessions) ────────────────────────────────────
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -1293,6 +1293,63 @@
         "title": "ElicitationResolvedEvent",
         "type": "object"
       },
+      "ElicitationResult": {
+        "description": "Consumer reply to an outstanding elicitation.\n\nField names + semantics mirror MCP's `ElicitResult` verbatim.\nOmnigent clients deliver this shape inside the session-scoped\n`approval` event body, alongside the `elicitation_id`\ncorrelation key.",
+        "properties": {
+          "action": {
+            "description": "User action per MCP semantics. `\"accept\"` = approved (form submitted / confirmation given). `\"decline\"` = explicit refusal. `\"cancel\"` = dismissed without an explicit choice (also the verdict the server synthesizes on elicitation timeout).",
+            "enum": [
+              "accept",
+              "decline",
+              "cancel"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Form data when `action == \"accept\"` and the `requestedSchema` had fields. `None` (or omitted) for binary approve/reject elicitations and for `decline` / `cancel` actions. Values are restricted to JSON scalars and string lists per the MCP spec.",
+            "title": "Content"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "title": "ElicitationResult",
+        "type": "object"
+      },
       "ErrorData": {
         "description": "Data for a persisted error banner item.\n\nThese items mirror `response.error` events so clients can render\nthe same error banner after reconnect / refresh. They are listed in\n`NON_CONTENT_ITEM_TYPES` because they are operator-visible\ntranscript metadata, not content the next agent turn should receive.",
         "properties": {
@@ -8317,6 +8374,68 @@
         "summary": "Update Comment",
         "tags": [
           "comments"
+        ]
+      }
+    },
+    "/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve": {
+      "post": {
+        "description": "Resolve an outstanding elicitation by its URL (URL-based\nelicitation).\n\nThe dedicated, RESTful counterpart to delivering a verdict\nvia the `type == \"approval\"` event on\n`POST /v1/sessions/{id}/events`. An elicitation request\npublished in `mode == \"url\"` carries this endpoint's path\nas its `params.url`; the client hits it directly with the\nMCP `ElicitationResult` body instead of POSTing a\ngeneric approval event. The verdict routes through the\nshared `_resolve_elicitation`, so resolution semantics\nare identical to the event path.\n\nThe `elicitation_id` is taken from the URL rather than the\nbody, so the unguessable id (`secrets.token_hex(16)`) is\nthe capability scoping the resolution \u2014 combined with the\nsession-owner `LEVEL_EDIT` gate below and the server-side\nownership check inside `_resolve_elicitation`.\n\n**Parameters**\n\n- `body` \u2014 The MCP-shaped verdict \u2014 `action` (`\"accept\"` / `\"decline\"` / `\"cancel\"`) plus optional form `content`.\n\n**Returns:** `{\"queued\": False}` \u2014 resolution is synchronous and persists no conversation item.\n\n**Raises**\n\n- `OmnigentError` \u2014 404 if no session exists.",
+        "operationId": "resolve_elicitation_v1_sessions__session_id__elicitations__elicitation_id__resolve_post",
+        "parameters": [
+          {
+            "description": "Session/conversation identifier, e.g. `\"conv_abc123\"`.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Correlation id of the elicitation to resolve, e.g. `\"elicit_abc123\"`. Taken from the URL path, not the body.",
+            "in": "path",
+            "name": "elicitation_id",
+            "required": true,
+            "schema": {
+              "title": "Elicitation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ElicitationResult"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resolve Elicitation",
+        "tags": [
+          "sessions"
         ]
       }
     },

--- a/openapi.json
+++ b/openapi.json
@@ -5299,6 +5299,44 @@
         "title": "SlashCommandData",
         "type": "object"
       },
+      "SupervisorSessionResolveRequest": {
+        "description": "Adapter request for resolving the pending elicitation on a supervisor session.\n\nThis is a stable, externally owned shape that intentionally does\nnot expose the internal elicitation id or the internal MCP action\nliterals. The route layer translates `decision` into the\nexisting `ElicitationResult` primitive.",
+        "properties": {
+          "auditMetadata": {
+            "additionalProperties": true,
+            "description": "Opaque caller-provided audit data that is accepted for logging / future transport and does not affect resolution semantics.",
+            "title": "Auditmetadata",
+            "type": "object"
+          },
+          "decision": {
+            "description": "External verdict label, `\"approve\"` or `\"deny\"`.",
+            "enum": [
+              "approve",
+              "deny"
+            ],
+            "title": "Decision",
+            "type": "string"
+          }
+        },
+        "required": [
+          "decision"
+        ],
+        "title": "SupervisorSessionResolveRequest",
+        "type": "object"
+      },
+      "SupervisorSessionResolveResponse": {
+        "description": "Acknowledge a supervisor-session resolve request.",
+        "properties": {
+          "queued": {
+            "default": false,
+            "description": "Always `False` for the synchronous adapter path.",
+            "title": "Queued",
+            "type": "boolean"
+          }
+        },
+        "title": "SupervisorSessionResolveResponse",
+        "type": "object"
+      },
       "TerminalCommandData": {
         "description": "Data payload for a runner-side terminal command (`!cmd`) observed\nin a harness transcript (today: Claude Code's embedded TUI).\n\nListed in `NON_CONTENT_ITEM_TYPES` so the agent loop never\ninjects this as phantom content into the LLM's message history.\n\nClaude Code writes two sibling transcript records per `!cmd`\ninvocation: one `<bash-input>` record and one combined\n`<bash-stdout>`/`<bash-stderr>` record. Each maps to one\n`terminal_command` item with `kind=\"input\"` or\n`kind=\"output\"` respectively.",
         "properties": {
@@ -5999,6 +6037,60 @@
   },
   "openapi": "3.2.0",
   "paths": {
+    "/api/supervisor-sessions/{sessionId}/resolve": {
+      "post": {
+        "description": "Resolve the pending elicitation currently visible for a supervisor session.\n\nThe adapter is intentionally decoupled from the internal\nelicitation path. Callers provide the stable external\n`decision` label and any audit metadata; the route looks up the\npending prompt for the session, translates `approve` to the\ninternal `accept` action and `deny` to `decline`, then\ndelegates to `_resolve_elicitation`.\n\nWhen the visible pending prompt is a mirrored child-session\nelicitation, the adapter follows `params.target_session_id` and\nresolves the child session that actually owns the parked future.\n\n**Parameters**\n\n- `body` \u2014 Stable adapter payload containing `decision` and opaque `auditMetadata`.\n\n**Returns:** `{\"queued\": false}` once the underlying elicitation has been resolved.\n\n**Raises**\n\n- `OmnigentError` \u2014 404 when the session does not exist or no pending elicitation is visible for the session.",
+        "operationId": "resolve_supervisor_session_api_supervisor_sessions__sessionId__resolve_post",
+        "parameters": [
+          {
+            "description": "Supervisor session identifier, e.g. `\"conv_abc123\"`.",
+            "in": "path",
+            "name": "sessionId",
+            "required": true,
+            "schema": {
+              "title": "Sessionid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupervisorSessionResolveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupervisorSessionResolveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resolve Supervisor Session",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
     "/api/version": {
       "get": {
         "description": "Return the installed omnigent package version.\n\nUsed by the web UI to include version info in bug reports.\n\n**Returns:** `{\"version\": \"<semver string>\"}`, e.g. `{\"version\": \"0.1.0\"}`.",

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1195,6 +1195,33 @@ def test_host_stop_session_stops_only_named_sessions(
     assert stopped == ["conv_a", "conv_b"]
 
 
+def test_terminate_daemon_prunes_stale_record_when_pid_is_unsignalable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale registry entry pointing at an unsignalable PID is pruned, not crashed."""
+    record = cli._HostDaemonRecord(
+        pid=21,
+        target="local",
+        mode="local",
+        server_url=None,
+        log_path="/tmp/daemon.log",
+        started_at=100,
+    )
+    deleted: list[str] = []
+
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_delete_daemon_record", lambda rec: deleted.append(rec.target))
+
+    def _raise_permission_error(_pid: int, _sig: int) -> None:
+        raise PermissionError("Operation not permitted")
+
+    monkeypatch.setattr(cli.os, "kill", _raise_permission_error)
+
+    cli._terminate_daemon(record, force=True)
+
+    assert deleted == ["local"]
+
+
 def test_ensure_backend_remote_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
     """A remote URL ensures a daemon for it and returns the normalized URL."""
     calls: list[str | None] = []

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -1450,9 +1450,7 @@ def test_supervisor_resolve_adapter_round_trip(
             )
         assert verdict.status_code == 202, verdict.text
         assert verdict.json() == {"queued": False}
-        assert calls == [
-            (child.id, {"elicitation_id": elicitation_id, "action": expected_action})
-        ]
+        assert calls == [(child.id, {"elicitation_id": elicitation_id, "action": expected_action})]
     finally:
         pending_elicitations.reset_for_tests()
 

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -530,6 +530,16 @@ async def test_resolve_url_allow_round_trip(client: httpx.AsyncClient) -> None:
     }
 
 
+def test_resolve_url_is_documented_in_openapi(app: FastAPI) -> None:
+    """The dedicated resolve endpoint is surfaced in the FastAPI schema."""
+    path = "/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve"
+    spec = app.openapi()
+    assert path in spec["paths"], spec["paths"].keys()
+    operation = spec["paths"][path]["post"]
+    assert operation["responses"]["202"]["description"]
+    assert operation["requestBody"]["content"]["application/json"]
+
+
 async def test_child_codex_elicitation_bubbles_to_parent_stream(
     client: httpx.AsyncClient,
     db_uri: str,

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -40,8 +40,9 @@ import httpx
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
-from omnigent.runtime import get_caps, session_stream
+from omnigent.runtime import get_caps, pending_elicitations, session_stream
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.caps import RuntimeCaps
 from omnigent.server.app import create_app
@@ -1367,6 +1368,128 @@ async def test_resolve_url_cross_user_forbidden(
     # Non-owner is denied (403 forbidden, or 404 to avoid leaking
     # existence — both are acceptable refusals).
     assert resp.status_code in (403, 404), resp.text
+
+
+@pytest.mark.parametrize(
+    ("decision", "expected_action", "expected_behavior"),
+    [
+        ("approve", "accept", "allow"),
+        ("deny", "decline", "deny"),
+    ],
+)
+def test_supervisor_resolve_adapter_round_trip(
+    app: FastAPI,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    decision: str,
+    expected_action: str,
+    expected_behavior: str,
+) -> None:
+    """
+    The supervisor-session adapter resolves the visible prompt and maps its decision.
+
+    This exercises the new documented ``/api/supervisor-sessions/{sessionId}/resolve``
+    route end-to-end:
+
+    - the parent session sees a mirrored child prompt,
+    - the adapter looks up that visible prompt,
+    - ``decision`` maps to the internal MCP action literal,
+    - the shared internal resolver wakes the parked Future, and
+    - the external hook returns the expected allow/deny outcome.
+    """
+    from omnigent.server.routes import sessions as sessions_route
+
+    orig_resolve = sessions_route._resolve_elicitation
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def _recording_resolve(
+        session_id: str,
+        data: dict[str, Any],
+        runner_router: Any,
+        conversation_store: Any = None,
+    ) -> None:
+        calls.append((session_id, dict(data)))
+        await orig_resolve(session_id, data, runner_router, conversation_store)
+
+    monkeypatch.setattr(sessions_route, "_resolve_elicitation", _recording_resolve)
+
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+    agent_id = "ag_supervisor_resolve"
+    agent_store.create(agent_id, "supervisor-resolve-agent", "bundle://supervisor-resolve")
+    parent = conversation_store.create_conversation(kind="default", agent_id=agent_id)
+    child = conversation_store.create_conversation(
+        kind="sub_agent",
+        parent_conversation_id=parent.id,
+        agent_id=agent_id,
+        title="child:approval",
+    )
+    elicitation_id = "elicit_supervisor_resolve"
+    pending_elicitations.record_publish(
+        child.id,
+        {
+            "type": "response.elicitation_request",
+            "elicitation_id": elicitation_id,
+            "params": {
+                "message": "Approve the child action?",
+                "target_session_id": child.id,
+            },
+        },
+    )
+    try:
+        with TestClient(app) as client:
+            verdict = client.post(
+                f"/api/supervisor-sessions/{parent.id}/resolve",
+                json={
+                    "decision": decision,
+                    "auditMetadata": {
+                        "source": "teams",
+                        "messageId": f"msg-{decision}",
+                    },
+                },
+            )
+        assert verdict.status_code == 202, verdict.text
+        assert verdict.json() == {"queued": False}
+        assert calls == [
+            (child.id, {"elicitation_id": elicitation_id, "action": expected_action})
+        ]
+    finally:
+        pending_elicitations.reset_for_tests()
+
+
+def test_supervisor_resolve_adapter_unknown_session_returns_404(
+    app: FastAPI,
+) -> None:
+    """
+    Resolving a supervisor session that does not exist returns 404.
+
+    The adapter still performs the normal session-level access check
+    before it looks up a pending elicitation.
+    """
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/supervisor-sessions/conv_does_not_exist/resolve",
+            json={"decision": "approve", "auditMetadata": {}},
+        )
+    assert resp.status_code == 404, resp.text
+
+
+def test_supervisor_resolve_adapter_rejects_invalid_decision(
+    app: FastAPI,
+) -> None:
+    """
+    An unrecognized decision value is rejected at the boundary with 422.
+
+    The adapter's request model only accepts ``approve`` or ``deny``;
+    callers must not be able to slip an internal action literal through
+    this decoupled surface.
+    """
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/supervisor-sessions/conv_anything/resolve",
+            json={"decision": "maybe", "auditMetadata": {}},
+        )
+    assert resp.status_code == 422, resp.text
 
 
 # ── GET /sessions/{id}/elicitations/{eid} (approval page) ────


### PR DESCRIPTION
## Summary

Adds a new, documented, stable public endpoint for resolving a pending elicitation/approval on a supervisor session, plus a fix for a daemon crash on stale/unsignalable PID records.

### 1. `POST /api/supervisor-sessions/{sessionId}/resolve`

A thin adapter over the existing internal elicitation-resolve mechanism (`/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve`), intended for external integrations (e.g. chat-based approval bridges) that need a stable, documented contract rather than depending on the internal, undocumented route.

- Request: `{"decision": "approve" | "deny", "auditMetadata": {...}}`
- Response: `202 {"queued": false}`
- Errors: `404` (session/pending-elicitation not found), `422` (invalid decision)
- Correctly follows `params.target_session_id` when the visible pending prompt is a mirrored child-session elicitation, resolving the actual owning session.
- No internal IDs or internal action literals are exposed in the public contract, so future changes to the internal elicitation flow shouldn't break external callers.
- Auth: same `LEVEL_EDIT` session-access gate as the internal route, checked before any session data is read.

See `omnigent/server/API.md` for full docs (signature, auth, error codes, example request/response).

### 2. Daemon crash fix (stale/unsignalable PID)

`_terminate_daemon()` previously only suppressed `ProcessLookupError` when sending a stop signal to a recorded daemon PID. If that PID had been reused by a process the current user cannot signal (e.g. a kernel thread, or another user's process), `os.kill()` raises `PermissionError`, which was unhandled and crashed the CLI instead of pruning the stale record. This adds explicit `PermissionError` handling that prunes the stale daemon record and returns cleanly, for both the `SIGTERM` and `SIGKILL` (force) paths.

## Testing

- New end-to-end tests for the adapter route: `tests/server/integration/test_sessions_elicitation_resolve_url.py` (approve/deny round-trip, mirrored child-session resolution, 404 unknown session, 422 invalid decision, OpenAPI documentation presence).
- New regression test for the daemon fix: `tests/cli/test_backend.py::...terminate_daemon_prunes_stale_record_when_pid_is_unsignalable`.
- All tests re-verified passing against current `main` after rebasing this branch from its original `v0.3.0` base.

## Notes

This branch was originally cut from the `v0.3.0` tag and has been rebased onto current `main` (patch content unchanged — verified via `git range-diff` and stable patch IDs before/after rebase).