### PR TITLE
feat: add MiniMax M3 provider

### DIFF
--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -57,6 +57,7 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
         "openrouter": "https://openrouter.ai/api/v1",
         "ollama": "http://localhost:11434/v1",
         "moonshot": "https://api.moonshot.cn/v1",
+        "minimax": "https://api.minimax.io/v1",
     }
 
     if provider in openai_compat_providers:

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -29,6 +29,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama": "http://localhost:11434/v1",
     "moonshot": "https://api.moonshot.cn/v1",
+    "minimax": "https://api.minimax.io/v1",
 }
 
 _DEFAULT_PROVIDER = "openai"

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -60,6 +60,10 @@ from omnigent.llms.routing import RoutedModel, infer_harness_from_model, parse_m
             "moonshot/kimi-k2-instruct",
             RoutedModel(provider="moonshot", model="kimi-k2-instruct"),
         ),
+        (
+            "minimax/MiniMax-M3",
+            RoutedModel(provider="minimax", model="MiniMax-M3"),
+        ),
     ],
 )
 def test_parse_with_provider_prefix(


### PR DESCRIPTION
## Summary
Add MiniMax as a new OpenAI-compatible LLM provider, following the existing provider architecture.

## Changes
- Register `minimax` in `PROVIDER_CONFIGS` (`omnigent/llms/routing.py`) with its default base URL
- Register `minimax` in the `openai_compat_providers` map (`omnigent/llms/adapters/__init__.py`) so it routes through `OpenAICompatibleAdapter`
- Add a `minimax/MiniMax-M3` case to the provider-prefix parsing test

## Testing
- `pytest tests/llms/test_routing.py` passing
