### PR TITLE
fix(web): persist brain-harness override across sessions

### DIFF
--- a/web/src/lib/harnessPreferences.test.ts
+++ b/web/src/lib/harnessPreferences.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLastHarness, writeLastHarness } from "./harnessPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("harnessPreferences", () => {
+  it("returns null when nothing is stored", () => {
+    expect(readLastHarness("ag_polly")).toBeNull();
+  });
+
+  it("returns null for null/undefined agent id", () => {
+    expect(readLastHarness(null)).toBeNull();
+    expect(readLastHarness(undefined)).toBeNull();
+  });
+
+  it("round-trips a written harness override", () => {
+    writeLastHarness("ag_polly", "openai-agents");
+    expect(readLastHarness("ag_polly")).toBe("openai-agents");
+  });
+
+  it("stores per-agent preferences independently", () => {
+    writeLastHarness("ag_polly", "openai-agents");
+    writeLastHarness("ag_debby", "claude-sdk");
+    expect(readLastHarness("ag_polly")).toBe("openai-agents");
+    expect(readLastHarness("ag_debby")).toBe("claude-sdk");
+  });
+
+  it("overwrites the previous pick for the same agent", () => {
+    writeLastHarness("ag_polly", "openai-agents");
+    writeLastHarness("ag_polly", "claude-sdk");
+    expect(readLastHarness("ag_polly")).toBe("claude-sdk");
+  });
+
+  it("clears the override when null is written", () => {
+    writeLastHarness("ag_polly", "openai-agents");
+    writeLastHarness("ag_polly", null);
+    expect(readLastHarness("ag_polly")).toBeNull();
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeLastHarness("ag_x", "claude-sdk")).not.toThrow();
+    expect(readLastHarness("ag_x")).toBeNull();
+  });
+});

