### PR TITLE
fix(web): remove collapse toggle from Files panel Working folder header

### DIFF
--- a/tests/e2e_ui/files/test_files_panel_header.py
+++ b/tests/e2e_ui/files/test_files_panel_header.py
@@ -1,16 +1,16 @@
-"""E2E: the Files rail "Working folder" header is a collapsible button.
+"""E2E: the Files rail "Working folder" header is a static label, not a toggle.
 
 The desktop Workspace rail renders ``FilesPanel`` in its ``frameless``
-(inline) mode. That must NOT downgrade the working-folder header to a plain
-label: it stays an interactive ``button`` carrying ``aria-expanded`` so it is
-focusable and toggles the file list. Only the mobile/full-screen drawer
-(which has its own X close button) uses a static label header.
+(inline) mode. The working-folder header is a plain label: the file list is
+the whole point of the panel, so there is nothing to collapse to. The header
+must NOT be a button and the file-scope switch (the panel content) must be
+visible with no toggle needed.
 
-This is the regression guard for that distinction: ``frameless`` once folded
-into a ``fullScreen`` flag that swapped the button for a ``<span>``, so the
-rail header silently stopped being a button. No message is sent — the header
-and its collapse state are rail state, not a function of any turn — so this
-stays a fast, LLM-free check.
+This is the regression guard against reintroducing the collapse chevron: the
+header once doubled as a collapse toggle carrying ``aria-expanded``, which
+made no sense in a panel whose only content is the file list. No message is
+sent — the header is rail state, not a function of any turn — so this stays a
+fast, LLM-free check.
 """
 
 from __future__ import annotations
@@ -22,12 +22,12 @@ from playwright.sync_api import Page, expect
 from tests.e2e_ui.conftest import open_right_rail
 
 
-def test_files_rail_working_folder_header_is_a_toggle_button(
+def test_files_rail_working_folder_header_is_a_static_label(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The rail's "Working folder" header is a button whose chevron collapses
-    the file list and flips ``aria-expanded``."""
+    """The rail's "Working folder" header is a static label (no toggle button),
+    and the file list is always visible."""
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -42,23 +42,12 @@ def test_files_rail_working_folder_header_is_a_toggle_button(
     # not depend on the remembered tab from a prior session.
     rail.get_by_role("tab", name=re.compile("^Files")).click()
 
-    # The header is a BUTTON (not a label): substring-matching "Working folder"
-    # tolerates the trailing working-directory basename the header also renders.
-    header = rail.get_by_role("button", name=re.compile("Working folder"))
-    expect(header).to_be_visible(timeout=30_000)
-    expect(header).to_have_attribute("aria-expanded", "true")
+    # The header text is present, but it is NOT a button — there is no collapse
+    # toggle. substring-matching "Working folder" tolerates the trailing
+    # working-directory basename the header also renders.
+    expect(rail.get_by_text("Working folder")).to_be_visible(timeout=30_000)
+    expect(rail.get_by_role("button", name=re.compile("Working folder"))).to_have_count(0)
 
-    # Expanded: the file-scope switch (Changed | All) is part of the content.
-    scope = rail.get_by_role("radiogroup", name="File scope")
-    expect(scope).to_be_visible()
-
-    # Collapsing via the header hides the content and flips aria-expanded.
-    header.click()
-    expect(header).to_have_attribute("aria-expanded", "false")
-    expect(scope).to_have_count(0)
-
-    # Expanding again restores the content — proving the header drives a real
-    # collapse toggle, not a one-way no-op.
-    header.click()
-    expect(header).to_have_attribute("aria-expanded", "true")
+    # The content is always shown: the file-scope switch (Changed | All) is
+    # visible with no toggle needed.
     expect(rail.get_by_role("radiogroup", name="File scope")).to_be_visible()

--- a/tests/e2e_ui/files/test_reload_persistence.py
+++ b/tests/e2e_ui/files/test_reload_persistence.py
@@ -1,4 +1,4 @@
-"""E2E: file-viewer, comment, and files-panel state survive a full browser reload.
+"""E2E: file-viewer and comment state survive a full browser reload.
 
 These tests prove the durability path that the AppShell unit tests can
 only approximate: ``AppShell.test.tsx`` mocks ``FileViewer`` and asserts
@@ -24,8 +24,6 @@ from pathlib import Path
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
-
-from tests.e2e_ui.conftest import open_right_rail
 
 # The agent spec uses ``os_env.cwd: .`` (see ``_TEST_AGENT_YAML`` in
 # conftest), so filesystem PUTs land in ``<repo-root>/<session_id>/``
@@ -183,42 +181,3 @@ def test_comment_persists_across_reload(
     ).json()
     assert len(comments) == 1, f"Expected exactly 1 persisted comment, got {comments}"
     assert comments[0]["body"] == _COMMENT_BODY
-
-
-def test_files_panel_collapsed_state_persists_across_reload(
-    page: Page,
-    seeded_session: tuple[str, str],
-) -> None:
-    """Collapse the Working-folder panel, reload, and assert it stays collapsed.
-
-    Unlike the file-viewer/comment cases above (server-persisted, URL-
-    rehydrated), the panel's collapsed state lives in a single app-global
-    localStorage key with no per-conversation keying — the same preference
-    the panel reads to carry the choice across *sessions*. A cold reload is
-    the strongest single-session proxy for that: it re-mounts ``FilesPanel``,
-    whose initial collapsed state is seeded purely from the stored
-    preference (``readFilesPanelPreferences().collapsed``). A failure after
-    reload means the choice wasn't persisted, the durability path the
-    AppShell unit test can only approximate with a mocked store.
-    """
-    base_url, session_id = seeded_session
-    page.goto(f"{base_url}/c/{session_id}")
-    open_right_rail(page)
-
-    # The Working-folder header doubles as the collapse toggle; ``aria-expanded``
-    # tracks the panel's collapsed state and starts expanded by default.
-    rail = page.get_by_role("complementary", name="Workspace")
-    header = rail.get_by_role("button", name=re.compile("Working folder"))
-    expect(header).to_have_attribute("aria-expanded", "true", timeout=30_000)
-
-    header.click()
-    expect(header).to_have_attribute("aria-expanded", "false")
-
-    page.reload()
-    open_right_rail(page)
-
-    # A cold reload must restore the collapsed choice from localStorage.
-    header_after = page.get_by_role("complementary", name="Workspace").get_by_role(
-        "button", name=re.compile("Working folder")
-    )
-    expect(header_after).to_have_attribute("aria-expanded", "false", timeout=30_000)

--- a/web/src/lib/filesPanelPreferences.test.ts
+++ b/web/src/lib/filesPanelPreferences.test.ts
@@ -20,11 +20,10 @@ describe("filesPanelPreferences", () => {
   });
 
   it("round-trips a written preference", () => {
-    writeFilesPanelPreferences({ changedOnly: true, sort: "alpha", collapsed: false });
+    writeFilesPanelPreferences({ changedOnly: true, sort: "alpha" });
     expect(readFilesPanelPreferences()).toEqual({
       changedOnly: true,
       sort: "alpha",
-      collapsed: false,
     });
   });
 
@@ -48,7 +47,6 @@ describe("filesPanelPreferences", () => {
     expect(readFilesPanelPreferences()).toEqual({
       changedOnly: false,
       sort: "recent",
-      collapsed: false,
     });
   });
 
@@ -57,7 +55,6 @@ describe("filesPanelPreferences", () => {
     expect(readFilesPanelPreferences()).toEqual({
       changedOnly: true,
       sort: "recent",
-      collapsed: false,
     });
   });
 });

