### PR TITLE
feat(web): rename sidebar "Chats" section to "Sessions"

### DIFF
--- a/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
+++ b/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
@@ -17,7 +17,7 @@ ate the chord and the route never changed.
 No LLM turn is needed — this exercises pure client-side keyboard + routing —
 so it skips the nightly/real-agent markers the approval suites carry. Two
 runner-bound sessions come from the ``seeded_session_pair`` fixture; both
-render under the sidebar's "Chats" group, so both are in the hotkey's ordered
+render under the sidebar's "Sessions" group, so both are in the hotkey's ordered
 list.
 """
 

--- a/tests/e2e_ui/sessions/test_pinned_session_hotkeys.py
+++ b/tests/e2e_ui/sessions/test_pinned_session_hotkeys.py
@@ -74,7 +74,7 @@ def _section(page: Page, title: str) -> Locator:
 
     Each ``ConversationSection`` renders an ``<h2>`` with a collapse button
     whose accessible name is the section title (e.g. "Pinned"). Scoping
-    lookups to the matching section keeps them off the "Chats" rows.
+    lookups to the matching section keeps them off the "Sessions" rows.
 
     :param page: Playwright page with the sidebar open.
     :param title: Section header text, e.g. ``"Pinned"``.

--- a/tests/e2e_ui/sessions/test_sidebar_pin_unpin.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pin_unpin.py
@@ -6,10 +6,10 @@ Pinning is a client-side navigation preference (persisted to
 conversation row (``data-testid="quick-pin-conversation"``). Toggling it
 moves the row between the sidebar's grouped sections:
 
-  - **Pin** lifts the row out of "Chats" and into a "Pinned" section
+  - **Pin** lifts the row out of "Sessions" and into a "Pinned" section
     rendered above it (``ConversationList`` peels pinned, non-archived
     rows into their own group — Sidebar.tsx).
-  - **Unpin** drops it back under "Chats".
+  - **Unpin** drops it back under "Sessions".
 
 These drive the real chain the ``Sidebar`` unit tests mock out: the live
 ``GET /v1/sessions`` list feeding ``useConversations`` → the section
@@ -53,7 +53,7 @@ def _section(page: Page, title: str) -> Locator:
 
     Each ``ConversationSection`` renders an ``<h2>`` with a collapse
     button whose accessible name is the section title (e.g. "Pinned",
-    "Chats"). Scoping row assertions to the matching section is how we
+    "Sessions"). Scoping row assertions to the matching section is how we
     prove a row is grouped under the right header.
 
     :param page: Playwright page with the sidebar open.
@@ -72,14 +72,14 @@ def test_pin_moves_session_to_pinned_section(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Pinning a Chats session lifts its row into the Pinned section.
+    """Pinning a Sessions-list row lifts it into the Pinned section.
 
     Failure modes this catches that the mocked unit test can't:
 
     - The live ``GET /v1/sessions`` row shape drifts so the owner split
-      drops the session out of "Chats" (it would never be pinnable).
+      drops the session out of "Sessions" (it would never be pinnable).
     - The pin toggle persists but the section peel regresses, leaving the
-      row under "Chats" after a pin.
+      row under "Sessions" after a pin.
 
     :param page: Playwright page fixture (fresh context per test).
     :param seeded_session: ``(base_url, session_id)`` for a pre-created
