### PR TITLE
feat(web): one-click "Run on this Mac" — start a local server + host

### DIFF
--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -326,14 +326,20 @@ You can see and change which binary is used in two places:
 
 A configured path is saved to `settings.json` (`omnigent_path`) only once it
 validates as a runnable CLI; clearing it reverts to auto-detection. Connecting
-to a **remote** server never needs the CLI — only "Start locally" and hosting do.
+to a **remote** server never needs the CLI — only starting a local server and
+hosting this machine do (and "Start locally" now does both).
 
 ### Start locally
 
-**"Start a server on this machine"** runs `omnigent server start` (idempotent —
-reuses a healthy one) and then connects this window to its
-`http://127.0.0.1:<port>` URL through the normal connect flow. It does not
-connect this machine as a runner — that stays an explicit step in the app.
+The setup page's **"Start locally"** button runs `omnigent server start`
+(idempotent — reuses a healthy one), attaches a host on this machine to that
+server, and connects this window to its `http://127.0.0.1:<port>` URL through
+the normal connect flow — a server **and** a runner in one click, so a
+first-run user is chatting without touching a terminal. Because this is the
+bundled, trusted setup page (not server-served code), it needs no separate
+hosting-consent dialog. On an older shell whose preload lacks the combined
+bridge it falls back to server-only, and the runner is connected later from the
+host menu.
 
 ### Connecting this machine as a runner
 
@@ -351,6 +357,16 @@ adopt a daemon already serving that server (one you started by hand) or spawn
 next time; **Always Allow** records the origin in `settings.json`
 (`allowed_hosting_origins`) so later connects skip the prompt. `stop` is
 fail-safe and needs no confirmation. The same bridge exposes `stop` / `restart`.
+
+A one-click **"Run on this Mac"** button offers the same thing from two more
+spots: the connect-a-host dialog's zero-host escape hatch and the host-selection
+dropdown. It goes through `startLocalHost` (not `controlHost`) — a detached
+daemon keyed by target in the same `~/.omnigent` registry the CLI uses, so it is
+visible to `omnigent host status` and never double-spawns — but it is gated by
+the identical native confirmation, since enrolling a runner still executes agent
+code. It renders **only** in the desktop shell: in a plain browser it hides
+itself and the surfaces fall back to their `omnigent host --server <url>` CLI
+instructions. Its status is read via `getLocalHostStatus`.
 
 Status is read live (host connected = a live daemon process **and** an online
 host tunnel; the shell never caches it). The host surface goes through the JS

