### PR TITLE
feat(web): surface server-queued messages in a docked strip above the composer

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -12981,6 +12981,46 @@ def create_runner_app(
             )
         await _cancel_active_turn(conv_id, expected_task=target)
 
+    def _publish_buffered_input_consumed(session_id: str, body: dict[str, Any]) -> None:
+        """Announce that a buffered message was just read by the agent.
+
+        A message queued behind an active turn gets no ``session.input.consumed``
+        at forward time (the Omnigent server suppresses it for a buffered
+        forward). Emit one here — when the buffer actually drains into the
+        agent's history — so the client's docked "Queued" row promotes into the
+        transcript at real pickup, not at forward. Carries ``persisted_item_id``
+        (the server-assigned id the forward supplied) as the committed item's
+        id so a later snapshot dedups it. No-op without that id (native forwards
+        omit it; they take the pending-inputs path and never buffer here).
+
+        ``cleared_pending_id`` is left null: the client promotes the optimistic
+        bubble by FIFO position (buffered messages drain in send order), the
+        same mechanism a non-native fresh-turn send already uses — the pending
+        entry never adopts the server id, so a by-id match wouldn't fire.
+
+        :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
+        :param body: The buffered message body being drained.
+        """
+        item_id = body.get("persisted_item_id")
+        if not isinstance(item_id, str) or not item_id:
+            return
+        _publish_event(
+            session_id,
+            {
+                "type": "session.input.consumed",
+                "data": {
+                    "item_id": item_id,
+                    "type": "message",
+                    "data": {
+                        "role": body.get("role", "user"),
+                        "content": body.get("content", []),
+                    },
+                    "created_by": body.get("created_by"),
+                    "cleared_pending_id": None,
+                },
+            },
+        )
+
     async def _check_and_start_next_turn(
         session_id: str,
     ) -> None:
@@ -13034,6 +13074,9 @@ def create_runner_app(
                         "content": next_body.get("content", []),
                     }
                 )
+                # No-op for native (the forward omits persisted_item_id) — kept
+                # for symmetry with the LLM branch below.
+                _publish_buffered_input_consumed(session_id, next_body)
             else:
                 # LLM harnesses: drain ALL buffered messages into history so
                 # rapid-fire input becomes a single continuation turn.
@@ -13049,6 +13092,9 @@ def create_runner_app(
                             "content": body.get("content", []),
                         }
                     )
+                    # The agent reads this drained message now — promote its
+                    # docked "Queued" row into the transcript at real pickup.
+                    _publish_buffered_input_consumed(session_id, body)
                 next_body = all_bodies[-1]
 
             # Reserve before the await so a concurrent POST sees an active turn.
@@ -14585,6 +14631,11 @@ def create_runner_app(
                                                     "content": _m.get("content", []),
                                                 }
                                             )
+                                            # Read mid-turn (not at post-turn
+                                            # drain) — promote its docked
+                                            # "Queued" row into the transcript
+                                            # now, at real pickup.
+                                            _publish_buffered_input_consumed(conv_id, _m)
                                     continue
                                 if _evt_type == "response.output_text.delta":
                                     delta = event.get("delta")

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8793,9 +8793,15 @@ async def _forward_event_to_runner(
             # Non-JSON / unexpected body — treat as not buffered; the
             # consume event still reconciles the message either way.
             buffered = False
-        # Publish input.consumed AFTER the forward succeeds —
-        # the runner has the message and will start the turn.
-        _publish_input_consumed(session_id, persisted_items[0])
+        # Publish input.consumed only for a message that starts a fresh
+        # turn — the runner has it and is about to read it. A buffered
+        # message is queued behind the active turn and NOT read yet; the
+        # runner emits its own session.input.consumed when it actually
+        # drains the buffer (post-turn continuation or mid-turn injection),
+        # and the relay forwards it. Publishing here would pop the client's
+        # docked "Queued" row at forward time, long before pickup.
+        if not buffered:
+            _publish_input_consumed(session_id, persisted_items[0])
         # Emit the routing_decision chip AFTER input.consumed so the
         # live SSE stream delivers the user bubble before the chip —
         # matching the store order (user message was persisted first).

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8584,7 +8584,7 @@ async def _forward_event_to_runner(
     artifact_store: ArtifactStore | None = None,
     has_mcp_servers: bool = False,
     created_by: str | None = None,
-) -> str:
+) -> tuple[str, bool]:
     """
     Persist a user event and forward it to the runner.
 
@@ -8612,7 +8612,11 @@ async def _forward_event_to_runner(
         this turn. ``False`` by default (agents without MCP servers).
     :param created_by: Authenticated identity of the posting actor,
         recorded on the persisted item for attribution.
-    :returns: The store-assigned id of the persisted item.
+    :returns: ``(item_id, buffered)`` — the store-assigned id of the
+        persisted item, and whether the runner queued it behind an
+        already-active turn (``status == "buffered"``, vs. starting a
+        fresh one). ``buffered`` is ``False`` when the forward failed
+        or the runner's response couldn't be parsed.
     """
     import uuid
 
