### PR TITLE
fix(runner) Share MCP servers across specs

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2597,8 +2597,8 @@ def _start_cli_runner_process(
         ``~/.omnigent/logs`` location; tests should pass a
         temporary directory to avoid writing to the developer's
         real home.
-    :param prewarm_spec_path: Optional YAML path; the runner spawns
-        its MCPs during the upload window. See designs/RUNNER_MCP.md.
+    :param prewarm_spec_path: Optional YAML path; the runner registers
+        its MCP routing metadata during startup without opening transports.
     :param isolate_session: ``True`` for shared-host runners;
         enables per-session workspace isolation so each
         session gets its own subdirectory. ``False`` (default)

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1007,7 +1007,7 @@ def create_app(
     )
 
     async def _start_pm() -> None:
-        """Start harness process manager; kick off MCP prewarm if requested."""
+        """Start harness process manager; register MCP prewarm metadata if requested."""
         await pm.start()
         prewarm_path = os.environ.get(_RUNNER_PREWARM_SPEC_PATH_ENV_VAR)
         if prewarm_path and mcp_manager is not None:
@@ -1021,7 +1021,7 @@ def create_app(
                 prewarm_spec = _load_spec(Path(prewarm_path), expand_env=True)
                 await mcp_manager.prewarm(prewarm_spec)
                 _logger.info(
-                    "runner MCP prewarm scheduled for %s (servers=%d)",
+                    "runner MCP prewarm registered for %s (servers=%d)",
                     prewarm_path,
                     len(prewarm_spec.mcp_servers or []),
                 )

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -46,20 +46,33 @@ _POOL_SPEC_CAPACITY = 8
 
 
 @dataclass
-class _ServerEntry:
-    """One MCP server within a spec's pool entry."""
+class _SharedServerEntry:
+    """One live MCP server connection shared by any spec with the same config."""
 
+    server_hash: str
     config: MCPServerConfig
     connection: McpServerConnection | None = None
     tools: list[McpToolDef] = field(default_factory=list)
     error: str | None = None
+    ref_count: int = 0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+
+
+@dataclass
+class _SpecServerRef:
+    """A spec-specific name/filter pointing at a shared MCP server."""
+
+    config: MCPServerConfig
+    server_hash: str
+    entry: _SharedServerEntry
 
 
 @dataclass
 class _SpecEntry:
     spec_hash: str
-    servers: dict[str, _ServerEntry] = field(default_factory=dict)
-    prewarm_task: asyncio.Task[None] | None = None
+    servers: dict[str, _SpecServerRef] = field(default_factory=dict)
+    server_hashes: set[str] = field(default_factory=set)
+    connect_task: asyncio.Task[None] | None = None
 
 
 @dataclass(frozen=True)
@@ -81,13 +94,53 @@ def compute_spec_hash(configs: list[MCPServerConfig], cwd: Path | None = None) -
                     "name": c.name,
                     "transport": c.transport,
                     "url": c.url,
+                    "headers": dict(c.headers or {}),
+                    "databricks_profile": c.databricks_profile,
                     "command": c.command,
                     "args": list(c.args or []),
                     "env": dict(c.env or {}),
                     "tools": list(getattr(c, "tools", None) or []),
+                    "timeout": c.timeout,
+                    "retry": _retry_payload(c.retry),
                 }
                 for c in configs
             ],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _retry_payload(retry: Any | None) -> Any:
+    """Return a stable JSON payload for a retry policy-like object."""
+    if retry is None:
+        return None
+    to_json = getattr(retry, "to_json", None)
+    if callable(to_json):
+        return json.loads(to_json())
+    return repr(retry)
+
+
+def compute_server_hash(config: MCPServerConfig, cwd: Path | None = None) -> str:
+    """Stable content hash over fields that determine one MCP connection.
+
+    ``name`` and ``tools`` are intentionally excluded: two specs can expose
+    the same underlying server with different namespaces or allow-lists while
+    sharing one transport/subprocess.
+    """
+    payload = json.dumps(
+        {
+            "cwd": str(cwd) if config.transport == "stdio" and cwd is not None else None,
+            "transport": config.transport,
+            "url": config.url,
+            "headers": dict(config.headers or {}),
+            "databricks_profile": config.databricks_profile,
+            "command": config.command,
+            "args": list(config.args or []),
+            "env": dict(config.env or {}),
+            "timeout": config.timeout,
+            "retry": _retry_payload(config.retry),
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -171,6 +224,7 @@ class RunnerMcpManager:
             API. When ``None``, inline elicitations are declined.
         """
         self._specs: dict[str, _SpecEntry] = {}
+        self._servers: dict[str, _SharedServerEntry] = {}
         self._lru: list[str] = []  # most-recent at end
         self._lock = asyncio.Lock()
         # Hold strong refs to fire-and-forget eviction-close tasks so
@@ -277,21 +331,17 @@ class RunnerMcpManager:
         return _elicit
 
     async def prewarm(self, spec: AgentSpec) -> None:
-        """Fire-and-forget background spawn of *spec*'s MCPs. Idempotent."""
+        """Register *spec*'s MCPs without spawning transports. Idempotent."""
         configs = list(spec.mcp_servers or [])
         if not configs:
             return
         spec_hash = compute_spec_hash(configs, self._stdio_cwd)
         async with self._lock:
-            entry = self._ensure_entry(spec_hash, configs)
-            if entry.prewarm_task is None or entry.prewarm_task.done():
-                entry.prewarm_task = asyncio.create_task(
-                    self._connect_all(entry),
-                    name=f"runner-mcp-prewarm:{spec_hash}",
-                )
+            self._ensure_entry(spec_hash, configs)
+            self._touch(spec_hash)
 
     async def schemas_for(self, spec: AgentSpec) -> McpSchemasResult:
-        """Resolve MCP schemas for *spec*; awaits any in-flight prewarm."""
+        """Resolve MCP schemas for *spec*; awaits any in-flight connect."""
         configs = list(spec.mcp_servers or [])
         if not configs:
             return McpSchemasResult(schemas=[], tool_names=set(), failures={})
@@ -299,36 +349,37 @@ class RunnerMcpManager:
         async with self._lock:
             entry = self._ensure_entry(spec_hash, configs)
             self._touch(spec_hash)
-            prewarm = entry.prewarm_task
-            needs_connect = any(s.connection is None for s in entry.servers.values())
-            if needs_connect and (prewarm is None or prewarm.done()):
-                entry.prewarm_task = asyncio.create_task(
+            connect_task = entry.connect_task
+            needs_connect = any(s.entry.connection is None for s in entry.servers.values())
+            if needs_connect and (connect_task is None or connect_task.done()):
+                entry.connect_task = asyncio.create_task(
                     self._connect_all(entry),
                     name=f"runner-mcp-on-demand:{spec_hash}",
                 )
-                prewarm = entry.prewarm_task
+                connect_task = entry.connect_task
 
-        # Await outside the lock so concurrent prewarms can proceed.
-        if prewarm is not None:
+        # Await outside the lock so concurrent connects can proceed.
+        if connect_task is not None:
             try:
-                await prewarm
+                await connect_task
             except Exception:
-                _logger.exception("runner mcp prewarm task raised; surfacing partial results")
+                _logger.exception("runner mcp connect task raised; surfacing partial results")
 
         schemas: list[dict[str, Any]] = []
         tool_names: set[str] = set()
         failures: dict[str, str] = {}
-        for server in entry.servers.values():
+        for ref in entry.servers.values():
+            server = ref.entry
             if server.error is not None:
-                failures[server.config.name] = server.error
+                failures[ref.config.name] = server.error
                 continue
             allowed = (
-                set(getattr(server.config, "tools", None) or [])
-                if getattr(server.config, "tools", None)
+                set(getattr(ref.config, "tools", None) or [])
+                if getattr(ref.config, "tools", None)
                 else None
             )
             for td in server.tools:
-                schema = _mcp_tool_schema(server.config.name, td, allowed)
+                schema = _mcp_tool_schema(ref.config.name, td, allowed)
                 if schema is None:
                     continue
                 schemas.append(schema)
@@ -363,15 +414,11 @@ class RunnerMcpManager:
                 f"runner has no MCPs registered for this spec; cannot dispatch {tool_name!r}"
             )
         spec_hash = compute_spec_hash(configs, self._stdio_cwd)
-        entry = self._specs.get(spec_hash)
-        if entry is None:
-            # Dispatch before schemas_for(): populate + await prewarm.
-            await self.schemas_for(spec)
-            entry = self._specs.get(spec_hash)
-        if entry is None:
-            raise RuntimeError(f"runner failed to initialize MCPs for spec {spec.name!r}")
+        async with self._lock:
+            entry = self._ensure_entry(spec_hash, configs)
+            self._touch(spec_hash)
 
-        route = self._resolve_tool_route(spec, tool_name)
+        route = await self._resolve_tool_route_connected(entry, spec, tool_name)
         if route is None:
             raise RuntimeError(f"runner has no live MCP serving tool {tool_name!r}")
         owning_server, bare_name = route
@@ -388,7 +435,7 @@ class RunnerMcpManager:
         self,
         spec: AgentSpec,
         tool_name: str,
-    ) -> tuple[_ServerEntry, str] | None:
+    ) -> tuple[_SharedServerEntry, str] | None:
         """
         Find the live server and bare MCP tool name for *tool_name*.
 
@@ -402,10 +449,11 @@ class RunnerMcpManager:
         entry = self._specs.get(spec_hash)
         if entry is None:
             return None
-        for server in entry.servers.values():
+        for ref in entry.servers.values():
+            server = ref.entry
             if server.error is not None:
                 continue
-            prefix = f"{server.config.name}__"
+            prefix = f"{ref.config.name}__"
             if tool_name.startswith(prefix):
                 bare_tool = tool_name[len(prefix) :]
                 if any(td.name == bare_tool for td in server.tools):
@@ -419,7 +467,7 @@ class RunnerMcpManager:
         self,
         spec: AgentSpec,
         tool_name: str,
-    ) -> _ServerEntry | None:
+    ) -> _SharedServerEntry | None:
         """
         Find the server entry that owns *tool_name*.
 
