### PR TITLE
feat(editors): freeze vscode releases to a branch + add dry_run

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -1,9 +1,12 @@
-# Build the VS Code extension and attach a SHA256-verified `.vsix` to a DRAFT
-# GitHub release. Triggered manually (workflow_dispatch), typically after a
-# "Release (vscode): vX.Y.Z" PR (from vscode-release-pr.yml) has merged. The
-# release version comes from `editors/vscode/package.json` — never typed by
-# hand here — so the tag and the packaged version can't diverge. A human
-# reviews the draft and clicks publish.
+# Build the VS Code extension from a FROZEN release branch and attach a
+# SHA256-verified `.vsix` to a DRAFT GitHub release. Triggered manually
+# (workflow_dispatch) with the target version; it checks out the
+# `release/vscode-v<version>` branch (created by vscode-release-pr.yml) rather
+# than main, so the built artifact is frozen to that branch — commits that land
+# on main after the release branch was cut cannot leak into the release. The
+# `vscode-v<version>` tag is created on the branch commit when the draft is
+# published. The version comes from the branch's `package.json` (verified to
+# match the input), so the tag and the packaged version can't diverge.
 #
 # This produces the ARTIFACT ONLY — it does NOT publish to the VS Code
 # Marketplace or Open VSX. That runs from the central secure-release repo
@@ -21,10 +24,15 @@ name: VS Code Extension Release
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Branch/tag/SHA to build from (default: the merged release commit on the default branch)."
-        required: false
+      version:
+        description: "Version to release, e.g. 0.2.0. Builds from the release/vscode-v<version> branch."
+        required: true
         type: string
+      dry_run:
+        description: "Build + package + checksum, but do NOT create the draft GitHub release."
+        required: false
+        type: boolean
+        default: true
 
 # Least privilege: creating a release + tag requires `contents: write`.
 permissions:
@@ -41,9 +49,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Validate version
+        # Runs before checkout, so the default editors/vscode workdir does not
+        # exist yet — run from the workspace root.
+        working-directory: ${{ github.workspace }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Strict X.Y.Z (matches vscode-release-pr.yml; vsce rejects suffixes).
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '$VERSION' is not a valid X.Y.Z."
+            exit 1
+          fi
+
+      # Build from the FROZEN release branch, not main. Later main commits can't
+      # leak into the release.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: release/vscode-v${{ inputs.version }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -55,16 +78,22 @@ jobs:
           npm run build
           npm run package
 
-      - name: Resolve version and tag from package.json
+      - name: Resolve tag and verify package.json version
         id: meta
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          version=$(node -p "require('./package.json').version")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=vscode-v$version" >> "$GITHUB_OUTPUT"
-          # Target the commit we actually built (inputs.ref may differ from the
-          # dispatch ref, so $GITHUB_SHA is not necessarily the built commit).
+          # The branch's package.json must already carry this version (the PR
+          # workflow bumped it). Guards against building the wrong branch/commit.
+          pkg_version=$(node -p "require('./package.json').version")
+          if [[ "$pkg_version" != "$VERSION" ]]; then
+            echo "::error::package.json version ($pkg_version) != requested version ($VERSION). Is release/vscode-v$VERSION the branch created by vscode-release-pr.yml?"
+            exit 1
+          fi
+          echo "tag=vscode-v$VERSION" >> "$GITHUB_OUTPUT"
+          # Tag/target the exact branch commit we built.
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "Building vscode-v$version" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Building vscode-v$VERSION from $(git rev-parse --short HEAD)" | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Compute SHA256 checksum
         run: |
@@ -77,9 +106,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.meta.outputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Dry run — built and checksummed $TAG but skipping the draft release." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           # Rerun-safe: upload assets to an existing release, else create a draft
-          # one (which creates the vscode-v<version> tag on the built commit).
+          # one (which creates the vscode-v<version> tag on the frozen branch
+          # commit when the draft is published).
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release upload "$TAG" omnigent-vscode-*.vsix omnigent-vscode-*.vsix.sha256 \
               --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/vscode-release-pr.yml
+++ b/.github/workflows/vscode-release-pr.yml
@@ -25,6 +25,11 @@ on:
         description: "Extension release version, e.g. 0.2.0 (no leading v)."
         required: true
         type: string
+      dry_run:
+        description: "Bump + draft the CHANGELOG and show the diff, but do NOT push the branch or open the PR."
+        required: false
+        type: boolean
+        default: true
 
 # Opening a PR needs contents + pull-requests write.
 permissions:
@@ -251,6 +256,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
         working-directory: editors/vscode
         run: |
           git config user.name "github-actions[bot]"
@@ -266,6 +272,12 @@ jobs:
             echo "::error::Release PR staged files outside editors/vscode:"
             git diff --cached --name-only | grep -v '^editors/vscode/'
             exit 1
+          fi
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Dry run — staged bump + CHANGELOG for v$VERSION but not pushing a branch or opening a PR." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            { echo '### Dry-run diff'; echo '```diff'; git diff --cached; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
           git commit -m "Release (vscode): v$VERSION"
           git push --force-with-lease origin "$BRANCH"

--- a/editors/vscode/PUBLISHING.md
+++ b/editors/vscode/PUBLISHING.md
@@ -26,24 +26,34 @@ cross-org). Both require SAML SSO to view.
 ## Steps to release
 
 No tags are pushed by hand — the version flows from a reviewed PR into the
