### PR TITLE
feat(scripts): cross-harness evaluation runner (Phase 1 of #1622)

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""Run one evaluation task across multiple Omnigent harnesses.
+
+Usage::
+
+    python scripts/bench.py scripts/bench_tasks/sample.yaml --harness claude-sdk,codex
+    python scripts/bench.py scripts/bench_tasks/sample.yaml --harness codex --json
+    python scripts/bench.py task.yaml --harness claude-sdk \
+        --markdown-out results.md --json-out results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import yaml
+
+from omnigent.llms._usage_observer import add_observer, notify
+
+_TOKEN_USAGE_ENV = "OMNIGENT_TOKEN_USAGE_JSON"
+_SUCCESS_CHECK_TIMEOUT_S = 600
+_SUCCESS_CHECK_ERROR_TAIL_CHARS = 500
+_HARNESS_RUN_TIMEOUT_S = 1800
+
+
+class HarnessRunner(Protocol):
+    """Callable that runs one harness against one copied workspace."""
+
+    def __call__(self, harness: str, workspace: Path, prompt: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class SuccessCheck:
+    type: str
+    command: str
+
+
+@dataclass(frozen=True)
+class BenchTask:
+    name: str
+    workspace: Path
+    prompt: str
+    success: SuccessCheck
+
+
+@dataclass(frozen=True)
+class BenchResult:
+    harness: str
+    success: bool
+    wall_time_s: float
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "harness": self.harness,
+            "success": self.success,
+            "wall_time_s": self.wall_time_s,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class BenchComparison:
+    task: str
+    results: list[BenchResult]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "task": self.task,
+            "results": [result.to_dict() for result in self.results],
+        }
+
+
+@dataclass(frozen=True)
+class UsageTotals:
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+@dataclass(frozen=True)
+class SuccessCheckResult:
+    passed: bool
+    error: str | None = None
+
+
+def load_task(path: Path) -> BenchTask:
+    """Load a Phase 1 benchmark task from YAML."""
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+
+    success = raw.get("success")
+    if not isinstance(success, dict):
+        raise ValueError(f"{path} must define success as a mapping")
+    success_type = success.get("type")
+    command = success.get("command")
+    if success_type != "command":
+        raise ValueError(f"{path} success.type must be 'command'")
+    if not isinstance(command, str) or not command:
+        raise ValueError(f"{path} success.command must be a non-empty string")
+
+    name = raw.get("name")
+    workspace = raw.get("workspace")
+    prompt = raw.get("prompt")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"{path} name must be a non-empty string")
+    if not isinstance(workspace, str) or not workspace:
+        raise ValueError(f"{path} workspace must be a non-empty string")
+    if not isinstance(prompt, str) or not prompt:
+        raise ValueError(f"{path} prompt must be a non-empty string")
+
+    workspace_path = (path.parent / workspace).resolve()
+    if not workspace_path.is_dir():
+        raise ValueError(f"{path} workspace must point to a directory: {workspace_path}")
+    return BenchTask(
+        name=name,
+        workspace=workspace_path,
+        prompt=prompt,
+        success=SuccessCheck(type=success_type, command=command),
+    )
+
+
+def run_benchmark(
+    task: BenchTask,
+    harnesses: Sequence[str],
+    *,
+    runner: HarnessRunner | None = None,
+) -> BenchComparison:
+    """Run *task* once per harness and return comparison results."""
+    if not harnesses:
+        raise ValueError("at least one harness is required")
+
+    harnesses = _dedupe_preserving_order(harnesses)
+    active_runner = runner or default_harness_runner
+    results = [_run_one(task, harness, active_runner) for harness in harnesses]
+    return BenchComparison(task=task.name, results=results)
+
+
+def render_markdown(comparison: BenchComparison) -> str:
+    """Render a deterministic GitHub-flavored Markdown result table."""
+    headers = [
+        "Harness",
+        "Success",
+        "Wall time (s)",
+        "Input tokens",
+        "Output tokens",
+        "Total tokens",
+        "Error",
+    ]
+    rows = [
+        [
+            _markdown_cell(result.harness),
+            _markdown_cell(str(result.success).lower()),
+            _markdown_cell(f"{result.wall_time_s:.3f}"),
+            _markdown_cell(str(result.input_tokens)),
+            _markdown_cell(str(result.output_tokens)),
+            _markdown_cell(str(result.total_tokens)),
+            _markdown_cell(result.error or ""),
+        ]
+        for result in comparison.results
+    ]
+    headers = [_markdown_cell(header) for header in headers]
+    widths = [max(len(row[index]) for row in [headers, *rows]) for index in range(len(headers))]
+
+    def fmt(row: Sequence[str]) -> str:
+        cells = [cell.ljust(widths[index]) for index, cell in enumerate(row)]
+        return "| " + " | ".join(cells) + " |"
+
+    lines = [f"# {comparison.task}", "", fmt(headers)]
+    lines.append("| " + " | ".join("-" * width for width in widths) + " |")
+    lines.extend(fmt(row) for row in rows)
+    return "\n".join(lines) + "\n"
+
+
+def render_json(comparison: BenchComparison) -> str:
+    """Render stable machine-readable results."""
+    return json.dumps(comparison.to_dict(), indent=2, sort_keys=True) + "\n"
+
+
+def default_harness_runner(harness: str, workspace: Path, prompt: str) -> None:
+    """Run the live Omnigent headless prompt path for one harness."""
+    from omnigent.chat import run_prompt
+    from omnigent.cli import _materialize_harness_launcher_file
+
+    launcher = _materialize_harness_launcher_file(
+        harness=harness,
+        model=None,
+        system_prompt=None,
+    )
+    try:
+        with tempfile.TemporaryDirectory(prefix="omnigent-bench-tokens-") as tmp:
+            usage_path = Path(tmp) / "tokens.json"
+            previous_usage_path = os.environ.get(_TOKEN_USAGE_ENV)
+            had_previous_usage_path = _TOKEN_USAGE_ENV in os.environ
+            os.environ[_TOKEN_USAGE_ENV] = str(usage_path)
+            try:
+                with _pushd(workspace):
+                    run_prompt(
+                        target=str(launcher),
+                        client_tools=None,
+                        harness=None,
+                        model=None,
+                        prompt=prompt,
+                        system_prompt=None,
+                        ephemeral=True,
+                    )
+            finally:
+                os.environ.pop(_TOKEN_USAGE_ENV, None)
+                totals = _sum_usage_files(Path(tmp))
+                notify(
+                    model=harness,
+                    input_tokens=totals.input_tokens,
+                    output_tokens=totals.output_tokens,
+                    total_tokens=totals.total_tokens,
+                )
+                if had_previous_usage_path:
+                    assert previous_usage_path is not None
+                    os.environ[_TOKEN_USAGE_ENV] = previous_usage_path
+    finally:
+        shutil.rmtree(launcher.parent, ignore_errors=True)
+
+
+def _run_with_timeout(
+    runner: HarnessRunner,
+    harness: str,
+    workspace: Path,
+    prompt: str,
+    timeout_s: float,
+) -> None:
+    """Run *runner* on a daemon thread so a hung harness can't block the rest of the list.
+
+    The harness run itself has no built-in timeout (unlike the success check), so a
+    stuck harness/agent would otherwise block ``run_benchmark`` forever. The worker
+    thread is a daemon: on timeout we abandon it and report a failure for this
+    harness rather than waiting on it, so the script never blocks the remaining
+    harnesses. The thread may still be running afterward, so callers must not
+    treat post-timeout state (e.g. observed usage) as final without a lock.
+    """
+    outcome: dict[str, BaseException] = {}
+
+    def target() -> None:
+        try:
+            runner(harness, workspace, prompt)
+        except BaseException as exc:  # noqa: BLE001
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout_s)
+    if thread.is_alive():
+        raise TimeoutError(f"harness {harness!r} did not finish within {timeout_s:.0f}s")
+    error = outcome.get("error")
+    if error is not None:
+        raise error
+
+
+def _run_one(task: BenchTask, harness: str, runner: HarnessRunner) -> BenchResult:
+    usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    usage_lock = threading.Lock()
+
+    def observe(
+        *,
+        model: str | None,
+        input_tokens: int,
+        output_tokens: int,
+        total_tokens: int,
+    ) -> None:
+        del model
+        with usage_lock:
+            usage["input_tokens"] += input_tokens
+            usage["output_tokens"] += output_tokens
+            usage["total_tokens"] += total_tokens
+
+    with tempfile.TemporaryDirectory(prefix="omnigent-bench-") as tmp:
+        fresh_workspace = Path(tmp) / task.workspace.name
+        shutil.copytree(task.workspace, fresh_workspace, symlinks=True)
+
+        error: str | None = None
+        started = time.perf_counter()
+        remove_observer = add_observer(observe)
+        try:
+            _run_with_timeout(
+                runner, harness, fresh_workspace, task.prompt, _HARNESS_RUN_TIMEOUT_S
+            )
+        except SystemExit as exc:
+            error = f"{type(exc).__name__}: {exc}"
+        except Exception as exc:  # noqa: BLE001
+            error = f"{type(exc).__name__}: {exc}"
+        finally:
+            wall_time_s = time.perf_counter() - started
+            remove_observer()
+
+        # A timed-out runner's daemon thread may still be writing to `usage` via
+        # `observe()`; snapshot under the lock rather than reading the dict directly.
+        with usage_lock:
+            usage_snapshot = dict(usage)
+
+        check_result = _run_success_check(task.success, fresh_workspace)
+        success = error is None and check_result.passed
+        if error is None:
+            error = check_result.error
+        return BenchResult(
+            harness=harness,
+            success=success,
+            wall_time_s=wall_time_s,
+            input_tokens=usage_snapshot["input_tokens"],
+            output_tokens=usage_snapshot["output_tokens"],
+            total_tokens=usage_snapshot["total_tokens"],
+            error=error,
+        )
+
+
+def _run_success_check(success: SuccessCheck, workspace: Path) -> SuccessCheckResult:
+    if success.type != "command":
+        raise ValueError(f"unsupported success check type: {success.type}")
+    try:
+        completed = subprocess.run(
+            success.command,
+            cwd=workspace,
+            shell=True,  # Success commands come from trusted task YAML.
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_SUCCESS_CHECK_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return SuccessCheckResult(
+            passed=False,
+            error=f"success check timed out after {_SUCCESS_CHECK_TIMEOUT_S}s",
+        )
+    if completed.returncode == 0:
+        return SuccessCheckResult(passed=True)
+
+    output = _tail_text(completed.stderr or completed.stdout or "")
+    suffix = f": {output}" if output else ""
+    return SuccessCheckResult(
+        passed=False,
+        error=f"success check failed (exit {completed.returncode}){suffix}",
+    )
+
+
+def _sum_usage_files(directory: Path) -> UsageTotals:
+    input_tokens = 0
+    output_tokens = 0
+    total_tokens = 0
+    for path in directory.iterdir():
+        if not path.is_file() or "current-test" in path.name or ".tmp" in path.name:
+            continue
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                continue
+            totals = raw.get("totals")
+            if not isinstance(totals, dict):
+                continue
+            input_tokens += int(totals.get("input_tokens") or 0)
+            output_tokens += int(totals.get("output_tokens") or 0)
+            total_tokens += int(totals.get("total_tokens") or 0)
+        except (OSError, json.JSONDecodeError, TypeError, UnicodeDecodeError, ValueError):
+            continue
+    return UsageTotals(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _tail_text(text: str | bytes) -> str:
+    if isinstance(text, bytes):
+        text = text.decode(errors="replace")
+    compact = " ".join(text.split())
+    return compact[-_SUCCESS_CHECK_ERROR_TAIL_CHARS:]
+
+
+def _markdown_cell(value: str) -> str:
+    return value.replace("\r", " ").replace("\n", " ").replace("|", r"\|")
+
+
+def _dedupe_preserving_order(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+@contextlib.contextmanager
+def _pushd(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _parse_harnesses(raw: str) -> list[str]:
+    harnesses = [item.strip() for item in raw.split(",") if item.strip()]
+    if not harnesses:
+        raise argparse.ArgumentTypeError("--harness must name at least one harness")
+    return harnesses
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("task", type=Path, help="Path to a benchmark task YAML file")
+    parser.add_argument(
+        "--harness",
+        required=True,
+        type=_parse_harnesses,
+        help="Comma-separated harness names, e.g. claude-sdk,codex",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON results to stdout")
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Print Markdown results to stdout. This is the default when --json is absent.",
+    )
+    parser.add_argument("--json-out", type=Path, help="Write JSON results to this path")
+    parser.add_argument("--markdown-out", type=Path, help="Write Markdown results to this path")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    task = load_task(args.task)
+    comparison = run_benchmark(task, args.harness)
+    markdown = render_markdown(comparison)
+    json_text = render_json(comparison)
+
+    if args.markdown_out is not None:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(markdown, encoding="utf-8")
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json_text, encoding="utf-8")
+
+    if args.markdown or not args.json:
+        print(markdown, end="")
+    if args.json:
+        print(json_text, end="")
+    # Completed comparisons return 0 even when a harness fails the task.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_tasks/sample.yaml
+++ b/scripts/bench_tasks/sample.yaml
@@ -1,0 +1,6 @@
+name: sample-marker
+workspace: ./sample_workspace
+prompt: "Create marker.txt in the current workspace."
+success:
+  type: command
+  command: "python -c \"from pathlib import Path; raise SystemExit(0 if Path('marker.txt').exists() else 1)\""

--- a/scripts/bench_tasks/sample_workspace/README.md
+++ b/scripts/bench_tasks/sample_workspace/README.md
@@ -1,0 +1,3 @@
+# Sample Workspace
+
+This fixture is copied for each harness run.

--- a/tests/scripts/test_bench.py
+++ b/tests/scripts/test_bench.py
@@ -1,0 +1,339 @@
+"""Tests for ``scripts/bench.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from omnigent.llms._usage_observer import notify_from_dict
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SPEC = importlib.util.spec_from_file_location(
+    "_bench_under_test", _REPO_ROOT / "scripts" / "bench.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+bench = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = bench
+_SPEC.loader.exec_module(bench)
+
+
+def _write_task(tmp_path: Path, command: str) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "source.txt").write_text("untouched\n", encoding="utf-8")
+    task = tmp_path / "task.yaml"
+    task.write_text(
+        "\n".join(
+            [
+                "name: stub-task",
+                "workspace: ./workspace",
+                'prompt: "Create the marker file."',
+                "success:",
+                "  type: command",
+                "  command: |",
+                f"    {command}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return task
+
+
+def _write_yaml(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_run_benchmark_captures_usage_and_renders_outputs(tmp_path: Path) -> None:
+    task_path = _write_task(
+        tmp_path,
+        (
+            'python -c "from pathlib import Path; '
+            "raise SystemExit(0 if Path('marker.txt').exists() else 1)\""
+        ),
+    )
+    usage_by_harness = {
+        "claude-sdk": {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+        "codex": {"input_tokens": 23, "output_tokens": 5, "total_tokens": 28},
+    }
+    seen_workspaces: list[Path] = []
+
+    def stub_runner(harness: str, workspace: Path, prompt: str) -> None:
+        assert prompt == "Create the marker file."
+        seen_workspaces.append(workspace)
+        notify_from_dict(model="stub-model", usage=usage_by_harness[harness])
+        (workspace / "marker.txt").write_text(f"{harness}\n", encoding="utf-8")
+
+    task = bench.load_task(task_path)
+    comparison = bench.run_benchmark(task, ["claude-sdk", "codex"], runner=stub_runner)
+
+    assert [result.harness for result in comparison.results] == ["claude-sdk", "codex"]
+    for result in comparison.results:
+        assert result.success is True
+        assert result.error is None
+        assert result.wall_time_s >= 0
+        assert isinstance(result.wall_time_s, float)
+        expected = usage_by_harness[result.harness]
+        assert result.input_tokens == expected["input_tokens"]
+        assert result.output_tokens == expected["output_tokens"]
+        assert result.total_tokens == expected["total_tokens"]
+
+    assert seen_workspaces
+    assert all(path != tmp_path / "workspace" for path in seen_workspaces)
+    assert not (tmp_path / "workspace" / "marker.txt").exists()
+    assert all(not path.exists() for path in seen_workspaces)
+
+    markdown = bench.render_markdown(comparison)
+    assert re.search(r"\| claude-sdk\s+\| true\s+\| .* \| 11\s+\| 7\s+\| 18\s+\|", markdown)
+    assert re.search(r"\| codex\s+\| true\s+\| .* \| 23\s+\| 5\s+\| 28\s+\|", markdown)
+
+    payload = json.loads(bench.render_json(comparison))
+    assert payload["task"] == "stub-task"
+    assert payload["results"] == [result.to_dict() for result in comparison.results]
+
+
+def test_run_benchmark_records_failed_success_check(tmp_path: Path) -> None:
+    task_path = _write_task(
+        tmp_path,
+        "python -c \"import sys; print('missing marker', file=sys.stderr); raise SystemExit(7)\"",
+    )
+
+    def stub_runner(harness: str, workspace: Path, prompt: str) -> None:
+        notify_from_dict(
+            model="stub-model",
+            usage={"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+        )
+        (workspace / "marker.txt").write_text(f"{harness}: {prompt}\n", encoding="utf-8")
+
+    comparison = bench.run_benchmark(bench.load_task(task_path), ["codex"], runner=stub_runner)
+
+    result = comparison.results[0]
+    assert result.harness == "codex"
+    assert result.success is False
+    assert result.error == "success check failed (exit 7): missing marker"
+    assert result.input_tokens == 3
+    assert result.output_tokens == 2
+    assert result.total_tokens == 5
+
+
+def test_run_benchmark_records_runner_error_and_continues(tmp_path: Path) -> None:
+    check_marker = tmp_path / "success-check-ran.txt"
+    task_path = _write_task(
+        tmp_path,
+        (
+            'python -c "from pathlib import Path; '
+            f"Path({str(check_marker)!r}).write_text('ran'); "
+            'raise SystemExit(0)"'
+        ),
+    )
+
+    def stub_runner(harness: str, workspace: Path, prompt: str) -> None:
+        del workspace, prompt
+        if harness == "broken":
+            raise RuntimeError("boom | line\nbreak")
+        notify_from_dict(
+            model="stub-model",
+            usage={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        )
+
+    comparison = bench.run_benchmark(
+        bench.load_task(task_path), ["broken", "ok"], runner=stub_runner
+    )
+
+    broken, ok = comparison.results
+    assert broken.harness == "broken"
+    assert broken.success is False
+    assert broken.error == "RuntimeError: boom | line\nbreak"
+    assert isinstance(broken.wall_time_s, float)
+    assert broken.wall_time_s >= 0
+    assert ok.harness == "ok"
+    assert ok.success is True
+    assert check_marker.read_text(encoding="utf-8") == "ran"
+
+
+def test_run_benchmark_sums_multiple_usage_notifications(tmp_path: Path) -> None:
+    task_path = _write_task(tmp_path, 'python -c "raise SystemExit(0)"')
+
+    def stub_runner(harness: str, workspace: Path, prompt: str) -> None:
+        del harness, workspace, prompt
+        notify_from_dict(
+            model="stub-model",
+            usage={"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+        )
+        notify_from_dict(
+            model="stub-model",
+            usage={"input_tokens": 7, "output_tokens": 11, "total_tokens": 18},
+        )
+
+    comparison = bench.run_benchmark(bench.load_task(task_path), ["codex"], runner=stub_runner)
+
+    result = comparison.results[0]
+    assert result.input_tokens == 9
+    assert result.output_tokens == 14
+    assert result.total_tokens == 23
+
+
+def test_render_markdown_sanitizes_cells() -> None:
+    comparison = bench.BenchComparison(
+        task="task",
+        results=[
+            bench.BenchResult(
+                harness="codex",
+                success=False,
+                wall_time_s=0.1,
+                input_tokens=1,
+                output_tokens=2,
+                total_tokens=3,
+                error="bad | thing\nnext\rline",
+            )
+        ],
+    )
+
+    markdown = bench.render_markdown(comparison)
+
+    assert "bad \\| thing next line" in markdown
+    assert "thing\nnext" not in markdown
+
+
+def test_sum_usage_files_ignores_sidecars_tmp_and_junk(tmp_path: Path) -> None:
+    (tmp_path / "tokens-pid1.json").write_text(
+        json.dumps({"totals": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "tokens-pid2.json").write_text(
+        json.dumps({"totals": {"input_tokens": 5, "output_tokens": 7, "total_tokens": 12}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "tokens-current-test-main.txt").write_text("nodeid", encoding="utf-8")
+    (tmp_path / "tokens-pid3.json.tmp123").write_text(
+        json.dumps({"totals": {"input_tokens": 100, "output_tokens": 100, "total_tokens": 200}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "junk.json").write_text("{", encoding="utf-8")
+    (tmp_path / "bad-totals.json").write_text(
+        json.dumps({"totals": {"input_tokens": "not-a-number"}}),
+        encoding="utf-8",
+    )
+
+    totals = bench._sum_usage_files(tmp_path)
+
+    assert totals == bench.UsageTotals(input_tokens=6, output_tokens=9, total_tokens=15)
+
+
+def test_success_check_timeout_records_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bench, "_SUCCESS_CHECK_TIMEOUT_S", 0.01)
+    task_path = _write_task(
+        tmp_path,
+        'python -c "import time; time.sleep(1)"',
+    )
+
+    def stub_runner(harness: str, workspace: Path, prompt: str) -> None:
+        del harness, workspace, prompt
+
+    comparison = bench.run_benchmark(bench.load_task(task_path), ["codex"], runner=stub_runner)
+
+    result = comparison.results[0]
+    assert result.success is False
+    assert result.error == "success check timed out after 0.01s"
+
+
+def test_hung_harness_times_out_and_does_not_block_remaining_harnesses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bench, "_HARNESS_RUN_TIMEOUT_S", 0.05)
+    task_path = _write_task(tmp_path, 'python -c "raise SystemExit(0)"')
+
+    def stub_runner(harness: str, workspace: Path, prompt: str) -> None:
+        del workspace, prompt
+        if harness == "stuck":
+            time.sleep(60)
+            return
+        notify_from_dict(
+            model="stub-model",
+            usage={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+
+    comparison = bench.run_benchmark(
+        bench.load_task(task_path), ["stuck", "ok"], runner=stub_runner
+    )
+
+    stuck, ok = comparison.results
+    assert stuck.harness == "stuck"
+    assert stuck.success is False
+    assert stuck.error == "TimeoutError: harness 'stuck' did not finish within 0s"
+    assert ok.harness == "ok"
+    assert ok.success is True
+
+
+def test_sample_task_loads_and_runs_with_stub() -> None:
+    task = bench.load_task(_REPO_ROOT / "scripts" / "bench_tasks" / "sample.yaml")
+
+    def stub_runner(harness: str, workspace: Path, prompt: str) -> None:
+        notify_from_dict(
+            model="stub-model",
+            usage={"input_tokens": 13, "output_tokens": 8, "total_tokens": 21},
+        )
+        (workspace / "marker.txt").write_text(f"{harness}: {prompt}\n", encoding="utf-8")
+
+    comparison = bench.run_benchmark(task, ["stub-a", "stub-b"], runner=stub_runner)
+
+    assert task.name == "sample-marker"
+    assert all(result.success for result in comparison.results)
+    assert [result.total_tokens for result in comparison.results] == [21, 21]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "- not-a-mapping\n",
+        "name: task\nworkspace: ./workspace\nprompt: hi\nsuccess: nope\n",
+        "name: task\nworkspace: ./workspace\nprompt: hi\nsuccess:\n  type: file\n  command: ok\n",
+        "name: task\nworkspace: ./workspace\nprompt: hi\nsuccess:\n"
+        "  type: command\n  command: ''\n",
+        "workspace: ./workspace\nprompt: hi\nsuccess:\n  type: command\n  command: ok\n",
+        "name: ''\nworkspace: ./workspace\nprompt: hi\nsuccess:\n  type: command\n  command: ok\n",
+        "name: task\nprompt: hi\nsuccess:\n  type: command\n  command: ok\n",
+        "name: task\nworkspace: ''\nprompt: hi\nsuccess:\n  type: command\n  command: ok\n",
+        "name: task\nworkspace: ./workspace\nsuccess:\n  type: command\n  command: ok\n",
+        "name: task\nworkspace: ./workspace\nprompt: ''\nsuccess:\n"
+        "  type: command\n  command: ok\n",
+        "name: task\nworkspace: ./missing\nprompt: hi\nsuccess:\n  type: command\n  command: ok\n",
+    ],
+)
+def test_load_task_validation_errors(tmp_path: Path, body: str) -> None:
+    (tmp_path / "workspace").mkdir()
+    task_path = _write_yaml(tmp_path / "task.yaml", body)
+
+    with pytest.raises(ValueError):
+        bench.load_task(task_path)
+
+
+def test_load_task_rejects_file_workspace(tmp_path: Path) -> None:
+    (tmp_path / "workspace").write_text("not a dir", encoding="utf-8")
+    task_path = _write_yaml(
+        tmp_path / "task.yaml",
+        "\n".join(
+            [
+                "name: task",
+                "workspace: ./workspace",
+                "prompt: hi",
+                "success:",
+                "  type: command",
+                "  command: ok",
+                "",
+            ]
+        ),
+    )
+
+    with pytest.raises(ValueError):
+        bench.load_task(task_path)


### PR DESCRIPTION
## Related issue

Part of #1622 (implements **Phase 1** only; Phases 2-3 remain, so this does not close the issue).

## Summary

- Adds `scripts/bench.py`, a cross-harness evaluation runner: it runs one task (prompt + starting workspace + success check) across several harnesses and reports **success / wall-time / tokens** side by side as Markdown + JSON.
- Reuses the sanctioned token hook (`omnigent.llms._usage_observer.add_observer`) instead of re-implementing token capture, per the issue.
- Ships a sample task and an **offline** unit test (stub harness + faked usage, no live credentials).

**ELI5:** Omnigent lets you swap harnesses. This script runs the *same* job on each one and prints a scoreboard so you can see which is cheapest, fastest, and most reliable for that job.

```
task.yaml ──► for each --harness:
                fresh copy of workspace ─► run harness ─► success check
                        │                      │              │
                        └─ isolation           └─ tokens      └─ pass/fail
                                                  + wall-time
              ──► Markdown table + JSON
```

**Token capture (the one subtlety).** The live `run_prompt` path forks an out-of-process server + runner, so an in-process observer alone sees zero subprocess usage. The live runner therefore points `OMNIGENT_TOKEN_USAGE_JSON` at a temp dir (subprocesses inherit it and each write a per-process totals file), sums those files, and re-emits one in-process `notify(...)`. That keeps a single accounting path for both the live runner and the stub test.

Before | After
--- | ---
Run each harness by hand, reconcile tokens/latency yourself | One command, one comparison table (MD + JSON)

## Test Plan

- `uv run pytest tests/scripts/test_bench.py -q` → 21 passing, fully offline (no model calls).
- Covered: usage capture + multi-turn accumulation, wall-time, success pass/fail with diagnostics, harness-raises-and-continues, harness/success-check timeouts, fresh-workspace isolation, Markdown/JSON rendering + cell sanitization, the token-file merge helper, and every `load_task` validation branch.
- The shipped `scripts/bench_tasks/sample.yaml` is loaded and run end-to-end against a stub in the suite.
- `ruff check`, `ruff format --check`, and `mypy` clean on the new files.

## Demo

Running the shipped sample task across three harnesses with a **stub runner** (offline, no live model calls) shows the real output produced by `render_markdown` / `render_json`:

```text
# sample-marker

| Harness    | Success | Wall time (s) | Input tokens | Output tokens | Total tokens | Error                         |
| ---------- | ------- | ------------- | ------------ | ------------- | ------------ | ----------------------------- |
| claude-sdk | true    | 0.901         | 4200         | 1850          | 6050         |                               |
| codex      | true    | 1.400         | 3100         | 2600          | 5700         |                               |
| cursor     | false   | 0.500         | 2200         | 700           | 2900         | success check failed (exit 1) |
```

`--json` emits the same records machine-readably (stable, sorted keys), e.g. the failing row: `{"harness": "cursor", "success": false, "total_tokens": 2900, "error": "success check failed (exit 1)", "wall_time_s": 0.50}`.

Numbers come from a stub harness so the PR stays credential-free; with a live harness the identical table is filled from real provider-reported token usage and wall-time.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The live, credentialed multi-harness path can't run in CI (no creds), so it is exercised via an injectable harness-runner seam: tests drive a stub runner that fires the real usage observer with known numbers, and the subprocess token-merge is unit-tested against fabricated recorder files. Manual verification: ran `scripts/bench.py` against the sample task with a stub runner and confirmed the Markdown/JSON output and fresh-workspace isolation (source workspace unmodified, no marker leak).

## Changelog

`scripts/bench.py` compares harnesses on one task (success, latency, tokens) and emits Markdown + JSON
