### PR TITLE
feat(hermes-native): live tool-call cards via a per-turn response_id

### DIFF
--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -23,12 +23,22 @@ launched in the same cwd never mirror the same row into two conversations. We th
 poll ``messages`` past a high-water ``id`` and POST new user/assistant rows as
 ``external_conversation_item`` events (which also seeds the session title).
 
-The web-facing ``running``/``idle`` *spinner* edges are intentionally NOT posted
-here: the runner's PTY-activity watcher owns those ``session.status`` edges for
-hermes-native (see :mod:`omnigent.runner.app`), exactly as for goose-/cursor-native.
-That watcher drives only the web "Working…" spinner, though — it never wakes a
-parent orchestrator. So this forwarder additionally derives turn completion from
-the message log (an ``assistant`` row with no ``tool_calls`` is the agentic loop's
+To make the web render this harness's in-flight tool calls **live** (a spinner +
+ticking elapsed timer, matching claude-/codex-native), the forwarder assigns one
+``response_id`` per turn — ``hermes_turn_{opening-msg-id}`` shared across every row
+of the turn — POSTs a ``running`` ``external_session_status`` edge carrying that id
+at turn start, and stamps the turn's mirrored ``function_call`` items with the same
+id (see :func:`_annotate_turn_actions`). The server keys the live card off a
+``running`` edge whose ``response_id`` matches the items' ``response_id`` (#1874).
+
+The forwarder deliberately does NOT take ``idle`` ownership: the runner's
+PTY-activity watcher (see :mod:`omnigent.runner.app`) still emits the id-less
+``running``/``idle`` ``session.status`` edges for hermes-native (as for
+goose-/cursor-native), and the server pops the active response id on *any* ``idle``
+— so an aborted turn (whose terminal row may never be written) still resolves the
+card. That watcher drives only the web spinner, though — it never wakes a parent
+orchestrator. So this forwarder additionally derives turn completion from the
+message log (an ``assistant`` row with no ``tool_calls`` is the agentic loop's
 terminal step) and POSTs an ``external_session_status: idle`` event once per
 completed turn — the SAME server contract claude-/codex-/opencode-/cursor-native
 use to mark a sub-agent turn terminal and wake its parent's inbox. The post is
@@ -47,6 +57,7 @@ import re
 import sqlite3
 import time
 from dataclasses import dataclass
+from itertools import groupby
 from pathlib import Path
 
 import httpx
@@ -223,12 +234,18 @@ class _ForwardState:
     :param heartbeat_ms: Wall-clock ms of the last persist. A sibling reads this
         to tell a live owner from a dead session's leftover claim. Stamped by
         :func:`_write_state`.