--- a/web/src/lib/filesPanelPreferences.ts
+++ b/web/src/lib/filesPanelPreferences.ts
@@ -20,8 +20,6 @@ export interface FilesPanelPreferences {
   changedOnly: boolean;
   /** Sort order for the changed-files flat list. */
   sort: ChangedSort;
-  /** true = the panel header is collapsed (content hidden). */
-  collapsed: boolean;
 }
 
 const STORAGE_KEY = "omnigent:files-panel-preferences";
@@ -31,7 +29,6 @@ const STORAGE_KEY = "omnigent:files-panel-preferences";
 export const DEFAULT_FILES_PANEL_PREFERENCES: FilesPanelPreferences = {
   changedOnly: false,
   sort: "recent",
-  collapsed: false,
 };
 
 /**
@@ -58,8 +55,6 @@ export function readFilesPanelPreferences(): FilesPanelPreferences {
         typeof p.sort === "string" && isValidSort(p.sort)
           ? p.sort
           : DEFAULT_FILES_PANEL_PREFERENCES.sort,
-      collapsed:
-        typeof p.collapsed === "boolean" ? p.collapsed : DEFAULT_FILES_PANEL_PREFERENCES.collapsed,
     };
   } catch {
     return DEFAULT_FILES_PANEL_PREFERENCES;

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2104,7 +2104,7 @@ describe("Files scope default and persistence", () => {
     expect(screen.getByTestId("files-panel")).toHaveAttribute("data-flat-view", "true");
     // The choice was written to localStorage — that's what makes it sticky.
     expect(localStorage.getItem(PREF_KEY)).toBe(
-      JSON.stringify({ changedOnly: true, sort: "recent", collapsed: false }),
+      JSON.stringify({ changedOnly: true, sort: "recent" }),
     );
 
     // Re-enter a *different* session fresh: it must open on the remembered

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -204,19 +204,19 @@ describe("FilesPanel working folder directory", () => {
 });
 
 describe("FilesPanel working folder header role", () => {
-  // The inline right-rail panel passes `frameless` to fill the rail height
-  // without the card chrome. That must NOT downgrade the "Working folder"
-  // header to a plain label: it stays a collapsible button (accessible name
-  // + aria-expanded) so the rail header is focusable and toggleable, and so
-  // the e2e suite can target it by role. Only the drawer (onClose), which
-  // has its own X close button, uses the static label header.
-  it("renders the header as a collapsible button in the standalone card", () => {
+  // The "Working folder" header is a static label in every mode — it is not a
+  // collapse toggle. Collapsing was removed: the panel's content is the whole
+  // point of the panel, so there is nothing to collapse to. The content is
+  // always visible and the header never carries aria-expanded.
+  it("renders the header as a static label (no toggle button) in the standalone card", () => {
     renderPanel({ conversationId: "conv_header_card", files: [] });
-    const header = screen.getByRole("button", { name: /working folder/i });
-    expect(header).toHaveAttribute("aria-expanded", "true");
+    expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
+    expect(screen.getByText("Working folder")).toBeInTheDocument();
+    // Content is always shown — the scope switch is part of it.
+    expect(screen.getByRole("radiogroup", { name: "File scope" })).toBeInTheDocument();
   });
 
-  it("renders the header as a collapsible button in frameless (inline rail) mode", () => {
+  it("renders the header as a static label (no toggle button) in frameless (inline rail) mode", () => {
     useAllFilesMock.mockReturnValue(allFilesResult([]));
     useChangedFilesMock.mockReturnValue(changedFilesResult([]));
     useDirectoryMock.mockReturnValue(directoryResult());
@@ -245,14 +245,14 @@ describe("FilesPanel working folder header role", () => {
       </MemoryRouter>,
     );
 
-    const header = screen.getByRole("button", { name: /working folder/i });
-    expect(header).toHaveAttribute("aria-expanded", "true");
+    expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
+    expect(screen.getByText("Working folder")).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: "File scope" })).toBeInTheDocument();
   });
 
-  it("renders a static label header (no toggle button) in the drawer", () => {
+  it("renders a static label header with a Close button in the drawer", () => {
     renderPanel({ conversationId: "conv_header_drawer", files: [], onClose: vi.fn() });
-    // The drawer has its own X close button, so the title is a plain label,
-    // not a collapse toggle.
+    // The drawer adds an X close button; the title is a plain label everywhere.
     expect(screen.queryByRole("button", { name: /working folder/i })).toBeNull();
     expect(screen.getByText("Working folder")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Close files" })).toBeInTheDocument();

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -1,7 +1,6 @@
 import {
   ArrowDownAZIcon,
   ArrowDownWideNarrowIcon,
-  ChevronDownIcon,
   EyeIcon,
   EyeOffIcon,
   FileClockIcon,
@@ -22,7 +21,6 @@ import {
   useWorkspaceFileSearch,
 } from "@/hooks/useWorkspaceChangedFiles";
 import { cn } from "@/lib/utils";
-import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
@@ -52,22 +50,16 @@ interface FilesPanelProps {
   sort: ChangedSort;
   onSortChange: (sort: ChangedSort) => void;
   /**
-   * When provided, the panel renders an X close button in the header
-   * (replacing the expand toggle) and fills its parent's height —
-   * dropping the rounded card chrome so it can serve as the entire
-   * content of a full-screen drawer. The collapse chevron and the
-   * expand toggle are hidden too: a full-screen drawer already owns
-   * the viewport, so those affordances would be a no-op or actively
-   * confusing.
+   * When provided, the panel renders an X close button in the header and
+   * fills its parent's height — dropping the rounded card chrome so it can
+   * serve as the entire content of a full-screen drawer.
    */
   onClose?: () => void;
   /**
    * Frameless mode: drops the rounded card chrome and fills the parent
    * container's height (like the `onClose` drawer) — but without a close
    * button. Used by the inline right panel where the panel is embedded in a
-   * split layout rather than a drawer. Unlike the drawer, it keeps the
-   * collapsible "Working folder" button header (with its chevron and
-   * `aria-expanded`), so the header stays a focusable, toggleable control.
+   * split layout rather than a drawer.
    */
   frameless?: boolean;
 }
