### PR TITLE
fix(sessions): drop invalid http_status kwarg from terminal-transfer …

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -17538,10 +17538,10 @@ def create_sessions_router(
             )
         if status >= 400:
             error = payload.get("error", {})
+            # OmnigentError derives http_status from code; pass the runner's code, not a status.
             raise OmnigentError(
                 error.get("message", "Terminal transfer failed"),
-                code=error.get("code", "internal_error"),
-                http_status=status,
+                code=error.get("code", ErrorCode.INTERNAL_ERROR),
             )
 
         _publish_and_persist_resource_event(

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1403,6 +1403,89 @@ async def test_transfer_terminal_authorizes_sessions_and_proxies_to_runner(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runner_status,runner_payload,expected_status,expected_code,expected_message",
+    [
+        # Runner returns its own error body (tunnel dropped mid-transfer,
+        # runner reports offline). The runner's code drives the HTTP status,
+        # and its message is surfaced verbatim.
+        (
+            503,
+            {
+                "error": {
+                    "code": ErrorCode.RUNNER_UNAVAILABLE,
+                    "message": "tunnel closed before request completed",
+                }
+            },
+            503,
+            ErrorCode.RUNNER_UNAVAILABLE,
+            "tunnel closed before request completed",
+        ),
+        # Runner returns an error with no body — fall back to INTERNAL_ERROR
+        # (→500) and the route's default transfer-failure message.
+        (
+            500,
+            {},
+            500,
+            ErrorCode.INTERNAL_ERROR,
+            "Terminal transfer failed",
+        ),
+    ],
+)
+async def test_transfer_terminal_surfaces_runner_error_without_crashing(
+    client: httpx.AsyncClient,
+    runner_status: int,
+    runner_payload: dict[str, Any],
+    expected_status: int,
+    expected_code: str,
+    expected_message: str,
+) -> None:
+    """A runner ``>=400`` (non-404/409) on terminal transfer yields a clean
+    error, not a 500 crash.
+
+    Regression for the masking bug at ``transfer_session_terminal`` — the
+    exact sibling of the one already fixed at ``create_session_terminal``:
+    its ``status >= 400`` branch built ``OmnigentError(..., http_status=status)``,
+    but ``OmnigentError`` has no ``http_status`` arg (it is a derived
+    property), so any runner error other than 404/409 turned into an
+    unhandled ``TypeError`` instead of a legible error. With the bug present,
+    ``client.post`` below raises ``TypeError`` rather than returning a
+    response, so this test errors out — the failure signal.
+
+    :param runner_status: HTTP status the fake runner returns for the
+        transfer proxy POST, e.g. ``503``.
+    :param runner_payload: JSON body the fake runner returns, e.g.
+        ``{"error": {"code": "runner_unavailable", "message": "..."}}``.
+    :param expected_status: HTTP status the route should surface (derived
+        from the error code), e.g. ``503``.
+    :param expected_code: Machine-readable error code the route should
+        surface, e.g. ``"runner_unavailable"``.
+    :param expected_message: The human-readable message the route should
+        surface.
+    :returns: None.
+    """
+    path = "/v1/sessions/conv_proxy/resources/terminals/terminal_bash_s1/transfer"
+    fake_runner = _FakeRunnerClient(responses={path: (runner_status, runner_payload)})
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.post(path, json={"target_session_id": "conv_local"})
+
+    # http_status is derived from the surfaced code: 503 proves the runner's
+    # ``runner_unavailable`` propagated; a 500 would mean it was masked by the
+    # old TypeError path or a generic internal error.
+    assert resp.status_code == expected_status
+    body = resp.json()
+    # The runner's own code/message reach the client unchanged — proves the
+    # error was surfaced, not swallowed or replaced by a generic 500.
+    assert body["error"]["code"] == expected_code
+    assert body["error"]["message"] == expected_message
+    # The transfer failed, so no resource is returned.
+    assert "id" not in body
+    # The proxy POST was actually attempted before the error was raised.
+    assert fake_runner.calls == [("POST", path)]
+
+
+@pytest.mark.asyncio
 async def test_delete_terminal_surfaces_runner_404(
     client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
…error

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary


The terminal-transfer route's ``status >= 400`` branch raised``OmnigentError(..., http_status=status)``, but ``OmnigentError`` has no``http_status`` constructor argument — it is a derived property mapped
from ``code``. Any runner error other than 404/409 therefore raised an unhandled ``TypeError`` and the client got an opaque 500 instead of the transfer-failure message.

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