--- a/web/src/lib/harnessPreferences.ts
+++ b/web/src/lib/harnessPreferences.ts
@@ -1,0 +1,58 @@
+// Persisted, app-global preference for which brain harness override the
+// new-session landing composer starts on, keyed by agent id.
+//
+// Bundle agents (e.g. Polly, Debby) let the user pick a brain harness
+// (claude-sdk, openai-agents, …) that overrides the agent spec's default.
+// This store remembers the last pick per agent so returning users start on
+// the harness they used last. The consumer validates the stored value
+// against the agent's current harness vocabulary and falls back to the
+// spec default when it no longer exists.
+
+const STORAGE_KEY = "omnigent:last-harness-by-agent";
+
+type HarnessMap = Record<string, string>;
+
+function readMap(): HarnessMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out: HarnessMap = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read the last brain-harness override for `agentId`. Returns `null` when
+ * nothing is stored, on a server render, or when storage is inaccessible.
+ */
+export function readLastHarness(agentId: string | null | undefined): string | null {
+  if (!agentId) return null;
+  return readMap()[agentId] ?? null;
+}
+
+/**
+ * Persist `harness` as the user's last brain-harness pick for `agentId`.
+ * Pass `null` to clear the override (the agent will use its spec default).
+ */
+export function writeLastHarness(agentId: string | null | undefined, harness: string | null): void {
+  if (typeof window === "undefined" || !agentId) return;
+  try {
+    const map = readMap();
+    if (harness === null) {
+      delete map[agentId];
+    } else {
+      map[agentId] = harness;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage quota or access errors shouldn't break the composer.
+  }
+}

--- a/web/src/lib/harnessPreferences.ts
+++ b/web/src/lib/harnessPreferences.ts
@@ -4,9 +4,8 @@
 // Bundle agents (e.g. Polly, Debby) let the user pick a brain harness
 // (claude-sdk, openai-agents, …) that overrides the agent spec's default.
 // This store remembers the last pick per agent so returning users start on
-// the harness they used last. The consumer validates the stored value
-// against the agent's current harness vocabulary and falls back to the
-// spec default when it no longer exists.
+// the harness they used last. A stale value (harness removed server-side)
+// is sent as `harness_override` and rejected by the server at create time.
 
 const STORAGE_KEY = "omnigent:last-harness-by-agent";
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1877,7 +1877,9 @@ export function NewChatLandingScreen() {
   // null = the agent spec's declared harness (no override sent); cleared on
   // every agent switch so a pick never leaks across agents.
   const [pickedHarness, setPickedHarness] = useState<string | null>(
-    () => landingDraft?.pickedHarness ?? readLastHarness(landingDraft?.pickedAgentId ?? readLastAgentId()),
+    () =>
+      landingDraft?.pickedHarness ??
+      readLastHarness(landingDraft?.pickedAgentId ?? readLastAgentId()),
   );
   // Per-session model + reasoning effort for the claude-native model picker.
   // "" = unselected: nothing is checked and `model_override` / `reasoning_effort`

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -61,6 +61,7 @@ import { WorkspacePicker, isNavigablePath } from "./WorkspacePicker";
 import { getCliServerUrl } from "@/lib/host";
 import { getOmnigentHostConfig } from "@/lib/host";
 import { readLastAgentId, writeLastAgentId } from "@/lib/agentPreferences";
+import { readLastHarness, writeLastHarness } from "@/lib/harnessPreferences";
 import { readHarnessOptions, writeHarnessOption } from "@/lib/modePreferences";
 import { useBrainHarnessLabels } from "@/lib/agentLabels";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
@@ -1876,7 +1877,7 @@ export function NewChatLandingScreen() {
   // null = the agent spec's declared harness (no override sent); cleared on
   // every agent switch so a pick never leaks across agents.
   const [pickedHarness, setPickedHarness] = useState<string | null>(
-    () => landingDraft?.pickedHarness ?? null,
+    () => landingDraft?.pickedHarness ?? readLastHarness(landingDraft?.pickedAgentId ?? readLastAgentId()),
   );
   // Per-session model + reasoning effort for the claude-native model picker.
   // "" = unselected: nothing is checked and `model_override` / `reasoning_effort`
@@ -2344,11 +2345,22 @@ export function NewChatLandingScreen() {
   // redundant.
   const agentLabel = selectedAgent ? selectedAgent.display_name : "Select agent";
 
-  // Select an agent/harness from the picker. Switching agents drops the
-  // harness override so a pick never leaks across agents; explicit picks
-  // persist (auto-defaults never do).
+  // Wrap the harness setter so every explicit pick is persisted to
+  // localStorage, keyed by the current agent id.
+  const handleSetPickedHarness = useCallback(
+    (harness: string | null) => {
+      setPickedHarness(harness);
+      writeLastHarness(effectiveAgentId, harness);
+    },
+    [effectiveAgentId],
+  );
+
+  // Select an agent/harness from the picker. Switching agents seeds the
+  // harness override from the user's last pick for that agent (so a
+  // returning user lands on the harness they used last); explicit picks
+  // persist via localStorage.
   const handleSelectAgent = (agent: AvailableAgent) => {
-    if (agent.id !== effectiveAgentId) setPickedHarness(null);
+    if (agent.id !== effectiveAgentId) setPickedHarness(readLastHarness(agent.id));
     setPickedAgentId(agent.id);
     writeLastAgentId(agent.id);
   };
@@ -2904,7 +2916,7 @@ export function NewChatLandingScreen() {
                   setBypassSandbox={setBypassSandbox}
                   setPickedModel={setPickedModel}
                   setPickedEffort={setPickedEffort}
-                  setPickedHarness={setPickedHarness}
+                  setPickedHarness={handleSetPickedHarness}
                 />
                 {smartRoutingEnabled &&
                   selectedAgent &&

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1271,7 +1271,7 @@ function AgentHarnessPicker({
   setBypassSandbox: (enabled: boolean) => void;
   setPickedModel: (model: string) => void;
   setPickedEffort: (effort: string) => void;
-  setPickedHarness: (harness: string | null) => void;
+  setPickedHarness: (harness: string | null, agentId?: string) => void;
 }) {
   // Controlled so clicking a knobbed row can commit the pick and close the
   // menu (see the sub-trigger onClick below) without diving into the submenu.
@@ -1460,7 +1460,7 @@ function AgentHarnessPicker({
             onSelectAgent(agent);
             // Picking the spec default clears the override so the session
             // tracks the spec.
-            setPickedHarness(h === defaultHarness ? null : h);
+            setPickedHarness(h === defaultHarness ? null : h, agent.id);
           }}
           host={host}
           labels={brainHarnessLabels}
@@ -1874,8 +1874,8 @@ export function NewChatLandingScreen() {
     () => landingDraft?.cursorExecMode ?? CURSOR_NATIVE_DEFAULT_EXEC_MODE,
   );
   // Per-session brain-harness override for bundle agents (polly / debby).
-  // null = the agent spec's declared harness (no override sent); cleared on
-  // every agent switch so a pick never leaks across agents.
+  // null = the agent spec's declared harness (no override sent). On agent
+  // switch, seeded from the user's last stored pick for that agent.
   const [pickedHarness, setPickedHarness] = useState<string | null>(
     () =>
       landingDraft?.pickedHarness ??
@@ -2348,11 +2348,14 @@ export function NewChatLandingScreen() {
   const agentLabel = selectedAgent ? selectedAgent.display_name : "Select agent";
 
   // Wrap the harness setter so every explicit pick is persisted to
-  // localStorage, keyed by the current agent id.
+  // localStorage. The caller can pass an explicit `agentId` for the
+  // switch-via-submenu path where `effectiveAgentId` still reflects the
+  // previously selected agent (the state update from `onSelectAgent` hasn't
+  // applied yet).
   const handleSetPickedHarness = useCallback(
-    (harness: string | null) => {
+    (harness: string | null, agentId?: string) => {
       setPickedHarness(harness);
-      writeLastHarness(effectiveAgentId, harness);
+      writeLastHarness(agentId ?? effectiveAgentId, harness);
     },
     [effectiveAgentId],
   );


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The per-session brain-harness pick (e.g. `claude-sdk` vs `openai-agents` for bundle agents like Polly/Debby) was lost on page refresh because it only lived in a module-scoped `landingDraft` variable.
- Added a new `harnessPreferences` localStorage store (`omnigent:last-harness-by-agent`) keyed by agent id, following the same pattern as `agentPreferences` and `modePreferences`.
- On mount, the landing composer now seeds `pickedHarness` from the stored preference; on agent switch it restores the stored pick for that agent; on explicit user pick it persists the choice.

## Test Plan

- Added 7 unit tests covering round-trip, per-agent isolation, overwrite, clear-on-null, and storage-error resilience — all passing.
- TypeScript compiles cleanly.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the `harnessPreferences` localStorage store. The wiring in `NewChatDialog` is straightforward prop-threading of the same read/write helpers already battle-tested by `agentPreferences` and `modePreferences`.

## Changelog

Brain-harness override (e.g. claude-sdk vs openai-agents) is now remembered across sessions per agent