### PR TITLE
fix(native-forwarders): classify POST failures in kimi/qwen/goose/kiro instead of blind-retrying

### DIFF
--- a/omnigent/goose_native_forwarder.py
+++ b/omnigent/goose_native_forwarder.py
@@ -37,6 +37,8 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_may_have_been_delivered
+
 _logger = logging.getLogger(__name__)
 
 #: Seconds between store polls. Goose flushes a ``messages`` row per agentic
@@ -46,6 +48,9 @@ _logger = logging.getLogger(__name__)
 #: rather than lagging a beat behind each one. 0.4s balances liveness vs. load.
 _DEFAULT_POLL_INTERVAL_S = 0.4
 _POST_TIMEOUT_S = 30.0
+#: Bounded retries for a server-rejected item before skipping it, so one
+#: poison item can't wedge the mirror forever (matches cursor_native_forwarder).
+_MAX_ITEM_POST_ATTEMPTS = 5
 
 # Supervisor backoff (mirrors cursor_native_forwarder.supervise_cursor_forwarder).
 _SUPERVISOR_INITIAL_BACKOFF_S = 1.0
@@ -351,6 +356,8 @@ async def forward_goose_store_to_session(
     persisted = _read_state(bridge_dir)
     goose_session_id: str | None = persisted.goose_session_id
     last_id = persisted.last_id if goose_session_id is not None else 0
+    failed_msg_id = -1
+    failed_attempts = 0
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
@@ -374,7 +381,63 @@ async def forward_goose_store_to_session(
                     )
                     for item in items:
                         if item.item_type:
-                            await _post_conversation_item(client, session_id=session_id, item=item)
+                            try:
+                                await _post_conversation_item(
+                                    client, session_id=session_id, item=item
+                                )
+                            except httpx.HTTPError as exc:
+                                if post_may_have_been_delivered(exc):
+                                    # Ambiguous: the request was sent but its
+                                    # response was lost, so the server may have
+                                    # committed the item. Items aren't deduped
+                                    # server-side, so re-posting would duplicate
+                                    # the web bubble — skip past it.
+                                    _logger.warning(
+                                        "goose forwarder skipping item after an "
+                                        "ambiguous POST failure (may already be "
+                                        "committed); msg_id=%s",
+                                        item.msg_id,
+                                        exc_info=True,
+                                    )
+                                elif isinstance(exc, httpx.HTTPStatusError):
+                                    # The server received and rejected the item.
+                                    # Retry a bounded number of polls, then skip
+                                    # so one poison item can't wedge the mirror.
+                                    if item.msg_id != failed_msg_id:
+                                        failed_msg_id, failed_attempts = item.msg_id, 0
+                                    failed_attempts += 1
+                                    if failed_attempts < _MAX_ITEM_POST_ATTEMPTS:
+                                        _logger.warning(
+                                            "goose forwarder POST rejected (HTTP "
+                                            "%s); retrying; msg_id=%s attempt=%s",
+                                            exc.response.status_code,
+                                            item.msg_id,
+                                            failed_attempts,
+                                        )
+                                        break
+                                    _logger.error(
+                                        "goose forwarder dropping item after %s "
+                                        "rejected POSTs (HTTP %s); mirror would "
+                                        "otherwise wedge; msg_id=%s",
+                                        failed_attempts,
+                                        exc.response.status_code,
+                                        item.msg_id,
+                                    )
+                                else:
+                                    # Connection-level failure: the server is
+                                    # unreachable, which is not this item's
+                                    # fault. Retry next poll.
+                                    _logger.warning(
+                                        "goose forwarder POST could not reach "
+                                        "the server; retrying; msg_id=%s",
+                                        item.msg_id,
+                                        exc_info=True,
+                                    )
+                                    break
+                        # Reached on a successful post, a non-mirrored row, an
+                        # ambiguous-delivery skip, or a poison-item drop:
+                        # advance past the item.
+                        failed_msg_id, failed_attempts = -1, 0
                         last_id = item.msg_id
                         _write_state(
                             bridge_dir,

--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -38,6 +38,8 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_may_have_been_delivered
+
 _logger = logging.getLogger(__name__)
 
 #: Poll cadence for new wire-log lines (matches cursor_native_forwarder).
@@ -49,6 +51,9 @@ _DISCOVER_SKEW_MS = 10_000
 #: Supervisor backoff bounds.
 _BACKOFF_INITIAL_S = 1.0
 _BACKOFF_MAX_S = 30.0
+#: Bounded retries for a server-rejected item before skipping it, so one
+#: poison item can't wedge the mirror forever (matches cursor_native_forwarder).
+_MAX_ITEM_POST_ATTEMPTS = 5
 
 
 @dataclass
@@ -290,6 +295,8 @@ async def forward_kimi_wire_to_session(
     state = _read_state(bridge_dir)
     wire_path = Path(state.wire_path) if state is not None else None
     last_line = state.last_line if state is not None else 0
+    failed_line = -1
+    failed_attempts = 0
     async with httpx.AsyncClient(timeout=15.0) as client:
         while True:
             if wire_path is None or not wire_path.exists():
@@ -313,8 +320,52 @@ async def forward_kimi_wire_to_session(
                             agent_name=agent_name,
                         )
                     except httpx.HTTPError as exc:
-                        _logger.warning("kimi forwarder: POST failed (will retry): %s", exc)
-                        break
+                        if post_may_have_been_delivered(exc):
+                            # Ambiguous: the request was sent but its response
+                            # was lost, so the server may have committed the
+                            # item. Conversation items aren't deduped
+                            # server-side, so re-posting would duplicate the
+                            # web bubble — skip past it.
+                            _logger.warning(
+                                "kimi forwarder skipping item after an ambiguous "
+                                "POST failure (may already be committed); "
+                                "line=%s",
+                                item.line_no,
+                                exc_info=True,
+                            )
+                        elif isinstance(exc, httpx.HTTPStatusError):
+                            # The server received and rejected the item. Retry
+                            # a bounded number of polls, then skip so one
+                            # poison item can't wedge the mirror forever.
+                            if item.line_no != failed_line:
+                                failed_line, failed_attempts = item.line_no, 0
+                            failed_attempts += 1
+                            if failed_attempts < _MAX_ITEM_POST_ATTEMPTS:
+                                _logger.warning(
+                                    "kimi forwarder POST rejected (HTTP %s); "
+                                    "retrying; line=%s attempt=%s",
+                                    exc.response.status_code,
+                                    item.line_no,
+                                    failed_attempts,
+                                )
+                                break
+                            _logger.error(
+                                "kimi forwarder dropping item after %s rejected "
+                                "POSTs (HTTP %s); mirror would otherwise wedge; "
+                                "line=%s",
+                                failed_attempts,
+                                exc.response.status_code,
+                                item.line_no,
+                            )
+                        else:
+                            # Connection-level failure: the server is
+                            # unreachable, which is not this item's fault.
+                            # Retry indefinitely; the poll cadence rides it out.
+                            _logger.warning("kimi forwarder: POST failed (will retry): %s", exc)
+                            break
+                    # Reached on a successful post, an ambiguous-delivery skip,
+                    # or a poison-item drop: advance past the item.
+                    failed_line, failed_attempts = -1, 0
                     last_line = item.line_no + 1
                     _write_state(bridge_dir, _ForwardState(str(wire_path), last_line))
             await asyncio.sleep(_POLL_INTERVAL_S)

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -14,18 +14,22 @@ import json
 import logging
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_may_have_been_delivered
 from omnigent.kiro_native_bridge import write_forwarder_ready
 
 _logger = logging.getLogger(__name__)
 
 _DEFAULT_POLL_INTERVAL_S = 0.7
 _POST_TIMEOUT_S = 30.0
+#: Bounded retries for a server-rejected message before skipping it, so one
+#: poison message can't wedge the mirror forever (matches cursor_native_forwarder).
+_MAX_ITEM_POST_ATTEMPTS = 5
 _DISCOVERY_SKEW_MS = 10_000
 _STATE_FILE = "kiro_session_forwarder.json"
 
@@ -49,6 +53,9 @@ class _KiroConversationMessage:
     message_id: str
     role: str
     text: str
+    #: File offset just past this message's JSONL line, so the forward
+    #: cursor can advance per message instead of per batch.
+    end_offset: int = 0
 
 
 def _kiro_cli_sessions_dir(home: Path | None = None) -> Path:
@@ -237,7 +244,7 @@ def _read_new_kiro_messages(
                     continue
                 message = _parse_kiro_jsonl_line(line)
                 if message is not None:
-                    messages.append(message)
+                    messages.append(replace(message, end_offset=offset))
             return messages, offset
     except OSError:
         return [], byte_offset
@@ -507,6 +514,8 @@ async def forward_kiro_session_to_omnigent(
     mirrored_external_session_id: str | None = None
     last_posted_cost: float | None = None
     last_posted_model: str | None = None
+    failed_message_id: str | None = None
+    failed_attempts = 0
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
@@ -542,11 +551,12 @@ async def forward_kiro_session_to_omnigent(
                             external_session_id=state.session_id,
                         )
                         mirrored_external_session_id = state.session_id
-                    messages, byte_offset = await asyncio.to_thread(
+                    messages, batch_end_offset = await asyncio.to_thread(
                         _read_new_kiro_messages,
                         jsonl_path,
                         state.byte_offset,
                     )
+                    retry_later = False
                     for message in messages:
                         # Mirror the transcript only. Running/idle status for
                         # kiro-native is owned by the PTY watcher's ``emit_status``
@@ -555,14 +565,79 @@ async def forward_kiro_session_to_omnigent(
                         # whose forwarders mirror the transcript, not the
                         # running/idle session status. Posting status here too
                         # double-sourced it (#1137).
-                        await _post_conversation_message(
-                            client,
-                            session_id=session_id,
-                            agent_name=agent_name,
-                            message=message,
-                        )
-                    if byte_offset != state.byte_offset:
-                        state.byte_offset = byte_offset
+                        try:
+                            await _post_conversation_message(
+                                client,
+                                session_id=session_id,
+                                agent_name=agent_name,
+                                message=message,
+                            )
+                        except httpx.HTTPError as exc:
+                            if post_may_have_been_delivered(exc):
+                                # Ambiguous: the request was sent but its
+                                # response was lost, so the server may have
+                                # committed the message. Items aren't deduped
+                                # server-side, so re-posting would duplicate
+                                # the web bubble — skip past it.
+                                _logger.warning(
+                                    "kiro forwarder skipping message after an "
+                                    "ambiguous POST failure (may already be "
+                                    "committed); message_id=%s",
+                                    message.message_id,
+                                    exc_info=True,
+                                )
+                            elif isinstance(exc, httpx.HTTPStatusError):
+                                # The server received and rejected the message.
+                                # Retry a bounded number of polls, then skip so
+                                # one poison message can't wedge the mirror.
+                                if message.message_id != failed_message_id:
+                                    failed_message_id = message.message_id
+                                    failed_attempts = 0
+                                failed_attempts += 1
+                                if failed_attempts < _MAX_ITEM_POST_ATTEMPTS:
+                                    _logger.warning(
+                                        "kiro forwarder POST rejected (HTTP %s); "
+                                        "retrying; message_id=%s attempt=%s",
+                                        exc.response.status_code,
+                                        message.message_id,
+                                        failed_attempts,
+                                    )
+                                    retry_later = True
+                                    break
+                                _logger.error(
+                                    "kiro forwarder dropping message after %s "
+                                    "rejected POSTs (HTTP %s); mirror would "
+                                    "otherwise wedge; message_id=%s",
+                                    failed_attempts,
+                                    exc.response.status_code,
+                                    message.message_id,
+                                )
+                            else:
+                                # Connection-level failure: the server is
+                                # unreachable, which is not this message's
+                                # fault. Retry next poll.
+                                _logger.warning(
+                                    "kiro forwarder POST could not reach the "
+                                    "server; retrying; message_id=%s",
+                                    message.message_id,
+                                    exc_info=True,
+                                )
+                                retry_later = True
+                                break
+                        # Advance the cursor past this message as soon as it is
+                        # posted (or skipped/dropped), so a failure later in
+                        # the batch never re-posts the messages already
+                        # delivered — the old batch-level cursor did exactly
+                        # that on any transient failure.
+                        failed_message_id, failed_attempts = None, 0
+                        # Monotonic: only ever move the cursor forward.
+                        if message.end_offset > state.byte_offset:
+                            state.byte_offset = message.end_offset
+                            _write_state(bridge_dir, state)
+                    # Only cover the batch tail (trailing non-mirrorable lines)
+                    # when nothing is pending a retry.
+                    if not retry_later and batch_end_offset > state.byte_offset:
+                        state.byte_offset = batch_end_offset
                         _write_state(bridge_dir, state)
                     write_forwarder_ready(bridge_dir)
                     # Forward kiro's credit metering as authoritative session

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -57,6 +57,7 @@ from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_may_have_been_delivered
 from omnigent.qwen_native_bridge import events_file_path
 
 _logger = logging.getLogger(__name__)
@@ -65,6 +66,9 @@ _logger = logging.getLogger(__name__)
 #: sub-second cadence keeps the mirrored chat tracking the terminal step by step.
 _DEFAULT_POLL_INTERVAL_S = 0.4
 _POST_TIMEOUT_S = 30.0
+#: Bounded retries for a server-rejected item before skipping it, so one
+#: poison item can't wedge the mirror forever (matches cursor_native_forwarder).
+_MAX_ITEM_POST_ATTEMPTS = 5
 
 # Supervisor backoff (mirrors goose_native_forwarder.supervise_goose_forwarder).
 _SUPERVISOR_INITIAL_BACKOFF_S = 1.0
@@ -316,6 +320,8 @@ async def forward_qwen_events_to_session(
     persisted = _read_state(bridge_dir)
     offset = persisted.offset
     seen = _new_seen(persisted.seen_uuids)
+    failed_uuid: str | None = None
+    failed_attempts = 0
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
@@ -325,10 +331,69 @@ async def forward_qwen_events_to_session(
                 items, new_offset = await asyncio.to_thread(
                     _read_new_events, target, offset, seen, agent_name
                 )
+                retry_later = False
                 for item in items:
-                    await _post_conversation_item(client, session_id=session_id, item=item)
+                    try:
+                        await _post_conversation_item(client, session_id=session_id, item=item)
+                    except httpx.HTTPError as exc:
+                        if post_may_have_been_delivered(exc):
+                            # Ambiguous: the request was sent but its response
+                            # was lost, so the server may have committed the
+                            # item. Items aren't deduped server-side, so
+                            # re-posting would duplicate the web bubble — mark
+                            # it seen and skip past it.
+                            _logger.warning(
+                                "qwen forwarder skipping item after an ambiguous "
+                                "POST failure (may already be committed); "
+                                "uuid=%s",
+                                item.uuid,
+                                exc_info=True,
+                            )
+                        elif isinstance(exc, httpx.HTTPStatusError):
+                            # The server received and rejected the item. Retry
+                            # a bounded number of polls, then skip so one
+                            # poison item can't wedge the mirror forever.
+                            if item.uuid != failed_uuid:
+                                failed_uuid, failed_attempts = item.uuid, 0
+                            failed_attempts += 1
+                            if failed_attempts < _MAX_ITEM_POST_ATTEMPTS:
+                                _logger.warning(
+                                    "qwen forwarder POST rejected (HTTP %s); "
+                                    "retrying; uuid=%s attempt=%s",
+                                    exc.response.status_code,
+                                    item.uuid,
+                                    failed_attempts,
+                                )
+                                retry_later = True
+                                break
+                            _logger.error(
+                                "qwen forwarder dropping item after %s rejected "
+                                "POSTs (HTTP %s); mirror would otherwise wedge; "
+                                "uuid=%s",
+                                failed_attempts,
+                                exc.response.status_code,
+                                item.uuid,
+                            )
+                        else:
+                            # Connection-level failure: the server is
+                            # unreachable, which is not this item's fault.
+                            # Retry next poll; the supervisor rides it out.
+                            _logger.warning(
+                                "qwen forwarder POST could not reach the server; "
+                                "retrying; uuid=%s",
+                                item.uuid,
+                                exc_info=True,
+                            )
+                            retry_later = True
+                            break
+                    # Reached on a successful post, an ambiguous-delivery skip,
+                    # or a poison-item drop: advance past the item.
+                    failed_uuid, failed_attempts = None, 0
                     seen[item.uuid] = None
-                if new_offset != offset or items:
+                # A retry-later break must NOT advance the offset: unposted
+                # items after the failed one would be skipped forever (``seen``
+                # only covers items that were marked above).
+                if not retry_later and (new_offset != offset or items):
                     offset = new_offset
                     _write_state(
                         bridge_dir,

--- a/tests/test_goose_native_forwarder.py
+++ b/tests/test_goose_native_forwarder.py
@@ -8,9 +8,13 @@ stripping, role mapping, and the idempotent high-water cursor.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 from pathlib import Path
+
+import httpx
+import pytest
 
 from omnigent import goose_native_forwarder as f
 
@@ -110,3 +114,81 @@ def test_default_sessions_db_honors_override(monkeypatch) -> None:
     assert f.default_sessions_db() == Path("/custom/sessions.db")
     monkeypatch.delenv("GOOSE_SESSIONS_DB", raising=False)
     assert f.default_sessions_db().name == "sessions.db"
+
+
+async def _run_forward_until(tmp_path: Path, done, extra_s: float = 0.1) -> None:
+    task = asyncio.create_task(
+        f.forward_goose_store_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="goose-native-ui",
+            goose_session_name="omni-1",
+            db_path=tmp_path / "sessions.db",
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        for _ in range(600):
+            await asyncio.sleep(0.01)
+            if done():
+                break
+        # A few more polls so a wrongful re-post would show up.
+        await asyncio.sleep(extra_s)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_ambiguous_post_failure_is_not_reposted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An item whose POST response was lost is skipped, not re-posted.
+
+    The server does not dedupe ``external_conversation_item`` POSTs, so a
+    blind retry after an ambiguous failure (request sent, response lost)
+    duplicates the web bubble. Mirrors cursor-native's handling.
+    """
+    _seed_db(tmp_path / "sessions.db")
+    delivered: list[int] = []
+
+    async def _fake_post(_client: object, *, session_id: str, item: object) -> None:
+        delivered.append(item.msg_id)  # type: ignore[attr-defined]
+        if len(delivered) == 1:
+            # The server committed the item but the response was lost.
+            raise httpx.ReadTimeout("response lost after delivery")
+
+    monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
+    await _run_forward_until(tmp_path, lambda: len(set(delivered)) >= 2)
+
+    # The first row was delivered exactly once despite the lost response.
+    assert delivered == sorted(set(delivered))
+
+
+async def test_poison_item_is_skipped_after_bounded_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deterministically rejected item stops wedging the mirror forever."""
+    _seed_db(tmp_path / "sessions.db")
+    delivered: list[int] = []
+    poison_id: list[int] = []
+
+    async def _fake_post(_client: object, *, session_id: str, item: object) -> None:
+        delivered.append(item.msg_id)  # type: ignore[attr-defined]
+        if not poison_id:
+            poison_id.append(item.msg_id)  # type: ignore[attr-defined]
+        if item.msg_id == poison_id[0]:  # type: ignore[attr-defined]
+            request = httpx.Request("POST", "http://ap")
+            raise httpx.HTTPStatusError(
+                "rejected", request=request, response=httpx.Response(400, request=request)
+            )
+
+    monkeypatch.setattr(f, "_post_conversation_item", _fake_post)
+    await _run_forward_until(tmp_path, lambda: len(set(delivered)) >= 2, extra_s=0.05)
+
+    # Bounded retries for the poison row, then the mirror moves on.
+    assert delivered.count(poison_id[0]) == f._MAX_ITEM_POST_ATTEMPTS
+    later = [m for m in delivered if m != poison_id[0]]
+    assert later and len(later) == len(set(later))

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -8,9 +8,14 @@ by the e2e gate, not here.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
+import httpx
+import pytest
+
+from omnigent import kimi_native_forwarder as knf
 from omnigent.kimi_native_forwarder import (
     _discover_wire,
     _ForwardState,
@@ -165,3 +170,100 @@ class TestDiscoverWire:
         self._make_session(home, "session_stale", "/ws", mtime=1000.0)
         # launch far in the future (ms) → the 1000s-mtime session is below the floor.
         assert _discover_wire(home, "/ws", launch_epoch_ms=9_000_000_000_000) is None
+
+
+class TestPostFailureHandling:
+    """The forward loop must not blindly re-post after a failed POST.
+
+    The server does not dedupe ``external_conversation_item`` POSTs, so a
+    blind retry after an ambiguous failure (request sent, response lost)
+    duplicates the web bubble; and an item the server deterministically
+    rejects used to be retried forever, wedging the mirror for the rest of
+    the session. Mirrors the cursor-native forwarder's handling.
+    """
+
+    def _wire_row(self, uuid: str, text: str) -> dict[str, object]:
+        return {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "uuid": uuid,
+                "part": {"type": "text", "text": text},
+            },
+        }
+
+    def _bind_wire(self, tmp_path: Path, uuids: list[str]) -> None:
+        wire = tmp_path / "wire.jsonl"
+        wire.write_text(
+            "\n".join(json.dumps(self._wire_row(u, f"text-{u}")) for u in uuids) + "\n",
+            encoding="utf-8",
+        )
+        knf._write_state(tmp_path, knf._ForwardState(str(wire), 0))
+
+    async def _run_until(self, tmp_path: Path, done, extra_polls: int = 10) -> None:
+        task = asyncio.create_task(
+            knf.forward_kimi_wire_to_session(
+                base_url="http://unused",
+                headers={},
+                session_id="conv_t",
+                bridge_dir=tmp_path,
+                kimi_home=tmp_path,
+                workspace=str(tmp_path),
+                launch_epoch_ms=0,
+            )
+        )
+        try:
+            for _ in range(400):
+                await asyncio.sleep(0.01)
+                if done():
+                    break
+            # A few more polls so any wrongful re-post would show up.
+            await asyncio.sleep(0.01 * extra_polls)
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    async def test_ambiguous_post_failure_is_not_reposted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An item whose POST response was lost is skipped, not re-posted."""
+        self._bind_wire(tmp_path, ["u1", "u2"])
+        monkeypatch.setattr(knf, "_POLL_INTERVAL_S", 0.01)
+        delivered: list[str] = []
+
+        async def fake_post(client, *, base_url, headers, session_id, item, agent_name):
+            delivered.append(item.response_id)
+            if item.response_id == "kimi:u1" and delivered.count("kimi:u1") == 1:
+                # The server committed the item but the response was lost.
+                raise httpx.ReadTimeout("response lost after delivery")
+
+        monkeypatch.setattr(knf, "_post_conversation_item", fake_post)
+        await self._run_until(tmp_path, lambda: "kimi:u2" in delivered)
+
+        assert delivered == ["kimi:u1", "kimi:u2"]
+
+    async def test_poison_item_is_skipped_after_bounded_retries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deterministically rejected item stops wedging the mirror."""
+        self._bind_wire(tmp_path, ["u1", "u2"])
+        monkeypatch.setattr(knf, "_POLL_INTERVAL_S", 0.01)
+        delivered: list[str] = []
+
+        async def fake_post(client, *, base_url, headers, session_id, item, agent_name):
+            delivered.append(item.response_id)
+            if item.response_id == "kimi:u1":
+                request = httpx.Request("POST", "http://ap")
+                raise httpx.HTTPStatusError(
+                    "rejected",
+                    request=request,
+                    response=httpx.Response(400, request=request),
+                )
+
+        monkeypatch.setattr(knf, "_post_conversation_item", fake_post)
+        await self._run_until(tmp_path, lambda: "kimi:u2" in delivered)
+
+        # Bounded retries for the poison item, then the mirror moves on.
+        assert delivered.count("kimi:u1") == knf._MAX_ITEM_POST_ATTEMPTS
+        assert delivered.count("kimi:u2") == 1

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -207,12 +208,15 @@ def test_read_new_kiro_messages_returns_user_and_assistant_text(tmp_path: Path) 
 
     messages, byte_offset = forwarder._read_new_kiro_messages(jsonl_path, 0)
 
-    assert messages == [
+    assert [replace(m, end_offset=0) for m in messages] == [
         forwarder._KiroConversationMessage(message_id="user-1", role="user", text="hey"),
         forwarder._KiroConversationMessage(
             message_id="assistant-1", role="assistant", text="Hello there"
         ),
     ]
+    # Each message carries the offset just past its own line, so the forward
+    # cursor can advance per message; the last one covers the whole read.
+    assert 0 < messages[0].end_offset < messages[1].end_offset
     assert byte_offset == jsonl_path.stat().st_size
 
 
@@ -246,9 +250,10 @@ def test_read_new_kiro_messages_holds_offset_at_partial_trailing_line(tmp_path: 
 
     # Only the complete record is delivered; the offset stops at its newline,
     # not at EOF (which would skip the partial record once it's finished).
-    assert messages == [
+    assert [replace(m, end_offset=0) for m in messages] == [
         forwarder._KiroConversationMessage(message_id="user-1", role="user", text="first")
     ]
+    assert messages[0].end_offset == offset
     assert offset == len((complete + "\n").encode("utf-8"))
     assert offset < jsonl_path.stat().st_size
 
@@ -257,7 +262,7 @@ def test_read_new_kiro_messages_holds_offset_at_partial_trailing_line(tmp_path: 
         handle.write("\n")
     messages, offset = forwarder._read_new_kiro_messages(jsonl_path, offset)
 
-    assert messages == [
+    assert [replace(m, end_offset=0) for m in messages] == [
         forwarder._KiroConversationMessage(
             message_id="assistant-1", role="assistant", text="second"
         )
@@ -339,7 +344,7 @@ async def test_forward_kiro_session_posts_conversation_messages(
             launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
         )
 
-    assert posted == [
+    assert [(sid, agent, replace(msg, end_offset=0)) for sid, agent, msg in posted] == [
         (
             "conv_kiro",
             "kiro-native-ui",
@@ -589,7 +594,7 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
             expected_session_id="resumed-session",
         )
 
-    assert posted == [
+    assert [replace(m, end_offset=0) for m in posted] == [
         forwarder._KiroConversationMessage(message_id="resumed-user", role="user", text=":0"),
         forwarder._KiroConversationMessage(
             message_id="resumed-assistant", role="assistant", text="resumed reply"
@@ -831,3 +836,128 @@ async def test_forward_kiro_session_mirrors_current_model_once(
 
     # Mirrored once; the unchanged second poll does not re-post.
     assert models == [("conv_kiro", "claude-haiku-4.5")]
+
+
+def _three_message_session(tmp_path: Path) -> tuple[Path, Path]:
+    """A kiro session with three mirrorable messages, for retry tests."""
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            {
+                "version": "v1",
+                "kind": "Prompt",
+                "data": {"message_id": f"m-{i}", "content": [{"kind": "text", "data": f"t{i}"}]},
+            }
+            for i in range(3)
+        ],
+    )
+    return sessions_dir, workspace
+
+
+async def _run_polls(
+    monkeypatch: pytest.MonkeyPatch, workspace: Path, tmp_path: Path, polls: int
+) -> None:
+    """Drive the forward loop for *polls* iterations, then cancel."""
+    remaining = {"n": polls}
+
+    async def _bounded_sleep(_seconds: float) -> None:
+        remaining["n"] -= 1
+        if remaining["n"] <= 0:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _bounded_sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_does_not_repost_delivered_batch_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mid-batch transient failure must not re-post already-delivered messages.
+
+    The cursor used to advance per *batch*: any failure on message k re-posted
+    the k-1 messages already delivered (duplicate web bubbles — no server-side
+    dedup). The cursor now advances per message.
+    """
+    sessions_dir, workspace = _three_message_session(tmp_path)
+    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    delivered: list[str] = []
+    fail_once = {"armed": True}
+
+    async def _fake_post(client, *, session_id, agent_name, message) -> None:
+        del client
+        if message.message_id == "m-1" and fail_once["armed"]:
+            fail_once["armed"] = False
+            # Connection-level failure: never delivered, retried next poll.
+            raise httpx.ConnectError("server unreachable")
+        delivered.append(message.message_id)
+
+    monkeypatch.setattr(forwarder, "_post_conversation_message", _fake_post)
+    await _run_polls(monkeypatch, workspace, tmp_path, polls=4)
+
+    # m-0 delivered exactly once; m-1/m-2 delivered on the retry poll.
+    assert delivered == ["m-0", "m-1", "m-2"]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_post_failure_is_not_reposted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A message whose POST response was lost is skipped, not re-posted."""
+    sessions_dir, workspace = _three_message_session(tmp_path)
+    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    attempts: list[str] = []
+
+    async def _fake_post(client, *, session_id, agent_name, message) -> None:
+        del client
+        attempts.append(message.message_id)
+        if message.message_id == "m-1" and attempts.count("m-1") == 1:
+            # The server committed the message but the response was lost.
+            raise httpx.ReadTimeout("response lost after delivery")
+
+    monkeypatch.setattr(forwarder, "_post_conversation_message", _fake_post)
+    await _run_polls(monkeypatch, workspace, tmp_path, polls=4)
+
+    assert attempts == ["m-0", "m-1", "m-2"]
+
+
+@pytest.mark.asyncio
+async def test_poison_message_is_skipped_after_bounded_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deterministically rejected message stops wedging the mirror forever."""
+    sessions_dir, workspace = _three_message_session(tmp_path)
+    monkeypatch.setattr(forwarder, "_kiro_cli_sessions_dir", lambda: sessions_dir)
+    attempts: list[str] = []
+
+    async def _fake_post(client, *, session_id, agent_name, message) -> None:
+        del client
+        attempts.append(message.message_id)
+        if message.message_id == "m-1":
+            request = httpx.Request("POST", "http://ap")
+            raise httpx.HTTPStatusError(
+                "rejected", request=request, response=httpx.Response(400, request=request)
+            )
+
+    monkeypatch.setattr(forwarder, "_post_conversation_message", _fake_post)
+    await _run_polls(monkeypatch, workspace, tmp_path, polls=10)
+
+    # Bounded retries for the poison message, then the mirror moves on; the
+    # already-delivered m-0 is never re-posted.
+    assert attempts.count("m-0") == 1
+    assert attempts.count("m-1") == forwarder._MAX_ITEM_POST_ATTEMPTS
+    assert attempts.count("m-2") == 1

--- a/tests/test_qwen_native_forwarder.py
+++ b/tests/test_qwen_native_forwarder.py
@@ -586,3 +586,94 @@ async def test_supervise_restarts_then_propagates_cancel(
 
     assert calls["n"] == 2
     assert sleeps == [1.0]  # initial backoff before the one restart
+
+
+async def test_ambiguous_post_failure_is_not_reposted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An item whose POST response was lost is marked seen, not re-posted.
+
+    The server does not dedupe ``external_conversation_item`` POSTs, so a
+    blind retry after an ambiguous failure (request sent, response lost)
+    duplicates the web bubble. Mirrors cursor-native's handling.
+    """
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "hello")) + _ev_bytes(_user_ev("u2", "world"))
+    )
+    delivered: list[str] = []
+
+    async def _fake_post(_client: object, *, session_id: str, item: object) -> None:
+        delivered.append(item.uuid)  # type: ignore[attr-defined]
+        if item.uuid == "u1" and delivered.count("u1") == 1:  # type: ignore[attr-defined]
+            # The server committed the item but the response was lost.
+            raise httpx.ReadTimeout("response lost after delivery")
+
+    monkeypatch.setattr(fwd, "_post_conversation_item", _fake_post)
+    task = asyncio.create_task(
+        fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0.01,
+        )
+    )
+    for _ in range(400):
+        if "u2" in delivered:
+            break
+        await asyncio.sleep(0.01)
+    # A few more polls so a wrongful re-post would show up.
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    assert delivered == ["u1", "u2"]
+    state = _read_state(bridge)
+    assert "u1" in (state.seen_uuids or [])
+
+
+async def test_poison_item_is_skipped_after_bounded_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deterministically rejected item stops wedging the mirror forever."""
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+    events_file_path(bridge).write_bytes(
+        _ev_bytes(_user_ev("u1", "hello")) + _ev_bytes(_user_ev("u2", "world"))
+    )
+    delivered: list[str] = []
+
+    async def _fake_post(_client: object, *, session_id: str, item: object) -> None:
+        delivered.append(item.uuid)  # type: ignore[attr-defined]
+        if item.uuid == "u1":  # type: ignore[attr-defined]
+            request = httpx.Request("POST", "http://ap")
+            raise httpx.HTTPStatusError(
+                "rejected", request=request, response=httpx.Response(400, request=request)
+            )
+
+    monkeypatch.setattr(fwd, "_post_conversation_item", _fake_post)
+    task = asyncio.create_task(
+        fwd.forward_qwen_events_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="conv",
+            bridge_dir=bridge,
+            agent_name=_AGENT,
+            poll_interval_s=0.01,
+        )
+    )
+    for _ in range(600):
+        if "u2" in delivered:
+            break
+        await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await task
+
+    # Bounded retries for the poison item, then the mirror moves on.
+    assert delivered.count("u1") == fwd._MAX_ITEM_POST_ATTEMPTS
+    assert delivered.count("u2") == 1


### PR DESCRIPTION
## Related issue

Closes #1901

## Summary

- The server does not dedupe `external_conversation_item` POSTs, but the kimi, qwen, goose, and kiro forwarders had exactly one reaction to any failed POST: retry the same item. An ambiguous failure (request sent, response lost) therefore re-posted an item the server had already committed — duplicate web bubbles after any network blip — and a deterministic rejection (4xx) was retried forever at the poll cadence, wedging the mirror for the rest of the session.
- Port the handling the cursor/codex/claude/antigravity forwarders already use: classify failures with the shared `post_may_have_been_delivered` (ambiguous → advance past the item), bound rejected-item retries with `_MAX_ITEM_POST_ATTEMPTS = 5` (then drop with an error log so the queue keeps flowing), and keep retrying indefinitely on connection-level failures (server unreachable is not the item's fault).
- kiro additionally moved from batch-level to per-message cursor accounting (each parsed message now carries its own `end_offset`, cursor is monotonic): a failure on message k used to re-post the k−1 messages already delivered.

ELI5: these mail clerks couldn't tell "the receipt got lost (probably delivered)" from "this letter will be rejected forever" — they re-sent in both cases, so the web chat got twin bubbles, or the whole queue froze behind one bad letter. Now they use the same triage the other clerks already do.

hermes has the same pattern but its loop is being reworked under the open P0 #1657, so it is deliberately left to that fix. Long-term, server-side idempotency (#1594) supersedes the client-side care.

## Test Plan

- Nine new tests — red on `main`, green here: per forwarder, an ambiguous failure delivers the item exactly once, and a poison item is retried exactly `_MAX_ITEM_POST_ATTEMPTS` times then skipped with later items still delivered; plus kiro's batch-prefix case (a mid-batch transient failure no longer re-posts the delivered prefix). All drive the real forward loops with only the item POST stubbed.
- Four existing kiro tests updated for the new `end_offset` field (assertions normalize it and additionally check per-message offsets are monotonic).
- `uv run --extra dev python -m pytest tests/test_kimi_native_forwarder.py tests/test_qwen_native_forwarder.py tests/test_goose_native_forwarder.py tests/test_kiro_native_session_forwarder.py` → 76 passed; `ruff check`, `ruff format --check`, `pre-commit` clean.

## Demo

Red→green across all four forwarders (same tests on `main` vs this branch):

![red-green](https://raw.githubusercontent.com/tomsen-ai/omnigent/demo-assets/native-forwarders-post-classify-red-green.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All nine failure scenarios are deterministic in the new unit tests (stubbed POSTs raise controlled `httpx` errors against the real forward loops); no timing dependence.

## Changelog

Native kimi/qwen/goose/kiro sessions no longer duplicate web messages after network blips, and one rejected message no longer freezes the transcript mirror
