### PR TITLE
fix(editors): use an OpenAI-surface model for the CHANGELOG drafter

### DIFF
--- a/.github/workflows/vscode-release-pr.yml
+++ b/.github/workflows/vscode-release-pr.yml
@@ -201,7 +201,11 @@ jobs:
 
           url = os.environ["GATEWAY_BASE_URL"].rstrip("/") + "/chat/completions"
           payload = json.dumps({
-              "model": "databricks-claude-opus-4-8",
+              # This model id is served on the gateway's OpenAI-compatible
+              # /chat/completions surface (same id auto-assign-reviewer.yml uses).
+              # NOTE: databricks-claude-opus-4-8 is only served on /anthropic, so
+              # it 400s here — keep an OpenAI-surface id.
+              "model": "databricks-claude-sonnet-4-6",
               "max_tokens": 1024,
               "temperature": 0,
               "messages": [

--- a/.github/workflows/vscode-release-pr.yml
+++ b/.github/workflows/vscode-release-pr.yml
@@ -201,10 +201,6 @@ jobs:
 
           url = os.environ["GATEWAY_BASE_URL"].rstrip("/") + "/chat/completions"
           payload = json.dumps({
-              # This model id is served on the gateway's OpenAI-compatible
-              # /chat/completions surface (same id auto-assign-reviewer.yml uses).
-              # NOTE: databricks-claude-opus-4-8 is only served on /anthropic, so
-              # it 400s here — keep an OpenAI-surface id.
               "model": "databricks-claude-sonnet-4-6",
               "max_tokens": 1024,
               "temperature": 0,


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes the `HTTP 400` from the CHANGELOG drafter in `vscode-release-pr.yml` (seen in a dry-run of the release-PR workflow).

The gateway serves models on two surfaces, and model ids aren't shared across them:
- `/chat/completions` (OpenAI-compatible) → `databricks-claude-sonnet-4-6` (what `auto-assign-reviewer.yml` uses)
- `/anthropic` (Messages) → `databricks-claude-opus-4-8` (what `polly-review.yml` uses)

The drafter POSTs to `/chat/completions` but was sending the **opus** id, which that surface doesn't serve → 400. It failed open (kept the CHANGELOG placeholder), so releases weren't blocked, but auto-drafting never worked.

Switches the model to `databricks-claude-sonnet-4-6` — the id already proven on that endpoint. Sonnet is more than enough for drafting changelog bullets.

## Test Plan

- YAML validated (`yaml.safe_load`); `pre-commit run --files` clean.
- Matched the request shape (endpoint + model id) against `auto-assign-reviewer.yml`, which uses the same `/chat/completions` transport successfully.
- Next real check: dispatch `vscode-release-pr.yml` with a new version + `dry_run: true` and confirm the run summary shows LLM-drafted bullets instead of the placeholder.

## Demo

N/A — CI workflow change, no runtime UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Release workflows can't be meaningfully unit-tested in CI. Verified the endpoint/model pairing against the working `auto-assign-reviewer.yml`; the drafter is fail-open, so a wrong model can only fall back to the placeholder, never block a release.
