### PR TITLE
fix(goose): reset ACP state after subprocess interrupt

### DIFF
--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -252,16 +252,21 @@ class GooseExecutor(Executor):
     # Low-level ACP transport
     # ------------------------------------------------------------------
 
+    def _reset_process_state(self) -> None:
+        """Clear state owned by a goose ACP subprocess."""
+        self._session_id = None
+        self._system_prompt_sent = False
+        self._initialized = False
+        self._image_supported = False
+
     async def _start_process(self) -> None:
         """Start ``goose acp`` as an asyncio subprocess.
 
         The StreamReader limit is raised to 16 MiB so a large ``session/new``
         response or tool output line can't hit the default 64 KiB per-line cap.
         """
-        # Reset handshake state: this may be a restart after the previous
-        # subprocess died. ``_initialized`` is a one-way latch.
-        self._initialized = False
-        self._image_supported = False
+        # This may be a restart after the previous subprocess died.
+        self._reset_process_state()
         env = os.environ.copy()
         env.update(self._provider_env())
         argv: list[str] = ["acp"]
@@ -926,10 +931,13 @@ class GooseExecutor(Executor):
         proc = self._proc
         if proc is None or proc.returncode is not None:
             return False
-        with contextlib.suppress(ProcessLookupError):
+        try:
             proc.terminate()
-            return True
-        return False
+        except ProcessLookupError:
+            self._reset_process_state()
+            return False
+        self._reset_process_state()
+        return True
 
     async def run_turn(
         self,

--- a/tests/test_goose_executor_interrupt.py
+++ b/tests/test_goose_executor_interrupt.py
@@ -47,12 +47,19 @@ async def test_interrupt_no_session_id_sends_sigterm() -> None:
     """Without a session_id, interrupt falls back to SIGTERM immediately."""
     ex = _make_executor()
     ex._proc = _live_proc()  # returncode=None → live
+    ex._system_prompt_sent = True
+    ex._initialized = True
+    ex._image_supported = True
     ex._session_id = None  # no ACP session established yet
 
     result = await ex.interrupt_session("s1")
 
     assert result is True
     ex._proc.terminate.assert_called_once()
+    assert ex._session_id is None
+    assert ex._system_prompt_sent is False
+    assert ex._initialized is False
+    assert ex._image_supported is False
 
 
 async def test_interrupt_with_session_sends_cancel_notification() -> None:
@@ -85,6 +92,9 @@ async def test_interrupt_cancel_send_error_falls_back_to_sigterm() -> None:
     ex = _make_executor()
     ex._proc = _live_proc()
     ex._session_id = "goose_session_99"
+    ex._system_prompt_sent = True
+    ex._initialized = True
+    ex._image_supported = True
 
     with patch.object(
         ex, "_send", new_callable=AsyncMock, side_effect=RuntimeError("broken pipe")
@@ -93,6 +103,10 @@ async def test_interrupt_cancel_send_error_falls_back_to_sigterm() -> None:
 
     assert result is True
     ex._proc.terminate.assert_called_once()
+    assert ex._session_id is None
+    assert ex._system_prompt_sent is False
+    assert ex._initialized is False
+    assert ex._image_supported is False
 
 
 async def test_interrupt_process_lookup_error_returns_false() -> None:
@@ -101,8 +115,14 @@ async def test_interrupt_process_lookup_error_returns_false() -> None:
     proc = _live_proc()
     proc.terminate.side_effect = ProcessLookupError
     ex._proc = proc
-    ex._session_id = None
+    ex._session_id = "stale-session"
+    ex._system_prompt_sent = True
+    ex._initialized = True
+    ex._image_supported = True
 
     result = await ex.interrupt_session("s1")
-    # suppress(ProcessLookupError) means we fall through to `return False`
     assert result is False
+    assert ex._session_id is None
+    assert ex._system_prompt_sent is False
+    assert ex._initialized is False
+    assert ex._image_supported is False


### PR DESCRIPTION
## Related issue

Closes #1924

## Summary

- Goose keeps ACP handshake, capability, session, and system-prompt state for the lifetime of its subprocess. When interruption falls back to SIGTERM, retaining that state can make the replacement process reuse a session it does not own and skip replaying context.
- Add a shared `_reset_process_state()` helper and call it both before starting a Goose ACP subprocess and after the SIGTERM fallback, including when `terminate()` races with process exit.
- Extend the interruption tests to verify all process-owned state is cleared.

## Test Plan

- CI: focused and full Python test suites pass, including the 68 tests in `tests/test_goose_executor_interrupt.py` reported by the automated review.
- CI: pre-commit, coverage, integration, E2E, E2E UI, security, Docker, and Windows checks pass.

## Demo

N/A. This is internal subprocess and ACP session-state cleanup with no new visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Stopping a Goose turn no longer leaves stale ACP session state behind when the subprocess is terminated.
