### PR TITLE
feat(deploy): Vercel deploy target (container function + Neon + Vercel Blob)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ omnigent/server/static/web-ui/
 # reason — `bundle deploy` must be able to sync it to the app source folder.
 # DAB local state directory (created by `databricks bundle deploy`).
 deploy/databricks/.databricks/
+# Vercel CLI project link + the env file `vercel env pull` / marketplace
+# installs write (holds live DATABASE_URL / BLOB_READ_WRITE_TOKEN secrets).
+.vercel
+.env.local

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -1,0 +1,12 @@
+# Vercel container deploy: pulls the CI-built server image instead of building
+# from source — the web UI bundle is gitignored, so a source build here would
+# ship without it. Vercel auto-detects `Dockerfile.vercel` at the repo root and
+# routes all traffic to the container. Walkthrough: deploy/vercel/README.md.
+# Pin a release by editing the tag (…/omnigent-server:vX.Y.Z).
+
+FROM ghcr.io/omnigent-ai/omnigent-server:latest
+
+# Vercel routes traffic to the port named by the PORT env var, defaulting to
+# 80. The entrypoint binds $PORT, so this default makes a zero-config deploy
+# line up; a PORT project env var in Vercel overrides it at runtime.
+ENV PORT=80

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -18,9 +18,22 @@ ENV PORT=80
 # in the base image.
 RUN /opt/venv/bin/pip install --no-cache-dir 'vercel>=0.5,<1' 'boto3>=1.30,<2'
 
-# Vercel gives a container 15 s to accept TCP connections, but first-boot
-# migrations against a remote Postgres take ~1 minute — so swap in the
-# bind-first entrypoint, which serves 503s while migrating in the background.
+# Overlay this checkout's entrypoint and Blob backend onto the image, so the
+# deploy tracks the repo even when the pulled image lags it (identical no-ops
+# once the image ships them). Without the overlay, an older image entrypoint
+# boots before binding (missing Vercel's 15 s accept window on cold starts)
+# and can't select the Blob artifact store.
+COPY deploy/docker/entrypoint.py /app/entrypoint.py
+COPY omnigent/stores/artifact_store/vercel_blob.py /build/omnigent/stores/artifact_store/vercel_blob.py
+
+# Pre-compile bytecode at build time: the image sets PYTHONDONTWRITEBYTECODE,
+# so without .pyc files every cold start re-parses the whole dependency tree,
+# stretching the boot the shim is hiding.
+RUN /opt/venv/bin/python -m compileall -q /opt/venv /build /app || true
+
+# Vercel gives a container 15 s to accept TCP connections, but boot takes
+# 10-60 s (migrations against a remote Postgres) — so swap in the bind-first
+# entrypoint, which serves 503s while booting in the background.
 # The interpreter path is absolute: Vercel's runtime overrides PATH, so a bare
 # `python` resolves to the system interpreter instead of the image's venv.
 COPY deploy/vercel/entrypoint.py /app/vercel_entrypoint.py

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -10,3 +10,18 @@ FROM ghcr.io/omnigent-ai/omnigent-server:latest
 # 80. The entrypoint binds $PORT, so this default makes a zero-config deploy
 # line up; a PORT project env var in Vercel overrides it at runtime.
 ENV PORT=80
+
+# Vercel containers have no persistent disk and requests spread across
+# instances, so a remote artifact store is required. The default is Vercel
+# Blob (auto-selected when the project has a connected Blob store) via the
+# official `vercel` SDK; boto3 covers the S3/R2 alternative. Neither ships
+# in the base image.
+RUN /opt/venv/bin/pip install --no-cache-dir 'vercel>=0.5,<1' 'boto3>=1.30,<2'
+
+# Vercel gives a container 15 s to accept TCP connections, but first-boot
+# migrations against a remote Postgres take ~1 minute — so swap in the
+# bind-first entrypoint, which serves 503s while migrating in the background.
+# The interpreter path is absolute: Vercel's runtime overrides PATH, so a bare
+# `python` resolves to the system interpreter instead of the image's venv.
+COPY deploy/vercel/entrypoint.py /app/vercel_entrypoint.py
+CMD ["/opt/venv/bin/python", "/app/vercel_entrypoint.py"]

--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ with your laptop.
 
 One `docker compose up` runs the server on any host you have (a VPS, a home
 server); **Render** and **Railway** deploy with one click; **Fly.io**, **Hugging
-Face Spaces**, **Modal**, **Cloudflare** (serverless, scale-to-zero), and
+Face Spaces**, **Modal**, **Cloudflare** (serverless, scale-to-zero), **Vercel**
+(container function + Neon Postgres), and
 **Databricks Apps** (backed by Lakebase Postgres and Unity Catalog Volumes) are
 covered too — and a **Cloudflare quick tunnel** (public) or **Tailscale**
 (private) reaches a server running on your own laptop without a deploy. The

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,13 +32,15 @@ after deploy by setting the `OMNIGENT_OIDC_*` vars (auth stays enabled; the
 issuer is what flips the mode); see the platform README for both
 walkthroughs.
 