@@ -429,7 +477,7 @@ class RunnerMcpManager:
 
         :param spec: Agent spec whose MCP servers to search.
         :param tool_name: Namespaced or bare MCP tool name.
-        :returns: The owning ``_ServerEntry``, or ``None`` if the
+        :returns: The owning shared server entry, or ``None`` if the
             tool is not found.
         """
         route = self._resolve_tool_route(spec, tool_name)
@@ -437,21 +485,22 @@ class RunnerMcpManager:
 
     async def shutdown(self) -> None:
         """Best-effort close of every active MCP connection."""
-        for spec_hash, entry in list(self._specs.items()):
-            if entry.prewarm_task is not None and not entry.prewarm_task.done():
-                entry.prewarm_task.cancel()
-            for server in entry.servers.values():
-                if server.connection is None:
-                    continue
-                try:
-                    await server.connection.close()
-                except Exception:
-                    _logger.exception(
-                        "error closing MCP %r in spec %s during shutdown",
-                        server.config.name,
-                        spec_hash,
-                    )
+        for _spec_hash, entry in list(self._specs.items()):
+            if entry.connect_task is not None and not entry.connect_task.done():
+                entry.connect_task.cancel()
+        for server_hash, server in list(self._servers.items()):
+            if server.connection is None:
+                continue
+            try:
+                await server.connection.close()
+            except Exception:
+                _logger.exception(
+                    "error closing MCP %r (%s) during shutdown",
+                    server.config.name,
+                    server_hash,
+                )
         self._specs.clear()
+        self._servers.clear()
         self._lru.clear()
 
     def _ensure_entry(self, spec_hash: str, configs: list[MCPServerConfig]) -> _SpecEntry:
@@ -461,7 +510,19 @@ class RunnerMcpManager:
             return entry
         entry = _SpecEntry(spec_hash=spec_hash)
         for cfg in configs:
-            entry.servers[cfg.name] = _ServerEntry(config=cfg)
+            server_hash = compute_server_hash(cfg, self._stdio_cwd)
+            server = self._servers.get(server_hash)
+            if server is None:
+                server = _SharedServerEntry(server_hash=server_hash, config=cfg)
+                self._servers[server_hash] = server
+            if server_hash not in entry.server_hashes:
+                server.ref_count += 1
+                entry.server_hashes.add(server_hash)
+            entry.servers[cfg.name] = _SpecServerRef(
+                config=cfg,
+                server_hash=server_hash,
+                entry=server,
+            )
         self._specs[spec_hash] = entry
         self._lru.append(spec_hash)
         self._evict_if_needed()
@@ -485,16 +546,28 @@ class RunnerMcpManager:
                 victim,
                 _POOL_SPEC_CAPACITY,
             )
-            if entry.prewarm_task is not None and not entry.prewarm_task.done():
-                entry.prewarm_task.cancel()
-            for server in entry.servers.values():
-                if server.connection is not None:
-                    task = asyncio.create_task(
-                        self._safe_close(server.connection, victim, server.config.name),
-                        name=f"runner-mcp-evict-close:{victim}:{server.config.name}",
-                    )
-                    self._evict_tasks.add(task)
-                    task.add_done_callback(self._evict_tasks.discard)
+            self._release_spec_entry(victim, entry)
+
+    def _release_spec_entry(self, spec_hash: str, entry: _SpecEntry) -> None:
+        """Release one spec entry and close shared servers no longer referenced."""
+        if entry.connect_task is not None and not entry.connect_task.done():
+            entry.connect_task.cancel()
+        for server_hash in entry.server_hashes:
+            server = self._servers.get(server_hash)
+            if server is None:
+                continue
+            server.ref_count -= 1
+            if server.ref_count > 0:
+                continue
+            self._servers.pop(server_hash, None)
+            if server.connection is None:
+                continue
+            task = asyncio.create_task(
+                self._safe_close(server.connection, spec_hash, server.config.name),
+                name=f"runner-mcp-evict-close:{spec_hash}:{server.config.name}",
+            )
+            self._evict_tasks.add(task)
+            task.add_done_callback(self._evict_tasks.discard)
 
     @staticmethod
     async def _safe_close(conn: McpServerConnection, spec_hash: str, name: str) -> None:
@@ -505,8 +578,20 @@ class RunnerMcpManager:
 
     async def _connect_all(self, entry: _SpecEntry) -> None:
         """Connect every MCP in *entry* concurrently. Failures recorded per server."""
+        unique_servers: dict[str, _SharedServerEntry] = {}
+        for ref in entry.servers.values():
+            unique_servers.setdefault(ref.server_hash, ref.entry)
+        await asyncio.gather(
+            *[
+                self._connect_server(server, entry.spec_hash)
+                for server in unique_servers.values()
+                if server.connection is None
+            ]
+        )
 
-        async def _one(server: _ServerEntry) -> None:
+    async def _connect_server(self, server: _SharedServerEntry, spec_hash: str) -> None:
+        """Connect one shared MCP server if needed."""
+        async with server.lock:
             if server.connection is not None:
                 return
             try:
@@ -520,8 +605,9 @@ class RunnerMcpManager:
                 server.tools = tools
                 server.error = None
                 _logger.info(
-                    "runner mcp connected: spec=%s server=%s tools=%d",
-                    entry.spec_hash,
+                    "runner mcp connected: spec=%s server_hash=%s server=%s tools=%d",
+                    spec_hash,
+                    server.server_hash,
                     server.config.name,
                     len(tools),
                 )
@@ -530,13 +616,36 @@ class RunnerMcpManager:
                 server.connection = None
                 server.tools = []
                 _logger.warning(
-                    "runner mcp connect failed: spec=%s server=%s error=%s",
-                    entry.spec_hash,
+                    "runner mcp connect failed: spec=%s server_hash=%s server=%s error=%s",
+                    spec_hash,
+                    server.server_hash,
                     server.config.name,
                     server.error,
                 )
 
-        await asyncio.gather(*[_one(s) for s in entry.servers.values()])
+    async def _resolve_tool_route_connected(
+        self,
+        entry: _SpecEntry,
+        spec: AgentSpec,
+        tool_name: str,
+    ) -> tuple[_SharedServerEntry, str] | None:
+        """Resolve a route, connecting only the named server when possible."""
+        if "__" in tool_name:
+            for ref in entry.servers.values():
+                prefix = f"{ref.config.name}__"
+                if not tool_name.startswith(prefix):
+                    continue
+                bare_name = tool_name[len(prefix) :]
+                await self._connect_server(ref.entry, entry.spec_hash)
+                if ref.entry.error is not None or ref.entry.connection is None:
+                    return None
+                if any(td.name == bare_name for td in ref.entry.tools):
+                    return ref.entry, bare_name
+                return None
+            return None
+
+        await self.schemas_for(spec)
+        return self._resolve_tool_route(spec, tool_name)
 
     def status_snapshot(self) -> dict[str, Any]:
         """JSON-able view of pool state for introspection."""
@@ -552,10 +661,10 @@ class RunnerMcpManager:
                         {
                             "name": s.config.name,
                             "status": "ready"
-                            if s.connection is not None and s.error is None
-                            else ("failed" if s.error else "pending"),
-                            "tools": [t.name for t in s.tools],
-                            "error": s.error,
+                            if s.entry.connection is not None and s.entry.error is None
+                            else ("failed" if s.entry.error else "pending"),
+                            "tools": [t.name for t in s.entry.tools],
+                            "error": s.entry.error,
                         }
                         for s in entry.servers.values()
                     ],

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -331,7 +331,11 @@ class RunnerMcpManager:
         return _elicit
 
     async def prewarm(self, spec: AgentSpec) -> None:
-        """Register *spec*'s MCPs without spawning transports. Idempotent."""
+        """Register *spec*'s MCPs without spawning transports.
+
+        This keeps runner startup cheap when a spec lists many MCPs; the
+        first schema lookup or tool call still pays the server cold-start.
+        """
         configs = list(spec.mcp_servers or [])
         if not configs:
             return

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -55,6 +55,7 @@ class _SharedServerEntry:
     tools: list[McpToolDef] = field(default_factory=list)
     error: str | None = None
     ref_count: int = 0