+    :param active_turn_id: The per-turn ``response_id`` of the turn currently in
+        flight (``hermes_turn_{opening-msg-id}``), or ``None`` between turns.
+        Persisted so a turn that spans polls — or a forwarder restart mid-turn —
+        keeps its id and does not re-emit a ``running`` edge (see
+        :func:`_annotate_turn_actions`).
     """
 
     hermes_session_id: str | None = None
     last_id: int = 0
     launch_epoch_s: float = 0.0
     heartbeat_ms: int = 0
+    active_turn_id: str | None = None
 
 
 def _read_state(bridge_dir: Path) -> _ForwardState:
@@ -242,11 +259,15 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
     last_id = data.get("last_id")
     launch_epoch_s = data.get("launch_epoch_s")
     heartbeat_ms = data.get("heartbeat_ms")
+    active_turn_id = data.get("active_turn_id")
     return _ForwardState(
         hermes_session_id=sid if isinstance(sid, str) else None,
         last_id=last_id if isinstance(last_id, int) else 0,
         launch_epoch_s=float(launch_epoch_s) if isinstance(launch_epoch_s, (int, float)) else 0.0,
         heartbeat_ms=heartbeat_ms if isinstance(heartbeat_ms, int) else 0,
+        active_turn_id=active_turn_id
+        if isinstance(active_turn_id, str) and active_turn_id
+        else None,
     )
 
 
@@ -265,6 +286,7 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> bool:
                     "hermes_session_id": state.hermes_session_id,
                     "last_id": state.last_id,
                     "launch_epoch_s": state.launch_epoch_s,
+                    "active_turn_id": state.active_turn_id,
                     # Stamp the heartbeat at persist time so every poll refreshes
                     # the session claim; a peer treats a claim older than
                     # ``_CLAIM_FRESH_MS`` as a dead session it may take over.
@@ -579,6 +601,83 @@ def _read_new_items(
     return items
 
 
+@dataclass
+class _TurnAction:
+    """One ordered step when mirroring a poll batch.
+
+    ``kind`` is ``"running"`` (POST a ``running`` status edge) or ``"item"`` (POST
+    a mirrored conversation item). ``turn_id_after`` is the turn id still active
+    once this step is applied — persisted after each step so a turn that spans
+    polls (or a forwarder restart mid-turn) keeps its id.
+    """
+
+    kind: str
+    msg_id: int
+    turn_id_after: str | None
+    response_id: str | None = None
+    item: _MirrorItem | None = None
+
+
+def _mirror_item_role(item: _MirrorItem) -> str | None:
+    """Return the ``role`` of a ``message`` mirror item, else ``None``."""
+    if item.item_type == "message":
+        role = item.item_data.get("role")
+        return role if isinstance(role, str) else None
+    return None
+
+
+def _annotate_turn_actions(
+    items: list[_MirrorItem], active_turn_id: str | None
+) -> tuple[list[_TurnAction], str | None]:
+    """Assign a per-turn ``response_id`` to a poll batch and interleave ``running``
+    edges at turn starts; return the ordered actions and the turn id still active
+    after the batch.
+
+    A Hermes turn is ``user -> (assistant+tool_calls -> tool)* ->
+    assistant-without-tool_calls``. Rows arrive append-only in ``id`` order and each
+    ``messages`` row is a single role, so items are grouped by ``msg_id``:
+
+    - a ``user`` group **opens** a turn → mint ``hermes_turn_{msg_id}`` and emit a
+      ``running`` edge before its items;
+    - assistant activity while no turn is active also mints one (missed-start
+      recovery — e.g. a forwarder that starts mid-turn), so its cards still go live;
+    - every mirrored item is re-stamped with the active turn id so the web renders
+      the turn's tool-call cards live against the ``running`` edge;
+    - an ``assistant`` group with **no** ``function_call`` item is the terminal step
+      → clear the id after it.
+
+    The ``idle`` edge is intentionally NOT emitted here: the existing completed-turn
+    idle post and the runner's PTY-activity watcher both resolve the card (the server
+    pops the active response id on any idle) and remain the abort-robust resolvers.
+    """
+    actions: list[_TurnAction] = []
+    for msg_id, group_iter in groupby(items, key=lambda it: it.msg_id):
+        group = list(group_iter)
+        has_function_call = any(it.item_type == "function_call" for it in group)
+        roles = {_mirror_item_role(it) for it in group}
+        opens = "user" in roles
+        is_assistant = "assistant" in roles
+        terminal = is_assistant and not has_function_call
+
+        if opens or (active_turn_id is None and (has_function_call or is_assistant)):
+            active_turn_id = f"hermes_turn_{msg_id}"
+            actions.append(
+                _TurnAction("running", msg_id, active_turn_id, response_id=active_turn_id)
+            )
+
+        for it in group:
+            if active_turn_id is not None:
+                it.response_id = active_turn_id
+            actions.append(_TurnAction("item", msg_id, active_turn_id, item=it))
+
+        if terminal:
+            active_turn_id = None
+            if actions:
+                actions[-1].turn_id_after = None
+
+    return actions, active_turn_id
+
+
 def _assistant_row_has_tool_calls(tool_calls: object) -> bool:
     """Whether an assistant ``messages`` row carries a non-empty ``tool_calls`` list.
 
