### PR TITLE
fix(runner): cancel pending futures after asyncio.wait in _spawn_async_tool

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -5861,6 +5861,9 @@ def _spawn_async_tool(
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if cancel_event.is_set():
+                # Drop the losing future (the tool coro). This cancels the
+                # task/coroutine but cannot interrupt an underlying
+                # asyncio.to_thread, so that thread may run to completion.
                 for fut in pending:
                     fut.cancel()
                 session_inbox.put_nowait(
@@ -5872,6 +5875,8 @@ def _spawn_async_tool(
                     }
                 )
                 return ""
+            # Drop the losing future (cancel_event.wait()) so it doesn't
+            # linger as a pending task for the life of the session.
             for fut in pending:
                 fut.cancel()
             result = next(iter(done)).result()

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -5853,7 +5853,7 @@ def _spawn_async_tool(
                 session_inbox=session_inbox if target_tool in _TERMINAL_TOOLS else None,
                 filesystem_registry=filesystem_registry,
             )
-            done, _pending = await asyncio.wait(
+            done, pending = await asyncio.wait(
                 [
                     asyncio.ensure_future(exec_coro),
                     asyncio.ensure_future(cancel_event.wait()),
@@ -5861,6 +5861,8 @@ def _spawn_async_tool(
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if cancel_event.is_set():
+                for fut in pending:
+                    fut.cancel()
                 session_inbox.put_nowait(
                     {
                         "handle_id": handle_id,
@@ -5870,6 +5872,8 @@ def _spawn_async_tool(
                     }
                 )
                 return ""
+            for fut in pending:
+                fut.cancel()
             result = next(iter(done)).result()
             session_inbox.put_nowait(
                 {

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7112,3 +7112,82 @@ async def test_approval_event_without_content_flattened() -> None:
     assert resp.status_code == 204
     assert captured["body"] == {"type": "approval", "elicitation_id": "e2", "action": "decline"}
     ApprovalEvent.model_validate(captured["body"])
+
+
+@pytest.mark.asyncio
+async def test_spawn_async_tool_cancels_losing_future_no_leak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_spawn_async_tool`` races the tool coro against ``cancel_event.wait()``
+    via ``asyncio.wait(FIRST_COMPLETED)``. The losing future must be cancelled
+    in BOTH branches, otherwise every ``sys_call_async`` permanently leaks one
+    pending task (the orphaned ``cancel_event.wait()`` on success, or the
+    orphaned tool coro on cancel).
+    """
+    from omnigent.runner import tool_dispatch
+
+    spawn_kw: dict[str, Any] = {
+        "server_client": None,
+        "terminal_registry": None,
+        "resource_registry": None,
+        "agent_spec": None,
+        "conversation_id": "conv_leak",
+        "task_id": None,
+        "agent_id": None,
+        "agent_name": None,
+        "runner_workspace": None,
+        "mcp_manager": None,
+        "filesystem_registry": None,
+    }
+
+    def _leaked(before: set[asyncio.Task[Any]]) -> list[str]:
+        cur = asyncio.current_task()
+        return [
+            t.get_name()
+            for t in asyncio.all_tasks()
+            if t not in before and t is not cur and not t.done()
+        ]
+
+    # Success path: tool finishes first, so cancel_event.wait() is the loser.
+    async def _fast(**_kw: Any) -> str:
+        return "ok"
+
+    monkeypatch.setattr(tool_dispatch, "execute_tool", _fast)
+    inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] = {}
+    before = set(asyncio.all_tasks())
+    tool_dispatch._spawn_async_tool(
+        {"tool": "noop", "args": "{}"},
+        session_inbox=inbox,
+        session_async_tasks=tasks,
+        **spawn_kw,
+    )
+    bg_task, _evt = next(iter(tasks.values()))
+    await bg_task
+    await asyncio.sleep(0)  # let the .cancel() propagate to the losing future
+    assert inbox.get_nowait()["status"] == "completed"
+    assert _leaked(before) == []
+
+    # Cancel path: cancel_event fires first, so the tool coro is the loser.
+    async def _slow(**_kw: Any) -> str:
+        await asyncio.sleep(30)
+        return "late"
+
+    monkeypatch.setattr(tool_dispatch, "execute_tool", _slow)
+    inbox = asyncio.Queue()
+    tasks = {}
+    before = set(asyncio.all_tasks())
+    tool_dispatch._spawn_async_tool(
+        {"tool": "slow", "args": "{}"},
+        session_inbox=inbox,
+        session_async_tasks=tasks,
+        **spawn_kw,
+    )
+    bg_task, evt = next(iter(tasks.values()))
+    await asyncio.sleep(0)  # let _bg reach asyncio.wait
+    evt.set()
+    await bg_task
+    await asyncio.sleep(0)
+    assert inbox.get_nowait()["status"] == "cancelled"
+    assert _leaked(before) == []


### PR DESCRIPTION
## Related issue

N/A

## Summary

When `asyncio.wait()` returns in `_spawn_async_tool`, the losing future (either the `exec_coro` or `cancel_event.wait()`) was never explicitly cancelled. In the cancellation branch this leaked the tool-execution task, which kept running silently in the background. Over long-running sessions with many async tool spawns and cancellations, these orphaned tasks accumulate.

This fix cancels all pending futures in both the cancel and success branches after `asyncio.wait` returns.

## Test Plan

- Code inspection: verified the `pending` set from `asyncio.wait` is now cancelled in both branches.
- Existing tests continue to pass.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable