### PR TITLE
fix(tools): validate built-in tool arguments

### DIFF
--- a/omnigent/tools/builtins/_arguments.py
+++ b/omnigent/tools/builtins/_arguments.py
@@ -1,0 +1,27 @@
+"""Argument parsing helpers for built-in tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_json_object_arguments(
+    arguments: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """
+    Parse raw tool arguments as a JSON object.
+
+    Empty arguments are treated as ``{}``, so required-argument tools can
+    return their normal missing-field errors instead of raising from
+    ``json.loads``.
+    """
+    if not arguments.strip():
+        return {}, None
+    try:
+        parsed = json.loads(arguments)
+    except json.JSONDecodeError:
+        return None, "malformed JSON arguments"
+    if not isinstance(parsed, dict):
+        return None, "arguments must be a JSON object"
+    return parsed, None

--- a/omnigent/tools/builtins/download_file.py
+++ b/omnigent/tools/builtins/download_file.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
 from omnigent.tools.builtins.upload_file import safe_resolve
 
 
@@ -72,10 +73,16 @@ class DownloadFileTool(Tool):
         :param ctx: Provides workspace path for saving.
         :returns: JSON string with the local file path, or error.
         """
-        args: dict[str, Any] = json.loads(arguments)
+        args, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return json.dumps({"error": error})
+        assert args is not None
+
         file_id = args.get("file_id")
-        if not file_id:
+        if file_id is None or file_id == "":
             return json.dumps({"error": "missing required 'file_id'"})
+        if not isinstance(file_id, str):
+            return json.dumps({"error": "'file_id' must be a string"})
 
         from omnigent.runtime import get_artifact_store, get_file_store
 

--- a/omnigent/tools/builtins/export_agent.py
+++ b/omnigent/tools/builtins/export_agent.py
@@ -7,7 +7,6 @@ location on disk.
 
 from __future__ import annotations
 
-import json
 import shutil
 from pathlib import Path
 
