### PR TITLE
fix(web): fold the reversed native-opencode alias to opencode-native

### DIFF
--- a/web/src/lib/nativeCodingAgents.test.ts
+++ b/web/src/lib/nativeCodingAgents.test.ts
@@ -16,6 +16,12 @@ describe("nativeCodingAgentForHarness", () => {
     expect(nativeCodingAgentForHarness("opencode-native")?.key).toBe("opencode");
   });
 
+  it("folds the reversed native-opencode alias to the opencode-native spec", () => {
+    expect(nativeCodingAgentForHarness("native-opencode")).toBe(
+      nativeCodingAgentForHarness("opencode-native"),
+    );
+  });
+
   it("resolves the canonical qwen-native harness", () => {
     const agent = nativeCodingAgentForHarness("qwen-native");
     expect(agent?.key).toBe("qwen");

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -180,6 +180,7 @@ const HARNESS_ALIASES: Record<string, string> = {
   "native-qwen": "qwen-native",
   "native-kimi": "kimi-native",
   "native-hermes": "hermes-native",
+  "native-opencode": "opencode-native",
 };
 
 export function nativeCodingAgentForAgentName(


### PR DESCRIPTION
## Related issue

Closes #1925

## Summary

- The server accepts both `native-opencode` and `opencode-native` (`omnigent/harness_plugins.py:548`), but the web reversed-alias map `HARNESS_ALIASES` (`web/src/lib/nativeCodingAgents.ts:174-183`) omitted `native-opencode`.
- Result: `nativeCodingAgentForHarness("native-opencode")` returned `undefined` (the opencode row is keyed by `opencode-native`), so an opencode agent forked/switched under that spelling lost its native-terminal wrapper and rendered as plain chat.
- Added the missing `"native-opencode": "opencode-native"` entry, plus a regression test.

## Test Plan

`npx vitest run src/lib/nativeCodingAgents.test.ts` (13 passed, up from 12). New test asserts `nativeCodingAgentForHarness("native-opencode")` resolves to the same spec as `opencode-native`. `npx oxlint` and `npx prettier --check` clean on both files.

## Demo

N/A. This is harness-resolution logic, not a visual change: the fix flips an edge case (an opencode agent addressed as `native-opencode`) from the plain-chat fallback to the native-terminal wrapper. There is no standalone visual diff to record without a live native-opencode session; the behavior is covered by the unit test above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Opencode agents addressed as `native-opencode` now render with their native terminal UI instead of falling back to plain chat.
