### PR TITLE
fix(claude-native): emit compactMetadata on resume compact_boundary

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3525,6 +3525,14 @@ def _claude_transcript_records_from_session_items(
                         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
                         "uuid": boundary_uuid,
                         "level": "info",
+                        # Claude scans every compact_boundary and destructures
+                        # compactMetadata; a missing object crashes /compact
+                        # (and auto-compact) on resume. token_count is the
+                        # post-compaction summary size.
+                        "compactMetadata": {
+                            "trigger": "auto",
+                            "postTokens": item.get("token_count"),
+                        },
                     }
                 )
                 parent_uuid = boundary_uuid

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -6138,6 +6138,7 @@ def test_claude_transcript_records_handles_compaction_item() -> None:
             "id": "cmp_1",
             "type": "compaction",
             "summary": "compaction summary",
+            "token_count": 4321,
             "compacted_messages": [
                 {
                     "type": "message",
@@ -6183,3 +6184,12 @@ def test_claude_transcript_records_handles_compaction_item() -> None:
         str(r.get("message", {}).get("content", "")) for r in records if r.get("type") == "user"
     ]
     assert any("after compaction" in t for t in user_texts)
+    # The compact_boundary must carry a non-null compactMetadata: Claude
+    # destructures it on every resume-time /compact and auto-compact, and a
+    # missing object crashes compaction ("Cannot destructure property
+    # 'cumulativeDroppedTokens' from null or undefined value").
+    boundaries = [
+        r for r in records if r.get("type") == "system" and r.get("subtype") == "compact_boundary"
+    ]
+    assert len(boundaries) == 1
+    assert boundaries[0]["compactMetadata"]["postTokens"] == 4321


### PR DESCRIPTION
## Related issue

Closes #1955

## Summary

Resumed **claude-native** sessions can never compact once context fills — both
manual `/compact` and auto-compaction fail, and keep failing on every following
turn, wedging the session.

- On resume, `_claude_transcript_records_from_session_items` writes a
  `compact_boundary` head marker but omits the `compactMetadata` object.
- Claude Code scans every `compact_boundary` on each compaction and
  destructures `compactMetadata`, so a missing object throws:
  `Cannot destructure property 'cumulativeDroppedTokens' from null or undefined value`.
- Fix: emit `compactMetadata` (`trigger` + `postTokens` from the item's
  `token_count`). Claude reads each sub-field via `??`, so a minimal object is
  enough. Introduced by #1535.

## Test Plan

- Extended `tests/test_claude_native.py::test_claude_transcript_records_handles_compaction_item`
  to assert the emitted boundary carries a non-null `compactMetadata`.
  `uv run pytest tests/test_claude_native.py -k compaction` → passes; fails
  before the fix.
- Verified end-to-end against a real wedged session: after the fix, a resumed
  claude-native session that previously errored on `/compact` compacts cleanly.

## Demo

No UI surface — this is a backend crash fix. Terminal before/after, replaying
Claude Code's own `compact_boundary` scan over a real resumed transcript:

```
BEFORE (unpatched transcript): CRASH -> Cannot destructure property
    'cumulativeDroppedTokens' from null or undefined value
AFTER  (with compactMetadata):  OK    -> maxDropped=0
```

In a live session this is the difference between `/compact` erroring on every
turn (wedged session) and compacting normally.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit test asserts the emitted `compact_boundary` includes `compactMetadata`.
Manual verification: reproduced the crash on a real resumed session, applied the
fix, and confirmed `/compact` then succeeds.

## Changelog

Fixed: resumed claude-native sessions no longer crash on compaction ("Cannot destructure property 'cumulativeDroppedTokens'")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