@@ -93,9 +93,9 @@ def test_pin_moves_session_to_pinned_section(
 
     row = _row(page, session_id)
     expect(row).to_be_visible()
-    # Owned, non-archived, unpinned → starts under "Chats", never
+    # Owned, non-archived, unpinned → starts under "Sessions", never
     # "Pinned" (no Pinned section exists yet).
-    expect(_section(page, "Chats").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
     expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
 
     # Pin via the row's quick action. Hover first so the desktop
@@ -105,11 +105,11 @@ def test_pin_moves_session_to_pinned_section(
     expect(pin_button).to_have_attribute("aria-label", "Pin conversation")
     pin_button.click()
 
-    # The row now lives under "Pinned" and out of "Chats", and the
+    # The row now lives under "Pinned" and out of "Sessions", and the
     # quick action flips to its unpin affordance — both prove the toggle
     # ran through the sidebar's pin state, not a local no-op.
     expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
-    expect(_section(page, "Chats").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+    expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
     expect(_row(page, session_id).get_by_test_id("quick-pin-conversation")).to_have_attribute(
         "aria-label", "Unpin conversation"
     )
@@ -119,10 +119,10 @@ def test_unpin_moves_session_back_to_recent(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Unpinning a pinned session drops its row back under Chats.
+    """Unpinning a pinned session drops its row back under Sessions.
 
     Pins first (so there's something to unpin), confirms the row is under
-    "Pinned", then unpins and asserts it returns to "Chats" and the
+    "Pinned", then unpins and asserts it returns to "Sessions" and the
     "Pinned" section no longer holds it. Catches a regression where the
     toggle is one-way (pin sticks, unpin no-ops) or the section peel
     fails to re-home the row.
@@ -156,8 +156,8 @@ def test_unpin_moves_session_back_to_recent(
     expect(unpin_button).to_have_attribute("aria-label", "Unpin conversation")
     unpin_button.click()
 
-    # Back under "Chats", and no longer in "Pinned".
-    expect(_section(page, "Chats").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    # Back under "Sessions", and no longer in "Pinned".
+    expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
     expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
 
 
@@ -218,7 +218,7 @@ def test_pinned_section_orders_by_pin_time_not_update_time(
 
     The Pinned section orders strictly by when each session was pinned
     (oldest pin on top, newest pin at the bottom), not by ``updated_at`` like
-    the Chats / Shared / Archived sections. The regression this guards: the
+    the Sessions / Shared / Archived sections. The regression this guards: the
     Pinned group reused the ``updated_at``-desc comparator, so a pinned
     session jumped the moment it got a new message.
 

--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -41,8 +41,8 @@ def _set_title(base_url: str, session_id: str, title: str) -> None:
 
 def _section(page: Page, title: str) -> Locator:
     """Locate the sidebar ``<section>`` whose collapse-header button reads
-    *title* (e.g. "Chats" or a project name). Section headers carry no count or
-    icon, so the header's accessible name is the bare title."""
+    *title* (e.g. "Sessions" or a project name). Section headers carry no count
+    or icon, so the header's accessible name is the bare title."""
     return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
 
 
@@ -70,9 +70,9 @@ def test_move_session_into_new_project(
 ) -> None:
     """Creating a project from the kebab moves the row into it.
 
-    The session starts under "Chats"; after "Add to project → Create new
+    The session starts under "Sessions"; after "Add to project → Create new
     project", a project folder with that name appears under the "Projects" group and the
-    row lives under it (once expanded) and no longer under "Chats".
+    row lives under it (once expanded) and no longer under "Sessions".
     """
     base_url, session_id = seeded_session
     title = f"e2e-proj-{uuid.uuid4().hex[:8]}"
@@ -83,7 +83,7 @@ def test_move_session_into_new_project(
 
     row = _row(page, session_id)
     expect(row).to_be_visible()
-    expect(_section(page, "Chats").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
 
     _move_to_new_project(page, row, project)
 
@@ -94,17 +94,17 @@ def test_move_session_into_new_project(
     expect(header).to_have_attribute("aria-expanded", "true")
 
     expect(_section(page, project).locator(f'a[href="/c/{session_id}"]')).to_be_visible()
-    expect(_section(page, "Chats").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+    expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
 
 
 def test_remove_session_from_project(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Removing a session from its project drops it back under "Chats".
+    """Removing a session from its project drops it back under "Sessions".
 
     Moves the row into a fresh project first, then uses the kebab's
-    "Remove from <project>" item and asserts the row returns to "Chats".
+    "Remove from <project>" item and asserts the row returns to "Sessions".
     """
     base_url, session_id = seeded_session
     title = f"e2e-proj-rm-{uuid.uuid4().hex[:8]}"
@@ -137,6 +137,6 @@ def test_remove_session_from_project(
     # Removal is confirmed (it may delete the implicit project) — accept it.
     page.get_by_role("button", name="Remove from project", exact=True).click()
 
-    # Back under "Chats", and the now-empty project folder is gone.
-    expect(_section(page, "Chats").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    # Back under "Sessions", and the now-empty project folder is gone.
+    expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
     expect(page.get_by_role("button", name=project, exact=True)).to_have_count(0)

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -161,7 +161,7 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("Sidebar shift-click selection", () => {
-  it("shift-click selects range between anchor and target within Chats", async () => {
+  it("shift-click selects range between anchor and target within Sessions", async () => {
     const sessions = [conv("s1"), conv("s2"), conv("s3"), conv("s4")];
     mockConversations(sessions);
     renderSidebar();
@@ -184,7 +184,7 @@ describe("Sidebar shift-click selection", () => {
     });
   });
 
-  it("shift-click does not select project sessions when selecting within Chats", async () => {
+  it("shift-click does not select project sessions when selecting within Sessions", async () => {
     // Set up project "Alpha" with 2 sessions, plus 3 unfiled chat sessions
     projectsMock.push("Alpha");
     const sessions = [

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -2,7 +2,7 @@
 // longer carries a filter funnel (agent-type filter + "Show archived"
 // toggle were removed). The sidebar fetches a single session list with
 // archived sessions included, rendering the non-archived ones as grouped
-// sections (Pinned / Projects / Chats / Shared with me). Archived sessions
+// sections (Pinned / Projects / Sessions / Shared with me). Archived sessions
 // are no longer listed here — they live on the Settings page.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -252,29 +252,29 @@ describe("Sidebar session list", () => {
     // chats are surfaced on /settings, reached via the footer Settings row.
     expect(screen.queryByRole("button", { name: "Archived" })).toBeNull();
     expect(screen.queryByText("conv_archived")).toBeNull();
-    // Active sessions still render in Chats.
-    const recentSection = screen.getByText("Chats").closest("section")!;
+    // Active sessions still render in the Sessions list.
+    const recentSection = screen.getByText("Sessions").closest("section")!;
     expect(within(recentSection).getByText("conv_active")).toBeInTheDocument();
     // The footer Settings link points at the settings page.
     expect(screen.getByTestId("settings-button")).toHaveAttribute("href", "/settings");
   });
 
-  it("renders sessions in one flat list with no connection grouping and no Sessions subheader", () => {
+  it("renders sessions in one flat list with no connection grouping", () => {
     // Liveness grouping is gone: sessions are no longer split into
-    // Connected / Disconnected sections. They all land in one flat list with
-    // NO "Sessions" subheader (it's the sidebar's baseline list, so the label
-    // is redundant). The per-row lifecycle badge still shows for a running
-    // session (the badge no longer reflects runner connection state).
+    // Connected / Disconnected sections. They all land in one flat list under
+    // the baseline "Sessions" header. The per-row lifecycle badge still shows
+    // for a running session (the badge no longer reflects runner connection
+    // state).
     const online = conv("conv_online", "Codex", { status: "running" });
     const offline = conv("conv_offline", "Claude Code", { status: "running" });
     mockConversations([online, offline]);
 
     renderSidebar();
 
-    // No connection-grouping headings, and no redundant "Sessions" subheader.
+    // No connection-grouping headings; the flat list keeps its "Sessions" header.
     expect(screen.queryByRole("heading", { name: "Connected" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Disconnected" })).toBeNull();
-    expect(screen.queryByRole("heading", { name: "Sessions" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Sessions" })).toBeInTheDocument();
 
     // Both rows render in the flat list, and the online running session shows
     // its lifecycle badge (in the row's time-marker slot, outside the link).
@@ -326,12 +326,12 @@ describe("Sidebar session list", () => {
   });
 });
 
-// Sidebar grouping: Pinned / Chats / Shared with me are distinguished by
+// Sidebar grouping: Pinned / Sessions / Shared with me are distinguished by
 // muted micro-headers + whitespace only (the pink divider rules are gone).
 // "Shared with me" = sessions where the caller's permission_level says
 // non-owner (< 4); null/4+ are the viewer's own sessions.
 describe("Sidebar sections", () => {
-  it("splits owned and shared sessions under Chats / Shared with me", () => {
+  it("splits owned and shared sessions under Sessions / Shared with me", () => {
     mockConversations([
       conv("conv_mine_legacy", "Claude Code"), // permission_level null = owner
       conv("conv_mine_acl", "Claude Code", { permission_level: 4 }),
@@ -340,10 +340,10 @@ describe("Sidebar sections", () => {
     renderSidebar();
 
     // Both headers render because both groups are non-empty.
-    const recentHeader = screen.getByText("Chats");
+    const recentHeader = screen.getByText("Sessions");
     const sharedHeader = screen.getByText("Shared with me");
     // Each row lands in the right <section>: a mis-split would either leak
-    // a shared session into Chats (viewer thinks they own it) or hide an
+    // a shared session into Sessions (viewer thinks they own it) or hide an
     // owned one under Shared with me.
     const recentSection = recentHeader.closest("section")!;
     const sharedSection = sharedHeader.closest("section")!;
@@ -353,13 +353,13 @@ describe("Sidebar sections", () => {
     expect(within(sharedSection).getByText("conv_shared")).toBeInTheDocument();
   });
 
-  it("titles the baseline list Chats even with no sibling group", () => {
+  it("titles the baseline list Sessions even with no sibling group", () => {
     mockConversations([conv("conv_only_mine", "Claude Code")]);
     renderSidebar();
-    // "Chats" always renders so the list is labeled (and collapsible)
+    // "Sessions" always renders so the list is labeled (and collapsible)
     // from the first session; empty sibling groups stay hidden.
     expect(screen.getByText("conv_only_mine")).toBeInTheDocument();
-    expect(screen.getByText("Chats")).toBeInTheDocument();
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
     expect(screen.queryByText("Shared with me")).toBeNull();
   });
 });
@@ -394,10 +394,10 @@ describe("Sidebar collapsible sections", () => {
   });
 });
 
-// Pagination belongs to the Chats list: collapsing Chats must take the
+// Pagination belongs to the Sessions list: collapsing it must take the
 // "Load more" button with it, or the button floats under nothing.
-describe("Sidebar load-more vs collapsed Chats", () => {
-  it("hides Load more while Chats is collapsed and restores it on expand", () => {
+describe("Sidebar load-more vs collapsed Sessions", () => {
+  it("hides Load more while Sessions is collapsed and restores it on expand", () => {
     const rows = [conv("conv_mine", "Claude Code")];
     useConvMock.mockImplementation(
       () =>
@@ -417,11 +417,11 @@ describe("Sidebar load-more vs collapsed Chats", () => {
     renderSidebar();
 
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Chats" }));
-    // Collapsed Chats hides its rows AND the pagination affordance.
+    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+    // Collapsed Sessions hides its rows AND the pagination affordance.
     expect(screen.queryByText("conv_mine")).toBeNull();
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Chats" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
   });
 
@@ -478,11 +478,11 @@ describe("Sidebar load-more vs collapsed Chats", () => {
   });
 });
 
-// Project feature: sessions carrying a project label are peeled out of
-// "Chats" into a folder under the "Projects" group (rendered between Pinned and
-// Chats). The project list comes from useProjects() (mocked here).
+// Project feature: sessions carrying a project label are peeled out of the
+// "Sessions" list into a folder under the "Projects" group (rendered between
+// Pinned and Sessions). The project list comes from useProjects() (mocked here).
 describe("Sidebar project sections", () => {
-  it("groups sessions by their project label, separate from Chats", () => {
+  it("groups sessions by their project label, separate from Sessions", () => {
     projectsMock.push("Customer X");
     mockConversations([
       conv("conv_unfiled", "Claude Code"),
@@ -491,8 +491,8 @@ describe("Sidebar project sections", () => {
     renderSidebar();
 
     // projects default collapsed, so the row is hidden until the header is
-    // clicked. The unfiled session stays visible in Chats regardless.
-    const recentSection = screen.getByText("Chats").closest("section")!;
+    // clicked. The unfiled session stays visible in Sessions regardless.
+    const recentSection = screen.getByText("Sessions").closest("section")!;
     expect(within(recentSection).getByText("conv_unfiled")).toBeInTheDocument();
     expect(within(recentSection).queryByText("conv_filed")).toBeNull();
     expect(screen.queryByText("conv_filed")).toBeNull();
@@ -633,12 +633,12 @@ describe("Sidebar project sections", () => {
 
   it("does not render a project section when useProjects returns nothing", () => {
     // A session with a stale project label but no matching project entry stays
-    // in Chats — projects are driven by the project list, not the labels alone.
+    // in Sessions — projects are driven by the project list, not the labels alone.
     mockConversations([conv("conv_filed", "Claude Code", { labels: { omni_project: "Ghost" } })]);
     renderSidebar();
 
     expect(screen.queryByText("Ghost")).toBeNull();
-    const recentSection = screen.getByText("Chats").closest("section")!;
+    const recentSection = screen.getByText("Sessions").closest("section")!;
     expect(within(recentSection).getByText("conv_filed")).toBeInTheDocument();
   });
 
@@ -809,21 +809,29 @@ describe("Sidebar collapsed project marker", () => {
 // Every section is expanded by default, but a collapse the user makes
 // persists across reloads.
 describe("Sidebar default section collapse", () => {
-  it("expands Pinned and Chats by default when there is no stored preference", () => {
+  it("expands Pinned and Sessions by default when there is no stored preference", () => {
     localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pin"]));
     mockConversations([conv("conv_pin", "Claude Code"), conv("conv_recent", "Claude Code")]);
     renderSidebar();
 
     expect(screen.getByRole("button", { name: /Pinned/ })).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByRole("button", { name: /Chats/ })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /Sessions/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
   });
 
-  it("honors a persisted collapse of Chats across remount", () => {
+  it("honors a persisted collapse of the Sessions list across remount", () => {
+    // "Chats" is the persisted collapse key (kept stable across the label
+    // rename); the header it collapses now reads "Sessions".
     localStorage.setItem("omnigent:collapsed-sidebar-sections", JSON.stringify(["Chats"]));
     mockConversations([conv("conv_recent", "Claude Code")]);
     renderSidebar();
 
-    expect(screen.getByRole("button", { name: /Chats/ })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /Sessions/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
     expect(screen.queryByText("conv_recent")).toBeNull();
   });
 });

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1403,7 +1403,10 @@ function ConversationList({
                 active={activeDrag != null && (activeDrag.project != null || activeDrag.isPinned)}
               >
                 <ConversationSection
-                  title="Chats"
+                  // "Sessions" is the visible label (matches the "New session"
+                  // button); "Chats" stays the persisted collapse-state key so
+                  // an existing user's collapse preference survives the rename.
+                  title="Sessions"
                   conversations={sections.sessions}
                   pinnedConversationIds={pinnedConversationIds}
                   collapsed={effectiveCollapsedSections.includes("Chats")}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1403,9 +1403,6 @@ function ConversationList({
                 active={activeDrag != null && (activeDrag.project != null || activeDrag.isPinned)}
               >
                 <ConversationSection
-                  // "Sessions" is the visible label (matches the "New session"
-                  // button); "Chats" stays the persisted collapse-state key so
-                  // an existing user's collapse preference survives the rename.
                   title="Sessions"
                   conversations={sections.sessions}
                   pinnedConversationIds={pinnedConversationIds}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The chat sidebar's flat session list was headed **"Chats"**, while the create button right above it reads **"New session"** — the two disagreed on what a conversation is called.
- Rename the visible section header to **"Sessions"** so the list and its create button use the same term.
- Only the *displayed* label changes. The section's persisted collapse-state key stays `"Chats"` (as does the drag-drop / hotkey-ordering identity), so an existing user's collapse preference survives the rename with no migration. A comment at the call site documents the label/key split.

## Test Plan

- Updated and ran the affected Vitest suites — `Sidebar.test.tsx`, `Sidebar.shiftSelect.test.tsx`, `sidebarNav.test.ts` (90 tests pass). Assertions now expect the `"Sessions"` header while the persisted-collapse test still writes the `"Chats"` key and confirms the `"Sessions"` header collapses, proving the label/key split.
- `tsc --noEmit` clean; `oxlint` clean on the changed files (the one warning is pre-existing, outside this diff); `pre-commit` passes.

## Demo

N/A — one-word header label swap. The behaviour is asserted by the updated render tests (the sidebar header now reads "Sessions"); no full-stack run was needed to observe it.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the updated unit tests above.

## Changelog

Renamed the sidebar's "Chats" section to "Sessions" to match the "New session" button

This pull request and its description were written by Isaac.