@@ -8772,13 +8776,23 @@ async def _forward_event_to_runner(
 
     # The runner's sessions-native POST returns 202 immediately
     # and starts the turn as a background task. No streaming
-    # response to drain — events flow through GET /stream.
+    # response to drain — events flow through GET /stream. Its body
+    # reports ``status``: ``"buffered"`` (queued behind an active turn)
+    # vs. ``"accepted"`` (started a fresh turn) — surfaced to the sender
+    # so the client shows a buffered message in the docked queue strip.
+    buffered = False
     try:
-        await runner_client.post(
+        _runner_resp = await runner_client.post(
             f"/v1/sessions/{session_id}/events",
             json=runner_body,
             timeout=10.0,
         )
+        try:
+            buffered = _runner_resp.json().get("status") == "buffered"
+        except (ValueError, AttributeError):
+            # Non-JSON / unexpected body — treat as not buffered; the
+            # consume event still reconciles the message either way.
+            buffered = False
         # Publish input.consumed AFTER the forward succeeds —
         # the runner has the message and will start the turn.
         _publish_input_consumed(session_id, persisted_items[0])
@@ -8800,7 +8814,7 @@ async def _forward_event_to_runner(
         )
         _publish_status(session_id, "idle")
 
-    return persisted_items[0].id
+    return persisted_items[0].id, buffered
 
 
 @dataclass
@@ -8816,10 +8830,15 @@ class _SessionEventDispatchResult:
         ``"pending_a1b2c3"`` — surfaced to the sender so it can adopt
         the id and dedupe against the snapshot. ``None`` for non-native
         events (already persisted, so no separate pending entry).
+    :param buffered: ``True`` when the runner queued this message behind
+        an already-active turn (rather than starting a fresh one), so
+        the client shows it in the docked queue strip until its
+        ``session.input.consumed`` promotes it.
     """
 
     item_id: str | None
     pending_id: str | None
+    buffered: bool = False
 
 
 async def _dispatch_session_event_to_runner(
@@ -9029,7 +9048,7 @@ async def _dispatch_session_event_to_runner(
                 _native_verdict,
             )
         return _SessionEventDispatchResult(item_id=None, pending_id=pending_id)
-    item_id = await _forward_event_to_runner(
+    item_id, buffered = await _forward_event_to_runner(
         session_id,
         conv,
         body,
@@ -9041,7 +9060,7 @@ async def _dispatch_session_event_to_runner(
         has_mcp_servers=has_mcp_servers,
         created_by=created_by,
     )
-    return _SessionEventDispatchResult(item_id=item_id, pending_id=None)
+    return _SessionEventDispatchResult(item_id=item_id, pending_id=None, buffered=buffered)
 
 
 def _extract_persistent_item_from_sse(
@@ -19376,6 +19395,11 @@ def create_sessions_router(
         # stability) and relies on stableKey + FIFO instead.
         if dispatch.pending_id is not None:
             response["pending_id"] = dispatch.pending_id
+        # The runner queued this message behind an already-active turn —
+        # tell the client so it shows it in the docked queue strip until
+        # the agent picks it up, rather than inline in the transcript.
+        if dispatch.buffered:
+            response["buffered"] = True
         return response
 
     # ── GET /sessions/{session_id}/stream ────────────────────────

--- a/tests/e2e_ui/chat/test_queued_message_lifecycle.py
+++ b/tests/e2e_ui/chat/test_queued_message_lifecycle.py
@@ -34,6 +34,16 @@ User-message bubbles are ``data-testid="message-bubble"`` +
 ``data-role="user"`` (see ``ChatPage.tsx``). The user's own message
 text is deterministic regardless of the LLM's reply, so assertions key
 off unique sentinel strings — no dependence on model output.
+
+The last tests cover the **docked queue** (``data-testid="queued-message"``):
+a follow-up sent while a turn is in flight is POSTed to the server IMMEDIATELY,
+and the server queues it into the running task's inbox. The client flags it
+``queued`` and shows it as a read-only row above the composer
+(``data-queued-state="queued"``) — NOT a transcript bubble — until its
+``session.input.consumed`` promotes it inline. The strip has no actions: the
+message is already on the server. So the queued strip is exactly "posted, not
+yet picked up," observable in the natural in-flight window without gating the
+LLM.
 """
 
 from __future__ import annotations
@@ -47,8 +57,11 @@ from playwright.sync_api import Page, expect
 # has no reason to echo them verbatim into its own bubble.
 _NAV_MSG = "sentinel-nav-7f3a remember this exact phrase"
 _PROMOTE_MSG = "sentinel-promote-91b2 keep this bubble"
-_QUEUE_MSG_A = "sentinel-queue-a-4d1e first of two"
-_QUEUE_MSG_B = "sentinel-queue-b-8c6f second of two"
+# Docked-queue test: A holds the turn open so B, sent while A streams, is
+# observably queued (docked above the composer) until A finishes and the agent
+# picks B up.
+_DOCK_MSG_A = "sentinel-dock-a-2f7d hold the turn open"
+_DOCK_MSG_B = "sentinel-dock-b-3e9a queued behind the first"
 
 _COMPOSER_PLACEHOLDER = "Ask the agent anything…"
 
@@ -56,6 +69,17 @@ _COMPOSER_PLACEHOLDER = "Ask the agent anything…"
 def _user_bubble(page: Page, text: str):
     """Locator for the user-message bubble carrying ``text``."""
     return page.locator('[data-testid="message-bubble"][data-role="user"]').filter(has_text=text)
+
+
+def _queued_row(page: Page, text: str):
+    """Locator for the docked queue row carrying ``text``.
+
+    A queued (posted-but-unconsumed) follow-up renders in the strip above the
+    composer (``data-testid="queued-message"``), NOT inline in the transcript;
+    once the agent picks it up it leaves the strip and becomes an ordinary
+    bubble.
+    """
+    return page.locator('[data-testid="queued-message"]').filter(has_text=text)
 
 
 def _send(page: Page, text: str) -> None:
@@ -149,37 +173,49 @@ def test_user_message_survives_navigation_away_and_back(
     expect(_user_bubble(page, _NAV_MSG)).to_be_visible()
 
 
-def test_second_message_queued_while_first_streams_both_render(
+def test_message_sent_while_busy_queues_then_promotes_on_pickup(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Queue a second message while the first turn is active: both render.
+    """A follow-up sent mid-turn queues above the composer, then promotes inline.
 
-    Sends A, then types B and clicks Send while A's turn is still in
-    flight (the composer keeps a working Send button whenever it holds a
-    draft — ``showInterruptButton = isWorking && !hasDraft``). Both user
-    bubbles must render and, once everything settles, persist as exactly
-    one bubble each.
+    The queued lifecycle end-to-end:
 
-    This exercises queueing two optimistic bubbles and promoting both as
-    their ``session.input.consumed`` events arrive in order — a count
-    other than 1 for either means the FIFO promotion dropped or
-    duplicated a queued bubble.
+    1. Send A → its turn goes to work. Send B while A is in flight: B is POSTed
+       immediately, but the server queues it into the running task's inbox, so
+       the client flags it ``queued`` and shows it as a read-only docked row
+       (``data-queued-state="queued"``) — NOT a transcript bubble.
+    2. The row is read-only — no client-side edit/delete/steer actions, since
+       the message is already on the server.
+    3. Let A's turn finish → the agent picks B up (``session.input.consumed``);
+       B leaves the strip and renders inline as exactly one transcript bubble,
+       without any user action, and A is unaffected.
+
+    Steps 1–2 ride the natural in-flight window (client send-time state), so no
+    LLM gating is needed; step 3 waits the turn out.
     """
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
 
-    _send(page, _QUEUE_MSG_A)
-    # A's optimistic bubble is up; the turn is now (or about to be)
-    # working. Queue B immediately by typing a draft and sending again.
-    expect(_user_bubble(page, _QUEUE_MSG_A)).to_be_visible(timeout=10_000)
-    _send(page, _QUEUE_MSG_B)
-    expect(_user_bubble(page, _QUEUE_MSG_B)).to_be_visible(timeout=10_000)
+    # Send A; as soon as its bubble is up the turn is (about to be) working.
+    _send(page, _DOCK_MSG_A)
+    expect(_user_bubble(page, _DOCK_MSG_A)).to_be_visible(timeout=10_000)
 
-    # Let both turns drain. Two distinct user messages were sent, so once
-    # the session goes idle there must be exactly one bubble for each —
-    # both consumed and promoted, neither dropped nor double-rendered.
+    # Send B while A is in flight → queued docked row, not a transcript bubble.
+    _send(page, _DOCK_MSG_B)
+    row = _queued_row(page, _DOCK_MSG_B)
+    expect(row).to_be_visible(timeout=10_000)
+    expect(row).to_have_attribute("data-queued-state", "queued")
+    expect(_user_bubble(page, _DOCK_MSG_B)).to_have_count(0)
+    # Read-only: no client-side actions on a posted message.
+    expect(row.get_by_test_id("queued-edit")).to_have_count(0)
+    expect(row.get_by_test_id("queued-delete")).to_have_count(0)
+    expect(row.get_by_test_id("queued-steer")).to_have_count(0)
+
+    # Drain the turn → the agent picks B up. It leaves the strip and renders
+    # inline as exactly one transcript bubble; A is unaffected.
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
     expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
-    expect(_user_bubble(page, _QUEUE_MSG_A)).to_have_count(1, timeout=60_000)
-    expect(_user_bubble(page, _QUEUE_MSG_B)).to_have_count(1, timeout=60_000)
+    expect(_queued_row(page, _DOCK_MSG_B)).to_have_count(0, timeout=60_000)
+    expect(_user_bubble(page, _DOCK_MSG_B)).to_have_count(1, timeout=60_000)
+    expect(_user_bubble(page, _DOCK_MSG_A)).to_have_count(1, timeout=60_000)

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -4249,6 +4249,135 @@ async def test_scaffold_subagent_defers_terminal_delivery_while_continuation_buf
 
 
 @pytest.mark.asyncio
+async def test_buffered_message_emits_input_consumed_at_drain_not_at_buffer() -> None:
+    """A message queued behind an active turn emits input.consumed at drain.
+
+    Guards the queued-message lifecycle: a follow-up posted while a turn is
+    active buffers (``status: "buffered"``) and gets NO ``session.input.consumed``
+    at forward time — the Omnigent server suppresses the eager publish. The
+    runner emits one only when it actually drains the buffer into the agent's
+    history (``_check_and_start_next_turn``), so the client's docked "Queued"
+    row promotes into the transcript at real pickup, not at forward.
+
+    Determinism reuses the gated two-turn harness: turn 1 blocks after its
+    delta so message B provably buffers; while it is buffered we assert NO
+    consumed event carries B's id; releasing turn 1 drains the buffer and the
+    consumed event then arrives carrying B's ``persisted_item_id``.
+    """
+    from omnigent.runner import app as runner_app
+
+    conv_id = "conv_buffered_consume_at_drain"
+    b_item_id = "item_buffered_B"
+    started = asyncio.Event()
+    release = asyncio.Event()
+    turns = [_sse_text_turn("TURN_ONE"), _sse_text_turn("TURN_TWO")]
+
+    async def _spec_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return a non-native scaffold spec so the message buffers/drains here.
+
+        :param agent_id: Agent id requested by the runner (unused).
+        :param session_id: Session id (unused).
+        :returns: A minimal scaffold spec bound to the test harness.
+        """
+        del agent_id, session_id
+        return AgentSpec(
+            spec_version=1,
+            name="buffered-consume-agent",
+            executor=ExecutorSpec(type="omnigent", config={"harness": _TEST_HARNESS_NAME}),
+        )
+
+    app = create_runner_app(
+        process_manager=cast(
+            HarnessProcessManager,
+            _FakeProcessManager(_GatedTwoTurnHarnessClient(turns, started, release)),
+        ),
+        spec_resolver=_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    def _consumed_ids_for(item_id: str) -> list[str]:
+        """Drain the session event queue; return input.consumed ids matching.
+
+        Reads the module-level per-session queue the SSE ``/stream`` endpoint
+        drains (see ``_drain_published_statuses``) — a live SSE ``GET`` can't
+        interleave with a ``POST`` on the ASGI transport.
+
+        :param item_id: The buffered message's persisted item id to match.
+        :returns: ``item_id`` values from ``session.input.consumed`` events
+            whose id equals ``item_id``.
+        """
+        queue = runner_app._session_event_queues_ref.get(conv_id)
+        seen: list[str] = []
+        while queue is not None and not queue.empty():
+            event = queue.get_nowait()
+            if not isinstance(event, dict) or event.get("type") != "session.input.consumed":
+                continue
+            data = event.get("data")
+            if isinstance(data, dict) and data.get("item_id") == item_id:
+                seen.append(item_id)
+        return seen
+
+    try:
+        async with _runner_test_client(app) as http:
+            # Turn A starts a background turn that blocks before completing.
+            resp_a = await http.post(
+                f"/v1/sessions/{conv_id}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": "ag_buffered",
+                    "model": "x",
+                    "content": [{"type": "input_text", "text": "start the turn"}],
+                },
+            )
+            assert resp_a.status_code == 202
+
+            await asyncio.wait_for(started.wait(), timeout=10.0)
+
+            # Message B arrives while A is active → buffers. Carries the
+            # server-assigned persisted_item_id the Omnigent forward supplies;
+            # that id is what the drain-time consumed event must echo back.
+            resp_b = await http.post(
+                f"/v1/sessions/{conv_id}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": "ag_buffered",
+                    "model": "x",
+                    "persisted_item_id": b_item_id,
+                    "content": [{"type": "input_text", "text": "queued behind A"}],
+                },
+            )
+            assert resp_b.status_code == 202
+            assert resp_b.json()["status"] == "buffered"
+
+            # While B is still buffered (turn A not released), NO consumed
+            # event for B has been emitted — the whole point of the fix.
+            assert _consumed_ids_for(b_item_id) == [], (
+                "input.consumed for B fired while it was still buffered — the "
+                "docked 'Queued' row would clear before real pickup"
+            )
+
+            # Release turn A → the buffer drains into history and turn B runs.
+            release.set()
+
+            # The consumed event for B now arrives, carrying its item id.
+            deadline = asyncio.get_running_loop().time() + 10.0
+            consumed: list[str] = []
+            while asyncio.get_running_loop().time() < deadline:
+                consumed = _consumed_ids_for(b_item_id)
+                if consumed:
+                    break
+                await asyncio.sleep(0.02)
+    finally:
+        release.set()
+
+    assert consumed == [b_item_id], (
+        f"expected exactly one session.input.consumed for B at drain time, got {consumed!r}"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status", "policy_response", "expected_output", "blocked_output"),
     [

--- a/tests/server/integration/test_sessions_model_override.py
+++ b/tests/server/integration/test_sessions_model_override.py
@@ -293,18 +293,25 @@ async def test_create_session_rejects_invalid_reasoning_effort(
 class _CaptureClient:
     """Stub runner client that records the POSTed body for inspection."""
 
-    def __init__(self, captured: dict[str, Any]) -> None:
+    def __init__(self, captured: dict[str, Any], runner_status: str = "accepted") -> None:
         self._captured = captured
+        self._runner_status = runner_status
 
     async def post(self, path: str, *, json: dict[str, Any], **_: Any) -> Any:
         """Record the path + body and return a fake 202 response."""
         self._captured["path"] = path
         self._captured["body"] = json
 
+        runner_status = self._runner_status
+
         class _Resp:
             status_code = 202
             headers: dict[str, str] = {}
             text = ""
+
+            @staticmethod
+            def json() -> dict[str, str]:
+                return {"status": runner_status}
 
         return _Resp()
 
@@ -312,9 +319,14 @@ class _CaptureClient:
         raise NotImplementedError
 
 
-def _stub_runner_client(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+def _stub_runner_client(
+    monkeypatch: pytest.MonkeyPatch, runner_status: str = "accepted"
+) -> dict[str, Any]:
     """Patch ``_get_runner_client`` to return a capturing stub.
 
+    :param runner_status: The ``status`` the fake runner reports in its
+        POST /events response body — ``"buffered"`` (queued behind an
+        active turn) or ``"accepted"`` (started a fresh turn).
     :returns: A dict the test inspects after the runner POST runs;
         contains ``path`` and ``body`` keys once the route fires.
     """
@@ -323,7 +335,7 @@ def _stub_runner_client(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     captured: dict[str, Any] = {}
 
     async def _stub(*_: Any, **__: Any) -> _CaptureClient:
-        return _CaptureClient(captured)
+        return _CaptureClient(captured, runner_status)
 
     monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub)
     return captured
@@ -373,6 +385,56 @@ async def test_runner_path_forwards_persisted_model_override(
         f"{sorted(captured['body'].keys())!r}. The persisted column did "
         f"not flow into _forward_event_to_runner's runner_body."
     )
+
+
+async def test_message_surfaces_buffered_when_runner_queues_behind_active_turn(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The POST /events response reports ``buffered`` from the runner status.
+
+    When the runner queues a message behind an already-active turn it
+    replies ``{"status": "buffered"}``; the AP route must surface that as
+    ``buffered: true`` so the client shows the message in the docked queue
+    strip (rather than predicting busy-ness client-side).
+    """
+    _stub_runner_client(monkeypatch, runner_status="buffered")
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json().get("buffered") is True, resp.text
+
+
+async def test_message_omits_buffered_when_runner_starts_fresh_turn(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh-turn send (runner ``status == "accepted"``) carries no ``buffered``."""
+    _stub_runner_client(monkeypatch, runner_status="accepted")
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json().get("buffered") is not True, resp.text
 
 
 async def test_create_time_model_override_forwards_on_first_event(

--- a/tests/server/integration/test_sessions_model_override.py
+++ b/tests/server/integration/test_sessions_model_override.py
@@ -341,6 +341,27 @@ def _stub_runner_client(
     return captured
 
 
+def _capture_input_consumed(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture ``session.input.consumed`` events published to the session stream.
+
+    Patches ``session_stream.publish`` in the sessions route module and
+    returns a list that collects only the consumed events, so a test can
+    assert whether the eager forward-time publish fired.
+
+    :returns: A list appended to as ``session.input.consumed`` events publish.
+    """
+    from omnigent.server.routes import sessions as sessions_mod
+
+    consumed: list[dict[str, Any]] = []
+
+    def _publish(sid: str, event: dict[str, Any]) -> None:
+        if isinstance(event, dict) and event.get("type") == "session.input.consumed":
+            consumed.append(event)
+
+    monkeypatch.setattr(sessions_mod.session_stream, "publish", _publish)
+    return consumed
+
+
 async def test_runner_path_forwards_persisted_model_override(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -397,8 +418,14 @@ async def test_message_surfaces_buffered_when_runner_queues_behind_active_turn(
     replies ``{"status": "buffered"}``; the AP route must surface that as
     ``buffered: true`` so the client shows the message in the docked queue
     strip (rather than predicting busy-ness client-side).
+
+    It must ALSO suppress the eager forward-time ``session.input.consumed``:
+    the message is queued, not read, so its consumed event is owned by the
+    runner's drain path. Publishing here would clear the client's docked
+    "Queued" row before real pickup.
     """
     _stub_runner_client(monkeypatch, runner_status="buffered")
+    consumed = _capture_input_consumed(monkeypatch)
 
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
@@ -413,14 +440,24 @@ async def test_message_surfaces_buffered_when_runner_queues_behind_active_turn(
     )
     assert resp.status_code == 202, resp.text
     assert resp.json().get("buffered") is True, resp.text
+    assert consumed == [], (
+        "a buffered message must NOT publish session.input.consumed at forward "
+        f"time — the runner emits it at drain; got {len(consumed)} event(s)"
+    )
 
 
 async def test_message_omits_buffered_when_runner_starts_fresh_turn(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A fresh-turn send (runner ``status == "accepted"``) carries no ``buffered``."""
+    """A fresh-turn send (runner ``status == "accepted"``) carries no ``buffered``.
+
+    And it DOES publish ``session.input.consumed`` at forward time: a
+    fresh-turn message is read immediately, so the eager publish is correct
+    (the moment ② forward and ③ consume coincide).
+    """
     _stub_runner_client(monkeypatch, runner_status="accepted")
+    consumed = _capture_input_consumed(monkeypatch)
 
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
@@ -435,6 +472,10 @@ async def test_message_omits_buffered_when_runner_starts_fresh_turn(
     )
     assert resp.status_code == 202, resp.text
     assert resp.json().get("buffered") is not True, resp.text
+    assert len(consumed) == 1, (
+        "a fresh-turn message must publish exactly one session.input.consumed "
+        f"at forward time; got {len(consumed)}"
+    )
 
 
 async def test_create_time_model_override_forwards_on_first_event(

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -51,6 +51,12 @@ export interface PostEventResponse {
    *  denial text via SSE but did not start a turn or persist the
    *  user message, so no `session.input.consumed` will follow. */
   denied?: boolean;
+  /** True when the runner queued this message behind an already-active
+   *  turn (rather than starting a fresh one). The client shows a
+   *  buffered message in the docked queue strip until its
+   *  `session.input.consumed` promotes it into the transcript. Absent
+   *  (falsy) when the message started a fresh turn. */
+  buffered?: boolean;
   /**
    * Server-assigned pending-input id for a native-terminal web
    * message, e.g. ``"pending_a1b2c3"``. It identifies the snapshot's
@@ -359,12 +365,14 @@ function postEventResponseFromWire(wire: {
   item_id?: string;
   denied?: boolean;
   pending_id?: string;
+  buffered?: boolean;
 }): PostEventResponse {
   return {
     queued: wire.queued,
     itemId: wire.item_id,
     denied: wire.denied,
     pendingId: wire.pending_id,
+    buffered: wire.buffered,
   };
 }
 

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -335,6 +335,22 @@ describe("buildPendingBubbles", () => {
     // p.author ("bob") wins over the viewer's selfAuthor ("alice").
     expect(bubble.createdBy).toBe("bob@example.com");
   });
+
+  it("renders every pending send as an ordinary inline bubble (no queued flag)", () => {
+    // Pending sends — whether they start a turn or land while one is running —
+    // render inline in the transcript like any optimistic bubble. There is no
+    // separate "queued" treatment; un-sent messages live in heldMessages and
+    // render in the docked strip until they auto-flush.
+    const mixed = [
+      { tempId: "tmp_now", content: [{ type: "input_text" as const, text: "starts a turn" }] },
+      { tempId: "tmp_q", content: [{ type: "input_text" as const, text: "sent behind" }] },
+    ];
+    const bubbles = buildPendingBubbles(mixed, null) as Extract<Bubble, { kind: "user" }>[];
+    expect(bubbles).toHaveLength(2);
+    expect(bubbles[0]!.itemId).toBe("tmp_now");
+    expect(bubbles[1]!.itemId).toBe("tmp_q");
+    expect(bubbles.every((b) => !("queued" in b))).toBe(true);
+  });
 });
 
 // ── mergePendingBubbles ────────────────────────────────────────────────────

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -18,6 +18,7 @@ import {
   CheckIcon,
   AlertTriangleIcon,
   ChevronDownIcon,
+  ClockIcon,
   CornerUpLeftIcon,
   CopyIcon,
   FileTextIcon,
@@ -297,7 +298,14 @@ export function containsMarkdownTable(items: RenderItem[]): boolean {
 }
 
 /**
- * Build optimistic user bubbles from the pending-send queue.
+ * Build optimistic user bubbles from the pending-send queue, for the
+ * transcript.
+ *
+ * Excludes `queued` sends: a message POSTed while the agent was busy sits in
+ * the docked strip above the composer (see {@link QueuedMessages}), NOT inline
+ * in the transcript, until its `session.input.consumed` clears the pending
+ * entry and promotes it into committed history. A non-queued send (starts a
+ * fresh turn) renders inline immediately.
  *
  * Author priority per bubble: `p.author` (captured at send time for
  * fresh sends, or from the snapshot's `created_by` for replayed entries)
@@ -313,23 +321,106 @@ export function containsMarkdownTable(items: RenderItem[]): boolean {
  * `selfAuthor` is null before identity resolves and in single-user
  * mode (no label shown).
  *
- * @param pending - the queued optimistic sends, in FIFO order.
+ * @param pending - the pending optimistic sends, in FIFO order.
  * @param selfAuthor - the viewer's attribution id, or null.
  */
 export function buildPendingBubbles(
   pending: PendingUserMessage[],
   selfAuthor: string | null,
 ): Bubble[] {
-  return pending.map((p) => {
-    const author = p.author ?? selfAuthor;
-    return {
-      kind: "user",
-      // No server item id yet; tempId keeps React keys stable until promotion.
-      itemId: p.tempId,
-      content: p.content,
-      ...(author !== null ? { createdBy: author } : {}),
-    };
-  });
+  return pending
+    .filter((p) => p.queued !== true)
+    .map((p) => {
+      const author = p.author ?? selfAuthor;
+      return {
+        kind: "user" as const,
+        // No server item id yet; tempId keeps React keys stable until promotion.
+        itemId: p.tempId,
+        content: p.content,
+        ...(author !== null ? { createdBy: author } : {}),
+      };
+    });
+}
+
+/**
+ * One-line preview text for a queued message row.
+ *
+ * The queued list is a compact strip, so it shows the typed text. An
+ * image-/file-only queued message has no text — fall back to the first
+ * attachment's filename so the row is never blank.
+ */
+function queuedMessagePreview(content: MessageContentBlock[]): string {
+  const text = extractUserText(content);
+  if (text) return text;
+  for (const c of content) {
+    if ((c.type === "input_image" || c.type === "input_file") && c.filename) {
+      return c.filename;
+    }
+  }
+  return "Attachment";
+}
+
+/**
+ * The docked message queue — a compact stack directly above the composer,
+ * mirroring the Codex chat UX: follow-ups waiting to be picked up sit right
+ * above the input.
+ *
+ * Shows the `queued` pending messages — follow-ups POSTed while the agent was
+ * busy, which the server queues into the running task's inbox. They're
+ * read-only here (the server has them; there's no client-side cancel/edit) and
+ * carry a "Queued" indicator (clock + label). Each leaves the strip and appears
+ * inline in the transcript once its `session.input.consumed` clears the pending
+ * entry. Column-aligned with the composer box.
+ */
+export function QueuedMessages() {
+  // Select the raw array (stable reference) and filter in render — a selector
+  // that returns `.filter(...)` builds a new array each call, which Zustand
+  // reads as a change and re-renders in a loop.
+  const pending = useChatStore((s) => s.pendingUserMessages);
+  const queued = pending.filter((p) => p.queued === true);
+  if (queued.length === 0) return null;
+
+  return (
+    <div className="px-4 md:px-6">
+      <div
+        data-testid="queued-messages"
+        // Cap the strip so a long queue can't push the composer off-screen or
+        // bury the transcript — it scrolls past ~5 rows (max-h-48) instead of
+        // growing without bound. `overflow-y-auto` keeps the rounded border
+        // clipping its children. Thin, muted thumb matches the app's themed
+        // scrollbar convention (see ForkSessionDialog) rather than the heavy
+        // default OS bar.
+        className={cn(
+          "mx-auto mb-1.5 flex max-h-48 w-full flex-col divide-y divide-border overflow-y-auto rounded-xl border border-border bg-muted/40 [scrollbar-color:var(--color-muted-foreground)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/40 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:w-2",
+          CHAT_COLUMN_WIDTH,
+        )}
+      >
+        {queued.map((msg) => (
+          <QueuedMessageRow key={msg.tempId} message={msg} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One row of the docked queue: a read-only preview of a message POSTed to a
+ * busy agent and awaiting pickup. No actions — the message is already on the
+ * server (there's no client-side cancel/edit); it clears on its own when the
+ * agent consumes it.
+ */
+function QueuedMessageRow({ message }: { message: PendingUserMessage }) {
+  return (
+    <div
+      data-testid="queued-message"
+      data-queued-state="queued"
+      className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground"
+    >
+      <ClockIcon className="size-3.5 shrink-0 animate-pulse" aria-hidden="true" />
+      <span className="min-w-0 flex-1 truncate">{queuedMessagePreview(message.content)}</span>
+      <span className="shrink-0 text-xs">Queued</span>
+    </div>
+  );
 }
 
 // A committed bubble that exists ONLY to render one or more
@@ -970,6 +1061,10 @@ export function ChatPage() {
       setReconnectDialogOpen(true);
       return;
     }
+    // Always POST immediately. If the agent is busy the server queues the
+    // message into the running task's inbox and `send` flags it `queued`, so
+    // it shows in the docked "Queued" strip until its `session.input.consumed`
+    // promotes it into the transcript.
     void useChatStore.getState().send(text, agentId, files, {
       onConversationCreated: (newId) => {
         // Eager URL update: the moment the server tells us this
@@ -1700,6 +1795,9 @@ function MainAgentSurface({
         containerRef={conversationRef}
         onReply={(text) => setReplyQuotes((prev) => [...prev, text])}
       />
+
+      {/* Follow-ups queued behind a busy agent, stacked above the composer. */}
+      <QueuedMessages />
 
       <Composer
         disabled={disabled}

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -2,7 +2,20 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Bubble } from "@/lib/renderItems";
 import { FileViewerContext } from "@/shell/FileViewerContext";
-import { BubbleView } from "./ChatPage";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useChatStore } from "@/store/chatStore";
+import { BubbleView, QueuedMessages } from "./ChatPage";
+
+// The steer/delete buttons use the app's Tooltip, which needs a
+// TooltipProvider ancestor (the app root supplies one globally). Mirror
+// that here so bare QueuedMessages renders don't throw.
+function renderQueue() {
+  return render(
+    <TooltipProvider>
+      <QueuedMessages />
+    </TooltipProvider>,
+  );
+}
 
 // UserBubble renders its text through the same markdown renderer as the
 // assistant bubble (FilePathAwareMessageResponse → Streamdown). These tests
@@ -98,6 +111,68 @@ describe("UserBubble markdown rendering", () => {
     // table would render as literal pipe text with no <table>/<td>.
     const cell = await screen.findByText("1", { selector: "td, td *" });
     expect(cell.closest("table")).not.toBeNull();
+  });
+});
+
+function queuedMsg(tempId: string, text: string) {
+  return {
+    tempId,
+    content: [{ type: "input_text" as const, text }],
+    queued: true as const,
+  };
+}
+
+describe("QueuedMessages docked list (posted, awaiting pickup)", () => {
+  afterEach(() => {
+    useChatStore.setState({ pendingUserMessages: [] });
+  });
+
+  it("renders a queued pending message as a read-only row (no actions)", () => {
+    useChatStore.setState({
+      pendingUserMessages: [queuedMsg("p1", "queued follow-up")],
+    });
+    renderQueue();
+    const row = screen.getByTestId("queued-message");
+    expect(row).toHaveAttribute("data-queued-state", "queued");
+    expect(row).toHaveTextContent("queued follow-up");
+    // No client-side actions — the message is already on the server.
+    expect(screen.queryByTestId("queued-edit")).toBeNull();
+    expect(screen.queryByTestId("queued-delete")).toBeNull();
+    expect(screen.queryByTestId("queued-steer")).toBeNull();
+  });
+
+  it("stacks multiple queued rows in FIFO order", () => {
+    useChatStore.setState({
+      pendingUserMessages: [queuedMsg("p1", "first"), queuedMsg("p2", "second")],
+    });
+    renderQueue();
+    const rows = screen.getAllByTestId("queued-message");
+    expect(rows[0]).toHaveTextContent("first");
+    expect(rows[1]).toHaveTextContent("second");
+  });
+
+  it("keeps NON-queued pending sends OUT of the strip — they render inline instead", () => {
+    // A send that started a fresh turn carries no `queued` flag; it renders as
+    // a transcript bubble, so the docked strip must ignore it.
+    useChatStore.setState({
+      pendingUserMessages: [
+        { tempId: "p1", content: [{ type: "input_text", text: "on its way" }] },
+      ],
+    });
+    const { container } = renderQueue();
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId("queued-messages")).toBeNull();
+  });
+});
+
+describe("UserBubble (no queued caption)", () => {
+  it("renders a bubble with no pending-pickup caption", () => {
+    // Queued messages live in the docked strip, not as transcript bubbles, so
+    // there's no separate 'Queued — waiting' caption on a bubble.
+    renderBubble(userBubble("delivered"));
+    const bubble = screen.getByTestId("message-bubble");
+    expect(bubble).not.toHaveAttribute("data-queued");
+    expect(screen.queryByTestId("queued-bubble-indicator")).toBeNull();
   });
 });
 

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2522,6 +2522,126 @@ describe("chatStore — send (cross-session routing)", () => {
   });
 });
 
+// A message POSTed while the agent is busy is flagged `queued` on its pending
+// entry, so it shows in the docked strip until its `session.input.consumed`
+// promotes it into the transcript. A message sent while idle starts a fresh
+// turn and carries no flag.
+describe("chatStore — send while busy (queued flag)", () => {
+  // Mock the events POST to report the runner's queue status. `buffered` is
+  // the authoritative signal the store reconciles `queued` from.
+  function mockEventsBuffered(buffered: boolean): void {
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.match(/\/v1\/sessions\/[^/]+\/events$/)) {
+        return mockResponse({ queued: true, item_id: "ci_mock", buffered });
+      }
+      return defaultFetchHandler(input, init);
+    });
+  }
+
+  it("POSTs immediately and flags a send as queued when the server reports buffered", async () => {
+    mockEventsBuffered(true);
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+      status: "streaming",
+    });
+
+    await useChatStore.getState().send("queue me", "agent_xyz");
+
+    const pending = useChatStore.getState().pendingUserMessages;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.queued).toBe(true);
+    // It really went to the server — no client-side holding.
+    const events = fetchMock.mock.calls.filter(([u]) =>
+      String(u).endsWith("/v1/sessions/conv_existing/events"),
+    );
+    expect(events).toHaveLength(1);
+    const body = JSON.parse((events[0]![1] as RequestInit).body as string);
+    expect(body.data.content).toEqual([{ type: "input_text", text: "queue me" }]);
+  });
+
+  it("reconciles queued to false when the server did NOT buffer (started a turn)", async () => {
+    // The optimistic prediction may say queued (local status streaming), but
+    // the server's `buffered=false` is authoritative — the message started a
+    // fresh turn, so it renders inline, not in the strip.
+    mockEventsBuffered(false);
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+      status: "streaming",
+    });
+
+    await useChatStore.getState().send("start now", "agent_xyz");
+
+    const pending = useChatStore.getState().pendingUserMessages;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.queued).toBe(false);
+  });
+
+  it("does not flag a send made while fully idle", async () => {
+    mockEventsBuffered(false);
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+      status: "idle",
+      sessionStatus: "idle",
+    });
+
+    await useChatStore.getState().send("start now", "agent_xyz");
+
+    const pending = useChatStore.getState().pendingUserMessages;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.queued).toBe(false);
+  });
+
+  it("keeps a native-terminal send flagged queued (no server buffered signal)", async () => {
+    // Native sessions ride the pending_inputs path — the runner returns no
+    // `buffered`, so the optimistic value (native → queued) stands.
+    useChatStore.setState({
+      conversationId: "conv_native",
+      abortController: new AbortController(),
+      status: "idle",
+      sessionStatus: "idle",
+      isNativeTerminalSession: true,
+    });
+
+    await useChatStore.getState().send("hey", "agent_xyz");
+
+    const pending = useChatStore.getState().pendingUserMessages;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.queued).toBe(true);
+  });
+
+  it("drops the queued flag when the agent picks the message up (consume → promote)", async () => {
+    // The flag rides only on the optimistic pending entry; its
+    // session.input.consumed promotes it into `blocks` as a committed bubble
+    // that carries no `queued`, so it leaves the strip on pickup.
+    mockEventsBuffered(true);
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+      status: "streaming",
+    });
+
+    await useChatStore.getState().send("queue me", "agent_xyz");
+    expect(useChatStore.getState().pendingUserMessages[0]!.queued).toBe(true);
+
+    handleSessionEvent({
+      type: "session_input_consumed",
+      itemId: "msg_q_1",
+      itemType: "message",
+      data: { role: "user", content: [{ type: "input_text", text: "queue me" }] },
+    });
+
+    const state = useChatStore.getState();
+    expect(state.pendingUserMessages).toEqual([]);
+    const promoted = state.blocks.find((b) => b.type === "user_message") as UserMessageBlock;
+    expect(promoted).toBeDefined();
+    expect("queued" in promoted).toBe(false);
+  });
+});
+
 describe("chatStore — send (file attachments)", () => {
   it("refreshes the pending entry with real file_ids after upload", async () => {
     // Claude-native's session.input.consumed is text-only, so the

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -141,6 +141,14 @@ export interface PendingUserMessage {
    * on snapshot-replayed entries (they're already server-owned).
    */
   posted?: boolean;
+  /**
+   * True when the server queued this message behind a busy turn. Decides
+   * WHERE an unconsumed message shows — the docked "Queued" strip vs. inline
+   * in the transcript — not whether it's consumed (that's
+   * `session.input.consumed`, which clears it either way). Unset on
+   * snapshot-replayed entries and slash echoes.
+   */
+  queued?: boolean;
 }
 
 /**
@@ -788,6 +796,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
       set({ status: "streaming", activeResponse: null });
     }
 
+    // Optimistic guess at "is the agent busy" so the docked "Queued" strip
+    // shows the message instantly, before the POST returns. The runner's
+    // `buffered` status reconciles `queued` below — this only covers the
+    // render gap. `serverBusy` catches the case `alreadyStreaming` misses:
+    // local `status` is `idle` but the agent loop is still draining
+    // (`running`/`waiting`). Native sends get no `buffered` signal, so their
+    // optimistic value stands.
+    const serverBusy = (() => {
+      const ss = get().sessionStatus;
+      return ss === "running" || ss === "waiting";
+    })();
+    const isQueuedSend = alreadyStreaming || serverBusy || get().isNativeTerminalSession;
+
     // Push to `pendingUserMessages` BEFORE the POST so the bubble
     // renders immediately AND so `session.input.consumed` finds an
     // entry to promote even if the SSE event races ahead of the POST
@@ -810,7 +831,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set((s) => ({
       pendingUserMessages: [
         ...s.pendingUserMessages,
-        { tempId, content, ...(selfAuthor !== null ? { author: selfAuthor } : {}) },
+        {
+          tempId,
+          content,
+          ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+          ...(isQueuedSend ? { queued: true } : {}),
+        },
       ],
       // A new turn supersedes the prior turn's background-shell tally: the
       // "N background tasks still running" label must give way to "Working…" the
@@ -925,9 +951,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // have since resolved — the stuck-pending-bubble bug. The live
         // bubble itself keeps rendering until its consumed event pops
         // it; only the navigation-survival policy changes here.
+        //
+        // Reconcile `queued` to the server's `buffered` — the authoritative
+        // "was this queued behind an active turn" — correcting the optimistic
+        // guess above. Native sends have no `buffered` signal, so keep theirs.
+        const isNative = get().isNativeTerminalSession;
         set((s) => ({
           pendingUserMessages: s.pendingUserMessages.map((p) =>
-            p.tempId === tempId ? { ...p, posted: true } : p,
+            p.tempId === tempId
+              ? {
+                  ...p,
+                  posted: true,
+                  ...(isNative ? {} : { queued: postResult.buffered === true }),
+                }
+              : p,
           ),
           pendingByConversation: removeFromPendingStash(s.pendingByConversation, sessionId, tempId),
         }));
@@ -3760,6 +3797,9 @@ export function handleSessionEvent(event: StreamEvent): void {
       //      the drop and strand the bubble as a duplicate.
       //   3. No pending entry — render the event payload as a fresh
       //      committed bubble (TUI-typed message, or another client).
+      // The "Queued" badge rides on the optimistic pending entry; promoting
+      // it into `blocks` here drops the entry, so the badge disappears the
+      // moment the agent picks the message up — no extra state needed.
       useChatStore.setState((s) => {
         if (hasCommittedItem(s.blocks, event.itemId)) return {};
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Messages are always POSTed to the server immediately. When the runner queues a message behind an already-active turn it returns `status: "buffered"`; this threads that status through the AP server's POST response so the client can tell a truly-queued message apart from one starting a fresh turn.

- Queued messages now render read-only in a docked **"Queued" strip** above the composer (pulsing clock + preview) instead of inline in the transcript, and clear on their own when the agent consumes them (`session.input.consumed`).
- `pendingUserMessages` stays the single source of truth; a new `queued` flag only decides *placement* (strip vs. inline), reconciled from the server's authoritative `buffered` status with an optimistic guess covering the render gap before the POST returns.

This PR doesn't support client-side queueing message on-purpose, since that means we need to add another layer before posting the messages to server. Currently the messages show as queued before they're consumed by the agent so hopefully that clarifies some confusion.
If there's a request to support client-side queueing & steering messages then we should design that separately, since not all harnesses support queueing messages (e.g. native claude code only supports steering).

### ELI5

You can keep typing while the agent is working. Anything you send while it's busy waits in a little tray just above the box that says "Queued" — as soon as the agent gets to it, it hops up into the conversation.

### Lifecycle

```
User sends ──▶ POST /events (always, immediately)
                    │
                    ▼
        pendingUserMessages[]  (single source of truth)
                    │
     queued = server `buffered`?  (optimistic guess reconciled on POST return)
          busy │              │ fresh turn
               ▼              ▼
   docked "Queued" strip   inline optimistic bubble
               └──────┬───────┘
                      │ session.input.consumed
                      ▼
           promoted into transcript (pending entry dropped)
```

## Test Plan

- `npm test` — 3489 passed (web unit/component suite, incl. new `chatStore` buffered→queued reconciliation and read-only strip tests).
- `npm run build` — succeeds.
- `pytest tests/server/integration/test_sessions_model_override.py` — 20 passed, incl. new `test_message_surfaces_buffered_when_runner_queues_behind_active_turn` and `test_message_omits_buffered_when_runner_starts_fresh_turn`.
- `ruff format --check` / `ruff check` — clean on changed Python files.

## Demo

https://github.com/user-attachments/assets/1248c47b-3453-40d7-b300-889a96671d59

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Messages sent while the agent is busy now wait in a "Queued" strip above the composer until the agent picks them up.

This pull request and its description were written by Isaac.
