### PR TITLE
fix(routing): infer openai-agents for xai/grok-* models

### DIFF
--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -84,11 +84,8 @@ _HARNESS_FOR_MODEL_PREFIX: dict[str, str] = {
     "databricks-gpt-": "openai-agents",
     "openai/gpt-": "openai-agents",
     "gpt-": "openai-agents",
-    # xAI exposes an OpenAI-compatible endpoint and is classified
-    # OPENAI_FAMILY in configure_models.py, so openai-agents is the
-    # right harness for both provider-prefixed and bare grok- strings.
+    # xAI is OpenAI-compatible; provider prefix required (bare grok- defaults to openai).
     "xai/grok-": "openai-agents",
-    "grok-": "openai-agents",
 }
 
 

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -84,6 +84,11 @@ _HARNESS_FOR_MODEL_PREFIX: dict[str, str] = {
     "databricks-gpt-": "openai-agents",
     "openai/gpt-": "openai-agents",
     "gpt-": "openai-agents",
+    # xAI exposes an OpenAI-compatible endpoint and is classified
+    # OPENAI_FAMILY in configure_models.py, so openai-agents is the
+    # right harness for both provider-prefixed and bare grok- strings.
+    "xai/grok-": "openai-agents",
+    "grok-": "openai-agents",
 }
 
 

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -96,12 +96,9 @@ def test_unknown_provider_raises() -> None:
         ("databricks-gpt-5-4", "openai-agents"),
         ("openai/gpt-5.4", "openai-agents"),
         ("gpt-5.4", "openai-agents"),
-        # xAI / Grok models → openai-agents (OpenAI-compatible endpoint,
-        # classified OPENAI_FAMILY in configure_models.py).
+        # xAI / Grok models -- provider prefix required.
         ("xai/grok-4.3", "openai-agents"),
         ("xai/grok-4", "openai-agents"),
-        ("grok-4.3", "openai-agents"),
-        ("grok-4", "openai-agents"),
         # Unknown model — no prefix match — returns empty string so the
         # downstream validator can surface a "harness required" error.
         ("llama3-groq", ""),

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -96,6 +96,12 @@ def test_unknown_provider_raises() -> None:
         ("databricks-gpt-5-4", "openai-agents"),
         ("openai/gpt-5.4", "openai-agents"),
         ("gpt-5.4", "openai-agents"),
+        # xAI / Grok models → openai-agents (OpenAI-compatible endpoint,
+        # classified OPENAI_FAMILY in configure_models.py).
+        ("xai/grok-4.3", "openai-agents"),
+        ("xai/grok-4", "openai-agents"),
+        ("grok-4.3", "openai-agents"),
+        ("grok-4", "openai-agents"),
         # Unknown model — no prefix match — returns empty string so the
         # downstream validator can surface a "harness required" error.
         ("llama3-groq", ""),


### PR DESCRIPTION
Closes #1927

If you configured an agent with model: xai/grok-4 but no explicit
harness, Omnigent failed with "harness required". Every other major
provider already had an entry in the harness routing table -- xAI was
just missing.

Added xai/grok- to the table, pointing to openai-agents. That's the
right target: xAI's API is OpenAI-compatible. Provider prefix is
required -- bare grok- would default to provider="openai" and route
to the wrong endpoint. Two test cases added to lock the routing in.