### PR TITLE
fix(runner): thread session workspace cwd into spawned harness subprocesses

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -19105,27 +19105,27 @@ def _build_spawn_env_from_spec(
         )
 
         if harness == "claude-sdk":
-            env = _build_claude_sdk_spawn_env(spec, workdir=workdir)
+            env = _build_claude_sdk_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "codex":
-            env = _build_codex_spawn_env(spec, workdir=workdir)
+            env = _build_codex_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "pi":
             env = _build_pi_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "openai-agents":
             env = _build_openai_agents_sdk_spawn_env(spec)
         elif harness == "cursor":
-            env = _build_cursor_spawn_env(spec, workdir=workdir)
+            env = _build_cursor_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "antigravity":
             env = _build_antigravity_spawn_env(spec)
         elif harness == "kimi":
             env = _build_kimi_spawn_env(spec, cwd=cwd)
         elif harness == "qwen":
-            env = _build_qwen_spawn_env(spec, workdir=workdir)
+            env = _build_qwen_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "goose":
-            env = _build_goose_spawn_env(spec, workdir=workdir)
+            env = _build_goose_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "acp":
-            env = _build_acp_spawn_env(spec, workdir=workdir)
+            env = _build_acp_spawn_env(spec, cwd=cwd, workdir=workdir)
         elif harness == "copilot":
