### PR TITLE
fix(runner): strip runner project root from child-shell PYTHONPATH in sys_os_shell

### DIFF
--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1329,10 +1329,24 @@ def _shell_impl(
         characters.
     """
     argv = _shell_argv(shell_path, command)
+    child_env = os.environ.copy()
+    if "PYTHONPATH" in child_env:
+        project_root = str(_project_root())
+        # The helper needs this checkout to import itself, but project
+        # commands should resolve packages from their own environment.
+        pythonpath_entries = [
+            entry for entry in child_env["PYTHONPATH"].split(os.pathsep) if entry != project_root
+        ]
+        if pythonpath_entries:
+            child_env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+        else:
+            del child_env["PYTHONPATH"]
+
     try:
         completed = subprocess.run(
             argv,
             cwd=str(cwd),
+            env=child_env,
             text=True,
             capture_output=True,
             timeout=timeout,

--- a/tests/inner/sandbox/test_sandbox_behavior.py
+++ b/tests/inner/sandbox/test_sandbox_behavior.py
@@ -26,6 +26,7 @@ Backend-specific emit assertions live in the per-backend modules
 
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 from collections.abc import Callable
@@ -34,7 +35,7 @@ from pathlib import Path
 import pytest
 
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
-from omnigent.inner.os_env import create_os_environment
+from omnigent.inner.os_env import _project_root, create_os_environment
 from tests.inner.sandbox.conftest import run_async
 
 # ---------------------------------------------------------------------------
@@ -645,6 +646,41 @@ def test_sandbox_helper_inherits_explicit_env_passthrough(
         f"stdout={result['stdout']!r} stderr={result.get('stderr')!r}"
     )
     assert "sk-still-blocked" not in (leak_check.get("stdout", "") + leak_check.get("stderr", ""))
+
+
+def test_sandbox_shell_child_pythonpath_excludes_omnigent_project_root(
+    tmp_path: Path,
+    active_sandbox_spec_factory: Callable[..., OSEnvSandboxSpec],
+) -> None:
+    """
+    Shell children should not import through the helper's omnigent
+    checkout entry in ``PYTHONPATH``.
+    """
+    os_env = create_os_environment(
+        OSEnvSpec(
+            type="caller_process",
+            cwd=str(tmp_path),
+            # The stripped entry comes from _start_locked's helper injection.
+            sandbox=active_sandbox_spec_factory(),
+        )
+    )
+    try:
+        result = run_async(
+            os_env.shell(
+                f"{sys.executable} -c \"import os;print(os.environ.get('PYTHONPATH',''))\""
+            )
+        )
+    finally:
+        os_env.close()
+
+    assert result["exit_code"] == 0, (
+        "Expected child shell to print PYTHONPATH successfully: "
+        f"stdout={result.get('stdout')!r} stderr={result.get('stderr')!r}"
+    )
+    child_pythonpath_entries = [
+        entry for entry in result["stdout"].strip().split(os.pathsep) if entry
+    ]
+    assert str(_project_root()) not in child_pythonpath_entries
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import base64
+import os
+import sys
 import tracemalloc
 from pathlib import Path
 
-from omnigent.inner.os_env import _read_impl, build_helper_env
+import pytest
+
+from omnigent.inner.os_env import _project_root, _read_impl, _shell_impl, build_helper_env
 from omnigent.inner.sandbox import SandboxPolicy
 from omnigent.runner.identity import (
     OMNIGENT_SESSION_ENV_VALUE,
@@ -109,6 +113,78 @@ def test_build_helper_env_active_passes_omnigent_session_marker() -> None:
     env = build_helper_env(parent, _active_policy())
 
     assert env[OMNIGENT_SESSION_ENV_VAR] == OMNIGENT_SESSION_ENV_VALUE
+
+
+# ---------------------------------------------------------------------------
+# _shell_impl
+# ---------------------------------------------------------------------------
+
+
+def _print_pythonpath_command() -> str:
+    return f"{sys.executable} -c \"import os;print(os.environ.get('PYTHONPATH',''))\""
+
+
+def test_shell_impl_strips_only_omnigent_project_root_from_pythonpath(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the helper checkout entry is stripped from child ``PYTHONPATH``."""
+    sentinel = "/tmp/omni1860-sentinel-does-not-exist"
+    project_root = str(_project_root())
+    monkeypatch.setenv("PYTHONPATH", f"{project_root}{os.pathsep}{sentinel}")
+
+    result = _shell_impl(
+        command=_print_pythonpath_command(),
+        timeout=5,
+        shell_path="/bin/sh",
+        cwd=tmp_path,
+    )
+
+    assert result["exit_code"] == 0, (
+        "Expected child shell to print PYTHONPATH successfully: "
+        f"stdout={result.get('stdout')!r} stderr={result.get('stderr')!r}"
+    )
+    child_pythonpath_entries = [
+        entry for entry in result["stdout"].strip().split(os.pathsep) if entry
+    ]
+    assert project_root not in child_pythonpath_entries
+    assert sentinel in child_pythonpath_entries
+
+
+def test_shell_impl_handles_absent_pythonpath(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing ``PYTHONPATH`` stays missing for child shell commands."""
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    result = _shell_impl(
+        command=_print_pythonpath_command(),
+        timeout=5,
+        shell_path="/bin/sh",
+        cwd=tmp_path,
+    )
+
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == ""
+
+
+def test_shell_impl_removes_pythonpath_when_only_project_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A helper-only ``PYTHONPATH`` entry is removed instead of left empty."""
+    monkeypatch.setenv("PYTHONPATH", str(_project_root()))
+
+    result = _shell_impl(
+        command=_print_pythonpath_command(),
+        timeout=5,
+        shell_path="/bin/sh",
+        cwd=tmp_path,
+    )
+
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related issue

Closes #1860

## Summary

`sys_os_shell` ran every agent shell command with the runner's own project root prepended to `PYTHONPATH`, so project commands (`uv run pytest`, `uv run python`) imported omnigent's copy of shared libraries (pydantic, mlflow, ...) instead of the project's own.

- The helper prepends `str(_project_root())` to its `PYTHONPATH` in `_start_locked` so it can import omnigent from a scratch cwd. That part is load-bearing and stays.
- The leak was that `_shell_impl` called `subprocess.run(...)` with no explicit `env=`, so the child shell inherited that poisoned `PYTHONPATH`.
- Fix: `_shell_impl` now builds an explicit child env that strips every `PYTHONPATH` entry equal to `str(_project_root())` by value (deleting the var if nothing remains). Only the runner's own entry is removed; every legitimate entry survives.

### ELI5

The agent's shell tool was quietly putting omnigent's own code folder at the front of `PYTHONPATH` for every command it ran.
So when your project ran `uv run pytest`, Python found omnigent's copy of a library before your project's copy.
Same version: a silent wrong import. Different version: a hard `ModuleNotFoundError: pydantic_core._pydantic_core`. And `pytest.importorskip('mlflow')` turned that crash into a SKIP, so a suite reported false-green.

### Before / After

```
Before:
  helper os.environ PYTHONPATH = /path/to/omnigent : <rest>
  _shell_impl -> subprocess.run(argv, cwd=...)          # no env=
  child shell PYTHONPATH        = /path/to/omnigent : <rest>
  uv run python  ->  imports omnigent's pydantic         [X]

After:
  _shell_impl builds child env = os.environ minus the /path/to/omnigent PYTHONPATH entry
  child shell PYTHONPATH        = <rest>                  # runner root stripped by value
  uv run python  ->  imports the project's pydantic       [OK]
  (_start_locked's helper-import prepend is untouched)
```

## Test Plan

Test-first (RED -> GREEN), all offline, no credentials:

- **RED**: added an E2E regression test (`tests/inner/sandbox/test_sandbox_behavior.py`) that runs a `sys_os_shell` command printing the child's `PYTHONPATH` and asserts the runner's project root is absent. On unfixed code it failed with `AssertionError: '.../omnigent' not in ['.../omnigent']`.
- **GREEN**: the same test passes after the fix.
- Added three direct `_shell_impl` unit tests (`tests/inner/test_os_env.py`) proving the strip is surgical: a sentinel non-omnigent entry survives, an absent `PYTHONPATH` stays absent, and a project-root-only value is removed (not left empty). The surgical assertion was verified to go RED under a blanket-wipe mutation.
- Suite: `uv run pytest tests/inner/test_os_env.py tests/inner/sandbox/` -> **34 passed, 27 skipped, 0 failed** (skips are backend-specific, e.g. non-Linux sandbox backends).

## Demo

N/A (non-visual runner/behavior fix).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The E2E test guards the reported regression end to end; the three `_shell_impl` unit tests cover the strip's edge cases (surgical removal, absent var, project-root-only) that the E2E path cannot reach because the helper's `PYTHONPATH` is always a single injected entry.

## Changelog

`sys_os_shell` commands now import the project's own packages instead of the runner's, so `uv run` project commands no longer pick up omnigent's dependency versions.
