### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/omnigent/llms/LLMCLIENT.md
+++ b/omnigent/llms/LLMCLIENT.md
@@ -215,6 +215,7 @@ Chat Completions IS the native format. Minimal translation (add model to payload
 | `deepseek` | `https://api.deepseek.com/v1` | `DEEPSEEK_API_KEY` |
 | `xai` | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
+| `requesty` | `https://router.requesty.ai/v1` | `REQUESTY_API_KEY` |
 | `ollama` | `http://localhost:11434/v1` | (none) |
 
 HTTP via sync `httpx` (already a project dependency).

--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -55,6 +55,7 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
         "deepseek": "https://api.deepseek.com/v1",
         "xai": "https://api.x.ai/v1",
         "openrouter": "https://openrouter.ai/api/v1",
+        "requesty": "https://router.requesty.ai/v1",
         "ollama": "http://localhost:11434/v1",
         "moonshot": "https://api.moonshot.cn/v1",
     }

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -27,6 +27,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "deepseek": "https://api.deepseek.com/v1",
     "xai": "https://api.x.ai/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "requesty": "https://router.requesty.ai/v1",
     "ollama": "http://localhost:11434/v1",
     "moonshot": "https://api.moonshot.cn/v1",
 }


### PR DESCRIPTION
Adds Requesty as an OpenAI-compatible provider, mirroring the existing OpenRouter entry.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth via `REQUESTY_API_KEY`.

Changes:
- `omnigent/llms/adapters/__init__.py`: `"requesty": "https://router.requesty.ai/v1"` in the `openai_compat_providers` base-URL dict (this also feeds the supported-providers set and the OpenAI-compatible adapter dispatch).
- `omnigent/llms/routing.py`: `requesty` in `PROVIDER_CONFIGS` (used by `parse_model_string` for `provider/model` routing).
- `omnigent/llms/LLMCLIENT.md`: a row in the OpenAI-compatible providers table (`requesty | https://router.requesty.ai/v1 | REQUESTY_API_KEY`).

Other OpenRouter mentions in the tree are docstrings/examples, left untouched. `ast.parse` passes on both edited Python files.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.