+    connect_task: asyncio.Task[None] | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
 
 
@@ -72,7 +73,6 @@ class _SpecEntry:
     spec_hash: str
     servers: dict[str, _SpecServerRef] = field(default_factory=dict)
     server_hashes: set[str] = field(default_factory=set)
-    connect_task: asyncio.Task[None] | None = None
 
 
 @dataclass(frozen=True)
@@ -353,42 +353,42 @@ class RunnerMcpManager:
         async with self._lock:
             entry = self._ensure_entry(spec_hash, configs)
             self._touch(spec_hash)
-            connect_task = entry.connect_task
-            needs_connect = any(s.entry.connection is None for s in entry.servers.values())
-            if needs_connect and (connect_task is None or connect_task.done()):
-                entry.connect_task = asyncio.create_task(
-                    self._connect_all(entry),
-                    name=f"runner-mcp-on-demand:{spec_hash}",
-                )
-                connect_task = entry.connect_task
+            refs = list(entry.servers.values())
+            for ref in refs:
+                self._retain_server_ref(ref.entry)
+            connect_tasks = {
+                ref.server_hash: task
+                for ref in refs
+                if (task := self._ensure_connect_task(ref.entry, entry.spec_hash)) is not None
+            }
 
-        # Await outside the lock so concurrent connects can proceed.
-        if connect_task is not None:
-            try:
-                await connect_task
-            except Exception:
-                _logger.exception("runner mcp connect task raised; surfacing partial results")
+        try:
+            if connect_tasks:
+                try:
+                    await asyncio.gather(*connect_tasks.values())
+                except Exception:
+                    _logger.exception("runner mcp connect task raised; surfacing partial results")
 
-        schemas: list[dict[str, Any]] = []
-        tool_names: set[str] = set()
-        failures: dict[str, str] = {}
-        for ref in entry.servers.values():
-            server = ref.entry
-            if server.error is not None:
-                failures[ref.config.name] = server.error
-                continue
-            allowed = (
-                set(getattr(ref.config, "tools", None) or [])
-                if getattr(ref.config, "tools", None)
-                else None
-            )
-            for td in server.tools:
-                schema = _mcp_tool_schema(ref.config.name, td, allowed)
-                if schema is None:
+            schemas: list[dict[str, Any]] = []
+            tool_names: set[str] = set()
+            failures: dict[str, str] = {}
+            for ref in refs:
+                server = ref.entry
+                if server.error is not None:
+                    failures[ref.config.name] = server.error
                     continue
-                schemas.append(schema)
-                tool_names.add(schema["name"])
-        return McpSchemasResult(schemas=schemas, tool_names=tool_names, failures=failures)
+                allowed = self._allowed_tools(ref)
+                for td in server.tools:
+                    schema = _mcp_tool_schema(ref.config.name, td, allowed)
+                    if schema is None:
+                        continue
+                    schemas.append(schema)
+                    tool_names.add(schema["name"])
+            return McpSchemasResult(schemas=schemas, tool_names=tool_names, failures=failures)
+        finally:
+            async with self._lock:
+                for ref in refs:
+                    self._release_server_ref(ref.entry, entry.spec_hash)
 
     async def call_tool(
         self,
@@ -418,22 +418,58 @@ class RunnerMcpManager:
                 f"runner has no MCPs registered for this spec; cannot dispatch {tool_name!r}"
             )
         spec_hash = compute_spec_hash(configs, self._stdio_cwd)
-        async with self._lock:
-            entry = self._ensure_entry(spec_hash, configs)
-            self._touch(spec_hash)
+        server_to_release: _SharedServerEntry | None = None
+        try:
+            if "__" in tool_name:
+                async with self._lock:
+                    entry = self._ensure_entry(spec_hash, configs)
+                    self._touch(spec_hash)
+                    route_ref = self._resolve_tool_ref(entry, tool_name)
+                    if route_ref is None:
+                        raise RuntimeError(f"runner has no live MCP serving tool {tool_name!r}")
+                    ref, bare_name = route_ref
+                    self._retain_server_ref(ref.entry)
+                    server_to_release = ref.entry
+                    connect_task = self._ensure_connect_task(ref.entry, entry.spec_hash)
 
