### PR TITLE
fix(web): return to prior conversation from settings back button

### DIFF
--- a/tests/e2e_ui/sessions/test_settings_back_navigation.py
+++ b/tests/e2e_ui/sessions/test_settings_back_navigation.py
@@ -1,0 +1,50 @@
+"""E2E: leaving Settings returns to the conversation you came from.
+
+Settings renders into the shared ``AppShell`` outlet under ``/settings`` — a
+URL that carries no conversation id. The "Back to Omnigent" link in the
+settings sidebar (``SettingsSidebarBody`` in ``shell/settingsNav.tsx``) used to
+be hardcoded to ``/``, so leaving settings always dropped the user on the home
+landing page instead of the conversation they were viewing.
+
+The Sidebar stays mounted across the transition into settings and now records
+the last non-settings location (via ``useTrackSettingsReturn``); the back link
+points at it. This test drives the real in-app flow — open a conversation, open
+Settings from the sidebar, click Back — and asserts the URL returns to
+``/c/<session_id>`` rather than ``/``.
+
+No LLM turn is involved.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+def test_settings_back_returns_to_conversation(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Conversation → Settings → Back lands back on the conversation, not home.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page).to_have_url(f"{base_url}/c/{session_id}")
+
+    # Enter Settings from the sidebar footer control. The conversations sidebar
+    # stays mounted and swaps its body to the settings section nav.
+    page.get_by_test_id("settings-button").click()
+    page.wait_for_url("**/settings**", timeout=30_000)
+
+    # The settings section nav renders in place of the conversation list.
+    back = page.get_by_role("link", name="Back to Omnigent")
+    expect(back).to_be_visible(timeout=30_000)
+
+    # Back returns to the conversation we came from — the fix. A regression to
+    # the hardcoded "/" would land on the home landing page instead.
+    back.click()
+    expect(page).to_have_url(f"{base_url}/c/{session_id}", timeout=30_000)

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -128,7 +128,7 @@ import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
 import { absoluteTime, relativeTime } from "@/lib/relativeTime";
-import { SettingsSidebarBody, useSettingsRoute } from "./settingsNav";
+import { SettingsSidebarBody, useSettingsRoute, useTrackSettingsReturn } from "./settingsNav";
 import {
   type ActiveChatOverride,
   COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
@@ -337,6 +337,10 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   // for the settings section nav (see settingsNav.tsx) — entering settings
   // shouldn't replace the whole sidebar.
   const { inSettings } = useSettingsRoute();
+  // Remember the pre-settings location so "Back to Omnigent" returns to the
+  // conversation the user was viewing, not the home page. Tracked here since
+  // the sidebar stays mounted across the transition into settings.
+  useTrackSettingsReturn();
 
   // Sync pinned ids to localStorage whenever state changes. Keeping
   // the write here (instead of inside the state updater) preserves the

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -7,7 +7,7 @@
 
 import { cleanup, fireEvent, render, renderHook, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useNavigate } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -32,7 +32,12 @@ vi.mock("@/hooks/useIsAdmin", () => ({
   useIsAdmin: () => mocks.isAdmin,
 }));
 
-import { SettingsSidebarBody, settingsNavGroups, useSettingsRoute } from "./settingsNav";
+import {
+  SettingsSidebarBody,
+  settingsNavGroups,
+  useSettingsRoute,
+  useTrackSettingsReturn,
+} from "./settingsNav";
 
 function renderBody(opts: { onNavClick?: () => void; onClose?: () => void } = {}) {
   const onNavClick = opts.onNavClick ?? vi.fn();
@@ -123,6 +128,37 @@ describe("SettingsSidebarBody", () => {
     const { onNavClick } = renderBody();
     fireEvent.click(screen.getByRole("link", { name: /Back to Omnigent/ }));
     expect(onNavClick).not.toHaveBeenCalled();
+  });
+
+  it("'Back to Omnigent' returns to the conversation the user came from", () => {
+    // Simulate the real flow: the sidebar (which stays mounted) tracks the
+    // pre-settings location, then the user enters /settings. Back must point at
+    // the conversation, not the home page.
+    function Harness() {
+      useTrackSettingsReturn();
+      const navigate = useNavigate();
+      const { inSettings } = useSettingsRoute();
+      return (
+        <>
+          <button type="button" onClick={() => navigate("/settings")}>
+            go-settings
+          </button>
+          {inSettings && <SettingsSidebarBody onNavClick={vi.fn()} onClose={vi.fn()} />}
+        </>
+      );
+    }
+    render(
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/c/conv_123?file=foo.ts"]}>
+          <Harness />
+        </MemoryRouter>
+      </TooltipProvider>,
+    );
+    fireEvent.click(screen.getByText("go-settings"));
+    expect(screen.getByRole("link", { name: /Back to Omnigent/ })).toHaveAttribute(
+      "href",
+      "/c/conv_123?file=foo.ts",
+    );
   });
 
   it("DOES close the sidebar when a section is tapped (drills into content)", () => {

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -6,6 +6,7 @@
 // selection is URL-driven (/settings/<section>) so the nav (in the sidebar)
 // and the content (in the outlet) stay in sync without shared state.
 
+import { useEffect } from "react";
 import {
   ArchiveIcon,
   ArrowLeftIcon,
@@ -142,6 +143,27 @@ export function useSettingsRoute(): { inSettings: boolean; section: SettingsSect
   return { inSettings: true, section };
 }
 
+// Last location the user was on before entering /settings — path + search so
+// the conversation (and its ?file= etc.) is preserved. "Back to Omnigent"
+// returns here instead of the home page. Module-scoped: the sidebar stays
+// mounted across the settings transition, so the value captured on the last
+// non-settings render survives into settings.
+let settingsReturnPath = "/";
+
+/**
+ * Record the current location as the settings return target whenever the user
+ * is NOT in settings. Call from a component that stays mounted across the
+ * transition into /settings (the Sidebar) so the last conversation is captured
+ * before the swap.
+ */
+export function useTrackSettingsReturn(): void {
+  const { pathname, search } = useLocation();
+  const { inSettings } = useSettingsRoute();
+  useEffect(() => {
+    if (!inSettings) settingsReturnPath = `${pathname}${search}`;
+  }, [inSettings, pathname, search]);
+}
+
 /**
  * Settings nav rendered INSIDE the sidebar card (replacing the conversation
  * list on /settings). Keeps the card chrome — a top row with "Back to
@@ -168,13 +190,14 @@ export function SettingsSidebarBody({
     <>
       <div className="flex items-center justify-between px-3 pt-3">
         <Button asChild variant="ghost" size="sm" className="gap-2 text-muted-foreground">
-          {/* No onNavClick here: on mobile the sidebar is a full-screen
-          overlay. Navigating to "/" exits /settings, so the sidebar swaps
-          back to the conversation list — but we keep the overlay OPEN so
-          mobile lands on that list rather than closing onto the homepage
-          content behind it. On desktop onNavClick is a no-op (persistent
-          card), so dropping it changes nothing there. */}
-          <Link to="/">
+          {/* Returns to wherever the user was before entering settings (the
+          conversation they were viewing, or home) — see settingsReturnPath.
+          No onNavClick here: on mobile the sidebar is a full-screen overlay.
+          Leaving /settings swaps the sidebar back to the conversation list —
+          but we keep the overlay OPEN so mobile lands on that list rather than
+          closing onto the content behind it. On desktop onNavClick is a no-op
+          (persistent card), so dropping it changes nothing there. */}
+          <Link to={settingsReturnPath}>
             <ArrowLeftIcon className="size-4" />
             Back to Omnigent
           </Link>


### PR DESCRIPTION
## Related issue

Closes #

## Summary

When viewing a conversation, navigating to Settings, then clicking **"Back to Omnigent"**, the user landed on the main landing page (`/`) instead of the conversation they were viewing.

- Settings renders into the shared `AppShell` outlet under a URL (`/settings`) that carries no conversation id, and the back link was hardcoded to `<Link to="/">` — so it had no context to return to.
- Now the Sidebar (which stays mounted across the transition into settings) records the last non-settings location — path **and** search, so `?file=` etc. are preserved — and the back link points at it, falling back to `/` when nothing was tracked (e.g. a deep-link straight into `/settings`).

## Test Plan

- **Unit** (`web/src/shell/settingsNav.test.tsx`): entering `/settings` from `/c/conv_123?file=foo.ts` makes "Back to Omnigent" resolve to `/c/conv_123?file=foo.ts`; existing behaviour preserved (default `/` when nothing tracked, mobile overlay stays open, section links still close it).
- **E2E** (`tests/e2e_ui/sessions/test_settings_back_navigation.py`): drives the real in-app flow — open a conversation, open Settings from the sidebar, click Back — and asserts the URL returns to `/c/<session_id>` rather than home. Passes locally (`pytest tests/e2e_ui/sessions/test_settings_back_navigation.py` → 1 passed).
- `cd web && npm test` → all pass. `npm run build` → clean.

## Demo

N/A — behavioural navigation fix, covered by the new Playwright e2e test. Flow: conversation → Settings → Back returns to the conversation.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the added unit and e2e tests.

## Changelog

"Back to Omnigent" from Settings now returns you to the conversation you were viewing instead of the home page

This pull request and its description were written by Isaac.
