### PR TITLE
fix(search): return conversation ids in search results

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -685,6 +685,10 @@ class ConversationItem(BaseModel):
     A persisted item with a store-assigned ID.
 
     :param id: Store-assigned item ID, e.g. ``"msg_abc123"``.
+    :param conversation_id: Conversation that owns the item when the
+        item was loaded from a store. Excluded from generic
+        ``model_dump()`` output so existing item API payloads stay
+        stable.
     :param type: Item type, e.g. ``"message"``,
         ``"function_call"``.
     :param status: Item status, e.g. ``"completed"``.
@@ -697,6 +701,7 @@ class ConversationItem(BaseModel):
     """
 
     id: str
+    conversation_id: str | None = Field(default=None, exclude=True)
     type: str
     status: str
     response_id: str

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
 # Attachment path markers the native executors prepend to prompt text
 # ("[Attached: /tmp/.../x.png]" from claude-native's _content_to_text,
@@ -685,10 +685,6 @@ class ConversationItem(BaseModel):
     A persisted item with a store-assigned ID.
 
     :param id: Store-assigned item ID, e.g. ``"msg_abc123"``.
-    :param conversation_id: Conversation that owns the item when the
-        item was loaded from a store. Excluded from generic
-        ``model_dump()`` output so existing item API payloads stay
-        stable.
     :param type: Item type, e.g. ``"message"``,
         ``"function_call"``.
     :param status: Item status, e.g. ``"completed"``.
@@ -700,14 +696,25 @@ class ConversationItem(BaseModel):
         mode. Lets owner and collaborator messages be distinguished.
     """
 
+    _conversation_id: str | None = PrivateAttr(default=None)
+
     id: str
-    conversation_id: str | None = Field(default=None, exclude=True)
     type: str
     status: str
     response_id: str
     created_at: int
     data: ItemData
     created_by: str | None = None
