### PR TITLE
fix(sessions): ignore superseded-tunnel disconnect that clobbers reconnect recovery

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1954,6 +1954,25 @@ def create_app(
             _session_status_cache,
         )
 
+        # Newest-wins guard: a superseded tunnel's teardown fires this
+        # hook after a fresh tunnel for the same ``runner_id`` already
+        # registered (``TunnelRegistry.register`` retires the old
+        # session, whose helper tasks then error out and run this
+        # teardown). Marking the runner's sessions ``failed`` here would
+        # clobber the live tunnel's recovery: reconnect-recovery
+        # (``_on_runner_connect`` -> ``_publish_runner_recovered_status``)
+        # may have just cleared a stale ``runner_disconnected`` failure,
+        # and this stale disconnect would silently re-fail the session.
+        # If a live tunnel is registered for this runner, the runner is
+        # NOT offline, so skip. Mirrors the registry's own
+        # generation-guarded ``deregister``.
+        if tunnel_registry.get(runner_id) is not None:
+            _logger.info(
+                "Runner %s disconnect superseded by a live tunnel; skipping offline-marking",
+                runner_id,
+            )
+            return
+
         # Direct by-runner lookup: read-after-write consistent (the
         # listing path may be served from an eventually-consistent
         # search index in alternate store backends) and


### PR DESCRIPTION
## Related issue

N/A

## Summary

Fixes a flaky CI failure in `tests/server/integration/test_sessions_tunnel_three_layer.py::test_on_runner_connect_clears_disconnect_failure_on_idle_reconnect` (`AssertionError: assert 'failed' != 'failed'`) by fixing the underlying production ordering bug it exposed.

- Root cause is a genuine ordering bug in `_on_runner_disconnect` (`omnigent/server/app.py`), not a test-only race. Under newest-wins tunnel supersession, a *superseded* tunnel's teardown fires `_on_runner_disconnect(runner_id)` and blindly marks every session bound to that runner `failed` via a by-runner store lookup, even though a *newer* live tunnel for the same runner has already reconnected and recovered the session.
- The window is: a fresh tunnel registers (`TunnelRegistry.register` retires the old session per newest-wins), its `_on_runner_connect` runs `_publish_runner_recovered_status` and clears the stale `runner_disconnected` failure to `idle`; meanwhile the old tunnel's helper tasks error out and run its teardown, whose `_on_runner_disconnect` re-marks the session `failed`. This stems from #1593's `_session_status_cache` "distinguish Disconnected from Failed" work, which introduced the reconnect-recovery clear that the stale disconnect then clobbers (credit, not blame).
- Fix: add a newest-wins guard at the top of `_on_runner_disconnect` - if `tunnel_registry.get(runner_id)` is still live, the runner is not actually offline (a newer tunnel superseded the closing one), so skip the offline-marking. This mirrors the registry's own generation-guarded `deregister(runner_id, session)`.

Genuine offline runners are unaffected: in every real-disconnect path the WS handler calls `registry.deregister(runner_id, session)` before invoking `on_runner_disconnect`, so `tunnel_registry.get(runner_id)` is `None` for a truly-gone runner and the session is still marked `failed`. The guard only short-circuits the stale-supersession case.

### ELI5

Two phone lines to the same worker. The worker's new line rings in and says "I'm back, I'm fine." A split second later the old dropped line's hang-up tone finally processes and the system yells "worker is DOWN!" - overwriting the good news. The fix: before declaring the worker down because a line dropped, check if they already have another line open. If they do, ignore the dropped one.

```
old tunnel closes          new tunnel opens (same runner_id)
      |                            |
      |                     register() -> retires old session (newest-wins)
      |                     _on_runner_connect -> recover: cache = "idle"  (good)
 old helper tasks error                |
 old teardown fires                    |
 _on_runner_disconnect  --------------> cache = "failed"  (STALE clobber)   <-- bug
                                        ^ guard: live tunnel present -> skip
```

## Test Plan

- Reproduced the exact CI assertion locally by inducing the timing (delay the disconnect mark-loop so it lands inside the recovery window). A/B with the guard toggled:
  - guard OFF -> `AssertionError: assert 'failed' != 'failed'` (the CI failure, reproduced deterministically)
  - guard ON -> passes
- Confirmed via tracing that with the guard removed the disconnect hook re-marks the session `failed` AFTER recovery cleared it, and does so while a live tunnel for the runner is registered (`live_tunnel=True`) - proving it is a stale superseded-tunnel disconnect.
- Whole file green: `test_sessions_tunnel_three_layer.py` -> 7 passed (including the sibling `test_on_runner_connect_preserves_genuine_failure_on_reconnect`, which asserts a genuine non-disconnect failure survives reconnect).
- Ran the exact CI command (below) in a loop; 10/10 completed runs green at 718 passed each (loop continuing green). Before the fix this configuration went fail->pass->fail->fail on CI.

```
uv run --no-sync python -m pytest tests/server/integration \
  --ignore=tests/server/integration/test_sessions_permission_request_hook.py \
  --ignore=tests/server/integration/test_sessions_elicitation_resolve_url.py \
  --ignore=tests/server/integration/test_sessions_policy_evaluate.py \
  -n 4 --dist worksteal --timeout=300
```

Note: this unblocks a maintainer-override merge on #1880 (whose CI tripped over this flake).

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The existing `test_on_runner_connect_clears_disconnect_failure_on_idle_reconnect` and `test_on_runner_connect_preserves_genuine_failure_on_reconnect` (both from #1593) already exercise the reconnect-recovery path this fix protects; the fix makes the first deterministic under load. Manual verification: deterministically reproduced the failing assertion with the guard removed and confirmed it passes with the guard, plus a green loop of the exact CI command.