@@ -16,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
 from omnigent.tools.builtins.upload_file import safe_resolve
 
 _SCHEMA: dict[str, Any] = {
@@ -105,13 +105,16 @@ class ExportAgentTool(Tool):
         :param ctx: Execution context with ``workspace`` path.
         :returns: Success message or error string.
         """
-        parsed: dict[str, Any] = json.loads(arguments) if arguments else {}
+        parsed, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return f"Error: {error}"
+        assert parsed is not None
         source_rel = parsed.get("source", "")
         target_str = parsed.get("target", "")
 
-        if not source_rel:
+        if not isinstance(source_rel, str) or not source_rel:
             return "Error: 'source' parameter is required."
-        if not target_str:
+        if not isinstance(target_str, str) or not target_str:
             return "Error: 'target' parameter is required."
 
         if ctx.workspace is None:

--- a/omnigent/tools/builtins/list_files.py
+++ b/omnigent/tools/builtins/list_files.py
@@ -6,6 +6,22 @@ import json
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
+
+
+def _parse_limit(value: Any) -> tuple[int | None, str | None]:
+    """
+    Validate and clamp the optional result limit.
+
+    Matches the public contract: default 20, maximum 100, positive integers only.
+    """
+    if value is None:
+        return 20, None
+    if not isinstance(value, int) or isinstance(value, bool):
+        return None, "'limit' must be an integer"
+    if value < 1:
+        return None, "'limit' must be at least 1"
+    return min(value, 100), None
 
 
 class ListFilesTool(Tool):
@@ -82,9 +98,19 @@ class ListFilesTool(Tool):
         :param ctx: Server-side execution context (unused).
         :returns: JSON string with file list and pagination info.
         """
-        args: dict[str, Any] = json.loads(arguments)
-        limit = min(args.get("limit", 20), 100)
+        args, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return json.dumps({"error": error})
+        assert args is not None
+
+        limit, error = _parse_limit(args.get("limit"))
+        if error is not None:
+            return json.dumps({"error": error})
+        assert limit is not None
+
         after = args.get("after")
+        if after is not None and not isinstance(after, str):
+            return json.dumps({"error": "'after' must be a string"})
 
         from omnigent.runtime import get_file_store
 

--- a/omnigent/tools/builtins/load_skill.py
+++ b/omnigent/tools/builtins/load_skill.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
 from omnigent.spec.types import SkillSpec
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
 
 
 class LoadSkillTool(Tool):
@@ -123,10 +123,16 @@ class LoadSkillTool(Tool):
         :returns: The skill content string, or an error
             message if the skill is not found.
         """
-        args: dict[str, str] = json.loads(arguments)
+        args, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return f"Error: {error}"
+        assert args is not None
+
         skill_name = args.get("name")
-        if skill_name is None:
+        if skill_name is None or skill_name == "":
             return "Error: missing required 'name' argument"
+        if not isinstance(skill_name, str):
+            return "Error: 'name' must be a string"
         skill = self._skills_by_name.get(skill_name)
         if skill is None:
             available = list(self._skills_by_name.keys())

--- a/omnigent/tools/builtins/read_skill_file.py
+++ b/omnigent/tools/builtins/read_skill_file.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path, PurePosixPath
 from typing import Any
 
 from omnigent.spec.types import SkillSpec
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
 
 
 class ReadSkillFileTool(Tool):
@@ -101,13 +101,21 @@ class ReadSkillFileTool(Tool):
             skill tools, required by the :class:`Tool` interface).
         :returns: The file contents, or an error message.
         """
-        args: dict[str, str] = json.loads(arguments)
+        args, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return f"Error: {error}"
+        assert args is not None
+
         skill_name = args.get("skill_name")
-        if skill_name is None:
+        if skill_name is None or skill_name == "":
             return "Error: missing required 'skill_name' argument"
+        if not isinstance(skill_name, str):
+            return "Error: 'skill_name' must be a string"
         rel_path = args.get("path")
-        if rel_path is None:
+        if rel_path is None or rel_path == "":
             return "Error: missing required 'path' argument"
+        if not isinstance(rel_path, str):
+            return "Error: 'path' must be a string"
 
         skill = self._skills_by_name.get(skill_name)
         if skill is None:

--- a/omnigent/tools/builtins/search_conversations.py
+++ b/omnigent/tools/builtins/search_conversations.py
@@ -6,6 +6,9 @@ import json
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
+
+_MAX_SEARCH_RESULTS = 100
 
 
 class SearchConversationsTool(Tool):
@@ -86,11 +89,18 @@ class SearchConversationsTool(Tool):
         :param ctx: Server-side execution context (unused).
         :returns: JSON string with search results.
         """
-        args: dict[str, Any] = json.loads(arguments)
+        args, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return json.dumps({"error": error})
+        assert args is not None
         query = args.get("query")
-        if not query:
+        if not isinstance(query, str) or not query.strip():
             return json.dumps({"error": "missing required 'query' argument"})
+        query = query.strip()
         limit = args.get("limit", 10)
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+            return json.dumps({"error": "limit must be a positive integer"})
+        limit = min(limit, _MAX_SEARCH_RESULTS)
 
         from omnigent.runtime import get_conversation_store
 

--- a/omnigent/tools/builtins/upload_file.py
+++ b/omnigent/tools/builtins/upload_file.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
 
 _SCHEMA: dict[str, Any] = {
     "type": "function",
@@ -105,10 +106,13 @@ class UploadFileTool(Tool):
         :param ctx: Execution context with ``workspace`` path.
         :returns: JSON string with ``file_id``, ``filename``, ``content_type``.
         """
-        parsed: dict[str, Any] = json.loads(arguments) if arguments else {}
+        parsed, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return f"Error: {error}"
+        assert parsed is not None
         rel_path = parsed.get("path", "")
-        if not rel_path:
-            return "Error: empty path"
+        if not isinstance(rel_path, str) or not rel_path:
+            return "Error: path must be a non-empty string"
 
         if ctx.workspace is None:
             return "Error: no workspace available"

--- a/omnigent/tools/builtins/web_search.py
+++ b/omnigent/tools/builtins/web_search.py
@@ -30,13 +30,13 @@ Usage in config.yaml::
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins._arguments import parse_json_object_arguments
 
 _logger = logging.getLogger(__name__)
 
@@ -178,10 +178,14 @@ class WebSearchTool(Tool):
                 "invoke() should never be called."
             )
 
