### PR TITLE
fix(codex-native): survive a cancelled flush() barrier in the delta coalescer

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -1098,10 +1098,15 @@ class _OutputTextDeltaCoalescer:
                 buffer_message_id = None
                 buffered_chars = 0
                 flush_deadline = None
-                item.done.set_result(None)
+                # A cancelled flush() leaves its barrier queued with an
+                # already-cancelled future; set_result on it would raise
+                # InvalidStateError, kill this worker, and wedge close().
+                if not item.done.done():
+                    item.done.set_result(None)
                 continue
             await self._flush_buffer(buffer, message_id=buffer_message_id)
-            item.done.set_result(None)
+            if not item.done.done():
+                item.done.set_result(None)
             return
 
     async def _flush_buffer(self, buffer: list[str], *, message_id: str | None) -> None:

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -15,6 +15,7 @@ only an already-mirrored value is not re-posted.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -423,6 +424,60 @@ async def test_post_user_message_truly_empty_is_skipped() -> None:
     await fwd._post_user_message(client, "conv_x", {"turnId": "t1"}, item)
 
     assert client.posts == []
+
+
+# ── delta coalescer: a cancelled flush() must not kill the worker ──────
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_survives_cancelled_flush_and_still_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled ``flush()`` must not kill the delta worker.
+
+    Stopping or deleting a session cancels the forwarder task, which can be
+    awaiting ``delta_coalescer.flush()`` at that moment; the cancellation
+    leaves the queued barrier holding an already-cancelled future. The worker
+    used to die calling ``set_result`` on it (``InvalidStateError``), after
+    which ``close()`` enqueued a stop marker nobody consumed — teardown hung
+    forever and the codex app-server subprocess leaked. The worker now skips
+    completed futures: it survives the poisoned barrier and ``close()``
+    completes.
+    """
+    in_flush = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_post(
+        client: object,
+        session_id: str,
+        delta: str,
+        *,
+        message_id: str | None = None,
+        index: int | None = None,
+        final: bool | None = None,
+    ) -> None:
+        in_flush.set()
+        await release.wait()
+
+    monkeypatch.setattr(fwd, "_post_output_text_delta", fake_post)
+    coalescer = fwd._OutputTextDeltaCoalescer(None, "conv_test")  # type: ignore[arg-type]
+
+    # "\n" forces an immediate flush; the worker blocks inside the stubbed
+    # HTTP post, so the barrier below queues behind a busy worker.
+    await coalescer.append("hello\n")
+    await asyncio.wait_for(in_flush.wait(), 2.0)
+
+    flush_task = asyncio.create_task(coalescer.flush())
+    await asyncio.sleep(0)  # let flush_task block on its barrier future
+    flush_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await flush_task
+
+    # The worker resumes and dequeues the poisoned barrier: it must survive
+    # and keep serving; close() must complete instead of hanging forever.
+    release.set()
+    await asyncio.wait_for(coalescer.close(), 2.0)
+    assert coalescer._worker_task is None
 
 
 # ── sub-agent usage pricing: seed the child coalescer's model ──────────


### PR DESCRIPTION
## Related issue

Closes #1898

## Summary

- Cancelling a task that awaits `flush()` — which is what stopping/deleting/rebuilding a session does to the forwarder task — cancels the barrier future while the barrier stays queued. The worker died calling `set_result` on the cancelled future (`InvalidStateError`); with the worker dead, `close()`'s stop marker was never consumed, the teardown `finally` hung forever past the runner's 10s bounded wait, and the codex app-server subprocess plus its websocket client leaked on every such stop.
- The worker now skips already-completed futures when acknowledging flush barriers and stop markers: it survives the poisoned barrier and `close()` completes, so teardown reaches the app-server cleanup.

ELI5: the mail clerk finished his batch, then stamped a receipt that had been voided while he worked — the stamp blew up, killing him, and the "close the office" note queued behind him was never read. Now he checks whether the receipt is void before stamping.

## Test Plan

- New `test_delta_coalescer_survives_cancelled_flush_and_still_closes` — red on `main` (worker dies with `InvalidStateError`, `close()` hangs past a 2s bound), green here. Uses the real coalescer with only the HTTP post stubbed.
- `uv run --extra dev python -m pytest tests/test_codex_native_forwarder.py` → 65 passed; `ruff check`, `ruff format --check`, and `pre-commit` clean.

## Demo

Before/after — the same cancelled-flush scenario on `main` vs
<img width="2400" height="1468" alt="codex-coalescer-repro-en" src="https://github.com/user-attachments/assets/62ccf24b-3996-4e4d-9b0e-ad7995c233bf" />
 this branch:


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The race is deterministic in the new unit test (the worker is held mid-flush by a stubbed post while the flush awaiter is cancelled); no timing dependence.

## Changelog

Stopping a codex-native session mid-stream no longer leaks the codex app-server subprocess
