### PR TITLE
fix(runner): neutral cancellation marker for internal harness respawns

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2944,6 +2944,38 @@ def create_runner_app(
                 _session_workspace_cache[session_id] = snapshot.workspace
         return _session_workspace_cache.get(session_id)
 
+    async def _fetch_session_model_override(session_id: str) -> str | None:
+        """One-shot uncached read of the persisted ``/model`` override.
+
+        Legacy (no-envelope) init only — current servers ship the override in
+        the init envelope. Deliberately NOT cached in ``_SessionSnapshot``:
+        ``model_override`` is mutable (a ``/model`` switch changes it), so a
+        value stored in the long-lived identity cache would go stale and reseed
+        the old model on a later re-init, forcing a needless respawn. Each init
+        re-reads it fresh.
+        """
+        try:
+            resp = await server_client.get(f"/v1/sessions/{session_id}")
+            if resp.status_code == 200:
+                raw = resp.json().get("model_override")
+                if isinstance(raw, str) and raw:
+                    return raw
+            else:
+                _logger.warning(
+                    "legacy model_override fallback for %s: session GET returned "
+                    "HTTP %s; a model-pinned first turn may respawn",
+                    session_id,
+                    resp.status_code,
+                )
+        except Exception:  # noqa: BLE001 — best-effort, but surface it
+            _logger.warning(
+                "legacy model_override fallback for %s failed; a model-pinned "
+                "first turn may respawn",
+                session_id,
+                exc_info=True,
+            )
+        return None
+
     async def _session_runtime_cwd(session_id: str) -> Path | None:
         workspace = await _session_workspace_value(session_id)
         if workspace and workspace.strip():
@@ -3312,12 +3344,25 @@ def create_runner_app(
                 server_client=server_client,
                 routing_class=_routing_class,
             )
+            # Seed the initial spawn with the persisted /model override so a
+            # model-pinned session's first turn doesn't force a wasteful
+            # model-switch respawn. Current servers ship the override in the
+            # init envelope (read fresh each init); legacy (no-envelope) servers
+            # fall back to a one-shot uncached GET. Both sources are read fresh
+            # so a later /model switch can't reseed a stale model. Native
+            # harnesses no-op (_build_spawn_env_from_spec guards on env=None).
+            _model_override = (
+                init_context.envelope.snapshot.model_override
+                if init_context.envelope is not None
+                else await _fetch_session_model_override(session_id)
+            )
             spawn_env = _build_spawn_env_from_spec(
                 spec,
                 harness_name,
                 workdir=_resolved_spec_workdir(spec_entry),
                 cwd=await _session_runtime_cwd(session_id),
                 session_id=session_id,
+                model_override=_model_override,
             )
             if spawn_env is None:
                 spawn_env = await _resolve_native_spawn_env(

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -456,17 +456,27 @@ def register_core_routes(
             # best-effort reverse GET whose failure would silently reintroduce
             # the first-turn respawn. Older runners ignore the extra
             # ``session_init`` key and still read the top-level id fields.
-            try:
-                init_body: dict[str, Any] = build_runner_session_init_payload(
-                    conv, server_version=VERSION
-                )
-            except ValueError:
-                # Not yet bound to an agent — fall back to the id-only body.
-                init_body = {
-                    "session_id": resp.id,
-                    "agent_id": conv.agent_id,
-                    "sub_agent_name": conv.sub_agent_name,
-                }
+            # A session not yet bound to an agent keeps the id-only body: the
+            # envelope builder requires an agent_id.
+            init_body: dict[str, Any] = {
+                "session_id": resp.id,
+                "agent_id": conv.agent_id,
+                "sub_agent_name": conv.sub_agent_name,
+            }
+            if conv.agent_id is not None:
+                try:
+                    init_body = build_runner_session_init_payload(conv, server_version=VERSION)
+                except Exception:
+                    # Must not fail the create, but the degradation loses the
+                    # seeded override — surface it instead of silently
+                    # downgrading (a bare ValueError catch would swallow a
+                    # pydantic ValidationError here).
+                    _logger.warning(
+                        "session-init envelope build failed for %s; falling back to the "
+                        "id-only body (a model-pinned first turn may respawn)",
+                        resp.id,
+                        exc_info=True,
+                    )
             try:
                 await _rc.post("/v1/sessions", json=init_body, timeout=10.0)
             except (httpx.HTTPError, ConnectionError):

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -48,6 +48,7 @@ from omnigent.runner.identity import (
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
 from omnigent.runner.routing import RunnerRouter
+from omnigent.runner.session_init_protocol import build_runner_session_init_payload
 from omnigent.runtime import (
     pending_elicitations,
     user_session_stream,
@@ -199,6 +200,7 @@ from omnigent.stores.conversation_store import (
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
+from omnigent.version import VERSION
 
 
 def register_core_routes(
@@ -448,16 +450,25 @@ def register_core_routes(
             _publish_terminal_pending(resp.id, True)
         _rc = await _get_runner_client(resp.id, runner_router)
         if _rc is not None and conv is not None:
+            # Send the full session-init envelope (not the legacy id-only body)
+            # so the runner seeds the first spawn from current session state —
+            # notably the persisted /model override — rather than relying on a
+            # best-effort reverse GET whose failure would silently reintroduce
+            # the first-turn respawn. Older runners ignore the extra
+            # ``session_init`` key and still read the top-level id fields.
             try:
-                await _rc.post(
-                    "/v1/sessions",
-                    json={
-                        "session_id": resp.id,
-                        "agent_id": conv.agent_id,
-                        "sub_agent_name": conv.sub_agent_name,
-                    },
-                    timeout=10.0,
+                init_body: dict[str, Any] = build_runner_session_init_payload(
+                    conv, server_version=VERSION
                 )
+            except ValueError:
+                # Not yet bound to an agent — fall back to the id-only body.
+                init_body = {
+                    "session_id": resp.id,
+                    "agent_id": conv.agent_id,
+                    "sub_agent_name": conv.sub_agent_name,
+                }
+            try:
+                await _rc.post("/v1/sessions", json=init_body, timeout=10.0)
             except (httpx.HTTPError, ConnectionError):
                 _logger.warning(
                     "Failed to notify runner about session %s",

--- a/tests/e2e/test_subagent_model_override_respawn_e2e.py
+++ b/tests/e2e/test_subagent_model_override_respawn_e2e.py
@@ -1,0 +1,294 @@
+"""Mock-LLM e2e guarding against the first-turn model-switch respawn.
+
+Reproduces the reported journey: an orchestrator (polly) dispatches a
+sub-agent via ``sys_session_send`` with an explicit ``args.model`` — the
+atomic create+turn path. The child session is created with the requested
+``model_override`` persisted, but its harness is warm-spawned at create time
+from a spawn env built WITHOUT the override (``entry.model = None``); the
+first turn then builds its spawn env WITH the override, so
+``process_manager.get_client`` sees ``requested_model != entry.model`` and
+tears down + respawns the harness (``harness_respawn_model_switch``) — a full
+context reload before the child can answer, and (intermittently) a synthetic
+``[System: interrupted]`` user-abandonment marker that can make the child
+abandon its task.
+
+Acceptance criteria from the issue: a model-pinned sub-agent dispatched via
+``sys_session_send`` completes its first turn with **zero** model-switch
+respawns and **zero** ``[System: interrupted]`` synthetic items on turn 1.
+
+The claude-sdk brain harness is swapped for openai-agents against a mock LLM
+(the standard mock-polly pattern from ``test_polly_e2e``); the plumbing under
+test — ``sys_session_send`` args.model -> child create (model_override) ->
+child warm spawn -> child turn-1 spawn env -> process-manager model
+reconciliation — is the real production path. The respawn is observed via the
+runner's own log (``OMNIGENT_DATA_DIR`` pins the log root per test), which is
+where the process manager reports the model-switch teardown.
+
+Run::
+
+    pytest tests/e2e/test_subagent_model_override_respawn_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tests.e2e.test_polly_e2e import (
+    _MOCK_BRAIN_MODEL,
+    _REPO,
+    _mock_polly_spec_dir,
+)
+from tests.e2e.test_polly_subagent_model_e2e import (
+    _RUN_TIMEOUT_SEC,
+    _api,
+    _polly_parent_id,
+    local_polly_server,  # noqa: F401  (imported fixture)
+)
+from tests.e2e.test_subagent_model_inheritance_e2e import (
+    _run_env,
+    _wait_for_children,
+)
+
+# The model the orchestrator pins the sub-agent to (the report's model-pinned
+# debater). A GPT-family id dispatched to the codex worker, which the mock
+# spec rewrite maps onto the SDK openai-agents harness — the harness class
+# whose model is baked into the spawn env (not in _LIVE_MODEL_CONFIG_HARNESSES),
+# so a first-turn model mismatch respawns the subprocess.
+_PINNED_MODEL = "gpt-5-4-mini"
+
+# The process manager's model-switch teardown line
+# (omnigent/runtime/harnesses/process_manager.py, reason
+# ``harness_respawn_model_switch``). Matched per child conversation id.
+_RESPAWN_LINE = "model changed {prior!r} -> {requested!r}; respawning"
+
+_INTERRUPTED_MARKER = "[System: interrupted]"
+
+
+def _runner_respawn_lines(data_dir: Path, child_id: str) -> list[str]:
+    """
+    Collect model-switch respawn log lines for *child_id* from the runner logs.
+
+    The ``omnigent run`` client spawns a local runner whose process logs land
+    under ``<OMNIGENT_DATA_DIR>/logs/runner/``. The model-switch teardown is
+    reported there by ``HarnessProcessManager.get_client``.
+
+    :param data_dir: The ``OMNIGENT_DATA_DIR`` passed to the run subprocess.
+    :param child_id: The child conversation id whose respawns to collect.
+    :returns: Matching log lines (empty when no respawn happened).
+    """
+    log_dir = data_dir / "logs" / "runner"
+    if not log_dir.exists():
+        return []
+    pattern = re.compile(rf"conversation {re.escape(child_id)}: model changed .*; respawning")
+    hits: list[str] = []
+    for log_file in sorted(log_dir.glob("*.log")):
+        for line in log_file.read_text(errors="replace").splitlines():
+            if pattern.search(line):
+                hits.append(line)
+    return hits
+
+
+def _child_items_after_turn_1(
+    base_url: str, child_id: str, *, timeout: float = 120.0
+) -> list[dict[str, Any]]:
+    """
+    Fetch the child's conversation items once its FIRST TURN has completed.
+
+    ``sys_session_send`` returns a ``"launching"`` handle before the child's
+    turn finishes, so the parent run can exit while the child is still
+    mid-turn. Both failure modes under test (the model-switch respawn and the
+    synthetic interrupted marker) happen *during* that turn — asserting before
+    it completes would pass vacuously. Completion is observed as the child's
+    assistant reply landing in its history (the mock LLM answers every child
+    turn), or an error item as the terminal fallback.
+
+    :param base_url: Local server base URL.
+    :param child_id: Child conversation id.
+    :param timeout: Seconds to wait for the turn to reach a terminal item.
+    :returns: The item rows recorded by the completed turn.
+    :raises TimeoutError: If the child's first turn never completes.
+    """
+    deadline = time.monotonic() + timeout
+    items: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        items = _api(base_url, f"/v1/sessions/{child_id}/items").get("data", [])
+        done = any(
+            (i.get("type") == "message" and i.get("role") == "assistant")
+            or i.get("type") == "error"
+            for i in items
+        )
+        if done:
+            return items
+        time.sleep(1)
+    raise TimeoutError(
+        f"child session {child_id} first turn reached no terminal item "
+        f"(assistant reply or error) within {timeout:.0f}s; "
+        f"items so far: {[i.get('type') for i in items]}"
+    )
+
+
+def test_model_pinned_subagent_first_turn_does_not_respawn(
+    local_polly_server: str,  # noqa: F811  (imported fixture)
+    mock_llm_server_url: str,
+    tmp_path: Path,
+) -> None:
+    """
+    A ``sys_session_send`` dispatch with an explicit model must not respawn on turn 1.
+
+    The child's harness should be spawned once, already at the pinned model
+    (the override is known at create time — it is in the create body). Today
+    the warm spawn runs at the default (``entry.model=None``) and turn 1
+    triggers a ``harness_respawn_model_switch`` teardown + context reload; on
+    the unlucky interleaving the respawn's cancel path also injects a
+    synthetic ``[System: interrupted]`` user-abandonment marker into the
+    child's turn-1 history, which can make the child abandon its task.
+
+    :param local_polly_server: Base URL of the in-tree local server fixture.
+    :param mock_llm_server_url: Mock LLM server base URL.
+    :param tmp_path: Per-test temp dir for the spec copy and runner data dir.
+    """
+    from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
+    reset_mock_llm(mock_llm_server_url)
+    # rewrite_sub_agent_harnesses=True maps the codex worker onto the SDK
+    # openai-agents harness so the child spawns without a native binary; the
+    # respawn under test lives in the shared process manager, not the harness.
+    polly_dir = _mock_polly_spec_dir(
+        tmp_path, mock_llm_server_url, rewrite_sub_agent_harnesses=True
+    )
+    # Pin the dispatched worker's credential to the mock, mirroring the brain's
+    # own auth block. Without it the child's provider resolution falls through
+    # to ambient detection, which picks up a cli-config provider from a
+    # developer's ~/.codex/config.toml; that hard-raises for every harness but
+    # codex, so the child's turn dies at setup and never reaches the respawn
+    # this test is about. Scoped to the dispatched worker: the shared helper
+    # must keep resolving ambiently for the siblings that assert on
+    # provider-localized model ids.
+    _codex_cfg = polly_dir / "agents" / "codex" / "config.yaml"
+    _codex_spec = yaml.safe_load(_codex_cfg.read_text())
+    _codex_spec["executor"]["auth"] = {
+        "type": "api_key",
+        "api_key": "mock-key",
+        "base_url": f"{mock_llm_server_url}/v1",
+    }
+    _codex_cfg.write_text(yaml.safe_dump(_codex_spec, sort_keys=False))
+    tag = uuid.uuid4().hex[:8]
+
+    # The brain pins the child to a model — the report's journey (a debby
+    # debate pins each debater; polly's per-dispatch args.model is the same
+    # atomic create+turn path).
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": f"call-pin-{tag}",
+                        "name": "sys_session_send",
+                        "arguments": json.dumps(
+                            {
+                                "agent": "codex",
+                                "title": "explore-readme",
+                                "args": {
+                                    "purpose": "explore",
+                                    "model": _PINNED_MODEL,
+                                    "input": "Report the first heading line of README.md.",
+                                },
+                            }
+                        ),
+                    }
+                ]
+            },
+            {"text": "Dispatched the model-pinned worker."},
+            {"text": "Turn complete."},
+        ],
+        key=_MOCK_BRAIN_MODEL,
+    )
+    # Serve the child's turn whatever model id it lands on.
+    configure_mock_llm(mock_llm_server_url, [{"text": "child done"}] * 4, key=_PINNED_MODEL)
+    configure_mock_llm(mock_llm_server_url, [{"text": "child done"}] * 4, key="default")
+
+    # Pin the spawned runner's data dir (logs/runner/*.log) per test so the
+    # respawn observation reads exactly this run's logs.
+    data_dir = tmp_path / "runner-data"
+    env = _run_env(mock_llm_server_url)
+    env["OMNIGENT_DATA_DIR"] = str(data_dir)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "run",
+            str(polly_dir),
+            "--server",
+            local_polly_server,
+            "-p",
+            "Dispatch one read-only explore task to codex pinned to a model.",
+        ],
+        cwd=str(_REPO),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+    assert result.returncode == 0, (
+        f"polly run exited {result.returncode}\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+
+    parent = _polly_parent_id(local_polly_server)
+    kids = _wait_for_children(local_polly_server, parent)
+    assert [k.get("tool") for k in kids] == ["codex"], (
+        f"expected exactly the dispatched codex child, got {[k.get('tool') for k in kids]}"
+    )
+    child_id = kids[0].get("session_id") or kids[0].get("id")
+    assert isinstance(child_id, str) and child_id
+
+    # Sanity: the dispatch really took the model-pinned path (otherwise the
+    # respawn assertions below would be vacuous).
+    child_row = _api(local_polly_server, f"/v1/sessions/{child_id}")
+    assert child_row.get("model_override") == _PINNED_MODEL, (
+        f"child session should persist model_override={_PINNED_MODEL!r}, "
+        f"got {child_row.get('model_override')!r} — the dispatch did not take "
+        f"the model-pinned path this test guards"
+    )
+
+    # Wait for the child's first turn to actually COMPLETE before asserting:
+    # the respawn and the interrupted marker both happen mid-turn, so checking
+    # earlier would pass without exercising either acceptance criterion.
+    items = _child_items_after_turn_1(local_polly_server, child_id)
+
+    # Acceptance criterion 1: zero harness model-switch respawns on turn 1.
+    # The override is in the child's create body, so the first spawn should
+    # already be at the pinned model; a "model changed None -> ...; respawning"
+    # line is the wasteful teardown + context reload this issue is about.
+    respawn_lines = _runner_respawn_lines(data_dir, child_id)
+    assert respawn_lines == [], (
+        f"model-pinned sub-agent {child_id} hit a first-turn harness "
+        f"model-switch respawn (teardown + context reload) — the override "
+        f"should be seeded into the FIRST spawn env instead of reconciled by "
+        f"respawn on turn 1:\n" + "\n".join(respawn_lines)
+    )
+
+    # Acceptance criterion 2: zero synthetic [System: interrupted] items on
+    # turn 1 — the respawn's cancel path must not tell the child the USER
+    # abandoned the request (that is what intermittently makes it drop its
+    # task).
+    assert items, f"child session {child_id} recorded no conversation items"
+    interrupted = [i for i in items if _INTERRUPTED_MARKER in json.dumps(i)]
+    assert interrupted == [], (
+        f"child session {child_id} turn 1 contains {len(interrupted)} synthetic "
+        f"{_INTERRUPTED_MARKER!r} item(s) — an internal model-switch respawn "
+        f"must not inject the user-abandonment marker:\n"
+        + "\n".join(json.dumps(i)[:300] for i in interrupted)
+    )

--- a/tests/runner/test_enforce_sandbox_gate.py
+++ b/tests/runner/test_enforce_sandbox_gate.py
@@ -314,3 +314,272 @@ async def test_enforce_sandbox_no_policy_leaves_spec_unchanged() -> None:
         f"Expected sandbox type 'none' (no policy), got '{sandbox['type']}'. "
         f"The gate is mutating specs even when no policy applies."
     )
+
+
+class _ModelOverrideServerClient(NullServerClient):
+    """Server client whose session GET returns a persisted model_override.
+
+    Mirrors the real server projecting the ``/model`` override in the
+    session snapshot, so ``create_session`` can seed the initial spawn.
+    """
+
+    def __init__(self, *, session_id: str, agent_id: str, model_override: str) -> None:
+        self._session_id = session_id
+        self._agent_id = agent_id
+        self._model_override = model_override
+
+    async def get(self, url: str, **kwargs: Any) -> Any:
+        """Return the snapshot for the session GET, empty 200 otherwise."""
+        del kwargs
+        if url == f"/v1/sessions/{self._session_id}":
+            body = {
+                "agent_id": self._agent_id,
+                "model_override": self._model_override,
+            }
+
+            class _SnapResponse:
+                status_code = 200
+
+                def json(self) -> dict[str, Any]:
+                    return body
+
+                def raise_for_status(self) -> None:
+                    """No-op: stub always succeeds."""
+
+            return _SnapResponse()
+        return self._Response()
+
+
+@pytest.mark.asyncio
+async def test_create_session_seeds_model_override_into_spawn_env() -> None:
+    """Legacy-server compatibility: the override seeds the spawn env via GET.
+
+    When the server sends only the legacy id-only init body (``session_id`` /
+    ``agent_id`` / ``sub_agent_name``, no ``session_init`` envelope — an older
+    server), ``_initialize_session`` has no envelope to read the persisted
+    ``/model`` override from, so it falls back to a one-shot uncached GET and
+    seeds the override into the initial spawn env. Current servers send the
+    envelope instead (covered by
+    :func:`test_create_session_seeds_model_override_from_envelope`). That the
+    first turn then reuses the seeded subprocess without a respawn is proven
+    against a real ``HarnessProcessManager`` by
+    ``tests/runtime/harnesses/test_process_manager.py::
+    test_get_client_seeds_model_and_reuses_without_respawn``.
+    """
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="model-seed-agent",
+        executor=ExecutorSpec(
+            config={"harness": "claude-sdk"},
+            model="databricks-claude-sonnet-4-6",
+        ),
+        os_env=OSEnvSpec(
+            type="caller_process",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+    pm = _FakeProcessManager(_ScriptedHarnessClient())
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_ModelOverrideServerClient(  # type: ignore[arg-type]
+            session_id="conv_model_seed",
+            agent_id="ag_test",
+            model_override="model-x",
+        ),
+    )
+
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_model_seed", "agent_id": "ag_test"},
+        )
+
+    assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+    # Exactly one spawn at create time — the seed means the first turn
+    # will not need to respawn for the override model.
+    assert len(pm.get_client_calls) == 1, (
+        f"expected a single create-time spawn, got {pm.get_client_calls}"
+    )
+    _conv_id, _harness, env = pm.get_client_calls[-1]
+    assert env is not None
+    # The override is baked into the spawn env, so the child starts on it.
+    assert env.get("HARNESS_CLAUDE_SDK_MODEL") == "model-x", (
+        "create_session must seed the persisted model_override into the "
+        f"initial spawn env; got {env.get('HARNESS_CLAUDE_SDK_MODEL')!r}"
+    )
+
+
+def _session_init_body(
+    *, session_id: str, agent_id: str, model_override: str | None
+) -> dict[str, Any]:
+    """Build a protocol-v2 ``session_init`` POST body carrying model_override.
+
+    Mirrors :func:`build_runner_session_init_payload` so the runner's init
+    takes the modern envelope path (no snapshot GET) and reads the override
+    straight from the envelope snapshot.
+    """
+    from omnigent.runner.session_init_protocol import (
+        SESSION_INIT_PAYLOAD_KEY,
+        SESSION_INIT_PROTOCOL_VERSION,
+        RunnerSessionInitEnvelope,
+        RunnerSessionInitSnapshot,
+    )
+
+    envelope = RunnerSessionInitEnvelope(
+        protocol_version=SESSION_INIT_PROTOCOL_VERSION,
+        server_version="0.0.0.dev0",
+        session_id=session_id,
+        agent_id=agent_id,
+        sub_agent_name=None,
+        snapshot=RunnerSessionInitSnapshot(
+            created_at=0,
+            updated_at=0,
+            model_override=model_override,
+        ),
+    )
+    return {
+        "session_id": session_id,
+        "agent_id": agent_id,
+        SESSION_INIT_PAYLOAD_KEY: envelope.model_dump(mode="json"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_session_seeds_model_override_from_envelope() -> None:
+    """Envelope path: the override seeds the spawn env with no snapshot GET.
+
+    The modern server ships the persisted ``/model`` override inside the
+    ``session_init`` envelope. ``_initialize_session`` must read it straight
+    from ``init_context.envelope.snapshot.model_override`` and seed the
+    initial spawn — never falling back to a server GET. The server client
+    here would raise on any GET, proving the value came from the envelope.
+    """
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+    class _NoSnapshotGetServerClient(NullServerClient):
+        """Fails a session-snapshot GET so a stray fallback read is caught.
+
+        Other GETs (e.g. history ``/items``) pass through to the benign
+        base stub — only the snapshot URL is forbidden, since the envelope
+        path must read model_override from the envelope, not a GET.
+        """
+
+        async def get(self, url: str, **kwargs: Any) -> Any:
+            if url == "/v1/sessions/conv_env_seed":
+                raise AssertionError(
+                    "envelope path must not GET the session snapshot for "
+                    "model_override; it must read the envelope"
+                )
+            return await super().get(url, **kwargs)
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="model-seed-agent",
+        executor=ExecutorSpec(
+            config={"harness": "claude-sdk"},
+            model="databricks-claude-sonnet-4-6",
+        ),
+        os_env=OSEnvSpec(
+            type="caller_process",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+    pm = _FakeProcessManager(_ScriptedHarnessClient())
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_NoSnapshotGetServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions",
+            json=_session_init_body(
+                session_id="conv_env_seed",
+                agent_id="ag_test",
+                model_override="model-x",
+            ),
+        )
+
+    assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+    assert len(pm.get_client_calls) == 1, (
+        f"expected a single create-time spawn, got {pm.get_client_calls}"
+    )
+    _conv_id, _harness, env = pm.get_client_calls[-1]
+    assert env is not None
+    assert env.get("HARNESS_CLAUDE_SDK_MODEL") == "model-x", (
+        "_initialize_session must seed the envelope's model_override into the "
+        f"initial spawn env; got {env.get('HARNESS_CLAUDE_SDK_MODEL')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reinit_after_model_switch_seeds_fresh_override() -> None:
+    """A re-init after a /model switch seeds the NEW model, never a stale one.
+
+    ``model_override`` is mutable, so it must not be cached in the long-lived
+    identity snapshot: a stale value would reseed the old model on a later
+    re-init and force the very model-switch respawn the seeding removes. The
+    legacy fallback reads it fresh each init, so switching the server-side
+    override between two inits must change the seeded spawn env.
+    """
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="model-seed-agent",
+        executor=ExecutorSpec(
+            config={"harness": "claude-sdk"},
+            model="databricks-claude-sonnet-4-6",
+        ),
+        os_env=OSEnvSpec(
+            type="caller_process",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+    pm = _FakeProcessManager(_ScriptedHarnessClient())
+    server = _ModelOverrideServerClient(
+        session_id="conv_switch",
+        agent_id="ag_test",
+        model_override="model-a",
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server,  # type: ignore[arg-type]
+    )
+
+    body = {"session_id": "conv_switch", "agent_id": "ag_test"}
+    async with _runner_client(app) as client:
+        resp_a = await client.post("/v1/sessions", json=body)
+        # User switches /model server-side; the runner must NOT serve a cached
+        # "model-a" on the next init.
+        server._model_override = "model-b"
+        resp_b = await client.post("/v1/sessions", json=body)
+
+    assert resp_a.status_code == 201, resp_a.text
+    assert resp_b.status_code == 201, resp_b.text
+    assert len(pm.get_client_calls) == 2, f"expected two spawns, got {pm.get_client_calls}"
+    assert pm.get_client_calls[0][2].get("HARNESS_CLAUDE_SDK_MODEL") == "model-a"
+    assert pm.get_client_calls[1][2].get("HARNESS_CLAUDE_SDK_MODEL") == "model-b", (
+        "re-init after a /model switch must seed the fresh override, not a "
+        f"stale cached one; got {pm.get_client_calls[1][2].get('HARNESS_CLAUDE_SDK_MODEL')!r}"
+    )

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -43,6 +43,7 @@ from omnigent.runtime.harnesses.process_manager import (
     HarnessProcessManager,
     NoLiveHarnessError,
     _default_tmp_parent,
+    _model_env_key,
     _pid_alive,
     _pids_holding_socket,
     _SubprocessEntry,
@@ -586,6 +587,40 @@ async def test_get_client_concurrent_first_calls_share_subprocess(
         # subprocess and either race to bind the same socket
         # (one fails) or succeed with two distinct entries.
         assert client_a is client_b
+    finally:
+        await manager.shutdown()
+
+
+async def test_get_client_seeds_model_and_reuses_without_respawn(
+    manager: HarnessProcessManager,
+) -> None:
+    """A seeded model env bakes into the first spawn; an identical later
+    call reuses it without a respawn.
+
+    When the initial spawn is seeded with the persisted ``/model``
+    override, the first turn requesting that same model must NOT tear
+    the subprocess down and respawn it.
+    """
+    model_key = _model_env_key(_TEST_HARNESS_NAME)
+    await manager.start()
+    try:
+        client_first = await manager.get_client(
+            "conv_a", _TEST_HARNESS_NAME, env={model_key: "model-x"}
+        )
+        entry = manager._entries["conv_a"]
+        # The first spawn baked the seeded model into the entry.
+        assert entry.model == "model-x"
+        pid_first = (await client_first.get("/pid")).json()["pid"]
+
+        # Identical model env → cached entry, no respawn.
+        client_second = await manager.get_client(
+            "conv_a", _TEST_HARNESS_NAME, env={model_key: "model-x"}
+        )
+        assert client_second is client_first
+        assert manager._entries["conv_a"] is entry
+        pid_second = (await client_second.get("/pid")).json()["pid"]
+        # Same PID proves no respawn happened on the second identical call.
+        assert pid_second == pid_first
     finally:
         await manager.shutdown()
 

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -10187,3 +10187,67 @@ async def test_create_child_session_duplicate_title_returns_409(
     assert resp2.status_code == 409, (
         f"expected 409 on duplicate child title, got {resp2.status_code}: {resp2.text}"
     )
+
+
+async def test_create_session_notifies_runner_with_init_envelope(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The create route notifies the runner with the session-init envelope.
+
+    Cross-component regression: the create route must send the full
+    ``session_init`` envelope — carrying the persisted ``/model`` override —
+    not the legacy id-only body. Otherwise the runner falls back to a
+    best-effort reverse GET and, on any failure, silently spawns the default
+    model and respawns on the first turn. Asserts the captured runner-init POST
+    is the envelope and that it carries the override.
+    """
+    from omnigent.runner.session_init_protocol import (
+        SESSION_INIT_PAYLOAD_KEY,
+        parse_runner_session_init_envelope,
+    )
+    from omnigent.server.routes import sessions as sessions_module
+
+    agent = await create_test_agent(client)
+
+    captured_inits: list[dict[str, Any]] = []
+
+    def forward_to_runner(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            captured_inits.append(json.loads(request.content))
+        return httpx.Response(201, json={"status": "initialized"})
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(forward_to_runner),
+        base_url="http://runner",
+    )
+
+    async def _fake_get_runner_client(
+        _session_id: str,
+        _runner_router: object,
+    ) -> httpx.AsyncClient:
+        return fake_runner
+
+    monkeypatch.setattr(sessions_module, "_get_runner_client", _fake_get_runner_client)
+    try:
+        resp = await client.post(
+            "/v1/sessions",
+            json={"agent_id": agent["id"], "model_override": "model-x"},
+        )
+        assert resp.status_code == 201, f"create failed: {resp.status_code} {resp.text}"
+    finally:
+        await fake_runner.aclose()
+
+    assert captured_inits, "create route did not notify the runner of the new session"
+    body = captured_inits[-1]
+    assert SESSION_INIT_PAYLOAD_KEY in body, (
+        "create route sent the legacy id-only body, not the init envelope; the "
+        f"runner would fall back to a reverse GET. Body keys: {sorted(body)}"
+    )
+    envelope = parse_runner_session_init_envelope(body)
+    assert envelope is not None
+    assert envelope.snapshot.model_override == "model-x", (
+        "the init envelope must carry the persisted /model override so the "
+        "runner seeds it into the first spawn; got "
+        f"{envelope.snapshot.model_override!r}"
+    )


### PR DESCRIPTION
## Related issue

Closes #1907

## Summary

A model-pinned session (an SDK sub-agent created with a `/model` override) spawned its harness at the **default** model, then the first turn requested the persisted override — forcing a full teardown + respawn (`harness_respawn_model_switch`) and context reload. One wasted respawn per model-pinned sub-agent, multiplied across fan-outs.

This is a rebase of the original branch onto current `main` (it was ~180 commits behind), re-architected around foundation that changed upstream. It now seeds the persisted `/model` override into the **first** spawn so the first turn needs no respawn:

- **Server:** the create route notifies the runner with the full session-init **envelope** (`build_runner_session_init_payload`) instead of the legacy id-only body, so the runner seeds the first spawn from current session state — including `model_override` — rather than depending on a best-effort reverse GET. Older runners ignore the extra `session_init` key and still read the top-level id fields.
- **Runner:** `_initialize_session` seeds the override into the initial spawn env, read **fresh** at each init — from the envelope on current servers, or a one-shot uncached GET on legacy (no-envelope) servers (which now **logs** on failure instead of silently degrading). `model_override` is deliberately **not** stored in the long-lived `_SessionSnapshot` identity cache: it is mutable (a `/model` switch changes it) and a stale cached value would reseed the old model on a later re-init, recreating the very respawn this removes.
- Mid-session `/model` switches still take the process-manager respawn path, unchanged; native harnesses no-op (the spawn-env builder guards on `env=None`).

The original PR also carried an origin-tagged cancellation-marker change; it was **dropped** — verified dead on current `main` (native "explicit user decline" interrupts return before the origin is consumed, internal respawns create no marker, and no in-process path reaches the tag), and out of scope for #1907.

## Test Plan

```
uv run pytest \
  tests/runner/test_enforce_sandbox_gate.py \
  tests/runtime/harnesses/test_process_manager.py \
  tests/server/test_runner_session_init.py \
  tests/server/integration/test_sessions_endpoints.py::test_create_session_notifies_runner_with_init_envelope
```

- **create route → envelope** (`test_create_session_notifies_runner_with_init_envelope`): over the real server, the create-route runner notify is the init envelope carrying the persisted `model_override`.
- **seed via envelope** and **seed via legacy GET fallback** (`test_enforce_sandbox_gate.py`): the override lands in the initial spawn env on both the current-server (envelope) and legacy (id-only body) paths.
- **staleness regression** (`test_reinit_after_model_switch_seeds_fresh_override`): a re-init after a `/model` switch seeds the new model, never a stale cached one.
- **no first-turn respawn** (`test_process_manager.py`): a real `HarnessProcessManager` proves a seeded model bakes into the first spawn and an identical later call reuses the same subprocess (same PID, no respawn).

## Demo

N/A — non-visual (runner/server behavior).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The server→runner-init wiring and the runner-side seed are covered as separate real-component tests (server emits the envelope; a real runner seeds it; a real process manager proves no respawn) rather than as one end-to-end run. A single tunnel-E2E through the bound-at-create sub-agent flow (parent-runner inheritance + sub-agent spec resolution) is a deliberate follow-up — the existing three-layer harness creates before binding, so it would exercise the wrong branch and read as a false acceptance.

## Changelog

A model-pinned session no longer wastes a harness respawn on its first turn: the persisted `/model` override is seeded into the initial spawn.
