### PR TITLE
fix(opencode): thread response_id onto running status edge

### DIFF
--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -419,11 +419,12 @@ class OpenCodeNativeForwarder:
             },
         )
 
-    async def _begin_turn_if_needed(self) -> None:
+    async def _begin_turn_if_needed(self, *, message_id: str | None = None) -> None:
         """Post a single ``running`` status at the start of a turn."""
         if not self.state.turn_active:
             self.state.turn_active = True
-            await self._post_status(_STATUS_RUNNING)
+            extra = {"response_id": self._response_id(message_id)} if message_id else None
+            await self._post_status(_STATUS_RUNNING, extra=extra)
 
     async def _end_turn(
         self, *, status: str = _STATUS_IDLE, extra: Mapping[str, Any] | None = None
@@ -457,7 +458,7 @@ class OpenCodeNativeForwarder:
         if role == "assistant":
             if self._bridge_dir is not None:
                 update_active_message_id(self._bridge_dir, message_id, status="busy")
-            await self._begin_turn_if_needed()
+            await self._begin_turn_if_needed(message_id=message_id)
             self._record_assistant_usage(message_id, info)
             await self._post_session_usage()
 
@@ -485,7 +486,7 @@ class OpenCodeNativeForwarder:
         elif part_type == "file":
             await self._handle_file_part(part)
         elif part_type == "step-start":
-            await self._begin_turn_if_needed()
+            await self._begin_turn_if_needed(message_id=part.get("messageID"))
         elif part_type == "step-finish":
             # A step's assistant text is complete once the step closes; flush
             # it so text and tool items land in the chat in step order.


### PR DESCRIPTION
## Summary

Extends live tool-call cards (spinner + elapsed timer) to opencode-native sessions, matching claude-native behavior (#1499).

## Changes

- Added  parameter to 
- Thread  onto the  status edge via the  hook
- Updated callers in  and  to pass 

## Testing

- [ ] Registering a flag completion function on a subcommand for an inherited persistent flag must not panic
- [ ] Shell completion generation functions execute successfully
- [ ] Live tool-call cards display correctly in opencode-native sessions

Fixes #1872