-**Three more platforms** are supported with a little more setup (not a single
+**Four more platforms** are supported with a little more setup (not a single
 button): **Fly.io** (`fly deploy`, or its web-UI Launch), **Hugging Face
-Spaces** (a demo-grade Docker Space), and **Modal** (`modal deploy`, an
-always-on web server with a durable artifact Volume). See the menu below.
-Fly and HF Spaces can run on the **SQLite lite tier** with no database to
-provision (see [Database: Postgres or SQLite](#database-postgres-or-sqlite));
-Modal needs a bring-your-own Postgres.
+Spaces** (a demo-grade Docker Space), **Modal** (`modal deploy`, an
+always-on web server with a durable artifact Volume), and **Vercel**
+(`vercel deploy`, a container function on Fluid compute with Neon Postgres).
+See the menu below. Fly and HF Spaces can run on the **SQLite lite tier**
+with no database to provision (see
+[Database: Postgres or SQLite](#database-postgres-or-sqlite)); Modal and
+Vercel need a bring-your-own Postgres (one marketplace command on Vercel).
 
 ---
 
@@ -69,6 +71,10 @@ deploy/
 │   ├── src/index.js      the Worker that fronts the container
 │   ├── wrangler.jsonc
 │   └── README.md
+│
+├── vercel/            ← Vercel container function (Fluid compute, Neon Postgres;
+│   └── README.md         tunnels reconnect at the function duration cap.
+│                         The Dockerfile.vercel shim lives at the repo root.)
 │
 ├── trycloudflare/     ← Cloudflare quick tunnel (public URL for a LOCAL server)
 │   └── README.md
@@ -115,6 +121,7 @@ deploy/
 | Deploy to Fly.io | Fly | [`fly/README.md`](fly/README.md): `fly deploy`, SQLite on a volume |
 | Deploy to Modal (durable artifact Volume) | Modal | [`modal/README.md`](modal/README.md): `modal deploy`, BYO Neon Postgres |
 | Deploy serverless (scale-to-zero, no VM/Postgres to manage) | Cloudflare Containers + D1 + R2 | [`cloudflare/README.md`](cloudflare/README.md): `wrangler deploy` |
+| Deploy on Vercel (container function + Neon Postgres) | Vercel | [`vercel/README.md`](vercel/README.md): `vercel deploy`; tunnels reconnect at the duration cap |
 | Stand up a quick demo (no DB to provision) | HF Spaces | [`hf-spaces/README.md`](hf-spaces/README.md): Docker Space, SQLite |
 | Share a server running on your **laptop**: demo it to teammates, or let remote runners & cloud sandboxes connect back to it (nothing to deploy) | Cloudflare quick tunnel | `cloudflared tunnel --url http://localhost:6767` |
 | Access your server privately from **your phone, tablet, or other personal devices** without exposing it to the internet | Tailscale | [`tailscale/README.md`](tailscale/README.md): `tailscale serve https / http://localhost:8000` |
@@ -362,8 +369,8 @@ guide lives at [`daytona/README.md`](daytona/README.md); the Islo guide
 Auth is driven by a single switch, `OMNIGENT_AUTH_ENABLED`. The framework
 default (a bare local `omnigent server`) leaves it off: single-user
 `header` mode, no login. The containerized deploys here (Docker / HF / Render /
-Railway / Modal / Fly) set `OMNIGENT_AUTH_ENABLED=1` by default in their
-entrypoints,
+Railway / Modal / Fly / Vercel) set `OMNIGENT_AUTH_ENABLED=1` by default in
+their entrypoints,
 since a network-exposed instance should be authenticated. With the switch on,
 the mode is chosen by your config: supply the `OMNIGENT_OIDC_*` vars and you
 get `oidc`, otherwise you get the built-in `accounts` flow.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,8 +39,9 @@ always-on web server with a durable artifact Volume), and **Vercel**
 (`vercel deploy`, a container function on Fluid compute with Neon Postgres).
 See the menu below. Fly and HF Spaces can run on the **SQLite lite tier**
 with no database to provision (see
-[Database: Postgres or SQLite](#database-postgres-or-sqlite)); Modal and
-Vercel need a bring-your-own Postgres (one marketplace command on Vercel).
+[Database: Postgres or SQLite](#database-postgres-or-sqlite)); Modal needs a
+bring-your-own Postgres, and Vercel needs Postgres (one marketplace command)
+plus an S3-compatible artifact bucket.
 
 ---
 

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -152,14 +152,21 @@ def _resolve_config() -> _ResolvedConfig:
     port = int(cfg.get("port") or os.environ.get("PORT") or _DEFAULT_PORT)
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
-    # Optional remote artifact store (S3 / Cloudflare R2 / MinIO / …). When set,
-    # the artifact STORE is remote and durable; artifact_dir stays local for the
-    # cookie secret and on-disk cache. Mirrors how DATABASE_URL selects the DB.
+    # Optional remote artifact store (S3 / Cloudflare R2 / MinIO / Vercel
+    # Blob / …). When set, the artifact STORE is remote and durable;
+    # artifact_dir stays local for the cookie secret and on-disk cache.
+    # Mirrors how DATABASE_URL selects the DB. With no explicit URI, a
+    # BLOB_READ_WRITE_TOKEN in the environment (Vercel injects it when a
+    # Blob store is connected to the project) selects Vercel Blob, so a
+    # Vercel deploy needs zero artifact config.
     artifact_store_uri = cfg.get("artifact_store_uri") or os.environ.get("OMNIGENT_ARTIFACT_URI")
-    if artifact_store_uri and not artifact_store_uri.startswith("s3://"):
+    if not artifact_store_uri and os.environ.get("BLOB_READ_WRITE_TOKEN"):
+        artifact_store_uri = "vercel-blob://"
+    if artifact_store_uri and not artifact_store_uri.startswith(("s3://", "vercel-blob://")):
         raise RuntimeError(
             "OMNIGENT_ARTIFACT_URI (or `artifact_store_uri:` in config) must be an "
-            f"'s3://bucket[/prefix]' URI, got: {artifact_store_uri!r}"
+            "'s3://bucket[/prefix]' or 'vercel-blob://[prefix]' URI, got: "
+            f"{artifact_store_uri!r}"
         )
 
     logger.info(
@@ -237,9 +244,11 @@ def _select_artifact_store(resolved_config: _ResolvedConfig) -> ArtifactStore:
 
     An ``s3://bucket[/prefix]`` ``artifact_store_uri`` selects the remote,
     durable :class:`~omnigent.stores.artifact_store.s3.S3ArtifactStore` (AWS S3,
-    Cloudflare R2, MinIO, …), which survives an ephemeral or multi-replica
-    deploy. Otherwise the local-filesystem store at ``artifact_dir`` is used.
-    Mirrors how ``DATABASE_URL`` selects the database backend.
+    Cloudflare R2, MinIO, …); a ``vercel-blob://[prefix]`` URI selects
+    :class:`~omnigent.stores.artifact_store.vercel_blob.VercelBlobArtifactStore`.
+    Both survive an ephemeral or multi-replica deploy. Otherwise the
+    local-filesystem store at ``artifact_dir`` is used. Mirrors how
+    ``DATABASE_URL`` selects the database backend.
 
     :param resolved_config: The resolved startup configuration.
     :returns: The selected
@@ -248,6 +257,10 @@ def _select_artifact_store(resolved_config: _ResolvedConfig) -> ArtifactStore:
     from omnigent.stores.artifact_store.local import LocalArtifactStore
 
     if resolved_config.artifact_store_uri:
+        if resolved_config.artifact_store_uri.startswith("vercel-blob://"):
+            from omnigent.stores.artifact_store.vercel_blob import VercelBlobArtifactStore
+
+            return VercelBlobArtifactStore(resolved_config.artifact_store_uri)
         from omnigent.stores.artifact_store.s3 import S3ArtifactStore
 
         return S3ArtifactStore(resolved_config.artifact_store_uri)

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -1,0 +1,185 @@
+# Omnigent on Vercel
+
+Run the Omnigent server as a **Vercel container function**: Vercel builds the
+one-line `Dockerfile.vercel` shim at the repo root (it pulls the prebuilt
+`ghcr.io/omnigent-ai/omnigent-server` image), serves it over HTTPS on
+`*.vercel.app`, and scales it on Fluid compute. Postgres comes from the Neon
+marketplace integration; durable artifacts go to any S3-compatible bucket.
+
+> [!NOTE]
+> **Know the tradeoffs before picking this target.** Vercel's WebSocket
+> support (public beta) closes every connection when the function hits its
+> max duration — **300 s on Hobby, 800 s on Pro** (1800 s beta). Omnigent's
+> runner and host tunnels auto-reconnect in ~0.5 s and in-flight turns
+> survive the cut, so sessions keep working — but the tunnels churn every
+> few minutes, and a request that is mid-flight over the tunnel at the
+> instant of the cut fails once. Vercel also has no persistent disk and no
+> way to pin traffic to one instance (see [Constraints](#constraints)).
+> For an always-on tunnel with no churn, use Render, Railway, Fly, or Modal
+> instead. This target suits kicking the tires and light single-user use.
+
+## How it works
+
+```
+        HTTPS / SSE / WebSocket
+browser ───────────────►  Vercel (Fluid compute)
+runner  ───────────────►      │ container function
+                              ▼
+                        omnigent server ──► DATABASE_URL (Neon Postgres,
+                        (Dockerfile.vercel │  marketplace integration)
+                         → prebuilt image) │
+                                           └► OMNIGENT_ARTIFACT_URI
+                                              s3://… (optional, durable)
+```
+
+- **`Dockerfile.vercel`** (repo root) — auto-detected by Vercel; the image is
+  built on Vercel's builders (no local Docker) and pushed to Vercel's
+  registry. It's a `FROM ghcr.io/omnigent-ai/omnigent-server` shim, so the
+  deploy runs the exact same entrypoint as every other container platform.
+- **Neon Postgres** — provisioned through the Vercel marketplace;
+  `DATABASE_URL` is injected automatically.
+- **S3-compatible bucket** (optional but recommended) — the container's disk
+  is ephemeral, so agent bundles and user files only survive instance
+  recycling when `OMNIGENT_ARTIFACT_URI` points at a bucket (AWS S3,
+  Cloudflare R2, …) via the native `S3ArtifactStore`.
+
+## Prerequisites
+
+- A Vercel account with **Fluid compute** (the default for projects created
+  since April 2025). WebSocket support is a public beta; the Hobby plan
+  works, Pro raises the tunnel-cut interval from 300 s to 800 s.
+- **Node** for the `vercel` CLI (`npx vercel …`); no local Docker needed.
+
+## Deploy
+
+### 1. Create the project
+
+From the repo root (a clone or your fork):
+
+```bash
+npx vercel login
+npx vercel deploy          # creates + links the project; picks up Dockerfile.vercel
+```
+
+The first deploy fails to boot without a database — that's expected; keep
+going.
+
+### 2. Provision Neon Postgres
+
+```bash
+npx vercel install neon    # marketplace integration; injects DATABASE_URL
+```
+
+(Or from the dashboard: **Storage → Create Database → Neon**, connected to
+the project.) The entrypoint normalizes Neon's `postgres://` URL
+automatically.
+
+### 3. Set the required env vars
+
+```bash
+# Session cookie secret — pin it: the disk is ephemeral, and a re-minted
+# secret would log everyone out on every instance recycle.
+openssl rand -hex 32 | npx vercel env add OMNIGENT_ACCOUNTS_COOKIE_SECRET production
+```
+
+The public base URL is auto-detected from Vercel's
+`VERCEL_PROJECT_PRODUCTION_URL`, so it needs no manual set.
+
+### 4. Deploy to production
+
+```bash
+npx vercel deploy --prod
+```
+
+The **first** boot runs all migrations against Neon before the server
+listens (~1 minute), so the first few requests may 5xx or time out while it
+migrates — just retry. Later cold starts are a few seconds.
+
+```bash
+curl https://<project>.vercel.app/health   # {"status":"ok"}
+```
+
+### 5. First admin + connect a host
+
+Open the URL — the Setup screen claims the first admin (username +
+password). Then connect a machine to actually run agents (the server is just
+the control plane):
+
+```bash
+omnigent login https://<project>.vercel.app
+omnigent host  --server https://<project>.vercel.app
+```
+
+## Durable artifacts (recommended)
+
+Without this, uploaded agents and files vanish whenever Vercel recycles the
+instance (it scales in after ~5 idle minutes). Point the artifact store at
+any S3-compatible bucket:
+
+```bash
+npx vercel env add OMNIGENT_ARTIFACT_URI production      # s3://<bucket>[/prefix]
+npx vercel env add AWS_ACCESS_KEY_ID production
+npx vercel env add AWS_SECRET_ACCESS_KEY production
+npx vercel env add AWS_ENDPOINT_URL_S3 production        # non-AWS only (e.g. R2)
+```
+
+For Cloudflare R2 credentials, see the walkthrough in
+[`../cloudflare/README.md`](../cloudflare/README.md#4-r2-s3-credentials-for-the-artifact-store);
+the store and env vars are identical here.
+
+## Raise the tunnel-cut interval (Pro)
+
+On Hobby, function max duration is fixed at 300 s, so runner/host tunnels
+reconnect every 5 minutes. On Pro, raise the project's default function max
+duration to **800 s** in the dashboard (**Settings → Functions**) to cut the
+churn to ~13-minute cycles. Reconnects are automatic either way.
+
+## Use your own IdP instead (OIDC)
+
+Switch the provider with env vars (OIDC requires HTTPS, which `*.vercel.app`
+provides):
+
+```bash
+npx vercel env add OMNIGENT_AUTH_PROVIDER production        # oidc
+npx vercel env add OMNIGENT_OIDC_ISSUER production          # e.g. https://github.com
+npx vercel env add OMNIGENT_OIDC_CLIENT_ID production
+npx vercel env add OMNIGENT_OIDC_CLIENT_SECRET production
+npx vercel env add OMNIGENT_OIDC_REDIRECT_URI production    # https://<project>.vercel.app/auth/callback
+openssl rand -hex 32 | npx vercel env add OMNIGENT_OIDC_COOKIE_SECRET production
+```
+
+Redeploy to apply. For Google Workspace, also set
+`OMNIGENT_OIDC_ALLOWED_DOMAINS` to restrict logins to your domain.
+
+## Constraints
+
+- **Tunnel churn.** Every WebSocket closes at the function's max duration
+  (300 s Hobby / 800 s Pro / 1800 s beta). Runners and hosts reconnect with
+  ~0.5 s backoff and running turns resume; a tunnel-proxied request caught
+  mid-flight at the cut fails once. Browser SSE streams and terminal tabs
+  reconnect the same way.
+- **Effectively single-instance.** The server keeps its runner registry and
+  live-event fan-out in process memory, and Vercel pins each WebSocket to
+  one instance while routing other requests freely. Under light traffic one
+  warm instance serves everything and this works; under bursty load or
+  mid-redeploy, requests can land on an instance that can't see your
+  runner's tunnel and fail until the tunnels cycle. There is no
+  single-instance pin on Vercel (unlike Modal's `max_containers=1`).
+- **No persistent disk.** Postgres is required (no SQLite lite tier), the
+  cookie secret must be pinned via env, and artifacts need an S3-compatible
+  bucket to survive.
+- **4.5 MB request-body cap** on Vercel functions — pushing an agent bundle
+  larger than that fails; trim the bundle.
+- **No scale-to-zero with connected runners.** A live tunnel keeps the
+  instance provisioned (memory is billed for instance lifetime; CPU only
+  while messages flow). With no runners or browsers connected, the instance
+  scales in after ~5 minutes and the next request cold-starts in a few
+  seconds.
+
+## Cost
+
+Fluid compute bills Active CPU (~$0.13/CPU-hr), provisioned memory
+(~$0.01/GB-hr while any instance is up), and invocations. A lightly used
+deploy with a runner connected during working hours lands in the low
+dollars/month on Pro; Hobby's included allotment covers kicking the tires.
+Neon has a free tier; marketplace billing is unified through Vercel.

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -168,14 +168,19 @@ Redeploy to apply. For Google Workspace, also set
   ~0.5 s backoff and running turns resume; a tunnel-proxied request caught
   mid-flight at the cut fails once. Browser SSE streams and terminal tabs
   reconnect the same way.
-- **Requests spread across instances.** The server keeps its runner
-  registry and live-event fan-out in process memory, and Vercel pins each
+- **Requests spread across instances.** The server keeps its runner/host
+  registries and live-event fan-out in process memory, and Vercel pins each
   WebSocket to one instance while routing other requests freely — including
-  to brand-new cold instances that answer 503 while booting. Under light
-  traffic one warm instance serves everything and this works; under bursty
-  load or mid-redeploy, requests can land on an instance that can't see
-  your runner's tunnel and fail until the tunnels cycle. There is no
-  single-instance pin on Vercel (unlike Modal's `max_containers=1`).
+  to brand-new cold instances that answer 503 while booting. With one warm
+  instance everything works; once a second instance is warm (bursty
+  traffic, mid-redeploy), requests landing on the wrong instance fail —
+  most visibly, host-tunnel features (the workspace folder picker, host
+  launches) return **409 "host is offline"** even though the host is
+  connected. Retrying rides it out (~1-in-N odds per attempt at N warm
+  instances), and instances converge back to one after ~5 quiet minutes.
+  There is no single-instance pin on Vercel (unlike Modal's
+  `max_containers=1`); this is the target's fundamental ceiling and why
+  it's rated demo-grade.
 - **No persistent disk.** Postgres is required (no SQLite lite tier), the
   cookie secret must be pinned via env, and artifacts **must** live in an
   S3-compatible bucket.

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -1,22 +1,24 @@
 # Omnigent on Vercel
 
 Run the Omnigent server as a **Vercel container function**: Vercel builds the
-one-line `Dockerfile.vercel` shim at the repo root (it pulls the prebuilt
+`Dockerfile.vercel` shim at the repo root (it pulls the prebuilt
 `ghcr.io/omnigent-ai/omnigent-server` image), serves it over HTTPS on
 `*.vercel.app`, and scales it on Fluid compute. Postgres comes from the Neon
-marketplace integration; durable artifacts go to any S3-compatible bucket.
+marketplace integration; artifacts go to an S3-compatible bucket you bring
+(AWS S3, Cloudflare R2, Tigris, …) — Vercel has no persistent disk.
 
 > [!NOTE]
 > **Know the tradeoffs before picking this target.** Vercel's WebSocket
 > support (public beta) closes every connection when the function hits its
 > max duration — **300 s on Hobby, 800 s on Pro** (1800 s beta). Omnigent's
-> runner and host tunnels auto-reconnect in ~0.5 s and in-flight turns
-> survive the cut, so sessions keep working — but the tunnels churn every
-> few minutes, and a request that is mid-flight over the tunnel at the
-> instant of the cut fails once. Vercel also has no persistent disk and no
-> way to pin traffic to one instance (see [Constraints](#constraints)).
-> For an always-on tunnel with no churn, use Render, Railway, Fly, or Modal
-> instead. This target suits kicking the tires and light single-user use.
+> runner and host tunnels auto-reconnect (~0.5 s, validated end to end) and
+> in-flight turns survive the cut, so sessions keep working — but the
+> tunnels churn every few minutes, and a request that is mid-flight over
+> the tunnel at the instant of the cut fails once. Traffic can also spread
+> across function instances with no way to pin it (see
+> [Constraints](#constraints)). For an always-on tunnel with no churn, use
+> Render, Railway, Fly, or Modal instead. This target suits kicking the
+> tires and light single-user use.
 
 ## How it works
 
@@ -29,19 +31,27 @@ runner  ───────────────►      │ container func
                         (Dockerfile.vercel │  marketplace integration)
                          → prebuilt image) │
                                            └► OMNIGENT_ARTIFACT_URI
-                                              s3://… (optional, durable)
+                                              s3://… (required, durable)
 ```
 
 - **`Dockerfile.vercel`** (repo root) — auto-detected by Vercel; the image is
   built on Vercel's builders (no local Docker) and pushed to Vercel's
-  registry. It's a `FROM ghcr.io/omnigent-ai/omnigent-server` shim, so the
-  deploy runs the exact same entrypoint as every other container platform.
+  registry. It's a `FROM ghcr.io/omnigent-ai/omnigent-server` shim plus
+  `boto3` for the S3 artifact store and a Vercel-specific entrypoint (below).
+- **Bind-first entrypoint** (`entrypoint.py` here) — Vercel gives a container
+  **15 s** to accept TCP connections, but a first boot runs Alembic
+  migrations (~1 min against Neon), and even a normal cold boot takes
+  ~10–25 s. The standard entrypoint binds only after migrating, so this
+  wrapper inverts the order: it binds immediately and answers **503** (HTTP)
+  or a retryable WS-upgrade denial while the real server boots behind it,
+  then delegates everything. Runners, hosts, and browsers just retry.
 - **Neon Postgres** — provisioned through the Vercel marketplace;
   `DATABASE_URL` is injected automatically.
-- **S3-compatible bucket** (optional but recommended) — the container's disk
-  is ephemeral, so agent bundles and user files only survive instance
-  recycling when `OMNIGENT_ARTIFACT_URI` points at a bucket (AWS S3,
-  Cloudflare R2, …) via the native `S3ArtifactStore`.
+- **S3-compatible bucket** — **required**, unlike most other targets. The
+  container's disk is per-instance and ephemeral, and requests round-robin
+  across instances, so agent bundles and user files must live in a bucket
+  (`OMNIGENT_ARTIFACT_URI`) via the native `S3ArtifactStore`. Without it,
+  even the built-in agents fail to load (`failed to load agent spec`).
 
 ## Prerequisites
 
@@ -49,6 +59,9 @@ runner  ───────────────►      │ container func
   since April 2025). WebSocket support is a public beta; the Hobby plan
   works, Pro raises the tunnel-cut interval from 300 s to 800 s.
 - **Node** for the `vercel` CLI (`npx vercel …`); no local Docker needed.
+- An **S3-compatible bucket** + access keys (AWS S3, Cloudflare R2, Tigris,
+  Backblaze B2, MinIO, …). For R2 key minting, see
+  [`../cloudflare/README.md`](../cloudflare/README.md#4-r2-s3-credentials-for-the-artifact-store).
 
 ## Deploy
 
@@ -58,21 +71,18 @@ From the repo root (a clone or your fork):
 
 ```bash
 npx vercel login
-npx vercel deploy          # creates + links the project; picks up Dockerfile.vercel
+npx vercel link --yes --project omnigent
 ```
-
-The first deploy fails to boot without a database — that's expected; keep
-going.
 
 ### 2. Provision Neon Postgres
 
 ```bash
-npx vercel install neon    # marketplace integration; injects DATABASE_URL
+npx vercel install neon    # injects DATABASE_URL into the project env
 ```
 
-(Or from the dashboard: **Storage → Create Database → Neon**, connected to
-the project.) The entrypoint normalizes Neon's `postgres://` URL
-automatically.
+The first run prints a browser URL to accept Neon's marketplace terms —
+open it, accept, and re-run the command. (Or from the dashboard:
+**Storage → Create Database → Neon**.)
 
 ### 3. Set the required env vars
 
@@ -80,20 +90,27 @@ automatically.
 # Session cookie secret — pin it: the disk is ephemeral, and a re-minted
 # secret would log everyone out on every instance recycle.
 openssl rand -hex 32 | npx vercel env add OMNIGENT_ACCOUNTS_COOKIE_SECRET production
+
+# Artifact store (required — see above): bucket + S3 credentials.
+npx vercel env add OMNIGENT_ARTIFACT_URI production      # s3://<bucket>[/prefix]
+npx vercel env add AWS_ACCESS_KEY_ID production
+npx vercel env add AWS_SECRET_ACCESS_KEY production
+npx vercel env add AWS_ENDPOINT_URL_S3 production        # non-AWS only (e.g. R2, Tigris)
 ```
 
 The public base URL is auto-detected from Vercel's
-`VERCEL_PROJECT_PRODUCTION_URL`, so it needs no manual set.
+`VERCEL_PROJECT_PRODUCTION_URL`, and the container binds the port Vercel
+routes to by default — no `PORT` or URL config needed.
 
 ### 4. Deploy to production
 
 ```bash
-npx vercel deploy --prod
+npx vercel deploy --prod --yes
 ```
 
-The **first** boot runs all migrations against Neon before the server
-listens (~1 minute), so the first few requests may 5xx or time out while it
-migrates — just retry. Later cold starts are a few seconds.
+While the server boots, requests return `503` with a JSON
+`"server starting"` detail. The **first** boot runs all migrations against
+Neon (~1 minute); later cold starts are ~10–25 s. Then:
 
 ```bash
 curl https://<project>.vercel.app/health   # {"status":"ok"}
@@ -102,37 +119,24 @@ curl https://<project>.vercel.app/health   # {"status":"ok"}
 ### 5. First admin + connect a host
 
 Open the URL — the Setup screen claims the first admin (username +
-password). Then connect a machine to actually run agents (the server is just
-the control plane):
+password). Then connect a machine to actually run agents (the server is
+just the control plane):
 
 ```bash
 omnigent login https://<project>.vercel.app
 omnigent host  --server https://<project>.vercel.app
 ```
 
-## Durable artifacts (recommended)
-
-Without this, uploaded agents and files vanish whenever Vercel recycles the
-instance (it scales in after ~5 idle minutes). Point the artifact store at
-any S3-compatible bucket:
-
-```bash
-npx vercel env add OMNIGENT_ARTIFACT_URI production      # s3://<bucket>[/prefix]
-npx vercel env add AWS_ACCESS_KEY_ID production
-npx vercel env add AWS_SECRET_ACCESS_KEY production
-npx vercel env add AWS_ENDPOINT_URL_S3 production        # non-AWS only (e.g. R2)
-```
-
-For Cloudflare R2 credentials, see the walkthrough in
-[`../cloudflare/README.md`](../cloudflare/README.md#4-r2-s3-credentials-for-the-artifact-store);
-the store and env vars are identical here.
-
 ## Raise the tunnel-cut interval (Pro)
 
 On Hobby, function max duration is fixed at 300 s, so runner/host tunnels
-reconnect every 5 minutes. On Pro, raise the project's default function max
-duration to **800 s** in the dashboard (**Settings → Functions**) to cut the
-churn to ~13-minute cycles. Reconnects are automatic either way.
+reconnect every 5 minutes. Observed cycle: a clean cut at ~310 s, then —
+because the tunnel was what kept the instance alive — the reconnect lands
+on a fresh instance and retries through its boot-time 503s, reconnecting
+~20 s later. The tunnel is up ~93% of the time on Hobby, hands-free. On
+Pro, raise the project's default function max duration to **800 s** in the
+dashboard (**Settings → Functions**) to stretch the cycle to ~13 minutes
+(~97% uptime).
 
 ## Use your own IdP instead (OIDC)
 
@@ -158,23 +162,24 @@ Redeploy to apply. For Google Workspace, also set
   ~0.5 s backoff and running turns resume; a tunnel-proxied request caught
   mid-flight at the cut fails once. Browser SSE streams and terminal tabs
   reconnect the same way.
-- **Effectively single-instance.** The server keeps its runner registry and
-  live-event fan-out in process memory, and Vercel pins each WebSocket to
-  one instance while routing other requests freely. Under light traffic one
-  warm instance serves everything and this works; under bursty load or
-  mid-redeploy, requests can land on an instance that can't see your
-  runner's tunnel and fail until the tunnels cycle. There is no
+- **Requests spread across instances.** The server keeps its runner
+  registry and live-event fan-out in process memory, and Vercel pins each
+  WebSocket to one instance while routing other requests freely — including
+  to brand-new cold instances that answer 503 while booting. Under light
+  traffic one warm instance serves everything and this works; under bursty
+  load or mid-redeploy, requests can land on an instance that can't see
+  your runner's tunnel and fail until the tunnels cycle. There is no
   single-instance pin on Vercel (unlike Modal's `max_containers=1`).
 - **No persistent disk.** Postgres is required (no SQLite lite tier), the
-  cookie secret must be pinned via env, and artifacts need an S3-compatible
-  bucket to survive.
+  cookie secret must be pinned via env, and artifacts **must** live in an
+  S3-compatible bucket.
 - **4.5 MB request-body cap** on Vercel functions — pushing an agent bundle
   larger than that fails; trim the bundle.
 - **No scale-to-zero with connected runners.** A live tunnel keeps the
   instance provisioned (memory is billed for instance lifetime; CPU only
   while messages flow). With no runners or browsers connected, the instance
-  scales in after ~5 minutes and the next request cold-starts in a few
-  seconds.
+  scales in after ~5 idle minutes and the next request cold-starts behind
+  ~10–25 s of 503s.
 
 ## Cost
 
@@ -182,4 +187,6 @@ Fluid compute bills Active CPU (~$0.13/CPU-hr), provisioned memory
 (~$0.01/GB-hr while any instance is up), and invocations. A lightly used
 deploy with a runner connected during working hours lands in the low
 dollars/month on Pro; Hobby's included allotment covers kicking the tires.
-Neon has a free tier; marketplace billing is unified through Vercel.
+Neon has a free tier; marketplace billing is unified through Vercel. The
+artifact bucket is billed by its provider (R2/Tigris free tiers cover light
+use).

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -36,8 +36,14 @@ runner  ───────────────►      │ container func
 
 - **`Dockerfile.vercel`** (repo root) — auto-detected by Vercel; the image is
   built on Vercel's builders (no local Docker) and pushed to Vercel's
-  registry. It's a `FROM ghcr.io/omnigent-ai/omnigent-server` shim plus
-  `boto3` for the S3 artifact store and a Vercel-specific entrypoint (below).
+  registry. It's a `FROM ghcr.io/omnigent-ai/omnigent-server` shim that
+  overlays this checkout's entrypoint + Blob backend (so the deploy tracks
+  the repo even when the pulled image lags it), pre-compiles bytecode for
+  faster cold boots, and adds the `vercel`/`boto3` SDKs.
+- **`vercel.json`** (repo root) — pins the function region to `iad1` to sit
+  next to Neon's default region; if you provision your database elsewhere,
+  change it to match. Cross-country DB round-trips dominate request latency
+  otherwise.
 - **Bind-first entrypoint** (`entrypoint.py` here) — Vercel gives a container
   **15 s** to accept TCP connections, but a first boot runs Alembic
   migrations (~1 min against Neon), and even a normal cold boot takes

--- a/deploy/vercel/entrypoint.py
+++ b/deploy/vercel/entrypoint.py
@@ -42,6 +42,42 @@ logger = logging.getLogger("omnigent.deploy.vercel")
 _STARTING_BODY = b'{"detail": "server starting (running database migrations); retry shortly"}'
 _FAILED_BODY = b'{"detail": "server failed to boot; see the deployment logs"}'
 
+# Browsers get an auto-refreshing page instead of raw JSON: a cold Vercel
+# instance answers 503 for its ~15 s boot, and without this a user landing
+# in that window sees a bare JSON blob and thinks the app is down.
+_STARTING_HTML = b"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="3" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Omnigent is starting\xe2\x80\xa6</title>
+    <style>
+      body { font-family: system-ui, sans-serif; background: #0d1218; color: #e6e8eb;
+             display: flex; align-items: center; justify-content: center;
+             height: 100vh; margin: 0; }
+      main { text-align: center; }
+      .spin { width: 28px; height: 28px; margin: 0 auto 16px;
+              border: 3px solid #2a3442; border-top-color: #e6e8eb;
+              border-radius: 50%; animation: r 0.9s linear infinite; }
+      @keyframes r { to { transform: rotate(360deg); } }
+      p { color: #8b949e; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="spin"></div>
+      <h1>Omnigent is starting</h1>
+      <p>This instance is booting (a few seconds). The page retries automatically.</p>
+    </main>
+  </body>
+</html>
+"""
+_FAILED_HTML = (
+    b"<!doctype html><html><body><h1>Omnigent failed to start</h1>"
+    b"<p>See the deployment logs.</p></body></html>"
+)
+
 
 def _log_fatal(prefix: str) -> None:
     """Log the current exception on one line.
@@ -86,10 +122,20 @@ class _DeferredApp:
             await self._real_app(scope, receive, send)
             return
         status = 500 if self._boot_failed else 503
-        body = _FAILED_BODY if self._boot_failed else _STARTING_BODY
+        # Content-negotiate: browsers (Accept: text/html) get an
+        # auto-refreshing page; API/tunnel clients get JSON.
+        accepts_html = b"text/html" in dict(scope.get("headers") or []).get(b"accept", b"")
+        if accepts_html and scope["type"] == "http":
+            body = _FAILED_HTML if self._boot_failed else _STARTING_HTML
+            content_type = b"text/html; charset=utf-8"
+        else:
+            body = _FAILED_BODY if self._boot_failed else _STARTING_BODY
+            content_type = b"application/json"
         headers = [
-            (b"content-type", b"application/json"),
+            (b"content-type", content_type),
             (b"retry-after", b"5"),
+            # Never cache the boot-window response in browsers or the edge.
+            (b"cache-control", b"no-store"),
         ]
         if scope["type"] == "websocket":
             # Refuse the upgrade with a retryable 5xx where the server

--- a/deploy/vercel/entrypoint.py
+++ b/deploy/vercel/entrypoint.py
@@ -1,0 +1,173 @@
+"""Vercel entrypoint for the Omnigent server: bind first, migrate behind a 503.
+
+Vercel container functions must accept TCP connections within **15 s** of
+boot, but the standard entrypoint (``deploy/docker/entrypoint.py``) binds
+only after running Alembic migrations — and a first boot against a fresh
+remote Postgres (Neon) spends ~1 minute on them, so that order can never
+fit the window. This wrapper inverts it: uvicorn binds immediately on a
+deferring ASGI shim that answers ``503`` (with ``Retry-After``) while
+config resolution, migrations, and app construction run in a worker
+thread; once the real app is ready, its lifespan is entered on the
+serving loop and every request is delegated to it.
+
+Ships only in the Vercel image: ``Dockerfile.vercel`` copies this file
+next to the standard entrypoint (``/app/entrypoint.py``, imported below)
+and swaps the ``CMD``. Every other platform keeps migrate-then-bind.
+
+Importing this module has no side effects beyond importing the standard
+entrypoint module (itself side-effect free); nothing touches the network
+or database until ``main()`` runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import traceback
+from contextlib import AsyncExitStack
+from typing import TYPE_CHECKING, Any
+
+import entrypoint  # the standard entrypoint, shipped at /app/entrypoint.py
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from entrypoint import _BuiltApp, _ResolvedConfig
+
+# Named under the omnigent.* hierarchy so post-boot lines still emit once the
+# app's logging config takes over the root logger.
+logger = logging.getLogger("omnigent.deploy.vercel")
+
+_STARTING_BODY = b'{"detail": "server starting (running database migrations); retry shortly"}'
+_FAILED_BODY = b'{"detail": "server failed to boot; see the deployment logs"}'
+
+
+def _log_fatal(prefix: str) -> None:
+    """Log the current exception on one line.
+
+    Vercel's log stream records each stderr line as a separate event and
+    can drop a multi-line traceback's continuation lines, so flatten it.
+    """
+    logger.error("FATAL: %s: %s", prefix, traceback.format_exc().replace("\n", " | "))
+
+
+def _migrate_and_build(resolved_config: _ResolvedConfig) -> _BuiltApp:
+    """Run the slow, blocking half of the standard entrypoint's ``main()``."""
+    entrypoint.run_migrations(resolved_config.database_url)
+    return entrypoint.build_app(resolved_config)
+
+
+class _DeferredApp:
+    """ASGI shim: 503 until the real app is ready, then pure delegation.
+
+    :param resolved_config: The pre-resolved startup config, or ``None``
+        when config resolution already failed (the shim then serves 500s
+        so the failure is visible in ``vercel logs`` instead of surfacing
+        as the platform's opaque could-not-connect error).
+    """
+
+    def __init__(self, resolved_config: _ResolvedConfig | None) -> None:
+        self._resolved_config = resolved_config
+        self._real_app: Callable[..., Awaitable[None]] | None = None
+        self._boot_failed = resolved_config is None
+        self._lifespan_stack: AsyncExitStack | None = None
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[dict[str, Any]]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        if scope["type"] == "lifespan":
+            await self._lifespan(receive, send)
+            return
+        if self._real_app is not None:
+            await self._real_app(scope, receive, send)
+            return
+        status = 500 if self._boot_failed else 503
+        body = _FAILED_BODY if self._boot_failed else _STARTING_BODY
+        headers = [
+            (b"content-type", b"application/json"),
+            (b"retry-after", b"5"),
+        ]
+        if scope["type"] == "websocket":
+            # Refuse the upgrade with a retryable 5xx where the server
+            # supports denial responses: a bare pre-accept close surfaces
+            # as a generic 403, which tunnel clients treat as fatal instead
+            # of retrying into the ready server.
+            await receive()
+            if "websocket.http.response" in (scope.get("extensions") or {}):
+                await send(
+                    {"type": "websocket.http.response.start", "status": status, "headers": headers}
+                )
+                await send({"type": "websocket.http.response.body", "body": body})
+            else:
+                await send({"type": "websocket.close", "code": 1013})
+            return
+        await send({"type": "http.response.start", "status": status, "headers": headers})
+        await send({"type": "http.response.body", "body": body})
+
+    async def _lifespan(
+        self,
+        receive: Callable[[], Awaitable[dict[str, Any]]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        await receive()  # lifespan.startup
+        boot_task = asyncio.get_running_loop().create_task(self._boot())
+        await send({"type": "lifespan.startup.complete"})
+        await receive()  # lifespan.shutdown
+        boot_task.cancel()
+        if self._lifespan_stack is not None:
+            await self._lifespan_stack.aclose()
+        await send({"type": "lifespan.shutdown.complete"})
+
+    async def _boot(self) -> None:
+        """Migrate + build off-loop, then enter the app's lifespan on-loop."""
+        if self._resolved_config is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            built = await loop.run_in_executor(None, _migrate_and_build, self._resolved_config)
+            stack = AsyncExitStack()
+            await stack.enter_async_context(built.app.router.lifespan_context(built.app))
+            self._lifespan_stack = stack
+            self._real_app = built.app
+            logger.info("Omnigent server ready; shim now delegating requests.")
+        except Exception:  # noqa: BLE001 — boot catch-all so failures land in logs
+            self._boot_failed = True
+            _log_fatal("omnigent server failed to boot")
+
+
+def main() -> None:
+    """Bind uvicorn on the deferring shim and boot the server behind it."""
+    import uvicorn
+
+    from omnigent.runner.transports.ws_tunnel.limits import RUNNER_TUNNEL_MAX_MESSAGE_BYTES
+
+    try:
+        # Env/config parsing only — no database traffic, so well inside the
+        # startup window. The slow parts run behind the shim in _boot().
+        resolved_config = entrypoint._resolve_config()
+        host, port = resolved_config.host, resolved_config.port
+    except Exception:  # noqa: BLE001 — startup catch-all so failures land in logs
+        _log_fatal("omnigent server configuration failed")
+        resolved_config = None
+        host = os.environ.get("HOST", "0.0.0.0")
+        port = int(os.environ.get("PORT", "8000"))
+
+    logger.info("Starting omnigent server (deferred boot) on %s:%d", host, port)
+    try:
+        uvicorn.run(
+            _DeferredApp(resolved_config),
+            host=host,
+            port=port,
+            ws_max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
+        )
+    except Exception:
+        _log_fatal("uvicorn exited")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/omnigent/server/paas_env.py
+++ b/omnigent/server/paas_env.py
@@ -80,6 +80,8 @@ def detect_base_url(
     - Fly.io: ``FLY_APP_NAME`` (→ ``https://<app>.fly.dev``).
     - Hugging Face Spaces: ``SPACE_HOST`` (host only, e.g.
       ``"user-space.hf.space"``).
+    - Vercel: ``VERCEL_PROJECT_PRODUCTION_URL`` (host only; the stable
+      production domain), falling back to the per-deployment ``VERCEL_URL``.
 
     :param environ: The process environment, e.g. ``os.environ``.
     :param host: The resolved bind host, used only for the local fallback,
@@ -101,4 +103,9 @@ def detect_base_url(
     hf_host = environ.get("SPACE_HOST")
     if hf_host:
         return f"https://{hf_host}"
+    # Prefer the stable production domain over the per-deployment URL so
+    # cookies / magic links keep working across redeploys.
+    vercel_host = environ.get("VERCEL_PROJECT_PRODUCTION_URL") or environ.get("VERCEL_URL")
+    if vercel_host:
+        return f"https://{vercel_host}"
     return f"http://{host}:{port}"

--- a/omnigent/stores/artifact_store/vercel_blob.py
+++ b/omnigent/stores/artifact_store/vercel_blob.py
@@ -1,0 +1,197 @@
+"""Vercel Blob implementation of ArtifactStore.
+
+Stores artifact blobs in a **private** Vercel Blob store over the network,
+so the artifact store survives an ephemeral or multi-replica deployment —
+the Vercel-native counterpart of :class:`~omnigent.stores.artifact_store.s3.S3ArtifactStore`
+for deploys where no S3-compatible bucket is available (Vercel has no
+persistent disk and its marketplace offers no object storage).
+
+Authentication uses the ``BLOB_READ_WRITE_TOKEN`` environment variable,
+which Vercel injects automatically when a Blob store is connected to the
+project (``vercel blob create-store <name> --access private --yes``). The
+token is a long-lived static credential that Vercel documents as usable
+from code running outside Vercel too.
+
+Storage location format::
+
+    vercel-blob://[<prefix>]
+
+Requirements::
+
+    pip install vercel
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import PurePosixPath, PureWindowsPath
+
+from omnigent.stores.artifact_store import ArtifactStore
+
+_TOKEN_ENV = "BLOB_READ_WRITE_TOKEN"
+
+
+def _ensure_sdk() -> None:
+    """
+    Verify that the official ``vercel`` SDK is installed.
+
+    :raises ImportError: If the package is not available.
+    """
+    try:
+        import vercel.blob  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "VercelBlobArtifactStore requires the official 'vercel' SDK. "
+            "Install with: pip install vercel"
+        ) from exc
+
+
+def _parse_blob_uri(storage_location: str) -> str:
+    """
+    Extract the optional pathname prefix from a ``vercel-blob://`` URI.
+
+    :param storage_location: The full URI, e.g. ``"vercel-blob://artifacts"``.
+    :returns: The prefix without leading/trailing slashes, ``""`` when absent.
+    :raises ValueError: If the URI doesn't start with ``vercel-blob://``.
+    """
+    if not storage_location.startswith("vercel-blob://"):
+        raise ValueError(
+            f"storage_location must start with 'vercel-blob://', got: {storage_location!r}"
+        )
+    return storage_location[len("vercel-blob://") :].strip("/")
+
+
+def _validate_key(key: str) -> None:
+    """
+    Validate an artifact key against traversal attacks.
+
+    Same validation as the other backends — reject empty keys, ``..``
+    sequences, backslashes, and absolute paths — so a crafted key can't
+    escape the configured prefix.
+
+    :param key: Forward-slash-separated artifact key, e.g.
+        ``"agents/agent_abc123/bundle.tar.gz"``.
+    :raises ValueError: If the key is invalid.
+    """
+    parts = PurePosixPath(key).parts
+    if (
+        not parts
+        or ".." in parts
+        or "\\" in key
+        or PurePosixPath(key).is_absolute()
+        or PureWindowsPath(key).is_absolute()
+    ):
+        raise ValueError(f"invalid artifact key: {key!r}")
+
+
+class VercelBlobArtifactStore(ArtifactStore):
+    """
+    Stores binary blobs in a private Vercel Blob store.
+
+    All I/O goes through the official ``vercel`` SDK — no local filesystem —
+    so the store is durable and shared across replicas. The
+    ``storage_location`` is a ``vercel-blob://[prefix]`` URI; keys are stored
+    under the prefix::
+
+        vercel-blob://artifacts
+            artifacts/agents/agent_abc123/bundle.tar.gz
+            artifacts/executor_storage/conv_123/agent.tar.gz
+
+    The Blob store must be created with **private** access; artifact blobs
+    (agent bundles, user files) must not be world-readable.
+
+    :param storage_location: Blob URI, e.g. ``"vercel-blob://artifacts"``.
+    :param token: Optional read-write token (for tests). When omitted, the
+        ``BLOB_READ_WRITE_TOKEN`` environment variable is required.
+    """
+
+    def __init__(self, storage_location: str, token: str | None = None) -> None:
+        """
+        Initialize the Vercel Blob artifact store.
+
+        :param storage_location: Blob URI, e.g. ``"vercel-blob://artifacts"``.
+        :param token: Optional read-write token override.
+        :raises ImportError: If the ``vercel`` SDK is not installed.
+        :raises ValueError: If the URI format is invalid or no token is set.
+        """
+        _ensure_sdk()
+        super().__init__(storage_location)
+        self._prefix = _parse_blob_uri(storage_location)
+        self._token = token or os.environ.get(_TOKEN_ENV) or ""
+        if not self._token:
+            raise ValueError(
+                f"VercelBlobArtifactStore requires the {_TOKEN_ENV} environment "
+                "variable (injected by Vercel when a Blob store is connected to "
+                "the project), or an explicit token."
+            )
+
+    def _resolve(self, key: str) -> str:
+        """
+        Map an artifact key to a full Blob pathname (prefix + key).
+
+        :param key: Forward-slash-separated artifact key.
+        :returns: The Blob pathname, e.g. ``"artifacts/agents/abc/bundle.tar.gz"``.
+        :raises ValueError: If the key is invalid.
+        """
+        _validate_key(key)
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    # ── ArtifactStore interface ──────────────────────────────
+
+    def put(self, key: str, data: bytes) -> None:
+        """
+        Upload bytes to the Blob store. Overwrites if the key exists.
+
+        :param key: Forward-slash-separated artifact key.
+        :param data: Raw bytes to store.
+        """
+        from vercel import blob
+
+        blob.put(
+            self._resolve(key),
+            data,
+            access="private",
+            overwrite=True,
+            token=self._token,
+        )
+
+    def get(self, key: str) -> bytes:
+        """
+        Download bytes for a key.
+
+        :param key: Forward-slash-separated artifact key.
+        :returns: The raw bytes of the stored blob.
+        :raises KeyError: If no blob exists for the key.
+        """
+        from vercel import blob
+
+        try:
+            return blob.get(self._resolve(key), access="private", token=self._token).content
+        except blob.BlobNotFoundError:
+            raise KeyError(key) from None
+
+    def delete(self, key: str) -> None:
+        """
+        Remove a blob. No-op if the key does not exist (Blob deletes are
+        idempotent).
+
+        :param key: Forward-slash-separated artifact key.
+        """
+        from vercel import blob
+
+        blob.delete(self._resolve(key), token=self._token)
+
+    def exists(self, key: str) -> bool:
+        """
+        Check whether a blob exists, via a metadata lookup (no download).
+
+        :param key: Forward-slash-separated artifact key.
+        :returns: ``True`` if the blob exists, ``False`` otherwise.
+        """
+        from vercel import blob
+
+        try:
+            blob.head(self._resolve(key), token=self._token)
+            return True
+        except blob.BlobNotFoundError:
+            return False

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -257,9 +257,23 @@ def _run_shim(app, scope: dict, received: list[dict]) -> list[dict]:
 def test_vercel_shim_serves_503_while_booting(_vercel_entrypoint) -> None:
     app = _vercel_entrypoint._DeferredApp(resolved_config=None)
     app._boot_failed = False  # still booting, not failed
-    sent = _run_shim(app, {"type": "http"}, [])
+    sent = _run_shim(app, {"type": "http", "headers": []}, [])
     assert sent[0]["status"] == 503
     assert (b"retry-after", b"5") in sent[0]["headers"]
+    assert (b"content-type", b"application/json") in sent[0]["headers"]
+
+
+def test_vercel_shim_serves_html_retry_page_to_browsers(_vercel_entrypoint) -> None:
+    # A browser landing in the boot window must get an auto-refreshing page,
+    # not a raw JSON blob that reads as "the app is down".
+    app = _vercel_entrypoint._DeferredApp(resolved_config=None)
+    app._boot_failed = False
+    scope = {"type": "http", "headers": [(b"accept", b"text/html,application/xhtml+xml")]}
+    sent = _run_shim(app, scope, [])
+    assert sent[0]["status"] == 503
+    assert (b"content-type", b"text/html; charset=utf-8") in sent[0]["headers"]
+    assert (b"cache-control", b"no-store") in sent[0]["headers"]
+    assert b'http-equiv="refresh"' in sent[1]["body"]
 
 
 def test_vercel_shim_denies_websocket_with_retryable_503(_vercel_entrypoint) -> None:
@@ -269,11 +283,10 @@ def test_vercel_shim_denies_websocket_with_retryable_503(_vercel_entrypoint) -> 
     app._boot_failed = False
     scope = {"type": "websocket", "extensions": {"websocket.http.response": {}}}
     sent = _run_shim(app, scope, [{"type": "websocket.connect"}])
-    assert sent[0] == {
-        "type": "websocket.http.response.start",
-        "status": 503,
-        "headers": [(b"content-type", b"application/json"), (b"retry-after", b"5")],
-    }
+    assert sent[0]["type"] == "websocket.http.response.start"
+    assert sent[0]["status"] == 503
+    assert (b"content-type", b"application/json") in sent[0]["headers"]
+    assert (b"retry-after", b"5") in sent[0]["headers"]
     assert sent[1]["type"] == "websocket.http.response.body"
 
 

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -105,6 +105,7 @@ def _entrypoint_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("ARTIFACT_DIR", str(tmp_path / "artifacts"))
     monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
     monkeypatch.delenv("OMNIGENT_ARTIFACT_URI", raising=False)
+    monkeypatch.delenv("BLOB_READ_WRITE_TOKEN", raising=False)
 
 
 def test_resolve_config_captures_s3_artifact_uri(
@@ -132,6 +133,27 @@ def test_resolve_config_rejects_non_s3_artifact_uri(
         _resolve_config()
 
 
+def test_resolve_config_defaults_to_vercel_blob_on_token(
+    _entrypoint_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A BLOB_READ_WRITE_TOKEN (Vercel injects it when a Blob store is
+    connected) selects Vercel Blob with zero artifact config."""
+    from deploy.docker.entrypoint import _resolve_config
+
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", "vercel_blob_rw_x")
+    assert _resolve_config().artifact_store_uri == "vercel-blob://"
+
+
+def test_resolve_config_explicit_uri_beats_blob_token(
+    _entrypoint_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from deploy.docker.entrypoint import _resolve_config
+
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", "vercel_blob_rw_x")
+    monkeypatch.setenv("OMNIGENT_ARTIFACT_URI", "s3://my-bucket/artifacts")
+    assert _resolve_config().artifact_store_uri == "s3://my-bucket/artifacts"
+
+
 @pytest.mark.parametrize(
     ("artifact_store_uri", "expected_type"),
     [
@@ -153,3 +175,123 @@ def test_select_artifact_store(
         port=8000,
     )
     assert isinstance(_select_artifact_store(resolved), expected_type)
+
+
+def test_select_artifact_store_vercel_blob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tests.stores.test_vercel_blob_artifact_store import _install_fake_blob_sdk
+
+    _install_fake_blob_sdk(monkeypatch)
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", "vercel_blob_rw_x")
+
+    from deploy.docker.entrypoint import _ResolvedConfig, _select_artifact_store
+    from omnigent.stores.artifact_store.vercel_blob import VercelBlobArtifactStore
+
+    resolved = _ResolvedConfig(
+        cfg={},
+        database_url="postgresql://localhost/omnigent",
+        artifact_dir=tmp_path,
+        artifact_store_uri="vercel-blob://",
+        host="0.0.0.0",
+        port=8000,
+    )
+    assert isinstance(_select_artifact_store(resolved), VercelBlobArtifactStore)
+
+
+# ── Vercel bind-first entrypoint ─────────────────────────────────────────
+# deploy/vercel/entrypoint.py wraps the standard entrypoint for Vercel's 15 s
+# container-startup window: it must bind before booting, so importing it has
+# to stay as cheap as importing the standard entrypoint, and its deferring
+# shim must answer retryable statuses (503, not a bare WS close that clients
+# see as a fatal 403) until the real app is ready.
+
+_VERCEL_ENTRYPOINT_MODULE = "deploy.vercel.entrypoint"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def _vercel_entrypoint(monkeypatch: pytest.MonkeyPatch):
+    """Import the Vercel entrypoint the way the image lays it out.
+
+    In the image both files sit in /app, so the module does a top-level
+    ``import entrypoint``; in the repo that target lives at
+    deploy/docker/entrypoint.py, so put that directory on sys.path.
+    """
+    monkeypatch.syspath_prepend(str(_REPO_ROOT / "deploy" / "docker"))
+    monkeypatch.delitem(sys.modules, "entrypoint", raising=False)
+    monkeypatch.delitem(sys.modules, _VERCEL_ENTRYPOINT_MODULE, raising=False)
+    return importlib.import_module(_VERCEL_ENTRYPOINT_MODULE)
+
+
+def test_vercel_entrypoint_imports_without_side_effects(
+    _fresh_entrypoint_import: list[str],
+    _vercel_entrypoint,
+) -> None:
+    # Same inertness contract as the standard entrypoint: no engine, no app,
+    # and none of the heavy boot modules pulled in at import time — a heavy
+    # import here would eat into Vercel's 15 s accept-connections window.
+    assert callable(_vercel_entrypoint.main)
+    assert _fresh_entrypoint_import == []
+    for module_name in _BOOT_MODULES:
+        assert module_name not in sys.modules
+
+
+def _run_shim(app, scope: dict, received: list[dict]) -> list[dict]:
+    """Drive one ASGI exchange against the deferring shim."""
+    import asyncio
+
+    sent: list[dict] = []
+    inbox = list(received)
+
+    async def receive() -> dict:
+        return inbox.pop(0)
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    asyncio.run(app(scope, receive, send))
+    return sent
+
+
+def test_vercel_shim_serves_503_while_booting(_vercel_entrypoint) -> None:
+    app = _vercel_entrypoint._DeferredApp(resolved_config=None)
+    app._boot_failed = False  # still booting, not failed
+    sent = _run_shim(app, {"type": "http"}, [])
+    assert sent[0]["status"] == 503
+    assert (b"retry-after", b"5") in sent[0]["headers"]
+
+
+def test_vercel_shim_denies_websocket_with_retryable_503(_vercel_entrypoint) -> None:
+    # A bare pre-accept close surfaces to tunnel clients as a fatal 403; the
+    # shim must use the denial-response extension so hosts/runners retry.
+    app = _vercel_entrypoint._DeferredApp(resolved_config=None)
+    app._boot_failed = False
+    scope = {"type": "websocket", "extensions": {"websocket.http.response": {}}}
+    sent = _run_shim(app, scope, [{"type": "websocket.connect"}])
+    assert sent[0] == {
+        "type": "websocket.http.response.start",
+        "status": 503,
+        "headers": [(b"content-type", b"application/json"), (b"retry-after", b"5")],
+    }
+    assert sent[1]["type"] == "websocket.http.response.body"
+
+
+def test_vercel_shim_closes_websocket_without_denial_extension(_vercel_entrypoint) -> None:
+    app = _vercel_entrypoint._DeferredApp(resolved_config=None)
+    app._boot_failed = False
+    sent = _run_shim(app, {"type": "websocket"}, [{"type": "websocket.connect"}])
+    assert sent == [{"type": "websocket.close", "code": 1013}]
+
+
+def test_vercel_shim_delegates_once_ready(_vercel_entrypoint) -> None:
+    app = _vercel_entrypoint._DeferredApp(resolved_config=None)
+    delegated: list[dict] = []
+
+    async def real_app(scope, receive, send) -> None:
+        delegated.append(scope)
+
+    app._real_app = real_app
+    sent = _run_shim(app, {"type": "http", "path": "/health"}, [])
+    assert delegated == [{"type": "http", "path": "/health"}]
+    assert sent == []

--- a/tests/server/test_paas_env.py
+++ b/tests/server/test_paas_env.py
@@ -70,6 +70,21 @@ def test_resolve_bind_host(configured_host: str | None, environ: dict[str, str],
         ),
         # Precedence: Fly beats HF when only those two are set.
         ({"FLY_APP_NAME": "myapp", "SPACE_HOST": "user-space.hf.space"}, "https://myapp.fly.dev"),
+        # Vercel: the stable production domain wins over the per-deployment URL.
+        (
+            {
+                "VERCEL_PROJECT_PRODUCTION_URL": "myapp.vercel.app",
+                "VERCEL_URL": "myapp-abc123.vercel.app",
+            },
+            "https://myapp.vercel.app",
+        ),
+        # Vercel: per-deployment URL is the fallback (preview deploys).
+        ({"VERCEL_URL": "myapp-abc123.vercel.app"}, "https://myapp-abc123.vercel.app"),
+        # Precedence: HF beats Vercel when both are set.
+        (
+            {"SPACE_HOST": "user-space.hf.space", "VERCEL_URL": "myapp-abc123.vercel.app"},
+            "https://user-space.hf.space",
+        ),
         # No provider var → local fallback to the bind address.
         ({}, "http://0.0.0.0:8000"),
     ],

--- a/tests/stores/test_vercel_blob_artifact_store.py
+++ b/tests/stores/test_vercel_blob_artifact_store.py
@@ -1,0 +1,146 @@
+"""Unit tests for VercelBlobArtifactStore against a faked ``vercel.blob`` SDK.
+
+The official ``vercel`` SDK is an optional runtime dependency (installed only
+in the Vercel deploy image), so these tests install an in-memory fake of the
+``vercel.blob`` module surface the store uses — ``put`` / ``get`` / ``head`` /
+``delete`` / ``BlobNotFoundError`` — and exercise the store's key resolution,
+error mapping, and token handling on top of it.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+
+_TOKEN = "vercel_blob_rw_test_token"
+
+
+@dataclass
+class _FakeGetResult:
+    content: bytes
+
+
+def _install_fake_blob_sdk(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, bytes], list]:
+    """Install an in-memory ``vercel.blob`` fake; returns (blobs, put_calls)."""
+    blobs: dict[str, bytes] = {}
+    put_calls: list[dict] = []
+
+    blob_module = types.ModuleType("vercel.blob")
+
+    class BlobNotFoundError(Exception):
+        pass
+
+    def put(path: str, body: bytes, *, access: str, overwrite: bool, token: str) -> None:
+        put_calls.append({"path": path, "access": access, "overwrite": overwrite, "token": token})
+        blobs[path] = body
+
+    def get(path: str, *, access: str, token: str) -> _FakeGetResult:
+        if path not in blobs:
+            raise BlobNotFoundError()
+        return _FakeGetResult(content=blobs[path])
+
+    def head(path: str, *, token: str) -> object:
+        if path not in blobs:
+            raise BlobNotFoundError()
+        return object()
+
+    def delete(path: str, *, token: str) -> None:
+        blobs.pop(path, None)
+
+    blob_module.BlobNotFoundError = BlobNotFoundError
+    blob_module.put = put
+    blob_module.get = get
+    blob_module.head = head
+    blob_module.delete = delete
+
+    vercel_module = types.ModuleType("vercel")
+    vercel_module.blob = blob_module
+    monkeypatch.setitem(sys.modules, "vercel", vercel_module)
+    monkeypatch.setitem(sys.modules, "vercel.blob", blob_module)
+    return blobs, put_calls
+
+
+@pytest.fixture()
+def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, bytes], list]:
+    return _install_fake_blob_sdk(monkeypatch)
+
+
+@pytest.fixture()
+def blob_store(fake_sdk):
+    from omnigent.stores.artifact_store.vercel_blob import VercelBlobArtifactStore
+
+    return VercelBlobArtifactStore("vercel-blob://artifacts", token=_TOKEN)
+
+
+def test_put_and_get_roundtrip(blob_store) -> None:
+    blob_store.put("agents/agent_abc/bundle.tar.gz", b"bundle-data")
+    assert blob_store.get("agents/agent_abc/bundle.tar.gz") == b"bundle-data"
+
+
+def test_keys_are_prefixed_and_private(blob_store, fake_sdk) -> None:
+    """Keys land under the URI prefix, uploaded private with overwrite —
+    artifact blobs must never be world-readable and re-puts must win."""
+    blobs, put_calls = fake_sdk
+    blob_store.put("k", b"v")
+    assert list(blobs) == ["artifacts/k"]
+    assert put_calls == [
+        {"path": "artifacts/k", "access": "private", "overwrite": True, "token": _TOKEN}
+    ]
+
+
+def test_no_prefix_uri(fake_sdk) -> None:
+    from omnigent.stores.artifact_store.vercel_blob import VercelBlobArtifactStore
+
+    blobs, _ = fake_sdk
+    store = VercelBlobArtifactStore("vercel-blob://", token=_TOKEN)
+    store.put("agents/a/bundle.tar.gz", b"x")
+    assert list(blobs) == ["agents/a/bundle.tar.gz"]
+
+
+def test_get_missing_raises_key_error(blob_store) -> None:
+    """A missing key must raise KeyError (not the SDK's BlobNotFoundError) so
+    callers like the agent-bundle loader catch a stable exception type."""
+    with pytest.raises(KeyError, match="no-such-key"):
+        blob_store.get("no-such-key")
+
+
+def test_exists_and_delete_idempotent(blob_store) -> None:
+    assert not blob_store.exists("k")
+    blob_store.put("k", b"v")
+    assert blob_store.exists("k")
+    blob_store.delete("k")
+    blob_store.delete("k")  # idempotent
+    assert not blob_store.exists("k")
+
+
+@pytest.mark.parametrize("bad_key", ["", "../escape", "a/../../b", "/absolute", "back\\slash"])
+def test_invalid_keys_rejected(blob_store, bad_key: str) -> None:
+    with pytest.raises(ValueError, match="invalid artifact key"):
+        blob_store.put(bad_key, b"x")
+
+
+def test_bad_uri_scheme_rejected(fake_sdk) -> None:
+    from omnigent.stores.artifact_store.vercel_blob import VercelBlobArtifactStore
+
+    with pytest.raises(ValueError, match="vercel-blob://"):
+        VercelBlobArtifactStore("s3://bucket", token=_TOKEN)
+
+
+def test_token_from_env(fake_sdk, monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.stores.artifact_store.vercel_blob import VercelBlobArtifactStore
+
+    _, put_calls = fake_sdk
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", "env-token")
+    VercelBlobArtifactStore("vercel-blob://").put("k", b"v")
+    assert put_calls[0]["token"] == "env-token"
+
+
+def test_missing_token_rejected(fake_sdk, monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnigent.stores.artifact_store.vercel_blob import VercelBlobArtifactStore
+
+    monkeypatch.delenv("BLOB_READ_WRITE_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="BLOB_READ_WRITE_TOKEN"):
+        VercelBlobArtifactStore("vercel-blob://")

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["iad1"]
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Vercel's Fluid compute now terminates WebSockets (public beta, June 2026) and runs Dockerfiles (June 30, 2026), which is enough to host the Omnigent server: connections are cut at the function duration cap (300 s Hobby / 800 s Pro) and the runner/host tunnels' existing auto-reconnect absorbs the churn. This adds `deploy/vercel/` as a fully Vercel-native target — Neon Postgres and a private Vercel Blob store both provisioned through Vercel's marketplace, no external accounts.

**ELI5:** you `vercel deploy` from the repo root, run `vercel install neon` + `vercel blob create-store`, and get a working multi-user Omnigent server on `*.vercel.app`. Your laptop's runner tunnels reconnect every ~5 minutes (Vercel's cap) instead of staying up forever — fine for kicking the tires, documented as such.

```
browser/runner ──► Vercel Fluid container (Dockerfile.vercel → prebuilt image)
                     │  bind-first entrypoint: uvicorn up in <1 s,
                     │  503s while migrations/boot run behind it
                     ├──► Neon Postgres   (marketplace, DATABASE_URL injected)
                     └──► Vercel Blob     (private store, BLOB_READ_WRITE_TOKEN injected)
```

What each piece is for (all three forced by live validation, not speculation):

- **`Dockerfile.vercel`** (repo root, auto-detected): `FROM` the prebuilt server image; absolute `/opt/venv/bin/python` in `CMD` because Vercel's runtime overrides `PATH` (bare `python` resolves to the system interpreter and crash-loops); installs the `vercel` + `boto3` SDKs for the remote artifact stores.
- **`deploy/vercel/entrypoint.py`** (bind-first shim): Vercel kills containers that don't accept TCP within **15 s**, but boot takes 10–60 s (migrations against Neon). The shim binds immediately, answers HTTP 503 and — critically — denies WebSocket upgrades with a **retryable 503 via the denial-response extension** (a bare pre-accept close surfaces as HTTP 403, which the host/runner clients classify as fatal and stop reconnecting), then delegates to the real app.
- **`VercelBlobArtifactStore`**: Vercel has no persistent disk and its marketplace has no S3-compatible object storage, so the artifact store must be remote; this backend uses the official `vercel` Python SDK against a private Blob store, auto-selected by the entrypoint when `BLOB_READ_WRITE_TOKEN` is present (explicit `vercel-blob://[prefix]` URIs also accepted alongside `s3://`).
- **`paas_env`**: Vercel public-URL detection (`VERCEL_PROJECT_PRODUCTION_URL` → `VERCEL_URL`) so accounts auth needs zero URL config.
- **Known edge (unchanged behavior, noted for reviewers):** `_ensure_builtin_agent` skips the bundle upload when the DB row's content hash is current, so switching an *existing* deployment to a new artifact store leaves built-in bundles missing until the row changes; fresh deploys (the documented path) are unaffected.

## Test Plan

Validated against a **live Vercel production deploy** (`omnigent.vercel.app`, Hobby plan) plus local Docker repros of the image:

- `vercel deploy --prod` from the repo root: `Dockerfile.vercel` auto-detected, image built remotely on Vercel's builders (~30 s), no local Docker.
- Fresh-install boot: wiped Neon schema → first request 503s → migrations + 11 built-in agents registered in ~14 s → `/health` 200. All 11 agent bundles observed in the private Blob store (`vercel blob list`).
- Auth: web Setup screen claimed the first admin; `omnigent login` (accounts mode) from the CLI.
- Tunnel churn (the core risk): host tunnel observed across three duration-cap cycles — cut at ~310 s, classified as an ingress recycle, retried through the replacement instance's boot-time 503s, reconnected in ~20 s, repeatedly, hands-free. (Before the WS denial fix, the reconnect died fatally on HTTP 403 — regression covered by unit test.)
- Full session E2E: `POST /v1/sessions` (claude-native agent, host on my laptop) → runner + tmux Claude TUI launched via the host tunnel → posted a user message → TUI replied `VERCEL_E2E_OK` → reply mirrored back through the runner tunnel into the conversation via the API.
- Zero-config port: no `PORT` project var needed (image `ENV PORT=80`, container runs as root on Vercel).
- Unit suites: `tests/stores/test_vercel_blob_artifact_store.py` (13 tests, faked `vercel.blob` SDK), `tests/deploy/test_docker_entrypoint_import.py` (import-inertness + shim ASGI behavior + store selection), `tests/server/test_paas_env.py` — all passing.

## Demo

N/A (non-visual: deploy target + backend store; behavior shown in the Test Plan).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The platform-dependent behaviors (15 s startup window, PATH override, WS duration cuts, denial-response handling by live tunnel clients, Blob writes from the deployed server) can only be exercised against Vercel itself; they were verified manually on a live production deploy as described in the Test Plan. Everything unit-testable is unit-tested: the Blob store backend (against a faked SDK), the deferring shim's ASGI behavior (including the retryable-503 WS denial that keeps tunnel clients reconnecting), entrypoint store selection/auto-detection, and Vercel base-URL detection.