+
+    def __init__(self, **data: Any) -> None:
+        conversation_id = data.pop("conversation_id", None)
+        super().__init__(**data)
+        self._conversation_id = conversation_id
+
+    @property
+    def conversation_id(self) -> str | None:
+        """Conversation that owns this item when loaded from a store."""
+        return self._conversation_id
 
     @model_validator(mode="after")
     def check_type_matches_data(self) -> ConversationItem:

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -418,6 +418,7 @@ def _to_item(row: SqlConversationItem) -> ConversationItem:
     """
     return ConversationItem(
         id=row.id,
+        conversation_id=row.conversation_id,
         type=row.type,
         status=row.status,
         response_id=row.response_id,
@@ -1494,6 +1495,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 persisted.append(
                     ConversationItem(
                         id=row.id,
+                        conversation_id=conversation_id,
                         type=row.type,
                         status=row.status,
                         response_id=row.response_id,

--- a/omnigent/tools/builtins/search_conversations.py
+++ b/omnigent/tools/builtins/search_conversations.py
@@ -120,7 +120,7 @@ def _format_results(
     results: list[dict[str, Any]] = []
     for item in items:
         result: dict[str, Any] = {
-            "conversation_id": item.response_id,
+            "conversation_id": getattr(item, "conversation_id", None) or item.response_id,
             "item_id": item.id,
             "created_at": item.created_at,
             "type": item.type,

--- a/tests/entities/test_conversation.py
+++ b/tests/entities/test_conversation.py
@@ -39,6 +39,23 @@ def test_to_api_dict_omits_created_by_when_none() -> None:
     assert "created_by" not in api
 
 
+def test_conversation_id_is_internal_metadata() -> None:
+    """Stored items can carry owner metadata without changing API dumps."""
+    item = ConversationItem(
+        id="msg_1",
+        conversation_id="conv_1",
+        type="message",
+        status="completed",
+        response_id="resp_1",
+        created_at=0,
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+    )
+
+    assert item.conversation_id == "conv_1"
+    assert "conversation_id" not in item.model_dump()
+    assert "conversation_id" not in item.to_api_dict()
+
+
 def test_to_api_dict_exposes_interrupted_assistant_marker() -> None:
     """Interrupted assistant items surface the reload marker in API shape."""
     item = ConversationItem(

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -301,11 +301,15 @@ def test_append_and_list_items(conversation_store: SqlAlchemyConversationStore) 
     assert len(items) == 2
     assert items[0].id.startswith("msg_")
     assert items[1].id.startswith("msg_")
+    assert items[0].conversation_id == conv.id
+    assert items[1].conversation_id == conv.id
 
     page = conversation_store.list_items(conv.id)
     assert len(page.data) == 2
     assert page.data[0].data.role == "user"
     assert page.data[1].data.role == "assistant"
+    assert page.data[0].conversation_id == conv.id
+    assert page.data[1].conversation_id == conv.id
 
 
 def test_append_records_human_author_attribution(
@@ -971,9 +975,11 @@ def test_search(conversation_store: SqlAlchemyConversationStore) -> None:
     results = conversation_store.search("Paris")
     assert len(results) == 1
     assert results[0].type == "message"
+    assert results[0].conversation_id == conv.id
 
     results = conversation_store.search("sunny")
     assert len(results) == 1
+    assert results[0].conversation_id == conv.id
 
     assert conversation_store.search("nonexistent") == []
 
@@ -1013,8 +1019,12 @@ def test_search_scoped_to_conversation(
     assert len(conversation_store.search("hello")) == 2
 
     # Scoped: only one per conversation
-    assert len(conversation_store.search("hello", conversation_id=conv1.id)) == 1
-    assert len(conversation_store.search("hello", conversation_id=conv2.id)) == 1
+    conv1_results = conversation_store.search("hello", conversation_id=conv1.id)
+    conv2_results = conversation_store.search("hello", conversation_id=conv2.id)
+    assert len(conv1_results) == 1
+    assert len(conv2_results) == 1
+    assert conv1_results[0].conversation_id == conv1.id
+    assert conv2_results[0].conversation_id == conv2.id
 
 
 def test_search_function_call_item(

--- a/tests/tools/builtins/test_search_conversations.py
+++ b/tests/tools/builtins/test_search_conversations.py
@@ -31,6 +31,7 @@ class _FakeItem:
     """Minimal stub for ConversationItem."""
 
     id: str
+    conversation_id: str | None
     response_id: str
     created_at: int
     type: str
@@ -101,7 +102,8 @@ def test_invoke_returns_results(monkeypatch: pytest.MonkeyPatch) -> None:
     items = [
         _FakeItem(
             id="item_1",
-            response_id="conv_1",
+            conversation_id="conv_1",
+            response_id="resp_1",
             created_at=1000,
             type="message",
             data=_message_data(),
@@ -142,7 +144,10 @@ def test_invoke_missing_query() -> None:
 
 def test_invoke_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     """invoke() passes limit to the store."""
-    items = [_FakeItem(f"item_{i}", f"conv_{i}", i, "message", _message_data()) for i in range(20)]
+    items = [
+        _FakeItem(f"item_{i}", f"conv_{i}", f"resp_{i}", i, "message", _message_data())
+        for i in range(20)
+    ]
     store = _FakeConversationStore(items)
     monkeypatch.setattr(
         "omnigent.runtime.get_conversation_store",
@@ -159,13 +164,13 @@ def test_invoke_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_extract_text_message() -> None:
     """Extract text from a message item."""
-    item = _FakeItem("i", "r", 0, "message", _message_data("Hello world"))
+    item = _FakeItem("i", "conv_1", "r", 0, "message", _message_data("Hello world"))
     assert _extract_text(item) == "Hello world"
 
 
 def test_extract_text_function_call() -> None:
     """Extract text from a function call item."""
-    item = _FakeItem("i", "r", 0, "function_call", _function_call_data())
+    item = _FakeItem("i", "conv_1", "r", 0, "function_call", _function_call_data())
     text = _extract_text(item)
     assert "web_search" in text
     assert '{"query": "test"}' in text
@@ -173,7 +178,7 @@ def test_extract_text_function_call() -> None:
 
 def test_extract_text_function_call_output() -> None:
     """Extract text from a function call output item."""
-    item = _FakeItem("i", "r", 0, "function_call_output", _function_call_output_data())
+    item = _FakeItem("i", "conv_1", "r", 0, "function_call_output", _function_call_output_data())
     assert _extract_text(item) == "Search results here"
 
 
@@ -184,7 +189,7 @@ def test_extract_text_unknown_type() -> None:
     class _Unknown:
         pass
 
-    item = _FakeItem("i", "r", 0, "unknown", _Unknown())
+    item = _FakeItem("i", "conv_1", "r", 0, "unknown", _Unknown())
     assert _extract_text(item) == ""
 
 
@@ -194,7 +199,7 @@ def test_extract_text_unknown_type() -> None:
 def test_format_results_includes_all_fields() -> None:
     """Each result has conversation_id, item_id, created_at, type."""
     items = [
-        _FakeItem("i1", "conv_1", 1000, "message", _message_data()),
+        _FakeItem("i1", "conv_1", "resp_1", 1000, "message", _message_data()),
     ]
     results = _format_results(items)
     assert len(results) == 1


### PR DESCRIPTION
## Summary

Fix conversation search results so the `conversation_id` field contains the actual owning conversation id instead of the item's `response_id`.

The SQL store already had the true `conversation_id` on each persisted row, but `ConversationItem` dropped that store metadata when rows were converted back into entities. `SearchConversationsTool._format_results` then filled the output `conversation_id` field with `item.response_id`, producing a plausible-looking but wrong id.

This PR:

- preserves the SQL conversation id on loaded/search result items as internal metadata
- returns that real conversation id from `search_conversations`
- keeps the metadata out of `model_dump()`, API payloads, and generated OpenAPI schema
- adds coverage for the entity behavior, store round-trip/search behavior, and tool formatting

An earlier version used a normal Pydantic field with `exclude=True`; CI caught that it still changed generated OpenAPI docs. The current version stores the value in Pydantic private state and verifies the OpenAPI drift test.

## Impact

Search results now point callers at the conversation that owns each matching item. Existing serialized conversation item payloads remain unchanged.

## Tests

- `env UV_CACHE_DIR=/private/tmp/omnigent-uv-cache uv run --locked ruff check omnigent/entities/conversation.py omnigent/stores/conversation_store/sqlalchemy_store.py omnigent/tools/builtins/search_conversations.py tests/entities/test_conversation.py tests/stores/test_conversation_store.py tests/tools/builtins/test_search_conversations.py`
- `env UV_CACHE_DIR=/private/tmp/omnigent-uv-cache uv run --locked --extra all pytest -p no:rerunfailures tests/entities/test_conversation.py tests/tools/builtins/test_search_conversations.py tests/stores/test_conversation_store.py tests/server/test_openapi_drift.py::test_openapi_json_matches_generator_output -q`
  - Local result: 184 passed
- `env UV_CACHE_DIR=/private/tmp/omnigent-uv-cache uv run --locked ruff format --check omnigent/entities/conversation.py omnigent/stores/conversation_store/sqlalchemy_store.py omnigent/tools/builtins/search_conversations.py tests/entities/test_conversation.py tests/stores/test_conversation_store.py tests/tools/builtins/test_search_conversations.py`
- `git diff --check`
- touched-file `pre-commit run --files ...`
- GitHub CI: Merge Ready reports all required checks green

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Test coverage

- [x] Automated tests added/updated
- [ ] Manual verification required

## Coverage notes

Tests cover internal metadata exclusion, SQL store item/list/search round-trips, scoped search across multiple conversations, tool result formatting, and OpenAPI schema stability.

## Doc impact

No docs update needed. The change corrects a built-in tool result value while keeping public item schemas stable.

## Demo

Non-visual before/after result formatting demo:

```text
before: conversation_id=resp_turn_42
after:  {'conversation_id': 'conv_project_alpha', 'item_id': 'item_1', 'created_at': 1000, 'type': 'message', 'text': 'deployment notes', 'role': 'assistant'}
```

Before this fix, `search_conversations` populated the `conversation_id` field with the item response id (`resp_turn_42`). After this fix, the result carries the owning conversation id (`conv_project_alpha`) while preserving the rest of the result shape.
