### PR TITLE
fix(runner): per-uid harness tmp parent on POSIX for multi-user hosts

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -198,8 +198,8 @@ def _default_tmp_parent() -> Path:
     length limits, and a short path such as ``.tmp/oa`` is useful
     for local worktrees whose absolute path is long.
 
-    :returns: Configured parent path, or the default
-        ``/tmp/omnigent``.
+    :returns: Configured parent path, or the per-uid default
+        ``/tmp/omnigent-<uid>`` on POSIX.
     """
     configured = os.environ.get(_TMP_PARENT_ENV_VAR)
     if configured:

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -50,16 +50,21 @@ _logger = logging.getLogger(__name__)
 # uuid-named subdir so concurrent Omnigent processes (zero-downtime restarts,
 # multi-tenant single-machine deployments) don't step on each other.
 #
-# POSIX pins ``/tmp/omnigent`` deliberately: Unix socket paths have a tight
-# length limit, so a short, predictable parent matters (gettempdir() can be a
-# long ``/var/folders/...`` path on macOS). Windows uses TCP loopback for the
-# harness IPC (no socket-path length concern) and has no ``/tmp`` — a literal
-# ``/tmp/omnigent`` there resolves to ``\tmp\omnigent`` on the current drive —
-# so use the real temp dir.
+# POSIX pins ``/tmp/omnigent-<uid>`` deliberately: Unix socket paths have a
+# tight length limit, so a short, predictable parent matters (gettempdir()
+# can be a long ``/var/folders/...`` path on macOS) — and the uid suffix
+# keeps the parent per-Unix-user. A shared parent breaks multi-user hosts:
+# whichever user's runner starts first creates it ``0700`` and locks every
+# other user out, and even a ``1777`` parent leaves ``_sweep_orphans``
+# walking other users' ``0700`` instance dirs (and all sockets sharing one
+# world-writable directory). Windows uses TCP loopback for the harness IPC
+# (no socket-path length concern) and has no ``/tmp`` — a literal
+# ``/tmp/omnigent`` there resolves to ``\tmp\omnigent`` on the current
+# drive — so use the real (already per-user) temp dir.
 if IS_WINDOWS:
     _TMP_PARENT = Path(tempfile.gettempdir()) / "omnigent"
 else:
-    _TMP_PARENT = Path("/tmp/omnigent")
+    _TMP_PARENT = Path(f"/tmp/omnigent-{os.getuid()}")
 _TMP_PARENT_ENV_VAR = "OMNIGENT_HARNESS_TMP_PARENT"
 
 # S1 (security): env var carrying the per-spawn bearer token for the harness

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -41,6 +41,7 @@ from omnigent.runtime.harnesses.process_manager import (
     _TMP_PARENT_ENV_VAR,
     HarnessProcessManager,
     NoLiveHarnessError,
+    _default_tmp_parent,
     _pid_alive,
     _pids_holding_socket,
 )
@@ -194,6 +195,28 @@ async def test_start_uses_harness_tmp_parent_env(
         assert (manager.instance_dir / _AP_PID_FILE).read_text(encoding="utf-8")
     finally:
         await manager.shutdown()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Per-uid tmp parent is POSIX-only; Windows uses gettempdir().",
+)
+def test_default_tmp_parent_is_per_uid_on_posix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default socket root is namespaced per Unix uid.
+
+    A shared ``/tmp/omnigent`` breaks multi-user hosts: the first
+    user's runner creates it ``0700`` and every other user's runner
+    then dies in ``_sweep_orphans`` stat()ing foreign instance dirs.
+    The POSIX default must carry the uid so each user gets a private
+    parent. Regression guard against the pre-fix bare ``/tmp/omnigent``.
+    """
+    monkeypatch.delenv(_TMP_PARENT_ENV_VAR, raising=False)
+    parent = _default_tmp_parent()
+    assert parent == Path(f"/tmp/omnigent-{os.getuid()}")
+    # The shared parent that locked out other users must be gone.
+    assert parent != Path("/tmp/omnigent")
 
 
 async def test_shutdown_without_start_is_noop(


### PR DESCRIPTION
## Related issue

Closes #2113

## Summary

On a multi-user Linux host (one Unix account per developer sharing one Omnigent server), the shared `/tmp/omnigent` harness tmp parent breaks runner startup:

- Whichever user's runner starts **first** creates `/tmp/omnigent` `0700`, so every other user's runner dies in `_sweep_orphans` — pre-0.4.0 as an unhandled `PermissionError` on `iterdir`, and even at `1777` the sweep still `stat()`s other users' `0700` `ap-*` instance dirs and all sockets share one world-writable dir.
- The documented `OMNIGENT_HARNESS_TMP_PARENT` override can't express a per-user path for host-daemon-spawned runners, since the daemon launch env doesn't carry operator env vars through.

Fix: suffix the POSIX parent with the uid — `/tmp/omnigent-<uid>`. Socket paths stay short and predictable, each user's sweep only sees its own instance dirs, single-user behavior is unchanged apart from the path name, and Windows is untouched (already per-user via `gettempdir()`).

## Test Plan

- **New unit test** `tests/runtime/harnesses/test_process_manager.py::test_default_tmp_parent_is_per_uid_on_posix` — asserts the POSIX default is `/tmp/omnigent-<uid>`. Verified it **fails before** the fix (`/tmp/omnigent` != `/tmp/omnigent-501`) and **passes after**.
- `uv run pytest tests/runtime/harnesses/test_process_manager.py` — green.
- `uv run ruff check` / `ruff format --check` on the changed files — clean.
- **Real-world**: reproduced on a shared Ubuntu 24.04 host — with the stock shared parent, a second Unix user's native-codex runner fails as above; with this change, concurrent sessions from two different Unix accounts both start and sweep cleanly in their own parents.

## Demo

N/A — non-visual runner/runtime change.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation only

## Test coverage

- [x] This change is covered by a new or existing test.

## Coverage notes

Adds a focused unit test for the per-uid default (fails-before / passes-after). Overall coverage held at baseline (81%). No behavior change for single-user or Windows deployments.

---

Follow-up offer (unchanged from the original description): happy to also propagate `OMNIGENT_HARNESS_TMP_PARENT` through the host-daemon spawn env so that override works for daemon-spawned runners too, if you'd prefer that as the primary knob.