-        parsed: dict[str, Any] = json.loads(arguments)
+        parsed, error = parse_json_object_arguments(arguments)
+        if error is not None:
+            return f"Error: {error}"
+        assert parsed is not None
         query = parsed.get("query")
-        if not query:
+        if not isinstance(query, str) or not query.strip():
             return "Error: 'query' parameter is required."
+        query = query.strip()
 
         return _search(query, self._config)
 

--- a/tests/tools/builtins/test_export_agent.py
+++ b/tests/tools/builtins/test_export_agent.py
@@ -112,6 +112,33 @@ def test_invoke_missing_target(tool_ctx: ToolContext) -> None:
     assert "Error" in result and "target" in result.lower()
 
 
+def test_invoke_rejects_invalid_arguments(tool_ctx: ToolContext) -> None:
+    """Malformed and non-object JSON return tool errors instead of raising."""
+    tool = ExportAgentTool()
+    malformed = tool.invoke("{", tool_ctx)
+    non_object = tool.invoke("[]", tool_ctx)
+    assert "Error" in malformed and "malformed JSON" in malformed
+    assert "Error" in non_object and "JSON object" in non_object
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"source": 123, "target": "/tmp/out"}, "source"),
+        ({"source": "my-agent", "target": True}, "target"),
+    ],
+)
+def test_invoke_rejects_non_string_paths(
+    tool_ctx: ToolContext,
+    payload: dict[str, object],
+    expected: str,
+) -> None:
+    """Non-string source/target values are rejected before filesystem access."""
+    tool = ExportAgentTool()
+    result = tool.invoke(json.dumps(payload), tool_ctx)
+    assert "Error" in result and expected in result.lower()
+
+
 def test_invoke_source_not_found(
     tool_ctx: ToolContext,
     tmp_path: Path,

--- a/tests/tools/builtins/test_file_tools.py
+++ b/tests/tools/builtins/test_file_tools.py
@@ -200,6 +200,57 @@ def test_list_files_empty(
     assert result["files"] == []
 
 
+def test_list_files_allows_empty_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    list_files has no required arguments, so an empty argument
+    string should behave like an empty JSON object.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tool_ctx: Tool execution context.
+    """
+    monkeypatch.setattr(
+        "omnigent.runtime.get_file_store",
+        lambda: _FakeFileStore(
+            [
+                _FakeFile(
+                    "file_1",
+                    "report.pdf",
+                    1024,
+                    "application/pdf",
+                    1000,
+                    session_id="conv_alice",
+                ),
+            ]
+        ),
+    )
+
+    tool = ListFilesTool()
+    result = json.loads(tool.invoke("", tool_ctx))
+
+    assert result["files"][0]["file_id"] == "file_1"
+
+
+@pytest.mark.parametrize("arguments", ["not-json", "[]"])
+def test_list_files_rejects_malformed_arguments(
+    arguments: str,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    Malformed or non-object arguments return a JSON error instead
+    of raising out of the tool invocation.
+
+    :param arguments: Raw tool argument string.
+    :param tool_ctx: Tool execution context.
+    """
+    tool = ListFilesTool()
+    result = json.loads(tool.invoke(arguments, tool_ctx))
+
+    assert "error" in result
+
+
 def test_list_files_respects_limit(
     monkeypatch: pytest.MonkeyPatch,
     tool_ctx: ToolContext,
@@ -223,6 +274,61 @@ def test_list_files_respects_limit(
     result = json.loads(tool.invoke('{"limit": 5}', tool_ctx))
 
     assert len(result["files"]) == 5
+
+
+def test_list_files_caps_limit_at_100(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    list_files clamps oversized limits to the documented maximum.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tool_ctx: Tool execution context.
+    """
+    files = [
+        _FakeFile(f"file_{i}", f"f{i}.txt", 100, None, i, session_id="conv_alice")
+        for i in range(150)
+    ]
+    monkeypatch.setattr(
+        "omnigent.runtime.get_file_store",
+        lambda: _FakeFileStore(files),
+    )
+
+    tool = ListFilesTool()
+    result = json.loads(tool.invoke('{"limit": 150}', tool_ctx))
+
+    assert len(result["files"]) == 100
+
+
+@pytest.mark.parametrize("limit", [0, -1, "5", True])
+def test_list_files_rejects_invalid_limit(
+    limit: object,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    Invalid limits are rejected before they reach the store.
+
+    :param limit: Invalid limit value to encode in the tool call.
+    :param tool_ctx: Tool execution context.
+    """
+    tool = ListFilesTool()
+    result = json.loads(tool.invoke(json.dumps({"limit": limit}), tool_ctx))
+
+    assert "error" in result
+    assert "limit" in result["error"]
+
+
+def test_list_files_rejects_non_string_after(tool_ctx: ToolContext) -> None:
+    """
+    The pagination cursor must be a string file id.
+
+    :param tool_ctx: Tool execution context.
+    """
+    tool = ListFilesTool()
+    result = json.loads(tool.invoke('{"after": 123}', tool_ctx))
+
+    assert result == {"error": "'after' must be a string"}
 
 
 def test_list_files_excludes_other_sessions(
@@ -434,6 +540,40 @@ def test_download_file_not_found(
 
     assert "error" in result
     assert "not found" in result["error"].lower()
+
+
+@pytest.mark.parametrize("arguments", ["", "not-json", "[]"])
+def test_download_file_rejects_invalid_arguments(
+    arguments: str,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    Invalid raw arguments return a JSON error instead of raising.
+
+    :param arguments: Raw tool argument string.
+    :param tool_ctx: Tool execution context.
+    """
+    tool = DownloadFileTool()
+    result = json.loads(tool.invoke(arguments, tool_ctx))
+
+    assert "error" in result
+
+
+@pytest.mark.parametrize("file_id", [123, True])
+def test_download_file_rejects_non_string_file_id(
+    file_id: object,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    ``file_id`` must be a string before querying the file store.
+
+    :param file_id: Invalid file id value.
+    :param tool_ctx: Tool execution context.
+    """
+    tool = DownloadFileTool()
+    result = json.loads(tool.invoke(json.dumps({"file_id": file_id}), tool_ctx))
+
+    assert result == {"error": "'file_id' must be a string"}
 
 
 def test_download_file_missing_content(

--- a/tests/tools/builtins/test_load_skill.py
+++ b/tests/tools/builtins/test_load_skill.py
@@ -103,6 +103,34 @@ def test_load_skill_missing_name_argument(
     assert "missing required 'name'" in result
 
 
+@pytest.mark.parametrize("arguments", ["not-json", "[]"])
+def test_load_skill_rejects_invalid_arguments(
+    arguments: str,
+    skill_no_resources: SkillSpec,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    Malformed or non-object arguments return an error string.
+    """
+    tool = LoadSkillTool([skill_no_resources])
+    result = tool.invoke(arguments, tool_ctx)
+
+    assert result.startswith("Error:")
+
+
+def test_load_skill_rejects_non_string_name(
+    skill_no_resources: SkillSpec,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    ``name`` must be a string skill name.
+    """
+    tool = LoadSkillTool([skill_no_resources])
+    result = tool.invoke(json.dumps({"name": 123}), tool_ctx)
+
+    assert result == "Error: 'name' must be a string"
+
+
 def test_load_skill_schema_lists_skill_names(
     skill_no_resources: SkillSpec,
     skill_with_resources: SkillSpec,

--- a/tests/tools/builtins/test_read_skill_file.py
+++ b/tests/tools/builtins/test_read_skill_file.py
@@ -192,3 +192,46 @@ def test_read_skill_file_missing_arguments(
         tool_ctx,
     )
     assert "missing required 'path'" in result_no_path
+
+
+@pytest.mark.parametrize("arguments", ["not-json", "[]"])
+def test_read_skill_file_rejects_invalid_arguments(
+    arguments: str,
+    skill_with_resources: SkillSpec,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    Malformed or non-object arguments return an error string.
+    """
+    tool = ReadSkillFileTool([skill_with_resources])
+    result = tool.invoke(arguments, tool_ctx)
+
+    assert result.startswith("Error:")
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            {"skill_name": 123, "path": "references/style-guide.md"},
+            "Error: 'skill_name' must be a string",
+        ),
+        (
+            {"skill_name": "code-review", "path": 123},
+            "Error: 'path' must be a string",
+        ),
+    ],
+)
+def test_read_skill_file_rejects_non_string_arguments(
+    payload: dict[str, object],
+    expected: str,
+    skill_with_resources: SkillSpec,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    Resource lookup fields must be strings before path handling.
+    """
+    tool = ReadSkillFileTool([skill_with_resources])
+    result = tool.invoke(json.dumps(payload), tool_ctx)
+
+    assert result == expected

--- a/tests/tools/builtins/test_search_conversations.py
+++ b/tests/tools/builtins/test_search_conversations.py
@@ -40,8 +40,10 @@ class _FakeItem:
 class _FakeConversationStore:
     def __init__(self, items: list[Any]) -> None:
         self._items = items
+        self.calls: list[dict[str, Any]] = []
 
     def search(self, query: str, limit: int = 10) -> list[Any]:
+        self.calls.append({"query": query, "limit": limit})
         return self._items[:limit]
 
 
@@ -140,6 +142,23 @@ def test_invoke_missing_query() -> None:
     assert "error" in result
 
 
+def test_invoke_rejects_invalid_arguments() -> None:
+    """invoke() returns structured errors for malformed/non-object arguments."""
+    tool = SearchConversationsTool()
+    malformed = json.loads(tool.invoke("{", _CTX))
+    non_object = json.loads(tool.invoke("[]", _CTX))
+    assert malformed == {"error": "malformed JSON arguments"}
+    assert non_object == {"error": "arguments must be a JSON object"}
+
+
+@pytest.mark.parametrize("limit", [0, -1, "3", True])
+def test_invoke_rejects_invalid_limit(limit: object) -> None:
+    """invoke() rejects limits that would otherwise reach the store."""
+    tool = SearchConversationsTool()
+    result = json.loads(tool.invoke(json.dumps({"query": "test", "limit": limit}), _CTX))
+    assert result == {"error": "limit must be a positive integer"}
+
+
 def test_invoke_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     """invoke() passes limit to the store."""
     items = [_FakeItem(f"item_{i}", f"conv_{i}", i, "message", _message_data()) for i in range(20)]
@@ -152,6 +171,19 @@ def test_invoke_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     tool = SearchConversationsTool()
     result = json.loads(tool.invoke('{"query": "test", "limit": 3}', _CTX))
     assert len(result["results"]) == 3
+
+
+def test_invoke_caps_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """invoke() caps large limits before querying the store."""
+    store = _FakeConversationStore([])
+    monkeypatch.setattr(
+        "omnigent.runtime.get_conversation_store",
+        lambda: store,
+    )
+
+    tool = SearchConversationsTool()
+    tool.invoke('{"query": "test", "limit": 1000}', _CTX)
+    assert store.calls == [{"query": "test", "limit": 100}]
 
 
 # ── _extract_text ────────────────────────────────────────

--- a/tests/tools/builtins/test_upload_file.py
+++ b/tests/tools/builtins/test_upload_file.py
@@ -179,3 +179,21 @@ def test_upload_file_rejects_empty_path(
 
     assert "Error" in result
     assert "empty" in result.lower()
+
+
+def test_upload_file_rejects_invalid_arguments(tool_ctx: ToolContext) -> None:
+    """Malformed and non-object JSON return tool errors instead of raising."""
+    tool = UploadFileTool()
+    malformed = tool.invoke("{", tool_ctx)
+    non_object = tool.invoke("[]", tool_ctx)
+    assert "Error" in malformed and "malformed JSON" in malformed
+    assert "Error" in non_object and "JSON object" in non_object
+
+
+@pytest.mark.parametrize("path", [123, True])
+def test_upload_file_rejects_non_string_path(tool_ctx: ToolContext, path: object) -> None:
+    """Non-string paths are rejected before path resolution."""
+    tool = UploadFileTool()
+    result = tool.invoke(json.dumps({"path": path}), tool_ctx)
+    assert "Error" in result
+    assert "non-empty string" in result

--- a/tests/tools/builtins/test_web_search.py
+++ b/tests/tools/builtins/test_web_search.py
@@ -97,6 +97,23 @@ def test_missing_query_returns_error(tool_ctx: ToolContext) -> None:
     assert "query" in result.lower()
 
 
+def test_invalid_arguments_return_error(tool_ctx: ToolContext) -> None:
+    """Malformed and non-object JSON return tool errors instead of raising."""
+    tool = WebSearchTool(llm_provider="anthropic")
+    malformed = tool.invoke("{", tool_ctx)
+    non_object = tool.invoke("[]", tool_ctx)
+    assert "Error" in malformed and "malformed JSON" in malformed
+    assert "Error" in non_object and "JSON object" in non_object
+
+
+@pytest.mark.parametrize("query", [123, True, "  "])
+def test_invalid_query_returns_error(tool_ctx: ToolContext, query: object) -> None:
+    """Invalid queries are rejected before backend selection."""
+    tool = WebSearchTool(llm_provider="anthropic")
+    result = tool.invoke(json.dumps({"query": query}), tool_ctx)
+    assert "Error" in result and "query" in result.lower()
+
+
 # ── search_provider: google ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

Harden the built-in tools that parse raw tool-call arguments by giving them a shared JSON-object parser and consistent validation failures.

Several built-ins accepted optional arguments in their schemas but called `json.loads(arguments)` directly. That meant an empty argument string, malformed JSON, or non-object JSON could escape as a raw `JSONDecodeError` or follow-on runtime exception instead of returning a tool-level error. The same parsing pattern existed across file, skill, search, export, upload, and web-search tools.

This PR:

- adds a shared JSON-object argument parser for built-in tools
- treats empty arguments as `{}` where the tool schema allows optional args
- returns structured tool errors for malformed JSON and non-object JSON
- validates ids, paths, queries, pagination, and limits before store/provider calls
- keeps the tool schemas and public API surface unchanged

The change is intentionally a single hardening pass over the same bug pattern. The diff is larger than a one-tool fix because the parser is shared and the tests cover each built-in that had the direct-parse behavior.

## Impact

Tool calls that previously could crash on bad argument payloads now fail predictably at the tool boundary. Valid calls keep the same behavior.

## Tests

- `env UV_CACHE_DIR=/private/tmp/omnigent-uv-cache uv run --locked ruff check omnigent/tools/builtins tests/tools/builtins`
- `env UV_CACHE_DIR=/private/tmp/omnigent-uv-cache uv run --locked --extra all pytest -p no:rerunfailures tests/tools/builtins -q`
  - Local result: 264 passed, 17 skipped
- `env UV_CACHE_DIR=/private/tmp/omnigent-uv-cache uv run --locked ruff format --check omnigent/tools/builtins tests/tools/builtins`
- `git diff --check`
- touched-file `pre-commit run --files ...`
- GitHub CI: Merge Ready reports all required checks green

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Test coverage

- [x] Automated tests added/updated
- [ ] Manual verification required

## Coverage notes

Tests exercise empty arguments, malformed JSON, non-object JSON, invalid ids/paths/query values, and valid argument paths for the affected built-ins.

## Doc impact

No docs update needed. This is defensive behavior for existing built-in tools and does not change user-facing schemas or documented commands.

## Demo

Non-visual behavior demo using the shared built-in argument parser:

```text
arguments='' -> value={}, error=None
arguments='{bad' -> value=None, error='malformed JSON arguments'
arguments='[]' -> value=None, error='arguments must be a JSON object'
arguments='{"limit": 2}' -> value={'limit': 2}, error=None
```

This is the common parser path used by the affected built-ins. Empty optional arguments now normalize to `{}`, malformed JSON returns a tool-level error, non-object JSON is rejected, and valid object arguments continue through unchanged.
