### PR TITLE
feat(editors): prefill release notes from the version's CHANGELOG section

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -102,6 +102,41 @@ jobs:
           echo "Built $vsix" | tee -a "$GITHUB_STEP_SUMMARY"
           cat "$vsix.sha256" | tee -a "$GITHUB_STEP_SUMMARY"
 
+      - name: Build release notes from the CHANGELOG section
+        env:
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          # Prefill the release notes with THIS version's CHANGELOG section only
+          # (the block under "## [<version>]", up to the next "## " heading).
+          python3 - "$VERSION" <<'PY'
+          import sys, re, pathlib
+          version = sys.argv[1]
+          text = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          # Match "## [<version>]" ... until the next "## " heading or EOF.
+          m = re.search(
+              r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## |\Z)",
+              text, re.MULTILINE | re.DOTALL,
+          )
+          body = (m.group(1).strip() if m else "")
+          out = pathlib.Path("/tmp/release_notes.md")
+          if body:
+              out.write_text(f"## {version}\n\n{body}\n", encoding="utf-8")
+              print(f"Release notes from CHANGELOG [{version}] section.")
+          else:
+              # Fallback: no matching section — keep a minimal generic note.
+              out.write_text(
+                  f"Omnigent VS Code extension `{version}`.\n", encoding="utf-8"
+              )
+              print(f"::warning::No '## [{version}]' CHANGELOG section found — using a generic note.")
+          PY
+          # Footer applies to every release; append after the CHANGELOG body.
+          {
+            echo ""
+            echo "---"
+            echo "Marketplace / Open VSX publishing runs from the secure-release repo, which downloads and SHA256-verifies the attached \`.vsix\`."
+          } >> /tmp/release_notes.md
+
       - name: Publish draft GitHub release with the .vsix + checksum
         env:
           GH_TOKEN: ${{ github.token }}
@@ -117,15 +152,17 @@ jobs:
           # one (which creates the vscode-v<version> tag on the frozen branch
           # commit when the draft is published).
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            # Rerun: refresh assets and the notes on the existing draft.
             gh release upload "$TAG" omnigent-vscode-*.vsix omnigent-vscode-*.vsix.sha256 \
               --repo "$GITHUB_REPOSITORY" --clobber
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file /tmp/release_notes.md
           else
             gh release create "$TAG" omnigent-vscode-*.vsix omnigent-vscode-*.vsix.sha256 \
               --repo "$GITHUB_REPOSITORY" \
               --draft \
               --target "${{ steps.meta.outputs.sha }}" \
               --title "VS Code extension $TAG" \
-              --notes "Omnigent VS Code extension \`$TAG\`. Marketplace / Open VSX publishing runs from the secure-release repo, which downloads and SHA256-verifies the attached \`.vsix\`."
+              --notes-file /tmp/release_notes.md
           fi
           echo "Drafted release $TAG with the .vsix + .sha256 — review and publish it from the Releases page." \
             | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Related issue

N/A

## Summary

Prefills the draft GitHub release notes with **this version's CHANGELOG section** instead of a generic one-liner.

`vscode-extension-release.yml` now extracts the `## [<version>]` block from `editors/vscode/CHANGELOG.md` (only that version's entry, up to the next `## ` heading) and passes it via `--notes-file`. So releasing `0.1.0` shows the `0.1.0` notes, `0.2.0` shows only the `0.2.0` notes, etc. It appends the secure-repo publishing footer, and falls back to a generic note if no matching section is found. On a rerun it also refreshes the notes on the existing draft (`gh release edit --notes-file`).

## Test Plan

- YAML validated (`yaml.safe_load`); `pre-commit run --files` clean.
- Unit-tested the extraction locally on a multi-section CHANGELOG: `0.2.0` returns only its block (stops at `## [0.1.0]`), `0.1.0` returns only its own, and a missing version hits the generic fallback.

## Demo

N/A — CI workflow change, no runtime UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Release workflows can't be meaningfully unit-tested in CI. Verified the section-extraction regex locally against a multi-version CHANGELOG (correct single-section extraction + fallback); the rest is a `gh release` flag change.