-            env = _build_copilot_spawn_env(spec, workdir=workdir)
+            env = _build_copilot_spawn_env(spec, cwd=cwd, workdir=workdir)
         else:
             builder_path = spawn_env_builders().get(harness)
             if builder_path is not None:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1152,6 +1152,7 @@ def _add_claude_sdk_skills_env(
 def _build_claude_sdk_spawn_env(
     spec: AgentSpec,
     *,
+    cwd: Path | None = None,
     workdir: Path | None = None,
 ) -> dict[str, str]:
     """
@@ -1176,6 +1177,11 @@ def _build_claude_sdk_spawn_env(
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_CLAUDE_SDK_MODEL"] = model
+    # Session workspace (the selected working folder), not the bundle workdir.
+    # Without this the SDK subprocess inherits the runner's launch cwd — see
+    # ``HARNESS_CLAUDE_SDK_CWD`` in ``omnigent/inner/claude_sdk_harness.py``.
+    if cwd is not None:
+        env["HARNESS_CLAUDE_SDK_CWD"] = str(cwd)
 
     # ── Auth resolution ────────────────────────────────────────────────
     # Priority (highest first):
@@ -1256,6 +1262,7 @@ def _build_claude_sdk_spawn_env(
 def _build_codex_spawn_env(
     spec: AgentSpec,
     *,
+    cwd: Path | None = None,
     workdir: Path | None = None,
 ) -> dict[str, str]:
     """
@@ -1312,6 +1319,11 @@ def _build_codex_spawn_env(
     env["HARNESS_CODEX_SKILLS_FILTER"] = json.dumps(spec.skills_filter)
     if spec.name:
         env["HARNESS_CODEX_AGENT_NAME"] = spec.name
+    # Session workspace (the selected working folder), not the bundle workdir.
+    # Without this the codex subprocess inherits the runner's launch cwd — see
+    # ``HARNESS_CODEX_CWD`` in ``omnigent/inner/codex_harness.py``.
+    if cwd is not None:
+        env["HARNESS_CODEX_CWD"] = str(cwd)
     if workdir is not None:
         env["HARNESS_CODEX_BUNDLE_DIR"] = str(workdir)
     os_env_payload = _serialize_os_env(spec.os_env)
@@ -1383,6 +1395,7 @@ def _build_pi_spawn_env(
 def _build_qwen_spawn_env(
     spec: AgentSpec,
     *,
+    cwd: Path | None = None,
     workdir: Path | None = None,
 ) -> dict[str, str]:
     """
@@ -1405,6 +1418,10 @@ def _build_qwen_spawn_env(
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_QWEN_MODEL"] = model
+    # Session workspace (selected working folder). ``None`` lets the qwen
+    # harness fall back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_QWEN_CWD.
+    if cwd is not None:
+        env["HARNESS_QWEN_CWD"] = str(cwd)
 
     # Generic-provider branch (slotted ahead of the legacy-profile /
     # databricks-prefix path): a ProviderAuth on the spec, or — when the spec
@@ -1428,6 +1445,7 @@ def _build_qwen_spawn_env(
 def _build_goose_spawn_env(
     spec: AgentSpec,
     *,
+    cwd: Path | None = None,
     workdir: Path | None = None,
 ) -> dict[str, str]:
     """
@@ -1451,6 +1469,10 @@ def _build_goose_spawn_env(
     model = _resolve_spec_model(spec)
     if model is not None and not model.startswith(("databricks-", "databricks/")):
         env["HARNESS_GOOSE_MODEL"] = model
+    # Session workspace (selected working folder). ``None`` lets the goose
+    # harness fall back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_GOOSE_CWD.
+    if cwd is not None:
+        env["HARNESS_GOOSE_CWD"] = str(cwd)
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_GOOSE_OS_ENV"] = os_env_payload
@@ -1460,6 +1482,7 @@ def _build_goose_spawn_env(
 def _build_acp_spawn_env(
     spec: AgentSpec,
     *,
+    cwd: Path | None = None,
     workdir: Path | None = None,
 ) -> dict[str, str]:
     """Build the env-var dict the generic ACP harness wrap reads.
@@ -1511,6 +1534,10 @@ def _build_acp_spawn_env(
     # else: no agent configured — leave HARNESS_ACP_COMMAND unset so the wrap
     # raises a clear request-time error pointing the user at `omnigent setup`.
 
+    # Session workspace (selected working folder). ``None`` lets the acp
+    # harness fall back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.
+    if cwd is not None:
+        env["HARNESS_ACP_CWD"] = str(cwd)
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_ACP_OS_ENV"] = os_env_payload
@@ -1704,6 +1731,7 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
 def _build_cursor_spawn_env(
     spec: AgentSpec,
     *,
+    cwd: Path | None = None,
     workdir: Path | None = None,
 ) -> dict[str, str]:
     """
@@ -1737,6 +1765,11 @@ def _build_cursor_spawn_env(
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_CURSOR_MODEL"] = model
+    # Session workspace (the selected working folder), not the bundle workdir.
+    # Without this the cursor subprocess inherits the runner's launch cwd — see
+    # ``HARNESS_CURSOR_CWD`` in ``omnigent/inner/cursor_harness.py``.
+    if cwd is not None:
+        env["HARNESS_CURSOR_CWD"] = str(cwd)
     # Auth precedence: an explicit api-key auth on the spec wins; with NO spec
     # auth at all, fall back to a CURSOR_API_KEY registered once via
     # ``omnigent setup`` (the dedicated ``cursor:`` config block), else an
@@ -1915,6 +1948,7 @@ def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
 def _build_copilot_spawn_env(
     spec: AgentSpec,
     *,
+    cwd: Path | None = None,
     workdir: Path | None = None,
 ) -> dict[str, str]:
     """
@@ -1948,6 +1982,11 @@ def _build_copilot_spawn_env(
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_COPILOT_MODEL"] = model
+    # Session workspace (the selected working folder), not the bundle workdir.
+    # Without this the copilot subprocess inherits the runner's launch cwd — see
+    # ``HARNESS_COPILOT_CWD`` in ``omnigent/inner/copilot_harness.py``.
+    if cwd is not None:
+        env["HARNESS_COPILOT_CWD"] = str(cwd)
     # Auth precedence: an explicit api-key auth on the spec wins (its ``api_key``
     # is the GitHub token); with NO spec auth at all, fall back to a token
     # registered once via ``omnigent setup`` (the dedicated ``copilot:`` config

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -1511,7 +1511,9 @@ async def test_runner_background_turn_emits_failed_when_spawn_env_build_raises(
             executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
         )
 
-    def _raising_build(spec: object, *, workdir: object = None) -> dict[str, str]:
+    def _raising_build(
+        spec: object, *, cwd: object = None, workdir: object = None
+    ) -> dict[str, str]:
         """
         Stand in for ``_build_claude_sdk_spawn_env`` and fail the way the
         no-model generic-provider path does.
@@ -1605,7 +1607,9 @@ async def test_runner_failed_status_carries_setup_error_message(
             executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
         )
 
-    def _raising_build(spec: object, *, workdir: object = None) -> dict[str, str]:
+    def _raising_build(
+        spec: object, *, cwd: object = None, workdir: object = None
+    ) -> dict[str, str]:
         """
         Fail the spawn-env build the way the no-model provider path does.
 

--- a/tests/runtime/test_spawn_env_cwd.py
+++ b/tests/runtime/test_spawn_env_cwd.py
@@ -1,0 +1,90 @@
+"""
+Tests that every spawn-env builder threads the session workspace ``cwd`` into
+its ``HARNESS_<H>_CWD`` env var.
+
+Regression guard for the bug where a session's selected working folder was
+honored by the Files panel / primary OS environment but NOT by the spawned
+harness subprocess (codex, claude-sdk, cursor, qwen, goose, copilot, acp):
+the builders accepted ``workdir`` (the agent bundle) but never the runtime
+``cwd``, so the subprocess inherited the runner's launch directory instead
+of the session workspace. Mirrors ``test_pi_spawn_env.py`` — pi/kimi already
+threaded ``cwd``; this locks the rest.
+
+Unit test — no subprocess spawn, no real CLIs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.runtime.workflow import (
+    _build_acp_spawn_env,
+    _build_claude_sdk_spawn_env,
+    _build_codex_spawn_env,
+    _build_copilot_spawn_env,
+    _build_cursor_spawn_env,
+    _build_goose_spawn_env,
+    _build_qwen_spawn_env,
+)
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+# (harness name, builder callable, HARNESS_<H>_CWD env var)
+_BUILDERS = [
+    ("claude-sdk", _build_claude_sdk_spawn_env, "HARNESS_CLAUDE_SDK_CWD"),
+    ("codex", _build_codex_spawn_env, "HARNESS_CODEX_CWD"),
+    ("cursor", _build_cursor_spawn_env, "HARNESS_CURSOR_CWD"),
+    ("qwen", _build_qwen_spawn_env, "HARNESS_QWEN_CWD"),
+    ("goose", _build_goose_spawn_env, "HARNESS_GOOSE_CWD"),
+    ("copilot", _build_copilot_spawn_env, "HARNESS_COPILOT_CWD"),
+    ("acp", _build_acp_spawn_env, "HARNESS_ACP_CWD"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point OMNIGENT_CONFIG_HOME at an empty temp dir so the developer's real
+    ``~/.omnigent/config.yaml`` cannot influence provider/model resolution.
+
+    Also stub ``detect_providers`` so ambient CLI config files (e.g.
+    ``~/.codex/config.toml``) on a developer's machine cannot leak into the
+    provider resolution path and cause spurious failures (matches the
+    isolation pattern in ``test_runner_dispatch.py`` / ``test_cli.py``).
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setattr("omnigent.onboarding.detected.detect_providers", list)
+
+
+def _make_spec(harness: str) -> AgentSpec:
+    return AgentSpec(
+        spec_version=1,
+        name=f"test-{harness}",
+        instructions="You are a test agent.",
+        executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+    )
+
+
+@pytest.mark.parametrize("harness,builder,cwd_var", _BUILDERS)
+def test_builder_threads_session_cwd_distinct_from_bundle(
+    tmp_path: Path, harness: str, builder, cwd_var: str
+) -> None:
+    """The session workspace lands in ``HARNESS_<H>_CWD``, separate from the
+    bundle ``workdir``. Conflating them launches the harness in the wrong repo."""
+    workspace = tmp_path / "selected-workspace"
+    workspace.mkdir()
+    bundle_dir = tmp_path / "runner-specs" / f"ag_{harness}"
+    bundle_dir.mkdir(parents=True)
+
+    env = builder(_make_spec(harness), cwd=workspace, workdir=bundle_dir)
+
+    assert env[cwd_var] == str(workspace)
+
+
+@pytest.mark.parametrize("harness,builder,cwd_var", _BUILDERS)
+def test_builder_omits_cwd_when_none(harness: str, builder, cwd_var: str) -> None:
+    """When no session workspace is provided the CWD var is absent, so the
+    harness applies its own OMNIGENT_RUNNER_WORKSPACE / inherited-cwd fallback."""
+    env = builder(_make_spec(harness), cwd=None, workdir=None)
+
+    assert cwd_var not in env


### PR DESCRIPTION
> **Status:** Rebased onto latest `main` (2026-07-08) — no conflicts, mergeable. All code CI passes; only the required *Maintainer Approval* check is pending review.

## Problem

A session's selected working folder (`snapshot.workspace`) is honored by the Files panel / primary OS environment, but **not** by the spawned harness subprocess. Starting a new session in a chosen project directory (e.g. via `FD-OC-Codex`) and asking the agent for its workspace returns the runner's **launch directory**, not the selected folder — the agent runs its tools in the wrong repository.

## Root cause

`_build_spawn_env_from_spec` (runner/app.py) receives the runtime `cwd` (from `_session_runtime_cwd`, which correctly resolves the session workspace) and forwards it only to the **pi** and **kimi** builders. The `codex`, `claude-sdk`, `cursor`, `qwen`, `goose`, and `copilot` builders neither accept `cwd` nor set their `HARNESS_<H>_CWD` env var.

The inner harnesses read that var for their working directory, e.g.:

```python
# omnigent/inner/codex_harness.py
_ENV_CWD = "HARNESS_CODEX_CWD"
...
cwd=os.environ.get(_ENV_CWD),
```

With the var unset, the harness subprocess falls back to `cwd=None` and inherits the runner's launch cwd instead of the session workspace.

## Fix

- Thread `cwd` into all six affected builders and set `HARNESS_<H>_CWD` when provided (mirrors the existing `pi`/`kimi` handling).
- Pass `cwd=cwd` at the corresponding dispatch call sites in `_build_spawn_env_from_spec`.
- `cwd=None` still omits the var, preserving each harness's own `OMNIGENT_RUNNER_WORKSPACE` / inherited-cwd fallback.

## Tests

- New `tests/runtime/test_spawn_env_cwd.py`: parametrized over all six harnesses — asserts the session workspace lands in `HARNESS_<H>_CWD` (distinct from the bundle `workdir`) and is omitted when `cwd is None`.
- Updated a `_raising_build` test double in `test_runner_dispatch.py` to mirror the new builder signature.
- `tests/runtime/test_spawn_env_cwd.py` + `test_pi_spawn_env.py` + `test_claude_sdk_spawn_env.py` + `test_runner_dispatch.py` pass locally.

## Related

- #1828 — companion fix for the **primary OS environment / Files panel**. This PR covers the **harness subprocess cwd** (codex/claude-sdk/cursor/qwen/goose/copilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
