### PR TITLE
fix(claude-sdk): bind ~/.claude/.credentials.json into the sandbox

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -881,8 +881,12 @@ def _claude_internal_write_roots() -> list[pathlib.Path]:
 def _claude_internal_write_files() -> list[pathlib.Path]:
     """Exact files the Claude CLI updates outside its writable roots."""
 
-    path = pathlib.Path.home() / ".claude.json"
-    return [path] if path.exists() else []
+    # .credentials.json holds the Claude CLI's OAuth token on Linux.
+    candidates = [
+        pathlib.Path.home() / ".claude.json",
+        pathlib.Path.home() / ".claude" / ".credentials.json",
+    ]
+    return [path for path in candidates if path.exists()]
 
 
 def prepare_claude_cli_path(

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -758,6 +758,21 @@ class TestConstructor(unittest.TestCase):
 
             self.assertEqual(paths, [config_path])
 
+    def test_claude_internal_write_files_includes_credentials_when_present(self):
+        from omnigent.inner.claude_sdk_executor import _claude_internal_write_files
+
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            config_path = home / ".claude.json"
+            config_path.write_text("{}\n", encoding="utf-8")
+            credentials_path = home / ".claude" / ".credentials.json"
+            credentials_path.parent.mkdir(parents=True, exist_ok=True)
+            credentials_path.write_text("{}\n", encoding="utf-8")
+            with patch("omnigent.inner.claude_sdk_executor.pathlib.Path.home", return_value=home):
+                paths = _claude_internal_write_files()
+
+            self.assertEqual(paths, [config_path, credentials_path])
+
 
 # ---------------------------------------------------------------------------
 # Tests: MCP tool building


### PR DESCRIPTION
## Related issue

Closes #1922

## Summary

- A user logged into the Claude Code CLI on the host still gets "Not logged in" from a sandboxed claude-sdk harness. `prepare_claude_cli_path` binds part of `~/.claude` into the sandbox (`backups`, `plugins`, `session-env`, `sessions`, plus `~/.claude.json`) but not `~/.claude/.credentials.json`, which is where the CLI keeps its OAuth token on Linux. The sandboxed CLI saw the account metadata in `~/.claude.json` but had no token, so it reported logged-out even though the host login was valid.
- Add `~/.claude/.credentials.json` to `_claude_internal_write_files()`, bound alongside `~/.claude.json` and only when it exists, so a host login works inside the sandbox with no extra setup.
- It is bound writable to match how `~/.claude.json` is already handled. The load-bearing effect is that the token becomes readable for the initial auth. Whether an in-place refresh persists back to the host over the bind mount depends on how the CLI writes the file, same as the existing `~/.claude.json` bind, so this does not change that behavior.
- This does place the OAuth token inside the CLI's own sandbox view. That is unavoidable for a sandboxed CLI to authenticate, and it is consistent with the already-bound `~/.claude.json` and the existing `CLAUDE_CODE_OAUTH_TOKEN` forwarding path in `omnigent/host/connect.py`.

## Test Plan

- New unit test `test_claude_internal_write_files_includes_credentials_when_present`: creates both `~/.claude.json` and `~/.claude/.credentials.json` under a temp home and asserts both are returned. Verified it **fails before the fix** (the function returned only `~/.claude.json`) and passes after.
- The two existing `_claude_internal_write_files` tests still pass unchanged; they do not create a `.credentials.json`, so the missing-file and config-only cases are unaffected.
- `uv run pytest tests/inner/test_claude_sdk_executor.py` -> **103 passed**.
- `ruff check` / `ruff format --check` on both files: clean.

## Demo

N/A (non-visual; covered by the unit test above).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covered by the new unit test, which fails without the fix. I did not run a full live bwrap sandbox repro (that path is Linux-only and needs a real host Claude login); the change is a single addition to the sandbox write-file list, exercised directly by the test.

## Changelog

Sandboxed claude-sdk harnesses now authenticate from an existing host Claude login (`~/.claude/.credentials.json` is bound into the sandbox).