-        route = await self._resolve_tool_route_connected(entry, spec, tool_name)
-        if route is None:
-            raise RuntimeError(f"runner has no live MCP serving tool {tool_name!r}")
-        owning_server, bare_name = route
-        if owning_server.connection is None:
-            raise RuntimeError(f"runner has no live MCP serving tool {tool_name!r}")
+                if connect_task is not None:
+                    await connect_task
+                if (
+                    ref.entry.error is None
+                    and ref.entry.connection is not None
+                    and self._server_has_allowed_tool(ref, bare_name)
+                ):
+                    route = (ref.entry, bare_name)
+                else:
+                    route = None
+            else:
+                await self.schemas_for(spec)
+                async with self._lock:
+                    entry = self._specs.get(spec_hash)
+                    route = (
+                        None
+                        if entry is None
+                        else self._resolve_tool_route_from_entry(entry, tool_name)
+                    )
+                    if route is not None:
+                        self._retain_server_ref(route[0])
+                        server_to_release = route[0]
 
-        return await owning_server.connection.call_tool(
-            bare_name,
-            arguments,
-            session_id=session_id,
-        )
+            if route is None:
+                raise RuntimeError(f"runner has no live MCP serving tool {tool_name!r}")
+            owning_server, bare_name = route
+            if owning_server.connection is None:
+                raise RuntimeError(f"runner has no live MCP serving tool {tool_name!r}")
+
+            return await owning_server.connection.call_tool(
+                bare_name,
+                arguments,
+                session_id=session_id,
+            )
+        finally:
+            if server_to_release is not None:
+                async with self._lock:
+                    self._release_server_ref(server_to_release, spec_hash)
 
     def _resolve_tool_route(
         self,
@@ -453,19 +489,71 @@ class RunnerMcpManager:
         entry = self._specs.get(spec_hash)
         if entry is None:
             return None
-        for ref in entry.servers.values():
+        return self._resolve_tool_route_from_entry(entry, tool_name)
+
+    def _resolve_tool_route_from_entry(
+        self,
+        entry: _SpecEntry,
+        tool_name: str,
+    ) -> tuple[_SharedServerEntry, str] | None:
+        """Find a connected, allowed MCP tool route inside *entry*."""
+        if "__" in tool_name:
+            route_ref = self._resolve_tool_ref(entry, tool_name)
+            if route_ref is None:
+                return None
+            ref, bare_tool = route_ref
+            if ref.entry.error is not None:
+                return None
+            if self._server_has_allowed_tool(ref, bare_tool):
+                return ref.entry, bare_tool
+            return None
+
+        for ref in self._ordered_server_refs(entry):
             server = ref.entry
             if server.error is not None:
                 continue
-            prefix = f"{ref.config.name}__"
-            if tool_name.startswith(prefix):
-                bare_tool = tool_name[len(prefix) :]
-                if any(td.name == bare_tool for td in server.tools):
-                    return server, bare_tool
-                return None
-            if "__" not in tool_name and any(td.name == tool_name for td in server.tools):
+            if self._server_has_allowed_tool(ref, tool_name):
                 return server, tool_name
         return None
+
+    @staticmethod
+    def _ordered_server_refs(entry: _SpecEntry) -> list[_SpecServerRef]:
+        """Prefer the longest namespace when server names overlap."""
+        return sorted(entry.servers.values(), key=lambda ref: len(ref.config.name), reverse=True)
+
+    def _resolve_tool_ref(
+        self,
+        entry: _SpecEntry,
+        tool_name: str,
+    ) -> tuple[_SpecServerRef, str] | None:
+        """Find the spec ref addressed by a namespaced tool name."""
+        if "__" not in tool_name:
+            return None
+        for ref in self._ordered_server_refs(entry):
+            prefix = f"{ref.config.name}__"
+            if not tool_name.startswith(prefix):
+                continue
+            bare_name = tool_name[len(prefix) :]
+            if not self._is_tool_allowed(ref, bare_name) or not is_valid_tool_name(bare_name):
+                return None
+            return ref, bare_name
+        return None
+
+    @staticmethod
+    def _allowed_tools(ref: _SpecServerRef) -> set[str] | None:
+        tools = getattr(ref.config, "tools", None)
+        return set(tools) if tools else None
+
+    def _is_tool_allowed(self, ref: _SpecServerRef, bare_name: str) -> bool:
+        allowed = self._allowed_tools(ref)
+        return allowed is None or bare_name in allowed
+
+    def _server_has_allowed_tool(self, ref: _SpecServerRef, bare_name: str) -> bool:
+        return (
+            self._is_tool_allowed(ref, bare_name)
+            and is_valid_tool_name(bare_name)
+            and any(td.name == bare_name for td in ref.entry.tools)
+        )
 
     def _resolve_owning_server(
         self,
@@ -489,23 +577,41 @@ class RunnerMcpManager:
 
     async def shutdown(self) -> None:
         """Best-effort close of every active MCP connection."""
-        for _spec_hash, entry in list(self._specs.items()):
-            if entry.connect_task is not None and not entry.connect_task.done():
-                entry.connect_task.cancel()
-        for server_hash, server in list(self._servers.items()):
-            if server.connection is None:
+        async with self._lock:
+            servers = list(self._servers.values())
+            connect_tasks = [
+                task
+                for server in servers
+                if (task := server.connect_task) is not None and not task.done()
+            ]
+            for server in servers:
+                server.ref_count = 0
+            self._specs.clear()
+            self._servers.clear()
+            self._lru.clear()
+            for task in connect_tasks:
+                task.cancel()
+
+        if connect_tasks:
+            await asyncio.gather(*connect_tasks, return_exceptions=True)
+
+        for server in servers:
+            conn = server.connection
+            if conn is None:
                 continue
+            server.connection = None
+            server.tools = []
             try:
-                await server.connection.close()
+                await conn.close()
             except Exception:
                 _logger.exception(
                     "error closing MCP %r (%s) during shutdown",
                     server.config.name,
-                    server_hash,
+                    server.server_hash,
                 )
-        self._specs.clear()
-        self._servers.clear()
-        self._lru.clear()
+
+        if self._evict_tasks:
+            await asyncio.gather(*list(self._evict_tasks), return_exceptions=True)
 
     def _ensure_entry(self, spec_hash: str, configs: list[MCPServerConfig]) -> _SpecEntry:
         """Return or create the pool entry for *spec_hash*. Caller holds lock."""
@@ -554,60 +660,105 @@ class RunnerMcpManager:
 
     def _release_spec_entry(self, spec_hash: str, entry: _SpecEntry) -> None:
         """Release one spec entry and close shared servers no longer referenced."""
-        if entry.connect_task is not None and not entry.connect_task.done():
-            entry.connect_task.cancel()
         for server_hash in entry.server_hashes:
             server = self._servers.get(server_hash)
-            if server is None:
-                continue
-            server.ref_count -= 1
-            if server.ref_count > 0:
-                continue
-            self._servers.pop(server_hash, None)
-            if server.connection is None:
-                continue
-            task = asyncio.create_task(
-                self._safe_close(server.connection, spec_hash, server.config.name),
-                name=f"runner-mcp-evict-close:{spec_hash}:{server.config.name}",
-            )
-            self._evict_tasks.add(task)
-            task.add_done_callback(self._evict_tasks.discard)
+            if server is not None:
+                self._release_server_ref(server, spec_hash)
 
     @staticmethod
-    async def _safe_close(conn: McpServerConnection, spec_hash: str, name: str) -> None:
+    async def _safe_close(conn: McpServerConnection, owner: str, name: str) -> None:
         try:
             await conn.close()
         except Exception:
-            _logger.exception("error closing evicted MCP %r in spec %s", name, spec_hash)
+            _logger.exception("error closing MCP %r for %s", name, owner)
 
-    async def _connect_all(self, entry: _SpecEntry) -> None:
-        """Connect every MCP in *entry* concurrently. Failures recorded per server."""
-        unique_servers: dict[str, _SharedServerEntry] = {}
-        for ref in entry.servers.values():
-            unique_servers.setdefault(ref.server_hash, ref.entry)
-        await asyncio.gather(
-            *[
-                self._connect_server(server, entry.spec_hash)
-                for server in unique_servers.values()
-                if server.connection is None
-            ]
+    def _schedule_close(self, conn: McpServerConnection, owner: str, name: str) -> None:
+        task = asyncio.create_task(
+            self._safe_close(conn, owner, name),
+            name=f"runner-mcp-close:{owner}:{name}",
         )
+        self._evict_tasks.add(task)
+        task.add_done_callback(self._evict_tasks.discard)
+
+    @staticmethod
+    def _retain_server_ref(server: _SharedServerEntry) -> None:
+        server.ref_count += 1
+
+    def _release_server_ref(self, server: _SharedServerEntry, owner: str) -> None:
+        """Release one server ref. Caller holds ``self._lock``."""
+        if server.ref_count <= 0:
+            return
+        server.ref_count -= 1
+        if server.ref_count > 0:
+            return
+        if server.connect_task is not None and not server.connect_task.done():
+            return
+
+        self._servers.pop(server.server_hash, None)
+        conn = server.connection
+        server.connection = None
+        server.tools = []
+        if conn is not None:
+            self._schedule_close(conn, owner, server.config.name)
+
+    def _ensure_connect_task(
+        self,
+        server: _SharedServerEntry,
+        spec_hash: str,
+    ) -> asyncio.Task[None] | None:
+        """Return an in-flight shared connect task, creating one if needed."""
+        if server.connection is not None:
+            return None
+        if server.connect_task is None or server.connect_task.done():
+            server.connect_task = asyncio.create_task(
+                self._connect_server(server, spec_hash),
+                name=f"runner-mcp-connect:{server.server_hash}",
+            )
+        return server.connect_task
 
     async def _connect_server(self, server: _SharedServerEntry, spec_hash: str) -> None:
         """Connect one shared MCP server if needed."""
-        async with server.lock:
-            if server.connection is not None:
-                return
-            try:
+        close_after_connect: McpServerConnection | None = None
+        current_task = asyncio.current_task()
+        try:
+            async with server.lock:
+                if server.connection is not None:
+                    return
+
                 conn = McpServerConnection(
                     config=server.config,
                     cwd=self._stdio_cwd,
                     elicitation_callback=self._build_elicitation_callback(),
                 )
-                tools = await conn.connect()
-                server.connection = conn
-                server.tools = tools
-                server.error = None
+                try:
+                    tools = await conn.connect()
+                except asyncio.CancelledError:
+                    await self._safe_close(conn, spec_hash, server.config.name)
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    async with self._lock:
+                        server.error = f"{type(exc).__name__}: {exc}"
+                        server.connection = None
+                        server.tools = []
+                    _logger.warning(
+                        "runner mcp connect failed: spec=%s server_hash=%s server=%s error=%s",
+                        spec_hash,
+                        server.server_hash,
+                        server.config.name,
+                        server.error,
+                    )
+                    return
+
+                async with self._lock:
+                    server.connection = conn
+                    server.tools = tools
+                    server.error = None
+                    if server.ref_count <= 0:
+                        self._servers.pop(server.server_hash, None)
+                        server.connection = None
+                        server.tools = []
+                        close_after_connect = conn
+
                 _logger.info(
                     "runner mcp connected: spec=%s server_hash=%s server=%s tools=%d",
                     spec_hash,
@@ -615,41 +766,23 @@ class RunnerMcpManager:
                     server.config.name,
                     len(tools),
                 )
-            except Exception as exc:  # noqa: BLE001
-                server.error = f"{type(exc).__name__}: {exc}"
-                server.connection = None
-                server.tools = []
-                _logger.warning(
-                    "runner mcp connect failed: spec=%s server_hash=%s server=%s error=%s",
-                    spec_hash,
-                    server.server_hash,
-                    server.config.name,
-                    server.error,
-                )
+        finally:
+            cleanup_conn: McpServerConnection | None = None
+            async with self._lock:
+                if server.connect_task is current_task:
+                    server.connect_task = None
+                if server.ref_count <= 0:
+                    self._servers.pop(server.server_hash, None)
+                    if server.connection is not None:
+                        cleanup_conn = server.connection
+                        server.connection = None
+                        server.tools = []
 
-    async def _resolve_tool_route_connected(
-        self,
-        entry: _SpecEntry,
-        spec: AgentSpec,
-        tool_name: str,
-    ) -> tuple[_SharedServerEntry, str] | None:
-        """Resolve a route, connecting only the named server when possible."""
-        if "__" in tool_name:
-            for ref in entry.servers.values():
-                prefix = f"{ref.config.name}__"
-                if not tool_name.startswith(prefix):
-                    continue
-                bare_name = tool_name[len(prefix) :]
-                await self._connect_server(ref.entry, entry.spec_hash)
-                if ref.entry.error is not None or ref.entry.connection is None:
-                    return None
-                if any(td.name == bare_name for td in ref.entry.tools):
-                    return ref.entry, bare_name
-                return None
-            return None
+            if cleanup_conn is not None and cleanup_conn is not close_after_connect:
+                await self._safe_close(cleanup_conn, spec_hash, server.config.name)
 
-        await self.schemas_for(spec)
-        return self._resolve_tool_route(spec, tool_name)
+        if close_after_connect is not None:
+            await self._safe_close(close_after_connect, spec_hash, server.config.name)
 
     def status_snapshot(self) -> dict[str, Any]:
         """JSON-able view of pool state for introspection."""

--- a/tests/runner/test_mcp_manager.py
+++ b/tests/runner/test_mcp_manager.py
@@ -270,9 +270,7 @@ async def test_shared_server_reused_across_different_specs(
     spec_search = _make_spec(cfg_search)
     spec_create = _make_spec(cfg_create)
 
-    assert compute_spec_hash(spec_search.mcp_servers) != compute_spec_hash(
-        spec_create.mcp_servers
-    )
+    assert compute_spec_hash(spec_search.mcp_servers) != compute_spec_hash(spec_create.mcp_servers)
     assert compute_server_hash(cfg_search) == compute_server_hash(cfg_create)
 
     manager = RunnerMcpManager()

--- a/tests/runner/test_mcp_manager.py
+++ b/tests/runner/test_mcp_manager.py
@@ -6,19 +6,22 @@ to runner-side ownership (designs/RUNNER_MCP.md):
 - partial failure: one MCP fails, others still surface their schemas
 - spec-hash pool reuse: same spec across calls shares one connection
   per server (only one connect per server lifetime)
+- per-server pool reuse: different specs sharing the same server config
+  reuse one connection while applying their own names/tool filters
 - invalid-name filtering: tools whose names violate the LLM-call
   constraint never reach the schema list
 - tool-name collision: two MCPs in the same spec exposing the same
   name produce well-defined dispatch behavior
 
 Plus new runner-side invariants the refactor introduced: LRU pool
-eviction at capacity, prewarm idempotency, and prewarm cancellation
-on shutdown.
+eviction at capacity, spawn-free prewarm registration, and on-demand
+connect cancellation on shutdown.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -31,6 +34,7 @@ from omnigent.runner.mcp_manager import (
     _POOL_SPEC_CAPACITY,
     McpSchemasResult,
     RunnerMcpManager,
+    compute_server_hash,
     compute_spec_hash,
 )
 from omnigent.spec.types import AgentSpec, MCPServerConfig
@@ -247,6 +251,45 @@ async def test_pool_separate_entries_for_different_specs(
 
 
 @pytest.mark.asyncio
+async def test_shared_server_reused_across_different_specs(
+    patch_connection: dict[str, Any],
+) -> None:
+    """Different spec hashes share one connection for identical server config.
+
+    The per-spec ``tools`` allow-list still filters schemas independently,
+    but it no longer forces another stdio/http MCP process.
+    """
+    patch_connection["__tools_for__"]["jira"] = [
+        _make_tool_def("search"),
+        _make_tool_def("create"),
+    ]
+    cfg_search = _make_config("jira")
+    cfg_search.tools = ["search"]
+    cfg_create = _make_config("jira")
+    cfg_create.tools = ["create"]
+    spec_search = _make_spec(cfg_search)
+    spec_create = _make_spec(cfg_create)
+
+    assert compute_spec_hash(spec_search.mcp_servers) != compute_spec_hash(
+        spec_create.mcp_servers
+    )
+    assert compute_server_hash(cfg_search) == compute_server_hash(cfg_create)
+
+    manager = RunnerMcpManager()
+    try:
+        first = await manager.schemas_for(spec_search)
+        second = await manager.schemas_for(spec_create)
+        snapshot = manager.status_snapshot()
+    finally:
+        await manager.shutdown()
+
+    assert first.tool_names == {"jira__search"}
+    assert second.tool_names == {"jira__create"}
+    assert patch_connection["jira"].connect_calls == 1
+    assert len(snapshot["specs"]) == 2
+
+
+@pytest.mark.asyncio
 async def test_invalid_tool_name_is_filtered(
     patch_connection: dict[str, Any],
     caplog: pytest.LogCaptureFixture,
@@ -364,6 +407,48 @@ async def test_call_tool_rejects_wrong_namespaced_server(
 
 
 @pytest.mark.asyncio
+async def test_call_tool_connects_only_target_namespaced_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct namespaced dispatch connects the addressed MCP only."""
+    connected: list[str] = []
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    class _TargetedConn:
+        """Connection stub that records which server was connected."""
+
+        def __init__(self, *, config: MCPServerConfig, cwd: Any = None, **_kwargs: Any) -> None:
+            """Record config for connect/call assertions."""
+            self._config = config
+
+        async def connect(self) -> list[McpToolDef]:
+            """Expose one tool whose name is shared across servers."""
+            connected.append(self._config.name)
+            return [_make_tool_def("run")]
+
+        async def close(self) -> None:
+            """No-op."""
+
+        async def call_tool(self, name: str, arguments: dict[str, Any], **_kw: Any) -> str:
+            """Record the call and return a stub output."""
+            calls.append((self._config.name, name, arguments))
+            return "ok"
+
+    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _TargetedConn)
+
+    spec = _make_spec(_make_config("used"), _make_config("unused"))
+    manager = RunnerMcpManager()
+    try:
+        output = await manager.call_tool(spec, "used__run", {"x": 1})
+    finally:
+        await manager.shutdown()
+
+    assert output == "ok"
+    assert connected == ["used"]
+    assert calls == [("used", "run", {"x": 1})]
+
+
+@pytest.mark.asyncio
 async def test_call_tool_against_failed_server_raises(
     patch_connection: dict[str, Any],
 ) -> None:
@@ -465,31 +550,23 @@ async def test_lru_eviction_at_pool_capacity(
 
 
 @pytest.mark.asyncio
-async def test_prewarm_is_idempotent(
+async def test_prewarm_registers_without_connecting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Calling prewarm twice with the same spec reuses the in-flight task.
-
-    Without idempotency, two background spawns would race and double the
-    cold-start cost.
-    """
+    """prewarm() records routing metadata but does not spawn MCP processes."""
     connect_calls = 0
-    started = asyncio.Event()
-    release = asyncio.Event()
 
-    class _SlowConn:
-        """Connection whose connect() blocks until *release* is set."""
+    class _CountingConn:
+        """Connection that records when an actual spawn/connect happens."""
 
         def __init__(self, *, config: MCPServerConfig, cwd: Any = None, **_kwargs: Any) -> None:
-            """Record the spawn; per-instance state is unused."""
+            """Record the config for the returned tool name."""
             self._config = config
 
         async def connect(self) -> list[McpToolDef]:
-            """Count the call, signal start, then block until released."""
+            """Count connect calls and return one tool."""
             nonlocal connect_calls
             connect_calls += 1
-            started.set()
-            await release.wait()
             return [_make_tool_def("t")]
 
         async def close(self) -> None:
@@ -499,34 +576,30 @@ async def test_prewarm_is_idempotent(
             """Unused in this test."""
             return ""
 
-    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _SlowConn)
+    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _CountingConn)
 
     spec = _make_spec(_make_config("slow"))
     manager = RunnerMcpManager()
     try:
         await manager.prewarm(spec)
-        # Wait until the first connect is actually executing so the
-        # second prewarm hits the "task in flight" branch.
-        await started.wait()
-        # Second prewarm — must NOT spawn another connect.
         await manager.prewarm(spec)
-        # Let prewarm finish so shutdown is clean.
-        release.set()
-        await manager.schemas_for(spec)
+        snapshot = manager.status_snapshot()
+        assert connect_calls == 0
+
+        result = await manager.schemas_for(spec)
     finally:
-        release.set()
         await manager.shutdown()
 
-    assert connect_calls == 1, (
-        f"second prewarm must reuse the in-flight task; got {connect_calls} connects"
-    )
+    assert snapshot["specs"][0]["servers"][0]["status"] == "pending"
+    assert result.tool_names == {"slow__t"}
+    assert connect_calls == 1
 
 
 @pytest.mark.asyncio
-async def test_shutdown_cancels_in_flight_prewarm(
+async def test_shutdown_cancels_in_flight_schema_connect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """shutdown() cancels prewarm tasks that never completed.
+    """shutdown() cancels on-demand connect tasks that never completed.
 
     Otherwise the runner would leak background tasks holding refs to
     half-opened MCP transports.
@@ -558,22 +631,25 @@ async def test_shutdown_cancels_in_flight_prewarm(
 
     spec = _make_spec(_make_config("hangs"))
     manager = RunnerMcpManager()
-    await manager.prewarm(spec)
+    schemas_task = asyncio.create_task(manager.schemas_for(spec))
     await started.wait()
-    # Capture the prewarm task ref before shutdown clears it.
+    # Capture the on-demand connect task ref before shutdown clears it.
     spec_hash = compute_spec_hash(spec.mcp_servers)
-    prewarm_task = manager._specs[spec_hash].prewarm_task
-    assert prewarm_task is not None and not prewarm_task.done(), (
-        "prewarm task must be in flight before shutdown"
+    connect_task = manager._specs[spec_hash].connect_task
+    assert connect_task is not None and not connect_task.done(), (
+        "connect task must be in flight before shutdown"
     )
 
     await manager.shutdown()
     # Give the cancellation a tick to propagate.
     await asyncio.sleep(0.01)
 
-    assert prewarm_task.cancelled() or prewarm_task.done(), (
-        "shutdown must cancel (or otherwise finalize) the in-flight prewarm task"
+    assert connect_task.cancelled() or connect_task.done(), (
+        "shutdown must cancel (or otherwise finalize) the in-flight connect task"
     )
+    schemas_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await schemas_task
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_mcp_manager.py
+++ b/tests/runner/test_mcp_manager.py
@@ -631,9 +631,9 @@ async def test_shutdown_cancels_in_flight_schema_connect(
     manager = RunnerMcpManager()
     schemas_task = asyncio.create_task(manager.schemas_for(spec))
     await started.wait()
-    # Capture the on-demand connect task ref before shutdown clears it.
-    spec_hash = compute_spec_hash(spec.mcp_servers)
-    connect_task = manager._specs[spec_hash].connect_task
+    # Capture the shared-server connect task ref before shutdown clears it.
+    server_hash = compute_server_hash(spec.mcp_servers[0])
+    connect_task = manager._servers[server_hash].connect_task
     assert connect_task is not None and not connect_task.done(), (
         "connect task must be in flight before shutdown"
     )
@@ -648,6 +648,143 @@ async def test_shutdown_cancels_in_flight_schema_connect(
     schemas_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await schemas_task
+
+
+@pytest.mark.asyncio
+async def test_evicted_spec_closes_late_completed_shared_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connect that finishes after spec eviction is still closed."""
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    closed: list[str] = []
+
+    class _SlowConn:
+        """Connection whose connect can be completed after LRU eviction."""
+
+        def __init__(self, *, config: MCPServerConfig, cwd: Any = None, **_kwargs: Any) -> None:
+            self._config = config
+
+        async def connect(self) -> list[McpToolDef]:
+            started.set()
+            await finish.wait()
+            return [_make_tool_def("run")]
+
+        async def close(self) -> None:
+            closed.append(self._config.name)
+
+        async def call_tool(self, name: str, arguments: dict[str, Any], **_kw: Any) -> str:
+            return "ok"
+
+    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _SlowConn)
+
+    spec = _make_spec(_make_config("shared"))
+    server_hash = compute_server_hash(spec.mcp_servers[0])
+    manager = RunnerMcpManager()
+    call_task = asyncio.create_task(manager.call_tool(spec, "shared__run", {}))
+    try:
+        await started.wait()
+        for i in range(_POOL_SPEC_CAPACITY):
+            await manager.prewarm(_make_spec(_make_config(f"evict-{i}")))
+
+        assert server_hash in manager._servers, "active call must keep the shared server tracked"
+        finish.set()
+        assert await call_task == "ok"
+        await asyncio.sleep(0.05)
+
+        assert server_hash not in manager._servers
+        assert closed == ["shared"]
+    finally:
+        if not call_task.done():
+            call_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await call_task
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shared_connect_survives_one_spec_eviction_while_referenced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Evicting one spec must not cancel a connect another spec still needs."""
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    connect_calls = 0
+
+    class _SlowConn:
+        """Shared connection that records connect count."""
+
+        def __init__(self, *, config: MCPServerConfig, cwd: Any = None, **_kwargs: Any) -> None:
+            self._config = config
+
+        async def connect(self) -> list[McpToolDef]:
+            nonlocal connect_calls
+            connect_calls += 1
+            started.set()
+            await finish.wait()
+            return [_make_tool_def("run"), _make_tool_def("other")]
+
+        async def close(self) -> None:
+            pass
+
+        async def call_tool(self, name: str, arguments: dict[str, Any], **_kw: Any) -> str:
+            return "ok"
+
+    monkeypatch.setattr(_mcp_manager_module, "McpServerConnection", _SlowConn)
+
+    cfg_run = _make_config("shared")
+    cfg_run.tools = ["run"]
+    cfg_other = _make_config("shared")
+    cfg_other.tools = ["other"]
+    spec_run = _make_spec(cfg_run)
+    spec_other = _make_spec(cfg_other)
+
+    manager = RunnerMcpManager()
+    call_task = asyncio.create_task(manager.call_tool(spec_run, "shared__run", {}))
+    try:
+        await started.wait()
+        await manager.prewarm(spec_other)
+        for i in range(_POOL_SPEC_CAPACITY - 1):
+            await manager.prewarm(_make_spec(_make_config(f"evict-other-{i}")))
+
+        finish.set()
+        assert await call_task == "ok"
+        schemas = await manager.schemas_for(spec_other)
+
+        assert schemas.tool_names == {"shared__other"}
+        assert connect_calls == 1
+    finally:
+        if not call_task.done():
+            call_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await call_task
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_tool_allowlist_blocks_dispatch(
+    patch_connection: dict[str, Any],
+) -> None:
+    """Per-spec tool filters apply to dispatch, not just schema listing."""
+    patch_connection["__tools_for__"]["jira"] = [
+        _make_tool_def("search"),
+        _make_tool_def("create"),
+    ]
+    cfg = _make_config("jira")
+    cfg.tools = ["search"]
+    spec = _make_spec(cfg)
+    manager = RunnerMcpManager()
+    try:
+        schemas = await manager.schemas_for(spec)
+        with pytest.raises(RuntimeError, match="no live MCP serving tool"):
+            await manager.call_tool(spec, "jira__create", {})
+        output = await manager.call_tool(spec, "jira__search", {"q": "one"})
+    finally:
+        await manager.shutdown()
+
+    assert schemas.tool_names == {"jira__search"}
+    assert output == "called search with {'q': 'one'}"
+    assert patch_connection["jira"].call_tool_calls == [("search", {"q": "one"})]
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -5,13 +5,14 @@ The endpoint resolves the opaque terminal resource id back to the
 runner-local registry entry and bridges PTY bytes to the
 browser-facing WebSocket via ``tmux attach``. These tests pin the
 route boundary and registry lookup; the actual PTY bridge is
-exercised by stubbing ``pty.fork`` / ``os.execve`` (the bridge
-logic itself is unit-tested elsewhere via the shared helper).
+exercised by stubbing the bridge spawn boundary or PTY fd (the
+bridge logic itself is unit-tested elsewhere via the shared helper).
 """
 
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -56,6 +57,19 @@ def _seed_registry(
     slot[(instance.name, instance.session_key)] = instance
 
 
+def _patch_attach_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+    on_spawn: Callable[[str, list[str], dict[str, str]], None],
+) -> None:
+    """Patch tmux attach spawn at the bridge boundary."""
+
+    def fake_fork_exec(tmux_path: str, argv: list[str], env: dict[str, str]) -> object:
+        on_spawn(tmux_path, argv, env)
+        raise RuntimeError("child exited")
+
+    monkeypatch.setattr("omnigent.terminals.ws_bridge._fork_exec_pty", fake_fork_exec)
+
+
 def test_runner_resource_attach_spawns_tmux_for_running_terminal(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -64,11 +78,9 @@ def test_runner_resource_attach_spawns_tmux_for_running_terminal(
     With a running registry entry, the runner spawns ``tmux attach``
     against the entry's local socket path.
 
-    Intercepts ``pty.fork`` to act as the child branch (returning 0)
-    so ``execve`` runs in the test process; ``execve`` is stubbed to
-    capture argv and the child env. ``_exit`` is raised as an exception so the child
-    branch terminates the test rather than continuing into the
-    parent path.
+    Intercepts the bridge's tmux attach spawn helper to capture argv
+    and child env, then raises so the websocket route unwinds without
+    touching a real PTY or tmux process.
 
     :param tmp_path: Pytest tmp directory.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -85,24 +97,11 @@ def test_runner_resource_attach_spawns_tmux_for_running_terminal(
     # argv (list) and the child env (dict) land under separate keys.
     captured: dict[str, object] = {}
 
-    def fake_fork() -> tuple[int, int]:
-        return 0, 0
-
-    def fake_execve(path: str, argv: list[str], env: dict[str, str]) -> None:
+    def record_spawn(_path: str, argv: list[str], env: dict[str, str]) -> None:
         captured["argv"] = argv
         captured["env"] = env
-        raise OSError("stop child path")
 
-    exit_exc = RuntimeError("child exited")
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.pty.fork", fake_fork)
-    # Production resolves the absolute tmux path and builds the child env
-    # in the parent; the child calls os.execve (no PATH search, explicit
-    # env) — patch execve, not execv/execvp.
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.os.execve", fake_execve)
-    monkeypatch.setattr(
-        "omnigent.terminals.ws_bridge.os._exit",
-        lambda code: (_ for _ in ()).throw(exit_exc),
-    )
+    _patch_attach_spawn(monkeypatch, record_spawn)
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
@@ -145,24 +144,11 @@ def test_runner_resource_attach_passes_read_only_to_tmux(
     # argv (list) and the child env (dict) land under separate keys.
     captured: dict[str, object] = {}
 
-    def fake_fork() -> tuple[int, int]:
-        return 0, 0
-
-    def fake_execve(path: str, argv: list[str], env: dict[str, str]) -> None:
+    def record_spawn(_path: str, argv: list[str], env: dict[str, str]) -> None:
         captured["argv"] = argv
         captured["env"] = env
-        raise OSError("stop child path")
 
-    exit_exc = RuntimeError("child exited")
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.pty.fork", fake_fork)
-    # Production resolves the absolute tmux path and builds the child env
-    # in the parent; the child calls os.execve (no PATH search, explicit
-    # env) — patch execve, not execv/execvp.
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.os.execve", fake_execve)
-    monkeypatch.setattr(
-        "omnigent.terminals.ws_bridge.os._exit",
-        lambda code: (_ for _ in ()).throw(exit_exc),
-    )
+    _patch_attach_spawn(monkeypatch, record_spawn)
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(
@@ -360,32 +346,11 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
 
     attach_argvs: list[list[str]] = []
 
-    def fake_fork() -> tuple[int, int]:
-        """Drive the child branch of ``pty.fork`` in-process.
-
-        :returns: ``(0, 0)`` — pid 0 selects the child path.
-        """
-        return 0, 0
-
-    def fake_execve(path: str, argv: list[str], env: dict[str, str]) -> None:
-        """Capture the tmux attach argv instead of exec'ing.
-
-        :param path: Absolute tmux binary path (unused).
-        :param argv: Full attach argv, recorded per-attach so the
-            test can assert which socket each bridge targeted.
-        :param env: Child env built in the parent (unused here; the
-            TERM pin is asserted by the spawns_tmux test above).
-        """
+    def record_spawn(_path: str, argv: list[str], _env: dict[str, str]) -> None:
+        """Capture the tmux attach argv instead of spawning."""
         attach_argvs.append(argv)
-        raise OSError("stop child path")
 
-    exit_exc = RuntimeError("child exited")
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.pty.fork", fake_fork)
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.os.execve", fake_execve)
-    monkeypatch.setattr(
-        "omnigent.terminals.ws_bridge.os._exit",
-        lambda code: (_ for _ in ()).throw(exit_exc),
-    )
+    _patch_attach_spawn(monkeypatch, record_spawn)
 
     # First attach: dead pane → recreate → bridge the fresh pane.
     with pytest.raises(RuntimeError, match="child exited"):
@@ -502,22 +467,11 @@ def test_runner_resource_attach_recreates_dead_qwen_terminal(
 
     attach_argvs: list[list[str]] = []
 
-    def fake_fork() -> tuple[int, int]:
-        """Drive the child branch of ``pty.fork`` in-process."""
-        return 0, 0
-
-    def fake_execve(path: str, argv: list[str], env: dict[str, str]) -> None:
-        """Capture the tmux attach argv instead of exec'ing."""
+    def record_spawn(_path: str, argv: list[str], _env: dict[str, str]) -> None:
+        """Capture the tmux attach argv instead of spawning."""
         attach_argvs.append(argv)
-        raise OSError("stop child path")
 
-    exit_exc = RuntimeError("child exited")
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.pty.fork", fake_fork)
-    monkeypatch.setattr("omnigent.terminals.ws_bridge.os.execve", fake_execve)
-    monkeypatch.setattr(
-        "omnigent.terminals.ws_bridge.os._exit",
-        lambda code: (_ for _ in ()).throw(exit_exc),
-    )
+    _patch_attach_spawn(monkeypatch, record_spawn)
 
     with pytest.raises(RuntimeError, match="child exited"):
         with TestClient(app).websocket_connect(


### PR DESCRIPTION
## Related issue

N/A

## Summary

Runner creation and multi-agent teams currently pay for every configured stdio MCP process per spec/session, even when several agents point at the same underlying MCP server. This makes duplicated Slack/Jira/Glean-style servers dominate local memory.

- Split runner MCP pooling into spec routing entries and shared per-server connection entries, keyed by the transport/auth/env/command fields that define one live MCP server.
- Keep spec-specific server names and `tools` allow-lists as routing metadata, so two agents can expose/filter the same shared connection differently without duplicating the subprocess.
- Make runner startup prewarm register MCP metadata only; actual transports now open on `schemas_for` or direct namespaced `call_tool`, and direct dispatch connects only the addressed MCP server.
- Keep in-flight connects owned by the shared server entry, with temporary operation refs so LRU eviction cannot orphan a late-completing connection.
- Enforce per-spec `tools` allow-lists during dispatch as well as schema advertisement.
- Update startup comments/logging and add runner MCP manager tests for shared-server reuse, spawn-free prewarm, lazy dispatch, shutdown cancellation, eviction-during-connect cleanup, and allow-list dispatch guards.
- Stabilize terminal attach WebSocket tests by stubbing the bridge spawn boundary instead of driving `pty.fork` child-path behavior in-process.

ELI5: Omnigent used to give every agent its own copy of the same tool helpers. Now it keeps one copy of a helper when the helper config is identical, and starts it only when somebody actually asks to use it.

```text
Before:
  spec A -> slack process
  spec B -> slack process
  spec C -> slack process

After:
  spec A --\
  spec B ----> shared slack process
  spec C --/
```

**Risk / Scope:** This intentionally trades startup memory for first-use latency. A stdio MCP that used to start during runner startup now starts on the first schema lookup or direct tool call, so the first turn that needs an `npx`/`uvx`-style MCP may pay subprocess spawn plus `tools/list` latency. HTTP MCPs should see little impact, and unused listed MCPs no longer consume memory just because a runner was created.

## Test Plan

- `uv run ruff format tests/runner/test_mcp_manager.py omnigent/runner/mcp_manager.py`
- `uv run ruff check tests/runner/test_mcp_manager.py omnigent/runner/mcp_manager.py`
- `uv run pytest tests/runner/test_mcp_manager.py` (`18 passed`)
- `uv run pytest tests/runner/test_terminal_resource_attach_ws.py -q` (`10 passed`)
- `uv run pytest tests/runner/test_terminal_resource_attach_ws.py -q -n 8` (`10 passed`)
- `uv run pre-commit run --files omnigent/runner/mcp_manager.py tests/runner/test_mcp_manager.py`
- `python3.12 -m compileall -q omnigent/runner/mcp_manager.py tests/runner/test_mcp_manager.py`
- `git diff --check`
- Attempted `uv run pre-commit run --all-files`; it failed because the `normalize uv.lock registry to pypi.org` hook modified an already-dirty local `uv.lock` from environment setup. Lockfiles are not part of this PR.

## Demo

N/A - backend runner memory/lifecycle refactor with no visual UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added focused unit coverage for the new pooling semantics, eviction-during-connect lifecycle, shutdown cancellation, and per-spec allow-list dispatch guards. Stabilized terminal attach WebSocket route tests and reran them under xdist. Reran the touched-file pre-commit gates. Full all-files pre-commit could not complete in this dirty local checkout because a lockfile normalization hook rewrote unrelated environment-generated lockfile changes.

## Changelog

Runner MCP servers are shared across matching agent specs and started lazily to reduce local memory use.
