### PR TITLE
fix(sandbox): keep bwrap helper spawnable when interpreter lives under a masked dotdir (#1)

### DIFF
--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -409,14 +409,33 @@ class BwrapSandboxBackend(SandboxBackend):
         # the host's ``.aws/`` content. Emitting the mask last keeps
         # the deny-wins guarantee on Linux regardless of how many
         # broader binds the policy stacks underneath.
-        bwrap_args.extend(
-            _dotfile_and_symlink_mask_args(
-                cwd_resolved,
-                policy.cwd_allow_hidden if policy.cwd_allow_hidden is not None else [],
-                policy,
-                argv=argv,
-            )
+        mask_args = _dotfile_and_symlink_mask_args(
+            cwd_resolved,
+            policy.cwd_allow_hidden if policy.cwd_allow_hidden is not None else [],
+            policy,
+            argv=argv,
         )
+        bwrap_args.extend(mask_args)
+
+        # Re-expose the helper interpreter (and target) if the dotfile
+        # mask above hid it. This happens when cwd is an ancestor of an
+        # interpreter that lives under a hidden dir (e.g. a uv-tool
+        # install under ``~/.local``): the cwd bind nominally covers it
+        # so no explicit bind was emitted, but the ``--tmpfs`` mask —
+        # emitted last to win over broad binds — then hides it. These
+        # binds come AFTER the mask so they win right back, scoped to
+        # exactly the interpreter subtree.
+        masked_dirs = _tmpfs_mask_dirs(mask_args)
+        reexpose = _interpreter_reexpose_after_mask(argv, masked_dirs)
+        if target is not None:
+            reexpose += _interpreter_reexpose_after_mask([target], masked_dirs)
+        seen_reexpose: set[tuple[str, str]] = set()
+        for i in range(0, len(reexpose) - 2, 3):
+            key = (reexpose[i + 1], reexpose[i + 2])
+            if key in seen_reexpose:
+                continue
+            seen_reexpose.add(key)
+            bwrap_args.extend(reexpose[i : i + 3])
 
         # AF_UNIX control-socket masks. A denied socket
         # (e.g. the managed tmux control socket) lives inside a bound
@@ -744,11 +763,32 @@ def _ensure_executable_visible(argv: list[str], cwd: Path) -> list[str]:
         cwd bind. Never includes a destination already covered by
         :data:`_DEFAULT_RO_DIRS` or by *cwd*.
     """
+    return _interpreter_chain_binds(argv, [Path(p) for p in _DEFAULT_RO_DIRS] + [cwd])
+
+
+def _interpreter_chain_binds(argv: Sequence[str], covered_prefixes: list[Path]) -> list[str]:
+    """
+    Walk ``argv[0]``'s symlink chain and return the ``--ro-bind-try``
+    args needed to reach each hop, skipping destinations already
+    covered by *covered_prefixes*.
+
+    Factored out of :func:`_ensure_executable_visible` so the post-mask
+    interpreter re-expose (:func:`_interpreter_reexpose_after_mask`) can
+    reuse the exact same walk with a NARROWER covered set — the default
+    mounts only, without cwd. cwd "covers" the interpreter only until
+    the dotfile masker ``--tmpfs``-masks a hidden ancestor dir under it
+    (e.g. a uv-tool install at ``~/.local/share/uv/tools/.../python``);
+    re-running the walk against the default mounts alone yields the
+    binds needed to punch the interpreter back through that mask.
+
+    :param argv: Helper argv. Only ``argv[0]`` is inspected.
+    :param covered_prefixes: Paths whose descendants need no explicit
+        bind (already visible inside the sandbox).
+    :returns: Extra bwrap args (possibly empty), as ``--ro-bind-try
+        <src> <dst>`` triples.
+    """
     if not argv:
         return []
-
-    covered_prefixes = [Path(p) for p in _DEFAULT_RO_DIRS]
-    covered_prefixes.append(cwd)
 
     extra: list[str] = []
     seen_dest: set[Path] = set()
@@ -797,6 +837,79 @@ def _ensure_executable_visible(argv: list[str], cwd: Path) -> list[str]:
             current = Path(os.path.normpath(str(current.parent / link)))
 
     return extra
+
+
+def _tmpfs_mask_dirs(mask_args: Sequence[str]) -> list[Path]:
+    """
+    Extract the directory destinations from dotfile-mask args.
+
+    The masker emits directory masks as ``--tmpfs <dir>`` and
+    file/symlink masks as ``--bind-try /dev/null <file>``. Only the
+    ``--tmpfs`` dirs can be an ancestor that hides the interpreter, so
+    those are what the re-expose pass needs to reason about.
+
+    :param mask_args: The bwrap args produced by
+        :func:`_dotfile_and_symlink_mask_args`.
+    :returns: The ``--tmpfs`` destination paths, in emit order.
+    """
+    dirs: list[Path] = []
+    i = 0
+    while i < len(mask_args):
+        token = mask_args[i]
+        if token == "--tmpfs" and i + 1 < len(mask_args):
+            dirs.append(Path(mask_args[i + 1]))
+            i += 2
+        elif token == "--bind-try":
+            i += 3
+        else:
+            i += 1
+    return dirs
+
+
+def _interpreter_reexpose_after_mask(
+    argv: Sequence[str], masked_dirs: Sequence[Path]
+) -> list[str]:
+    """
+    Re-expose the helper interpreter chain ON TOP of dotfile masks.
+
+    :func:`_ensure_executable_visible` skips explicit binds for an
+    interpreter that cwd nominally covers. When cwd is an ancestor of
+    the interpreter and the interpreter lives under a hidden dir (e.g. a
+    ``uv tool``-installed omnigent at
+    ``~/.local/share/uv/tools/omnigent/bin/python``), the dotfile masker
+    ``--tmpfs``-masks that dir — and, being emitted last, the mask wins
+    over the cwd bind, so the interpreter vanishes and bwrap's
+    ``execvp`` fails with ``ENOENT``.
+
+    This recomputes the interpreter binds WITHOUT the cwd-coverage skip
+    (only the always-present default mounts count as covered) and keeps
+    only the ones that land STRICTLY inside a masked dir. Emitted after
+    the mask, they layer over it and reach exactly the interpreter
+    subtree — never the masked dir itself (which would re-expose the
+    whole ``.local`` and defeat the mask) and never paths the mask never
+    touched (which would be redundant with the cwd bind).
+
+    :param argv: Helper argv; only ``argv[0]`` is inspected.
+    :param masked_dirs: Directory paths the dotfile masker ``--tmpfs``-ed
+        (from :func:`_tmpfs_mask_dirs`).
+    :returns: Extra ``--ro-bind-try`` triples, or empty when nothing the
+        interpreter needs was masked.
+    """
+    if not argv or not masked_dirs:
+        return []
+    binds = _interpreter_chain_binds(argv, [Path(p) for p in _DEFAULT_RO_DIRS])
+    out: list[str] = []
+    for i in range(0, len(binds) - 2, 3):
+        flag, src, dst = binds[i], binds[i + 1], binds[i + 2]
+        dst_path = Path(dst)
+        # Strictly inside a masked dir: within it, but not the dir
+        # itself (equal would re-expose the whole masked dotdir).
+        if any(
+            _is_within(dst_path, m, resolve=False) and not _is_within(m, dst_path, resolve=False)
+            for m in masked_dirs
+        ):
+            out.extend([flag, src, dst])
+    return out
 
 
 def _is_within(path: Path, root: Path, *, resolve: bool = True) -> bool:

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -889,6 +889,31 @@ def _claude_internal_write_files() -> list[pathlib.Path]:
     return [path for path in candidates if path.exists()]
 
 
+def _resolve_sandbox_cwd(spec_cwd: str | None) -> pathlib.Path:
+    """Resolve the sandbox root, rooting relative paths at the session
+    working folder rather than the runner daemon's process cwd.
+
+    A relative ``os_env.cwd`` — notably the default ``"."`` — resolved
+    against ``os.getcwd()`` lands on the runner daemon's ``$HOME`` when
+    no workspace is selected. That both roots the sandbox at the whole
+    home dir and disagrees with the tmux terminal, which uses
+    ``OMNIGENT_RUNNER_WORKSPACE``. Prefer that workspace as the base so
+    the two agree; fall back to the process cwd only when it is unset.
+    An absolute ``spec_cwd`` is honored verbatim.
+
+    :param spec_cwd: The spec's ``os_env.cwd``, or ``None``.
+    :returns: The resolved, absolute sandbox root.
+    """
+    base = os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or os.getcwd()
+    if spec_cwd:
+        path = pathlib.Path(spec_cwd)
+        if not path.is_absolute():
+            path = pathlib.Path(base) / path
+    else:
+        path = pathlib.Path(base)
+    return path.resolve(strict=False)
+
+
 def prepare_claude_cli_path(
     real_cli_path: str | None,
     spec: OSEnvSpec | None,
@@ -913,7 +938,7 @@ def prepare_claude_cli_path(
     if sandbox_spec.type == "none":
         return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=True)
 
-    cwd = pathlib.Path(spec.cwd or os.getcwd()).resolve(strict=False)
+    cwd = _resolve_sandbox_cwd(spec.cwd)
     sandbox = resolve_sandbox(spec, cwd)
     if not sandbox.active:
         return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=False)
@@ -965,7 +990,7 @@ def prepare_tight_cli_process_path(
         ),
     )
     try:
-        resolved_cwd = pathlib.Path(cwd or os.getcwd()).resolve(strict=False)
+        resolved_cwd = _resolve_sandbox_cwd(cwd)
         sandbox = resolve_sandbox(spec, resolved_cwd)
     except (OSError, NotImplementedError) as exc:
         logger.warning(

--- a/omnigent/inner/claude_sdk_harness.py
+++ b/omnigent/inner/claude_sdk_harness.py
@@ -272,7 +272,15 @@ def _build_claude_sdk_executor() -> Executor:
     agent_name_raw = os.environ.get(_ENV_AGENT_NAME, "").strip()
     agent_name = agent_name_raw or None
     return ClaudeSDKExecutor(
-        cwd=os.environ.get(_ENV_CWD),
+        # Run the CLI in the session workspace: an explicit
+        # HARNESS_CLAUDE_SDK_CWD wins, else the runner's
+        # OMNIGENT_RUNNER_WORKSPACE (the folder the user launched in, and
+        # the same one the tmux terminal uses), else the process cwd.
+        # Without the workspace fallback the CLI ran out of the runner
+        # daemon's $HOME — disagreeing with the terminal and rooting the
+        # sandbox at the whole home dir. Mirrors goose / kimi / pi / qwen
+        # / hermes harness cwd resolution.
+        cwd=os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None,
         os_env=_resolve_os_env(),
         model=os.environ.get(_ENV_MODEL),
         permission_mode=os.environ.get(_ENV_PERMISSION_MODE, _DEFAULT_PERMISSION_MODE),

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -824,6 +824,61 @@ def test_wrap_launcher_argv_target_already_in_default_mounts(
     )
 
 
+def test_wrap_launcher_argv_reexposes_interpreter_under_masked_dotdir(
+    tmp_path: Path,
+) -> None:
+    """
+    When cwd is an ancestor of the helper interpreter and the
+    interpreter lives under a hidden dir (a ``uv tool`` install at
+    ``~/.local/share/uv/tools/omnigent/bin/python`` with cwd=``$HOME``),
+    the dotfile masker ``--tmpfs``-masks ``.local`` — and, emitted last,
+    that mask would hide the interpreter and make bwrap's ``execvp``
+    fail with ENOENT.
+
+    The argv must therefore (1) still mask ``.local`` (the sibling
+    content stays hidden), (2) emit a ``--ro-bind-try`` of the
+    interpreter's ``bin`` dir AFTER the mask so it wins, and (3) NOT
+    re-bind ``.local`` itself (which would defeat the mask).
+    """
+    interp_bin = tmp_path / ".local" / "share" / "uv" / "tools" / "omnigent" / "bin"
+    interp_bin.mkdir(parents=True)
+    interp = interp_bin / "python"
+    interp.write_text("#!/bin/sh\n")
+    interp.chmod(0o755)
+
+    backend = _make_backend()
+    # overflow="warn" so the $HOME-sized walk doesn't raise on the
+    # unrelated dotdirs a real home carries; the mask itself is unaffected.
+    policy = _make_policy(tmp_path, cwd_hidden_scan_overflow="warn")
+    argv = backend.wrap_launcher_argv(
+        [str(interp), "-c", "pass"], policy, tmp_path, target=str(interp)
+    )
+
+    cwd = tmp_path.resolve(strict=False)
+    local_dir = str(cwd / ".local")
+    bin_dir = str(interp_bin.resolve(strict=False))
+
+    def _last_index(pred: object) -> int:
+        return max((i for i, _ in enumerate(argv) if pred(i)), default=-1)  # type: ignore[operator]
+
+    mask_pos = _last_index(lambda i: argv[i] == "--tmpfs" and argv[i + 1] == local_dir)
+    assert mask_pos >= 0, f".local should still be --tmpfs-masked. argv: {argv}"
+
+    bind_pos = _last_index(
+        lambda i: argv[i] == "--ro-bind-try" and i + 2 < len(argv) and argv[i + 2] == bin_dir
+    )
+    assert bind_pos > mask_pos, (
+        "The interpreter bin dir must be re-bound with --ro-bind-try AFTER "
+        f"the .local --tmpfs mask so it wins. mask_pos={mask_pos}, "
+        f"bind_pos={bind_pos}. argv: {argv}"
+    )
+
+    # The masked dotdir itself must not be re-exposed wholesale.
+    assert not _has_pair(argv, "--ro-bind-try", local_dir, local_dir), (
+        ".local was re-bound wholesale, defeating the dotfile mask."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Dotfile masking + symlink defense
 # ---------------------------------------------------------------------------
@@ -1214,6 +1269,49 @@ print(json.dumps(results))
         f"clone(CLONE_NEWNET) returned errno={parsed['clone_newnet']['errno']}"
         f" instead of EPERM; the MASKED_EQ rule for CLONE_NEWNET in"
         " _bwrap_extra_seccomp_rules() is missing or incorrect."
+    )
+
+
+@pytestmark_bwrap
+def test_interpreter_under_masked_dotdir_still_spawns(tmp_path: Path) -> None:
+    """
+    End-to-end: an interpreter reachable only via a hidden dir INSIDE
+    cwd still runs, while sibling content under that dir stays masked.
+
+    Mirrors the reported failure — a ``uv tool``-installed omnigent at
+    ``~/.local/share/uv/tools/omnigent/bin/python`` with the sandbox
+    rooted at ``$HOME`` — where the dotfile masker ``--tmpfs``-masked
+    ``.local`` and bwrap died with ``execvp ...: No such file or
+    directory``. Proves the interpreter now execs AND that the mask
+    still hides an unrelated secret alongside it.
+    """
+    real_python = os.path.realpath(sys.executable)
+    interp_bin = tmp_path / ".local" / "share" / "uv" / "tools" / "omnigent" / "bin"
+    interp_bin.mkdir(parents=True)
+    interp = interp_bin / "python"
+    interp.symlink_to(real_python)
+    # A secret elsewhere under .local, NOT on the interpreter's path.
+    secret = tmp_path / ".local" / "secret.txt"
+    secret.write_text("TOPSECRET")
+
+    backend = _make_backend()
+    policy = _make_policy(tmp_path, cwd_hidden_scan_overflow="warn")
+    probe = (
+        "import pathlib,sys;"
+        f"print('SECRET_LEAK' if pathlib.Path({str(secret)!r}).exists() else 'ok');"
+        "sys.stdout.write('RAN')"
+    )
+    argv = backend.wrap_launcher_argv([str(interp), "-c", probe], policy, tmp_path)
+    completed = subprocess.run(argv, capture_output=True, text=True, timeout=30, check=False)
+
+    assert completed.returncode == 0, (
+        f"interpreter under masked .local failed to spawn (rc="
+        f"{completed.returncode}). stderr={completed.stderr[-400:]!r}"
+    )
+    assert "RAN" in completed.stdout, f"probe did not run. stdout={completed.stdout!r}"
+    assert "SECRET_LEAK" not in completed.stdout, (
+        "the re-expose bind leaked an unrelated secret under the masked "
+        ".local dir; only the interpreter subtree should be re-exposed."
     )
 
 

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2517,6 +2517,26 @@ async def test_get_or_create_client_surfaces_cli_stderr_on_connect_timeout(monke
     assert options.stderr is None
 
 
+def test_resolve_sandbox_cwd_roots_relative_at_runner_workspace(monkeypatch) -> None:
+    """A relative ``os_env.cwd`` (notably the default ``"."``) resolves
+    against ``OMNIGENT_RUNNER_WORKSPACE`` — not the daemon's process cwd
+    — so the sandbox root matches the tmux terminal and never falls back
+    to ``$HOME``. Absolute paths are honored verbatim."""
+    from omnigent.inner.claude_sdk_executor import _resolve_sandbox_cwd
+
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/home/bobby/code/agents")
+    monkeypatch.chdir("/tmp")
+
+    assert str(_resolve_sandbox_cwd(".")) == "/home/bobby/code/agents"
+    assert str(_resolve_sandbox_cwd(None)) == "/home/bobby/code/agents"
+    assert str(_resolve_sandbox_cwd("src")) == "/home/bobby/code/agents/src"
+    assert str(_resolve_sandbox_cwd("/etc/foo")) == "/etc/foo"
+
+    # No workspace set → falls back to the process cwd (prior behavior).
+    monkeypatch.delenv("OMNIGENT_RUNNER_WORKSPACE", raising=False)
+    assert str(_resolve_sandbox_cwd(".")) == "/tmp"
+
+
 @pytest.mark.parametrize("env_value", ["1", "true", "yes"])
 def test_prepare_claude_cli_path_bypasses_wrapper_when_env_set(
     monkeypatch, caplog, env_value: str

--- a/tests/inner/test_claude_sdk_harness.py
+++ b/tests/inner/test_claude_sdk_harness.py
@@ -141,6 +141,54 @@ def test_executor_factory_reads_env_vars(
     assert os_env_value.sandbox.type == "none"
 
 
+def test_executor_factory_cwd_falls_back_to_runner_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no ``HARNESS_CLAUDE_SDK_CWD``, the factory falls back to the
+    runner's ``OMNIGENT_RUNNER_WORKSPACE`` (the folder the user launched
+    in, and what the tmux terminal uses) rather than leaving cwd unset —
+    which let the SDK root the CLI at the daemon's ``$HOME``. Mirrors the
+    kimi / pi / hermes harnesses.
+    """
+    monkeypatch.delenv("HARNESS_CLAUDE_SDK_CWD", raising=False)
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/home/bobby/code/agents")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, *, cwd: str | None, **_kwargs: Any) -> None:
+        captured["cwd"] = cwd
+
+    with patch(
+        "omnigent.inner.claude_sdk_harness.ClaudeSDKExecutor.__init__",
+        _fake_init,
+    ):
+        claude_sdk_harness._build_claude_sdk_executor()
+
+    assert captured["cwd"] == "/home/bobby/code/agents"
+
+
+def test_executor_factory_explicit_cwd_wins_over_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``HARNESS_CLAUDE_SDK_CWD`` takes precedence over the
+    ``OMNIGENT_RUNNER_WORKSPACE`` fallback."""
+    monkeypatch.setenv("HARNESS_CLAUDE_SDK_CWD", "/tmp/explicit")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/home/bobby/code/agents")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, *, cwd: str | None, **_kwargs: Any) -> None:
+        captured["cwd"] = cwd
+
+    with patch(
+        "omnigent.inner.claude_sdk_harness.ClaudeSDKExecutor.__init__",
+        _fake_init,
+    ):
+        claude_sdk_harness._build_claude_sdk_executor()
+
+    assert captured["cwd"] == "/tmp/explicit"
+
+
 def test_executor_factory_decodes_os_env_json(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
A bwrap-sandboxed agent (like claude-sdk) would crash on launch with `bwrap: execvp .../python: No such file or directory` whenever its Python interpreter lived under a hidden directory inside the sandbox's working folder — the common case being a uv tool-installed omnigent at `~/.local/share/uv/tools/omnigent/bin/python` with the sandbox rooted at `$HOME`. I fixed the two interacting causes:

- The sandbox masker was hiding the interpreter. The dotfile masker `--tmpfs` masks hidden dirs like `.local` (and, being emitted last, wins over the broad cwd bind), but nothing re-exposed the interpreter living inside it. Now, after the mask, the interpreter's directory chain is re-bound scoped strictly to the interpreter subtree — so `.local` stays masked (sibling secrets stay hidden) but the interpreter itself is reachable again.
- The sandbox was rooting at `$HOME`. A relative `os_env.cwd` (the default ".") resolved against the runner daemon's process cwd, which landed on `$HOME` when no workspace was picked — both triggering the bug above and disagreeing with the terminal. It now resolves against `OMNIGENT_RUNNER_WORKSPACE` (the session's working folder, same as the terminal uses), matching the kimi/pi/hermes harnesses.

## Related issue

Closes #1921

## Test Plan
I added five tests across three files. In `test_bwrap_sandbox.py`,` test_wrap_launcher_argv_reexposes_ir` is an argv-shape test that builds a fake interpreter at `<cwd>/.local/share/uv/tools/omnigent/bin/python` and asserts `.local` is still  `--tmpfs`-masked, the interpreter's `--ro-bind-try` lands after the mask so it wins, and `.local` isn't re-bound wholesale; `test_interpreter_under_masked_dotdir_still_spawns` (gated on `@pytestmark_bwrap`) symlinks a real interpreter under `.local/...`, plants a sibling `secret.txt`, spawns through real` bwrap`, and asserts `rc==0`, that the probe ran, and that the secret did not leak. In `test_claude_sdk_harness.py` I added` test_executor_factory_cwd_falls_back_to_runner_workspace` (with no `HARNESS_CLAUDE_SDK_CWD`, cwd falls back to `OMNIGENT_RUNNER_WORKSPACE`) and `test_executor_factory_explicit_cwd_wins_over_workspace` (the explicit env var takes precedence), and in `test_claude_sdk_executor.py` I added `test_resolve_sandbox_cwd_roots_relative_at_runner_workspace`, a resolution table covering `".", None` a relative `"src"`, an absolute path and the no-workspace fallback. To verify, I ran `pytest` on those three suites (159 passed) plus `test_seatbelt_sandbox.py` and` test_cwd_scan.py` for the shared walker, drove the issue's exact repro against a real bwrap to confirm that with `cwd=$HOME` the` .local` dir stays masked yet the helper spawns `rc=0`, and confirmed `ruff format` and `ruff check` were clean on all changed files.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated - 5 new tests across `test_bwrap_sandbox.py`, `test_claude_sdk_executor.py`, `test_claude_sdk_harness.py`
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed - ran the report's repro against real bwrap
- [x] Existing tests cover this change - test_seatbelt_sandbox.py / test_cwd_scan.py stay green
- [ ] Not applicable