--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -639,11 +639,15 @@
           startLocalBtn.disabled = true;
           startLocalBtn.textContent = "Starting…";
           try {
-            const result = await setup.startLocalServer();
+            // Start the local server AND attach a host on this machine in one
+            // click, so the app is usable end-to-end without a terminal. Fall
+            // back to server-only on an older shell that lacks the newer bridge.
+            const result = setup.startLocalAndHost
+              ? await setup.startLocalAndHost()
+              : await setup.startLocalServer();
             if (result && result.ok && result.url) {
               // Hand off to the normal connect/navigate flow; on success the
-              // window loads the server and this page goes away. Connecting this
-              // machine as a runner is done later from the host menu.
+              // window loads the server and this page goes away.
               input.value = result.url;
               await setup.setServerUrl(result.url);
               return;

--- a/web/electron/src/localHost.js
+++ b/web/electron/src/localHost.js
@@ -1,0 +1,428 @@
+// Spawn and supervise a local Omnigent host daemon on the user's machine.
+//
+// Background: a "host" is a machine that runs agent sessions; it dials OUT to
+// the Omnigent server over a websocket tunnel. Normally the user starts one by
+// typing `omnigent host` in a terminal. The desktop shell can do it for them —
+// it has a real process to fork — so the New Chat empty state can offer a
+// one-click "Run on this Mac".
+//
+// This module mirrors the Python CLI's own background-daemon machinery so the
+// two stay interchangeable (a daemon this module spawns is visible to
+// `omnigent host status`, and vice-versa):
+//   * argv          → `python -m omnigent.host._daemon_entry --local|--server`
+//                      (exactly `_ensure_host_daemon` in omnigent/cli.py)
+//   * detach        → { detached: true } + child.unref()  (≈ start_new_session)
+//   * logs          → ~/.omnigent/logs/host-daemon/daemon-*.log
+//   * running-check → ~/.omnigent/daemons/<sha256(target)[:16]>.json + kill(pid,0)
+//
+// THE HARD PART is locating the runtime. A macOS .app launched from Finder/Dock
+// inherits a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), so it will NOT see
+// ~/.local/bin, /opt/homebrew/bin, or a uv-installed `omni`. We search known
+// install dirs first, then fall back to the user's login-shell PATH, and we
+// prepend the discovered bin dir to the daemon's PATH so the host's own runners
+// can find node/claude/codex.
+//
+// Pure logic (mode decision, argv, needsLogin, runtime resolution with injected
+// fs/exec) is exported for unit tests that import this without `electron`.
+
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const { execFileSync, spawn } = require("node:child_process");
+const { LOCAL_HOSTS } = require("./url");
+
+/** Shared per-user Omnigent state dir. Mirrors the CLI's `~/.omnigent`. */
+const STATE_DIR = path.join(os.homedir(), ".omnigent");
+/** Where the CLI records background daemons (one JSON per target). */
+const DAEMON_DIR = path.join(STATE_DIR, "daemons");
+/** Where the CLI writes daemon logs; we write ours alongside. */
+const DAEMON_LOG_DIR = path.join(STATE_DIR, "logs", "host-daemon");
+/** Per-server auth records written by `omnigent login`. */
+const AUTH_TOKENS_PATH = path.join(STATE_DIR, "auth_tokens.json");
+/** The CLI's marker target for a local (server-owning) daemon. */
+const LOCAL_DAEMON_MARKER = "local";
+
+/**
+ * Bin directories an Omnigent CLI install commonly lands in but a
+ * Finder-launched .app's PATH omits. Order = preference.
+ */
+function knownBinDirs() {
+  const home = os.homedir();
+  return [
+    path.join(home, ".local", "bin"), // uv tool / pipx default
+    "/opt/homebrew/bin", // Homebrew on Apple silicon
+    "/usr/local/bin", // Homebrew on Intel / manual installs
+    path.join(home, ".local", "share", "uv", "tools", "omnigent", "bin"),
+  ];
+}
+
+/** TTL for the cached runtime resolution; a retry after install busts it. */
+const RUNTIME_CACHE_TTL_MS = 30_000;
+let _runtimeCache = null; // { at: epochMs, value: RuntimeInfo | null }
+
+/**
+ * Whether a server URL points at this machine's loopback interface. A loopback
+ * server needs no login (the token check is skipped for it), but — unlike an
+ * absent URL — the host must still connect to that *specific* server, not spawn
+ * a fresh one. Empty/unparseable counts as non-loopback here (the caller only
+ * uses this to suppress the login hint).
+ *
+ * @param {string|null} serverUrl
+ * @returns {boolean}
+ */
+function isLoopbackServer(serverUrl) {
+  if (!serverUrl) return false;
+  try {
+    return LOCAL_HOSTS.has(new URL(serverUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decide the daemon connection mode for a connected server origin.
+ *
+ * "local" means `omni host ""` — the daemon SPAWNS AND OWNS a fresh local
+ * server. That is only right when there is no server to connect to yet (a
+ * from-scratch launch). Whenever the UI is already pinned to a concrete server
+ * — even a loopback one it just started — the host must dial THAT server with
+ * `--server <url>` ("remote"), or it would spawn a second, competing server the
+ * pinned UI has no tunnel to. So only a null/empty/unparseable URL is "local".
+ *
+ * @param {string|null} serverUrl Connected server origin, or null.
+ * @returns {"local"|"remote"}
+ */
+function decideMode(serverUrl) {
+  if (!serverUrl) return "local";
+  try {
+    // Parse only to validate; an unparseable URL falls back to local spawn.
+    return new URL(serverUrl).protocol ? "remote" : "local";
+  } catch {
+    return "local";
+  }
+}
+
+/**
+ * Build the `omni host` CLI args for a mode/server.
+ *
+ * `omni host` registers this machine as a host in the foreground (it self-
+ * registers in the daemon registry that {@link readDaemonRecord} reads, so a
+ * daemon we spawn is visible to `omnigent host status` and we never double-
+ * spawn). Local mode uses the empty-string positional `omni host ""`, which
+ * the host group's parser binds to `--server` and treats as "spawn + connect
+ * to a local server" (see `_HostGroup` in omnigent/cli.py). Remote mode passes
+ * `--server <url>`.
+ *
+ * NOTE: deliberately NOT `python -m omnigent.host._daemon_entry` — that entry
+ * does not write the registry record our status check relies on.
+ *
+ * @param {"local"|"remote"} mode
+ * @param {string|null} serverUrl Required (and used) only for "remote".
+ * @returns {string[]} e.g. ["host", ""] or ["host", "--server", "https://…"].
+ */
+function daemonArgs(mode, serverUrl) {
+  return mode === "local" ? ["host", ""] : ["host", "--server", serverUrl];
+}
+
+/**
+ * The CLI's normalized "target" for a mode/server — the key its daemon
+ * registry is hashed by. Lets us find a daemon the CLI itself spawned.
+ *
+ * @param {"local"|"remote"} mode
+ * @param {string|null} serverUrl
+ * @returns {string} "local" or the trailing-slash-stripped server URL.
+ */
+function daemonTarget(mode, serverUrl) {
+  if (mode === "local" || !serverUrl) return LOCAL_DAEMON_MARKER;
+  return serverUrl.replace(/\/+$/, "");
+}
+
+/**
+ * Path of the CLI daemon-registry JSON for a target:
+ * ~/.omnigent/daemons/<sha256(target)[:16]>.json. Mirrors
+ * `_daemon_record_path` in omnigent/cli.py.
+ *
+ * @param {string} target
+ * @returns {string}
+ */
+function daemonRecordPath(target) {
+  const digest = crypto.createHash("sha256").update(target, "utf8").digest("hex").slice(0, 16);
+  return path.join(DAEMON_DIR, `${digest}.json`);
+}
+
+/** True when a process with `pid` exists (kill -0). False on ESRCH/garbage. */
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means it exists but we can't signal it — still "alive".
+    return err && err.code === "EPERM";
+  }
+}
+
+/**
+ * Read the CLI daemon record for a target and report whether it's running.
+ *
+ * Reading the CLI's own source of truth (not an Electron-private pid) means a
+ * daemon started from a terminal is also detected, so we never double-spawn.
+ *
+ * @param {string} target
+ * @param {{ readFileSync?: typeof fs.readFileSync }} [deps]
+ * @returns {{ running: boolean, pid: number|null, logPath: string|null }}
+ */
+function readDaemonRecord(target, deps = {}) {
+  const readFileSync = deps.readFileSync ?? fs.readFileSync;
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(daemonRecordPath(target), "utf8"));
+  } catch {
+    return { running: false, pid: null, logPath: null };
+  }
+  const pid = typeof raw.pid === "number" ? raw.pid : Number.parseInt(raw.pid, 10);
+  const logPath = typeof raw.log_path === "string" && raw.log_path ? raw.log_path : null;
+  return { running: pidAlive(pid), pid: Number.isInteger(pid) ? pid : null, logPath };
+}
+
+/**
+ * Whether a remote server lacks a usable stored login token. SOFT signal:
+ * ambient credentials (e.g. Databricks) may still authenticate, so callers
+ * warn but don't block. Reads the same `~/.omnigent/auth_tokens.json` the
+ * `omnigent login` flow writes; the key is the trailing-slash-stripped URL.
+ *
+ * A Databricks pointer record (auth_type: "databricks", no token) counts as
+ * "has credentials" — it points at a CLI OAuth cache the host can mint from.
+ *
+ * @param {string|null} serverUrl
+ * @param {{ readFileSync?: typeof fs.readFileSync, now?: () => number }} [deps]
+ * @returns {boolean} True only for a remote server with no usable record.
+ */
+function computeNeedsLogin(serverUrl, deps = {}) {
+  // A local/loopback server needs no login, and an absent URL (local spawn
+  // mode) needs none either.
+  if (!serverUrl || isLoopbackServer(serverUrl)) return false;
+  const readFileSync = deps.readFileSync ?? fs.readFileSync;
+  const now = deps.now ?? Date.now;
+  let data;
+  try {
+    data = JSON.parse(readFileSync(AUTH_TOKENS_PATH, "utf8"));
+  } catch {
+    return true; // no token file → no stored credentials
+  }
+  const entry = data[serverUrl.replace(/\/+$/, "")];
+  if (!entry || typeof entry !== "object") return true;
+  if (entry.auth_type === "databricks") return false; // pointer record → ambient OAuth
+  if (typeof entry.token !== "string" || entry.token === "") return true;
+  // Expired tokens count as missing (mirrors cli_auth.load_token).
+  if (typeof entry.expires_at === "number" && entry.expires_at * 1000 < now()) return true;
+  return false;
+}
+
+/**
+ * Locate the Omnigent runtime, preferring an `omnigent`/`omni` binary. Tries,
+ * in order: known install dirs, the login shell's PATH (the Finder minimal-PATH
+ * escape hatch), then the bare process PATH. Caches the first hit with a short
+ * TTL so a post-install retry re-probes.
+ *
+ * @param {{
+ *   accessSync?: typeof fs.accessSync,
+ *   runShellProbe?: () => string|null,
+ *   pathEnv?: string,
+ *   binDirs?: string[],
+ *   now?: () => number,
+ *   noCache?: boolean,
+ * }} [deps]
+ * @returns {{ binary: string, binDir: string }|null} Resolved runtime, or null.
+ */
+function resolveOmnigentRuntime(deps = {}) {
+  const now = deps.now ?? Date.now;
+  if (!deps.noCache && _runtimeCache && now() - _runtimeCache.at < RUNTIME_CACHE_TTL_MS) {
+    return _runtimeCache.value;
+  }
+  const accessSync = deps.accessSync ?? fs.accessSync;
+  const binDirs = deps.binDirs ?? knownBinDirs();
+  const names = ["omnigent", "omni"];
+
+  const isExec = (p) => {
+    try {
+      accessSync(p, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  let resolved = null;
+  // 1) Known install dirs.
+  outer: for (const dir of binDirs) {
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      if (isExec(candidate)) {
+        resolved = { binary: candidate, binDir: dir };
+        break outer;
+      }
+    }
+  }
+  // 2) Login-shell PATH probe (Finder minimal-PATH escape hatch).
+  if (!resolved) {
+    const probe = (deps.runShellProbe ?? defaultShellProbe)();
+    if (probe && isExec(probe)) resolved = { binary: probe, binDir: path.dirname(probe) };
+  }
+  // 3) Bare process PATH (covers `npm run dev` / a normal-PATH launch).
+  if (!resolved) {
+    const pathEnv = deps.pathEnv ?? process.env.PATH ?? "";
+    outer2: for (const dir of pathEnv.split(path.delimiter)) {
+      if (!dir) continue;
+      for (const name of names) {
+        const candidate = path.join(dir, name);
+        if (isExec(candidate)) {
+          resolved = { binary: candidate, binDir: dir };
+          break outer2;
+        }
+      }
+    }
+  }
+
+  if (!deps.noCache) _runtimeCache = { at: now(), value: resolved };
+  return resolved;
+}
+
+/** Clear the runtime resolution cache (used by the "retry after install" path). */
+function clearRuntimeCache() {
+  _runtimeCache = null;
+}
+
+/**
+ * Ask the user's login shell where `omnigent`/`omni` resolves. Time-bounded and
+ * never throws — a slow or broken shell must not stall the connect flow.
+ *
+ * @returns {string|null} Absolute path to the resolved binary, or null.
+ */
+function defaultShellProbe() {
+  const shell = process.env.SHELL || "/bin/zsh";
+  try {
+    const out = execFileSync(shell, ["-lic", "command -v omnigent || command -v omni"], {
+      timeout: 4000,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const line = out
+      .split("\n")
+      .map((s) => s.trim())
+      .find(Boolean);
+    return line && line.startsWith("/") ? line : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Report the local-host state for a connected server. Pure-ish: all filesystem
+ * and runtime probing flows through injectable deps so this is unit-testable.
+ *
+ * @param {{ serverUrl: string|null }} params
+ * @param {object} [deps] Injected fs/probe/now for tests.
+ * @returns {import("./localHost").LocalHostStatus}
+ */
+function getLocalHostStatus({ serverUrl }, deps = {}) {
+  const mode = decideMode(serverUrl);
+  const target = daemonTarget(mode, serverUrl);
+  const record = readDaemonRecord(target, deps);
+  const runtime = resolveOmnigentRuntime(deps);
+  return {
+    running: record.running,
+    runtimeAvailable: runtime !== null,
+    mode,
+    needsLogin: computeNeedsLogin(serverUrl, deps),
+    serverUrl: serverUrl ?? null,
+    logPath: record.logPath,
+  };
+}
+
+/**
+ * Spawn a detached host daemon for the connected server, unless one is already
+ * running for that target. Returns a structured result (never throws) so the
+ * renderer can show an error and fall back to the CLI instructions.
+ *
+ * @param {{ serverUrl: string|null }} params
+ * @returns {Promise<import("./localHost").StartLocalHostResult>}
+ */
+async function startLocalHost({ serverUrl }) {
+  const mode = decideMode(serverUrl);
+  const target = daemonTarget(mode, serverUrl);
+
+  const existing = readDaemonRecord(target);
+  if (existing.running) {
+    return { ok: true, logPath: existing.logPath }; // already up — never double-spawn
+  }
+
+  const runtime = resolveOmnigentRuntime();
+  if (!runtime) {
+    return {
+      ok: false,
+      error: "Couldn't find the Omnigent CLI on this machine. Install it, then retry.",
+    };
+  }
+
+  let logFd = null;
+  let logPath = null;
+  try {
+    fs.mkdirSync(DAEMON_LOG_DIR, { recursive: true });
+    logPath = path.join(
+      DAEMON_LOG_DIR,
+      `daemon-electron-${process.pid}-${target.replace(/[^\w.-]/g, "_")}.log`,
+    );
+    logFd = fs.openSync(logPath, "a");
+  } catch (err) {
+    return { ok: false, error: `Couldn't open a log file: ${err.message}` };
+  }
+
+  // Prepend the runtime's bin dir to PATH so the daemon AND the runners it
+  // spawns can find node/claude/codex despite the app's minimal PATH.
+  const childPath = `${runtime.binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+  const env = { ...process.env, PATH: childPath };
+
+  try {
+    const child = spawn(runtime.binary, daemonArgs(mode, serverUrl), {
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+      env,
+    });
+    child.unref();
+    fs.closeSync(logFd);
+    return { ok: true, logPath };
+  } catch (err) {
+    if (logFd !== null) {
+      try {
+        fs.closeSync(logFd);
+      } catch {
+        /* ignore */
+      }
+    }
+    return { ok: false, error: `Couldn't start the host: ${err.message}`, logPath };
+  }
+}
+
+module.exports = {
+  // pure / testable
+  decideMode,
+  isLoopbackServer,
+  daemonArgs,
+  daemonTarget,
+  daemonRecordPath,
+  readDaemonRecord,
+  computeNeedsLogin,
+  resolveOmnigentRuntime,
+  clearRuntimeCache,
+  // effectful
+  getLocalHostStatus,
+  startLocalHost,
+  // constants (for tests)
+  STATE_DIR,
+  AUTH_TOKENS_PATH,
+  LOCAL_DAEMON_MARKER,
+};

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -35,6 +35,7 @@ const { normalizeUrl, expandDatabricksWorkspaceUrl } = require("./url");
 const { registerWorkspaceChromeHide } = require("./workspace-chrome");
 const omnigentCli = require("./omnigent_cli");
 const serverManager = require("./server_manager");
+const localHost = require("./localHost");
 
 /** Absolute path to the bundled setup page (the "connect to server" form). */
 const SETUP_PAGE = path.join(__dirname, "..", "setup", "index.html");
@@ -1848,6 +1849,27 @@ function registerIpc() {
     return serverManager.startLocalServer(cliPath);
   });
 
+  // Setup page → start (or reuse) the local server AND attach a host on this
+  // machine to it, so a fresh install is usable end-to-end in one click. Returns
+  // the server URL so the setup page hands off to the normal navigation flow.
+  // The setup page is the trusted, bundled origin that also chooses the CLI
+  // path, so no separate host-enrollment consent is needed here.
+  ipcMain.handle("omnigent:start-local-server-and-host", async (event) => {
+    if (!isSetupPageSender(event)) {
+      throw new Error("start-local-server-and-host is only available to the setup page");
+    }
+    const cliPath = resolvedCliPath();
+    if (!cliPath) {
+      return { ok: false, error: "The omnigent CLI was not found. Install it or set its path." };
+    }
+    const server = await serverManager.startLocalServer(cliPath);
+    if (!server.ok || !server.url) return server;
+    // Best-effort host attach: if it fails, the server is still up and usable,
+    // so surface the URL and let the user connect a host from the host menu.
+    await localHost.startLocalHost({ serverUrl: server.url });
+    return server;
+  });
+
   // SPA → this machine's identity: is the CLI installed, and its host id. Both
   // come from local config (no `omnigent host status` subprocess), so this is
   // instant — it lets the new-session picker tag/connect "this machine" without
@@ -1920,6 +1942,51 @@ function registerIpc() {
     } else {
       result = { ok: false, error: `unknown host action '${action}'` };
     }
+    broadcastHostStatus();
+    return result;
+  });
+
+  // SPA → read this machine's local-host daemon status for the window's own
+  // server (running? runtime present? needs login?). Read-only — no subprocess,
+  // no consent — so pinned-origin gating alone is enough. The renderer passes a
+  // serverUrl for convenience, but we use the window's authoritative server so a
+  // foreign page can't probe an arbitrary target.
+  ipcMain.handle("omnigent:get-local-host-status", (event) => {
+    if (!isPinnedOriginSender(event)) {
+      console.warn("[omnigent] get-local-host-status from untrusted sender dropped");
+      return null;
+    }
+    const serverUrl = senderServerUrl(event);
+    return localHost.getLocalHostStatus({ serverUrl });
+  });
+
+  // SPA → one-click: spawn a host on this machine for the window's own server.
+  // On a local server this ensures a local server AND attaches a host in a
+  // single `omni host ""`. Enrolling the machine as a runner executes agent code
+  // locally, so — exactly like host-control start — gate on the native consent
+  // dialog: isPinnedOriginSender proves the call came FROM the pinned page, not
+  // that the USER asked. The serverUrl decision uses the window's own server,
+  // never the renderer-supplied arg.
+  ipcMain.handle("omnigent:start-local-host", async (event) => {
+    if (!isPinnedOriginSender(event)) {
+      throw new Error("start-local-host is only available to a connected server page");
+    }
+    const serverUrl = senderServerUrl(event);
+    if (!serverUrl) return { ok: false, error: "this window is not connected to a server" };
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!(await confirmHostEnrollment(win))) {
+      return { ok: false, error: "Hosting wasn't approved for this server." };
+    }
+    // Ensure the CLI is authenticated for a remote server first (local needs
+    // none) — otherwise the daemon would just fail on a 401. This mirrors the
+    // host-control start path, so the detached daemon works for remote servers
+    // too, not only loopback.
+    const cliPath = resolvedCliPath();
+    if (cliPath) {
+      const auth = await serverManager.ensureServerAuth(cliPath, serverUrl);
+      if (!auth.ok) return { ok: false, error: auth.error };
+    }
+    const result = await localHost.startLocalHost({ serverUrl });
     broadcastHostStatus();
     return result;
   });

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -104,6 +104,21 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
    * setup page, so a connected server can't repoint the CLI at an arbitrary one.
    */
   resetCliPath: () => ipcRenderer.invoke("omnigent:cli-reset-path"),
+  /**
+   * One-click: spawn a host on this machine for the window's server. On a local
+   * server this ensures a local server AND attaches a host. Resolves
+   * `{ ok, error?, logPath? }`. The serverUrl arg is a convenience; the main
+   * process authoritatively uses the window's own pinned server.
+   * @param {string} serverUrl
+   */
+  startLocalHost: (serverUrl) => ipcRenderer.invoke("omnigent:start-local-host", serverUrl),
+  /**
+   * Read the local-host daemon status for the window's server (no subprocess —
+   * reads the same registry the CLI uses). Resolves a LocalHostStatus or null.
+   * @param {string} serverUrl
+   */
+  getLocalHostStatus: (serverUrl) =>
+    ipcRenderer.invoke("omnigent:get-local-host-status", serverUrl),
 });
 
 // Setup-page bridge: persist + navigate to a server URL, and read the saved
@@ -136,4 +151,10 @@ contextBridge.exposeInMainWorld("omnigentSetup", {
    * caller then connects to `url` via setServerUrl.
    */
   startLocalServer: () => ipcRenderer.invoke("omnigent:start-local-server"),
+  /**
+   * Start (or reuse) the local server AND attach a host on this machine to it,
+   * so the app is usable end-to-end in one click. Resolves `{ok, url?, error?}`;
+   * the caller connects to `url` via setServerUrl.
+   */
+  startLocalAndHost: () => ipcRenderer.invoke("omnigent:start-local-server-and-host"),
 });

--- a/web/electron/test/localHost.test.js
+++ b/web/electron/test/localHost.test.js
@@ -1,0 +1,231 @@
+// Tests for the local-host spawn/status logic (src/localHost.js), run with
+// `node --test` (no extra deps). Covers the pure, dependency-injected pieces:
+// the connection-mode decision, the `omni host` argv it builds, the daemon
+// registry path, needsLogin from an auth-tokens fixture, and runtime
+// resolution under the Finder minimal-PATH constraint. The effectful spawn
+// (detached child) is exercised by manual e2e, not here.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+
+const {
+  decideMode,
+  isLoopbackServer,
+  daemonArgs,
+  daemonTarget,
+  daemonRecordPath,
+  computeNeedsLogin,
+  resolveOmnigentRuntime,
+  readDaemonRecord,
+} = require("../src/localHost");
+
+describe("decideMode", () => {
+  it("is local ONLY with no server URL — the from-scratch spawn case", () => {
+    assert.equal(decideMode(null), "local");
+    assert.equal(decideMode(""), "local");
+  });
+
+  it("connects to a concrete server — loopback included — with --server", () => {
+    // A loopback URL means the UI already started/pinned a server; the host
+    // must dial THAT one, not spawn a competing second server.
+    assert.equal(decideMode("http://localhost:6767"), "remote");
+    assert.equal(decideMode("http://127.0.0.1:6767"), "remote");
+    assert.equal(decideMode("http://[::1]:6767/"), "remote");
+    assert.equal(decideMode("https://omnigent-app.databricksapps.com"), "remote");
+    assert.equal(decideMode("https://example.com:8443/path"), "remote");
+  });
+
+  it("falls back to local on an unparseable URL", () => {
+    assert.equal(decideMode("not a url"), "local");
+  });
+});
+
+describe("isLoopbackServer", () => {
+  it("is true only for a parseable loopback URL", () => {
+    assert.equal(isLoopbackServer("http://localhost:6767"), true);
+    assert.equal(isLoopbackServer("http://127.0.0.1:6767"), true);
+    assert.equal(isLoopbackServer("http://[::1]:6767/"), true);
+    assert.equal(isLoopbackServer("https://example.com"), false);
+    assert.equal(isLoopbackServer(null), false);
+    assert.equal(isLoopbackServer(""), false);
+    assert.equal(isLoopbackServer("not a url"), false);
+  });
+});
+
+describe("daemonArgs", () => {
+  it('uses the empty-string positional for local mode (omni host "")', () => {
+    assert.deepEqual(daemonArgs("local", null), ["host", ""]);
+  });
+
+  it("passes --server for remote mode — including a loopback server", () => {
+    assert.deepEqual(daemonArgs("remote", "https://example.com"), [
+      "host",
+      "--server",
+      "https://example.com",
+    ]);
+    assert.deepEqual(daemonArgs("remote", "http://127.0.0.1:6767"), [
+      "host",
+      "--server",
+      "http://127.0.0.1:6767",
+    ]);
+  });
+});
+
+describe("daemonTarget / daemonRecordPath", () => {
+  it("normalizes the target the same way the CLI keys its registry", () => {
+    assert.equal(daemonTarget("local", null), "local");
+    assert.equal(daemonTarget("remote", "https://example.com/"), "https://example.com");
+  });
+
+  it("hashes the target to the CLI's sha256[:16].json record path", () => {
+    const target = "https://example.com";
+    const digest = crypto.createHash("sha256").update(target, "utf8").digest("hex").slice(0, 16);
+    assert.ok(daemonRecordPath(target).endsWith(`${digest}.json`));
+  });
+});
+
+describe("computeNeedsLogin", () => {
+  const future = () => 1_000_000; // ms "now"
+  const tokenFile = (obj) => ({
+    readFileSync: () => JSON.stringify(obj),
+    now: future,
+  });
+
+  it("is false for a local server regardless of stored tokens", () => {
+    assert.equal(computeNeedsLogin(null, tokenFile({})), false);
+    assert.equal(computeNeedsLogin("http://localhost:6767", tokenFile({})), false);
+  });
+
+  it("is true for a remote server with no token file", () => {
+    assert.equal(
+      computeNeedsLogin("https://example.com", {
+        readFileSync: () => {
+          throw new Error("ENOENT");
+        },
+        now: future,
+      }),
+      true,
+    );
+  });
+
+  it("is false when a valid (unexpired) token is stored", () => {
+    assert.equal(
+      computeNeedsLogin(
+        "https://example.com",
+        tokenFile({ "https://example.com": { token: "jwt", expires_at: 100_000 } }),
+      ),
+      false,
+    );
+  });
+
+  it("treats an expired token as missing", () => {
+    // expires_at is in seconds; 1 * 1000 < 1_000_000 → expired.
+    assert.equal(
+      computeNeedsLogin(
+        "https://example.com",
+        tokenFile({ "https://example.com": { token: "jwt", expires_at: 1 } }),
+      ),
+      true,
+    );
+  });
+
+  it("treats a Databricks pointer record as having credentials", () => {
+    assert.equal(
+      computeNeedsLogin(
+        "https://example.com",
+        tokenFile({ "https://example.com": { auth_type: "databricks", workspace_host: "x" } }),
+      ),
+      false,
+    );
+  });
+
+  it("matches the key with trailing slashes stripped", () => {
+    assert.equal(
+      computeNeedsLogin(
+        "https://example.com/",
+        tokenFile({ "https://example.com": { token: "jwt", expires_at: 100_000 } }),
+      ),
+      false,
+    );
+  });
+});
+
+describe("resolveOmnigentRuntime", () => {
+  it("prefers an executable in a known bin dir", () => {
+    const result = resolveOmnigentRuntime({
+      noCache: true,
+      binDirs: ["/opt/homebrew/bin", "/usr/local/bin"],
+      accessSync: (p) => {
+        if (p !== "/opt/homebrew/bin/omnigent") throw new Error("ENOENT");
+      },
+      runShellProbe: () => null,
+      pathEnv: "",
+    });
+    assert.deepEqual(result, { binary: "/opt/homebrew/bin/omnigent", binDir: "/opt/homebrew/bin" });
+  });
+
+  it("falls back to the login-shell probe when known dirs miss (Finder PATH)", () => {
+    const result = resolveOmnigentRuntime({
+      noCache: true,
+      binDirs: ["/opt/homebrew/bin"],
+      accessSync: (p) => {
+        // Known dir misses; only the probe's path is executable.
+        if (p !== "/Users/me/.local/bin/omni") throw new Error("ENOENT");
+      },
+      runShellProbe: () => "/Users/me/.local/bin/omni",
+      pathEnv: "",
+    });
+    assert.deepEqual(result, {
+      binary: "/Users/me/.local/bin/omni",
+      binDir: "/Users/me/.local/bin",
+    });
+  });
+
+  it("falls back to the process PATH last", () => {
+    const result = resolveOmnigentRuntime({
+      noCache: true,
+      binDirs: [],
+      accessSync: (p) => {
+        if (p !== "/custom/bin/omnigent") throw new Error("ENOENT");
+      },
+      runShellProbe: () => null,
+      pathEnv: "/custom/bin:/other",
+    });
+    assert.deepEqual(result, { binary: "/custom/bin/omnigent", binDir: "/custom/bin" });
+  });
+
+  it("returns null when nothing resolves", () => {
+    const result = resolveOmnigentRuntime({
+      noCache: true,
+      binDirs: ["/opt/homebrew/bin"],
+      accessSync: () => {
+        throw new Error("ENOENT");
+      },
+      runShellProbe: () => null,
+      pathEnv: "",
+    });
+    assert.equal(result, null);
+  });
+});
+
+describe("readDaemonRecord", () => {
+  it("reports not-running when no record exists", () => {
+    const record = readDaemonRecord("local", {
+      readFileSync: () => {
+        throw new Error("ENOENT");
+      },
+    });
+    assert.deepEqual(record, { running: false, pid: null, logPath: null });
+  });
+
+  it("reports not-running for a dead pid but surfaces the log path", () => {
+    const record = readDaemonRecord("local", {
+      // pid 1 is almost certainly not us and kill(1,0) raises EPERM... so use a
+      // pid that is structurally valid but (very likely) dead.
+      readFileSync: () => JSON.stringify({ pid: 2 ** 31 - 1, log_path: "/tmp/d.log" }),
+    });
+    assert.equal(record.running, false);
+    assert.equal(record.logPath, "/tmp/d.log");
+  });
+});

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -130,6 +130,10 @@ interface ElectronDesktopApi extends NativeShellApi {
   getCliStatus?: () => Promise<CliStatus | null>;
   /** Clear the CLI-path override (revert to auto-detection); resolves status. */
   resetCliPath?: () => Promise<CliStatus | null>;
+  /** One-click: spawn a host on this machine for the window's server. */
+  startLocalHost?: (serverUrl: string) => Promise<StartLocalHostResult>;
+  /** Read the local-host daemon status for the window's server (no subprocess). */
+  getLocalHostStatus?: (serverUrl: string) => Promise<LocalHostStatus | null>;
 }
 
 /** A lifecycle action for the host daemon. */
@@ -163,6 +167,30 @@ export interface HostIdentity {
 export interface HostActionResult {
   ok: boolean;
   error?: string;
+}
+
+/** Result of a one-click local-host spawn from the desktop shell. */
+export interface StartLocalHostResult {
+  ok: boolean;
+  error?: string;
+  /** Path to the daemon's log file, when one was opened. */
+  logPath?: string | null;
+}
+
+/** The local-host daemon's status for a given server, from the desktop shell. */
+export interface LocalHostStatus {
+  /** Whether a host daemon for this server is currently running. */
+  running: boolean;
+  /** Whether the `omnigent` CLI was found on this machine. */
+  runtimeAvailable: boolean;
+  /** Whether the daemon would target a local server (`omni host ""`) or remote. */
+  mode: "local" | "remote";
+  /** Whether the user likely needs to sign in to this (remote) server first. */
+  needsLogin: boolean;
+  /** The server URL this status is for, or null. */
+  serverUrl: string | null;
+  /** Path to the daemon's log file, or null when not running. */
+  logPath: string | null;
 }
 
 /** Data backing the title-bar server picker, from the Electron shell. */
@@ -550,6 +578,39 @@ export async function resetCliPath(): Promise<CliStatus | null> {
     return await electron.resetCliPath();
   } catch (err) {
     console.warn("[nativeBridge] electron resetCliPath failed:", err);
+    return null;
+  }
+}
+
+/**
+ * One-click: spawn a host on this machine for the given server, via the desktop
+ * shell. On a local server this ensures a local server AND attaches a host in a
+ * single step. Resolves `{ ok, error? }`; a no-op `{ ok: false }` outside the
+ * shell (or under a shell too old to expose the bridge).
+ */
+export async function startLocalHost(serverUrl: string): Promise<StartLocalHostResult> {
+  const electron = electronApi();
+  if (!electron?.startLocalHost) return { ok: false, error: "not running under the desktop shell" };
+  try {
+    return await electron.startLocalHost(serverUrl);
+  } catch (err) {
+    console.warn("[nativeBridge] electron startLocalHost failed:", err);
+    return { ok: false, error: String(err) };
+  }
+}
+
+/**
+ * Read the local-host daemon status for the given server from the desktop shell
+ * (reads the same daemon registry the CLI uses — no subprocess). Resolves `null`
+ * outside the Electron shell or under a shell too old to expose the bridge.
+ */
+export async function getLocalHostStatus(serverUrl: string): Promise<LocalHostStatus | null> {
+  const electron = electronApi();
+  if (!electron?.getLocalHostStatus) return null;
+  try {
+    return await electron.getLocalHostStatus(serverUrl);
+  } catch (err) {
+    console.warn("[nativeBridge] electron getLocalHostStatus failed:", err);
     return null;
   }
 }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -80,6 +80,7 @@ import {
   onHostStatusChanged,
   type HostIdentity,
 } from "@/lib/nativeBridge";
+import { RunOnThisMacButton } from "./RunOnThisMacButton";
 import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
@@ -300,9 +301,12 @@ function HostOption({ host, subtitle }: { host: Host; subtitle?: string }) {
 export function ConnectHostInstructions({
   serverUrl,
   label,
+  onHostOnline,
 }: {
   serverUrl: string;
   label?: string;
+  /** Called once a one-click "Run on this Mac" host comes online (desktop only). */
+  onHostOnline?: () => void;
 }) {
   // Databricks/internal deployments add the "Databricks Lakebox" connect
   // path; OSS deployments (where the lakebox launcher is excluded) show
@@ -314,6 +318,9 @@ export function ConnectHostInstructions({
   return (
     <div className="flex flex-col gap-4 rounded-lg border border-dashed border-border p-4">
       {label && <p className="text-xs text-muted-foreground">{label}</p>}
+      {/* Desktop-only one-click host spawn. Self-hides in a browser (and when
+          the CLI is missing), leaving the manual command below as the path. */}
+      <RunOnThisMacButton serverUrl={serverUrl} onHostOnline={onHostOnline} />
       {databricksFeatures ? (
         <Tabs defaultValue="local">
           <TabsList className="w-full">
@@ -3084,22 +3091,25 @@ export function NewChatLandingScreen() {
                       </DropdownMenuItem>
                     );
                   })}
-                  {/* Desktop shell, machine not in the list yet: offer to connect
-                    it in one click. */}
+                  {/* Desktop shell, machine not in the list yet: one-click spawn
+                    a host on this Mac. Its internal click/polling state machine
+                    needs to survive the menu staying open, so it's a plain row
+                    (not a DropdownMenuItem, which would close on select). It
+                    self-hides outside Electron / when the CLI is missing. */}
                   {showConnectThisMachine && (
-                    <DropdownMenuItem
-                      onSelect={() => {
-                        pendingConnectRef.current = true;
-                      }}
-                      disabled={connectingThisMachine}
-                      data-testid="new-chat-landing-run-on-this-machine"
-                      className="gap-2 text-xs"
-                    >
-                      <MonitorIcon className="size-4 shrink-0 text-muted-foreground" />
-                      <span className="text-xs">
-                        {connectingThisMachine ? "Connecting this machine…" : "Run on this machine"}
-                      </span>
-                    </DropdownMenuItem>
+                    <div className="px-2 py-1" data-testid="new-chat-landing-run-on-this-machine">
+                      <RunOnThisMacButton
+                        serverUrl={serverUrl}
+                        onHostOnline={() => {
+                          void (async () => {
+                            const identity = await getHostIdentity();
+                            setDesktopHost(identity);
+                            await queryClient.invalidateQueries({ queryKey: ["hosts"] });
+                            if (identity?.hostId) selectHost(identity.hostId);
+                          })();
+                        }}
+                      />
+                    </div>
                   )}
                   {(allHosts.length > 0 || showConnectThisMachine) && <DropdownMenuSeparator />}
                   {/* Persistent escape hatch: open the connect-a-host
@@ -3357,6 +3367,10 @@ export function NewChatLandingScreen() {
           <ConnectHostInstructions
             serverUrl={serverUrl}
             label="Run this on the machine you want to use, then pick it from the host menu:"
+            onHostOnline={() => {
+              void queryClient.invalidateQueries({ queryKey: ["hosts"] });
+              setConnectOpen(false);
+            }}
           />
         </DialogContent>
       </Dialog>

--- a/web/src/shell/RunOnThisMacButton.test.tsx
+++ b/web/src/shell/RunOnThisMacButton.test.tsx
@@ -1,0 +1,137 @@
+// Unit tests for RunOnThisMacButton — the one-click "spawn a host on this Mac"
+// affordance shown inside the Electron desktop shell.
+//
+// What we lock:
+//   1. Outside the desktop shell → renders nothing.
+//   2. Shell reports no capability (null status) → renders nothing.
+//   3. Runtime not installed → a non-actionable hint, not the active button.
+//   4. Click → spinner, then on a successful spawn it polls and flips to
+//      "online", calling onHostOnline.
+//   5. A failed spawn surfaces the error.
+//   6. needsLogin shows a soft warning but leaves the button enabled.
+//
+// The native bridge is mocked: this pins the component's own state machine,
+// not the IPC plumbing (covered by nativeBridge.test.ts) or the daemon spawn
+// (covered by localHost/e2e).
+
+import { cleanup, fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RunOnThisMacButton } from "./RunOnThisMacButton";
+import {
+  getLocalHostStatus,
+  isElectronShell,
+  startLocalHost,
+  type LocalHostStatus,
+} from "@/lib/nativeBridge";
+
+vi.mock("@/lib/nativeBridge", () => ({
+  isElectronShell: vi.fn(),
+  getLocalHostStatus: vi.fn(),
+  startLocalHost: vi.fn(),
+}));
+
+const mockIsElectron = vi.mocked(isElectronShell);
+const mockGetStatus = vi.mocked(getLocalHostStatus);
+const mockStart = vi.mocked(startLocalHost);
+
+function status(overrides: Partial<LocalHostStatus> = {}): LocalHostStatus {
+  return {
+    running: false,
+    runtimeAvailable: true,
+    mode: "local",
+    needsLogin: false,
+    serverUrl: "http://localhost:6767",
+    logPath: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: in the desktop shell, runtime available, no hosts online yet.
+  mockIsElectron.mockReturnValue(true);
+  mockGetStatus.mockResolvedValue(status());
+  mockStart.mockResolvedValue({ ok: true, logPath: "/tmp/d.log" });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("RunOnThisMacButton", () => {
+  it("renders nothing outside the desktop shell", async () => {
+    mockIsElectron.mockReturnValue(false);
+    const { container } = render(<RunOnThisMacButton serverUrl="http://localhost:6767" />);
+    await waitFor(() => expect(mockIsElectron).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId("run-on-this-mac")).toBeNull();
+  });
+
+  it("renders nothing when the shell reports no capability", async () => {
+    mockGetStatus.mockResolvedValue(null);
+    const { container } = render(<RunOnThisMacButton serverUrl="http://localhost:6767" />);
+    await waitFor(() => expect(mockGetStatus).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a hint (not the active button) when the runtime is missing", async () => {
+    mockGetStatus.mockResolvedValue(status({ runtimeAvailable: false }));
+    render(<RunOnThisMacButton serverUrl="http://localhost:6767" />);
+    expect(await screen.findByTestId("run-on-this-mac-no-runtime")).toBeInTheDocument();
+    expect(screen.queryByTestId("run-on-this-mac")).toBeNull();
+  });
+
+  it("starts a host on click, then flips to online and calls onHostOnline", async () => {
+    vi.useFakeTimers();
+    const onHostOnline = vi.fn();
+    render(<RunOnThisMacButton serverUrl="http://localhost:6767" onHostOnline={onHostOnline} />);
+    // Let the mount-time capability probe resolve.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const button = screen.getByTestId("run-on-this-mac");
+
+    // Click → spawn. After the spawn resolves, the component enters polling.
+    // Make the next status poll report the host as running.
+    mockGetStatus.mockResolvedValue(status({ running: true }));
+    await act(async () => {
+      fireEvent.click(button);
+      await Promise.resolve();
+    });
+    expect(mockStart).toHaveBeenCalledWith("http://localhost:6767");
+
+    // Advance to the first poll tick.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+    expect(screen.getByTestId("run-on-this-mac-online")).toBeInTheDocument();
+    expect(onHostOnline).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces an error when the spawn fails", async () => {
+    mockStart.mockResolvedValue({ ok: false, error: "No CLI found" });
+    render(<RunOnThisMacButton serverUrl="http://localhost:6767" />);
+    const button = await screen.findByTestId("run-on-this-mac");
+    await act(async () => {
+      fireEvent.click(button);
+      await Promise.resolve();
+    });
+    expect(await screen.findByTestId("run-on-this-mac-error")).toHaveTextContent("No CLI found");
+  });
+
+  it("shows a soft login warning but keeps the button enabled", async () => {
+    mockGetStatus.mockResolvedValue(status({ mode: "remote", needsLogin: true }));
+    render(<RunOnThisMacButton serverUrl="https://example.com" />);
+    expect(await screen.findByTestId("run-on-this-mac-needs-login")).toBeInTheDocument();
+    expect(screen.getByTestId("run-on-this-mac")).not.toBeDisabled();
+  });
+
+  it("seeds straight to online when a host is already running", async () => {
+    mockGetStatus.mockResolvedValue(status({ running: true }));
+    render(<RunOnThisMacButton serverUrl="http://localhost:6767" />);
+    expect(await screen.findByTestId("run-on-this-mac-online")).toBeInTheDocument();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/shell/RunOnThisMacButton.tsx
+++ b/web/src/shell/RunOnThisMacButton.tsx
@@ -1,0 +1,207 @@
+// One-click "Run on this Mac" — spawn a host on the user's own machine.
+//
+// A host is a machine that runs agent sessions and dials OUT to the connected
+// server; normally a user starts one with `omnigent host` in a terminal. Inside
+// the Electron desktop shell we can fork the process for them, so this button
+// turns that into one click. It renders ONLY in the desktop shell when the main
+// process reports a usable runtime — in a plain browser (or an older shell) it
+// returns null, and the surfaces that embed it keep their CLI-instructions
+// fallback.
+//
+// The button drives a small state machine: idle → starting → polling → online,
+// with an error branch. "polling" waits for the freshly-spawned daemon to show
+// up via the main process's own status (`getLocalHostStatus().running`), which
+// reads the same daemon registry the CLI does. Kept free of react-query / the
+// server host list so it can be dropped into any surface (dialogs, the sidebar)
+// without a QueryClientProvider in scope.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  CheckIcon,
+  CircleHelpIcon,
+  Loader2Icon,
+  MonitorIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import {
+  getLocalHostStatus,
+  isElectronShell,
+  startLocalHost,
+  type LocalHostStatus,
+} from "@/lib/nativeBridge";
+
+/** While polling, how often to re-check the main process, and the overall cap. */
+const POLL_INTERVAL_MS = 1500;
+const POLL_TIMEOUT_MS = 45_000;
+
+type Phase = "idle" | "starting" | "polling" | "online" | "error";
+
+export function RunOnThisMacButton({
+  serverUrl,
+  className,
+  onHostOnline,
+}: {
+  /** The connected server URL (from `getCliServerUrl()`). */
+  serverUrl: string;
+  className?: string;
+  /** Called once the host comes online — lets a surface close its dialog. */
+  onHostOnline?: () => void;
+}) {
+  // The main process's local-host capability/status for this server.
+  // `undefined` = still loading; `null` = no capability (hide entirely).
+  const [capability, setCapability] = useState<LocalHostStatus | null | undefined>(undefined);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const onHostOnlineRef = useRef(onHostOnline);
+  onHostOnlineRef.current = onHostOnline;
+
+  // Resolve capability once on mount (only meaningful inside Electron).
+  useEffect(() => {
+    if (!isElectronShell()) {
+      setCapability(null);
+      return;
+    }
+    let cancelled = false;
+    void getLocalHostStatus(serverUrl).then((status) => {
+      if (cancelled) return;
+      setCapability(status);
+      if (status?.running) setPhase("online");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [serverUrl]);
+
+  const markOnline = useCallback(() => {
+    setPhase("online");
+    onHostOnlineRef.current?.();
+  }, []);
+
+  // While polling, poll the main process's own status (which reads the daemon
+  // registry), with a timeout.
+  useEffect(() => {
+    if (phase !== "polling") return;
+    let cancelled = false;
+    const startedAt = Date.now();
+    const interval = window.setInterval(() => {
+      void getLocalHostStatus(serverUrl).then((status) => {
+        if (cancelled) return;
+        if (status?.running) {
+          markOnline();
+        } else if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          setError("Taking longer than expected — check the host menu in a moment.");
+          setPhase("error");
+        }
+      });
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [phase, serverUrl, markOnline]);
+
+  const handleStart = useCallback(async () => {
+    setError(null);
+    setPhase("starting");
+    const result = await startLocalHost(serverUrl);
+    if (result.ok) {
+      setPhase("polling");
+    } else {
+      setError(result.error ?? "Couldn't start a host on this Mac.");
+      setPhase("error");
+    }
+  }, [serverUrl]);
+
+  // Not in the desktop shell, or the shell reports no capability → render
+  // nothing so the embedding surface shows its CLI fallback instead.
+  if (capability === undefined || capability === null) return null;
+
+  // Runtime missing: the CLI isn't installed on this machine. Offer a clear,
+  // non-actionable hint rather than a button that can only fail.
+  if (!capability.runtimeAvailable) {
+    return (
+      <div
+        className={cn("flex items-center gap-2 text-xs text-muted-foreground", className)}
+        data-testid="run-on-this-mac-no-runtime"
+      >
+        <MonitorIcon className="size-4 shrink-0 opacity-60" />
+        <span>Install the Omnigent CLI to run a host on this Mac.</span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex" aria-label="Why this is unavailable">
+                <CircleHelpIcon className="size-3.5" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-64">
+              The desktop app couldn't find the <code>omnigent</code> CLI. Install it (e.g.{" "}
+              <code>uv tool install omnigent</code>), then reopen this menu.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    );
+  }
+
+  if (phase === "online") {
+    return (
+      <div
+        className={cn("flex items-center gap-2 text-xs text-green-600", className)}
+        data-testid="run-on-this-mac-online"
+      >
+        <CheckIcon className="size-4 shrink-0" />
+        <span>Running on this Mac</span>
+      </div>
+    );
+  }
+
+  const busy = phase === "starting" || phase === "polling";
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        disabled={busy}
+        onClick={handleStart}
+        data-testid="run-on-this-mac"
+        className="justify-center"
+      >
+        {busy ? (
+          <Loader2Icon className="size-3.5 animate-spin" />
+        ) : (
+          <MonitorIcon className="size-3.5" />
+        )}
+        {phase === "starting"
+          ? "Starting…"
+          : phase === "polling"
+            ? "Connecting…"
+            : "Run on this Mac"}
+      </Button>
+      {phase === "error" && error && (
+        <p
+          className="flex items-center gap-1.5 text-xs text-destructive"
+          data-testid="run-on-this-mac-error"
+        >
+          <TriangleAlertIcon className="size-3.5 shrink-0" />
+          <span>{error}</span>
+        </p>
+      )}
+      {phase === "idle" && capability.needsLogin && (
+        <p
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
+          data-testid="run-on-this-mac-needs-login"
+        >
+          <TriangleAlertIcon className="size-3.5 shrink-0" />
+          <span>You may need to sign in first for this server.</span>
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Related issue

https://github.com/omnigent-ai/omnigent/issues/1934

## Summary

This PR adds a one-click **Run on this Mac** affordance to the Electron desktop
shell so a first-time user can start running agent sessions without opening a
terminal (`omni host` / `omni server start`).

-Only the desktop shell can spawn a local process, so this feature is **desktop-only** — the button self-hides in
  a plain browser, where the existing `omni host` CLI instructions remain.
- Button surfaced in three places: the **Connect-a-host dialog**, the **host dropdown** (replacing the older text-only "Run on this machine" item), and the desktop **setup screen** ("Start locally" now brings up a server **and** a host).
- New IPC seams: `nativeBridge` `startLocalHost` / `getLocalHostStatus` wrappers, preload bridges, and consent-gated main-process handlers (`start-local-host`, `get-local-host-status`, and a setup-gated `start-local-server-and-host` that reuses the existing `serverManager` to bring up the server, then attaches a host). The start path reuses the existing native host-enrollment confirmation, since enrolling the machine as a runner executes agent code.
- `localHost.js` spawns a detached daemon and reads status from the same `~/.omnigent` daemon registry the CLI uses, so a daemon started here is visible to `omnigent host status` and never double-spawned.

## Test Plan

- Unit: `web/electron` `node --test` for `localHost` / `localServer` (25 pass); `vitest` for `RunOnThisMacButton` (7 pass).
- `npm run type-check` and `oxlint` clean on touched files; full web suite green (3529 pass).
- Manual (desktop): from a fresh setup page, **Start locally** spins up a local server and attaches a host in one click; the window loads the SPA with this machine already hosting. From a connected UI, **Run on this Mac** in the Connect-a-host dialog and host dropdown goes Starting → Connecting → "Running on this Mac", and host filesystem/session operations work against the pinned server (verified the earlier double-server 409 is resolved). In a plain browser the button is absent and the CLI instructions remain.

## Demo

<!-- TODO: attach the screen recording of Start locally + Run on this Mac. -->
_Screen recording to be attached._

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The pure logic (mode decision, argv, daemon-registry status, runtime resolution, loopback detection) is unit-tested with dependency injection. The effectful detached spawn is covered by manual desktop end-to-end verification, since it forks a real process and can't run under the unit harness.

## Changelog

One-click "Run on this Mac" in the desktop app starts a local server and host