@@ -260,8 +252,7 @@ function SearchFilterInput({
 // ---------------------------------------------------------------------------
 
 /**
- * Right-side Files card. Always visible on desktop; collapses its content via
- * the chevron in the header.
+ * Right-side Files card. Always visible on desktop.
  *
  * - Flat view: changed files only (registry-backed, any depth).
  * - Tree view: all on-disk files in the workspace root, expandable folders.
@@ -293,7 +284,6 @@ export function FilesPanel({
   const runnerWentOffline = useChatStore(
     (s) => s.conversationId === conversationId && s.sessionStatus === "failed",
   );
-  const [collapsed, setCollapsed] = useState(() => readFilesPanelPreferences().collapsed);
   const [changedSearch, setChangedSearch] = useState("");
   const [treeSearch, setTreeSearch] = useState("");
   const [debouncedTreeSearch, setDebouncedTreeSearch] = useState("");
@@ -304,25 +294,19 @@ export function FilesPanel({
   const [treeExclude, setTreeExclude] = useState("");
   const [debouncedTreeExclude, setDebouncedTreeExclude] = useState("");
   const [showSearchFilters, setShowSearchFilters] = useState(false);
-  // The drawer (onClose) owns the full viewport, so it gets a static,
-  // always-open header with its own X close button — a collapse chevron there
-  // would be a no-op. The inline rail (frameless) and the standalone card keep
-  // the collapsible "Working folder" *button* header (accessible name +
-  // aria-expanded), which is what lets it be focused/toggled and asserted on.
-  const isDrawer = onClose !== undefined;
-  // Both the drawer and the inline rail fill their parent's height and drop the
+  // The drawer (onClose) adds an X close button to the header. Both the drawer
+  // and the inline rail (frameless) fill their parent's height and drop the
   // rounded card chrome; only the standalone card caps content at max-h.
+  const isDrawer = onClose !== undefined;
   const fillHeight = isDrawer || frameless === true;
-  // The drawer is always open; everywhere else the header chevron toggles it.
-  const contentVisible = isDrawer || !collapsed;
   const changedQuery = useWorkspaceChangedFiles(conversationId, {
-    enabled: contentVisible,
+    enabled: true,
   });
   const allFilesQuery = useWorkspaceAllFiles(conversationId, {
-    enabled: contentVisible && !flatView,
+    enabled: !flatView,
   });
   const envQuery = useWorkspaceEnvironment(conversationId, {
-    enabled: contentVisible,
+    enabled: true,
   });
   const workingDir = envQuery.data?.root ?? null;
   const changedCount = changedQuery.data?.data.length ?? 0;
@@ -359,7 +343,7 @@ export function FilesPanel({
     debouncedTreeInclude,
     debouncedTreeExclude,
     {
-      enabled: contentVisible && !flatView && debouncedTreeSearch.trim().length > 0,
+      enabled: !flatView && debouncedTreeSearch.trim().length > 0,
     },
   );
   // Highlight the filters toggle when include/exclude carry a value.
@@ -372,204 +356,154 @@ export function FilesPanel({
         fillHeight ? "flex h-full min-h-0 flex-col" : "flex min-h-0 flex-col",
       )}
     >
-      {/* Header — single row: [title · workingDir] [eye] [chevron / close] */}
+      {/* Header — single row: [title · workingDir] [eye] [close?] */}
       <div className="flex shrink-0 items-center gap-2 px-3 py-2">
-        {isDrawer ? (
-          <>
-            <span className="shrink-0 font-medium text-sm">Working folder</span>
-            {workingDir && <WorkingDirLabel dir={workingDir} />}
-            <div className="ml-auto flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-              <HiddenFilesToggle
-                showHidden={showHidden}
-                onToggle={() => onShowHiddenChange(!showHidden)}
-                size="4"
-                hiddenCount={hiddenFilesCount}
-              />
-              {onClose && (
-                <button
-                  type="button"
-                  aria-label="Close files"
-                  className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                  onClick={onClose}
-                >
-                  <XIcon className="size-4" />
-                </button>
-              )}
-            </div>
-          </>
-        ) : (
-          <>
+        <span className="shrink-0 font-medium text-sm">Working folder</span>
+        {workingDir && <WorkingDirLabel dir={workingDir} />}
+        <div className="ml-auto flex items-center gap-1">
+          <HiddenFilesToggle
+            showHidden={showHidden}
+            onToggle={() => onShowHiddenChange(!showHidden)}
+            size={isDrawer ? "4" : "3.5"}
+            hiddenCount={hiddenFilesCount}
+          />
+          {onClose && (
             <button
               type="button"
-              className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
-              onClick={() =>
-                setCollapsed((v) => {
-                  const next = !v;
-                  writeFilesPanelPreferences({ ...readFilesPanelPreferences(), collapsed: next });
-                  return next;
-                })
-              }
-              aria-expanded={!collapsed}
+              aria-label="Close files"
+              className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={onClose}
             >
-              <span className="shrink-0 font-medium text-sm">Working folder</span>
-              {workingDir && <WorkingDirLabel dir={workingDir} />}
-              <ChevronDownIcon
-                className={cn(
-                  "ml-auto size-4 shrink-0 text-muted-foreground transition-transform duration-150",
-                  collapsed && "-rotate-90",
-                )}
-              />
+              <XIcon className="size-4" />
             </button>
-            {!collapsed && (
-              <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-                <HiddenFilesToggle
-                  showHidden={showHidden}
-                  onToggle={() => onShowHiddenChange(!showHidden)}
-                  size="3.5"
-                  hiddenCount={hiddenFilesCount}
-                />
-              </div>
-            )}
-          </>
-        )}
+          )}
+        </div>
       </div>
       {/* Content */}
-      {contentVisible && (
-        <>
-          <div className="shrink-0 border-t border-border" />
-          {/* Search toolbar — the Changed | All scope switch leads, then the
+      <div className="shrink-0 border-t border-border" />
+      {/* Search toolbar — the Changed | All scope switch leads, then the
               search field, then the per-view trailing control (Sort for the
               changed list, glob filters for the tree). Lives outside the
               scroll container so negative margins aren't clipped. */}
-          {flatView && (
-            <div
-              className="shrink-0 flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <FileScopeSwitch
-                flatView={flatView}
-                onChange={onFlatViewChange}
-                count={changedCount}
+      {flatView && (
+        <div
+          className="shrink-0 flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
+              <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
+              <input
+                aria-label="Search changed files"
+                className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+                onChange={(event) => setChangedSearch(event.target.value)}
+                placeholder="Search"
+                type="search"
+                value={changedSearch}
               />
-              <div className="flex min-w-0 flex-1 items-center gap-2">
-                <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
-                  <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
-                  <input
-                    aria-label="Search changed files"
-                    className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
-                    onChange={(event) => setChangedSearch(event.target.value)}
-                    placeholder="Search"
-                    type="search"
-                    value={changedSearch}
-                  />
-                </div>
-                <SortSelector sort={changedSort} onChange={onSortChange} />
-              </div>
             </div>
-          )}
-          {!flatView && (
-            <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
-              <div className="flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch">
-                <FileScopeSwitch
-                  flatView={flatView}
-                  onChange={onFlatViewChange}
-                  count={changedCount}
-                />
-                <div className="flex min-w-0 flex-1 items-center gap-2">
-                  <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
-                    <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
-                    <input
-                      aria-label="Search all files"
-                      className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
-                      onChange={(event) => setTreeSearch(event.target.value)}
-                      placeholder="Search"
-                      type="search"
-                      value={treeSearch}
-                    />
-                  </div>
-                  <button
-                    type="button"
-                    aria-label={showSearchFilters ? "Hide search filters" : "Show search filters"}
-                    aria-expanded={showSearchFilters}
-                    title="Files to include / exclude"
-                    className={cn(
-                      "flex shrink-0 cursor-pointer items-center gap-1 rounded-full px-2.5 py-[4px] hover:bg-muted",
-                      showSearchFilters || treeFiltersActive
-                        ? "text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                    onClick={() => setShowSearchFilters((v) => !v)}
-                  >
-                    <SlidersHorizontalIcon className="size-3.5" />
-                    {treeFiltersActive && !showSearchFilters && (
-                      <span className="size-1.5 rounded-full bg-primary" aria-hidden />
-                    )}
-                  </button>
-                  <SortSelector sort={changedSort} onChange={onSortChange} />
-                </div>
-              </div>
-              {showSearchFilters && (
-                <div className="flex flex-col gap-1.5 border-border border-t px-3 py-2">
-                  <SearchFilterInput
-                    label="files to include"
-                    placeholder="e.g. *.ts, src/**"
-                    value={treeInclude}
-                    onChange={setTreeInclude}
-                  />
-                  <SearchFilterInput
-                    label="files to exclude"
-                    placeholder="e.g. **/node_modules, *.test.ts"
-                    value={treeExclude}
-                    onChange={setTreeExclude}
-                  />
-                </div>
-              )}
-            </div>
-          )}
-          <section
-            className={cn(
-              "overflow-y-auto px-2 pb-2",
-              flatView ? "pt-1" : "pt-2",
-              fillHeight ? "min-h-0 flex-1" : "max-h-72",
-            )}
-          >
-            {flatView ? (
-              <FlatFileList
-                files={changedQuery.data?.data}
-                isLoading={changedQuery.isLoading}
-                isError={changedQuery.isError}
-                error={changedQuery.error}
-                onFileSelect={onFileSelect}
-                showHidden={showHidden}
-                onShowHidden={() => onShowHiddenChange(true)}
-                searchQuery={changedSearch}
-                sort={changedSort}
-                conversationId={conversationId}
-                runnerWentOffline={runnerWentOffline}
-              />
-            ) : (
-              <FolderTree
-                files={allFilesQuery.data?.data}
-                isLoading={allFilesQuery.isLoading}
-                isError={allFilesQuery.isError}
-                error={allFilesQuery.error}
-                onFileSelect={onFileSelect}
-                conversationId={conversationId}
-                showHidden={showHidden}
-                onShowHidden={() => onShowHiddenChange(true)}
-                changedFiles={changedQuery.data?.data}
-                sort={changedSort}
-                runnerWentOffline={runnerWentOffline}
-                searchQuery={debouncedTreeSearch}
-                searchResults={treeSearchQuery.data}
-                isSearching={treeSearchQuery.isFetching}
-                isSearchError={treeSearchQuery.isError}
-                searchError={treeSearchQuery.error instanceof Error ? treeSearchQuery.error : null}
-              />
-            )}
-          </section>
-        </>
+            <SortSelector sort={changedSort} onChange={onSortChange} />
+          </div>
+        </div>
       )}
+      {!flatView && (
+        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+          <div className="flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch">
+            <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
+                <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
+                <input
+                  aria-label="Search all files"
+                  className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+                  onChange={(event) => setTreeSearch(event.target.value)}
+                  placeholder="Search"
+                  type="search"
+                  value={treeSearch}
+                />
+              </div>
+              <button
+                type="button"
+                aria-label={showSearchFilters ? "Hide search filters" : "Show search filters"}
+                aria-expanded={showSearchFilters}
+                title="Files to include / exclude"
+                className={cn(
+                  "flex shrink-0 cursor-pointer items-center gap-1 rounded-full px-2.5 py-[4px] hover:bg-muted",
+                  showSearchFilters || treeFiltersActive
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setShowSearchFilters((v) => !v)}
+              >
+                <SlidersHorizontalIcon className="size-3.5" />
+                {treeFiltersActive && !showSearchFilters && (
+                  <span className="size-1.5 rounded-full bg-primary" aria-hidden />
+                )}
+              </button>
+              <SortSelector sort={changedSort} onChange={onSortChange} />
+            </div>
+          </div>
+          {showSearchFilters && (
+            <div className="flex flex-col gap-1.5 border-border border-t px-3 py-2">
+              <SearchFilterInput
+                label="files to include"
+                placeholder="e.g. *.ts, src/**"
+                value={treeInclude}
+                onChange={setTreeInclude}
+              />
+              <SearchFilterInput
+                label="files to exclude"
+                placeholder="e.g. **/node_modules, *.test.ts"
+                value={treeExclude}
+                onChange={setTreeExclude}
+              />
+            </div>
+          )}
+        </div>
+      )}
+      <section
+        className={cn(
+          "overflow-y-auto px-2 pb-2",
+          flatView ? "pt-1" : "pt-2",
+          fillHeight ? "min-h-0 flex-1" : "max-h-72",
+        )}
+      >
+        {flatView ? (
+          <FlatFileList
+            files={changedQuery.data?.data}
+            isLoading={changedQuery.isLoading}
+            isError={changedQuery.isError}
+            error={changedQuery.error}
+            onFileSelect={onFileSelect}
+            showHidden={showHidden}
+            onShowHidden={() => onShowHiddenChange(true)}
+            searchQuery={changedSearch}
+            sort={changedSort}
+            conversationId={conversationId}
+            runnerWentOffline={runnerWentOffline}
+          />
+        ) : (
+          <FolderTree
+            files={allFilesQuery.data?.data}
+            isLoading={allFilesQuery.isLoading}
+            isError={allFilesQuery.isError}
+            error={allFilesQuery.error}
+            onFileSelect={onFileSelect}
+            conversationId={conversationId}
+            showHidden={showHidden}
+            onShowHidden={() => onShowHiddenChange(true)}
+            changedFiles={changedQuery.data?.data}
+            sort={changedSort}
+            runnerWentOffline={runnerWentOffline}
+            searchQuery={debouncedTreeSearch}
+            searchResults={treeSearchQuery.data}
+            isSearching={treeSearchQuery.isFetching}
+            isSearchError={treeSearchQuery.isError}
+            searchError={treeSearchQuery.error instanceof Error ? treeSearchQuery.error : null}
+          />
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

The "Working folder" header in the Files panel doubled as a collapse toggle (a chevron + `aria-expanded`). But the file list is the panel's only content — collapsing it just leaves an empty panel with nothing to reveal, so the affordance was pointless (and confusing).

- Make the "Working folder" header a static label everywhere; the file list is always visible.
- The full-screen drawer keeps its `X` close button (unchanged).
- Drop the now-unused `collapsed` field from `filesPanelPreferences` and the collapse-specific unit/e2e coverage, replacing the e2e header test with a guard that the header is a static label (not a toggle button).

## Test Plan

- `web/` unit tests: `FilesPanel.test.tsx` (35), `filesPanelPreferences.test.ts` (6), `AppShell.test.tsx` — all pass.
- `tsc -b`, `oxlint`, and `prettier --check` clean on all changed files.
- `pre-commit run --files ...` clean (ruff format/check, web prettier).
- E2E: rewrote `tests/e2e_ui/files/test_files_panel_header.py` to assert the header is a static label (no toggle button) and the file-scope switch is always visible; ran it against a freshly built SPA + spawned server — passes. Removed `test_files_panel_collapsed_state_persists_across_reload` (its premise no longer exists).

## Demo

The "Working folder" header now renders as a plain label + working-dir basename + the hidden-files (eye) toggle, with **no chevron**, and the file list is always shown below. Verified via the e2e run's captured screenshot (`test-finished-1.png`): the caret is gone and the Changed | All scope switch + file tree render immediately with no toggle needed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the rewritten e2e test against a real spawned server and inspected the captured screenshot to confirm the caret is gone and the file list renders without any collapse step.

## Changelog

Removed the collapse toggle from the Files panel "Working folder" header — the file list is always visible

This pull request and its description were written by Isaac.