@@ -626,7 +725,11 @@ def _count_completed_turns(db_path: Path, hermes_session_id: str) -> int:
 
 
 async def _post_external_session_status(
-    client: httpx.AsyncClient, *, session_id: str, status: str
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    status: str,
+    response_id: str | None = None,
 ) -> None:
     """POST one ``external_session_status`` event to the Sessions API.
 
@@ -636,11 +739,19 @@ async def _post_external_session_status(
     emits only a web-spinner ``session.status`` edge for hermes-native and never
     wakes a parent, which is why this explicit post is required.
 
+    When *response_id* is given (the turn's ``hermes_turn_{id}``), a ``running``
+    edge carries it so the server marks that response id active and the web renders
+    the turn's tool-call cards live; ``idle`` posts omit it (the server pops the
+    active id on any idle).
+
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
+    data: dict[str, object] = {"status": status}
+    if response_id is not None:
+        data["response_id"] = response_id
     resp = await client.post(
         f"/v1/sessions/{session_id}/events",
-        json={"type": "external_session_status", "data": {"status": status}},
+        json={"type": "external_session_status", "data": data},
     )
     resp.raise_for_status()
 
@@ -776,6 +887,12 @@ async def forward_hermes_store_to_session(
     persisted = _read_state(bridge_dir)
     hermes_session_id: str | None = persisted.hermes_session_id
     last_id = persisted.last_id if hermes_session_id is not None else 0
+    # The turn currently in flight (its shared ``response_id``), threaded through
+    # every ``_write_state`` so it survives polls / a restart. Reset whenever the
+    # tailed hermes session changes (discovery, claim-yield, compaction re-pin).
+    active_turn_id: str | None = (
+        persisted.active_turn_id if hermes_session_id is not None else None
+    )
     # Track whether we have already PATCHed the external_session_id to the
     # Omnigent server so we do it at most once per forwarder lifetime.
     _external_id_synced = False
@@ -798,12 +915,20 @@ async def forward_hermes_store_to_session(
                         last_id = (
                             persisted.last_id if persisted.hermes_session_id == resolved else 0
                         )
+                        # Discovery only (re)binds on a cold start or a
+                        # claim-yield / compaction re-pin reacquire — never the
+                        # mid-turn restart-resume case, which keeps its session
+                        # pinned and skips this block. So always start turn
+                        # tracking fresh here; restoring the one-shot ``persisted``
+                        # snapshot could resurrect a stale turn id on reacquire.
+                        active_turn_id = None
                         _write_state(
                             bridge_dir,
                             _ForwardState(
                                 hermes_session_id=resolved,
                                 last_id=last_id,
                                 launch_epoch_s=launch_epoch_s,
+                                active_turn_id=active_turn_id,
                             ),
                         )
                 # PATCH the external_session_id once so the server
@@ -837,22 +962,53 @@ async def forward_hermes_store_to_session(
                             session_id,
                         )
                         hermes_session_id = None
+                        active_turn_id = None
                     else:
                         items = await asyncio.to_thread(
                             _read_new_items, db, hermes_session_id, last_id, agent_name
                         )
-                        for item in items:
-                            if item.item_type:
+                        # Assign a per-turn response_id and interleave ``running``
+                        # edges at turn starts; items are re-stamped in place so
+                        # the turn's tool-call cards render live on the web.
+                        turn_actions, active_turn_id = _annotate_turn_actions(
+                            items, active_turn_id
+                        )
+                        for action in turn_actions:
+                            if action.kind == "running" and action.response_id is not None:
+                                # Best-effort: the running edge only makes the
+                                # turn's cards render live. If it fails, mirroring
+                                # (and the idle/PTY-watcher resolution) must still
+                                # proceed — never abort the turn for a live-card post.
+                                try:
+                                    await _post_external_session_status(
+                                        client,
+                                        session_id=session_id,
+                                        status="running",
+                                        response_id=action.response_id,
+                                    )
+                                except Exception:  # noqa: BLE001 — live-card edge is best-effort
+                                    _logger.debug(
+                                        "hermes forwarder running-edge post failed; "
+                                        "cards may not go live; session=%s",
+                                        session_id,
+                                        exc_info=True,
+                                    )
+                            elif (
+                                action.kind == "item"
+                                and action.item is not None
+                                and action.item.item_type
+                            ):
                                 await _post_conversation_item(
-                                    client, session_id=session_id, item=item
+                                    client, session_id=session_id, item=action.item
                                 )
-                            last_id = item.msg_id
+                            last_id = action.msg_id
                             _write_state(
                                 bridge_dir,
                                 _ForwardState(
                                     hermes_session_id=hermes_session_id,
                                     last_id=last_id,
                                     launch_epoch_s=launch_epoch_s,
+                                    active_turn_id=action.turn_id_after,
                                 ),
                             )
                         if not compaction_persisted and await asyncio.to_thread(
@@ -888,6 +1044,7 @@ async def forward_hermes_store_to_session(
                                 ):
                                     hermes_session_id = child
                                     last_id = 0
+                                    active_turn_id = None
                                     compaction_persisted = False
                                     _external_id_synced = False
                                     # The idle dedup baseline is per-terminal but
@@ -911,6 +1068,7 @@ async def forward_hermes_store_to_session(
                                             hermes_session_id=child,
                                             last_id=0,
                                             launch_epoch_s=launch_epoch_s,
+                                            active_turn_id=None,
                                         ),
                                     )
                                     continue
@@ -932,6 +1090,7 @@ async def forward_hermes_store_to_session(
                                 hermes_session_id=hermes_session_id,
                                 last_id=last_id,
                                 launch_epoch_s=launch_epoch_s,
+                                active_turn_id=active_turn_id,
                             ),
                         )
                         # Turn each newly-completed turn into an

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -525,8 +525,11 @@ async def test_forward_loop_rebases_idle_count_on_compaction_repin(tmp_path, mon
 
     idle_posts: list[str] = []
 
-    async def _fake_idle(_client, *, session_id, status):
-        idle_posts.append(status)
+    async def _fake_idle(_client, *, session_id, status, response_id=None):
+        # This test isolates the idle/parent-wake dedup; the running edge (live
+        # card) is covered by the _annotate_turn_actions tests below.
+        if status == "idle":
+            idle_posts.append(status)
 
     monkeypatch.setattr(f, "_post_external_session_status", _fake_idle)
 
@@ -856,8 +859,11 @@ async def _run_hermes_loop(
     async def _noop_item(_client, *, session_id, item):
         pass
 
-    async def _record_status(_client, *, session_id, status):
-        statuses.append(status)
+    async def _record_status(_client, *, session_id, status, response_id=None):
+        # Idle-only: these loop tests assert the parent-wake idle dedup; the
+        # running edge has dedicated coverage in the _annotate_turn_actions tests.
+        if status == "idle":
+            statuses.append(status)
 
     monkeypatch.setattr(f, "_post_conversation_item", _noop_item)
     monkeypatch.setattr(f, "_post_external_session_status", _record_status)
@@ -936,8 +942,9 @@ async def test_forward_loop_idle_dedupes_and_posts_per_new_turn(tmp_path, monkey
     async def _noop_item(_client, *, session_id, item):
         pass
 
-    async def _record_status(_client, *, session_id, status):
-        statuses.append(status)
+    async def _record_status(_client, *, session_id, status, response_id=None):
+        if status == "idle":
+            statuses.append(status)
 
     monkeypatch.setattr(f, "_post_conversation_item", _noop_item)
     monkeypatch.setattr(f, "_post_external_session_status", _record_status)
@@ -978,3 +985,184 @@ async def test_forward_loop_idle_dedupes_and_posts_per_new_turn(tmp_path, monkey
     # one-per-poll across the six iterations.
     assert statuses == ["idle", "idle"]
     assert hstatus.read_posted_count(bridge_dir) == 2
+
+
+# ---------------------------------------------------------------------------
+# Live tool-call cards: per-turn response_id + running edge (issue #1874).
+# ---------------------------------------------------------------------------
+
+
+def _mi(msg_id: int, item_type: str, *, role: str | None = None) -> f._MirrorItem:
+    """Build a mirror item like ``_read_new_items`` produces (per-row id)."""
+    data: dict[str, object] = {}
+    if role is not None:
+        data["role"] = role
+    return f._MirrorItem(
+        msg_id=msg_id, item_type=item_type, item_data=data, response_id=f"hermes:{msg_id}"
+    )
+
+
+def test_annotate_shares_one_turn_id_and_emits_running_once() -> None:
+    # user -> assistant+tool_call -> tool -> assistant(final): one turn.
+    items = [
+        _mi(1, "message", role="user"),
+        _mi(2, "function_call"),
+        _mi(3, "function_call_output"),
+        _mi(4, "message", role="assistant"),
+    ]
+    actions, active = f._annotate_turn_actions(items, None)
+    running = [a.response_id for a in actions if a.kind == "running"]
+    assert running == ["hermes_turn_1"]  # exactly one running edge, at the open
+    stamped = {a.item.response_id for a in actions if a.kind == "item" and a.item.item_type}
+    assert stamped == {"hermes_turn_1"}  # every item shares the turn id
+    assert active is None  # terminal assistant row closes the turn
+    assert actions[-1].turn_id_after is None
+
+
+def test_annotate_new_id_per_turn_across_polls() -> None:
+    # Turn 1 completes in poll 1; turn 2 opens in poll 2 → a distinct id, and the
+    # running edge fires once per turn (state carried via the returned active id).
+    a1, active = f._annotate_turn_actions(
+        [_mi(1, "message", role="user"), _mi(2, "message", role="assistant")], None
+    )
+    assert [a.response_id for a in a1 if a.kind == "running"] == ["hermes_turn_1"]
+    assert active is None
+    a2, active = f._annotate_turn_actions(
+        [_mi(3, "message", role="user"), _mi(4, "message", role="assistant")], active
+    )
+    assert [a.response_id for a in a2 if a.kind == "running"] == ["hermes_turn_3"]
+    assert active is None
+
+
+def test_annotate_no_duplicate_running_mid_turn() -> None:
+    # A turn split across polls: the opener is in poll 1, the rest in poll 2 with
+    # the id carried in — no second running edge.
+    a1, active = f._annotate_turn_actions(
+        [_mi(1, "message", role="user"), _mi(2, "function_call")], None
+    )
+    assert [a.response_id for a in a1 if a.kind == "running"] == ["hermes_turn_1"]
+    assert active == "hermes_turn_1"
+    a2, active = f._annotate_turn_actions(
+        [_mi(3, "function_call_output"), _mi(4, "message", role="assistant")], active
+    )
+    assert [a.kind for a in a2 if a.kind == "running"] == []  # no re-open
+    assert {a.item.response_id for a in a2 if a.kind == "item" and a.item.item_type} == {
+        "hermes_turn_1"
+    }
+    assert active is None
+
+
+def test_annotate_abort_then_new_user_reopens() -> None:
+    # Turn opens but never reaches a terminal row (abort); a new user row still
+    # starts a fresh turn (id overwritten), proving no stuck state blocks it.
+    a1, active = f._annotate_turn_actions(
+        [_mi(1, "message", role="user"), _mi(2, "function_call")], None
+    )
+    assert [a.response_id for a in a1 if a.kind == "running"] == ["hermes_turn_1"]
+    assert active == "hermes_turn_1"  # still in flight, no terminal seen
+    a2, active = f._annotate_turn_actions([_mi(5, "message", role="user")], active)
+    assert [a.response_id for a in a2 if a.kind == "running"] == ["hermes_turn_5"]
+    assert active == "hermes_turn_5"
+
+
+def test_annotate_recovers_missed_opener() -> None:
+    # Forwarder starts mid-turn (no user opener in the batch); assistant activity
+    # with no active turn mints an id and emits running so its cards still go live.
+    items = [_mi(7, "function_call"), _mi(8, "function_call_output")]
+    actions, active = f._annotate_turn_actions(items, None)
+    assert [a.response_id for a in actions if a.kind == "running"] == ["hermes_turn_7"]
+    assert active == "hermes_turn_7"
+
+
+async def test_post_external_session_status_carries_response_id(tmp_path) -> None:
+    client = _FakeClient()
+    await f._post_external_session_status(
+        client, session_id="conv_r", status="running", response_id="hermes_turn_9"
+    )
+    _url, body = client.posts[0]
+    assert body["type"] == "external_session_status"
+    assert body["data"] == {"status": "running", "response_id": "hermes_turn_9"}
+    # idle omits response_id (server pops the active id on any idle).
+    await f._post_external_session_status(client, session_id="conv_r", status="idle")
+    _url, body = client.posts[1]
+    assert body["data"] == {"status": "idle"}
+
+
+def test_forward_state_active_turn_id_roundtrip(tmp_path: Path) -> None:
+    state = f._ForwardState(
+        hermes_session_id="s1", last_id=4, launch_epoch_s=1.0, active_turn_id="hermes_turn_4"
+    )
+    assert f._write_state(tmp_path, state) is True
+    assert f._read_state(tmp_path).active_turn_id == "hermes_turn_4"
+
+
+async def test_forward_loop_emits_running_then_idle_for_tool_call_turn(
+    tmp_path, monkeypatch
+) -> None:
+    """End-to-end over the poll loop: a tool-call turn yields a running edge (with
+    the turn id) followed by idle, and the mirrored items carry that same id."""
+    workspace = str(tmp_path)
+    db = tmp_path / "state.db"
+    con = sqlite3.connect(db)
+    con.executescript(_SCHEMA)
+    con.execute(
+        "INSERT INTO sessions(id, source, cwd, started_at) VALUES (?,?,?,?)",
+        ("s1", "cli", workspace, 1000.0),
+    )
+    tc = json.dumps([{"id": "c1", "call_id": "c1", "function": {"name": "f", "arguments": "{}"}}])
+    con.executemany(
+        "INSERT INTO messages"
+        "(session_id, role, content, tool_call_id, tool_calls, tool_name, active)"
+        " VALUES (?,?,?,?,?,?,?)",
+        [
+            ("s1", "user", "do it", None, None, None, 1),
+            ("s1", "assistant", "", None, tc, None, 1),
+            ("s1", "tool", "result", "c1", None, "f", 1),
+            ("s1", "assistant", "done", None, None, None, 1),
+        ],
+    )
+    con.commit()
+    con.close()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    statuses: list[tuple[str, str | None]] = []
+    posted_items: list[f._MirrorItem] = []
+
+    async def _record_item(_client, *, session_id, item):
+        posted_items.append(item)
+
+    async def _record_status(_client, *, session_id, status, response_id=None):
+        statuses.append((status, response_id))
+
+    monkeypatch.setattr(f, "_post_conversation_item", _record_item)
+    monkeypatch.setattr(f, "_post_external_session_status", _record_status)
+
+    iteration = {"n": 0}
+
+    async def _sleep(_s):
+        iteration["n"] += 1
+        if iteration["n"] >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(f.asyncio, "sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await f.forward_hermes_store_to_session(
+            base_url="http://x",
+            headers={},
+            session_id="conv_tc",
+            bridge_dir=bridge_dir,
+            agent_name="hermes-native-ui",
+            workspace=workspace,
+            launch_epoch_s=1000.0,
+            db_path=db,
+        )
+
+    # running (with the turn id) before idle; the function_call item carries the
+    # same id so the web renders the card live against the running edge.
+    assert ("running", "hermes_turn_1") in statuses
+    assert statuses[0] == ("running", "hermes_turn_1")
+    assert ("idle", None) in statuses
+    fc = [it for it in posted_items if it.item_type == "function_call"]
+    assert fc and all(it.response_id == "hermes_turn_1" for it in fc)


### PR DESCRIPTION
## Related issue

Closes #1874

## Summary

Extends live tool-call cards (a spinner + ticking elapsed timer while a tool runs) to
**hermes-native** sessions, matching claude-native (#1499) and codex-native.

The server + web are harness-agnostic: a tool-call card renders **live** when a
`session.status` `running`/`waiting` edge carries a `response_id` **and** the mirrored
`function_call` items carry that **same** `response_id`; the server tracks it
(`active_response_id`) so a mid-turn reconnect stays live. hermes-native was missing that:
`omnigent/hermes_native_forwarder.py` stamped a **per-row** id (`hermes:{msg_id}`) — so a
turn's rows never shared an id — and never posted a `running` edge (running/idle came only
from the runner's **id-less** PTY-activity watcher).

This change, entirely in the forwarder:

- **Per-turn id.** `_annotate_turn_actions` groups a poll batch by `msg_id` and assigns one
  `hermes_turn_{opening-msg-id}` per turn (`user → (assistant+tool_calls → tool)* →
  assistant-without-tool_calls`), re-stamping every mirrored item with it. The id is
  persisted in `_ForwardState.active_turn_id` so a turn spanning polls — or a forwarder
  restart mid-turn — keeps it (and doesn't re-emit `running`).
- **`running` edge.** `_post_external_session_status` gained a `response_id`; the forwarder
  posts `running`+id at turn start (best-effort — a failed live-card edge never aborts
  mirroring), and assistant activity with no open turn mints one too (missed-start recovery,
  e.g. a forwarder that starts mid-turn).
- **No idle-ownership change.** The existing completed-turn `idle` post and the PTY-activity
  watcher stay the resolvers — the server pops `active_response_id` on **any** `idle`, so an
  aborted turn (whose terminal row may never be written) still resolves the card, with no
  watchdog needed. Discovery starts turn tracking fresh, so a claim-yield / compaction re-pin
  reacquire never resurrects a stale id.

No server or web changes — the server already reads `response_id` from
`external_session_status` and the web already maps the `hermes` harness to its icon.

## Test Plan

- `uv run python -m pytest tests/test_hermes_native_forwarder.py tests/test_hermes_native.py -q` — all green; `ruff check` / `ruff format` clean.
- The new unit tests cover the turn state machine directly (see Coverage notes) plus an
  end-to-end pass over the poll loop asserting `running`(+turn id) precedes `idle` and the
  `function_call` item carries that id.

## Demo

Backend forwarder change with a UI-visible effect (hermes-native tool-call cards now render
live). Before/after of what the forwarder emits for a `user → assistant+tool_call → tool →
assistant` turn:

**Before** — per-row ids, no running edge → the web shows a static/completed card:
```
external_conversation_item  function_call        response_id=hermes:2
external_conversation_item  function_call_output response_id=hermes:3
# running/idle only from the id-less PTY watcher → no id to render a live card
```

**After** — one turn id + a running edge → the web renders a live spinner+timer:
```
external_session_status     running   response_id=hermes_turn_1   ← card goes live
external_conversation_item  function_call        response_id=hermes_turn_1
external_conversation_item  function_call_output response_id=hermes_turn_1
external_session_status     idle                                  ← card resolves
```

(A live web screenshot can be added on request — it needs a running hermes CLI + web UI
session mid tool call.)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`tests/test_hermes_native_forwarder.py` (new tests): one turn shares a single id and emits
exactly one `running` edge; a second turn gets a new id; a turn split across polls does not
re-emit `running`; an aborted turn (open, no terminal) followed by a new user row re-opens
with a fresh id (no stuck state); missed-opener recovery mints an id; `_ForwardState`
`active_turn_id` round-trips; `_post_external_session_status` includes `response_id` only when
given; and an end-to-end poll-loop pass over a tool-call turn asserts the running→idle order
and item stamping. Existing idle/parent-wake and compaction-re-pin tests still pass.

This pull request and its description were written by Isaac.
