### PR TITLE
fix(editors): push release branch without a PR when main is already at the version

### DIFF
--- a/.github/workflows/vscode-release-pr.yml
+++ b/.github/workflows/vscode-release-pr.yml
@@ -279,6 +279,21 @@ jobs:
             { echo '### Dry-run diff'; echo '```diff'; git diff --cached; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+
+          # If nothing is staged, `main` is already at this version (e.g. a first
+          # release where package.json + CHANGELOG were prepared by hand). There
+          # is no diff to open a PR for, but the release branch must still exist
+          # so vscode-extension-release.yml can build the frozen `.vsix` from it.
+          # Push the branch at the current commit and skip the PR.
+          if git diff --cached --quiet; then
+            git push --force-with-lease origin "$BRANCH"
+            echo "No changes to release for v$VERSION — main is already at this version." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "Pushed branch \`$BRANCH\` at the current commit (no PR). Build from it with the **VS Code Extension Release** workflow." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           git commit -m "Release (vscode): v$VERSION"
           git push --force-with-lease origin "$BRANCH"
           gh pr create \


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes a `vscode-release-pr.yml` failure when the target version already equals `main`'s `package.json` version (e.g. the first release, where the version + CHANGELOG were prepared by hand).

Previously the bump + CHANGELOG steps staged nothing, so `git commit` failed with `nothing to commit, working tree clean` (exit 1) and the `release/vscode-v<version>` branch was **never pushed** — leaving `vscode-extension-release.yml` (which builds the frozen `.vsix` from that branch) with no branch to check out.

Now, on a non-dry run with no staged diff, the workflow **pushes the branch at the current commit and skips the PR**. There's no diff to review, but the branch still exists so the build workflow can build from it. When there *is* a diff, behavior is unchanged (commit → push → open PR).

## Test Plan

- YAML validated (`yaml.safe_load`); `pre-commit run --files` clean.
- Traced the three cases: (1) `dry_run: true` → diff-only summary, no push; (2) non-dry, no diff → push branch, no PR (the fixed case); (3) non-dry, with diff → commit + push + PR (unchanged).

## Demo

N/A — CI workflow change, no runtime UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Release workflows can't be meaningfully unit-tested in CI. Verified by reasoning through the three dispatch cases against the observed failure (`nothing to commit` on a re-run of the current version); the no-diff path now pushes the branch instead of erroring.