-`.vsix` and the release tag, so they can't diverge.
+`.vsix` and the release tag, so they can't diverge. The `.vsix` is built from a
+**frozen `release/vscode-v<version>` branch**, not `main`, so commits that land
+on `main` mid-release can't leak into the artifact. Both dispatch workflows
+default to `dry_run: true`; flip it to `false` to actually push the branch /
+create the release.
 
-1. **Open the release PR.** Run the **VS Code Extension Release PR** workflow
-   (`vscode-release-pr.yml`) with the target version (e.g. `0.2.0`). It bumps
-   `editors/vscode/package.json`, adds a `CHANGELOG.md` section, and opens a
-   `Release (vscode): v0.2.0` PR. Review and merge it.
+1. **Cut the release branch.** Run the **VS Code Extension Release PR** workflow
+   (`vscode-release-pr.yml`) with the target version (e.g. `0.2.0`) and
+   `dry_run: false`. It cuts the `release/vscode-v0.2.0` branch, bumps
+   `editors/vscode/package.json`, drafts a `CHANGELOG.md` section, and opens a
+   `Release (vscode): v0.2.0` PR. (A `dry_run: true` pass just shows the diff in
+   the run summary without pushing.) Review the PR — but **don't merge yet**.
 2. **Build the draft release.** Run the **VS Code Extension Release** workflow
-   (`vscode-extension-release.yml`). It reads the version from `package.json`,
-   builds the `.vsix`, attaches it and its `.sha256`, and creates a **draft**
-   `vscode-v<version>` release (a dedicated tag namespace kept separate from the
-   Python release tags `v[0-9]*`).
+   (`vscode-extension-release.yml`) with the **same version** and
+   `dry_run: false`. It checks out the `release/vscode-v0.2.0` branch (not
+   `main`), verifies the branch's `package.json` matches, builds the `.vsix` +
+   `.sha256`, and creates a **draft** `vscode-v<version>` release (a dedicated
+   tag namespace kept separate from the Python release tags `v[0-9]*`). A
+   `dry_run: true` pass builds and checksums without creating the release.
 3. **Publish the draft.** The workflow leaves the release as a draft: it is not
    public and the `vscode-v<version>` git tag is not created until you publish.
    On GitHub, open the repo's **Releases** page, find the draft, confirm the
    attached `.vsix` + `.sha256` and the notes look right, then click **Publish
-   release**. Publishing creates the tag and makes the release downloadable by
-   the secure-repo workflow.
-4. **Smoke-test the `.vsix` locally.** Download the `.vsix` from the published
+   release**. Publishing creates the tag on the frozen branch commit and makes
+   the release downloadable by the secure-repo workflow.
+4. **Merge the release PR into `main`** (now that the tag is cut) so the version
+   bump and CHANGELOG land on `main`.
+5. **Smoke-test the `.vsix` locally.** Download the `.vsix` from the published
    release and install it into a clean VS Code, then confirm the extension
    activates and opens a local server:
 
@@ -57,7 +67,7 @@ No tags are pushed by hand — the version flows from a reviewed PR into the
    running server's UI (not a blank pane or an error). This catches packaging
    problems (missing files, a broken bundle) before anything reaches the
    marketplaces.
-5. **Publish to the marketplaces.** Dispatch `omnigent-vscode.yml` in the
+6. **Publish to the marketplaces.** Dispatch `omnigent-vscode.yml` in the
    secure-release repo (once it exists), pointing at the `vscode-v<version>`
    tag; run with `dry-run: true` first, then publish for real.
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Makes VS Code extension releases build from a **frozen release branch** instead of `main`, and adds a **`dry_run`** option (default `true`) to both release workflows.

- **Freeze the build (`vscode-extension-release.yml`):** now takes a `version` input and checks out `release/vscode-v<version>` (the branch `vscode-release-pr.yml` creates) rather than `main`. It verifies the branch's `package.json` matches the requested version and tags the exact frozen branch commit. This closes the gap where `editors/vscode` commits landing on `main` between the release PR and the build could leak into the artifact. The release PR is merged only *after* the tag is cut.
- **`dry_run` on both workflows (default `true`):**
  - `vscode-release-pr.yml` — dry run stages the version bump + drafted CHANGELOG and prints the diff to the run summary, without pushing a branch or opening a PR.
  - `vscode-extension-release.yml` — dry run builds, packages, and checksums the `.vsix` without creating the draft release.
- **`PUBLISHING.md`:** "Steps to release" rewritten for the freeze-first flow (cut branch → build from branch → publish draft → merge PR) and documents `dry_run`.

## Test Plan

- Both workflow YAMLs validated (`yaml.safe_load`); `pre-commit run --files` clean.
- Traced the version contract: `release/vscode-v<version>` branch name matches between the two workflows; the build step hard-fails if the branch's `package.json` version ≠ the dispatched version.

## Demo

N/A — CI workflows + docs, no runtime UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Release workflows can't be meaningfully unit-tested in CI. Verified manually: both YAMLs parse, pre-commit passes, the two workflows agree on the `release/vscode-v<version>` branch name, and the build guards against a version mismatch. The `dry_run` default (`true`) means an accidental dispatch is a no-op.
