### PR TITLE
fix(harnesses): handle missing lsof binary in _pids_holding_socket

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1356,13 +1356,16 @@ async def _pids_holding_socket(socket_path: Path) -> list[int]:
     :returns: List of holding PIDs (often a single one — the
         bound runner).
     """
-    proc = await asyncio.create_subprocess_exec(
-        "lsof",
-        "-t",
-        str(socket_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "lsof",
+            "-t",
+            str(socket_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return []
     stdout, _ = await proc.communicate()
     if proc.returncode != 0:
         return []


### PR DESCRIPTION
## Related issue

N/A

## Summary

`_pids_holding_socket` shelled out to `lsof` unconditionally to find PIDs
holding a runner's socket file. On hosts where `lsof` isn't installed,
`asyncio.create_subprocess_exec` raises `FileNotFoundError`, which propagated
up and crashed the caller instead of degrading gracefully.

This wraps the subprocess spawn in a `try`/`except FileNotFoundError` and
returns an empty PID list when `lsof` is missing, matching the existing
"no holders found" behavior on non-zero exit.

## Test Plan

Ran `uv run ruff format --check` and `uv run ruff check` on the changed file
(both pass). Manually verified the function returns `[]` instead of raising
when `lsof` is not on `PATH`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by temporarily renaming `lsof` off `PATH` and confirming
`_pids_holding_socket` returns `[]` instead of raising `FileNotFoundError`.
No existing test exercised this path; adding a dedicated unit test would
require mocking `asyncio.create_subprocess_exec`, which felt like more
machinery than this small guard warrants.

## Changelog

Fixed a crash in harness socket-holder detection on systems without `lsof` installed