### PR TITLE
wire OTel GenAI metric instruments

### DIFF
--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -38,6 +38,7 @@ import json
 import logging
 import os
 import secrets
+import time
 import uuid
 from collections import deque
 from collections.abc import Callable
@@ -409,6 +410,7 @@ class ExecutorAdapter(HarnessApp):
                     )
 
                 response_text: str | None = None
+                _turn_start_s = time.monotonic()
                 async for event in executor.run_turn(
                     messages=messages,
                     tools=tools,
@@ -446,12 +448,26 @@ class ExecutorAdapter(HarnessApp):
                                 _active_tool_parent = None
                         elif isinstance(event, TurnComplete):
                             response_text = event.response
-                            if event.usage is not None:
+                            if event.usage is not None and agent_span is not None:
                                 from omnigent.runtime.telemetry import record_llm_usage
 
                                 # Record usage on the agent span for
                                 # aggregate visibility.
-                                record_llm_usage(agent_span, event.usage)
+                                record_llm_usage(
+                                    agent_span,
+                                    event.usage,
+                                    model=request.model_override or request.model,
+                                    duration_s=time.monotonic() - _turn_start_s,
+                                )
+                    # Emit tool duration metric outside the tracing guard so
+                    # metrics fire even when MLflow tracing is not configured.
+                    if isinstance(event, ToolCallComplete) and event.duration_ms >= 0:
+                        from omnigent.runtime.telemetry import record_tool_metric
+
+                        record_tool_metric(
+                            _strip_mcp_tool_prefix(event.name),
+                            event.duration_ms,
+                        )
                     # --- End tracing ---
                     self._translate_event(event, ctx)
                     if isinstance(event, TurnComplete):

--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -61,6 +61,12 @@ _initialized: bool = False
 _metrics_initialized: bool = False
 _logs_initialized: bool = False
 
+# GenAI OTel semantic convention histogram instruments.
+# Populated by _init_otel_metrics(); None when no meter provider is configured.
+_token_usage_histogram: Any | None = None
+_operation_duration_histogram: Any | None = None
+_tool_duration_histogram: Any | None = None
+
 
 class _RemoteParentTraceState:
     """
@@ -342,15 +348,29 @@ def trace_context_for_response(
         yield
 
 
-def record_llm_usage(span: LiveSpan, usage: dict[str, Any]) -> None:
+def record_llm_usage(
+    span: LiveSpan,
+    usage: dict[str, Any],
+    *,
+    model: str | None = None,
+    duration_s: float | None = None,
+) -> None:
     """
-    Record token usage on an LLM span.
+    Record token usage on an LLM span and emit OTel metric instruments.
 
     MLflow stores usage as a single JSON dict under
     ``mlflow.chat.tokenUsage`` and translates each field to the
-    corresponding ``gen_ai.usage.*`` attribute on OTLP export —
+    corresponding ``gen_ai.usage.*`` attribute on OTLP export --
     ``input_tokens``, ``output_tokens``, ``total_tokens``, plus
     optional cache fields.
+
+    When ``model`` is provided and the OTel meter provider is
+    configured, also emits:
+
+    * ``gen_ai.client.token.usage`` histogram -- one data point per
+      token type (``gen_ai.token.type=input`` / ``output``).
+    * ``gen_ai.client.operation.duration`` histogram -- when
+      ``duration_s`` is also provided.
 
     Cache breakdown attributes are recorded only when present.
     Their absence is meaningful (the provider did not report
@@ -361,6 +381,14 @@ def record_llm_usage(span: LiveSpan, usage: dict[str, Any]) -> None:
         keys: ``"input_tokens"``, ``"output_tokens"``,
         ``"total_tokens"``, ``"cache_read_input_tokens"``,
         ``"cache_creation_input_tokens"``.
+    :param model: Provider-prefixed model string, e.g.
+        ``"anthropic/claude-sonnet-4-6"``. When set, metric
+        attributes ``gen_ai.provider.name`` and
+        ``gen_ai.request.model`` are derived via
+        :func:`parse_provider_name`.
+    :param duration_s: Wall time of the LLM turn in seconds.
+        Emitted to ``gen_ai.client.operation.duration`` when
+        ``model`` is also set.
     """
     from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 
@@ -379,6 +407,45 @@ def record_llm_usage(span: LiveSpan, usage: dict[str, Any]) -> None:
             usage["cache_creation_input_tokens"]
         )
     span.set_attribute(SpanAttributeKey.CHAT_USAGE, payload)
+
+    if model and (_token_usage_histogram is not None or _operation_duration_histogram is not None):
+        provider_name, model_name = parse_provider_name(model)
+        metric_attrs: dict[str, str] = {
+            "gen_ai.provider.name": provider_name,
+            "gen_ai.request.model": model_name,
+        }
+        if _token_usage_histogram is not None:
+            input_tokens = int(usage.get("input_tokens", 0))
+            output_tokens = int(usage.get("output_tokens", 0))
+            if input_tokens:
+                _token_usage_histogram.record(
+                    input_tokens, {**metric_attrs, "gen_ai.token.type": "input"}
+                )
+            if output_tokens:
+                _token_usage_histogram.record(
+                    output_tokens, {**metric_attrs, "gen_ai.token.type": "output"}
+                )
+        if _operation_duration_histogram is not None and duration_s is not None:
+            _operation_duration_histogram.record(
+                duration_s,
+                {**metric_attrs, "gen_ai.operation.name": "chat"},
+            )
+
+
+def record_tool_metric(tool_name: str, duration_ms: float) -> None:
+    """
+    Emit the ``agent.tool.duration`` histogram for a completed tool call.
+
+    No-op when the OTel meter provider is not configured.
+
+    :param tool_name: Tool name without MCP prefix, e.g. ``"web_search"``.
+    :param duration_ms: Tool execution wall time in milliseconds.
+    """
+    if _tool_duration_histogram is not None and duration_ms >= 0:
+        _tool_duration_histogram.record(
+            duration_ms / 1000.0,
+            {"agent.tool.name": tool_name},
+        )
 
 
 def record_error(span: LiveSpan, exc: BaseException) -> None:
@@ -552,6 +619,24 @@ def _init_otel_metrics() -> None:
             resource=Resource.create({SERVICE_NAME: service_name}),
         )
         otel_metrics.set_meter_provider(provider)
+
+        global _token_usage_histogram, _operation_duration_histogram, _tool_duration_histogram
+        meter = otel_metrics.get_meter("omnigent")
+        _token_usage_histogram = meter.create_histogram(
+            name="gen_ai.client.token.usage",
+            unit="{token}",
+            description="Measures number of input and output tokens used.",
+        )
+        _operation_duration_histogram = meter.create_histogram(
+            name="gen_ai.client.operation.duration",
+            unit="s",
+            description="Duration of a GenAI LLM operation.",
+        )
+        _tool_duration_histogram = meter.create_histogram(
+            name="agent.tool.duration",
+            unit="s",
+            description="Duration of a tool call.",
+        )
         _metrics_initialized = True
     except Exception:
         _logger.exception("failed to initialize OpenTelemetry metrics")

--- a/tests/runtime/test_telemetry.py
+++ b/tests/runtime/test_telemetry.py
@@ -863,3 +863,223 @@ def test_init_forces_unified_provider_mode(
     monkeypatch.setattr(telemetry, "_metrics_initialized", False)
     telemetry.init()
     assert os.environ.get("MLFLOW_USE_DEFAULT_TRACER_PROVIDER") == "false"
+
+
+# ── GenAI OTel metric instruments (#1053) ─────────────────
+
+
+@pytest.fixture
+def metric_reader() -> Iterator[Any]:
+    """
+    Install a fresh in-memory metric reader so tests can assert on
+    emitted histogram data points without network I/O.
+
+    Resets the module-level histogram vars before and after each
+    test so instrument state does not leak between tests.
+    """
+    from opentelemetry import metrics as otel_metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    otel_metrics.set_meter_provider(provider)
+
+    meter = otel_metrics.get_meter("omnigent-test")
+    token_hist = meter.create_histogram("gen_ai.client.token.usage", unit="{token}")
+    op_hist = meter.create_histogram("gen_ai.client.operation.duration", unit="s")
+    tool_hist = meter.create_histogram("agent.tool.duration", unit="s")
+
+    telemetry._token_usage_histogram = token_hist  # type: ignore[attr-defined]
+    telemetry._operation_duration_histogram = op_hist  # type: ignore[attr-defined]
+    telemetry._tool_duration_histogram = tool_hist  # type: ignore[attr-defined]
+
+    yield reader
+
+    telemetry._token_usage_histogram = None  # type: ignore[attr-defined]
+    telemetry._operation_duration_histogram = None  # type: ignore[attr-defined]
+    telemetry._tool_duration_histogram = None  # type: ignore[attr-defined]
+
+
+def _collect_metrics(reader: Any) -> dict[str, Any]:
+    """
+    Flush the reader and return a flat dict keyed by metric name.
+
+    :param reader: ``InMemoryMetricReader`` fixture value.
+    :returns: Dict mapping metric name to its ``Metric`` object.
+    """
+    metrics = reader.get_metrics_data()
+    result: dict[str, Any] = {}
+    for rm in metrics.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                result[m.name] = m
+    return result
+
+
+def test_record_llm_usage_emits_token_usage_histogram(
+    in_memory_exporter: InMemorySpanExporter,
+    metric_reader: Any,
+) -> None:
+    """
+    ``record_llm_usage`` with a model string emits input and output
+    token counts to ``gen_ai.client.token.usage`` with the correct
+    attributes (``gen_ai.provider.name``, ``gen_ai.request.model``,
+    ``gen_ai.token.type``).
+    """
+    import mlflow
+    from mlflow.entities import SpanType
+
+    with telemetry.trace_context_for_response(response_id=_RESP_ID):
+        with mlflow.start_span("chat", span_type=SpanType.CHAT_MODEL) as span:
+            telemetry.record_llm_usage(
+                span,
+                {"input_tokens": 200, "output_tokens": 80},
+                model="anthropic/claude-sonnet-4-6",
+            )
+
+    metrics = _collect_metrics(metric_reader)
+    assert "gen_ai.client.token.usage" in metrics, (
+        "expected gen_ai.client.token.usage metric, got: " + str(list(metrics.keys()))
+    )
+
+    data_points = metrics["gen_ai.client.token.usage"].data.data_points
+    by_type = {dp.attributes.get("gen_ai.token.type"): dp for dp in data_points}
+
+    assert by_type["input"].sum == 200, f"expected input sum=200, got {by_type['input'].sum}"
+    assert by_type["output"].sum == 80, f"expected output sum=80, got {by_type['output'].sum}"
+    assert by_type["input"].attributes["gen_ai.provider.name"] == "anthropic"
+    assert by_type["input"].attributes["gen_ai.request.model"] == "claude-sonnet-4-6"
+
+
+def test_record_llm_usage_emits_operation_duration_histogram(
+    in_memory_exporter: InMemorySpanExporter,
+    metric_reader: Any,
+) -> None:
+    """
+    ``record_llm_usage`` with ``duration_s`` emits to
+    ``gen_ai.client.operation.duration`` keyed by provider and model.
+    """
+    import mlflow
+    from mlflow.entities import SpanType
+
+    with telemetry.trace_context_for_response(response_id=_RESP_ID):
+        with mlflow.start_span("chat", span_type=SpanType.CHAT_MODEL) as span:
+            telemetry.record_llm_usage(
+                span,
+                {"input_tokens": 10, "output_tokens": 5},
+                model="openai/gpt-5.4",
+                duration_s=1.5,
+            )
+
+    metrics = _collect_metrics(metric_reader)
+    assert "gen_ai.client.operation.duration" in metrics, (
+        "expected gen_ai.client.operation.duration metric"
+    )
+
+    data_points = metrics["gen_ai.client.operation.duration"].data.data_points
+    assert len(data_points) == 1
+    dp = data_points[0]
+    assert dp.sum == pytest.approx(1.5, rel=1e-6)
+    assert dp.attributes["gen_ai.provider.name"] == "openai"
+    assert dp.attributes["gen_ai.request.model"] == "gpt-5.4"
+    assert dp.attributes["gen_ai.operation.name"] == "chat"
+
+
+def test_record_llm_usage_no_metrics_when_histograms_uninitialized(
+    in_memory_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``record_llm_usage`` is backward-compatible: when the OTel meter
+    provider is not configured (histogram vars are None), calling it
+    with or without ``model`` raises no error and only records the
+    MLflow span attribute.
+    """
+    import mlflow
+    from mlflow.entities import SpanType
+    from mlflow.tracing.constant import SpanAttributeKey
+
+    monkeypatch.setattr(telemetry, "_token_usage_histogram", None)
+    monkeypatch.setattr(telemetry, "_operation_duration_histogram", None)
+
+    with telemetry.trace_context_for_response(response_id=_RESP_ID):
+        with mlflow.start_span("chat", span_type=SpanType.CHAT_MODEL) as span:
+            telemetry.record_llm_usage(
+                span,
+                {"input_tokens": 5, "output_tokens": 3},
+                model="anthropic/claude-haiku-4-5",
+                duration_s=0.8,
+            )
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    payload = _read_attr(spans[0], SpanAttributeKey.CHAT_USAGE)
+    assert payload["input_tokens"] == 5
+    assert payload["output_tokens"] == 3
+
+
+def test_record_tool_metric_emits_tool_duration_histogram(
+    metric_reader: Any,
+) -> None:
+    """
+    ``record_tool_metric`` emits the ``agent.tool.duration`` histogram
+    in seconds (converted from milliseconds) with an
+    ``agent.tool.name`` attribute.
+    """
+    telemetry.record_tool_metric("web_search", 350.0)
+
+    metrics = _collect_metrics(metric_reader)
+    assert "agent.tool.duration" in metrics, (
+        "expected agent.tool.duration metric, got: " + str(list(metrics.keys()))
+    )
+
+    data_points = metrics["agent.tool.duration"].data.data_points
+    assert len(data_points) == 1
+    dp = data_points[0]
+    assert dp.sum == pytest.approx(0.35, rel=1e-6), (
+        f"expected 0.35s (350ms / 1000), got {dp.sum}"
+    )
+    assert dp.attributes["agent.tool.name"] == "web_search"
+
+
+def test_record_tool_metric_noop_when_histogram_uninitialized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``record_tool_metric`` is a no-op when no OTel meter provider is
+    configured -- no exception, no side effects.
+    """
+    monkeypatch.setattr(telemetry, "_tool_duration_histogram", None)
+    telemetry.record_tool_metric("web_fetch", 100.0)  # must not raise
+
+
+def test_record_llm_usage_no_histogram_when_model_is_none(
+    in_memory_exporter: InMemorySpanExporter,
+    metric_reader: Any,
+) -> None:
+    """
+    ``record_llm_usage`` with no ``model`` argument emits no metric
+    data points even when the OTel histograms are initialized.
+    The MLflow span attribute is still set.
+    """
+    import mlflow
+    from mlflow.entities import SpanType
+    from mlflow.tracing.constant import SpanAttributeKey
+
+    with telemetry.trace_context_for_response(response_id=_RESP_ID):
+        with mlflow.start_span("chat", span_type=SpanType.CHAT_MODEL) as span:
+            telemetry.record_llm_usage(span, {"input_tokens": 7, "output_tokens": 3})
+
+    # Span attribute must still be set.
+    spans = in_memory_exporter.get_finished_spans()
+    payload = _read_attr(spans[0], SpanAttributeKey.CHAT_USAGE)
+    assert payload["input_tokens"] == 7
+
+    # No metric data points should have been emitted.
+    metrics = _collect_metrics(metric_reader)
+    token_metric = metrics.get("gen_ai.client.token.usage")
+    if token_metric is not None:
+        assert len(token_metric.data.data_points) == 0, (
+            "expected no data points when model is None"
+        )


### PR DESCRIPTION
Closes #1053

The OTel MeterProvider was already getting initialized when an OTLP
endpoint is set, but we never actually created any instruments after
that, so the metrics pipeline was a no-op end to end.

This adds the three GenAI histograms from the semconv spec -- token
usage (split by input/output), LLM call duration, and tool call
duration. Tool duration is wired outside the tracing guard so it fires
even when MLflow tracing is not configured.

Six unit tests added in test_telemetry.py covering the happy path,
correct attributes, and backward-compat when no provider is configured.

No behavior change when OTLP is not set up.